### PR TITLE
style: :lipstick: Change empty comment space to 32px

### DIFF
--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -675,7 +675,7 @@ const PostPage = ({ id, postData }: Props): ReactElement => {
           </>
         )}
         {comments?.postComments?.edges?.length === 0 && !isLoadingComments && (
-          <div className="my-10 text-center text-theme-label-quaternary typo-subhead">
+          <div className="my-8 text-center text-theme-label-quaternary typo-subhead">
             Be the first to comment.
           </div>
         )}


### PR DESCRIPTION
An issue was logged with regards to the bottom space of the empty comment section.
This original issue is actually not valid as the "place new comment" is always pushed to the bottom of the screen.

See feedback in Jira:
https://dailydotdev.atlassian.net/jira/software/projects/DD/boards/1?selectedIssue=DD-266

However, this raised a new styling update to change from 40px to 32px space on the empty comment div.