### PR TITLE
feat: profile tooltip

### DIFF
--- a/packages/shared/src/components/TagLinks.tsx
+++ b/packages/shared/src/components/TagLinks.tsx
@@ -1,0 +1,46 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import Link from 'next/link';
+import { Button } from './buttons/Button';
+
+interface TagLinkProps {
+  tag: string;
+  className?: string;
+}
+
+export function TagLink({ tag, className }: TagLinkProps): ReactElement {
+  return (
+    <Link href={`/tags/${tag}`} passHref key={tag}>
+      <Button
+        tag="a"
+        className={classNames('btn-tertiaryFloat xsmall', className)}
+      >
+        #{tag}
+      </Button>
+    </Link>
+  );
+}
+
+interface TagLinksProps {
+  tags: string[];
+  className?: string;
+  tagClassName?: string;
+}
+
+export function TagLinks({
+  tags,
+  className,
+  tagClassName,
+}: TagLinksProps): ReactElement {
+  if (tags.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={classNames('flex flex-wrap gap-2 mt-3 mb-4', className)}>
+      {tags.map((tag) => (
+        <TagLink key={tag} tag={tag} className={tagClassName} />
+      ))}
+    </div>
+  );
+}

--- a/packages/shared/src/components/comments/CommentAuthor.tsx
+++ b/packages/shared/src/components/comments/CommentAuthor.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import { Author } from '../../graphql/comments';
 import { ProfileLink } from '../profile/ProfileLink';
 import FeatherIcon from '../../../icons/feather.svg';
+import { ProfileTooltip } from '../profile/ProfileTooltip';
 
 export interface CommentAuthorProps {
   postAuthorId: string | null;
@@ -13,17 +14,19 @@ export default function CommentAuthor({
   author,
 }: CommentAuthorProps): ReactElement {
   return (
-    <ProfileLink
-      user={author}
-      className="overflow-hidden font-bold whitespace-nowrap commentAuthor text-theme-label-primary typo-callout"
-    >
-      {author.name}
-      {author.id === postAuthorId && (
-        <span className="flex items-center ml-2 text-theme-status-help typo-footnote">
-          <FeatherIcon className="ml-1 text-base icon" />
-          Author
-        </span>
-      )}
-    </ProfileLink>
+    <ProfileTooltip user={author}>
+      <ProfileLink
+        user={author}
+        className="overflow-hidden w-fit font-bold whitespace-nowrap commentAuthor text-theme-label-primary typo-callout"
+      >
+        {author.name}
+        {author.id === postAuthorId && (
+          <span className="flex items-center ml-2 text-theme-status-help typo-footnote">
+            <FeatherIcon className="ml-1 text-base icon" />
+            Author
+          </span>
+        )}
+      </ProfileLink>
+    </ProfileTooltip>
   );
 }

--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import { Comment } from '../../graphql/comments';
+import styles from './comments.module.css';
 import { CommentBox, CommentPublishDate } from './common';
 import CommentActionButtons, {
   CommentActionProps,
@@ -9,13 +10,14 @@ import { ProfileImageLink } from '../profile/ProfileImageLink';
 import CommentAuthor from './CommentAuthor';
 import classed from '../../lib/classed';
 import Markdown from '../Markdown';
+import { ProfileTooltip } from '../profile/ProfileTooltip';
 
 export interface Props extends CommentActionProps {
   comment: Comment;
   postAuthorId: string | null;
 }
 
-const MainCommentBox = classed(CommentBox, 'my-2');
+const MainCommentBox = classed(CommentBox, 'my-2', styles.commentBox);
 
 export default function MainComment({
   comment,
@@ -28,7 +30,9 @@ export default function MainComment({
   return (
     <article className="flex flex-col items-stretch mt-4" data-testid="comment">
       <div className="flex items-center">
-        <ProfileImageLink user={comment.author} />
+        <ProfileTooltip user={comment.author}>
+          <ProfileImageLink user={comment.author} />
+        </ProfileTooltip>
         <div className="flex flex-col ml-2">
           <CommentAuthor postAuthorId={postAuthorId} author={comment.author} />
           <CommentPublishDate comment={comment} />

--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react';
 import { Comment } from '../../graphql/comments';
-import styles from './comments.module.css';
 import { CommentBox, CommentPublishDate } from './common';
 import CommentActionButtons, {
   CommentActionProps,
@@ -17,7 +16,7 @@ export interface Props extends CommentActionProps {
   postAuthorId: string | null;
 }
 
-const MainCommentBox = classed(CommentBox, 'my-2', styles.commentBox);
+const MainCommentBox = classed(CommentBox, 'my-2');
 
 export default function MainComment({
   comment,

--- a/packages/shared/src/components/comments/SubComment.tsx
+++ b/packages/shared/src/components/comments/SubComment.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
-import styles from './comments.module.css';
 import { Comment } from '../../graphql/comments';
 import { CommentBox, CommentPublishDate } from './common';
 import CommentActionButtons, {
@@ -55,7 +54,7 @@ export default function SubComment({
         <SubCommentBox>
           <CommentAuthor postAuthorId={postAuthorId} author={comment.author} />
           <CommentPublishDate comment={comment} />
-          <div className={classNames(styles.commentBox, 'mt-2')}>
+          <div className="mt-2">
             <Markdown content={comment.contentHtml} />
           </div>
         </SubCommentBox>

--- a/packages/shared/src/components/comments/SubComment.tsx
+++ b/packages/shared/src/components/comments/SubComment.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
+import styles from './comments.module.css';
 import { Comment } from '../../graphql/comments';
 import { CommentBox, CommentPublishDate } from './common';
 import CommentActionButtons, {
@@ -42,13 +43,17 @@ export default function SubComment({
             lastComment ? 'h-4' : 'bottom-0',
           )}
         />
-        <ProfileImageLink className="w-8 h-8" user={comment.author} />
+        <ProfileImageLink
+          user={comment.author}
+          picture={{ size: 'medium' }}
+          tooltip={{ content: comment.author.username }}
+        />
       </div>
       <div className="flex flex-col flex-1 items-stretch ml-2">
         <SubCommentBox>
           <CommentAuthor postAuthorId={postAuthorId} author={comment.author} />
           <CommentPublishDate comment={comment} />
-          <div className="mt-2">
+          <div className={classNames(styles.commentBox, 'mt-2')}>
             <Markdown content={comment.contentHtml} />
           </div>
         </SubCommentBox>

--- a/packages/shared/src/components/comments/SubComment.tsx
+++ b/packages/shared/src/components/comments/SubComment.tsx
@@ -10,6 +10,7 @@ import { ProfileImageLink } from '../profile/ProfileImageLink';
 import CommentAuthor from './CommentAuthor';
 import classed from '../../lib/classed';
 import Markdown from '../Markdown';
+import { ProfileTooltip } from '../profile/ProfileTooltip';
 
 export interface Props extends CommentActionProps {
   comment: Comment;
@@ -43,11 +44,12 @@ export default function SubComment({
             lastComment ? 'h-4' : 'bottom-0',
           )}
         />
-        <ProfileImageLink
-          user={comment.author}
-          picture={{ size: 'medium' }}
-          tooltip={{ content: comment.author.username }}
-        />
+        <ProfileTooltip user={comment.author}>
+          <ProfileImageLink
+            user={comment.author}
+            picture={{ size: 'medium' }}
+          />
+        </ProfileTooltip>
       </div>
       <div className="flex flex-col flex-1 items-stretch ml-2">
         <SubCommentBox>

--- a/packages/shared/src/components/comments/comments.module.css
+++ b/packages/shared/src/components/comments/comments.module.css
@@ -1,6 +1,0 @@
-.commentBox {
-  & a:not(:global(.commentAuthor)) {
-    color: var(--theme-label-link);
-    word-break: break-all;
-  }
-}

--- a/packages/shared/src/components/comments/common.tsx
+++ b/packages/shared/src/components/comments/common.tsx
@@ -1,6 +1,5 @@
 import React, { HTMLAttributes, ReactElement, ReactNode } from 'react';
 import classed from '../../lib/classed';
-import styles from './comments.module.css';
 import { Comment } from '../../graphql/comments';
 import { commentDateFormat } from '../../lib/dateFormat';
 
@@ -18,7 +17,8 @@ export function CommentPublishDate({
   );
 }
 
-export const commentBoxClassNames = `py-3 px-4 bg-theme-bg-secondary rounded-lg break-words typo-callout ${styles.commentBox}`;
+export const commentBoxClassNames =
+  'py-3 px-4 bg-theme-bg-secondary rounded-lg break-words typo-callout';
 
 const StyledCommentBox = classed('div', commentBoxClassNames);
 

--- a/packages/shared/src/components/profile/ProfileImageLink.tsx
+++ b/packages/shared/src/components/profile/ProfileImageLink.tsx
@@ -1,18 +1,21 @@
-import React, { ReactElement } from 'react';
+import React, { forwardRef, ReactElement, Ref } from 'react';
 import { ProfileLink, ProfileLinkProps } from './ProfileLink';
 import { ProfilePicture, ProfilePictureProps } from '../ProfilePicture';
 
 interface ProfileImageLinkProps extends ProfileLinkProps {
   picture?: Omit<ProfilePictureProps, 'user'>;
+  ref?: Ref<HTMLAnchorElement>;
 }
 
-export function ProfileImageLink({
-  picture = { size: 'large' },
-  ...props
-}: ProfileImageLinkProps): ReactElement {
+function ProfileImageLinkComponent(
+  { picture = { size: 'large' }, ...props }: ProfileImageLinkProps,
+  ref?: Ref<HTMLAnchorElement>,
+): ReactElement {
   return (
-    <ProfileLink {...props}>
+    <ProfileLink {...props} ref={ref}>
       <ProfilePicture {...picture} user={props.user} />
     </ProfileLink>
   );
 }
+
+export const ProfileImageLink = forwardRef(ProfileImageLinkComponent);

--- a/packages/shared/src/components/profile/ProfileImageLink.tsx
+++ b/packages/shared/src/components/profile/ProfileImageLink.tsx
@@ -1,18 +1,18 @@
 import React, { ReactElement } from 'react';
-import classNames from 'classnames';
 import { ProfileLink, ProfileLinkProps } from './ProfileLink';
-import { ProfilePicture } from '../ProfilePicture';
+import { ProfilePicture, ProfilePictureProps } from '../ProfilePicture';
+
+interface ProfileImageLinkProps extends ProfileLinkProps {
+  picture?: Omit<ProfilePictureProps, 'user'>;
+}
 
 export function ProfileImageLink({
-  className,
+  picture = { size: 'large' },
   ...props
-}: ProfileLinkProps): ReactElement {
+}: ProfileImageLinkProps): ReactElement {
   return (
-    <ProfileLink
-      className={classNames(className, 'block w-10 h-10')}
-      {...props}
-    >
-      <ProfilePicture user={props.user} size="large" />
+    <ProfileLink {...props}>
+      <ProfilePicture {...picture} user={props.user} />
     </ProfileLink>
   );
 }

--- a/packages/shared/src/components/profile/ProfileLink.tsx
+++ b/packages/shared/src/components/profile/ProfileLink.tsx
@@ -1,29 +1,36 @@
 import React, { HTMLAttributes, ReactElement } from 'react';
 import Link from 'next/link';
 import classNames from 'classnames';
-import { PublicProfile } from '../../lib/user';
 import { LinkWithTooltip } from '../tooltips/LinkWithTooltip';
+import { Author } from '../../graphql/comments';
+import { SimpleTooltipProps } from '../tooltips/SimpleTooltip';
+
+export enum ProfileLinkTooltip {
+  Text = 'text',
+  Profile = 'profile',
+  Disabled = 'disabled',
+}
 
 export interface ProfileLinkProps extends HTMLAttributes<HTMLAnchorElement> {
-  user: Pick<PublicProfile, 'image' | 'permalink' | 'username' | 'name'>;
-  disableTooltip?: boolean;
+  user: Author;
+  tooltip?: SimpleTooltipProps;
 }
 
 export function ProfileLink({
   user,
-  disableTooltip,
+  tooltip,
   children,
   className,
   ...props
 }: ProfileLinkProps): ReactElement {
-  const LinkComponent = disableTooltip ? Link : LinkWithTooltip;
+  const LinkComponent = tooltip ? LinkWithTooltip : Link;
 
   return (
     <LinkComponent
       href={user.permalink}
       passHref
       prefetch={false}
-      tooltip={{ content: user.name }}
+      tooltip={tooltip}
     >
       <a
         {...props}

--- a/packages/shared/src/components/profile/ProfileLink.tsx
+++ b/packages/shared/src/components/profile/ProfileLink.tsx
@@ -1,43 +1,28 @@
-import React, { HTMLAttributes, ReactElement } from 'react';
+import React, { forwardRef, HTMLAttributes, ReactElement, Ref } from 'react';
 import Link from 'next/link';
 import classNames from 'classnames';
-import { LinkWithTooltip } from '../tooltips/LinkWithTooltip';
 import { Author } from '../../graphql/comments';
-import { SimpleTooltipProps } from '../tooltips/SimpleTooltip';
-
-export enum ProfileLinkTooltip {
-  Text = 'text',
-  Profile = 'profile',
-  Disabled = 'disabled',
-}
 
 export interface ProfileLinkProps extends HTMLAttributes<HTMLAnchorElement> {
   user: Author;
-  tooltip?: SimpleTooltipProps;
+  ref?: Ref<HTMLAnchorElement>;
 }
 
-export function ProfileLink({
-  user,
-  tooltip,
-  children,
-  className,
-  ...props
-}: ProfileLinkProps): ReactElement {
-  const LinkComponent = tooltip ? LinkWithTooltip : Link;
-
+function ProfileLinkComponent(
+  { user, children, className, ...props }: ProfileLinkProps,
+  ref?: Ref<HTMLAnchorElement>,
+): ReactElement {
   return (
-    <LinkComponent
-      href={user.permalink}
-      passHref
-      prefetch={false}
-      tooltip={tooltip}
-    >
+    <Link href={user.permalink} passHref prefetch={false}>
       <a
         {...props}
+        ref={ref}
         className={classNames(className, 'flex items-center no-underline')}
       >
         {children}
       </a>
-    </LinkComponent>
+    </Link>
   );
 }
+
+export const ProfileLink = forwardRef(ProfileLinkComponent);

--- a/packages/shared/src/components/profile/ProfileTolltipContent.tsx
+++ b/packages/shared/src/components/profile/ProfileTolltipContent.tsx
@@ -48,7 +48,11 @@ export function ProfileTooltipContent({
       <ProfileLink className="text-theme-label-secondary" user={user}>
         @{user.username}
       </ProfileLink>
-      <p className="mt-3 line-clamp-3 text-theme-label-tertiary">{user.bio}</p>
+      {user.bio && (
+        <p className="mt-3 line-clamp-3 text-theme-label-tertiary">
+          {user.bio}
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/shared/src/components/profile/ProfileTolltipContent.tsx
+++ b/packages/shared/src/components/profile/ProfileTolltipContent.tsx
@@ -1,11 +1,5 @@
 import React, { ReactElement } from 'react';
-import request from 'graphql-request';
-import { useQuery } from 'react-query';
-import {
-  UserTooltipContentData,
-  USER_TOOLTIP_CONTENT_QUERY,
-} from '../../graphql/users';
-import { apiUrl } from '../../lib/config';
+import { UserTooltipContentData } from '../../graphql/users';
 import { Author } from '../../graphql/comments';
 import Rank from '../Rank';
 import { ProfileImageLink } from './ProfileImageLink';
@@ -14,19 +8,13 @@ import { TagLinks } from '../TagLinks';
 
 export interface ProfileTooltipContentProps {
   user: Author;
+  data?: UserTooltipContentData;
 }
 
 export function ProfileTooltipContent({
   user,
+  data: { rank, tags },
 }: ProfileTooltipContentProps): ReactElement {
-  const key = ['readingRank', user.id];
-  const { data: { rank, tags } = {} } = useQuery<UserTooltipContentData>(
-    key,
-    () =>
-      request(`${apiUrl}/graphql`, USER_TOOLTIP_CONTENT_QUERY, { id: user.id }),
-    { refetchOnWindowFocus: false },
-  );
-
   return (
     <div className="flex flex-col flex-shrink font-normal typo-callout">
       <div className="relative w-fit">

--- a/packages/shared/src/components/profile/ProfileTolltipContent.tsx
+++ b/packages/shared/src/components/profile/ProfileTolltipContent.tsx
@@ -27,7 +27,7 @@ export function ProfileTooltipContent({
   );
 
   return (
-    <div className="flex flex-col font-normal typo-callout">
+    <div className="flex flex-col flex-shrink font-normal typo-callout">
       <div className="relative w-fit">
         <ProfileImageLink user={user} picture={{ size: 'xxlarge' }} />
         {userReadingRank && (
@@ -47,7 +47,7 @@ export function ProfileTooltipContent({
       <ProfileLink className="text-theme-label-secondary" user={user}>
         @{user.username}
       </ProfileLink>
-      <p className="mt-3 text-theme-label-tertiary">{user.bio}</p>
+      <p className="mt-3 line-clamp-3 text-theme-label-tertiary">{user.bio}</p>
     </div>
   );
 }

--- a/packages/shared/src/components/profile/ProfileTolltipContent.tsx
+++ b/packages/shared/src/components/profile/ProfileTolltipContent.tsx
@@ -35,6 +35,7 @@ export function ProfileTooltipContent({
             className="absolute -right-2 -bottom-2 rounded-8 bg-theme-bg-primary"
             rank={userReadingRank.currentRank}
             colorByRank
+            data-testid={userReadingRank.currentRank}
           />
         )}
       </div>

--- a/packages/shared/src/components/profile/ProfileTolltipContent.tsx
+++ b/packages/shared/src/components/profile/ProfileTolltipContent.tsx
@@ -2,14 +2,15 @@ import React, { ReactElement } from 'react';
 import request from 'graphql-request';
 import { useQuery } from 'react-query';
 import {
-  UserReadingRankData,
-  USER_READING_RANK_QUERY,
+  UserTooltipContentData,
+  USER_TOOLTIP_CONTENT_QUERY,
 } from '../../graphql/users';
 import { apiUrl } from '../../lib/config';
 import { Author } from '../../graphql/comments';
 import Rank from '../Rank';
 import { ProfileImageLink } from './ProfileImageLink';
 import { ProfileLink } from './ProfileLink';
+import { TagLinks } from '../TagLinks';
 
 export interface ProfileTooltipContentProps {
   user: Author;
@@ -19,10 +20,10 @@ export function ProfileTooltipContent({
   user,
 }: ProfileTooltipContentProps): ReactElement {
   const key = ['readingRank', user.id];
-  const { data: { userReadingRank } = {} } = useQuery<UserReadingRankData>(
+  const { data: { rank, tags } = {} } = useQuery<UserTooltipContentData>(
     key,
     () =>
-      request(`${apiUrl}/graphql`, USER_READING_RANK_QUERY, { id: user.id }),
+      request(`${apiUrl}/graphql`, USER_TOOLTIP_CONTENT_QUERY, { id: user.id }),
     { refetchOnWindowFocus: false },
   );
 
@@ -30,12 +31,12 @@ export function ProfileTooltipContent({
     <div className="flex flex-col flex-shrink font-normal typo-callout">
       <div className="relative w-fit">
         <ProfileImageLink user={user} picture={{ size: 'xxlarge' }} />
-        {userReadingRank && (
+        {rank && (
           <Rank
             className="absolute -right-2 -bottom-2 rounded-8 bg-theme-bg-primary"
-            rank={userReadingRank.currentRank}
+            rank={rank.currentRank}
             colorByRank
-            data-testid={userReadingRank.currentRank}
+            data-testid={rank.currentRank}
           />
         )}
       </div>
@@ -45,14 +46,20 @@ export function ProfileTooltipContent({
       >
         {user.name}
       </ProfileLink>
-      <ProfileLink className="text-theme-label-secondary" user={user}>
+      <ProfileLink className="mb-3 text-theme-label-secondary" user={user}>
         @{user.username}
       </ProfileLink>
       {user.bio && (
-        <p className="mt-3 line-clamp-3 text-theme-label-tertiary">
+        <p className="mb-3 line-clamp-3 text-theme-label-tertiary">
           {user.bio}
         </p>
       )}
+      {tags?.length && (
+        <span className="typo-subhead text-theme-label-quaternary">
+          Loves reading about
+        </span>
+      )}
+      <TagLinks className="mb-0" tags={tags?.map(({ value }) => value) || []} />
     </div>
   );
 }

--- a/packages/shared/src/components/profile/ProfileTolltipContent.tsx
+++ b/packages/shared/src/components/profile/ProfileTolltipContent.tsx
@@ -1,0 +1,53 @@
+import React, { ReactElement } from 'react';
+import request from 'graphql-request';
+import { useQuery } from 'react-query';
+import {
+  UserReadingRankData,
+  USER_READING_RANK_QUERY,
+} from '../../graphql/users';
+import { apiUrl } from '../../lib/config';
+import { Author } from '../../graphql/comments';
+import Rank from '../Rank';
+import { ProfileImageLink } from './ProfileImageLink';
+import { ProfileLink } from './ProfileLink';
+
+export interface ProfileTooltipContentProps {
+  user: Author;
+}
+
+export function ProfileTooltipContent({
+  user,
+}: ProfileTooltipContentProps): ReactElement {
+  const key = ['readingRank', user.id];
+  const { data: { userReadingRank } = {} } = useQuery<UserReadingRankData>(
+    key,
+    () =>
+      request(`${apiUrl}/graphql`, USER_READING_RANK_QUERY, { id: user.id }),
+    { refetchOnWindowFocus: false },
+  );
+
+  return (
+    <div className="flex flex-col font-normal typo-callout">
+      <div className="relative w-fit">
+        <ProfileImageLink user={user} picture={{ size: 'xxlarge' }} />
+        {userReadingRank && (
+          <Rank
+            className="absolute -right-2 -bottom-2 rounded-8 bg-theme-bg-primary"
+            rank={userReadingRank.currentRank}
+            colorByRank
+          />
+        )}
+      </div>
+      <ProfileLink
+        className="mt-5 font-bold text-theme-label-primary"
+        user={user}
+      >
+        {user.name}
+      </ProfileLink>
+      <ProfileLink className="text-theme-label-secondary" user={user}>
+        @{user.username}
+      </ProfileLink>
+      <p className="mt-3 text-theme-label-tertiary">{user.bio}</p>
+    </div>
+  );
+}

--- a/packages/shared/src/components/profile/ProfileTooltip.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltip.tsx
@@ -11,7 +11,7 @@ import {
 
 export interface ProfileTooltipProps extends ProfileTooltipContentProps {
   children: ReactElement;
-  link?: Omit<LinkWithTooltipProps, 'children'>;
+  link?: Omit<LinkWithTooltipProps, 'children' | 'tooltip'>;
 }
 
 export function ProfileTooltip({
@@ -20,19 +20,23 @@ export function ProfileTooltip({
   link,
 }: ProfileTooltipProps): ReactElement {
   const Tooltip = link ? LinkWithTooltip : SimpleTooltip;
+  const props = {
+    interactive: true,
+    container: {
+      arrow: false,
+      paddingClassName: 'p-6',
+      roundedClassName: 'rounded-16',
+      className:
+        'w-72 bg-theme-bg-primary shadow-2 border border-theme-divider-secondary',
+    },
+  };
 
   return (
     <Tooltip
       content={<ProfileTooltipContent user={user} />}
       {...link}
-      interactive
-      container={{
-        arrow: false,
-        paddingClassName: 'p-6',
-        roundedClassName: 'rounded-16',
-        className:
-          'w-72 bg-theme-bg-primary shadow-2 border border-theme-divider-secondary',
-      }}
+      {...props}
+      tooltip={props}
     >
       {children}
     </Tooltip>

--- a/packages/shared/src/components/profile/ProfileTooltip.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltip.tsx
@@ -1,0 +1,40 @@
+import React, { ReactElement } from 'react';
+import {
+  LinkWithTooltip,
+  LinkWithTooltipProps,
+} from '../tooltips/LinkWithTooltip';
+import { SimpleTooltip } from '../tooltips/SimpleTooltip';
+import {
+  ProfileTooltipContent,
+  ProfileTooltipContentProps,
+} from './ProfileTolltipContent';
+
+export interface ProfileTooltipProps extends ProfileTooltipContentProps {
+  children: ReactElement;
+  link?: Omit<LinkWithTooltipProps, 'children'>;
+}
+
+export function ProfileTooltip({
+  children,
+  user,
+  link,
+}: ProfileTooltipProps): ReactElement {
+  const Tooltip = link ? LinkWithTooltip : SimpleTooltip;
+
+  return (
+    <Tooltip
+      content={<ProfileTooltipContent user={user} />}
+      {...link}
+      interactive
+      container={{
+        arrow: false,
+        paddingClassName: 'p-6',
+        roundedClassName: 'rounded-16',
+        className:
+          'w-72 bg-theme-bg-primary shadow-2 border border-theme-divider-secondary',
+      }}
+    >
+      {children}
+    </Tooltip>
+  );
+}

--- a/packages/shared/src/components/profile/ProfileTooltip.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltip.tsx
@@ -1,4 +1,11 @@
-import React, { ReactElement } from 'react';
+import request from 'graphql-request';
+import React, { ReactElement, useState } from 'react';
+import { useQuery } from 'react-query';
+import {
+  UserTooltipContentData,
+  USER_TOOLTIP_CONTENT_QUERY,
+} from '../../graphql/users';
+import { apiUrl } from '../../lib/config';
 import {
   LinkWithTooltip,
   LinkWithTooltipProps,
@@ -19,6 +26,7 @@ export function ProfileTooltip({
   user,
   link,
 }: ProfileTooltipProps): ReactElement {
+  const [shouldFetch, setShouldFetch] = useState(false);
   const Tooltip = link ? LinkWithTooltip : SimpleTooltip;
   const props = {
     interactive: true,
@@ -31,11 +39,26 @@ export function ProfileTooltip({
     },
   };
 
+  const key = ['readingRank', user.id];
+  const { data } = useQuery<UserTooltipContentData>(
+    key,
+    () =>
+      request(`${apiUrl}/graphql`, USER_TOOLTIP_CONTENT_QUERY, {
+        id: user.id,
+      }),
+    {
+      refetchOnWindowFocus: false,
+      enabled: shouldFetch,
+      onSettled: () => setShouldFetch(false),
+    },
+  );
+
   return (
     <Tooltip
-      content={<ProfileTooltipContent user={user} />}
+      content={data ? <ProfileTooltipContent user={user} data={data} /> : null}
       {...link}
       {...props}
+      onTrigger={() => setShouldFetch(true)}
       tooltip={props}
     >
       {children}

--- a/packages/shared/src/components/profile/ProfileTooltipContent.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltipContent.spec.tsx
@@ -1,17 +1,9 @@
 import React from 'react';
 import nock from 'nock';
 import { render, screen } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import { ProfileTooltipContent } from './ProfileTolltipContent';
 import { Author } from '../../graphql/comments';
-import {
-  UserTooltipContentData,
-  USER_TOOLTIP_CONTENT_QUERY,
-} from '../../graphql/users';
-import {
-  MockedGraphQLResponse,
-  mockGraphQL,
-} from '../../../__tests__/helpers/graphql';
+import { UserTooltipContentData } from '../../graphql/users';
 
 beforeEach(() => {
   nock.cleanAll();
@@ -36,30 +28,13 @@ const defaultTagsData = [
   { value: 'webdev', count: 1 },
 ];
 
-const createRankMock = (
-  { rank = defaultRankData, tags = defaultTagsData } = {},
-  userId: string = defaultUser.id,
-): MockedGraphQLResponse<UserTooltipContentData> => ({
-  request: {
-    query: USER_TOOLTIP_CONTENT_QUERY,
-    variables: { id: userId },
-  },
-  result: {
-    data: { rank, tags },
-  },
-});
+const mockRank = { rank: defaultRankData, tags: defaultTagsData };
 
 const renderComponent = (
-  mocks: MockedGraphQLResponse[] = [createRankMock()],
   user: Author = defaultUser,
+  rank: UserTooltipContentData = mockRank,
 ) => {
-  const client = new QueryClient();
-  mocks.forEach(mockGraphQL);
-  return render(
-    <QueryClientProvider client={client}>
-      <ProfileTooltipContent user={user} />
-    </QueryClientProvider>,
-  );
+  return render(<ProfileTooltipContent user={user} data={rank} />);
 };
 
 describe('ProfileTooltipContent component', () => {

--- a/packages/shared/src/components/profile/ProfileTooltipContent.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltipContent.spec.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import nock from 'nock';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { ProfileTooltipContent } from './ProfileTolltipContent';
+import { Author } from '../../graphql/comments';
+import {
+  UserReadingRankData,
+  USER_READING_RANK_QUERY,
+} from '../../graphql/users';
+import {
+  MockedGraphQLResponse,
+  mockGraphQL,
+} from '../../../__tests__/helpers/graphql';
+
+beforeEach(() => {
+  nock.cleanAll();
+  jest.clearAllMocks();
+});
+
+const defaultUser = {
+  id: '1',
+  image: 'test.sample.com',
+  username: 'sshanzel',
+  name: 'Lee Hansel Solevilla',
+  permalink: 'https://app.daily.dev/sshanzel',
+  bio: 'Sample bio',
+};
+
+const createRankMock = (
+  data: UserReadingRankData = {
+    userReadingRank: { currentRank: 5 },
+  },
+  userId: string = defaultUser.id,
+): MockedGraphQLResponse<UserReadingRankData> => ({
+  request: {
+    query: USER_READING_RANK_QUERY,
+    variables: { id: userId },
+  },
+  result: {
+    data,
+  },
+});
+
+const renderComponent = (
+  mocks: MockedGraphQLResponse[] = [createRankMock()],
+  user: Author = defaultUser,
+) => {
+  const client = new QueryClient();
+  mocks.forEach(mockGraphQL);
+  return render(
+    <QueryClientProvider client={client}>
+      <ProfileTooltipContent user={user} />
+    </QueryClientProvider>,
+  );
+};
+
+describe('ProfileTooltipContent component', () => {
+  it('should show username', async () => {
+    renderComponent();
+    await screen.findByText('@sshanzel');
+  });
+
+  it('should show full name', async () => {
+    renderComponent();
+    await screen.findByText('Lee Hansel Solevilla');
+  });
+
+  it('should show bio', async () => {
+    renderComponent();
+    await screen.findByText('Sample bio');
+  });
+
+  it('should show user image', async () => {
+    renderComponent();
+    await screen.findByAltText(`sshanzel's profile`);
+  });
+
+  it('should show user rank', async () => {
+    renderComponent();
+    await screen.findByTestId('5');
+  });
+});

--- a/packages/shared/src/components/profile/ProfileTooltipContent.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltipContent.spec.tsx
@@ -5,8 +5,8 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { ProfileTooltipContent } from './ProfileTolltipContent';
 import { Author } from '../../graphql/comments';
 import {
-  UserReadingRankData,
-  USER_READING_RANK_QUERY,
+  UserTooltipContentData,
+  USER_TOOLTIP_CONTENT_QUERY,
 } from '../../graphql/users';
 import {
   MockedGraphQLResponse,
@@ -27,18 +27,25 @@ const defaultUser = {
   bio: 'Sample bio',
 };
 
+const defaultRankData = { currentRank: 5 };
+const defaultTagsData = [
+  { value: 'javascript', count: 5 },
+  { value: 'ai', count: 4 },
+  { value: 'devops', count: 3 },
+  { value: 'cloud', count: 2 },
+  { value: 'webdev', count: 1 },
+];
+
 const createRankMock = (
-  data: UserReadingRankData = {
-    userReadingRank: { currentRank: 5 },
-  },
+  { rank = defaultRankData, tags = defaultTagsData } = {},
   userId: string = defaultUser.id,
-): MockedGraphQLResponse<UserReadingRankData> => ({
+): MockedGraphQLResponse<UserTooltipContentData> => ({
   request: {
-    query: USER_READING_RANK_QUERY,
+    query: USER_TOOLTIP_CONTENT_QUERY,
     variables: { id: userId },
   },
   result: {
-    data,
+    data: { rank, tags },
   },
 });
 
@@ -79,5 +86,12 @@ describe('ProfileTooltipContent component', () => {
   it('should show user rank', async () => {
     renderComponent();
     await screen.findByTestId('5');
+  });
+
+  it('should show most read tags', async () => {
+    renderComponent();
+    defaultTagsData.forEach(async (tag) => {
+      expect(await screen.findByText(tag.value));
+    });
   });
 });

--- a/packages/shared/src/components/tooltips/BaseTooltip.module.css
+++ b/packages/shared/src/components/tooltips/BaseTooltip.module.css
@@ -104,59 +104,61 @@
   transform: rotate(45deg);
 }
 
-.animate {
+.tippyTooltip {
   will-change: transform;
 
-  &[data-popper-placement^='top'] {
-    animation: fade-in-top 0.2s ease-in-out;
+  &[data-state='visible'] {
+    &[data-popper-placement^='top'] {
+      animation: fade-in-top ease-in-out;
+    }
+
+    &[data-popper-placement^='bottom'] {
+      animation: fade-in-bottom ease-in-out;
+    }
+
+    &[data-popper-placement^='left'] {
+      animation: fade-in-left ease-in-out;
+    }
+
+    &[data-popper-placement^='right'] {
+      animation: fade-in-right ease-in-out;
+    }
   }
 
-  &[data-popper-placement^='bottom'] {
-    animation: fade-in-bottom 0.2s ease-in-out;
+  &[data-state='hidden'] {
+    opacity: 0;
+    &[data-placement^='top'] {
+      animation: fade-out-top ease-in-out;
+    }
+
+    &[data-placement^='bottom'] {
+      animation: fade-out-bottom ease-in-out;
+    }
+
+    &[data-placement^='left'] {
+      animation: fade-out-left ease-in-out;
+    }
+
+    &[data-placement^='right'] {
+      animation: fade-out-right ease-in-out;
+    }
   }
 
-  &[data-popper-placement^='left'] {
-    animation: fade-in-left 0.2s ease-in-out;
+  &[data-placement^='top'] .tippyTooltipArrow {
+    left: calc(50% - 0.25rem);
+    bottom: -0.1875rem;
   }
 
-  &[data-popper-placement^='right'] {
-    animation: fade-in-right 0.2s ease-in-out;
-  }
-}
-
-.unMount {
-  opacity: 1;
-  &[data-popper-placement^='top'] {
-    animation: fade-out-top 0.2s ease-in-out;
+  &[data-placement^='bottom'] .tippyTooltipArrow {
+    left: calc(50% - 0.25rem);
+    top: -0.1875rem;
   }
 
-  &[data-popper-placement^='bottom'] {
-    animation: fade-out-bottom 0.2s ease-in-out;
+  &[data-placement^='left'] .tippyTooltipArrow {
+    right: -0.1875rem;
   }
 
-  &[data-popper-placement^='left'] {
-    animation: fade-out-left 0.2s ease-in-out;
+  &[data-placement^='right'] .tippyTooltipArrow {
+    left: -0.1875rem;
   }
-
-  &[data-popper-placement^='right'] {
-    animation: fade-out-right 0.2s ease-in-out;
-  }
-}
-
-.tippyTooltip[data-popper-placement^='top'] > .tippyTooltipArrow {
-  left: calc(50% - 0.25rem);
-  bottom: -0.1875rem;
-}
-
-.tippyTooltip[data-popper-placement^='bottom'] > .tippyTooltipArrow {
-  left: calc(50% - 0.25rem);
-  top: -0.1875rem;
-}
-
-.tippyTooltip[data-popper-placement^='left'] > .tippyTooltipArrow {
-  right: -0.1875rem;
-}
-
-.tippyTooltip[data-popper-placement^='right'] > .tippyTooltipArrow {
-  left: -0.1875rem;
 }

--- a/packages/shared/src/components/tooltips/BaseTooltip.tsx
+++ b/packages/shared/src/components/tooltips/BaseTooltip.tsx
@@ -84,22 +84,24 @@ export function BaseTooltip(
       allowHTML
       animation={!(disableInAnimation && disableOutAnimation)}
       content={
-        <BaseTooltipContainer
-          {...container}
-          placement={placement}
-          arrowClassName={classNames(
-            styles.tippyTooltipArrow,
-            container.arrowClassName,
-          )}
-          className={classNames(
-            styles.tippyTooltip,
-            !disableInAnimation && styles.animate,
-            unMounting && styles.unMount,
-            container.className,
-          )}
-        >
-          {mounted && content}
-        </BaseTooltipContainer>
+        !content ? null : (
+          <BaseTooltipContainer
+            {...container}
+            placement={placement}
+            arrowClassName={classNames(
+              styles.tippyTooltipArrow,
+              container.arrowClassName,
+            )}
+            className={classNames(
+              styles.tippyTooltip,
+              !disableInAnimation && styles.animate,
+              unMounting && styles.unMount,
+              container.className,
+            )}
+          >
+            {mounted && content}
+          </BaseTooltipContainer>
+        )
       }
     >
       {children}

--- a/packages/shared/src/components/tooltips/BaseTooltip.tsx
+++ b/packages/shared/src/components/tooltips/BaseTooltip.tsx
@@ -23,8 +23,6 @@ export interface TooltipProps
     | 'children'
     | 'placement'
     | 'delay'
-    | 'disableInAnimation'
-    | 'disableOutAnimation'
     | 'interactive'
     | 'onTrigger'
     | 'duration'
@@ -35,8 +33,6 @@ export interface TooltipProps
 export interface BaseTooltipProps extends TippyProps {
   container?: Omit<BaseTooltipContainerProps, 'children'>;
   placement?: TooltipPosition;
-  disableInAnimation?: boolean;
-  disableOutAnimation?: boolean;
 }
 
 export function BaseTooltip(
@@ -49,8 +45,6 @@ export function BaseTooltip(
     container = {},
     children,
     content,
-    disableInAnimation,
-    disableOutAnimation,
     ...props
   }: BaseTooltipProps,
   ref?: Ref<Element>,
@@ -74,7 +68,6 @@ export function BaseTooltip(
       duration={duration}
       className={styles.tippyTooltip}
       allowHTML
-      animation={!(disableInAnimation && disableOutAnimation)}
       content={
         !content ? null : (
           <BaseTooltipContainer

--- a/packages/shared/src/components/tooltips/BaseTooltip.tsx
+++ b/packages/shared/src/components/tooltips/BaseTooltip.tsx
@@ -81,6 +81,7 @@ export function BaseTooltip(
       placement={placement}
       onHide={onHide}
       delay={delay}
+      on
       allowHTML
       animation={!(disableInAnimation && disableOutAnimation)}
       content={

--- a/packages/shared/src/components/tooltips/BaseTooltip.tsx
+++ b/packages/shared/src/components/tooltips/BaseTooltip.tsx
@@ -81,7 +81,6 @@ export function BaseTooltip(
       placement={placement}
       onHide={onHide}
       delay={delay}
-      on
       allowHTML
       animation={!(disableInAnimation && disableOutAnimation)}
       content={

--- a/packages/shared/src/components/tooltips/BaseTooltip.tsx
+++ b/packages/shared/src/components/tooltips/BaseTooltip.tsx
@@ -38,6 +38,7 @@ export function BaseTooltip(
   }: BaseTooltipProps,
   ref?: Ref<Element>,
 ): ReactElement {
+  const [mounted, setMounted] = useState(false);
   const [unMounting, setUnMounting] = useState(false);
   const onHide = ({ unmount }) => {
     if (disableOutAnimation) {
@@ -50,10 +51,18 @@ export function BaseTooltip(
     }, DEFAULT_OUT_ANIMATION);
   };
 
+  const lazyPlugin = {
+    fn: () => ({
+      onMount: () => setMounted(true),
+      onHidden: () => setMounted(false),
+    }),
+  };
+
   return (
     <Tippy
       ref={ref}
       {...props}
+      plugins={[lazyPlugin]}
       placement={placement}
       onHide={onHide}
       delay={delay}
@@ -74,7 +83,7 @@ export function BaseTooltip(
             container.className,
           )}
         >
-          {content}
+          {mounted && content}
         </BaseTooltipContainer>
       }
     >

--- a/packages/shared/src/components/tooltips/BaseTooltip.tsx
+++ b/packages/shared/src/components/tooltips/BaseTooltip.tsx
@@ -16,6 +16,21 @@ const DEFAULT_OUT_ANIMATION = 200;
 export const getShouldLoadTooltip = (): boolean =>
   !isTouchDevice() && !isTesting;
 
+export interface TooltipProps
+  extends Pick<
+    BaseTooltipProps,
+    | 'content'
+    | 'children'
+    | 'placement'
+    | 'delay'
+    | 'disableInAnimation'
+    | 'disableOutAnimation'
+    | 'interactive'
+    | 'onTrigger'
+  > {
+  container?: Omit<BaseTooltipContainerProps, 'placement' | 'children'>;
+}
+
 export interface BaseTooltipProps extends TippyProps {
   container?: Omit<BaseTooltipContainerProps, 'children'>;
   placement?: TooltipPosition;

--- a/packages/shared/src/components/tooltips/LinkWithTooltip.tsx
+++ b/packages/shared/src/components/tooltips/LinkWithTooltip.tsx
@@ -1,11 +1,10 @@
 import React, { ReactElement, useMemo, useState } from 'react';
 import Link, { LinkProps } from 'next/link';
-import { BaseTooltip, getShouldLoadTooltip } from './BaseTooltip';
-import { SimpleTooltipProps } from './SimpleTooltip';
+import { BaseTooltip, getShouldLoadTooltip, TooltipProps } from './BaseTooltip';
 
 export interface LinkWithTooltipProps extends LinkProps {
   children?: ReactElement;
-  tooltip: SimpleTooltipProps;
+  tooltip: TooltipProps;
 }
 
 export function LinkWithTooltip({

--- a/packages/shared/src/components/tooltips/LinkWithTooltip.tsx
+++ b/packages/shared/src/components/tooltips/LinkWithTooltip.tsx
@@ -18,7 +18,8 @@ export function LinkWithTooltip({
     () =>
       React.cloneElement(children, {
         ...children.props,
-        'aria-label': typeof tooltip.content === 'string' ? tooltip.content : undefined,
+        'aria-label':
+          typeof tooltip.content === 'string' ? tooltip.content : undefined,
         ref: (el: Element) => setElement(el),
       }),
     [children],

--- a/packages/shared/src/components/tooltips/LinkWithTooltip.tsx
+++ b/packages/shared/src/components/tooltips/LinkWithTooltip.tsx
@@ -3,7 +3,7 @@ import Link, { LinkProps } from 'next/link';
 import { BaseTooltip, getShouldLoadTooltip } from './BaseTooltip';
 import { SimpleTooltipProps } from './SimpleTooltip';
 
-interface LinkWithTooltipProps extends LinkProps {
+export interface LinkWithTooltipProps extends LinkProps {
   children?: ReactElement;
   tooltip: SimpleTooltipProps;
 }
@@ -18,7 +18,7 @@ export function LinkWithTooltip({
     () =>
       React.cloneElement(children, {
         ...children.props,
-        'aria-label': tooltip.content,
+        'aria-label': typeof tooltip.content === 'string' && tooltip.content,
         ref: (el: Element) => setElement(el),
       }),
     [children],

--- a/packages/shared/src/components/tooltips/LinkWithTooltip.tsx
+++ b/packages/shared/src/components/tooltips/LinkWithTooltip.tsx
@@ -18,7 +18,7 @@ export function LinkWithTooltip({
     () =>
       React.cloneElement(children, {
         ...children.props,
-        'aria-label': typeof tooltip.content === 'string' && tooltip.content,
+        'aria-label': typeof tooltip.content === 'string' ? tooltip.content : undefined,
         ref: (el: Element) => setElement(el),
       }),
     [children],

--- a/packages/shared/src/components/tooltips/SimpleTooltip.tsx
+++ b/packages/shared/src/components/tooltips/SimpleTooltip.tsx
@@ -1,26 +1,11 @@
 import React, { ReactElement, useMemo } from 'react';
 import dynamicParent from '../../lib/dynamicParent';
-import { getShouldLoadTooltip, BaseTooltipProps } from './BaseTooltip';
-import { BaseTooltipContainerProps } from './BaseTooltipContainer';
+import { getShouldLoadTooltip, TooltipProps } from './BaseTooltip';
 
 const BaseTooltipLoader = () =>
   import(/* webpackChunkName: "lazyTooltip" */ './BaseTooltip');
 
-export interface SimpleTooltipProps
-  extends Pick<
-    BaseTooltipProps,
-    | 'content'
-    | 'children'
-    | 'placement'
-    | 'delay'
-    | 'disableInAnimation'
-    | 'disableOutAnimation'
-    | 'interactive'
-  > {
-  container?: Omit<BaseTooltipContainerProps, 'placement' | 'children'>;
-}
-
-const TippyTooltip = dynamicParent<SimpleTooltipProps>(
+const TippyTooltip = dynamicParent<TooltipProps>(
   () => BaseTooltipLoader().then((mod) => mod.BaseTooltip),
   React.Fragment,
 );
@@ -28,8 +13,9 @@ const TippyTooltip = dynamicParent<SimpleTooltipProps>(
 export function SimpleTooltip({
   children,
   content,
+  onTrigger,
   ...props
-}: SimpleTooltipProps): ReactElement {
+}: TooltipProps): ReactElement {
   /**
    * We introduced the `shouldShow` variable to manage a re-focus issue
    * The old implementation would re-focus the tooltip whenever a modal would close
@@ -45,10 +31,11 @@ export function SimpleTooltip({
     [children],
   );
 
-  const onTrigger = (_, event) => {
+  const onTooltipTrigger = (_, event) => {
     if (event.type !== 'focus') {
       shouldShow = true;
     }
+    onTrigger?.(_, event);
   };
 
   const onUntrigger = (_, event) => {
@@ -65,7 +52,7 @@ export function SimpleTooltip({
       {...props}
       shouldLoad={getShouldLoadTooltip()}
       content={content}
-      onTrigger={onTrigger}
+      onTrigger={onTooltipTrigger}
       onUntrigger={onUntrigger}
       onShow={() => shouldShow}
     >

--- a/packages/shared/src/components/tooltips/SimpleTooltip.tsx
+++ b/packages/shared/src/components/tooltips/SimpleTooltip.tsx
@@ -15,6 +15,7 @@ export interface SimpleTooltipProps
     | 'delay'
     | 'disableInAnimation'
     | 'disableOutAnimation'
+    | 'interactive'
   > {
   container?: Omit<BaseTooltipContainerProps, 'placement' | 'children'>;
 }

--- a/packages/shared/src/graphql/comments.ts
+++ b/packages/shared/src/graphql/comments.ts
@@ -10,6 +10,7 @@ export interface Author {
   image: string;
   permalink: string;
   username: string;
+  bio: string;
 }
 
 export interface Comment {
@@ -50,6 +51,7 @@ export const COMMENT_FRAGMENT = gql`
       image
       permalink
       username
+      bio
     }
   }
 `;

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -24,11 +24,28 @@ export const USER_STATS_QUERY = gql`
 
 export type UserReadingRank = { currentRank: number };
 export type UserReadingRankData = { userReadingRank: UserReadingRank };
+export type MostReadTag = { value: string; count: number };
+export type UserTooltipContentData = {
+  rank: UserReadingRank;
+  tags: MostReadTag[];
+};
 
 export const USER_READING_RANK_QUERY = gql`
   query UserReadingRank($id: ID!) {
     userReadingRank(id: $id) {
       currentRank
+    }
+  }
+`;
+
+export const USER_TOOLTIP_CONTENT_QUERY = gql`
+  query UserTooltipContent($id: ID!) {
+    rank: userReadingRank(id: $id) {
+      currentRank
+    }
+    tags: userMostReadTags(id: $id) {
+      value
+      count
     }
   }
 `;

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -45,7 +45,6 @@ export const USER_TOOLTIP_CONTENT_QUERY = gql`
     }
     tags: userMostReadTags(id: $id) {
       value
-      count
     }
   }
 `;

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -136,6 +136,12 @@ module.exports = {
         'screen-80': '80vh',
         screen: '100vh',
       },
+      width: {
+        fit: 'fit-content',
+      },
+      height: {
+        fit: 'fit-content',
+      },
     },
   },
   variants: {

--- a/packages/webapp/components/CalendarHeatmap.tsx
+++ b/packages/webapp/components/CalendarHeatmap.tsx
@@ -189,9 +189,8 @@ export default function CalendarHeatmap<T extends { date: string }>({
           value?.originalValue,
           addDays(startDateWithEmptyDays, index),
         )}
-        disableOutAnimation
-        disableInAnimation
-        delay={[1, 90]}
+        duration={0}
+        delay={[0, 70]}
         container={{
           paddingClassName: 'py-3 px-4',
           roundedClassName: 'rounded-3',

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -48,7 +48,6 @@ import { logReadArticle } from '@dailydotdev/shared/src/lib/analytics';
 import useSubscription from '@dailydotdev/shared/src/hooks/useSubscription';
 import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
 import { ClickableText } from '@dailydotdev/shared/src/components/buttons/ClickableText';
-import Link from 'next/link';
 import useUpvotePost from '@dailydotdev/shared/src/hooks/useUpvotePost';
 import useBookmarkPost from '@dailydotdev/shared/src/hooks/useBookmarkPost';
 import useNotification from '@dailydotdev/shared/src/hooks/useNotification';
@@ -63,6 +62,7 @@ import MenuIcon from '@dailydotdev/shared/icons/menu.svg';
 import { CardNotification } from '@dailydotdev/shared/src/components/cards/Card';
 import { SimpleTooltip } from '@dailydotdev/shared/src/components/tooltips/SimpleTooltip';
 import { LinkWithTooltip } from '@dailydotdev/shared/src/components/tooltips/LinkWithTooltip';
+import { TagLinks } from '@dailydotdev/shared/src/components/TagLinks';
 import PostToc from '../../components/widgets/PostToc';
 import { getLayout as getMainLayout } from '../../components/layouts/MainLayout';
 import styles from './postPage.module.css';
@@ -582,15 +582,7 @@ const PostPage = ({ id, postData }: Props): ReactElement => {
             </div>
           )}
         </div>
-        <div className="flex flex-wrap gap-2 mt-3 mb-4">
-          {postById?.post.tags.map((t) => (
-            <Link href={`/tags/${t}`} passHref key={t}>
-              <Button tag="a" className="btn-tertiaryFloat xsmall">
-                #{t}
-              </Button>
-            </Link>
-          ))}
-        </div>
+        <TagLinks tags={postById?.post.tags || []} />
         {postById?.post?.toc?.length > 0 && (
           <PostToc
             post={postById.post}

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -536,7 +536,6 @@ const PostPage = ({ id, postData }: Props): ReactElement => {
                 <ProfileLink
                   user={postById.post.author}
                   data-testid="authorLink"
-                  disableTooltip
                   className="flex-1 mr-auto ml-2"
                 >
                   <SourceImage


### PR DESCRIPTION
DD-36 #done

I have included a tailwind [extended config](https://github.com/tailwindlabs/tailwindcss/discussions/2727#discussioncomment-686642) that I used to use which has now been merged. But since we haven't upgraded yet. I am applying it explicitly.

New component:
 - `ProfileTooltip` - this has all the necessary styling and configuration for a custom tooltip.

Details that must be present in the tooltip:
 - Profile picture (rank to be on the lower right corner) - must be a link
 - Name - must be a link
 - Handle - must be a link
 - Bio

I have also refactored the `ProfileLink` component which now doesn't have a `tooltip` (and `disableTooltip` props) out of the box. We made the `tooltip` component a wrapper which if you don't really need it, then just don't wrap the `children` in itself.

I also applied a lazy mechanism in our `BaseTooltip` as I noticed the content property is rendered whenever its target component is available. This impacts the performance greatly if a single page has many tooltips and custom ones.