### PR TITLE
fix: level up bug

### DIFF
--- a/packages/shared/src/components/RankProgress.tsx
+++ b/packages/shared/src/components/RankProgress.tsx
@@ -66,6 +66,12 @@ export function RankProgress({
   const badgeRef = useRef<SVGSVGElement>();
 
   const finalRank = shownRank === STEPS_PER_RANK.length;
+  const levelUp = () =>
+    rank >= shownRank &&
+    rank > 0 &&
+    (rank !== rankLastWeek || progress === STEPS_PER_RANK[rank - 1]);
+  const getLevelText = levelUp() ? 'Level up' : '+1 Reading day';
+  const shouldForceColor = animatingProgress || forceColor || fillByDefault;
 
   const steps = useMemo(() => {
     if (
@@ -212,13 +218,6 @@ export function RankProgress({
     return `Next level: ${RANK_NAMES[rank]}`;
   };
 
-  const levelUp = () =>
-    rank >= shownRank &&
-    rank > 0 &&
-    (rank !== rankLastWeek || progress === STEPS_PER_RANK[rank - 1]);
-  const getLevelText = levelUp() ? 'Level up' : '+1 Reading day';
-  const shouldForceColor = animatingProgress || forceColor || fillByDefault;
-
   return (
     <>
       <div
@@ -277,7 +276,7 @@ export function RankProgress({
                 ref={badgeRef}
               />
             ) : (
-              <strong className="flex absolute inset-0 justify-center items-center typo-callout text-theme-rank">
+              <strong className="flex absolute inset-0 justify-center items-center text-theme-rank typo-callout">
                 +1
               </strong>
             )}

--- a/packages/shared/src/components/RankProgress.tsx
+++ b/packages/shared/src/components/RankProgress.tsx
@@ -173,7 +173,7 @@ export function RankProgress({
   };
 
   const onProgressTransitionEnd = () => {
-    if (showRankAnimation) {
+    if (showRankAnimation || levelUp()) {
       setAnimatingProgress(false);
       animateRank();
     } else {
@@ -190,7 +190,10 @@ export function RankProgress({
   useEffect(() => {
     if (
       progress > prevProgress &&
-      (!rank || showRankAnimation || STEPS_PER_RANK[rank - 1] !== progress)
+      (!rank ||
+        showRankAnimation ||
+        levelUp() ||
+        STEPS_PER_RANK[rank - 1] !== progress)
     ) {
       if (!showRadialProgress) animateRank();
       setAnimatingProgress(true);
@@ -209,7 +212,10 @@ export function RankProgress({
     return `Next level: ${RANK_NAMES[rank]}`;
   };
 
-  const levelUp = () => rank >= shownRank && rank > 0;
+  const levelUp = () =>
+    rank >= shownRank &&
+    rank > 0 &&
+    (rank !== rankLastWeek || progress === STEPS_PER_RANK[rank - 1]);
   const getLevelText = levelUp() ? 'Level up' : '+1 Reading day';
   const shouldForceColor = animatingProgress || forceColor || fillByDefault;
 
@@ -271,7 +277,7 @@ export function RankProgress({
                 ref={badgeRef}
               />
             ) : (
-              <strong className="flex absolute inset-0 justify-center items-center typo-callout">
+              <strong className="flex absolute inset-0 justify-center items-center typo-callout text-theme-rank">
                 +1
               </strong>
             )}


### PR DESCRIPTION
There was a bug in level up not firing when the previous week rank was the same as the new rank.
Decided to add a double check on this.

Also added a whole section in confluence for all new rank text:
https://dailydotdev.atlassian.net/wiki/spaces/HAN/pages/113901569/Weekly+goal+texts