### PR TITLE
fix: profile tooltip rank version

### DIFF
--- a/packages/shared/src/components/profile/ProfileTooltip.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltip.tsx
@@ -45,6 +45,7 @@ export function ProfileTooltip({
     () =>
       request(`${apiUrl}/graphql`, USER_TOOLTIP_CONTENT_QUERY, {
         id: user.id,
+        version: 2,
       }),
     {
       refetchOnWindowFocus: false,

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -44,8 +44,8 @@ export const USER_READING_RANK_QUERY = gql`
 `;
 
 export const USER_TOOLTIP_CONTENT_QUERY = gql`
-  query UserTooltipContent($id: ID!) {
-    rank: userReadingRank(id: $id) {
+  query UserTooltipContent($id: ID!, $version: Int) {
+    rank: userReadingRank(id: $id, version: $version) {
       currentRank
     }
     tags: userMostReadTags(id: $id) {

--- a/packages/webapp/package-lock.json
+++ b/packages/webapp/package-lock.json
@@ -17319,22 +17319,6 @@
       "resolved": "https://registry.npmjs.org/react-swipeable/-/react-swipeable-6.2.0.tgz",
       "integrity": "sha512-nWQ8dEM8e/uswZLSIkXUsAnQmnX4MTcryOHBQIQYRMJFDpgDBSiVbKsz/BZVCIScF4NtJh16oyxwaNOepR6xSw=="
     },
-    "react-tooltip": {
-      "version": "4.2.21",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.21.tgz",
-      "integrity": "sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==",
-      "requires": {
-        "prop-types": "^15.7.2",
-        "uuid": "^7.0.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
-        }
-      }
-    },
     "react-transition-group": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -39,7 +39,6 @@
     "react-parallax-tilt": "^1.5.83",
     "react-query": "^3.34.8",
     "react-swipeable": "^6.2.0",
-    "react-tooltip": "^4.2.21",
     "react-transition-group": "^4.4.2",
     "react-virtual": "^2.10.0"
   },

--- a/packages/webapp/pages/[userId]/index.tsx
+++ b/packages/webapp/pages/[userId]/index.tsx
@@ -73,7 +73,7 @@ const readHistoryToTooltip = (
       <strong>
         {value.reads} article{value.reads > 1 ? 's' : ''} read
       </strong>
-      {' on'} {formattedDate}
+      &nbsp;on {formattedDate}
     </>
   );
 };

--- a/packages/webapp/pages/[userId]/index.tsx
+++ b/packages/webapp/pages/[userId]/index.tsx
@@ -32,13 +32,11 @@ import {
 } from '@dailydotdev/shared/src/components/profile/ActivitySection';
 import { ReadingTagProgress } from '@dailydotdev/shared/src/components/profile/ReadingTagProgress';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
-import dynamic from 'next/dynamic';
 import Rank from '@dailydotdev/shared/src/components/Rank';
 import { RANKS, RankHistoryProps } from '@dailydotdev/shared/src/lib/rank';
 import CommentsSection from '@dailydotdev/shared/src/components/profile/CommentsSection';
 import PostsSection from '@dailydotdev/shared/src/components/profile/PostsSection';
 import AuthorStats from '@dailydotdev/shared/src/components/profile/AuthorStats';
-import ProgressiveEnhancementContext from '@dailydotdev/shared/src/contexts/ProgressiveEnhancementContext';
 import { Dropdown } from '@dailydotdev/shared/src/components/fields/Dropdown';
 import useMedia from '@dailydotdev/shared/src/hooks/useMedia';
 import { laptop } from '@dailydotdev/shared/src/styles/media';
@@ -49,8 +47,6 @@ import {
   getStaticPaths as getProfileStaticPaths,
   ProfileLayoutProps,
 } from '../../components/layouts/ProfileLayout';
-
-const ReactTooltip = dynamic(() => import('react-tooltip'));
 
 export const getStaticProps = getProfileStaticProps;
 export const getStaticPaths = getProfileStaticPaths;
@@ -118,7 +114,6 @@ const getHistoryTitle = (
 };
 
 const ProfilePage = ({ profile }: ProfileLayoutProps): ReactElement => {
-  const { windowLoaded } = useContext(ProgressiveEnhancementContext);
   const { user, tokenRefreshed } = useContext(AuthContext);
   const fullHistory = useMedia([laptop.replace('@media ', '')], [true], false);
   const [selectedHistoryYear, setSelectedHistoryYear] = useState(0);
@@ -287,13 +282,6 @@ const ProfilePage = ({ profile }: ProfileLayoutProps): ReactElement => {
                 <div className="ml-2">More</div>
               </div>
             </div>
-            {windowLoaded && (
-              <ReactTooltip
-                backgroundColor="var(--balloon-color)"
-                delayHide={100}
-                html
-              />
-            )}
           </ActivityContainer>
         </>
       )}


### PR DESCRIPTION
## Changes

Describe what this PR does
- Profile Tooltip query to utilize version 2 of the reading rank
- Have also checked all existing implementations of query for `useReadingRank` all seem to use v2 now.
- Fixes the lacking of space in heatmap tooltip label
- Removed unused package

## Manual Testing

- On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

- Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [x] Laptop (1020px)

DD-{number} #done
