### PR TITLE
fix: share comment icon size updated

### DIFF
--- a/packages/shared/src/components/ShareNewCommentPopup.tsx
+++ b/packages/shared/src/components/ShareNewCommentPopup.tsx
@@ -42,10 +42,7 @@ export default function ShareNewCommentPopup({
         className="absolute left-2 h-16"
         style={{ top: '-4.375rem', width: '6.25rem' }}
       />
-      <ShareIcon
-        className="absolute -top-8 left-6"
-        style={{ fontSize: '4rem' }}
-      />
+      <ShareIcon className="absolute -top-8 left-6" size="xxxxlarge" />
       <h2 className="mt-2 typo-title3">
         That&apos;s a great comment, {user.name?.split(' ')[0]}!
       </h2>


### PR DESCRIPTION
## Changes

### Describe what this PR does

Share comment icon size fixed and now uses standard way of changing size of the icon

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
