### PR TITLE
fix: track active page state correctly

### DIFF
--- a/packages/shared/src/hooks/analytics/useTrackLifecycleEvents.ts
+++ b/packages/shared/src/hooks/analytics/useTrackLifecycleEvents.ts
@@ -3,6 +3,11 @@ import listenToLifecycleEvents from '../../lib/lifecycle';
 import { AnalyticsContextData } from './useAnalyticsContextData';
 import { AnalyticsEvent } from './useAnalyticsQueue';
 
+const ACTIVE_STATES = ['active', 'passive'];
+
+const isActiveState = (state: string): boolean =>
+  ACTIVE_STATES.indexOf(state) > -1;
+
 export default function useTrackLifecycleEvents(
   setEnabled: (enabled: boolean) => void,
   contextData: AnalyticsContextData,
@@ -27,7 +32,10 @@ export default function useTrackLifecycleEvents(
             });
           }
         });
-      } else if (event.detail.oldState === 'active') {
+      } else if (
+        isActiveState(event.detail.oldState) &&
+        !isActiveState(event.detail.newState)
+      ) {
         setEnabled(false);
         const now = new Date();
         durationEventsQueue.current.forEach((value, key) =>


### PR DESCRIPTION
Our feed engine uses the client's indication of whether the session is active or not for certain decisions.
After some data analysis and debugging, I found out that there's some issue in how we track it.
The edge case opens new tab -> type URL -> navigate to the new URL will be marked as an active session.
This fix makes sure the user clicked somewhere in the window object or at least scrolled down a bit before the session was marked as active.
I also fixed an edge case where events were not sent on page unload.