### PR TITLE
fix: missing padding on checkbox

### DIFF
--- a/packages/shared/src/components/fields/Checkbox.tsx
+++ b/packages/shared/src/components/fields/Checkbox.tsx
@@ -38,7 +38,7 @@ export const Checkbox = forwardRef(function Checkbox(
   return (
     <label
       className={classNames(
-        'relative inline-flex items-center text-theme-label-tertiary z-1 cursor-pointer select-none font-bold typo-footnote',
+        'relative inline-flex items-center text-theme-label-tertiary z-1 cursor-pointer select-none font-bold typo-footnote p-1',
         styles.label,
         className,
         { checked: actualChecked },

--- a/packages/shared/src/components/fields/Checkbox.tsx
+++ b/packages/shared/src/components/fields/Checkbox.tsx
@@ -38,7 +38,7 @@ export const Checkbox = forwardRef(function Checkbox(
   return (
     <label
       className={classNames(
-        'relative inline-flex items-center text-theme-label-tertiary z-1 cursor-pointer select-none font-bold typo-footnote p-1',
+        'relative inline-flex items-center text-theme-label-tertiary z-1 cursor-pointer select-none font-bold typo-footnote p-1 pr-3',
         styles.label,
         className,
         { checked: actualChecked },

--- a/packages/shared/src/components/modals/NewRankModal.tsx
+++ b/packages/shared/src/components/modals/NewRankModal.tsx
@@ -185,7 +185,7 @@ export default function NewRankModal({
       <Checkbox
         ref={inputRef}
         name="neverShow"
-        className="self-center mt-6 mb-7"
+        className="self-center mt-4 mb-7"
       >
         Never show this popup again
       </Checkbox>


### PR DESCRIPTION
DD-291 #done

In our design spec, our checkbox has `4px` padding = `0.25rem` and a right padding of `12px` = `0.75rem`.

![Screen Shot 2021-11-10 at 10 30 17 AM](https://user-images.githubusercontent.com/13744167/141038738-cfdcd516-a413-4543-bd61-8a5da9de89ff.png)

Affected existing implementations:

![Screen Shot 2021-11-10 at 10 33 37 AM](https://user-images.githubusercontent.com/13744167/141039100-e154d08d-3772-4553-b8fc-5312117d15bc.png)

![Screen Shot 2021-11-10 at 10 34 22 AM](https://user-images.githubusercontent.com/13744167/141039160-2f154ee9-478a-4e74-86fa-9df8faa87775.png)

