### PR TITLE
fix: data management on advanced settings mutation

### DIFF
--- a/packages/shared/src/hooks/useMutateFilters.ts
+++ b/packages/shared/src/hooks/useMutateFilters.ts
@@ -144,9 +144,12 @@ export default function useMutateFilters(user?: LoggedUser): ReturnType {
         onMutateAdvancedSettings(
           advancedSettings,
           queryClient,
-          (feedSettings, feedAdvancedSettings) => {
+          (feedSettings, [feedAdvancedSettings]) => {
             const newData = cloneDeep(feedSettings);
-            newData.advancedSettings = feedAdvancedSettings;
+            const index = newData.advancedSettings.findIndex(
+              (settings) => settings.id === feedAdvancedSettings.id,
+            );
+            newData.advancedSettings[index] = feedAdvancedSettings;
             return newData;
           },
           user,


### PR DESCRIPTION
DD-297 #done

Didn't realize the parameter here is the variable used for the request for reactivity.