### PR TITLE
fix: preview min height

### DIFF
--- a/packages/shared/src/components/Markdown.tsx
+++ b/packages/shared/src/components/Markdown.tsx
@@ -1,15 +1,23 @@
-import React, { ReactElement } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 import { sanitize } from 'dompurify';
+import classNames from 'classnames';
 import styles from './markdown.module.css';
+
+interface MarkdownProps {
+  content: string;
+  style?: CSSProperties;
+  className?: string;
+}
 
 export default function Markdown({
   content,
-}: {
-  content: string;
-}): ReactElement {
+  style,
+  className,
+}: MarkdownProps): ReactElement {
   return (
     <div
-      className={styles.markdown}
+      className={classNames(styles.markdown, className)}
+      style={style}
       dangerouslySetInnerHTML={{
         __html: sanitize(content, { ADD_ATTR: ['target'] }),
       }}

--- a/packages/shared/src/components/modals/NewCommentModal.tsx
+++ b/packages/shared/src/components/modals/NewCommentModal.tsx
@@ -268,7 +268,7 @@ export default function NewCommentModal({
         </Tab>
         <Tab
           label="Preview"
-          style={{ minHeight: '28rem' }}
+          style={{ minHeight: '27.175rem' }}
           className="flex flex-col"
         >
           {isPreview && previewContent?.preview && (

--- a/packages/shared/src/components/modals/NewCommentModal.tsx
+++ b/packages/shared/src/components/modals/NewCommentModal.tsx
@@ -268,11 +268,15 @@ export default function NewCommentModal({
         </Tab>
         <Tab
           label="Preview"
-          style={{ minHeight: '27.175rem' }}
+          style={{ height: '27.175rem' }}
           className="flex flex-col"
         >
           {isPreview && previewContent?.preview && (
-            <Markdown content={previewContent.preview} />
+            <Markdown
+              style={{ height: '22.5rem' }}
+              className="overflow-y-auto"
+              content={previewContent.preview}
+            />
           )}
           {isPreview && (
             <Button


### PR DESCRIPTION
## Changes

Describe what this PR does
- since we have fixed the additional button in the preview mode, the height changed, so it the min-height should.

## Manual Testing

- On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

- Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

DD-{number} #done
