### PR TITLE
fix: prevent comments from reloading to placeholders

### DIFF
--- a/packages/extension/src/companion/common.tsx
+++ b/packages/extension/src/companion/common.tsx
@@ -4,8 +4,6 @@ import {
   PointerColor,
 } from '@dailydotdev/shared/src/components/Pointer';
 
-export const initialDataKey = 'initial';
-
 export const getCompanionWrapper = (): HTMLElement =>
   document
     .querySelector('daily-companion-app')

--- a/packages/extension/src/companion/common.tsx
+++ b/packages/extension/src/companion/common.tsx
@@ -4,6 +4,8 @@ import {
   PointerColor,
 } from '@dailydotdev/shared/src/components/Pointer';
 
+export const initialDataKey = 'initial';
+
 export const getCompanionWrapper = (): HTMLElement =>
   document
     .querySelector('daily-companion-app')

--- a/packages/extension/src/companion/companionRequest.tsx
+++ b/packages/extension/src/companion/companionRequest.tsx
@@ -1,6 +1,6 @@
 import request from 'graphql-request';
 import { browser } from 'webextension-polyfill-ts';
-import { initialDataKey } from './common';
+import { initialDataKey } from '@dailydotdev/shared/src/lib/constants';
 
 const proxyRequest = {
   apply(_, __, args) {

--- a/packages/extension/src/companion/companionRequest.tsx
+++ b/packages/extension/src/companion/companionRequest.tsx
@@ -1,10 +1,10 @@
 import request from 'graphql-request';
 import { browser } from 'webextension-polyfill-ts';
+import { initialDataKey } from './common';
 
 const proxyRequest = {
   apply(_, __, args) {
-    const initialCol = 'initial';
-    const { [initialCol]: initial, ...variables } = args?.[2];
+    const { [initialDataKey]: initial, ...variables } = args?.[2];
 
     browser.runtime.sendMessage({
       type: 'GRAPHQL_REQUEST',

--- a/packages/extension/src/companion/companionRequest.tsx
+++ b/packages/extension/src/companion/companionRequest.tsx
@@ -3,14 +3,18 @@ import { browser } from 'webextension-polyfill-ts';
 
 const proxyRequest = {
   apply(_, __, args) {
+    const initialCol = 'initial';
+    const { [initialCol]: initial, ...variables } = args?.[2];
+
     browser.runtime.sendMessage({
       type: 'GRAPHQL_REQUEST',
       url: args?.[0],
       document: args?.[1],
-      variables: args?.[2],
+      variables,
       headers: args?.[3],
     });
-    return null;
+
+    return initial ?? null;
   },
 };
 

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -12,6 +12,7 @@ import MainComment from '../comments/MainComment';
 import PlaceholderCommentList from '../comments/PlaceholderCommentList';
 import DeleteCommentModal from '../modals/DeleteCommentModal';
 import { useRequestProtocol } from '../../hooks/useRequestProtocol';
+import { initialDataKey } from '../../lib/constants';
 
 export interface ParentComment {
   authorName: string;
@@ -92,7 +93,7 @@ export function PostComments({
         requestMethod(
           `${apiUrl}/graphql`,
           POST_COMMENTS_QUERY,
-          { postId: id, initial: comments },
+          { postId: id, [initialDataKey]: comments },
           { requestKey: JSON.stringify(queryKey) },
         ),
       {

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -92,7 +92,7 @@ export function PostComments({
         requestMethod(
           `${apiUrl}/graphql`,
           POST_COMMENTS_QUERY,
-          { postId: id },
+          { postId: id, initial: comments },
           { requestKey: JSON.stringify(queryKey) },
         ),
       {

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -15,6 +15,7 @@ export const contentGuidlines = 'https://daily.dev/support/content-guidelines';
 export const companionExplainerVideo = 'https://r.daily.dev/companion-overview';
 export const companionPermissionGrantedLink =
   'https://r.daily.dev/try-the-companion';
+export const initialDataKey = 'initial';
 
 export const isDevelopment = process.env.NODE_ENV === 'development';
 export const isProduction = process.env.NODE_ENV === 'production';


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Our companion request method was retuning `null` as a default, this causes react query to refresh to `null` then only to the actual data
- The fix introduced a optional object that can be returned, this optional object is the temporary previous object.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-124 #done 
