### PR TITLE
Wt 140 companion icons

### DIFF
--- a/packages/extension/public/css/daily-companion-app.css
+++ b/packages/extension/public/css/daily-companion-app.css
@@ -8,7 +8,4 @@ daily-companion-app {
   position: fixed;
   z-index: 2147483647;
   font-feature-settings: normal!important;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }

--- a/packages/extension/public/css/daily-companion-app.css
+++ b/packages/extension/public/css/daily-companion-app.css
@@ -8,4 +8,7 @@ daily-companion-app {
   position: fixed;
   z-index: 2147483647;
   font-feature-settings: normal!important;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }

--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -209,7 +209,7 @@ export default function CompanionMenu({
       >
         <Button
           buttonSize="medium"
-          icon={<UpvoteIcon filled={post?.upvoted} />}
+          icon={<UpvoteIcon className="icon" filled={post?.upvoted} />}
           pressed={post?.upvoted}
           onClick={toggleUpvote}
           className="btn-tertiary-avocado"
@@ -224,7 +224,7 @@ export default function CompanionMenu({
         <Button
           buttonSize="medium"
           className="btn-tertiary"
-          icon={<CommentIcon />}
+          icon={<CommentIcon className="icon" />}
           onClick={() => openNewComment('comment button')}
         />
       </SimpleTooltip>
@@ -239,7 +239,7 @@ export default function CompanionMenu({
           pressed={post?.bookmarked}
           className="btn-tertiary-bun"
           onClick={toggleBookmark}
-          icon={<BookmarkIcon filled={post?.bookmarked} />}
+          icon={<BookmarkIcon className="icon" filled={post?.bookmarked} />}
         />
       </SimpleTooltip>
       <SimpleTooltip
@@ -251,7 +251,7 @@ export default function CompanionMenu({
         <Button
           buttonSize="medium"
           className="btn-tertiary"
-          icon={<MenuIcon />}
+          icon={<MenuIcon className="icon" />}
           onClick={onContextOptions}
         />
       </SimpleTooltip>

--- a/packages/shared/src/styles/components/buttons.css
+++ b/packages/shared/src/styles/components/buttons.css
@@ -10,7 +10,7 @@
   & .icon {
     width: 1em;
     height: 1em;
-    font-size: 1.5rem;
+    font-size: 1.75rem;
   }
 
   &.xsmall {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The old icon class was 24px, this one renders 28px to the new icon spec.
- Currently only used by the companion buttons anyway (actively, as it's a button > .icon selector)

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-140 #done
