### PR TITLE
test: update local alerts and mutation to be called

### DIFF
--- a/packages/shared/src/components/Settings.spec.tsx
+++ b/packages/shared/src/components/Settings.spec.tsx
@@ -147,7 +147,7 @@ it('should utilize front-end default settings for first time users', async () =>
 it('should utilize local cache settings for anonymous users', async () => {
   const localBootData = {
     ...defaultBootData,
-    settings: { ...defaultBootData.settings, theme: 'darcula' },
+    settings: { ...defaultBootData.settings, theme: 'cozy' },
   };
   localStorage.setItem(BOOT_LOCAL_KEY, JSON.stringify(localBootData));
   renderBootProvider(defaultBootData);
@@ -156,7 +156,7 @@ it('should utilize local cache settings for anonymous users', async () => {
   await waitFor(() =>
     expect(
       // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
-      radio.find((el) => queryByText(el.parentElement, 'Dark')),
+      radio.find((el) => queryByText(el.parentElement, 'Cozy')),
     ).toBeChecked(),
   );
 });

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -39,7 +39,7 @@ function useRefreshToken(
   }, [accessToken, refresh]);
 }
 
-const BOOT_LOCAL_KEY = 'boot:local';
+export const BOOT_LOCAL_KEY = 'boot:local';
 const BOOT_QUERY_KEY = 'boot';
 
 function filteredProps<T extends Record<string, unknown>>(

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -17,7 +17,7 @@ import AuthContext from './AuthContext';
 import { apiUrl } from '../lib/config';
 import { storageWrapper } from '../lib/storageWrapper';
 
-enum ThemeMode {
+export enum ThemeMode {
   Light = 'light',
   Dark = 'dark',
   Auto = 'auto',


### PR DESCRIPTION
DD-399

Explicit test cases to ensure whenever new changes are introduced things won't be broken.

We have realized the two items below require attention:
- should utilize default front-end settings for a first-time user.
- should not override settings for an anonymous user and utilize local settings.
- should call `updateAlerts` with mock
~~should keep the stored local version on double execution (still discussing with Chris about this case)~~
