### PR TITLE
fix: interactiveness of mention popup

### DIFF
--- a/packages/shared/src/components/Markdown.tsx
+++ b/packages/shared/src/components/Markdown.tsx
@@ -4,6 +4,7 @@ import styles from './markdown.module.css';
 import { ProfileTooltip } from './profile/ProfileTooltip';
 import { useProfileTooltip } from '../hooks/useProfileTooltip';
 import { CaretOffset } from '../lib/element';
+import useDebounce from '../hooks/useDebounce';
 
 interface MarkdownProps {
   content: string;
@@ -20,6 +21,7 @@ export default function Markdown({ content }: MarkdownProps): ReactElement {
     userId,
     requestUserInfo: true,
   });
+  const [clearUser, cancelUserClearing] = useDebounce(() => setUserId(''), 200);
 
   useEffect(() => {
     if (!content || !ref?.current) {
@@ -50,22 +52,21 @@ export default function Markdown({ content }: MarkdownProps): ReactElement {
         topOffset * -1 + TOOLTIP_SPACING,
       ];
 
+      cancelUserClearing();
       setOffset(result);
       setUserId(id);
     };
 
-    const onMouseOut = () => setUserId('');
-
     elements.forEach((element) => {
       element.addEventListener('mouseenter', onHover);
-      element.addEventListener('mouseleave', onMouseOut);
+      element.addEventListener('mouseleave', clearUser);
     });
 
     // eslint-disable-next-line consistent-return
     return () => {
       elements.forEach((element) => {
         element.removeEventListener('mouseenter', onHover);
-        element.removeEventListener('mouseleave', onMouseOut);
+        element.removeEventListener('mouseleave', clearUser);
       });
     };
   }, [content, userId]);
@@ -85,6 +86,8 @@ export default function Markdown({ content }: MarkdownProps): ReactElement {
         offset,
         visible: !!userId,
       }}
+      onMouseEnter={cancelUserClearing}
+      onMouseLeave={clearUser}
     >
       <div
         ref={ref}

--- a/packages/shared/src/components/Markdown.tsx
+++ b/packages/shared/src/components/Markdown.tsx
@@ -85,6 +85,7 @@ export default function Markdown({ content }: MarkdownProps): ReactElement {
         placement: 'top-start',
         offset,
         visible: !!userId,
+        onShow: cancelUserClearing,
       }}
       onMouseEnter={cancelUserClearing}
       onMouseLeave={clearUser}

--- a/packages/shared/src/components/PostsSearch.tsx
+++ b/packages/shared/src/components/PostsSearch.tsx
@@ -94,7 +94,7 @@ export default function PostsSearch({
   };
 
   const { selectedItemIndex, onKeyDown } = useAutoComplete(items, submitQuery);
-  const debounceQuery = useDebounce<string>((value) => setQuery(value), 100);
+  const [debounceQuery] = useDebounce<string>((value) => setQuery(value), 100);
   const onValueChanged = (value: string) => {
     if (!value.length) {
       hideMenu();

--- a/packages/shared/src/components/profile/ProfileTooltip.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltip.tsx
@@ -30,6 +30,7 @@ export function ProfileTooltip({
   user,
   link,
   tooltip = {},
+  ...rest
 }: Omit<ProfileTooltipProps, 'user'> & {
   user?: Partial<Author>;
 }): ReactElement {
@@ -48,7 +49,7 @@ export function ProfileTooltip({
     },
     content:
       data?.user && !isLoading ? (
-        <ProfileTooltipContent user={data.user} data={data} />
+        <ProfileTooltipContent user={data.user} data={data} {...rest} />
       ) : null,
     ...tooltip,
   };

--- a/packages/shared/src/components/profile/ProfileTooltipContent.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltipContent.tsx
@@ -9,14 +9,22 @@ import { UserTooltipContentData } from '../../hooks/useProfileTooltip';
 export interface ProfileTooltipContentProps {
   user: Author;
   data?: UserTooltipContentData;
+  onMouseEnter?: () => unknown;
+  onMouseLeave?: () => unknown;
 }
 
 export function ProfileTooltipContent({
   user,
   data: { rank, tags },
+  onMouseEnter,
+  onMouseLeave,
 }: ProfileTooltipContentProps): ReactElement {
   return (
-    <div className="flex flex-col font-normal shrink typo-callout">
+    <div
+      className="flex flex-col font-normal shrink typo-callout"
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
       <div className="relative w-fit">
         <ProfileImageLink user={user} picture={{ size: 'xxlarge' }} />
         {rank && (

--- a/packages/shared/src/components/tooltips/BaseTooltip.tsx
+++ b/packages/shared/src/components/tooltips/BaseTooltip.tsx
@@ -25,6 +25,7 @@ export interface TooltipProps
     | 'delay'
     | 'interactive'
     | 'onTrigger'
+    | 'onShow'
     | 'duration'
     | 'visible'
     | 'offset'

--- a/packages/shared/src/components/tooltips/SimpleTooltip.tsx
+++ b/packages/shared/src/components/tooltips/SimpleTooltip.tsx
@@ -14,6 +14,7 @@ export function SimpleTooltip({
   children,
   content,
   onTrigger,
+  onShow,
   ...props
 }: TooltipProps): ReactElement {
   /**
@@ -47,6 +48,14 @@ export function SimpleTooltip({
     shouldShow = true;
   };
 
+  const onTooltipShow = (_) => {
+    if (shouldShow) {
+      return onShow?.(_);
+    }
+
+    return false;
+  };
+
   return (
     <TippyTooltip
       {...props}
@@ -54,7 +63,7 @@ export function SimpleTooltip({
       content={content}
       onTrigger={onTooltipTrigger}
       onUntrigger={onUntrigger}
-      onShow={() => shouldShow}
+      onShow={onTooltipShow}
     >
       {component}
     </TippyTooltip>

--- a/packages/shared/src/hooks/analytics/useAnalyticsQueue.ts
+++ b/packages/shared/src/hooks/analytics/useAnalyticsQueue.ts
@@ -41,7 +41,7 @@ export default function useAnalyticsQueue(): {
   );
 
   const queueRef = useRef<AnalyticsEvent[]>([]);
-  const debouncedSendEvents = useDebounce(() => {
+  const [debouncedSendEvents] = useDebounce(() => {
     if (enabledRef.current && queueRef.current.length) {
       const queue = queueRef.current;
       queueRef.current = [];

--- a/packages/shared/src/hooks/useDebounce.spec.ts
+++ b/packages/shared/src/hooks/useDebounce.spec.ts
@@ -5,16 +5,16 @@ import useDebounce from './useDebounce';
 it('should call the callback only once', async () => {
   const mock = jest.fn();
   const { result } = renderHook(() => useDebounce(mock, 10));
-  result.current();
-  result.current();
+  result[0].current();
+  result[0].current();
   await waitFor(() => expect(mock).toBeCalledTimes(1));
 });
 
 it('should call the callback again after the cooldown period', async () => {
   const mock = jest.fn();
   const { result } = renderHook(() => useDebounce(mock, 10));
-  result.current();
+  result[0].current();
   await waitFor(() => expect(mock).toBeCalledTimes(1));
-  result.current();
+  result[0].current();
   await waitFor(() => expect(mock).toBeCalledTimes(2));
 });

--- a/packages/shared/src/hooks/useDebounce.spec.ts
+++ b/packages/shared/src/hooks/useDebounce.spec.ts
@@ -5,16 +5,18 @@ import useDebounce from './useDebounce';
 it('should call the callback only once', async () => {
   const mock = jest.fn();
   const { result } = renderHook(() => useDebounce(mock, 10));
-  result[0].current();
-  result[0].current();
+  const [callback] = result.current as ReturnType<typeof useDebounce>;
+  callback();
+  callback();
   await waitFor(() => expect(mock).toBeCalledTimes(1));
 });
 
 it('should call the callback again after the cooldown period', async () => {
   const mock = jest.fn();
   const { result } = renderHook(() => useDebounce(mock, 10));
-  result[0].current();
+  const [callback] = result.current as ReturnType<typeof useDebounce>;
+  callback();
   await waitFor(() => expect(mock).toBeCalledTimes(1));
-  result[0].current();
+  callback();
   await waitFor(() => expect(mock).toBeCalledTimes(2));
 });

--- a/packages/shared/src/hooks/useUserMention.ts
+++ b/packages/shared/src/hooks/useUserMention.ts
@@ -77,7 +77,7 @@ export function useUserMention({
       },
     );
   const { recommendedMentions: mentions } = data;
-  const fetchUsers = useDebounce(refetch, 100);
+  const [fetchUsers] = useDebounce(refetch, 100);
 
   const initializeMention = async (isInvalidCallback?: () => unknown) => {
     await nextTick();


### PR DESCRIPTION
## Changes

### Describe what this PR does
- In my previous PR we introduced manual handling of state on where we should display the tooltip or not. Unfortunately, it introduced an edge case where the popup lost its interactiveness.
- Also refactored the use debounce hook to be cancellable
- Fixed the primary concern in this PR

Verified workability in this link: https://daily-webapp-i28cjgu9g-dailydotdev.vercel.app/posts/RcIbqXVDf

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

DD-{number} #done
