### PR TITLE
fix: re-inject content script on load

### DIFF
--- a/packages/extension/src/newtab/App.tsx
+++ b/packages/extension/src/newtab/App.tsx
@@ -25,6 +25,10 @@ import { version } from '../../package.json';
 import MainFeedPage from './MainFeedPage';
 import { DndContextProvider } from './DndContext';
 import { BootDataProvider } from '../../../shared/src/contexts/BootProvider';
+import {
+  registerBrowserContentScripts,
+  useExtensionPermission,
+} from '../companion/useExtensionPermission';
 
 const AnalyticsConsentModal = dynamic(() => import('./AnalyticsConsentModal'));
 
@@ -57,6 +61,9 @@ function InternalApp({
     shouldShowLogin,
     loginState,
   } = useContext(AuthContext);
+  const { contentScriptGranted } = useExtensionPermission({
+    origin: 'on extension load',
+  });
   const [analyticsConsent, setAnalyticsConsent] = usePersistentState(
     'consent',
     false,
@@ -88,6 +95,12 @@ function InternalApp({
     routeChangedCallbackRef.current();
     dismissToast();
   };
+
+  useEffect(() => {
+    if (contentScriptGranted) {
+      registerBrowserContentScripts();
+    }
+  }, [contentScriptGranted]);
 
   return (
     <DndContextProvider>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
