### PR TITLE
feat: added the MyFeedButton component

### DIFF
--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -1,0 +1,114 @@
+import React, { ReactElement, useContext } from 'react';
+import classNames from 'classnames';
+import PlusIcon from '@dailydotdev/shared/icons/plus.svg';
+import FilterIcon from '@dailydotdev/shared/icons/outline/filter.svg';
+import { IFlags } from 'flagsmith';
+import { Button } from '../buttons/Button';
+import FeaturesContext from '../../contexts/FeaturesContext';
+import { Features, getFeatureValue } from '../../lib/featureManagement';
+import { ButtonOrLink, ItemInner, NavItem, SidebarMenuItem } from './common';
+
+const UnfilteredMyFeedButton = ({
+  sidebarExpanded,
+  flags,
+  action,
+}: {
+  sidebarExpanded: boolean;
+  flags: IFlags;
+  action: () => unknown;
+}) => {
+  const buttonCopy =
+    getFeatureValue(Features.MyFeedButtonCopy, flags) || 'Create my feed';
+  const explainerCopy =
+    getFeatureValue(Features.MyFeedExplainerCopy, flags) ||
+    'Devs with a personal feed get 11.5x more relevant articles';
+
+  return (
+    <div
+      className={classNames(
+        'flex flex-col items-center rounded-12 border-theme-status-success',
+        sidebarExpanded
+          ? 'shadow-2-avocado border p-3 m-4'
+          : 'mx-3 mb-2.5 mt-16',
+      )}
+    >
+      <p
+        className={classNames(
+          'typo-footnote  transition-all ',
+          sidebarExpanded
+            ? 'mb-3 h-auto transform opacity-100 ease-linear duration-200 translate-y-0 delay-200'
+            : 'm-0 transform duration-0 delay-0 opacity-0 translate-y-full h-0',
+        )}
+      >
+        {explainerCopy}
+      </p>
+
+      <Button
+        className="btn-primary-avocado"
+        buttonSize={sidebarExpanded ? 'medium' : 'xsmall'}
+        icon={<PlusIcon />}
+        iconOnly={!sidebarExpanded}
+        onClick={action}
+      >
+        {sidebarExpanded && buttonCopy}
+      </Button>
+    </div>
+  );
+};
+
+const FilteredMyFeedButton = ({
+  item,
+  sidebarExpanded,
+  action,
+}: {
+  item: SidebarMenuItem;
+  sidebarExpanded: boolean;
+  action: () => unknown;
+}) => {
+  return (
+    <NavItem className="mt-6">
+      <ButtonOrLink item={item}>
+        <ItemInner item={item} sidebarExpanded={sidebarExpanded} />
+      </ButtonOrLink>
+      <Button
+        iconOnly
+        className="mr-3"
+        buttonSize="xsmall"
+        icon={<FilterIcon />}
+        onClick={action}
+      />
+    </NavItem>
+  );
+};
+
+export default function MyFeedButton({
+  menuItem,
+  sidebarExpanded,
+  filtered = false,
+  action,
+}: {
+  menuItem: SidebarMenuItem;
+  sidebarExpanded: boolean;
+  filtered: boolean;
+  action: () => unknown;
+}): ReactElement {
+  const { flags } = useContext(FeaturesContext);
+
+  if (filtered) {
+    return (
+      <FilteredMyFeedButton
+        action={action}
+        sidebarExpanded={sidebarExpanded}
+        item={menuItem}
+      />
+    );
+  }
+
+  return (
+    <UnfilteredMyFeedButton
+      action={action}
+      sidebarExpanded={sidebarExpanded}
+      flags={flags}
+    />
+  );
+}

--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -63,33 +63,40 @@ const UnfilteredMyFeedButton = ({
   return (
     <div
       className={classNames(
-        `flex flex-col items-center rounded-12 `,
-        statusColor[explainerColor].border,
-        sidebarExpanded
-          ? `${statusColor[explainerColor].shadow} border p-3 m-4`
-          : 'mx-3 mb-2.5 mt-16',
+        'h-[8.125rem] flex flex-col',
+        !sidebarExpanded && 'justify-center',
       )}
     >
-      <p
+      <div
         className={classNames(
-          'typo-footnote transition-all',
+          `flex flex-col items-center rounded-12`,
+          statusColor[explainerColor].border,
           sidebarExpanded
-            ? 'mb-3 h-auto transform opacity-100 ease-linear duration-200 translate-y-0 delay-200'
-            : 'm-0 transform duration-0 delay-0 opacity-0 translate-y-full h-0',
+            ? `${statusColor[explainerColor].shadow} border p-3 m-4`
+            : 'mx-3 ',
         )}
       >
-        {explainerCopy}
-      </p>
+        <p
+          className={classNames(
+            'typo-footnote transition-all w-[11.25rem]',
+            sidebarExpanded
+              ? 'mb-3 h-auto transform opacity-100 ease-linear duration-200  delay-200'
+              : 'm-0 transform duration-0 delay-0 opacity-0  h-0',
+          )}
+        >
+          {explainerCopy}
+        </p>
 
-      <Button
-        className={statusColor[buttonColor].button}
-        buttonSize={sidebarExpanded ? 'medium' : 'xsmall'}
-        icon={<PlusIcon />}
-        iconOnly={!sidebarExpanded}
-        onClick={action}
-      >
-        {sidebarExpanded && buttonCopy}
-      </Button>
+        <Button
+          className={classNames('w-full', statusColor[buttonColor].button)}
+          buttonSize={sidebarExpanded ? 'small' : 'xsmall'}
+          icon={<PlusIcon />}
+          iconOnly={!sidebarExpanded}
+          onClick={action}
+        >
+          {sidebarExpanded && buttonCopy}
+        </Button>
+      </div>
     </div>
   );
 };

--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -78,10 +78,10 @@ const UnfilteredMyFeedButton = ({
       >
         <p
           className={classNames(
-            'typo-footnote transition-all w-[11.25rem]',
+            'typo-footnote transition-all w-[11.25rem] mb-3',
             sidebarExpanded
-              ? 'mb-3 transform opacity-100 ease-linear duration-200  delay-200'
-              : 'm-0 transform duration-0 delay-0 opacity-0',
+              ? 'transform opacity-100 ease-linear duration-200  delay-200'
+              : 'transform duration-0 delay-0 opacity-0',
           )}
         >
           {explainerCopy}

--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -41,24 +41,46 @@ const statusColor = {
   },
 };
 
+interface MyFeedButtonSharedProps {
+  sidebarExpanded: boolean;
+  action: () => unknown;
+}
+type UnfilteredMyFeedButtonProps = MyFeedButtonSharedProps & {
+  flags: IFlags;
+};
+type MyFeedButtonProps = MyFeedButtonSharedProps & {
+  item: SidebarMenuItem;
+  filtered: boolean;
+};
+type FilteredMyFeedButtonProps = MyFeedButtonSharedProps & {
+  item: SidebarMenuItem;
+};
+
 const UnfilteredMyFeedButton = ({
   sidebarExpanded,
   flags,
   action,
-}: {
-  sidebarExpanded: boolean;
-  flags: IFlags;
-  action: () => unknown;
-}) => {
-  const buttonCopy =
-    getFeatureValue(Features.MyFeedButtonCopy, flags) || 'Create my feed';
-  const buttonColor =
-    getFeatureValue(Features.MyFeedButtonColor, flags) || 'success';
-  const explainerCopy =
-    getFeatureValue(Features.MyFeedExplainerCopy, flags) ||
-    'Devs with a personal feed get 11.5x more relevant articles';
-  const explainerColor =
-    getFeatureValue(Features.MyFeedExplainerColor, flags) || 'success';
+}: UnfilteredMyFeedButtonProps) => {
+  const buttonCopy = getFeatureValue(
+    Features.MyFeedButtonCopy,
+    flags,
+    'Create my feed',
+  );
+  const buttonColor = getFeatureValue(
+    Features.MyFeedButtonColor,
+    flags,
+    'success',
+  );
+  const explainerCopy = getFeatureValue(
+    Features.MyFeedExplainerCopy,
+    flags,
+    'Devs with a personal feed get 11.5x more relevant articles',
+  );
+  const explainerColor = getFeatureValue(
+    Features.MyFeedExplainerColor,
+    flags,
+    'success',
+  );
 
   return (
     <div
@@ -105,11 +127,7 @@ const FilteredMyFeedButton = ({
   item,
   sidebarExpanded,
   action,
-}: {
-  item: SidebarMenuItem;
-  sidebarExpanded: boolean;
-  action: () => unknown;
-}) => {
+}: FilteredMyFeedButtonProps) => {
   return (
     <NavItem className="mt-6">
       <ButtonOrLink item={item}>
@@ -127,16 +145,11 @@ const FilteredMyFeedButton = ({
 };
 
 export default function MyFeedButton({
-  menuItem,
+  item,
   sidebarExpanded,
   filtered = false,
   action,
-}: {
-  menuItem: SidebarMenuItem;
-  sidebarExpanded: boolean;
-  filtered: boolean;
-  action: () => unknown;
-}): ReactElement {
+}: MyFeedButtonProps): ReactElement {
   const { flags } = useContext(FeaturesContext);
 
   if (filtered) {
@@ -144,7 +157,7 @@ export default function MyFeedButton({
       <FilteredMyFeedButton
         action={action}
         sidebarExpanded={sidebarExpanded}
-        item={menuItem}
+        item={item}
       />
     );
   }

--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -80,8 +80,8 @@ const UnfilteredMyFeedButton = ({
           className={classNames(
             'typo-footnote transition-all w-[11.25rem]',
             sidebarExpanded
-              ? 'mb-3 h-auto transform opacity-100 ease-linear duration-200  delay-200'
-              : 'm-0 transform duration-0 delay-0 opacity-0  h-0',
+              ? 'mb-3 transform opacity-100 ease-linear duration-200  delay-200'
+              : 'm-0 transform duration-0 delay-0 opacity-0',
           )}
         >
           {explainerCopy}

--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -8,6 +8,39 @@ import FeaturesContext from '../../contexts/FeaturesContext';
 import { Features, getFeatureValue } from '../../lib/featureManagement';
 import { ButtonOrLink, ItemInner, NavItem, SidebarMenuItem } from './common';
 
+const statusColor = {
+  success: {
+    border: 'border-theme-status-success',
+    shadow: 'shadow-2-avocado',
+    button: 'btn-primary-avocado',
+  },
+  error: {
+    border: 'border-theme-status-error',
+    shadow: 'shadow-2-ketchup',
+    button: 'btn-primary-ketchup',
+  },
+  help: {
+    border: 'border-theme-status-help',
+    shadow: 'shadow-2-cheese',
+    button: 'btn-primary-cheese',
+  },
+  warning: {
+    border: 'border-theme-status-warning',
+    shadow: 'shadow-2-bun',
+    button: 'btn-primary-bun',
+  },
+  cabbage: {
+    border: 'border-theme-status-cabbage',
+    shadow: 'shadow-2-cabbage',
+    button: 'btn-primary-cabbage',
+  },
+  fill: {
+    border: 'border-theme-status-fill',
+    shadow: 'shadow-2-water',
+    button: 'btn-primary-water',
+  },
+};
+
 const UnfilteredMyFeedButton = ({
   sidebarExpanded,
   flags,
@@ -19,22 +52,27 @@ const UnfilteredMyFeedButton = ({
 }) => {
   const buttonCopy =
     getFeatureValue(Features.MyFeedButtonCopy, flags) || 'Create my feed';
+  const buttonColor =
+    getFeatureValue(Features.MyFeedButtonColor, flags) || 'success';
   const explainerCopy =
     getFeatureValue(Features.MyFeedExplainerCopy, flags) ||
     'Devs with a personal feed get 11.5x more relevant articles';
+  const explainerColor =
+    getFeatureValue(Features.MyFeedExplainerColor, flags) || 'success';
 
   return (
     <div
       className={classNames(
-        'flex flex-col items-center rounded-12 border-theme-status-success',
+        `flex flex-col items-center rounded-12 `,
+        statusColor[explainerColor].border,
         sidebarExpanded
-          ? 'shadow-2-avocado border p-3 m-4'
+          ? `${statusColor[explainerColor].shadow} border p-3 m-4`
           : 'mx-3 mb-2.5 mt-16',
       )}
     >
       <p
         className={classNames(
-          'typo-footnote  transition-all ',
+          'typo-footnote transition-all',
           sidebarExpanded
             ? 'mb-3 h-auto transform opacity-100 ease-linear duration-200 translate-y-0 delay-200'
             : 'm-0 transform duration-0 delay-0 opacity-0 translate-y-full h-0',
@@ -44,7 +82,7 @@ const UnfilteredMyFeedButton = ({
       </p>
 
       <Button
-        className="btn-primary-avocado"
+        className={statusColor[buttonColor].button}
         buttonSize={sidebarExpanded ? 'medium' : 'xsmall'}
         icon={<PlusIcon />}
         iconOnly={!sidebarExpanded}

--- a/packages/shared/src/components/sidebar/Sidebar.spec.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.spec.tsx
@@ -43,10 +43,10 @@ const resizeWindow = (x, y) => {
 };
 
 const renderComponent = (
+  alertsData = defaultAlerts,
   mocks: MockedGraphQLResponse[] = [createMockFeedSettings()],
   user: LoggedUser = defaultUser,
   sidebarExpanded = true,
-  alertsData = defaultAlerts,
 ): RenderResult => {
   const settingsContext: SettingsContextData = {
     spaciness: 'eco',
@@ -104,7 +104,7 @@ const renderComponent = (
   );
 };
 
-it('should remove alert dot for filter alert when there is a pre-configured feedSettings', async () => {
+it('should remove feed filter button once user has filters', async () => {
   let mutationCalled = false;
   mockGraphQL({
     request: {
@@ -117,8 +117,9 @@ it('should remove alert dot for filter alert when there is a pre-configured feed
     },
   });
   renderComponent();
+
   await act(async () => {
-    const trigger = await screen.findByText('Feed filters');
+    const trigger = await screen.findByText('Create my feed');
     // eslint-disable-next-line testing-library/no-node-access
     trigger.parentElement.click();
   });
@@ -149,7 +150,7 @@ it('should toggle the sidebar on button click', async () => {
 });
 
 it('should show the sidebar as closed if user has this set', async () => {
-  renderComponent([], null, false);
+  renderComponent(defaultAlerts, [], null, false);
   const trigger = await screen.findByLabelText('Open sidebar');
   expect(trigger).toBeInTheDocument();
 
@@ -193,4 +194,10 @@ it('should render the mobile sidebar version on small screens', async () => {
 
   const sidebar = await screen.findByTestId('sidebar-aside');
   expect(sidebar).toHaveClass('-translate-x-70');
+});
+
+it('should show the my feed items if the user has filters', async () => {
+  renderComponent({ filter: false });
+  const section = await screen.findByText('My feed');
+  expect(section).toBeInTheDocument();
 });

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -133,8 +133,12 @@ export default function Sidebar({
     activePageProp === '/' ? `/${defaultFeed}` : activePageProp;
   const { alerts } = useContext(AlertContext);
   const { trackEvent } = useContext(AnalyticsContext);
-  const { isLoaded, isAnimated, setLoaded, setHidden } =
-    useDynamicLoadedAnimation();
+  const {
+    isLoaded,
+    isAnimated,
+    setLoaded: openFeedFilters,
+    setHidden,
+  } = useDynamicLoadedAnimation();
   const { sidebarExpanded, toggleSidebarExpanded, loadedSettings } =
     useContext(SettingsContext);
   const [showSettings, setShowSettings] = useState(false);
@@ -251,8 +255,8 @@ export default function Sidebar({
               <MyFeedButton
                 sidebarExpanded={sidebarExpanded}
                 filtered={!alerts?.filter}
-                menuItem={myFeedMenuItem}
-                action={setLoaded}
+                item={myFeedMenuItem}
+                action={openFeedFilters}
               />
             )}
             <RenderSection

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import SettingsContext from '../../contexts/SettingsContext';
 import { FeedSettingsModal } from '../modals/FeedSettingsModal';
 import HotIcon from '../../../icons/hot.svg';
-import FilterIcon from '../../../icons/filter.svg';
 import UpvoteIcon from '../../../icons/upvote.svg';
 import SearchIcon from '../../../icons/magnifying.svg';
 import DiscussIcon from '../../../icons/comment.svg';
@@ -13,6 +12,8 @@ import SettingsIcon from '../../../icons/settings.svg';
 import FeedbackIcon from '../../../icons/feedback.svg';
 import DocsIcon from '../../../icons/docs.svg';
 import TerminalIcon from '../../../icons/terminal.svg';
+import HomeIcon from '../../../icons/home.svg';
+
 import {
   ButtonOrLink,
   ItemInner,
@@ -32,12 +33,12 @@ import InvitePeople from './InvitePeople';
 import SidebarRankProgress from '../SidebarRankProgress';
 import AlertContext from '../../contexts/AlertContext';
 import FeedFilters from '../filters/FeedFilters';
-import { AlertColor, AlertDot } from '../AlertDot';
 import { useDynamicLoadedAnimation } from '../../hooks/useDynamicLoadAnimated';
 import SidebarUserButton from './SidebarUserButton';
 import AuthContext from '../../contexts/AuthContext';
 import useHideMobileSidebar from '../../hooks/useHideMobileSidebar';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
+import MyFeedButton from './MyFeedButton';
 
 const bottomMenuItems: SidebarMenuItem[] = [
   {
@@ -149,15 +150,6 @@ export default function Sidebar({
 
   const discoverMenuItems: SidebarMenuItem[] = [
     {
-      icon: <ListIcon Icon={FilterIcon} />,
-      alert: alerts.filter && (
-        <AlertDot className="-top-0.5 right-2.5" color={AlertColor.Fill} />
-      ),
-      title: 'Feed filters',
-      action: setLoaded,
-      hideOnMobile: true,
-    },
-    {
       icon: <ListIcon Icon={HotIcon} />,
       title: 'Popular',
       path: '/popular',
@@ -183,6 +175,13 @@ export default function Sidebar({
       hideOnMobile: true,
     },
   ];
+
+  const myFeedMenuItem: SidebarMenuItem = {
+    icon: <ListIcon Icon={HomeIcon} />,
+    title: 'My feed',
+    path: '/my-feed',
+    action: () => onNavTabClick?.('my-feed'),
+  };
 
   const manageMenuItems: SidebarMenuItem[] = [
     {
@@ -245,6 +244,14 @@ export default function Sidebar({
               sidebarRendered={sidebarRendered}
               onShowDndClick={onShowDndClick}
             />
+            {sidebarRendered && (
+              <MyFeedButton
+                sidebarExpanded={sidebarExpanded}
+                filtered={!alerts?.filter}
+                menuItem={myFeedMenuItem}
+                action={setLoaded}
+              />
+            )}
             <RenderSection
               {...defaultRenderSectionProps}
               title="Discover"

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -68,6 +68,7 @@ interface NavItemProps {
   color?: string;
   active?: boolean;
   children?: ReactNode;
+  className?: string;
 }
 
 export const btnClass =
@@ -207,6 +208,7 @@ export const MenuIcon = ({
   </SimpleTooltip>
 );
 export const NavItem = ({
+  className,
   color,
   active,
   children,
@@ -217,7 +219,11 @@ export const NavItem = ({
 
   return (
     <RawNavItem
-      className={classNames(color || baseClasses, active && 'bg-theme-active')}
+      className={classNames(
+        className,
+        color || baseClasses,
+        active && 'bg-theme-active',
+      )}
     >
       {children}
     </RawNavItem>

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -2,7 +2,9 @@ import { IFlags } from 'flagsmith';
 
 export enum Features {
   MyFeedButtonCopy = 'my_feed_button_copy',
+  MyFeedButtonColor = 'my_feed_button_color',
   MyFeedExplainerCopy = 'my_feed_explainer_copy',
+  MyFeedExplainerColor = 'my_feed_explainer_color',
   SignupButtonCopy = 'signup_button_copy',
   DevcardLimit = 'feat_limit_dev_card',
   FeedVersion = 'feed_version',

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -1,6 +1,8 @@
 import { IFlags } from 'flagsmith';
 
 export enum Features {
+  MyFeedButtonCopy = 'my_feed_button_copy',
+  MyFeedExplainerCopy = 'my_feed_explainer_copy',
   SignupButtonCopy = 'signup_button_copy',
   DevcardLimit = 'feat_limit_dev_card',
   FeedVersion = 'feed_version',


### PR DESCRIPTION
This PR introduces the MyFeedButton component.
This component can render based on the alert flag.

1. User already filtered something:
2. User hasn't filtered yet

Option 1 will show the My feed button
Option 2 will show the flagged text component.

The different states:

Filtered expanded:
<img width="306" alt="Screenshot 2021-12-30 at 15 19 45" src="https://user-images.githubusercontent.com/554874/147747417-1bef642d-44c8-4c8f-b426-27d65a3ae679.png">

Filtered small:
<img width="203" alt="Screenshot 2021-12-30 at 15 19 55" src="https://user-images.githubusercontent.com/554874/147747436-eb0880c0-0f6c-4801-9239-89fd1d65f4a0.png">

Unfiltered expanded:
<img width="295" alt="Screenshot 2021-12-30 at 15 19 16" src="https://user-images.githubusercontent.com/554874/147747450-8eef4875-6b88-420b-bc7e-4be5c048c6d6.png">

Unfiltered small:
<img width="207" alt="Screenshot 2021-12-30 at 15 19 22" src="https://user-images.githubusercontent.com/554874/147747465-07994d25-188b-4883-85df-bf09ea58cb31.png">

For this component we also introduced 4 new flagsmith values:
1. MyFeedButtonCopy = 'my_feed_button_copy',
2. MyFeedButtonColor = 'my_feed_button_color',
3. MyFeedExplainerCopy = 'my_feed_explainer_copy',
4. MyFeedExplainerColor = 'my_feed_explainer_color',