### PR TITLE
fix: feed algorithm dropdown ui glitch

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -216,7 +216,7 @@ export default function MainFeedLayout({
         )}
         {sortingEnabled && isSortableFeed && (
           <Dropdown
-            className="w-40"
+            className="w-[10.25rem]"
             buttonSize="medium"
             selectedIndex={selectedAlgo}
             options={algorithmsList}


### PR DESCRIPTION
Since we have changed the text for the label on our default feed algorithm, it expanded.

Before:
<img width="324" alt="Screen Shot 2022-01-17 at 6 18 15 PM" src="https://user-images.githubusercontent.com/13744167/149751388-8837bf99-f39f-4883-b648-2df5c0fc712a.png">

After:
<img width="279" alt="Screen Shot 2022-01-17 at 6 18 58 PM" src="https://user-images.githubusercontent.com/13744167/149751493-36f54393-c9fa-47bd-9431-393a0a1a58ad.png">

