### PR TITLE
fix: responsive modal class selector prioritization

### DIFF
--- a/packages/shared/src/components/modals/ResponsiveModal.module.css
+++ b/packages/shared/src/components/modals/ResponsiveModal.module.css
@@ -10,7 +10,7 @@
     }
   }
 
-  & :global(.modal) {
+  & :global(.modal):global(.responsive) {
     position: absolute;
     max-width: 30rem;
     min-height: 100%;

--- a/packages/shared/src/components/modals/ResponsiveModal.tsx
+++ b/packages/shared/src/components/modals/ResponsiveModal.tsx
@@ -21,6 +21,7 @@ export function ResponsiveModal({
   return (
     <StyledModal
       {...props}
+      contentClassName="responsive"
       className={classNames(
         className,
         styles.responsiveModal,

--- a/packages/shared/src/components/modals/StyledModal.tsx
+++ b/packages/shared/src/components/modals/StyledModal.tsx
@@ -1,4 +1,5 @@
 import Modal from 'react-modal';
+import classNames from 'classnames';
 import React, { ReactElement, ReactNode } from 'react';
 import classed from '../../lib/classed';
 import styles from './StyledModal.module.css';
@@ -6,17 +7,19 @@ import styles from './StyledModal.module.css';
 export interface ModalProps extends Modal.Props {
   padding?: boolean;
   children?: ReactNode;
+  contentClassName?: string;
 }
 
 export function ReactModalAdapter({
   className,
+  contentClassName,
   ...props
 }: ModalProps): ReactElement {
   return (
     <Modal
       portalClassName={className.toString()}
       overlayClassName="overlay"
-      className="focus:outline-none modal"
+      className={classNames('focus:outline-none modal', contentClassName)}
       {...props}
     />
   );


### PR DESCRIPTION
The values for responsive modal are being overridden due to the class selector prioritization.

Now we have added another selector to have higher priority when using `StyledModal`

Before:
![Screen Shot 2021-12-23 at 4 34 22 PM](https://user-images.githubusercontent.com/13744167/147212243-dcce7dfe-8f24-49cf-9719-47018e7f1857.png)

Preview:
![image](https://user-images.githubusercontent.com/13744167/147212212-10e5a444-6964-4db7-9a91-ae4a5c96dd0f.png)
