### PR TITLE
fix: companion state on spa site navigation

### DIFF
--- a/packages/extension/src/companion/index.tsx
+++ b/packages/extension/src/companion/index.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { browser } from 'webextension-polyfill-ts';
-import { themeModes } from '@dailydotdev/shared/src/contexts/SettingsContext';
+import {
+  applyTheme,
+  themeModes,
+} from '@dailydotdev/shared/src/contexts/SettingsContext';
 import { getCompanionWrapper } from './common';
 import App, { CompanionData } from './App';
 
-const renderApp = ({ ...props }: CompanionData) => {
-  const { settings } = props;
-  getCompanionWrapper().classList.add(themeModes[settings.theme]);
+const renderApp = (props: CompanionData) => {
+  const container = getCompanionWrapper();
+  applyTheme(themeModes[props.settings.theme]);
 
   // Set target of the React app to shadow dom
-  ReactDOM.render(<App {...props} />, getCompanionWrapper());
+  ReactDOM.render(<App {...props} />, container);
 };
 
 browser.runtime.onMessage.addListener(
@@ -25,7 +28,11 @@ browser.runtime.onMessage.addListener(
     visit,
     accessToken,
   }) => {
-    if (postData && !settings.optOutCompanion) {
+    if (settings.optOutCompanion) {
+      return;
+    }
+
+    if (postData) {
       renderApp({
         deviceId,
         url,
@@ -37,6 +44,11 @@ browser.runtime.onMessage.addListener(
         visit,
         accessToken,
       });
+    } else {
+      const container = getCompanionWrapper();
+      if (container) {
+        ReactDOM.unmountComponentAtNode(container);
+      }
     }
   },
 );

--- a/packages/extension/src/content/index.tsx
+++ b/packages/extension/src/content/index.tsx
@@ -14,3 +14,12 @@ wrapper.id = 'daily-companion-wrapper';
 shadow.appendChild(wrapper);
 
 browser.runtime.sendMessage({ type: 'CONTENT_LOADED' });
+
+let lastUrl = window.location.href;
+new MutationObserver(() => {
+  const current = window.location.href;
+  if (current !== lastUrl) {
+    lastUrl = current;
+    browser.runtime.sendMessage({ type: 'CONTENT_LOADED' });
+  }
+}).observe(document, { subtree: true, childList: true });

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -74,20 +74,23 @@ export const remoteThemes: Record<ThemeMode, RemoteTheme> = {
   [ThemeMode.Auto]: 'auto',
 };
 
-export function applyTheme(themeMode: ThemeMode): void {
-  if (document.documentElement.classList.contains(themeMode)) {
+export function applyTheme(
+  themeMode: ThemeMode,
+  el: HTMLElement = document.documentElement,
+): void {
+  if (!el || el.classList.contains(themeMode)) {
     return;
   }
 
   if (themeMode === ThemeMode.Dark) {
-    document.documentElement.classList.remove(ThemeMode.Light);
-    document.documentElement.classList.remove(ThemeMode.Auto);
+    el.classList.remove(ThemeMode.Light);
+    el.classList.remove(ThemeMode.Auto);
   } else if (themeMode === ThemeMode.Light) {
-    document.documentElement.classList.add(ThemeMode.Light);
-    document.documentElement.classList.remove(ThemeMode.Auto);
+    el.classList.add(ThemeMode.Light);
+    el.classList.remove(ThemeMode.Auto);
   } else {
-    document.documentElement.classList.remove(ThemeMode.Light);
-    document.documentElement.classList.add(ThemeMode.Auto);
+    el.classList.remove(ThemeMode.Light);
+    el.classList.add(ThemeMode.Auto);
   }
 }
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- A mutation observer that watches the changes with `document`. Sends a message when change is detected.
- Have tried window and document listeners for watching the URL change, but none has worked.
- Have also tried `browser.onUpdated.addEventListener` but had some issues with background worker.

Works on both Chrome and Firefox.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing
Steps to test:
1. Install the app from this build.
2. Visit https://dev.to/kbatavia12/project-ideas-frustrated-3lai
3. Navigate to devto's homepage (hides companion).
4. Search "Project ideas!!! (Frustrated)"
5. Open the same article
6. Should show companion again.

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-116 #done
