### PR TITLE
fix: remove icon from hover effect

### DIFF
--- a/packages/shared/src/components/fields/Checkbox.module.css
+++ b/packages/shared/src/components/fields/Checkbox.module.css
@@ -18,8 +18,6 @@
 }
 
 .label {
-  &:hover,
-  &:focus-within,
   &:global(.checked) {
     color: var(--theme-label-primary);
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We currently show the icon on hovering the checkbox, which is weird
- We now only show it once it's actually checked
- According to design spec: https://github.com/dailydotdev/daily/issues/371

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-176 #done 
