### PR TITLE
refactor: hide publication date

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -7,6 +7,7 @@ import React, {
   useRef,
 } from 'react';
 import classNames from 'classnames';
+import { IBulletTrainFeature } from 'flagsmith';
 import useFeed, { PostItem } from '../hooks/useFeed';
 import { Ad, Post } from '../graphql/posts';
 import AuthContext from '../contexts/AuthContext';
@@ -34,6 +35,7 @@ import AnalyticsContext from '../contexts/AnalyticsContext';
 import { adAnalyticsEvent, postAnalyticsEvent } from '../lib/feed';
 import PostOptionsMenu from './PostOptionsMenu';
 import useNotification from '../hooks/useNotification';
+import FeaturesContext from '../contexts/FeaturesContext';
 
 export type FeedProps<T> = {
   feedQueryKey: unknown[];
@@ -55,6 +57,9 @@ const getStyle = (useList: boolean, spaciness: Spaciness): CSSProperties => {
   return {};
 };
 
+const getShouldDisplayPublishDate = (hideDate: IBulletTrainFeature) =>
+  !hideDate?.enabled ? true : !parseInt(hideDate.value, 10);
+
 export default function Feed<T>({
   feedQueryKey,
   query,
@@ -63,6 +68,10 @@ export default function Feed<T>({
   onEmptyFeed,
   emptyScreen,
 }: FeedProps<T>): ReactElement {
+  const { flags } = useContext(FeaturesContext);
+  const displayPublicationDate = getShouldDisplayPublishDate(
+    flags?.hide_publication_date,
+  );
   const { trackEvent } = useContext(AnalyticsContext);
   const currentSettings = useContext(FeedContext);
   const { user } = useContext(AuthContext);
@@ -213,6 +222,7 @@ export default function Feed<T>({
             index={index}
             row={row}
             column={column}
+            displayPublicationDate={displayPublicationDate}
             columns={virtualizedNumCards}
             key={getFeedItemKey(items, index)}
             useList={useList}

--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -23,6 +23,7 @@ export type FeedItemComponentProps = {
   useList: boolean;
   openNewTab: boolean;
   insaneMode: boolean;
+  displayPublicationDate: boolean;
   nativeShareSupport: boolean;
   postMenuIndex: number | undefined;
   postNotificationIndex: number | undefined;
@@ -104,6 +105,7 @@ export default function FeedItemComponent({
   nativeShareSupport,
   postMenuIndex,
   postNotificationIndex,
+  displayPublicationDate,
   notification,
   showCommentPopupId,
   setShowCommentPopupId,
@@ -130,7 +132,10 @@ export default function FeedItemComponent({
       return (
         <PostTag
           ref={inViewRef}
-          post={item.post}
+          post={{
+            ...item.post,
+            createdAt: displayPublicationDate && item.post.createdAt,
+          }}
           data-testid="postItem"
           onUpvoteClick={(post, upvoted) =>
             onUpvote(post, index, row, column, upvoted)

--- a/packages/shared/src/components/cards/PostCard.spec.tsx
+++ b/packages/shared/src/components/cards/PostCard.spec.tsx
@@ -1,10 +1,7 @@
 import React from 'react';
 import { render, RenderResult, screen, waitFor } from '@testing-library/react';
-import { act } from '@testing-library/react-hooks';
-import { IFlags } from 'flagsmith';
 import { Post } from '../../graphql/posts';
 import { PostCard, PostCardProps } from './PostCard';
-import { FeaturesContextProvider } from '../../contexts/FeaturesContext';
 
 const defaultPost: Post = {
   id: 'e3fd75b62cadd02073a31ee3444975cc',
@@ -61,15 +58,8 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-const renderComponent = (
-  props: Partial<PostCardProps> = {},
-  flags: IFlags = {},
-): RenderResult => {
-  return render(
-    <FeaturesContextProvider flags={flags}>
-      <PostCard {...defaultProps} {...props} />
-    </FeaturesContextProvider>,
-  );
+const renderComponent = (props: Partial<PostCardProps> = {}): RenderResult => {
+  return render(<PostCard {...defaultProps} {...props} />);
 };
 
 it('should call on link click on component left click', async () => {
@@ -117,23 +107,19 @@ it('should call on bookmark click on bookmark button click', async () => {
   );
 });
 
-it('should not display publication date based on features flags', async () => {
-  act(async () => {
-    renderComponent(
-      {},
-      { hide_publication_date: { enabled: true, value: '1' } },
-    );
-    const el = await screen.findByText('Jun 13, 2018');
-    expect(el).not.toBeInTheDocument();
+it('should not display publication date if empty', async () => {
+  renderComponent({
+    ...defaultProps,
+    post: { ...defaultPost, createdAt: null },
   });
+  const el = await screen.findByText('Jun 13, 2018');
+  expect(el).not.toBeInTheDocument();
 });
 
 it('should format publication date', async () => {
-  act(async () => {
-    renderComponent();
-    const el = await screen.findByText('Jun 13, 2018');
-    expect(el).toBeInTheDocument();
-  });
+  renderComponent();
+  const el = await screen.findByText('Jun 13, 2018');
+  expect(el).toBeInTheDocument();
 });
 
 it('should format read time when available', async () => {

--- a/packages/shared/src/components/cards/PostCard.spec.tsx
+++ b/packages/shared/src/components/cards/PostCard.spec.tsx
@@ -107,12 +107,12 @@ it('should call on bookmark click on bookmark button click', async () => {
   );
 });
 
-it('should not display publication date if empty', async () => {
+it('should not display publication date createdAt is empty', async () => {
   renderComponent({
     ...defaultProps,
     post: { ...defaultPost, createdAt: null },
   });
-  const el = await screen.findByText('Jun 13, 2018');
+  const el = screen.queryByText('Jun 13, 2018');
   expect(el).not.toBeInTheDocument();
 });
 

--- a/packages/shared/src/components/cards/PostCard.spec.tsx
+++ b/packages/shared/src/components/cards/PostCard.spec.tsx
@@ -129,9 +129,11 @@ it('should not display publication date based on features flags', async () => {
 });
 
 it('should format publication date', async () => {
-  renderComponent();
-  const el = await screen.findByText('Jun 13, 2018');
-  expect(el).toBeInTheDocument();
+  act(async () => {
+    renderComponent();
+    const el = await screen.findByText('Jun 13, 2018');
+    expect(el).toBeInTheDocument();
+  });
 });
 
 it('should format read time when available', async () => {

--- a/packages/shared/src/components/cards/PostMetadata.tsx
+++ b/packages/shared/src/components/cards/PostMetadata.tsx
@@ -1,20 +1,13 @@
-import React, { ReactElement, ReactNode, useContext, useMemo } from 'react';
-import { IBulletTrainFeature } from 'flagsmith';
+import React, { ReactElement, ReactNode, useMemo } from 'react';
 import classNames from 'classnames';
 import { Post } from '../../graphql/posts';
 import { postDateFormat } from '../../lib/dateFormat';
-import FeaturesContext from '../../contexts/FeaturesContext';
 import classed from '../../lib/classed';
 
 const Separator = classed(
   'div',
   'mx-1 w-0.5 h-0.5 rounded-full bg-theme-label-tertiary',
 );
-
-const shouldDisplayPublishDate = (hidePublicationDate: IBulletTrainFeature) =>
-  !hidePublicationDate?.enabled
-    ? true
-    : !parseInt(hidePublicationDate.value, 10);
 
 export default function PostMetadata({
   post,
@@ -25,9 +18,10 @@ export default function PostMetadata({
   className?: string;
   children?: ReactNode;
 }): ReactElement {
-  const { flags } = useContext(FeaturesContext);
-  const date = useMemo(() => postDateFormat(post.createdAt), [post.createdAt]);
-  const shouldDisplay = shouldDisplayPublishDate(flags?.hide_publication_date);
+  const date = useMemo(
+    () => post.createdAt && postDateFormat(post.createdAt),
+    [post.createdAt],
+  );
 
   return (
     <div
@@ -36,8 +30,8 @@ export default function PostMetadata({
         className,
       )}
     >
-      {shouldDisplay && <time dateTime={post.createdAt}>{date}</time>}
-      {shouldDisplay && !!post.readTime && <Separator />}
+      {!!post.createdAt && <time dateTime={post.createdAt}>{date}</time>}
+      {!!post.createdAt && !!post.readTime && <Separator />}
       {!!post.readTime && (
         <span data-testid="readTime">{post.readTime}m read time</span>
       )}

--- a/packages/shared/src/components/cards/PostMetadata.tsx
+++ b/packages/shared/src/components/cards/PostMetadata.tsx
@@ -1,8 +1,20 @@
 import React, { ReactElement, ReactNode, useContext, useMemo } from 'react';
+import { IBulletTrainFeature } from 'flagsmith';
 import classNames from 'classnames';
 import { Post } from '../../graphql/posts';
 import { postDateFormat } from '../../lib/dateFormat';
 import FeaturesContext from '../../contexts/FeaturesContext';
+import classed from '../../lib/classed';
+
+const Separator = classed(
+  'div',
+  'mx-1 w-0.5 h-0.5 rounded-full bg-theme-label-tertiary',
+);
+
+const shouldDisplayPublishDate = (hidePublicationDate: IBulletTrainFeature) =>
+  !hidePublicationDate?.enabled
+    ? true
+    : !parseInt(hidePublicationDate.value, 10);
 
 export default function PostMetadata({
   post,
@@ -15,6 +27,7 @@ export default function PostMetadata({
 }): ReactElement {
   const { flags } = useContext(FeaturesContext);
   const date = useMemo(() => postDateFormat(post.createdAt), [post.createdAt]);
+  const shouldDisplay = shouldDisplayPublishDate(flags?.hide_publication_date);
 
   return (
     <div
@@ -23,13 +36,11 @@ export default function PostMetadata({
         className,
       )}
     >
-      {flags && !flags.feat_hide_article_date && (
-        <>
-          <time dateTime={post.createdAt}>{date}</time>
-          <div className="mx-1 w-0.5 h-0.5 rounded-full bg-theme-label-tertiary" />
-        </>
+      {shouldDisplay && <time dateTime={post.createdAt}>{date}</time>}
+      {shouldDisplay && !!post.readTime && <Separator />}
+      {!!post.readTime && (
+        <span data-testid="readTime">{post.readTime}m read time</span>
       )}
-      <span data-testid="readTime">{post.readTime}m read time</span>
       {children}
     </div>
   );

--- a/packages/shared/src/components/cards/PostMetadata.tsx
+++ b/packages/shared/src/components/cards/PostMetadata.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement, ReactNode, useMemo } from 'react';
+import React, { ReactElement, ReactNode, useContext, useMemo } from 'react';
 import classNames from 'classnames';
 import { Post } from '../../graphql/posts';
 import { postDateFormat } from '../../lib/dateFormat';
+import FeaturesContext from '../../contexts/FeaturesContext';
 
 export default function PostMetadata({
   post,
@@ -12,6 +13,7 @@ export default function PostMetadata({
   className?: string;
   children?: ReactNode;
 }): ReactElement {
+  const { flags } = useContext(FeaturesContext);
   const date = useMemo(() => postDateFormat(post.createdAt), [post.createdAt]);
 
   return (
@@ -21,13 +23,13 @@ export default function PostMetadata({
         className,
       )}
     >
-      <time dateTime={post.createdAt}>{date}</time>
-      {!!post.readTime && (
+      {flags && !flags.feat_hide_article_date && (
         <>
+          <time dateTime={post.createdAt}>{date}</time>
           <div className="mx-1 w-0.5 h-0.5 rounded-full bg-theme-label-tertiary" />
-          <span data-testid="readTime">{post.readTime}m read time</span>
         </>
       )}
+      <span data-testid="readTime">{post.readTime}m read time</span>
       {children}
     </div>
   );

--- a/packages/shared/src/hooks/feed/useVirtualFeedGrid.ts
+++ b/packages/shared/src/hooks/feed/useVirtualFeedGrid.ts
@@ -4,7 +4,7 @@ import { FeedItem } from '../useFeed';
 import { useVirtualWindow } from '../useVirtualWindow';
 import { Spaciness } from '../../graphql/settings';
 
-export const cardHeightPx = 364;
+export const cardHeightPx = 366;
 export const listHeightPx = 78;
 
 const getFeedGap = (useList: boolean, spaciness: Spaciness): number => {


### PR DESCRIPTION
DD-340 #done

The separator now has 2 conditions for whether to be displayed or not.

The article publication date should also now be depending on our flagsmith value.