### PR TITLE
fix: fixed a testing case for brave browser

### DIFF
--- a/packages/extension/src/newtab/dnd.ts
+++ b/packages/extension/src/newtab/dnd.ts
@@ -20,9 +20,7 @@ const BRAVE_DEFAULT_URL = 'chrome://new-tab-page';
 
 const browserTest = () =>
   process.env.TARGET_BROWSER === 'chrome' ? CHROME_DEFAULT_URL : DEFAULT_URL;
-const braveTest = () => (isBrave() ? BRAVE_DEFAULT_URL : browserTest());
-
-export const getDefaultLink = (): string => braveTest();
+const getDefaultLink = () => (isBrave() ? BRAVE_DEFAULT_URL : browserTest());
 interface DndOption<T extends TimeFormat> {
   value: number;
   label: string;

--- a/packages/extension/src/newtab/dnd.ts
+++ b/packages/extension/src/newtab/dnd.ts
@@ -1,3 +1,4 @@
+import { isBrave } from '@dailydotdev/shared/src/lib/constants';
 import { addDays, addHours, addMinutes } from 'date-fns';
 
 export type TimeFormat =
@@ -15,9 +16,14 @@ export enum CustomTime {
 
 const DEFAULT_URL = 'https://www.google.com';
 const CHROME_DEFAULT_URL = 'chrome-search://local-ntp/local-ntp.html';
+const BRAVE_DEFAULT_URL = 'chrome://new-tab-page';
 
-export const getDefaultLink = (): string =>
-  process.env.TARGET_BROWSER === 'chrome' ? CHROME_DEFAULT_URL : DEFAULT_URL;
+export const getDefaultLink = (): string => {
+  const browserTest = () =>
+    process.env.TARGET_BROWSER === 'chrome' ? CHROME_DEFAULT_URL : DEFAULT_URL;
+  const braveTest = () => (isBrave() ? BRAVE_DEFAULT_URL : browserTest());
+  return braveTest();
+};
 interface DndOption<T extends TimeFormat> {
   value: number;
   label: string;

--- a/packages/extension/src/newtab/dnd.ts
+++ b/packages/extension/src/newtab/dnd.ts
@@ -20,7 +20,7 @@ const BRAVE_DEFAULT_URL = 'chrome://new-tab-page';
 
 const browserTest = () =>
   process.env.TARGET_BROWSER === 'chrome' ? CHROME_DEFAULT_URL : DEFAULT_URL;
-export const getDefaultLink = () =>
+export const getDefaultLink = (): string =>
   isBrave() ? BRAVE_DEFAULT_URL : browserTest();
 interface DndOption<T extends TimeFormat> {
   value: number;

--- a/packages/extension/src/newtab/dnd.ts
+++ b/packages/extension/src/newtab/dnd.ts
@@ -18,12 +18,11 @@ const DEFAULT_URL = 'https://www.google.com';
 const CHROME_DEFAULT_URL = 'chrome-search://local-ntp/local-ntp.html';
 const BRAVE_DEFAULT_URL = 'chrome://new-tab-page';
 
-export const getDefaultLink = (): string => {
-  const browserTest = () =>
-    process.env.TARGET_BROWSER === 'chrome' ? CHROME_DEFAULT_URL : DEFAULT_URL;
-  const braveTest = () => (isBrave() ? BRAVE_DEFAULT_URL : browserTest());
-  return braveTest();
-};
+const browserTest = () =>
+  process.env.TARGET_BROWSER === 'chrome' ? CHROME_DEFAULT_URL : DEFAULT_URL;
+const braveTest = () => (isBrave() ? BRAVE_DEFAULT_URL : browserTest());
+
+export const getDefaultLink = (): string => braveTest();
 interface DndOption<T extends TimeFormat> {
   value: number;
   label: string;

--- a/packages/extension/src/newtab/dnd.ts
+++ b/packages/extension/src/newtab/dnd.ts
@@ -20,7 +20,8 @@ const BRAVE_DEFAULT_URL = 'chrome://new-tab-page';
 
 const browserTest = () =>
   process.env.TARGET_BROWSER === 'chrome' ? CHROME_DEFAULT_URL : DEFAULT_URL;
-const getDefaultLink = () => (isBrave() ? BRAVE_DEFAULT_URL : browserTest());
+export const getDefaultLink = () =>
+  isBrave() ? BRAVE_DEFAULT_URL : browserTest();
 interface DndOption<T extends TimeFormat> {
   value: number;
   label: string;

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -1,3 +1,5 @@
+// We have to declare the navigator because brave is not set in the types of the navigator, yet it does exist
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 declare const navigator: any;
 export const faq = 'https://github.com/dailydotdev/daily/blob/master/FAQs.md';
 export const requestFeature =
@@ -17,13 +19,13 @@ export const isProduction = process.env.NODE_ENV === 'production';
 export const isTesting =
   process.env.NODE_ENV === 'test' || (!isDevelopment && !isProduction);
 
-export const isBrave = () => {
+export const isBrave = (): boolean => {
   if (!window.Promise) {
     return false;
   }
   if (
-    typeof navigator.brave == 'undefined' ||
-    typeof navigator.brave.isBrave != 'function'
+    typeof navigator.brave === 'undefined' ||
+    typeof navigator.brave.isBrave !== 'function'
   ) {
     return false;
   }

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -1,6 +1,4 @@
-// We have to declare the navigator because brave is not set in the types of the navigator, yet it does exist
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare const navigator: any;
+declare const navigator: Navigator & { brave?: { isBrave: unknown } };
 export const faq = 'https://github.com/dailydotdev/daily/blob/master/FAQs.md';
 export const requestFeature =
   'https://github.com/dailydotdev/daily/issues/new?assignees=&labels=Type%3A+Feature&template=---feature-request.md&title=%F0%9F%A7%A9+FEATURE+REQUEST%3A+';
@@ -23,11 +21,5 @@ export const isBrave = (): boolean => {
   if (!window.Promise) {
     return false;
   }
-  if (
-    typeof navigator.brave === 'undefined' ||
-    typeof navigator.brave.isBrave !== 'function'
-  ) {
-    return false;
-  }
-  return true;
+  return typeof navigator.brave?.isBrave === 'function';
 };

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -1,3 +1,4 @@
+declare const navigator: any;
 export const faq = 'https://github.com/dailydotdev/daily/blob/master/FAQs.md';
 export const requestFeature =
   'https://github.com/dailydotdev/daily/issues/new?assignees=&labels=Type%3A+Feature&template=---feature-request.md&title=%F0%9F%A7%A9+FEATURE+REQUEST%3A+';
@@ -15,3 +16,16 @@ export const isDevelopment = process.env.NODE_ENV === 'development';
 export const isProduction = process.env.NODE_ENV === 'production';
 export const isTesting =
   process.env.NODE_ENV === 'test' || (!isDevelopment && !isProduction);
+
+export const isBrave = () => {
+  if (!window.Promise) {
+    return false;
+  }
+  if (
+    typeof navigator.brave == 'undefined' ||
+    typeof navigator.brave.isBrave != 'function'
+  ) {
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
In chrome we use the default new tab as: `chrome-search://local-ntp/local-ntp.html`.
Brave however doesn't provide a inner tab url, so we have to resolve to setting the chrome search default like so: `chrome://new-tab-page`.

I've added a constant check for brave browser.
Running it in Chrome:
<img width="571" alt="Screenshot 2021-12-06 at 11 34 41" src="https://user-images.githubusercontent.com/554874/144805968-5ab86c34-9e47-4ab6-af6f-7cdc6750d8bd.png">

And in Brave:
<img width="514" alt="Screenshot 2021-12-06 at 11 34 35" src="https://user-images.githubusercontent.com/554874/144805985-264e7a3c-7cb3-4e81-a352-b350dd877643.png">