### PR TITLE
fix: hotfix markdown links

### DIFF
--- a/packages/shared/src/components/Markdown.tsx
+++ b/packages/shared/src/components/Markdown.tsx
@@ -10,7 +10,9 @@ export default function Markdown({
   return (
     <div
       className={styles.markdown}
-      dangerouslySetInnerHTML={{ __html: sanitize(content) }}
+      dangerouslySetInnerHTML={{
+        __html: sanitize(content, { ADD_ATTR: ['target'] }),
+      }}
     />
   );
 }

--- a/packages/shared/src/components/markdown.module.css
+++ b/packages/shared/src/components/markdown.module.css
@@ -30,7 +30,7 @@
     @apply whitespace-pre-wrap;
   }
   & :not(pre) > code {
-    @apply bg-theme-float border border-theme-divider-quaternary px-2 py-1 mx-1 rounded-6;
+    @apply bg-theme-float typo-footnote border border-theme-divider-quaternary px-1 rounded-6;
   }
   & :where(ul) {
     @apply list-disc my-8 pl-8;


### PR DESCRIPTION
Solved a hotfix for the comment links not opening in a new tab.
Also fixed a small issue with inline code styles.