### PR TITLE
refactor: fetching shadow dom on extension only

### DIFF
--- a/packages/shared/src/lib/element.ts
+++ b/packages/shared/src/lib/element.ts
@@ -8,8 +8,13 @@ export type CaretOffset = [number, number];
 export type CaretPosition = [Column, Row];
 
 const isFirefox = process.env.TARGET_BROWSER === 'firefox';
+const isExtension = !!process.env.TARGET_BROWSER;
 
 const getShadowDom = (ownerDocument = false): Document => {
+  if (!isExtension) {
+    return null;
+  }
+
   const companion = document.querySelector('daily-companion-app');
 
   if (!companion) {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Have changed the decision process where the user mention tooltip will append the result so we won't have to bother from the list and ensure it will always be the actual DOM for webapp.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
