### PR TITLE
fix: :lipstick: Feed Filter Button was not showing on mobile

### DIFF
--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -57,7 +57,7 @@ export default function FeedFilters({
   return (
     <aside
       className={classNames(
-        'fixed top-14 left-0 z-3 bottom-0 self-stretch bg-theme-bg-primary rounded-r-2xl border-t border-r border-theme-divider-primary overflow-y-auto',
+        'fixed top-0 laptop:top-14 left-0 z-3 bottom-0 self-stretch bg-theme-bg-primary rounded-r-2xl border-t border-r border-theme-divider-primary overflow-y-auto',
         'transition-transform duration-200 ease-linear delay-100',
         isOpen ? 'translate-x-0' : '-translate-x-96 pointer-events-none',
       )}

--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -136,7 +136,6 @@ const UnfilteredMyFeedButton = ({
 
 const FilteredMyFeedButton = ({
   item,
-  sidebarRendered,
   sidebarExpanded,
   action,
   isActive,
@@ -147,17 +146,15 @@ const FilteredMyFeedButton = ({
       <ButtonOrLink item={item} useNavButtonsNotLinks={useNavButtonsNotLinks}>
         <ItemInner item={item} sidebarExpanded={sidebarExpanded} />
       </ButtonOrLink>
-      {sidebarRendered && (
-        <SimpleTooltip placement="right" content="Feed filters">
-          <Button
-            iconOnly
-            className="mr-3 btn-tertiary"
-            buttonSize="xsmall"
-            icon={<FilterIcon />}
-            onClick={action}
-          />
-        </SimpleTooltip>
-      )}
+      <SimpleTooltip placement="right" content="Feed filters">
+        <Button
+          iconOnly
+          className="mr-3 btn-tertiary"
+          buttonSize="xsmall"
+          icon={<FilterIcon />}
+          onClick={action}
+        />
+      </SimpleTooltip>
     </NavItem>
   );
 };
@@ -176,7 +173,6 @@ export default function MyFeedButton({
     return (
       <FilteredMyFeedButton
         action={action}
-        sidebarRendered={sidebarRendered}
         sidebarExpanded={sidebarExpanded}
         item={item}
         isActive={isActive}


### PR DESCRIPTION
We removed the Feed Filter Button from rendering on the mobile version.
This made it impossible for people to open the feed filters from the menu.

I've added this button on the mobile version now.

DD-484 #done 