### PR TITLE
fix: date issue on FireFox

### DIFF
--- a/packages/webapp/pages/[userId]/index.tsx
+++ b/packages/webapp/pages/[userId]/index.tsx
@@ -127,7 +127,8 @@ const ProfilePage = ({ profile }: ProfileLayoutProps): ReactElement => {
       return [start, subYears(subDays(start, 2), 1)];
     }
     const selected = parseInt(dropdownOptions[selectedHistoryYear], 10);
-    const startYear = new Date(`01-01-${selected}`);
+    const startYear = new Date(selected, 0, 1);
+
     return [addDays(endOfYear(startYear), 1), startYear];
   }, [selectedHistoryYear]);
   const [readingHistory, setReadingHistory] =


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We initialised a `new Date()` in a wrong way, `01-01-2022` is not a valid format. (However Chrome seems super lenient I guess 🤷‍♂️
- Changed to `new Date(2022, 0, 1)` which is the supported format.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
