### PR TITLE
feat: remove all responsive props on the MainLayout

### DIFF
--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -66,7 +66,6 @@ export default function MainFeedPage({
 
   return (
     <MainLayout
-      responsive={false}
       showRank
       greeting
       mainPage

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -24,7 +24,6 @@ import { LinkWithTooltip } from './tooltips/LinkWithTooltip';
 
 export interface MainLayoutProps extends HTMLAttributes<HTMLDivElement> {
   showOnlyLogo?: boolean;
-  responsive?: boolean;
   showRank?: boolean;
   greeting?: boolean;
   mainPage?: boolean;
@@ -45,7 +44,6 @@ const Greeting = dynamic(
 export default function MainLayout({
   children,
   showOnlyLogo,
-  responsive = true,
   showRank,
   greeting,
   mainPage,
@@ -66,15 +64,9 @@ export default function MainLayout({
 
   return (
     <>
-      {!responsive && <PromotionalBanner />}
+      <PromotionalBanner />
       <header
-        className={`${
-          styles.header
-        } relative flex items-center px-4 border-b border-theme-divider-tertiary tablet:px-8 laptop:px-4 ${
-          responsive
-            ? 'laptop:absolute laptop:top-0 laptop:left-0 laptop:w-full laptop:border-b-0'
-            : 'non-responsive-header'
-        }`}
+        className={`${styles.header} relative flex items-center px-4 border-b border-theme-divider-tertiary tablet:px-8 laptop:px-4 non-responsive-header`}
       >
         <LinkWithTooltip
           href={process.env.NEXT_PUBLIC_WEBAPP_URL}

--- a/packages/shared/src/components/PromotionalBanner.tsx
+++ b/packages/shared/src/components/PromotionalBanner.tsx
@@ -8,10 +8,11 @@ import { apiUrl } from '../lib/config';
 import { BANNER_QUERY, BannerData } from '../graphql/banner';
 import ProgressiveEnhancementContext from '../contexts/ProgressiveEnhancementContext';
 import usePersistentState from '../hooks/usePersistentState';
+import { isTesting } from '../lib/constants';
 
 export default function PromotionalBanner(): ReactElement {
   // Disable this component in Jest environment
-  if (typeof jest !== 'undefined') {
+  if (isTesting) {
     return <></>;
   }
   const { windowLoaded } = useContext(ProgressiveEnhancementContext);

--- a/packages/shared/src/components/PromotionalBanner.tsx
+++ b/packages/shared/src/components/PromotionalBanner.tsx
@@ -10,6 +10,10 @@ import ProgressiveEnhancementContext from '../contexts/ProgressiveEnhancementCon
 import usePersistentState from '../hooks/usePersistentState';
 
 export default function PromotionalBanner(): ReactElement {
+  // Disable this component in Jest environment
+  if (typeof jest !== 'undefined') {
+    return <></>;
+  }
   const { windowLoaded } = useContext(ProgressiveEnhancementContext);
   const [lastSeen, setLastSeen] = usePersistentState(
     'lastSeenBanner',

--- a/packages/webapp/components/layouts/BookmarkFeedPage.tsx
+++ b/packages/webapp/components/layouts/BookmarkFeedPage.tsx
@@ -71,7 +71,6 @@ export function getBookmarkFeedLayout(
 }
 
 export const bookmarkFeedLayoutProps: MainLayoutProps = {
-  responsive: false,
   showRank: true,
   greeting: true,
   mainPage: true,

--- a/packages/webapp/components/layouts/MainFeedPage.tsx
+++ b/packages/webapp/components/layouts/MainFeedPage.tsx
@@ -78,7 +78,6 @@ export function getMainFeedLayout(
 }
 
 export const mainFeedLayoutProps: MainLayoutProps = {
-  responsive: false,
   showRank: true,
   greeting: true,
   mainPage: true,

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -285,9 +285,7 @@ export const getLayout = (
   page: ReactNode,
   props: ProfileLayoutProps,
 ): ReactNode =>
-  getMainLayout(<ProfileLayout {...props}>{page}</ProfileLayout>, null, {
-    responsive: false,
-  });
+  getMainLayout(<ProfileLayout {...props}>{page}</ProfileLayout>, null);
 
 interface ProfileParams extends ParsedUrlQuery {
   userId: string;

--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -375,8 +375,5 @@ const DevCardPage = (): ReactElement => {
 };
 
 DevCardPage.getLayout = getMainLayout;
-DevCardPage.layoutProps = {
-  responsive: false,
-};
 
 export default DevCardPage;

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -837,9 +837,6 @@ const PostPage = ({ id, postData }: Props): ReactElement => {
 };
 
 PostPage.getLayout = getMainLayout;
-PostPage.layoutProps = {
-  responsive: false,
-};
 
 export default PostPage;
 


### PR DESCRIPTION
We had some unused occurrences of the responsive prop for the MainLayout.
This actually broke the layout for the reading history page, as it was not passed.

Since we don't use it anywhere, we decided to remove this prop.
This only caused jest not to acknowledge this component use, so decided to render an empty once in Jest only.

Sidenote:
This is also needed for the re-layout