### PR TITLE
fix: rank steps to display when legendary the week prior

### DIFF
--- a/packages/shared/src/lib/rank.ts
+++ b/packages/shared/src/lib/rank.ts
@@ -112,7 +112,7 @@ export const getNextRankText = ({
 }: GetNextRankTextProps): string => {
   if (finalRank && progress >= RANKS[rank - 1].steps) return FINAL_RANK;
   if (finalRank || (nextRank === rankLastWeek && progress < RANKS[rank].steps))
-    return `Re-earn: ${progress}/${RANKS[rank].steps} days`;
+    return `Re-earn: ${progress}/${RANKS[rank - 1].steps} days`;
   if (nextRank === 0) return `Earn: ${progress ?? 0}/1 days`;
   if (showNextLevel) return `Next level: ${RANKS[rank].name}`;
   return `Earn: ${progress ?? 0}/${RANKS[rank].steps} days`;

--- a/packages/shared/src/lib/rank.ts
+++ b/packages/shared/src/lib/rank.ts
@@ -102,6 +102,11 @@ interface GetNextRankTextProps {
   rankLastWeek?: number;
   showNextLevel?: boolean;
 }
+
+const getRank = (rank: number) => {
+  return rank === 0 ? rank : rank - 1;
+};
+
 export const getNextRankText = ({
   nextRank,
   rank = 0,
@@ -112,7 +117,7 @@ export const getNextRankText = ({
 }: GetNextRankTextProps): string => {
   if (finalRank && progress >= RANKS[rank - 1].steps) return FINAL_RANK;
   if (finalRank || (nextRank === rankLastWeek && progress < RANKS[rank].steps))
-    return `Re-earn: ${progress}/${RANKS[rank - 1].steps} days`;
+    return `Re-earn: ${progress}/${RANKS[getRank(rank)].steps} days`;
   if (nextRank === 0) return `Earn: ${progress ?? 0}/1 days`;
   if (showNextLevel) return `Next level: ${RANKS[rank].name}`;
   return `Earn: ${progress ?? 0}/${RANKS[rank].steps} days`;


### PR DESCRIPTION
## Changes

- Describe what this PR does
The app crashes on load for someone who has a legendary status the week prior.

## Manual Testing

- On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

DD-{number} #done
