### PR TITLE
fix: We forgot to add dynamic fonts on the ads

### DIFF
--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -191,6 +191,7 @@ export default function FeedItemComponent({
           onRender={(ad) => onAdRender(ad, index, row, column)}
           onLinkClick={(ad) => onAdClick(ad, index, row, column)}
           showImage={!insaneMode}
+          postHeadingFont={postHeadingFont}
         />
       );
     default:

--- a/packages/shared/src/components/cards/AdCard.tsx
+++ b/packages/shared/src/components/cards/AdCard.tsx
@@ -5,6 +5,7 @@ import React, {
   Ref,
   useEffect,
 } from 'react';
+import classNames from 'classnames';
 import {
   Card,
   CardImage,
@@ -24,10 +25,18 @@ export type AdCardProps = {
   onRender?: Callback;
   onLinkClick?: Callback;
   showImage?: boolean;
+  postHeadingFont: string;
 } & HTMLAttributes<HTMLDivElement>;
 
 export const AdCard = forwardRef(function AdCard(
-  { ad, onRender, onLinkClick, showImage = true, ...props }: AdCardProps,
+  {
+    ad,
+    onRender,
+    onLinkClick,
+    showImage = true,
+    postHeadingFont,
+    ...props
+  }: AdCardProps,
   ref: Ref<HTMLElement>,
 ): ReactElement {
   const showBlurredImage = ad.source === 'Carbon';
@@ -40,7 +49,9 @@ export const AdCard = forwardRef(function AdCard(
     <Card {...props} ref={ref}>
       <AdLink ad={ad} onLinkClick={onLinkClick} />
       <CardTextContainer>
-        <CardTitle className="my-4 line-clamp-4">{ad.description}</CardTitle>
+        <CardTitle className={classNames('my-4 line-clamp-4', postHeadingFont)}>
+          {ad.description}
+        </CardTitle>
       </CardTextContainer>
       <CardSpace />
       {showImage && (

--- a/packages/shared/src/components/cards/AdList.tsx
+++ b/packages/shared/src/components/cards/AdList.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, ReactElement, Ref, useEffect } from 'react';
+import classNames from 'classnames';
 import { AdCardProps } from './AdCard';
 import {
   ListCard,
@@ -11,7 +12,7 @@ import AdLink from './AdLink';
 import AdAttribution from './AdAttribution';
 
 export const AdList = forwardRef(function AdList(
-  { ad, onRender, onLinkClick, ...props }: AdCardProps,
+  { ad, onRender, onLinkClick, postHeadingFont, ...props }: AdCardProps,
   ref: Ref<HTMLElement>,
 ): ReactElement {
   useEffect(() => {
@@ -24,7 +25,9 @@ export const AdList = forwardRef(function AdList(
       <ListCardAside />
       <ListCardDivider />
       <ListCardMain>
-        <ListCardTitle className="line-clamp-4">{ad.description}</ListCardTitle>
+        <ListCardTitle className={classNames('line-clamp-4', postHeadingFont)}>
+          {ad.description}
+        </ListCardTitle>
         <AdAttribution ad={ad} className="mt-2" />
       </ListCardMain>
     </ListCard>


### PR DESCRIPTION
## Changes

- With the introduction of the dynamic font AB test we forgot to add the fonts to the ad cards

Test case:
<img width="665" alt="Screenshot 2022-03-04 at 17 12 23" src="https://user-images.githubusercontent.com/554874/156789198-8e0dd31b-b824-4b91-ace2-b0db080ae783.png">

## Manual Testing

- On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

- Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)
