### PR TITLE
fix: dropdown content overflow

### DIFF
--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -99,10 +99,7 @@ export function Dropdown({
   };
 
   return (
-    <div
-      className={classNames('truncate', styles.dropdown, className)}
-      {...props}
-    >
+    <div className={classNames(styles.dropdown, className)} {...props}>
       <button
         type="button"
         ref={triggerRef}
@@ -117,7 +114,9 @@ export function Dropdown({
         aria-expanded={isVisible}
       >
         {icon}
-        {options[selectedIndex]}
+        <span className="flex flex-1 mr-1 truncate">
+          {options[selectedIndex]}
+        </span>
         <ArrowIcon
           className={classNames(
             'text-xl ml-auto transform transition-transform group-hover:text-theme-label-tertiary',

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -99,7 +99,10 @@ export function Dropdown({
   };
 
   return (
-    <div className={classNames(styles.dropdown, className)} {...props}>
+    <div
+      className={classNames('truncate', styles.dropdown, className)}
+      {...props}
+    >
       <button
         type="button"
         ref={triggerRef}


### PR DESCRIPTION
DD-351 #done

As reported [in this issue](https://github.com/dailydotdev/daily/issues/373), the content of our `Dropdown` component overflows or breaks up into two lines:
![image](https://user-images.githubusercontent.com/13744167/144799798-916a2ce2-d0ce-4062-9b11-9f23d46394c5.png)


We applied truncating of the content and both cases should now be fixed. The `truncate` class has the following properties:
```
overflow: hidden;
text-overflow: ellipsis;
white-space: nowrap;
```

Preview of the fix:

![Screen Shot 2021-12-06 at 2 39 30 PM](https://user-images.githubusercontent.com/13744167/144799413-8e13d560-b38d-40ea-8839-9f3a963c7356.png)
