### PR TITLE
fix: adjust scout comment icons

### DIFF
--- a/packages/shared/src/components/comments/CommentAuthor.tsx
+++ b/packages/shared/src/components/comments/CommentAuthor.tsx
@@ -24,7 +24,7 @@ export default function CommentAuthor({
         {author.name}
         {author.id === postAuthorId && (
           <span className="flex items-center ml-2 text-theme-status-help typo-footnote">
-            <FeatherIcon className="mx-1 text-base icon" />
+            <FeatherIcon className="mx-0.5" size="small" />
             Author
           </span>
         )}

--- a/packages/shared/src/components/comments/ScoutBadge.tsx
+++ b/packages/shared/src/components/comments/ScoutBadge.tsx
@@ -4,7 +4,7 @@ import ScoutIcon from '../icons/Scout';
 export default function ScoutBadge(): ReactElement {
   return (
     <span className="flex items-center ml-2 font-bold text-theme-color-bun typo-footnote">
-      <ScoutIcon className="mr-1" size="small" />
+      <ScoutIcon className="mr-0.5" size="small" />
       Scout
     </span>
   );


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The comment icons had different sizes and spacing

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-150 #done 
