### PR TITLE
fix: font rendered different on some sites

### DIFF
--- a/packages/extension/public/css/daily-companion-app.css
+++ b/packages/extension/public/css/daily-companion-app.css
@@ -8,4 +8,7 @@ daily-companion-app {
   position: fixed;
   z-index: 2147483647;
   font-feature-settings: normal!important;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }

--- a/packages/extension/public/css/daily-companion-app.css
+++ b/packages/extension/public/css/daily-companion-app.css
@@ -7,7 +7,7 @@ daily-companion-app {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Ubuntu, Segoe UI, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
   position: fixed;
   z-index: 2147483647;
-  font-feature-settings: normal!important;
+  font-feature-settings: normal !important;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We adapted font-rendering from each website, but we wanted to render smoothly
- This PR introduces the same font rendering for all websites so we uniform our companion fonts.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-108 #done
