### PR TITLE
fix: :bug: We introduced a breaking close button in the bookmark branch

### DIFF
--- a/packages/shared/src/components/modals/ModalCloseButton.tsx
+++ b/packages/shared/src/components/modals/ModalCloseButton.tsx
@@ -11,10 +11,11 @@ function ModalCloseButtonComponent(
     <Button
       {...props}
       ref={ref}
-      className={classNames('btn-tertiary', className)}
+      className={classNames('btn-tertiary right-4 top-1 z-1', className)}
       buttonSize="small"
       title="Close"
       icon={<XIcon />}
+      style={{ position: 'absolute', ...style }}
     />
   );
 }


### PR DESCRIPTION
## Changes

- We removed the absolute position on the close button breaking the implementation
- Changed it back to absolute
- Fixed the position for the bookmarks (it was off from the top)

![Screenshot 2022-02-08 at 14 38 09](https://user-images.githubusercontent.com/554874/152988654-dba743f2-071e-47cc-b390-918f7181fa65.png)

## Manual Testing

- On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
