### PR TITLE
fix: navigation not shown even when user has filters

### DIFF
--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement, useContext, useEffect } from 'react';
 import { useQueryClient } from 'react-query';
 import classNames from 'classnames';
 import sizeN from '../../../macros/sizeN.macro';
@@ -6,7 +6,7 @@ import FilterMenu from './FilterMenu';
 import XIcon from '../../../icons/x.svg';
 import PlusIcon from '../../../icons/plus.svg';
 import { menuItemClassNames } from '../multiLevelMenu/MultiLevelMenuMaster';
-import {
+import useFeedSettings, {
   getFeedSettingsQueryKey,
   updateLocalFeedSettings,
 } from '../../hooks/useFeedSettings';
@@ -15,6 +15,7 @@ import { Button } from '../buttons/Button';
 import { AllTagCategoriesData } from '../../graphql/feedSettings';
 import { Features, isFeaturedEnabled } from '../../lib/featureManagement';
 import FeaturesContext from '../../contexts/FeaturesContext';
+import AlertContext from '../../contexts/AlertContext';
 
 const asideWidth = sizeN(89);
 
@@ -28,7 +29,9 @@ export default function FeedFilters({
   onBack,
 }: FeedFiltersProps): ReactElement {
   const client = useQueryClient();
+  const { alerts, updateAlerts } = useContext(AlertContext);
   const { user, showLogin } = useContext(AuthContext);
+  const { hasAnyFilter } = useFeedSettings();
   const { flags } = useContext(FeaturesContext);
   const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
 
@@ -39,6 +42,12 @@ export default function FeedFilters({
     updateLocalFeedSettings(feedSettings);
     showLogin('create feed filters');
   };
+
+  useEffect(() => {
+    if (isOpen && alerts?.filter && hasAnyFilter && user && !shouldShowMyFeed) {
+      updateAlerts({ filter: false });
+    }
+  }, [isOpen, alerts, user, hasAnyFilter]);
 
   return (
     <aside

--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext, useEffect } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import { useQueryClient } from 'react-query';
 import classNames from 'classnames';
 import sizeN from '../../../macros/sizeN.macro';
@@ -6,11 +6,10 @@ import FilterMenu from './FilterMenu';
 import XIcon from '../../../icons/x.svg';
 import PlusIcon from '../../../icons/plus.svg';
 import { menuItemClassNames } from '../multiLevelMenu/MultiLevelMenuMaster';
-import useFeedSettings, {
+import {
   getFeedSettingsQueryKey,
   updateLocalFeedSettings,
 } from '../../hooks/useFeedSettings';
-import AlertContext from '../../contexts/AlertContext';
 import AuthContext from '../../contexts/AuthContext';
 import { Button } from '../buttons/Button';
 import { AllTagCategoriesData } from '../../graphql/feedSettings';
@@ -30,18 +29,8 @@ export default function FeedFilters({
 }: FeedFiltersProps): ReactElement {
   const client = useQueryClient();
   const { user, showLogin } = useContext(AuthContext);
-  const { alerts, updateAlerts } = useContext(AlertContext);
-  const { hasAnyFilter } = useFeedSettings();
   const { flags } = useContext(FeaturesContext);
   const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
-
-  useEffect(() => {
-    if (isOpen) {
-      if (alerts?.filter && hasAnyFilter && user) {
-        updateAlerts({ filter: false });
-      }
-    }
-  }, [isOpen, alerts, user, hasAnyFilter]);
 
   const onCreate = () => {
     // apply analytics

--- a/packages/shared/src/components/sidebar/MyFeedAlert.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedAlert.tsx
@@ -30,6 +30,7 @@ export default function MyFeedAlert({
             target="_blank"
             rel="noopener"
           >
+            {' '}
             Learn more.
           </a>
         )}

--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -123,7 +123,6 @@ const FilteredMyFeedButton = ({
         buttonSize="xsmall"
         icon={<FilterIcon />}
         onClick={action}
-        data-testId="myFeedFilter"
       />
     </NavItem>
   );

--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -123,6 +123,7 @@ const FilteredMyFeedButton = ({
         buttonSize="xsmall"
         icon={<FilterIcon />}
         onClick={action}
+        data-testId="myFeedFilter"
       />
     </NavItem>
   );

--- a/packages/shared/src/components/sidebar/Sidebar.spec.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.spec.tsx
@@ -123,20 +123,14 @@ const renderComponent = (
   );
 };
 
-it('should not render create my feed button once user has filters', async () => {
+it('should not render create my feed button if user has alerts.filter as false', async () => {
   features = defaultFeatures;
   renderComponent({ filter: false });
-  await waitFor(() => {
-    const data = client.getQueryData(getFeedSettingsQueryKey(defaultUser));
-    expect(data).toBeTruthy();
-  });
-
   const createMyFeed = screen.queryByText('Create my feed');
   expect(createMyFeed).not.toBeInTheDocument();
 });
 
 it('should remove filter alert if the user has filters and opened feed filters', async () => {
-  features = defaultFeatures;
   let mutationCalled = false;
   mockGraphQL({
     request: {
@@ -151,7 +145,7 @@ it('should remove filter alert if the user has filters and opened feed filters',
   renderComponent({ filter: true });
 
   await act(async () => {
-    const feedFilters = await screen.findByTestId('myFeedFilter');
+    const feedFilters = await screen.findByText('Feed filters');
     feedFilters.click();
   });
 

--- a/packages/shared/src/components/sidebar/Sidebar.spec.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.spec.tsx
@@ -15,8 +15,14 @@ import {
   mockGraphQL,
   MockedGraphQLResponse,
 } from '../../../__tests__/helpers/graphql';
-import { FEED_SETTINGS_QUERY } from '../../graphql/feedSettings';
-import { getFeedSettingsQueryKey } from '../../hooks/useFeedSettings';
+import {
+  AllTagCategoriesData,
+  FEED_SETTINGS_QUERY,
+} from '../../graphql/feedSettings';
+import {
+  getFeedSettingsQueryKey,
+  getHasAnyFilter,
+} from '../../hooks/useFeedSettings';
 import { AlertContextProvider } from '../../contexts/AlertContext';
 import { waitForNock } from '../../../__tests__/helpers/utilities';
 import ProgressiveEnhancementContext from '../../contexts/ProgressiveEnhancementContext';
@@ -150,8 +156,9 @@ it('should remove filter alert if the user has filters and opened feed filters',
   });
 
   await waitFor(() => {
-    const data = client.getQueryData(getFeedSettingsQueryKey(defaultUser));
-    expect(data).toBeTruthy();
+    const key = getFeedSettingsQueryKey(defaultUser);
+    const data = client.getQueryData(key) as AllTagCategoriesData;
+    expect(getHasAnyFilter(data.feedSettings)).toBeTruthy();
   });
 
   expect(updateAlerts).toBeCalledWith({ filter: false });

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -281,7 +281,7 @@ export default function Sidebar({
                 action={openFeedFilters}
               />
             )}
-            {sidebarExpanded && !alerts?.myFeed && (
+            {sidebarExpanded && alerts?.myFeed && (
               <MyFeedAlert alerts={alerts} hideAlert={hideMyFeedAlert} />
             )}
             <RenderSection

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, useContext, useState, useMemo } from 'react';
+import React, {
+  ReactElement,
+  useContext,
+  useState,
+  useMemo,
+  useEffect,
+} from 'react';
 import classNames from 'classnames';
 import SettingsContext from '../../contexts/SettingsContext';
 import { FeedSettingsModal } from '../modals/FeedSettingsModal';
@@ -43,6 +49,8 @@ import usePersistentContext from '../../hooks/usePersistentContext';
 import MyFeedAlert from './MyFeedAlert';
 import FeaturesContext from '../../contexts/FeaturesContext';
 import { AlertColor, AlertDot } from '../AlertDot';
+import { Features, isFeaturedEnabled } from '../../lib/featureManagement';
+import useFeedSettings from '../../hooks/useFeedSettings';
 
 const bottomMenuItems: SidebarMenuItem[] = [
   {
@@ -145,9 +153,18 @@ export default function Sidebar({
   const { sidebarExpanded, toggleSidebarExpanded, loadedSettings } =
     useContext(SettingsContext);
   const [showSettings, setShowSettings] = useState(false);
+  const { user } = useContext(AuthContext);
+  const { hasAnyFilter } = useFeedSettings();
   const { flags } = useContext(FeaturesContext);
-  // const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
-  const shouldShowMyFeed = true;
+  const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
+
+  useEffect(() => {
+    if (isLoaded) {
+      if (alerts?.filter && hasAnyFilter && user) {
+        updateAlerts({ filter: false });
+      }
+    }
+  }, [isLoaded, alerts, user, hasAnyFilter]);
 
   useHideMobileSidebar({
     state: openMobileSidebar,
@@ -278,7 +295,7 @@ export default function Sidebar({
             {sidebarRendered && shouldShowMyFeed && (
               <MyFeedButton
                 sidebarExpanded={sidebarExpanded}
-                filtered={!alerts?.filter}
+                filtered={user && hasAnyFilter}
                 item={myFeedMenuItem}
                 flags={flags}
                 action={openFeedFilters}

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -246,7 +246,7 @@ export default function Sidebar({
   }
 
   const shouldHideMyFeedAlert =
-    (alerts?.filter && !alerts?.myFeed) || (!alerts?.filter && !alerts?.myFeed);
+    alerts?.filter || (!alerts?.filter && !alerts?.myFeed);
 
   return (
     <>

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -245,9 +245,6 @@ export default function Sidebar({
     return <></>;
   }
 
-  const shouldHideMyFeedAlert =
-    alerts?.filter || (!alerts?.filter && !alerts?.myFeed);
-
   return (
     <>
       {openMobileSidebar && sidebarRendered === false && (
@@ -284,7 +281,7 @@ export default function Sidebar({
                 action={openFeedFilters}
               />
             )}
-            {sidebarExpanded && !shouldHideMyFeedAlert && (
+            {sidebarExpanded && !alerts?.myFeed && (
               <MyFeedAlert alerts={alerts} hideAlert={hideMyFeedAlert} />
             )}
             <RenderSection

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -1,10 +1,4 @@
-import React, {
-  ReactElement,
-  useContext,
-  useState,
-  useMemo,
-  useEffect,
-} from 'react';
+import React, { ReactElement, useContext, useState, useMemo } from 'react';
 import classNames from 'classnames';
 import SettingsContext from '../../contexts/SettingsContext';
 import { FeedSettingsModal } from '../modals/FeedSettingsModal';
@@ -50,7 +44,6 @@ import MyFeedAlert from './MyFeedAlert';
 import FeaturesContext from '../../contexts/FeaturesContext';
 import { AlertColor, AlertDot } from '../AlertDot';
 import { Features, isFeaturedEnabled } from '../../lib/featureManagement';
-import useFeedSettings from '../../hooks/useFeedSettings';
 
 const bottomMenuItems: SidebarMenuItem[] = [
   {
@@ -153,18 +146,8 @@ export default function Sidebar({
   const { sidebarExpanded, toggleSidebarExpanded, loadedSettings } =
     useContext(SettingsContext);
   const [showSettings, setShowSettings] = useState(false);
-  const { user } = useContext(AuthContext);
-  const { hasAnyFilter } = useFeedSettings();
   const { flags } = useContext(FeaturesContext);
   const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
-
-  useEffect(() => {
-    if (isLoaded) {
-      if (alerts?.filter && hasAnyFilter && user) {
-        updateAlerts({ filter: false });
-      }
-    }
-  }, [isLoaded, alerts, user, hasAnyFilter]);
 
   useHideMobileSidebar({
     state: openMobileSidebar,
@@ -295,7 +278,7 @@ export default function Sidebar({
             {sidebarRendered && shouldShowMyFeed && (
               <MyFeedButton
                 sidebarExpanded={sidebarExpanded}
-                filtered={user && hasAnyFilter}
+                filtered={!alerts?.filter}
                 item={myFeedMenuItem}
                 flags={flags}
                 action={openFeedFilters}

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -245,6 +245,9 @@ export default function Sidebar({
     return <></>;
   }
 
+  const shouldHideMyFeedAlert =
+    (alerts?.filter && !alerts?.myFeed) || (!alerts?.filter && !alerts?.myFeed);
+
   return (
     <>
       {openMobileSidebar && sidebarRendered === false && (
@@ -281,7 +284,7 @@ export default function Sidebar({
                 action={openFeedFilters}
               />
             )}
-            {sidebarExpanded && alerts?.myFeed && (
+            {sidebarExpanded && !shouldHideMyFeedAlert && (
               <MyFeedAlert alerts={alerts} hideAlert={hideMyFeedAlert} />
             )}
             <RenderSection

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -33,6 +33,12 @@ export type FeedSettingsReturnType = {
 
 let avoidRefresh = false;
 
+export const getHasAnyFilter = (feedSettings: FeedSettings): boolean =>
+  feedSettings?.includeTags?.length > 0 ||
+  feedSettings?.blockedTags?.length > 0 ||
+  feedSettings?.excludeSources?.length > 0 ||
+  feedSettings?.advancedSettings?.length > 0;
+
 export const LOCAL_FEED_SETTINGS_KEY = 'feedSettings:local';
 
 export const updateLocalFeedSettings = (feedSettings: FeedSettings): void => {
@@ -110,19 +116,13 @@ export default function useFeedSettings(): FeedSettingsReturnType {
     }, 100);
   }, [tagsCategories, feedSettings, avoidRefresh]);
 
-  const hasAnyFilter =
-    feedSettings?.includeTags?.length > 0 ||
-    feedSettings?.blockedTags?.length > 0 ||
-    feedSettings?.excludeSources?.length > 0 ||
-    feedSettings?.advancedSettings?.length > 0;
-
   return useMemo(() => {
     return {
       tagsCategories,
       feedSettings,
       isLoading,
       advancedSettings,
-      hasAnyFilter,
+      hasAnyFilter: getHasAnyFilter(feedSettings),
       setAvoidRefresh,
     };
   }, [
@@ -130,7 +130,6 @@ export default function useFeedSettings(): FeedSettingsReturnType {
     feedSettings,
     isLoading,
     advancedSettings,
-    hasAnyFilter,
     setAvoidRefresh,
   ]);
 }


### PR DESCRIPTION
DD-457 #done
DD-455 #done

~~Currently, the decision to identify whether the user has any filter is based on the `alerts.filter` which is used to display alerts, for us to declare a user has any filter is to check if there's an actual filter applied on their feed settings. The case results in the "My Feed" not being displayed.~~

![image](https://user-images.githubusercontent.com/13744167/148501556-06533995-998c-4a18-8083-3b20994420dc.png)

Also, I noticed a false positive in one of the test cases namely `should remove feed filter button once user has filters`
I think the primary purpose of this test is to see that the button is not rendered anymore since the user has an existing filter. With that, it clicks the "Create my feed" button which should have not been there in the first place. Then it tests the `updateAlerts` to be called which should only happen when the user has clicked the close button (already covered) or the user with pre-existing filters open the `FeedFilters` but it proceeds since that specific button also opens `FeedFilters`.

In terms of testing the experiment, I have made it to be explicitly defined so we can be sure our pre-existing tests were not affected by it.