### PR TITLE
fix: update comment upvote label when interaction is made

### DIFF
--- a/packages/shared/src/components/comments/CommentActionButtons.tsx
+++ b/packages/shared/src/components/comments/CommentActionButtons.tsx
@@ -136,14 +136,12 @@ export default function CommentActionButtons({
           className="btn-tertiary"
         />
       )}
-      {comment.numUpvotes > 0 && (
+      {numUpvotes > 0 && (
         <ClickableText
           className="ml-auto"
           {...getTooltipProps('See who upvoted')}
-          title={`${comment.numUpvotes} upvote${
-            comment.numUpvotes === 1 ? '' : 's'
-          }`}
-          onClick={() => onShowUpvotes(comment.id, comment.numUpvotes)}
+          title={`${numUpvotes} upvote${numUpvotes === 1 ? '' : 's'}`}
+          onClick={() => onShowUpvotes(comment.id, numUpvotes)}
         />
       )}
     </div>


### PR DESCRIPTION
Jira Ticket: DD-216#done

After further investigation, it is much better to use the local state declared in the `CommentActionButton` component since it is much expensive to `refetch` the value using `react-query` from the server passing down to where the upvote has happened.