### PR TITLE
feat: remove star wars themed devcards

### DIFF
--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -97,35 +97,7 @@ const CUSTOM_BG = 'CUSTOM_BG';
 const BY_RANK_BG = 'BY_RANK_BG';
 
 // This can be used for themed devCards
-const bgUrlOption = [
-  {
-    label: 'May 4th - Hyperdrive',
-    value:
-      'https://daily-now-res.cloudinary.com/image/upload/v1651591210/devcard/bg/may4_hyperdrive.jpg',
-    caption: {
-      text: '(Limited edition)',
-      className: 'text-theme-color-cheese',
-    },
-  },
-  {
-    label: 'May 4th - Dark',
-    value:
-      'https://daily-now-res.cloudinary.com/image/upload/v1651591209/devcard/bg/may4_dark.jpg',
-    caption: {
-      text: '(Limited edition)',
-      className: 'text-theme-color-cheese',
-    },
-  },
-  {
-    label: 'May 4th - Saber',
-    value:
-      'https://daily-now-res.cloudinary.com/image/upload/v1651591210/devcard/bg/may4_saber.jpg',
-    caption: {
-      text: '(Limited edition)',
-      className: 'text-theme-color-cheese',
-    },
-  },
-];
+const bgUrlOption = [];
 
 const Step2 = ({
   onGenerateImage,


### PR DESCRIPTION
## Changes
We no longer need to show the Star Wars themed devcards

### Describe what this PR does
- Removed the devcards from the code.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
