### PR TITLE
fix: sharebar copied text placement

### DIFF
--- a/packages/shared/src/components/ShareBar.tsx
+++ b/packages/shared/src/components/ShareBar.tsx
@@ -38,7 +38,7 @@ export default function ShareBar({ post }: { post: Post }): ReactElement {
     );
 
   return (
-    <div className="hidden laptopL:inline-flex flex-row items-center px-3 mt-20 mb-6 rounded-2xl border bg-theme-bg-primary border-theme-divider-quaternary">
+    <div className="hidden laptopL:inline-flex relative flex-row items-center px-3 mt-20 mb-6 rounded-2xl border bg-theme-bg-primary border-theme-divider-quaternary">
       {copying && (
         <div
           className={classNames(


### PR DESCRIPTION
Preview before the fix:

![image](https://user-images.githubusercontent.com/13744167/147338886-a8fbd0a9-9705-4c54-84c8-a719299e27e5.png)


Preview after the fix:
![image](https://user-images.githubusercontent.com/13744167/147339145-f1c07503-ba63-4d81-8a16-b7c5edd86a98.png)
