### PR TITLE
fix: sidebar icon size to match guideline

### DIFF
--- a/packages/shared/src/components/icons/Search/index.tsx
+++ b/packages/shared/src/components/icons/Search/index.tsx
@@ -3,7 +3,7 @@ import Icon, { IconProps } from '../../Icon';
 import OutlinedIcon from './outlined.svg';
 import FilledIcon from './filled.svg';
 
-const SearchIcon = ({ size = 'medium', ...rest }: IconProps): ReactElement => (
+const SearchIcon = ({ size, ...rest }: IconProps): ReactElement => (
   <Icon
     {...rest}
     size={size}


### PR DESCRIPTION
## Changes

### Describe what this PR does
Default search icon size removed, because it is controlled by general icon component and now we have correct size of the icon in the sidebar

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
