### PR TITLE
fix: :bug: Fixed a bug in the most visited sites stack

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -199,11 +199,11 @@ export default function MainFeedLayout({
   const header = (
     <LayoutHeader>
       {!isSearchOn && <h3 className="typo-headline">{feedTitles[feedName]}</h3>}
-      <div className="flex flex-row flex-wrap gap-4 mr-px">
+      <div className="flex flex-row flex-wrap items-center mr-px">
         {navChildren}
         {isUpvoted && (
           <Dropdown
-            className="w-44"
+            className="ml-4 w-44"
             buttonSize="medium"
             icon={<CalendarIcon />}
             selectedIndex={selectedPeriod}
@@ -213,7 +213,7 @@ export default function MainFeedLayout({
         )}
         {sortingEnabled && isSortableFeed && (
           <Dropdown
-            className="w-[10.25rem]"
+            className="ml-4 w-[10.25rem]"
             buttonSize="medium"
             selectedIndex={selectedAlgo}
             options={algorithmsList}


### PR DESCRIPTION
We where using a `gap-4` which caused all individual items in the most visited sites to space out.
I've decided to add separate margins to the dropdowns.

And add a items align so they are centered with the button.

Before:
![image](https://user-images.githubusercontent.com/554874/149779010-dad65e9d-8d20-4260-811d-b93d34f7139c.png)

After:
![Screenshot 2022-01-17 at 15 34 43](https://user-images.githubusercontent.com/554874/149778983-5148c58b-6f93-445e-9abf-07735caed9ac.png)

DD-478 #done 