### PR TITLE
fix: companion animation bug

### DIFF
--- a/packages/extension/src/companion/Companion.tsx
+++ b/packages/extension/src/companion/Companion.tsx
@@ -52,7 +52,8 @@ const Container = ({
       ref={containerRef}
       data-testId="companion"
       className={classNames(
-        'flex fixed flex-row top-[7.5rem] items-stretch right-0 z-10 max-w-[26.5rem] transition-transform',
+        'flex fixed flex-row top-[7.5rem] items-stretch right-0 z-10 max-w-[26.5rem]',
+        shouldLoad && 'transition-transform',
         companionExpanded ? 'translate-x-0' : 'translate-x-[22.5rem]',
       )}
     >

--- a/packages/extension/src/companion/CompanionPopupButton.tsx
+++ b/packages/extension/src/companion/CompanionPopupButton.tsx
@@ -12,7 +12,7 @@ import useExtensionAlerts from '../lib/useExtensionAlerts';
 export const CompanionPopupButton = (): ReactElement => {
   const { alerts, updateAlerts } = useExtensionAlerts();
   const { trackEvent } = useContext(AnalyticsContext);
-  const { contentScriptGranted } = useExtensionPermission({
+  const { contentScriptGranted, isFetched } = useExtensionPermission({
     origin: 'companion permission button',
   });
   const [showCompanionPermission, setShowCompanionPermission] = useState(
@@ -48,7 +48,7 @@ export const CompanionPopupButton = (): ReactElement => {
     setShowCompanionPermission(!showCompanionPermission);
   };
 
-  if (contentScriptGranted) {
+  if (contentScriptGranted || !isFetched) {
     return null;
   }
 

--- a/packages/extension/src/companion/useExtensionPermission.ts
+++ b/packages/extension/src/companion/useExtensionPermission.ts
@@ -6,6 +6,7 @@ import { companionPermissionGrantedLink } from '@dailydotdev/shared/src/lib/cons
 import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 
 interface UseExtensionPermission {
+  isFetched?: boolean;
   contentScriptGranted: boolean;
   registerContentScripts: () => Promise<boolean>;
 }
@@ -40,7 +41,7 @@ export const useExtensionPermission = ({
 }: UseExtensionPermissionProps): UseExtensionPermission => {
   const client = useQueryClient();
   const { trackEvent } = useContext(AnalyticsContext);
-  const { data: contentScriptGranted } = useQuery(
+  const { data: contentScriptGranted, isFetched } = useQuery(
     contentScriptKey,
     getContentScriptPermission,
     {
@@ -74,7 +75,7 @@ export const useExtensionPermission = ({
   };
 
   return useMemo(
-    () => ({ contentScriptGranted, registerContentScripts }),
-    [contentScriptGranted],
+    () => ({ contentScriptGranted, registerContentScripts, isFetched }),
+    [contentScriptGranted, isFetched],
   );
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- After further investigation, it seems the animation bug only happens on some sites - then I realized it is on those where we used to have an issue with enlarged dailydev logo at load.
- Now the animation should also be enabled only until the assets are loaded.
- The issue is when the transform property is forcing to render the animation.
- Also includes the fix for unintentionally showing the companion button.

Sample link:
https://blog.jetbrains.com/webstorm/2022/05/webstorm-2022-2-roadmap/

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
