### PR TITLE
fix: in some cases the close button was below the rank text

### DIFF
--- a/packages/shared/src/components/modals/ModalCloseButton.tsx
+++ b/packages/shared/src/components/modals/ModalCloseButton.tsx
@@ -11,7 +11,7 @@ function ModalCloseButtonComponent(
     <Button
       {...props}
       ref={ref}
-      className={classNames('btn-tertiary right-4 top-1', className)}
+      className={classNames('btn-tertiary right-4 top-1 z-1', className)}
       title="Close"
       icon={<XIcon />}
       style={{ position: 'absolute', ...style }}

--- a/packages/shared/src/components/modals/NewRankModal.tsx
+++ b/packages/shared/src/components/modals/NewRankModal.tsx
@@ -109,7 +109,7 @@ export default function NewRankModal({
     >
       <ModalCloseButton onClick={closeModal} />
       <div
-        className={`${styles.rankProgressContainer} relative flex items-center justify-center mt-6`}
+        className={`${styles.rankProgressContainer} relative flex items-center justify-center mt-6 z-0`}
       >
         {!user || !rankAnimationEnded ? (
           <RankProgress


### PR DESCRIPTION
## Changes

- Realised we had this issue open in regards to the new rank modal, so perfect time to fix it.
- Is was possible for the rank text to be overlapping the close button
- By setting a fixed z-index we ensure it's always higher.

## Manual Testing

- On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

DD-499 #done
