### PR TITLE
feat: advanced settings page

### DIFF
--- a/packages/shared/src/components/fields/Switch.tsx
+++ b/packages/shared/src/components/fields/Switch.tsx
@@ -66,9 +66,9 @@ export function Switch({
       {children && (
         <span
           className={classNames(
-            'ml-3 font-bold typo-footnote',
+            'ml-3 font-bold',
             styles.children,
-            defaultTypo && 'text-theme-label-tertiary',
+            defaultTypo && 'text-theme-label-tertiary typo-footnote',
             labelClassName,
           )}
         >

--- a/packages/shared/src/components/fields/Switch.tsx
+++ b/packages/shared/src/components/fields/Switch.tsx
@@ -5,21 +5,25 @@ import styles from './Switch.module.css';
 export interface SwitchProps {
   children?: ReactNode;
   className?: string;
+  labelClassName?: string;
   inputId: string;
   name: string;
   checked?: boolean;
   onToggle?: () => unknown;
   compact?: boolean;
+  defaultTypo?: boolean;
 }
 
 export function Switch({
   className,
+  labelClassName,
   inputId,
   name,
   checked,
   children,
   onToggle,
   compact = true,
+  defaultTypo = true,
 }: SwitchProps): ReactElement {
   return (
     <label
@@ -62,8 +66,10 @@ export function Switch({
       {children && (
         <span
           className={classNames(
-            'ml-3 text-theme-label-tertiary font-bold typo-footnote',
+            'ml-3 font-bold typo-footnote',
             styles.children,
+            defaultTypo && 'text-theme-label-tertiary',
+            labelClassName,
           )}
         >
           {children}

--- a/packages/shared/src/components/fields/Switch.tsx
+++ b/packages/shared/src/components/fields/Switch.tsx
@@ -66,9 +66,9 @@ export function Switch({
       {children && (
         <span
           className={classNames(
-            'ml-3 font-bold',
+            'ml-3 font-bold text-theme-label-tertiary',
+            defaultTypo && 'typo-footnote',
             styles.children,
-            defaultTypo && 'text-theme-label-tertiary typo-footnote',
             labelClassName,
           )}
         >

--- a/packages/shared/src/components/filters/AdvancedSettings.spec.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.spec.tsx
@@ -93,6 +93,8 @@ it('should display advanced settings title and description', async () => {
   expect(
     await screen.findByText('Description for Tech magazines'),
   ).toBeInTheDocument();
+  const checkbox = await screen.findByRole('checkbox');
+  await waitFor(() => expect(checkbox).not.toBeChecked());
 });
 
 it('should mutate update feed advanced settings', async () => {

--- a/packages/shared/src/components/filters/AdvancedSettings.spec.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.spec.tsx
@@ -27,8 +27,7 @@ import { getFeedSettingsQueryKey } from '../../hooks/useMutateFilters';
 import { waitForNock } from '../../../__tests__/helpers/utilities';
 
 const showLogin = jest.fn();
-// eslint-disable-next-line prefer-const, no-undef-init
-let loggedUser: LoggedUser = undefined;
+let loggedUser: LoggedUser;
 
 beforeEach(() => {
   loggedUser = undefined;

--- a/packages/shared/src/components/filters/AdvancedSettings.spec.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.spec.tsx
@@ -101,7 +101,7 @@ it('should display advanced settings title and description', async () => {
   await waitFor(() => expect(checkbox).not.toBeChecked());
 });
 
-it('should display advanced settings title and description including the appropriate enabled state', async () => {
+it('should display advanced settings title and description including the appropriate enabled state using unregistered user', async () => {
   const { baseElement } = renderComponent([
     createAdvancedSettingsAndFiltersMock({}),
   ]);

--- a/packages/shared/src/components/filters/AdvancedSettings.spec.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.spec.tsx
@@ -1,0 +1,131 @@
+import nock from 'nock';
+import React from 'react';
+import {
+  render,
+  RenderResult,
+  screen,
+  waitFor,
+  fireEvent,
+} from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import defaultUser from '../../../__tests__/fixture/loggedUser';
+import AuthContext from '../../contexts/AuthContext';
+import {
+  MockedGraphQLResponse,
+  mockGraphQL,
+} from '../../../__tests__/helpers/graphql';
+import { LoggedUser } from '../../lib/user';
+import {
+  FEED_SETTINGS_QUERY,
+  FeedSettings,
+  AllTagCategoriesData,
+  AdvancedSettings,
+  UPDATE_ADVANCED_SETTINGS_FILTERS_MUTATION,
+} from '../../graphql/feedSettings';
+import AdvancedSettingsPage from './AdvancedSettings';
+import { getFeedSettingsQueryKey } from '../../hooks/useMutateFilters';
+import { waitForNock } from '../../../__tests__/helpers/utilities';
+
+const showLogin = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  nock.cleanAll();
+});
+
+const createAdvancedSettingsAndFiltersMock = (
+  loggedIn = true,
+  feedSettings: FeedSettings = {
+    advancedSettings: [{ id: 1, enabled: false }],
+  },
+  advancedSettings: AdvancedSettings[] = [
+    {
+      id: 1,
+      title: 'Tech magazines',
+      description: 'Description for Tech magazines',
+      defaultEnabledState: true,
+    },
+  ],
+): MockedGraphQLResponse<AllTagCategoriesData> => ({
+  request: { query: FEED_SETTINGS_QUERY, variables: { loggedIn } },
+  result: {
+    data: {
+      feedSettings,
+      advancedSettings,
+    },
+  },
+});
+
+let client: QueryClient;
+
+const renderComponent = (
+  mocks: MockedGraphQLResponse[] = [createAdvancedSettingsAndFiltersMock()],
+  user: LoggedUser = defaultUser,
+): RenderResult => {
+  client = new QueryClient();
+  mocks.forEach(mockGraphQL);
+  return render(
+    <QueryClientProvider client={client}>
+      <AuthContext.Provider
+        value={{
+          user,
+          shouldShowLogin: false,
+          showLogin,
+          logout: jest.fn(),
+          updateUser: jest.fn(),
+          tokenRefreshed: true,
+          getRedirectUri: jest.fn(),
+          trackingId: '',
+          loginState: null,
+          closeLogin: jest.fn(),
+        }}
+      >
+        <AdvancedSettingsPage />
+      </AuthContext.Provider>
+    </QueryClientProvider>,
+  );
+};
+
+it('should display advanced settings title and description', async () => {
+  const { baseElement } = renderComponent();
+  await waitFor(() => expect(baseElement).not.toHaveAttribute('aria-busy'));
+  expect(await screen.findByText('Tech magazines')).toBeInTheDocument();
+  expect(
+    await screen.findByText('Description for Tech magazines'),
+  ).toBeInTheDocument();
+});
+
+it('should mutate update feed advanced settings', async () => {
+  let mutationCalled = false;
+
+  const { baseElement } = renderComponent();
+
+  await waitForNock();
+
+  await waitFor(async () => {
+    const data = await client.getQueryData(
+      getFeedSettingsQueryKey(defaultUser),
+    );
+    expect(data).toBeTruthy();
+  });
+
+  const params = [{ id: 1, enabled: true }];
+
+  mockGraphQL({
+    request: {
+      query: UPDATE_ADVANCED_SETTINGS_FILTERS_MUTATION,
+      variables: { settings: params },
+    },
+    result: () => {
+      mutationCalled = true;
+      return { data: { advancedSettings: params } };
+    },
+  });
+
+  const checkbox = await screen.findByRole('checkbox');
+  fireEvent.click(checkbox);
+
+  await waitFor(() => expect(baseElement).not.toHaveAttribute('aria-busy'));
+  await waitFor(() => expect(mutationCalled).toBeTruthy());
+  await waitFor(() => expect(checkbox).toBeChecked());
+});

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -5,7 +5,7 @@ import useMutateFilters from '../../hooks/useMutateFilters';
 import { LoginModalMode } from '../../types/LoginModalMode';
 import { FilterSwitch } from './FilterSwitch';
 
-const advancedSettingsKey = 'advancedSettings';
+const ADVANCED_SETTINGS_KEY = 'advancedSettings';
 
 function AdvancedSettingsFilter(): ReactElement {
   const [settings, setSettings] = useState({});
@@ -43,10 +43,10 @@ function AdvancedSettingsFilter(): ReactElement {
         <FilterSwitch
           key={id}
           title={title}
-          name={advancedSettingsKey}
+          name={ADVANCED_SETTINGS_KEY}
           description={description}
           onToggle={() => onToggle(id)}
-          inputId={`${title}-${id}`}
+          inputId={`${ADVANCED_SETTINGS_KEY}-${id}`}
         />
       ))}
     </section>

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -39,7 +39,7 @@ function AdvancedSettingsFilter(): ReactElement {
 
   return (
     <section className="flex flex-col px-6" aria-busy={isLoading}>
-      {advancedSettings?.map(({ id, title, description }, i) => (
+      {advancedSettings?.map(({ id, title, description }) => (
         <div key={title} className="flex flex-col my-4">
           <Switch
             className="h-8"
@@ -47,7 +47,7 @@ function AdvancedSettingsFilter(): ReactElement {
             defaultTypo={false}
             labelClassName="typo-callout"
             name={advancedSettingsKey}
-            inputId={`${advancedSettingsKey}-${i}`}
+            inputId={`${advancedSettingsKey}-${id}`}
             onToggle={() => onToggle(id)}
           >
             {title}

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -17,7 +17,7 @@ function AdvancedSettingsFilter(): ReactElement {
         const map = { ...settingsMap };
         map[currentSettings.id] = currentSettings.enabled;
         return map;
-      }, {}),
+      }, {}) || {},
     [feedSettings?.advancedSettings],
   );
 

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -8,23 +8,19 @@ import { Switch } from '../fields/Switch';
 const advancedSettingsKey = 'advancedSettings';
 
 function AdvancedSettingsFilter(): ReactElement {
+  const [settings, setSettings] = useState({});
   const { feedSettings, advancedSettings, isLoading } = useFeedSettings();
   const { user, showLogin } = useContext(AuthContext);
   const { updateAdvancedSettings } = useMutateFilters(user);
-  const [settingsMap, setSettingsMap] = useState<Record<number, boolean>>({});
 
   const onToggle = async (id: number) => {
     if (!user) {
-      showLogin('add source', LoginModalMode.ContentQuality);
+      showLogin('configure advanced settings', LoginModalMode.ContentQuality);
       return;
     }
-    setSettingsMap((state) => ({
-      ...state,
-      [id]: !settingsMap[id],
-    }));
 
     await updateAdvancedSettings({
-      advancedSettings: [{ id, enabled: !settingsMap[id] }],
+      advancedSettings: [{ id, enabled: !settings[id] }],
     });
   };
 
@@ -34,31 +30,29 @@ function AdvancedSettingsFilter(): ReactElement {
     }
 
     const map = {};
-
-    feedSettings?.advancedSettings?.forEach(
+    feedSettings.advancedSettings.forEach(
       // eslint-disable-next-line no-return-assign
-      (settings) => (map[settings.id] = settings.enabled),
+      ({ id, enabled }) => (map[id] = enabled),
     );
-
-    setSettingsMap(map);
+    setSettings(map);
   }, [feedSettings?.advancedSettings]);
 
   return (
     <section className="flex flex-col px-6" aria-busy={isLoading}>
-      {advancedSettings?.map((option, i) => (
-        <div key={option.title} className="flex flex-col my-4">
+      {advancedSettings?.map(({ id, title, description }, i) => (
+        <div key={title} className="flex flex-col my-4">
           <Switch
-            checked={settingsMap[option.id]}
+            checked={settings[id]}
             defaultTypo={false}
             labelClassName="typo-callout"
             name={advancedSettingsKey}
             inputId={`${advancedSettingsKey}-${i}`}
-            onToggle={() => onToggle(option.id)}
+            onToggle={() => onToggle(id)}
           >
-            {option.title}
+            {title}
           </Switch>
           <p className="mt-3 typo-callout text-theme-label-tertiary">
-            {option.description}
+            {description}
           </p>
         </div>
       ))}

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -1,0 +1,82 @@
+import request from 'graphql-request';
+import React, { ReactElement, useContext, useEffect, useState } from 'react';
+import { useQuery } from 'react-query';
+import AuthContext from '../../contexts/AuthContext';
+import {
+  AdvancedSettings,
+  FeedSettingsData,
+  FEED_ADVANCED_SETTINGS_AND_LIST,
+} from '../../graphql/feedSettings';
+import useMutateFilters from '../../hooks/useMutateFilters';
+import { apiUrl } from '../../lib/config';
+import { LoginModalMode } from '../../types/LoginModalMode';
+import { Switch } from '../fields/Switch';
+
+const advancedSettings = 'advancedSettings';
+
+function AdvancedSettingsFilter(): ReactElement {
+  const { user, showLogin } = useContext(AuthContext);
+  const { updateAdvancedSettings } = useMutateFilters();
+  const [settingsMap, setSettingsMap] = useState<Record<number, boolean>>({});
+  const { data, isLoading } = useQuery<
+    FeedSettingsData & { advancedSettings: AdvancedSettings[] }
+  >(advancedSettings, () =>
+    request(`${apiUrl}/graphql`, FEED_ADVANCED_SETTINGS_AND_LIST, {
+      loggedIn: !!user,
+    }),
+  );
+
+  const onToggle = async (id: number) => {
+    if (!user) {
+      showLogin('add source', LoginModalMode.ContentQuality);
+      return;
+    }
+    setSettingsMap((state) => ({
+      ...state,
+      [id]: !settingsMap[id],
+    }));
+
+    await updateAdvancedSettings({
+      advancedSettings: [{ id, enabled: !settingsMap[id] }],
+    });
+  };
+
+  useEffect(() => {
+    if (!data?.feedSettings?.advancedSettings) {
+      return;
+    }
+
+    const map = {};
+
+    data.feedSettings?.advancedSettings?.forEach(
+      // eslint-disable-next-line no-return-assign
+      (settings) => (map[settings.id] = settings.enabled),
+    );
+
+    setSettingsMap(map);
+  }, [data?.feedSettings?.advancedSettings]);
+
+  return (
+    <section className="flex flex-col px-6" aria-busy={isLoading}>
+      {data?.advancedSettings.map((option, i) => (
+        <div key={option.title} className="flex flex-col my-4">
+          <Switch
+            checked={settingsMap[option.id]}
+            defaultTypo={false}
+            labelClassName="typo-callout"
+            name={advancedSettings}
+            inputId={`${advancedSettings}-${i}`}
+            onToggle={() => onToggle(option.id)}
+          >
+            {option.title}
+          </Switch>
+          <p className="mt-3 typo-callout text-theme-label-tertiary">
+            {option.description}
+          </p>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+export default AdvancedSettingsFilter;

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -34,16 +34,19 @@ function AdvancedSettingsFilter(): ReactElement {
 
   return (
     <section className="flex flex-col px-6" aria-busy={isLoading}>
-      {advancedSettings?.map(({ id, title, description }) => (
-        <FilterSwitch
-          key={id}
-          title={title}
-          name={ADVANCED_SETTINGS_KEY}
-          description={description}
-          onToggle={() => onToggle(id)}
-          inputId={`${ADVANCED_SETTINGS_KEY}-${id}`}
-        />
-      ))}
+      {advancedSettings?.map(
+        ({ id, title, description, defaultEnabledState }) => (
+          <FilterSwitch
+            key={id}
+            title={title}
+            checked={settings[id] ?? defaultEnabledState}
+            name={ADVANCED_SETTINGS_KEY}
+            description={description}
+            onToggle={() => onToggle(id)}
+            inputId={`${ADVANCED_SETTINGS_KEY}-${id}`}
+          />
+        ),
+      )}
     </section>
   );
 }

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -15,7 +15,7 @@ function AdvancedSettingsFilter(): ReactElement {
 
   const onToggle = async (id: number) => {
     if (!user) {
-      showLogin('configure advanced settings', LoginModalMode.ContentQuality);
+      showLogin('advanced settings', LoginModalMode.ContentQuality);
       return;
     }
 

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -1,30 +1,17 @@
-import request from 'graphql-request';
 import React, { ReactElement, useContext, useEffect, useState } from 'react';
-import { useQuery } from 'react-query';
 import AuthContext from '../../contexts/AuthContext';
-import {
-  AdvancedSettings,
-  FeedSettingsData,
-  FEED_ADVANCED_SETTINGS_AND_LIST,
-} from '../../graphql/feedSettings';
+import useFeedSettings from '../../hooks/useFeedSettings';
 import useMutateFilters from '../../hooks/useMutateFilters';
-import { apiUrl } from '../../lib/config';
 import { LoginModalMode } from '../../types/LoginModalMode';
 import { Switch } from '../fields/Switch';
 
-const advancedSettings = 'advancedSettings';
+const advancedSettingsKey = 'advancedSettings';
 
 function AdvancedSettingsFilter(): ReactElement {
+  const { feedSettings, advancedSettings, isLoading } = useFeedSettings();
   const { user, showLogin } = useContext(AuthContext);
   const { updateAdvancedSettings } = useMutateFilters();
   const [settingsMap, setSettingsMap] = useState<Record<number, boolean>>({});
-  const { data, isLoading } = useQuery<
-    FeedSettingsData & { advancedSettings: AdvancedSettings[] }
-  >(advancedSettings, () =>
-    request(`${apiUrl}/graphql`, FEED_ADVANCED_SETTINGS_AND_LIST, {
-      loggedIn: !!user,
-    }),
-  );
 
   const onToggle = async (id: number) => {
     if (!user) {
@@ -42,30 +29,30 @@ function AdvancedSettingsFilter(): ReactElement {
   };
 
   useEffect(() => {
-    if (!data?.feedSettings?.advancedSettings) {
+    if (!feedSettings?.advancedSettings) {
       return;
     }
 
     const map = {};
 
-    data.feedSettings?.advancedSettings?.forEach(
+    feedSettings?.advancedSettings?.forEach(
       // eslint-disable-next-line no-return-assign
       (settings) => (map[settings.id] = settings.enabled),
     );
 
     setSettingsMap(map);
-  }, [data?.feedSettings?.advancedSettings]);
+  }, [feedSettings?.advancedSettings]);
 
   return (
     <section className="flex flex-col px-6" aria-busy={isLoading}>
-      {data?.advancedSettings.map((option, i) => (
+      {advancedSettings?.map((option, i) => (
         <div key={option.title} className="flex flex-col my-4">
           <Switch
             checked={settingsMap[option.id]}
             defaultTypo={false}
             labelClassName="typo-callout"
-            name={advancedSettings}
-            inputId={`${advancedSettings}-${i}`}
+            name={advancedSettingsKey}
+            inputId={`${advancedSettingsKey}-${i}`}
             onToggle={() => onToggle(option.id)}
           >
             {option.title}

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -40,7 +40,7 @@ function AdvancedSettingsFilter(): ReactElement {
             key={id}
             label={title}
             checked={settings[id] ?? defaultEnabledState}
-            name={ADVANCED_SETTINGS_KEY}
+            name={`${ADVANCED_SETTINGS_KEY}-${id}`}
             description={description}
             onToggle={() => onToggle(id)}
             inputId={`${ADVANCED_SETTINGS_KEY}-${id}`}

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -10,7 +10,7 @@ const advancedSettingsKey = 'advancedSettings';
 function AdvancedSettingsFilter(): ReactElement {
   const { feedSettings, advancedSettings, isLoading } = useFeedSettings();
   const { user, showLogin } = useContext(AuthContext);
-  const { updateAdvancedSettings } = useMutateFilters();
+  const { updateAdvancedSettings } = useMutateFilters(user);
   const [settingsMap, setSettingsMap] = useState<Record<number, boolean>>({});
 
   const onToggle = async (id: number) => {

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -3,7 +3,7 @@ import AuthContext from '../../contexts/AuthContext';
 import useFeedSettings from '../../hooks/useFeedSettings';
 import useMutateFilters from '../../hooks/useMutateFilters';
 import { LoginModalMode } from '../../types/LoginModalMode';
-import { Switch } from '../fields/Switch';
+import { FilterSwitch } from './FilterSwitch';
 
 const advancedSettingsKey = 'advancedSettings';
 
@@ -40,22 +40,15 @@ function AdvancedSettingsFilter(): ReactElement {
   return (
     <section className="flex flex-col px-6" aria-busy={isLoading}>
       {advancedSettings?.map(({ id, title, description }) => (
-        <div key={title} className="flex flex-col my-4">
-          <Switch
-            className="h-8"
-            checked={settings[id]}
-            defaultTypo={false}
-            labelClassName="typo-callout"
-            name={advancedSettingsKey}
-            inputId={`${advancedSettingsKey}-${id}`}
-            onToggle={() => onToggle(id)}
-          >
-            {title}
-          </Switch>
-          <p className="mt-3 typo-callout text-theme-label-tertiary">
-            {description}
-          </p>
-        </div>
+        <FilterSwitch
+          key={id}
+          id={id}
+          title={title}
+          name={advancedSettingsKey}
+          description={description}
+          onToggleFilter={onToggle}
+          inputId={`${title}-${id}`}
+        />
       ))}
     </section>
   );

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext, useEffect, useState } from 'react';
+import React, { ReactElement, useContext, useMemo } from 'react';
 import AuthContext from '../../contexts/AuthContext';
 import useFeedSettings from '../../hooks/useFeedSettings';
 import useMutateFilters from '../../hooks/useMutateFilters';
@@ -8,10 +8,18 @@ import { FilterSwitch } from './FilterSwitch';
 const ADVANCED_SETTINGS_KEY = 'advancedSettings';
 
 function AdvancedSettingsFilter(): ReactElement {
-  const [settings, setSettings] = useState({});
   const { feedSettings, advancedSettings, isLoading } = useFeedSettings();
   const { user, showLogin } = useContext(AuthContext);
   const { updateAdvancedSettings } = useMutateFilters(user);
+  const settings = useMemo(
+    () =>
+      feedSettings?.advancedSettings?.reduce((settingsMap, currentSettings) => {
+        const map = { ...settingsMap };
+        map[currentSettings.id] = currentSettings.enabled;
+        return map;
+      }, {}),
+    [feedSettings?.advancedSettings],
+  );
 
   const onToggle = async (id: number) => {
     if (!user) {
@@ -23,19 +31,6 @@ function AdvancedSettingsFilter(): ReactElement {
       advancedSettings: [{ id, enabled: !settings[id] }],
     });
   };
-
-  useEffect(() => {
-    if (!feedSettings?.advancedSettings) {
-      return;
-    }
-
-    const map = {};
-    feedSettings.advancedSettings.forEach(
-      // eslint-disable-next-line no-return-assign
-      ({ id, enabled }) => (map[id] = enabled),
-    );
-    setSettings(map);
-  }, [feedSettings?.advancedSettings]);
 
   return (
     <section className="flex flex-col px-6" aria-busy={isLoading}>

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -42,11 +42,10 @@ function AdvancedSettingsFilter(): ReactElement {
       {advancedSettings?.map(({ id, title, description }) => (
         <FilterSwitch
           key={id}
-          id={id}
           title={title}
           name={advancedSettingsKey}
           description={description}
-          onToggleFilter={onToggle}
+          onToggle={() => onToggle(id)}
           inputId={`${title}-${id}`}
         />
       ))}

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -42,6 +42,7 @@ function AdvancedSettingsFilter(): ReactElement {
       {advancedSettings?.map(({ id, title, description }, i) => (
         <div key={title} className="flex flex-col my-4">
           <Switch
+            className="h-8"
             checked={settings[id]}
             defaultTypo={false}
             labelClassName="typo-callout"

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -38,7 +38,7 @@ function AdvancedSettingsFilter(): ReactElement {
         ({ id, title, description, defaultEnabledState }) => (
           <FilterSwitch
             key={id}
-            title={title}
+            label={title}
             checked={settings[id] ?? defaultEnabledState}
             name={ADVANCED_SETTINGS_KEY}
             description={description}

--- a/packages/shared/src/components/filters/FilterMenu.tsx
+++ b/packages/shared/src/components/filters/FilterMenu.tsx
@@ -21,7 +21,7 @@ export default function FilterMenu(): ReactElement {
     {
       icon: <FilterIcon className="mr-3 text-xl" />,
       title: 'Advanced',
-      component: () => dynamic(() => import('./Test')),
+      component: () => dynamic(() => import('./AdvancedSettings')),
     },
     {
       icon: <BlockIcon className="mr-3 text-xl" />,

--- a/packages/shared/src/components/filters/FilterSwitch.tsx
+++ b/packages/shared/src/components/filters/FilterSwitch.tsx
@@ -1,13 +1,13 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { Switch, SwitchProps } from '../fields/Switch';
 
 interface FilterSwitchProps extends SwitchProps {
-  title: string;
-  description: string;
+  label: ReactNode;
+  description: ReactNode;
 }
 
 export function FilterSwitch({
-  title,
+  label,
   description,
   ...props
 }: FilterSwitchProps): ReactElement {
@@ -19,7 +19,7 @@ export function FilterSwitch({
         labelClassName="typo-callout"
         {...props}
       >
-        {title}
+        {label}
       </Switch>
       <p className="mt-3 typo-callout text-theme-label-tertiary">
         {description}

--- a/packages/shared/src/components/filters/FilterSwitch.tsx
+++ b/packages/shared/src/components/filters/FilterSwitch.tsx
@@ -2,17 +2,13 @@ import React, { ReactElement } from 'react';
 import { Switch, SwitchProps } from '../fields/Switch';
 
 interface FilterSwitchProps extends SwitchProps {
-  id: number | string;
   title: string;
   description: string;
-  onToggleFilter: (id: number | string) => unknown;
 }
 
 export function FilterSwitch({
-  id,
   title,
   description,
-  onToggleFilter,
   ...props
 }: FilterSwitchProps): ReactElement {
   return (
@@ -21,7 +17,6 @@ export function FilterSwitch({
         className="h-8"
         defaultTypo={false}
         labelClassName="typo-callout"
-        onToggle={() => onToggleFilter(id)}
         {...props}
       >
         {title}

--- a/packages/shared/src/components/filters/FilterSwitch.tsx
+++ b/packages/shared/src/components/filters/FilterSwitch.tsx
@@ -1,0 +1,36 @@
+import React, { ReactElement } from 'react';
+import { Switch, SwitchProps } from '../fields/Switch';
+
+interface FilterSwitchProps extends SwitchProps {
+  id: number | string;
+  title: string;
+  description: string;
+  onToggleFilter: (id: number | string) => unknown;
+}
+
+export function FilterSwitch({
+  id,
+  title,
+  description,
+  onToggleFilter,
+  ...props
+}: FilterSwitchProps): ReactElement {
+  return (
+    <div className="flex flex-col my-4">
+      <Switch
+        className="h-8"
+        defaultTypo={false}
+        labelClassName="typo-callout"
+        onToggle={() => onToggleFilter(id)}
+        {...props}
+      >
+        {title}
+      </Switch>
+      <p className="mt-3 typo-callout text-theme-label-tertiary">
+        {description}
+      </p>
+    </div>
+  );
+}
+
+export default FilterSwitch;

--- a/packages/shared/src/graphql/feedSettings.ts
+++ b/packages/shared/src/graphql/feedSettings.ts
@@ -81,6 +81,7 @@ export const FEED_SETTINGS_QUERY = gql`
       id
       title
       description
+      defaultEnabledState
     }
   }
 `;

--- a/packages/shared/src/graphql/feedSettings.ts
+++ b/packages/shared/src/graphql/feedSettings.ts
@@ -44,7 +44,7 @@ export interface AllTagCategoriesData {
   feedSettings?: FeedSettings;
   loggedIn?: boolean;
   tagsCategories?: TagCategory[];
-  advancedSettings: AdvancedSettings[];
+  advancedSettings?: AdvancedSettings[];
 }
 
 export interface FeedSettingsData {

--- a/packages/shared/src/graphql/feedSettings.ts
+++ b/packages/shared/src/graphql/feedSettings.ts
@@ -44,7 +44,7 @@ export interface AllTagCategoriesData {
   feedSettings?: FeedSettings;
   loggedIn?: boolean;
   tagsCategories?: TagCategory[];
-  advancedSettings: FeedAdvancedSettings[];
+  advancedSettings: AdvancedSettings[];
 }
 
 export interface FeedSettingsData {

--- a/packages/shared/src/graphql/feedSettings.ts
+++ b/packages/shared/src/graphql/feedSettings.ts
@@ -1,6 +1,19 @@
 import { gql } from 'graphql-request';
 import { Source } from './sources';
 
+export interface AdvancedSettings {
+  id: number;
+  title: string;
+  description: string;
+  defaultEnabledState: boolean;
+}
+
+export interface FeedAdvancedSettings
+  extends Partial<Omit<AdvancedSettings, 'defaultEnabledState'>> {
+  id: number;
+  enabled: boolean;
+}
+
 export interface Tag {
   name: string;
 }
@@ -17,6 +30,7 @@ export interface FeedSettings {
   includeTags?: string[];
   blockedTags?: string[];
   excludeSources?: Source[];
+  advancedSettings?: FeedAdvancedSettings[];
 }
 
 export interface TagCategory {
@@ -57,6 +71,73 @@ export const FEED_SETTINGS_QUERY = gql`
     feedSettings @include(if: $loggedIn) {
       includeTags
       blockedTags
+    }
+    tags: popularTags {
+      name
+    }
+  }
+`;
+
+export const FEED_ADVANCED_SETTINGS_AND_LIST = gql`
+  query FeedAdvancedSettings($loggedIn: Boolean!) {
+    feedSettings @include(if: $loggedIn) {
+      advancedSettings {
+        id
+        enabled
+      }
+    }
+    advancedSettings {
+      id
+      title
+      description
+    }
+  }
+`;
+
+export const TAGS_SETTINGS_QUERY = gql`
+  query FeedSettings {
+    feedSettings {
+      includeTags
+    }
+  }
+`;
+
+export const ALL_SOURCES_QUERY = gql`
+  query AllSources {
+    sources(first: 500) {
+      edges {
+        node {
+          id
+          image
+          name
+        }
+      }
+    }
+  }
+`;
+
+export const ALL_SOURCES_AND_SETTINGS_QUERY = gql`
+  query AllSourcesAndSettings {
+    feedSettings {
+      excludeSources {
+        id
+      }
+    }
+    sources(first: 500) {
+      edges {
+        node {
+          id
+          image
+          name
+        }
+      }
+    }
+  }
+`;
+
+export const SOURCES_SETTINGS_QUERY = gql`
+  query SourcesSettings {
+    feedSettings {
       excludeSources {
         id
         image
@@ -78,6 +159,15 @@ export const REMOVE_FILTERS_FROM_FEED_MUTATION = gql`
   mutation RemoveFiltersFromFeed($filters: FiltersInput!) {
     feedSettings: removeFiltersFromFeed(filters: $filters) {
       id
+    }
+  }
+`;
+
+export const UPDATE_ADVANCED_SETTINGS_FILTERS_MUTATION = gql`
+  mutation UpdateFeedAdvancedSettings($settings: [FeedAdvancedSettingsInput]!) {
+    feedSettings: updateFeedAdvancedSettings(settings: $settings) {
+      id
+      enabled
     }
   }
 `;

--- a/packages/shared/src/graphql/feedSettings.ts
+++ b/packages/shared/src/graphql/feedSettings.ts
@@ -44,6 +44,7 @@ export interface AllTagCategoriesData {
   feedSettings?: FeedSettings;
   loggedIn?: boolean;
   tagsCategories?: TagCategory[];
+  advancedSettings: FeedAdvancedSettings[];
 }
 
 export interface FeedSettingsData {
@@ -71,9 +72,18 @@ export const FEED_SETTINGS_QUERY = gql`
     feedSettings @include(if: $loggedIn) {
       includeTags
       blockedTags
+      advancedSettings {
+        id
+        enabled
+      }
     }
     tags: popularTags {
       name
+    }
+    advancedSettings {
+      id
+      title
+      description
     }
   }
 `;

--- a/packages/shared/src/graphql/feedSettings.ts
+++ b/packages/shared/src/graphql/feedSettings.ts
@@ -88,59 +88,6 @@ export const FEED_SETTINGS_QUERY = gql`
   }
 `;
 
-export const TAGS_SETTINGS_QUERY = gql`
-  query FeedSettings {
-    feedSettings {
-      includeTags
-    }
-  }
-`;
-
-export const ALL_SOURCES_QUERY = gql`
-  query AllSources {
-    sources(first: 500) {
-      edges {
-        node {
-          id
-          image
-          name
-        }
-      }
-    }
-  }
-`;
-
-export const ALL_SOURCES_AND_SETTINGS_QUERY = gql`
-  query AllSourcesAndSettings {
-    feedSettings {
-      excludeSources {
-        id
-      }
-    }
-    sources(first: 500) {
-      edges {
-        node {
-          id
-          image
-          name
-        }
-      }
-    }
-  }
-`;
-
-export const SOURCES_SETTINGS_QUERY = gql`
-  query SourcesSettings {
-    feedSettings {
-      excludeSources {
-        id
-        image
-        name
-      }
-    }
-  }
-`;
-
 export const ADD_FILTERS_TO_FEED_MUTATION = gql`
   mutation AddFiltersToFeed($filters: FiltersInput!) {
     feedSettings: addFiltersToFeed(filters: $filters) {

--- a/packages/shared/src/graphql/feedSettings.ts
+++ b/packages/shared/src/graphql/feedSettings.ts
@@ -77,9 +77,6 @@ export const FEED_SETTINGS_QUERY = gql`
         enabled
       }
     }
-    tags: popularTags {
-      name
-    }
     advancedSettings {
       id
       title

--- a/packages/shared/src/graphql/feedSettings.ts
+++ b/packages/shared/src/graphql/feedSettings.ts
@@ -88,22 +88,6 @@ export const FEED_SETTINGS_QUERY = gql`
   }
 `;
 
-export const FEED_ADVANCED_SETTINGS_AND_LIST = gql`
-  query FeedAdvancedSettings($loggedIn: Boolean!) {
-    feedSettings @include(if: $loggedIn) {
-      advancedSettings {
-        id
-        enabled
-      }
-    }
-    advancedSettings {
-      id
-      title
-      description
-    }
-  }
-`;
-
 export const TAGS_SETTINGS_QUERY = gql`
   query FeedSettings {
     feedSettings {

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -4,6 +4,7 @@ import { requestIdleCallback } from 'next/dist/client/request-idle-callback';
 import { request } from 'graphql-request';
 import {
   AllTagCategoriesData,
+  FeedAdvancedSettings,
   FeedSettings,
   FEED_SETTINGS_QUERY,
   TagCategory,
@@ -17,6 +18,7 @@ export type FeedSettingsReturnType = {
   tagsCategories: TagCategory[];
   feedSettings: FeedSettings;
   isLoading: boolean;
+  advancedSettings: FeedAdvancedSettings[];
 };
 
 export default function useFeedSettings(): FeedSettingsReturnType {
@@ -25,12 +27,14 @@ export default function useFeedSettings(): FeedSettingsReturnType {
   const filtersKey = getFeedSettingsQueryKey(user);
   const queryClient = useQueryClient();
 
-  const { data: { tagsCategories, feedSettings } = {}, isLoading } =
-    useQuery<AllTagCategoriesData>(filtersKey, () =>
-      request(`${apiUrl}/graphql`, FEED_SETTINGS_QUERY, {
-        loggedIn: !!user?.id,
-      }),
-    );
+  const {
+    data: { tagsCategories, feedSettings, advancedSettings } = {},
+    isLoading,
+  } = useQuery<AllTagCategoriesData>(filtersKey, () =>
+    request(`${apiUrl}/graphql`, FEED_SETTINGS_QUERY, {
+      loggedIn: !!user?.id,
+    }),
+  );
 
   useEffect(() => {
     if (isFirstLoad) {
@@ -49,6 +53,7 @@ export default function useFeedSettings(): FeedSettingsReturnType {
       tagsCategories,
       feedSettings,
       isLoading,
+      advancedSettings,
     };
   }, [tagsCategories, feedSettings, isLoading]);
 }

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -3,8 +3,8 @@ import { useQuery, useQueryClient } from 'react-query';
 import { requestIdleCallback } from 'next/dist/client/request-idle-callback';
 import { request } from 'graphql-request';
 import {
+  AdvancedSettings,
   AllTagCategoriesData,
-  FeedAdvancedSettings,
   FeedSettings,
   FEED_SETTINGS_QUERY,
   TagCategory,
@@ -18,7 +18,7 @@ export type FeedSettingsReturnType = {
   tagsCategories: TagCategory[];
   feedSettings: FeedSettings;
   isLoading: boolean;
-  advancedSettings: FeedAdvancedSettings[];
+  advancedSettings: AdvancedSettings[];
 };
 
 export default function useFeedSettings(): FeedSettingsReturnType {

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -55,5 +55,5 @@ export default function useFeedSettings(): FeedSettingsReturnType {
       isLoading,
       advancedSettings,
     };
-  }, [tagsCategories, feedSettings, isLoading]);
+  }, [tagsCategories, feedSettings, isLoading, advancedSettings]);
 }

--- a/packages/shared/src/hooks/useMutateFilters.ts
+++ b/packages/shared/src/hooks/useMutateFilters.ts
@@ -135,9 +135,9 @@ export default function useMutateFilters(user?: LoggedUser): ReturnType {
     { advancedSettings: FeedAdvancedSettings[] },
     () => Promise<void>
   >(
-    (advancedSettings) =>
+    ({ advancedSettings: settings }) =>
       request(`${apiUrl}/graphql`, UPDATE_ADVANCED_SETTINGS_FILTERS_MUTATION, {
-        filters: { advancedSettings },
+        settings,
       }),
     {
       onMutate: ({ advancedSettings }) =>
@@ -146,24 +146,7 @@ export default function useMutateFilters(user?: LoggedUser): ReturnType {
           queryClient,
           (feedSettings, feedAdvancedSettings) => {
             const newData = cloneDeep(feedSettings);
-            const existing: { [key in string]: FeedAdvancedSettings } = {};
-            newData.advancedSettings.forEach(
-              // eslint-disable-next-line no-return-assign
-              (settings) => (existing[settings.id] = settings),
-            );
-            // eslint-disable-next-line no-return-assign
-            feedAdvancedSettings.forEach((settings) => {
-              if (existing[settings.id] === undefined) {
-                return newData.advancedSettings.push(settings);
-              }
-
-              if (existing[settings.id].enabled === settings.enabled) {
-                return null;
-              }
-
-              // eslint-disable-next-line no-return-assign
-              return (existing[settings.id].enabled = settings.enabled);
-            });
+            newData.advancedSettings = feedAdvancedSettings;
             return newData;
           },
           user,


### PR DESCRIPTION
DD-245 #done

Advanced Settings page:
- Created a new property in `feedSettings` which will hold the actual list of advanced settings and the user's preferences itself.
- New component that might be used for future switches namely `FilterSwitch`. The component requires a `title` and `description`.

Enabled = true:
![Screen Shot 2021-10-29 at 4 47 14 PM](https://user-images.githubusercontent.com/13744167/139405376-ceb82d01-139b-445e-b77d-9303ac98f579.png)

Enabled = false:
![Screen Shot 2021-10-29 at 4 47 44 PM](https://user-images.githubusercontent.com/13744167/139405469-ff75b8c2-bfa3-4091-8142-162002921589.png)

Notice the first few articles were tagged as part of "Tech magazines" in my local DB and it went away after the change.
