### PR TITLE
refactor: tracking for tags filter event was always search

### DIFF
--- a/packages/shared/src/components/filters/TagsFilter.tsx
+++ b/packages/shared/src/components/filters/TagsFilter.tsx
@@ -25,7 +25,7 @@ export default function TagsFilter({
     useTagContext();
   const { onFollowTags, onUnfollowTags, onBlockTags, onUnblockTags } =
     useTagAndSource({
-      origin: 'tags search',
+      origin: `tags ${query?.length > 0 ? 'search' : 'filter'}`,
     });
 
   const { data: searchResults } = useQuery<SearchTagsData>(


### PR DESCRIPTION
The tracking was hard coded to "tags search" because of the last change to uniform the tracking.
I've now made this dynamic based on the search query.

Meaning if the search query is active we can assume someone is one the search page.
In this case we should track on "tags search"

Else they are on the main page so track: "tags filter"

DD-309 #done 