### PR TITLE
fix: :lipstick: Fixing the article position

### DIFF
--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -243,7 +243,12 @@ const PostPage = ({ id, postData }: Props): ReactElement => {
   return (
     <>
       <div className="flex relative flex-row flex-wrap justify-center pb-20 laptop:pb-0 w-full max-w-full">
-        <PageContainer className={classNames('pt-6 laptop:pb-6', pageBorders)}>
+        <PageContainer
+          className={classNames(
+            'pt-6 laptop:pb-6 laptop:self-stretch',
+            pageBorders,
+          )}
+        >
           <Head>
             <link rel="preload" as="image" href={postById?.post.image} />
           </Head>


### PR DESCRIPTION
We introduced a `tablet:self-center` on the PageContainer class, however for the article page this needs to stretch on laptop devices.

There are edge cases where the sidebar would be longer than the main part, forcing this to "center" while we want to stretch this to get the borders show fully.

DD-426 #done