### PR TITLE
fix: backwards compatibility - page to be centered

### DIFF
--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -21,7 +21,7 @@ export const PageContainer = classed(
   'main',
   styles.pageContainer,
   pagePaddings,
-  'relative flex flex-col w-full items-stretch z-1',
+  'relative flex flex-col w-full items-stretch z-1 tablet:self-center',
 );
 
 export const PageWidgets = classed(


### PR DESCRIPTION
There was an overhaul with the classes on the article page and to support backward compatibility for other pages, we will have to keep a class that to keep different pages centered as default.