### PR TITLE
fix: preview tooltip getting cut-off

### DIFF
--- a/packages/shared/src/components/Markdown.tsx
+++ b/packages/shared/src/components/Markdown.tsx
@@ -90,7 +90,7 @@ export default function Markdown({
         offset,
         visible: !!userId,
         onShow: cancelUserClearing,
-        appendTo: appendTooltipTo,
+        appendTo: appendTooltipTo || document?.body || 'parent',
       }}
       onMouseEnter={cancelUserClearing}
       onMouseLeave={clearUser}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Append the tooltip to `document.body` so it won't get cut off by the modal's `overflow: hidden`.

Deployed at: https://preview.app.daily.dev/

Preview: 
![image](https://user-images.githubusercontent.com/13744167/173836377-c3886e60-d7a1-4699-8de4-543f7b19ad6e.png)


### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-147 #done
