### PR TITLE
fix: cleanup unused and finished experiments

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -30,9 +30,6 @@ import {
   postAnalyticsEvent,
 } from '../lib/feed';
 import PostOptionsMenu from './PostOptionsMenu';
-import FeaturesContext from '../contexts/FeaturesContext';
-import { Features, getFeatureValue } from '../lib/featureManagement';
-import { getThemeFont } from './utilities';
 import { PostModal } from './modals/PostModal';
 import { usePostModalNavigation } from '../hooks/usePostModalNavigation';
 import {
@@ -112,15 +109,6 @@ export default function Feed<T>({
   onEmptyFeed,
   emptyScreen,
 }: FeedProps<T>): ReactElement {
-  const { flags } = useContext(FeaturesContext);
-  const postHeadingFont = getThemeFont(
-    getFeatureValue(Features.PostCardHeadingFont, flags),
-    Features.PostCardHeadingFont.defaultValue,
-  );
-  const displayPublicationDate = !parseInt(
-    getFeatureValue(Features.HidePublicationDate, flags),
-    10,
-  );
   const { trackEvent } = useContext(AnalyticsContext);
   const currentSettings = useContext(FeedContext);
   const { user } = useContext(AuthContext);
@@ -298,7 +286,6 @@ export default function Feed<T>({
             index={index}
             row={calculateRow(index, numCards)}
             column={calculateColumn(index, numCards)}
-            displayPublicationDate={displayPublicationDate}
             columns={virtualizedNumCards}
             key={getFeedItemKey(items, index)}
             useList={useList}
@@ -320,7 +307,6 @@ export default function Feed<T>({
             onMenuClick={onMenuClick}
             onCommentClick={onCommentClick}
             onAdClick={onAdClick}
-            postHeadingFont={postHeadingFont}
           />
         ))}
       </div>

--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -23,11 +23,9 @@ export type FeedItemComponentProps = {
   useList: boolean;
   openNewTab: boolean;
   insaneMode: boolean;
-  displayPublicationDate: boolean;
   nativeShareSupport: boolean;
   postMenuIndex: number | undefined;
   showCommentPopupId: string | undefined;
-  postHeadingFont: string;
   setShowCommentPopupId: (value: string | undefined) => void;
   isSendingComment: boolean;
   comment: (variables: {
@@ -99,7 +97,6 @@ export default function FeedItemComponent({
   openNewTab,
   nativeShareSupport,
   postMenuIndex,
-  displayPublicationDate,
   showCommentPopupId,
   setShowCommentPopupId,
   isSendingComment,
@@ -114,7 +111,6 @@ export default function FeedItemComponent({
   onMenuClick,
   onCommentClick,
   onAdClick,
-  postHeadingFont,
 }: FeedItemComponentProps): ReactElement {
   const PostTag = useList ? PostList : PostCard;
   const AdTag = useList ? AdList : AdCard;
@@ -137,7 +133,7 @@ export default function FeedItemComponent({
           ref={inViewRef}
           post={{
             ...item.post,
-            createdAt: displayPublicationDate && item.post.createdAt,
+            createdAt: item.post.createdAt,
           }}
           data-testid="postItem"
           onUpvoteClick={(post, upvoted) =>
@@ -155,7 +151,6 @@ export default function FeedItemComponent({
           menuOpened={postMenuIndex === index}
           showImage={!insaneMode}
           onCommentClick={(post) => onCommentClick(post, index, row, column)}
-          postHeadingFont={postHeadingFont}
         >
           {showCommentPopupId === item.post.id && (
             <CommentPopup
@@ -178,7 +173,6 @@ export default function FeedItemComponent({
           data-testid="adItem"
           onLinkClick={(ad) => onAdClick(ad, index, row, column)}
           showImage={!insaneMode}
-          postHeadingFont={postHeadingFont}
         />
       );
     default:

--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -133,7 +133,6 @@ export default function FeedItemComponent({
           ref={inViewRef}
           post={{
             ...item.post,
-            createdAt: item.post.createdAt,
           }}
           data-testid="postItem"
           onUpvoteClick={(post, upvoted) =>

--- a/packages/shared/src/components/LoginButton.tsx
+++ b/packages/shared/src/components/LoginButton.tsx
@@ -6,7 +6,6 @@ import FeaturesContext from '../contexts/FeaturesContext';
 import { Features, getFeatureValue } from '../lib/featureManagement';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../hooks/analytics/useAnalyticsQueue';
-import { getThemeColor } from './utilities';
 
 const getAnalyticsEvent = (
   eventName: string,
@@ -30,10 +29,6 @@ export default function LoginButton({
   const { flags } = useContext(FeaturesContext);
   const { trackEvent } = useContext(AnalyticsContext);
   const buttonCopy = getFeatureValue(Features.SignupButtonCopy, flags);
-  const buttonColor = getThemeColor(
-    getFeatureValue(Features.SignupButtonColor, flags),
-    Features.MyFeedButtonColor.defaultValue,
-  );
 
   useEffect(() => {
     trackEvent(getAnalyticsEvent('impression', buttonCopy));
@@ -48,7 +43,7 @@ export default function LoginButton({
     <Button
       onClick={onClick}
       icon={icon}
-      className={classNames(className, buttonColor.button)}
+      className={classNames(className, 'btn-primary')}
     >
       <span className="hidden laptop:inline">{buttonCopy}</span>
       <span className="laptop:hidden">Sign up</span>

--- a/packages/shared/src/components/cards/AdCard.tsx
+++ b/packages/shared/src/components/cards/AdCard.tsx
@@ -18,11 +18,10 @@ export type AdCardProps = {
   ad: Ad;
   onLinkClick?: Callback;
   showImage?: boolean;
-  postHeadingFont: string;
 } & HTMLAttributes<HTMLDivElement>;
 
 export const AdCard = forwardRef(function AdCard(
-  { ad, onLinkClick, showImage = true, postHeadingFont, ...props }: AdCardProps,
+  { ad, onLinkClick, showImage = true, ...props }: AdCardProps,
   ref: Ref<HTMLElement>,
 ): ReactElement {
   const showBlurredImage = ad.source === 'Carbon';
@@ -31,7 +30,9 @@ export const AdCard = forwardRef(function AdCard(
     <Card {...props} ref={ref}>
       <AdLink ad={ad} onLinkClick={onLinkClick} />
       <CardTextContainer>
-        <CardTitle className={classNames('my-4 line-clamp-4', postHeadingFont)}>
+        <CardTitle
+          className={classNames('my-4 line-clamp-4 font-bold typo-title3')}
+        >
           {ad.description}
         </CardTitle>
       </CardTextContainer>

--- a/packages/shared/src/components/cards/AdList.tsx
+++ b/packages/shared/src/components/cards/AdList.tsx
@@ -12,7 +12,7 @@ import AdLink from './AdLink';
 import AdAttribution from './AdAttribution';
 
 export const AdList = forwardRef(function AdList(
-  { ad, onLinkClick, postHeadingFont, ...props }: AdCardProps,
+  { ad, onLinkClick, ...props }: AdCardProps,
   ref: Ref<HTMLElement>,
 ): ReactElement {
   return (
@@ -21,7 +21,9 @@ export const AdList = forwardRef(function AdList(
       <ListCardAside />
       <ListCardDivider />
       <ListCardMain>
-        <ListCardTitle className={classNames('line-clamp-4', postHeadingFont)}>
+        <ListCardTitle
+          className={classNames('line-clamp-4 font-bold typo-title3')}
+        >
           {ad.description}
         </ListCardTitle>
         <AdAttribution ad={ad} className="mt-2" />

--- a/packages/shared/src/components/cards/Card.tsx
+++ b/packages/shared/src/components/cards/Card.tsx
@@ -12,7 +12,7 @@ import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 const Title = classed(
   'h3',
   styles.title,
-  'text-theme-label-primary multi-truncate line-clamp-3',
+  'text-theme-label-primary multi-truncate line-clamp-3 font-bold typo-title3',
 );
 
 export const CardTitle = classed(Title, 'my-2 break-words');

--- a/packages/shared/src/components/cards/PostCard.tsx
+++ b/packages/shared/src/components/cards/PostCard.tsx
@@ -47,7 +47,6 @@ export type PostCardProps = {
   enableMenu?: boolean;
   menuOpened?: boolean;
   showImage?: boolean;
-  postHeadingFont: string;
 } & HTMLAttributes<HTMLDivElement>;
 
 export const PostCard = forwardRef(function PostCard(
@@ -67,7 +66,6 @@ export const PostCard = forwardRef(function PostCard(
     children,
     showImage = true,
     style,
-    postHeadingFont,
     ...props
   }: PostCardProps,
   ref: Ref<HTMLElement>,
@@ -94,9 +92,7 @@ export const PostCard = forwardRef(function PostCard(
             post={post}
           />
         </CardHeader>
-        <CardTitle className={classNames(className, postHeadingFont)}>
-          {post.title}
-        </CardTitle>
+        <CardTitle className={className}>{post.title}</CardTitle>
       </CardTextContainer>
       <CardSpace />
       <PostMetadata

--- a/packages/shared/src/components/cards/PostList.tsx
+++ b/packages/shared/src/components/cards/PostList.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, ReactElement, Ref, useState } from 'react';
-import classNames from 'classnames';
 import { Comment } from '../../graphql/comments';
 import { PostCardProps } from './PostCard';
 import {
@@ -36,7 +35,6 @@ export const PostList = forwardRef(function PostList(
     menuOpened,
     className,
     children,
-    postHeadingFont,
     ...props
   }: PostCardProps,
   ref: Ref<HTMLElement>,
@@ -64,9 +62,7 @@ export const PostList = forwardRef(function PostList(
       </ListCardAside>
       <ListCardDivider />
       <ListCardMain>
-        <ListCardTitle className={classNames(className, postHeadingFont)}>
-          {post.title}
-        </ListCardTitle>
+        <ListCardTitle className={className}>{post.title}</ListCardTitle>
         <PostMetadata
           createdAt={post.createdAt}
           readTime={post.readTime}

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -77,17 +77,6 @@ export const getThemeColor = (color: string, fallback: string): ThemeColor => {
   return themeColors[color] ?? themeColors[fallback];
 };
 
-const themeFonts = {
-  bodyBold: 'font-bold typo-body',
-  body: 'typo-body',
-  title3: 'typo-title3',
-  title3Bold: 'font-bold typo-title3',
-};
-
-export const getThemeFont = (font: string, fallback: string): string => {
-  return themeFonts[font] ?? themeFonts[fallback];
-};
-
 export const postEventName = (
   update: Pick<PostBootData, 'upvoted' | 'bookmarked'>,
 ): string => {

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -6,24 +6,13 @@ export class Features {
     'Access all features',
   );
 
-  static readonly SignupButtonColor = new Features(
-    'signup_button_theme_color',
-    'primary',
-    ['primary', 'avocado', 'water', 'cabbage', 'bacon'],
-  );
-
   static readonly DevcardLimit = new Features('feat_limit_dev_card', '50');
 
   static readonly FeedVersion = new Features('feed_version', '1');
 
-  static readonly HidePublicationDate = new Features(
-    'hide_publication_date',
-    '0',
-  );
-
   static readonly LoginModalButtonCopyPrefix = new Features(
     'login_modal_button_copy_prefix',
-    'Sign in with',
+    'Connect with',
   );
 
   static readonly LoginModalDescriptionCopy = new Features(


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Cleanup unused experiments
- Text related ones remain active, but changed to winners
- Logic related ones get completely removed

Note: We should only turn them off once we deploy the extension to a new version and give it a week or so.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
