### PR TITLE
style: fix long card titles breaking words

### DIFF
--- a/packages/shared/src/components/cards/Card.module.css
+++ b/packages/shared/src/components/cards/Card.module.css
@@ -1,5 +1,6 @@
 .title {
   -webkit-line-clamp: 3;
+  word-break: break-word;
 }
 
 .blur {

--- a/packages/shared/src/components/cards/Card.tsx
+++ b/packages/shared/src/components/cards/Card.tsx
@@ -13,7 +13,7 @@ const Title = classed(
   'font-bold typo-body text-theme-label-primary multi-truncate',
 );
 
-export const CardTitle = classed(Title, 'my-2');
+export const CardTitle = classed(Title, 'my-2 break-word');
 
 export const ListCardTitle = classed(Title, 'mr-2');
 


### PR DESCRIPTION
When a card title has a super long word in it, it would not break.
This fix introduces a break-word for it.

The CSS fix does most of the word, however I've also included the Tailwind class for browser fallback.

The issue:
![image](https://user-images.githubusercontent.com/554874/138844427-e6c2f7fb-6f50-4a16-a465-b8c8c31b9961.png)

The fix in action:
![Screenshot 2021-10-26 at 10 49 32](https://user-images.githubusercontent.com/554874/138844372-2f0e9e31-0e85-4398-b7b9-aab4959e6f1d.png)

DD-281 #done 