### PR TITLE
fix: fallback image for article without banner image

### DIFF
--- a/packages/shared/src/components/history/ReadingHistoryItem.tsx
+++ b/packages/shared/src/components/history/ReadingHistoryItem.tsx
@@ -41,6 +41,7 @@ function ReadingHistoryItem({
           imgSrc={post.image}
           imgAlt={post.title}
           className="w-16 laptop:w-24 h-16 rounded-16"
+          fallbackSrc="https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/1"
         />
         <SourceShadow />
         <LazyImage

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -261,6 +261,7 @@ const PostPage = ({ id, postData }: Props): ReactElement => {
             imgAlt="Post cover image"
             ratio="21%"
             eager
+            fallbackSrc="https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/1"
           />
         </a>
         <PostHeader post={postById.post} />


### PR DESCRIPTION
## Changes

Describe what this PR does
- Fallback image when the post doesn't have a banner image

Quick link: https://daily-webapp-e3cq2jddo-dailydotdev.vercel.app/posts/ziY-dEmqA

- Screenshots if applicable can also help
![image](https://user-images.githubusercontent.com/13744167/152813197-b051a4e4-72b1-4403-9d8c-2861dcc381ba.png)


## Manual Testing

- On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

DD-{number} #done
