### PR TITLE
refactor: clickable area was wrong for the multi menu master

### DIFF
--- a/packages/shared/src/components/multiLevelMenu/MultiLevelMenuMaster.tsx
+++ b/packages/shared/src/components/multiLevelMenu/MultiLevelMenuMaster.tsx
@@ -18,7 +18,7 @@ export default function MultiLevelMenuMaster({
         >
           <button
             type="button"
-            className="flex items-center w-full py-3 px-4"
+            className="flex items-center py-3 px-4 w-full"
             onClick={
               item.action ||
               (() => setMultiLevelMenuDetail(item, item.component))

--- a/packages/shared/src/components/multiLevelMenu/MultiLevelMenuMaster.tsx
+++ b/packages/shared/src/components/multiLevelMenu/MultiLevelMenuMaster.tsx
@@ -13,12 +13,12 @@ export default function MultiLevelMenuMaster({
     <ul className="mt-6">
       {menuItems.map((item) => (
         <li
-          className="py-3 px-4 first:border-t border-b cursor-pointer border-theme-divider-tertiary"
+          className="first:border-t border-b cursor-pointer border-theme-divider-tertiary"
           key={item.title}
         >
           <button
             type="button"
-            className="flex items-center w-full"
+            className="flex items-center w-full py-3 px-4"
             onClick={
               item.action ||
               (() => setMultiLevelMenuDetail(item, item.component))


### PR DESCRIPTION
The padding was set on the `li` instead of the button making it non clickable.

DD-308 #done
closing https://github.com/dailydotdev/daily/issues/343