### PR TITLE
fix: use links instead of buttons for sidebar actions

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -3,6 +3,8 @@
   <component name="CommitMessageInspectionProfile">
     <profile version="1.0">
       <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
       <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
     </profile>
   </component>

--- a/packages/shared/package-lock.json
+++ b/packages/shared/package-lock.json
@@ -12304,7 +12304,8 @@
     "react-swipeable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-6.2.0.tgz",
-      "integrity": "sha512-nWQ8dEM8e/uswZLSIkXUsAnQmnX4MTcryOHBQIQYRMJFDpgDBSiVbKsz/BZVCIScF4NtJh16oyxwaNOepR6xSw=="
+      "integrity": "sha512-nWQ8dEM8e/uswZLSIkXUsAnQmnX4MTcryOHBQIQYRMJFDpgDBSiVbKsz/BZVCIScF4NtJh16oyxwaNOepR6xSw==",
+      "dev": true
     },
     "react-transition-group": {
       "version": "4.4.2",

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -208,7 +208,6 @@ export default function Sidebar({
 
   const defaultRenderSectionProps = useMemo(() => {
     return {
-      useNavButtonsNotLinks,
       sidebarExpanded,
       sidebarRendered,
       activePage,
@@ -246,11 +245,13 @@ export default function Sidebar({
               {...defaultRenderSectionProps}
               title="Discover"
               items={discoverMenuItems}
+              useNavButtonsNotLinks={useNavButtonsNotLinks}
             />
             <RenderSection
               {...defaultRenderSectionProps}
               title="Manage"
               items={manageMenuItems}
+              useNavButtonsNotLinks={false}
             />
           </Nav>
           <div className="flex-1" />
@@ -258,6 +259,7 @@ export default function Sidebar({
             <RenderSection
               {...defaultRenderSectionProps}
               items={bottomMenuItems}
+              useNavButtonsNotLinks={false}
             />
             <InvitePeople
               sidebarExpanded={sidebarExpanded || !sidebarRendered}


### PR DESCRIPTION
`useNavButtonsNotLinks` was applied on all the actions even though some of them had to be links in the extension.
This PR splits the usage of this property between the different sections.

DD-376 #done