### PR TITLE
fix: text overflow on companion user mention

### DIFF
--- a/packages/shared/src/components/RecommendedMention.tsx
+++ b/packages/shared/src/components/RecommendedMention.tsx
@@ -28,7 +28,7 @@ export function RecommendedMention({
   return (
     <ul
       className="flex overflow-hidden flex-col rounded-16 border border-theme-divider-secondary text-theme-label-primary"
-      style={{ minWidth: '15rem' }}
+      style={{ width: '15rem' }}
       role="listbox"
     >
       {users.map((user, index) => (

--- a/packages/shared/src/components/RecommendedMention.tsx
+++ b/packages/shared/src/components/RecommendedMention.tsx
@@ -27,8 +27,7 @@ export function RecommendedMention({
 
   return (
     <ul
-      className="flex overflow-hidden flex-col rounded-16 border border-theme-divider-secondary text-theme-label-primary"
-      style={{ width: '15rem' }}
+      className="flex overflow-hidden flex-col w-70 rounded-16 border border-theme-divider-secondary text-theme-label-primary"
       role="listbox"
     >
       {users.map((user, index) => (

--- a/packages/shared/src/components/profile/UserShortInfo.tsx
+++ b/packages/shared/src/components/profile/UserShortInfo.tsx
@@ -1,9 +1,9 @@
 import classNames from 'classnames';
 import React, { ReactElement } from 'react';
 import { Author } from '../../graphql/comments';
-import classed from '../../lib/classed';
 import { ProfileImageSize, ProfilePicture } from '../ProfilePicture';
 import { TooltipProps } from '../tooltips/BaseTooltip';
+import { getTextEllipsis } from '../utilities';
 import { ProfileTooltip } from './ProfileTooltip';
 
 // reference: https://stackoverflow.com/a/54049872/5532217
@@ -28,10 +28,7 @@ interface UserShortInfoProps<Tag extends AnyTag> {
   appendTooltipTo?: HTMLElement;
 }
 
-const TextEllipsis = classed(
-  'span',
-  'overflow-hidden whitespace-nowrap text-ellipsis',
-);
+const TextEllipsis = getTextEllipsis();
 
 export function UserShortInfo<Tag extends AnyTag>({
   imageSize = 'xlarge',
@@ -71,7 +68,7 @@ export function UserShortInfo<Tag extends AnyTag>({
         scrollingContainer={scrollingContainer}
       >
         <div className="flex overflow-hidden flex-col flex-1 ml-4 typo-callout">
-          <TextEllipsis className="font-bold">{name}</TextEllipsis>
+          <TextEllipsis className="font-bold">{name} AAaa</TextEllipsis>
           <TextEllipsis className="text-theme-label-secondary">
             @{username}
           </TextEllipsis>

--- a/packages/shared/src/components/profile/UserShortInfo.tsx
+++ b/packages/shared/src/components/profile/UserShortInfo.tsx
@@ -68,7 +68,7 @@ export function UserShortInfo<Tag extends AnyTag>({
         scrollingContainer={scrollingContainer}
       >
         <div className="flex overflow-hidden flex-col flex-1 ml-4 typo-callout">
-          <TextEllipsis className="font-bold">{name} AAaa</TextEllipsis>
+          <TextEllipsis className="font-bold">{name}</TextEllipsis>
           <TextEllipsis className="text-theme-label-secondary">
             @{username}
           </TextEllipsis>

--- a/packages/shared/src/components/profile/UserShortInfo.tsx
+++ b/packages/shared/src/components/profile/UserShortInfo.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, { ReactElement } from 'react';
 import { Author } from '../../graphql/comments';
+import classed from '../../lib/classed';
 import { ProfileImageSize, ProfilePicture } from '../ProfilePicture';
 import { TooltipProps } from '../tooltips/BaseTooltip';
 import { ProfileTooltip } from './ProfileTooltip';
@@ -26,6 +27,11 @@ interface UserShortInfoProps<Tag extends AnyTag> {
   scrollingContainer?: HTMLElement;
   appendTooltipTo?: HTMLElement;
 }
+
+const TextEllipsis = classed(
+  'span',
+  'overflow-hidden whitespace-nowrap text-ellipsis',
+);
 
 export function UserShortInfo<Tag extends AnyTag>({
   imageSize = 'xlarge',
@@ -64,9 +70,11 @@ export function UserShortInfo<Tag extends AnyTag>({
         tooltip={tooltipProps}
         scrollingContainer={scrollingContainer}
       >
-        <div className="flex flex-col flex-1 ml-4 typo-callout">
-          <span className="font-bold">{name}</span>
-          <span className="text-theme-label-secondary">@{username}</span>
+        <div className="flex overflow-hidden flex-col flex-1 ml-4 typo-callout">
+          <TextEllipsis className="font-bold">{name}</TextEllipsis>
+          <TextEllipsis className="text-theme-label-secondary">
+            @{username}
+          </TextEllipsis>
           {bio && <span className="mt-1 text-theme-label-tertiary">{bio}</span>}
         </div>
       </ProfileTooltip>

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -1,5 +1,5 @@
-import React, { ReactElement } from 'react';
-import classed from '../lib/classed';
+import React, { HTMLAttributes, ReactElement, ReactHTML } from 'react';
+import classed, { ClassedHTML } from '../lib/classed';
 import styles from './utilities.module.css';
 import ArrowIcon from './icons/Arrow';
 import { PostBootData } from '../lib/boot';
@@ -181,3 +181,11 @@ export const HotLabel = (): ReactElement => (
     Hot
   </div>
 );
+
+export const getTextEllipsis = <
+  P extends HTMLAttributes<T>,
+  T extends HTMLElement,
+>(
+  type: keyof ReactHTML = 'span',
+): ClassedHTML<P, T> =>
+  classed<P, T>(type, 'overflow-hidden whitespace-nowrap text-ellipsis');

--- a/packages/shared/src/lib/classed.ts
+++ b/packages/shared/src/lib/classed.ts
@@ -20,6 +20,11 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 
+export type ClassedHTML<
+  P extends HTMLAttributes<T>,
+  T extends HTMLElement,
+> = ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+
 function classed(
   type: 'input',
   ...className: string[]
@@ -74,7 +79,7 @@ function classed(
 function classed<P extends HTMLAttributes<T>, T extends HTMLElement>(
   type: keyof ReactHTML,
   ...className: string[]
-): ForwardRefExoticComponent<PropsWithoutRef<P> & RefAttributes<T>>;
+): ClassedHTML<P, T>;
 
 function classed<P extends SVGAttributes<T>, T extends SVGElement>(
   type: keyof ReactSVG,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- New width of the user mention container
- Applied ellipsis on overflowing texts

Reference for the fix: https://dailydotdev.slack.com/archives/C02AA18RD1D/p1655126916308559?thread_ts=1655123456.781379&cid=C02AA18RD1D

Preview:
![image](https://user-images.githubusercontent.com/13744167/173561337-ad4c7759-663d-4e47-a61c-04849a57ef93.png)


### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
