### PR TITLE
fix: extension comment modal size

### DIFF
--- a/packages/shared/src/components/modals/CommentBox.tsx
+++ b/packages/shared/src/components/modals/CommentBox.tsx
@@ -103,7 +103,7 @@ function CommentBox({
 
   return (
     <>
-      <div className="overflow-auto" style={{ maxHeight: '31rem' }}>
+      <div className="overflow-auto max-h-[31rem]">
         <article
           className={classNames(
             'flex flex-col items-stretch',


### PR DESCRIPTION
## Changes

### Describe what this PR does

Now we use tailwind class instead of inline style, so it's our plugin can convert it from rem to pixels and it's solves issue with modal height in companion and we don't rely on site font size

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
