### PR TITLE
fix: companion popup placement

### DIFF
--- a/packages/extension/src/companion/CompanionPopupButton.tsx
+++ b/packages/extension/src/companion/CompanionPopupButton.tsx
@@ -53,7 +53,6 @@ export const CompanionPopupButton = ({
     <SimpleTooltip
       content={<CompanionPermission />}
       placement="bottom-start"
-      offset={[-140, 12]}
       container={{
         paddingClassName: 'px-6 py-4',
         bgClassName: 'bg-theme-bg-primary',

--- a/packages/shared/src/components/tooltips/BaseTooltip.tsx
+++ b/packages/shared/src/components/tooltips/BaseTooltip.tsx
@@ -72,6 +72,7 @@ export function BaseTooltip(
     <Tippy
       ref={ref}
       {...props}
+      maxWidth=""
       plugins={[lazyPlugin]}
       placement={placement}
       delay={delay}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- After further checking, it seems the root cause of miscalculation in the offset (and had to use) was the max width that was set default from tippyjs. Our component exceeds it, but since the value was explicitly set, it has been thought to be the actual width.
- Also checked from the actual library if the removal of the max width is safe, and there seems to be no issue about it: https://github.com/atomiks/tippyjs/issues/451#issuecomment-473252780

There was also an issue before for its misplacement when the user is not logged in. This has resolved that issue as well. Have thoroughly checked and all seems to be in place now and much more stable.

Issues to close:
- https://github.com/dailydotdev/daily/issues/620
- https://github.com/dailydotdev/daily/issues/574

Will close the relevant issues once we have verified the fix.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-198 #done
