### PR TITLE
fix: mobile sidebar height and invisible share text

### DIFF
--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -224,7 +224,9 @@ export default function Sidebar({
           <div className="flex-1" />
           <Nav>
             <RenderSection items={bottomMenuItems} />
-            <InvitePeople sidebarExpanded={sidebarExpanded} />
+            <InvitePeople
+              sidebarExpanded={sidebarExpanded || !sidebarRendered}
+            />
             {sidebarRendered && (
               <SidebarRankProgress sidebarExpanded={sidebarExpanded} />
             )}

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -73,7 +73,7 @@ export const SidebarBackdrop = classed(
 );
 export const SidebarAside = classed(
   'aside',
-  'flex flex-col w-70 laptop:-translate-x-0 bg-theme-bg-primary z-3 border-r border-theme-divider-tertiary transition-all transform duration-300 ease-in-out group fixed laptop:sticky top-0 laptop:top-14 h-screen laptop:h-[calc(100vh-theme(space.14))]',
+  'flex flex-col w-70 laptop:-translate-x-0 bg-theme-bg-primary z-3 border-r border-theme-divider-tertiary transition-all transform duration-300 ease-in-out group fixed laptop:sticky top-0 laptop:top-14 h-full laptop:h-[calc(100vh-theme(space.14))]',
 );
 export const SidebarScrollWrapper = classed(
   'div',

--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -1,6 +1,7 @@
 html {
   background: var(--theme-background-primary);
   color: var(--theme-label-primary);
+  height: -webkit-fill-available;
 }
 
 :root {
@@ -12,6 +13,9 @@ html {
 body {
   min-width: 20rem;
   overflow-y: scroll;
+  min-height: 100vh;
+  /* mobile viewport bug fix */
+  min-height: -webkit-fill-available;
 
   &.ReactModal__Body--open .ReactModal__Content,
   &.ReactModal__Body--open .ReactModal__Content > * {


### PR DESCRIPTION
We had some issues with the mobile sidebar height on the mobile view because of the 100vh usage.
Also the share link was invisible on mobile devices.

Introducing a fallback for Safari to fix the push of the sidebar height.