### PR TITLE
feat: added the top sites toggle to the profile

### DIFF
--- a/packages/extension/src/newtab/MostVisitedSites.tsx
+++ b/packages/extension/src/newtab/MostVisitedSites.tsx
@@ -1,13 +1,24 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useContext, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import PlusIcon from '@dailydotdev/shared/icons/plus.svg';
 import { QuaternaryButton } from '@dailydotdev/shared/src/components/buttons/QuaternaryButton';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import useTopSites from './useTopSites';
 import MostVisitedSitesModal from './MostVisitedSitesModal';
 
 export default function MostVisitedSites(): ReactElement {
+  const { user, tokenRefreshed } = useContext(AuthContext);
   const { topSites, askTopSitesPermission } = useTopSites();
   const [showModal, setShowModal] = useState(false);
+  const [showTopSites, setShowTopSites] = useState(true);
+
+  useEffect(() => {
+    if (tokenRefreshed && user && !user.showTopSites) {
+      setShowTopSites(false);
+    }
+  }, [user, tokenRefreshed]);
+
+  if (!showTopSites) return <></>;
 
   return (
     <>

--- a/packages/shared/src/components/modals/AccountDetailsModal.spec.tsx
+++ b/packages/shared/src/components/modals/AccountDetailsModal.spec.tsx
@@ -27,6 +27,7 @@ const defaultUser = {
   infoConfirmed: true,
   premium: false,
   createdAt: '2020-07-26T13:04:35.000Z',
+  showTopSites: true,
 };
 
 const renderComponent = (user: Partial<LoggedUser> = {}): RenderResult => {
@@ -88,6 +89,7 @@ it('should submit information on button click', async () => {
     timezone: 'Europe/London',
     twitter: null,
     hashnode: null,
+    showTopSites: true,
   });
   expect(onRequestClose).toBeCalledTimes(1);
 });

--- a/packages/shared/src/components/profile/ProfileForm.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileForm.spec.tsx
@@ -35,6 +35,7 @@ const defaultUser = {
   infoConfirmed: true,
   premium: false,
   createdAt: '2020-07-26T13:04:35.000Z',
+  showTopSites: true,
 };
 
 const renderComponent = (user: Partial<LoggedUser> = {}): RenderResult => {
@@ -86,6 +87,7 @@ it('should submit information', async () => {
     timezone: userTimezone,
     twitter: null,
     hashnode: null,
+    showTopSites: true,
   });
   expect(onSuccessfulSubmit).toBeCalledWith(true);
   expect(updateUser).toBeCalledWith({ ...defaultUser, username: 'idoshamun' });
@@ -115,6 +117,7 @@ it('should set optional fields on callback', async () => {
     timezone: userTimezone,
     twitter: null,
     hashnode: null,
+    showTopSites: true,
   });
   expect(onSuccessfulSubmit).toBeCalledWith(true);
   expect(updateUser).toBeCalledWith({

--- a/packages/shared/src/components/profile/ProfileForm.tsx
+++ b/packages/shared/src/components/profile/ProfileForm.tsx
@@ -299,6 +299,13 @@ export default function ProfileForm({
       >
         Subscribe to the Weekly Recap
       </FormSwitch>
+      <FormSwitch
+        name="showTopSites"
+        inputId="showTopSites"
+        checked={user.showTopSites}
+      >
+        Show top sites
+      </FormSwitch>
       {mode !== 'update' && (
         <details
           className={`flex flex-col w-full border-b border-theme-divider-tertiary ${styles.optionalFields}`}

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -40,6 +40,7 @@ export interface UserProfile {
   bio?: string;
   acceptedMarketing?: boolean;
   timezone?: string;
+  showTopSites?: boolean;
 }
 
 export interface UpvoterProfile
@@ -116,6 +117,7 @@ export function loggedUserToProfile(user: LoggedUser): UserProfile {
     portfolio: user.github,
     bio: user.bio,
     acceptedMarketing: user.acceptedMarketing,
+    showTopSites: user.showTopSites,
   };
 }
 

--- a/packages/webapp/__tests__/register.tsx
+++ b/packages/webapp/__tests__/register.tsx
@@ -42,6 +42,7 @@ const defaultUser = {
   premium: false,
   createdAt: '2020-07-26T13:04:35.000Z',
   permalink: 'https://app.daily.dev/ido',
+  showTopSites: true,
 };
 
 const renderComponent = (user: Partial<LoggedUser> = {}): RenderResult => {
@@ -99,6 +100,7 @@ it('should submit information on button click', async () => {
     timezone: userTimezone,
     twitter: null,
     hashnode: null,
+    showTopSites: true,
   });
 });
 


### PR DESCRIPTION
Added a new field to the user profile, user can turn off the top sites.
This is only for logged in users.

Users that are not logged in, will always see the top sites, if they choose too.
Hence I choose the solution of ALWAYS show only hide if user opts out.

Related changes in [API](https://github.com/dailydotdev/daily-api/pull/798) and [Gateway](https://github.com/dailydotdev/daily-gateway/pull/381)

DD-252 #done 