### PR TITLE
fix: highest possible z-index and remove conditional copy link

### DIFF
--- a/packages/extension/public/css/daily-companion-app.css
+++ b/packages/extension/public/css/daily-companion-app.css
@@ -6,6 +6,6 @@ daily-companion-app {
   tab-size: 4;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Ubuntu, Segoe UI, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
   position: fixed;
-  z-index: 100001;
+  z-index: 2147483647;
   font-feature-settings: normal!important;
 }

--- a/packages/extension/src/companion/CompanionContent.tsx
+++ b/packages/extension/src/companion/CompanionContent.tsx
@@ -59,23 +59,21 @@ export default function CompanionContent({
           <LogoIcon className="w-8 rounded-8" />
         </a>
         {post?.trending && <HotLabel />}
-        {post?.summary && (
-          <SimpleTooltip
-            placement="top"
-            content="Copy link"
-            appendTo="parent"
-            container={{ className: 'shadow-2 whitespace-nowrap' }}
-          >
-            <Button
-              icon={<CopyIcon />}
-              className={classNames(
-                'ml-auto',
-                copying ? 'btn-tertiary-avocado' : ' btn-tertiary',
-              )}
-              onClick={() => copyLink()}
-            />
-          </SimpleTooltip>
-        )}
+        <SimpleTooltip
+          placement="top"
+          content="Copy link"
+          appendTo="parent"
+          container={{ className: 'shadow-2 whitespace-nowrap' }}
+        >
+          <Button
+            icon={<CopyIcon />}
+            className={classNames(
+              'ml-auto',
+              copying ? 'btn-tertiary-avocado' : ' btn-tertiary',
+            )}
+            onClick={() => copyLink()}
+          />
+        </SimpleTooltip>
       </div>
       <p className="flex-1 my-4 typo-callout">
         <TLDRText>TLDR -</TLDRText>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The copy link was currently conditionally rendered which is no longer needed
- We've now set the z-index of the companion to be the highest possible z-index so it will always be on top of everything.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-131 #done
