### PR TITLE
fix: amplitude race condition

### DIFF
--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -12,7 +12,6 @@
   },
   "__prod__permissions": [
     "storage",
-    "alarms",
     "https://daily.dev/",
     "https://*.daily.dev/",
     "https://dailynow.co/",
@@ -20,7 +19,6 @@
   ],
   "__dev__permissions": [
     "storage",
-    "alarms",
     "http://localhost/"
   ],
   "optional_permissions": [

--- a/packages/shared/src/hooks/useAnalytics.ts
+++ b/packages/shared/src/hooks/useAnalytics.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import {
   getAmplitudeClient,
+  initAmplitude,
   initializeAnalyticsQueue,
   loadAnalyticsScript,
   trackPageView,
@@ -37,15 +38,7 @@ export default function useAnalytics(
       loadAnalyticsScript();
       if (!initializedAmp) {
         setInitializedAmp(true);
-        getAmplitudeClient().then((amplitude) => {
-          amplitude.init(process.env.NEXT_PUBLIC_AMPLITUDE, user?.id, {
-            includeReferrer: true,
-            includeUtm: true,
-            sameSiteCookie: 'Lax',
-            domain: process.env.NEXT_PUBLIC_DOMAIN,
-          });
-          amplitude.setVersionName(version);
-        });
+        initAmplitude(user, version);
       }
     }
   }, [trackingId, canLoadScripts, showCookie]);


### PR DESCRIPTION
The lazy-load of Amplitude SDK caused a race condition of the first revenue event and initialization.
To fix it we save the events in temporary queue until the client is loaded