### PR TITLE
refactor: local storage utilization for feed filters

### DIFF
--- a/packages/shared/__tests__/setup.ts
+++ b/packages/shared/__tests__/setup.ts
@@ -3,6 +3,7 @@ import 'fake-indexeddb/auto';
 import nodeFetch from 'node-fetch';
 import { NextRouter } from 'next/router';
 import { clear } from 'idb-keyval';
+import { storageWrapper as storage } from '../src/lib/storageWrapper';
 
 process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3000';
 process.env.NEXT_PUBLIC_WEBAPP_URL = '/';
@@ -64,6 +65,7 @@ jest.mock('next/router', () => ({
 
 beforeEach(() => {
   clear();
+  storage.clear();
 });
 
 jest.mock('../src/lib/analytics', () => ({

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -48,7 +48,7 @@ import {
   FeedSettings,
   FEED_SETTINGS_QUERY,
 } from '../graphql/feedSettings';
-import { getFeedSettingsQueryKey } from '../hooks/useMutateFilters';
+import { getFeedSettingsQueryKey } from '../hooks/useFeedSettings';
 
 const showLogin = jest.fn();
 let nextCallback: (value: PostsEngaged) => unknown = null;

--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -3,7 +3,7 @@ import { Item } from '@dailydotdev/react-contexify';
 import dynamic from 'next/dynamic';
 import useFeedSettings from '../hooks/useFeedSettings';
 import useReportPost from '../hooks/useReportPost';
-import { Post } from '../graphql/posts';
+import { Post, ReportReason } from '../graphql/posts';
 import TrashIcon from '../../icons/trash.svg';
 import HammerIcon from '../../icons/hammer.svg';
 import EyeIcon from '../../icons/eye.svg';
@@ -37,6 +37,14 @@ const MenuIcon = ({ Icon }) => {
   return <Icon className="mr-2 text-2xl" />;
 };
 
+type ReportPostAsync = (
+  postIndex: number,
+  post: Post,
+  reason: ReportReason,
+  comment: string,
+  blockSource: boolean,
+) => Promise<unknown>;
+
 export default function PostOptionsMenu({
   postIndex,
   post,
@@ -64,18 +72,23 @@ export default function PostOptionsMenu({
     onRemovePost?.(_postIndex);
   };
 
-  const onReportPost = async (
+  const onReportPost: ReportPostAsync = async (
     reportPostIndex,
     reportedPost,
     reason,
     comment,
     blockSource,
   ): Promise<void> => {
-    reportPost({
+    const shouldProceed = await reportPost({
       id: reportedPost?.id,
       reason,
       comment,
     });
+
+    if (!shouldProceed) {
+      return;
+    }
+
     trackEvent(
       postAnalyticsEvent('report post', reportedPost, {
         extra: { origin: 'post context menu' },
@@ -91,26 +104,49 @@ export default function PostOptionsMenu({
 
   const onBlockSource = async (): Promise<void> => {
     setAvoidRefresh(true);
-    await onUnfollowSource({ source: post?.source });
+    const shouldProceed = await onUnfollowSource({
+      source: post?.source,
+      requireLogin: true,
+    });
+    if (!shouldProceed) {
+      setAvoidRefresh(false);
+      return;
+    }
     showMessageAndRemovePost(`🚫 ${post?.source?.name} blocked`, postIndex);
     setAvoidRefresh(false);
   };
 
   const onBlockTag = async (tag: string): Promise<void> => {
     setAvoidRefresh(true);
-    await onBlockTags({ tags: [tag] });
+    const shouldProceed = await onBlockTags({
+      tags: [tag],
+      requireLogin: true,
+    });
+
+    if (!shouldProceed) {
+      setAvoidRefresh(false);
+      return;
+    }
+
     await showMessageAndRemovePost(`⛔️ #${tag} blocked`, postIndex);
     setAvoidRefresh(false);
   };
 
   const onHidePost = async (): Promise<void> => {
-    const promise = hidePost(post.id);
+    const shouldProceed = await hidePost(post.id);
+
+    if (!shouldProceed) {
+      return;
+    }
+
     trackEvent(
       postAnalyticsEvent('hide post', post, {
         extra: { origin: 'post context menu' },
       }),
     );
-    await Promise.all([promise, onRemovePost?.(postIndex)]);
+
+    await onRemovePost?.(postIndex);
+
     if (!postIndex) {
       onMessage(
         '🙈 This article won’t show up on your feed anymore',

--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -79,13 +79,13 @@ export default function PostOptionsMenu({
     comment,
     blockSource,
   ): Promise<void> => {
-    const shouldProceed = await reportPost({
+    const { successful } = await reportPost({
       id: reportedPost?.id,
       reason,
       comment,
     });
 
-    if (!shouldProceed) {
+    if (!successful) {
       return;
     }
 
@@ -104,11 +104,11 @@ export default function PostOptionsMenu({
 
   const onBlockSource = async (): Promise<void> => {
     setAvoidRefresh(true);
-    const shouldProceed = await onUnfollowSource({
+    const { successful } = await onUnfollowSource({
       source: post?.source,
       requireLogin: true,
     });
-    if (!shouldProceed) {
+    if (!successful) {
       setAvoidRefresh(false);
       return;
     }
@@ -118,12 +118,12 @@ export default function PostOptionsMenu({
 
   const onBlockTag = async (tag: string): Promise<void> => {
     setAvoidRefresh(true);
-    const shouldProceed = await onBlockTags({
+    const { successful } = await onBlockTags({
       tags: [tag],
       requireLogin: true,
     });
 
-    if (!shouldProceed) {
+    if (!successful) {
       setAvoidRefresh(false);
       return;
     }
@@ -133,9 +133,9 @@ export default function PostOptionsMenu({
   };
 
   const onHidePost = async (): Promise<void> => {
-    const shouldProceed = await hidePost(post.id);
+    const { successful } = await hidePost(post.id);
 
-    if (!shouldProceed) {
+    if (!successful) {
       return;
     }
 

--- a/packages/shared/src/components/filters/AdvancedSettings.spec.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.spec.tsx
@@ -23,7 +23,7 @@ import {
   UPDATE_ADVANCED_SETTINGS_FILTERS_MUTATION,
 } from '../../graphql/feedSettings';
 import AdvancedSettingsPage from './AdvancedSettings';
-import { getFeedSettingsQueryKey } from '../../hooks/useMutateFilters';
+import { getFeedSettingsQueryKey } from '../../hooks/useFeedSettings';
 import { waitForNock } from '../../../__tests__/helpers/utilities';
 import AlertContext, {
   AlertContextData,

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -2,8 +2,10 @@ import React, { ReactElement, useContext, useMemo } from 'react';
 import AlertContext from '../../contexts/AlertContext';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 import AuthContext from '../../contexts/AuthContext';
+import FeaturesContext from '../../contexts/FeaturesContext';
 import useFeedSettings from '../../hooks/useFeedSettings';
 import useMutateFilters from '../../hooks/useMutateFilters';
+import { Features, isFeaturedEnabled } from '../../lib/featureManagement';
 import { FilterSwitch } from './FilterSwitch';
 
 const ADVANCED_SETTINGS_KEY = 'advancedSettings';
@@ -14,6 +16,8 @@ function AdvancedSettingsFilter(): ReactElement {
   const { user, showLogin } = useContext(AuthContext);
   const { updateAdvancedSettings } = useMutateFilters(user);
   const { alerts, updateAlerts } = useContext(AlertContext);
+  const { flags } = useContext(FeaturesContext);
+  const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
   const settings = useMemo(
     () =>
       feedSettings?.advancedSettings?.reduce((settingsMap, currentSettings) => {
@@ -25,12 +29,12 @@ function AdvancedSettingsFilter(): ReactElement {
   );
 
   const onToggle = (id: number, defaultEnabledState: boolean) => {
-    if (!user) {
+    if (!shouldShowMyFeed && !user) {
       showLogin('advanced settings');
       return;
     }
 
-    if (alerts?.filter) {
+    if (alerts?.filter && user) {
       updateAlerts({ filter: false });
     }
 

--- a/packages/shared/src/components/filters/BlockedFilter.spec.tsx
+++ b/packages/shared/src/components/filters/BlockedFilter.spec.tsx
@@ -71,7 +71,7 @@ const renderComponent = (
           closeLogin: jest.fn(),
         }}
       >
-        <BlockedFilter setUnblockItem={setUnblockItem} />
+        <BlockedFilter onUnblockItem={setUnblockItem} />
       </AuthContext.Provider>
     </QueryClientProvider>,
   );

--- a/packages/shared/src/components/filters/BlockedFilter.tsx
+++ b/packages/shared/src/components/filters/BlockedFilter.tsx
@@ -7,7 +7,7 @@ import useTagAndSource from '../../hooks/useTagAndSource';
 import BlockIcon from '../../../icons/block.svg';
 
 export default function BlockedFilter({
-  setUnblockItem,
+  onUnblockItem,
 }: FilterMenuProps): ReactElement {
   const { feedSettings, isLoading } = useFeedSettings();
   const { onUnblockTags, onFollowSource } = useTagAndSource({
@@ -15,14 +15,14 @@ export default function BlockedFilter({
   });
 
   const tagItemAction = (event: React.MouseEvent, tag: string) => {
-    setUnblockItem({
+    onUnblockItem({
       tag,
       action: () => onUnblockTags({ tags: [tag] }),
     });
   };
 
   const sourceItemAction = (source) => {
-    setUnblockItem({
+    onUnblockItem({
       source,
       action: () => onFollowSource({ source }),
     });

--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -12,7 +12,9 @@ import XIcon from '../../../icons/x.svg';
 import { menuItemClassNames } from '../multiLevelMenu/MultiLevelMenuMaster';
 import useFeedSettings from '../../hooks/useFeedSettings';
 import AlertContext from '../../contexts/AlertContext';
-import { useDynamicLoadedAnimation } from '../../hooks/useDynamicLoadAnimated';
+import { Source } from '../../graphql/sources';
+import UnblockModal from '../modals/UnblockModal';
+import AuthContext from '../../contexts/AuthContext';
 
 const asideWidth = sizeN(89);
 
@@ -21,20 +23,28 @@ interface FeedFiltersProps {
   onBack?: () => void;
 }
 
+interface UnblockItem {
+  tag?: string;
+  source?: Source;
+  action?: () => unknown;
+}
+
 export default function FeedFilters({
   isOpen,
   onBack,
 }: FeedFiltersProps): ReactElement {
+  const [unblockItem, setUnblockItem] = useState<UnblockItem>();
+  const { user } = useContext(AuthContext);
   const { alerts, updateAlerts } = useContext(AlertContext);
   const { hasAnyFilter } = useFeedSettings();
 
   useEffect(() => {
     if (isOpen) {
-      if (alerts?.filter && hasAnyFilter) {
+      if (alerts?.filter && hasAnyFilter && user) {
         updateAlerts({ filter: false });
       }
     }
-  }, [isOpen, alerts, hasAnyFilter]);
+  }, [isOpen, alerts, user, hasAnyFilter]);
 
   return (
     <aside
@@ -55,7 +65,15 @@ export default function FeedFilters({
           <XIcon className="text-2xl -rotate-90 text-theme-label-tertiary" />
         </button>
       </div>
-      <FilterMenu />
+      <FilterMenu onUnblockItem={setUnblockItem} />
+      {unblockItem && (
+        <UnblockModal
+          item={unblockItem}
+          isOpen={!!unblockItem}
+          onConfirm={unblockItem.action}
+          onRequestClose={() => setUnblockItem(null)}
+        />
+      )}
     </aside>
   );
 }

--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -16,6 +16,8 @@ import UnblockModal from '../modals/UnblockModal';
 import AuthContext from '../../contexts/AuthContext';
 import { Button } from '../buttons/Button';
 import { AllTagCategoriesData } from '../../graphql/feedSettings';
+import { Features, isFeaturedEnabled } from '../../lib/featureManagement';
+import FeaturesContext from '../../contexts/FeaturesContext';
 
 const asideWidth = sizeN(89);
 
@@ -39,6 +41,8 @@ export default function FeedFilters({
   const { user } = useContext(AuthContext);
   const { alerts, updateAlerts } = useContext(AlertContext);
   const { hasAnyFilter } = useFeedSettings();
+  const { flags } = useContext(FeaturesContext);
+  const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
 
   useEffect(() => {
     if (isOpen) {
@@ -74,14 +78,16 @@ export default function FeedFilters({
         <button onClick={onBack} type="button">
           <XIcon className="text-2xl -rotate-90 text-theme-label-tertiary" />
         </button>
-        <Button
-          className="btn-primary-avocado"
-          buttonSize="small"
-          icon={<PlusIcon className="mr-1" />}
-          onClick={onCreate}
-        >
-          Create
-        </Button>
+        {shouldShowMyFeed && (
+          <Button
+            className="btn-primary-avocado"
+            buttonSize="small"
+            icon={<PlusIcon className="mr-1" />}
+            onClick={onCreate}
+          >
+            Create
+          </Button>
+        )}
       </div>
       <FilterMenu onUnblockItem={setUnblockItem} />
       {unblockItem && (

--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -1,10 +1,4 @@
-import React, {
-  ReactElement,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { ReactElement, useContext, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import sizeN from '../../../macros/sizeN.macro';
 import FilterMenu from './FilterMenu';

--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -38,7 +38,7 @@ export default function FeedFilters({
 }: FeedFiltersProps): ReactElement {
   const client = useQueryClient();
   const [unblockItem, setUnblockItem] = useState<UnblockItem>();
-  const { user } = useContext(AuthContext);
+  const { user, showLogin } = useContext(AuthContext);
   const { alerts, updateAlerts } = useContext(AlertContext);
   const { hasAnyFilter } = useFeedSettings();
   const { flags } = useContext(FeaturesContext);
@@ -57,7 +57,7 @@ export default function FeedFilters({
     const key = getFeedSettingsQueryKey(user);
     const { feedSettings } = client.getQueryData(key) as AllTagCategoriesData;
     updateLocalFeedSettings(feedSettings);
-    window.location.replace(`${process.env.NEXT_PUBLIC_WEBAPP_URL}register`);
+    showLogin('create feed filters');
   };
 
   return (

--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -12,6 +12,7 @@ import XIcon from '../../../icons/x.svg';
 import { menuItemClassNames } from '../multiLevelMenu/MultiLevelMenuMaster';
 import useFeedSettings from '../../hooks/useFeedSettings';
 import AlertContext from '../../contexts/AlertContext';
+import { useDynamicLoadedAnimation } from '../../hooks/useDynamicLoadAnimated';
 
 const asideWidth = sizeN(89);
 
@@ -26,31 +27,13 @@ export default function FeedFilters({
 }: FeedFiltersProps): ReactElement {
   const { alerts, updateAlerts } = useContext(AlertContext);
   const { hasAnyFilter } = useFeedSettings();
-  const [hidden, setHidden] = useState(true);
-  const timeoutRef = useRef<number>();
 
   useEffect(() => {
     if (isOpen) {
       if (alerts?.filter && hasAnyFilter) {
         updateAlerts({ filter: false });
       }
-
-      if (!hidden) {
-        return;
-      }
-
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-      setHidden(false);
-      return;
     }
-
-    if (hidden) {
-      return;
-    }
-
-    timeoutRef.current = window.setTimeout(() => setHidden(true), 300);
-    // eslint-disable-next-line consistent-return
-    return () => timeoutRef.current && clearTimeout(timeoutRef.current);
   }, [isOpen, alerts, hasAnyFilter]);
 
   return (
@@ -59,7 +42,6 @@ export default function FeedFilters({
         'fixed top-14 left-0 z-3 bottom-0 self-stretch bg-theme-bg-primary rounded-r-2xl border-t border-r border-theme-divider-primary overflow-y-auto',
         'transition-transform duration-200 ease-linear delay-100',
         isOpen ? 'translate-x-0' : '-translate-x-96 pointer-events-none',
-        hidden && 'invisible',
       )}
       style={{ width: asideWidth }}
     >

--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -1,14 +1,21 @@
 import React, { ReactElement, useContext, useEffect, useState } from 'react';
+import { useQueryClient } from 'react-query';
 import classNames from 'classnames';
 import sizeN from '../../../macros/sizeN.macro';
 import FilterMenu from './FilterMenu';
 import XIcon from '../../../icons/x.svg';
+import PlusIcon from '../../../icons/plus.svg';
 import { menuItemClassNames } from '../multiLevelMenu/MultiLevelMenuMaster';
-import useFeedSettings from '../../hooks/useFeedSettings';
+import useFeedSettings, {
+  getFeedSettingsQueryKey,
+  updateLocalFeedSettings,
+} from '../../hooks/useFeedSettings';
 import AlertContext from '../../contexts/AlertContext';
 import { Source } from '../../graphql/sources';
 import UnblockModal from '../modals/UnblockModal';
 import AuthContext from '../../contexts/AuthContext';
+import { Button } from '../buttons/Button';
+import { AllTagCategoriesData } from '../../graphql/feedSettings';
 
 const asideWidth = sizeN(89);
 
@@ -27,6 +34,7 @@ export default function FeedFilters({
   isOpen,
   onBack,
 }: FeedFiltersProps): ReactElement {
+  const client = useQueryClient();
   const [unblockItem, setUnblockItem] = useState<UnblockItem>();
   const { user } = useContext(AuthContext);
   const { alerts, updateAlerts } = useContext(AlertContext);
@@ -40,6 +48,14 @@ export default function FeedFilters({
     }
   }, [isOpen, alerts, user, hasAnyFilter]);
 
+  const onCreate = () => {
+    // apply analytics
+    const key = getFeedSettingsQueryKey(user);
+    const { feedSettings } = client.getQueryData(key) as AllTagCategoriesData;
+    updateLocalFeedSettings(feedSettings);
+    window.location.replace(`${process.env.NEXT_PUBLIC_WEBAPP_URL}register`);
+  };
+
   return (
     <aside
       className={classNames(
@@ -52,12 +68,20 @@ export default function FeedFilters({
       <div
         className={classNames(
           menuItemClassNames,
-          'border-b border-theme-divider-tertiary',
+          'border-b border-theme-divider-tertiary flex-row justify-between',
         )}
       >
         <button onClick={onBack} type="button">
           <XIcon className="text-2xl -rotate-90 text-theme-label-tertiary" />
         </button>
+        <Button
+          className="btn-primary-avocado"
+          buttonSize="small"
+          icon={<PlusIcon className="mr-1" />}
+          onClick={onCreate}
+        >
+          Create
+        </Button>
       </div>
       <FilterMenu onUnblockItem={setUnblockItem} />
       {unblockItem && (

--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -78,7 +78,7 @@ export default function FeedFilters({
         <button onClick={onBack} type="button">
           <XIcon className="text-2xl -rotate-90 text-theme-label-tertiary" />
         </button>
-        {shouldShowMyFeed && (
+        {shouldShowMyFeed && !user && (
           <Button
             className="btn-primary-avocado"
             buttonSize="small"

--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext, useEffect, useState } from 'react';
+import React, { ReactElement, useContext, useEffect } from 'react';
 import { useQueryClient } from 'react-query';
 import classNames from 'classnames';
 import sizeN from '../../../macros/sizeN.macro';
@@ -11,8 +11,6 @@ import useFeedSettings, {
   updateLocalFeedSettings,
 } from '../../hooks/useFeedSettings';
 import AlertContext from '../../contexts/AlertContext';
-import { Source } from '../../graphql/sources';
-import UnblockModal from '../modals/UnblockModal';
 import AuthContext from '../../contexts/AuthContext';
 import { Button } from '../buttons/Button';
 import { AllTagCategoriesData } from '../../graphql/feedSettings';
@@ -26,18 +24,11 @@ interface FeedFiltersProps {
   onBack?: () => void;
 }
 
-interface UnblockItem {
-  tag?: string;
-  source?: Source;
-  action?: () => unknown;
-}
-
 export default function FeedFilters({
   isOpen,
   onBack,
 }: FeedFiltersProps): ReactElement {
   const client = useQueryClient();
-  const [unblockItem, setUnblockItem] = useState<UnblockItem>();
   const { user, showLogin } = useContext(AuthContext);
   const { alerts, updateAlerts } = useContext(AlertContext);
   const { hasAnyFilter } = useFeedSettings();
@@ -89,15 +80,7 @@ export default function FeedFilters({
           </Button>
         )}
       </div>
-      <FilterMenu onUnblockItem={setUnblockItem} />
-      {unblockItem && (
-        <UnblockModal
-          item={unblockItem}
-          isOpen={!!unblockItem}
-          onConfirm={unblockItem.action}
-          onRequestClose={() => setUnblockItem(null)}
-        />
-      )}
+      <FilterMenu />
     </aside>
   );
 }

--- a/packages/shared/src/components/filters/FilterMenu.tsx
+++ b/packages/shared/src/components/filters/FilterMenu.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useState } from 'react';
 import dynamic from 'next/dynamic';
 import MultiLevelMenu from '../multiLevelMenu/MultiLevelMenu';
-import { FilterMenuProps, MenuItem } from './common';
+import { MenuItem } from './common';
 import HashtagIcon from '../../../icons/hashtag.svg';
 import FilterIcon from '../../../icons/filter.svg';
 import BlockIcon from '../../../icons/block.svg';
@@ -9,19 +9,26 @@ import PlusIcon from '../../../icons/plus.svg';
 import TagsFilter from './TagsFilter';
 import BlockedFilter from './BlockedFilter';
 import AdvancedSettingsFilter from './AdvancedSettings';
+import UnblockModal from '../modals/UnblockModal';
+import { Source } from '../../graphql/sources';
 
 const NewSourceModal = dynamic(() => import('../modals/NewSourceModal'));
 
-export default function FilterMenu({
-  onUnblockItem,
-}: FilterMenuProps): ReactElement {
+interface UnblockItem {
+  tag?: string;
+  source?: Source;
+  action?: () => unknown;
+}
+
+export default function FilterMenu(): ReactElement {
+  const [unblockItem, setUnblockItem] = useState<UnblockItem>();
   const [showNewSourceModal, setShowNewSourceModal] = useState(false);
 
   const menuItems: MenuItem[] = [
     {
       icon: <HashtagIcon className="mr-3 text-xl" />,
       title: 'Manage tags',
-      component: <TagsFilter onUnblockItem={onUnblockItem} />,
+      component: <TagsFilter onUnblockItem={setUnblockItem} />,
     },
     {
       icon: <FilterIcon className="mr-3 text-xl" />,
@@ -31,7 +38,7 @@ export default function FilterMenu({
     {
       icon: <BlockIcon className="mr-3 text-xl" />,
       title: 'Blocked items',
-      component: <BlockedFilter onUnblockItem={onUnblockItem} />,
+      component: <BlockedFilter onUnblockItem={setUnblockItem} />,
     },
     {
       icon: <PlusIcon className="mr-3 text-xl" />,
@@ -47,6 +54,14 @@ export default function FilterMenu({
         <NewSourceModal
           isOpen={showNewSourceModal}
           onRequestClose={() => setShowNewSourceModal(false)}
+        />
+      )}
+      {unblockItem && (
+        <UnblockModal
+          item={unblockItem}
+          isOpen={!!unblockItem}
+          onConfirm={unblockItem.action}
+          onRequestClose={() => setUnblockItem(null)}
         />
       )}
     </>

--- a/packages/shared/src/components/filters/FilterMenu.tsx
+++ b/packages/shared/src/components/filters/FilterMenu.tsx
@@ -9,9 +9,6 @@ import PlusIcon from '../../../icons/plus.svg';
 import TagsFilter from './TagsFilter';
 import BlockedFilter from './BlockedFilter';
 import AdvancedSettingsFilter from './AdvancedSettings';
-import UnblockModal from '../modals/UnblockModal';
-import { Tag } from '../../graphql/feedSettings';
-import { Source } from '../../graphql/sources';
 
 const NewSourceModal = dynamic(() => import('../modals/NewSourceModal'));
 

--- a/packages/shared/src/components/filters/FilterMenu.tsx
+++ b/packages/shared/src/components/filters/FilterMenu.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useState } from 'react';
 import dynamic from 'next/dynamic';
 import MultiLevelMenu from '../multiLevelMenu/MultiLevelMenu';
-import { MenuItem } from './common';
+import { FilterMenuProps, MenuItem } from './common';
 import HashtagIcon from '../../../icons/hashtag.svg';
 import FilterIcon from '../../../icons/filter.svg';
 import BlockIcon from '../../../icons/block.svg';
@@ -15,19 +15,16 @@ import { Source } from '../../graphql/sources';
 
 const NewSourceModal = dynamic(() => import('../modals/NewSourceModal'));
 
-export default function FilterMenu(): ReactElement {
+export default function FilterMenu({
+  onUnblockItem,
+}: FilterMenuProps): ReactElement {
   const [showNewSourceModal, setShowNewSourceModal] = useState(false);
-  const [unblockItem, setUnblockItem] = useState<{
-    tag?: Tag | string;
-    source?: Source;
-    action?: () => unknown;
-  }>();
 
   const menuItems: MenuItem[] = [
     {
       icon: <HashtagIcon className="mr-3 text-xl" />,
       title: 'Manage tags',
-      component: <TagsFilter setUnblockItem={setUnblockItem} />,
+      component: <TagsFilter onUnblockItem={onUnblockItem} />,
     },
     {
       icon: <FilterIcon className="mr-3 text-xl" />,
@@ -37,7 +34,7 @@ export default function FilterMenu(): ReactElement {
     {
       icon: <BlockIcon className="mr-3 text-xl" />,
       title: 'Blocked items',
-      component: <BlockedFilter setUnblockItem={setUnblockItem} />,
+      component: <BlockedFilter onUnblockItem={onUnblockItem} />,
     },
     {
       icon: <PlusIcon className="mr-3 text-xl" />,
@@ -53,14 +50,6 @@ export default function FilterMenu(): ReactElement {
         <NewSourceModal
           isOpen={showNewSourceModal}
           onRequestClose={() => setShowNewSourceModal(false)}
-        />
-      )}
-      {unblockItem && (
-        <UnblockModal
-          item={unblockItem}
-          isOpen={!!unblockItem}
-          onConfirm={unblockItem.action}
-          onRequestClose={() => setUnblockItem(null)}
         />
       )}
     </>

--- a/packages/shared/src/components/filters/TagsFilter.spec.tsx
+++ b/packages/shared/src/components/filters/TagsFilter.spec.tsx
@@ -1,4 +1,5 @@
 import nock from 'nock';
+import { IFlags } from 'flagsmith';
 import React from 'react';
 import {
   render,
@@ -67,18 +68,19 @@ const createAllTagCategoriesMock = (
 let client: QueryClient;
 
 const defaultAlerts: Alerts = { filter: false };
+const defaultFlags: IFlags = {};
+const myFeedOnEnabledFlag = { my_feed_on: { enabled: true, value: 'true' } };
 
 const renderComponent = (
   mocks: MockedGraphQLResponse[] = [createAllTagCategoriesMock()],
   alertsData = defaultAlerts,
+  flags: IFlags = defaultFlags,
 ): RenderResult => {
   client = new QueryClient();
   mocks.forEach(mockGraphQL);
   return render(
     <QueryClientProvider client={client}>
-      <FeaturesContext.Provider
-        value={{ flags: { my_feed_on: { enabled: true, value: 'true' } } }}
-      >
+      <FeaturesContext.Provider value={{ flags }}>
         <AlertContextProvider
           alerts={alertsData}
           updateAlerts={updateAlerts}
@@ -274,7 +276,11 @@ it('should clear all tags on click', async () => {
 
 it('should utilize query cache to follow a tag when not logged in', async () => {
   loggedUser = null;
-  renderComponent([createAllTagCategoriesMock(null)]);
+  renderComponent(
+    [createAllTagCategoriesMock(null)],
+    defaultAlerts,
+    myFeedOnEnabledFlag,
+  );
   await waitForNock();
   const category = await screen.findByText('Frontend');
   // eslint-disable-next-line testing-library/no-node-access
@@ -300,7 +306,11 @@ it('should utilize query cache to follow a tag when not logged in', async () => 
 it('should utilize query cache to unfollow a tag when not logged in', async () => {
   loggedUser = null;
   const unfollow = 'react';
-  renderComponent();
+  renderComponent(
+    [createAllTagCategoriesMock()],
+    defaultAlerts,
+    myFeedOnEnabledFlag,
+  );
   await waitForNock();
   const category = await screen.findByText('Frontend');
   // eslint-disable-next-line testing-library/no-node-access

--- a/packages/shared/src/components/filters/TagsFilter.spec.tsx
+++ b/packages/shared/src/components/filters/TagsFilter.spec.tsx
@@ -8,7 +8,6 @@ import {
   screen,
   fireEvent,
 } from '@testing-library/react';
-import { act } from '@testing-library/react-hooks';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import defaultUser from '../../../__tests__/fixture/loggedUser';
 import AuthContext from '../../contexts/AuthContext';
@@ -197,11 +196,8 @@ it('should follow a tag on click and remove filter alert if enabled', async () =
   const buttonDiv = await screen.findByTestId('tagCategoryTags');
   expect(buttonDiv).toBeVisible();
 
-  await act(async () => {
-    // eslint-disable-next-line testing-library/prefer-screen-queries
-    const button = await screen.findByText('#webdev');
-    fireEvent.click(button);
-  });
+  const button = await waitFor(() => screen.findByText('#webdev'));
+  fireEvent.click(button);
 
   await waitFor(() => expect(addFilterMutationCalled).toBeTruthy());
   await waitFor(() => expect(alertsMutationCalled).toBeTruthy());
@@ -291,7 +287,7 @@ it('should utilize local storage to follow a tag when not logged in', async () =
   const button = await screen.findByTestId('tagCategoryTags');
   expect(button).toBeVisible();
 
-  const webdev = await waitFor(() => screen.findByText('#webdev'));
+  const webdev = await screen.findByText('#webdev');
   expect(webdev).toBeVisible();
   fireEvent.click(webdev);
 
@@ -313,7 +309,7 @@ it('should utilize local storage to unfollow a tag when not logged in', async ()
   const button = await screen.findByTestId('tagCategoryTags');
   expect(button).toBeVisible();
 
-  const webdev = await waitFor(() => screen.findByText(`#${unfollow}`));
+  const webdev = await screen.findByText(`#${unfollow}`);
   expect(webdev).toBeVisible();
   fireEvent.click(webdev);
 

--- a/packages/shared/src/components/filters/TagsFilter.spec.tsx
+++ b/packages/shared/src/components/filters/TagsFilter.spec.tsx
@@ -322,9 +322,22 @@ it('should utilize query cache to unfollow a tag when not logged in', async () =
   expect(button).toBeVisible();
 
   await act(async () => {
-    const webdev = await screen.findByText(`#${unfollow}`);
-    expect(webdev).toBeVisible();
-    fireEvent.click(webdev);
+    const react = await screen.findByText(`#${unfollow}`);
+    expect(react).toBeVisible();
+    fireEvent.click(react);
+  });
+
+  const { feedSettings: initialSettings } = client.getQueryData(
+    getFeedSettingsQueryKey(),
+  ) as AllTagCategoriesData;
+  expect(
+    initialSettings.includeTags.find((tag) => tag === unfollow),
+  ).toBeTruthy();
+
+  await act(async () => {
+    const react = await screen.findByText(`#${unfollow}`);
+    expect(react).toBeVisible();
+    fireEvent.click(react);
   });
 
   const { feedSettings } = client.getQueryData(

--- a/packages/shared/src/components/filters/TagsFilter.spec.tsx
+++ b/packages/shared/src/components/filters/TagsFilter.spec.tsx
@@ -32,6 +32,7 @@ import {
 } from '../../hooks/useFeedSettings';
 import { AlertContextProvider } from '../../contexts/AlertContext';
 import { Alerts, UPDATE_ALERTS } from '../../graphql/alerts';
+import FeaturesContext from '../../contexts/FeaturesContext';
 
 const showLogin = jest.fn();
 const updateAlerts = jest.fn();
@@ -78,29 +79,33 @@ const renderComponent = (
   mocks.forEach(mockGraphQL);
   return render(
     <QueryClientProvider client={client}>
-      <AlertContextProvider
-        alerts={alertsData}
-        updateAlerts={updateAlerts}
-        loadedAlerts
+      <FeaturesContext.Provider
+        value={{ flags: { my_feed_on: { enabled: true, value: 'true' } } }}
       >
-        <AuthContext.Provider
-          value={{
-            user: loggedUser,
-            shouldShowLogin: false,
-            showLogin,
-            logout: jest.fn(),
-            updateUser: jest.fn(),
-            tokenRefreshed: true,
-            getRedirectUri: jest.fn(),
-            trackingId: '',
-            loginState: null,
-            closeLogin: jest.fn(),
-            loadedUserFromCache: true,
-          }}
+        <AlertContextProvider
+          alerts={alertsData}
+          updateAlerts={updateAlerts}
+          loadedAlerts
         >
-          <TagsFilter />
-        </AuthContext.Provider>
-      </AlertContextProvider>
+          <AuthContext.Provider
+            value={{
+              user: loggedUser,
+              shouldShowLogin: false,
+              showLogin,
+              logout: jest.fn(),
+              updateUser: jest.fn(),
+              tokenRefreshed: true,
+              getRedirectUri: jest.fn(),
+              trackingId: '',
+              loginState: null,
+              closeLogin: jest.fn(),
+              loadedUserFromCache: true,
+            }}
+          >
+            <TagsFilter />
+          </AuthContext.Provider>
+        </AlertContextProvider>
+      </FeaturesContext.Provider>
     </QueryClientProvider>,
   );
 };

--- a/packages/shared/src/components/filters/TagsFilter.spec.tsx
+++ b/packages/shared/src/components/filters/TagsFilter.spec.tsx
@@ -273,7 +273,7 @@ it('should clear all tags on click', async () => {
   await waitFor(() => expect(mutationCalled).toBeTruthy());
 });
 
-it('should utilize local storage when not logged in', async () => {
+it('should utilize local storage to follow a tag when not logged in', async () => {
   loggedUser = null;
   renderComponent([createAllTagCategoriesMock(null)]);
   await waitForNock();
@@ -292,4 +292,26 @@ it('should utilize local storage when not logged in', async () => {
 
   const feedSettings = getLocalFeedSettings();
   expect(feedSettings.includeTags.length).toEqual(1);
+});
+
+it('should utilize local storage to unfollow a tag when not logged in', async () => {
+  loggedUser = null;
+  const unfollow = 'react';
+  renderComponent();
+  await waitForNock();
+  const category = await screen.findByText('Frontend');
+  // eslint-disable-next-line testing-library/no-node-access
+  const container = category.parentElement.parentElement;
+
+  container.click();
+
+  const button = await screen.findByTestId('tagCategoryTags');
+  expect(button).toBeVisible();
+
+  const webdev = await waitFor(() => screen.findByText(`#${unfollow}`));
+  expect(webdev).toBeVisible();
+  fireEvent.click(webdev);
+
+  const feedSettings = getLocalFeedSettings();
+  expect(feedSettings.includeTags.find((tag) => tag === unfollow)).toBeFalsy();
 });

--- a/packages/shared/src/components/filters/TagsFilter.spec.tsx
+++ b/packages/shared/src/components/filters/TagsFilter.spec.tsx
@@ -25,7 +25,7 @@ import {
   TagCategory,
 } from '../../graphql/feedSettings';
 import { waitForNock } from '../../../__tests__/helpers/utilities';
-import { getFeedSettingsQueryKey } from '../../hooks/useMutateFilters';
+import { getFeedSettingsQueryKey } from '../../hooks/useFeedSettings';
 import AlertContext, {
   AlertContextData,
   ALERT_DEFAULTS,

--- a/packages/shared/src/components/filters/TagsFilter.tsx
+++ b/packages/shared/src/components/filters/TagsFilter.tsx
@@ -29,6 +29,9 @@ export default function TagsFilter({
     useTagAndSource({
       origin: `tags ${query?.length > 0 ? 'search' : 'filter'}`,
     });
+  const isTagBlocked = feedSettings?.blockedTags?.some(
+    (tag) => tag === contextSelectedTag,
+  );
 
   const { data: searchResults } = useQuery<SearchTagsData>(
     searchKey,
@@ -80,7 +83,14 @@ export default function TagsFilter({
           />
           <TagOptionsMenu
             tag={contextSelectedTag}
-            onBlock={() => onBlockTags({ tags: [contextSelectedTag] })}
+            onBlock={
+              !isTagBlocked &&
+              (() => onBlockTags({ tags: [contextSelectedTag] }))
+            }
+            onUnblock={
+              isTagBlocked &&
+              (() => onUnblockTags({ tags: [contextSelectedTag] }))
+            }
             onHidden={() => setContextSelectedTag(null)}
           />
         </>

--- a/packages/shared/src/components/filters/TagsFilter.tsx
+++ b/packages/shared/src/components/filters/TagsFilter.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, useMemo, useRef, useState } from 'react';
+import React, {
+  ReactElement,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useQuery } from 'react-query';
 import request from 'graphql-request';
 import { SearchField } from '../fields/SearchField';
@@ -15,6 +21,8 @@ import useTagAndSource, {
 } from '../../hooks/useTagAndSource';
 import { FilterMenuProps } from './common';
 import MenuIcon from '../../../icons/menu.svg';
+import FeaturesContext from '../../contexts/FeaturesContext';
+import { Features, getFeatureValue } from '../../lib/featureManagement';
 
 export default function TagsFilter({
   onUnblockItem,
@@ -22,6 +30,9 @@ export default function TagsFilter({
   const searchRef = useRef<HTMLDivElement>(null);
   const [query, setQuery] = useState<string>(null);
   const searchKey = getSearchTagsQueryKey(query);
+  const { flags } = useContext(FeaturesContext);
+  const myFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
+  const shouldShowMyFeed = myFeed === 'true';
   const { tagsCategories, feedSettings, isLoading } = useFeedSettings();
   const { contextSelectedTag, setContextSelectedTag, onTagContextOptions } =
     useTagContext();
@@ -48,12 +59,16 @@ export default function TagsFilter({
     };
   }, [feedSettings]);
 
-  const tagUnblockAction = ({ tags: [tag] }: TagActionArguments) =>
-    onUnblockItem({
+  const tagUnblockAction = ({ tags: [tag] }: TagActionArguments) => {
+    if (shouldShowMyFeed) {
+      return onUnblockTags({ tags: [tag] });
+    }
+
+    return onUnblockItem({
       tag,
       action: () => onUnblockTags({ tags: [tag] }),
     });
-
+  };
   return (
     <div
       className="flex flex-col"

--- a/packages/shared/src/components/filters/TagsFilter.tsx
+++ b/packages/shared/src/components/filters/TagsFilter.tsx
@@ -23,6 +23,7 @@ import { FilterMenuProps } from './common';
 import MenuIcon from '../../../icons/menu.svg';
 import FeaturesContext from '../../contexts/FeaturesContext';
 import { Features, isFeaturedEnabled } from '../../lib/featureManagement';
+import AuthContext from '../../contexts/AuthContext';
 
 export default function TagsFilter({
   onUnblockItem,
@@ -31,6 +32,7 @@ export default function TagsFilter({
   const [query, setQuery] = useState<string>(null);
   const searchKey = getSearchTagsQueryKey(query);
   const { flags } = useContext(FeaturesContext);
+  const { user } = useContext(AuthContext);
   const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
   const { tagsCategories, feedSettings, isLoading } = useFeedSettings();
   const { contextSelectedTag, setContextSelectedTag, onTagContextOptions } =
@@ -59,7 +61,7 @@ export default function TagsFilter({
   }, [feedSettings]);
 
   const tagUnblockAction = ({ tags: [tag] }: TagActionArguments) => {
-    if (shouldShowMyFeed) {
+    if (shouldShowMyFeed && !user) {
       return onUnblockTags({ tags: [tag] });
     }
 

--- a/packages/shared/src/components/filters/TagsFilter.tsx
+++ b/packages/shared/src/components/filters/TagsFilter.tsx
@@ -22,7 +22,7 @@ import useTagAndSource, {
 import { FilterMenuProps } from './common';
 import MenuIcon from '../../../icons/menu.svg';
 import FeaturesContext from '../../contexts/FeaturesContext';
-import { Features, getFeatureValue } from '../../lib/featureManagement';
+import { Features, isFeaturedEnabled } from '../../lib/featureManagement';
 
 export default function TagsFilter({
   onUnblockItem,
@@ -31,8 +31,7 @@ export default function TagsFilter({
   const [query, setQuery] = useState<string>(null);
   const searchKey = getSearchTagsQueryKey(query);
   const { flags } = useContext(FeaturesContext);
-  const myFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
-  const shouldShowMyFeed = myFeed === 'true';
+  const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
   const { tagsCategories, feedSettings, isLoading } = useFeedSettings();
   const { contextSelectedTag, setContextSelectedTag, onTagContextOptions } =
     useTagContext();

--- a/packages/shared/src/components/filters/TagsFilter.tsx
+++ b/packages/shared/src/components/filters/TagsFilter.tsx
@@ -10,12 +10,14 @@ import useFeedSettings from '../../hooks/useFeedSettings';
 import TagItemList from './TagItemList';
 import TagOptionsMenu from './TagOptionsMenu';
 import useTagContext from '../../hooks/useTagContext';
-import useTagAndSource from '../../hooks/useTagAndSource';
+import useTagAndSource, {
+  TagActionArguments,
+} from '../../hooks/useTagAndSource';
 import { FilterMenuProps } from './common';
 import MenuIcon from '../../../icons/menu.svg';
 
 export default function TagsFilter({
-  setUnblockItem,
+  onUnblockItem,
 }: FilterMenuProps): ReactElement {
   const searchRef = useRef<HTMLDivElement>(null);
   const [query, setQuery] = useState<string>(null);
@@ -43,12 +45,11 @@ export default function TagsFilter({
     };
   }, [feedSettings]);
 
-  const tagUnblockAction = ({ tags }) => {
-    setUnblockItem({
-      tag: tags,
-      action: () => onUnblockTags({ tags }),
+  const tagUnblockAction = ({ tags: [tag] }: TagActionArguments) =>
+    onUnblockItem({
+      tag,
+      action: () => onUnblockTags({ tags: [tag] }),
     });
-  };
 
   return (
     <div

--- a/packages/shared/src/components/filters/common.tsx
+++ b/packages/shared/src/components/filters/common.tsx
@@ -2,6 +2,8 @@ import { ReactNode } from 'react';
 import { Source } from '../../graphql/sources';
 import classed from '../../lib/classed';
 
+export type BooleanPromise = Promise<{ successful: boolean }>;
+
 export interface MenuItem {
   icon?: ReactNode;
   title: string;

--- a/packages/shared/src/components/filters/common.tsx
+++ b/packages/shared/src/components/filters/common.tsx
@@ -1,5 +1,4 @@
 import { ReactNode } from 'react';
-import { Tag } from '../../graphql/feedSettings';
 import { Source } from '../../graphql/sources';
 import classed from '../../lib/classed';
 
@@ -11,11 +10,11 @@ export interface MenuItem {
 }
 
 export interface FilterMenuProps {
-  setUnblockItem?: ({ tag, source, action }: UnblockModalType) => void;
+  onUnblockItem?: ({ tag, source, action }: UnblockModalType) => void;
 }
 
 export interface UnblockModalType {
-  tag?: Tag | string;
+  tag?: string;
   source?: Source;
   action?: () => unknown;
 }

--- a/packages/shared/src/components/sidebar/Sidebar.spec.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.spec.tsx
@@ -16,7 +16,7 @@ import {
   MockedGraphQLResponse,
 } from '../../../__tests__/helpers/graphql';
 import { FEED_SETTINGS_QUERY } from '../../graphql/feedSettings';
-import { getFeedSettingsQueryKey } from '../../hooks/useMutateFilters';
+import { getFeedSettingsQueryKey } from '../../hooks/useFeedSettings';
 import { AlertContextProvider } from '../../contexts/AlertContext';
 import { waitForNock } from '../../../__tests__/helpers/utilities';
 import ProgressiveEnhancementContext from '../../contexts/ProgressiveEnhancementContext';

--- a/packages/shared/src/graphql/feedSettings.ts
+++ b/packages/shared/src/graphql/feedSettings.ts
@@ -16,7 +16,6 @@ export interface FeedAdvancedSettings
 
 export interface Tag {
   name?: string;
-  string;
 }
 
 export interface TagsData {
@@ -33,6 +32,13 @@ export interface FeedSettings {
   excludeSources?: Source[];
   advancedSettings?: FeedAdvancedSettings[];
 }
+
+export const getEmptyFeedSettings = (): FeedSettings => ({
+  includeTags: [],
+  blockedTags: [],
+  excludeSources: [],
+  advancedSettings: [],
+});
 
 export interface TagCategory {
   id: string;

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -87,13 +87,10 @@ export default function useFeedSettings(): FeedSettingsReturnType {
   const { tagsCategories, feedSettings, advancedSettings } = feedQuery;
 
   useEffect(() => {
-    if (!user?.id) {
+    if (!user?.id || avoidRefresh) {
       return;
     }
 
-    if (avoidRefresh) {
-      return;
-    }
     if (isFirstLoad) {
       setIsFirstLoad(false);
       return;

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -14,6 +14,8 @@ import AuthContext from '../contexts/AuthContext';
 import { apiUrl } from '../lib/config';
 import { generateQueryKey } from '../lib/query';
 import { LoggedUser } from '../lib/user';
+import FeaturesContext from '../contexts/FeaturesContext';
+import { Features, getFeatureValue } from '../lib/featureManagement';
 
 export const getFeedSettingsQueryKey = (user?: LoggedUser): string[] => [
   user?.id,
@@ -64,6 +66,8 @@ export default function useFeedSettings(): FeedSettingsReturnType {
   const [isFirstLoad, setIsFirstLoad] = useState(true);
   const filtersKey = getFeedSettingsQueryKey(user);
   const queryClient = useQueryClient();
+  const { flags } = useContext(FeaturesContext);
+  const shouldShowMyFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
   const setAvoidRefresh = (value: boolean) => {
     avoidRefresh = value;
   };
@@ -107,7 +111,7 @@ export default function useFeedSettings(): FeedSettingsReturnType {
       return;
     }
 
-    if (user) {
+    if (user || !shouldShowMyFeed) {
       storage.removeItem(LOCAL_FEED_SETTINGS_KEY);
       return;
     }

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -43,11 +43,11 @@ export const getLocalFeedSettings = (): FeedSettings => {
     return getEmptyFeedSettings();
   }
 
-  const localFeedSettings = JSON.parse(
-    storage.getItem(LOCAL_FEED_SETTINGS_KEY),
-  ) as FeedSettings;
-
-  return localFeedSettings;
+  try {
+    return JSON.parse(value) as FeedSettings;
+  } catch (ex) {
+    return getEmptyFeedSettings();
+  }
 };
 
 const isObjectEmpty = (obj: unknown) => {

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -121,7 +121,6 @@ export default function useFeedSettings(): FeedSettingsReturnType {
       feedSettings: { ...localFeedSettings },
     };
     client.setQueryData<AllTagCategoriesData>(filtersKey, updatedFeedSettings);
-    updateLocalFeedSettings(updatedFeedSettings.feedSettings);
   }, [feedQuery, loadedUserFromCache, user]);
 
   const hasAnyFilter =

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -103,9 +103,9 @@ export default function useFeedSettings(): FeedSettingsReturnType {
   }, [tagsCategories, feedSettings, avoidRefresh]);
 
   useEffect(() => {
-    const isEmpty = isObjectEmpty(feedSettings);
-    const isFeedQueryEmpty = Object.keys(feedQuery).length === 0;
-    if (!isEmpty || !loadedUserFromCache || isFeedQueryEmpty) {
+    const isFeedQueryEmpty = isObjectEmpty(feedQuery);
+    const isFeedSettingsEmpty = isObjectEmpty(feedSettings);
+    if (!isFeedSettingsEmpty || !loadedUserFromCache || isFeedQueryEmpty) {
       return;
     }
 

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -60,19 +60,6 @@ const isObjectEmpty = (obj: unknown) => {
   return Object.keys(obj).length === 0;
 };
 
-const getQueryFeedSettings = (
-  { feedSettings: remoteSettings }: AllTagCategoriesData,
-  { feedSettings: localSettings }: AllTagCategoriesData,
-  isLoggedIn: boolean,
-  shouldShowMyFeed: boolean,
-): FeedSettings => {
-  if (!shouldShowMyFeed || isLoggedIn) {
-    return remoteSettings;
-  }
-
-  return isObjectEmpty(localSettings) ? getEmptyFeedSettings() : localSettings;
-};
-
 export default function useFeedSettings(): FeedSettingsReturnType {
   const { user } = useContext(AuthContext);
   const [isFirstLoad, setIsFirstLoad] = useState(true);
@@ -93,12 +80,13 @@ export default function useFeedSettings(): FeedSettingsReturnType {
         { loggedIn: !!user?.id },
       );
 
-      const feedSettings = getQueryFeedSettings(
-        req,
-        feedQuery,
-        !!user,
-        shouldShowMyFeed,
-      );
+      if (user || !shouldShowMyFeed) {
+        return req;
+      }
+
+      const feedSettings = isObjectEmpty(feedQuery.feedSettings)
+        ? getEmptyFeedSettings()
+        : feedQuery.feedSettings;
 
       return { ...req, feedSettings };
     },

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -32,6 +32,7 @@ export type FeedSettingsReturnType = {
 };
 
 let avoidRefresh = false;
+let hasClearedCache = false;
 
 export const LOCAL_FEED_SETTINGS_KEY = 'feedSettings:local';
 
@@ -104,12 +105,12 @@ export default function useFeedSettings(): FeedSettingsReturnType {
   useEffect(() => {
     const isFeedQueryEmpty = isObjectEmpty(feedQuery);
     const isFeedSettingsEmpty = isObjectEmpty(feedSettings);
-    if (!isFeedSettingsEmpty || !loadedUserFromCache || isFeedQueryEmpty) {
-      return;
-    }
-
-    if (user || !shouldShowMyFeed) {
-      storage.removeItem(LOCAL_FEED_SETTINGS_KEY);
+    if (
+      !isFeedSettingsEmpty ||
+      !loadedUserFromCache ||
+      isFeedQueryEmpty ||
+      !shouldShowMyFeed
+    ) {
       return;
     }
 
@@ -118,7 +119,14 @@ export default function useFeedSettings(): FeedSettingsReturnType {
       ...current,
       feedSettings: { ...localFeedSettings },
     }));
-  }, [feedQuery, loadedUserFromCache, user]);
+  }, [feedQuery, feedSettings, loadedUserFromCache, user]);
+
+  useEffect(() => {
+    if (!hasClearedCache && loadedUserFromCache && user) {
+      hasClearedCache = true;
+      storage.removeItem(LOCAL_FEED_SETTINGS_KEY);
+    }
+  }, [loadedUserFromCache, user]);
 
   const hasAnyFilter =
     feedSettings?.includeTags?.length > 0 ||

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -114,13 +114,10 @@ export default function useFeedSettings(): FeedSettingsReturnType {
     }
 
     const localFeedSettings = getLocalFeedSettings();
-    const queryData =
-      client.getQueryData<AllTagCategoriesData>(filtersKey) || {};
-    const updatedFeedSettings = {
-      ...queryData,
+    client.setQueryData<AllTagCategoriesData>(filtersKey, (current) => ({
+      ...current,
       feedSettings: { ...localFeedSettings },
-    };
-    client.setQueryData<AllTagCategoriesData>(filtersKey, updatedFeedSettings);
+    }));
   }, [feedQuery, loadedUserFromCache, user]);
 
   const hasAnyFilter =

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -15,7 +15,7 @@ import { apiUrl } from '../lib/config';
 import { generateQueryKey } from '../lib/query';
 import { LoggedUser } from '../lib/user';
 import FeaturesContext from '../contexts/FeaturesContext';
-import { Features, getFeatureValue } from '../lib/featureManagement';
+import { Features, isFeaturedEnabled } from '../lib/featureManagement';
 
 export const getFeedSettingsQueryKey = (user?: LoggedUser): string[] => [
   user?.id,
@@ -67,8 +67,7 @@ export default function useFeedSettings(): FeedSettingsReturnType {
   const filtersKey = getFeedSettingsQueryKey(user);
   const queryClient = useQueryClient();
   const { flags } = useContext(FeaturesContext);
-  const myFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
-  const shouldShowMyFeed = myFeed === 'true';
+  const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
   const setAvoidRefresh = (value: boolean) => {
     avoidRefresh = value;
   };

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -67,7 +67,8 @@ export default function useFeedSettings(): FeedSettingsReturnType {
   const filtersKey = getFeedSettingsQueryKey(user);
   const queryClient = useQueryClient();
   const { flags } = useContext(FeaturesContext);
-  const shouldShowMyFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
+  const myFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
+  const shouldShowMyFeed = myFeed === 'true';
   const setAvoidRefresh = (value: boolean) => {
     avoidRefresh = value;
   };

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -52,21 +52,25 @@ export const getLocalFeedSettings = (): FeedSettings => {
   }
 };
 
+const isObjectEmpty = (obj: unknown) => {
+  if (typeof obj === 'undefined' || obj === null) {
+    return true;
+  }
+
+  return Object.keys(obj).length === 0;
+};
+
 const getQueryFeedSettings = (
-  response: AllTagCategoriesData,
-  local: AllTagCategoriesData,
+  { feedSettings: remoteSettings }: AllTagCategoriesData,
+  { feedSettings: localSettings }: AllTagCategoriesData,
   isLoggedIn: boolean,
   shouldShowMyFeed: boolean,
 ): FeedSettings => {
-  if (!shouldShowMyFeed) {
-    return response.feedSettings;
+  if (!shouldShowMyFeed || isLoggedIn) {
+    return remoteSettings;
   }
 
-  if (!response.feedSettings && !local.feedSettings) {
-    return getEmptyFeedSettings();
-  }
-
-  return isLoggedIn ? response.feedSettings : local.feedSettings;
+  return isObjectEmpty(localSettings) ? getEmptyFeedSettings() : localSettings;
 };
 
 export default function useFeedSettings(): FeedSettingsReturnType {

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -114,6 +114,12 @@ export default function useFeedSettings(): FeedSettingsReturnType {
       return;
     }
 
+    /*
+      This sets the initial value for the `feedSettings` property
+      The query that fetches the information related to this property doesn't include this mentioned prop if not logged in - results to be `undefined`
+      This also covers to initially load the filters left by the user if they have not finished the registration and came back
+    */
+
     const localFeedSettings = getLocalFeedSettings();
     client.setQueryData<AllTagCategoriesData>(filtersKey, (current) => ({
       ...current,

--- a/packages/shared/src/hooks/useMutateFilters.ts
+++ b/packages/shared/src/hooks/useMutateFilters.ts
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 import { QueryClient, useMutation, useQueryClient } from 'react-query';
 import request from 'graphql-request';
 import cloneDeep from 'lodash.clonedeep';
@@ -374,17 +374,36 @@ export default function useMutateFilters(user?: LoggedUser): ReturnType {
     },
   );
 
-  return {
-    followTags: shouldFilterLocally ? onFollowTags : followTagsRemote,
-    unfollowTags: shouldFilterLocally ? onUnfollowTags : unfollowTagsRemote,
-    blockTag: shouldFilterLocally ? onBlockTags : blockTagRemote,
-    unblockTag: shouldFilterLocally ? onUnblockTags : unblockTagRemote,
-    followSource: shouldFilterLocally ? onFollowSource : followSourceRemote,
-    unfollowSource: shouldFilterLocally
-      ? onUnfollowSource
-      : unfollowSourceRemote,
-    updateAdvancedSettings: shouldFilterLocally
-      ? onAdvancedSettingsUpdate
-      : updateAdvancedSettingsRemote,
-  };
+  return useMemo(
+    () => ({
+      followTags: shouldFilterLocally ? onFollowTags : followTagsRemote,
+      unfollowTags: shouldFilterLocally ? onUnfollowTags : unfollowTagsRemote,
+      blockTag: shouldFilterLocally ? onBlockTags : blockTagRemote,
+      unblockTag: shouldFilterLocally ? onUnblockTags : unblockTagRemote,
+      followSource: shouldFilterLocally ? onFollowSource : followSourceRemote,
+      unfollowSource: shouldFilterLocally
+        ? onUnfollowSource
+        : unfollowSourceRemote,
+      updateAdvancedSettings: shouldFilterLocally
+        ? onAdvancedSettingsUpdate
+        : updateAdvancedSettingsRemote,
+    }),
+    [
+      shouldFilterLocally,
+      onFollowTags,
+      onUnfollowTags,
+      onBlockTags,
+      onUnblockTags,
+      onFollowSource,
+      onUnfollowSource,
+      onAdvancedSettingsUpdate,
+      followTagsRemote,
+      unfollowTagsRemote,
+      blockTagRemote,
+      unblockTagRemote,
+      followSourceRemote,
+      unfollowSourceRemote,
+      updateAdvancedSettingsRemote,
+    ],
+  );
 }

--- a/packages/shared/src/hooks/useMutateFilters.ts
+++ b/packages/shared/src/hooks/useMutateFilters.ts
@@ -167,7 +167,7 @@ export default function useMutateFilters(user?: LoggedUser): ReturnType {
   const queryClient = useQueryClient();
   const { flags } = useContext(FeaturesContext);
   const shouldShowMyFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
-  const shouldStoreFiltersLocally = shouldShowMyFeed && !user;
+  const shouldStoreFiltersLocally = shouldShowMyFeed === 'true' && !user;
 
   const onAdvancedSettingsUpdate = ({
     advancedSettings,

--- a/packages/shared/src/hooks/useMutateFilters.ts
+++ b/packages/shared/src/hooks/useMutateFilters.ts
@@ -18,7 +18,7 @@ import {
   updateLocalFeedSettings,
 } from './useFeedSettings';
 import FeaturesContext from '../contexts/FeaturesContext';
-import { Features, getFeatureValue } from '../lib/featureManagement';
+import { Features, isFeaturedEnabled } from '../lib/featureManagement';
 
 export const getSearchTagsQueryKey = (query: string): string[] => [
   'searchTags',
@@ -166,8 +166,8 @@ const onMutateSourcesSettings = async (
 export default function useMutateFilters(user?: LoggedUser): ReturnType {
   const queryClient = useQueryClient();
   const { flags } = useContext(FeaturesContext);
-  const shouldShowMyFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
-  const shouldStoreFiltersLocally = shouldShowMyFeed === 'true' && !user;
+  const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
+  const shouldStoreFiltersLocally = shouldShowMyFeed && !user;
 
   const onAdvancedSettingsUpdate = ({
     advancedSettings,

--- a/packages/shared/src/hooks/useMutateFilters.ts
+++ b/packages/shared/src/hooks/useMutateFilters.ts
@@ -39,11 +39,11 @@ type FollowTagsPromise = (params: TagsMutationProps) => Promise<unknown>;
 
 type FollowTags = FollowTagsFunc | FollowTagsPromise;
 // eslint-disable-next-line @typescript-eslint/no-shadow
-type FollowSource = ({ source: Source }) => Promise<unknown>;
+type FollowSource = (params: SourceMutationProps) => Promise<unknown>;
 
-type UpdateAdvancedSettings = (params: {
-  advancedSettings: FeedAdvancedSettings[];
-}) => Promise<unknown>;
+type UpdateAdvancedSettings = (
+  params: AdvancedSettingsMutationProps,
+) => Promise<unknown>;
 
 type ReturnType = {
   followTags: FollowTags;

--- a/packages/shared/src/hooks/useMutateFilters.ts
+++ b/packages/shared/src/hooks/useMutateFilters.ts
@@ -12,18 +12,32 @@ import {
   UPDATE_ADVANCED_SETTINGS_FILTERS_MUTATION,
 } from '../graphql/feedSettings';
 import { Source } from '../graphql/sources';
-
-export const getFeedSettingsQueryKey = (user?: LoggedUser): string[] => [
-  user?.id,
-  'feedSettings',
-];
+import {
+  getFeedSettingsQueryKey,
+  updateLocalFeedSettings,
+} from './useFeedSettings';
 
 export const getSearchTagsQueryKey = (query: string): string[] => [
   'searchTags',
   query,
 ];
 
-type FollowTags = ({ tags: Array }) => Promise<unknown>;
+interface TagsMutationProps {
+  tags: string[];
+}
+
+interface SourceMutationProps {
+  source: Source;
+}
+
+interface AdvancedSettingsMutationProps {
+  advancedSettings: FeedAdvancedSettings[];
+}
+
+type FollowTagsFunc = (params: TagsMutationProps) => unknown;
+type FollowTagsPromise = (params: TagsMutationProps) => Promise<unknown>;
+
+type FollowTags = FollowTagsFunc | FollowTagsPromise;
 // eslint-disable-next-line @typescript-eslint/no-shadow
 type FollowSource = ({ source: Source }) => Promise<unknown>;
 
@@ -45,7 +59,11 @@ async function updateQueryData(
   queryClient: QueryClient,
   newSettings: FeedSettings,
   keys: string[][],
+  isLoggedUser: boolean,
 ): Promise<void> {
+  if (!isLoggedUser) {
+    updateLocalFeedSettings(newSettings);
+  }
   await Promise.all(
     keys.map(async (key) => {
       await queryClient.cancelQueries(key);
@@ -76,9 +94,9 @@ const onMutateAdvancedSettings = async (
   const feedSettings = queryClient.getQueryData<FeedSettingsData>(queryKey);
   const newData = manipulate(feedSettings.feedSettings, advancedSettings);
   const keys = [queryKey, queryKey];
-  await updateQueryData(queryClient, newData, keys);
+  await updateQueryData(queryClient, newData, keys, !!user);
   return async () => {
-    await updateQueryData(queryClient, feedSettings.feedSettings, keys);
+    await updateQueryData(queryClient, feedSettings.feedSettings, keys, !!user);
   };
 };
 
@@ -97,9 +115,9 @@ const onMutateTagsSettings = async (
   const feedSettings = queryClient.getQueryData<FeedSettingsData>(queryKey);
   const newData = manipulate(feedSettings.feedSettings, tags);
   const keys = [queryKey, getFeedSettingsQueryKey(user)];
-  await updateQueryData(queryClient, newData, keys);
+  await updateQueryData(queryClient, newData, keys, !!user);
   return async () => {
-    await updateQueryData(queryClient, feedSettings.feedSettings, keys);
+    await updateQueryData(queryClient, feedSettings.feedSettings, keys, !!user);
   };
 };
 
@@ -118,19 +136,40 @@ const onMutateSourcesSettings = async (
   const feedSettings = queryClient.getQueryData<FeedSettingsData>(queryKey);
   const newData = manipulate(feedSettings.feedSettings, source);
   const keys = [queryKey, getFeedSettingsQueryKey(user)];
-  await updateQueryData(queryClient, newData, keys);
+  await updateQueryData(queryClient, newData, keys, !!user);
   return async () => {
-    await updateQueryData(queryClient, feedSettings.feedSettings, keys);
+    await updateQueryData(queryClient, feedSettings.feedSettings, keys, !!user);
   };
 };
 
 export default function useMutateFilters(user?: LoggedUser): ReturnType {
   const queryClient = useQueryClient();
 
-  const { mutateAsync: updateAdvancedSettings } = useMutation<
+  const onAdvancedSettingsUpdate = ({
+    advancedSettings,
+  }: AdvancedSettingsMutationProps) =>
+    onMutateAdvancedSettings(
+      advancedSettings,
+      queryClient,
+      (feedSettings, [feedAdvancedSettings]) => {
+        const newData = cloneDeep(feedSettings);
+        const index = newData.advancedSettings.findIndex(
+          (settings) => settings.id === feedAdvancedSettings.id,
+        );
+        if (index === -1) {
+          newData.advancedSettings.push(feedAdvancedSettings);
+        } else {
+          newData.advancedSettings[index] = feedAdvancedSettings;
+        }
+        return newData;
+      },
+      user,
+    );
+
+  const { mutateAsync: updateAdvancedSettingsRemote } = useMutation<
     unknown,
     unknown,
-    { advancedSettings: FeedAdvancedSettings[] },
+    AdvancedSettingsMutationProps,
     () => Promise<void>
   >(
     ({ advancedSettings: settings }) =>
@@ -138,32 +177,27 @@ export default function useMutateFilters(user?: LoggedUser): ReturnType {
         settings,
       }),
     {
-      onMutate: ({ advancedSettings }) =>
-        onMutateAdvancedSettings(
-          advancedSettings,
-          queryClient,
-          (feedSettings, [feedAdvancedSettings]) => {
-            const newData = cloneDeep(feedSettings);
-            const index = newData.advancedSettings.findIndex(
-              (settings) => settings.id === feedAdvancedSettings.id,
-            );
-            if (index === -1) {
-              newData.advancedSettings.push(feedAdvancedSettings);
-            } else {
-              newData.advancedSettings[index] = feedAdvancedSettings;
-            }
-            return newData;
-          },
-          user,
-        ),
+      onMutate: onAdvancedSettingsUpdate,
       onError: (err, _, rollback) => rollback(),
     },
   );
 
-  const { mutateAsync: followTags } = useMutation<
+  const onFollowTags = ({ tags }: TagsMutationProps) =>
+    onMutateTagsSettings(
+      tags,
+      queryClient,
+      (feedSettings, manipulateTags) => {
+        const newData = cloneDeep(feedSettings);
+        newData.includeTags = newData.includeTags.concat(manipulateTags);
+        return newData;
+      },
+      user,
+    );
+
+  const { mutateAsync: followTagsRemote } = useMutation<
     unknown,
     unknown,
-    { tags: Array<string> },
+    TagsMutationProps,
     () => Promise<void>
   >(
     ({ tags }) =>
@@ -173,25 +207,33 @@ export default function useMutateFilters(user?: LoggedUser): ReturnType {
         },
       }),
     {
-      onMutate: ({ tags }) =>
-        onMutateTagsSettings(
-          tags,
-          queryClient,
-          (feedSettings, manipulateTags) => {
-            const newData = cloneDeep(feedSettings);
-            newData.includeTags = newData.includeTags.concat(manipulateTags);
-            return newData;
-          },
-          user,
-        ),
+      onMutate: onFollowTags,
       onError: (err, _, rollback) => rollback(),
     },
   );
 
-  const { mutateAsync: blockTag } = useMutation<
+  const onBlockTags = ({ tags }: TagsMutationProps) =>
+    onMutateTagsSettings(
+      tags,
+      queryClient,
+      (feedSettings, manipulateTags) => {
+        const newData = cloneDeep(feedSettings);
+        newData.blockedTags = [
+          ...Array.from(new Set(newData.blockedTags.concat(manipulateTags))),
+        ];
+
+        newData.includeTags = newData.includeTags.filter(
+          (value) => manipulateTags.indexOf(value) < 0,
+        );
+        return newData;
+      },
+      user,
+    );
+
+  const { mutateAsync: blockTagRemote } = useMutation<
     unknown,
     unknown,
-    { tags: Array<string> },
+    TagsMutationProps,
     () => Promise<void>
   >(
     ({ tags }) =>
@@ -201,33 +243,29 @@ export default function useMutateFilters(user?: LoggedUser): ReturnType {
         },
       }),
     {
-      onMutate: ({ tags }) =>
-        onMutateTagsSettings(
-          tags,
-          queryClient,
-          (feedSettings, manipulateTags) => {
-            const newData = cloneDeep(feedSettings);
-            newData.blockedTags = [
-              ...Array.from(
-                new Set(newData.blockedTags.concat(manipulateTags)),
-              ),
-            ];
-
-            newData.includeTags = newData.includeTags.filter(
-              (value) => manipulateTags.indexOf(value) < 0,
-            );
-            return newData;
-          },
-          user,
-        ),
+      onMutate: onBlockTags,
       onError: (err, _, rollback) => rollback(),
     },
   );
 
-  const { mutateAsync: unfollowTags } = useMutation<
+  const onUnfollowTags = ({ tags }: TagsMutationProps) =>
+    onMutateTagsSettings(
+      tags,
+      queryClient,
+      (feedSettings, manipulateTags) => {
+        const newData = cloneDeep(feedSettings);
+        newData.includeTags = newData.includeTags.filter(
+          (value) => manipulateTags.indexOf(value) < 0,
+        );
+        return newData;
+      },
+      user,
+    );
+
+  const { mutateAsync: unfollowTagsRemote } = useMutation<
     unknown,
     unknown,
-    { tags: Array<string> },
+    TagsMutationProps,
     () => void
   >(
     ({ tags }) =>
@@ -237,27 +275,29 @@ export default function useMutateFilters(user?: LoggedUser): ReturnType {
         },
       }),
     {
-      onMutate: ({ tags }) =>
-        onMutateTagsSettings(
-          tags,
-          queryClient,
-          (feedSettings, manipulateTags) => {
-            const newData = cloneDeep(feedSettings);
-            newData.includeTags = newData.includeTags.filter(
-              (value) => manipulateTags.indexOf(value) < 0,
-            );
-            return newData;
-          },
-          user,
-        ),
+      onMutate: onUnfollowTags,
       onError: (err, _, rollback) => rollback(),
     },
   );
 
-  const { mutateAsync: unblockTag } = useMutation<
+  const onUnblockTags = ({ tags }: TagsMutationProps) =>
+    onMutateTagsSettings(
+      tags,
+      queryClient,
+      (feedSettings, manipulateTags) => {
+        const newData = cloneDeep(feedSettings);
+        newData.blockedTags = newData.blockedTags.filter(
+          (value) => manipulateTags.indexOf(value) < 0,
+        );
+        return newData;
+      },
+      user,
+    );
+
+  const { mutateAsync: unblockTagRemote } = useMutation<
     unknown,
     unknown,
-    { tags: Array<string> },
+    TagsMutationProps,
     () => void
   >(
     ({ tags }) =>
@@ -267,27 +307,32 @@ export default function useMutateFilters(user?: LoggedUser): ReturnType {
         },
       }),
     {
-      onMutate: ({ tags }) =>
-        onMutateTagsSettings(
-          tags,
-          queryClient,
-          (feedSettings, manipulateTags) => {
-            const newData = cloneDeep(feedSettings);
-            newData.blockedTags = newData.blockedTags.filter(
-              (value) => manipulateTags.indexOf(value) < 0,
-            );
-            return newData;
-          },
-          user,
-        ),
+      onMutate: onUnblockTags,
       onError: (err, _, rollback) => rollback(),
     },
   );
 
-  const { mutateAsync: followSource } = useMutation<
+  const onFollowSource = ({ source }: SourceMutationProps) =>
+    onMutateSourcesSettings(
+      source,
+      queryClient,
+      (feedSettings, manipulateSource) => {
+        const newData = cloneDeep(feedSettings);
+        const index = newData.excludeSources.findIndex(
+          (s) => s.id === manipulateSource.id,
+        );
+        if (index > -1) {
+          newData.excludeSources.splice(index, 1);
+        }
+        return newData;
+      },
+      user,
+    );
+
+  const { mutateAsync: followSourceRemote } = useMutation<
     unknown,
     unknown,
-    { source: Source },
+    SourceMutationProps,
     () => void
   >(
     ({ source }) =>
@@ -297,30 +342,27 @@ export default function useMutateFilters(user?: LoggedUser): ReturnType {
         },
       }),
     {
-      onMutate: ({ source }) =>
-        onMutateSourcesSettings(
-          source,
-          queryClient,
-          (feedSettings, manipulateSource) => {
-            const newData = cloneDeep(feedSettings);
-            const index = newData.excludeSources.findIndex(
-              (s) => s.id === manipulateSource.id,
-            );
-            if (index > -1) {
-              newData.excludeSources.splice(index, 1);
-            }
-            return newData;
-          },
-          user,
-        ),
+      onMutate: onFollowSource,
       onError: (err, _, rollback) => rollback(),
     },
   );
 
-  const { mutateAsync: unfollowSource } = useMutation<
+  const onUnfollowSource = ({ source }: SourceMutationProps) =>
+    onMutateSourcesSettings(
+      source,
+      queryClient,
+      (feedSettings, manipulateSource) => {
+        const newData = cloneDeep(feedSettings);
+        newData.excludeSources.push(manipulateSource);
+        return newData;
+      },
+      user,
+    );
+
+  const { mutateAsync: unfollowSourceRemote } = useMutation<
     unknown,
     unknown,
-    { source: Source },
+    SourceMutationProps,
     () => Promise<void>
   >(
     ({ source }) =>
@@ -330,28 +372,20 @@ export default function useMutateFilters(user?: LoggedUser): ReturnType {
         },
       }),
     {
-      onMutate: ({ source }) =>
-        onMutateSourcesSettings(
-          source,
-          queryClient,
-          (feedSettings, manipulateSource) => {
-            const newData = cloneDeep(feedSettings);
-            newData.excludeSources.push(manipulateSource);
-            return newData;
-          },
-          user,
-        ),
+      onMutate: onUnfollowSource,
       onError: (err, _, rollback) => rollback(),
     },
   );
 
   return {
-    followTags,
-    unfollowTags,
-    blockTag,
-    unblockTag,
-    followSource,
-    unfollowSource,
-    updateAdvancedSettings,
+    followTags: user ? followTagsRemote : onFollowTags,
+    unfollowTags: user ? unfollowTagsRemote : onUnfollowTags,
+    blockTag: user ? blockTagRemote : onBlockTags,
+    unblockTag: user ? unblockTagRemote : onUnblockTags,
+    followSource: user ? followSourceRemote : onFollowSource,
+    unfollowSource: user ? unfollowSourceRemote : onUnfollowSource,
+    updateAdvancedSettings: user
+      ? updateAdvancedSettingsRemote
+      : onAdvancedSettingsUpdate,
   };
 }

--- a/packages/shared/src/hooks/useReportPost.ts
+++ b/packages/shared/src/hooks/useReportPost.ts
@@ -1,3 +1,4 @@
+import { useContext } from 'react';
 import { useMutation } from 'react-query';
 import request from 'graphql-request';
 import {
@@ -6,28 +7,58 @@ import {
   ReportReason,
 } from '../graphql/posts';
 import { apiUrl } from '../lib/config';
+import AuthContext from '../contexts/AuthContext';
 
 type UseReportPostRet = {
   reportPost: (variables: {
     id: string;
     reason: ReportReason;
     comment?: string;
-  }) => Promise<void>;
-  hidePost: (id: string) => Promise<void>;
+  }) => Promise<boolean>;
+  hidePost: (id: string) => Promise<boolean>;
 };
 
+interface ReportPostProps {
+  id: string;
+  reason: ReportReason;
+  comment: string;
+}
+
 export default function useReportPost(): UseReportPostRet {
-  const { mutateAsync: reportPost } = useMutation<
+  const { user, showLogin } = useContext(AuthContext);
+  const { mutateAsync: reportPostAsync } = useMutation<
     void,
     unknown,
-    { id: string; reason: ReportReason; comment: string }
+    ReportPostProps
   >((variables) =>
     request(`${apiUrl}/graphql`, REPORT_POST_MUTATION, variables),
   );
 
-  const { mutateAsync: hidePost } = useMutation<void, unknown, string>((id) =>
-    request(`${apiUrl}/graphql`, HIDE_POST_MUTATION, { id }),
+  const { mutateAsync: hidePostAsync } = useMutation<void, unknown, string>(
+    (id) => request(`${apiUrl}/graphql`, HIDE_POST_MUTATION, { id }),
   );
+
+  const reportPost = async (params: ReportPostProps) => {
+    if (!user) {
+      showLogin('report post');
+      return false;
+    }
+
+    await reportPostAsync(params);
+
+    return true;
+  };
+
+  const hidePost = async (id: string) => {
+    if (!user) {
+      showLogin('hide post');
+      return false;
+    }
+
+    await hidePostAsync(id);
+
+    return true;
+  };
 
   return { reportPost, hidePost };
 }

--- a/packages/shared/src/hooks/useReportPost.ts
+++ b/packages/shared/src/hooks/useReportPost.ts
@@ -8,14 +8,15 @@ import {
 } from '../graphql/posts';
 import { apiUrl } from '../lib/config';
 import AuthContext from '../contexts/AuthContext';
+import { BooleanPromise } from '../components/filters/common';
 
 type UseReportPostRet = {
   reportPost: (variables: {
     id: string;
     reason: ReportReason;
     comment?: string;
-  }) => Promise<boolean>;
-  hidePost: (id: string) => Promise<boolean>;
+  }) => BooleanPromise;
+  hidePost: (id: string) => BooleanPromise;
 };
 
 interface ReportPostProps {
@@ -41,23 +42,23 @@ export default function useReportPost(): UseReportPostRet {
   const reportPost = async (params: ReportPostProps) => {
     if (!user) {
       showLogin('report post');
-      return false;
+      return { success: false };
     }
 
     await reportPostAsync(params);
 
-    return true;
+    return { success: true };
   };
 
   const hidePost = async (id: string) => {
     if (!user) {
       showLogin('hide post');
-      return false;
+      return { success: false };
     }
 
     await hidePostAsync(id);
 
-    return true;
+    return { success: true };
   };
 
   return { reportPost, hidePost };

--- a/packages/shared/src/hooks/useReportPost.ts
+++ b/packages/shared/src/hooks/useReportPost.ts
@@ -42,23 +42,23 @@ export default function useReportPost(): UseReportPostRet {
   const reportPost = async (params: ReportPostProps) => {
     if (!user) {
       showLogin('report post');
-      return { success: false };
+      return { successful: false };
     }
 
     await reportPostAsync(params);
 
-    return { success: true };
+    return { successful: true };
   };
 
   const hidePost = async (id: string) => {
     if (!user) {
       showLogin('hide post');
-      return { success: false };
+      return { successful: false };
     }
 
     await hidePostAsync(id);
 
-    return { success: true };
+    return { successful: true };
   };
 
   return { reportPost, hidePost };

--- a/packages/shared/src/hooks/useTagAndSource.ts
+++ b/packages/shared/src/hooks/useTagAndSource.ts
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useMemo } from 'react';
 import { Features, isFeaturedEnabled } from '../lib/featureManagement';
 import AuthContext from '../contexts/AuthContext';
 import AnalyticsContext from '../contexts/AnalyticsContext';
@@ -170,12 +170,22 @@ export default function useTagAndSource({
     return true;
   };
 
-  return {
-    onFollowTags,
-    onUnfollowTags,
-    onBlockTags,
-    onUnblockTags,
-    onFollowSource,
-    onUnfollowSource,
-  };
+  return useMemo(
+    () => ({
+      onFollowTags,
+      onUnfollowTags,
+      onBlockTags,
+      onUnblockTags,
+      onFollowSource,
+      onUnfollowSource,
+    }),
+    [
+      onFollowTags,
+      onUnfollowTags,
+      onBlockTags,
+      onUnblockTags,
+      onFollowSource,
+      onUnfollowSource,
+    ],
+  );
 }

--- a/packages/shared/src/hooks/useTagAndSource.ts
+++ b/packages/shared/src/hooks/useTagAndSource.ts
@@ -14,22 +14,26 @@ export interface SourceActionArguments {
   source: Source;
 }
 
-export default function useTagAndSource({
-  origin,
-  postId,
-}: {
+interface UseTagAndSourceProps {
   origin?: string;
   postId?: string;
-}): {
+}
+
+interface UseTagAndSource {
   onFollowTags: ({ tags, category }: TagActionArguments) => void;
   onUnfollowTags: ({ tags, category }: TagActionArguments) => void;
   onBlockTags: ({ tags }: TagActionArguments) => Promise<unknown>;
   onUnblockTags: ({ tags }: TagActionArguments) => Promise<unknown>;
   onFollowSource: ({ source }: SourceActionArguments) => Promise<unknown>;
   onUnfollowSource: ({ source }: SourceActionArguments) => Promise<unknown>;
-} {
+}
+
+export default function useTagAndSource({
+  origin,
+  postId,
+}: UseTagAndSourceProps): UseTagAndSource {
   const { alerts, updateAlerts } = useContext(AlertContext);
-  const { user, showLogin } = useContext(AuthContext);
+  const { user } = useContext(AuthContext);
   const { trackEvent } = useContext(AnalyticsContext);
   const {
     followTags,
@@ -41,29 +45,19 @@ export default function useTagAndSource({
   } = useMutateFilters(user);
 
   const onFollowTags = async ({ tags, category }: TagActionArguments) => {
-    if (!user) {
-      showLogin(origin);
-      return;
-    }
-
     trackEvent({
       event_name: `follow${category ? ' all' : ''}`,
       target_type: 'tag',
       target_id: category || tags[0],
       extra: JSON.stringify({ origin }),
     });
-    if (alerts?.filter) {
+    if (alerts?.filter && user) {
       updateAlerts({ filter: false });
     }
     await followTags({ tags });
   };
 
   const onUnfollowTags = async ({ tags, category }: TagActionArguments) => {
-    if (!user) {
-      showLogin(origin);
-      return;
-    }
-
     trackEvent({
       event_name: `unfollow${category ? ' all' : ''}`,
       target_type: 'tag',
@@ -74,11 +68,6 @@ export default function useTagAndSource({
   };
 
   const onBlockTags = async ({ tags }: TagActionArguments) => {
-    if (!user) {
-      showLogin(origin);
-      return;
-    }
-
     trackEvent({
       event_name: 'block',
       target_type: 'tag',
@@ -89,11 +78,6 @@ export default function useTagAndSource({
   };
 
   const onUnblockTags = async ({ tags }: TagActionArguments) => {
-    if (!user) {
-      showLogin(origin);
-      return;
-    }
-
     trackEvent({
       event_name: 'unblock',
       target_type: 'tag',
@@ -104,11 +88,6 @@ export default function useTagAndSource({
   };
 
   const onFollowSource = async ({ source }: SourceActionArguments) => {
-    if (!user) {
-      showLogin(origin);
-      return;
-    }
-
     trackEvent({
       event_name: 'follow',
       target_type: 'source',
@@ -119,11 +98,6 @@ export default function useTagAndSource({
   };
 
   const onUnfollowSource = async ({ source }: SourceActionArguments) => {
-    if (!user) {
-      showLogin(origin);
-      return;
-    }
-
     trackEvent({
       event_name: 'unfollow',
       target_type: 'source',

--- a/packages/shared/src/hooks/useTagAndSource.ts
+++ b/packages/shared/src/hooks/useTagAndSource.ts
@@ -6,6 +6,7 @@ import useMutateFilters from './useMutateFilters';
 import { Source } from '../graphql/sources';
 import AlertContext from '../contexts/AlertContext';
 import FeaturesContext from '../contexts/FeaturesContext';
+import { BooleanPromise } from '../components/filters/common';
 
 export interface TagActionArguments {
   tags: Array<string>;
@@ -24,12 +25,12 @@ interface UseTagAndSourceProps {
 }
 
 interface UseTagAndSource {
-  onFollowTags: (params: TagActionArguments) => void;
-  onUnfollowTags: (params: TagActionArguments) => void;
-  onBlockTags: (params: TagActionArguments) => Promise<boolean>;
-  onUnblockTags: (params: TagActionArguments) => Promise<unknown>;
-  onFollowSource: (params: SourceActionArguments) => Promise<unknown>;
-  onUnfollowSource: (params: SourceActionArguments) => Promise<unknown>;
+  onFollowTags: (params: TagActionArguments) => BooleanPromise;
+  onUnfollowTags: (params: TagActionArguments) => BooleanPromise;
+  onBlockTags: (params: TagActionArguments) => BooleanPromise;
+  onUnblockTags: (params: TagActionArguments) => BooleanPromise;
+  onFollowSource: (params: SourceActionArguments) => BooleanPromise;
+  onUnfollowSource: (params: SourceActionArguments) => BooleanPromise;
 }
 
 export default function useTagAndSource({
@@ -52,7 +53,7 @@ export default function useTagAndSource({
 
     return requireLogin;
   };
-  // (!shouldShowMyFeed && !user) || (requireLogin && !user);
+
   const {
     followTags,
     unfollowTags,
@@ -69,7 +70,7 @@ export default function useTagAndSource({
   }: TagActionArguments) => {
     if (shouldShowLogin(requireLogin)) {
       showLogin(origin);
-      return false;
+      return { successful: false };
     }
     trackEvent({
       event_name: `follow${category ? ' all' : ''}`,
@@ -81,7 +82,7 @@ export default function useTagAndSource({
       updateAlerts({ filter: false });
     }
     await followTags({ tags });
-    return true;
+    return { successful: true };
   };
 
   const onUnfollowTags = async ({
@@ -91,7 +92,7 @@ export default function useTagAndSource({
   }: TagActionArguments) => {
     if (shouldShowLogin(requireLogin)) {
       showLogin(origin);
-      return false;
+      return { successful: false };
     }
     trackEvent({
       event_name: `unfollow${category ? ' all' : ''}`,
@@ -100,13 +101,13 @@ export default function useTagAndSource({
       extra: JSON.stringify({ origin }),
     });
     await unfollowTags({ tags });
-    return true;
+    return { successful: true };
   };
 
   const onBlockTags = async ({ tags, requireLogin }: TagActionArguments) => {
     if (shouldShowLogin(requireLogin)) {
       showLogin(origin);
-      return false;
+      return { successful: false };
     }
 
     trackEvent({
@@ -116,13 +117,13 @@ export default function useTagAndSource({
       extra: JSON.stringify({ origin, post_id: postId }),
     });
     await blockTag({ tags });
-    return true;
+    return { successful: true };
   };
 
   const onUnblockTags = async ({ tags, requireLogin }: TagActionArguments) => {
     if (shouldShowLogin(requireLogin)) {
       showLogin(origin);
-      return false;
+      return { successful: false };
     }
     trackEvent({
       event_name: 'unblock',
@@ -131,7 +132,7 @@ export default function useTagAndSource({
       extra: JSON.stringify({ origin, post_id: postId }),
     });
     await unblockTag({ tags });
-    return true;
+    return { successful: true };
   };
 
   const onFollowSource = async ({
@@ -140,7 +141,7 @@ export default function useTagAndSource({
   }: SourceActionArguments) => {
     if (shouldShowLogin(requireLogin)) {
       showLogin(origin);
-      return false;
+      return { successful: false };
     }
     trackEvent({
       event_name: 'follow',
@@ -149,7 +150,7 @@ export default function useTagAndSource({
       extra: JSON.stringify({ origin, post_id: postId }),
     });
     await followSource({ source });
-    return true;
+    return { successful: true };
   };
 
   const onUnfollowSource = async ({
@@ -158,7 +159,7 @@ export default function useTagAndSource({
   }: SourceActionArguments) => {
     if (shouldShowLogin(requireLogin)) {
       showLogin(origin);
-      return false;
+      return { successful: false };
     }
     trackEvent({
       event_name: 'unfollow',
@@ -167,7 +168,7 @@ export default function useTagAndSource({
       extra: JSON.stringify({ origin, post_id: postId }),
     });
     await unfollowSource({ source });
-    return true;
+    return { successful: true };
   };
 
   return useMemo(

--- a/packages/shared/src/hooks/useTagAndSource.ts
+++ b/packages/shared/src/hooks/useTagAndSource.ts
@@ -37,7 +37,8 @@ export default function useTagAndSource({
   postId,
 }: UseTagAndSourceProps): UseTagAndSource {
   const { flags } = useContext(FeaturesContext);
-  const shouldShowMyFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
+  const myFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
+  const shouldShowMyFeed = myFeed === 'true';
   const { alerts, updateAlerts } = useContext(AlertContext);
   const { user, showLogin } = useContext(AuthContext);
   const { trackEvent } = useContext(AnalyticsContext);

--- a/packages/shared/src/hooks/useTagAndSource.ts
+++ b/packages/shared/src/hooks/useTagAndSource.ts
@@ -41,8 +41,18 @@ export default function useTagAndSource({
   const { alerts, updateAlerts } = useContext(AlertContext);
   const { user, showLogin } = useContext(AuthContext);
   const { trackEvent } = useContext(AnalyticsContext);
-  const shouldShowLogin = (requireLogin?: boolean) =>
-    (!shouldShowMyFeed && !user) || (requireLogin && !user);
+  const shouldShowLogin = (requireLogin?: boolean) => {
+    if (user) {
+      return false;
+    }
+
+    if (!shouldShowMyFeed) {
+      return true;
+    }
+
+    return requireLogin;
+  };
+  // (!shouldShowMyFeed && !user) || (requireLogin && !user);
   const {
     followTags,
     unfollowTags,

--- a/packages/shared/src/hooks/useTagAndSource.ts
+++ b/packages/shared/src/hooks/useTagAndSource.ts
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { Features, getFeatureValue } from '../lib/featureManagement';
+import { Features, isFeaturedEnabled } from '../lib/featureManagement';
 import AuthContext from '../contexts/AuthContext';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import useMutateFilters from './useMutateFilters';
@@ -37,8 +37,7 @@ export default function useTagAndSource({
   postId,
 }: UseTagAndSourceProps): UseTagAndSource {
   const { flags } = useContext(FeaturesContext);
-  const myFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
-  const shouldShowMyFeed = myFeed === 'true';
+  const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
   const { alerts, updateAlerts } = useContext(AlertContext);
   const { user, showLogin } = useContext(AuthContext);
   const { trackEvent } = useContext(AnalyticsContext);

--- a/packages/shared/src/lib/storageWrapper.ts
+++ b/packages/shared/src/lib/storageWrapper.ts
@@ -24,9 +24,18 @@ export default function Storage(): Partial<Storage> {
     }
   }
 
+  function removeItem(key: string): void {
+    if (isLocalStorageEnabled()) {
+      localStorage.removeItem(key);
+    } else {
+      delete inMemoryStorage[key];
+    }
+  }
+
   return {
     getItem,
     setItem,
+    removeItem,
   };
 }
 export const storageWrapper = Storage();

--- a/packages/shared/src/lib/storageWrapper.ts
+++ b/packages/shared/src/lib/storageWrapper.ts
@@ -32,10 +32,21 @@ export default function Storage(): Partial<Storage> {
     }
   }
 
+  function clear(): void {
+    if (isLocalStorageEnabled()) {
+      localStorage.clear();
+    } else {
+      Object.keys(inMemoryStorage).forEach((key) => {
+        delete inMemoryStorage[key];
+      });
+    }
+  }
+
   return {
     getItem,
     setItem,
     removeItem,
+    clear,
   };
 }
 export const storageWrapper = Storage();

--- a/packages/webapp/__tests__/SourcePage.tsx
+++ b/packages/webapp/__tests__/SourcePage.tsx
@@ -17,7 +17,7 @@ import {
   FeedSettings,
   REMOVE_FILTERS_FROM_FEED_MUTATION,
 } from '@dailydotdev/shared/src/graphql/feedSettings';
-import { getFeedSettingsQueryKey } from '@dailydotdev/shared/src/hooks/useMutateFilters';
+import { getFeedSettingsQueryKey } from '@dailydotdev/shared/src/hooks/useFeedSettings';
 import SourcePage from '../pages/sources/[source]';
 import ad from './fixture/ad';
 import defaultUser from './fixture/loggedUser';

--- a/packages/webapp/__tests__/TagPage.tsx
+++ b/packages/webapp/__tests__/TagPage.tsx
@@ -13,7 +13,7 @@ import {
   FeedSettings,
   REMOVE_FILTERS_FROM_FEED_MUTATION,
 } from '@dailydotdev/shared/src/graphql/feedSettings';
-import { getFeedSettingsQueryKey } from '@dailydotdev/shared/src/hooks/useMutateFilters';
+import { getFeedSettingsQueryKey } from '@dailydotdev/shared/src/hooks/useFeedSettings';
 import SettingsContext, {
   SettingsContextData,
 } from '@dailydotdev/shared/src/contexts/SettingsContext';


### PR DESCRIPTION
DD-430 #done
[DD-442](https://dailydotdev.atlassian.net/jira/software/projects/DD/boards/1?selectedIssue=DD-442) #done - pre-existing issue (unblock a tag)
[DD-445](https://dailydotdev.atlassian.net/jira/software/projects/DD/boards/1?selectedIssue=DD-445) #done - pre-existing issue (reporting and hiding post)
[DD-446](https://dailydotdev.atlassian.net/jira/software/projects/DD/boards/1?selectedIssue=DD-446) #done - pre-existing issue (blocking a source and a tag)

This includes quite a few fixes since I was on it already and have thought of fixing it along the way.

The issues were:
- Unblock a tag on context menu after searching a tag
- Reporting a post as an anonymous user
- Hiding a post as an  anonymous user
- Blocking a tag as an  anonymous user
- Blocking a source as an anonymous user

I have also worked on some refactoring to apply proper types. One of the key ones were receiving a callback as a prop, I thought using the prefix `set` (i.e. `setValue`) is most commonly used on state-related declarations, so I changed the props to follow our common prefix in the codebase using `on` (i.e. `onValueChanged`).

At `FeedFilters.tsx` it can be noticed that I removed some mechanism for animation since it is being handled outside by our custom hook already, it shouldn't be necessary on the inside anymore.

Most of the core changes were part of the `useMutateFilters` where it manages the cache for `react-query` and instead of reworking the whole `FeedFilters` (and all the components underneath) to accept a dynamic prop where the outside component to decide whether we use data from local storage or the query.

We now just toggle whether we should utilize local storage or not so the core process flow won't be affected.
