### PR TITLE
fix: feed page header content placement

### DIFF
--- a/packages/extension/src/newtab/CustomLinks.tsx
+++ b/packages/extension/src/newtab/CustomLinks.tsx
@@ -14,7 +14,7 @@ export function CustomLinks({
   onOptions,
 }: CustomLinksProps): ReactElement {
   return (
-    <div className="flex flex-row gap-2 p-2 rounded-14 border border-theme-divider-secondary">
+    <div className="hidden laptop:flex flex-row gap-2 p-2 rounded-14 border border-theme-divider-secondary">
       {links.map((url, i) => (
         <a
           href={url}

--- a/packages/shared/src/components/CreateMyFeedButton.tsx
+++ b/packages/shared/src/components/CreateMyFeedButton.tsx
@@ -59,7 +59,8 @@ const textClass = ({ sidebarExpanded }: ClassProps) => {
         : 'duration-0 delay-0 opacity-0',
     ),
     feed_top: 'typo-footnote ml-2 text-center tablet:text-left',
-    feed_title: 'typo-footnote text-center tablet:text-left',
+    feed_title:
+      'typo-footnote w-70 laptopL:w-auto text-center tablet:text-left',
     feed_ad: 'typo-body font-bold mx-6 text-center mb-6',
   };
 };

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -78,7 +78,7 @@ const getPropsByFeed = ({
 
 const LayoutHeader = classed(
   'header',
-  'flex flex-wrap overflow-x-auto relative justify-between items-center self-stretch mb-6 min-h-14 no-scrollbar',
+  'flex flex-row justify-between items-center overflow-x-auto relative justify-between items-center self-stretch mb-6 min-h-14 no-scrollbar',
 );
 
 export const getShouldRedirect = (
@@ -234,7 +234,7 @@ export default function MainFeedLayout({
   const header = (
     <LayoutHeader>
       {!isSearchOn && getFeedTitle()}
-      <div className="flex flex-col tablet:flex-row flex-wrap items-center mr-px w-full tablet:w-auto">
+      <div className="flex flex-row flex-wrap items-center mr-px">
         {navChildren}
         {isUpvoted && (
           <Dropdown
@@ -248,7 +248,7 @@ export default function MainFeedLayout({
         )}
         {sortingEnabled && isSortableFeed && (
           <Dropdown
-            className="mt-4 tablet:mt-0 tablet:ml-4 w-[10.25rem]"
+            className="laptop:ml-4 w-[10.25rem]"
             buttonSize="large"
             selectedIndex={selectedAlgo}
             options={algorithmsList}

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -234,11 +234,11 @@ export default function MainFeedLayout({
   const header = (
     <LayoutHeader>
       {!isSearchOn && getFeedTitle()}
-      <div className="flex flex-row flex-wrap items-center mr-px">
+      <div className="flex flex-row flex-wrap gap-4 items-center mr-px">
         {navChildren}
         {isUpvoted && (
           <Dropdown
-            className="ml-4 w-44"
+            className="w-44"
             buttonSize="large"
             icon={<CalendarIcon />}
             selectedIndex={selectedPeriod}
@@ -248,7 +248,7 @@ export default function MainFeedLayout({
         )}
         {sortingEnabled && isSortableFeed && (
           <Dropdown
-            className="laptop:ml-4 w-[10.25rem]"
+            className="w-[10.25rem]"
             buttonSize="large"
             selectedIndex={selectedAlgo}
             options={algorithmsList}

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -78,7 +78,7 @@ const getPropsByFeed = ({
 
 const LayoutHeader = classed(
   'header',
-  'flex flex-row justify-between items-center overflow-x-auto relative justify-between items-center self-stretch mb-6 min-h-14 no-scrollbar',
+  'flex justify-between items-center overflow-x-auto relative justify-between mb-6 min-h-14 no-scrollbar',
 );
 
 export const getShouldRedirect = (
@@ -232,7 +232,13 @@ export default function MainFeedLayout({
   };
 
   const header = (
-    <LayoutHeader>
+    <LayoutHeader
+      className={
+        myFeedPosition !== 'feed_title'
+          ? 'flex-row'
+          : 'flex-col tablet:flex-row'
+      }
+    >
       {!isSearchOn && getFeedTitle()}
       <div className="flex flex-row flex-wrap gap-4 items-center mr-px">
         {navChildren}


### PR DESCRIPTION
## Changes

Describe what this PR does
- Custom links should be hidden on tablet and below
- The dropdown should be in the same row with the title always

Previews:
![Screen Shot 2022-02-15 at 11 57 46 PM](https://user-images.githubusercontent.com/13744167/154099424-9278b9f9-472f-4f71-b87b-f00ab7cc00d1.png)

![Screen Shot 2022-02-15 at 11 58 03 PM](https://user-images.githubusercontent.com/13744167/154099487-12bf4d84-e0f6-4c77-8146-c917a7441f72.png)

![Screen Shot 2022-02-15 at 11 58 24 PM](https://user-images.githubusercontent.com/13744167/154099564-c002f80f-b970-4b2b-8ca3-d3a8d1178baa.png)

## Manual Testing

- On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

- Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

DD-{number} #done
