### PR TITLE
build(extension): upgrading manifest v2 to v3

### DIFF
--- a/packages/extension/package-lock.json
+++ b/packages/extension/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "extension",
-	"version": "3.10.3",
+	"version": "3.10.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -4465,6 +4465,12 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
 			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+			"dev": true
+		},
+		"@types/webextension-polyfill": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.8.2.tgz",
+			"integrity": "sha512-Pd+p5AQx6s78jr4gDC2p3vbw+uxP2DLLqE9iAJJpZ+OUqDm3txr6uN2wUBEwjVgZTNdBHPsxawGvPCTipF2s6w==",
 			"dev": true
 		},
 		"@types/webpack": {
@@ -21498,17 +21504,9 @@
 			}
 		},
 		"webextension-polyfill": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz",
-			"integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw=="
-		},
-		"webextension-polyfill-ts": {
-			"version": "0.22.0",
-			"resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.22.0.tgz",
-			"integrity": "sha512-3P33ClMwZ/qiAT7UH1ROrkRC1KM78umlnPpRhdC/292UyoTTW9NcjJEqDsv83HbibcTB6qCtpVeuB2q2/oniHQ==",
-			"requires": {
-				"webextension-polyfill": "^0.7.0"
-			}
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.8.0.tgz",
+			"integrity": "sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ=="
 		},
 		"webidl-conversions": {
 			"version": "4.0.2",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -18,6 +18,7 @@
   "prettier": "@dailydotdev/prettier-config",
   "dependencies": {
     "@babel/runtime": "^7.16.0",
+    "@dailydotdev/react-contexify": "^5.0.0",
     "@dailydotdev/shared": "*",
     "classnames": "^2.3.1",
     "date-fns": "^2.25.0",
@@ -31,7 +32,6 @@
     "preact": "^10.5.15",
     "preact-render-to-string": "^5.1.19",
     "react": "npm:@preact/compat@0.0.3",
-    "@dailydotdev/react-contexify": "^5.0.0",
     "react-dom": "npm:@preact/compat@0.0.3",
     "react-intersection-observer": "^8.32.2",
     "react-modal": "^3.14.3",
@@ -39,7 +39,7 @@
     "react-tooltip": "^4.2.21",
     "react-transition-group": "^4.4.2",
     "react-virtual": "^2.8.2",
-    "webextension-polyfill-ts": "^0.22.0"
+    "webextension-polyfill": "^0.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",
@@ -65,6 +65,7 @@
     "@types/react": "^17.0.34",
     "@types/react-modal": "^3.13.1",
     "@types/react-transition-group": "^4.4.4",
+    "@types/webextension-polyfill": "^0.8.2",
     "@types/webpack": "^4.41.31",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -1,4 +1,4 @@
-import { browser, Runtime } from 'webextension-polyfill-ts';
+import { action, tabs, runtime, Runtime } from 'webextension-polyfill';
 import { getBootData } from '@dailydotdev/shared/src/lib/boot';
 
 const cacheAmplitudeDeviceId = async ({
@@ -15,14 +15,14 @@ const cacheAmplitudeDeviceId = async ({
   }
 };
 
-browser.browserAction.onClicked.addListener(() => {
-  const url = browser.extension.getURL('index.html?source=button');
-  browser.tabs.create({ url, active: true });
+action.onClicked.addListener(() => {
+  const url = runtime.getURL('index.html?source=button');
+  tabs.create({ url, active: true });
 });
 
-browser.runtime.onInstalled.addListener(async (details) => {
+runtime.onInstalled.addListener(async (details) => {
   await Promise.all([
     cacheAmplitudeDeviceId(details),
-    browser.runtime.setUninstallURL('https://daily.dev/uninstall'),
+    runtime.setUninstallURL('https://daily.dev/uninstall'),
   ]);
 });

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -10,15 +10,17 @@
     "48": "icons/48.png",
     "128": "icons/128.png"
   },
-  "__prod__permissions": [
+  "__prod__host_permissions": [
     "https://daily.dev/",
     "https://*.daily.dev/",
     "https://dailynow.co/",
     "https://*.dailynow.co/"
   ],
-  "__dev__permissions": [
-    "storage",
+  "__dev__host_permissions": [
     "http://localhost/"
+  ],
+  "__dev__permissions": [
+    "storage"
   ],
   "optional_permissions": [
     "topSites"

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -25,7 +25,10 @@
   "optional_permissions": [
     "topSites"
   ],
-  "content_security_policy": "script-src 'self' https://www.google-analytics.com; object-src 'self'",
+  "content_security_policy": {
+    "extension_pages": "object-src 'self'",
+    "sandbox": "script-src 'self' https://www.google-analytics.com"
+  },
   "__firefox__content_security_policy": "object-src 'self'",
   "browser_action": {
     "default_icon": {

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -45,9 +45,10 @@
   "chrome_url_overrides": {
     "newtab": "index.html"
   },
-  "web_accessible_resources": [
-    "index.html"
-  ],
+  "web_accessible_resources": [{
+    "resources": ["index.html"],
+    "matches": ""
+  }],
   "__firefox__browser_specific_settings": {
     "gecko": {
       "strict_min_version": "54.0"

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "version": "0.0.0",
   "name": "daily.dev | The Homepage Developers Deserve",
   "short_name": "daily.dev",

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -30,7 +30,7 @@
     "sandbox": "script-src 'self' https://www.google-analytics.com"
   },
   "__firefox__content_security_policy": "object-src 'self'",
-  "browser_action": {
+  "action": {
     "default_icon": {
       "16": "icons/action_16.png",
       "32": "icons/action_32.png"

--- a/packages/extension/src/newtab/App.tsx
+++ b/packages/extension/src/newtab/App.tsx
@@ -19,7 +19,7 @@ import { SubscriptionContextProvider } from '@dailydotdev/shared/src/contexts/Su
 import FeaturesContext from '@dailydotdev/shared/src/contexts/FeaturesContext';
 import { SettingsContextProvider } from '@dailydotdev/shared/src/contexts/SettingsContext';
 import { AnalyticsContextProvider } from '@dailydotdev/shared/src/contexts/AnalyticsContext';
-import { browser } from 'webextension-polyfill-ts';
+import { runtime } from 'webextension-polyfill';
 import usePersistentState from '@dailydotdev/shared/src/hooks/usePersistentState';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
 import useTrackPageView from '@dailydotdev/shared/src/hooks/analytics/useTrackPageView';
@@ -49,7 +49,7 @@ Modal.defaultStyles = {};
 
 const shouldShowConsent = process.env.TARGET_BROWSER === 'firefox';
 
-const getRedirectUri = () => browser.runtime.getURL('index.html');
+const getRedirectUri = () => runtime.getURL('index.html');
 
 function InternalApp({
   pageRef,
@@ -89,7 +89,7 @@ function InternalApp({
     if (tokenRefreshed && user && !user.infoConfirmed) {
       window.location.replace(
         `${process.env.NEXT_PUBLIC_WEBAPP_URL}register?redirect_uri=${encodeURI(
-          browser.runtime.getURL('index.html'),
+          runtime.getURL('index.html'),
         )}`,
       );
     }

--- a/packages/extension/src/newtab/index.tsx
+++ b/packages/extension/src/newtab/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import '@dailydotdev/shared/src/styles/globals.css';
 import { get as getCache } from 'idb-keyval';
-import { browser } from 'webextension-polyfill-ts';
+import { tabs } from 'webextension-polyfill';
 import App from './App';
 import { DndSettings } from './DndContext';
 
@@ -27,9 +27,9 @@ const renderApp = () => {
 };
 
 const redirectApp = async (url: string) => {
-  const tab = await browser.tabs.getCurrent();
+  const tab = await tabs.getCurrent();
   window.stop();
-  await browser.tabs.update(tab.id, { url });
+  await tabs.update(tab.id, { url });
 };
 
 (async () => {

--- a/packages/extension/src/newtab/useSettingsMigration.ts
+++ b/packages/extension/src/newtab/useSettingsMigration.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { browser } from 'webextension-polyfill-ts';
+import { storage } from 'webextension-polyfill';
 import usePersistentState from '@dailydotdev/shared/src/hooks/usePersistentState';
 import { apiUrl } from '@dailydotdev/shared/src/lib/config';
 import request, { gql } from 'graphql-request';
@@ -108,15 +108,15 @@ export default function useSettingsMigration(
       }),
     {
       onSuccess: async () => {
-        await setSettings(null);
-        await browser.storage.local.set({ [SETTINGS_V2_KEY]: {} });
+        setSettings(null);
+        await storage.local.set({ [SETTINGS_V2_KEY]: {} });
         setMigrationCompleted(true);
       },
     },
   );
 
   useEffect(() => {
-    browser.storage.local.get(SETTINGS_V2_KEY).then(setSettings);
+    storage.local.get(SETTINGS_V2_KEY).then(setSettings);
   }, []);
 
   const hasSettings = checkIfHasSettings(settings);

--- a/packages/extension/src/newtab/useTopSites.tsx
+++ b/packages/extension/src/newtab/useTopSites.tsx
@@ -1,4 +1,8 @@
-import { browser, TopSites } from 'webextension-polyfill-ts';
+import {
+  topSites as browserTopSites,
+  TopSites,
+  permissions,
+} from 'webextension-polyfill';
 import { useEffect, useState } from 'react';
 
 type TopSite = TopSites.MostVisitedURL;
@@ -12,14 +16,14 @@ export default function useTopSites(): UseTopSitesRet {
 
   const getTopSites = async (): Promise<void> => {
     try {
-      setTopSites((await browser.topSites.get()).slice(0, 8));
+      setTopSites((await browserTopSites.get()).slice(0, 8));
     } catch (err) {
       setTopSites(undefined);
     }
   };
 
   const askTopSitesPermission = async (): Promise<boolean> => {
-    const granted = await browser.permissions.request({
+    const granted = await permissions.request({
       permissions: ['topSites'],
     });
     if (granted) {

--- a/packages/extension/webpack.config.js
+++ b/packages/extension/webpack.config.js
@@ -73,9 +73,6 @@ module.exports = {
   resolve: {
     extensions: ['.svg', '.ts', '.tsx', '.js', '.json'],
     alias: {
-      'webextension-polyfill-ts': path.resolve(
-        path.join(__dirname, 'node_modules', 'webextension-polyfill-ts'),
-      ),
       react: path.resolve(
         path.join(__dirname, 'node_modules', 'preact', 'compat'),
       ),


### PR DESCRIPTION
The changes made in the manifest were purely based on the [guide in this document](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#declarativenetrequest-conditional-perms).

I have separated each commit to isolate the changes required from the document.

- [Host permissions: ](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#host-permissions) 082d8f08f51ade0971d2a6a1b76e9385242d3fae
- [Content security policy:](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#content-security-policy) 0da511e943ca1f824002e6e5717c29c892f25a41
- [Action API unification:](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#action-api-unification) dc077ca860f5190c3a46b3e3442b964d5ed0130e
- [WIP - web accessible resources:](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#web-accessible-resources) dc077ca860f5190c3a46b3e3442b964d5ed0130e
- [Remotely hosted code:](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#remotely-hosted-code) Not applicable
- [Executing arbitrary strings:](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#executing-arbitrary-strings) Not applicable
- [Background service workers:](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#background-service-workers) Not applicable
- [Modifying network requests:](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#background-service-workers) Not applicable

[Sunset for deprecated APIs](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#background-service-workers) - we only had to change one API- [`chrome.extension.getURL()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/extension/getURL) -> [`runtime.getURL()`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getURL)
![chrome.extension.getURL](https://user-images.githubusercontent.com/13744167/145685609-25ac2a8d-c2d0-464f-8c13-a3b3df81e1a6.png)

We also had to switch the package we are using for web extension polyfills. The [`webextension-polyfill-ts`](https://www.npmjs.com/package/webextension-polyfill-ts) has now been deprecated and we will have to switch to `webextension-polyfill` since the former was just a wrapper for TS implementations. There is now an official package to support the types through `@types/webextension-polyfill`
![image](https://user-images.githubusercontent.com/13744167/145685754-5bfed5b3-988b-4224-8190-8e73edd322a4.png)


**Note:** based on [firefox's timeline](https://blog.mozilla.org/addons/2021/05/27/manifest-v3-update/) (Implementation timeline part) for migrating v3 they will start accepting submissions by early 2022 and they have not specified any future date. That means, this PR should be blocked until such time they allow the submissions. What about Chrome's decision for disallowing Manifest v2 apps?

After further reading, our app would still be allowed to be submitted even under manifest v2 based on [Chrome's timeline for v3](https://developer.chrome.com/docs/extensions/mv3/mv2-sunset/) up until the end of 2022.

Existing extensions can still be updated but new apps won't be accepted. With that, we should still be safe for uploading new versions but I have still created this PR in order for us to make the transition faster when the time comes.
![image](https://user-images.githubusercontent.com/13744167/145686003-03dde008-03fc-45d1-982b-69b7e8e3cdb8.png)
