### PR TITLE
fix: do not update article page on posts engaged event

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,4 +3,9 @@
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="JSX" />
   </component>
+  <component name="SwUserDefinedSpecifications">
+    <option name="specTypeByUrl">
+      <map />
+    </option>
+  </component>
 </project>

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -398,6 +398,26 @@ it('should update post on subscription message', async () => {
   expect(el).toHaveTextContent('15 Upvotes');
 });
 
+it('should not update post on subscription message when id is not the same', async () => {
+  renderPost();
+  await waitFor(async () => {
+    const data = await client.getQueryData([
+      'post',
+      '0e4005b2d3cf191f8c44c2718a457a1e',
+    ]);
+    expect(data).toBeTruthy();
+  });
+  nextCallback({
+    postsEngaged: {
+      id: 'asd',
+      numUpvotes: 15,
+      numComments: 0,
+    },
+  });
+  const el = await screen.findByTestId('statsBar');
+  expect(el).not.toHaveTextContent('15 Upvotes');
+});
+
 it('should send bookmark mutation', async () => {
   let mutationCalled = false;
   renderPost({}, [

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -146,18 +146,17 @@ const PostPage = ({ id, postData }: Props): ReactElement => {
   useSubscription(
     () => ({
       query: POSTS_ENGAGED_SUBSCRIPTION,
-      variables: {
-        ids: [id],
-      },
     }),
     {
       next: (data: PostsEngaged) => {
-        queryClient.setQueryData<PostData>(postQueryKey, (oldPost) => ({
-          post: {
-            ...oldPost.post,
-            ...data.postsEngaged,
-          },
-        }));
+        if (data.postsEngaged.id === id) {
+          queryClient.setQueryData<PostData>(postQueryKey, (oldPost) => ({
+            post: {
+              ...oldPost.post,
+              ...data.postsEngaged,
+            },
+          }));
+        }
       },
     },
   );


### PR DESCRIPTION
## Changes

### Describe what this PR does

Earlier we removed the filter functionality of the `postsEngaged` subscription. This caused the article page to receive every event that is occurring in the system.
Unfortunately, we didn't handle the case where we receive an event of another post in the callback.
This is now fixed :)


### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

DD-597 #done