### PR TITLE
refactor: removal of win free gift button from the extension and webapp

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -21,10 +21,7 @@ import BookmarkIcon from '../../icons/bookmark.svg';
 import { LazyImage } from './LazyImage';
 import styles from './MainLayout.module.css';
 import LayoutIcon from '../../icons/layout.svg';
-import { QuaternaryButton } from './buttons/QuaternaryButton';
-import GiftIcon from '../../icons/gift.svg';
 import usePersistentState from '../hooks/usePersistentState';
-import OnboardingContext from '../contexts/OnboardingContext';
 
 export interface MainLayoutProps extends HTMLAttributes<HTMLDivElement> {
   showOnlyLogo?: boolean;
@@ -63,33 +60,9 @@ export default function MainLayout({
 }: MainLayoutProps): ReactElement {
   const { windowLoaded } = useContext(ProgressiveEnhancementContext);
   const { user, showLogin, loadingUser } = useContext(AuthContext);
-  const { onboardingStep } = useContext(OnboardingContext) || {};
   const [showSettings, setShowSettings] = useState(false);
   const [showGreeting, setShowGreeting] = useState(false);
-  const [epicPrizesClicked, setEpicPrizesClicked, epicPrizesLoaded] =
-    usePersistentState('epicPrizesClicked', undefined, false);
-
-  const beforeBookmarkButtons = (
-    <>
-      {epicPrizesLoaded && (onboardingStep > 2 || user) && (
-        <QuaternaryButton
-          tag="a"
-          id="monthly-prizes-button"
-          href="https://daily.dev/monthly-prize"
-          target="_blank"
-          rel="noopener"
-          icon={<GiftIcon />}
-          pressed={!epicPrizesClicked}
-          className="btn-tertiary-bacon mx-0.5 hidden tablet:flex"
-          reverse
-          responsiveLabelClass="laptop:flex"
-          onClick={() => setEpicPrizesClicked(true)}
-        >
-          Win epic prizes
-        </QuaternaryButton>
-      )}
-    </>
-  );
+  usePersistentState('epicPrizesClicked', undefined, false);
 
   const afterBookmarkButtons = (
     <>
@@ -155,7 +128,6 @@ export default function MainLayout({
         <div className="flex-1" />
         {!showOnlyLogo && !loadingUser && (
           <>
-            {beforeBookmarkButtons}
             {user ? (
               <>
                 <Link

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -21,7 +21,6 @@ import BookmarkIcon from '../../icons/bookmark.svg';
 import { LazyImage } from './LazyImage';
 import styles from './MainLayout.module.css';
 import LayoutIcon from '../../icons/layout.svg';
-import usePersistentState from '../hooks/usePersistentState';
 
 export interface MainLayoutProps extends HTMLAttributes<HTMLDivElement> {
   showOnlyLogo?: boolean;
@@ -62,7 +61,6 @@ export default function MainLayout({
   const { user, showLogin, loadingUser } = useContext(AuthContext);
   const [showSettings, setShowSettings] = useState(false);
   const [showGreeting, setShowGreeting] = useState(false);
-  usePersistentState('epicPrizesClicked', undefined, false);
 
   const afterBookmarkButtons = (
     <>


### PR DESCRIPTION
Issue item: [DD-204 #done](https://dailydotdev.atlassian.net/browse/DD-204)

Removal of the `Win Free Gift` button before the bookmarks button.

Since this is a `shared` component that is used by both `webapp` and `extension`, changes are only needed from this component.

Extension preview:
![Screen Shot 2021-09-24 at 11 15 09 PM](https://user-images.githubusercontent.com/13744167/134699060-8171b40a-b34b-4811-adcc-adec04bcd8d4.png)
