### PR TITLE
fix: outline icons spacing and size

### DIFF
--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -63,7 +63,7 @@ export default function BookmarkFeedLayout({
   const shareBookmarksButton = (style: string, text?: string) => (
     <Button
       className={style}
-      icon={<SourceIcon />}
+      icon={<SourceIcon className="icon" />}
       onClick={() => setShowSharedBookmarks(true)}
     >
       {text}

--- a/packages/shared/src/components/widgets/PostUsersHighlights.tsx
+++ b/packages/shared/src/components/widgets/PostUsersHighlights.tsx
@@ -87,10 +87,10 @@ const UserHighlight = (props: SourceAuthorProps) => {
       {Icon && (
         <Icon
           className={classNames(
-            'absolute w-5 h-5 top-11 left-11',
+            'absolute w-5 h-5 top-10 left-10',
             userType === 'author'
-              ? 'top-11 left-11 text-theme-color-cheese'
-              : 'top-10 left-10 text-theme-color-bun',
+              ? 'text-theme-color-cheese'
+              : 'text-theme-color-bun',
           )}
         />
       )}


### PR DESCRIPTION
## Changes

### Describe what this PR does

Few icons sizes and spacings were updated (found inconsistencies during testing)

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
