### PR TITLE
fix: radial progress color

### DIFF
--- a/packages/shared/src/components/RankProgressWrapper.tsx
+++ b/packages/shared/src/components/RankProgressWrapper.tsx
@@ -90,6 +90,7 @@ export default function RankProgressWrapper({
           onRequestClose={closeRanksModal}
           onShowAccount={() => setShowAccountDetails(true)}
           reads={reads}
+          previousRank={rankLastWeek}
           devCardLimit={devCardLimit}
         />
       )}

--- a/packages/shared/src/components/modals/RanksModal/RankBadgeItem.tsx
+++ b/packages/shared/src/components/modals/RanksModal/RankBadgeItem.tsx
@@ -79,9 +79,9 @@ const RankBadgeItem = ({
             showRank === itemRank.level ? 'w-10 h-10' : 'w-8 h-8',
           )}
           colorByRank={
-            finalRankCompleted || previousRank === itemRank.level
-              ? true
-              : showRank > itemRank.level
+            finalRankCompleted ||
+            previousRank >= itemRank.level ||
+            showRank > itemRank.level
           }
         />
       </RankBadgeContainer>

--- a/packages/shared/src/components/modals/RanksModal/RankBadgeItem.tsx
+++ b/packages/shared/src/components/modals/RanksModal/RankBadgeItem.tsx
@@ -78,7 +78,11 @@ const RankBadgeItem = ({
           className={classNames(
             showRank === itemRank.level ? 'w-10 h-10' : 'w-8 h-8',
           )}
-          colorByRank={finalRankCompleted ? true : showRank > itemRank.level}
+          colorByRank={
+            finalRankCompleted || previousRank === itemRank.level
+              ? true
+              : showRank > itemRank.level
+          }
         />
       </RankBadgeContainer>
       <RankBadgeName

--- a/packages/shared/src/components/modals/RanksModal/RankBadgeItem.tsx
+++ b/packages/shared/src/components/modals/RanksModal/RankBadgeItem.tsx
@@ -20,6 +20,7 @@ const RankBadgeItem = ({
   showRank,
   itemRank,
   progress,
+  previousRank,
 }: RankBadgeItemProps): ReactElement => {
   const rankCompleted = isRankCompleted(showRank, itemRank.level, progress);
   const finalRankCompleted = isFinalRankCompleted(showRank, progress);
@@ -64,7 +65,9 @@ const RankBadgeItem = ({
             style={
               {
                 '--radial-progress-completed-step': `var(--theme-rank-${
-                  finalRankCompleted ? showRank : showRank - 1
+                  finalRankCompleted || previousRank === itemRank.level
+                    ? showRank
+                    : showRank - 1
                 }-color)`,
               } as CSSProperties
             }

--- a/packages/shared/src/components/modals/RanksModal/RanksBadges.tsx
+++ b/packages/shared/src/components/modals/RanksModal/RanksBadges.tsx
@@ -14,7 +14,11 @@ import {
 import RankBadgeItem from './RankBadgeItem';
 import { ModalText } from '../common';
 
-const RanksBadges = ({ rank, progress }: RanksBadgesProps): ReactElement => {
+const RanksBadges = ({
+  rank,
+  progress,
+  previousRank,
+}: RanksBadgesProps): ReactElement => {
   const finalRank = isFinalRank(rank);
   const showRank = getShowRank(finalRank, rank, progress);
   const offest = showRank === RANKS.length ? showRank : showRank - 1;
@@ -32,6 +36,7 @@ const RanksBadges = ({ rank, progress }: RanksBadgesProps): ReactElement => {
             showRank={showRank}
             itemRank={itemRank}
             progress={progress}
+            previousRank={previousRank}
           />
         ))}
       </RanksBadgesList>

--- a/packages/shared/src/components/modals/RanksModal/common.tsx
+++ b/packages/shared/src/components/modals/RanksModal/common.tsx
@@ -5,6 +5,7 @@ import { LoggedUser } from '../../../lib/user';
 import { ModalProps } from '../StyledModal';
 
 export interface RanksModalProps extends ModalProps {
+  previousRank?: number;
   rank: number;
   progress: number;
   tags: TopTags;
@@ -14,12 +15,16 @@ export interface RanksModalProps extends ModalProps {
   devCardLimit: number;
   onShowAccount?: () => void;
 }
-export type RanksBadgesProps = Pick<RanksModalProps, 'rank' | 'progress'>;
+export type RanksBadgesProps = Pick<
+  RanksModalProps,
+  'rank' | 'progress' | 'previousRank'
+>;
 
 export interface RankBadgeItemProps {
   showRank: number;
   itemRank: Rank;
   progress: number;
+  previousRank?: number;
 }
 export interface RanksTagsProps {
   tags: Tag[];

--- a/packages/shared/src/components/modals/RanksModal/index.tsx
+++ b/packages/shared/src/components/modals/RanksModal/index.tsx
@@ -24,6 +24,7 @@ export default function RanksModal({
   onRequestClose,
   onShowAccount,
   className,
+  previousRank,
   ...props
 }: RanksModalProps): ReactElement {
   const { user, showLogin } = useContext(AuthContext);
@@ -41,7 +42,11 @@ export default function RanksModal({
         <ModalCloseButton onClick={onRequestClose} />
       </ModalHeader>
       <IntroSection onShowAccount={onShowAccount} user={user} />
-      <RanksBadges rank={rank} progress={progress} />
+      <RanksBadges
+        rank={rank}
+        progress={progress}
+        previousRank={previousRank}
+      />
       {!user && (
         <div className="flex flex-col items-center mt-2">
           <span className="typo-footnote">

--- a/packages/shared/src/lib/rank.ts
+++ b/packages/shared/src/lib/rank.ts
@@ -115,13 +115,13 @@ export const getNextRankText = ({
   rankLastWeek,
   showNextLevel = true,
 }: GetNextRankTextProps): string => {
-  const { steps, name } = RANKS[getRank(rank)];
+  const { steps } = RANKS[getRank(rank)];
   if (finalRank && progress >= steps) return FINAL_RANK;
   if (finalRank || (nextRank === rankLastWeek && progress < steps))
     return `Re-earn: ${progress}/${steps} days`;
   if (nextRank === 0) return `Earn: ${progress ?? 0}/1 days`;
-  if (showNextLevel) return `Next level: ${name}`;
-  return `Earn: ${progress ?? 0}/${steps} days`;
+  if (showNextLevel) return `Next level: ${RANKS[rank].name}`;
+  return `Earn: ${progress ?? 0}/${RANKS[rank].steps} days`;
 };
 
 export const isFinalRank = (rank: number): boolean => rank === RANKS.length;


### PR DESCRIPTION
## Changes

Describe what this PR does
The radial progress color must be consistent with the color in the sidebar. There's a discrepancy when the user is trying to re-earn the previous rank.

Fixed preview:
![image](https://user-images.githubusercontent.com/13744167/152961615-95202e6c-25b0-4db7-8f34-9fe7ea1cec06.png)

## Manual Testing

- On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

DD-{number} #done
