### PR TITLE
fix: excluded list for companion - webapp mention feature not working

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -17,6 +17,8 @@ import {
 } from '../lib/extensionAlerts';
 
 const excludedCompanionOrigins = [
+  'http://localhost',
+  'http://app.daily.dev',
   'https://twitter.com',
   'https://www.google.com',
   'https://stackoverflow.com',
@@ -24,6 +26,7 @@ const excludedCompanionOrigins = [
   'https://meet.google.com',
   'https://calendar.google.com',
   'chrome-extension://',
+  'moz-extension://',
   'https://api.daily.dev',
 ];
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The only way for us to identify whether the companion is active is if it was found in the DOM. Our mention user feature relies on it for which DOM to apply the tooltip.
- After further checking, our webapp was not yet included in our list to not initialize the companion.

Probably we need to come up with another option for identifying if companion was activated. Probably close the shadow DOM when no post was found from the link? Though this is probably up for a different discussion. Just laying down my thoughts.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-636 #done
