### PR TITLE
fix: companion button content shift

### DIFF
--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -39,7 +39,7 @@ export type MainFeedPageProps = {
 export default function MainFeedPage({
   onPageChanged,
 }: MainFeedPageProps): ReactElement {
-  const { user } = useContext(AuthContext);
+  const { user, loadingUser } = useContext(AuthContext);
   const [feedName, setFeedName] = useState<string>('default');
   const [isSearchOn, setIsSearchOn] = useState(false);
   const [searchQuery, setSearchQuery] = useState<string>();
@@ -108,7 +108,9 @@ export default function MainFeedPage({
       onNavTabClick={onNavTabClick}
       screenCentered={false}
       customBanner={isDndActive && <DndBanner />}
-      additionalButtons={placement === 'header' && <CompanionPopupButton />}
+      additionalButtons={
+        !loadingUser && placement === 'header' && <CompanionPopupButton />
+      }
     >
       <FeedLayout>
         <MainFeedLayout


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We will now wait until the loading of the user finishes.
- Initially tried to use `loadedUserFromCache` but the profile component is not rendered until the `loadingUser` is false.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
