### PR TITLE
fix: feed jumpyness through module css

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -221,7 +221,7 @@ export default function Feed<T>({
     row: number,
     column: number,
   ): void => {
-    document.body.classList.add('overflow-hidden', 'pr-0', 'laptop:pr-2');
+    document.body.classList.add('hidden-scrollbar');
     trackEvent(
       postAnalyticsEvent('comments click', post, {
         columns: virtualizedNumCards,
@@ -256,7 +256,7 @@ export default function Feed<T>({
 
   useEffect(() => {
     if (!selectedPost) {
-      document.body.classList.remove('overflow-hidden', 'pr-0', 'laptop:pr-2');
+      document.body.classList.remove('hidden-scrollbar');
     }
   }, [selectedPost]);
 

--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -21,6 +21,14 @@ body {
   &.ReactModal__Body--open .ReactModal__Content > * {
     overscroll-behavior-y: none;
   }
+
+  &.hidden-scrollbar {
+    overflow: hidden;
+
+    @screen laptop {
+      padding-right: 0.5rem;
+    }
+  }
 }
 
 @define-mixin dark-mode {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Tailwindcss has become quite annoying now. In the previous deployment, it recognizes the `pr-2` class, but the current one doesn't anymore.
- As much as I don't want to use module CSS, we have no choice but to utilize it since tailwindcss is pretty unstable as of the moment.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

DD-{number} #done
