### PR TITLE
fix: user mention in firefox

### DIFF
--- a/packages/shared/src/lib/element.ts
+++ b/packages/shared/src/lib/element.ts
@@ -97,8 +97,9 @@ const getNodeText = (node: Node) => {
 };
 
 export function setCaretPosition(el: Node, col: number): void {
-  const range = document.createRange();
-  const sel = window.getSelection();
+  const shadowDom = getShadowDom();
+  const range = (shadowDom || document).createRange();
+  const sel = (shadowDom || window).getSelection();
 
   range.setStart(el, col);
   range.collapse(true);

--- a/packages/shared/src/lib/element.ts
+++ b/packages/shared/src/lib/element.ts
@@ -7,9 +7,21 @@ type Row = number;
 export type CaretOffset = [number, number];
 export type CaretPosition = [Column, Row];
 
-const getShadowDom = (): Document =>
-  document.querySelector('daily-companion-app')
-    ?.shadowRoot as unknown as Document;
+const isFirefox = process.env.TARGET_BROWSER === 'firefox';
+
+const getShadowDom = (): Document => {
+  const companion = document.querySelector('daily-companion-app');
+
+  if (!companion) {
+    return null;
+  }
+
+  if (!isFirefox) {
+    return companion.shadowRoot as unknown as Document;
+  }
+
+  return companion.shadowRoot.ownerDocument;
+};
 
 export function getCaretPostition(el: Element): CaretPosition {
   const dom = getShadowDom() || window;

--- a/packages/shared/src/lib/element.ts
+++ b/packages/shared/src/lib/element.ts
@@ -126,10 +126,12 @@ export const getSplittedText = (
   [col, row]: CaretPosition,
   query: string,
 ): [Node, string, string] => {
+  const companion = getShadowDom();
+  const offset = companion ? 0 : 1;
   const node = Array.from(textarea.childNodes).find((_, i) => i === row);
   const text = getNodeText(node);
   const left = text?.substring(0, col - 1) || '';
-  const right = text?.substring(col + query.length - 1) || '';
+  const right = text?.substring(col + query.length - offset) || '';
 
   return [node, left, right];
 };

--- a/packages/shared/src/lib/element.ts
+++ b/packages/shared/src/lib/element.ts
@@ -9,14 +9,14 @@ export type CaretPosition = [Column, Row];
 
 const isFirefox = process.env.TARGET_BROWSER === 'firefox';
 
-const getShadowDom = (): Document => {
+const getShadowDom = (ownerDocument = false): Document => {
   const companion = document.querySelector('daily-companion-app');
 
   if (!companion) {
     return null;
   }
 
-  if (!isFirefox) {
+  if (!isFirefox && !ownerDocument) {
     return companion.shadowRoot as unknown as Document;
   }
 
@@ -97,9 +97,8 @@ const getNodeText = (node: Node) => {
 };
 
 export function setCaretPosition(el: Node, col: number): void {
-  const shadowDom = getShadowDom();
-  const range = (shadowDom || document).createRange();
-  const sel = (shadowDom || window).getSelection();
+  const range = (getShadowDom(true) || document).createRange();
+  const sel = (getShadowDom() || window).getSelection();
 
   range.setStart(el, col);
   range.collapse(true);

--- a/packages/shared/src/lib/element.ts
+++ b/packages/shared/src/lib/element.ts
@@ -126,7 +126,7 @@ export const getSplittedText = (
   query: string,
 ): [Node, string, string] => {
   const companion = getShadowDom();
-  const offset = companion ? 0 : 1;
+  const offset = companion && isFirefox ? 0 : 1;
   const node = Array.from(textarea.childNodes).find((_, i) => i === row);
   const text = getNodeText(node);
   const left = text?.substring(0, col - 1) || '';


### PR DESCRIPTION
## Changes

### Describe what this PR does
As always, Firefox has some issues with our Companion 😆 
- The user mention feature wasn't working due to the specific object we're using when getting and setting the caret position (either window, document, or shadowroot's `ownerDocument`).
- There were also some differences with the offset when its companion for Firefox. 

Have tested out on both Firefox and Chrome 🚢 

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-138 #done
