### PR TITLE
fix: firefox companion multiple instances

### DIFF
--- a/packages/extension/src/companion/useExtensionPermission.ts
+++ b/packages/extension/src/companion/useExtensionPermission.ts
@@ -29,9 +29,10 @@ export const getContentScriptPermission = (): Promise<boolean> =>
 
 export const getContentScriptPermissionAndRegister =
   async (): Promise<void> => {
+    const isFirefox = process.env.TARGET_BROWSER === 'firefox';
     const permission = await getContentScriptPermission();
 
-    if (permission) {
+    if (permission && !isFirefox) {
       await registerBrowserContentScripts();
     }
   };

--- a/packages/extension/src/content/index.tsx
+++ b/packages/extension/src/content/index.tsx
@@ -1,16 +1,20 @@
 import { browser } from 'webextension-polyfill-ts';
 
-// Inject app div
-const appContainer = document.createElement('daily-companion-app');
-document.body.appendChild(appContainer);
+const hasRendered = !!document.querySelector('daily-companion-app');
 
-// Create shadow dom
-const shadow = document
-  .querySelector('daily-companion-app')
-  .attachShadow({ mode: 'open' });
+if (!hasRendered) {
+  // Inject app div
+  const appContainer = document.createElement('daily-companion-app');
+  document.body.appendChild(appContainer);
 
-const wrapper = document.createElement('div');
-wrapper.id = 'daily-companion-wrapper';
-shadow.appendChild(wrapper);
+  // Create shadow dom
+  const shadow = document
+    .querySelector('daily-companion-app')
+    .attachShadow({ mode: 'open' });
 
-browser.runtime.sendMessage({ type: 'CONTENT_LOADED' });
+  const wrapper = document.createElement('div');
+  wrapper.id = 'daily-companion-wrapper';
+  shadow.appendChild(wrapper);
+
+  browser.runtime.sendMessage({ type: 'CONTENT_LOADED' });
+}


### PR DESCRIPTION
## Changes

### Describe what this PR does
Every step of the way, we check content scripts if permission is already given. With Chrome, no matter how many you register your scripts, when re-injecting it, the current one just gets replaced. For Firefox, it registers another instance.

There are two ways to go about this issue.

The first is (https://github.com/dailydotdev/apps/commit/099a46205e2b80153224ca51e23bd0a8a77e35be), to target where we inject the scripts and exclude Firefox if `permissions.contains` return `true`. The API only returns true if it was registered already.

The second one is (https://github.com/dailydotdev/apps/commit/c0648292321a8512330de3b60161eef977ed8fb1), before creating another instance in the DOM, we will check first if our element already exists. 

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
