### PR TITLE
fix: fix flagged version of login button

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extension",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "scripts": {
     "dev:chrome": "cross-env NODE_ENV=development cross-env TARGET_BROWSER=chrome webpack --watch",
     "dev:firefox": "cross-env NODE_ENV=development cross-env TARGET_BROWSER=firefox webpack --watch",

--- a/packages/shared/src/components/LoginButton.tsx
+++ b/packages/shared/src/components/LoginButton.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useContext, useEffect } from 'react';
+import React, { ReactElement, ReactNode, useContext, useEffect } from 'react';
+import classNames from 'classnames';
 import { Button } from './buttons/Button';
 import AuthContext from '../contexts/AuthContext';
 import FeaturesContext from '../contexts/FeaturesContext';
@@ -16,7 +17,14 @@ const getAnalyticsEvent = (
   feed_item_title: copy,
 });
 
-export default function LoginButton(): ReactElement {
+interface LoginButtonProps {
+  icon?: ReactNode;
+  className?: string;
+}
+export default function LoginButton({
+  icon,
+  className,
+}: LoginButtonProps): ReactElement {
   const { showLogin } = useContext(AuthContext);
   const { flags } = useContext(FeaturesContext);
   const { trackEvent } = useContext(AnalyticsContext);
@@ -33,7 +41,11 @@ export default function LoginButton(): ReactElement {
   };
 
   return (
-    <Button onClick={onClick} className="btn-primary">
+    <Button
+      onClick={onClick}
+      icon={icon}
+      className={classNames('btn-primary', className)}
+    >
       <span className="hidden laptop:inline">{buttonCopy}</span>
       <span className="laptop:hidden">Login</span>
     </Button>

--- a/packages/shared/src/components/LoginButton.tsx
+++ b/packages/shared/src/components/LoginButton.tsx
@@ -47,7 +47,7 @@ export default function LoginButton({
       className={classNames('btn-primary', className)}
     >
       <span className="hidden laptop:inline">{buttonCopy}</span>
-      <span className="laptop:hidden">Login</span>
+      <span className="laptop:hidden">Sign up</span>
     </Button>
   );
 }

--- a/packages/shared/src/components/LoginButton.tsx
+++ b/packages/shared/src/components/LoginButton.tsx
@@ -29,7 +29,7 @@ export default function LoginButton({
   const { flags } = useContext(FeaturesContext);
   const { trackEvent } = useContext(AnalyticsContext);
   const buttonCopy =
-    getFeatureValue(Features.SignupButtonCopy, flags) || 'Login';
+    getFeatureValue(Features.SignupButtonCopy, flags) || 'Access all features';
 
   useEffect(() => {
     trackEvent(getAnalyticsEvent('impression', buttonCopy));

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -21,6 +21,7 @@ import { LoggedUser } from '../lib/user';
 import usePromotionalBanner from '../hooks/usePromotionalBanner';
 import { useSwipeableSidebar } from '../hooks/useSwipeableSidebar';
 import SettingsContext from '../contexts/SettingsContext';
+import LoginButton from './LoginButton';
 
 export interface MainLayoutProps extends HTMLAttributes<HTMLDivElement> {
   showOnlyLogo?: boolean;
@@ -89,7 +90,7 @@ export default function MainLayout({
   enableSearch,
   onShowDndClick,
 }: MainLayoutProps): ReactElement {
-  const { user, showLogin, loadingUser } = useContext(AuthContext);
+  const { user, loadingUser } = useContext(AuthContext);
   const { trackEvent } = useContext(AnalyticsContext);
   const { sidebarRendered } = useSidebarRendered();
   const { bannerData, setLastSeen } = usePromotionalBanner();
@@ -147,12 +148,7 @@ export default function MainLayout({
                     onShowDndClick={onShowDndClick}
                   />
                 ) : (
-                  <Button
-                    onClick={() => showLogin('main button')}
-                    className="hidden laptop:block btn-primary"
-                  >
-                    Login
-                  </Button>
+                  <LoginButton className="hidden laptop:block" />
                 )}
               </>
             )}

--- a/packages/shared/src/components/sidebar/SidebarUserButton.tsx
+++ b/packages/shared/src/components/sidebar/SidebarUserButton.tsx
@@ -8,6 +8,7 @@ import AuthContext from '../../contexts/AuthContext';
 import SettingsIcon from '../../../icons/settings.svg';
 import UserIcon from '../../../icons/user.svg';
 import { SidebarUserButtonProps } from './common';
+import LoginButton from '../LoginButton';
 
 const { onMenuClick } = useProfileMenu();
 
@@ -19,7 +20,7 @@ export default function SidebarUserButton({
   sidebarRendered,
   onShowDndClick,
 }: SidebarUserButtonProps): ReactElement {
-  const { user, showLogin, loadingUser } = useContext(AuthContext);
+  const { user, loadingUser } = useContext(AuthContext);
 
   return (
     <>
@@ -49,13 +50,7 @@ export default function SidebarUserButton({
               <ProfileMenu onShowDndClick={onShowDndClick} />
             </>
           ) : (
-            <Button
-              onClick={() => showLogin('main button')}
-              className="btn-primary"
-              icon={<UserIcon />}
-            >
-              Login
-            </Button>
+            <LoginButton icon={<UserIcon />} />
           )}
         </li>
       )}

--- a/packages/webapp/__tests__/MainLayout.tsx
+++ b/packages/webapp/__tests__/MainLayout.tsx
@@ -60,12 +60,12 @@ it('should show login button when not logged-in', async () => {
   renderLayout();
   // Experiment doesn't support mobile resolution which both yields two elements.
   expect(await screen.findAllByText('Access all features')).toHaveLength(2);
-  expect(await screen.findAllByText('Login')).toHaveLength(2);
+  expect(await screen.findAllByText('Sign up')).toHaveLength(2);
 });
 
 it('should show login when clicking on the button', async () => {
   renderLayout();
-  const [el] = await screen.findAllByText('Login');
+  const [el] = await screen.findAllByText('Access all features');
   el.click();
   expect(showLogin).toBeCalledTimes(1);
 });

--- a/packages/webapp/__tests__/MainLayout.tsx
+++ b/packages/webapp/__tests__/MainLayout.tsx
@@ -58,8 +58,9 @@ const renderLayout = (user: LoggedUser = null): RenderResult => {
 
 it('should show login button when not logged-in', async () => {
   renderLayout();
-  // Experiment doesn't support mobile resolution which both yields two elements, for a total of 4
-  expect(await screen.findAllByText('Login')).toHaveLength(4);
+  // Experiment doesn't support mobile resolution which both yields two elements.
+  expect(await screen.findAllByText('Access all features')).toHaveLength(2);
+  expect(await screen.findAllByText('Login')).toHaveLength(2);
 });
 
 it('should show login when clicking on the button', async () => {

--- a/packages/webapp/__tests__/MainLayout.tsx
+++ b/packages/webapp/__tests__/MainLayout.tsx
@@ -58,8 +58,8 @@ const renderLayout = (user: LoggedUser = null): RenderResult => {
 
 it('should show login button when not logged-in', async () => {
   renderLayout();
-  // Experiment doesn't support mobile resolution which yields two elements
-  expect(await screen.findAllByText('Login')).toHaveLength(2);
+  // Experiment doesn't support mobile resolution which both yields two elements, for a total of 4
+  expect(await screen.findAllByText('Login')).toHaveLength(4);
 });
 
 it('should show login when clicking on the button', async () => {


### PR DESCRIPTION
Added the login button flagged version to be uniform.

Do note for the mobile sidebar version it will always render "Login" but at least this makes everything loaded from 1 component now.

DD-390 #done 