### PR TITLE
fix: back button on post modal

### DIFF
--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -11,7 +11,6 @@ import MainFeedLayout, {
 } from '@dailydotdev/shared/src/components/MainFeedLayout';
 import FeedLayout from '@dailydotdev/shared/src/components/FeedLayout';
 import dynamic from 'next/dynamic';
-
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import useDefaultFeed from '@dailydotdev/shared/src/hooks/useDefaultFeed';
 import { useMyFeed } from '@dailydotdev/shared/src/hooks/useMyFeed';

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -265,7 +265,7 @@ export default function Feed<T>({
         <PostModal
           isOpen
           id={selectedPost.id}
-          onRequestClose={onCloseModal}
+          onRequestClose={() => onCloseModal(false)}
           onPreviousPost={onPrevious}
           onNextPost={onNext}
           isFetchingNextPage={isFetchingNextPage}

--- a/packages/shared/src/components/modals/PostModal.tsx
+++ b/packages/shared/src/components/modals/PostModal.tsx
@@ -39,8 +39,6 @@ export function PostModal({
   const [position, setPosition] =
     useState<CSSProperties['position']>('relative');
   const { tokenRefreshed } = useContext(AuthContext);
-  const [currentPage, setCurrentPage] = useState<string>();
-  const isExtension = !!process.env.TARGET_BROWSER;
   useResetScrollForResponsiveModal();
   useHideOnModal(props.isOpen);
 
@@ -53,26 +51,6 @@ export function PostModal({
     () => request(`${apiUrl}/graphql`, POST_BY_ID_QUERY, { id }),
     { enabled: !!id && tokenRefreshed },
   );
-
-  useEffect(() => {
-    if (isExtension) {
-      return;
-    }
-
-    if (!currentPage) {
-      setCurrentPage(window.location.pathname);
-    }
-
-    window.history.replaceState({}, `Post: ${id}`, `/posts/${id}`);
-  }, [id]);
-
-  const onClose: typeof onRequestClose = (e) => {
-    if (!isExtension && currentPage) {
-      window.history.replaceState({}, `Feed`, currentPage);
-      setCurrentPage(undefined);
-    }
-    onRequestClose(e);
-  };
 
   useEffect(() => {
     const modal = document.getElementById('post-modal');
@@ -126,7 +104,7 @@ export function PostModal({
       className={classNames(className, 'post-modal focus:outline-none')}
       overlayClassName="post-modal-overlay"
       id="post-modal"
-      onRequestClose={onClose}
+      onRequestClose={onRequestClose}
     >
       <PostContent
         position={position}
@@ -134,7 +112,7 @@ export function PostModal({
         onPreviousPost={onPreviousPost}
         onNextPost={onNextPost}
         className="post-content"
-        onClose={onClose}
+        onClose={onRequestClose}
         isLoading={isLoading || !isFetched || isFetchingNextPage}
         isModal
       />

--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -8,8 +8,8 @@ import { useKeyboardNavigation } from './useKeyboardNavigation';
 interface UsePostModalNavigation {
   onPrevious: () => void;
   onNext: () => Promise<void>;
-  onOpenModal: (index: number) => void;
-  onCloseModal: () => void;
+  onOpenModal: (index: number, fromPopState?: boolean) => void;
+  onCloseModal: (fromPopState?: boolean) => void;
   isFetchingNextPage?: boolean;
   selectedPost: Post | null;
 }
@@ -18,15 +18,83 @@ export const usePostModalNavigation = (
   items: FeedItem[],
   fetchPage: () => Promise<unknown>,
 ): UsePostModalNavigation => {
+  const [currentPage, setCurrentPage] = useState<string>();
+  const isExtension = !!process.env.TARGET_BROWSER;
   const [openedPostIndex, setOpenedPostIndex] = useState<number>(null);
   const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
   const { trackEvent } = useContext(AnalyticsContext);
 
+  const changeHistory = (data: unknown, title: string, url: string) => {
+    if (!isExtension) {
+      window.history.pushState(data, title, url);
+    }
+  };
+
+  const getPost = (index) =>
+    index !== null && items[index].type === 'post'
+      ? (items[index] as PostItem).post
+      : null;
+
+  const onChangeSelected = (index: number, fromPopState = false) => {
+    setOpenedPostIndex(index);
+    const post = !fromPopState && getPost(index);
+    if (post) {
+      changeHistory({}, `Post: ${post.id}`, `/posts/${post.id}`);
+    }
+  };
+
+  const onOpenModal = (index, fromPopState = false) => {
+    onChangeSelected(index, fromPopState);
+    if (!currentPage) {
+      setCurrentPage(window.location.pathname);
+    }
+  };
+
+  const onCloseModal = (fromPopState = false) => {
+    setOpenedPostIndex(null);
+    setCurrentPage(undefined);
+    if (!fromPopState) {
+      changeHistory({}, `Feed`, currentPage);
+    }
+  };
+
+  useEffect(() => {
+    const onPopState = () => {
+      const url = new URL(window.location.href);
+      if (url.pathname.indexOf('/posts/') !== 0) {
+        onCloseModal(true);
+        return;
+      }
+
+      const [, , postId] = url.pathname.split('/');
+      const index = items.findIndex((item) => {
+        if (item.type !== 'post') {
+          return false;
+        }
+
+        return item.post.id === postId;
+      });
+
+      if (index === -1) {
+        onCloseModal();
+        return;
+      }
+
+      onOpenModal(index, true);
+    };
+
+    window.addEventListener('popstate', onPopState);
+
+    return () => {
+      window.removeEventListener('popstate', onPopState);
+    };
+  }, [items]);
+
   const ret = useMemo<UsePostModalNavigation>(
     () => ({
       isFetchingNextPage,
-      onCloseModal: () => setOpenedPostIndex(null),
-      onOpenModal: (index) => setOpenedPostIndex(index),
+      onCloseModal,
+      onOpenModal,
       onPrevious() {
         let index = openedPostIndex - 1;
         for (; index > 0 && items[index].type !== 'post'; index -= 1);
@@ -41,7 +109,7 @@ export const usePostModalNavigation = (
             extra: { origin: 'article modal' },
           }),
         );
-        setOpenedPostIndex(index);
+        onChangeSelected(index);
       },
       async onNext() {
         let index = openedPostIndex + 1;
@@ -73,12 +141,9 @@ export const usePostModalNavigation = (
             extra: { origin: 'article modal' },
           }),
         );
-        setOpenedPostIndex(index);
+        onChangeSelected(index);
       },
-      selectedPost:
-        openedPostIndex !== null && items[openedPostIndex].type === 'post'
-          ? (items[openedPostIndex] as PostItem).post
-          : null,
+      selectedPost: getPost(openedPostIndex),
     }),
     [items, openedPostIndex, isFetchingNextPage],
   );


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Instead of replacing history on navigation - we should push the history based on the user's action.
- This should allow the user to utilize the native browser's function of the back and forward button
- This means the back button for mobile should function as intended as well. This will greatly improve users' experience, I believe.
- Since we have a custom hook that manages the navigation - I migrated everything related to navigation in that hook itself.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-634 #done
