### PR TITLE
fix: cleanup tailwind classes

### DIFF
--- a/packages/shared/src/components/InteractionCounter.tsx
+++ b/packages/shared/src/components/InteractionCounter.tsx
@@ -34,15 +34,13 @@ export default function InteractionCounter({
     <span className={`relative overflow-hidden ${styles.interactionCounter}`}>
       <span
         className={
-          animate
-            ? 'transform opacity-0 -translate-y-full'
-            : 'transform opacity-100 translate-y-0'
+          animate ? 'opacity-0 -translate-y-full' : 'opacity-100 translate-y-0'
         }
       >
         {shownValue}
       </span>
       <span
-        className={`absolute top-0 left-0 transform ${
+        className={`absolute top-0 left-0 ${
           animate ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-full'
         }`}
         onTransitionEnd={updateShownValue}

--- a/packages/shared/src/components/cards/Card.module.css
+++ b/packages/shared/src/components/cards/Card.module.css
@@ -1,7 +1,3 @@
-.title {
-  word-break: break-word;
-}
-
 .blur {
   filter: blur(1.25rem);
 }
@@ -43,17 +39,19 @@
 
 .flag {
   will-change: transform;
-  z-index: 0;
+  z-index: -1;
   transition: transform 0.1s linear;
 }
 
-.cardContainer:hover .flag, .flag:hover {
+.cardContainer:hover .flag,
+.flag:hover {
   transform: none;
   z-index: 1;
   transition: transform 0.1s linear, z-index 0.1s step-end;
 }
 
-.header > a, .header > button {
+.header > a,
+.header > button {
   margin: 0 0.375rem;
 }
 

--- a/packages/shared/src/components/cards/Card.tsx
+++ b/packages/shared/src/components/cards/Card.tsx
@@ -15,7 +15,7 @@ const Title = classed(
   'font-bold typo-body text-theme-label-primary multi-truncate line-clamp-3',
 );
 
-export const CardTitle = classed(Title, 'my-2 break-word');
+export const CardTitle = classed(Title, 'my-2 break-words');
 
 export const ListCardTitle = classed(Title, 'mr-2');
 
@@ -34,7 +34,7 @@ export const CardLink = classed(
 export const Card = classed(
   'article',
   styles.card,
-  'relative flex flex-col p-2 rounded-2xl bg-theme-bg-secondary border border-theme-divider-tertiary hover:border-theme-divider-secondary shadow-2',
+  'relative h-full flex flex-col p-2 rounded-2xl bg-theme-bg-secondary border border-theme-divider-tertiary hover:border-theme-divider-secondary shadow-2',
 );
 
 export const CardHeader = classed(

--- a/packages/shared/src/components/cards/TrendingFlag.tsx
+++ b/packages/shared/src/components/cards/TrendingFlag.tsx
@@ -21,7 +21,7 @@ export default function TrendingFlag({
       <SimpleTooltip content={description}>
         <div
           className={classNames(
-            'flex items-center bg-theme-status-error transform',
+            'flex items-center bg-theme-status-error',
             styles.flag,
             listMode
               ? 'h-5 w-full justify-center mouse:translate-x-9 rounded-l'

--- a/packages/shared/src/components/comments/common.tsx
+++ b/packages/shared/src/components/comments/common.tsx
@@ -18,7 +18,7 @@ export function CommentPublishDate({
 }
 
 export const commentBoxClassNames =
-  'py-3 px-4 bg-theme-bg-secondary rounded-lg break-words typo-callout';
+  'py-3 px-4 bg-theme-bg-secondary rounded-lg break-words-overflow typo-callout';
 
 const StyledCommentBox = classed('div', commentBoxClassNames);
 

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -119,7 +119,7 @@ export function Dropdown({
         </span>
         <ArrowIcon
           className={classNames(
-            'text-xl ml-auto transform transition-transform group-hover:text-theme-label-tertiary',
+            'text-xl ml-auto transition-transform group-hover:text-theme-label-tertiary',
             isVisible ? 'rotate-0' : 'rotate-180',
             styles.chevron,
           )}

--- a/packages/shared/src/components/filters/TagButton.tsx
+++ b/packages/shared/src/components/filters/TagButton.tsx
@@ -40,9 +40,7 @@ const UnblockTagButton = ({
   <GenericTagButton
     {...props}
     className={classNames('btn-tagBlocked', className)}
-    icon={
-      <BlockIcon className="ml-2 text-xl transition-transform transform icon" />
-    }
+    icon={<BlockIcon className="ml-2 text-xl transition-transform icon" />}
     action={action}
     tag={tag}
   />
@@ -62,7 +60,7 @@ const UnfollowTagButton = ({
     {...props}
     className={classNames('btn-primary', className)}
     icon={
-      <PlusIcon className="ml-2 text-xl transition-transform transform rotate-45 icon" />
+      <PlusIcon className="ml-2 text-xl transition-transform rotate-45 icon" />
     }
     action={action}
     tag={tag}
@@ -83,7 +81,7 @@ const FollowTagButton = ({
     {...props}
     className={classNames('btn-tag', className)}
     icon={
-      <PlusIcon className="ml-2 text-xl transition-transform transform rotate-0 icon" />
+      <PlusIcon className="ml-2 text-xl transition-transform rotate-0 icon" />
     }
     action={action}
     tag={tag}

--- a/packages/shared/src/components/filters/TagCategoryDropdown.tsx
+++ b/packages/shared/src/components/filters/TagCategoryDropdown.tsx
@@ -31,7 +31,7 @@ export default function TagCategoryDropdown({
     <TagCategoryDetails>
       <TagCategorySummary>
         <div className="flex items-center">
-          <ArrowIcon className="mr-2 text-xl transition-transform transform rotate-90 icon text-theme-label-tertiary" />{' '}
+          <ArrowIcon className="mr-2 text-xl transition-transform rotate-90 icon text-theme-label-tertiary" />{' '}
           <span className="mr-3 typo-title1">{tagCategory.emoji}</span>{' '}
           <h4 className="font-bold typo-callout">{tagCategory.title}</h4>{' '}
         </div>

--- a/packages/shared/src/components/modals/NewCommentModal.module.css
+++ b/packages/shared/src/components/modals/NewCommentModal.module.css
@@ -1,6 +1,5 @@
 .textarea {
   min-height: 11rem;
-  word-break: break-word;
 
   &:focus {
     outline: 0;

--- a/packages/shared/src/components/modals/NewCommentModal.tsx
+++ b/packages/shared/src/components/modals/NewCommentModal.tsx
@@ -301,7 +301,7 @@ export default function NewCommentModal({
         <ProfilePicture user={user} size="small" />
         <div
           className={classNames(
-            'ml-3 flex-1 text-theme-label-primary bg-none border-none caret-theme-label-link whitespace-pre-line break-words typo-subhead',
+            'ml-3 flex-1 text-theme-label-primary bg-none border-none caret-theme-label-link whitespace-pre-line break-words break-words-overflow typo-subhead',
             styles.textarea,
           )}
           ref={commentRef}

--- a/packages/shared/src/components/multiLevelMenu/MultiLevelMenuDetail.tsx
+++ b/packages/shared/src/components/multiLevelMenu/MultiLevelMenuDetail.tsx
@@ -18,7 +18,7 @@ export default function MultiLevelMenuDetail({
         <Button
           className="p-0 typo-callout text-theme-label-tertiary btn-quaternary"
           onClick={() => setMultiLevelMenuDetail(null, null)}
-          icon={<ArrowIcon className="mr-2 text-2xl transform -rotate-90" />}
+          icon={<ArrowIcon className="mr-2 text-2xl -rotate-90" />}
         >
           {item?.title}
         </Button>

--- a/packages/shared/src/components/multiLevelMenu/MultiLevelMenuMaster.tsx
+++ b/packages/shared/src/components/multiLevelMenu/MultiLevelMenuMaster.tsx
@@ -30,7 +30,7 @@ export default function MultiLevelMenuMaster({
           >
             {item.icon}
             <a className="flex-1 text-left typo-headline">{item.title}</a>
-            <ArrowIcon className="text-xl transform rotate-90" />
+            <ArrowIcon className="text-xl rotate-90" />
           </MenuButton>
         </li>
       ))}

--- a/packages/shared/src/components/profile/PostsSection.tsx
+++ b/packages/shared/src/components/profile/PostsSection.tsx
@@ -238,7 +238,7 @@ export default function PostsSection({
               <LazyImage
                 imgSrc={post.source.image}
                 imgAlt={post.source.name}
-                className={`top-1/2 left-0 w-8 h-8 bg-theme-bg-primary rounded-full transform -translate-x-1/2 -translate-y-1/2 ${styles.sourceImage}`}
+                className={`top-1/2 left-0 w-8 h-8 bg-theme-bg-primary rounded-full -translate-x-1/2 -translate-y-1/2 ${styles.sourceImage}`}
                 absolute
               />
             </div>

--- a/packages/shared/src/components/profile/ProfileTolltipContent.tsx
+++ b/packages/shared/src/components/profile/ProfileTolltipContent.tsx
@@ -38,7 +38,7 @@ export function ProfileTooltipContent({
         @{user.username}
       </ProfileLink>
       {user.bio && (
-        <p className="mb-3 line-clamp-3 text-theme-label-tertiary">
+        <p className="mb-3 break-words line-clamp-3 text-theme-label-tertiary">
           {user.bio}
         </p>
       )}

--- a/packages/shared/src/components/profile/common.module.css
+++ b/packages/shared/src/components/profile/common.module.css
@@ -1,6 +1,5 @@
 .commentContent {
   max-height: 3.75rem;
-  word-break: break-word;
   -webkit-line-clamp: 3;
 
   @screen tablet {

--- a/packages/shared/src/components/profile/common.tsx
+++ b/packages/shared/src/components/profile/common.tsx
@@ -25,7 +25,7 @@ export function CommentContent({
       {...props}
       className={classNames(
         className,
-        'p-0 m-0 theme-label-primary multi-truncate whitespace-pre-wrap typo-callout tablet:flex-1 tablet:mr-6',
+        'p-0 m-0 theme-label-primary multi-truncate break-words whitespace-pre-wrap typo-callout tablet:flex-1 tablet:mr-6',
         styles.commentContent,
       )}
     />

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -79,7 +79,7 @@ export const SidebarBackdrop = classed(
 );
 export const SidebarAside = classed(
   'aside',
-  'flex flex-col w-70 laptop:-translate-x-0 left-0 bg-theme-bg-primary z-3 border-r border-theme-divider-tertiary transition-[width,transform] transform duration-300 ease-in-out group fixed top-0  h-full ',
+  'flex flex-col w-70 laptop:-translate-x-0 left-0 bg-theme-bg-primary z-3 border-r border-theme-divider-tertiary transition-[width,transform] duration-300 ease-in-out group fixed top-0  h-full ',
 );
 export const SidebarScrollWrapper = classed(
   'div',

--- a/packages/shared/src/styles/components/menu.css
+++ b/packages/shared/src/styles/components/menu.css
@@ -3,7 +3,7 @@
   opacity: 0;
   user-select: none;
   z-index: 100;
-  @apply py-1 px-0 m-0 bg-theme-bg-secondary rounded-xl border border-theme-divider-secondary shadow-2 transform -translate-x-full;
+  @apply py-1 px-0 m-0 bg-theme-bg-secondary rounded-xl border border-theme-divider-secondary shadow-2 -translate-x-full;
 
   &.scrollable {
     height: 15rem;
@@ -45,15 +45,19 @@
       outline: none;
     }
 
-    &:not(.react-contexify__item--disabled):hover > .react-contexify__item__content {
+    &:not(.react-contexify__item--disabled):hover
+      > .react-contexify__item__content {
       @apply bg-theme-hover;
     }
 
-    &:not(.react-contexify__item--disabled):focus, &:not(.react-contexify__item--disabled).focus > .react-contexify__item__content {
+    &:not(.react-contexify__item--disabled):focus,
+    &:not(.react-contexify__item--disabled).focus
+      > .react-contexify__item__content {
       @apply bg-theme-float;
     }
 
-    &:not(.react-contexify__item--disabled):active > .react-contexify__item__content {
+    &:not(.react-contexify__item--disabled):active
+      > .react-contexify__item__content {
       @apply bg-theme-active;
     }
   }

--- a/packages/shared/src/styles/utilities.css
+++ b/packages/shared/src/styles/utilities.css
@@ -24,3 +24,12 @@
     display: none; /* Chrome, Safari and Opera */
   }
 }
+
+@layer utilities {
+  .break-words {
+    word-break: break-word;
+  }
+  .break-words-overflow {
+    overflow-wrap: break-word;
+  }
+}

--- a/packages/shared/src/styles/utilities.css
+++ b/packages/shared/src/styles/utilities.css
@@ -25,11 +25,9 @@
   }
 }
 
-@layer utilities {
-  .break-words {
-    word-break: break-word;
-  }
-  .break-words-overflow {
-    overflow-wrap: break-word;
-  }
+.break-words {
+  word-break: break-word;
+}
+.break-words-overflow {
+  overflow-wrap: break-word;
 }

--- a/packages/webapp/components/KeywordManagement.tsx
+++ b/packages/webapp/components/KeywordManagement.tsx
@@ -135,7 +135,7 @@ export default function KeywordManagement({
                 className="w-16 h-16 rounded-2xl"
               />
               <p
-                className="flex-1 self-center p-0 tablet:mr-6 ml-4 whitespace-pre-wrap break-words text-theme-label-primary typo-callout multi-truncate"
+                className="flex-1 self-center p-0 tablet:mr-6 ml-4 whitespace-pre-wrap break-words-overflow text-theme-label-primary typo-callout multi-truncate"
                 style={{
                   maxHeight: '3.75rem',
                   maxWidth: '19.25rem',

--- a/packages/webapp/components/widgets/BestDiscussions.tsx
+++ b/packages/webapp/components/widgets/BestDiscussions.tsx
@@ -136,7 +136,7 @@ export default function BestDiscussions({
           className="self-start my-2 ml-2 btn-tertiary"
           buttonSize="small"
           tag="a"
-          rightIcon={<ArrowIcon className="transform rotate-90 icon" />}
+          rightIcon={<ArrowIcon className="rotate-90 icon" />}
           onClick={onLucky}
           onMouseUp={(event) => event.button === 1 && onLucky()}
         >

--- a/packages/webapp/components/widgets/SimilarPosts.tsx
+++ b/packages/webapp/components/widgets/SimilarPosts.tsx
@@ -164,7 +164,7 @@ export default function SimilarPosts({
           className="self-start my-2 ml-2 btn-tertiary"
           buttonSize="small"
           tag="a"
-          rightIcon={<ArrowIcon className="transform rotate-90 icon" />}
+          rightIcon={<ArrowIcon className="rotate-90 icon" />}
         >
           Show more
         </Button>

--- a/packages/webapp/pages/404.tsx
+++ b/packages/webapp/pages/404.tsx
@@ -13,7 +13,7 @@ export default function Custom404(): ReactElement {
         style={{ width: '55%', maxWidth: '32.75rem' }}
         className="self-center mb-10"
       />
-      <h1 className="mx-9 font-bold text-center break-words typo-title1">
+      <h1 className="mx-9 font-bold text-center break-words-overflow typo-title1">
         Oops, this page couldn’t be found
       </h1>
     </div>


### PR DESCRIPTION
Since the Tailwind `break-words` is broken by design, we decided to take hands in own matters and override those to make them do what they promise.

Giving us the `break-words` class to break words and `break-words-overflow` to define the overflow for breaking words.

I also took the liberty in this PR to clean-out no longer needed Tailwind classes for `transform`.

And found a couple weird edge cases I fixed:

1. When posts had the hot filter they did not match the full height:
![Screenshot 2022-01-18 at 16 42 23](https://user-images.githubusercontent.com/554874/149964060-ec1cadaa-f6a1-47fd-a472-3856969c60d6.png)

(Fixed by adding the h-full to the card)
Related the z-index was off, so decided to force to `-1` to always be behind the cards
 
2. Profile bio had no overflow:
![Screenshot 2022-01-18 at 17 03 26](https://user-images.githubusercontent.com/554874/149964126-d8d1aaac-f87d-49a5-b0bb-52f2f9efa7d6.png)

Fixed by adding `break-words`
![Screenshot 2022-01-18 at 17 04 13](https://user-images.githubusercontent.com/554874/149964155-a0d0e988-c6b5-44ae-9b40-74a8bf7ac346.png)