### PR TITLE
refactor: signup button copy experiment

### DIFF
--- a/packages/extension/package-lock.json
+++ b/packages/extension/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "extension",
-	"version": "3.10.3",
+	"version": "3.10.4",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/shared/src/components/LoginButton.tsx
+++ b/packages/shared/src/components/LoginButton.tsx
@@ -1,0 +1,40 @@
+import React, { ReactElement, useContext, useEffect } from 'react';
+import { Button } from './buttons/Button';
+import AuthContext from '../contexts/AuthContext';
+import FeaturesContext from '../contexts/FeaturesContext';
+import { getFeatureValue } from '../lib/featureManagement';
+import AnalyticsContext from '../contexts/AnalyticsContext';
+import { AnalyticsEvent } from '../hooks/analytics/useAnalyticsQueue';
+
+const getAnalyticsEvent = (
+  eventName: string,
+  copy: string,
+): Partial<AnalyticsEvent> => ({
+  event_name: eventName,
+  target_type: 'signup button',
+  target_id: 'header',
+  feed_item_title: copy,
+});
+
+export default function LoginButton(): ReactElement {
+  const { showLogin } = useContext(AuthContext);
+  const { flags } = useContext(FeaturesContext);
+  const { trackEvent } = useContext(AnalyticsContext);
+  const copy = getFeatureValue('signup_button_copy', flags) || 'Login';
+
+  useEffect(() => {
+    trackEvent(getAnalyticsEvent('impression', copy));
+  }, [copy]);
+
+  const onClick = () => {
+    trackEvent(getAnalyticsEvent('click', copy));
+    showLogin('main button');
+  };
+
+  return (
+    <Button onClick={onClick} className="btn-primary">
+      <span className="hidden laptop:inline">{copy}</span>
+      <span className="laptop:hidden">Login</span>
+    </Button>
+  );
+}

--- a/packages/shared/src/components/LoginButton.tsx
+++ b/packages/shared/src/components/LoginButton.tsx
@@ -20,20 +20,20 @@ export default function LoginButton(): ReactElement {
   const { showLogin } = useContext(AuthContext);
   const { flags } = useContext(FeaturesContext);
   const { trackEvent } = useContext(AnalyticsContext);
-  const copy = getFeatureValue('signup_button_copy', flags) || 'Login';
+  const buttonCopy = getFeatureValue('signup_button_copy', flags) || 'Login';
 
   useEffect(() => {
-    trackEvent(getAnalyticsEvent('impression', copy));
-  }, [copy]);
+    trackEvent(getAnalyticsEvent('impression', buttonCopy));
+  }, [buttonCopy]);
 
   const onClick = () => {
-    trackEvent(getAnalyticsEvent('click', copy));
+    trackEvent(getAnalyticsEvent('click', buttonCopy));
     showLogin('main button');
   };
 
   return (
     <Button onClick={onClick} className="btn-primary">
-      <span className="hidden laptop:inline">{copy}</span>
+      <span className="hidden laptop:inline">{buttonCopy}</span>
       <span className="laptop:hidden">Login</span>
     </Button>
   );

--- a/packages/shared/src/components/LoginButtons.tsx
+++ b/packages/shared/src/components/LoginButtons.tsx
@@ -6,11 +6,12 @@ import { LegalNotice } from './utilities';
 import { Button } from './buttons/Button';
 import AuthContext from '../contexts/AuthContext';
 import { apiUrl } from '../lib/config';
-import { logSignupProviderClick } from '../lib/analytics';
+import AnalyticsContext from '../contexts/AnalyticsContext';
 
 export default function LoginButtons(): ReactElement {
   const router = useRouter();
   const { getRedirectUri } = useContext(AuthContext);
+  const { trackEvent } = useContext(AnalyticsContext);
 
   const authUrl = (provider: string, redirectUri: string) =>
     `${apiUrl}/v1/auth/authorize?provider=${provider}&redirect_uri=${encodeURI(
@@ -19,8 +20,12 @@ export default function LoginButtons(): ReactElement {
       router.query.author ? 'author' : 'default'
     }`;
 
-  const login = async (provider: string): Promise<void> => {
-    await logSignupProviderClick(provider);
+  const login = (provider: string): void => {
+    trackEvent({
+      event_name: 'click',
+      target_type: 'signup provider',
+      target_id: provider,
+    });
     const redirectUri = getRedirectUri();
     window.location.href = authUrl(provider, redirectUri);
   };

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -8,7 +8,6 @@ import React, {
 import dynamic from 'next/dynamic';
 import { CSSTransition } from 'react-transition-group';
 import classNames from 'classnames';
-import { Button } from './buttons/Button';
 import ProgressiveEnhancementContext from '../contexts/ProgressiveEnhancementContext';
 import AuthContext from '../contexts/AuthContext';
 import PromotionalBanner from './PromotionalBanner';
@@ -21,6 +20,7 @@ import { HeaderButton } from './buttons/common';
 import ProfileButton from './profile/ProfileButton';
 import { SimpleTooltip } from './tooltips/SimpleTooltip';
 import { LinkWithTooltip } from './tooltips/LinkWithTooltip';
+import LoginButton from './LoginButton';
 
 export interface MainLayoutProps extends HTMLAttributes<HTMLDivElement> {
   showOnlyLogo?: boolean;
@@ -129,12 +129,7 @@ export default function MainLayout({
                   />
                 </SimpleTooltip>
                 {afterBookmarkButtons}
-                <Button
-                  onClick={() => showLogin('main button')}
-                  className="btn-primary"
-                >
-                  Login
-                </Button>
+                <LoginButton />
               </>
             )}
           </>

--- a/packages/shared/src/components/modals/LoginModal.tsx
+++ b/packages/shared/src/components/modals/LoginModal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect } from 'react';
+import React, { ReactElement, useContext, useEffect } from 'react';
 import classNames from 'classnames';
 import DailyDevLogo from '../../svg/DailyDevLogo';
 import { StyledModal, ModalProps } from './StyledModal';
@@ -6,7 +6,7 @@ import { ModalCloseButton } from './ModalCloseButton';
 import LoginButtons from '../LoginButtons';
 import { LoginModalMode } from '../../types/LoginModalMode';
 import styles from './LoginModal.module.css';
-import { logSignupStart } from '../../lib/analytics';
+import AnalyticsContext from '../../contexts/AnalyticsContext';
 
 export type LoginModalProps = {
   mode: LoginModalMode;
@@ -21,10 +21,13 @@ export default function LoginModal({
   children,
   ...props
 }: LoginModalProps): ReactElement {
+  const { trackEvent } = useContext(AnalyticsContext);
+
   useEffect(() => {
-    if (props.isOpen) {
-      logSignupStart(trigger);
-    }
+    trackEvent({
+      event_name: `${props.isOpen ? 'open' : 'close'} signup`,
+      extra: JSON.stringify({ trigger }),
+    });
   }, [props.isOpen]);
 
   return (

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -210,20 +210,6 @@ const logEvent = async (
 export const logReadArticle = async (origin: string): Promise<void> =>
   logEvent('read article', { origin });
 
-export const logSignupStart = async (trigger: string): Promise<void> =>
-  logEvent('signup start', { trigger });
-
-export const logSignupProviderClick = async (provider: string): Promise<void> =>
-  logEvent('signup provider click', { provider });
-
-export const logSignupFormStart = async (): Promise<void> =>
-  logEvent('signup form start');
-
-export const logSignupFormSubmit = async (
-  optionalFields: boolean,
-): Promise<void> =>
-  logEvent('signup form submit', { 'optional fields': optionalFields });
-
 export const logGoToDevCardImpression = async (origin: string): Promise<void> =>
   logEvent('go to devcard impression', { origin });
 

--- a/packages/webapp/__tests__/MainLayout.tsx
+++ b/packages/webapp/__tests__/MainLayout.tsx
@@ -29,12 +29,13 @@ const renderLayout = (user: LoggedUser = null): RenderResult => {
 
 it('should show login button when not logged-in', async () => {
   renderLayout();
-  await screen.findByText('Login');
+  // Experiment doesn't support mobile resolution which yields two elements
+  expect(await screen.findAllByText('Login')).toHaveLength(2);
 });
 
 it('should show login when clicking on the button', async () => {
   renderLayout();
-  const el = await screen.findByText('Login');
+  const [el] = await screen.findAllByText('Login');
   el.click();
   expect(showLogin).toBeCalledTimes(1);
 });

--- a/packages/webapp/pages/register.tsx
+++ b/packages/webapp/pages/register.tsx
@@ -11,23 +11,26 @@ import {
   ResponsivePageContainer,
   ProfileHeading,
 } from '@dailydotdev/shared/src/components/utilities';
-import {
-  logSignupFormStart,
-  logSignupFormSubmit,
-} from '@dailydotdev/shared/src/lib/analytics';
+import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 import MainLayout from '../components/layouts/MainLayout';
 
 export default function Register(): ReactElement {
   const { user, logout } = useContext(AuthContext);
   const router = useRouter();
   const [disableSubmit, setDisableSubmit] = useState<boolean>(true);
+  const { trackEvent } = useContext(AnalyticsContext);
 
   useEffect(() => {
-    logSignupFormStart();
+    trackEvent({
+      event_name: 'start signup form',
+    });
   }, []);
 
   const onSuccessfulSubmit = async (optionalFields: boolean) => {
-    await logSignupFormSubmit(optionalFields);
+    trackEvent({
+      event_name: 'submit signup form',
+      extra: JSON.stringify({ optional_fields: optionalFields }),
+    });
     await router?.replace((router.query.redirect_uri as string) || '/');
   };
 


### PR DESCRIPTION
We want to try out different copies for the login button in the header.
For this purpose I added a new feature `signup_button_copy` in Flagsmith. This feature will hold the string for the button.
Please note, in mobile resolution we will keep the current copy due to space restrictions.

I also migrated the relevant signup events to our in-house analytics tracking so we can monitor the performance of the experiment.

DD-362 #done