### PR TITLE
fix: layout shift after making a search

### DIFF
--- a/packages/shared/src/components/PostsSearch.tsx
+++ b/packages/shared/src/components/PostsSearch.tsx
@@ -105,6 +105,10 @@ export default function PostsSearch({
     if (value && value !== initialQueryProp) {
       debounceQuery(value);
     }
+
+    if (menuPosition === null) {
+      showSuggestions();
+    }
   };
 
   useEffect(() => {

--- a/packages/shared/src/components/fields/AutoCompleteMenu.tsx
+++ b/packages/shared/src/components/fields/AutoCompleteMenu.tsx
@@ -44,7 +44,7 @@ export default function AutoCompleteMenu({
         top: placement?.y,
         left: placement?.x,
         opacity: isOpen ? 1 : 0,
-        width: placement?.width,
+        width: placement?.width ?? 0,
         transform: 'none',
       }}
     >


### PR DESCRIPTION
## Changes

### Describe what this PR does
- After making a search on a mobile device, the UI shifts. We now set `0` width whenever the suggestion is not available.
- I have also found another issue where it won't display a suggestion after you hit enter and then type something. Should be fixed here as well.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-166 #done
