### PR TITLE
feat(NewSourceModal.tsx): adding link to Content guidelines

### DIFF
--- a/packages/shared/src/components/modals/NewSourceModal.tsx
+++ b/packages/shared/src/components/modals/NewSourceModal.tsx
@@ -17,6 +17,7 @@ import { Radio } from '../fields/Radio';
 import { formToJson } from '../../lib/form';
 import { apiUrl } from '../../lib/config';
 import fetchTimeout from '../../lib/fetchTimeout';
+import { contentGuidlines } from '../../lib/constants';
 import {
   REQUEST_SOURCE_MUTATION,
   SOURCE_BY_FEED_QUERY,
@@ -245,6 +246,14 @@ export default function NewSourceModal(props: ModalProps): ReactElement {
         Have an idea for a new source? Insert its link below to add it to the
         feed.
       </p>
+      <a
+        className="font-bold underline text-theme-label-link"
+        target="_blank"
+        rel="noopener"
+        href={contentGuidlines}
+      >
+        Content guidelines
+      </a>
       <form
         className="flex flex-col px-10 w-full"
         ref={scrapeFormRef}

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -11,6 +11,7 @@ export const reputationGuide =
   'https://daily.dev/posts/what-is-reputation-how-do-i-earn-it';
 export const ownershipGuide =
   'https://daily.dev/posts/claiming-ownership-on-an-article-you-wrote';
+export const contentGuidlines = 'https://daily.dev/support/content-guidelines';
 
 export const isDevelopment = process.env.NODE_ENV === 'development';
 export const isProduction = process.env.NODE_ENV === 'production';


### PR DESCRIPTION
## Changes

### Describe what this PR does
Adding Content guidelines link to new source modal
![image](https://user-images.githubusercontent.com/37303618/161298841-aefd6d7c-39a3-4edc-a742-33bfd8f567c0.png)

Closes dailydotdev/daily#297

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

DD-{number} #done
