### PR TITLE
fix: hotfix the search bar position being off

### DIFF
--- a/packages/shared/src/components/fields/AutoCompleteMenu.tsx
+++ b/packages/shared/src/components/fields/AutoCompleteMenu.tsx
@@ -45,6 +45,7 @@ export default function AutoCompleteMenu({
         left: placement?.x,
         opacity: isOpen ? 1 : 0,
         width: placement?.width,
+        transform: 'none',
       }}
     >
       {sanitizedItems.map((item, index) => (

--- a/packages/shared/src/styles/components/menu.css
+++ b/packages/shared/src/styles/components/menu.css
@@ -12,7 +12,6 @@
   }
 
   &.menu-secondary {
-    @apply transform-none;
     & .react-contexify__item__content {
       @apply text-theme-label-primary;
 

--- a/packages/shared/src/styles/components/menu.css
+++ b/packages/shared/src/styles/components/menu.css
@@ -12,6 +12,7 @@
   }
 
   &.menu-secondary {
+    @apply transform-none;
     & .react-contexify__item__content {
       @apply text-theme-label-primary;
 


### PR DESCRIPTION
The react context menu was wrong for the both search dropdowns.
This fixed that issue by removing the transform for these dropdowns.

DD-306 #done 