### PR TITLE
fix: remove amplitude cache key

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -5,7 +5,7 @@ browser.browserAction.onClicked.addListener(() => {
   browser.tabs.create({ url, active: true });
 });
 
-browser.runtime.onInstalled.addListener(async (details) => {
+browser.runtime.onInstalled.addListener(async () => {
   await Promise.all([
     browser.runtime.setUninstallURL('https://daily.dev/uninstall'),
   ]);

--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -1,19 +1,4 @@
-import { browser, Runtime } from 'webextension-polyfill-ts';
-import { getBootData } from '@dailydotdev/shared/src/lib/boot';
-
-const cacheAmplitudeDeviceId = async ({
-  reason,
-}: Runtime.OnInstalledDetailsType): Promise<void> => {
-  if (reason === 'install') {
-    const boot = await getBootData('extension');
-    if (boot.visit.ampStorage) {
-      localStorage.setItem(
-        `amp_${process.env.NEXT_PUBLIC_AMPLITUDE.slice(0, 6)}`,
-        boot.visit.ampStorage,
-      );
-    }
-  }
-};
+import { browser } from 'webextension-polyfill-ts';
 
 browser.browserAction.onClicked.addListener(() => {
   const url = browser.extension.getURL('index.html?source=button');
@@ -22,7 +7,6 @@ browser.browserAction.onClicked.addListener(() => {
 
 browser.runtime.onInstalled.addListener(async (details) => {
   await Promise.all([
-    cacheAmplitudeDeviceId(details),
     browser.runtime.setUninstallURL('https://daily.dev/uninstall'),
   ]);
 });


### PR DESCRIPTION
## Changes

- We forgot to remove the amplitude cache key

## Manual Testing

- On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

- Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

DD-{number} #done
