### PR TITLE
fix: profile menu to not render when user is empty

### DIFF
--- a/packages/shared/src/components/ProfileMenu.tsx
+++ b/packages/shared/src/components/ProfileMenu.tsx
@@ -31,6 +31,10 @@ export default function ProfileMenu({
   const { user, logout } = useContext(AuthContext);
   const shouldShowDnD = !!process.env.TARGET_BROWSER;
 
+  if (!user) {
+    return <></>;
+  }
+
   return (
     <>
       {showAccountDetails && (


### PR DESCRIPTION
DD-386 #done

Fix logout crash on the mobile version. The profile menu is rendered even when user is not available.