### PR TITLE
fix: body scrolling when modal is open should be disabled

### DIFF
--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -32,6 +32,11 @@ body {
       }
     }
   }
+
+  &.ReactModal__Body--open {
+    height: 100vh;
+    overflow: hidden;
+  }
 }
 
 @define-mixin dark-mode {

--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -33,9 +33,10 @@ body {
     }
   }
 
-  &.ReactModal__Body--open {
-    height: 100vh;
-    overflow: hidden;
+  &.ReactModal__Body--open .ReactModal__Content,
+  &.ReactModal__Body--open .ReactModal__Content > * {
+    touch-action: none;
+    overscroll-behavior-y: none;
   }
 }
 


### PR DESCRIPTION
DD-218 #done

`react-modal` attaches a class on the body whenever it is opened, I included some styles to disable scrolling once it happened.

As per the Jira ticket's comment of Tsahi, this should be applied across all popup/modal, hence, did not create any sort of condition.

Reference to the fix applied: https://github.com/reactjs/react-modal/issues/99#issuecomment-265402455