### PR TITLE
chore: cleanup feature flags for my feed

### DIFF
--- a/packages/shared/src/components/CreateMyFeedButton.tsx
+++ b/packages/shared/src/components/CreateMyFeedButton.tsx
@@ -2,16 +2,13 @@ import React, { ReactElement, useContext, useEffect } from 'react';
 import classNames from 'classnames';
 import { IFlags } from 'flagsmith';
 import PlusIcon from './icons/Plus';
-import UserIcon from './icons/User';
 import { Button } from './buttons/Button';
 import { Features, getFeatureValue } from '../lib/featureManagement';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../hooks/analytics/useAnalyticsQueue';
-import { getThemeColor, ThemeColor } from './utilities';
+import { getThemeColor } from './utilities';
 
 interface CreateMyFeedButtonProps {
-  type: string;
-  sidebarExpanded?: boolean;
   flags: IFlags;
   action: () => unknown;
 }
@@ -19,61 +16,15 @@ interface CreateMyFeedButtonProps {
 const getAnalyticsEvent = (
   eventName: string,
   copy: string,
-  type: string,
 ): Partial<AnalyticsEvent> => ({
   event_name: eventName,
   target_type: 'my feed button',
-  target_id: type,
+  target_id: 'feed_top',
   feed_item_title: copy,
 });
 
-interface ClassProps {
-  explainerColor?: ThemeColor;
-  sidebarExpanded?: boolean;
-}
-const wrapperClasses = ({ sidebarExpanded }: ClassProps) => {
-  return {
-    sidebar: classNames('h-[8.125rem]', sidebarExpanded && 'justify-center'),
-    feed_title: 'w-full tablet:w-auto',
-    feed_top: 'w-full items-center mb-8',
-  };
-};
-
-const innerWrapClasses = ({ explainerColor, sidebarExpanded }: ClassProps) => {
-  return {
-    sidebar: classNames(
-      'flex-col',
-      sidebarExpanded ? `${explainerColor.shadow} border p-3 m-4` : 'mx-3',
-    ),
-    feed_title: `flex-col tablet:flex-row-reverse`,
-    feed_top: `${explainerColor.shadow} p-2 border flex-col tablet:flex-row`,
-    feed_ad: `${explainerColor.shadow} p-2 border flex-col flex-1 justify-center`,
-  };
-};
-const textClass = ({ sidebarExpanded }: ClassProps) => {
-  return {
-    sidebar: classNames(
-      'typo-footnote w-[11.25rem] mb-3 transform',
-      sidebarExpanded
-        ? 'opacity-100 ease-linear duration-200 delay-200'
-        : 'duration-0 delay-0 opacity-0',
-    ),
-    feed_top: 'typo-footnote ml-2 text-center tablet:text-left',
-    feed_title:
-      'typo-footnote w-70 laptopL:w-auto text-center tablet:text-left',
-    feed_ad: 'typo-body font-bold mx-6 text-center mb-6',
-  };
-};
-const buttonClass = {
-  sidebar: 'w-full',
-  feed_title: 'w-auto my-4 tablet:my-0 tablet:mr-4',
-  feed_top: 'ml-0 mt-4 tablet:ml-8 tablet:mt-0',
-};
-
 export default function CreateMyFeedButton({
-  sidebarExpanded,
   flags,
-  type,
   action,
 }: CreateMyFeedButtonProps): ReactElement {
   const { trackEvent } = useContext(AnalyticsContext);
@@ -88,46 +39,36 @@ export default function CreateMyFeedButton({
     Features.MyFeedExplainerColor.defaultValue,
   );
   const onClick = () => {
-    trackEvent(getAnalyticsEvent('click', buttonCopy, type));
+    trackEvent(getAnalyticsEvent('click', buttonCopy));
     action();
   };
-  const isSidebar = type === 'sidebar';
 
   useEffect(() => {
-    trackEvent(getAnalyticsEvent('impression', buttonCopy, type));
+    trackEvent(getAnalyticsEvent('impression', buttonCopy));
   }, [buttonCopy]);
 
   return (
-    <div
-      className={classNames(
-        wrapperClasses({ sidebarExpanded })[type],
-        'flex flex-col',
-      )}
-    >
+    <div className="flex flex-col items-center mb-8 w-full">
       <div
         className={classNames(
-          innerWrapClasses({ explainerColor, sidebarExpanded })[type],
-          `flex items-center rounded-12`,
+          'p-2 border flex-col tablet:flex-row flex items-center rounded-12',
           explainerColor.border,
+          explainerColor.shadow,
         )}
       >
-        {type === 'feed_ad' && <UserIcon className="mb-4 typo-giga1" />}
-        <p
-          className={classNames(
-            textClass({ sidebarExpanded })[type],
-            ' transition-all',
-          )}
-        >
+        <p className="ml-2 text-center tablet:text-left transition-all typo-footnote">
           {explainerCopy}
         </p>
         <Button
-          className={classNames(buttonClass[type], buttonColor.button)}
-          buttonSize={isSidebar && !sidebarExpanded ? 'xsmall' : 'small'}
+          className={classNames(
+            'ml-0 mt-4 tablet:ml-8 tablet:mt-0',
+            buttonColor.button,
+          )}
+          buttonSize="small"
           icon={<PlusIcon />}
-          iconOnly={isSidebar && sidebarExpanded}
           onClick={onClick}
         >
-          {((isSidebar && sidebarExpanded) || !isSidebar) && buttonCopy}
+          {buttonCopy}
         </Button>
       </div>
     </div>

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -48,7 +48,6 @@ export type FeedProps<T> = {
   className?: string;
   onEmptyFeed?: () => unknown;
   emptyScreen?: ReactNode;
-  createMyFeedCard?: ReactNode;
   header?: ReactNode;
 };
 
@@ -112,7 +111,6 @@ export default function Feed<T>({
   header,
   onEmptyFeed,
   emptyScreen,
-  createMyFeedCard,
 }: FeedProps<T>): ReactElement {
   const { flags } = useContext(FeaturesContext);
   const postHeadingFont = getThemeFont(
@@ -294,7 +292,6 @@ export default function Feed<T>({
           cardClass(useList, numCards),
         )}
       >
-        {createMyFeedCard}
         {items.map((item, index) => (
           <FeedItemComponent
             items={items}

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -142,7 +142,7 @@ export default function MainFeedLayout({
   searchChildren,
   navChildren,
 }: MainFeedLayoutProps): ReactElement {
-  const { shouldShowMyFeed, myFeedPosition } = useMyFeed();
+  const { shouldShowMyFeed } = useMyFeed();
   const [defaultFeed, updateDefaultFeed] = useDefaultFeed(shouldShowMyFeed);
   const { sortingEnabled, loadedSettings } = useContext(SettingsContext);
   const { user, tokenRefreshed } = useContext(AuthContext);
@@ -218,27 +218,15 @@ export default function MainFeedLayout({
   );
 
   const getFeedTitle = () => {
-    if (shouldShowMyFeed && alerts?.filter && myFeedPosition === 'feed_title') {
-      return (
-        <CreateMyFeedButton
-          type={myFeedPosition}
-          action={openFeedFilters}
-          flags={flags}
-        />
-      );
+    if (shouldShowMyFeed && alerts?.filter) {
+      return <CreateMyFeedButton action={openFeedFilters} flags={flags} />;
     }
 
     return <h3 className="typo-headline">{feedTitles[feedName]}</h3>;
   };
 
   const header = (
-    <LayoutHeader
-      className={
-        myFeedPosition !== 'feed_title'
-          ? 'flex-row'
-          : 'flex-col tablet:flex-row'
-      }
-    >
+    <LayoutHeader className="flex-col tablet:flex-row">
       {!isSearchOn && getFeedTitle()}
       <div className="flex flex-row flex-wrap gap-4 items-center mr-px">
         {navChildren}
@@ -305,15 +293,6 @@ export default function MainFeedLayout({
       ),
       query: query.query,
       variables,
-      createMyFeedCard: shouldShowMyFeed &&
-        alerts?.filter &&
-        myFeedPosition === 'feed_ad' && (
-          <CreateMyFeedButton
-            type="feed_ad"
-            action={openFeedFilters}
-            flags={flags}
-          />
-        ),
       emptyScreen: <FeedEmptyScreen openFeedFilters={openFeedFilters} />,
       header: !isSearchOn && header,
     };
@@ -333,15 +312,6 @@ export default function MainFeedLayout({
   return (
     <>
       <FeedPage>
-        {shouldShowMyFeed &&
-          alerts?.filter &&
-          myFeedPosition === 'feed_top' && (
-            <CreateMyFeedButton
-              type={myFeedPosition}
-              action={openFeedFilters}
-              flags={flags}
-            />
-          )}
         {isSearchOn && search}
         {feedProps && <Feed {...feedProps} />}
         {children}

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -46,7 +46,6 @@ import { AlertColor, AlertDot } from '../AlertDot';
 import { useMyFeed } from '../../hooks/useMyFeed';
 import useDefaultFeed from '../../hooks/useDefaultFeed';
 import { Features, getFeatureValue } from '../../lib/featureManagement';
-import CreateMyFeedButton from '../CreateMyFeedButton';
 import CreateMyFeedModal from '../modals/CreateMyFeedModal';
 
 const bottomMenuItems: SidebarMenuItem[] = [
@@ -139,7 +138,7 @@ export default function Sidebar({
   setOpenMobileSidebar,
   onShowDndClick,
 }: SidebarProps): ReactElement {
-  const { shouldShowMyFeed, myFeedPosition } = useMyFeed();
+  const { shouldShowMyFeed } = useMyFeed();
   const [defaultFeed] = useDefaultFeed(shouldShowMyFeed);
   const activePage =
     activePageProp === '/' ? `/${defaultFeed}` : activePageProp;
@@ -318,17 +317,6 @@ export default function Sidebar({
         <SidebarScrollWrapper>
           <Nav>
             <SidebarUserButton sidebarRendered={sidebarRendered} />
-            {shouldShowMyFeed &&
-              myFeedPosition === 'sidebar' &&
-              alerts?.filter &&
-              sidebarRendered && (
-                <CreateMyFeedButton
-                  type={myFeedPosition}
-                  action={openFeedFilters}
-                  sidebarExpanded={sidebarExpanded}
-                  flags={flags}
-                />
-              )}
             {shouldShowMyFeed && !alerts?.filter && (
               <MyFeedButton
                 sidebarRendered={sidebarRendered}

--- a/packages/shared/src/hooks/useMyFeed.ts
+++ b/packages/shared/src/hooks/useMyFeed.ts
@@ -4,11 +4,7 @@ import AnalyticsContext from '../contexts/AnalyticsContext';
 import AuthContext from '../contexts/AuthContext';
 import { BOOT_QUERY_KEY } from '../contexts/BootProvider';
 import FeaturesContext from '../contexts/FeaturesContext';
-import {
-  Features,
-  isFeaturedEnabled,
-  getFeatureValue,
-} from '../lib/featureManagement';
+import { Features, isFeaturedEnabled } from '../lib/featureManagement';
 import { storageWrapper as storage } from '../lib/storageWrapper';
 import {
   getLocalFeedSettings,
@@ -19,7 +15,6 @@ import useMutateFilters from './useMutateFilters';
 interface UseMyFeed {
   registerLocalFilters: () => Promise<{ hasFilters: boolean }>;
   shouldShowMyFeed: boolean;
-  myFeedPosition: string;
   checkHasLocalFilters: () => boolean;
 }
 
@@ -30,7 +25,6 @@ export function useMyFeed(): UseMyFeed {
   const { user } = useContext(AuthContext);
   const { flags } = useContext(FeaturesContext);
   const shouldShowMyFeed = isFeaturedEnabled(Features.MyFeedOn, flags);
-  const myFeedPosition = getFeatureValue(Features.MyFeedPosition, flags);
 
   const registerLocalFilters = async () => {
     const feedSettings = getLocalFeedSettings(true);
@@ -61,14 +55,8 @@ export function useMyFeed(): UseMyFeed {
     () => ({
       registerLocalFilters,
       shouldShowMyFeed,
-      myFeedPosition,
       checkHasLocalFilters,
     }),
-    [
-      registerLocalFilters,
-      shouldShowMyFeed,
-      myFeedPosition,
-      checkHasLocalFilters,
-    ],
+    [registerLocalFilters, shouldShowMyFeed, checkHasLocalFilters],
   );
 }

--- a/packages/shared/src/lib/featureManagement.spec.ts
+++ b/packages/shared/src/lib/featureManagement.spec.ts
@@ -2,14 +2,14 @@ import { Features, getFeatureValue } from './featureManagement';
 
 const defaultFlags = {
   enabled: true,
-  value: 'feed_title',
+  value: 'signup_button_copy',
 };
 
-const defaultValue = 'sidebar';
+const defaultValue = 'Access all features';
 
 describe('feature testing', () => {
   it('should return the default for a disabled feature', () => {
-    const test = getFeatureValue(Features.MyFeedPosition, {
+    const test = getFeatureValue(Features.SignupButtonCopy, {
       my_feed_position: {
         ...defaultFlags,
         enabled: false,
@@ -19,7 +19,7 @@ describe('feature testing', () => {
   });
 
   it('should return the default for a not allowed feature value', () => {
-    const test = getFeatureValue(Features.MyFeedPosition, {
+    const test = getFeatureValue(Features.SignupButtonCopy, {
       my_feed_position: {
         ...defaultFlags,
         value: 'false_value',
@@ -29,9 +29,9 @@ describe('feature testing', () => {
   });
 
   it('should return the correct value when a flag is set', () => {
-    const differentValue = 'feed_title';
-    const test = getFeatureValue(Features.MyFeedPosition, {
-      my_feed_position: {
+    const differentValue = 'different_value';
+    const test = getFeatureValue(Features.SignupButtonCopy, {
+      signup_button_copy: {
         ...defaultFlags,
         value: differentValue,
       },
@@ -40,7 +40,7 @@ describe('feature testing', () => {
   });
 
   it('should return the default if the flag doesnt exist', () => {
-    const test = getFeatureValue(Features.MyFeedPosition, {});
+    const test = getFeatureValue(Features.SignupButtonCopy, {});
     expect(test).toEqual(defaultValue);
   });
 });

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -33,16 +33,9 @@ export class Features {
 
   static readonly MyFeedOn = new Features('my_feed_on');
 
-  static readonly MyFeedPosition = new Features('my_feed_position', 'sidebar', [
-    'sidebar',
-    'feed_title',
-    'feed_ad',
-    'feed_top',
-  ]);
-
   static readonly MyFeedButtonCopy = new Features(
     'my_feed_button_copy',
-    'Create my feed',
+    'Choose tags',
   );
 
   static readonly MyFeedButtonColor = new Features(
@@ -52,7 +45,7 @@ export class Features {
 
   static readonly MyFeedExplainerCopy = new Features(
     'my_feed_explainer_copy',
-    'Devs with a personal feed get 11.5x more relevant articles',
+    'Get the content you need by creating a personal feed',
   );
 
   static readonly MyFeedExplainerColor = new Features(


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The current my feed flags are done so can be removed from the code
- The my_feed_position added a lot of spaghetti code and could be removed completely.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
