### PR TITLE
Change texts in profile page

### DIFF
--- a/packages/shared/src/components/profile/PostsSection.tsx
+++ b/packages/shared/src/components/profile/PostsSection.tsx
@@ -146,7 +146,7 @@ export default function PostsSection({
         <br />
         <a
           className="no-underline text-theme-label-link"
-          href="mailto:hi@daily.dev?subject=Add my articles retroactively"
+          href="mailto:hi@daily.dev?subject=Email us to add your articles retroactively"
           target="_blank"
           rel="noopener"
         >


### PR DESCRIPTION
Changing the text from "Add your articles retroactively" to "Email us to add your articles retroactively" for extra clarity.