### PR TITLE
fix: mobile feed filter button was not always rendering

### DIFF
--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -145,7 +145,7 @@ export default function MyFeedButton({
     return (
       <FilteredMyFeedButton
         action={action}
-        sidebarExpanded={sidebarExpanded}
+        sidebarExpanded={sidebarExpanded || sidebarRendered === false}
         item={item}
         isActive={isActive}
         useNavButtonsNotLinks={useNavButtonsNotLinks}

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -203,7 +203,7 @@ export const MenuIcon = ({
       absolute
       className={`btn btn-primary h-6 w-6 top-3 -right-3 z-3 ${
         sidebarExpanded &&
-        'transition-opacity  invisible group-hover:visible opacity-0 group-hover:opacity-100'
+        'transition-opacity invisible group-hover:visible opacity-0 group-hover:opacity-100'
       }`}
       buttonSize="xsmall"
     >


### PR DESCRIPTION
We weren't checking if the sidebar rendered value was false, this could cause the feed filter button to disappear on mobile devices.

DD-494 #done 