### PR TITLE
feat: close companion on escape key

### DIFF
--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -18,6 +18,7 @@ import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext'
 import { postAnalyticsEvent } from '@dailydotdev/shared/src/lib/feed';
 import { postEventName } from '@dailydotdev/shared/src/components/utilities';
 import NewCommentModal from '@dailydotdev/shared/src/components/modals/NewCommentModal';
+import { useKeyboardNavigation } from '@dailydotdev/shared/src/hooks/useKeyboardNavigation';
 import CompanionContextMenu from './CompanionContextMenu';
 import '@dailydotdev/shared/src/styles/globals.css';
 import { CompanionHelper, getCompanionWrapper } from './common';
@@ -148,6 +149,20 @@ export default function CompanionMenu({
   };
 
   const tooltipContainerProps = { className: 'shadow-2 whitespace-nowrap' };
+
+  const onsEscape = () => {
+    if (!companionState) {
+      return;
+    }
+
+    trackEvent({ event_name: 'close companion' });
+    toggleCompanionExpanded({ companionExpandedValue: false });
+    setCompanionState(false);
+  };
+
+  useKeyboardNavigation(window, [['Escape', onsEscape]], {
+    disabledModalOpened: true,
+  });
 
   return (
     <div className="group flex relative flex-col gap-2 self-center p-2 my-6 w-14 rounded-l-16 border border-theme-divider-quaternary bg-theme-bg-primary">

--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -150,7 +150,7 @@ export default function CompanionMenu({
 
   const tooltipContainerProps = { className: 'shadow-2 whitespace-nowrap' };
 
-  const onsEscape = () => {
+  const onEscape = () => {
     if (!companionState) {
       return;
     }

--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -160,7 +160,7 @@ export default function CompanionMenu({
     setCompanionState(false);
   };
 
-  useKeyboardNavigation(window, [['Escape', onsEscape]], {
+  useKeyboardNavigation(window, [['Escape', onEscape]], {
     disabledModalOpened: true,
   });
 

--- a/packages/shared/src/hooks/useKeyboardNavigation.ts
+++ b/packages/shared/src/hooks/useKeyboardNavigation.ts
@@ -20,7 +20,7 @@ export const useKeyboardNavigation = (
       const [base] = (e.composedPath?.() as HTMLElement[]) || e.path || [];
       const tagName =
         base?.tagName.toLowerCase() as keyof JSX.IntrinsicElements;
-      if (optional?.disableOnTags?.indexOf(tagName) !== -1) {
+      if (optional?.disableOnTags?.includes(tagName)) {
         return;
       }
 

--- a/packages/shared/src/hooks/useKeyboardNavigation.ts
+++ b/packages/shared/src/hooks/useKeyboardNavigation.ts
@@ -4,7 +4,10 @@ type Keypress = [string, (e: KeyboardEvent) => unknown];
 
 interface OptionalParameters {
   disableOnTags?: (keyof JSX.IntrinsicElements)[];
+  disabledModalOpened?: boolean;
 }
+
+const MODAL_SELECTOR = '.ReactModal__Overlay--after-open';
 
 export const useKeyboardNavigation = (
   element: HTMLElement | Window,
@@ -21,6 +24,14 @@ export const useKeyboardNavigation = (
       const tagName =
         base?.tagName.toLowerCase() as keyof JSX.IntrinsicElements;
       if (optional?.disableOnTags?.includes(tagName)) {
+        return;
+      }
+
+      if (
+        optional.disabledModalOpened &&
+        ((element as HTMLElement).querySelector?.(MODAL_SELECTOR) ||
+          (element as Window).document?.querySelector?.(MODAL_SELECTOR))
+      ) {
         return;
       }
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Set the companion in collapsed form when `esc` key is pressed.
- Should not close when any of our modal is open. 

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
