### PR TITLE
fix: hotfixes relayout

### DIFF
--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -151,7 +151,7 @@ export default function Sidebar({
     {
       icon: <ListIcon Icon={FilterIcon} />,
       alert: alerts.filter && (
-        <AlertDot className="-top-0.5 -right-0.5" color={AlertColor.Fill} />
+        <AlertDot className="-top-0.5 right-2.5" color={AlertColor.Fill} />
       ),
       title: 'Feed filters',
       action: setLoaded,

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -71,7 +71,7 @@ interface NavItemProps {
 }
 
 export const btnClass =
-  'flex flex-1 items-center px-5 laptop:px-3 h-10 laptop:h-7';
+  'flex flex-1 items-center pl-2 laptop:pl-0 pr-5 laptop:pr-3 h-10 laptop:h-7';
 export const SidebarBackdrop = classed(
   'div',
   'fixed w-full h-full bg-theme-overlay-quaternary z-3 cursor-pointer inset-0',
@@ -101,7 +101,7 @@ export const ListIcon = ({ Icon }: ListIconProps): ReactElement => (
 
 const ItemInnerIcon = ({ alert, icon }: SidebarMenuItem) => {
   return (
-    <span className="relative mr-3">
+    <span className="relative px-3">
       {alert}
       {icon}
     </span>
@@ -117,7 +117,7 @@ const ItemInnerIconTooltip = ({
   <SimpleTooltip {...tooltip} content={title} placement="right">
     <span
       className={classNames(
-        'relative mr-3',
+        'relative px-3',
         tooltip.visible !== undefined && 'pointer-events-none',
       )}
     >

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -238,7 +238,7 @@ const PostPage = ({ id, postData }: Props): ReactElement => {
 
   return (
     <>
-      <div className="flex relative flex-col flex-wrap mx-auto w-full max-w-full">
+      <div className="flex relative flex-col flex-wrap mx-auto w-full laptopL:w-auto max-w-full">
         <PageContainer className="pt-6 laptop:pb-6 laptopL:mr-[22.5rem] laptop:border-r laptop:border-l laptop:border-theme-divider-tertiary">
           <Head>
             <link rel="preload" as="image" href={postById?.post.image} />

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -238,7 +238,7 @@ const PostPage = ({ id, postData }: Props): ReactElement => {
 
   return (
     <>
-      <div className="flex relative flex-col flex-wrap mx-auto max-w-full">
+      <div className="flex relative flex-col flex-wrap mx-auto w-full max-w-full">
         <PageContainer className="pt-6 laptop:pb-6 laptopL:mr-[22.5rem] laptop:border-r laptop:border-l laptop:border-theme-divider-tertiary">
           <Head>
             <link rel="preload" as="image" href={postById?.post.image} />


### PR DESCRIPTION
Fixed a placement issue of the mobile article page not being full width
Tooltip minimized hover was not covering the full space