### PR TITLE
fix: position of the close button

### DIFF
--- a/packages/shared/src/components/ShareNewCommentPopup.tsx
+++ b/packages/shared/src/components/ShareNewCommentPopup.tsx
@@ -38,7 +38,7 @@ export default function ShareNewCommentPopup({
       className="hidden laptop:flex fixed right-6 bottom-6 z-3 flex-col px-6 pt-10 pb-6 rounded-2xl border shadow-2 bg-theme-bg-tertiary border-theme-divider-secondary"
       style={{ width: '20.625rem' }}
     >
-      <ModalCloseButton onClick={onRequestClose} />
+      <ModalCloseButton onClick={onRequestClose} className="top-2" />
       <Confetti
         className="absolute left-2 h-16"
         style={{ top: '-4.375rem', width: '6.25rem' }}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Share new comment modal was missing the top offset needed for the close button

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

Before:
<img width="369" alt="Screenshot 2022-05-16 at 13 43 16" src="https://user-images.githubusercontent.com/554874/170229935-b1f39934-1dfa-4498-a964-e843cbc5fa80.png">

After:
<img width="389" alt="Screenshot 2022-05-25 at 11 25 50" src="https://user-images.githubusercontent.com/554874/170229958-2b97c0a1-f644-4e81-9321-0599acdef326.png">

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-76 #done
