### PR TITLE
feat: change the companion comment scrollable section

### DIFF
--- a/packages/extension/src/companion/CompanionContent.tsx
+++ b/packages/extension/src/companion/CompanionContent.tsx
@@ -105,7 +105,6 @@ export default function CompanionContent({
       />
       {viewComments && (
         <CompanionDiscussion
-          className="overflow-auto absolute top-full right-0 -left-px min-h-[14rem]"
           style={{ maxHeight: `calc(100vh - ${heightPx})` }}
           post={post}
           onShowUpvoted={onShowUpvotedComment}

--- a/packages/extension/src/companion/CompanionDiscussion.tsx
+++ b/packages/extension/src/companion/CompanionDiscussion.tsx
@@ -42,18 +42,24 @@ export function CompanionDiscussion({
       style={style}
       className={classNames(
         className,
-        'p-6 rounded-bl-16 border border-t-2 border-r-0 bg-theme-bg-primary border-theme-divider-quaternary',
+        'py-6 flex absolute top-full right-0 -left-px flex-col min-h-[14rem] rounded-bl-16 border border-t-2 border-r-0 bg-theme-bg-primary border-theme-divider-quaternary',
       )}
     >
-      <NewComment user={user} onNewComment={openNewComment} />
-      <h3 className="my-8 font-bold typo-callout">Discussion</h3>
-      <PostComments
-        post={post}
-        applyBottomMargin={false}
-        onClick={onCommentClick}
-        onClickUpvote={onShowUpvoted}
-        modalParentSelector={getCompanionWrapper}
+      <NewComment
+        className="laptop:px-6"
+        user={user}
+        onNewComment={openNewComment}
       />
+      <div className="overflow-auto flex-1 px-6 mt-8">
+        <h3 className="mb-8 font-bold typo-callout">Discussion</h3>
+        <PostComments
+          post={post}
+          applyBottomMargin={false}
+          onClick={onCommentClick}
+          onClickUpvote={onShowUpvoted}
+          modalParentSelector={getCompanionWrapper}
+        />
+      </div>
       {parentComment && (
         <NewCommentModal
           isOpen={!!parentComment}

--- a/packages/shared/src/components/post/NewComment.tsx
+++ b/packages/shared/src/components/post/NewComment.tsx
@@ -7,15 +7,17 @@ import styles from './NewComment.module.css';
 
 interface NewCommentProps {
   user?: LoggedUser;
+  className?: string;
   onNewComment: () => unknown;
 }
 
 export function NewComment({
   user,
+  className,
   onNewComment,
 }: NewCommentProps): ReactElement {
   return (
-    <NewCommentContainer>
+    <NewCommentContainer className={className}>
       <button
         type="button"
         className={classNames(


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Remodel the companion comment section
- Only the actual comments and title are scrollable now
See screenshot:
<img width="435" alt="Screenshot 2022-06-07 at 16 57 43" src="https://user-images.githubusercontent.com/554874/172413387-c15c83a8-1ea1-4c98-8307-099c0111a5ce.png">


### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-119 #done
