### PR TITLE
refactor: companion menu comments button behavior

### DIFF
--- a/packages/extension/src/companion/Companion.tsx
+++ b/packages/extension/src/companion/Companion.tsx
@@ -69,6 +69,7 @@ export default function Companion({
 }: CompanionProps): ReactElement {
   const client = useQueryClient();
   const containerRef = useRef<HTMLDivElement>();
+  const [isCommentsOpen, setIsCommentsOpen] = useState(false);
   const [assetsLoaded, setAssetsLoaded] = useState(isTesting);
   const [post, setPost] = useState<PostBootData>(postData);
   const [companionState, setCompanionState] =
@@ -135,8 +136,13 @@ export default function Companion({
         onOptOut={onOptOut}
         companionState={companionState}
         setCompanionState={setCompanionState}
+        onOpenComments={() => setIsCommentsOpen(true)}
       />
-      <CompanionContent post={post} />
+      <CompanionContent
+        post={post}
+        viewComments={isCommentsOpen}
+        onViewComments={setIsCommentsOpen}
+      />
     </Container>
   );
 }

--- a/packages/extension/src/companion/CompanionContent.tsx
+++ b/packages/extension/src/companion/CompanionContent.tsx
@@ -23,13 +23,16 @@ import { getCompanionWrapper } from './common';
 
 type CompanionContentProps = {
   post: PostBootData;
+  viewComments?: boolean;
+  onViewComments?: (state: boolean) => void;
 };
 
 export default function CompanionContent({
   post,
+  viewComments,
+  onViewComments,
 }: CompanionContentProps): ReactElement {
   const { notification, onMessage } = useNotification();
-  const [isCommentsOpen, setIsCommentsOpen] = useState(false);
   const [copying, copyLink] = useCopyLink(() => post.commentsPermalink);
   const [heightRem, setHeightRem] = useState('0');
   const copyLinkAndNotify = () => {
@@ -67,7 +70,7 @@ export default function CompanionContent({
       ref={onContainerChange}
       className={classNames(
         'flex relative flex-col p-6 h-auto rounded-tl-16 border border-r-0 w-[22.5rem] border-theme-divider-quaternary bg-theme-bg-primary',
-        !isCommentsOpen && 'rounded-bl-16',
+        !viewComments && 'rounded-bl-16',
       )}
     >
       {notification && (
@@ -108,11 +111,11 @@ export default function CompanionContent({
       <CompanionEngagements
         post={post}
         commentsNum={commentsNum}
-        isCommentsOpen={isCommentsOpen}
-        onCommentsClick={() => setIsCommentsOpen(!isCommentsOpen)}
+        isCommentsOpen={viewComments}
+        onCommentsClick={() => onViewComments(!viewComments)}
         onUpvotesClick={() => onShowUpvotedPost(post.id, post.numUpvotes)}
       />
-      {isCommentsOpen && (
+      {viewComments && (
         <CompanionDiscussion
           className="overflow-auto absolute top-full right-0 -left-px min-h-[14rem]"
           style={{ maxHeight: `calc(100vh - ${heightRem}` }}

--- a/packages/extension/src/companion/CompanionContextMenu.tsx
+++ b/packages/extension/src/companion/CompanionContextMenu.tsx
@@ -18,6 +18,7 @@ type CompanionContextMenuProps = {
   postData: PostBootData;
   onReport: (T) => void;
   onBlockSource: (T) => void;
+  onViewDiscussion: () => void;
   onDisableCompanion: () => void;
 } & Pick<NotificationProps, 'onMessage'>;
 
@@ -26,6 +27,7 @@ export default function CompanionContextMenu({
   onMessage,
   onReport,
   onBlockSource,
+  onViewDiscussion,
   onDisableCompanion,
 }: CompanionContextMenuProps): ReactElement {
   const { trackEvent } = useContext(AnalyticsContext);
@@ -78,10 +80,8 @@ export default function CompanionContextMenu({
         className="menu-primary"
         animation="fade"
       >
-        <Item>
-          <a className="flex w-full" href={postData?.commentsPermalink}>
-            <CommentIcon className="mr-2 text-xl" /> View discussion
-          </a>
+        <Item onClick={onViewDiscussion}>
+          <CommentIcon className="mr-2 text-xl" /> View discussion
         </Item>
         <Item onClick={onShareOrCopyLink}>
           <ShareIcon className="mr-2 text-xl" /> Share article

--- a/packages/extension/src/companion/CompanionDiscussion.tsx
+++ b/packages/extension/src/companion/CompanionDiscussion.tsx
@@ -1,18 +1,13 @@
-import React, {
-  ReactElement,
-  useState,
-  CSSProperties,
-  useContext,
-} from 'react';
+import React, { ReactElement, CSSProperties, useContext } from 'react';
 import classNames from 'classnames';
 import { PostBootData } from '@dailydotdev/shared/src/lib/boot';
-import { usePostComment } from '@dailydotdev/shared/src/hooks/usePostComment';
 import { NewComment } from '@dailydotdev/shared/src/components/post/NewComment';
 import { PostComments } from '@dailydotdev/shared/src/components/post/PostComments';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import NewCommentModal from '@dailydotdev/shared/src/components/modals/NewCommentModal';
-import { useBackgroundRequest } from './useBackgroundRequest';
 import { getCompanionWrapper } from './common';
+import { useCompanionPostComment } from './useCompanionPostComment';
+import { useBackgroundRequest } from './useBackgroundRequest';
 
 interface CompanionDiscussionProps {
   post: PostBootData;
@@ -31,27 +26,16 @@ export function CompanionDiscussion({
     return null;
   }
 
-  const [input, setInput] = useState<string>('');
   const { user } = useContext(AuthContext);
   const {
     closeNewComment,
     openNewComment,
     onCommentClick,
-    updatePostComments,
+    onInput,
     parentComment,
-  } = usePostComment(post);
-  const mutationKey = ['post_comments_mutations', post?.id];
+  } = useCompanionPostComment(post);
   const postCommentsQueryKey = ['post_comments', post?.id];
-  const previewQueryKey = ['comment_preview', input];
-  const mentionQueryKey = ['user-mention', post?.id];
-  useBackgroundRequest(mentionQueryKey);
-  useBackgroundRequest(previewQueryKey);
   useBackgroundRequest(postCommentsQueryKey);
-  useBackgroundRequest(mutationKey, ({ req, res }) => {
-    const isNew = req.variables.id !== res.comment.id;
-    updatePostComments(res.comment, isNew);
-    closeNewComment();
-  });
 
   return (
     <div
@@ -75,7 +59,7 @@ export function CompanionDiscussion({
           isOpen={!!parentComment}
           parentSelector={getCompanionWrapper}
           onRequestClose={closeNewComment}
-          onInputChange={setInput}
+          onInputChange={onInput}
           {...parentComment}
         />
       )}

--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -19,10 +19,12 @@ import usePersistentContext from '@dailydotdev/shared/src/hooks/usePersistentCon
 import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 import { postAnalyticsEvent } from '@dailydotdev/shared/src/lib/feed';
 import { postEventName } from '@dailydotdev/shared/src/components/utilities';
+import NewCommentModal from '@dailydotdev/shared/src/components/modals/NewCommentModal';
 import CompanionContextMenu from './CompanionContextMenu';
 import '@dailydotdev/shared/src/styles/globals.css';
-import { CompanionHelper } from './common';
+import { CompanionHelper, getCompanionWrapper } from './common';
 import useCompanionActions from './useCompanionActions';
+import { useCompanionPostComment } from './useCompanionPostComment';
 
 if (!isTesting) {
   Modal.setAppElement('daily-companion-app');
@@ -83,6 +85,8 @@ export default function CompanionMenu({
     onRemoveUpvoteMutate: () =>
       updatePost({ upvoted: false, numUpvotes: post.numUpvotes + -1 }),
   });
+  const { parentComment, closeNewComment, openNewComment, onInput } =
+    useCompanionPostComment(post);
 
   /**
    * Use a cleanup effect to always set the local cache helper state to false on destroy
@@ -209,11 +213,10 @@ export default function CompanionMenu({
         container={tooltipContainerProps}
       >
         <Button
-          href={`${post?.commentsPermalink}?c=true`}
-          tag="a"
           buttonSize="medium"
           className="btn-tertiary"
           icon={<CommentIcon />}
+          onClick={openNewComment}
         />
       </SimpleTooltip>
       <SimpleTooltip
@@ -250,6 +253,15 @@ export default function CompanionMenu({
         onBlockSource={blockSource}
         onDisableCompanion={optOut}
       />
+      {parentComment && (
+        <NewCommentModal
+          isOpen={!!parentComment}
+          parentSelector={getCompanionWrapper}
+          onRequestClose={closeNewComment}
+          onInputChange={onInput}
+          {...parentComment}
+        />
+      )}
     </div>
   );
 }

--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -37,6 +37,7 @@ type CompanionMenuProps = {
   companionState: boolean;
   onOptOut: () => void;
   setCompanionState: (T) => void;
+  onOpenComments?: () => void;
 };
 
 export default function CompanionMenu({
@@ -46,6 +47,7 @@ export default function CompanionMenu({
   companionState,
   onOptOut,
   setCompanionState,
+  onOpenComments,
 }: CompanionMenuProps): ReactElement {
   const { trackEvent } = useContext(AnalyticsContext);
   const { user, showLogin } = useContext(AuthContext);
@@ -86,7 +88,7 @@ export default function CompanionMenu({
       updatePost({ upvoted: false, numUpvotes: post.numUpvotes + -1 }),
   });
   const { parentComment, closeNewComment, openNewComment, onInput } =
-    useCompanionPostComment(post);
+    useCompanionPostComment(post, { onCommentSuccess: onOpenComments });
 
   /**
    * Use a cleanup effect to always set the local cache helper state to false on destroy
@@ -252,6 +254,7 @@ export default function CompanionMenu({
         onReport={report}
         onBlockSource={blockSource}
         onDisableCompanion={optOut}
+        onViewDiscussion={onOpenComments}
       />
       {parentComment && (
         <NewCommentModal

--- a/packages/extension/src/companion/useBackgroundPaginatedRequest.ts
+++ b/packages/extension/src/companion/useBackgroundPaginatedRequest.ts
@@ -6,17 +6,19 @@ export const useBackgroundPaginatedRequest = <T extends InfiniteData<unknown>>(
 ): T => {
   const client = useQueryClient();
   const data = client.getQueryData<T>(queryKey);
-  useBackgroundRequest(queryKey, ({ res, req }) => {
-    if (!res) {
-      return;
-    }
+  useBackgroundRequest(queryKey, {
+    callback: ({ res, req }) => {
+      if (!res) {
+        return;
+      }
 
-    const current = client.getQueryData(queryKey) as T;
-    const updated = { ...current } as T;
-    const index = updated.pages.length - 1;
-    updated.pageParams[index] = req.variables.after;
-    updated.pages[index] = res;
-    client.setQueryData(queryKey, updated);
+      const current = client.getQueryData(queryKey) as T;
+      const updated = { ...current } as T;
+      const index = updated.pages.length - 1;
+      updated.pageParams[index] = req.variables.after;
+      updated.pages[index] = res;
+      client.setQueryData(queryKey, updated);
+    },
   });
 
   return data;

--- a/packages/extension/src/companion/useBackgroundRequest.ts
+++ b/packages/extension/src/companion/useBackgroundRequest.ts
@@ -2,18 +2,23 @@ import { QueryKey, useQueryClient } from 'react-query';
 import { isQueryKeySame } from '@dailydotdev/shared/src/graphql/common';
 import { useRawBackgroundRequest } from './useRawBackgroundRequest';
 
+interface UseBackgroundRequestOptionalProps {
+  callback?: (params: unknown) => void;
+  enabled?: boolean;
+}
+
 export const useBackgroundRequest = (
   queryKey: QueryKey,
-  command?: (params: unknown) => void,
+  { callback, enabled = true }: UseBackgroundRequestOptionalProps = {},
 ): void => {
   const client = useQueryClient();
   useRawBackgroundRequest(({ key, ...args }) => {
-    if (!isQueryKeySame(key, queryKey)) {
+    if (!enabled || !isQueryKeySame(key, queryKey)) {
       return;
     }
 
-    if (command) {
-      command({ key, ...args });
+    if (callback) {
+      callback({ key, ...args });
     } else {
       client.setQueryData(queryKey, args.res);
     }

--- a/packages/extension/src/companion/useCompanionPostComment.ts
+++ b/packages/extension/src/companion/useCompanionPostComment.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Post } from '@dailydotdev/shared/src/graphql/posts';
 import {
   usePostComment,
@@ -19,8 +19,8 @@ export const useCompanionPostComment = (
   post: Post,
   params: UseCompanionPostCommentOptionalProps = {},
 ): UseCompanionPostComment => {
-  const { closeNewComment, updatePostComments, parentComment, ...props } =
-    usePostComment(post, params);
+  const postComment = usePostComment(post, params);
+  const { closeNewComment, updatePostComments, parentComment } = postComment;
   const [input, setInput] = useState<string>('');
   const previewQueryKey = ['comment_preview', input];
   const mentionQueryKey = ['user-mention', post?.id];
@@ -37,11 +37,5 @@ export const useCompanionPostComment = (
     },
   });
 
-  return {
-    ...props,
-    onInput: setInput,
-    closeNewComment,
-    updatePostComments,
-    parentComment,
-  };
+  return useMemo(() => ({ ...postComment, onInput: setInput }), [postComment]);
 };

--- a/packages/extension/src/companion/useCompanionPostComment.ts
+++ b/packages/extension/src/companion/useCompanionPostComment.ts
@@ -6,13 +6,18 @@ import {
 } from '@dailydotdev/shared/src/hooks/usePostComment';
 import { useBackgroundRequest } from './useBackgroundRequest';
 
+interface UseCompanionPostCommentOptionalProps
+  extends UsePostCommentOptionalProps {
+  onCommentSuccess?: () => void;
+}
+
 interface UseCompanionPostComment extends ReturnType<typeof usePostComment> {
   onInput: (value: string) => void;
 }
 
 export const useCompanionPostComment = (
   post: Post,
-  params: UsePostCommentOptionalProps = {},
+  params: UseCompanionPostCommentOptionalProps = {},
 ): UseCompanionPostComment => {
   const { closeNewComment, updatePostComments, parentComment, ...props } =
     usePostComment(post, params);
@@ -28,6 +33,7 @@ export const useCompanionPostComment = (
       const isNew = req.variables.id !== res.comment.id;
       updatePostComments(res.comment, isNew);
       closeNewComment();
+      params?.onCommentSuccess();
     },
   });
 

--- a/packages/extension/src/companion/useCompanionPostComment.ts
+++ b/packages/extension/src/companion/useCompanionPostComment.ts
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { Post } from '@dailydotdev/shared/src/graphql/posts';
+import {
+  usePostComment,
+  UsePostCommentOptionalProps,
+} from '@dailydotdev/shared/src/hooks/usePostComment';
+import { useBackgroundRequest } from './useBackgroundRequest';
+
+interface UseCompanionPostComment extends ReturnType<typeof usePostComment> {
+  onInput: (value: string) => void;
+}
+
+export const useCompanionPostComment = (
+  post: Post,
+  params: UsePostCommentOptionalProps = {},
+): UseCompanionPostComment => {
+  const { closeNewComment, updatePostComments, parentComment, ...props } =
+    usePostComment(post, params);
+  const [input, setInput] = useState<string>('');
+  const previewQueryKey = ['comment_preview', input];
+  const mentionQueryKey = ['user-mention', post?.id];
+  const mutationKey = ['post_comments_mutations', post?.id];
+  useBackgroundRequest(mentionQueryKey, { enabled: !!parentComment });
+  useBackgroundRequest(previewQueryKey, { enabled: !!parentComment });
+  useBackgroundRequest(mutationKey, {
+    enabled: !!parentComment,
+    callback: ({ req, res }) => {
+      const isNew = req.variables.id !== res.comment.id;
+      updatePostComments(res.comment, isNew);
+      closeNewComment();
+    },
+  });
+
+  return {
+    ...props,
+    onInput: setInput,
+    closeNewComment,
+    updatePostComments,
+    parentComment,
+  };
+};

--- a/packages/shared/src/hooks/usePostComment.ts
+++ b/packages/shared/src/hooks/usePostComment.ts
@@ -50,7 +50,8 @@ export const usePostComment = (
   const { user, showLogin } = useContext(AuthContext);
   const key = ['post_comments', post?.id];
   const postCommentNumKey = ['post_comments_num', post?.id];
-  const commentsNum = client.getQueryData<number>(postCommentNumKey);
+  const commentsNum =
+    client.getQueryData<number>(postCommentNumKey) || post.numComments;
   const comments = client.getQueryData<PostCommentsData>(key);
   const [lastScroll, setLastScroll] = useState(0);
   const [parentComment, setParentComment] = useState<ParentComment>(null);

--- a/packages/shared/src/hooks/usePostComment.ts
+++ b/packages/shared/src/hooks/usePostComment.ts
@@ -51,7 +51,7 @@ export const usePostComment = (
   const key = ['post_comments', post?.id];
   const postCommentNumKey = ['post_comments_num', post?.id];
   const commentsNum =
-    client.getQueryData<number>(postCommentNumKey) || post.numComments;
+    client.getQueryData<number>(postCommentNumKey) || post?.numComments;
   const comments = client.getQueryData<PostCommentsData>(key);
   const [lastScroll, setLastScroll] = useState(0);
   const [parentComment, setParentComment] = useState<ParentComment>(null);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added option to enable or disable listening for messages in background workers (inspired by react-query ❤️).
- Created a custom hook for managing the state and background workers in companion comments
- Changed the behavior for the comments button in the companion menu and in the context menu for viewing discussion
  - It should now open a modal in the main menu comments button. If submitted, it will open the discussion panel
  - The "View discussion" in Context menu should open the discussion panel.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
