### PR TITLE
feat: introducing HTML lang attribute for next app

### DIFF
--- a/packages/webapp/next.config.js
+++ b/packages/webapp/next.config.js
@@ -17,6 +17,10 @@ module.exports = withTM(
     },
     ...withPreact(
       withBundleAnalyzer({
+        i18n: {
+          locales: ["en"],
+          defaultLocale: "en",
+        },
         webpack5: true,
         webpack: (config, { dev, isServer }) => {
           config.module.rules.push({


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We included a HTML lang attribute on the extension, but not on the webapp
- This change introduces the lang attribute on the webapp as well.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing
Extension before:
<img width="330" alt="Screenshot 2022-05-16 at 12 55 33" src="https://user-images.githubusercontent.com/554874/168578513-89de7cc8-7304-4bea-af26-1817f3a52497.png">

Webapp before:
<img width="332" alt="Screenshot 2022-05-16 at 12 56 19" src="https://user-images.githubusercontent.com/554874/168578538-19025518-ea30-4127-a930-20a1c2e0a335.png">

Webapp after:
<img width="329" alt="Screenshot 2022-05-16 at 12 57 20" src="https://user-images.githubusercontent.com/554874/168578557-5409b7ee-e9cd-456a-907c-2bd8595facaa.png">

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-623 #done
