### PR TITLE
feat: add aria-label to scroll to top button

### DIFF
--- a/packages/shared/src/components/ScrollToTopButton.tsx
+++ b/packages/shared/src/components/ScrollToTopButton.tsx
@@ -33,12 +33,14 @@ export default function ScrollToTopButton(): ReactElement {
   return (
     <>
       <Button
+        aria-label="scroll to top"
         {...props}
         className="laptop:hidden right-4 z-2 btn-primary"
         buttonSize="large"
         style={{ ...style, bottom: '4.5rem' }}
       />
       <Button
+        aria-label="scroll to top"
         {...props}
         className="hidden laptop:flex right-8 bottom-8 z-2 btn-primary"
         buttonSize="xlarge"


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We didn't have a aria-label describing the scroll to top button
- Added aria-label as "scroll to top" to identify this button for screen readers

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing
Before: It was simply called "button, group" in voiceover.
<img width="1323" alt="Screenshot 2022-05-16 at 16 25 58" src="https://user-images.githubusercontent.com/554874/168615862-c8a7e3fa-0fdf-4064-8060-29d28fd57205.png">

After it's called scroll to top, button, group
<img width="998" alt="Screenshot 2022-05-16 at 16 23 17" src="https://user-images.githubusercontent.com/554874/168616029-4ed3dc44-2c7b-4194-a18c-a8bb20e15b40.png">

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-622 #done
