### PR TITLE
fix: render the dropdown as primary menu and smaller text

### DIFF
--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -25,6 +25,7 @@ export interface DropdownProps {
   onChange: (value: string, index: number) => unknown;
   buttonSize?: 'small' | 'medium' | 'large' | 'select';
   scrollable?: boolean;
+  menuType?: string;
 }
 
 const getButtonSizeClass = (buttonSize: string): string => {
@@ -48,6 +49,7 @@ export function Dropdown({
   onChange,
   buttonSize = 'large',
   scrollable = false,
+  menuType = 'primary',
   ...props
 }: DropdownProps): ReactElement {
   const [id] = useState(`dropdown-${Math.random().toString(36).substring(7)}`);
@@ -124,9 +126,7 @@ export function Dropdown({
       <Menu
         disableBoundariesCheck
         id={id}
-        className={`${
-          scrollable ? 'menu-secondary scrollable' : 'menu-primary'
-        }`}
+        className={`${scrollable && 'scrollable'} menu-${menuType}`}
         animation="fade"
         onHidden={() => setVisibility(false)}
         style={{ width: menuWidth }}

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -29,7 +29,7 @@ export interface DropdownProps {
 
 const getButtonSizeClass = (buttonSize: string): string => {
   if (buttonSize === 'select') {
-    return 'h-9 rounded-10';
+    return 'h-9 rounded-10 text-theme-label-primary typo-callout';
   }
   if (buttonSize === 'medium') {
     return 'h-10 rounded-xl';
@@ -124,7 +124,9 @@ export function Dropdown({
       <Menu
         disableBoundariesCheck
         id={id}
-        className={`menu-primary ${scrollable && 'scrollable'}`}
+        className={`${
+          scrollable ? 'menu-secondary scrollable' : 'menu-primary'
+        }`}
         animation="fade"
         onHidden={() => setVisibility(false)}
         style={{ width: menuWidth }}

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -25,7 +25,7 @@ export interface DropdownProps {
   onChange: (value: string, index: number) => unknown;
   buttonSize?: 'small' | 'medium' | 'large' | 'select';
   scrollable?: boolean;
-  menuType?: string;
+  menuClassName?: string;
 }
 
 const getButtonSizeClass = (buttonSize: string): string => {
@@ -49,7 +49,7 @@ export function Dropdown({
   onChange,
   buttonSize = 'large',
   scrollable = false,
-  menuType = 'primary',
+  menuClassName = 'menu-primary',
   ...props
 }: DropdownProps): ReactElement {
   const [id] = useState(`dropdown-${Math.random().toString(36).substring(7)}`);
@@ -126,7 +126,7 @@ export function Dropdown({
       <Menu
         disableBoundariesCheck
         id={id}
-        className={`${scrollable && 'scrollable'} menu-${menuType}`}
+        className={`${scrollable && 'scrollable'} ${menuClassName}`}
         animation="fade"
         onHidden={() => setVisibility(false)}
         style={{ width: menuWidth }}

--- a/packages/shared/src/components/profile/ProfileForm.tsx
+++ b/packages/shared/src/components/profile/ProfileForm.tsx
@@ -170,7 +170,7 @@ export default function ProfileForm({
           onChange={timezoneUpdated}
           options={timeZoneValues}
           scrollable
-          menuType="secondary"
+          menuClassName="menu-secondary"
         />
         <div className="px-2 mt-1 typo-caption1 text-theme-label-tertiary">
           Your current time zone. Used to calculate your weekly goal&apos;s

--- a/packages/shared/src/components/profile/ProfileForm.tsx
+++ b/packages/shared/src/components/profile/ProfileForm.tsx
@@ -170,6 +170,7 @@ export default function ProfileForm({
           onChange={timezoneUpdated}
           options={timeZoneValues}
           scrollable
+          menuType="secondary"
         />
         <div className="px-2 mt-1 typo-caption1 text-theme-label-tertiary">
           Your current time zone. Used to calculate your weekly goal&apos;s

--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -35,7 +35,6 @@ body {
 
   &.ReactModal__Body--open .ReactModal__Content,
   &.ReactModal__Body--open .ReactModal__Content > * {
-    touch-action: none;
     overscroll-behavior-y: none;
   }
 }

--- a/packages/shared/src/styles/components/menu.css
+++ b/packages/shared/src/styles/components/menu.css
@@ -9,11 +9,6 @@
     & .react-contexify__item__content {
       @apply text-theme-label-tertiary;
     }
-
-    &.scrollable {
-      height: 15rem;
-      overflow-y: scroll;
-    }
   }
 
   &.menu-secondary {
@@ -29,6 +24,10 @@
         flex: 1;
         @apply truncate;
       }
+    }
+    &.scrollable {
+      height: 15rem;
+      overflow-y: scroll;
     }
   }
 

--- a/packages/shared/src/styles/components/menu.css
+++ b/packages/shared/src/styles/components/menu.css
@@ -5,6 +5,11 @@
   z-index: 100;
   @apply py-1 px-0 m-0 bg-theme-bg-secondary rounded-xl border border-theme-divider-secondary shadow-2 transform -translate-x-full;
 
+  &.scrollable {
+    height: 15rem;
+    overflow-y: scroll;
+  }
+
   &.menu-primary {
     & .react-contexify__item__content {
       @apply text-theme-label-tertiary;
@@ -24,10 +29,6 @@
         flex: 1;
         @apply truncate;
       }
-    }
-    &.scrollable {
-      height: 15rem;
-      overflow-y: scroll;
     }
   }
 


### PR DESCRIPTION
DD-314 #done 

The current dropdown already uses the new styleguide for formfields.
However, as a quick fix, we decided to make this inline with the overall used form field styles (old one)

This means we now render this dropdown in 15px (callout) instead of the previous body (17px)
Also made sure the content for this scrollable dropdown is rendering in the primary color.

Lastly I've added a new ticket in Jira so we can pick up the new form styleguide.
https://dailydotdev.atlassian.net/jira/software/projects/DD/boards/1?selectedIssue=DD-315

For reference the new render:
![Screenshot 2021-11-17 at 09 12 27](https://user-images.githubusercontent.com/554874/142154439-4c3c1d64-9084-4aae-a9ce-29838d96a024.png)