### PR TITLE
feat: my feed page

### DIFF
--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -11,7 +11,7 @@ import { HeaderButton } from '@dailydotdev/shared/src/components/buttons/common'
 import FeaturesContext from '@dailydotdev/shared/src/contexts/FeaturesContext';
 import {
   Features,
-  getFeatureValue,
+  isFeaturedEnabled,
 } from '@dailydotdev/shared/src/lib/featureManagement';
 import MostVisitedSites from './MostVisitedSites';
 
@@ -40,8 +40,7 @@ export default function MainFeedPage({
   const [showDnd, setShowDnd] = useState(false);
   const [defaultFeed] = usePersistentContext('defaultFeed', 'popular');
   const { flags } = useContext(FeaturesContext);
-  const myFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
-  const shouldShowMyFeed = myFeed === 'true';
+  const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
   const enableSearch = () => {
     setIsSearchOn(true);
     setSearchQuery(null);

--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -1,18 +1,15 @@
 import React, { ReactElement, useContext, useMemo, useState } from 'react';
 import usePersistentContext from '@dailydotdev/shared/src/hooks/usePersistentContext';
 import MainLayout from '@dailydotdev/shared/src/components/MainLayout';
-import MainFeedLayout from '@dailydotdev/shared/src/components/MainFeedLayout';
+import MainFeedLayout, {
+  getShouldRedirect,
+} from '@dailydotdev/shared/src/components/MainFeedLayout';
 import FeedLayout from '@dailydotdev/shared/src/components/FeedLayout';
 import dynamic from 'next/dynamic';
 import TimerIcon from '@dailydotdev/shared/icons/timer.svg';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import SimpleTooltip from '@dailydotdev/shared/src/components/tooltips/SimpleTooltip';
 import { HeaderButton } from '@dailydotdev/shared/src/components/buttons/common';
-import FeaturesContext from '@dailydotdev/shared/src/contexts/FeaturesContext';
-import {
-  Features,
-  isFeaturedEnabled,
-} from '@dailydotdev/shared/src/lib/featureManagement';
 import MostVisitedSites from './MostVisitedSites';
 
 const PostsSearch = dynamic(
@@ -39,8 +36,6 @@ export default function MainFeedPage({
   const [searchQuery, setSearchQuery] = useState<string>();
   const [showDnd, setShowDnd] = useState(false);
   const [defaultFeed] = usePersistentContext('defaultFeed', 'popular');
-  const { flags } = useContext(FeaturesContext);
-  const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
   const enableSearch = () => {
     setIsSearchOn(true);
     setSearchQuery(null);
@@ -53,9 +48,11 @@ export default function MainFeedPage({
     }
     setFeedName(tab);
     const isMyFeed = tab === '/my-feed';
-    const shouldRedirect =
-      (isMyFeed && !shouldShowMyFeed) || (isMyFeed && !user);
-    onPageChanged(`/${shouldRedirect ? 'popular' : tab}`);
+    if (getShouldRedirect(isMyFeed, !!user)) {
+      onPageChanged(`/`);
+    } else {
+      onPageChanged(`/${tab}`);
+    }
   };
 
   const activePage = useMemo(() => {

--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -8,6 +8,11 @@ import TimerIcon from '@dailydotdev/shared/icons/timer.svg';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import SimpleTooltip from '@dailydotdev/shared/src/components/tooltips/SimpleTooltip';
 import { HeaderButton } from '@dailydotdev/shared/src/components/buttons/common';
+import FeaturesContext from '@dailydotdev/shared/src/contexts/FeaturesContext';
+import {
+  Features,
+  getFeatureValue,
+} from '@dailydotdev/shared/src/lib/featureManagement';
 import MostVisitedSites from './MostVisitedSites';
 
 const PostsSearch = dynamic(
@@ -34,6 +39,9 @@ export default function MainFeedPage({
   const [searchQuery, setSearchQuery] = useState<string>();
   const [showDnd, setShowDnd] = useState(false);
   const [defaultFeed] = usePersistentContext('defaultFeed', 'popular');
+  const { flags } = useContext(FeaturesContext);
+  const myFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
+  const shouldShowMyFeed = myFeed === 'true';
   const enableSearch = () => {
     setIsSearchOn(true);
     setSearchQuery(null);
@@ -45,7 +53,10 @@ export default function MainFeedPage({
       setIsSearchOn(false);
     }
     setFeedName(tab);
-    onPageChanged(`/${tab}`);
+    const isMyFeed = tab === '/my-feed';
+    const shouldRedirect =
+      (isMyFeed && !shouldShowMyFeed) || (isMyFeed && !user);
+    onPageChanged(`/${shouldRedirect ? 'popular' : tab}`);
   };
 
   const activePage = useMemo(() => {

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -47,9 +47,13 @@ type FeedQueryProps = {
   variables?: Record<string, unknown>;
 };
 
-const getPropsByFeed = (
-  shouldShowMyFeed: boolean,
-): Record<string, FeedQueryProps> => {
+interface PropsByFeedOptionalParams {
+  shouldShowMyFeed?: boolean;
+}
+
+const getPropsByFeed = ({
+  shouldShowMyFeed = false,
+}: PropsByFeedOptionalParams = {}): Record<string, FeedQueryProps> => {
   const myFeed = shouldShowMyFeed
     ? {
         'my-feed': {
@@ -139,7 +143,7 @@ export default function MainFeedLayout({
     10,
   );
   const feedName = feedNameProp === 'default' ? defaultFeed : feedNameProp;
-  const propsByFeed = getPropsByFeed(shouldShowMyFeed);
+  const propsByFeed = getPropsByFeed({ shouldShowMyFeed });
 
   useEffect(() => {
     if (defaultFeed !== null && feedName !== null && feedName !== defaultFeed) {

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -47,24 +47,18 @@ type FeedQueryProps = {
   variables?: Record<string, unknown>;
 };
 
-interface PropsByFeedOptionalParams {
+interface FeedOptionalParams {
   shouldShowMyFeed?: boolean;
 }
 
 const getPropsByFeed = ({
   shouldShowMyFeed = false,
-}: PropsByFeedOptionalParams = {}): Record<string, FeedQueryProps> => {
-  const myFeed = shouldShowMyFeed
-    ? {
-        'my-feed': {
-          query: ANONYMOUS_FEED_QUERY,
-          queryIfLogged: FEED_QUERY,
-        },
-      }
-    : {};
-
+}: FeedOptionalParams = {}): Record<string, FeedQueryProps> => {
   return {
-    ...myFeed,
+    'my-feed': {
+      query: ANONYMOUS_FEED_QUERY,
+      queryIfLogged: FEED_QUERY,
+    },
     popular: {
       query: ANONYMOUS_FEED_QUERY,
       queryIfLogged: shouldShowMyFeed ? ANONYMOUS_FEED_QUERY : FEED_QUERY,
@@ -91,6 +85,21 @@ const LayoutHeader = classed(
   'header',
   'flex overflow-x-auto relative items-center self-stretch mb-6 h-11 no-scrollbar',
 );
+
+export const getShouldRedirect = (
+  isOnMyFeed: boolean,
+  isLoggedIn: boolean,
+): boolean => {
+  if (!isOnMyFeed) {
+    return false;
+  }
+
+  if (!isLoggedIn) {
+    return true;
+  }
+
+  return false;
+};
 
 export type MainFeedLayoutProps = {
   feedName: string;

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -44,9 +44,13 @@ type FeedQueryProps = {
 };
 
 const propsByFeed: Record<string, FeedQueryProps> = {
-  popular: {
+  'my-feed': {
     query: ANONYMOUS_FEED_QUERY,
     queryIfLogged: FEED_QUERY,
+  },
+  popular: {
+    query: ANONYMOUS_FEED_QUERY,
+    queryIfLogged: ANONYMOUS_FEED_QUERY,
   },
   search: {
     query: ANONYMOUS_FEED_QUERY,

--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -1,8 +1,8 @@
 import React, { ReactElement, useContext } from 'react';
 import classNames from 'classnames';
-import PlusIcon from '@dailydotdev/shared/icons/plus.svg';
-import FilterIcon from '@dailydotdev/shared/icons/outline/filter.svg';
 import { IFlags } from 'flagsmith';
+import PlusIcon from '../../../icons/plus.svg';
+import FilterIcon from '../../../icons/outline/filter.svg';
 import { Button } from '../buttons/Button';
 import FeaturesContext from '../../contexts/FeaturesContext';
 import { Features, getFeatureValue } from '../../lib/featureManagement';

--- a/packages/webapp/__tests__/MyFeedPage.tsx
+++ b/packages/webapp/__tests__/MyFeedPage.tsx
@@ -3,6 +3,7 @@ import {
   ANONYMOUS_FEED_QUERY,
   FEED_QUERY,
 } from '@dailydotdev/shared/src/graphql/feed';
+import FeaturesContext from '@dailydotdev/shared/src/contexts/FeaturesContext';
 import nock from 'nock';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import React from 'react';
@@ -81,21 +82,25 @@ const renderComponent = (
   };
   return render(
     <QueryClientProvider client={client}>
-      <AuthContext.Provider
-        value={{
-          user,
-          shouldShowLogin: false,
-          showLogin,
-          logout: jest.fn(),
-          updateUser: jest.fn(),
-          tokenRefreshed: true,
-          getRedirectUri: jest.fn(),
-        }}
+      <FeaturesContext.Provider
+        value={{ flags: { my_feed_on: { enabled: true } } }}
       >
-        <SettingsContext.Provider value={settingsContext}>
-          {MyFeed.getLayout(<MyFeed />, {}, MyFeed.layoutProps)}
-        </SettingsContext.Provider>
-      </AuthContext.Provider>
+        <AuthContext.Provider
+          value={{
+            user,
+            shouldShowLogin: false,
+            showLogin,
+            logout: jest.fn(),
+            updateUser: jest.fn(),
+            tokenRefreshed: true,
+            getRedirectUri: jest.fn(),
+          }}
+        >
+          <SettingsContext.Provider value={settingsContext}>
+            {MyFeed.getLayout(<MyFeed />, {}, MyFeed.layoutProps)}
+          </SettingsContext.Provider>
+        </AuthContext.Provider>
+      </FeaturesContext.Provider>
     </QueryClientProvider>,
   );
 };

--- a/packages/webapp/__tests__/MyFeedPage.tsx
+++ b/packages/webapp/__tests__/MyFeedPage.tsx
@@ -1,5 +1,8 @@
 import { FeedData } from '@dailydotdev/shared/src/graphql/posts';
-import { ANONYMOUS_FEED_QUERY } from '@dailydotdev/shared/src/graphql/feed';
+import {
+  ANONYMOUS_FEED_QUERY,
+  FEED_QUERY,
+} from '@dailydotdev/shared/src/graphql/feed';
 import nock from 'nock';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import React from 'react';
@@ -11,7 +14,7 @@ import SettingsContext, {
 } from '@dailydotdev/shared/src/contexts/SettingsContext';
 import { mocked } from 'ts-jest/utils';
 import { NextRouter, useRouter } from 'next/router';
-import Popular from '../pages/popular';
+import MyFeed from '../pages/my-feed';
 import ad from './fixture/ad';
 import defaultUser from './fixture/loggedUser';
 import defaultFeedPage from './fixture/feed';
@@ -25,7 +28,7 @@ beforeEach(() => {
   mocked(useRouter).mockImplementation(
     () =>
       ({
-        pathname: '/popular',
+        pathname: '/my-feed',
         query: {},
         replace: jest.fn(),
         push: jest.fn(),
@@ -90,16 +93,16 @@ const renderComponent = (
         }}
       >
         <SettingsContext.Provider value={settingsContext}>
-          {Popular.getLayout(<Popular />, {}, Popular.layoutProps)}
+          {MyFeed.getLayout(<MyFeed />, {}, MyFeed.layoutProps)}
         </SettingsContext.Provider>
       </AuthContext.Provider>
     </QueryClientProvider>,
   );
 };
 
-it('should request anonymous feed', async () => {
+it('should request user feed', async () => {
   renderComponent([
-    createFeedMock(defaultFeedPage, ANONYMOUS_FEED_QUERY, {
+    createFeedMock(defaultFeedPage, FEED_QUERY, {
       first: 7,
       loggedIn: true,
       unreadOnly: false,

--- a/packages/webapp/__tests__/PopularPage.tsx
+++ b/packages/webapp/__tests__/PopularPage.tsx
@@ -1,5 +1,8 @@
 import { FeedData } from '@dailydotdev/shared/src/graphql/posts';
-import { ANONYMOUS_FEED_QUERY } from '@dailydotdev/shared/src/graphql/feed';
+import {
+  ANONYMOUS_FEED_QUERY,
+  FEED_QUERY,
+} from '@dailydotdev/shared/src/graphql/feed';
 import nock from 'nock';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import React from 'react';
@@ -97,9 +100,9 @@ const renderComponent = (
   );
 };
 
-it('should request anonymous feed', async () => {
+it('should request user feed', async () => {
   renderComponent([
-    createFeedMock(defaultFeedPage, ANONYMOUS_FEED_QUERY, {
+    createFeedMock(defaultFeedPage, FEED_QUERY, {
       first: 7,
       loggedIn: true,
       unreadOnly: false,

--- a/packages/webapp/components/layouts/MainFeedPage.tsx
+++ b/packages/webapp/components/layouts/MainFeedPage.tsx
@@ -12,7 +12,7 @@ import dynamic from 'next/dynamic';
 import FeaturesContext from '@dailydotdev/shared/src/contexts/FeaturesContext';
 import {
   Features,
-  getFeatureValue,
+  isFeaturedEnabled,
 } from '@dailydotdev/shared/src/lib/featureManagement';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { getLayout } from './FeedLayout';
@@ -39,8 +39,7 @@ export default function MainFeedPage({
   const router = useRouter();
   const { user } = useContext(AuthContext);
   const { flags } = useContext(FeaturesContext);
-  const myFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
-  const shouldShowMyFeed = myFeed === 'true';
+  const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
   const [feedName, setFeedName] = useState(getFeedName(router?.pathname));
   const [isSearchOn, setIsSearchOn] = useState(router?.pathname === '/search');
 

--- a/packages/webapp/components/layouts/MainFeedPage.tsx
+++ b/packages/webapp/components/layouts/MainFeedPage.tsx
@@ -7,13 +7,10 @@ import React, {
 } from 'react';
 import { useRouter } from 'next/router';
 import { MainLayoutProps } from '@dailydotdev/shared/src/components/MainLayout';
-import MainFeedLayout from '@dailydotdev/shared/src/components/MainFeedLayout';
+import MainFeedLayout, {
+  getShouldRedirect,
+} from '@dailydotdev/shared/src/components/MainFeedLayout';
 import dynamic from 'next/dynamic';
-import FeaturesContext from '@dailydotdev/shared/src/contexts/FeaturesContext';
-import {
-  Features,
-  isFeaturedEnabled,
-} from '@dailydotdev/shared/src/lib/featureManagement';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { getLayout } from './FeedLayout';
 
@@ -38,15 +35,13 @@ export default function MainFeedPage({
 }: MainFeedPageProps): ReactElement {
   const router = useRouter();
   const { user } = useContext(AuthContext);
-  const { flags } = useContext(FeaturesContext);
-  const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
   const [feedName, setFeedName] = useState(getFeedName(router?.pathname));
   const [isSearchOn, setIsSearchOn] = useState(router?.pathname === '/search');
 
   useEffect(() => {
     const isMyFeed = router?.pathname === '/my-feed';
-    if ((isMyFeed && !shouldShowMyFeed) || (isMyFeed && !user)) {
-      router.replace('popular');
+    if (getShouldRedirect(isMyFeed, !!user)) {
+      router.replace('/');
     } else if (router?.pathname === '/search') {
       setIsSearchOn(true);
       if (!feedName) {

--- a/packages/webapp/components/layouts/MainFeedPage.tsx
+++ b/packages/webapp/components/layouts/MainFeedPage.tsx
@@ -1,8 +1,20 @@
-import React, { ReactElement, ReactNode, useEffect, useState } from 'react';
+import React, {
+  ReactElement,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 import { useRouter } from 'next/router';
 import { MainLayoutProps } from '@dailydotdev/shared/src/components/MainLayout';
 import MainFeedLayout from '@dailydotdev/shared/src/components/MainFeedLayout';
 import dynamic from 'next/dynamic';
+import FeaturesContext from '@dailydotdev/shared/src/contexts/FeaturesContext';
+import {
+  Features,
+  getFeatureValue,
+} from '@dailydotdev/shared/src/lib/featureManagement';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { getLayout } from './FeedLayout';
 
 const PostsSearch = dynamic(
@@ -25,11 +37,18 @@ export default function MainFeedPage({
   children,
 }: MainFeedPageProps): ReactElement {
   const router = useRouter();
+  const { user } = useContext(AuthContext);
+  const { flags } = useContext(FeaturesContext);
+  const myFeed = getFeatureValue(Features.MyFeedOn, flags, 'false');
+  const shouldShowMyFeed = myFeed === 'true';
   const [feedName, setFeedName] = useState(getFeedName(router?.pathname));
   const [isSearchOn, setIsSearchOn] = useState(router?.pathname === '/search');
 
   useEffect(() => {
-    if (router?.pathname === '/search') {
+    const isMyFeed = router?.pathname === '/my-feed';
+    if ((isMyFeed && !shouldShowMyFeed) || (isMyFeed && !user)) {
+      router.replace('popular');
+    } else if (router?.pathname === '/search') {
       setIsSearchOn(true);
       if (!feedName) {
         setFeedName('popular');

--- a/packages/webapp/pages/feed/[feedId].tsx
+++ b/packages/webapp/pages/feed/[feedId].tsx
@@ -1,7 +1,0 @@
-import React, { ReactElement } from 'react';
-
-function CustomFeedPage(): ReactElement {
-  return <div>Custom Feed Page</div>;
-}
-
-export default CustomFeedPage;

--- a/packages/webapp/pages/my-feed.tsx
+++ b/packages/webapp/pages/my-feed.tsx
@@ -1,26 +1,10 @@
-import React, { ReactElement } from 'react';
-import { NextSeoProps } from 'next-seo/lib/types';
-import { NextSeo } from 'next-seo';
+import React, { Fragment, ReactElement } from 'react';
 import {
   getMainFeedLayout,
   mainFeedLayoutProps,
 } from '../components/layouts/MainFeedPage';
-import { defaultOpenGraph, defaultSeo } from '../next-seo';
 
-const seo: NextSeoProps = {
-  title: 'My Feed posts on daily.dev',
-  titleTemplate: '%s',
-  openGraph: { ...defaultOpenGraph },
-  ...defaultSeo,
-};
-
-const MyFeed = (): ReactElement => {
-  return (
-    <>
-      <NextSeo {...seo} />
-    </>
-  );
-};
+const MyFeed = (): ReactElement => <></>;
 
 MyFeed.getLayout = getMainFeedLayout;
 MyFeed.layoutProps = mainFeedLayoutProps;

--- a/packages/webapp/pages/my-feed.tsx
+++ b/packages/webapp/pages/my-feed.tsx
@@ -1,0 +1,28 @@
+import React, { ReactElement } from 'react';
+import { NextSeoProps } from 'next-seo/lib/types';
+import { NextSeo } from 'next-seo';
+import {
+  getMainFeedLayout,
+  mainFeedLayoutProps,
+} from '../components/layouts/MainFeedPage';
+import { defaultOpenGraph, defaultSeo } from '../next-seo';
+
+const seo: NextSeoProps = {
+  title: 'My Feed posts on daily.dev',
+  titleTemplate: '%s',
+  openGraph: { ...defaultOpenGraph },
+  ...defaultSeo,
+};
+
+const MyFeed = (): ReactElement => {
+  return (
+    <>
+      <NextSeo {...seo} />
+    </>
+  );
+};
+
+MyFeed.getLayout = getMainFeedLayout;
+MyFeed.layoutProps = mainFeedLayoutProps;
+
+export default MyFeed;


### PR DESCRIPTION
DD-428 #done
DD-430 #done

A dedicated page for "My Feed" page/tab under `my-feed` route.

This PR also refactored the usage of popular page/tab to utilize anonymous feed query.