### PR TITLE
fix: devcard notif should not show when explicitly defined

### DIFF
--- a/packages/shared/src/contexts/AlertContext.tsx
+++ b/packages/shared/src/contexts/AlertContext.tsx
@@ -11,6 +11,7 @@ export const ALERT_DEFAULTS: Alerts = {
 
 export interface AlertContextData {
   alerts: Alerts;
+  loadedAlerts?: boolean;
   updateAlerts?: UseMutateAsyncFunction<
     unknown,
     unknown,
@@ -23,17 +24,20 @@ export const MAX_DATE = new Date(3021, 0, 1);
 
 const AlertContext = React.createContext<AlertContextData>({
   alerts: ALERT_DEFAULTS,
+  loadedAlerts: false,
 });
 
 interface AlertContextProviderProps {
   children: ReactNode;
   alerts?: Alerts;
+  loadedAlerts?: boolean;
   updateAlerts: (alerts: Alerts) => unknown;
 }
 
 export const AlertContextProvider = ({
   children,
   alerts = ALERT_DEFAULTS,
+  loadedAlerts,
   updateAlerts,
 }: AlertContextProviderProps): ReactElement => {
   const { mutateAsync: updateRemoteAlerts } = useMutation<
@@ -61,6 +65,7 @@ export const AlertContextProvider = ({
   const alertContextData = useMemo<AlertContextData>(
     () => ({
       alerts,
+      loadedAlerts,
       updateAlerts: updateRemoteAlerts,
     }),
     [alerts, updateRemoteAlerts],

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -159,7 +159,11 @@ export const BootDataProvider = ({
           loadedSettings={loadedFromCache}
           updateSettings={updateSettings}
         >
-          <AlertContextProvider alerts={alerts} updateAlerts={updateAlerts}>
+          <AlertContextProvider
+            alerts={alerts}
+            updateAlerts={updateAlerts}
+            loadedAlerts={loadedFromCache}
+          >
             {children}
           </AlertContextProvider>
         </SettingsContextProvider>

--- a/packages/shared/src/hooks/useReadingRank.ts
+++ b/packages/shared/src/hooks/useReadingRank.ts
@@ -39,13 +39,14 @@ const defaultRank: MyRankData = {
 const checkShouldShowRankModal = (
   rankLastSeen: Date,
   lastReadTime: Date,
+  loadedAlerts: boolean,
   neverShowRankModal?: boolean,
 ) => {
   if (neverShowRankModal !== null && neverShowRankModal !== undefined) {
     return !neverShowRankModal;
   }
 
-  if (rankLastSeen === undefined) {
+  if (loadedAlerts && !rankLastSeen) {
     return true;
   }
 
@@ -92,8 +93,9 @@ export default function useReadingRank(): ReturnType {
     });
 
   const shouldShowRankModal = checkShouldShowRankModal(
-    loadedAlerts && alerts?.rankLastSeen,
+    alerts?.rankLastSeen,
     cachedRank?.rank?.lastReadTime || remoteRank?.rank?.lastReadTime,
+    loadedAlerts,
     neverShowRankModal,
   );
 

--- a/packages/shared/src/hooks/useReadingRank.ts
+++ b/packages/shared/src/hooks/useReadingRank.ts
@@ -42,15 +42,11 @@ const checkShouldShowRankModal = (
   neverShowRankModal?: boolean,
 ) => {
   if (neverShowRankModal !== null && neverShowRankModal !== undefined) {
-    return neverShowRankModal;
+    return !neverShowRankModal;
   }
 
-  if (rankLastSeen === undefined) {
+  if (!rankLastSeen) {
     return true;
-  }
-
-  if (rankLastSeen === null) {
-    return false;
   }
 
   if (!lastReadTime) {
@@ -61,7 +57,7 @@ const checkShouldShowRankModal = (
 };
 
 export default function useReadingRank(): ReturnType {
-  const { alerts, updateAlerts } = useContext(AlertContext);
+  const { alerts, loadedAlerts, updateAlerts } = useContext(AlertContext);
   const { user, tokenRefreshed } = useContext(AuthContext);
   const [levelUp, setLevelUp] = useState(false);
   const queryClient = useQueryClient();
@@ -95,11 +91,13 @@ export default function useReadingRank(): ReturnType {
       neverShowRankModal: newNeverShowRankModal,
     });
 
-  const shouldShowRankModal = checkShouldShowRankModal(
-    alerts?.rankLastSeen,
-    cachedRank?.rank?.lastReadTime || remoteRank?.rank?.lastReadTime,
-    neverShowRankModal,
-  );
+  const shouldShowRankModal =
+    loadedAlerts &&
+    checkShouldShowRankModal(
+      alerts?.rankLastSeen,
+      cachedRank?.rank?.lastReadTime || remoteRank?.rank?.lastReadTime,
+      neverShowRankModal,
+    );
 
   const updateShownProgress = async () => {
     if (document.visibilityState === 'hidden') {

--- a/packages/shared/src/hooks/useReadingRank.ts
+++ b/packages/shared/src/hooks/useReadingRank.ts
@@ -113,6 +113,9 @@ export default function useReadingRank(): ReturnType {
     }
   };
 
+  // Let the rank update and then show progress animation, slight delay so the user won't miss it
+  const displayProgress = () => setTimeout(updateShownProgress, 300);
+
   useEffect(() => {
     if (remoteRank && loadedCache) {
       if (
@@ -120,11 +123,12 @@ export default function useReadingRank(): ReturnType {
         remoteRank.rank.progressThisWeek < cachedRank.rank.progressThisWeek
       ) {
         cacheRank();
-        return;
+      } else if (cachedRank && !cachedRank.rank.rankLastWeek) {
+        cacheRank();
+        displayProgress();
+      } else {
+        displayProgress();
       }
-
-      // Let the rank update and then show progress animation, slight delay so the user won't miss it
-      setTimeout(updateShownProgress, 300);
     }
   }, [remoteRank, loadedCache]);
 

--- a/packages/shared/src/hooks/useReadingRank.ts
+++ b/packages/shared/src/hooks/useReadingRank.ts
@@ -117,8 +117,7 @@ export default function useReadingRank(): ReturnType {
     if (remoteRank && loadedCache) {
       if (
         !cachedRank ||
-        remoteRank.rank.progressThisWeek < cachedRank.rank.progressThisWeek ||
-        !cachedRank.rank.rankLastWeek
+        remoteRank.rank.progressThisWeek < cachedRank.rank.progressThisWeek
       ) {
         cacheRank();
         return;

--- a/packages/shared/src/hooks/useReadingRank.ts
+++ b/packages/shared/src/hooks/useReadingRank.ts
@@ -122,11 +122,17 @@ export default function useReadingRank(): ReturnType {
         !cachedRank ||
         remoteRank.rank.progressThisWeek < cachedRank.rank.progressThisWeek
       ) {
+        /* if there is no cache value or it is not the most updated let's set the cache */
         cacheRank();
       } else if (cachedRank && !cachedRank.rank.rankLastWeek) {
+        /*
+          else if the cache value has data but missing some properties rankLastWeek, let's re-set it
+          with that, this can mean the user is on their first week, which should see the progress animation
+        */
         cacheRank();
         displayProgress();
       } else {
+        /* else - the cache has pre-existing value so we just need to check if we should display the progress */
         displayProgress();
       }
     }

--- a/packages/shared/src/hooks/useReadingRank.ts
+++ b/packages/shared/src/hooks/useReadingRank.ts
@@ -45,11 +45,11 @@ const checkShouldShowRankModal = (
     return !neverShowRankModal;
   }
 
-  if (!rankLastSeen) {
+  if (rankLastSeen === undefined) {
     return true;
   }
 
-  if (!lastReadTime) {
+  if (!rankLastSeen) {
     return false;
   }
 

--- a/packages/shared/src/hooks/useReadingRank.ts
+++ b/packages/shared/src/hooks/useReadingRank.ts
@@ -91,13 +91,11 @@ export default function useReadingRank(): ReturnType {
       neverShowRankModal: newNeverShowRankModal,
     });
 
-  const shouldShowRankModal =
-    loadedAlerts &&
-    checkShouldShowRankModal(
-      alerts?.rankLastSeen,
-      cachedRank?.rank?.lastReadTime || remoteRank?.rank?.lastReadTime,
-      neverShowRankModal,
-    );
+  const shouldShowRankModal = checkShouldShowRankModal(
+    loadedAlerts && alerts?.rankLastSeen,
+    cachedRank?.rank?.lastReadTime || remoteRank?.rank?.lastReadTime,
+    neverShowRankModal,
+  );
 
   const updateShownProgress = async () => {
     if (document.visibilityState === 'hidden') {


### PR DESCRIPTION
DD-393 #done

The previous mechanism for identifying the `rankLastSeen` [was removed](https://github.com/dailydotdev/apps/pull/763/files#diff-591811d5ed8112fe53d4882f8cfd46634f04cb39e40a12c0086ef7fe21510158L76-L84) but I have also realized to use the same process the other providers do when checking for the remote value's availability.