### PR TITLE
build: add gitpod configuration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,10 +4,8 @@ ports:
     onOpen: open-browser
   - port: 4000
     onOpen: ignore
-    visibility: public
   - port: 5000
     onOpen: ignore
-    visibility: public
   - port: 6379
     onOpen: ignore
   - port: 3306

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,20 @@
+# List the ports you want to expose and what to do when they are served. See https://www.gitpod.io/docs/config-ports/
+ports:
+  - port: 5002
+    onOpen: open-preview
+
+# List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - name: docker-compose
+    init: docker-compose pull
+    command: docker-compose up
+  - name: webapp
+    before: |
+      nvm install
+      nvm use
+    init: |
+      npm i -g lerna
+      lerna bootstrap
+    command: |
+      cd packages/webapp
+      npm run start

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -25,6 +25,7 @@ tasks:
       sudo apt-get update
       sudo apt-get install -y netcat
     init: |
+      sleep 30
       ./wait-for.sh localhost:5432
       ./wait-for.sh localhost:3306
     command: |

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,13 +1,33 @@
 # List the ports you want to expose and what to do when they are served. See https://www.gitpod.io/docs/config-ports/
 ports:
   - port: 5002
-    onOpen: open-preview
+    onOpen: open-browser
+  - port: 4000
+    onOpen: ignore
+    visibility: public
+  - port: 5000
+    onOpen: ignore
+    visibility: public
+  - port: 6379
+    onOpen: ignore
+  - port: 3306
+    onOpen: ignore
+  - port: 5432
+    onOpen: ignore
 
 # List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/config-start-tasks/
 tasks:
   - name: docker-compose
     init: docker-compose pull
     command: docker-compose up
+  - name: seed
+    init: |
+      ./wait-for.sh localhost:5432
+      ./wait-for.sh localhost:3306
+    command: |
+      docker exec apps-daily-api-1 node ./node_modules/typeorm/cli.js migration:run
+      docker exec apps-daily-gateway-1 yarn run db:migrate:latest
+      docker exec apps-daily-api-1 node bin/import.js
   - name: webapp
     before: |
       nvm install

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -21,6 +21,9 @@ tasks:
     init: docker-compose pull
     command: docker-compose up
   - name: seed
+    before: |
+      sudo apt-get update
+      sudo apt-get install -y netcat
     init: |
       ./wait-for.sh localhost:5432
       ./wait-for.sh localhost:3306
@@ -37,4 +40,4 @@ tasks:
       lerna bootstrap
     command: |
       cd packages/webapp
-      npm run start
+      npm run dev

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
   </a>
 </p>
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/dailydotdev/apps/)
+
 This monorepo contains daily.dev's application suite. The repo includes the web app and the extension, along with shared components for the two.
 The decision was made to allow faster iterations and to keep features parity in both platforms.
 

--- a/wait-for.sh
+++ b/wait-for.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-WAIT_TIMEOUT=15
+WAIT_TIMEOUT=60
 WAIT_QUIET=0
 
 echoerr() {


### PR DESCRIPTION
The new Gitpod config allows provisioning a new environment quickly.
This can be great for contributors and technical interviews.