### PR TITLE
fix: :bug: Making sure the mobile rank only shows on mobile

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -156,7 +156,7 @@ export default function MainLayout({
                 )}
               </>
             )}
-            <MobileHeaderRankProgress />
+            <MobileHeaderRankProgress sidebarRendered={sidebarRendered} />
           </>
         )}
       </header>

--- a/packages/shared/src/components/MobileHeaderRankProgress.tsx
+++ b/packages/shared/src/components/MobileHeaderRankProgress.tsx
@@ -27,7 +27,11 @@ export default function MobileHeaderRankProgress({
 }: MobileHeaderRankProgressProps): ReactElement {
   const { isLoading, rank, nextRank } = useReadingRank();
 
-  if (isLoading || sidebarRendered) {
+  if (sidebarRendered) {
+    return <></>;
+  }
+
+  if (isLoading) {
     return <Wrapper>&nbsp;</Wrapper>;
   }
 

--- a/packages/shared/src/components/MobileHeaderRankProgress.tsx
+++ b/packages/shared/src/components/MobileHeaderRankProgress.tsx
@@ -19,12 +19,19 @@ const Wrapper = ({ children, ...props }: WrapperProps) => {
   );
 };
 
-export default function MobileHeaderRankProgress(): ReactElement {
+interface MobileHeaderRankProgressProps {
+  sidebarRendered: boolean;
+}
+export default function MobileHeaderRankProgress({
+  sidebarRendered,
+}: MobileHeaderRankProgressProps): ReactElement {
   const { isLoading, rank, nextRank } = useReadingRank();
 
-  if (isLoading) {
+  if (isLoading || sidebarRendered) {
     return <Wrapper>&nbsp;</Wrapper>;
   }
+
+  console.log('did I make it?');
 
   return (
     <Wrapper

--- a/packages/shared/src/components/MobileHeaderRankProgress.tsx
+++ b/packages/shared/src/components/MobileHeaderRankProgress.tsx
@@ -31,8 +31,6 @@ export default function MobileHeaderRankProgress({
     return <Wrapper>&nbsp;</Wrapper>;
   }
 
-  console.log('did I make it?');
-
   return (
     <Wrapper
       style={


### PR DESCRIPTION
## Changes

- We always rendered the mobile header rank wrapper
- This wrapper contains the `NewRankModal` so it would show up twice on desktop.
- Added a `sidebarRendered` prop to it so it will render the empty wrapper on desktop.

## Manual Testing

- On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
