### PR TITLE
fix: some small icon issues fixed

### DIFF
--- a/packages/shared/src/components/icons/Facebook/index.tsx
+++ b/packages/shared/src/components/icons/Facebook/index.tsx
@@ -4,7 +4,7 @@ import WhiteIcon from './white.svg';
 import ColorIcon from './color.svg';
 
 const FacebookIcon = (props: IconProps): ReactElement => (
-  <Icon {...props} IconOutlined={ColorIcon} IconFilled={WhiteIcon} />
+  <Icon {...props} IconOutlined={WhiteIcon} IconFilled={ColorIcon} />
 );
 
 export default FacebookIcon;

--- a/packages/shared/src/components/profile/EditImageWithJoinedDate.tsx
+++ b/packages/shared/src/components/profile/EditImageWithJoinedDate.tsx
@@ -21,7 +21,8 @@ export interface EditImageWithJoinedDateProps
 }
 
 const Provider = classed('div', 'flex items-center my-0.5');
-const providerIconClass = 'icon text-base mr-3 w-auto h-auto';
+const providerIconClass = 'icon text-base mr-3';
+const providerIconStyles = { width: 'auto', height: 'auto' };
 
 const TWO_MEGABYTES = 2 * 1024 * 1024;
 
@@ -88,12 +89,19 @@ export default function EditImageWithJoinedDate({
         <div className="flex flex-col ml-6 text-theme-label-quaternary typo-caption1">
           {user?.providers[0] === 'google' ? (
             <Provider>
-              <GoogleIcon className={providerIconClass} />
+              <GoogleIcon
+                style={providerIconStyles}
+                className={providerIconClass}
+              />
               <span>via Google</span>
             </Provider>
           ) : (
             <Provider>
-              <GitHubIcon filled className={providerIconClass} />
+              <GitHubIcon
+                filled
+                style={providerIconStyles}
+                className={providerIconClass}
+              />
               <span>via GitHub</span>
             </Provider>
           )}

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -210,7 +210,7 @@ export default function ProfileLayout({
                     href={`https://twitter.com/${twitterHandle}`}
                     target="_blank"
                     rel="noopener"
-                    icon={<TwitterIcon filled />}
+                    icon={<TwitterIcon />}
                     className="btn-tertiary"
                   />
                 </SimpleTooltip>


### PR DESCRIPTION
## Changes

### Describe what this PR does
Found some small issues during testing on a preview env, so quickly fixed everything and one more time checked everything:
- Facebook icon filled is color and outlined is white now
- Profile twitter social icon is white
- GitHub icon size was wrong, because tailwind classnames were overwritten, so I changed it to inline styles for now (will be changed once we have icon sizes guideline)

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
