### PR TITLE
fix: devcard overlap on sidebar

### DIFF
--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -179,7 +179,7 @@ const Step2 = ({
   return (
     <div className="flex flex-col self-stretch laptop:self-center mx-2 mt-5">
       <h1 className="mx-3 mb-8 font-bold typo-title1">Share your #DevCard</h1>
-      <main className="grid grid-cols-1 laptop:grid-cols-2 gap-10 laptop:gap-20">
+      <main className="grid grid-cols-1 laptopL:grid-cols-2 gap-10 laptop:gap-20">
         <section className="flex flex-col">
           <Tilt
             className="overflow-hidden relative self-stretch laptop:w-96"

--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -179,10 +179,10 @@ const Step2 = ({
   return (
     <div className="flex flex-col self-stretch laptop:self-center mx-2 mt-5">
       <h1 className="mx-3 mb-8 font-bold typo-title1">Share your #DevCard</h1>
-      <main className="grid grid-cols-1 laptop:grid-cols-2 gap-10 laptopL:gap-20">
+      <main className="flex flex-col laptop:flex-row gap-10 laptopL:gap-20">
         <section className="flex flex-col">
           <Tilt
-            className="overflow-hidden relative self-stretch laptop:w-96"
+            className="overflow-hidden relative self-stretch w-fit"
             glareEnable
             perspective={1000}
             glareMaxOpacity={0.25}
@@ -194,7 +194,7 @@ const Step2 = ({
             <LazyImage
               imgSrc={devCardSrc}
               imgAlt="Your Dev Card"
-              ratio="136.5%"
+              className="w-72 h-[25rem]"
               eager
             />
             {isLoadingImage && <LoaderOverlay invertColor />}
@@ -279,7 +279,7 @@ const Step2 = ({
           <div className="flex flex-col items-start self-stretch mt-10">
             <h4 className="mt-1 font-bold typo-caption1">Embed</h4>
             <textarea
-              className="self-stretch py-2 px-4 mt-1 laptop:w-80 bg-theme-float rounded-10 resize-none typo-body"
+              className="self-stretch py-2 px-4 mt-1 w-80 bg-theme-float rounded-10 resize-none laptopL:w-[25rem] typo-body"
               readOnly
               wrap="hard"
               style={{ height: rem(124) }}

--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -382,6 +382,6 @@ const DevCardPage = (): ReactElement => {
 };
 
 DevCardPage.getLayout = getMainLayout;
-// DevCardPage.layoutProps = { screenCentered: false };
+DevCardPage.layoutProps = { screenCentered: false };
 
 export default DevCardPage;

--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -179,7 +179,7 @@ const Step2 = ({
   return (
     <div className="flex flex-col self-stretch laptop:self-center mx-2 mt-5">
       <h1 className="mx-3 mb-8 font-bold typo-title1">Share your #DevCard</h1>
-      <main className="grid grid-cols-1 laptopL:grid-cols-2 gap-10 laptop:gap-20">
+      <main className="grid grid-cols-1 laptop:grid-cols-2 gap-10 laptopL:gap-20">
         <section className="flex flex-col">
           <Tilt
             className="overflow-hidden relative self-stretch laptop:w-96"
@@ -382,5 +382,6 @@ const DevCardPage = (): ReactElement => {
 };
 
 DevCardPage.getLayout = getMainLayout;
+// DevCardPage.layoutProps = { screenCentered: false };
 
 export default DevCardPage;


### PR DESCRIPTION
## Changes

The sidebar overlaps on the content - we have now changed the breakpoints.

Max size before breaking:
![Screen Shot 2022-02-10 at 7 11 45 PM](https://user-images.githubusercontent.com/13744167/153395511-b0528dd8-65a0-4fc9-87ab-da999f153631.png)

## Manual Testing

- On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

DD-{number} #done
