### PR TITLE
fix: shareable links for extension

### DIFF
--- a/packages/shared/src/components/ShareBar.tsx
+++ b/packages/shared/src/components/ShareBar.tsx
@@ -7,7 +7,6 @@ import { Post } from '../graphql/posts';
 import { useCopyPostLink } from '../hooks/useCopyPostLink';
 import {
   getFacebookShareLink,
-  getShareableLink,
   getTwitterShareLink,
   getWhatsappShareLink,
 } from '../lib/share';
@@ -25,8 +24,8 @@ const ColorfulShareButton = classed(
 ) as unknown as FunctionComponent<ButtonProps<'a'>>;
 
 export default function ShareBar({ post }: { post: Post }): ReactElement {
-  const href = getShareableLink();
-  const [copying, copyLink] = useCopyPostLink();
+  const href = post.commentsPermalink;
+  const [copying, copyLink] = useCopyPostLink(href);
   const { trackEvent } = useContext(AnalyticsContext);
 
   const onClick = (media: string) =>

--- a/packages/shared/src/components/ShareMobile.tsx
+++ b/packages/shared/src/components/ShareMobile.tsx
@@ -6,11 +6,12 @@ import { Button } from './buttons/Button';
 import { WidgetContainer } from './widgets/common';
 
 export interface Props {
+  link: string;
   share: () => Promise<void>;
 }
 
-export function ShareMobile({ share }: Props): ReactElement {
-  const [copying, copyLink] = useCopyPostLink();
+export function ShareMobile({ share, link }: Props): ReactElement {
+  const [copying, copyLink] = useCopyPostLink(link);
 
   return (
     <WidgetContainer className="flex laptop:hidden flex-col gap-2 items-start py-3 px-1">

--- a/packages/shared/src/components/ShareNewCommentPopup.tsx
+++ b/packages/shared/src/components/ShareNewCommentPopup.tsx
@@ -8,7 +8,6 @@ import ShareIcon from '../../icons/share.svg';
 import Confetti from '../svg/ConfettiSvg';
 import {
   getFacebookShareLink,
-  getShareableLink,
   getTwitterShareLink,
   getWhatsappShareLink,
 } from '../lib/share';
@@ -29,9 +28,9 @@ export default function ShareNewCommentPopup({
   post,
   onRequestClose,
 }: ShareNewCommentPopupProps): ReactElement {
-  const href = getShareableLink();
+  const href = post.commentsPermalink;
   const { user } = useContext(AuthContext);
-  const [copying, copyLink] = useCopyLink(() => post.commentsPermalink);
+  const [copying, copyLink] = useCopyLink(() => href);
 
   return (
     <div

--- a/packages/shared/src/components/post/PostWidgets.tsx
+++ b/packages/shared/src/components/post/PostWidgets.tsx
@@ -62,7 +62,7 @@ export function PostWidgets({
       )}
       <PostUsersHighlights post={post} />
       <ShareBar post={post} />
-      <ShareMobile share={sharePost} />
+      <ShareMobile share={sharePost} link={post.commentsPermalink} />
       {tokenRefreshed && (
         <FurtherReading currentPost={post} className="laptopL:w-[19.5rem]" />
       )}

--- a/packages/shared/src/hooks/useCopyPostLink.ts
+++ b/packages/shared/src/hooks/useCopyPostLink.ts
@@ -1,8 +1,7 @@
-import { getShareableLink } from '../lib/share';
 import { CopyNotifyFunction, useCopyLink } from './useCopyLink';
 
-export function useCopyPostLink(): [boolean, CopyNotifyFunction] {
-  const [copying, copy] = useCopyLink(getShareableLink);
+export function useCopyPostLink(link: string): [boolean, CopyNotifyFunction] {
+  const [copying, copy] = useCopyLink(() => link);
 
   return [copying, copy];
 }

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -1,5 +1,3 @@
-export const getShareableLink = (): string =>
-  typeof window !== 'undefined' ? window.location.href.split('?')[0] : '';
 export const getWhatsappShareLink = (link: string): string =>
   `https://wa.me/?text=${encodeURIComponent(link)}`;
 export const getTwitterShareLink = (link: string, text: string): string =>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We used to rely on the browser API to get URLs, but since we introduced the article modal for extension and webapp we need a more reliable source of URLs
- Changed to pass through the post commentsPermalink as this is always a valid url.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-110 #done
