### PR TITLE
refactor: article page classes layout

### DIFF
--- a/packages/shared/src/components/utilities.module.css
+++ b/packages/shared/src/components/utilities.module.css
@@ -16,11 +16,7 @@
   }
 }
 
-.newCommentContainer {
-  max-width: $pageMaxWidth;
-}
-
-.pageSidebar {
+.pageWidgets {
   max-width: $pageMaxWidth;
 }
 

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -13,22 +13,30 @@ export const LegalNotice = classed(
   styles.legal,
 );
 
+export const pageBorders =
+  'laptop:border-r laptop:border-l laptop:border-theme-divider-tertiary';
+const pagePaddings = 'px-4 tablet:px-8';
+
 export const PageContainer = classed(
   'main',
   styles.pageContainer,
-  'relative flex flex-col w-full items-stretch px-4 z-1 tablet:px-8 tablet:self-center',
+  pagePaddings,
+  'relative flex flex-col w-full items-stretch z-1 tablet:self-center',
 );
 
-export const PageSidebar = classed(
+export const PageWidgets = classed(
   'aside',
-  styles.pageSidebar,
-  'laptopL:absolute right-0 px-4 tablet:px-8 order-2 laptop:pb-10 laptopL:pb-0 laptop:order-3 laptopL:order-2 laptopL:px-6 laptop:border-r laptop:border-l w-full laptopL:w-auto laptop:border-theme-divider-tertiary laptopL:border-none tablet:self-center',
+  styles.pageWidgets,
+  pagePaddings,
+  pageBorders,
+  'w-full',
+  'laptopL:px-6 laptopL:w-auto laptopL:border-none',
 );
 
 export const NewCommentContainer = classed(
   'div',
-  styles.newCommentContainer,
-  'pb-20 laptop:pb-6 laptop:border-r order-3 laptop:order-2 laptopL:order-3 laptop:border-l laptop:border-theme-divider-tertiary relative flex flex-col w-full items-stretch px-4 z-1 tablet:px-8 laptopL:mr-[22.5rem] tablet:self-center',
+  'flex fixed right-0 bottom-0 left-0 z-2 flex-col items-stretch py-3 px-4 w-full bg-theme-bg-primary',
+  'laptop:relative laptop:p-0 laptop:bg-none ',
 );
 
 export const NoPaddingPageContainer = classed(

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -24,13 +24,12 @@ export const PageContainer = classed(
   'relative flex flex-col w-full items-stretch z-1',
 );
 
-export const widgetsWidth = 'laptopL:w-[19.5rem]';
 export const PageWidgets = classed(
   'aside',
   styles.pageWidgets,
   pagePaddings,
   pageBorders,
-  widgetsWidth,
+  'laptopL:min-w-[19.5rem]',
   'w-full laptopL:px-6 laptopL:w-auto laptopL:border-none',
 );
 

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -29,8 +29,7 @@ export const PageWidgets = classed(
   styles.pageWidgets,
   pagePaddings,
   pageBorders,
-  'w-full',
-  'laptopL:px-6 laptopL:w-auto laptopL:border-none',
+  'w-full laptopL:px-6 laptopL:w-auto laptopL:border-none',
 );
 
 export const NewCommentContainer = classed(

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -29,7 +29,7 @@ export const PageWidgets = classed(
   styles.pageWidgets,
   pagePaddings,
   pageBorders,
-  'laptopL:min-w-[2.5rem]',
+  'laptopL:min-w-[22.5rem]',
   'w-full laptopL:px-6 laptopL:w-auto laptopL:border-none',
 );
 

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -29,7 +29,7 @@ export const PageWidgets = classed(
   styles.pageWidgets,
   pagePaddings,
   pageBorders,
-  'w-full laptopL:px-6 laptopL:w-auto laptopL:border-none',
+  'w-full min-w-[19.5rem] laptopL:px-6 laptopL:w-auto laptopL:border-none',
 );
 
 export const NewCommentContainer = classed(

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -21,15 +21,17 @@ export const PageContainer = classed(
   'main',
   styles.pageContainer,
   pagePaddings,
-  'relative flex flex-col w-full items-stretch z-1 tablet:self-center',
+  'relative flex flex-col w-full items-stretch z-1',
 );
 
+export const widgetsWidth = 'laptopL:w-[19.5rem]';
 export const PageWidgets = classed(
   'aside',
   styles.pageWidgets,
   pagePaddings,
   pageBorders,
-  'w-full min-w-[19.5rem] laptopL:px-6 laptopL:w-auto laptopL:border-none',
+  widgetsWidth,
+  'w-full laptopL:px-6 laptopL:w-auto laptopL:border-none',
 );
 
 export const NewCommentContainer = classed(

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -29,7 +29,7 @@ export const PageWidgets = classed(
   styles.pageWidgets,
   pagePaddings,
   pageBorders,
-  'laptopL:min-w-[19.5rem]',
+  'laptopL:min-w-[2.5rem]',
   'w-full laptopL:px-6 laptopL:w-auto laptopL:border-none',
 );
 

--- a/packages/webapp/components/posts/NewComment.tsx
+++ b/packages/webapp/components/posts/NewComment.tsx
@@ -16,21 +16,19 @@ export function NewComment({
 }: NewCommentProps): ReactElement {
   return (
     <NewCommentContainer>
-      <div className="fixed laptop:relative inset-x-0 laptop:right-[unset] bottom-0 laptop:bottom-[unset] laptop:left-[unset] z-2 py-3 px-4 laptop:px-0 laptop:pt-4 laptop:pb-0 laptop:mt-auto w-full laptop:bg-none bg-theme-bg-primary">
-        <button
-          type="button"
-          className={classNames(
-            'flex w-full h-10 items-center px-4 bg-theme-bg-secondary text-theme-label-secondary border-none rounded-2xl cursor-pointer typo-callout focus-outline',
-            styles.discussionBar,
-          )}
-          onClick={onNewComment}
-        >
-          {user && (
-            <ProfilePicture user={user} size="small" className="mr-3 -ml-2" />
-          )}
-          Start the discussion...
-        </button>
-      </div>
+      <button
+        type="button"
+        className={classNames(
+          'flex w-full h-10 items-center px-4 bg-theme-bg-secondary text-theme-label-secondary rounded-2xl typo-callout focus-outline',
+          styles.discussionBar,
+        )}
+        onClick={onNewComment}
+      >
+        {user && (
+          <ProfilePicture user={user} size="small" className="mr-3 -ml-2" />
+        )}
+        Start the discussion...
+      </button>
     </NewCommentContainer>
   );
 }

--- a/packages/webapp/components/posts/PostWidgets.tsx
+++ b/packages/webapp/components/posts/PostWidgets.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useContext } from 'react';
-import { PageSidebar } from '@dailydotdev/shared/src/components/utilities';
+import { PageWidgets } from '@dailydotdev/shared/src/components/utilities';
 import { ShareMobile } from '@dailydotdev/shared/src/components/ShareMobile';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { postAnalyticsEvent } from '@dailydotdev/shared/src/lib/feed';
@@ -35,12 +35,12 @@ export function PostWidgets({ post }: PostWidgetsProps): ReactElement {
   };
 
   return (
-    <PageSidebar>
+    <PageWidgets>
       <ShareBar post={post} />
       <ShareMobile share={sharePost} />
       {tokenRefreshed && (
         <FurtherReading currentPost={post} className="laptopL:w-[19.5rem]" />
       )}
-    </PageSidebar>
+    </PageWidgets>
   );
 }

--- a/packages/webapp/components/posts/PostWidgets.tsx
+++ b/packages/webapp/components/posts/PostWidgets.tsx
@@ -1,8 +1,5 @@
 import React, { ReactElement, useContext } from 'react';
-import {
-  PageWidgets,
-  widgetsWidth,
-} from '@dailydotdev/shared/src/components/utilities';
+import { PageWidgets } from '@dailydotdev/shared/src/components/utilities';
 import { ShareMobile } from '@dailydotdev/shared/src/components/ShareMobile';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { postAnalyticsEvent } from '@dailydotdev/shared/src/lib/feed';
@@ -42,7 +39,7 @@ export function PostWidgets({ post }: PostWidgetsProps): ReactElement {
       <ShareBar post={post} />
       <ShareMobile share={sharePost} />
       {tokenRefreshed && (
-        <FurtherReading currentPost={post} className={widgetsWidth} />
+        <FurtherReading currentPost={post} className="laptopL:w-[19.5rem]" />
       )}
     </PageWidgets>
   );

--- a/packages/webapp/components/posts/PostWidgets.tsx
+++ b/packages/webapp/components/posts/PostWidgets.tsx
@@ -1,5 +1,8 @@
 import React, { ReactElement, useContext } from 'react';
-import { PageWidgets } from '@dailydotdev/shared/src/components/utilities';
+import {
+  PageWidgets,
+  widgetsWidth,
+} from '@dailydotdev/shared/src/components/utilities';
 import { ShareMobile } from '@dailydotdev/shared/src/components/ShareMobile';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { postAnalyticsEvent } from '@dailydotdev/shared/src/lib/feed';
@@ -39,7 +42,7 @@ export function PostWidgets({ post }: PostWidgetsProps): ReactElement {
       <ShareBar post={post} />
       <ShareMobile share={sharePost} />
       {tokenRefreshed && (
-        <FurtherReading currentPost={post} className="laptopL:w-[19.5rem]" />
+        <FurtherReading currentPost={post} className={widgetsWidth} />
       )}
     </PageWidgets>
   );

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useContext, useEffect, useState } from 'react';
+import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 import { useQuery, useQueryClient } from 'react-query';
@@ -10,7 +11,10 @@ import {
 import { ParsedUrlQuery } from 'querystring';
 import { NextSeo } from 'next-seo';
 import { LazyImage } from '@dailydotdev/shared/src/components/LazyImage';
-import { PageContainer } from '@dailydotdev/shared/src/components/utilities';
+import {
+  pageBorders,
+  PageContainer,
+} from '@dailydotdev/shared/src/components/utilities';
 import {
   POST_BY_ID_QUERY,
   POST_BY_ID_STATIC_FIELDS_QUERY,
@@ -238,8 +242,8 @@ const PostPage = ({ id, postData }: Props): ReactElement => {
 
   return (
     <>
-      <div className="flex relative flex-col flex-wrap mx-auto w-full laptopL:w-auto max-w-full">
-        <PageContainer className="pt-6 laptop:pb-6 laptopL:mr-[22.5rem] laptop:border-r laptop:border-l laptop:border-theme-divider-tertiary">
+      <div className="flex relative flex-row flex-wrap justify-center pb-20 laptop:pb-0 w-full max-w-full">
+        <PageContainer className={classNames('pt-6 laptop:pb-6', pageBorders)}>
           <Head>
             <link rel="preload" as="image" href={postById?.post.image} />
           </Head>
@@ -293,8 +297,8 @@ const PostPage = ({ id, postData }: Props): ReactElement => {
           {authorOnboarding && (
             <AuthorOnboarding onSignUp={!user && (() => showLogin('author'))} />
           )}
+          <NewComment user={user} onNewComment={openNewComment} />
         </PageContainer>
-        <NewComment user={user} onNewComment={openNewComment} />
         <PostWidgets post={postById.post} />
       </div>
 


### PR DESCRIPTION
DD-392 #done

This might require a bit of focus when reviewing (sorry about that) since I have refactored the classes and made the containers to use fewer and simple classes as much as possible.

Also, instead of applying the classes in one line (if there's a lot of differences), with `classed` I realized it accepts a rest argument which we can utilize to separate the different screen classes (as it is a bit difficult for complex layouts in one line) for easier understanding and readability. But it depends if it makes sense, probably just my personal pov.

```
classed(
  'tag',
  'base classes'
  'laptop classes',
  'tablet classes'
)
```

The jumpy widgets' container was caused by the `right-0` position which sets the element to the edge initially.

I have used flexbox so it will automatically set the placement (side-by-side) regardless of the box model and positioning. This also improves predictability. IMHO `absolute` values are pretty unstable at times, so I've decided to refactor the positioning.

I have also taken the `NewComment` inside the `PageContainer` so it won't have to think about its own box model styling which is basically the same with `PageContainer`. I have also removed its nested `div` as its classes were not necessary anymore.

**Note: I have used the light theme for the current layout - the dark theme is for the updated classes (this PR)**

I have used the browser's defined screen sizes in the console for toggling between previews.

**Screen resolution: 1440p**
current:
![1440p - old](https://user-images.githubusercontent.com/13744167/147547738-4532898c-540e-4664-bf3b-da23922ac413.png)
new:
![1440p](https://user-images.githubusercontent.com/13744167/147547745-b1957d5a-c64e-4078-9546-fd7e0a800af2.png)


**Screen resolution: 1080p**
current:
![1080p - old](https://user-images.githubusercontent.com/13744167/147547558-70a003b1-c3d1-4e79-b584-b140e23a89e3.png)
new:
![1080p](https://user-images.githubusercontent.com/13744167/147547565-04ac383d-7f68-4219-aff9-be5185dd6598.png)

**Screen resolution: iPad Pro**
current:
![iPad Pro - old](https://user-images.githubusercontent.com/13744167/147547926-c32fa93c-a530-4e71-9e86-bb89f8657d9c.png)
new:
![iPad Pro](https://user-images.githubusercontent.com/13744167/147547938-c7678fb7-8c6a-4839-a51b-3efd0c6392e4.png)

**Screen resolution: iPad**
current:
![iPad - old](https://user-images.githubusercontent.com/13744167/147548046-55cfa3a4-3e5a-410c-a387-84a47de15c10.png)
new:
![iPad](https://user-images.githubusercontent.com/13744167/147548056-2aec156d-c752-4677-b854-0eb69ab30312.png)

**Screen resolution: Mobile iPhone 6/7/8 Plus**

current:
![Mobile iPhone 6:7:8 Plus - old](https://user-images.githubusercontent.com/13744167/147548133-d3e58db4-8137-4040-992f-83909bf29bce.png)
new:
![Mobile iPhone 6:7:8 Plus](https://user-images.githubusercontent.com/13744167/147548140-21f6baf3-0ace-4db5-98a7-34d197a7a952.png)

Screen recording for the behavior on load:
https://drive.google.com/file/d/1Hu5Zf9He9HutzuPZuXnFYzSh_oSsBsSk/view?usp=sharing
