### PR TITLE
fix: updated the name of the newsletter subscription

### DIFF
--- a/packages/shared/src/components/history/ReadingHistory.spec.tsx
+++ b/packages/shared/src/components/history/ReadingHistory.spec.tsx
@@ -64,8 +64,13 @@ describe('ReadingHistoryList component', () => {
   });
 
   it('should show date section for reads of the same year', async () => {
+    const year = new Date().getFullYear();
+    const date = new Date(`${year}-03-31 07:15:51.247`);
+    const weekday = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][
+      date.getDay()
+    ];
     render(<ReadHistoryList {...props} />);
-    await screen.findByText('Wed, 31 Mar');
+    await screen.findByText(`${weekday}, 31 Mar`);
   });
 
   it('should show date section for reads of the different year', async () => {

--- a/packages/shared/src/components/profile/ProfileForm.tsx
+++ b/packages/shared/src/components/profile/ProfileForm.tsx
@@ -297,7 +297,7 @@ export default function ProfileForm({
         inputId="acceptedMarketing"
         checked={user.acceptedMarketing}
       >
-        Subscribe to the Weekly Recap
+        Subscribe to the Community Newsletter
       </FormSwitch>
       {mode !== 'update' && (
         <details

--- a/packages/shared/src/lib/dateFormat.spec.ts
+++ b/packages/shared/src/lib/dateFormat.spec.ts
@@ -90,9 +90,14 @@ describe('getReadHistoryDateFormat', () => {
   });
 
   it('should return formatted date for the same year', () => {
-    const expected = 'Wed, 31 Mar';
     const year = new Date().getFullYear();
     const date = new Date(`${year}-03-31 07:15:51.247`);
+
+    const weekday = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][
+      date.getDay()
+    ];
+    const expected = `${weekday}, 31 Mar`;
+
     const actual = getReadHistoryDateFormat(date);
     expect(actual).toEqual(expected);
   });


### PR DESCRIPTION
Renamed the newsletter subscribe option from `Weekly Recap` to `Community Newsletter`