### PR TITLE
fix: update cache key to prevent client error

### DIFF
--- a/packages/shared/src/components/SidebarRankProgress.spec.tsx
+++ b/packages/shared/src/components/SidebarRankProgress.spec.tsx
@@ -14,6 +14,7 @@ import { MY_READING_RANK_QUERY, MyRankData } from '../graphql/users';
 import SidebarRankProgress from './SidebarRankProgress';
 import { SettingsContextProvider } from '../contexts/SettingsContext';
 import { RemoteSettings } from '../graphql/settings';
+import { RANK_CACHE_KEY } from '../hooks/useReadingRank';
 
 jest.mock('../hooks/usePersistentState', () => {
   const originalModule = jest.requireActual('../hooks/usePersistentState');
@@ -108,7 +109,7 @@ it('should create dynamically the progress bar according to the props', async ()
 });
 
 it('should first show cached rank and animate to fetched rank', async () => {
-  await setCache('rank', {
+  await setCache(RANK_CACHE_KEY, {
     rank: { progressThisWeek: 0, currentRank: 1, readToday: false },
     userId: defaultUser.id,
   });
@@ -124,7 +125,7 @@ it('should first show cached rank and animate to fetched rank', async () => {
 });
 
 it('should show rank for anonymous users', async () => {
-  await setCache('rank', {
+  await setCache(RANK_CACHE_KEY, {
     rank: { progressThisWeek: 1, currentRank: 1, readToday: false },
     userId: null,
   });
@@ -136,7 +137,7 @@ it('should show rank for anonymous users', async () => {
 });
 
 it('should show rank if show weekly goals toggle is checked', async () => {
-  await setCache('rank', {
+  await setCache(RANK_CACHE_KEY, {
     rank: { progressThisWeek: 1, currentRank: 1, readToday: false },
     userId: defaultUser.id,
   });
@@ -148,7 +149,7 @@ it('should show rank if show weekly goals toggle is checked', async () => {
 });
 
 it('should not show rank if show weekly goals toggle is not checked', async () => {
-  await setCache('rank', {
+  await setCache(RANK_CACHE_KEY, {
     rank: { progressThisWeek: 1, currentRank: 0, readToday: false },
     userId: defaultUser.id,
   });

--- a/packages/shared/src/hooks/useReadingRank.ts
+++ b/packages/shared/src/hooks/useReadingRank.ts
@@ -71,6 +71,8 @@ const checkShouldShowRankModal = (
   return new Date(rankLastSeen) < new Date(lastReadTime);
 };
 
+export const RANK_CACHE_KEY = 'rank_v2';
+
 export default function useReadingRank(): ReturnType {
   const { alerts, loadedAlerts, updateAlerts } = useContext(AlertContext);
   const { user, tokenRefreshed } = useContext(AuthContext);
@@ -80,7 +82,7 @@ export default function useReadingRank(): ReturnType {
 
   const [cachedRank, setCachedRank, loadedCache] = usePersistentState<
     MyRankData & { userId: string; neverShowRankModal?: boolean }
-  >('rank', null);
+  >(RANK_CACHE_KEY, null);
   const neverShowRankModal = cachedRank?.neverShowRankModal;
   const queryKey = getRankQueryKey(user);
   const { data: remoteRank } = useQuery<MyRankData>(


### PR DESCRIPTION
## Changes

The current implementation breaks if the previous cache version is present.
I changed the cache key to fix this issue and ignore the existing cache.

## Manual Testing

- On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
