### PR TITLE
fix: re-add the feed filters if the user has the ab test set to off

### DIFF
--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -1,10 +1,9 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import PlusIcon from '@dailydotdev/shared/icons/plus.svg';
 import FilterIcon from '@dailydotdev/shared/icons/outline/filter.svg';
 import { IFlags } from 'flagsmith';
 import { Button } from '../buttons/Button';
-import FeaturesContext from '../../contexts/FeaturesContext';
 import { Features, getFeatureValue } from '../../lib/featureManagement';
 import { ButtonOrLink, ItemInner, NavItem, SidebarMenuItem } from './common';
 
@@ -50,6 +49,7 @@ type UnfilteredMyFeedButtonProps = MyFeedButtonSharedProps & {
 };
 type MyFeedButtonProps = MyFeedButtonSharedProps & {
   item: SidebarMenuItem;
+  flags: IFlags;
   filtered: boolean;
 };
 type FilteredMyFeedButtonProps = MyFeedButtonSharedProps & {
@@ -148,15 +148,9 @@ export default function MyFeedButton({
   item,
   sidebarExpanded,
   filtered = false,
+  flags,
   action,
 }: MyFeedButtonProps): ReactElement {
-  const { flags } = useContext(FeaturesContext);
-  const shouldShowMyFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
-
-  if (shouldShowMyFeed === 'false') {
-    return <></>;
-  }
-
   if (filtered) {
     return (
       <FilteredMyFeedButton

--- a/packages/shared/src/components/sidebar/Sidebar.spec.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.spec.tsx
@@ -47,7 +47,6 @@ const features: FeaturesData = {
   flags: {
     my_feed_on: {
       enabled: true,
-      value: 'true',
     },
   },
 };

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -146,7 +146,7 @@ export default function Sidebar({
     useContext(SettingsContext);
   const [showSettings, setShowSettings] = useState(false);
   const { flags } = useContext(FeaturesContext);
-  const shouldShowMyFeed = getFeatureValue(Features.MyFeedOn, flags, true);
+  const shouldShowMyFeed = getFeatureValue(Features.MyFeedOn, flags, false);
 
   useHideMobileSidebar({
     state: openMobileSidebar,
@@ -187,7 +187,7 @@ export default function Sidebar({
       hideOnMobile: true,
     },
   ];
-  if (shouldShowMyFeed !== 'true') {
+  if (shouldShowMyFeed) {
     discoverMenuItems.unshift({
       icon: <ListIcon Icon={FilterIcon} />,
       alert: alerts.filter && (
@@ -267,7 +267,7 @@ export default function Sidebar({
               sidebarRendered={sidebarRendered}
               onShowDndClick={onShowDndClick}
             />
-            {sidebarRendered && shouldShowMyFeed === 'true' && (
+            {sidebarRendered && shouldShowMyFeed && (
               <MyFeedButton
                 sidebarExpanded={sidebarExpanded}
                 filtered={!alerts?.filter}

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -146,7 +146,7 @@ export default function Sidebar({
     useContext(SettingsContext);
   const [showSettings, setShowSettings] = useState(false);
   const { flags } = useContext(FeaturesContext);
-  const shouldShowMyFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
+  const shouldShowMyFeed = getFeatureValue(Features.MyFeedOn, flags, true);
 
   useHideMobileSidebar({
     state: openMobileSidebar,

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -13,7 +13,7 @@ import FeedbackIcon from '../../../icons/feedback.svg';
 import DocsIcon from '../../../icons/docs.svg';
 import TerminalIcon from '../../../icons/terminal.svg';
 import HomeIcon from '../../../icons/home.svg';
-
+import FilterIcon from '../../../icons/outline/filter.svg';
 import {
   ButtonOrLink,
   ItemInner,
@@ -40,6 +40,9 @@ import useHideMobileSidebar from '../../hooks/useHideMobileSidebar';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 import MyFeedButton from './MyFeedButton';
 import usePersistentContext from '../../hooks/usePersistentContext';
+import FeaturesContext from '../../contexts/FeaturesContext';
+import { Features, getFeatureValue } from '../../lib/featureManagement';
+import { AlertColor, AlertDot } from '../AlertDot';
 
 const bottomMenuItems: SidebarMenuItem[] = [
   {
@@ -142,6 +145,8 @@ export default function Sidebar({
   const { sidebarExpanded, toggleSidebarExpanded, loadedSettings } =
     useContext(SettingsContext);
   const [showSettings, setShowSettings] = useState(false);
+  const { flags } = useContext(FeaturesContext);
+  const shouldShowMyFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
 
   useHideMobileSidebar({
     state: openMobileSidebar,
@@ -182,6 +187,17 @@ export default function Sidebar({
       hideOnMobile: true,
     },
   ];
+  if (shouldShowMyFeed !== 'true') {
+    discoverMenuItems.unshift({
+      icon: <ListIcon Icon={FilterIcon} />,
+      alert: alerts.filter && (
+        <AlertDot className="-top-0.5 right-2.5" color={AlertColor.Fill} />
+      ),
+      title: 'Feed filters',
+      action: openFeedFilters,
+      hideOnMobile: true,
+    });
+  }
 
   const myFeedMenuItem: SidebarMenuItem = {
     icon: <ListIcon Icon={HomeIcon} />,
@@ -251,11 +267,12 @@ export default function Sidebar({
               sidebarRendered={sidebarRendered}
               onShowDndClick={onShowDndClick}
             />
-            {sidebarRendered && (
+            {sidebarRendered && shouldShowMyFeed === 'true' && (
               <MyFeedButton
                 sidebarExpanded={sidebarExpanded}
                 filtered={!alerts?.filter}
                 item={myFeedMenuItem}
+                flags={flags}
                 action={openFeedFilters}
               />
             )}

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -41,7 +41,7 @@ import AnalyticsContext from '../../contexts/AnalyticsContext';
 import MyFeedButton from './MyFeedButton';
 import usePersistentContext from '../../hooks/usePersistentContext';
 import FeaturesContext from '../../contexts/FeaturesContext';
-import { Features, getFeatureValue } from '../../lib/featureManagement';
+import { Features, isFeaturedEnabled } from '../../lib/featureManagement';
 import { AlertColor, AlertDot } from '../AlertDot';
 
 const bottomMenuItems: SidebarMenuItem[] = [
@@ -146,7 +146,7 @@ export default function Sidebar({
     useContext(SettingsContext);
   const [showSettings, setShowSettings] = useState(false);
   const { flags } = useContext(FeaturesContext);
-  const shouldShowMyFeed = getFeatureValue(Features.MyFeedOn, flags, false);
+  const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
 
   useHideMobileSidebar({
     state: openMobileSidebar,

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -11,14 +11,16 @@ export enum Features {
   FeedVersion = 'feed_version',
   HidePublicationDate = 'hide_publication_date',
 }
+const isBoolean = (val) => 'boolean' === typeof val;
 
 export const getFeatureValue = (
   key: Features,
   flags: IFlags,
-  defaultValue: string = undefined,
-): string | undefined => {
+  defaultValue: boolean | string = undefined,
+): string | undefined | boolean => {
   if (flags[key]?.enabled) {
-    return flags[key].value;
+    return isBoolean(defaultValue) ? true : flags[key].value;
   }
+
   return defaultValue;
 };

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -11,7 +11,7 @@ export enum Features {
   FeedVersion = 'feed_version',
   HidePublicationDate = 'hide_publication_date',
 }
-const isBoolean = (val) => 'boolean' === typeof val;
+const isBoolean = (val) => !!val === val;
 
 export const getFeatureValue = (
   key: Features,

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -11,16 +11,17 @@ export enum Features {
   FeedVersion = 'feed_version',
   HidePublicationDate = 'hide_publication_date',
 }
-const isBoolean = (val) => !!val === val;
 
 export const getFeatureValue = (
   key: Features,
   flags: IFlags,
-  defaultValue: boolean | string = undefined,
-): string | undefined | boolean => {
+  defaultValue: string = undefined,
+): string | undefined => {
   if (flags[key]?.enabled) {
-    return isBoolean(defaultValue) ? true : flags[key].value;
+    return flags[key].value;
   }
-
   return defaultValue;
 };
+
+export const isFeaturedEnabled = (key: Features, flags: IFlags): boolean =>
+  flags[key]?.enabled;


### PR DESCRIPTION
We accidentally removed the feed filter option for people who have the AB test set to false.
This PR reintroduces it.

By doing so we had to re-arrange the flag loading a bit.

DD-447 #done 