### PR TITLE
fix: first start on cleaning up flaky tests

### DIFF
--- a/packages/shared/src/components/SidebarRankProgress.spec.tsx
+++ b/packages/shared/src/components/SidebarRankProgress.spec.tsx
@@ -1,14 +1,8 @@
 import React from 'react';
-import {
-  act,
-  render,
-  RenderResult,
-  screen,
-  waitFor,
-} from '@testing-library/react';
+import { render, RenderResult, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import nock from 'nock';
-import { set as setCache, clear } from 'idb-keyval';
+import { set as setCache } from 'idb-keyval';
 import {
   MockedGraphQLResponse,
   mockGraphQL,


### PR DESCRIPTION
## Changes
Refactored the looped tests to work based on `jest.each` function.
This allows for the cleanup to happen more steadily.

### Describe what this PR does
- Change flaky test

### **Please make sure existing components are not breaking/affected by this PR**
Note: Flaky test still occur, we have to dive deeper into a proper cleanup solution

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

WT-10
