### PR TITLE
fix: markdown link color was missing

### DIFF
--- a/packages/shared/src/components/markdown.module.css
+++ b/packages/shared/src/components/markdown.module.css
@@ -49,7 +49,7 @@
     @apply my-2;
   }
   & :where(a) {
-    @apply hover:underline;
+    @apply text-theme-label-link hover:underline;
   }
   & :where(hr) {
     @apply border-theme-divider-secondary my-10;


### PR DESCRIPTION
With the latest removal of the comment css we missed the actual markdown link color.

Reintroduced it as to color provided in spec.

<img width="613" alt="Screenshot 2021-12-12 at 11 20 51" src="https://user-images.githubusercontent.com/554874/145704084-fa5b27a4-1131-4893-83c3-d04d0d2d6cf6.png">