### PR TITLE
[fix]: change the background color of the mostvisited websites

### DIFF
--- a/packages/extension/src/newtab/MostVisitedSites.tsx
+++ b/packages/extension/src/newtab/MostVisitedSites.tsx
@@ -24,7 +24,7 @@ export default function MostVisitedSites(): ReactElement {
               href={topSite.url}
               rel="noopener noreferrer"
               className={classNames(
-                'focus-outline w-8 h-8 rounded-lg overflow-hidden bg-[#0E1217] border-[#2D323B]',
+                'focus-outline w-8 h-8 rounded-lg overflow-hidden bg-white border border-theme-divider-secondary',
                 index > 0 && 'ml-2',
                 index >= 4 && 'hidden laptopL:block',
               )}

--- a/packages/extension/src/newtab/MostVisitedSites.tsx
+++ b/packages/extension/src/newtab/MostVisitedSites.tsx
@@ -24,7 +24,7 @@ export default function MostVisitedSites(): ReactElement {
               href={topSite.url}
               rel="noopener noreferrer"
               className={classNames(
-                'focus-outline w-8 h-8 rounded-lg overflow-hidden bg-white',
+                'focus-outline w-8 h-8 rounded-lg overflow-hidden bg-[#0E1217] border-[#2D323B]',
                 index > 0 && 'ml-2',
                 index >= 4 && 'hidden laptopL:block',
               )}


### PR DESCRIPTION
### [fix]: change the background colour of the most visited websites

Due to non-uniform favicons of different websites, the design is taking. Hence, by matching the background of png favicons with the daily dev's background, the UI of the application would improve. I have added border colour as well to distinguish between adjacent icons.