### PR TITLE
fix: cookie z-index and intial value storage

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -194,6 +194,7 @@ export default function MainFeedLayout({
       isSessionLoaded &&
       myFeedOnboardingVersion !== 'control'
     ) {
+      setIsFirstSession(true);
       setMyFeedMode(MyFeedMode.Auto);
       setCreateMyFeed(true);
     }

--- a/packages/webapp/components/CookieBanner.module.css
+++ b/packages/webapp/components/CookieBanner.module.css
@@ -1,4 +1,5 @@
 .cookieBanner {
+  z-index: 20;
   @screen laptop {
     left: unset
   }

--- a/packages/webapp/components/CookieBanner.tsx
+++ b/packages/webapp/components/CookieBanner.tsx
@@ -20,7 +20,7 @@ export default function CookieBanner({
   return (
     <div
       className={classNames(
-        'fixed left-0 bottom-0 w-full flex flex-col py-4 pr-14 pl-4 text-theme-label-secondary bg-theme-bg-tertiary border-t border-theme-divider-secondary z-2 typo-footnote laptop:w-48 laptop:right-6 laptop:bottom-6 laptop:p-6 laptop:items-center laptop:text-center laptop:border laptop:rounded-2xl',
+        'fixed left-0 bottom-0 w-full flex flex-col py-4 pr-14 pl-4 text-theme-label-secondary bg-theme-bg-tertiary border-t border-theme-divider-secondary typo-footnote laptop:w-48 laptop:right-6 laptop:bottom-6 laptop:p-6 laptop:items-center laptop:text-center laptop:border laptop:rounded-2xl',
         styles.cookieBanner,
       )}
     >


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Z-index of the cookie banner was too low
- We didn't set the actual cache, so refresh would re-assess

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
