### PR TITLE
feat: similar posts button label updated

### DIFF
--- a/packages/shared/src/components/widgets/SimilarPosts.tsx
+++ b/packages/shared/src/components/widgets/SimilarPosts.tsx
@@ -163,7 +163,7 @@ export default function SimilarPosts({
           tag="a"
           rightIcon={<ArrowIcon className="rotate-90" />}
         >
-          Show more
+          View all
         </Button>
       </Link>
     </section>


### PR DESCRIPTION
## Changes

### Describe what this PR does
As we decided in our slack conversation label is updated from _show more_ to _view all_ to make it more clear for the user 

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
