### PR TITLE
build: update next-pwa to the latest version

### DIFF
--- a/packages/extension/package-lock.json
+++ b/packages/extension/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "extension",
-	"version": "3.15.4",
+	"version": "3.15.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/webapp/package-lock.json
+++ b/packages/webapp/package-lock.json
@@ -4,10 +4,18 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@ampproject/remapping": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+			"integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+			"requires": {
+				"@jridgewell/trace-mapping": "^0.3.0"
+			}
+		},
 		"@apideck/better-ajv-errors": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.2.tgz",
-			"integrity": "sha512-JdEazx7qiVqTBzzBl5rolRwl5cmhihjfIcpqRzIZjtT6b18liVmDn/VlWpqW4C/qP2hrFFMLRV1wlex8ZVBPTg==",
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.3.tgz",
+			"integrity": "sha512-9o+HO2MbJhJHjDYZaDxJmSDckvDpiuItEsrIShV0DXeCshXWRHhqYyU/PKHMkuClOmFnZhRd6wzv4vpDu/dRKg==",
 			"requires": {
 				"json-schema": "^0.4.0",
 				"jsonpointer": "^5.0.0",
@@ -3561,6 +3569,25 @@
 				}
 			}
 		},
+		"@jridgewell/resolve-uri": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+			"integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew=="
+		},
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.4.11",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
+			"integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg=="
+		},
+		"@jridgewell/trace-mapping": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
+			"integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+			"requires": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
 		"@napi-rs/triples": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.1.0.tgz",
@@ -3768,9 +3795,9 @@
 			"integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
 		},
 		"@rollup/plugin-babel": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz",
-			"integrity": "sha512-9uIC8HZOnVLrLHxayq/PTzw+uS25E14KPUBh5ktF+18Mjo5yK0ToMMx6epY0uEgkjwJw0aBW4x2horYXh8juWw==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
+			"integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.10.4",
 				"@rollup/pluginutils": "^3.1.0"
@@ -3803,11 +3830,11 @@
 					"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
 				},
 				"resolve": {
-					"version": "1.21.0",
-					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
-					"integrity": "sha512-3wCbTpk5WJlyE4mSOtDLhqQmGFi0/TD9VPwmiolnk8U0wRgMEktqCXd3vy5buTO3tljvalNvKrjHEfrd2WpEKA==",
+					"version": "1.22.0",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+					"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
 					"requires": {
-						"is-core-module": "^2.8.0",
+						"is-core-module": "^2.8.1",
 						"path-parse": "^1.0.7",
 						"supports-preserve-symlinks-flag": "^1.0.0"
 					}
@@ -4061,12 +4088,9 @@
 			},
 			"dependencies": {
 				"json5": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-					"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-					"requires": {
-						"minimist": "^1.2.5"
-					}
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+					"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
 				}
 			}
 		},
@@ -6344,34 +6368,14 @@
 			}
 		},
 		"babel-loader": {
-			"version": "8.2.3",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.3.tgz",
-			"integrity": "sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==",
+			"version": "8.2.4",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.4.tgz",
+			"integrity": "sha512-8dytA3gcvPPPv4Grjhnt8b5IIiTcq/zeXOPk4iTYI0SVXcsmuGg7JtBRDp8S9X+gJfhQ8ektjXZlDu1Bb33U8A==",
 			"requires": {
 				"find-cache-dir": "^3.3.1",
-				"loader-utils": "^1.4.0",
+				"loader-utils": "^2.0.0",
 				"make-dir": "^3.1.0",
 				"schema-utils": "^2.6.5"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"loader-utils": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^1.0.1"
-					}
-				}
 			}
 		},
 		"babel-plugin-dynamic-import-node": {
@@ -11570,14 +11574,59 @@
 			"dev": true
 		},
 		"jake": {
-			"version": "10.8.2",
-			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.2.tgz",
-			"integrity": "sha512-eLpKyrfG3mzvGE2Du8VoPbeSkRry093+tyNjdYaBbJS9v17knImYGNXQCUV0gLxQtF82m3E8iRb/wdSQZLoq7A==",
+			"version": "10.8.4",
+			"resolved": "https://registry.npmjs.org/jake/-/jake-10.8.4.tgz",
+			"integrity": "sha512-MtWeTkl1qGsWUtbl/Jsca/8xSoK3x0UmS82sNbjqxxG/de/M/3b1DntdjHgPMC50enlTNwXOCRqPXLLt5cCfZA==",
 			"requires": {
 				"async": "0.9.x",
-				"chalk": "^2.4.2",
+				"chalk": "^4.0.2",
 				"filelist": "^1.0.1",
 				"minimatch": "^3.0.4"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"jest": {
@@ -14652,7 +14701,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
 			"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-			"dev": true,
 			"requires": {
 				"big.js": "^5.2.2",
 				"emojis-list": "^3.0.0",
@@ -14804,11 +14852,11 @@
 			"dev": true
 		},
 		"magic-string": {
-			"version": "0.25.7",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-			"integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
 			"requires": {
-				"sourcemap-codec": "^1.4.4"
+				"sourcemap-codec": "^1.4.8"
 			}
 		},
 		"make-dir": {
@@ -15399,16 +15447,16 @@
 			}
 		},
 		"next-pwa": {
-			"version": "5.4.4",
-			"resolved": "https://registry.npmjs.org/next-pwa/-/next-pwa-5.4.4.tgz",
-			"integrity": "sha512-Wo7DctXO9ZZzMCuRK/q2U3x5k49LBRv7p31woJIUfiR6tJChSMoojHUvvgeCY72gSo4mtovS5KRm6iHIs/kxeg==",
+			"version": "5.5.2",
+			"resolved": "https://registry.npmjs.org/next-pwa/-/next-pwa-5.5.2.tgz",
+			"integrity": "sha512-NOZxIS/4Qa4lsPG99CNh3ZA1vfVJ3vpZjBvfouXOfWn0K9CLjBRZwGkJAcWsMWngSGoTN1hUkg97Pe+9xESzWQ==",
 			"requires": {
-				"babel-loader": "^8.2.3",
+				"babel-loader": "^8.2.4",
 				"clean-webpack-plugin": "^4.0.0",
 				"globby": "^11.0.4",
-				"terser-webpack-plugin": "^5.2.5",
-				"workbox-webpack-plugin": "^6.4.2",
-				"workbox-window": "^6.4.2"
+				"terser-webpack-plugin": "^5.3.1",
+				"workbox-webpack-plugin": "^6.5.2",
+				"workbox-window": "^6.5.2"
 			},
 			"dependencies": {
 				"braces": {
@@ -15471,12 +15519,12 @@
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 				},
 				"micromatch": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+					"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
 					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.2.3"
+						"braces": "^3.0.2",
+						"picomatch": "^2.3.1"
 					}
 				},
 				"picomatch": {
@@ -17826,9 +17874,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.64.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.64.0.tgz",
-			"integrity": "sha512-+c+lbw1lexBKSMb1yxGDVfJ+vchJH3qLbmavR+awDinTDA2C5Ug9u7lkOzj62SCu0PKUExsW36tpgW7Fmpn3yQ==",
+			"version": "2.70.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.70.2.tgz",
+			"integrity": "sha512-EitogNZnfku65I1DD5Mxe8JYRUCy0hkK5X84IlDtUs+O6JRMpRciXTzyCUuX11b5L5pvjH+OmFXiQ3XjabcXgg==",
 			"requires": {
 				"fsevents": "~2.3.2"
 			},
@@ -18355,7 +18403,8 @@
 		"source-map-url": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"dev": true
 		},
 		"sourcemap-codec": {
 			"version": "1.4.8",
@@ -19634,15 +19683,21 @@
 			}
 		},
 		"terser": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
-			"integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
+			"version": "5.12.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.12.1.tgz",
+			"integrity": "sha512-NXbs+7nisos5E+yXwAD+y7zrcTkMqb0dEJxIGtSKPdCBzopf7ni4odPul2aechpV7EXNvOudYOX2bb5tln1jbQ==",
 			"requires": {
+				"acorn": "^8.5.0",
 				"commander": "^2.20.0",
 				"source-map": "~0.7.2",
 				"source-map-support": "~0.5.20"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "8.7.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+					"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ=="
+				},
 				"commander": {
 					"version": "2.20.3",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -19672,11 +19727,11 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.0.tgz",
-			"integrity": "sha512-LPIisi3Ol4chwAaPP8toUJ3L4qCM1G0wao7L3qNv57Drezxj6+VEyySpPw4B1HSO2Eg/hDY/MNF5XihCAoqnsQ==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz",
+			"integrity": "sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==",
 			"requires": {
-				"jest-worker": "^27.4.1",
+				"jest-worker": "^27.4.5",
 				"schema-utils": "^3.1.1",
 				"serialize-javascript": "^6.0.0",
 				"source-map": "^0.6.1",
@@ -19700,9 +19755,9 @@
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 				},
 				"jest-worker": {
-					"version": "27.4.6",
-					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.4.6.tgz",
-					"integrity": "sha512-gHWJF/6Xi5CTG5QCvROr6GcmpIqNYpDJyc8A1h/DyXqH1tD6SnRCM0d3U5msV31D2LB/U+E0M+W4oyvKV44oNw==",
+					"version": "27.5.1",
+					"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+					"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
 					"requires": {
 						"@types/node": "*",
 						"merge-stream": "^2.0.0",
@@ -20828,26 +20883,26 @@
 			"dev": true
 		},
 		"workbox-background-sync": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.4.2.tgz",
-			"integrity": "sha512-P7c8uG5X2k+DMICH9xeSA9eUlCOjHHYoB42Rq+RtUpuwBxUOflAXR1zdsMWj81LopE4gjKXlTw7BFd1BDAHo7g==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-6.5.3.tgz",
+			"integrity": "sha512-0DD/V05FAcek6tWv9XYj2w5T/plxhDSpclIcAGjA/b7t/6PdaRkQ7ZgtAX6Q/L7kV7wZ8uYRJUoH11VjNipMZw==",
 			"requires": {
 				"idb": "^6.1.4",
-				"workbox-core": "6.4.2"
+				"workbox-core": "6.5.3"
 			}
 		},
 		"workbox-broadcast-update": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-6.4.2.tgz",
-			"integrity": "sha512-qnBwQyE0+PWFFc/n4ISXINE49m44gbEreJUYt2ldGH3+CNrLmJ1egJOOyUqqu9R4Eb7QrXcmB34ClXG7S37LbA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-6.5.3.tgz",
+			"integrity": "sha512-4AwCIA5DiDrYhlN+Miv/fp5T3/whNmSL+KqhTwRBTZIL6pvTgE4lVuRzAt1JltmqyMcQ3SEfCdfxczuI4kwFQg==",
 			"requires": {
-				"workbox-core": "6.4.2"
+				"workbox-core": "6.5.3"
 			}
 		},
 		"workbox-build": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-6.4.2.tgz",
-			"integrity": "sha512-WMdYLhDIsuzViOTXDH+tJ1GijkFp5khSYolnxR/11zmfhNDtuo7jof72xPGFy+KRpsz6tug39RhivCj77qqO0w==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-6.5.3.tgz",
+			"integrity": "sha512-8JNHHS7u13nhwIYCDea9MNXBNPHXCs5KDZPKI/ZNTr3f4sMGoD7hgFGecbyjX1gw4z6e9bMpMsOEJNyH5htA/w==",
 			"requires": {
 				"@apideck/better-ajv-errors": "^0.3.1",
 				"@babel/core": "^7.11.1",
@@ -20867,26 +20922,25 @@
 				"rollup": "^2.43.1",
 				"rollup-plugin-terser": "^7.0.0",
 				"source-map": "^0.8.0-beta.0",
-				"source-map-url": "^0.4.0",
 				"stringify-object": "^3.3.0",
 				"strip-comments": "^2.0.1",
 				"tempy": "^0.6.0",
 				"upath": "^1.2.0",
-				"workbox-background-sync": "6.4.2",
-				"workbox-broadcast-update": "6.4.2",
-				"workbox-cacheable-response": "6.4.2",
-				"workbox-core": "6.4.2",
-				"workbox-expiration": "6.4.2",
-				"workbox-google-analytics": "6.4.2",
-				"workbox-navigation-preload": "6.4.2",
-				"workbox-precaching": "6.4.2",
-				"workbox-range-requests": "6.4.2",
-				"workbox-recipes": "6.4.2",
-				"workbox-routing": "6.4.2",
-				"workbox-strategies": "6.4.2",
-				"workbox-streams": "6.4.2",
-				"workbox-sw": "6.4.2",
-				"workbox-window": "6.4.2"
+				"workbox-background-sync": "6.5.3",
+				"workbox-broadcast-update": "6.5.3",
+				"workbox-cacheable-response": "6.5.3",
+				"workbox-core": "6.5.3",
+				"workbox-expiration": "6.5.3",
+				"workbox-google-analytics": "6.5.3",
+				"workbox-navigation-preload": "6.5.3",
+				"workbox-precaching": "6.5.3",
+				"workbox-range-requests": "6.5.3",
+				"workbox-recipes": "6.5.3",
+				"workbox-routing": "6.5.3",
+				"workbox-strategies": "6.5.3",
+				"workbox-streams": "6.5.3",
+				"workbox-sw": "6.5.3",
+				"workbox-window": "6.5.3"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
@@ -20898,45 +20952,38 @@
 					}
 				},
 				"@babel/compat-data": {
-					"version": "7.16.8",
-					"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.8.tgz",
-					"integrity": "sha512-m7OkX0IdKLKPpBlJtF561YJal5y/jyI5fNfWbPxh2D/nbzzGI4qRyrD8xO2jB24u7l+5I2a43scCG2IrfjC50Q=="
+					"version": "7.17.7",
+					"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
+					"integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ=="
 				},
 				"@babel/core": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.7.tgz",
-					"integrity": "sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==",
+					"version": "7.17.9",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.9.tgz",
+					"integrity": "sha512-5ug+SfZCpDAkVp9SFIZAzlW18rlzsOcJGaetCjkySnrXXDUw9AR8cDUm1iByTmdWM6yxX6/zycaV76w3YTF2gw==",
 					"requires": {
+						"@ampproject/remapping": "^2.1.0",
 						"@babel/code-frame": "^7.16.7",
-						"@babel/generator": "^7.16.7",
-						"@babel/helper-compilation-targets": "^7.16.7",
-						"@babel/helper-module-transforms": "^7.16.7",
-						"@babel/helpers": "^7.16.7",
-						"@babel/parser": "^7.16.7",
+						"@babel/generator": "^7.17.9",
+						"@babel/helper-compilation-targets": "^7.17.7",
+						"@babel/helper-module-transforms": "^7.17.7",
+						"@babel/helpers": "^7.17.9",
+						"@babel/parser": "^7.17.9",
 						"@babel/template": "^7.16.7",
-						"@babel/traverse": "^7.16.7",
-						"@babel/types": "^7.16.7",
+						"@babel/traverse": "^7.17.9",
+						"@babel/types": "^7.17.0",
 						"convert-source-map": "^1.7.0",
 						"debug": "^4.1.0",
 						"gensync": "^1.0.0-beta.2",
-						"json5": "^2.1.2",
-						"semver": "^6.3.0",
-						"source-map": "^0.5.0"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.5.7",
-							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-							"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-						}
+						"json5": "^2.2.1",
+						"semver": "^6.3.0"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.16.8",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
-					"integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
+					"version": "7.17.9",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.9.tgz",
+					"integrity": "sha512-rAdDousTwxbIxbz5I7GEQ3lUip+xVCXooZNbsydCWs3xA7ZsYOv+CFRdzGxRX78BmQHu9B1Eso59AOZQOJDEdQ==",
 					"requires": {
-						"@babel/types": "^7.16.8",
+						"@babel/types": "^7.17.0",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					},
@@ -20949,32 +20996,23 @@
 					}
 				},
 				"@babel/helper-compilation-targets": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
-					"integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+					"version": "7.17.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
+					"integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
 					"requires": {
-						"@babel/compat-data": "^7.16.4",
+						"@babel/compat-data": "^7.17.7",
 						"@babel/helper-validator-option": "^7.16.7",
 						"browserslist": "^4.17.5",
 						"semver": "^6.3.0"
 					}
 				},
 				"@babel/helper-function-name": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
-					"integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+					"version": "7.17.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+					"integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
 					"requires": {
-						"@babel/helper-get-function-arity": "^7.16.7",
 						"@babel/template": "^7.16.7",
-						"@babel/types": "^7.16.7"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
-					"integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
-					"requires": {
-						"@babel/types": "^7.16.7"
+						"@babel/types": "^7.17.0"
 					}
 				},
 				"@babel/helper-hoist-variables": {
@@ -20994,26 +21032,26 @@
 					}
 				},
 				"@babel/helper-module-transforms": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
-					"integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
+					"version": "7.17.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+					"integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
 					"requires": {
 						"@babel/helper-environment-visitor": "^7.16.7",
 						"@babel/helper-module-imports": "^7.16.7",
-						"@babel/helper-simple-access": "^7.16.7",
+						"@babel/helper-simple-access": "^7.17.7",
 						"@babel/helper-split-export-declaration": "^7.16.7",
 						"@babel/helper-validator-identifier": "^7.16.7",
 						"@babel/template": "^7.16.7",
-						"@babel/traverse": "^7.16.7",
-						"@babel/types": "^7.16.7"
+						"@babel/traverse": "^7.17.3",
+						"@babel/types": "^7.17.0"
 					}
 				},
 				"@babel/helper-simple-access": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
-					"integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+					"version": "7.17.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+					"integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
 					"requires": {
-						"@babel/types": "^7.16.7"
+						"@babel/types": "^7.17.0"
 					}
 				},
 				"@babel/helper-split-export-declaration": {
@@ -21035,19 +21073,19 @@
 					"integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ=="
 				},
 				"@babel/helpers": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.7.tgz",
-					"integrity": "sha512-9ZDoqtfY7AuEOt3cxchfii6C7GDyyMBffktR5B2jvWv8u2+efwvpnVKXMWzNehqy68tKgAfSwfdw/lWpthS2bw==",
+					"version": "7.17.9",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
+					"integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
 					"requires": {
 						"@babel/template": "^7.16.7",
-						"@babel/traverse": "^7.16.7",
-						"@babel/types": "^7.16.7"
+						"@babel/traverse": "^7.17.9",
+						"@babel/types": "^7.17.0"
 					}
 				},
 				"@babel/highlight": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
-					"integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
+					"version": "7.17.9",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.9.tgz",
+					"integrity": "sha512-J9PfEKCbFIv2X5bjTMiZu6Vf341N05QIY+d6FvVKynkG1S7G0j3I0QoRtWIrXhZ+/Nlb5Q0MzqL7TokEJ5BNHg==",
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.16.7",
 						"chalk": "^2.0.0",
@@ -21055,14 +21093,14 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.16.8",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.8.tgz",
-					"integrity": "sha512-i7jDUfrVBWc+7OKcBzEe5n7fbv3i2fWtxKzzCvOjnzSxMfWMigAhtfJ7qzZNGFNMsCCd67+uz553dYKWXPvCKw=="
+					"version": "7.17.9",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.9.tgz",
+					"integrity": "sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg=="
 				},
 				"@babel/runtime": {
-					"version": "7.16.7",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-					"integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+					"version": "7.17.9",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
+					"integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
 					"requires": {
 						"regenerator-runtime": "^0.13.4"
 					}
@@ -21078,35 +21116,35 @@
 					}
 				},
 				"@babel/traverse": {
-					"version": "7.16.8",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.8.tgz",
-					"integrity": "sha512-xe+H7JlvKsDQwXRsBhSnq1/+9c+LlQcCK3Tn/l5sbx02HYns/cn7ibp9+RV1sIUqu7hKg91NWsgHurO9dowITQ==",
+					"version": "7.17.9",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.9.tgz",
+					"integrity": "sha512-PQO8sDIJ8SIwipTPiR71kJQCKQYB5NGImbOviK8K+kg5xkNSYXLBupuX9QhatFowrsvo9Hj8WgArg3W7ijNAQw==",
 					"requires": {
 						"@babel/code-frame": "^7.16.7",
-						"@babel/generator": "^7.16.8",
+						"@babel/generator": "^7.17.9",
 						"@babel/helper-environment-visitor": "^7.16.7",
-						"@babel/helper-function-name": "^7.16.7",
+						"@babel/helper-function-name": "^7.17.9",
 						"@babel/helper-hoist-variables": "^7.16.7",
 						"@babel/helper-split-export-declaration": "^7.16.7",
-						"@babel/parser": "^7.16.8",
-						"@babel/types": "^7.16.8",
+						"@babel/parser": "^7.17.9",
+						"@babel/types": "^7.17.0",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0"
 					}
 				},
 				"@babel/types": {
-					"version": "7.16.8",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
-					"integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
+					"version": "7.17.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+					"integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
 					"requires": {
 						"@babel/helper-validator-identifier": "^7.16.7",
 						"to-fast-properties": "^2.0.0"
 					}
 				},
 				"ajv": {
-					"version": "8.9.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.9.0.tgz",
-					"integrity": "sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==",
+					"version": "8.11.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+					"integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
 					"requires": {
 						"fast-deep-equal": "^3.1.1",
 						"json-schema-traverse": "^1.0.0",
@@ -21115,26 +21153,26 @@
 					}
 				},
 				"browserslist": {
-					"version": "4.19.1",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
-					"integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+					"version": "4.20.2",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
+					"integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
 					"requires": {
-						"caniuse-lite": "^1.0.30001286",
-						"electron-to-chromium": "^1.4.17",
+						"caniuse-lite": "^1.0.30001317",
+						"electron-to-chromium": "^1.4.84",
 						"escalade": "^3.1.1",
-						"node-releases": "^2.0.1",
+						"node-releases": "^2.0.2",
 						"picocolors": "^1.0.0"
 					}
 				},
 				"caniuse-lite": {
-					"version": "1.0.30001300",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz",
-					"integrity": "sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA=="
+					"version": "1.0.30001332",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
+					"integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw=="
 				},
 				"electron-to-chromium": {
-					"version": "1.4.48",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.48.tgz",
-					"integrity": "sha512-RT3SEmpv7XUA+tKXrZGudAWLDpa7f8qmhjcLaM6OD/ERxjQ/zAojT8/Vvo0BSzbArkElFZ1WyZ9FuwAYbkdBNA=="
+					"version": "1.4.111",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.111.tgz",
+					"integrity": "sha512-/s3+fwhKf1YK4k7btOImOzCQLpUjS6MaPf0ODTNuT4eTM1Bg4itBpLkydhOzJmpmH6Z9eXFyuuK5czsmzRzwtw=="
 				},
 				"escalade": {
 					"version": "3.1.1",
@@ -21162,15 +21200,20 @@
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 					"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
 				},
+				"json5": {
+					"version": "2.2.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+					"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+				},
 				"lodash": {
 					"version": "4.17.21",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 				},
 				"node-releases": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-					"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.3.tgz",
+					"integrity": "sha512-maHFz6OLqYxz+VQyCAtA3PTX4UP/53pa05fyDNc9CwjvJ0yEh6+xBwKsgCxMNhS8taUKBFYxfuiaD9U/55iFaw=="
 				},
 				"semver": {
 					"version": "6.3.0",
@@ -21188,127 +21231,126 @@
 			}
 		},
 		"workbox-cacheable-response": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-6.4.2.tgz",
-			"integrity": "sha512-9FE1W/cKffk1AJzImxgEN0ceWpyz1tqNjZVtA3/LAvYL3AC5SbIkhc7ZCO82WmO9IjTfu8Vut2X/C7ViMSF7TA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-6.5.3.tgz",
+			"integrity": "sha512-6JE/Zm05hNasHzzAGKDkqqgYtZZL2H06ic2GxuRLStA4S/rHUfm2mnLFFXuHAaGR1XuuYyVCEey1M6H3PdZ7SQ==",
 			"requires": {
-				"workbox-core": "6.4.2"
+				"workbox-core": "6.5.3"
 			}
 		},
 		"workbox-core": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.4.2.tgz",
-			"integrity": "sha512-1U6cdEYPcajRXiboSlpJx6U7TvhIKbxRRerfepAJu2hniKwJ3DHILjpU/zx3yvzSBCWcNJDoFalf7Vgd7ey/rw=="
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-6.5.3.tgz",
+			"integrity": "sha512-Bb9ey5n/M9x+l3fBTlLpHt9ASTzgSGj6vxni7pY72ilB/Pb3XtN+cZ9yueboVhD5+9cNQrC9n/E1fSrqWsUz7Q=="
 		},
 		"workbox-expiration": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-6.4.2.tgz",
-			"integrity": "sha512-0hbpBj0tDnW+DZOUmwZqntB/8xrXOgO34i7s00Si/VlFJvvpRKg1leXdHHU8ykoSBd6+F2KDcMP3swoCi5guLw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-6.5.3.tgz",
+			"integrity": "sha512-jzYopYR1zD04ZMdlbn/R2Ik6ixiXbi15c9iX5H8CTi6RPDz7uhvMLZPKEndZTpfgmUk8mdmT9Vx/AhbuCl5Sqw==",
 			"requires": {
 				"idb": "^6.1.4",
-				"workbox-core": "6.4.2"
+				"workbox-core": "6.5.3"
 			}
 		},
 		"workbox-google-analytics": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-6.4.2.tgz",
-			"integrity": "sha512-u+gxs3jXovPb1oul4CTBOb+T9fS1oZG+ZE6AzS7l40vnyfJV79DaLBvlpEZfXGv3CjMdV1sT/ltdOrKzo7HcGw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-6.5.3.tgz",
+			"integrity": "sha512-3GLCHotz5umoRSb4aNQeTbILETcrTVEozSfLhHSBaegHs1PnqCmN0zbIy2TjTpph2AGXiNwDrWGF0AN+UgDNTw==",
 			"requires": {
-				"workbox-background-sync": "6.4.2",
-				"workbox-core": "6.4.2",
-				"workbox-routing": "6.4.2",
-				"workbox-strategies": "6.4.2"
+				"workbox-background-sync": "6.5.3",
+				"workbox-core": "6.5.3",
+				"workbox-routing": "6.5.3",
+				"workbox-strategies": "6.5.3"
 			}
 		},
 		"workbox-navigation-preload": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-6.4.2.tgz",
-			"integrity": "sha512-viyejlCtlKsbJCBHwhSBbWc57MwPXvUrc8P7d+87AxBGPU+JuWkT6nvBANgVgFz6FUhCvRC8aYt+B1helo166g==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-6.5.3.tgz",
+			"integrity": "sha512-bK1gDFTc5iu6lH3UQ07QVo+0ovErhRNGvJJO/1ngknT0UQ702nmOUhoN9qE5mhuQSrnK+cqu7O7xeaJ+Rd9Tmg==",
 			"requires": {
-				"workbox-core": "6.4.2"
+				"workbox-core": "6.5.3"
 			}
 		},
 		"workbox-precaching": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-6.4.2.tgz",
-			"integrity": "sha512-CZ6uwFN/2wb4noHVlALL7UqPFbLfez/9S2GAzGAb0Sk876ul9ukRKPJJ6gtsxfE2HSTwqwuyNVa6xWyeyJ1XSA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-6.5.3.tgz",
+			"integrity": "sha512-sjNfgNLSsRX5zcc63H/ar/hCf+T19fRtTqvWh795gdpghWb5xsfEkecXEvZ8biEi1QD7X/ljtHphdaPvXDygMQ==",
 			"requires": {
-				"workbox-core": "6.4.2",
-				"workbox-routing": "6.4.2",
-				"workbox-strategies": "6.4.2"
+				"workbox-core": "6.5.3",
+				"workbox-routing": "6.5.3",
+				"workbox-strategies": "6.5.3"
 			}
 		},
 		"workbox-range-requests": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-6.4.2.tgz",
-			"integrity": "sha512-SowF3z69hr3Po/w7+xarWfzxJX/3Fo0uSG72Zg4g5FWWnHpq2zPvgbWerBZIa81zpJVUdYpMa3akJJsv+LaO1Q==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-6.5.3.tgz",
+			"integrity": "sha512-pGCP80Bpn/0Q0MQsfETSfmtXsQcu3M2QCJwSFuJ6cDp8s2XmbUXkzbuQhCUzKR86ZH2Vex/VUjb2UaZBGamijA==",
 			"requires": {
-				"workbox-core": "6.4.2"
+				"workbox-core": "6.5.3"
 			}
 		},
 		"workbox-recipes": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-6.4.2.tgz",
-			"integrity": "sha512-/oVxlZFpAjFVbY+3PoGEXe8qyvtmqMrTdWhbOfbwokNFtUZ/JCtanDKgwDv9x3AebqGAoJRvQNSru0F4nG+gWA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-6.5.3.tgz",
+			"integrity": "sha512-IcgiKYmbGiDvvf3PMSEtmwqxwfQ5zwI7OZPio3GWu4PfehA8jI8JHI3KZj+PCfRiUPZhjQHJ3v1HbNs+SiSkig==",
 			"requires": {
-				"workbox-cacheable-response": "6.4.2",
-				"workbox-core": "6.4.2",
-				"workbox-expiration": "6.4.2",
-				"workbox-precaching": "6.4.2",
-				"workbox-routing": "6.4.2",
-				"workbox-strategies": "6.4.2"
+				"workbox-cacheable-response": "6.5.3",
+				"workbox-core": "6.5.3",
+				"workbox-expiration": "6.5.3",
+				"workbox-precaching": "6.5.3",
+				"workbox-routing": "6.5.3",
+				"workbox-strategies": "6.5.3"
 			}
 		},
 		"workbox-routing": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-6.4.2.tgz",
-			"integrity": "sha512-0ss/n9PAcHjTy4Ad7l2puuod4WtsnRYu9BrmHcu6Dk4PgWeJo1t5VnGufPxNtcuyPGQ3OdnMdlmhMJ57sSrrSw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-6.5.3.tgz",
+			"integrity": "sha512-DFjxcuRAJjjt4T34RbMm3MCn+xnd36UT/2RfPRfa8VWJGItGJIn7tG+GwVTdHmvE54i/QmVTJepyAGWtoLPTmg==",
 			"requires": {
-				"workbox-core": "6.4.2"
+				"workbox-core": "6.5.3"
 			}
 		},
 		"workbox-strategies": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-6.4.2.tgz",
-			"integrity": "sha512-YXh9E9dZGEO1EiPC3jPe2CbztO5WT8Ruj8wiYZM56XqEJp5YlGTtqRjghV+JovWOqkWdR+amJpV31KPWQUvn1Q==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-6.5.3.tgz",
+			"integrity": "sha512-MgmGRrDVXs7rtSCcetZgkSZyMpRGw8HqL2aguszOc3nUmzGZsT238z/NN9ZouCxSzDu3PQ3ZSKmovAacaIhu1w==",
 			"requires": {
-				"workbox-core": "6.4.2"
+				"workbox-core": "6.5.3"
 			}
 		},
 		"workbox-streams": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-6.4.2.tgz",
-			"integrity": "sha512-ROEGlZHGVEgpa5bOZefiJEVsi5PsFjJG9Xd+wnDbApsCO9xq9rYFopF+IRq9tChyYzhBnyk2hJxbQVWphz3sog==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-6.5.3.tgz",
+			"integrity": "sha512-vN4Qi8o+b7zj1FDVNZ+PlmAcy1sBoV7SC956uhqYvZ9Sg1fViSbOpydULOssVJ4tOyKRifH/eoi6h99d+sJ33w==",
 			"requires": {
-				"workbox-core": "6.4.2",
-				"workbox-routing": "6.4.2"
+				"workbox-core": "6.5.3",
+				"workbox-routing": "6.5.3"
 			}
 		},
 		"workbox-sw": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-6.4.2.tgz",
-			"integrity": "sha512-A2qdu9TLktfIM5NE/8+yYwfWu+JgDaCkbo5ikrky2c7r9v2X6DcJ+zSLphNHHLwM/0eVk5XVf1mC5HGhYpMhhg=="
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-6.5.3.tgz",
+			"integrity": "sha512-BQBzm092w+NqdIEF2yhl32dERt9j9MDGUTa2Eaa+o3YKL4Qqw55W9yQC6f44FdAHdAJrJvp0t+HVrfh8AiGj8A=="
 		},
 		"workbox-webpack-plugin": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-webpack-plugin/-/workbox-webpack-plugin-6.4.2.tgz",
-			"integrity": "sha512-CiEwM6kaJRkx1cP5xHksn13abTzUqMHiMMlp5Eh/v4wRcedgDTyv6Uo8+Hg9MurRbHDosO5suaPyF9uwVr4/CQ==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-webpack-plugin/-/workbox-webpack-plugin-6.5.3.tgz",
+			"integrity": "sha512-Es8Xr02Gi6Kc3zaUwR691ZLy61hz3vhhs5GztcklQ7kl5k2qAusPh0s6LF3wEtlpfs9ZDErnmy5SErwoll7jBA==",
 			"requires": {
 				"fast-json-stable-stringify": "^2.1.0",
 				"pretty-bytes": "^5.4.1",
-				"source-map-url": "^0.4.0",
 				"upath": "^1.2.0",
 				"webpack-sources": "^1.4.3",
-				"workbox-build": "6.4.2"
+				"workbox-build": "6.5.3"
 			}
 		},
 		"workbox-window": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-6.4.2.tgz",
-			"integrity": "sha512-KVyRKmrJg7iB+uym/B/CnEUEFG9CvnTU1Bq5xpXHbtgD9l+ShDekSl1wYpqw/O0JfeeQVOFb8CiNfvnwWwqnWQ==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-6.5.3.tgz",
+			"integrity": "sha512-GnJbx1kcKXDtoJBVZs/P7ddP0Yt52NNy4nocjBpYPiRhMqTpJCNrSL+fGHZ/i/oP6p/vhE8II0sA6AZGKGnssw==",
 			"requires": {
 				"@types/trusted-types": "^2.0.2",
-				"workbox-core": "6.4.2"
+				"workbox-core": "6.5.3"
 			}
 		},
 		"wrap-ansi": {

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -27,7 +27,7 @@
     "next": "^11.1.3",
     "next-plugin-preact": "^3.0.6",
     "@prefresh/next": "^1.5.0",
-    "next-pwa": "^5.4.4",
+    "next-pwa": "^5.5.2",
     "next-seo": "^4.28.1",
     "preact": "^10.6.4",
     "preact-render-to-string": "^5.1.19",


### PR DESCRIPTION
I think the overload cache issue was caused only for users who used the webapp for a long time with an old service worker definition. The old SW didn't set a limit on the image cache, thus causing it to explode (my local cache was 4GB 🤯).

I update next-pwa to the latest version to make sure we are aligned with the newest settings and also confirmed locally that cache is limited to ~300mb.
I'm still not 100% what takes up all this storage because I tried to delete the caches one by one and still remained with ~170mb. But I think 300mb is a decent cap for now.

Closes dailydotdev/daily#372
DD-437 #done