### PR TITLE
fix: access safely to the flags object

### DIFF
--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -75,15 +75,15 @@ export class Features {
   ) {}
 }
 
+export const isFeaturedEnabled = (key: Features, flags: IFlags): boolean =>
+  flags?.[key?.id]?.enabled;
+
 export const getFeatureValue = (
   key: Features,
   flags: IFlags,
 ): string | undefined => {
-  if (flags[key?.id]?.enabled) {
+  if (isFeaturedEnabled(key, flags)) {
     return flags[key?.id].value;
   }
   return key?.defaultValue ?? undefined;
 };
-
-export const isFeaturedEnabled = (key: Features, flags: IFlags): boolean =>
-  flags[key?.id]?.enabled;


### PR DESCRIPTION
When I set up my new Mac and bootstrapped from scratch our development environment, I noticed that I receive critical errors on the first load. This happened when trying to access the flags object when it is still null. I use optional chaining to make sure we handle these situations correctly.