### PR TITLE
fix: scroll on mobile for modal

### DIFF
--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -35,7 +35,6 @@ body {
 
   &.ReactModal__Body--open .ReactModal__Content,
   &.ReactModal__Body--open .ReactModal__Content > * {
-    touch-action: none;
     overscroll-behavior-y: none;
   }
 }


### PR DESCRIPTION
DD-311 #done

Removed the `touch-action` property that prevented scrolling on mobile.

Also checked other modals that use scrolling for mobile and it worked.