### PR TITLE
fix: refetch issue

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -46,7 +46,7 @@ export default function PostOptionsMenu({
   setShowDeletePost,
   setShowBanPost,
 }: PostOptionsMenuProps): ReactElement {
-  useFeedSettings();
+  const { setAvoidRefresh } = useFeedSettings();
   const { trackEvent } = useContext(AnalyticsContext);
   const { reportPost, hidePost } = useReportPost();
   const { onUnfollowSource, onBlockTags } = useTagAndSource({
@@ -90,13 +90,17 @@ export default function PostOptionsMenu({
   };
 
   const onBlockSource = async (): Promise<void> => {
+    setAvoidRefresh(true);
     await onUnfollowSource({ source: post?.source });
     showMessageAndRemovePost(`🚫 ${post?.source?.name} blocked`, postIndex);
+    setAvoidRefresh(false);
   };
 
   const onBlockTag = async (tag: string): Promise<void> => {
+    setAvoidRefresh(true);
     await onBlockTags({ tags: [tag] });
-    showMessageAndRemovePost(`⛔️ #${tag} blocked`, postIndex);
+    await showMessageAndRemovePost(`⛔️ #${tag} blocked`, postIndex);
+    setAvoidRefresh(false);
   };
 
   const onHidePost = async (): Promise<void> => {
@@ -159,13 +163,16 @@ export default function PostOptionsMenu({
       action: onBlockSource,
     },
   ];
-  post?.tags?.forEach((tag) =>
-    postOptions.push({
-      icon: <MenuIcon Icon={BlockIcon} />,
-      text: `Not interested in #${tag}`,
-      action: () => onBlockTag(tag),
-    }),
-  );
+  post?.tags?.forEach((tag) => {
+    if (tag.length) {
+      postOptions.push({
+        icon: <MenuIcon Icon={BlockIcon} />,
+        text: `Not interested in #${tag}`,
+        action: () => onBlockTag(tag),
+      });
+    }
+  });
+
   postOptions.push({
     icon: <MenuIcon Icon={FlagIcon} />,
     text: 'Report',

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -18,13 +18,19 @@ export type FeedSettingsReturnType = {
   feedSettings: FeedSettings;
   isLoading: boolean;
   advancedSettings: AdvancedSettings[];
+  setAvoidRefresh: (value: boolean) => void;
 };
+
+let avoidRefresh = false;
 
 export default function useFeedSettings(): FeedSettingsReturnType {
   const { user } = useContext(AuthContext);
   const [isFirstLoad, setIsFirstLoad] = useState(true);
   const filtersKey = getFeedSettingsQueryKey(user);
   const queryClient = useQueryClient();
+  const setAvoidRefresh = (value: boolean) => {
+    avoidRefresh = value;
+  };
 
   const {
     data: { tagsCategories, feedSettings, advancedSettings } = {},
@@ -36,6 +42,9 @@ export default function useFeedSettings(): FeedSettingsReturnType {
   );
 
   useEffect(() => {
+    if (avoidRefresh) {
+      return;
+    }
     if (isFirstLoad) {
       setIsFirstLoad(false);
       return;
@@ -45,7 +54,7 @@ export default function useFeedSettings(): FeedSettingsReturnType {
       queryClient.invalidateQueries(generateQueryKey('popular', user));
       queryClient.invalidateQueries(generateQueryKey('recent', user));
     }, 100);
-  }, [tagsCategories, feedSettings]);
+  }, [tagsCategories, feedSettings, avoidRefresh]);
 
   return useMemo(() => {
     return {
@@ -53,6 +62,13 @@ export default function useFeedSettings(): FeedSettingsReturnType {
       feedSettings,
       isLoading,
       advancedSettings,
+      setAvoidRefresh,
     };
-  }, [tagsCategories, feedSettings, isLoading, advancedSettings]);
+  }, [
+    tagsCategories,
+    feedSettings,
+    isLoading,
+    advancedSettings,
+    setAvoidRefresh,
+  ]);
 }


### PR DESCRIPTION
We had a issue where the background refetch would happen if you use a block action from the context menu.
This would only happen on the second article in a row.

Due to this, we introduced a new state manager inside the useFeedSettings hook, that is not bound to singular states, making the refresh temporary disabled when using it from there.

Also a super small issue where empty tags where displayed was solved.