### PR TITLE
fix: hotfix where the timezone can't be read if the user doesn't exist

### DIFF
--- a/packages/shared/src/components/modals/RanksModal.tsx
+++ b/packages/shared/src/components/modals/RanksModal.tsx
@@ -179,7 +179,7 @@ const TimezoneText = ({ onShowAccount }) => {
     </p>
   );
 
-  const loggedTimezoneDescription = !user.timezone ? accountDetails : null;
+  const loggedTimezoneDescription = !user?.timezone ? accountDetails : null;
   const timezoneDescription = !user ? signIn : loggedTimezoneDescription;
 
   return timezoneDescription;


### PR DESCRIPTION
There was an issue where a non-logged in user could not click the ranks modal.
Because of a user check that was not optionally chained.