### PR TITLE
feat: test and fixes

### DIFF
--- a/packages/shared/src/components/PostsSearch.tsx
+++ b/packages/shared/src/components/PostsSearch.tsx
@@ -107,11 +107,11 @@ export default function PostsSearch({
     }
   };
 
-  if (autoFocus) {
-    useEffect(() => {
+  useEffect(() => {
+    if (autoFocus) {
       searchBoxRef.current?.querySelector('input').focus();
-    }, [searchBoxRef]);
-  }
+    }
+  }, [searchBoxRef, autoFocus]);
 
   const isOpen = !!menuPosition && !!items.length;
   return (

--- a/packages/shared/src/components/PostsSearch.tsx
+++ b/packages/shared/src/components/PostsSearch.tsx
@@ -15,12 +15,14 @@ const AutoCompleteMenu = dynamic(() => import('./fields/AutoCompleteMenu'), {
 export type PostsSearchProps = {
   initialQuery?: string;
   placeholder?: string;
-  onSubmitQuery: (query: string) => Promise<unknown>;
   suggestionType?: string;
+  autoFocus?: boolean;
+  onSubmitQuery: (query: string) => Promise<unknown>;
 };
 
 export default function PostsSearch({
   initialQuery: initialQueryProp,
+  autoFocus = true,
   placeholder,
   onSubmitQuery,
   suggestionType = 'searchPostSuggestions',
@@ -105,9 +107,11 @@ export default function PostsSearch({
     }
   };
 
-  useEffect(() => {
-    searchBoxRef.current?.querySelector('input').focus();
-  }, [searchBoxRef]);
+  if (autoFocus) {
+    useEffect(() => {
+      searchBoxRef.current?.querySelector('input').focus();
+    }, [searchBoxRef]);
+  }
 
   const isOpen = !!menuPosition && !!items.length;
   return (

--- a/packages/shared/src/components/sidebar/Sidebar.spec.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.spec.tsx
@@ -35,6 +35,11 @@ const defaultAlerts: AlertContextData = {
   updateAlerts,
 };
 
+const resizeWindow = (x, y) => {
+  window.resizeTo(x, y);
+  window.dispatchEvent(new Event('resize'));
+};
+
 const renderComponent = (
   mocks = [createMockFeedSettings()],
   user: LoggedUser = defaultUser,
@@ -161,4 +166,12 @@ it('should set all navigation urls', async () => {
       element.path,
     );
   });
+});
+
+it('should render the mobile sidebar version on small screens', async () => {
+  await resizeWindow(1019, 768);
+  renderComponent();
+
+  const sidebar = await screen.findByTestId('sidebar-aside');
+  expect(sidebar).toHaveClass('-translate-x-70');
 });

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -200,6 +200,7 @@ export default function Sidebar({
         <SidebarBackdrop onClick={setOpenMobileSidebar} />
       )}
       <SidebarAside
+        data-testid="sidebar-aside"
         className={classNames(
           sidebarExpanded ? 'laptop:w-60' : 'laptop:w-11',
           openMobileSidebar ? '-translate-x-0' : '-translate-x-70',

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -196,7 +196,9 @@ export default function Sidebar({
 
   return (
     <>
-      {openMobileSidebar && <SidebarBackdrop onClick={setOpenMobileSidebar} />}
+      {openMobileSidebar && !sidebarRendered && (
+        <SidebarBackdrop onClick={setOpenMobileSidebar} />
+      )}
       <SidebarAside
         className={classNames(
           sidebarExpanded ? 'laptop:w-60' : 'laptop:w-11',

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -65,7 +65,8 @@ interface NavItemProps {
   children?: ReactNode;
 }
 
-export const btnClass = 'flex flex-1 items-center px-3 h-7';
+export const btnClass =
+  'flex flex-1 items-center px-5 laptop:px-3 h-10 laptop:h-7';
 export const SidebarBackdrop = classed(
   'div',
   'fixed w-full h-full bg-theme-overlay-quaternary z-3 cursor-pointer inset-0',

--- a/packages/webapp/components/RouterPostsSearch.tsx
+++ b/packages/webapp/components/RouterPostsSearch.tsx
@@ -5,11 +5,13 @@ import { useRouter } from 'next/router';
 export type RouterPostsSearchProps = {
   suggestionType?: string;
   placeholder?: string;
+  autoFocus?: boolean;
 };
 
 export default function RouterPostsSearch({
   suggestionType,
   placeholder,
+  autoFocus,
 }: RouterPostsSearchProps): ReactElement {
   const router = useRouter();
 
@@ -25,6 +27,7 @@ export default function RouterPostsSearch({
       placeholder={placeholder}
       initialQuery={router.query.q?.toString()}
       onSubmitQuery={onSubmitQuery}
+      autoFocus={autoFocus}
     />
   );
 }

--- a/packages/webapp/components/layouts/BookmarkFeedPage.tsx
+++ b/packages/webapp/components/layouts/BookmarkFeedPage.tsx
@@ -31,7 +31,12 @@ export default function BookmarkFeedPage({
     <BookmarkFeedLayout
       searchQuery={router.query?.q?.toString()}
       searchChildren={
-        user && <PostsSearch suggestionType="searchBookmarksSuggestions" />
+        user && (
+          <PostsSearch
+            autoFocus={false}
+            suggestionType="searchBookmarksSuggestions"
+          />
+        )
       }
     >
       {children}

--- a/packages/webapp/pages/history.tsx
+++ b/packages/webapp/pages/history.tsx
@@ -40,7 +40,7 @@ const History = (): ReactElement => {
       {seo}
       <ResponsiveNoPaddingPageContainer
         className={classNames(
-          'flex flex-col',
+          'flex flex-col mx-auto',
           isInitialLoading && 'h-screen overflow-hidden',
         )}
         aria-busy={isLoading}


### PR DESCRIPTION
In this PR we are fixing some edge-cases and re-evaluated the test cases we had.
The cases actually seem significant enough.

Decided to add a mobile render check for the sidebar to see if we are not breaking the mobile version.

- 0553e88add3d8e92b87bba3bdb65f4fac00491eb -> Added more space according to SC for the mobile version
- 8e89d4eae50933ddb1fcf149bf8eb07d37c95c2f -> Mobile backdrop was visible on desktop if you expand from mobile to desktop
- 275a38f96049cf01f1b939d8e789a9101919891b -> Reading history alignment was not set
- 22473237770ba8bee92b8aa86b3f881e0e5aaa2c -> Added a autoFocus attribute for the postSearch component
- 3c74a7d9fee0918135bc5b82245f13222a6e363f -> Added the mobile render test case for the sidebar

DD-350 #done 