### PR TITLE
refactor: use features enum to store available flags

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -7,7 +7,6 @@ import React, {
   useRef,
 } from 'react';
 import classNames from 'classnames';
-import { IBulletTrainFeature } from 'flagsmith';
 import useFeed, { PostItem } from '../hooks/useFeed';
 import { Ad, Post } from '../graphql/posts';
 import AuthContext from '../contexts/AuthContext';
@@ -36,6 +35,7 @@ import { adAnalyticsEvent, postAnalyticsEvent } from '../lib/feed';
 import PostOptionsMenu from './PostOptionsMenu';
 import useNotification from '../hooks/useNotification';
 import FeaturesContext from '../contexts/FeaturesContext';
+import { Features, getFeatureValue } from '../lib/featureManagement';
 
 export type FeedProps<T> = {
   feedQueryKey: unknown[];
@@ -57,9 +57,6 @@ const getStyle = (useList: boolean, spaciness: Spaciness): CSSProperties => {
   return {};
 };
 
-const getShouldDisplayPublishDate = (hideDate: IBulletTrainFeature) =>
-  !hideDate?.enabled ? true : !parseInt(hideDate.value, 10);
-
 export default function Feed<T>({
   feedQueryKey,
   query,
@@ -69,9 +66,8 @@ export default function Feed<T>({
   emptyScreen,
 }: FeedProps<T>): ReactElement {
   const { flags } = useContext(FeaturesContext);
-  const displayPublicationDate = getShouldDisplayPublishDate(
-    flags?.hide_publication_date,
-  );
+  const displayPublicationDate =
+    !parseInt(getFeatureValue(Features.HidePublicationDate, flags), 10) || true;
   const { trackEvent } = useContext(AnalyticsContext);
   const currentSettings = useContext(FeedContext);
   const { user } = useContext(AuthContext);

--- a/packages/shared/src/components/HeaderRankProgress.tsx
+++ b/packages/shared/src/components/HeaderRankProgress.tsx
@@ -14,7 +14,7 @@ import OnboardingContext from '../contexts/OnboardingContext';
 import Rank from './Rank';
 import styles from './HeaderRankProgress.module.css';
 import FeaturesContext from '../contexts/FeaturesContext';
-import { getFeatureValue } from '../lib/featureManagement';
+import { Features, getFeatureValue } from '../lib/featureManagement';
 
 const RanksModal = dynamic(
   () => import(/* webpackChunkName: "ranksModal" */ './modals/RanksModal'),
@@ -43,7 +43,7 @@ export default function HeaderRankProgress({
   const [showRanksModal, setShowRanksModal] = useState(false);
   const { flags } = useContext(FeaturesContext);
   const devCardLimit = parseInt(
-    getFeatureValue('feat_limit_dev_card', flags),
+    getFeatureValue(Features.DevcardLimit, flags),
     10,
   );
 

--- a/packages/shared/src/components/LoginButton.tsx
+++ b/packages/shared/src/components/LoginButton.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useContext, useEffect } from 'react';
 import { Button } from './buttons/Button';
 import AuthContext from '../contexts/AuthContext';
 import FeaturesContext from '../contexts/FeaturesContext';
-import { getFeatureValue } from '../lib/featureManagement';
+import { Features, getFeatureValue } from '../lib/featureManagement';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../hooks/analytics/useAnalyticsQueue';
 
@@ -20,7 +20,8 @@ export default function LoginButton(): ReactElement {
   const { showLogin } = useContext(AuthContext);
   const { flags } = useContext(FeaturesContext);
   const { trackEvent } = useContext(AnalyticsContext);
-  const buttonCopy = getFeatureValue('signup_button_copy', flags) || 'Login';
+  const buttonCopy =
+    getFeatureValue(Features.SignupButtonCopy, flags) || 'Login';
 
   useEffect(() => {
     trackEvent(getAnalyticsEvent('impression', buttonCopy));

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -29,6 +29,7 @@ import {
 import usePersistentState from '../hooks/usePersistentState';
 import FeaturesContext from '../contexts/FeaturesContext';
 import { generateQueryKey } from '../lib/query';
+import { Features, getFeatureValue } from '../lib/featureManagement';
 
 const SearchEmptyScreen = dynamic(
   () => import(/* webpackChunkName: "emptySearch" */ './SearchEmptyScreen'),
@@ -151,7 +152,8 @@ export default function MainFeedLayout({
   const { user, tokenRefreshed } = useContext(AuthContext);
   const { onboardingStep, onboardingReady } = useContext(OnboardingContext);
   const { flags } = useContext(FeaturesContext);
-  const feedVersion = parseInt(flags?.feed_version?.value, 10) || 1;
+  const feedVersion =
+    parseInt(getFeatureValue(Features.FeedVersion, flags), 10) || 1;
   const [defaultFeed, setDefaultFeed] = usePersistentState(
     'defaultFeed',
     null,

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -1,7 +1,14 @@
 import { IFlags } from 'flagsmith';
 
+export enum Features {
+  SignupButtonCopy = 'signup_button_copy',
+  DevcardLimit = 'feat_limit_dev_card',
+  FeedVersion = 'feed_version',
+  HidePublicationDate = 'hide_publication_date',
+}
+
 export const getFeatureValue = (
-  key: string,
+  key: Features,
   flags: IFlags,
 ): string | undefined => {
   if (flags[key]?.enabled) {


### PR DESCRIPTION
Following Lee's suggestion, I introduce a new enum that will make it easy to use feature flags.