### PR TITLE
fix: on slow devices the boot would load after update overwritting

### DIFF
--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -112,19 +112,20 @@ export const BootDataProvider = ({
     updatedBootData: Partial<BootCacheData>,
     update = true,
   ) => {
+    let updatedData = { ...updatedBootData };
     if (update) {
       if (lastAppliedChange) {
-        updatedBootData = { ...lastAppliedChange, ...updatedBootData };
+        updatedData = { ...lastAppliedChange, ...updatedData };
       }
-      setLastAppliedChange(updatedBootData);
+      setLastAppliedChange(updatedData);
     } else {
       if (lastAppliedChange) {
-        updatedBootData = { ...updatedBootData, ...lastAppliedChange };
+        updatedData = { ...updatedData, ...lastAppliedChange };
       }
       setLastAppliedChange(null);
     }
 
-    const updated = updateLocalBootData(cachedBootData, updatedBootData);
+    const updated = updateLocalBootData(cachedBootData, updatedData);
     setCachedBootData(updated);
   };
 

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -91,6 +91,8 @@ export const BootDataProvider = ({
   const queryClient = useQueryClient();
   const [cachedBootData, setCachedBootData] =
     useState<Partial<BootCacheData>>();
+  const [lastAppliedChange, setLastAppliedChange] =
+    useState<Partial<BootCacheData>>();
   const loadedFromCache = cachedBootData !== undefined;
   const { user, settings, flags = {}, alerts } = cachedBootData || {};
   const {
@@ -106,7 +108,22 @@ export const BootDataProvider = ({
     }
   }, []);
 
-  const setBootData = (updatedBootData: Partial<BootCacheData>) => {
+  const setBootData = (
+    updatedBootData: Partial<BootCacheData>,
+    update = true,
+  ) => {
+    if (update) {
+      if (lastAppliedChange) {
+        updatedBootData = { ...lastAppliedChange, ...updatedBootData };
+      }
+      setLastAppliedChange(updatedBootData);
+    } else {
+      if (lastAppliedChange) {
+        updatedBootData = { ...updatedBootData, ...lastAppliedChange };
+      }
+      setLastAppliedChange(null);
+    }
+
     const updated = updateLocalBootData(cachedBootData, updatedBootData);
     setCachedBootData(updated);
   };
@@ -117,7 +134,7 @@ export const BootDataProvider = ({
       if (!bootRemoteData.user || !('providers' in bootRemoteData.user)) {
         delete bootRemoteData.settings;
       }
-      setBootData(bootRemoteData);
+      setBootData(bootRemoteData, false);
     }
   }, [bootRemoteData]);
 


### PR DESCRIPTION
The cached data would be overwritten while updating on slow connections.
We introduced a temporary update state that has priority.