### PR TITLE
fix: copy link on extension and delete comment makes the app stucked

### DIFF
--- a/packages/shared/src/components/ShareNewCommentPopup.tsx
+++ b/packages/shared/src/components/ShareNewCommentPopup.tsx
@@ -13,11 +13,11 @@ import {
   getWhatsappShareLink,
 } from '../lib/share';
 import { Post } from '../graphql/posts';
-import { useCopyPostLink } from '../hooks/useCopyPostLink';
 import { Button } from './buttons/Button';
 import { ModalCloseButton } from './modals/ModalCloseButton';
 import classed from '../lib/classed';
 import { SimpleTooltip } from './tooltips/SimpleTooltip';
+import { useCopyLink } from '../hooks/useCopyLink';
 
 const ShareButton = classed(Button, 'text-white');
 interface ShareNewCommentPopupProps {
@@ -31,7 +31,7 @@ export default function ShareNewCommentPopup({
 }: ShareNewCommentPopupProps): ReactElement {
   const href = getShareableLink();
   const { user } = useContext(AuthContext);
-  const [copying, copyLink] = useCopyPostLink();
+  const [copying, copyLink] = useCopyLink(() => post.commentsPermalink);
 
   return (
     <div

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -151,7 +151,6 @@ export function PostComments({
           commentId={pendingComment.comment.id}
           parentId={pendingComment.parentId}
           postId={post.id}
-          ariaHideApp={!(process?.env?.NODE_ENV === 'test')}
         />
       )}
     </>

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -341,7 +341,6 @@ export function PostContent({
           isOpen={!!parentComment}
           onRequestClose={closeNewComment}
           {...parentComment}
-          ariaHideApp={!(process?.env?.NODE_ENV === 'test')}
           onComment={onNewComment}
         />
       )}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The copy link was using a generic function that checks the URL - while on extension, it won't be usable
- The app gets stucked on extension if you will hit the delete button. In the console, there was an error message regarding "`process` is undefined"

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

DD-{number} #done
