### PR TITLE
feat: sidebar icon and red dot

### DIFF
--- a/packages/shared/src/components/RedDot.tsx
+++ b/packages/shared/src/components/RedDot.tsx
@@ -2,6 +2,6 @@ import React, { ReactElement } from 'react';
 
 export default function RedDot(): ReactElement {
   return (
-    <div className="absolute top-0.5 right-0.5 w-2.5 h-2.5 bg-ketchup-40 rounded-full" />
+    <div className="absolute top-0.5 right-0.5 w-2.5 h-2.5 rounded-full bg-theme-status-error" />
   );
 }

--- a/packages/shared/src/components/Sidebar.tsx
+++ b/packages/shared/src/components/Sidebar.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement, useContext, useEffect, useState } from 'react';
-import dynamic from 'next/dynamic';
 import classNames from 'classnames';
 import sizeN from '../../macros/sizeN.macro';
 import SettingsIcon from '../../icons/settings.svg';
@@ -7,12 +6,10 @@ import { getTooltipProps } from '../lib/tooltip';
 import FeedFilters from './filters/FeedFilters';
 import OnboardingContext from '../contexts/OnboardingContext';
 import { useRedDot } from '../hooks/useRedDot';
+import RedDot from './RedDot';
 
 const asideWidth = sizeN(89);
 const SIDEBAR_RED_DOT_STATE = 'sidebar_red_dot';
-const RedDot = dynamic(
-  () => import(/* webpackChunkName: "redDot" */ './RedDot'),
-);
 
 export default function Sidebar(): ReactElement {
   const [opened, setOpened] = useState(false);
@@ -20,7 +17,10 @@ export default function Sidebar(): ReactElement {
   const { onboardingStep, incrementOnboardingStep } =
     useContext(OnboardingContext);
   const hightlightTrigger = onboardingStep === 2;
-  const [showRedDot, hideRedDot] = useRedDot(SIDEBAR_RED_DOT_STATE);
+  const [shouldShowRedDot, setShouldShowRedDot] = useRedDot(
+    SIDEBAR_RED_DOT_STATE,
+    true,
+  );
 
   useEffect(() => {
     if (opened && !enableQueries) {
@@ -35,8 +35,8 @@ export default function Sidebar(): ReactElement {
       setOpened(false);
     } else {
       setOpened(true);
-      if (showRedDot) {
-        hideRedDot();
+      if (shouldShowRedDot) {
+        setShouldShowRedDot(false);
       }
       if (hightlightTrigger) {
         incrementOnboardingStep();
@@ -92,7 +92,7 @@ export default function Sidebar(): ReactElement {
       >
         <div className="relative">
           <SettingsIcon />
-          {showRedDot && <RedDot />}
+          {shouldShowRedDot && <RedDot />}
         </div>
         {hightlightTrigger && (
           <div

--- a/packages/shared/src/hooks/useRedDot.ts
+++ b/packages/shared/src/hooks/useRedDot.ts
@@ -1,11 +1,14 @@
 import usePersistentState from './usePersistentState';
 
-export function useRedDot(key: string): [boolean, () => void] {
-  const [showRedDot, setShowRedDot] = usePersistentState(key, null, true);
+export function useRedDot(
+  key: string,
+  emptyValue?: boolean | string | null,
+): [boolean | string | null, (value) => Promise<void>] {
+  const [shouldShowRedDot, setShouldShowRedDot] = usePersistentState(
+    key,
+    null,
+    emptyValue,
+  );
 
-  const hideRedDot = (): void => {
-    setShowRedDot(false);
-  };
-
-  return [showRedDot, hideRedDot];
+  return [shouldShowRedDot, setShouldShowRedDot];
 }


### PR DESCRIPTION
Changed the sidebar icon and introduced the red dot

The red dot works on local storage for now, we need to revisit when it needs to hide on a later stage.
When multiple red dots will be applicable we can expand a parameter for the storage name for each one.

![Screenshot 2021-10-12 at 09 34 43](https://user-images.githubusercontent.com/554874/136912302-6fdc461f-ee3a-4892-b0a6-a94ae7f9b38f.png)

DD-156 #done