### PR TITLE
refactor: update page state for duration based events

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="CommitMessageInspectionProfile">
-    <profile version="1.0">
-      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
-    </profile>
-  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/packages/shared/src/hooks/analytics/useAnalyticsContextData.ts
+++ b/packages/shared/src/hooks/analytics/useAnalyticsContextData.ts
@@ -1,5 +1,6 @@
 import { MutableRefObject, useMemo } from 'react';
 import { AnalyticsEvent, PushToQueueFunc } from './useAnalyticsQueue';
+import { getCurrentLifecycleState } from '../../lib/lifecycle';
 
 export type AnalyticsContextData = {
   trackEvent: (event: AnalyticsEvent) => void;
@@ -19,6 +20,7 @@ const getGlobalSharedProps = (): Partial<AnalyticsEvent> => ({
   page_referrer: document.referrer,
   window_height: window.innerHeight,
   window_width: window.innerWidth,
+  page_state: getCurrentLifecycleState(),
 });
 
 const generateEvent = (
@@ -60,6 +62,9 @@ export default function useAnalyticsContextData(
           durationEventsQueue.current.delete(id);
           event.event_duration =
             now.getTime() - event.event_timestamp.getTime();
+          if (window.scrollY > 0 && event.event_name !== 'page inactive') {
+            event.page_state = 'active';
+          }
           pushToQueue([event]);
         }
       },

--- a/packages/shared/src/hooks/analytics/useAnalyticsSharedProps.ts
+++ b/packages/shared/src/hooks/analytics/useAnalyticsSharedProps.ts
@@ -10,7 +10,6 @@ import { AnalyticsEvent } from './useAnalyticsQueue';
 import FeaturesContext from '../../contexts/FeaturesContext';
 import SettingsContext from '../../contexts/SettingsContext';
 import AuthContext from '../../contexts/AuthContext';
-import { getCurrentLifecycleState } from '../../lib/lifecycle';
 
 export default function useAnalyticsSharedProps(
   app: string,
@@ -58,7 +57,6 @@ export default function useAnalyticsSharedProps(
       utm_term: query?.utm_term,
       visit_id: visitId,
       feature_flags: flags ? JSON.stringify(flags) : null,
-      page_state: getCurrentLifecycleState(),
     };
   }, [
     sharedPropsRef,

--- a/packages/shared/src/hooks/analytics/useTrackLifecycleEvents.ts
+++ b/packages/shared/src/hooks/analytics/useTrackLifecycleEvents.ts
@@ -15,6 +15,15 @@ export default function useTrackLifecycleEvents(
       if (event.detail.newState === 'active') {
         setEnabled(true);
         contextData.trackEventEnd('page inactive');
+        // Update events page state to active
+        durationEventsQueue.current.forEach((value, key) => {
+          if (value.page_state !== 'active' && value.event_name !== 'page inactive') {
+            durationEventsQueue.current.set(key, {
+              ...value,
+              page_state: 'active',
+            });
+          }
+        });
       } else if (event.detail.oldState === 'active') {
         setEnabled(false);
         const now = new Date();

--- a/packages/shared/src/hooks/analytics/useTrackLifecycleEvents.ts
+++ b/packages/shared/src/hooks/analytics/useTrackLifecycleEvents.ts
@@ -17,7 +17,10 @@ export default function useTrackLifecycleEvents(
         contextData.trackEventEnd('page inactive');
         // Update events page state to active
         durationEventsQueue.current.forEach((value, key) => {
-          if (value.page_state !== 'active' && value.event_name !== 'page inactive') {
+          if (
+            value.page_state !== 'active' &&
+            value.event_name !== 'page inactive'
+          ) {
             durationEventsQueue.current.set(key, {
               ...value,
               page_state: 'active',


### PR DESCRIPTION
Duration-based events capture the page state at the time when the event starts. This can create cases where at first the page state was passive (open new tab) so all the impressions are marked as passive, and then the user decided to focus on the tab and continue their use on our platform. So in this case we want to mark all these impressions as active impressions or any other event for that matter.
Another important change is to mark events as active if the user scrolled down the page. Even if the page state is passive the user can still scroll it. I think that if the user scrolls it means that they're active and we should adjust the state accordingly.