### PR TITLE
fix: explicitly defining the start date of heatmap

### DIFF
--- a/packages/shared/src/components/history/ReadingHistory.spec.tsx
+++ b/packages/shared/src/components/history/ReadingHistory.spec.tsx
@@ -13,6 +13,7 @@ import ReadHistoryList, { ReadHistoryListProps } from './ReadingHistoryList';
 import { ReadHistoryInfiniteData } from '../../hooks/useInfiniteReadingHistory';
 import AuthContext from '../../contexts/AuthContext';
 import user from '../../../__tests__/fixture/loggedUser';
+import { getLabel } from '../../lib/dateFormat.spec';
 
 beforeEach(() => {
   nock.cleanAll();
@@ -103,28 +104,6 @@ describe('ReadingHistoryList component', () => {
     renderComponent();
     await screen.findByText('Yesterday');
   });
-
-  const getLabel = (toCompare: Date) => {
-    const today = new Date();
-
-    if (
-      isSameDay(today, toCompare) &&
-      isSameMonth(today, toCompare) &&
-      isSameYear(today, toCompare)
-    ) {
-      return 'Today';
-    }
-
-    if (
-      isSameDay(subDays(today, 1), toCompare) &&
-      isSameMonth(today, toCompare) &&
-      isSameYear(today, toCompare)
-    ) {
-      return 'Yesterday';
-    }
-
-    return '';
-  };
 
   it('should show date section for reads of the same year', async () => {
     const weekday = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][

--- a/packages/shared/src/components/history/ReadingHistory.spec.tsx
+++ b/packages/shared/src/components/history/ReadingHistory.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { isSameDay, isSameMonth, isSameYear, subDays } from 'date-fns';
+import { subDays } from 'date-fns';
 import {
   fireEvent,
   render,

--- a/packages/shared/src/components/history/ReadingHistory.spec.tsx
+++ b/packages/shared/src/components/history/ReadingHistory.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { subDays } from 'date-fns';
+import { isSameDay, isSameMonth, isSameYear, subDays } from 'date-fns';
 import {
   fireEvent,
   render,
@@ -43,6 +43,7 @@ describe('ReadingHistoryList component', () => {
     createdThisYear,
     createdAtDifferentYear,
   ];
+  const sorted = timestamps.sort((a, b) => a.getTime() - b.getTime());
   const post = {
     id: 'p1',
     title: 'Most Recent Post',
@@ -57,7 +58,7 @@ describe('ReadingHistoryList component', () => {
       {
         readHistory: {
           pageInfo: { hasNextPage: true, endCursor: '' },
-          edges: timestamps.map((timestamp, index) => ({
+          edges: sorted.map((timestamp, index) => ({
             node: { timestamp, post: { ...post, id: `p${index}` } },
           })),
         },
@@ -103,14 +104,36 @@ describe('ReadingHistoryList component', () => {
     await screen.findByText('Yesterday');
   });
 
+  const getLabel = (toCompare: Date) => {
+    const today = new Date();
+
+    if (
+      isSameDay(today, toCompare) &&
+      isSameMonth(today, toCompare) &&
+      isSameYear(today, toCompare)
+    ) {
+      return 'Today';
+    }
+
+    if (
+      isSameDay(subDays(today, 1), toCompare) &&
+      isSameMonth(today, toCompare) &&
+      isSameYear(today, toCompare)
+    ) {
+      return 'Yesterday';
+    }
+
+    return '';
+  };
+
   it('should show date section for reads of the same year', async () => {
-    const year = new Date().getFullYear();
-    const date = new Date(`${year}-03-31 07:15:51.247`);
     const weekday = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][
-      date.getDay()
+      createdThisYear.getDay()
     ];
     renderComponent();
-    await screen.findByText(`${weekday}, 31 Mar`);
+    const label = getLabel(createdThisYear) || `${weekday}, 31 Mar`;
+    expect(label).toEqual('Today');
+    await screen.findByText(label);
   });
 
   it('should show date section for reads of the different year', async () => {

--- a/packages/shared/src/lib/dateFormat.spec.ts
+++ b/packages/shared/src/lib/dateFormat.spec.ts
@@ -1,11 +1,26 @@
-import { subDays } from 'date-fns';
+import { addDays, subDays } from 'date-fns';
 import {
   postDateFormat,
   commentDateFormat,
   getReadHistoryDateFormat,
+  isDateOnlyEqual,
 } from './dateFormat';
 
 const now = new Date(2020, 5, 1, 12, 0, 0);
+
+export const getLabel = (toCompare: Date): string => {
+  const today = new Date();
+
+  if (isDateOnlyEqual(today, toCompare)) {
+    return 'Today';
+  }
+
+  if (isDateOnlyEqual(today, addDays(toCompare, 1))) {
+    return 'Yesterday';
+  }
+
+  return '';
+};
 
 describe('postDateFormat', () => {
   it('should return "Now" when less than a minute', () => {
@@ -96,8 +111,7 @@ describe('getReadHistoryDateFormat', () => {
     const weekday = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][
       date.getDay()
     ];
-    const expected = `${weekday}, 31 Mar`;
-
+    const expected = getLabel(date) || `${weekday}, 31 Mar`;
     const actual = getReadHistoryDateFormat(date);
     expect(actual).toEqual(expected);
   });

--- a/packages/webapp/pages/[userId]/index.tsx
+++ b/packages/webapp/pages/[userId]/index.tsx
@@ -126,8 +126,8 @@ const ProfilePage = ({ profile }: ProfileLayoutProps): ReactElement => {
       const start = startOfTomorrow();
       return [start, subYears(subDays(start, 2), 1)];
     }
-    const startYear = new Date(0);
-    startYear.setFullYear(parseInt(dropdownOptions[selectedHistoryYear], 10));
+    const selected = parseInt(dropdownOptions[selectedHistoryYear], 10);
+    const startYear = new Date(`01-01-${selected}`);
     return [addDays(endOfYear(startYear), 1), startYear];
   }, [selectedHistoryYear]);
   const [readingHistory, setReadingHistory] =


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The core issue was when generating the heatmap - we have a function that creates an array, based on the week columns we will have to create.
- The concern came from the way we generate the start date - we utilize the function `new Date(0)` and set its year. Unfortunately, it looks like from `UTC-1` and lower, the value it returns is `31-12-1969` which is supposed to be `01-01-1970`.
- To avoid the incorrect start date, I have now explicitly defined that the calculation should start at `01-01-YYYY` based on the selected year.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

## Relevant Issues
- https://github.com/dailydotdev/daily/issues/501

DD-573 #done
