### PR TITLE
fix: fix the upvotes modal close button

### DIFF
--- a/packages/shared/src/components/modals/ModalCloseButton.tsx
+++ b/packages/shared/src/components/modals/ModalCloseButton.tsx
@@ -11,7 +11,7 @@ function ModalCloseButtonComponent(
     <Button
       {...props}
       ref={ref}
-      className={classNames('btn-tertiary right-4 top-1 z-1', className)}
+      className={classNames('btn-tertiary right-4 z-1', className)}
       buttonSize="small"
       title="Close"
       icon={<XIcon />}

--- a/packages/shared/src/components/modals/UpvotedPopupModal.tsx
+++ b/packages/shared/src/components/modals/UpvotedPopupModal.tsx
@@ -50,7 +50,7 @@ export function UpvotedPopupModal({
         },
       }}
     >
-      <header className="py-4 px-6 w-full border-b border-theme-divider-tertiary">
+      <header className="py-4 px-6 w-full border-b border-theme-divider-tertiary flex items-center">
         <h3 className="font-bold typo-title3">Upvoted by</h3>
         <ModalCloseButton onClick={onRequestClose} />
       </header>


### PR DESCRIPTION
## Changes

- The upvotes header was not justifying the items
- The top-1 class was not actually used
- We have another task to unify these modals so this won't happen again.

## Manual Testing

- On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?