### PR TITLE
fix: refresh token utilization

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -44,8 +44,13 @@ const sendBootData = async (req, sender) => {
 
   const url = sender?.tab?.url;
 
-  const [deviceId, { postData, settings, flags, user, alerts, visit }] =
-    await Promise.all([getOrGenerateDeviceId(), getBootData('companion', url)]);
+  const [
+    deviceId,
+    { postData, settings, flags, user, alerts, visit, accessToken },
+  ] = await Promise.all([
+    getOrGenerateDeviceId(),
+    getBootData('companion', url),
+  ]);
 
   let settingsOutput = settings;
   if (!cacheData?.user || !('providers' in cacheData?.user)) {
@@ -60,6 +65,7 @@ const sendBootData = async (req, sender) => {
     user,
     alerts,
     visit,
+    accessToken,
   });
 };
 

--- a/packages/extension/src/companion/App.tsx
+++ b/packages/extension/src/companion/App.tsx
@@ -5,22 +5,34 @@ import { Boot } from '@dailydotdev/shared/src/lib/boot';
 import FeaturesContext from '@dailydotdev/shared/src/contexts/FeaturesContext';
 import { AuthContextProvider } from '@dailydotdev/shared/src/contexts/AuthContext';
 import { SettingsContextProvider } from '@dailydotdev/shared/src/contexts/SettingsContext';
+import { useRefreshToken } from '@dailydotdev/shared/src/hooks/useRefreshToken';
 import { AlertContextProvider } from '@dailydotdev/shared/src/contexts/AlertContext';
 import { AnalyticsContextProvider } from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 import Toast from '@dailydotdev/shared/src/components/notifications/Toast';
+import { apiUrl } from '@dailydotdev/shared/src/lib/config';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
 import Companion from './Companion';
 import CustomRouter from '../lib/CustomRouter';
 import { companionFetch } from './companionFetch';
 import { version } from '../../package.json';
+import { useBackgroundRequest } from './useBackgroundRequest';
 
 const queryClient = new QueryClient();
 const router = new CustomRouter();
 
 export type CompanionData = { url: string; deviceId: string } & Pick<
   Boot,
-  'postData' | 'settings' | 'flags' | 'alerts' | 'user' | 'visit'
+  | 'postData'
+  | 'settings'
+  | 'flags'
+  | 'alerts'
+  | 'user'
+  | 'visit'
+  | 'accessToken'
 >;
+
+const refreshTokenKey = 'refresh_token';
+
 export default function App({
   deviceId,
   url,
@@ -30,7 +42,9 @@ export default function App({
   user,
   alerts,
   visit,
+  accessToken,
 }: CompanionData): ReactElement {
+  const [token, setToken] = useState(accessToken);
   const [isOptOutCompanion, setIsOptOutCompanion] = useState<boolean>(
     settings?.optOutCompanion,
   );
@@ -40,6 +54,16 @@ export default function App({
   }
 
   const memoizedFlags = useMemo(() => ({ flags }), [flags]);
+  const refetchData = () =>
+    companionFetch(`${apiUrl}/v1/auth/refreshToken`, {
+      headers: { requestKey: refreshTokenKey },
+    });
+
+  useRefreshToken(token, refetchData);
+  useBackgroundRequest(refreshTokenKey, {
+    queryClient,
+    callback: ({ res }) => setToken(res),
+  });
 
   return (
     <div>

--- a/packages/extension/src/companion/App.tsx
+++ b/packages/extension/src/companion/App.tsx
@@ -55,14 +55,14 @@ export default function App({
 
   const memoizedFlags = useMemo(() => ({ flags }), [flags]);
   const refetchData = () =>
-    companionFetch(`${apiUrl}/v1/auth/refreshToken`, {
+    companionFetch(`${apiUrl}/boot`, {
       headers: { requestKey: refreshTokenKey },
     });
 
   useRefreshToken(token, refetchData);
   useBackgroundRequest(refreshTokenKey, {
     queryClient,
-    callback: ({ res }) => setToken(res),
+    callback: ({ res }) => setToken(res.accessToken),
   });
 
   return (

--- a/packages/extension/src/companion/Companion.spec.tsx
+++ b/packages/extension/src/companion/Companion.spec.tsx
@@ -67,6 +67,7 @@ const renderComponent = (postdata, settings): RenderResult => {
       user={defaultUser}
       flags={{}}
       deviceId="123"
+      accessToken={{ token: '', expiresIn: '' }}
     />,
   );
 };

--- a/packages/extension/src/companion/Companion.tsx
+++ b/packages/extension/src/companion/Companion.tsx
@@ -7,7 +7,7 @@ import React, {
   useState,
   LegacyRef,
 } from 'react';
-import { useQueryClient } from 'react-query';
+import { useQuery } from 'react-query';
 import classNames from 'classnames';
 import Modal from 'react-modal';
 import { isTesting } from '@dailydotdev/shared/src/lib/constants';
@@ -68,7 +68,6 @@ export default function Companion({
   companionExpanded,
   onOptOut,
 }: CompanionProps): ReactElement {
-  const client = useQueryClient();
   const containerRef = useRef<HTMLDivElement>();
   const [isCommentsOpen, setIsCommentsOpen] = useState(false);
   const [assetsLoaded, setAssetsLoaded] = useState(isTesting);
@@ -77,19 +76,12 @@ export default function Companion({
     useState<boolean>(companionExpanded);
   const { user, closeLogin, loadingUser, shouldShowLogin, loginState } =
     useContext(AuthContext);
+  useQuery(REQUEST_PROTOCOL_KEY, () => ({
+    requestMethod: companionRequest,
+    fetchMethod: companionFetch,
+  }));
 
   const routeChangedCallbackRef = useTrackPageView();
-
-  useEffect(() => {
-    if (!assetsLoaded) {
-      return;
-    }
-
-    client.setQueryData(REQUEST_PROTOCOL_KEY, {
-      requestMethod: companionRequest,
-      fetchMethod: companionFetch,
-    });
-  }, [assetsLoaded]);
 
   useEffect(() => {
     if (routeChangedCallbackRef.current) {

--- a/packages/extension/src/companion/index.tsx
+++ b/packages/extension/src/companion/index.tsx
@@ -14,7 +14,17 @@ const renderApp = ({ ...props }: CompanionData) => {
 };
 
 browser.runtime.onMessage.addListener(
-  ({ deviceId, url, postData, settings, flags, user, alerts, visit }) => {
+  ({
+    deviceId,
+    url,
+    postData,
+    settings,
+    flags,
+    user,
+    alerts,
+    visit,
+    accessToken,
+  }) => {
     if (postData && !settings.optOutCompanion) {
       renderApp({
         deviceId,
@@ -25,6 +35,7 @@ browser.runtime.onMessage.addListener(
         user,
         alerts,
         visit,
+        accessToken,
       });
     }
   },

--- a/packages/extension/src/companion/useBackgroundRequest.ts
+++ b/packages/extension/src/companion/useBackgroundRequest.ts
@@ -1,17 +1,22 @@
-import { QueryKey, useQueryClient } from 'react-query';
+import { QueryKey, QueryClient, useQueryClient } from 'react-query';
 import { isQueryKeySame } from '@dailydotdev/shared/src/graphql/common';
 import { useRawBackgroundRequest } from './useRawBackgroundRequest';
 
 interface UseBackgroundRequestOptionalProps {
+  queryClient?: QueryClient;
   callback?: (params: unknown) => void;
   enabled?: boolean;
 }
 
 export const useBackgroundRequest = (
   queryKey: QueryKey,
-  { callback, enabled = true }: UseBackgroundRequestOptionalProps = {},
+  {
+    callback,
+    queryClient,
+    enabled = true,
+  }: UseBackgroundRequestOptionalProps = {},
 ): void => {
-  const client = useQueryClient();
+  const client = queryClient || useQueryClient();
   useRawBackgroundRequest(({ key, ...args }) => {
     if (!enabled || !isQueryKeySame(key, queryKey)) {
       return;

--- a/packages/extension/src/companion/useCompanionPostComment.ts
+++ b/packages/extension/src/companion/useCompanionPostComment.ts
@@ -33,7 +33,7 @@ export const useCompanionPostComment = (
       const isNew = req.variables.id !== res.comment.id;
       updatePostComments(res.comment, isNew);
       closeNewComment();
-      params?.onCommentSuccess();
+      params?.onCommentSuccess?.();
     },
   });
 

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -3,6 +3,7 @@ import React, {
   ReactNode,
   useCallback,
   useEffect,
+  useRef,
   useState,
 } from 'react';
 import { useQuery, useQueryClient } from 'react-query';
@@ -20,24 +21,25 @@ import {
 } from './SettingsContext';
 import { storageWrapper as storage } from '../lib/storageWrapper';
 
-function useRefreshToken(
+export function useRefreshToken(
   accessToken: AccessToken,
   refresh: () => Promise<unknown>,
-) {
-  const [refreshTokenTimeout, setRefreshTokenTimeout] = useState<number>();
+): void {
+  const timeout = useRef<number>();
 
   useEffect(() => {
     if (accessToken) {
-      if (refreshTokenTimeout) {
-        clearTimeout(refreshTokenTimeout);
+      if (timeout.current) {
+        window.clearTimeout(timeout.current);
       }
       const expiresInMillis = differenceInMilliseconds(
         new Date(accessToken.expiresIn),
         new Date(),
       );
       // Refresh token before it expires
-      setRefreshTokenTimeout(
-        window.setTimeout(refresh, expiresInMillis - 1000 * 60 * 2),
+      timeout.current = window.setTimeout(
+        refresh,
+        expiresInMillis - 1000 * 60 * 2,
       );
     }
   }, [accessToken, refresh]);

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -3,12 +3,10 @@ import React, {
   ReactNode,
   useCallback,
   useEffect,
-  useRef,
   useState,
 } from 'react';
 import { useQuery, useQueryClient } from 'react-query';
-import { differenceInMilliseconds } from 'date-fns';
-import { AccessToken, BootCacheData, getBootData } from '../lib/boot';
+import { BootCacheData, getBootData } from '../lib/boot';
 import FeaturesContext from './FeaturesContext';
 import { AuthContextProvider } from './AuthContext';
 import { AnonymousUser, LoggedUser } from '../lib/user';
@@ -20,30 +18,7 @@ import {
   themeModes,
 } from './SettingsContext';
 import { storageWrapper as storage } from '../lib/storageWrapper';
-
-export function useRefreshToken(
-  accessToken: AccessToken,
-  refresh: () => Promise<unknown>,
-): void {
-  const timeout = useRef<number>();
-
-  useEffect(() => {
-    if (accessToken) {
-      if (timeout.current) {
-        window.clearTimeout(timeout.current);
-      }
-      const expiresInMillis = differenceInMilliseconds(
-        new Date(accessToken.expiresIn),
-        new Date(),
-      );
-      // Refresh token before it expires
-      timeout.current = window.setTimeout(
-        refresh,
-        expiresInMillis - 1000 * 60 * 2,
-      );
-    }
-  }, [accessToken, refresh]);
-}
+import { useRefreshToken } from '../hooks/useRefreshToken';
 
 export const BOOT_LOCAL_KEY = 'boot:local';
 export const BOOT_QUERY_KEY = 'boot';

--- a/packages/shared/src/hooks/useRefreshToken.ts
+++ b/packages/shared/src/hooks/useRefreshToken.ts
@@ -1,0 +1,27 @@
+import { useRef, useEffect } from 'react';
+import { differenceInMilliseconds } from 'date-fns';
+import { AccessToken } from '../lib/boot';
+
+export function useRefreshToken(
+  accessToken: AccessToken,
+  refresh: () => Promise<unknown>,
+): void {
+  const timeout = useRef<number>();
+
+  useEffect(() => {
+    if (accessToken) {
+      if (timeout.current) {
+        window.clearTimeout(timeout.current);
+      }
+      const expiresInMillis = differenceInMilliseconds(
+        new Date(accessToken.expiresIn),
+        new Date(),
+      );
+      // Refresh token before it expires
+      timeout.current = window.setTimeout(
+        refresh,
+        expiresInMillis - 1000 * 60 * 2,
+      );
+    }
+  }, [accessToken, refresh]);
+}


### PR DESCRIPTION
## Changes

I think this is one comment from our beta user has really helped us finding the root cause.

> As an FYI, I couldn’t commit the above message because of the “Access denied” error, but after a refresh of the page, I could. Same thing with the “markdown preview”, after the refresh it works. So perhaps a timing issue since I took a while to write the comment? Not sure, but I’ll keep an eye to see if I can reproduce it.

### Describe what this PR does
- We received quite a few feedback relating to making a comment. After further investigation, it was realized the token for making requests was not refreshed, meaning, every request gets rejected (upvotes/comments/upvotes modal/etc).
- We are now utilizing the custom hook used in boot for refreshing the token.
- Instead of re-requesting the whole boot data - we now instead request for the refreshed token.

Blocked until this PR is merged: https://github.com/dailydotdev/daily-gateway/pull/471

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

Manually waited for quite some while to ensure the token is refreshed (vice-versa), to ensure workability.
Preview:
![image](https://user-images.githubusercontent.com/13744167/172119540-99ab01be-67ed-4833-962a-22d8740d6fc3.png)

![image](https://user-images.githubusercontent.com/13744167/172119713-fe734fdc-ec28-43b3-bcb1-6cafeae4b88a.png)

As it can be noticed, the requests have succeeded after the refresh token call.

Preview before the fix:
![image](https://user-images.githubusercontent.com/13744167/172119779-7d868051-739f-46a7-a7d7-b911677cb391.png)



DD-WT-113 #done
