### PR TITLE
fix: rank text and cache

### DIFF
--- a/packages/shared/src/components/RankProgress.tsx
+++ b/packages/shared/src/components/RankProgress.tsx
@@ -213,8 +213,8 @@ export function RankProgress({
       finalRank ||
       (useRank === rankLastWeek && progress < STEPS_PER_RANK[rank - 1])
     )
-      return `Re-earn: ${progress}/${STEPS_PER_RANK[rank - 1]} reading days`;
-    if (useRank === 0) return `Earn: ${progress}/3 reading days`;
+      return `Re-earn: ${progress}/${STEPS_PER_RANK[rank - 1]} days`;
+    if (useRank === 0) return `Earn: ${progress}/3 days`;
     return `Next level: ${RANK_NAMES[rank]}`;
   };
 

--- a/packages/shared/src/hooks/useReadingRank.ts
+++ b/packages/shared/src/hooks/useReadingRank.ts
@@ -119,7 +119,8 @@ export default function useReadingRank(): ReturnType {
     if (remoteRank && loadedCache) {
       if (
         !cachedRank ||
-        remoteRank.rank.progressThisWeek < cachedRank.rank.progressThisWeek
+        remoteRank.rank.progressThisWeek < cachedRank.rank.progressThisWeek ||
+        !cachedRank.rank.rankLastWeek
       ) {
         cacheRank();
         return;


### PR DESCRIPTION
We decided to remove the "reading" part from the text.
This way it will always show up nicely and still inform the user what's going on.

I've also added a check to see if the newly introduced "rankLastWeek" exists in the local cached rank.
If not we should always force update the cache.

This gave a weird effect for users with a old rank that would never correctly update.