### PR TITLE
fix: registration stuck-up on logout

### DIFF
--- a/packages/shared/src/contexts/AuthContext.tsx
+++ b/packages/shared/src/contexts/AuthContext.tsx
@@ -31,9 +31,25 @@ export interface AuthContextData {
 const AuthContext = React.createContext<AuthContextData>(null);
 export default AuthContext;
 
+const getQueryParams = () => {
+  const urlSearchParams = new URLSearchParams(window.location.search);
+  const params = Object.fromEntries(urlSearchParams.entries());
+
+  return params;
+};
+
+const REGISTRATION_PATH = '/register';
+
 const logout = async (): Promise<void> => {
   await dispatchLogout();
-  window.location.reload();
+  const params = getQueryParams();
+  if (params.redirect_uri) {
+    window.location.replace(params.redirect_uri);
+  } else if (window.location.pathname === REGISTRATION_PATH) {
+    window.location.replace(process.env.NEXT_PUBLIC_WEBAPP_URL);
+  } else {
+    window.location.reload();
+  }
 };
 
 export type AuthContextProviderProps = {


### PR DESCRIPTION
The reason for getting stuck on logout while at the registration page is we do `reload` only when logging out.

To better catch the case, we first check
- if there is any `redirect_uri` to utilize for redirection.
- if none - we redirect to our app's home page if it is logging out at the registration page (just to make sure to catch all cases).
- else we reload like how it is supposed to be before