### PR TITLE
fix: enable scroll for profile page coming from post modal

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -277,6 +277,12 @@ export default function Feed<T>({
   }
 
   useEffect(() => {
+    return () => {
+      document.body.classList.remove('hidden-scrollbar');
+    };
+  }, []);
+
+  useEffect(() => {
     if (!selectedPost) {
       document.body.classList.remove('hidden-scrollbar');
     }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We had a edge case where we never cleaned up the `hidden-scrollbar` when navigation without page-refresh.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-168 #done
