### PR TITLE
feat: ask to generate dev card in the ranks popups

### DIFF
--- a/packages/shared/src/components/DevCardPlaceholder.tsx
+++ b/packages/shared/src/components/DevCardPlaceholder.tsx
@@ -2,14 +2,19 @@ import React, { ReactElement } from 'react';
 
 export default function DevCardPlaceholder({
   profileImage,
+  rank,
   ...props
-}: React.SVGProps<SVGSVGElement> & { profileImage?: string }): ReactElement {
+}: React.SVGProps<SVGSVGElement> & {
+  profileImage?: string;
+  rank?: number;
+}): ReactElement {
+  const colorPrefix =
+    rank > 0 ? `--theme-rank-${rank}-color` : '--theme-rank-5-color';
   return (
     <svg
-      width={108}
-      height={148}
       xmlns="http://www.w3.org/2000/svg"
       xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 108 148"
       {...props}
     >
       <defs>
@@ -20,8 +25,8 @@ export default function DevCardPlaceholder({
           y2="100%"
           id="devcard_placeholder_svg__b"
         >
-          <stop stopColor="#CE3AF3" offset="0%" />
-          <stop stopColor="#7147ED" offset="100%" />
+          <stop stopColor={`var(${colorPrefix}-top)`} offset="0%" />
+          <stop stopColor={`var(${colorPrefix}-bottom)`} offset="100%" />
         </linearGradient>
         <pattern
           id="devcard_placeholder_svg__c"

--- a/packages/shared/src/components/HeaderRankProgress.tsx
+++ b/packages/shared/src/components/HeaderRankProgress.tsx
@@ -30,7 +30,7 @@ export default function HeaderRankProgress({
   const { user } = useContext(AuthContext);
   const { onboardingStep, onboardingReady, incrementOnboardingStep } =
     useContext(OnboardingContext);
-  const [showModal, setShowModal] = useState(false);
+  const [showRanksModal, setShowRanksModal] = useState(false);
 
   const {
     isLoading,
@@ -49,7 +49,7 @@ export default function HeaderRankProgress({
   const showWelcome = onboardingStep === 1;
   const showRankAnimation = levelUp && neverShowRankModal;
   const closeRanksModal = () => {
-    setShowModal(false);
+    setShowRanksModal(false);
     if (showWelcome) {
       incrementOnboardingStep();
     }
@@ -66,7 +66,7 @@ export default function HeaderRankProgress({
             { [styles.attention]: showWelcome },
             className,
           )}
-          onClick={() => setShowModal(true)}
+          onClick={() => setShowRanksModal(true)}
         >
           {showWelcome ? (
             <div
@@ -98,11 +98,11 @@ export default function HeaderRankProgress({
           )}
         </button>
       )}
-      {showModal && (
+      {showRanksModal && (
         <RanksModal
           rank={rank}
           progress={progress}
-          isOpen={showModal}
+          isOpen={showRanksModal}
           onRequestClose={closeRanksModal}
         />
       )}

--- a/packages/shared/src/components/modals/NewRankModal.tsx
+++ b/packages/shared/src/components/modals/NewRankModal.tsx
@@ -21,6 +21,7 @@ import { ModalCloseButton } from './ModalCloseButton';
 import { ModalProps } from './StyledModal';
 import { ResponsiveModal } from './ResponsiveModal';
 import styles from './NewRankModal.module.css';
+import useGoToDevCardButton from '../../hooks/useGoToDevCardButton';
 
 export interface NewRankModalProps extends Omit<ModalProps, 'onRequestClose'> {
   rank: number;
@@ -43,6 +44,7 @@ export default function NewRankModal({
   const [animatingRank, setAnimatingRank] = useState(false);
   const [rankAnimationEnded, setRankAnimationEnded] = useState(false);
   const inputRef = useRef<HTMLInputElement>();
+  const [onGenerateDevCardClick] = useGoToDevCardButton('new rank popup');
 
   const title = useMemo(() => {
     if (user) {
@@ -166,9 +168,20 @@ export default function NewRankModal({
         )}
       </p>
       {user ? (
-        <Button className="btn-primary self-center" onClick={closeModal}>
-          Awesome!
-        </Button>
+        <div className="flex self-center gap-4">
+          <Button
+            className="btn-secondary"
+            tag="a"
+            href="/devcard"
+            target="_blank"
+            onClick={onGenerateDevCardClick}
+          >
+            Generate Dev Card
+          </Button>
+          <Button className="btn-primary" onClick={closeModal}>
+            Awesome!
+          </Button>
+        </div>
       ) : (
         <LoginButtons />
       )}

--- a/packages/shared/src/components/modals/RanksModal.tsx
+++ b/packages/shared/src/components/modals/RanksModal.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, ReactElement } from 'react';
+import React, { CSSProperties, ReactElement, useContext } from 'react';
 import classNames from 'classnames';
 import { RankProgress } from '../RankProgress';
 import { RANK_NAMES, STEPS_PER_RANK } from '../../lib/rank';
@@ -8,6 +8,9 @@ import { ModalCloseButton } from './ModalCloseButton';
 import { ModalProps } from './StyledModal';
 import { ResponsiveModal } from './ResponsiveModal';
 import styles from './RanksModal.module.css';
+import useGoToDevCardButton from '../../hooks/useGoToDevCardButton';
+import DevCardPlaceholder from '../DevCardPlaceholder';
+import AuthContext from '../../contexts/AuthContext';
 
 const RankItem = ({
   rank,
@@ -74,6 +77,9 @@ export default function RanksModal({
   className,
   ...props
 }: RanksModalProps): ReactElement {
+  const { user } = useContext(AuthContext);
+  const [onGenerateDevCardClick] = useGoToDevCardButton('ranks instructions');
+
   return (
     <ResponsiveModal
       {...props}
@@ -106,9 +112,26 @@ export default function RanksModal({
           />
         ))}
       </ul>
-      <Button className="btn-primary m-8" onClick={onRequestClose}>
-        {confirmationText || `Ok, let’s do it`}
-      </Button>
+      <div className="h-px w-full bg-theme-divider-tertiary mt-8 mb-5 -mx-2" />
+      <div className="flex px-4 mb-6 self-stretch items-start">
+        <DevCardPlaceholder profileImage={user?.image} width={44} rank={rank} />
+        <div className="flex flex-col ml-4 flex-1">
+          <div className="font-bold typo-callout">Your Dev Card</div>
+          <div className="text-theme-label-tertiary typo-footnote mt-0.5">
+            Your Dev Card will show you stats about the publications and topics
+            you love to read.
+          </div>
+          <Button
+            className="btn-secondary mt-4 self-start"
+            tag="a"
+            href="/devcard"
+            target="_blank"
+            onClick={onGenerateDevCardClick}
+          >
+            Generate
+          </Button>
+        </div>
+      </div>
     </ResponsiveModal>
   );
 }

--- a/packages/shared/src/components/modals/RanksModal.tsx
+++ b/packages/shared/src/components/modals/RanksModal.tsx
@@ -118,8 +118,7 @@ export default function RanksModal({
         <div className="flex flex-col ml-4 flex-1">
           <div className="font-bold typo-callout">Your Dev Card</div>
           <div className="text-theme-label-tertiary typo-footnote mt-0.5">
-            Your Dev Card will show you stats about the publications and topics
-            you love to read.
+            Generate a personal dev card to show the world the topics you love.
           </div>
           <Button
             className="btn-secondary mt-4 self-start"

--- a/packages/shared/src/hooks/useGoToDevCardButton.ts
+++ b/packages/shared/src/hooks/useGoToDevCardButton.ts
@@ -4,7 +4,7 @@ import {
   logGoToDevCardImpression,
 } from '../lib/analytics';
 
-export type UseGenerateDevCardButtonReturn = [onClick: () => Promise<void>];
+export type UseGenerateDevCardButtonReturn = [() => Promise<void>];
 
 export default function useGoToDevCardButton(
   origin: string,

--- a/packages/shared/src/hooks/useGoToDevCardButton.ts
+++ b/packages/shared/src/hooks/useGoToDevCardButton.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import {
+  logGoToDevCardClick,
+  logGoToDevCardImpression,
+} from '../lib/analytics';
+
+export type UseGenerateDevCardButtonReturn = [onClick: () => Promise<void>];
+
+export default function useGoToDevCardButton(
+  origin: string,
+): UseGenerateDevCardButtonReturn {
+  useEffect(() => {
+    logGoToDevCardImpression(origin);
+  }, []);
+
+  return [() => logGoToDevCardClick(origin)];
+}

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -169,6 +169,23 @@ export const logSignupFormSubmit = async (
   amp.logEvent('signup form submit', { 'optional fields': optionalFields });
 };
 
+export const logGoToDevCardImpression = async (
+  origin: string,
+): Promise<void> => {
+  const amp = await getAmplitudeClient();
+  amp.logEvent('go to devcard impression', { origin });
+};
+
+export const logGoToDevCardClick = async (origin: string): Promise<void> => {
+  const amp = await getAmplitudeClient();
+  amp.logEvent('go to devcard click', { origin });
+};
+
+export const logGenerateDevCard = async (): Promise<void> => {
+  const amp = await getAmplitudeClient();
+  amp.logEvent('generate devcard');
+};
+
 export const initAmplitude = async (
   userId: string,
   version: string,

--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -12,7 +12,8 @@ import { FormErrorMessage } from '@dailydotdev/shared/src/components/utilities';
 import Tilt from 'react-parallax-tilt';
 import { NextSeoProps } from 'next-seo/lib/types';
 import { NextSeo } from 'next-seo';
-import DevCardPlaceholder from '../components/DevCardPlaceholder';
+import DevCardPlaceholder from '@dailydotdev/shared/src/components/DevCardPlaceholder';
+import { logGenerateDevCard } from '@dailydotdev/shared/src/lib/analytics';
 import { DevCardData, GENERATE_DEVCARD_MUTATION } from '../graphql/devcard';
 import { getLayout as getMainLayout } from '../components/layouts/MainLayout';
 import { defaultOpenGraph } from '../next-seo';
@@ -35,7 +36,7 @@ const Step1 = ({
 
   return (
     <>
-      <DevCardPlaceholder profileImage={user?.image} />
+      <DevCardPlaceholder profileImage={user?.image} width={108} />
       <h1 className="mt-10 typo-title1 font-bold">Grab your Dev Card</h1>
       <p
         className="mt-4 typo-body text-theme-label-secondary text-center"
@@ -220,6 +221,7 @@ const DevCardPage = (): ReactElement => {
       onMutate() {
         setImageError(null);
         setIsLoadingImage(true);
+        logGenerateDevCard();
       },
       onSuccess(data: DevCardData) {
         const img = new Image();


### PR DESCRIPTION
To expose the Dev Card feature, we embed a dedicated button in the new rank popup and in the ranks instructions.
Amplitude events were added to track the funnel