### PR TITLE
feat: reintroduced the show top sites toggle in the webapp

### DIFF
--- a/packages/extension/src/newtab/MostVisitedSites.tsx
+++ b/packages/extension/src/newtab/MostVisitedSites.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement, useContext, useState } from 'react';
 import classNames from 'classnames';
 import PlusIcon from '@dailydotdev/shared/icons/plus.svg';
+import SettingsContext from '@dailydotdev/shared/src/contexts/SettingsContext';
 import { QuaternaryButton } from '@dailydotdev/shared/src/components/buttons/QuaternaryButton';
 import useTopSites from './useTopSites';
 import MostVisitedSitesModal from './MostVisitedSitesModal';
-import SettingsContext from '@dailydotdev/shared/src/contexts/SettingsContext';
 
 export default function MostVisitedSites(): ReactElement {
   const { showTopSites } = useContext(SettingsContext);

--- a/packages/extension/src/newtab/MostVisitedSites.tsx
+++ b/packages/extension/src/newtab/MostVisitedSites.tsx
@@ -1,13 +1,19 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useContext, useState } from 'react';
 import classNames from 'classnames';
 import PlusIcon from '@dailydotdev/shared/icons/plus.svg';
 import { QuaternaryButton } from '@dailydotdev/shared/src/components/buttons/QuaternaryButton';
 import useTopSites from './useTopSites';
 import MostVisitedSitesModal from './MostVisitedSitesModal';
+import SettingsContext from '@dailydotdev/shared/src/contexts/SettingsContext';
 
 export default function MostVisitedSites(): ReactElement {
+  const { showTopSites } = useContext(SettingsContext);
   const { topSites, askTopSitesPermission } = useTopSites();
   const [showModal, setShowModal] = useState(false);
+
+  if (!showTopSites) {
+    return <></>;
+  }
 
   return (
     <>

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -131,6 +131,8 @@ const renderComponent = (
     insaneMode: false,
     loadedSettings: true,
     toggleInsaneMode: jest.fn(),
+    showTopSites: true,
+    toggleShowTopSites: jest.fn(),
   };
   return render(
     <QueryClientProvider client={queryClient}>

--- a/packages/shared/src/components/Settings.spec.tsx
+++ b/packages/shared/src/components/Settings.spec.tsx
@@ -41,6 +41,7 @@ const defaultSettings: RemoteSettings = {
   showOnlyUnreadPosts: true,
   spaciness: 'roomy',
   insaneMode: false,
+  showTopSites: true,
 };
 
 const createSettingsMock = (
@@ -230,3 +231,24 @@ it('should mutate open links in new tab setting', () =>
     ) as HTMLInputElement;
     fireEvent.click(checkbox);
   }));
+
+it('should not have the show top sites switch in the webapp', async () => {
+  renderComponent([], null);
+  const checkbox = screen.queryByText('Show top sites');
+  expect(checkbox).not.toBeInTheDocument();
+});
+
+it('should mutate show top sites setting in extension', () => {
+  process.env.TARGET_BROWSER = 'chrome';
+  testSettingsMutation({ showTopSites: false }, async () => {
+    const checkboxes = await screen.findAllByRole('checkbox');
+    const checkbox = checkboxes.find((el) =>
+      // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
+      queryByText(el.parentElement, 'Show top sites'),
+    ) as HTMLInputElement;
+
+    await waitFor(() => expect(checkbox).toBeChecked());
+
+    fireEvent.click(checkbox);
+  });
+});

--- a/packages/shared/src/components/Settings.tsx
+++ b/packages/shared/src/components/Settings.tsx
@@ -24,6 +24,7 @@ const densities = [
   { label: 'Roomy', value: 'roomy' },
   { label: 'Cozy', value: 'cozy' },
 ];
+const isExtension = process.env.TARGET_BROWSER;
 
 export default function Settings({
   panelMode = false,
@@ -44,6 +45,8 @@ export default function Settings({
     toggleOpenNewTab,
     insaneMode,
     toggleInsaneMode,
+    showTopSites,
+    toggleShowTopSites,
   } = useContext(SettingsContext);
   const [themes, setThemes] = useState([
     { label: 'Dark', value: 'dark' },
@@ -157,6 +160,18 @@ export default function Settings({
           >
             Open links in new tab
           </Switch>
+          {isExtension && (
+            <Switch
+              inputId="top-sites-switch"
+              name="top-sites"
+              className="my-3 big"
+              checked={showTopSites}
+              onToggle={toggleShowTopSites}
+              compact={false}
+            >
+              Show top sites
+            </Switch>
+          )}
         </div>
       </Section>
       <Section className="tablet:hidden">

--- a/packages/shared/src/contexts/AnalyticsContext.spec.tsx
+++ b/packages/shared/src/contexts/AnalyticsContext.spec.tsx
@@ -40,11 +40,13 @@ const settings: SettingsContextData = {
   setTheme: jest.fn(),
   themeMode: 'light',
   insaneMode: true,
+  showTopSites: true,
   toggleInsaneMode: jest.fn(),
   openNewTab: true,
   setSpaciness: jest.fn(),
   toggleOpenNewTab: jest.fn(),
   toggleShowOnlyUnreadPosts: jest.fn(),
+  toggleShowTopSites: jest.fn(),
   showOnlyUnreadPosts: false,
 };
 

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -28,11 +28,13 @@ export type SettingsContextData = {
   showOnlyUnreadPosts: boolean;
   openNewTab: boolean;
   insaneMode: boolean;
+  showTopSites: boolean;
   setTheme: (theme) => Promise<void>;
   toggleShowOnlyUnreadPosts: () => Promise<void>;
   toggleOpenNewTab: () => Promise<void>;
   setSpaciness: (density: Spaciness) => Promise<void>;
   toggleInsaneMode: () => Promise<void>;
+  toggleShowTopSites: () => Promise<void>;
   loadedSettings: boolean;
 };
 
@@ -44,6 +46,7 @@ type Settings = {
   showOnlyUnreadPosts: boolean;
   openNewTab: boolean;
   insaneMode: boolean;
+  showTopSites: boolean;
 };
 
 const deprecatedLightModeStorageKey = 'showmethelight';
@@ -53,6 +56,7 @@ const defaultSettings: Settings = {
   showOnlyUnreadPosts: false,
   openNewTab: true,
   insaneMode: false,
+  showTopSites: true,
 };
 
 function applyTheme(themeMode: string): void {
@@ -186,6 +190,8 @@ export const SettingsContextProvider = ({
         setSettings({ ...settings, spaciness: density }),
       toggleInsaneMode: () =>
         setSettings({ ...settings, insaneMode: !settings.insaneMode }),
+      toggleShowTopSites: () =>
+        setSettings({ ...settings, showTopSites: !settings.showTopSites }),
       loadedSettings,
     }),
     [settings, loadedSettings, userId, currentTheme],

--- a/packages/shared/src/graphql/settings.ts
+++ b/packages/shared/src/graphql/settings.ts
@@ -9,6 +9,7 @@ export type RemoteSettings = {
   theme: RemoteTheme;
   spaciness: Spaciness;
   insaneMode: boolean;
+  showTopSites: boolean;
 };
 
 export type UserSettingsData = { userSettings: RemoteSettings };
@@ -21,6 +22,7 @@ export const USER_SETTINGS_QUERY = gql`
       theme
       spaciness
       insaneMode
+      showTopSites
     }
   }
 `;

--- a/packages/webapp/__tests__/BookmarksPage.tsx
+++ b/packages/webapp/__tests__/BookmarksPage.tsx
@@ -77,6 +77,8 @@ const renderComponent = (
     insaneMode: false,
     loadedSettings: true,
     toggleInsaneMode: jest.fn(),
+    showTopSites: true,
+    toggleShowTopSites: jest.fn(),
   };
   return render(
     <QueryClientProvider client={client}>

--- a/packages/webapp/__tests__/BookmarksSearchPage.tsx
+++ b/packages/webapp/__tests__/BookmarksSearchPage.tsx
@@ -79,6 +79,8 @@ const renderComponent = (
     insaneMode: false,
     loadedSettings: true,
     toggleInsaneMode: jest.fn(),
+    showTopSites: true,
+    toggleShowTopSites: jest.fn(),
   };
   return render(
     <QueryClientProvider client={client}>

--- a/packages/webapp/__tests__/MostDiscussedPage.tsx
+++ b/packages/webapp/__tests__/MostDiscussedPage.tsx
@@ -74,6 +74,8 @@ const renderComponent = (
     insaneMode: false,
     loadedSettings: true,
     toggleInsaneMode: jest.fn(),
+    showTopSites: true,
+    toggleShowTopSites: jest.fn(),
   };
   return render(
     <QueryClientProvider client={client}>

--- a/packages/webapp/__tests__/MostUpvotedPage.tsx
+++ b/packages/webapp/__tests__/MostUpvotedPage.tsx
@@ -74,6 +74,8 @@ const renderComponent = (
     insaneMode: false,
     loadedSettings: true,
     toggleInsaneMode: jest.fn(),
+    showTopSites: true,
+    toggleShowTopSites: jest.fn(),
   };
   return render(
     <QueryClientProvider client={client}>

--- a/packages/webapp/__tests__/PopularPage.tsx
+++ b/packages/webapp/__tests__/PopularPage.tsx
@@ -78,6 +78,8 @@ const renderComponent = (
     insaneMode: false,
     loadedSettings: true,
     toggleInsaneMode: jest.fn(),
+    showTopSites: true,
+    toggleShowTopSites: jest.fn(),
   };
   return render(
     <QueryClientProvider client={client}>

--- a/packages/webapp/__tests__/RecentPage.tsx
+++ b/packages/webapp/__tests__/RecentPage.tsx
@@ -77,6 +77,8 @@ const renderComponent = (
     insaneMode: false,
     loadedSettings: true,
     toggleInsaneMode: jest.fn(),
+    showTopSites: true,
+    toggleShowTopSites: jest.fn(),
   };
   return render(
     <QueryClientProvider client={client}>

--- a/packages/webapp/__tests__/SearchPage.tsx
+++ b/packages/webapp/__tests__/SearchPage.tsx
@@ -84,6 +84,8 @@ const renderComponent = (
     insaneMode: false,
     loadedSettings: true,
     toggleInsaneMode: jest.fn(),
+    showTopSites: true,
+    toggleShowTopSites: jest.fn(),
   };
   return render(
     <QueryClientProvider client={client}>

--- a/packages/webapp/__tests__/SourcePage.tsx
+++ b/packages/webapp/__tests__/SourcePage.tsx
@@ -108,6 +108,8 @@ const renderComponent = (
     insaneMode: false,
     loadedSettings: true,
     toggleInsaneMode: jest.fn(),
+    showTopSites: true,
+    toggleShowTopSites: jest.fn(),
   };
   return render(
     <QueryClientProvider client={client}>

--- a/packages/webapp/__tests__/TagPage.tsx
+++ b/packages/webapp/__tests__/TagPage.tsx
@@ -99,6 +99,8 @@ const renderComponent = (
     insaneMode: false,
     loadedSettings: true,
     toggleInsaneMode: jest.fn(),
+    showTopSites: true,
+    toggleShowTopSites: jest.fn(),
   };
   return render(
     <QueryClientProvider client={client}>


### PR DESCRIPTION
DD-252 #done 
We used to have a toggle to turn off the top sites that are shown in the extension.

Since this is an extension only feature, I decided to only show the settings toggle on the extension.

For reference:
The webapp:
![Screenshot 2021-11-17 at 10 44 29](https://user-images.githubusercontent.com/554874/142172033-835393e9-dcad-446b-bd48-e0e0d969f767.png)

Then the default state for the extension:
You can see the toggle default to true and the top sites are shown.
![Screenshot 2021-11-17 at 10 44 41](https://user-images.githubusercontent.com/554874/142172063-f65bff41-205d-4eeb-ab7b-7f05c8d12eb9.png)

When toggled off the top sites are removed:
![Screenshot 2021-11-17 at 10 44 46](https://user-images.githubusercontent.com/554874/142172161-3189bb6f-5f34-4233-bbb6-d0be49c0f8ec.png)

Added the following tests 🧪
- Check if the switch is not shown in the webapp
- Check that the switch is shown in the extension
- - And the default is true
- - And that it changes the mutation to false on click

Note:
Be aware I needed to add the `showTopSites` and `toggleShowTopSites` to the SettingsContext so it includes a lot of test where this is added.