### PR TITLE
fix: the heatmap could have a read higher than bin value

### DIFF
--- a/packages/webapp/components/CalendarHeatmap.tsx
+++ b/packages/webapp/components/CalendarHeatmap.tsx
@@ -66,6 +66,11 @@ function getBin(value: number, bins: number[]): number {
   if (!value) {
     return 0;
   }
+
+  if (value > Math.max.apply(null, bins)) {
+    return bins.length;
+  }
+
   return bins.findIndex((binMaxValue) => value <= binMaxValue) + 1;
 }
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The current heatmap could have a reading day higher than the highest bin (if the sole day was exponantionally higher than the second highest)
- In this fix we ensure that a reading day higher than the highest bin always returns it's highest index.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

Minimum viable test:

```js
const uniques = [1,2,3,4,7];
const binSize = Math.floor(uniques.length / 3);

console.log(uniques[Math.min(binSize*(5+1), uniques.length -1)]);
// Return 7

Array.from(new Array(3), (_, i) => uniques[Math.min(binSize * (i + 1), uniques.length - 1)])
// Return [ 2, 3, 4 ]

```

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-621 #done