### PR TITLE
fix: boot data invalidation

### DIFF
--- a/packages/shared/src/components/profile/ProfileForm.tsx
+++ b/packages/shared/src/components/profile/ProfileForm.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
 } from 'react';
 import classNames from 'classnames';
+import { useQueryClient } from 'react-query';
 import { updateProfile, UserProfile } from '../../lib/user';
 import { TextField } from '../fields/TextField';
 import { Switch } from '../fields/Switch';
@@ -28,6 +29,7 @@ import {
 import { storageWrapper as storage } from '../../lib/storageWrapper';
 import { Features, isFeaturedEnabled } from '../../lib/featureManagement';
 import FeaturesContext from '../../contexts/FeaturesContext';
+import { BOOT_QUERY_KEY } from '../../contexts/BootProvider';
 
 const REQUIRED_FIELDS_COUNT = 4;
 const timeZoneOptions = getTimeZoneOptions();
@@ -74,6 +76,7 @@ export default function ProfileForm({
   const [hashnodeHint, setHashnodeHint] = useState<string>();
   const [emailHint, setEmailHint] = useState(defaultEmailHint);
   const { flags } = useContext(FeaturesContext);
+  const client = useQueryClient();
 
   const updateDisableSubmit = () => {
     if (formRef.current) {
@@ -139,6 +142,7 @@ export default function ProfileForm({
       if (feedSettings) {
         await updateFeedFilters(feedSettings);
         storage.removeItem(LOCAL_FEED_SETTINGS_KEY);
+        await client.invalidateQueries(BOOT_QUERY_KEY);
       }
 
       onSuccessfulSubmit?.(filledFields.length > REQUIRED_FIELDS_COUNT);

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -40,7 +40,7 @@ function useRefreshToken(
 }
 
 export const BOOT_LOCAL_KEY = 'boot:local';
-const BOOT_QUERY_KEY = 'boot';
+export const BOOT_QUERY_KEY = 'boot';
 
 function filteredProps<T extends Record<string, unknown>>(
   obj: T,


### PR DESCRIPTION
When the registration finishes and we proceed with the redirection the boot query is not being requested which should actually happen as the data were updated (even on window.location.replace the state doesn't refresh).

For the accurate alerts to be displayed right after registration, the user needs to refetch the boot data.