### PR TITLE
build: Fixed a duplicate volumes issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3"
 
 volumes:
   db:
+  pg:
   redis:
 
 services:
@@ -29,10 +30,9 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./pg-init-scripts:/docker-entrypoint-initdb.d
-      - db:/var/lib/postgresql/data
+      - pg:/var/lib/postgresql/data
     environment:
-      - POSTGRES_MULTIPLE_DATABASES=api,api_test
+      - POSTGRES_DB=api
       - POSTGRES_PASSWORD=12345
     command:
       - "postgres"


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We used a duplicate `db` image for the mysql and postgres image, this caused the postgres to exit pre-install
- Moved the postgres to it's own `pg` volume

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
N/A

### Did you test the modified components media queries?
N/A