### PR TITLE
fix: modify share colors to reflect design

### DIFF
--- a/packages/shared/src/components/fields/TextField.tsx
+++ b/packages/shared/src/components/fields/TextField.tsx
@@ -35,6 +35,7 @@ interface InputFontColorProps {
   disabled?: boolean;
   focused?: boolean;
   hasInput?: boolean;
+  actionIcon?: React.ReactElement<IconProps>;
 }
 
 export const getInputFontColor = ({
@@ -42,7 +43,12 @@ export const getInputFontColor = ({
   disabled,
   focused,
   hasInput,
+  actionIcon,
 }: InputFontColorProps): string => {
+  if (readOnly && actionIcon) {
+    return 'text-theme-label-primary';
+  }
+
   if (readOnly) {
     return 'text-theme-label-quaternary';
   }
@@ -192,7 +198,13 @@ export function TextField({
           <span
             className={classNames(
               'mr-2',
-              getInputFontColor({ readOnly, disabled, hasInput, focused }),
+              getInputFontColor({
+                readOnly,
+                disabled,
+                hasInput,
+                focused,
+                actionIcon,
+              }),
             )}
           >
             {leftIcon}
@@ -224,7 +236,13 @@ export function TextField({
             readOnly={readOnly}
             className={classNames(
               'self-stretch',
-              getInputFontColor({ readOnly, disabled, hasInput, focused }),
+              getInputFontColor({
+                readOnly,
+                disabled,
+                hasInput,
+                focused,
+                actionIcon,
+              }),
             )}
             disabled={disabled}
             {...props}

--- a/packages/shared/src/components/widgets/SocialShareIcon.tsx
+++ b/packages/shared/src/components/widgets/SocialShareIcon.tsx
@@ -25,7 +25,7 @@ export const SocialShareIcon = ({
         onClick={onClick}
         target="_blank"
         rel="noopener"
-        className={classNames(className, 'mb-2')}
+        className={classNames(className, 'mb-2 text-white')}
         iconOnly
         icon={icon}
       />

--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -131,6 +131,7 @@ body {
   --theme-color-onion: theme('colors.onion.40');
   --theme-color-water: theme('colors.water.40');
   --theme-color-salt: theme('colors.salt.40');
+  --theme-color-email: theme('colors.pepper.10');
 }
 
 @define-mixin light-mode {
@@ -232,6 +233,7 @@ body {
   --theme-color-onion: theme('colors.onion.60');
   --theme-color-water: theme('colors.water.60');
   --theme-color-salt: theme('colors.pepper.40');
+  --theme-color-email: theme('colors.pepper.10');
 }
 
 @media (prefers-color-scheme: light) {

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -24,7 +24,7 @@ module.exports = {
           reddit: '#FF4500',
           linkedin: '#0077B5',
           telegram: '#24A2E0',
-          email: 'var(--theme-rank-1-color-bottom)',
+          email: 'var(--theme-color-email)',
           primary: 'var(--theme-background-primary)',
           secondary: 'var(--theme-background-secondary)',
           tertiary: 'var(--theme-background-tertiary)',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We had some issues with light-mode colors and the textfield

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-{number} #done
