### PR TITLE
fix: stop keypress propagation to avoid conflict with site's keybindings

### DIFF
--- a/packages/shared/src/components/modals/CommentBox.tsx
+++ b/packages/shared/src/components/modals/CommentBox.tsx
@@ -99,6 +99,7 @@ function CommentBox({
   const handleKeydown = (e: KeyboardEvent<HTMLDivElement>) => {
     const defaultCallback = () => onMentionKeypress(e);
     onKeyDown(e, defaultCallback);
+    e.stopPropagation();
   };
 
   return (


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The only input we have in our companion app is the comment box.
- Stopping the propagation on keypress.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-125 #done
