### PR TITLE
fix: people with recent feed in storage get a error

### DIFF
--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -43,10 +43,14 @@ export default function MainFeedPage({
   const [searchQuery, setSearchQuery] = useState<string>();
   const [showDnd, setShowDnd] = useState(false);
   const { registerLocalFilters, shouldShowMyFeed } = useMyFeed();
-  const [defaultFeed] = usePersistentContext(
+  const [defaultFeed, undefined, deleteFeedKey] = usePersistentContext(
     'defaultFeed',
     shouldShowMyFeed ? 'my-feed' : 'popular',
   );
+  if (defaultFeed === 'recent') {
+    deleteFeedKey();
+    setFeedName(shouldShowMyFeed ? 'my-feed' : 'popular');
+  }
   const enableSearch = () => {
     setIsSearchOn(true);
     setSearchQuery(null);

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -134,10 +134,14 @@ export default function MainFeedLayout({
   navChildren,
 }: MainFeedLayoutProps): ReactElement {
   const { shouldShowMyFeed } = useMyFeed();
-  const [defaultFeed, updateDefaultFeed] = usePersistentContext(
+  const [defaultFeed, updateDefaultFeed, deleteFeedKey] = usePersistentContext(
     'defaultFeed',
     shouldShowMyFeed ? 'my-feed' : 'popular',
   );
+  if (defaultFeed === 'recent') {
+    deleteFeedKey();
+    feedNameProp = shouldShowMyFeed ? 'my-feed' : 'popular';
+  }
   const { user, tokenRefreshed } = useContext(AuthContext);
   const { flags } = useContext(FeaturesContext);
   const feedVersion = parseInt(

--- a/packages/shared/src/hooks/usePersistentContext.ts
+++ b/packages/shared/src/hooks/usePersistentContext.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from 'react-query';
-import { get as getCache, set as setCache } from 'idb-keyval';
+import { get as getCache, set as setCache, del as delCache } from 'idb-keyval';
 
 function getAsyncCache<T>(key, valueWhenCacheEmpty): Promise<T> {
   return getCache<T>(key)
@@ -17,7 +17,7 @@ function getAsyncCache<T>(key, valueWhenCacheEmpty): Promise<T> {
 export default function usePersistentContext<T>(
   key: string,
   valueWhenCacheEmpty?: T,
-): [T, (value: T) => Promise<void>] {
+): [T, (value: T) => Promise<void>, () => Promise<void>] {
   const queryClient = useQueryClient();
 
   const { data } = useQuery<unknown, unknown, T>(
@@ -36,5 +36,7 @@ export default function usePersistentContext<T>(
     },
   );
 
-  return [data, updateValue];
+  const deleteKey = () => delCache(key);
+
+  return [data, updateValue, deleteKey];
 }


### PR DESCRIPTION
There is an edge case where people still had the `recent` feed in their local storage items.
This would cause the feed query to break.

To fix this we now delete the key, and reset the feed locally to their popular one.
I did not want to update their storage as this might be weird behaviour from us as an application, now we leave the ball in their hands.