### PR TITLE
fix: spaces only comment

### DIFF
--- a/packages/shared/src/components/cards/CommentPopup.tsx
+++ b/packages/shared/src/components/cards/CommentPopup.tsx
@@ -101,7 +101,7 @@ export default function CommentPopup({
           <Button
             icon={<CommentIcon />}
             onClick={() => onSubmit?.(comment)}
-            disabled={!comment?.length}
+            disabled={!comment?.trim().length}
             loading={loading}
             className={classNames('btn-primary', listMode && 'self-end')}
           >

--- a/packages/shared/src/components/modals/NewCommentModal.spec.tsx
+++ b/packages/shared/src/components/modals/NewCommentModal.spec.tsx
@@ -195,6 +195,40 @@ it('should send commentOnComment mutation', async () => {
   expect(onRequestClose).toBeCalledTimes(1);
 });
 
+it('should not send comment if the input is spaces only', async () => {
+  let mutationCalled = false;
+  const newComment = {
+    __typename: 'Comment',
+    id: 'new',
+    content: 'comment',
+    createdAt: new Date(2017, 1, 10, 0, 1).toISOString(),
+    permalink: 'https://daily.dev',
+  };
+  renderComponent({ commentId: 'c1' }, [
+    {
+      request: {
+        query: COMMENT_ON_COMMENT_MUTATION,
+        variables: { id: 'c1', content: 'comment' },
+      },
+      result: () => {
+        mutationCalled = true;
+        return {
+          data: {
+            comment: newComment,
+          },
+        };
+      },
+    },
+  ]);
+  const input = await screen.findByRole('textbox');
+  input.innerText = '   ';
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  const el = await screen.findByText('Comment');
+  el.click();
+  await waitFor(() => expect(onComment).not.toBeCalled());
+  expect(mutationCalled).toBeFalsy();
+});
+
 it('should show alert in case of an error', async () => {
   let mutationCalled = false;
   renderComponent({ commentId: 'c1' }, [

--- a/packages/shared/src/components/modals/NewCommentModal.tsx
+++ b/packages/shared/src/components/modals/NewCommentModal.tsx
@@ -196,7 +196,7 @@ export default function NewCommentModal({
   const sendComment = async (
     event: MouseEvent | KeyboardEvent,
   ): Promise<void> => {
-    if (sendingComment) {
+    if (sendingComment || !input?.trim().length) {
       return;
     }
     setErrorMessage(null);
@@ -333,7 +333,7 @@ export default function NewCommentModal({
           Markdown supported
         </ClickableText>
         <Button
-          disabled={!input?.length}
+          disabled={!input?.trim().length}
           loading={sendingComment}
           onClick={sendComment}
           className="btn-primary-avocado"


### PR DESCRIPTION
DD-476 #done

On submitting a comment - it should return as soon as the input is noticed to be empty or contains spaces only.