### PR TITLE
refactor: text field guideline update

### DIFF
--- a/packages/shared/src/components/fields/TextField.spec.tsx
+++ b/packages/shared/src/components/fields/TextField.spec.tsx
@@ -57,7 +57,7 @@ it('should set hint role as alert when invalid', async () => {
   await waitFor(() => expect(el).toHaveAttribute('role', 'alert'));
 });
 
-it('should show both label and placeholder in compact mode', async () => {
+it('should show both label and placeholder in secondary mode', async () => {
   renderComponent({ fieldType: 'secondary', placeholder: 'Placeholder' });
   const input = getInput();
   await waitFor(() => expect(input.placeholder).toEqual('Placeholder'));

--- a/packages/shared/src/components/fields/TextField.spec.tsx
+++ b/packages/shared/src/components/fields/TextField.spec.tsx
@@ -63,3 +63,15 @@ it('should show both label and placeholder in secondary mode', async () => {
   await waitFor(() => expect(input.placeholder).toEqual('Placeholder'));
   await waitFor(() => expect(getLabel()).toHaveTextContent('Name'));
 });
+
+it('should show label and placeholder based in its state in tertiary mode', async () => {
+  renderComponent({
+    fieldType: 'tertiary',
+    placeholder: 'Placeholder',
+    label: 'Label',
+  });
+  const input = getInput();
+  await waitFor(() => expect(input.placeholder).toEqual('Label'));
+  input.focus();
+  await waitFor(() => expect(input.placeholder).toEqual('Placeholder'));
+});

--- a/packages/shared/src/components/fields/TextField.spec.tsx
+++ b/packages/shared/src/components/fields/TextField.spec.tsx
@@ -25,7 +25,7 @@ it('should set by default placeholder as label', () => {
 
 it('should show label when focused', async () => {
   renderComponent();
-  expect(getLabel()).toHaveClass('hidden');
+  expect(screen.queryByText('Name')).not.toBeInTheDocument();
   const input = getInput();
   input.focus();
   await waitFor(() => expect(input.placeholder).toEqual(''));
@@ -58,7 +58,7 @@ it('should set hint role as alert when invalid', async () => {
 });
 
 it('should show both label and placeholder in compact mode', async () => {
-  renderComponent({ compact: true, placeholder: 'Placeholder' });
+  renderComponent({ fieldType: 'secondary', placeholder: 'Placeholder' });
   const input = getInput();
   await waitFor(() => expect(input.placeholder).toEqual('Placeholder'));
   await waitFor(() => expect(getLabel()).toHaveTextContent('Name'));

--- a/packages/shared/src/components/fields/TextField.tsx
+++ b/packages/shared/src/components/fields/TextField.tsx
@@ -56,9 +56,9 @@ export function TextField({
     onInput: baseOnInput,
     focusInput,
   } = useInputField(value, valueChanged);
-  const isPrimary = fieldType === 'primary';
-  const isSecondary = fieldType === 'secondary';
-  const isTertiary = fieldType === 'tertiary';
+  const isPrimaryField = fieldType === 'primary';
+  const isSecondaryField = fieldType === 'secondary';
+  const isTertiaryField = fieldType === 'tertiary';
   const [inputLength, setInputLength] = useState<number>(0);
   const [validInput, setValidInput] = useState<boolean>(undefined);
   const [idleTimeout, setIdleTimeout] = useState<number>(undefined);
@@ -117,11 +117,11 @@ export function TextField({
   };
 
   const getPlaceholder = () => {
-    if (isTertiary) {
+    if (isTertiaryField) {
       return focused ? placeholder : label;
     }
 
-    if (focused || isSecondary) {
+    if (focused || isSecondaryField) {
       return placeholder ?? '';
     }
 
@@ -161,7 +161,7 @@ export function TextField({
       className={classNames(className, 'flex flex-col items-stretch')}
       style={style}
     >
-      {isSecondary && (
+      {isSecondaryField && (
         <label
           className="px-2 mb-1 font-bold text-theme-label-primary typo-caption1"
           htmlFor={inputId}
@@ -174,7 +174,7 @@ export function TextField({
         onClick={focusInput}
         className={classNames(
           'flex flex-row items-center',
-          isSecondary ? 'h-9 rounded-10' : 'h-12 rounded-14',
+          isSecondaryField ? 'h-9 rounded-10' : 'h-12 rounded-14',
           leftIcon && 'pl-3',
           rightIcon && 'pr-3',
           {
@@ -194,7 +194,7 @@ export function TextField({
             rightIcon && 'mr-2',
           )}
         >
-          {isPrimary && (focused || hasInput) && (
+          {isPrimaryField && (focused || hasInput) && (
             <label
               className={classNames('typo-caption1', getLabelColor())}
               htmlFor={inputId}

--- a/packages/shared/src/components/fields/TextField.tsx
+++ b/packages/shared/src/components/fields/TextField.tsx
@@ -21,7 +21,6 @@ export interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   valid?: boolean;
   validityChanged?: (valid: boolean) => void;
   valueChanged?: (value: string) => void;
-  compact?: boolean;
   fieldType?: FieldType;
   leftIcon?: ReactNode;
   rightIcon?: ReactNode;

--- a/packages/shared/src/components/fields/TextField.tsx
+++ b/packages/shared/src/components/fields/TextField.tsx
@@ -10,6 +10,7 @@ import classNames from 'classnames';
 import { useInputField } from '../../hooks/useInputField';
 import { BaseField, FieldInput } from './common';
 import styles from './TextField.module.css';
+import { Button } from '../buttons/Button';
 
 type FieldType = 'primary' | 'secondary' | 'tertiary';
 
@@ -23,7 +24,8 @@ export interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   valueChanged?: (value: string) => void;
   fieldType?: FieldType;
   leftIcon?: ReactNode;
-  rightIcon?: ReactNode;
+  actionIcon?: ReactNode;
+  onActionIconClick?: () => unknown;
 }
 
 export function TextField({
@@ -43,7 +45,8 @@ export function TextField({
   fieldType = 'primary',
   readOnly,
   leftIcon,
-  rightIcon,
+  actionIcon,
+  onActionIconClick,
   disabled,
   ...props
 }: TextFieldProps): ReactElement {
@@ -176,7 +179,7 @@ export function TextField({
           'flex flex-row items-center',
           isSecondaryField ? 'h-9 rounded-10' : 'h-12 rounded-14',
           leftIcon && 'pl-3',
-          rightIcon && 'pr-3',
+          actionIcon && 'pr-3',
           {
             readOnly,
             focused,
@@ -191,7 +194,7 @@ export function TextField({
         <div
           className={classNames(
             'flex flex-col flex-1 items-start max-w-full',
-            rightIcon && 'mr-2',
+            actionIcon && 'mr-2',
           )}
         >
           {isPrimaryField && (focused || hasInput) && (
@@ -224,6 +227,14 @@ export function TextField({
           >
             {maxLength - inputLength}
           </div>
+        )}
+        {actionIcon && (
+          <Button
+            buttonSize="small"
+            className="btn-tertiary"
+            onClick={onActionIconClick}
+            icon={actionIcon}
+          />
         )}
       </BaseField>
       {(hint?.length || saveHintSpace) && (

--- a/packages/shared/src/components/fields/TextField.tsx
+++ b/packages/shared/src/components/fields/TextField.tsx
@@ -161,7 +161,7 @@ export function TextField({
       className={classNames(className, 'flex flex-col items-stretch')}
       style={style}
     >
-      {fieldType === 'secondary' && (
+      {isSecondary && (
         <label
           className="px-2 mb-1 font-bold text-theme-label-primary typo-caption1"
           htmlFor={inputId}

--- a/packages/shared/src/components/fields/common.tsx
+++ b/packages/shared/src/components/fields/common.tsx
@@ -3,11 +3,11 @@ import styles from './fields.module.css';
 
 export const FieldInput = classed(
   'input',
-  'min-w-0 text-theme-label-primary bg-transparent typo-body caret-theme-label-link focus:outline-none',
+  'min-w-0 text-theme-label-tertiary bg-transparent typo-body caret-theme-label-link focus:outline-none',
 );
 
 export const BaseField = classed(
   'div',
-  'flex px-3 items-center overflow-hidden bg-theme-float border border-transparent cursor-text',
+  'flex px-4 items-center overflow-hidden bg-theme-float border border-transparent cursor-text',
   styles.field,
 );

--- a/packages/shared/src/components/profile/ProfileForm.tsx
+++ b/packages/shared/src/components/profile/ProfileForm.tsx
@@ -133,7 +133,7 @@ export default function ProfileForm({
 
   const twitterField = (
     <FormField
-      compact
+      fieldType="secondary"
       inputId="twitter"
       name="twitter"
       label="Twitter"
@@ -153,7 +153,7 @@ export default function ProfileForm({
     <>
       <SectionHeading>About</SectionHeading>
       <FormField
-        compact
+        fieldType="secondary"
         inputId="bio"
         name="bio"
         label="Bio"
@@ -162,7 +162,7 @@ export default function ProfileForm({
         validityChanged={updateDisableSubmit}
       />
       <FormField
-        compact
+        fieldType="secondary"
         inputId="company"
         name="company"
         label="Company"
@@ -171,7 +171,7 @@ export default function ProfileForm({
         validityChanged={updateDisableSubmit}
       />
       <FormField
-        compact
+        fieldType="secondary"
         inputId="title"
         name="title"
         label="Job title"
@@ -182,7 +182,7 @@ export default function ProfileForm({
       <SectionHeading>Social</SectionHeading>
       {mode !== 'author' && twitterField}
       <FormField
-        compact
+        fieldType="secondary"
         inputId="github"
         name="github"
         label="GitHub"
@@ -196,7 +196,7 @@ export default function ProfileForm({
         valueChanged={() => githubHint && setGithubHint(null)}
       />
       <FormField
-        compact
+        fieldType="secondary"
         inputId="hashnode"
         name="hashnode"
         label="Hashnode"
@@ -210,7 +210,7 @@ export default function ProfileForm({
         valueChanged={() => hashnodeHint && setHashnodeHint(null)}
       />
       <FormField
-        compact
+        fieldType="secondary"
         inputId="portfolio"
         name="portfolio"
         label="Website"
@@ -240,7 +240,7 @@ export default function ProfileForm({
     >
       <SectionHeading>Profile</SectionHeading>
       <FormField
-        compact
+        fieldType="secondary"
         inputId="name"
         name="name"
         label="Name"
@@ -251,7 +251,7 @@ export default function ProfileForm({
         validityChanged={updateDisableSubmit}
       />
       <FormField
-        compact
+        fieldType="secondary"
         inputId="username"
         name="username"
         label="Username"
@@ -265,7 +265,7 @@ export default function ProfileForm({
         valueChanged={() => usernameHint && setUsernameHint(null)}
       />
       <FormField
-        compact
+        fieldType="secondary"
         inputId="email"
         name="email"
         label="Email"

--- a/packages/shared/src/hooks/useInputField.ts
+++ b/packages/shared/src/hooks/useInputField.ts
@@ -31,9 +31,7 @@ export function useInputField(
   };
 
   useEffect(() => {
-    if (value) {
-      setInput(value.toString());
-    }
+    setInput(value?.toString() || '');
   }, [value]);
 
   const onFocus = () => setFocused(true);


### PR DESCRIPTION
## Changes

The primary change to look for is the variation of the font colors based on which `fieldType` the input is. The `tertiary` is a new addition that is used already in the custom links so there are no pre-existing implementations of it.

The `compact` property is now gone and was replaced by being the `secondary` field type.

Primary is the common and default implementation of the text field.

This now supports icons inside the text field itself and the padding varies between having one or not.

## Testing

- Did you introduce testing for this PR
- ☑️ Did you test the webapp? **Yes**
- ☑️ Did you test the extension? **Yes**

DD-495 #done

**Note:** just waiting for Tsahi's answer regarding the right icon but this should be alright to be reviewed.
