### PR TITLE
fix: fix re focus state for tooltips

### DIFF
--- a/packages/shared/src/components/modals/ResponsiveModal.tsx
+++ b/packages/shared/src/components/modals/ResponsiveModal.tsx
@@ -16,6 +16,7 @@ export function ResponsiveModal({
 }: ModalProps): ReactElement {
   useResetScrollForResponsiveModal();
   useHideOnModal(props.isOpen);
+
   return (
     <StyledModal
       {...props}

--- a/packages/shared/src/components/tooltips/SimpleTooltip.tsx
+++ b/packages/shared/src/components/tooltips/SimpleTooltip.tsx
@@ -20,6 +20,7 @@ export function SimpleTooltip({
   content,
   ...props
 }: SimpleTooltipProps): ReactElement {
+  let shouldShow = true;
   const component = useMemo(
     () =>
       React.cloneElement(children, {
@@ -29,11 +30,30 @@ export function SimpleTooltip({
     [children],
   );
 
+  const onTrigger = (_, event) => {
+    if (event.type !== 'focus') {
+      shouldShow = true;
+    }
+  };
+
+  const onUntrigger = (_, event) => {
+    const bodyPath = event.path.filter((path) => document.body === path)[0];
+    if (bodyPath.className === 'ReactModal__Body--open') {
+      shouldShow = false;
+      return;
+    }
+    shouldShow = true;
+  };
+
   return (
     <TippyTooltip
       shouldLoad={getShouldLoadTooltip()}
       {...props}
       content={content}
+      onClick
+      onTrigger={onTrigger}
+      onUntrigger={onUntrigger}
+      onShow={() => shouldShow}
     >
       {component}
     </TippyTooltip>

--- a/packages/shared/src/components/tooltips/SimpleTooltip.tsx
+++ b/packages/shared/src/components/tooltips/SimpleTooltip.tsx
@@ -20,6 +20,11 @@ export function SimpleTooltip({
   content,
   ...props
 }: SimpleTooltipProps): ReactElement {
+  /**
+   * We introduced the `shouldShow` variable to manage a re-focus issue
+   * The old implementation would re-focus the tooltip whenever a modal would close
+   * Read more on the PR: https://github.com/dailydotdev/apps/pull/713
+   */
   let shouldShow = true;
   const component = useMemo(
     () =>

--- a/packages/shared/src/components/tooltips/SimpleTooltip.tsx
+++ b/packages/shared/src/components/tooltips/SimpleTooltip.tsx
@@ -50,7 +50,6 @@ export function SimpleTooltip({
       shouldLoad={getShouldLoadTooltip()}
       {...props}
       content={content}
-      onClick
       onTrigger={onTrigger}
       onUntrigger={onUntrigger}
       onShow={() => shouldShow}


### PR DESCRIPTION
There was an issue with the re-focus from closing modal which would always trigger the focus on tooltips.
To fix this I introduced a local variable that keeps track if the modal was the previous cause.

Do note we can not solve this with setState as this will not trigger since the component is technically still mounting.
Hate to use `let` here but it seems to be the only viable fix.

See video for resolution: (Tab still works, hover works and refocus doesn't show now)

https://user-images.githubusercontent.com/554874/144201177-42188cae-1dbf-47a5-8d02-54921528a041.mp4