### PR TITLE
fix: added optional padding to the responsive modal

### DIFF
--- a/packages/shared/src/components/modals/FeedSettingsModal.tsx
+++ b/packages/shared/src/components/modals/FeedSettingsModal.tsx
@@ -9,7 +9,11 @@ export function FeedSettingsModal({
   ...modalProps
 }: ModalProps): ReactElement {
   return (
-    <ResponsiveModal {...modalProps} onRequestClose={onRequestClose}>
+    <ResponsiveModal
+      {...modalProps}
+      onRequestClose={onRequestClose}
+      padding={false}
+    >
       <header className="py-4 px-6 w-full border-b border-theme-divider-tertiary">
         <h3 className="font-bold typo-title3">Customize</h3>
         <ModalCloseButton onClick={onRequestClose} />

--- a/packages/shared/src/components/modals/ResponsiveModal.module.css
+++ b/packages/shared/src/components/modals/ResponsiveModal.module.css
@@ -15,7 +15,6 @@
     max-width: 30rem;
     min-height: 100%;
     align-items: stretch;
-    padding: 0.5rem;
     border: none;
     border-radius: 0;
 
@@ -25,5 +24,10 @@
       border: 1px solid var(--theme-divider-secondary);
       border-radius: 1rem;
     }
+  }
+}
+.addPadding {
+  & :global(.modal) {
+    padding: 0.5rem;
   }
 }

--- a/packages/shared/src/components/modals/ResponsiveModal.tsx
+++ b/packages/shared/src/components/modals/ResponsiveModal.tsx
@@ -12,6 +12,7 @@ export const responsiveModalBreakpoint = breakpoint;
 
 export function ResponsiveModal({
   className,
+  padding = true,
   ...props
 }: ModalProps): ReactElement {
   useResetScrollForResponsiveModal();
@@ -20,7 +21,11 @@ export function ResponsiveModal({
   return (
     <StyledModal
       {...props}
-      className={classNames(className, styles.responsiveModal)}
+      className={classNames(
+        className,
+        styles.responsiveModal,
+        padding && styles.addPadding,
+      )}
     />
   );
 }

--- a/packages/shared/src/components/modals/StyledModal.tsx
+++ b/packages/shared/src/components/modals/StyledModal.tsx
@@ -4,6 +4,7 @@ import classed from '../../lib/classed';
 import styles from './StyledModal.module.css';
 
 export interface ModalProps extends Modal.Props {
+  padding?: boolean;
   children?: ReactNode;
 }
 

--- a/packages/shared/src/components/modals/UpvotedPopupModal.tsx
+++ b/packages/shared/src/components/modals/UpvotedPopupModal.tsx
@@ -42,9 +42,9 @@ export function UpvotedPopupModal({
     <ResponsiveModal
       {...modalProps}
       onRequestClose={onRequestClose}
+      padding={false}
       style={{
         content: {
-          padding: 0,
           maxHeight: '40rem',
           overflow: 'hidden',
         },


### PR DESCRIPTION
We re-use the responsive modal quite a lot, which is great.

However in some cases we want to remove the main modal's padding as this is per design for the new modal types.
There are quite a lot of these new ones coming, so decided to abstract by adding a padding parameter which is defaulted to true (as still most ones need the padding now)

Example of the first one that doesn't need it is actually the new FeedSettingsModal, but also the UpvotedPopupModal already had a hotfix for this issue.