### PR TITLE
fix: update alerts function was not defined in the alerts context

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -3,8 +3,6 @@
   <component name="CommitMessageInspectionProfile">
     <profile version="1.0">
       <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
       <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
     </profile>
   </component>

--- a/packages/shared/src/contexts/AlertContext.tsx
+++ b/packages/shared/src/contexts/AlertContext.tsx
@@ -58,10 +58,10 @@ export const AlertContextProvider = ({
     },
   );
 
-  const alertContextData = useMemo(
+  const alertContextData = useMemo<AlertContextData>(
     () => ({
       alerts,
-      updateRemoteAlerts,
+      updateAlerts: updateRemoteAlerts,
     }),
     [alerts, updateRemoteAlerts],
   );

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -133,6 +133,16 @@ export const BootDataProvider = ({
     [queryClient],
   );
 
+  const updateSettings = useCallback(
+    (updatedSettings) => setBootData({ settings: updatedSettings }),
+    [setBootData],
+  );
+
+  const updateAlerts = useCallback(
+    (updatedAlerts) => setBootData({ alerts: updatedAlerts }),
+    [setBootData],
+  );
+
   return (
     <FeaturesContext.Provider value={{ flags }}>
       <AuthContextProvider
@@ -147,16 +157,9 @@ export const BootDataProvider = ({
         <SettingsContextProvider
           settings={settings}
           loadedSettings={loadedFromCache}
-          updateSettings={(updatedSettings) =>
-            setBootData({ settings: updatedSettings })
-          }
+          updateSettings={updateSettings}
         >
-          <AlertContextProvider
-            alerts={alerts}
-            updateAlerts={(updatedAlerts) =>
-              setBootData({ alerts: updatedAlerts })
-            }
-          >
+          <AlertContextProvider alerts={alerts} updateAlerts={updateAlerts}>
             {children}
           </AlertContextProvider>
         </SettingsContextProvider>


### PR DESCRIPTION
Due to our recent change in the boot provider, we mistakenly renamed the `updateAlerts` function.
It caused critical errors throughout the app when trying to call this function as it was undefined.
The most common case is when the feed filters had the alert on and the app need to turn off this alert by dispatching the call.
Key learning here is to use explicit types in functions like `useMemo` and create test cases to prevent it.