### PR TITLE
fix: rendering my feed nav item on mobile

### DIFF
--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -185,6 +185,10 @@ export default function MyFeedButton({
     );
   }
 
+  if (!sidebarRendered) {
+    return <></>;
+  }
+
   return (
     <UnfilteredMyFeedButton
       action={action}

--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -44,6 +44,7 @@ const statusColor = {
 };
 
 interface MyFeedButtonSharedProps {
+  sidebarRendered?: boolean;
   sidebarExpanded: boolean;
   action: () => unknown;
   isActive?: boolean;
@@ -135,6 +136,7 @@ const UnfilteredMyFeedButton = ({
 
 const FilteredMyFeedButton = ({
   item,
+  sidebarRendered,
   sidebarExpanded,
   action,
   isActive,
@@ -145,21 +147,24 @@ const FilteredMyFeedButton = ({
       <ButtonOrLink item={item} useNavButtonsNotLinks={useNavButtonsNotLinks}>
         <ItemInner item={item} sidebarExpanded={sidebarExpanded} />
       </ButtonOrLink>
-      <SimpleTooltip placement="right" content="Feed filters">
-        <Button
-          iconOnly
-          className="mr-3 btn-tertiary"
-          buttonSize="xsmall"
-          icon={<FilterIcon />}
-          onClick={action}
-        />
-      </SimpleTooltip>
+      {sidebarRendered && (
+        <SimpleTooltip placement="right" content="Feed filters">
+          <Button
+            iconOnly
+            className="mr-3 btn-tertiary"
+            buttonSize="xsmall"
+            icon={<FilterIcon />}
+            onClick={action}
+          />
+        </SimpleTooltip>
+      )}
     </NavItem>
   );
 };
 
 export default function MyFeedButton({
   item,
+  sidebarRendered,
   sidebarExpanded,
   filtered = false,
   flags,
@@ -171,6 +176,7 @@ export default function MyFeedButton({
     return (
       <FilteredMyFeedButton
         action={action}
+        sidebarRendered={sidebarRendered}
         sidebarExpanded={sidebarExpanded}
         item={item}
         isActive={isActive}

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -287,8 +287,9 @@ export default function Sidebar({
         <SidebarScrollWrapper>
           <Nav>
             <SidebarUserButton sidebarRendered={sidebarRendered} />
-            {sidebarRendered && shouldShowMyFeed && (
+            {shouldShowMyFeed && (
               <MyFeedButton
+                sidebarRendered={sidebarRendered}
                 sidebarExpanded={sidebarExpanded}
                 filtered={!alerts?.filter}
                 item={myFeedMenuItem}


### PR DESCRIPTION
Just as on our current implementation, we are not allowing feed filters to be changed on mobile hence, not seen in my feed nav item.

Preview:

![image](https://user-images.githubusercontent.com/13744167/149470304-a725a4cb-b303-4fc1-8755-47cbee387e27.png)
