### PR TITLE
refactor: user settings in boot query

### DIFF
--- a/packages/extension/src/newtab/App.tsx
+++ b/packages/extension/src/newtab/App.tsx
@@ -17,7 +17,6 @@ import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { OnboardingContextProvider } from '@dailydotdev/shared/src/contexts/OnboardingContext';
 import { SubscriptionContextProvider } from '@dailydotdev/shared/src/contexts/SubscriptionContext';
 import FeaturesContext from '@dailydotdev/shared/src/contexts/FeaturesContext';
-import { SettingsContextProvider } from '@dailydotdev/shared/src/contexts/SettingsContext';
 import { AnalyticsContextProvider } from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 import { browser } from 'webextension-polyfill-ts';
 import usePersistentState from '@dailydotdev/shared/src/hooks/usePersistentState';
@@ -140,17 +139,15 @@ export default function App(): ReactElement {
         <QueryClientProvider client={queryClient}>
           <BootDataProvider app="extension" getRedirectUri={getRedirectUri}>
             <SubscriptionContextProvider>
-              <SettingsContextProvider>
-                <OnboardingContextProvider>
-                  <AnalyticsContextProvider
-                    app="extension"
-                    version={version}
-                    getPage={() => pageRef.current}
-                  >
-                    <InternalApp pageRef={pageRef} />
-                  </AnalyticsContextProvider>
-                </OnboardingContextProvider>
-              </SettingsContextProvider>
+              <OnboardingContextProvider>
+                <AnalyticsContextProvider
+                  app="extension"
+                  version={version}
+                  getPage={() => pageRef.current}
+                >
+                  <InternalApp pageRef={pageRef} />
+                </AnalyticsContextProvider>
+              </OnboardingContextProvider>
             </SubscriptionContextProvider>
           </BootDataProvider>
         </QueryClientProvider>

--- a/packages/shared/__tests__/setup.ts
+++ b/packages/shared/__tests__/setup.ts
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 import 'fake-indexeddb/auto';
 import nodeFetch from 'node-fetch';
 import { NextRouter } from 'next/router';
+import { clear } from 'idb-keyval';
 
 process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3000';
 process.env.NEXT_PUBLIC_WEBAPP_URL = '/';
@@ -60,6 +61,10 @@ jest.mock('next/router', () => ({
       } as unknown as NextRouter),
   ),
 }));
+
+beforeEach(() => {
+  clear();
+});
 
 jest.mock('../src/lib/analytics', () => ({
   ...jest.requireActual('../src/lib/analytics'),

--- a/packages/shared/src/components/Settings.spec.tsx
+++ b/packages/shared/src/components/Settings.spec.tsx
@@ -10,6 +10,7 @@ import {
 } from '@testing-library/react';
 import { act } from '@testing-library/react-hooks';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { clear } from 'idb-keyval';
 import { mockGraphQL } from '../../__tests__/helpers/graphql';
 import { SettingsContextProvider } from '../contexts/SettingsContext';
 import Settings from './Settings';
@@ -25,6 +26,7 @@ import { LoginModalMode } from '../types/LoginModalMode';
 beforeEach(() => {
   jest.clearAllMocks();
   nock.cleanAll();
+  clear();
 });
 
 const showLogin = jest.fn();
@@ -109,9 +111,7 @@ const testSettingsMutation = async (
   updateFunc: () => Promise<void>,
   initialSettings = defaultSettings,
 ) => {
-  await act(async () => {
-    renderComponent();
-  });
+  renderComponent(defaultUser, initialSettings);
 
   let mutationCalled = false;
   mockGraphQL({
@@ -147,29 +147,29 @@ it('should mutate density setting', () =>
     fireEvent.click(cozy);
   }));
 
-// it('should set theme to dark mode setting', () =>
-//   testSettingsMutation({ theme: 'darcula' }, async () => {
-//     const radios = await screen.findAllByRole('radio');
-//     const radio = radios.find((el) =>
-//       // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
-//       queryByText(el.parentElement, 'Dark'),
-//     ) as HTMLInputElement;
-//     fireEvent.click(radio);
-//   }));
+it('should set theme to dark mode setting', () =>
+  testSettingsMutation({ theme: 'darcula' }, async () => {
+    const radios = await screen.findAllByRole('radio');
+    const radio = radios.find((el) =>
+      // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
+      queryByText(el.parentElement, 'Dark'),
+    ) as HTMLInputElement;
+    fireEvent.click(radio);
+  }));
 
-// it('should set light to dark mode setting', () =>
-//   testSettingsMutation(
-//     { theme: 'bright' },
-//     async () => {
-//       const radios = await screen.findAllByRole('radio');
-//       const radio = radios.find((el) =>
-//         // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
-//         queryByText(el.parentElement, 'Light'),
-//       ) as HTMLInputElement;
-//       fireEvent.click(radio);
-//     },
-//     { ...defaultSettings, theme: 'darcula' },
-//   ));
+it('should set light to dark mode setting', () =>
+  testSettingsMutation(
+    { theme: 'bright' },
+    async () => {
+      const radios = await screen.findAllByRole('radio');
+      const radio = radios.find((el) =>
+        // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
+        queryByText(el.parentElement, 'Light'),
+      ) as HTMLInputElement;
+      fireEvent.click(radio);
+    },
+    { ...defaultSettings, theme: 'darcula' },
+  ));
 
 it('should mutate hide read posts setting', () =>
   testSettingsMutation({ showOnlyUnreadPosts: false }, async () => {

--- a/packages/shared/src/components/Settings.spec.tsx
+++ b/packages/shared/src/components/Settings.spec.tsx
@@ -8,7 +8,6 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
-import { act } from '@testing-library/react-hooks';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { clear } from 'idb-keyval';
 import { mockGraphQL } from '../../__tests__/helpers/graphql';

--- a/packages/shared/src/components/Settings.spec.tsx
+++ b/packages/shared/src/components/Settings.spec.tsx
@@ -209,17 +209,17 @@ it('should open login when hide read posts is clicked and the user is logged out
   );
 });
 
-// it('should mutate show most visited sites setting in extension', () => {
-//   process.env.TARGET_BROWSER = 'chrome';
-//   testSettingsMutation({ showTopSites: false }, async () => {
-//     const checkboxes = await screen.findAllByRole('checkbox');
-//     const checkbox = checkboxes.find((el) =>
-//       // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
-//       queryByText(el.parentElement, 'Show most visited sites'),
-//     ) as HTMLInputElement;
+it('should mutate show most visited sites setting in extension', () => {
+  process.env.TARGET_BROWSER = 'chrome';
+  testSettingsMutation({ showTopSites: false }, async () => {
+    const checkboxes = await screen.findAllByRole('checkbox');
+    const checkbox = checkboxes.find((el) =>
+      // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
+      queryByText(el.parentElement, 'Show most visited sites'),
+    ) as HTMLInputElement;
 
-//     await waitFor(() => expect(checkbox).toBeChecked());
+    await waitFor(() => expect(checkbox).toBeChecked());
 
-//     fireEvent.click(checkbox);
-//   });
-// });
+    fireEvent.click(checkbox);
+  });
+});

--- a/packages/shared/src/components/Settings.spec.tsx
+++ b/packages/shared/src/components/Settings.spec.tsx
@@ -9,7 +9,6 @@ import {
   waitFor,
 } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { clear } from 'idb-keyval';
 import { mockGraphQL } from '../../__tests__/helpers/graphql';
 import { SettingsContextProvider } from '../contexts/SettingsContext';
 import Settings from './Settings';
@@ -25,7 +24,6 @@ import { LoginModalMode } from '../types/LoginModalMode';
 beforeEach(() => {
   jest.clearAllMocks();
   nock.cleanAll();
-  clear();
 });
 
 const showLogin = jest.fn();

--- a/packages/shared/src/components/Settings.tsx
+++ b/packages/shared/src/components/Settings.tsx
@@ -21,7 +21,6 @@ const densities = [
   { label: 'Roomy', value: 'roomy' },
   { label: 'Cozy', value: 'cozy' },
 ];
-const isExtension = process.env.TARGET_BROWSER;
 const Section = classed('section', 'flex flex-col font-bold mt-6');
 const SectionTitle = classed(
   'h3',
@@ -32,6 +31,7 @@ export default function Settings({
   className,
   ...props
 }: HTMLAttributes<HTMLDivElement>): ReactElement {
+  const isExtension = process.env.TARGET_BROWSER;
   const { user, showLogin } = useContext(AuthContext);
   const {
     spaciness,

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -14,6 +14,7 @@ import { AnonymousUser, LoggedUser } from '../lib/user';
 import usePersistentState from '../hooks/usePersistentState';
 import { AlertContextProvider } from './AlertContext';
 import { generateQueryKey } from '../lib/query';
+import { SettingsContextProvider } from './SettingsContext';
 
 function useRefreshToken(
   accessToken: AccessToken,
@@ -103,9 +104,11 @@ export const BootDataProvider = ({
         loadedUserFromCache={loadedFromCache}
         visit={bootData?.visit}
       >
-        <AlertContextProvider alerts={bootData?.alerts}>
-          {children}
-        </AlertContextProvider>
+        <SettingsContextProvider remoteSettings={bootData?.settings}>
+          <AlertContextProvider alerts={bootData?.alerts}>
+            {children}
+          </AlertContextProvider>
+        </SettingsContextProvider>
       </AuthContextProvider>
     </FeaturesContextProvider>
   );

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -163,11 +163,11 @@ export const SettingsContextProvider = ({
     const theme = storageWrapper.getItem(themeModeStorageKey) as ThemeMode;
     if (theme) {
       setCurrentTheme(theme);
-      return;
-    }
-    const lightMode = storageWrapper.getItem(deprecatedLightModeStorageKey);
-    if (lightMode === 'true') {
-      applyTheme(ThemeMode.Light);
+    } else {
+      const lightMode = storageWrapper.getItem(deprecatedLightModeStorageKey);
+      if (lightMode === 'true') {
+        applyTheme(ThemeMode.Light);
+      }
     }
   }, []);
 

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -136,7 +136,7 @@ export const SettingsContextProvider = ({
   );
 
   useEffect(() => {
-    if (remoteSettings) {
+    if (remoteSettings && userId) {
       const { theme: remoteTheme, ...remoteData } = remoteSettings;
       const theme = themeModes[remoteTheme];
       setCurrentTheme(theme);

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -171,18 +171,22 @@ export const SettingsContextProvider = ({
     }
   }, []);
 
-  const setSettings = async (
+  const updateRemoteSettingsFn = async (
     newSettings: Settings,
-    remoteTheme?: RemoteTheme,
+    theme: ThemeMode,
   ): Promise<void> => {
-    await setCachedSettings(newSettings);
-
     if (userId) {
+      const remoteTheme = getRemoteTheme(theme);
       await updateRemoteSettings({
         ...newSettings,
         theme: remoteTheme,
       });
     }
+  };
+
+  const setSettings = async (newSettings: Settings): Promise<void> => {
+    await setCachedSettings(newSettings);
+    await updateRemoteSettingsFn(newSettings, currentTheme);
   };
 
   const contextData = useMemo<SettingsContextData>(
@@ -191,8 +195,7 @@ export const SettingsContextProvider = ({
       themeMode: currentTheme,
       setTheme: async (theme: ThemeMode) => {
         setCurrentTheme(theme);
-        const remoteTheme = getRemoteTheme(theme);
-        await setSettings(settings, remoteTheme);
+        await updateRemoteSettingsFn(settings, theme);
         storageWrapper.setItem(themeModeStorageKey, theme);
       },
       toggleShowOnlyUnreadPosts: () =>

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -143,7 +143,7 @@ export const SettingsContextProvider = ({
       storageWrapper.setItem(themeModeStorageKey, theme);
       setCachedSettings(remoteData);
     }
-  }, [remoteSettings]);
+  }, [remoteSettings, userId]);
 
   useEffect(() => {
     const theme = storageWrapper.getItem(themeModeStorageKey) as ThemeMode;

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -80,18 +80,14 @@ function applyTheme(themeMode: ThemeMode): void {
     return;
   }
 
-  if (themeMode === ThemeMode.Auto) {
-    document.documentElement.classList.remove(ThemeMode.Light);
-    document.documentElement.classList.add(ThemeMode.Auto);
+  document.documentElement.classList.remove(ThemeMode.Light);
+  document.documentElement.classList.remove(ThemeMode.Auto);
+
+  if (themeMode === ThemeMode.Dark) {
     return;
   }
 
-  document.documentElement.classList.remove(ThemeMode.Auto);
-  if (themeMode === ThemeMode.Light) {
-    document.documentElement.classList.add(ThemeMode.Light);
-  } else {
-    document.documentElement.classList.remove(ThemeMode.Light);
-  }
+  document.documentElement.classList.add(themeMode);
 }
 
 export type SettingsContextProviderProps = {

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -63,26 +63,16 @@ const defaultSettings: Settings = {
   showTopSites: true,
 };
 
-const getThemeMode = (remoteTheme: RemoteTheme): ThemeMode => {
-  switch (remoteTheme) {
-    case 'bright':
-      return ThemeMode.Light;
-    case 'darcula':
-      return ThemeMode.Dark;
-    default:
-      return ThemeMode.Auto;
-  }
+const themeModes: Record<RemoteTheme, ThemeMode> = {
+  bright: ThemeMode.Light,
+  darcula: ThemeMode.Dark,
+  auto: ThemeMode.Auto,
 };
 
-const getRemoteTheme = (theme: ThemeMode): RemoteTheme => {
-  switch (theme) {
-    case ThemeMode.Light:
-      return 'bright';
-    case ThemeMode.Dark:
-      return 'darcula';
-    default:
-      return ThemeMode.Auto;
-  }
+const remoteThemes: Record<ThemeMode, RemoteTheme> = {
+  [ThemeMode.Light]: 'bright',
+  [ThemeMode.Dark]: 'darcula',
+  [ThemeMode.Auto]: 'auto',
 };
 
 function applyTheme(themeMode: ThemeMode): void {
@@ -152,7 +142,7 @@ export const SettingsContextProvider = ({
   useEffect(() => {
     if (remoteSettings) {
       const { theme: remoteTheme, ...remoteData } = remoteSettings;
-      const theme = getThemeMode(remoteTheme);
+      const theme = themeModes[remoteTheme];
       setCurrentTheme(theme);
       storageWrapper.setItem(themeModeStorageKey, theme);
       setCachedSettings(remoteData);
@@ -176,7 +166,7 @@ export const SettingsContextProvider = ({
     theme: ThemeMode,
   ): Promise<void> => {
     if (userId) {
-      const remoteTheme = getRemoteTheme(theme);
+      const remoteTheme = remoteThemes[theme];
       await updateRemoteSettings({
         ...newSettings,
         theme: remoteTheme,

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -6,21 +6,24 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { useMutation, useQuery } from 'react-query';
+import { useMutation } from 'react-query';
 import request from 'graphql-request';
 import {
   RemoteSettings,
   RemoteTheme,
   Spaciness,
   UPDATE_USER_SETTINGS_MUTATION,
-  USER_SETTINGS_QUERY,
-  UserSettingsData,
 } from '../graphql/settings';
-import ProgressiveEnhancementContext from './ProgressiveEnhancementContext';
 import AuthContext from './AuthContext';
 import usePersistentState from '../hooks/usePersistentState';
 import { apiUrl } from '../lib/config';
 import { storageWrapper } from '../lib/storageWrapper';
+
+enum ThemeMode {
+  Light = 'light',
+  Dark = 'dark',
+  Auto = 'auto',
+}
 
 export type SettingsContextData = {
   spaciness: Spaciness;
@@ -29,7 +32,7 @@ export type SettingsContextData = {
   openNewTab: boolean;
   insaneMode: boolean;
   showTopSites: boolean;
-  setTheme: (theme) => Promise<void>;
+  setTheme: (theme: ThemeMode) => Promise<void>;
   toggleShowOnlyUnreadPosts: () => Promise<void>;
   toggleOpenNewTab: () => Promise<void>;
   setSpaciness: (density: Spaciness) => Promise<void>;
@@ -49,6 +52,7 @@ type Settings = {
   showTopSites: boolean;
 };
 
+const settingsCacheKey = 'settings';
 const deprecatedLightModeStorageKey = 'showmethelight';
 const themeModeStorageKey = 'theme';
 const defaultSettings: Settings = {
@@ -59,104 +63,121 @@ const defaultSettings: Settings = {
   showTopSites: true,
 };
 
-function applyTheme(themeMode: string): void {
-  if (themeMode !== 'auto') {
-    document.documentElement.classList.remove('auto');
-    const lightMode = themeMode === 'light';
-    if (lightMode) {
-      document.documentElement.classList.add('light');
-    } else {
-      document.documentElement.classList.remove('light');
-    }
+const getThemeMode = (remoteTheme: RemoteTheme): ThemeMode => {
+  switch (remoteTheme) {
+    case 'bright':
+      return ThemeMode.Light;
+    case 'darcula':
+      return ThemeMode.Dark;
+    default:
+      return ThemeMode.Auto;
+  }
+};
+
+const getRemoteTheme = (theme: ThemeMode): RemoteTheme => {
+  switch (theme) {
+    case ThemeMode.Light:
+      return 'bright';
+    case ThemeMode.Dark:
+      return 'darcula';
+    default:
+      return ThemeMode.Auto;
+  }
+};
+
+function applyTheme(themeMode: ThemeMode): void {
+  if (document.documentElement.classList.contains(themeMode)) {
+    return;
+  }
+
+  if (themeMode === ThemeMode.Auto) {
+    document.documentElement.classList.remove(ThemeMode.Light);
+    document.documentElement.classList.add(ThemeMode.Auto);
+    return;
+  }
+
+  document.documentElement.classList.remove(ThemeMode.Auto);
+  if (themeMode === ThemeMode.Light) {
+    document.documentElement.classList.add(ThemeMode.Light);
   } else {
-    document.documentElement.classList.remove('light');
-    document.documentElement.classList.add('auto');
+    document.documentElement.classList.remove(ThemeMode.Light);
   }
 }
 
 export type SettingsContextProviderProps = {
   children?: ReactNode;
+  remoteSettings?: RemoteSettings;
 };
 
 export const SettingsContextProvider = ({
   children,
+  remoteSettings,
 }: SettingsContextProviderProps): ReactElement => {
-  const { windowLoaded } = useContext(ProgressiveEnhancementContext);
-  const { user, tokenRefreshed } = useContext(AuthContext);
-  const canFetchRemote = windowLoaded && tokenRefreshed;
+  const { user } = useContext(AuthContext);
   const userId = user?.id;
 
   const [settings, setCachedSettings, loadedSettings] = usePersistentState(
-    'settings',
+    settingsCacheKey,
     defaultSettings,
   );
-  const [currentTheme, setCurrentTheme] = useState('dark');
-  const { data: remoteSettings } = useQuery<UserSettingsData>(
-    ['userSettings', userId],
-    () => request(`${apiUrl}/graphql`, USER_SETTINGS_QUERY),
-    {
-      enabled: canFetchRemote && !!userId,
-    },
-  );
+  const [currentTheme, setCurrentTheme] = useState(ThemeMode.Dark);
+
+  useEffect(() => {
+    applyTheme(currentTheme);
+  }, [currentTheme]);
 
   const { mutateAsync: updateRemoteSettings } = useMutation<
     unknown,
     unknown,
-    RemoteSettings
-  >((newSettings) =>
-    request(`${apiUrl}/graphql`, UPDATE_USER_SETTINGS_MUTATION, {
-      data: newSettings,
-    }),
+    RemoteSettings,
+    () => Promise<void>
+  >(
+    (params) =>
+      request(`${apiUrl}/graphql`, UPDATE_USER_SETTINGS_MUTATION, {
+        data: params,
+      }),
+    {
+      onMutate: (params) => {
+        const rollback = Object.keys(params).reduce(
+          (values, key) => ({ ...values, [key]: settings[key] }),
+          {},
+        );
+
+        return () => setCachedSettings({ ...settings, ...rollback });
+      },
+      onError: (_, __, rollback) => rollback(),
+    },
   );
 
   useEffect(() => {
     if (remoteSettings) {
-      const remoteTheme = remoteSettings.userSettings.theme;
-      let theme: string;
-      if (remoteTheme === 'bright') {
-        theme = 'light';
-      } else if (remoteTheme === 'darcula') {
-        theme = 'dark';
-      } else {
-        theme = 'auto';
-      }
-      applyTheme(theme);
+      const { theme: remoteTheme, ...remoteData } = remoteSettings;
+      const theme = getThemeMode(remoteTheme);
       setCurrentTheme(theme);
       storageWrapper.setItem(themeModeStorageKey, theme);
-      const cloneSettings = { ...remoteSettings.userSettings };
-      delete cloneSettings.theme;
-      setCachedSettings(cloneSettings);
+      setCachedSettings(remoteData);
     }
   }, [remoteSettings]);
 
   useEffect(() => {
-    const themeModeCookieValue = storageWrapper.getItem(themeModeStorageKey);
-    if (themeModeCookieValue) {
-      setCurrentTheme(themeModeCookieValue);
-      applyTheme(themeModeCookieValue);
-    } else {
-      const lightModeCookieValue = storageWrapper.getItem(
-        deprecatedLightModeStorageKey,
-      );
-      if (lightModeCookieValue === 'true') {
-        applyTheme('light');
-      }
+    const theme = storageWrapper.getItem(themeModeStorageKey) as ThemeMode;
+    if (theme) {
+      setCurrentTheme(theme);
+      return;
+    }
+    const lightMode = storageWrapper.getItem(deprecatedLightModeStorageKey);
+    if (lightMode === 'true') {
+      applyTheme(ThemeMode.Light);
     }
   }, []);
 
-  const updateRemoteSettingsFn = async (
+  const setSettings = async (
     newSettings: Settings,
-    theme: string,
-  ) => {
+    remoteTheme?: RemoteTheme,
+  ): Promise<void> => {
+    await setCachedSettings(newSettings);
+
     if (userId) {
-      let remoteTheme: RemoteTheme;
-      if (theme === 'light') {
-        remoteTheme = 'bright';
-      } else if (theme === 'dark') {
-        remoteTheme = 'darcula';
-      } else {
-        remoteTheme = 'auto';
-      }
       await updateRemoteSettings({
         ...newSettings,
         theme: remoteTheme,
@@ -164,19 +185,14 @@ export const SettingsContextProvider = ({
     }
   };
 
-  const setSettings = async (newSettings: Settings): Promise<void> => {
-    await setCachedSettings(newSettings);
-    await updateRemoteSettingsFn(newSettings, currentTheme);
-  };
-
   const contextData = useMemo<SettingsContextData>(
     () => ({
       ...settings,
       themeMode: currentTheme,
-      setTheme: async (theme: string) => {
-        applyTheme(theme);
+      setTheme: async (theme: ThemeMode) => {
         setCurrentTheme(theme);
-        await updateRemoteSettingsFn(settings, theme);
+        const remoteTheme = getRemoteTheme(theme);
+        await setSettings(settings, remoteTheme);
         storageWrapper.setItem(themeModeStorageKey, theme);
       },
       toggleShowOnlyUnreadPosts: () =>

--- a/packages/shared/src/lib/boot.ts
+++ b/packages/shared/src/lib/boot.ts
@@ -2,6 +2,7 @@ import { IFlags } from 'flagsmith';
 import { AnonymousUser, LoggedUser } from './user';
 import { apiUrl } from './config';
 import { Alerts } from '../graphql/alerts';
+import { RemoteSettings } from '../graphql/settings';
 
 export type AccessToken = { token: string; expiresIn: string };
 export type Visit = { ampStorage?: string; sessionId: string; visitId: string };
@@ -11,6 +12,7 @@ export type Boot = {
   alerts: Alerts;
   visit: Visit;
   flags: IFlags;
+  settings: RemoteSettings;
 };
 
 export async function getBootData(app: string): Promise<Boot> {

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -25,7 +25,6 @@ import { SubscriptionContextProvider } from '@dailydotdev/shared/src/contexts/Su
 import FeaturesContext from '@dailydotdev/shared/src/contexts/FeaturesContext';
 import { AnalyticsContextProvider } from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 import { canonicalFromRouter } from '@dailydotdev/shared/src/lib/canonical';
-import { SettingsContextProvider } from '@dailydotdev/shared/src/contexts/SettingsContext';
 import '@dailydotdev/shared/src/styles/globals.css';
 import useThirdPartyAnalytics from '@dailydotdev/shared/src/hooks/useThirdPartyAnalytics';
 import useTrackPageView from '@dailydotdev/shared/src/hooks/analytics/useTrackPageView';
@@ -182,17 +181,15 @@ export default function App(props: AppProps): ReactElement {
       <QueryClientProvider client={queryClient}>
         <BootDataProvider app="web" getRedirectUri={getRedirectUri}>
           <SubscriptionContextProvider>
-            <SettingsContextProvider>
-              <OnboardingContextProvider>
-                <AnalyticsContextProvider
-                  app="webapp"
-                  version={version}
-                  getPage={getPage}
-                >
-                  <InternalApp {...props} />
-                </AnalyticsContextProvider>
-              </OnboardingContextProvider>
-            </SettingsContextProvider>
+            <OnboardingContextProvider>
+              <AnalyticsContextProvider
+                app="webapp"
+                version={version}
+                getPage={getPage}
+              >
+                <InternalApp {...props} />
+              </AnalyticsContextProvider>
+            </OnboardingContextProvider>
           </SubscriptionContextProvider>
         </BootDataProvider>
       </QueryClientProvider>


### PR DESCRIPTION
DD-337 #done

As part of serving the user's settings in a much faster time, we decided to move it to the boot query.

Since I was already working on the `SettingsContext`, I took the opportunity to refactor and apply some types with the strings we work with.

It may be noticed that the `const isExtension = process.env.TARGET_BROWSER;` was taken inside the component, the test was failing due to the fact the value was generated when we run the test, and simply overriding the value make it fail. So the component has to check it by the runtime to see if it actually has the correct value.

The related `boot` changes PR is now just waiting for additional checks but this should be safe for review. Related PR:
https://github.com/dailydotdev/daily-gateway/pull/394 