### PR TITLE
refactor: use react-query to fetch feed

### DIFF
--- a/.idea/dataSources.local.xml
+++ b/.idea/dataSources.local.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="dataSourceStorageLocal" created-in="IU-211.7628.21" />
-</project>

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -119,6 +119,9 @@ const renderComponent = (
           updateUser: jest.fn(),
           tokenRefreshed: true,
           getRedirectUri: jest.fn(),
+          closeLogin: jest.fn(),
+          trackingId: user?.id,
+          loginState: null,
         }}
       >
         <OnboardingContext.Provider
@@ -132,7 +135,7 @@ const renderComponent = (
           }}
         >
           <SettingsContext.Provider value={settingsContext}>
-            <Feed query={ANONYMOUS_FEED_QUERY} />
+            <Feed feedQueryKey={['feed']} query={ANONYMOUS_FEED_QUERY} />
           </SettingsContext.Provider>
         </OnboardingContext.Provider>
       </AuthContext.Provider>

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -1,6 +1,5 @@
 import React, {
   CSSProperties,
-  DependencyList,
   ReactElement,
   ReactNode,
   useCallback,

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -96,13 +96,13 @@ const cardHeightPx = 364;
 const listHeightPx = 78;
 
 export default function Feed<T>({
-                                  feedQueryKey,
-                                  query,
-                                  variables,
-                                  className,
-                                  onEmptyFeed,
-                                  emptyScreen,
-                                }: FeedProps<T>): ReactElement {
+  feedQueryKey,
+  query,
+  variables,
+  className,
+  onEmptyFeed,
+  emptyScreen,
+}: FeedProps<T>): ReactElement {
   const currentSettings = useContext(FeedContext);
   const { user, showLogin } = useContext(AuthContext);
   const { trackEngagement } = useContext(OnboardingContext);

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -137,14 +137,14 @@ const generateFeedQueryKey = (
 };
 
 function ButtonOrLink({
-                        asLink,
-                        href,
-                        ...props
-                      }: { asLink: boolean; href: string } & ButtonProps<'button'>) {
+  asLink,
+  href,
+  ...props
+}: { asLink: boolean; href: string } & ButtonProps<'button'>) {
   if (asLink) {
     return (
       <Link href={href} passHref prefetch={false}>
-        <Button {...props} tag='a' />
+        <Button {...props} tag="a" />
       </Link>
     );
   }

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -1,5 +1,4 @@
 import React, {
-  DependencyList,
   ReactElement,
   ReactNode,
   useContext,

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -1,4 +1,4 @@
-import { DependencyList, useContext, useMemo } from 'react';
+import { useContext, useMemo } from 'react';
 import request from 'graphql-request';
 import {
   InfiniteData,

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -62,23 +62,23 @@ const updateCachedPage = (
 
 const updateCachedPost =
   (feedQueryKey: unknown[], queryClient: QueryClient) =>
-    (pageIndex: number, index: number, post: Post) => {
-      updateCachedPage(feedQueryKey, queryClient, pageIndex, (page) => {
-        // eslint-disable-next-line no-param-reassign
-        page.edges[index].node = post;
-        return page;
-      });
-    };
+  (pageIndex: number, index: number, post: Post) => {
+    updateCachedPage(feedQueryKey, queryClient, pageIndex, (page) => {
+      // eslint-disable-next-line no-param-reassign
+      page.edges[index].node = post;
+      return page;
+    });
+  };
 
 const removeCachedPost =
   (feedQueryKey: unknown[], queryClient: QueryClient) =>
-    (pageIndex: number, index: number) => {
-      updateCachedPage(feedQueryKey, queryClient, pageIndex, (page) => {
-        // eslint-disable-next-line no-param-reassign
-        page.edges.splice(index, 1);
-        return page;
-      });
-    };
+  (pageIndex: number, index: number) => {
+    updateCachedPage(feedQueryKey, queryClient, pageIndex, (page) => {
+      // eslint-disable-next-line no-param-reassign
+      page.edges.splice(index, 1);
+      return page;
+    });
+  };
 
 const findIndexOfPostInData = (
   data: InfiniteData<FeedData>,

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -1,11 +1,12 @@
-import {
-  DependencyList,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { DependencyList, useContext, useMemo } from 'react';
 import request from 'graphql-request';
+import {
+  InfiniteData,
+  QueryClient,
+  useInfiniteQuery,
+  useQueryClient,
+} from 'react-query';
+import cloneDeep from 'lodash.clonedeep';
 import {
   Ad,
   FeedData,
@@ -16,8 +17,14 @@ import {
 import AuthContext from '../contexts/AuthContext';
 import { apiUrl } from '../lib/config';
 import useSubscription from './useSubscription';
+import { Connection } from '../graphql/common';
 
-export type PostItem = { type: 'post'; post: Post };
+export type PostItem = {
+  type: 'post';
+  post: Post;
+  page: number;
+  index: number;
+};
 export type AdItem = { type: 'ad'; ad: Ad };
 export type PlaceholderItem = { type: 'placeholder' };
 export type FeedItem = PostItem | AdItem | PlaceholderItem;
@@ -25,69 +32,171 @@ export type FeedItem = PostItem | AdItem | PlaceholderItem;
 export type FeedReturnType = {
   items: FeedItem[];
   fetchPage: () => Promise<void>;
-  updateItem: (index: number, item: FeedItem) => void;
-  updatePost: (index: number, post: Post) => void;
-  removeItem: (index: number) => void;
-  isLoading: boolean;
+  updatePost: (page: number, index: number, post: Post) => void;
+  removePost: (page: number, index: number) => void;
   canFetchMore: boolean;
   emptyFeed: boolean;
 };
 
+const updateCachedPage = (
+  feedQueryKey: unknown[],
+  queryClient: QueryClient,
+  pageIndex: number,
+  manipulate: (page: Connection<Post>) => Connection<Post>,
+): void => {
+  queryClient.setQueryData<InfiniteData<FeedData>>(
+    feedQueryKey,
+    (currentData) => {
+      const { pages } = currentData;
+      const currentPage = cloneDeep(pages[pageIndex]);
+      currentPage.page = manipulate(currentPage.page);
+      const newPages = [
+        ...pages.slice(0, pageIndex),
+        currentPage,
+        ...pages.slice(pageIndex + 1),
+      ];
+      return { pages: newPages, pageParams: currentData.pageParams };
+    },
+  );
+};
+
+const updateCachedPost =
+  (feedQueryKey: unknown[], queryClient: QueryClient) =>
+    (pageIndex: number, index: number, post: Post) => {
+      updateCachedPage(feedQueryKey, queryClient, pageIndex, (page) => {
+        // eslint-disable-next-line no-param-reassign
+        page.edges[index].node = post;
+        return page;
+      });
+    };
+
+const removeCachedPost =
+  (feedQueryKey: unknown[], queryClient: QueryClient) =>
+    (pageIndex: number, index: number) => {
+      updateCachedPage(feedQueryKey, queryClient, pageIndex, (page) => {
+        // eslint-disable-next-line no-param-reassign
+        page.edges.splice(index, 1);
+        return page;
+      });
+    };
+
+const findIndexOfPostInData = (
+  data: InfiniteData<FeedData>,
+  id: string,
+): { pageIndex: number; index: number } => {
+  for (let pageIndex = 0; pageIndex < data.pages.length; pageIndex += 1) {
+    const page = data.pages[pageIndex];
+    for (let index = 0; index < page.page.edges.length; index += 1) {
+      const item = page.page.edges[index];
+      if (item.node.id === id) {
+        return { pageIndex, index };
+      }
+    }
+  }
+  return { pageIndex: -1, index: -1 };
+};
+
 export default function useFeed<T>(
+  feedQueryKey: unknown[],
   pageSize: number,
   adSpot: number,
   placeholdersPerPage: number,
   showOnlyUnreadPosts: boolean,
   query?: string,
   variables?: T,
-  dep?: DependencyList,
 ): FeedReturnType {
-  const [emptyFeed, setEmptyFeed] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const [cooldown, setCooldown] = useState(false);
-  const [loadedItems, setLoadedItems] = useState<FeedItem[]>([]);
-  const [lastPage, setLastPage] = useState<FeedData>(null);
-  const [lastAd, setLastAd] = useState<Ad>(null);
   const { user, tokenRefreshed } = useContext(AuthContext);
-  const [postIds, setPostIds] = useState<string[]>([]);
+  const queryClient = useQueryClient();
+  const feedQuery = useInfiniteQuery<FeedData>(
+    feedQueryKey,
+    ({ pageParam }) =>
+      request(`${apiUrl}/graphql`, query, {
+        ...variables,
+        first: pageSize,
+        after: pageParam,
+        loggedIn: !!user,
+        unreadOnly: showOnlyUnreadPosts,
+      }),
+    {
+      enabled: query && tokenRefreshed,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      getNextPageParam: (lastPage) =>
+        lastPage.page.pageInfo.hasNextPage && lastPage.page.pageInfo.endCursor,
+    },
+  );
+
+  const adsQuery = useInfiniteQuery<Ad>(
+    ['ads'],
+    async () => {
+      const res = await fetch(`${apiUrl}/v1/a`);
+      const ads: Ad[] = await res.json();
+      return ads[0];
+    },
+    {
+      enabled: query && tokenRefreshed,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      getNextPageParam: () => ({}),
+    },
+  );
+
   const items = useMemo(() => {
-    if (isLoading) {
-      return [
-        ...loadedItems,
+    let newItems: FeedItem[] = [];
+    if (feedQuery.data) {
+      newItems = feedQuery.data.pages.flatMap(
+        ({ page }, pageIndex): FeedItem[] => {
+          const posts: FeedItem[] = page.edges.map(({ node }, index) => ({
+            type: 'post',
+            post: node,
+            page: pageIndex,
+            index,
+          }));
+          if (adsQuery.data?.pages[pageIndex]) {
+            posts.splice(adSpot, 0, {
+              type: 'ad',
+              ad: adsQuery.data?.pages[pageIndex],
+            });
+          } else if (
+            adsQuery.isFetching &&
+            pageIndex === feedQuery.data.pages.length - 1
+          ) {
+            posts.splice(adSpot, 0, {
+              type: 'placeholder',
+            });
+          }
+          return posts;
+        },
+      );
+    }
+    if (feedQuery.isFetching) {
+      newItems.push(
         ...Array(placeholdersPerPage).fill({ type: 'placeholder' }),
-      ];
+      );
     }
-    return loadedItems;
-  }, [loadedItems, isLoading]);
+    return newItems;
+  }, [
+    feedQuery.data,
+    feedQuery.isFetching,
+    adsQuery.data,
+    adsQuery.isFetching,
+  ]);
 
-  const resetFeed = (): void => {
-    setLoadedItems([]);
-    setLastPage(null);
-    setLastAd(null);
-  };
-
-  const updateItem = (index: number, item: FeedItem): void =>
-    setLoadedItems([
-      ...loadedItems.slice(0, index),
-      item,
-      ...loadedItems.slice(index + 1),
-    ]);
-
-  const updatePost = (index: number, post: Post): void => {
-    const item = loadedItems[index];
-    if (item.type === 'post') {
-      updateItem(index, {
-        ...(item as PostItem),
-        post,
-      });
+  const postIds = useMemo(() => {
+    const ids = [];
+    // Use for loop to reduce number of iterations over the array
+    for (let i = 0; i < items.length; i += 1) {
+      const item = items[i];
+      if (item.type === 'post') {
+        ids.push(item.post.id);
+      }
     }
-  };
+    return ids;
+  }, [items]);
 
-  const removeItem = (index: number): void =>
-    setLoadedItems([
-      ...loadedItems.slice(0, index),
-      ...loadedItems.slice(index + 1),
-    ]);
+  const updatePost = updateCachedPost(feedQueryKey, queryClient);
 
   useSubscription(
     () => ({
@@ -98,13 +207,13 @@ export default function useFeed<T>(
     }),
     {
       next: (data: PostsEngaged) => {
-        const index = loadedItems.findIndex(
-          (item) =>
-            item.type === 'post' && item.post.id === data.postsEngaged.id,
+        const { pageIndex, index } = findIndexOfPostInData(
+          feedQuery.data,
+          data.postsEngaged.id,
         );
         if (index > -1) {
-          updatePost(index, {
-            ...(loadedItems[index] as PostItem).post,
+          updatePost(pageIndex, index, {
+            ...feedQuery.data.pages[pageIndex].page.edges[index].node,
             ...data.postsEngaged,
           });
         }
@@ -113,92 +222,17 @@ export default function useFeed<T>(
     [postIds],
   );
 
-  const fetchPage = async (lastPageParam: FeedData = lastPage) => {
-    if ((isLoading && lastPageParam) || cooldown) {
-      return;
-    }
-    setIsLoading(true);
-    const adPromise = fetch(`${apiUrl}/v1/a`);
-    const res = await request<FeedData>(`${apiUrl}/graphql`, query, {
-      ...variables,
-      first: pageSize,
-      after: lastPageParam?.page.pageInfo.endCursor,
-      loggedIn: !!user,
-      unreadOnly: showOnlyUnreadPosts,
-    });
-    if (!lastPageParam && !res.page.edges.length) {
-      setEmptyFeed(true);
-    } else if (emptyFeed) {
-      setEmptyFeed(false);
-    }
-    setLastPage(res);
-    setIsLoading(false);
-    setCooldown(true);
-    // Disable fetching for a short time to prevent multi-fetching
-    setTimeout(() => setCooldown(false), 200);
-    try {
-      const adRes = await adPromise;
-      const ads: Ad[] = await adRes.json();
-      setLastAd(ads?.[0]);
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
-    }
-  };
-
-  const refreshFeed = async (): Promise<void> => {
-    resetFeed();
-    await fetchPage(null);
-  };
-
-  // First page fetch
-  useEffect(() => {
-    if (query && tokenRefreshed) {
-      refreshFeed();
-    }
-  }, [query, tokenRefreshed, showOnlyUnreadPosts, variables, ...(dep ?? [])]);
-
-  // Add new posts to feed with a placeholder for the ad
-  useEffect(() => {
-    if (lastPage) {
-      const newItems: FeedItem[] = lastPage.page.edges.map(
-        ({ node }): PostItem => ({ type: 'post', post: node }),
-      );
-      newItems.splice(adSpot, 0, { type: 'placeholder' });
-      setLoadedItems([...loadedItems, ...newItems]);
-      setPostIds([
-        ...postIds,
-        ...lastPage.page.edges.map(({ node }): string => node.id),
-      ]);
-    } else {
-      setPostIds([]);
-    }
-  }, [lastPage]);
-
-  // Replace ad placeholder with an actual ad
-  useEffect(() => {
-    if (lastAd) {
-      let i;
-      for (
-        i = loadedItems.length - 1;
-        i >= 0 && loadedItems[i].type !== 'placeholder';
-        i -= 1
-      );
-      if (i >= 0 && i < loadedItems.length) {
-        updateItem(i, { type: 'ad', ad: lastAd });
-      }
-    }
-  }, [lastAd]);
-
   return {
     items,
-    fetchPage,
-    updateItem,
+    fetchPage: async () => {
+      const adPromise = adsQuery.fetchNextPage();
+      await feedQuery.fetchNextPage();
+      await adPromise;
+    },
     updatePost,
-    removeItem,
-    isLoading,
-    canFetchMore:
-      lastPage?.page.pageInfo.hasNextPage && !cooldown && !isLoading,
-    emptyFeed,
+    removePost: removeCachedPost(feedQueryKey, queryClient),
+    canFetchMore: feedQuery.hasNextPage,
+    emptyFeed:
+      !feedQuery?.data?.pages[0]?.page.edges.length && !feedQuery.isFetching,
   };
 }

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -29,8 +29,7 @@ import { canonicalFromRouter } from '@dailydotdev/shared/src/lib/canonical';
 import { SettingsContextProvider } from '@dailydotdev/shared/src/contexts/SettingsContext';
 import '@dailydotdev/shared/src/styles/globals.css';
 import useAnalytics from '@dailydotdev/shared/src/hooks/useAnalytics';
-import HelpUsGrowModalWithContext
-  from '@dailydotdev/shared/src/components/modals/HelpUsGrowModalWithContext';
+import HelpUsGrowModalWithContext from '@dailydotdev/shared/src/components/modals/HelpUsGrowModalWithContext';
 import Seo from '../next-seo';
 
 // const ReactQueryDevtools = dynamic(
@@ -44,7 +43,7 @@ const LoginModal = dynamic(
   () =>
     import(
       /* webpackChunkName: "loginModal" */ '@dailydotdev/shared/src/components/modals/LoginModal'
-      ),
+    ),
 );
 const CookieBanner = dynamic(() => import('../components/CookieBanner'));
 

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -29,8 +29,14 @@ import { canonicalFromRouter } from '@dailydotdev/shared/src/lib/canonical';
 import { SettingsContextProvider } from '@dailydotdev/shared/src/contexts/SettingsContext';
 import '@dailydotdev/shared/src/styles/globals.css';
 import useAnalytics from '@dailydotdev/shared/src/hooks/useAnalytics';
-import HelpUsGrowModalWithContext from '@dailydotdev/shared/src/components/modals/HelpUsGrowModalWithContext';
+import HelpUsGrowModalWithContext
+  from '@dailydotdev/shared/src/components/modals/HelpUsGrowModalWithContext';
 import Seo from '../next-seo';
+
+// const ReactQueryDevtools = dynamic(
+//   () => import('react-query/devtools').then((mod) => mod.ReactQueryDevtools),
+//   { ssr: false },
+// );
 
 const queryClient = new QueryClient();
 
@@ -38,7 +44,7 @@ const LoginModal = dynamic(
   () =>
     import(
       /* webpackChunkName: "loginModal" */ '@dailydotdev/shared/src/components/modals/LoginModal'
-    ),
+      ),
 );
 const CookieBanner = dynamic(() => import('../components/CookieBanner'));
 

--- a/packages/webapp/pages/bookmarks.tsx
+++ b/packages/webapp/pages/bookmarks.tsx
@@ -78,7 +78,7 @@ const BookmarksPage = (): ReactElement => {
           feedQueryKey={['bookmarks', user?.id ?? 'anonymous']}
           query={BOOKMARKS_FEED_QUERY}
           onEmptyFeed={() => setShowEmptyScreen(true)}
-          className='my-3'
+          className="my-3"
         />
       )}
     </FeedPage>

--- a/packages/webapp/pages/bookmarks.tsx
+++ b/packages/webapp/pages/bookmarks.tsx
@@ -73,11 +73,14 @@ const BookmarksPage = (): ReactElement => {
         <BookmarkIcon className={customFeedIcon} />
         <span>Bookmarks</span>
       </CustomFeedHeader>
-      <Feed
-        query={BOOKMARKS_FEED_QUERY}
-        onEmptyFeed={() => setShowEmptyScreen(true)}
-        className="my-3"
-      />
+      {tokenRefreshed && (
+        <Feed
+          feedQueryKey={['bookmarks', user?.id ?? 'anonymous']}
+          query={BOOKMARKS_FEED_QUERY}
+          onEmptyFeed={() => setShowEmptyScreen(true)}
+          className='my-3'
+        />
+      )}
     </FeedPage>
   );
 };

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -119,7 +119,7 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
         <Button
           className={`btn-primary laptop:hidden ${buttonClass}`}
           {...buttonProps}
-          aria-label='Add source to feed'
+          aria-label="Add source to feed"
         />
         <Button
           className={`btn-primary hidden laptop:flex ${buttonClass}`}
@@ -136,7 +136,7 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
         ]}
         query={SOURCE_FEED_QUERY}
         variables={queryVariables}
-        className='my-3'
+        className="my-3"
       />
     </FeedPage>
   );

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -119,7 +119,7 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
         <Button
           className={`btn-primary laptop:hidden ${buttonClass}`}
           {...buttonProps}
-          aria-label="Add source to feed"
+          aria-label='Add source to feed'
         />
         <Button
           className={`btn-primary hidden laptop:flex ${buttonClass}`}
@@ -129,9 +129,14 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
         </Button>
       </CustomFeedHeader>
       <Feed
+        feedQueryKey={[
+          'sourceFeed',
+          user?.id ?? 'anonymous',
+          Object.values(queryVariables),
+        ]}
         query={SOURCE_FEED_QUERY}
         variables={queryVariables}
-        className="my-3"
+        className='my-3'
       />
     </FeedPage>
   );

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -104,7 +104,7 @@ const TagPage = ({ tag }: TagPageProps): ReactElement => {
         <Button
           className={`btn-primary laptop:hidden ${buttonClass}`}
           {...buttonProps}
-          aria-label='Add tag to feed'
+          aria-label="Add tag to feed"
         />
         <Button
           className={`btn-primary hidden laptop:flex ${buttonClass}`}
@@ -121,7 +121,7 @@ const TagPage = ({ tag }: TagPageProps): ReactElement => {
         ]}
         query={TAG_FEED_QUERY}
         variables={queryVariables}
-        className='my-3'
+        className="my-3"
       />
     </FeedPage>
   );

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -104,7 +104,7 @@ const TagPage = ({ tag }: TagPageProps): ReactElement => {
         <Button
           className={`btn-primary laptop:hidden ${buttonClass}`}
           {...buttonProps}
-          aria-label="Add tag to feed"
+          aria-label='Add tag to feed'
         />
         <Button
           className={`btn-primary hidden laptop:flex ${buttonClass}`}
@@ -114,9 +114,14 @@ const TagPage = ({ tag }: TagPageProps): ReactElement => {
         </Button>
       </CustomFeedHeader>
       <Feed
+        feedQueryKey={[
+          'tagFeed',
+          user?.id ?? 'anonymous',
+          Object.values(queryVariables),
+        ]}
         query={TAG_FEED_QUERY}
         variables={queryVariables}
-        className="my-3"
+        className='my-3'
       />
     </FeedPage>
   );


### PR DESCRIPTION
react-query handles caching, retries, and everything needed to make our app more resilient.
This is a much preferred implementation than using the Fetch API.