### PR TITLE
fix: flaky tests for rank-related

### DIFF
--- a/packages/shared/src/components/SidebarRankProgress.spec.tsx
+++ b/packages/shared/src/components/SidebarRankProgress.spec.tsx
@@ -170,14 +170,10 @@ RANKS.forEach((rank) => {
       userId: null,
     });
     renderComponent([], null);
-    await waitFor(() => {
-      expect(screen.queryAllByTestId('completedPath').length).toEqual(
-        rank.level === 7 ? 1 : rank.steps,
-      );
-      expect(screen.queryAllByTestId('remainingPath').length).toEqual(
-        rank.level === 7 ? 0 : 1,
-      );
-    });
+    const completed = await screen.findAllByTestId('completedPath');
+    const remaining = await screen.findAllByTestId('remainingPath');
+    expect(completed.length).toEqual(rank.level === 7 ? 1 : rank.steps);
+    expect(remaining.length).toEqual(rank.level === 7 ? 0 : 1);
   });
 });
 

--- a/packages/shared/src/components/SidebarRankProgress.spec.tsx
+++ b/packages/shared/src/components/SidebarRankProgress.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, RenderResult, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { act } from 'react-dom/test-utils';
 import nock from 'nock';
 import { set as setCache } from 'idb-keyval';
 import {
@@ -192,6 +193,7 @@ RANKS.forEach((rank) => {
       userId: null,
     });
     renderComponent([], null);
+    await act(() => new Promise((resolve) => setTimeout(resolve, 500)));
     await waitFor(() => {
       expect(screen.queryAllByTestId('completedPath').length).toEqual(
         rank.steps - 1,

--- a/packages/shared/src/components/SidebarRankProgress.spec.tsx
+++ b/packages/shared/src/components/SidebarRankProgress.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { render, RenderResult, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { act } from 'react-dom/test-utils';
 import nock from 'nock';
 import { set as setCache } from 'idb-keyval';
 import {
@@ -193,7 +192,6 @@ RANKS.forEach((rank) => {
       userId: null,
     });
     renderComponent([], null);
-    await act(() => new Promise((resolve) => setTimeout(resolve, 500)));
     await waitFor(() => {
       expect(screen.queryAllByTestId('completedPath').length).toEqual(
         rank.steps - 1,

--- a/packages/shared/src/components/SidebarRankProgress.spec.tsx
+++ b/packages/shared/src/components/SidebarRankProgress.spec.tsx
@@ -170,10 +170,14 @@ RANKS.forEach((rank) => {
       userId: null,
     });
     renderComponent([], null);
-    const completed = await screen.findAllByTestId('completedPath');
-    const remaining = await screen.findAllByTestId('remainingPath');
-    expect(completed.length).toEqual(rank.level === 7 ? 1 : rank.steps);
-    expect(remaining.length).toEqual(rank.level === 7 ? 0 : 1);
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('completedPath').length).toEqual(
+        rank.level === 7 ? 1 : rank.steps,
+      );
+      expect(screen.queryAllByTestId('remainingPath').length).toEqual(
+        rank.level === 7 ? 0 : 1,
+      );
+    });
   });
 });
 

--- a/packages/shared/src/hooks/useReadingRank.ts
+++ b/packages/shared/src/hooks/useReadingRank.ts
@@ -165,16 +165,7 @@ export default function useReadingRank(
   // For anonymous users
   useEffect(() => {
     if (loadedCache && tokenRefreshed) {
-      if (cachedRank?.userId !== user?.id) {
-        // Reset cache on user change
-        if (remoteRank) {
-          cacheRank();
-        } else if (user) {
-          setCachedRank(null);
-        } else {
-          cacheRank(defaultRank);
-        }
-      } else if (!user) {
+      if (!user) {
         // Check anonymous progress
         let rank = cachedRank ?? defaultRank;
         if (rank.rank.lastReadTime) {
@@ -182,6 +173,15 @@ export default function useReadingRank(
             rank = defaultRank;
           } else if (rank.rank.readToday && !isToday(rank.rank.lastReadTime)) {
             rank.rank.readToday = false;
+          }
+        } else if (cachedRank?.userId !== user?.id) {
+          // Reset cache on user change
+          if (remoteRank) {
+            cacheRank();
+          } else if (user) {
+            setCachedRank(null);
+          } else {
+            cacheRank(defaultRank);
           }
         }
         queryClient.setQueryData<MyRankData>(queryKey, rank);

--- a/packages/shared/src/hooks/useReadingRank.ts
+++ b/packages/shared/src/hooks/useReadingRank.ts
@@ -187,7 +187,7 @@ export default function useReadingRank(
         queryClient.setQueryData<MyRankData>(queryKey, rank);
       }
     }
-  }, [user, tokenRefreshed, loadedCache]);
+  }, [user, tokenRefreshed, loadedUserFromCache, loadedCache]);
 
   return {
     isLoading: !cachedRank,


### PR DESCRIPTION
## Changes

Describe what this PR does
- fixed a condition where it always passes when since the user is not yet loaded when triggered

## Manual Testing

- On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

- Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [x] Laptop (1020px)

DD-565 #done
