### PR TITLE
fix: width of the search bar

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -78,7 +78,7 @@ const getPropsByFeed = ({
 
 const LayoutHeader = classed(
   'header',
-  'flex justify-between items-center overflow-x-auto relative justify-between mb-6 min-h-14 no-scrollbar',
+  'flex justify-between items-center overflow-x-auto relative justify-between mb-6 min-h-14 w-full no-scrollbar',
 );
 
 export const getShouldRedirect = (


### PR DESCRIPTION
## Changes

- Since we fixed the search bar to `flex-1` we actually had to make sure the header spans 100% of the width.
- It's the `LayoutHeader` which is only used on the feed pages and tested as you can see in the screens.

## Manual Testing

- On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

- Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

![Screenshot 2022-02-23 at 09 31 28](https://user-images.githubusercontent.com/554874/155277968-8edc48c4-1e1b-41e9-84df-9de90d2a0c0c.png)
![Screenshot 2022-02-23 at 09 31 36](https://user-images.githubusercontent.com/554874/155277984-1c836f73-48a5-483d-860a-95dd3c54a1c2.png)

![Screenshot 2022-02-23 at 09 32 14](https://user-images.githubusercontent.com/554874/155278007-e86dfe1a-0835-4349-8c39-b127d3c6479d.png)
![Screenshot 2022-02-23 at 09 32 47](https://user-images.githubusercontent.com/554874/155278024-3f520eb8-951c-4c8a-a506-32e6f405e6ae.png)

![Screenshot 2022-02-23 at 09 32 22](https://user-images.githubusercontent.com/554874/155278029-83f76054-84a4-4113-943f-bf60c5ba3b88.png)
![Screenshot 2022-02-23 at 09 32 37](https://user-images.githubusercontent.com/554874/155278038-856f30c6-7be1-4c63-8401-d66f8abac739.png)

DD-559 #done
