### PR TITLE
fix: change view discussion to webapp post link

### DIFF
--- a/packages/extension/src/companion/CompanionContextMenu.tsx
+++ b/packages/extension/src/companion/CompanionContextMenu.tsx
@@ -18,7 +18,6 @@ type CompanionContextMenuProps = {
   postData: PostBootData;
   onReport: (T) => void;
   onBlockSource: (T) => void;
-  onViewDiscussion: () => void;
   onDisableCompanion: () => void;
 };
 
@@ -26,7 +25,6 @@ export default function CompanionContextMenu({
   postData,
   onReport,
   onBlockSource,
-  onViewDiscussion,
   onDisableCompanion,
 }: CompanionContextMenuProps): ReactElement {
   const { displayToast } = useToastNotification();
@@ -72,8 +70,10 @@ export default function CompanionContextMenu({
         className="menu-primary"
         animation="fade"
       >
-        <Item onClick={onViewDiscussion}>
-          <CommentIcon className="mr-2 text-xl" /> View discussion
+        <Item>
+          <a className="flex w-full" href={postData?.commentsPermalink}>
+            <CommentIcon className="mr-2 text-xl" /> View discussion
+          </a>
         </Item>
         <Item onClick={() => onShareOrCopyLink()}>
           <ShareIcon className="mr-2 text-xl" /> Share article

--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -245,7 +245,6 @@ export default function CompanionMenu({
         onReport={report}
         onBlockSource={blockSource}
         onDisableCompanion={optOut}
-        onViewDiscussion={onOpenComments}
       />
       {parentComment && (
         <NewCommentModal


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Change the view discussion button in the companion context to link to the post commentsPermalink as before.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-111 #done
