### PR TITLE
feat: cleanup my feed modal types to winner

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -33,6 +33,7 @@ import CreateMyFeedButton from './CreateMyFeedButton';
 import { useDynamicLoadedAnimation } from '../hooks/useDynamicLoadAnimated';
 import FeedFilters from './filters/FeedFilters';
 import AlertContext from '../contexts/AlertContext';
+import CreateMyFeedModal from './modals/CreateMyFeedModal';
 
 const SearchEmptyScreen = dynamic(
   () => import(/* webpackChunkName: "emptySearch" */ './SearchEmptyScreen'),
@@ -155,6 +156,7 @@ export default function MainFeedLayout({
     setLoaded: openFeedFilters,
     setHidden,
   } = useDynamicLoadedAnimation();
+  const [createMyFeed, setCreateMyFeed] = useState(false);
 
   const feedTitles = {
     'my-feed': 'My feed',
@@ -203,6 +205,16 @@ export default function MainFeedLayout({
     query = { query: null };
   }
 
+  const openCreateMyFeed = () => {
+    setCreateMyFeed(true);
+    openFeedFilters();
+  };
+
+  const closeCreateMyFeed = () => {
+    setCreateMyFeed(false);
+    setHidden();
+  };
+
   const [selectedAlgo, setSelectedAlgo, loadedAlgo] = usePersistentContext(
     DEFAULT_ALGORITHM_KEY,
     0,
@@ -219,7 +231,7 @@ export default function MainFeedLayout({
 
   const getFeedTitle = () => {
     if (shouldShowMyFeed && alerts?.filter) {
-      return <CreateMyFeedButton action={openFeedFilters} flags={flags} />;
+      return <CreateMyFeedButton action={openCreateMyFeed} flags={flags} />;
     }
 
     return <h3 className="typo-headline">{feedTitles[feedName]}</h3>;
@@ -316,7 +328,12 @@ export default function MainFeedLayout({
         {feedProps && <Feed {...feedProps} />}
         {children}
       </FeedPage>
-      {isLoaded && (
+      {isLoaded && createMyFeed ? (
+        <CreateMyFeedModal
+          isOpen={isAnimated}
+          onRequestClose={closeCreateMyFeed}
+        />
+      ) : (
         <FeedFilters
           isOpen={isAnimated}
           onBack={setHidden}

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -205,16 +205,6 @@ export default function MainFeedLayout({
     query = { query: null };
   }
 
-  const openCreateMyFeed = () => {
-    setCreateMyFeed(true);
-    openFeedFilters();
-  };
-
-  const closeCreateMyFeed = () => {
-    setCreateMyFeed(false);
-    setHidden();
-  };
-
   const [selectedAlgo, setSelectedAlgo, loadedAlgo] = usePersistentContext(
     DEFAULT_ALGORITHM_KEY,
     0,
@@ -231,7 +221,12 @@ export default function MainFeedLayout({
 
   const getFeedTitle = () => {
     if (shouldShowMyFeed && alerts?.filter) {
-      return <CreateMyFeedButton action={openCreateMyFeed} flags={flags} />;
+      return (
+        <CreateMyFeedButton
+          action={() => setCreateMyFeed(true)}
+          flags={flags}
+        />
+      );
     }
 
     return <h3 className="typo-headline">{feedTitles[feedName]}</h3>;
@@ -328,16 +323,17 @@ export default function MainFeedLayout({
         {feedProps && <Feed {...feedProps} />}
         {children}
       </FeedPage>
-      {isLoaded && createMyFeed ? (
-        <CreateMyFeedModal
-          isOpen={isAnimated}
-          onRequestClose={closeCreateMyFeed}
-        />
-      ) : (
+      {isLoaded && (
         <FeedFilters
           isOpen={isAnimated}
           onBack={setHidden}
           directlyOpenedTab="Manage tags"
+        />
+      )}
+      {createMyFeed && (
+        <CreateMyFeedModal
+          isOpen={createMyFeed}
+          onRequestClose={() => setCreateMyFeed(false)}
         />
       )}
     </>

--- a/packages/shared/src/components/filters/TagsFilter.tsx
+++ b/packages/shared/src/components/filters/TagsFilter.tsx
@@ -7,7 +7,6 @@ import React, {
 } from 'react';
 import { useQuery } from 'react-query';
 import request from 'graphql-request';
-import classNames from 'classnames';
 import { SearchField } from '../fields/SearchField';
 import { apiUrl } from '../../lib/config';
 import { getSearchTagsQueryKey } from '../../hooks/useMutateFilters';
@@ -24,23 +23,6 @@ import { FilterMenuProps } from './common';
 import MenuIcon from '../icons/Menu';
 import AuthContext from '../../contexts/AuthContext';
 import { useMyFeed } from '../../hooks/useMyFeed';
-import { Features, getFeatureValue } from '../../lib/featureManagement';
-import FeaturesContext from '../../contexts/FeaturesContext';
-
-const containerClass = {
-  v3: 'flex-col-reverse',
-  v5: 'flex-col-reverse',
-};
-
-const searchFieldClass = {
-  v3: 'mt-6 mb-2',
-  v5: 'mb-2',
-};
-
-const paragraphClass = {
-  v4: 'mb-2',
-  v5: 'mb-6',
-};
 
 export default function TagsFilter({
   onUnblockItem,
@@ -60,8 +42,6 @@ export default function TagsFilter({
   const isTagBlocked = feedSettings?.blockedTags?.some(
     (tag) => tag === contextSelectedTag,
   );
-  const { flags } = useContext(FeaturesContext);
-  const feedFilterModalType = getFeatureValue(Features.FeedFilterModal, flags);
   const { data: searchResults } = useQuery<SearchTagsData>(
     searchKey,
     () => request(`${apiUrl}/graphql`, SEARCH_TAGS_QUERY, { query }),
@@ -94,31 +74,16 @@ export default function TagsFilter({
       aria-busy={isLoading}
       data-testid="tagsFilter"
     >
-      <div
-        className={classNames(
-          containerClass[feedFilterModalType] ?? 'flex-col',
-          'flex px-6 pb-6',
-        )}
-      >
+      <div className="flex flex-col px-6 pb-6">
         <SearchField
           inputId="search-filters"
           placeholder="Search"
-          className={classNames(
-            searchFieldClass[feedFilterModalType] ?? 'mb-6',
-          )}
+          className="mb-6"
           ref={searchRef}
           valueChanged={setQuery}
         />
-
-        {['v1', 'v2', 'v4'].includes(feedFilterModalType) && (
-          <h3 className="mb-3 typo-headline">Choose tags to follow</h3>
-        )}
-        <p
-          className={classNames(
-            paragraphClass[feedFilterModalType],
-            'typo-callout text-theme-label-tertiary',
-          )}
-        >
+        <h3 className="mb-3 typo-headline">Choose tags to follow</h3>
+        <p className="mb-2 typo-callout text-theme-label-tertiary">
           Let’s super-charge your feed with relevant content! Start by choosing
           tags you want to follow, and we will curate your feed accordingly.
         </p>

--- a/packages/shared/src/components/modals/CreateMyFeedModal.spec.tsx
+++ b/packages/shared/src/components/modals/CreateMyFeedModal.spec.tsx
@@ -86,7 +86,6 @@ const renderComponent = (
           isOpen
           onRequestClose={onRequestClose}
           ariaHideApp={false}
-          feedFilterModalType="v2"
         />
       </AuthContext.Provider>
     </QueryClientProvider>,

--- a/packages/shared/src/components/modals/CreateMyFeedModal.tsx
+++ b/packages/shared/src/components/modals/CreateMyFeedModal.tsx
@@ -5,121 +5,39 @@ import { ResponsiveModal } from './ResponsiveModal';
 import styles from './AccountDetailsModal.module.css';
 import TagsFilter from '../filters/TagsFilter';
 import CreateFeedFilterButton from '../CreateFeedFilterButton';
-import PlusIcon from '../icons/Plus';
 import XIcon from '../icons/Close';
 import { Button } from '../buttons/Button';
-
-type TypeProps = {
-  feedFilterModalType: string;
-};
-
-type CreateMyFeedModalProps = TypeProps & ModalProps;
-
-type LayoutModalProps = TypeProps & Pick<ModalProps, 'onRequestClose'>;
-
-const buttonClass = {
-  v4: 'w-40',
-  v5: 'w-40 ml-3',
-};
-
-const buttonSize = {
-  v2: 'small',
-  v3: 'medium',
-};
-
-const headerTitle = {
-  v3: 'Choose tags to follow',
-  v4: 'Feed filters',
-  v5: 'Choose tags to follow',
-};
-
-const headerClass = {
-  v4: 'flex-row-reverse',
-};
-
-const ModalFooter = ({
-  feedFilterModalType,
-  onRequestClose,
-}: LayoutModalProps) => {
-  return (
-    <footer className="flex fixed responsiveModalBreakpoint:sticky bottom-0 justify-center items-center py-3 border-t border-theme-divider-tertiary bg-theme-bg-tertiary">
-      {feedFilterModalType === 'v5' && (
-        <Button className="mr-3 w-40 btn-secondary" onClick={onRequestClose}>
-          Cancel
-        </Button>
-      )}
-      <CreateFeedFilterButton
-        className={classNames(
-          buttonClass[feedFilterModalType],
-          'btn-primary-cabbage',
-        )}
-        feedFilterModalType={feedFilterModalType}
-      />
-    </footer>
-  );
-};
 
 export default function CreateMyFeedModal({
   className,
   onRequestClose,
-  feedFilterModalType,
   ...modalProps
-}: CreateMyFeedModalProps): ReactElement {
+}: ModalProps): ReactElement {
   return (
     <ResponsiveModal
       className={classNames(className, styles.accountDetailsModal)}
       {...modalProps}
       onRequestClose={onRequestClose}
     >
-      {feedFilterModalType === 'v3' && (
+      <header className="flex fixed responsiveModalBreakpoint:sticky top-0 left-0 z-3 flex-row-reverse justify-between items-center py-4 px-6 w-full border-b border-theme-divider-tertiary bg-theme-bg-tertiary">
         <Button
-          className="fixed top-8 right-8 btn-tertiary-float bg-theme-bg-tertiary"
-          buttonSize="large"
+          className="btn-tertiary"
+          buttonSize="small"
           title="Close"
           icon={<XIcon />}
           onClick={onRequestClose}
-          position="fixed"
         />
-      )}
-      <header
-        className={classNames(
-          headerClass[feedFilterModalType],
-          'flex fixed responsiveModalBreakpoint:sticky top-0 left-0 z-3 justify-between items-center py-4 px-6 w-full border-b border-theme-divider-tertiary bg-theme-bg-tertiary',
-        )}
-      >
-        {['v2', 'v4'].includes(feedFilterModalType) && (
-          <Button
-            className="btn-tertiary"
-            buttonSize="small"
-            title="Close"
-            icon={<XIcon />}
-            onClick={onRequestClose}
-          />
-        )}
-        <h3 className="font-bold typo-title3">
-          {headerTitle[feedFilterModalType]}
-        </h3>
-        {['v2', 'v3'].includes(feedFilterModalType) && (
-          <CreateFeedFilterButton
-            className={classNames(
-              buttonClass[feedFilterModalType],
-              'btn-primary-cabbage',
-            )}
-            buttonSize={buttonSize[feedFilterModalType]}
-            icon={feedFilterModalType === 'v2' && <PlusIcon />}
-            feedFilterModalType={feedFilterModalType}
-          />
-        )}
+        <h3 className="font-bold typo-title3">Feed filters</h3>
       </header>
       <section className="mt-6">
         <TagsFilter />
       </section>
-      {['v4', 'v5'].includes(feedFilterModalType) && (
-        <ModalFooter
-          feedFilterModalType={feedFilterModalType}
-          onRequestClose={onRequestClose}
+      <footer className="flex fixed responsiveModalBreakpoint:sticky bottom-0 justify-center items-center py-3 border-t border-theme-divider-tertiary bg-theme-bg-tertiary">
+        <CreateFeedFilterButton
+          className="w-40 btn-primary-cabbage"
+          feedFilterModalType="v4"
         />
-      )}
+      </footer>
     </ResponsiveModal>
   );
 }

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -52,7 +52,6 @@ import {
   getFeatureValue,
   isFeaturedEnabled,
 } from '../../lib/featureManagement';
-import CreateMyFeedModal from '../modals/CreateMyFeedModal';
 
 const SubmitArticleModal = dynamic(
   () => import('../modals/SubmitArticleModal'),
@@ -171,7 +170,6 @@ export default function Sidebar({
   const shouldShowDnD = !!process.env.TARGET_BROWSER;
   const { flags } = useContext(FeaturesContext);
   const popularFeedCopy = getFeatureValue(Features.PopularFeedCopy, flags);
-  const feedFilterModal = getFeatureValue(Features.FeedFilterModal, flags);
   const submitArticleSidebarButton = getFeatureValue(
     Features.SubmitArticleSidebarButton,
     flags,
@@ -418,15 +416,7 @@ export default function Sidebar({
           onRequestClose={() => setShowSettings(false)}
         />
       )}
-      {isLoaded && feedFilterModal === 'v1' ? (
-        <FeedFilters isOpen={isAnimated} onBack={setHidden} />
-      ) : (
-        <CreateMyFeedModal
-          isOpen={isAnimated}
-          onRequestClose={() => setHidden()}
-          feedFilterModalType={feedFilterModal}
-        />
-      )}
+      {isLoaded && <FeedFilters isOpen={isAnimated} onBack={setHidden} />}
     </>
   );
 }

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -97,14 +97,6 @@ export class Features {
     ['bodyBold', 'body', 'title3', 'title3Bold'],
   );
 
-  static readonly FeedFilterModal = new Features('feed_filter_modal', 'v1', [
-    'v1',
-    'v2',
-    'v3',
-    'v4',
-    'v5',
-  ]);
-
   static readonly CompanionPermissionPlacement = new Features(
     'companion_permission_placement',
     'off',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We decided on a winning AB test
- Removed all spaghetti code related to create my feed modal

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
