### PR TITLE
fix: remove typos from LoginModal

### DIFF
--- a/packages/extension/package-lock.json
+++ b/packages/extension/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "extension",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/shared/src/components/modals/LoginModal.tsx
+++ b/packages/shared/src/components/modals/LoginModal.tsx
@@ -38,7 +38,7 @@ export default function LoginModal({
       <div className="mt-6 mb-8 text-theme-label-secondary text-center typo-callout">
         {mode === LoginModalMode.ContentQuality
           ? `Our community cares about content quality. We require social authentication to prevent abuse.`
-          : `Unlock useful featu'es by signing in. A bunch of cool stuff like content filters 'nd bookmarks are waiting just for you.`}
+          : `Unlock useful features by signing in. A bunch of cool stuff like content filters and bookmarks are waiting just for you.`}
       </div>
       <LoginButtons />
       {children}


### PR DESCRIPTION
I was exploring the chrome extension interface and, when I tried to log in, I saw these things that might be typos.

![Screenshot from 2021-08-18 16-52-11](https://user-images.githubusercontent.com/61197792/130172368-76e13a88-7507-4df8-9129-c47282f9d20c.png)

The current pull request aims to solve this.

It's worth saying that after I bootstrapped the project, I ran the tests and a bunch of them are giving warnings. One of them is failing: the [PostCard test, in line 109](https://github.com/dailydotdev/apps/blob/master/packages/shared/src/components/cards/PostCard.spec.tsx#L109).  However, it seems to be caused by the function [postDateFormat](https://github.com/dailydotdev/apps/blob/master/packages/shared/src/lib/dateFormat.ts#L8), which is not formatting the date as expected.

Hope I can help!