### PR TITLE
fix: added spacing to the author onboarding element

### DIFF
--- a/packages/webapp/components/posts/AuthorOnboarding.tsx
+++ b/packages/webapp/components/posts/AuthorOnboarding.tsx
@@ -16,7 +16,7 @@ export function AuthorOnboarding({
   return (
     <section
       className={classNames(
-        'p-6 bg-theme-bg-secondary rounded-2xl',
+        'p-6 bg-theme-bg-secondary rounded-2xl mb-6',
         styles.authorOnboarding,
       )}
     >


### PR DESCRIPTION
The author onboarding element was missing spacing.
Added a margin bottom to offset it from the new comment block.

Laptop size:
![Screenshot 2022-01-10 at 13 57 58](https://user-images.githubusercontent.com/554874/148762721-cfe89c83-c17c-493e-867d-fb232d4127ab.png)

Tablet size:
![Screenshot 2022-01-10 at 14 01 49](https://user-images.githubusercontent.com/554874/148762940-cf72a59e-f1af-447f-bc4f-907420963078.png)

Mobile size:
![Screenshot 2022-01-10 at 14 01 42](https://user-images.githubusercontent.com/554874/148762990-677312b6-df83-4942-ae10-98816c7b9e4d.png)

DD-453 #done 