### PR TITLE
Adding border-radius to glare container

### DIFF
--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -136,7 +136,7 @@ const Step2 = ({
           glareMaxOpacity={0.25}
           glarePosition="all"
           trackOnWindow
-          style={{ transformStyle: 'preserve-3d', borderRadius: '35px' }}
+          style={{ transformStyle: 'preserve-3d', borderRadius: '2rem' }}
         >
           <LazyImage
             imgSrc={devCardSrc}

--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -130,13 +130,13 @@ const Step2 = ({
     <>
       <div className="flex flex-col self-stretch laptop:self-center items-center mx-2">
         <Tilt
-          className="self-stretch laptop:w-96"
+          className="self-stretch laptop:w-96 overflow-hidden"
           glareEnable
           perspective={1000}
           glareMaxOpacity={0.25}
           glarePosition="all"
           trackOnWindow
-          style={{ transformStyle: 'preserve-3d' }}
+          style={{ transformStyle: 'preserve-3d', borderRadius: '35px' }}
         >
           <LazyImage
             imgSrc={devCardSrc}


### PR DESCRIPTION
When hovering over the devcard, while the image has border-radius as part of the png, the glare on top of the image does not, leaving sharp corners only when hovering. Overflow hidden is added using the tailwind class while the border-radius was added as an inline style