### PR TITLE
fix: window is not defined yet on shareable link

### DIFF
--- a/packages/shared/src/components/ShareBar.tsx
+++ b/packages/shared/src/components/ShareBar.tsx
@@ -18,6 +18,7 @@ import classed from '../lib/classed';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { postAnalyticsEvent } from '../lib/feed';
 import { SimpleTooltip } from './tooltips/SimpleTooltip';
+import ProgressiveEnhancementContext from '../contexts/ProgressiveEnhancementContext';
 
 const ShareButton = classed(Button, 'my-1');
 const ColorfulShareButton = classed(
@@ -26,7 +27,7 @@ const ColorfulShareButton = classed(
 ) as unknown as FunctionComponent<ButtonProps<'a'>>;
 
 export default function ShareBar({ post }: { post: Post }): ReactElement {
-  const href = getShareableLink();
+  const { windowLoaded } = useContext(ProgressiveEnhancementContext);
   const [copying, copyLink] = useCopyPostLink();
   const { trackEvent } = useContext(AnalyticsContext);
 
@@ -36,6 +37,12 @@ export default function ShareBar({ post }: { post: Post }): ReactElement {
         extra: { media, origin: 'share bar' },
       }),
     );
+
+  if (!windowLoaded) {
+    return <></>;
+  }
+
+  const href = getShareableLink();
 
   return (
     <div className="hidden laptopL:inline-flex flex-row items-center px-3 mt-20 mb-6 rounded-2xl border bg-theme-bg-primary border-theme-divider-quaternary">

--- a/packages/shared/src/components/ShareBar.tsx
+++ b/packages/shared/src/components/ShareBar.tsx
@@ -18,7 +18,6 @@ import classed from '../lib/classed';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { postAnalyticsEvent } from '../lib/feed';
 import { SimpleTooltip } from './tooltips/SimpleTooltip';
-import ProgressiveEnhancementContext from '../contexts/ProgressiveEnhancementContext';
 
 const ShareButton = classed(Button, 'my-1');
 const ColorfulShareButton = classed(
@@ -27,7 +26,7 @@ const ColorfulShareButton = classed(
 ) as unknown as FunctionComponent<ButtonProps<'a'>>;
 
 export default function ShareBar({ post }: { post: Post }): ReactElement {
-  const { windowLoaded } = useContext(ProgressiveEnhancementContext);
+  const href = getShareableLink();
   const [copying, copyLink] = useCopyPostLink();
   const { trackEvent } = useContext(AnalyticsContext);
 
@@ -37,12 +36,6 @@ export default function ShareBar({ post }: { post: Post }): ReactElement {
         extra: { media, origin: 'share bar' },
       }),
     );
-
-  if (!windowLoaded) {
-    return <></>;
-  }
-
-  const href = getShareableLink();
 
   return (
     <div className="hidden laptopL:inline-flex flex-row items-center px-3 mt-20 mb-6 rounded-2xl border bg-theme-bg-primary border-theme-divider-quaternary">

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -1,5 +1,10 @@
-export const getShareableLink = (): string =>
-  window.location.href.split('?')[0];
+export const getShareableLink = (): string => {
+  try {
+    return window.location.href.split('?')[0];
+  } catch (ex) {
+    return '';
+  }
+};
 export const getWhatsappShareLink = (link: string): string =>
   `https://wa.me/?text=${encodeURIComponent(link)}`;
 export const getTwitterShareLink = (link: string, text: string): string =>

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -1,10 +1,5 @@
-export const getShareableLink = (): string => {
-  try {
-    return window.location.href.split('?')[0];
-  } catch (ex) {
-    return '';
-  }
-};
+export const getShareableLink = (): string =>
+  typeof window !== 'undefined' ? window.location.href.split('?')[0] : '';
 export const getWhatsappShareLink = (link: string): string =>
   `https://wa.me/?text=${encodeURIComponent(link)}`;
 export const getTwitterShareLink = (link: string, text: string): string =>

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -238,7 +238,7 @@ const PostPage = ({ id, postData }: Props): ReactElement => {
 
   return (
     <>
-      <div className="flex relative flex-col flex-wrap mx-auto">
+      <div className="flex relative flex-col flex-wrap mx-auto max-w-full">
         <PageContainer className="pt-6 laptop:pb-6 laptopL:mr-[22.5rem] laptop:border-r laptop:border-l laptop:border-theme-divider-tertiary">
           <Head>
             <link rel="preload" as="image" href={postById?.post.image} />
@@ -293,8 +293,8 @@ const PostPage = ({ id, postData }: Props): ReactElement => {
           {authorOnboarding && (
             <AuthorOnboarding onSignUp={!user && (() => showLogin('author'))} />
           )}
+          <NewComment user={user} onNewComment={openNewComment} />
         </PageContainer>
-        <NewComment user={user} onNewComment={openNewComment} />
         <PostWidgets post={postById.post} />
       </div>
 

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -293,8 +293,8 @@ const PostPage = ({ id, postData }: Props): ReactElement => {
           {authorOnboarding && (
             <AuthorOnboarding onSignUp={!user && (() => showLogin('author'))} />
           )}
-          <NewComment user={user} onNewComment={openNewComment} />
         </PageContainer>
+        <NewComment user={user} onNewComment={openNewComment} />
         <PostWidgets post={postById.post} />
       </div>
 


### PR DESCRIPTION
When `window` is not yet defined, the shareable link can't be fetched yet.