### PR TITLE
fix: don't show the bookmarks sharing modal while loading

### DIFF
--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -5,6 +5,7 @@ import React, {
   useMemo,
   useState,
 } from 'react';
+import dynamic from 'next/dynamic';
 import { BOOKMARKS_FEED_QUERY, SEARCH_BOOKMARKS_QUERY } from '../graphql/feed';
 import AuthContext from '../contexts/AuthContext';
 import { CustomFeedHeader, FeedPage, FeedPageHeader } from './utilities';
@@ -12,7 +13,6 @@ import SearchEmptyScreen from './SearchEmptyScreen';
 import Feed, { FeedProps } from './Feed';
 import BookmarkEmptyScreen from './BookmarkEmptyScreen';
 import { Button } from './buttons/Button';
-import dynamic from 'next/dynamic';
 
 export type BookmarkFeedLayoutProps = {
   searchQuery?: string;
@@ -65,10 +65,10 @@ export default function BookmarkFeedLayout({
       <FeedPageHeader className="mb-5">
         <h3 className="font-bold typo-callout">Bookmarks</h3>
       </FeedPageHeader>
-      <CustomFeedHeader className="relative flex  mb-6">
+      <CustomFeedHeader className="flex relative mb-6">
         {searchChildren}
         <Button
-          className="btn-secondary ml-4"
+          className="ml-4 btn-secondary"
           buttonSize="medium"
           onClick={() => setShowSharedBookmarks(true)}
         >

--- a/packages/shared/src/components/modals/SharedBookmarksModal.tsx
+++ b/packages/shared/src/components/modals/SharedBookmarksModal.tsx
@@ -1,18 +1,18 @@
-import React, { ReactElement, useContext, useEffect, useState } from 'react';
+import React, { ReactElement } from 'react';
 import classNames from 'classnames';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
+import request from 'graphql-request';
 import CopyIcon from '../../../icons/copy.svg';
 import { Button } from '../buttons/Button';
 import { ResponsiveModal } from './ResponsiveModal';
 import { ModalProps } from './StyledModal';
 import styles from './AccountDetailsModal.module.css';
 import { Switch } from '../fields/Switch';
-import { useMutation, useQuery, useQueryClient } from 'react-query';
 import {
   BookmarksSharingData,
   BOOKMARK_SHARING_MUTATION,
   BOOKMARK_SHARING_QUERY,
 } from '../../graphql/bookmarksSharing';
-import request from 'graphql-request';
 import { apiUrl } from '../../lib/config';
 import { TextField } from '../fields/TextField';
 import { ModalHeader } from './common';
@@ -27,10 +27,10 @@ export default function SharedBookmarksModal({
   className,
   ...props
 }: ModalProps): ReactElement {
-  const { data: bookmarksSharingData } = useQuery<BookmarksSharingData>(
-    'bookmarksSharing',
-    () => request(`${apiUrl}/graphql`, BOOKMARK_SHARING_QUERY),
-  );
+  const { data: bookmarksSharingData, isFetched } =
+    useQuery<BookmarksSharingData>('bookmarksSharing', () =>
+      request(`${apiUrl}/graphql`, BOOKMARK_SHARING_QUERY),
+    );
   const queryClient = useQueryClient();
 
   const { mutateAsync: updateBookmarksSharing } = useMutation<{
@@ -49,9 +49,13 @@ export default function SharedBookmarksModal({
     },
   );
 
-  const [isRssUrlCopied, copyRssUrl] = useCopyLink(
+  const [, copyRssUrl] = useCopyLink(
     () => bookmarksSharingData?.bookmarksSharing?.rssUrl,
   );
+
+  if (!isFetched || !bookmarksSharingData?.bookmarksSharing) {
+    return <></>;
+  }
 
   return (
     <>
@@ -94,7 +98,7 @@ export default function SharedBookmarksModal({
             />
           )}
         </section>
-        <section className="m-4 p-6 rounded-16 border border-theme-divider-tertiary">
+        <section className="p-6 m-4 rounded-16 border border-theme-divider-tertiary">
           <p className="typo-callout text-theme-label-tertiary">
             Need inspiration? we prepared some tutorials explaining some best
             practices of integrating your bookmarks with other platforms.
@@ -110,7 +114,7 @@ export default function SharedBookmarksModal({
             >
               Explore tutorials
             </Button>
-            <div className="flex items-center gap-2 h-8 text-2xl">
+            <div className="flex gap-2 items-center h-8 text-2xl">
               <DiscordIcon />
               <TwitterIcon />
               <SlackIcon />

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -125,7 +125,10 @@ export const FormErrorMessage = classed(
 
 export const ProfileHeading = classed('h1', 'm-0 self-start typo-title2');
 
-export const BookmarksModelHeading = classed('h1', 'm-0 self-start typo-title3');
+export const BookmarksModelHeading = classed(
+  'h1',
+  'm-0 self-start typo-title3',
+);
 
 export const ActiveTabIndicator = classed(
   'div',

--- a/packages/shared/src/graphql/bookmarksSharing.ts
+++ b/packages/shared/src/graphql/bookmarksSharing.ts
@@ -8,7 +8,6 @@ export type BookmarksSharing = {
 
 export type BookmarksSharingData = { bookmarksSharing: BookmarksSharing };
 
-
 export const BOOKMARK_SHARING_QUERY = gql`
   query BookmarksSharing {
     bookmarksSharing {


### PR DESCRIPTION
## Changes

Defer showing the modal while loading the data from the server.
This should prevent the glitch of the toggle switch from turning on immediately.

## Manual Testing

- On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

DD-{number} #done
