### PR TITLE
fix: jumpy ui on modal close for mobile devices.

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -222,7 +222,8 @@ export default function Feed<T>({
     column: number,
   ): void => {
     document.body.classList.add('overflow-hidden');
-    document.body.classList.add('pr-2');
+    document.body.classList.add('pr-0');
+    document.body.classList.add('laptop:pr-2');
     trackEvent(
       postAnalyticsEvent('comments click', post, {
         columns: virtualizedNumCards,
@@ -258,7 +259,8 @@ export default function Feed<T>({
   useEffect(() => {
     if (!selectedPost) {
       document.body.classList.remove('overflow-hidden');
-      document.body.classList.remove('pr-2');
+      document.body.classList.remove('pr-0');
+      document.body.classList.remove('laptop:pr-2');
     }
   }, [selectedPost]);
 

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -221,9 +221,7 @@ export default function Feed<T>({
     row: number,
     column: number,
   ): void => {
-    document.body.classList.add('overflow-hidden');
-    document.body.classList.add('pr-0');
-    document.body.classList.add('laptop:pr-2');
+    document.body.classList.add('overflow-hidden', 'pr-0', 'laptop:pr-2');
     trackEvent(
       postAnalyticsEvent('comments click', post, {
         columns: virtualizedNumCards,
@@ -258,9 +256,7 @@ export default function Feed<T>({
 
   useEffect(() => {
     if (!selectedPost) {
-      document.body.classList.remove('overflow-hidden');
-      document.body.classList.remove('pr-0');
-      document.body.classList.remove('laptop:pr-2');
+      document.body.classList.remove('overflow-hidden', 'pr-0', 'laptop:pr-2');
     }
   }, [selectedPost]);
 

--- a/packages/shared/src/components/modals/PostModal.module.css
+++ b/packages/shared/src/components/modals/PostModal.module.css
@@ -8,10 +8,6 @@
     align-items: unset;
 
     @screen tablet {
-      margin-top: 3.5rem;
-    }
-
-    @screen laptop {
       margin-top: 0;
     }
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- fixes the jumpy UI on mobile devices (tablet and below screen sizes - since scrollbar doesn't take space on mobile devices)
- removed unnecessary top margin on tablet size for modal overlay

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

DD-{number} #done
