### PR TITLE
fix: the source was not always linking to the source feed

### DIFF
--- a/packages/webapp/components/posts/PostHeader.tsx
+++ b/packages/webapp/components/posts/PostHeader.tsx
@@ -63,31 +63,22 @@ export function PostHeader({ post }: PostHeaderProps): ReactElement {
 
   return (
     <Container className="flex items-center mb-2">
-      {author ? (
-        <LinkWithTooltip
-          href={`/sources/${source.id}`}
-          passHref
-          prefetch={false}
-          tooltip={{
-            placement: 'bottom',
-            content: source.name,
-          }}
-        >
-          <SourceImage
-            className="cursor-pointer"
-            imgSrc={source.image}
-            imgAlt={source.name}
-            background="var(--theme-background-secondary)"
-          />
-        </LinkWithTooltip>
-      ) : (
+      <LinkWithTooltip
+        href={`/sources/${source.id}`}
+        passHref
+        prefetch={false}
+        tooltip={{
+          placement: 'bottom',
+          content: source.name,
+        }}
+      >
         <SourceImage
           className="cursor-pointer"
           imgSrc={source.image}
           imgAlt={source.name}
           background="var(--theme-background-secondary)"
         />
-      )}
+      </LinkWithTooltip>
       {author ? (
         <ProfileLink
           user={author}


### PR DESCRIPTION
For some reason we had a check if the author was known.
If not we would never link to the source feed.

We can safely remove this check, which this PR does.

DD-400 #done 