### PR TITLE
refactor: use graphql-ws as new transport layer

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="CommitMessageInspectionProfile">
-    <profile version="1.0">
-      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
-    </profile>
-  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/packages/extension/package-lock.json
+++ b/packages/extension/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "extension",
-	"version": "3.10.1",
+	"version": "3.10.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/shared/package-lock.json
+++ b/packages/shared/package-lock.json
@@ -5336,11 +5336,6 @@
 				"babel-preset-current-node-syntax": "^1.0.0"
 			}
 		},
-		"backo2": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
-		},
 		"bail": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
@@ -7490,11 +7485,6 @@
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
 			"dev": true
 		},
-		"eventemitter3": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-			"integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
-		},
 		"events": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -8225,6 +8215,11 @@
 					}
 				}
 			}
+		},
+		"graphql-ws": {
+			"version": "5.5.5",
+			"resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.5.5.tgz",
+			"integrity": "sha512-hvyIS71vs4Tu/yUYHPvGXsTgo0t3arU820+lT5VjZS2go0ewp2LqyCgxEN56CzOG7Iys52eRhHBiD1gGRdiQtw=="
 		},
 		"growly": {
 			"version": "1.3.0",
@@ -9152,11 +9147,6 @@
 				"html-escaper": "^2.0.0",
 				"istanbul-lib-report": "^3.0.0"
 			}
-		},
-		"iterall": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-			"integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
 		},
 		"jest": {
 			"version": "26.6.3",
@@ -13884,18 +13874,6 @@
 			"integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
 			"dev": true
 		},
-		"subscriptions-transport-ws": {
-			"version": "0.9.19",
-			"resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.19.tgz",
-			"integrity": "sha512-dxdemxFFB0ppCLg10FTtRqH/31FNRL1y1BQv8209MK5I4CwALb7iihQg+7p65lFcIl8MHatINWBLOqpgU4Kyyw==",
-			"requires": {
-				"backo2": "^1.0.2",
-				"eventemitter3": "^3.1.0",
-				"iterall": "^1.2.1",
-				"symbol-observable": "^1.0.4",
-				"ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-			}
-		},
 		"sugarss": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
@@ -13990,11 +13968,6 @@
 			"resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
 			"integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
 			"dev": true
-		},
-		"symbol-observable": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
 		},
 		"symbol-tree": {
 			"version": "3.2.4",
@@ -15105,7 +15078,8 @@
 		"ws": {
 			"version": "7.4.6",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-			"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+			"integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+			"dev": true
 		},
 		"xml": {
 			"version": "1.0.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -108,10 +108,10 @@
     "amplitude-js": "^8.9.1",
     "balloon-css": "^1.2.0",
     "flagsmith": "^1.6.10",
+    "graphql-ws": "^5.5.5",
     "lazysizes": "^5.3.2",
     "linkifyjs": "^2.1.9",
     "lodash.clonedeep": "^4.5.0",
-    "node-fetch": "^2.6.6",
-    "subscriptions-transport-ws": "^0.9.19"
+    "node-fetch": "^2.6.6"
   }
 }

--- a/packages/shared/src/contexts/SubscriptionContext.tsx
+++ b/packages/shared/src/contexts/SubscriptionContext.tsx
@@ -6,13 +6,13 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { SubscriptionClient } from 'subscriptions-transport-ws';
+import { Client } from 'graphql-ws';
 import { requestIdleCallback } from 'next/dist/client/request-idle-callback';
 import ProgressiveEnhancementContext from './ProgressiveEnhancementContext';
 import AuthContext from './AuthContext';
 
 export interface SubscriptionContextData {
-  subscriptionClient: SubscriptionClient;
+  subscriptionClient: Client;
   connected: boolean;
 }
 
@@ -33,8 +33,7 @@ export const SubscriptionContextProvider = ({
   const { tokenRefreshed } = useContext(AuthContext);
 
   const [connected, setConnected] = useState(false);
-  const [subscriptionClient, setSubscriptionClient] =
-    useState<SubscriptionClient>(null);
+  const [subscriptionClient, setSubscriptionClient] = useState<Client>(null);
 
   useEffect(() => {
     if (windowLoaded && tokenRefreshed) {
@@ -43,7 +42,7 @@ export const SubscriptionContextProvider = ({
           /* webpackChunkName: "subscriptions" */ '../graphql/subscriptions'
         ).then(({ subscriptionClient: loadedSubscriptionClient }) => {
           setSubscriptionClient(loadedSubscriptionClient);
-          loadedSubscriptionClient.onConnected(() => setConnected(true));
+          loadedSubscriptionClient.on('connected', () => setConnected(true));
         });
       });
     }

--- a/packages/shared/src/graphql/subscriptions.ts
+++ b/packages/shared/src/graphql/subscriptions.ts
@@ -1,8 +1,6 @@
-import { SubscriptionClient } from 'subscriptions-transport-ws';
+import { createClient } from 'graphql-ws';
 
-export const subscriptionClient = new SubscriptionClient(
-  process.env.NEXT_PUBLIC_SUBS_URL,
-  {
-    reconnect: true,
-  },
-);
+export const subscriptionClient = createClient({
+  url: process.env.NEXT_PUBLIC_SUBS_URL,
+  lazy: false,
+});

--- a/packages/shared/src/hooks/useSubscription.ts
+++ b/packages/shared/src/hooks/useSubscription.ts
@@ -1,18 +1,13 @@
 import { DependencyList, useContext, useEffect, useRef } from 'react';
-import { OperationOptions } from 'subscriptions-transport-ws';
 import SubscriptionContext from '../contexts/SubscriptionContext';
-
-interface Payload<T> {
-  data: T;
-}
 
 export interface SubscriptionCallbacks<T> {
   next?: (value: T) => unknown;
-  error?: (error: Error) => unknown;
+  error?: (error: unknown) => unknown;
 }
 
 export default function useSubscription<T>(
-  request: () => OperationOptions,
+  request: () => { query: string; variables?: Record<string, unknown> },
   { next, error }: SubscriptionCallbacks<T>,
   deps?: DependencyList,
 ): void {
@@ -30,14 +25,13 @@ export default function useSubscription<T>(
 
   useEffect(() => {
     if (connected) {
-      const observable = subscriptionClient.request(request());
-      const { unsubscribe } = observable.subscribe({
-        next: (value: Payload<T>) => {
-          nextRef.current?.(value.data);
+      return subscriptionClient.subscribe<T>(request(), {
+        next: (value: T) => {
+          nextRef.current?.(value);
         },
         error: (subscribeError) => errorRef.current?.(subscribeError),
+        complete: () => {},
       });
-      return unsubscribe;
     }
     return undefined;
   }, [connected, ...(deps ?? [])]);


### PR DESCRIPTION
`subscriptions-transport-ws` is no longer maintained and the suggested package for GraphQL Subscription is now `graphql-ws` which is also supported by our new API.

DD-288