### PR TITLE
fix: make sure card images cover

### DIFF
--- a/packages/shared/src/components/cards/PostCard.tsx
+++ b/packages/shared/src/components/cards/PostCard.tsx
@@ -153,7 +153,7 @@ export const PostCard = forwardRef(function PostCard(
             alt="Post Cover image"
             src={post.image}
             fallbackSrc="https://res.cloudinary.com/daily-now/image/upload/f_auto/v1/placeholders/1"
-            className={isV1 ? 'my-2' : 'mt-2'}
+            className={classNames('object-cover', isV1 ? 'my-2' : 'mt-2')}
             loading="lazy"
           />
         )}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Card images where cropped, need to be cover

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-219 #done 