### PR TITLE
fix: header to display both create feed and dropdowns

### DIFF
--- a/packages/shared/src/components/CreateMyFeedButton.tsx
+++ b/packages/shared/src/components/CreateMyFeedButton.tsx
@@ -48,7 +48,7 @@ export default function CreateMyFeedButton({
   }, [buttonCopy]);
 
   return (
-    <div className="flex flex-col items-center mb-8 w-full">
+    <div className="flex flex-col items-center mb-4 w-full">
       <div
         className={classNames(
           'p-2 border flex-col tablet:flex-row flex items-center rounded-12',

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -265,7 +265,7 @@ export default function MainFeedLayout({
           flags={flags}
         />
       )}
-      <div className="flex flex-row flex-wrap gap-4 items-center mr-px w-full">
+      <div className="flex flex-row flex-wrap gap-4 items-center mr-px w-full h-12">
         <h3 className="flex flex-1 typo-headline">{feedTitles[feedName]}</h3>
         {navChildren}
         {isUpvoted && (

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -257,23 +257,16 @@ export default function MainFeedLayout({
     </LayoutHeader>
   );
 
-  const getFeedTitle = () => {
-    if (shouldShowMyFeed && alerts?.filter) {
-      return (
+  const header = (
+    <LayoutHeader className="flex-col">
+      {shouldShowMyFeed && alerts?.filter && (
         <CreateMyFeedButton
           action={() => setCreateMyFeed(true)}
           flags={flags}
         />
-      );
-    }
-
-    return <h3 className="typo-headline">{feedTitles[feedName]}</h3>;
-  };
-
-  const header = (
-    <LayoutHeader className="flex-row">
-      {!isSearchOn && getFeedTitle()}
-      <div className="flex flex-row flex-wrap gap-4 items-center mr-px">
+      )}
+      <div className="flex flex-row flex-wrap gap-4 items-center mr-px w-full">
+        <h3 className="flex flex-1 typo-headline">{feedTitles[feedName]}</h3>
         {navChildren}
         {isUpvoted && (
           <Dropdown


### PR DESCRIPTION
## Changes

### Describe what this PR does
- From the link, it looks like both elements need to be present even when the user has no filters yet.

https://miro.com/app/board/uXjVOPPtumw=/?invite_link_id=273386981736

Preview:

![image](https://user-images.githubusercontent.com/13744167/176432673-639eca27-96c7-4b04-9d71-5bbe3ee17230.png)

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-172 #done
