### PR TITLE
chore: closing AB test for companion

### DIFF
--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -88,28 +88,28 @@ export class Features {
 
   static readonly CompanionPermissionPlacement = new Features(
     'companion_permission_placement',
-    'off',
+    'header',
     ['off', 'header', 'sidebar'],
   );
 
   static readonly CompanionPermissionTitle = new Features(
     'companion_permission_title',
-    'The companion lets you comment and upvote directly on an article! 🤯',
+    'Try the new companion feature!',
   );
 
   static readonly CompanionPermissionDescription = new Features(
     'companion_permission_description',
-    'Heads up! We need to ask for some extra permissions so you can enjoy the power of the companion.',
+    "We'll ask for extra permissions so we can show the companion directly on an article!",
   );
 
   static readonly CompanionPermissionLink = new Features(
     'companion_permission_link',
-    'Watch the Companion overview',
+    'Overview Video',
   );
 
   static readonly CompanionPermissionButton = new Features(
     'companion_permission_button',
-    'Add the companion now!',
+    'Activate companion',
   );
 
   static readonly PostCardVersion = new Features('post_card_version', 'v1', [


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Closing the AB test winners for all flags
- Keeping the `companion_permission_placement` active as we might reintroduce soon

Winners described here: https://dailydotdev.atlassian.net/wiki/spaces/HAN/pages/edit-v2/234160129

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-211 #done