### PR TITLE
fix: tooltip's unnecessary aria-label

### DIFF
--- a/packages/shared/src/components/tooltips/SimpleTooltip.tsx
+++ b/packages/shared/src/components/tooltips/SimpleTooltip.tsx
@@ -23,14 +23,17 @@ export function SimpleTooltip({
    * Read more on the PR: https://github.com/dailydotdev/apps/pull/713
    */
   let shouldShow = true;
-  const component = useMemo(
-    () =>
-      React.cloneElement(children, {
-        ...children.props,
-        'aria-label': typeof content === 'string' && content,
-      }),
-    [children],
-  );
+  const component = useMemo(() => {
+    const tooltipProps = {};
+    if (typeof content === 'string') {
+      tooltipProps['aria-label'] = content;
+    }
+
+    return React.cloneElement(children, {
+      ...tooltipProps,
+      ...children.props,
+    });
+  }, [children]);
 
   const onTooltipTrigger = (_, event) => {
     shouldShow = event.type !== 'focus';


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Related concern: https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1652520139195169
- For tooltips that are not of type string - the `aria-label` has a value of `false` due to the condition - we now set a condition to only add the property when necessary.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
