### PR TITLE
feat: add weekly goals toggle in customize settings

### DIFF
--- a/packages/extension/src/newtab/ShortcutLinks.spec.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.spec.tsx
@@ -84,6 +84,7 @@ const defaultSettings: RemoteSettings = {
   showTopSites: true,
   sidebarExpanded: true,
   sortingEnabled: false,
+  showWeeklyGoals: true,
   customLinks: [
     'http://custom1.com',
     'http://custom2.com',

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -138,6 +138,8 @@ const renderComponent = (
     toggleShowTopSites: jest.fn(),
     toggleSortingEnabled: jest.fn(),
     sortingEnabled: false,
+    toggleShowWeeklyGoals: jest.fn(),
+    showWeeklyGoals: true,
     sidebarExpanded: true,
     toggleSidebarExpanded: jest.fn(),
   };

--- a/packages/shared/src/components/Settings.spec.tsx
+++ b/packages/shared/src/components/Settings.spec.tsx
@@ -39,6 +39,7 @@ const defaultSettings: RemoteSettings = {
   showTopSites: true,
   sidebarExpanded: true,
   sortingEnabled: false,
+  showWeeklyGoals: true,
 };
 
 const updateSettings = jest.fn();
@@ -261,6 +262,16 @@ it('should mutate feed sorting enabled setting', () =>
     const checkbox = checkboxes.find((el) =>
       // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
       queryByText(el.parentElement, 'Show feed sorting menu'),
+    ) as HTMLInputElement;
+    fireEvent.click(checkbox);
+  }));
+
+it('should mutate show weekly goals widget setting', () =>
+  testSettingsMutation({ showWeeklyGoals: false }, async () => {
+    const checkboxes = await screen.findAllByRole('checkbox');
+    const checkbox = checkboxes.find((el) =>
+      // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
+      queryByText(el.parentElement, 'Show Weekly Goal widget'),
     ) as HTMLInputElement;
     fireEvent.click(checkbox);
   }));

--- a/packages/shared/src/components/Settings.tsx
+++ b/packages/shared/src/components/Settings.tsx
@@ -47,6 +47,8 @@ export default function Settings({
     toggleShowTopSites,
     sortingEnabled,
     toggleSortingEnabled,
+    showWeeklyGoals,
+    toggleShowWeeklyGoals,
   } = useContext(SettingsContext);
   const [themes, setThemes] = useState([
     { label: 'Dark', value: 'dark' },
@@ -147,6 +149,16 @@ export default function Settings({
             compact={false}
           >
             Show feed sorting menu
+          </Switch>
+          <Switch
+            inputId="weekly-goal-widget-switch"
+            name="weekly-goal-widget"
+            className="my-3 big"
+            checked={showWeeklyGoals}
+            onToggle={toggleShowWeeklyGoals}
+            compact={false}
+          >
+            Show Weekly Goal widget
           </Switch>
         </div>
       </Section>

--- a/packages/shared/src/components/Settings.tsx
+++ b/packages/shared/src/components/Settings.tsx
@@ -56,7 +56,7 @@ export default function Settings({
     { label: 'Auto', value: 'auto' },
   ]);
 
-  const onToggleForLoggedUnUsers = (
+  const onToggleForLoggedInUsers = (
     onToggleFunc: () => Promise<void> | void,
   ): Promise<void> | void => {
     if (!user) {
@@ -115,7 +115,7 @@ export default function Settings({
             name="hide-read"
             className="my-3"
             checked={showOnlyUnreadPosts}
-            onToggle={() => onToggleForLoggedUnUsers(toggleShowOnlyUnreadPosts)}
+            onToggle={() => onToggleForLoggedInUsers(toggleShowOnlyUnreadPosts)}
             compact={false}
           >
             Hide read posts
@@ -157,7 +157,7 @@ export default function Settings({
             name="weekly-goal-widget"
             className="my-3 big"
             checked={showWeeklyGoals}
-            onToggle={() => onToggleForLoggedUnUsers(toggleShowWeeklyGoals)}
+            onToggle={() => onToggleForLoggedInUsers(toggleShowWeeklyGoals)}
             compact={false}
           >
             Show Weekly Goal widget

--- a/packages/shared/src/components/Settings.tsx
+++ b/packages/shared/src/components/Settings.tsx
@@ -150,16 +150,18 @@ export default function Settings({
           >
             Show feed sorting menu
           </Switch>
-          <Switch
-            inputId="weekly-goal-widget-switch"
-            name="weekly-goal-widget"
-            className="my-3 big"
-            checked={showWeeklyGoals}
-            onToggle={toggleShowWeeklyGoals}
-            compact={false}
-          >
-            Show Weekly Goal widget
-          </Switch>
+          {user && (
+            <Switch
+              inputId="weekly-goal-widget-switch"
+              name="weekly-goal-widget"
+              className="my-3 big"
+              checked={showWeeklyGoals}
+              onToggle={toggleShowWeeklyGoals}
+              compact={false}
+            >
+              Show Weekly Goal widget
+            </Switch>
+          )}
         </div>
       </Section>
     </div>

--- a/packages/shared/src/components/Settings.tsx
+++ b/packages/shared/src/components/Settings.tsx
@@ -56,13 +56,15 @@ export default function Settings({
     { label: 'Auto', value: 'auto' },
   ]);
 
-  const onShowOnlyUnreadPosts = (): Promise<void> | void => {
+  const onToggleForLoggedUnUsers = (
+    onToggleFunc: () => Promise<void> | void,
+  ): Promise<void> | void => {
     if (!user) {
       showLogin('settings');
       return undefined;
     }
 
-    return toggleShowOnlyUnreadPosts();
+    return onToggleFunc();
   };
 
   useEffect(() => {
@@ -113,7 +115,7 @@ export default function Settings({
             name="hide-read"
             className="my-3"
             checked={showOnlyUnreadPosts}
-            onToggle={onShowOnlyUnreadPosts}
+            onToggle={() => onToggleForLoggedUnUsers(toggleShowOnlyUnreadPosts)}
             compact={false}
           >
             Hide read posts
@@ -150,18 +152,16 @@ export default function Settings({
           >
             Show feed sorting menu
           </Switch>
-          {user && (
-            <Switch
-              inputId="weekly-goal-widget-switch"
-              name="weekly-goal-widget"
-              className="my-3 big"
-              checked={showWeeklyGoals}
-              onToggle={toggleShowWeeklyGoals}
-              compact={false}
-            >
-              Show Weekly Goal widget
-            </Switch>
-          )}
+          <Switch
+            inputId="weekly-goal-widget-switch"
+            name="weekly-goal-widget"
+            className="my-3 big"
+            checked={showWeeklyGoals}
+            onToggle={() => onToggleForLoggedUnUsers(toggleShowWeeklyGoals)}
+            compact={false}
+          >
+            Show Weekly Goal widget
+          </Switch>
         </div>
       </Section>
     </div>

--- a/packages/shared/src/contexts/BootProvider.spec.tsx
+++ b/packages/shared/src/contexts/BootProvider.spec.tsx
@@ -56,6 +56,7 @@ const defaultSettings: RemoteSettings = {
   showTopSites: true,
   sidebarExpanded: true,
   sortingEnabled: false,
+  showWeeklyGoals: true,
 };
 
 const defaultBootData: BootCacheData = {
@@ -121,6 +122,8 @@ const SettingsMock = ({ toTheme, toSpaciness }: SettingsMockProps) => {
     showTopSites,
     toggleSortingEnabled,
     sortingEnabled,
+    showWeeklyGoals,
+    toggleShowWeeklyGoals,
   } = useContext(SettingsContext);
 
   return (
@@ -145,6 +148,13 @@ const SettingsMock = ({ toTheme, toSpaciness }: SettingsMockProps) => {
         data-test-value={showOnlyUnreadPosts}
       >
         Show Only Unread
+      </button>
+      <button
+        onClick={toggleShowWeeklyGoals}
+        type="button"
+        data-test-value={showWeeklyGoals}
+      >
+        Show Weekly Goal widget
       </button>
       <button
         onClick={() => setSpaciness(toSpaciness)}

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -32,6 +32,7 @@ export type SettingsContextData = {
   showTopSites: boolean;
   sidebarExpanded: boolean;
   sortingEnabled: boolean;
+  showWeeklyGoals: boolean;
   setTheme: (theme: ThemeMode) => Promise<void>;
   toggleShowOnlyUnreadPosts: () => Promise<void>;
   toggleOpenNewTab: () => Promise<void>;
@@ -40,6 +41,7 @@ export type SettingsContextData = {
   toggleShowTopSites: () => Promise<void>;
   toggleSidebarExpanded: () => Promise<void>;
   toggleSortingEnabled: () => Promise<void>;
+  toggleShowWeeklyGoals: () => Promise<void>;
   loadedSettings: boolean;
   customLinks?: string[];
   updateCustomLinks: (links: string[]) => Promise<unknown>;
@@ -178,6 +180,11 @@ export const SettingsContextProvider = ({
         }),
       toggleSortingEnabled: () =>
         setSettings({ ...settings, sortingEnabled: !settings.sortingEnabled }),
+      toggleShowWeeklyGoals: () =>
+        setSettings({
+          ...settings,
+          showWeeklyGoals: !settings.showWeeklyGoals,
+        }),
       loadedSettings,
       updateCustomLinks: (links: string[]) =>
         setSettings({ ...settings, customLinks: links }),

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -94,6 +94,7 @@ const defaultSettings: RemoteSettings = {
   showTopSites: true,
   sidebarExpanded: true,
   sortingEnabled: false,
+  showWeeklyGoals: true,
   theme: remoteThemes[ThemeMode.Dark],
 };
 

--- a/packages/shared/src/graphql/settings.ts
+++ b/packages/shared/src/graphql/settings.ts
@@ -12,6 +12,7 @@ export type RemoteSettings = {
   showTopSites: boolean;
   sidebarExpanded: boolean;
   sortingEnabled: boolean;
+  showWeeklyGoals: boolean;
   customLinks?: string[];
 };
 
@@ -28,6 +29,7 @@ export const USER_SETTINGS_QUERY = gql`
       showTopSites
       sidebarExpanded
       sortingEnabled
+      showWeeklyGoals
       customLinks
     }
   }


### PR DESCRIPTION
## Changes

This PR adds the new toggle for Weekly goals widget in Customize settings. It is enabled by default and is toggable only for logged in users.

Untoggled:
<img width="469" alt="Screenshot 2022-01-31 at 11 58 32" src="https://user-images.githubusercontent.com/33021204/151782372-cdfa779e-0b4a-49d8-8b0e-a7a5f00a2bb8.png">

Toggled:
<img width="471" alt="Screenshot 2022-01-31 at 11 58 50" src="https://user-images.githubusercontent.com/33021204/151782381-eec32c95-efaf-4fba-9822-39834ea21c8c.png">


## Testing

Added the unit tests as well.

Comment: for the other toggles only the capital letter is in upper case. "Show Weekly goal widget" title seems inconsistent. WDYT?

DD-506 #done
