### PR TITLE
fix: :bug: Fix breaking on non-existing rank call

### DIFF
--- a/packages/shared/src/components/Rank.tsx
+++ b/packages/shared/src/components/Rank.tsx
@@ -221,10 +221,10 @@ const rankPaths: ((fill: string) => ReactNode)[] = [
 ];
 
 const getColorPath = (rank, id) => {
-  return rankPaths[rank > 0 ? getRank(rank) : 0](`url(#${id})`);
+  return rankPaths[getRank(rank)](`url(#${id})`);
 };
 const getOutlinePath = (rank) => {
-  return outlinePaths[rank > 0 ? getRank(rank) : 0];
+  return outlinePaths[getRank(rank)];
 };
 
 export default forwardRef(function Rank(

--- a/packages/shared/src/components/Rank.tsx
+++ b/packages/shared/src/components/Rank.tsx
@@ -8,6 +8,7 @@ import React, {
   useState,
 } from 'react';
 import classNames from 'classnames';
+import { getRank } from '../lib/rank';
 
 export interface RankProps extends HTMLAttributes<SVGElement> {
   rank: number;
@@ -220,10 +221,10 @@ const rankPaths: ((fill: string) => ReactNode)[] = [
 ];
 
 const getColorPath = (rank, id) => {
-  return rankPaths[rank > 0 ? rank - 1 : 0](`url(#${id})`);
+  return rankPaths[rank > 0 ? getRank(rank) : 0](`url(#${id})`);
 };
 const getOutlinePath = (rank) => {
-  return outlinePaths[rank > 0 ? rank - 1 : 0];
+  return outlinePaths[rank > 0 ? getRank(rank) : 0];
 };
 
 export default forwardRef(function Rank(

--- a/packages/shared/src/components/RankProgress.tsx
+++ b/packages/shared/src/components/RankProgress.tsx
@@ -98,7 +98,7 @@ export type RankProgressProps = {
 };
 
 const getRankName = (rank: number): string =>
-  rank > 0 ? RANKS[getRank(rank)].name : NO_RANK;
+  rank > 0 ? RANKS[rank - 1].name : NO_RANK;
 
 export function RankProgress({
   progress,

--- a/packages/shared/src/components/RankProgress.tsx
+++ b/packages/shared/src/components/RankProgress.tsx
@@ -98,7 +98,7 @@ export type RankProgressProps = {
 };
 
 const getRankName = (rank: number): string =>
-  rank > 0 ? RANKS[rank - 1].name : NO_RANK;
+  rank > 0 ? RANKS[getRank(rank)].name : NO_RANK;
 
 export function RankProgress({
   progress,
@@ -118,7 +118,7 @@ export function RankProgress({
   const [animatingProgress, setAnimatingProgress] = useState(false);
   const [forceColor, setForceColor] = useState(false);
   const [shownRank, setShownRank] = useState(
-    showRankAnimation ? rank - 1 : rank,
+    showRankAnimation ? getRank(rank) : rank,
   );
   const attentionRef = useRef<HTMLDivElement>();
   const progressRef = useRef<HTMLDivElement>();

--- a/packages/shared/src/components/RankProgressWrapper.tsx
+++ b/packages/shared/src/components/RankProgressWrapper.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { RankProgress } from './RankProgress';
 import useReadingRank from '../hooks/useReadingRank';
 import AuthContext from '../contexts/AuthContext';
-import { RANKS } from '../lib/rank';
+import { getRank, RANKS } from '../lib/rank';
 import FeaturesContext from '../contexts/FeaturesContext';
 import { Features, getFeatureValue } from '../lib/featureManagement';
 
@@ -59,7 +59,9 @@ export default function RankProgressWrapper({
         onClick={() => setShowRanksModal(true)}
       >
         <RankProgress
-          progress={showRankAnimation ? RANKS[nextRank - 1].steps : progress}
+          progress={
+            showRankAnimation ? RANKS[getRank(nextRank)].steps : progress
+          }
           rank={showRankAnimation ? nextRank : rank}
           nextRank={nextRank}
           showRankAnimation={showRankAnimation}

--- a/packages/shared/src/components/modals/NewRankModal.tsx
+++ b/packages/shared/src/components/modals/NewRankModal.tsx
@@ -82,7 +82,7 @@ export default function NewRankModal({
       } else {
         setAnimatingRank(true);
         setShownRank(rank);
-        setShownProgress(RANKS[rank - 1].steps);
+        setShownProgress(RANKS[getRank(rank)].steps);
       }
     };
 
@@ -123,8 +123,8 @@ export default function NewRankModal({
         ) : (
           <>
             <RadialProgress
-              progress={RANKS[rank - 1].steps}
-              steps={RANKS[rank - 1].steps}
+              progress={RANKS[getRank(rank)].steps}
+              steps={RANKS[getRank(rank)].steps}
               className={styles.radialProgress}
             />
             <img
@@ -158,7 +158,7 @@ export default function NewRankModal({
       </div>
       <h1 className="mt-2 font-bold text-center typo-callout">{title}</h1>
       <p className="mt-1 mb-8 text-center text-theme-label-secondary typo-callout">
-        You earned the {RANKS[rank - 1].name?.toLowerCase()} rank
+        You earned the {RANKS[getRank(rank)].name?.toLowerCase()} rank
         {!user && (
           <>
             <br />

--- a/packages/shared/src/components/modals/RanksModal/RankBadgeItem.tsx
+++ b/packages/shared/src/components/modals/RanksModal/RankBadgeItem.tsx
@@ -1,6 +1,7 @@
 import React, { CSSProperties, ReactElement } from 'react';
 import classNames from 'classnames';
 import {
+  getRank,
   isFinalRankCompleted,
   isRankCompleted,
   RANKS,
@@ -78,7 +79,7 @@ const RankBadgeItem = ({
                 '--radial-progress-completed-step': `var(--theme-rank-${
                   finalRankCompleted || previousRank === itemRank.level
                     ? showRank
-                    : showRank - 1
+                    : getRank(showRank)
                 }-color)`,
               } as CSSProperties
             }

--- a/packages/shared/src/lib/rank.ts
+++ b/packages/shared/src/lib/rank.ts
@@ -126,7 +126,7 @@ export const getNextRankText = ({
 
 export const isFinalRank = (rank: number): boolean => rank === RANKS.length;
 export const isFinalRankCompleted = (rank: number, progress: number): boolean =>
-  isFinalRank(rank) && progress === RANKS[rank - 1].steps;
+  isFinalRank(rank) && progress === RANKS[getRank(rank)].steps;
 export const getShowRank = (rank: number, progress: number): number => {
   if (isFinalRank(rank) || isFinalRank(progress)) {
     return rank;
@@ -141,6 +141,7 @@ export const isRankCompleted = (
 ): boolean => {
   return (
     currentRank > checkRank ||
-    (currentRank === RANKS.length && progress === RANKS[currentRank - 1].steps)
+    (currentRank === RANKS.length &&
+      progress === RANKS[getRank(currentRank)].steps)
   );
 };


### PR DESCRIPTION
## Changes

- We didn't implement `getRank` everywhere 
- In this case it was failing in the `NewRankModal`
- `You earned the {RANKS[rank - 1].name?.toLowerCase()} rank`
- Should have been:
- `You earned the {RANKS[getRank(rank)].name?.toLowerCase()} rank`

The case is that for rank 0 it will try and get -1 which doesn't exists.
Because of this danger I decided to implement the `getRank` function everywhere this pattern was used.
It can't really break since it will check if it's 0 or not.

Tested for these use-cases on webapp and extension now.

## Manual Testing

- On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
