### PR TITLE
hotfix: ad load

### DIFF
--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react';
+import { useContext, useEffect, useMemo } from 'react';
 import request from 'graphql-request';
 import {
   InfiniteData,
@@ -136,13 +136,22 @@ export default function useFeed<T>(
       return ads[0];
     },
     {
+      getNextPageParam: () => Date.now(),
       enabled: query && tokenRefreshed,
       refetchOnMount: false,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
-      getNextPageParam: () => ({}),
     },
   );
+
+  useEffect(() => {
+    if (
+      !adsQuery.isFetching &&
+      adsQuery.data?.pages?.length < feedQuery.data?.pages?.length
+    ) {
+      adsQuery.fetchNextPage();
+    }
+  }, [adsQuery.data, feedQuery.data, adsQuery.isFetching]);
 
   const items = useMemo(() => {
     let newItems: FeedItem[] = [];
@@ -178,7 +187,7 @@ export default function useFeed<T>(
   }, [
     feedQuery.data,
     feedQuery.isFetching,
-    adsQuery.data?.pages?.length,
+    adsQuery.data,
     adsQuery.isFetching,
   ]);
 

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -178,7 +178,7 @@ export default function useFeed<T>(
   }, [
     feedQuery.data,
     feedQuery.isFetching,
-    adsQuery.data,
+    adsQuery.data?.pages?.length,
     adsQuery.isFetching,
   ]);
 


### PR DESCRIPTION
We had an issue where the ad infinite query would not load on time.
this introduces a useEffect way of reloading the ads if they take longer than the next feed page.