### PR TITLE
fix: :bug: Fix the re-earn state for the popup modal

### DIFF
--- a/packages/shared/src/components/RankProgressWrapper.tsx
+++ b/packages/shared/src/components/RankProgressWrapper.tsx
@@ -83,6 +83,7 @@ export default function RankProgressWrapper({
           reads={reads}
           previousRank={rankLastWeek}
           devCardLimit={devCardLimit}
+          nextRank={nextRank}
         />
       )}
       {levelUp && shouldShowRankModal && (

--- a/packages/shared/src/components/modals/RanksModal/RanksBadges.tsx
+++ b/packages/shared/src/components/modals/RanksModal/RanksBadges.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import {
   getNextRankText,
-  getShowRank,
+  getRank,
   isFinalRank,
   RANKS,
   RANK_OFFSET,
@@ -17,10 +17,14 @@ import { ModalText } from '../common';
 const RanksBadges = ({
   rank,
   progress,
+  nextRank,
   previousRank,
 }: RanksBadgesProps): ReactElement => {
   const finalRank = isFinalRank(rank);
-  const showRank = getShowRank(rank, progress);
+  const showRank =
+    progress === RANKS[getRank(rank)].steps && rank !== RANKS.length
+      ? rank + 1
+      : rank;
 
   return (
     <RanksBadgesSection>
@@ -42,9 +46,10 @@ const RanksBadges = ({
       </RanksBadgesList>
       <ModalText className="mt-1 mb-3 text-center">
         {getNextRankText({
-          nextRank: rank + 1,
+          rankLastWeek: previousRank,
           rank,
           finalRank,
+          nextRank,
           progress,
           showNextLevel: false,
         })}

--- a/packages/shared/src/components/modals/RanksModal/common.tsx
+++ b/packages/shared/src/components/modals/RanksModal/common.tsx
@@ -6,6 +6,7 @@ import { ModalProps } from '../StyledModal';
 
 export interface RanksModalProps extends ModalProps {
   previousRank?: number;
+  nextRank?: number;
   rank: number;
   progress: number;
   tags: TopTags;
@@ -16,7 +17,7 @@ export interface RanksModalProps extends ModalProps {
 }
 export type RanksBadgesProps = Pick<
   RanksModalProps,
-  'rank' | 'progress' | 'previousRank'
+  'rank' | 'progress' | 'previousRank' | 'nextRank'
 >;
 
 export interface RankBadgeItemProps {

--- a/packages/shared/src/components/modals/RanksModal/index.tsx
+++ b/packages/shared/src/components/modals/RanksModal/index.tsx
@@ -24,6 +24,7 @@ export default function RanksModal({
   onRequestClose,
   className,
   previousRank,
+  nextRank,
   ...props
 }: RanksModalProps): ReactElement {
   const { user, showLogin } = useContext(AuthContext);
@@ -44,6 +45,7 @@ export default function RanksModal({
       <RanksBadges
         rank={rank}
         progress={progress}
+        nextRank={nextRank}
         previousRank={previousRank}
       />
       {!user && (


### PR DESCRIPTION
## Changes

- We did not take the previous rank into account when it comes to the re-earn for the popup.
- Also fixed the state of the badges in the popup

## Manual Testing

- On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
