### PR TITLE
feat: delete account

### DIFF
--- a/packages/shared/src/components/modals/AccountDetailsModal.tsx
+++ b/packages/shared/src/components/modals/AccountDetailsModal.tsx
@@ -18,6 +18,8 @@ import { ModalProps } from './StyledModal';
 import { ProfileHeading } from '../utilities';
 import styles from './AccountDetailsModal.module.css';
 import classed from '../../lib/classed';
+import DeleteAccountModal from './DeleteAccountModal';
+import DeletedAccountConfirmationModal from './DeletedAccountConfirmationModal';
 
 const FooterLink = classed(
   'a',
@@ -30,116 +32,134 @@ export default function AccountDetailsModal({
 }: ModalProps): ReactElement {
   const { user, logout, deleteAccount } = useContext(AuthContext);
 
+  const [showDeleteAccount, setShowDeleteAccount] = useState(false);
+  const [deletedAccount, setDeletedAccount] = useState(false);
   const [disableSubmit, setDisableSubmit] = useState<boolean>(false);
 
   return (
-    <ResponsiveModal
-      className={classNames(className, styles.accountDetailsModal)}
-      {...props}
-    >
-      <header className="flex fixed responsiveModalBreakpoint:sticky top-0 left-0 z-3 justify-between items-center px-4 w-full h-12 border-b bg-theme-bg-secondary border-theme-divider-tertiary">
-        <Button
-          title="Close"
-          onClick={props.onRequestClose}
-          icon={<XIcon />}
-          className="btn-tertiary"
-        />
-        <Button
-          buttonSize="small"
-          type="submit"
-          disabled={disableSubmit}
-          form="profileForm"
-          className="btn-primary"
-        >
-          Save changes
-        </Button>
-      </header>
-      <div className="px-4 pt-6 pb-4">
-        <ProfileHeading>Account Details</ProfileHeading>
-        <EditImageWithJoinedDate user={user} />
-        <ProfileForm
-          id="profileForm"
-          setDisableSubmit={setDisableSubmit}
-          onSuccessfulSubmit={() => props.onRequestClose(null)}
-          mode="update"
-        />
-      </div>
-      <footer className="flex flex-col px-4 pb-6 -my-1">
-        <FooterLink href={faq} target="_blank" rel="noopener">
-          FAQ
-        </FooterLink>
-        <FooterLink href={requestFeature} target="_blank" rel="noopener">
-          Request a feature
-        </FooterLink>
-        <FooterLink href={reportIssue} target="_blank" rel="noopener">
-          Report an issue
-        </FooterLink>
-        <FooterLink href={privacyPolicy} target="_blank" rel="noopener">
-          Privacy policy
-        </FooterLink>
-        <FooterLink href={cookiePolicy} target="_blank" rel="noopener">
-          Cookie policy
-        </FooterLink>
-        <FooterLink href={termsOfService} target="_blank" rel="noopener">
-          Terms of service
-        </FooterLink>
-        {user.premium && (
-          <FooterLink
-            href="mailto:support@daily.dev?subject=Cancel my premium subscription"
-            target="_blank"
-            rel="noopener"
+    <>
+      <ResponsiveModal
+        className={classNames(className, styles.accountDetailsModal)}
+        {...props}
+      >
+        <header className="flex fixed responsiveModalBreakpoint:sticky top-0 left-0 z-3 justify-between items-center px-4 w-full h-12 border-b bg-theme-bg-secondary border-theme-divider-tertiary">
+          <Button
+            title="Close"
+            onClick={props.onRequestClose}
+            icon={<XIcon />}
+            className="btn-tertiary"
+          />
+          <Button
+            buttonSize="small"
+            type="submit"
+            disabled={disableSubmit}
+            form="profileForm"
+            className="btn-primary"
           >
-            Cancel subscription
+            Save changes
+          </Button>
+        </header>
+        <div className="px-4 pt-6 pb-4">
+          <ProfileHeading>Account Details</ProfileHeading>
+          <EditImageWithJoinedDate user={user} />
+          <ProfileForm
+            id="profileForm"
+            setDisableSubmit={setDisableSubmit}
+            onSuccessfulSubmit={() => props.onRequestClose(null)}
+            mode="update"
+          />
+        </div>
+        <footer className="flex flex-col px-4 pb-6 -my-1">
+          <FooterLink href={faq} target="_blank" rel="noopener">
+            FAQ
           </FooterLink>
-        )}
-        <Button
-          onClick={logout}
-          buttonSize="small"
-          className="self-start mt-5 btn-tertiary"
-        >
-          Logout
-        </Button>
-      </footer>
-      <section className="px-4 pb-10 flex flex-col">
-        <strong className="typo-headline text-theme-status-error mb-4">
-          Danger Zone
-        </strong>
-        <p className="typo-callout text-theme-label-tertiary">
-          Deleting your account will:
-          <br />
-          <br />
-          <ol>
-            <li>
-              1. Permanently delete your profile, along with your authentication
-              associations.
-            </li>
-            <li>
-              2. Permanently delete all your content, including your articles,
-              bookmarks, comments, upvotes, etc.
-            </li>
-            <li>3. Allow your username to become available to anyone.</li>
-          </ol>
-          <br />
-          Important: deleting your account is unrecoverable and cannot be
-          undone. Feel free to contact{' '}
-          <a
-            className="text-theme-label-link"
-            href="mailto:support@daily.dev?subject=I have a question about deleting my account"
-            target="_blank"
-            rel="noopener"
+          <FooterLink href={requestFeature} target="_blank" rel="noopener">
+            Request a feature
+          </FooterLink>
+          <FooterLink href={reportIssue} target="_blank" rel="noopener">
+            Report an issue
+          </FooterLink>
+          <FooterLink href={privacyPolicy} target="_blank" rel="noopener">
+            Privacy policy
+          </FooterLink>
+          <FooterLink href={cookiePolicy} target="_blank" rel="noopener">
+            Cookie policy
+          </FooterLink>
+          <FooterLink href={termsOfService} target="_blank" rel="noopener">
+            Terms of service
+          </FooterLink>
+          {user.premium && (
+            <FooterLink
+              href="mailto:support@daily.dev?subject=Cancel my premium subscription"
+              target="_blank"
+              rel="noopener"
+            >
+              Cancel subscription
+            </FooterLink>
+          )}
+          <Button
+            onClick={logout}
+            buttonSize="small"
+            className="self-start mt-5 btn-tertiary"
           >
-            support@daily.dev
-          </a>{' '}
-          with any questions.
-        </p>
-        <Button
-          onClick={deleteAccount}
-          buttonSize="small"
-          className="self-start mt-5 btn-primary-ketchup text-theme-label-primary"
-        >
-          Delete account
-        </Button>
-      </section>
-    </ResponsiveModal>
+            Logout
+          </Button>
+        </footer>
+        <section className="flex flex-col px-4 pb-10">
+          <strong className="mb-4 typo-headline text-theme-status-error">
+            Danger Zone
+          </strong>
+          <p className="typo-callout text-theme-label-tertiary">
+            Deleting your account will:
+            <br />
+            <br />
+            <ol>
+              <li>
+                1. Permanently delete your profile, along with your
+                authentication associations.
+              </li>
+              <li>
+                2. Permanently delete all your content, including your articles,
+                bookmarks, comments, upvotes, etc.
+              </li>
+              <li>3. Allow your username to become available to anyone.</li>
+            </ol>
+            <br />
+            Important: deleting your account is unrecoverable and cannot be
+            undone. Feel free to contact{' '}
+            <a
+              className="text-theme-label-link"
+              href="mailto:support@daily.dev?subject=I have a question about deleting my account"
+              target="_blank"
+              rel="noopener"
+            >
+              support@daily.dev
+            </a>{' '}
+            with any questions.
+          </p>
+          <Button
+            onClick={() => setShowDeleteAccount(true)}
+            buttonSize="small"
+            className="self-start mt-5 btn-primary-ketchup text-theme-label-primary"
+          >
+            Delete account
+          </Button>
+        </section>
+      </ResponsiveModal>
+      {showDeleteAccount && (
+        <DeleteAccountModal
+          deleteAccount={deleteAccount}
+          isOpen={showDeleteAccount}
+          onDelete={() => setDeletedAccount(true)}
+          onRequestClose={() => setShowDeleteAccount(false)}
+        />
+      )}
+      {deletedAccount && (
+        <DeletedAccountConfirmationModal
+          isOpen={deletedAccount}
+          onRequestClose={() => window.location.reload()}
+        />
+      )}
+    </>
   );
 }

--- a/packages/shared/src/components/modals/AccountDetailsModal.tsx
+++ b/packages/shared/src/components/modals/AccountDetailsModal.tsx
@@ -59,7 +59,7 @@ export default function AccountDetailsModal({
             Save changes
           </Button>
         </header>
-        <div className="px-4 pt-6 pb-4">
+        <div className="responsiveModalBreakpoint:px-10 pt-6 pb-4 px-6z">
           <ProfileHeading>Account Details</ProfileHeading>
           <EditImageWithJoinedDate user={user} />
           <ProfileForm
@@ -69,7 +69,7 @@ export default function AccountDetailsModal({
             mode="update"
           />
         </div>
-        <footer className="flex flex-col px-4 pb-6 -my-1">
+        <footer className="flex flex-col px-6 responsiveModalBreakpoint:px-10 pb-6 -my-1">
           <FooterLink href={faq} target="_blank" rel="noopener">
             FAQ
           </FooterLink>
@@ -100,12 +100,12 @@ export default function AccountDetailsModal({
           <Button
             onClick={logout}
             buttonSize="small"
-            className="self-start mt-5 btn-tertiary"
+            className="self-start mt-5 btn-secondary"
           >
             Logout
           </Button>
         </footer>
-        <section className="flex flex-col px-4 pb-10">
+        <section className="flex flex-col px-6 responsiveModalBreakpoint:px-10 pb-10">
           <strong className="mb-4 typo-headline text-theme-status-error">
             Danger Zone
           </strong>
@@ -140,7 +140,7 @@ export default function AccountDetailsModal({
           <Button
             onClick={() => setShowDeleteAccount(true)}
             buttonSize="small"
-            className="self-start mt-5 btn-primary-ketchup text-theme-label-primary"
+            className="self-start mt-6 btn-primary-ketchup text-theme-label-primary"
           >
             Delete account
           </Button>

--- a/packages/shared/src/components/modals/AccountDetailsModal.tsx
+++ b/packages/shared/src/components/modals/AccountDetailsModal.tsx
@@ -28,7 +28,7 @@ export default function AccountDetailsModal({
   className,
   ...props
 }: ModalProps): ReactElement {
-  const { user, logout } = useContext(AuthContext);
+  const { user, logout, deleteAccount } = useContext(AuthContext);
 
   const [disableSubmit, setDisableSubmit] = useState<boolean>(false);
 
@@ -64,7 +64,7 @@ export default function AccountDetailsModal({
           mode="update"
         />
       </div>
-      <footer className="flex flex-col px-4 pb-10 -my-1">
+      <footer className="flex flex-col px-4 pb-6 -my-1">
         <FooterLink href={faq} target="_blank" rel="noopener">
           FAQ
         </FooterLink>
@@ -100,6 +100,46 @@ export default function AccountDetailsModal({
           Logout
         </Button>
       </footer>
+      <section className="px-4 pb-10 flex flex-col">
+        <strong className="typo-headline text-theme-status-error mb-4">
+          Danger Zone
+        </strong>
+        <p className="typo-callout text-theme-label-tertiary">
+          Deleting your account will:
+          <br />
+          <br />
+          <ol>
+            <li>
+              1. Permanently delete your profile, along with your authentication
+              associations.
+            </li>
+            <li>
+              2. Permanently delete all your content, including your articles,
+              bookmarks, comments, upvotes, etc.
+            </li>
+            <li>3. Allow your username to become available to anyone.</li>
+          </ol>
+          <br />
+          Important: deleting your account is unrecoverable and cannot be
+          undone. Feel free to contact{' '}
+          <a
+            className="text-theme-label-link"
+            href="mailto:support@daily.dev?subject=I have a question about deleting my account"
+            target="_blank"
+            rel="noopener"
+          >
+            support@daily.dev
+          </a>{' '}
+          with any questions.
+        </p>
+        <Button
+          onClick={deleteAccount}
+          buttonSize="small"
+          className="self-start mt-5 btn-primary-ketchup text-theme-label-primary"
+        >
+          Delete account
+        </Button>
+      </section>
     </ResponsiveModal>
   );
 }

--- a/packages/shared/src/components/modals/AccountDetailsModal.tsx
+++ b/packages/shared/src/components/modals/AccountDetailsModal.tsx
@@ -59,7 +59,7 @@ export default function AccountDetailsModal({
             Save changes
           </Button>
         </header>
-        <div className="responsiveModalBreakpoint:px-10 pt-6 pb-4 px-6z">
+        <div className="mobileL:px-10 pt-6 pb-4 px-6">
           <ProfileHeading>Account Details</ProfileHeading>
           <EditImageWithJoinedDate user={user} />
           <ProfileForm
@@ -69,7 +69,7 @@ export default function AccountDetailsModal({
             mode="update"
           />
         </div>
-        <footer className="flex flex-col px-6 responsiveModalBreakpoint:px-10 pb-6 -my-1">
+        <footer className="flex flex-col px-6 mobileL:px-10 pb-6 -my-1">
           <FooterLink href={faq} target="_blank" rel="noopener">
             FAQ
           </FooterLink>
@@ -105,7 +105,7 @@ export default function AccountDetailsModal({
             Logout
           </Button>
         </footer>
-        <section className="flex flex-col px-6 responsiveModalBreakpoint:px-10 pb-10">
+        <section className="flex flex-col px-6 mobileL:px-10 pb-10">
           <strong className="mb-4 typo-headline text-theme-status-error">
             Danger Zone
           </strong>

--- a/packages/shared/src/components/modals/AccountDetailsModal.tsx
+++ b/packages/shared/src/components/modals/AccountDetailsModal.tsx
@@ -59,7 +59,7 @@ export default function AccountDetailsModal({
             Save changes
           </Button>
         </header>
-        <div className="mobileL:px-10 pt-6 pb-4 px-6">
+        <div className="px-6 mobileL:px-10 pt-6 pb-4">
           <ProfileHeading>Account Details</ProfileHeading>
           <EditImageWithJoinedDate user={user} />
           <ProfileForm

--- a/packages/shared/src/components/modals/DeleteAccountModal.spec.tsx
+++ b/packages/shared/src/components/modals/DeleteAccountModal.spec.tsx
@@ -1,0 +1,62 @@
+import { render, RenderResult, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { LoggedUser } from '../../lib/user';
+import AuthContext from '../../contexts/AuthContext';
+import DeleteAccountModal from './DeleteAccountModal';
+
+const deleteAccount = jest.fn();
+
+const onRequestClose = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const defaultUser = {
+  id: 'u1',
+  username: 'idoshamun',
+  name: 'Ido Shamun',
+  providers: ['github'],
+  email: 'ido@acme.com',
+  image: 'https://daily.dev/ido.png',
+  infoConfirmed: true,
+  premium: false,
+  createdAt: '2020-07-26T13:04:35.000Z',
+};
+
+const renderComponent = (user: Partial<LoggedUser> = {}): RenderResult => {
+  return render(
+    <AuthContext.Provider
+      value={{
+        user: { ...defaultUser, ...user },
+        shouldShowLogin: false,
+        showLogin: jest.fn(),
+        updateUser: jest.fn(),
+        deleteAccount,
+        tokenRefreshed: true,
+      }}
+    >
+      <DeleteAccountModal
+        isOpen
+        deleteAccount={deleteAccount}
+        onDelete={jest.fn()}
+        onRequestClose={onRequestClose}
+        ariaHideApp={false}
+      />
+    </AuthContext.Provider>,
+  );
+};
+
+it('should close modal on cancel', async () => {
+  renderComponent();
+  const el = await screen.findByText('Cancel');
+  el.click();
+  expect(onRequestClose).toBeCalledTimes(1);
+});
+
+it('should send deleteAccount action', async () => {
+  renderComponent();
+  const el = await screen.findByText('Delete');
+  el.click();
+  await waitFor(() => expect(deleteAccount).toBeCalledTimes(1));
+});

--- a/packages/shared/src/components/modals/DeleteAccountModal.tsx
+++ b/packages/shared/src/components/modals/DeleteAccountModal.tsx
@@ -1,0 +1,58 @@
+import React, { ReactElement, MouseEvent, useState } from 'react';
+import { Button } from '../buttons/Button';
+import { ModalProps } from './StyledModal';
+import {
+  ConfirmationModal,
+  ConfirmationHeading,
+  ConfirmationDescription,
+  ConfirmationButtons,
+} from './ConfirmationModal';
+
+export interface Props extends ModalProps {
+  deleteAccount: () => unknown;
+  onDelete: () => unknown;
+}
+
+export default function DeleteAccountModal({
+  deleteAccount,
+  onDelete,
+  ...props
+}: Props): ReactElement {
+  const [deleting, setDeleting] = useState<boolean>(false);
+
+  const onBanPost = async (event: MouseEvent): Promise<void> => {
+    if (deleting) {
+      return;
+    }
+    setDeleting(true);
+    try {
+      await deleteAccount();
+      onDelete();
+      props.onRequestClose(event);
+    } catch (err) {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <ConfirmationModal {...props}>
+      <ConfirmationHeading>Delete Account</ConfirmationHeading>
+      <ConfirmationDescription>
+        Are you sure you want to delete your account? This action cannot be
+        undone.
+      </ConfirmationDescription>
+      <ConfirmationButtons>
+        <Button className="btn-secondary" onClick={props.onRequestClose}>
+          Cancel
+        </Button>
+        <Button
+          className="btn-primary-ketchup"
+          loading={deleting}
+          onClick={onBanPost}
+        >
+          Delete
+        </Button>
+      </ConfirmationButtons>
+    </ConfirmationModal>
+  );
+}

--- a/packages/shared/src/components/modals/DeleteAccountModal.tsx
+++ b/packages/shared/src/components/modals/DeleteAccountModal.tsx
@@ -20,7 +20,7 @@ export default function DeleteAccountModal({
 }: Props): ReactElement {
   const [deleting, setDeleting] = useState<boolean>(false);
 
-  const onBanPost = async (event: MouseEvent): Promise<void> => {
+  const onDeleteAccount = async (event: MouseEvent): Promise<void> => {
     if (deleting) {
       return;
     }
@@ -48,7 +48,7 @@ export default function DeleteAccountModal({
         <Button
           className="btn-primary-ketchup"
           loading={deleting}
-          onClick={onBanPost}
+          onClick={onDeleteAccount}
         >
           Delete
         </Button>

--- a/packages/shared/src/components/modals/DeletedAccountConfirmationModal.tsx
+++ b/packages/shared/src/components/modals/DeletedAccountConfirmationModal.tsx
@@ -1,0 +1,31 @@
+import React, { ReactElement } from 'react';
+import { ModalProps } from './StyledModal';
+import {
+  ConfirmationButtons,
+  ConfirmationDescription,
+  ConfirmationHeading,
+  ConfirmationModal,
+} from './ConfirmationModal';
+import { Button } from '../buttons/Button';
+import Icon from '../../../icons/v.svg';
+
+export default function DeletedAccountConfirmationModal({
+  ...props
+}: ModalProps): ReactElement {
+  const { onRequestClose } = props;
+  return (
+    <ConfirmationModal {...props}>
+      <Icon style={{ fontSize: '4rem' }} />
+      <ConfirmationHeading>Account deleted successfully</ConfirmationHeading>
+      <ConfirmationDescription>
+        We deleted your personal information and removed the content associated
+        with your profile.
+      </ConfirmationDescription>
+      <ConfirmationButtons>
+        <Button className="btn-primary-avocado" onClick={onRequestClose}>
+          Thanks!
+        </Button>
+      </ConfirmationButtons>
+    </ConfirmationModal>
+  );
+}

--- a/packages/shared/src/contexts/AuthContext.tsx
+++ b/packages/shared/src/contexts/AuthContext.tsx
@@ -3,7 +3,7 @@ import {
   AnonymousUser,
   LoggedUser,
   logout as dispatchLogout,
-  deleteAccount as dispatchDeleteAccount,
+  deleteAccount,
 } from '../lib/user';
 import { LoginModalMode } from '../types/LoginModalMode';
 import { Visit } from '../lib/boot';
@@ -34,10 +34,6 @@ export default AuthContext;
 const logout = async (): Promise<void> => {
   await dispatchLogout();
   window.location.reload();
-};
-
-const deleteAccount = async (): Promise<void> => {
-  await dispatchDeleteAccount();
 };
 
 export type AuthContextProviderProps = {

--- a/packages/shared/src/contexts/AuthContext.tsx
+++ b/packages/shared/src/contexts/AuthContext.tsx
@@ -3,6 +3,7 @@ import {
   AnonymousUser,
   LoggedUser,
   logout as dispatchLogout,
+  deleteAccount as dispatchDeleteAccount,
 } from '../lib/user';
 import { LoginModalMode } from '../types/LoginModalMode';
 import { Visit } from '../lib/boot';
@@ -24,6 +25,7 @@ export interface AuthContextData {
   getRedirectUri: () => string;
   anonymous?: AnonymousUser;
   visit?: Visit;
+  deleteAccount?: () => Promise<void>;
 }
 
 const AuthContext = React.createContext<AuthContextData>(null);
@@ -31,6 +33,11 @@ export default AuthContext;
 
 const logout = async (): Promise<void> => {
   await dispatchLogout();
+  window.location.reload();
+};
+
+const deleteAccount = async (): Promise<void> => {
+  await dispatchDeleteAccount();
   window.location.reload();
 };
 
@@ -76,6 +83,7 @@ export const AuthContextProvider = ({
       getRedirectUri,
       anonymous: user,
       visit,
+      deleteAccount,
     }),
     [user, loginState, loadingUser, tokenRefreshed, loadedUserFromCache, visit],
   );

--- a/packages/shared/src/contexts/AuthContext.tsx
+++ b/packages/shared/src/contexts/AuthContext.tsx
@@ -38,7 +38,6 @@ const logout = async (): Promise<void> => {
 
 const deleteAccount = async (): Promise<void> => {
   await dispatchDeleteAccount();
-  window.location.reload();
 };
 
 export type AuthContextProviderProps = {

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -80,6 +80,13 @@ export async function logout(): Promise<void> {
   });
 }
 
+export async function deleteAccount() {
+  await fetch(`${apiUrl}/v1/users/delete`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+}
+
 export async function updateProfile(
   profile: UserProfile,
 ): Promise<LoggedUser | APIError> {

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -80,7 +80,7 @@ export async function logout(): Promise<void> {
   });
 }
 
-export async function deleteAccount() {
+export async function deleteAccount(): Promise<void> {
   await fetch(`${apiUrl}/v1/users/delete`, {
     method: 'POST',
     credentials: 'include',

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -81,8 +81,8 @@ export async function logout(): Promise<void> {
 }
 
 export async function deleteAccount(): Promise<void> {
-  await fetch(`${apiUrl}/v1/users/delete`, {
-    method: 'POST',
+  await fetch(`${apiUrl}/v1/users/me`, {
+    method: 'DELETE',
     credentials: 'include',
   });
 }


### PR DESCRIPTION
DD-59 #done

Related PRs:
[API](https://github.com/dailydotdev/daily-api/pull/800) and [Gateway](https://github.com/dailydotdev/daily-gateway/pull/384)

**Description of work:**
Added a danger zone section to the account details modal.

![Screenshot 2021-11-19 at 11 39 15](https://user-images.githubusercontent.com/554874/142600763-59778ff9-ce7f-49e8-a6a6-2e6b7a02a4c8.png)

Clicking on delete account will first invoke a confirmation popup

![Screenshot 2021-11-19 at 11 39 22](https://user-images.githubusercontent.com/554874/142600788-7a88da6f-8e03-453e-9241-2cb0700fbe37.png)

After which a confirmation success popup is shown, clicking this or out of it, will invoke page refresh to cleanup.

![Screenshot 2021-11-19 at 11 39 26](https://user-images.githubusercontent.com/554874/142600803-9c0ef910-ad44-458e-97fe-57d5f234c45f.png)

**Introduced test:**
`DeleteAccountModal` => This test makes sure the deleteAccount function is called.

**Actions:**
Behind the scenes, this will invoke the `me/delete` endpoint on the Gateway,
This will invoke a cleanup for all gateway tables and send a CDC which tells the API to also cleanup in the background.