### PR TITLE
fix: read article tooltip

### DIFF
--- a/packages/shared/src/components/post/PostModalActions.tsx
+++ b/packages/shared/src/components/post/PostModalActions.tsx
@@ -73,16 +73,22 @@ export function PostModalActions({
 
   return (
     <Container {...props} className={classNames('gap-2', className)}>
-      <Button
-        className={inlineActions ? 'btn-tertiary' : 'btn-secondary'}
-        tag="a"
-        href={post.permalink}
-        target="_blank"
-        icon={<OpenLinkIcon />}
-        onClick={onReadArticle}
+      <SimpleTooltip
+        placement="bottom"
+        content="Read article"
+        disabled={!inlineActions}
       >
-        {!inlineActions && 'Read article'}
-      </Button>
+        <Button
+          className={inlineActions ? 'btn-tertiary' : 'btn-secondary'}
+          tag="a"
+          href={post.permalink}
+          target="_blank"
+          icon={<OpenLinkIcon />}
+          onClick={onReadArticle}
+        >
+          {!inlineActions && 'Read article'}
+        </Button>
+      </SimpleTooltip>
       <SimpleTooltip placement="bottom" content="Options">
         <Button
           className={classNames('btn-tertiary', !inlineActions && 'ml-auto')}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixes the missing tooltip when the post modal header is sticky.
- The close button has a tooltip, so no changes are needed for it.

Preview: 
![image](https://user-images.githubusercontent.com/13744167/176403167-0a7e76e6-5370-4e61-8b8e-2f89ee537887.png)

![image](https://user-images.githubusercontent.com/13744167/176403206-918af57b-e275-4a51-8f6d-eddf58fef42b.png)

![image](https://user-images.githubusercontent.com/13744167/176403229-33a84231-5696-44e6-9ede-abed2e11a29c.png)


### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
