### PR TITLE
fix: invalidate ranks query on read

### DIFF
--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -408,6 +408,8 @@ it('should increase reading rank progress', async () => {
       },
       reads: 0,
     });
+    const state = queryClient.getQueryState(queryKey);
+    expect(state.isInvalidated).toEqual(true);
   });
 });
 

--- a/packages/shared/src/hooks/feed/useFeedOnPostClick.ts
+++ b/packages/shared/src/hooks/feed/useFeedOnPostClick.ts
@@ -27,7 +27,7 @@ export default function useFeedOnPostClick(
     );
     await logReadArticle('feed');
     if (!post.read) {
-      incrementReadingRank();
+      await incrementReadingRank();
     }
     const item = items[index] as PostItem;
     updatePost(item.page, item.index, { ...post, read: true });

--- a/packages/shared/src/hooks/useIncrementReadingRank.ts
+++ b/packages/shared/src/hooks/useIncrementReadingRank.ts
@@ -6,7 +6,7 @@ import { MyRankData } from '../graphql/users';
 import { RANKS } from '../lib/rank';
 
 type ReturnType = {
-  incrementReadingRank: () => MyRankData;
+  incrementReadingRank: () => Promise<MyRankData>;
 };
 
 const MAX_PROGRESS = RANKS[RANKS.length - 1].steps;
@@ -16,9 +16,10 @@ export default function useIncrementReadingRank(): ReturnType {
   const queryClient = useQueryClient();
 
   return {
-    incrementReadingRank: () =>
-      queryClient.setQueryData<MyRankData>(
-        getRankQueryKey(user),
+    incrementReadingRank: async () => {
+      const queryKey = getRankQueryKey(user);
+      const data = queryClient.setQueryData<MyRankData>(
+        queryKey,
         (currentRank) => {
           if (
             !currentRank ||
@@ -42,6 +43,9 @@ export default function useIncrementReadingRank(): ReturnType {
             reads: currentRank.reads,
           };
         },
-      ),
+      );
+      await queryClient.invalidateQueries(queryKey);
+      return data;
+    },
   };
 }


### PR DESCRIPTION
## Changes

On increment reading rank, we need to invalidate the ranks query to reflect the updates in the same session.

## Manual Testing

- On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?