### PR TITLE
feat: Added a features class to maintain default states in one place

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -69,7 +69,7 @@ export default function Feed<T>({
 }: FeedProps<T>): ReactElement {
   const { flags } = useContext(FeaturesContext);
   const displayPublicationDate = !parseInt(
-    getFeatureValue(Features.HidePublicationDate, flags, '0'),
+    getFeatureValue(Features.HidePublicationDate, flags),
     10,
   );
   const { trackEvent } = useContext(AnalyticsContext);

--- a/packages/shared/src/components/LoginButton.tsx
+++ b/packages/shared/src/components/LoginButton.tsx
@@ -28,11 +28,7 @@ export default function LoginButton({
   const { showLogin } = useContext(AuthContext);
   const { flags } = useContext(FeaturesContext);
   const { trackEvent } = useContext(AnalyticsContext);
-  const buttonCopy = getFeatureValue(
-    Features.SignupButtonCopy,
-    flags,
-    'Access all features',
-  );
+  const buttonCopy = getFeatureValue(Features.SignupButtonCopy, flags);
 
   useEffect(() => {
     trackEvent(getAnalyticsEvent('impression', buttonCopy));

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -116,7 +116,7 @@ export default function MainFeedLayout({
   const { user, tokenRefreshed } = useContext(AuthContext);
   const { flags } = useContext(FeaturesContext);
   const feedVersion = parseInt(
-    getFeatureValue(Features.FeedVersion, flags, '1'),
+    getFeatureValue(Features.FeedVersion, flags),
     10,
   );
   const feedName = feedNameProp === 'default' ? defaultFeed : feedNameProp;

--- a/packages/shared/src/components/modals/LoginModal.tsx
+++ b/packages/shared/src/components/modals/LoginModal.tsx
@@ -24,12 +24,10 @@ export default function LoginModal({
   const loginModalDescriptionCopy = getFeatureValue(
     Features.LoginModalDescriptionCopy,
     flags,
-    'Unlock useful features by signing in. A bunch of cool stuff like content filters and bookmarks are waiting just for you.',
   );
   const buttonCopyPrefix = getFeatureValue(
     Features.LoginModalButtonCopyPrefix,
     flags,
-    'Sign in with',
   );
   useTrackModal({ isOpen: props.isOpen, title: 'signup', trigger });
 

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -1,21 +1,58 @@
 import { IFlags } from 'flagsmith';
 
-export enum Features {
-  SignupButtonCopy = 'signup_button_copy',
-  DevcardLimit = 'feat_limit_dev_card',
-  FeedVersion = 'feed_version',
-  HidePublicationDate = 'hide_publication_date',
-  LoginModalButtonCopyPrefix = 'login_modal_button_copy_prefix',
-  LoginModalDescriptionCopy = 'login_modal_description_copy',
+export class Features {
+  static readonly SignupButtonCopy = new Features(
+    'SignupButtonCopy',
+    'signup_button_copy',
+    'Access all features',
+  );
+
+  static readonly DevcardLimit = new Features(
+    'DevcardLimit',
+    'feat_limit_dev_card',
+  );
+
+  static readonly FeedVersion = new Features(
+    'FeedVersion',
+    'feed_version',
+    '1',
+  );
+
+  static readonly HidePublicationDate = new Features(
+    'HidePublicationDate',
+    'hide_publication_date',
+    '0',
+  );
+
+  static readonly LoginModalButtonCopyPrefix = new Features(
+    'LoginModalButtonCopyPrefix',
+    'login_modal_button_copy_prefix',
+    'Sign in with',
+  );
+
+  static readonly LoginModalDescriptionCopy = new Features(
+    'LoginModalDescriptionCopy',
+    'login_modal_description_copy',
+    'Unlock useful features by signing in. A bunch of cool stuff like content filters and bookmarks are waiting just for you.',
+  );
+
+  private constructor(
+    private readonly key: string,
+    public readonly id: string,
+    public readonly defaultValue?: string,
+  ) {}
+
+  toString(): string {
+    return this.key;
+  }
 }
 
 export const getFeatureValue = (
   key: Features,
   flags: IFlags,
-  defaultValue: string = undefined,
 ): string | undefined => {
-  if (flags[key]?.enabled) {
-    return flags[key].value;
+  if (flags[key?.id]?.enabled) {
+    return flags[key?.id].value;
   }
-  return defaultValue;
+  return key?.defaultValue ?? undefined;
 };

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -2,7 +2,6 @@ import { IFlags } from 'flagsmith';
 
 export class Features {
   static readonly SignupButtonCopy = new Features(
-    'SignupButtonCopy',
     'signup_button_copy',
     'Access all features',
   );
@@ -12,39 +11,27 @@ export class Features {
     'feat_limit_dev_card',
   );
 
-  static readonly FeedVersion = new Features(
-    'FeedVersion',
-    'feed_version',
-    '1',
-  );
+  static readonly FeedVersion = new Features('feed_version', '1');
 
   static readonly HidePublicationDate = new Features(
-    'HidePublicationDate',
     'hide_publication_date',
     '0',
   );
 
   static readonly LoginModalButtonCopyPrefix = new Features(
-    'LoginModalButtonCopyPrefix',
     'login_modal_button_copy_prefix',
     'Sign in with',
   );
 
   static readonly LoginModalDescriptionCopy = new Features(
-    'LoginModalDescriptionCopy',
     'login_modal_description_copy',
     'Unlock useful features by signing in. A bunch of cool stuff like content filters and bookmarks are waiting just for you.',
   );
 
   private constructor(
-    private readonly key: string,
     public readonly id: string,
     public readonly defaultValue?: string,
   ) {}
-
-  toString(): string {
-    return this.key;
-  }
 }
 
 export const getFeatureValue = (


### PR DESCRIPTION
We decided to convert the existing Features Enum into a object containing the Flagsmith ID and the default value.
This way we remove any friction and make this file the single source of truth around flags.

Since a enum can't contain arrays of objects and a const object would introduce some changeable options I've decided to go for this class approach.
This gives us the abilities of an enum, while maintaining the dynamics of objects.

DD-448 #done 