### PR TITLE
fix: redirect user to registration if not yet confirmed

### DIFF
--- a/packages/shared/src/contexts/AuthContext.tsx
+++ b/packages/shared/src/contexts/AuthContext.tsx
@@ -38,7 +38,7 @@ const getQueryParams = () => {
   return params;
 };
 
-const REGISTRATION_PATH = '/register';
+export const REGISTRATION_PATH = '/register';
 
 const logout = async (): Promise<void> => {
   await dispatchLogout();

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -99,6 +99,10 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
       !user.infoConfirmed &&
       window.location.pathname.indexOf(REGISTRATION_PATH) !== 0
     ) {
+      /*  this will check if the user came from our registration
+          if the user has clicked the logout button in the registration - it should go through here because the user will be redirected
+          and since the window.location.replace did not clear all the local state and data like window.location.replace - we will have to force a reload
+      */
       const referrer = document.referrer && new URL(document.referrer);
       if (referrer.pathname?.indexOf(REGISTRATION_PATH) !== -1) {
         window.location.reload();

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -13,7 +13,9 @@ import 'focus-visible';
 import Modal from 'react-modal';
 import { DefaultSeo } from 'next-seo';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import AuthContext, {
+  REGISTRATION_PATH,
+} from '@dailydotdev/shared/src/contexts/AuthContext';
 import { Router } from 'next/router';
 import { useCookieBanner } from '@dailydotdev/shared/src/hooks/useCookieBanner';
 import ProgressiveEnhancementContext, {
@@ -95,14 +97,20 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
       tokenRefreshed &&
       user &&
       !user.infoConfirmed &&
-      window.location.pathname.indexOf('/register') !== 0
+      window.location.pathname.indexOf(REGISTRATION_PATH) !== 0
     ) {
+      const referrer = document.referrer && new URL(document.referrer);
+      if (referrer.pathname?.indexOf(REGISTRATION_PATH) !== -1) {
+        window.location.reload();
+        return;
+      }
+
       window.location.replace(
         `/register?redirect_uri=${encodeURI(window.location.pathname)}`,
       );
     }
     updateCookieBanner(user);
-  }, [user, loadingUser, tokenRefreshed]);
+  }, [user, loadingUser, tokenRefreshed, router.pathname]);
 
   const getLayout =
     (Component as CompnentGetLayout).getLayout || ((page) => page);

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -101,7 +101,7 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
     ) {
       /*  this will check if the user came from our registration
           if the user has clicked the logout button in the registration - it should go through here because the user will be redirected
-          and since the window.location.replace did not clear all the local state and data like window.location.replace - we will have to force a reload
+          and since the window.location.replace did not clear all the local state and data like window.location.reload - we will have to force a reload
       */
       const referrer = document.referrer && new URL(document.referrer);
       if (referrer.pathname?.indexOf(REGISTRATION_PATH) !== -1) {


### PR DESCRIPTION
Clicking the logout button on registration already works on the extension, but on the webapp, there needs an additional check whether we should `reload` to clear the local state and data (as it doesn't automatically clear up by the `window.location.replace` which should have been).

I have also found a bug (which I don't know if this should be directed at `nextjs` repo). In our `_app.tsx` file, it should detect when the user has arrived - like `window.location.reload` it goes through the `useEffect` as mentioned before it should also happen with `window.location.replace` since we are not using the `next/link` or `next/router` which is the native redirect to keep all local state and data.

Reproducing the bug mentioned above:
1. Register
2. Once the form is displayed, click our dailydev logo on the top-most left corner.
3. This won't redirect even though the user info has not yet been confirmed.

The expected behavior on step 3 should be redirected to the form again.

Fix: since `nextjs` acknowledges the changes in the route even using `window.location.replace` as nextjs-native redirect - we have included the `router.pathname` as a dependency.