### PR TITLE
fix: It was possible for duplicate featured comment authors to popup

### DIFF
--- a/packages/shared/src/components/cards/Card.tsx
+++ b/packages/shared/src/components/cards/Card.tsx
@@ -7,6 +7,7 @@ import classed from '../../lib/classed';
 import { getTooltipProps } from '../../lib/tooltip';
 import { Post } from '../../graphql/posts';
 import { ProfilePicture } from '../ProfilePicture';
+import { unqiueAuthors } from '../comments/common';
 
 const Title = classed(
   'h3',
@@ -88,7 +89,7 @@ export const featuredCommentsToButtons = (
   className = 'mx-1',
   tooltipPosition: 'up' | 'down' | 'left' | 'right' = 'down',
 ): ReactNode[] =>
-  comments?.map((comment) => (
+  unqiueAuthors(comments)?.map((comment) => (
     <button
       type="button"
       {...getTooltipProps(`See ${comment.author.name}'s comment`, {

--- a/packages/shared/src/components/comments/common.tsx
+++ b/packages/shared/src/components/comments/common.tsx
@@ -6,7 +6,7 @@ import { Comment } from '../../graphql/comments';
 import { commentDateFormat } from '../../lib/dateFormat';
 
 export const unqiueAuthors = (comments: Comment[]): Comment[] =>
-  comments.filter(
+  comments?.filter(
     (comment, i) =>
       comments.findIndex(
         (matchComment) =>

--- a/packages/shared/src/components/comments/common.tsx
+++ b/packages/shared/src/components/comments/common.tsx
@@ -5,6 +5,15 @@ import styles from './comments.module.css';
 import { Comment } from '../../graphql/comments';
 import { commentDateFormat } from '../../lib/dateFormat';
 
+export const unqiueAuthors = (comments: Comment[]): Comment[] =>
+  comments.filter(
+    (comment, i) =>
+      comments.findIndex(
+        (matchComment) =>
+          matchComment?.author?.username === comment?.author?.username,
+      ) === i,
+  );
+
 export function CommentPublishDate({
   comment,
 }: {

--- a/packages/webapp/components/widgets/BestDiscussions.tsx
+++ b/packages/webapp/components/widgets/BestDiscussions.tsx
@@ -11,6 +11,7 @@ import classed from '@dailydotdev/shared/src/lib/classed';
 import { postAnalyticsEvent } from '@dailydotdev/shared/src/lib/feed';
 import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 import { ProfilePicture } from '@dailydotdev/shared/src/components/ProfilePicture';
+import { unqiueAuthors } from '@dailydotdev/shared/src/components/comments/common';
 
 export type BestDiscussionsProps = {
   posts: Post[] | null;
@@ -51,9 +52,11 @@ const ListItem = ({ post, onLinkClick }: PostProps): ReactElement => (
       {post.featuredComments?.length > 0 && (
         <div
           className="relative mr-2 h-6"
-          style={{ width: `${post.featuredComments.length + 0.5}rem` }}
+          style={{
+            width: `${unqiueAuthors(post.featuredComments).length + 0.5}rem`,
+          }}
         >
-          {post.featuredComments.map((comment, index) => (
+          {unqiueAuthors(post.featuredComments).map((comment, index) => (
             <ProfilePicture
               key={comment.author.username}
               user={comment.author}


### PR DESCRIPTION
Added a check for duplicate authors based on their username.
This filters out the duplicates.

On the card:
![Screenshot 2021-11-16 at 11 46 18](https://user-images.githubusercontent.com/554874/141963731-fd2584a2-d768-4f06-84ec-58b601d64b13.png)
![Screenshot 2021-11-16 at 11 45 48](https://user-images.githubusercontent.com/554874/141963716-6f9e7c40-c5d8-4b83-9b77-a34daf6305c0.png)

And on the best discussions tab
![Screenshot 2021-11-16 at 11 46 24](https://user-images.githubusercontent.com/554874/141963777-3c8379c9-ae56-4429-9535-3709ebf46ec6.png)
![Screenshot 2021-11-16 at 11 45 37](https://user-images.githubusercontent.com/554874/141963784-a795caa5-fe95-4696-9844-c3f72d1c54b9.png)
 
DD-307 #done 