### PR TITLE
fix: window being undefined

### DIFF
--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -83,8 +83,10 @@ export const usePostModalNavigation = (
     [items, openedPostIndex, isFetchingNextPage],
   );
 
+  const parent = typeof window !== 'undefined' ? window : null;
+
   useKeyboardNavigation(
-    window,
+    parent,
     [
       ['ArrowLeft', ret.onPrevious],
       ['ArrowRight', ret.onNext],


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The reason window is null, is when we navigate to the source page, the getStaticProps doesn't have the context of window yet, so it crashes.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

DD-{number} #done
