### PR TITLE
refactor: comment box from div contenteditable to textarea

### DIFF
--- a/packages/shared/src/components/modals/CommentBox.tsx
+++ b/packages/shared/src/components/modals/CommentBox.tsx
@@ -98,8 +98,7 @@ function CommentBox({
   };
 
   const handleKeydown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    const defaultCallback = () => onMentionKeypress(e);
-    onKeyDown(e, defaultCallback);
+    onKeyDown(e);
     e.stopPropagation();
   };
 
@@ -162,6 +161,7 @@ function CommentBox({
             placeholder="Write your comment..."
             onInput={onTextareaInput}
             onKeyDown={handleKeydown}
+            onKeyUp={onMentionKeypress}
             onClick={onInputClick}
             onPaste={onPaste}
             tabIndex={0}

--- a/packages/shared/src/components/modals/CommentBox.tsx
+++ b/packages/shared/src/components/modals/CommentBox.tsx
@@ -92,7 +92,7 @@ function CommentBox({
   };
 
   const handleKeydown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if ((e.ctrlKey || e.metaKey) && e.keyCode === 13 && input?.length) {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && input?.length) {
       return sendComment(e);
     }
 

--- a/packages/shared/src/components/modals/CommentBox.tsx
+++ b/packages/shared/src/components/modals/CommentBox.tsx
@@ -3,7 +3,6 @@ import React, {
   useContext,
   useEffect,
   ClipboardEvent,
-  KeyboardEventHandler,
   MouseEvent,
   KeyboardEvent,
 } from 'react';
@@ -35,10 +34,6 @@ export interface CommentBoxProps {
   parentSelector?: () => HTMLElement;
   sendComment: (event: MouseEvent | KeyboardEvent) => Promise<void>;
   onInput?: (value: string) => unknown;
-  onKeyDown: (
-    e: KeyboardEvent<HTMLTextAreaElement>,
-    defaultCallback?: KeyboardEventHandler<HTMLTextAreaElement>,
-  ) => unknown;
   post: Post;
 }
 
@@ -53,7 +48,6 @@ function CommentBox({
   errorMessage,
   sendingComment,
   onInput,
-  onKeyDown,
   sendComment,
   parentSelector,
   post,
@@ -98,8 +92,15 @@ function CommentBox({
   };
 
   const handleKeydown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    onKeyDown(e);
-    e.stopPropagation();
+    if ((e.ctrlKey || e.metaKey) && e.keyCode === 13 && input?.length) {
+      return sendComment(e);
+    }
+
+    if (e.key === 'Enter' && mentions?.length) {
+      return e.preventDefault();
+    }
+
+    return e.stopPropagation();
   };
 
   const onTextareaInput = (e: React.FormEvent<HTMLTextAreaElement>) => {

--- a/packages/shared/src/components/modals/CommentBox.tsx
+++ b/packages/shared/src/components/modals/CommentBox.tsx
@@ -20,6 +20,7 @@ import { useUserMention } from '../../hooks/useUserMention';
 import { Post } from '../../graphql/posts';
 import AtIcon from '../icons/At';
 import { cleanupEmptySpaces } from '../../lib/strings';
+import { isTouchDevice } from '../../lib/tooltip';
 
 export interface CommentBoxProps {
   authorName: string;
@@ -162,9 +163,9 @@ function CommentBox({
             placeholder="Write your comment..."
             onInput={onTextareaInput}
             onKeyDown={handleKeydown}
-            onKeyUp={onMentionKeypress}
+            onKeyUp={!isTouchDevice() && onMentionKeypress}
             onClick={onInputClick}
-            onTouchEnd={onMentionKeypress}
+            onTouchEnd={isTouchDevice() && onMentionKeypress}
             onPaste={onPaste}
             tabIndex={0}
             aria-label="New comment box"

--- a/packages/shared/src/components/modals/CommentBox.tsx
+++ b/packages/shared/src/components/modals/CommentBox.tsx
@@ -16,7 +16,11 @@ import { ProfilePicture } from '../ProfilePicture';
 import { ClickableText } from '../buttons/ClickableText';
 import Markdown from '../Markdown';
 import { RecommendedMentionTooltip } from '../tooltips/RecommendedMentionTooltip';
-import { useUserMention } from '../../hooks/useUserMention';
+import {
+  fixHeight,
+  UPDOWN_ARROW_KEYS,
+  useUserMention,
+} from '../../hooks/useUserMention';
 import { Post } from '../../graphql/posts';
 import AtIcon from '../icons/At';
 import { cleanupEmptySpaces } from '../../lib/strings';
@@ -96,7 +100,10 @@ function CommentBox({
       return sendComment(e);
     }
 
-    if (e.key === 'Enter' && mentions?.length) {
+    if (
+      (e.key === 'Enter' || UPDOWN_ARROW_KEYS.indexOf(e.key) !== -1) &&
+      mentions?.length
+    ) {
       return e.preventDefault();
     }
 
@@ -104,13 +111,7 @@ function CommentBox({
   };
 
   const onTextareaInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
-    const attr = e.currentTarget.getAttribute('data-min-height');
-    const minHeight = parseInt(attr, 10);
-    commentRef.current.style.height = 'auto';
-    commentRef.current.style.height = `${Math.max(
-      e.currentTarget.scrollHeight,
-      minHeight,
-    )}px`;
+    fixHeight(e.currentTarget);
     onInput(cleanupEmptySpaces(e.currentTarget.value));
   };
 

--- a/packages/shared/src/components/modals/CommentBox.tsx
+++ b/packages/shared/src/components/modals/CommentBox.tsx
@@ -5,6 +5,7 @@ import React, {
   ClipboardEvent,
   MouseEvent,
   KeyboardEvent,
+  useRef,
 } from 'react';
 import classNames from 'classnames';
 import AuthContext from '../../contexts/AuthContext';
@@ -53,6 +54,7 @@ function CommentBox({
   parentSelector,
   post,
 }: CommentBoxProps): ReactElement {
+  const eventRef = useRef<KeyboardEvent>();
   const { user } = useContext(AuthContext);
   const {
     onMentionClick,
@@ -93,6 +95,7 @@ function CommentBox({
   };
 
   const handleKeydown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    eventRef.current = e;
     if ((e.ctrlKey || e.metaKey) && e.keyCode === 13 && input?.length) {
       return sendComment(e);
     }
@@ -113,6 +116,7 @@ function CommentBox({
       minHeight,
     )}px`;
     onInput(cleanupEmptySpaces(e.currentTarget.value));
+    onMentionKeypress(eventRef.current);
   };
 
   return (
@@ -165,7 +169,6 @@ function CommentBox({
             onKeyDown={handleKeydown}
             onKeyUp={!isTouchDevice() && onMentionKeypress}
             onClick={onInputClick}
-            onTouchEnd={isTouchDevice() && onMentionKeypress}
             onPaste={onPaste}
             tabIndex={0}
             aria-label="New comment box"

--- a/packages/shared/src/components/modals/CommentBox.tsx
+++ b/packages/shared/src/components/modals/CommentBox.tsx
@@ -6,7 +6,6 @@ import React, {
   KeyboardEventHandler,
   MouseEvent,
   KeyboardEvent,
-  useState,
 } from 'react';
 import classNames from 'classnames';
 import AuthContext from '../../contexts/AuthContext';
@@ -59,7 +58,6 @@ function CommentBox({
   parentSelector,
   post,
 }: CommentBoxProps): ReactElement {
-  const [height, setHeight] = useState('auto');
   const { user } = useContext(AuthContext);
   const {
     onMentionClick,
@@ -106,11 +104,13 @@ function CommentBox({
   };
 
   const onTextareaInput = (e: React.FormEvent<HTMLTextAreaElement>) => {
-    const minHeight = parseInt(
-      e.currentTarget.getAttribute('data-min-height'),
-      10,
-    );
-    setHeight(`${Math.max(e.currentTarget.scrollHeight, minHeight)}px`);
+    const attr = e.currentTarget.getAttribute('data-min-height');
+    const minHeight = parseInt(attr, 10);
+    commentRef.current.style.height = 'auto';
+    commentRef.current.style.height = `${Math.max(
+      e.currentTarget.scrollHeight,
+      minHeight,
+    )}px`;
     onInput(cleanupEmptySpaces(e.currentTarget.value));
   };
 
@@ -167,7 +167,6 @@ function CommentBox({
             tabIndex={0}
             aria-label="New comment box"
             aria-multiline
-            style={{ height }}
           />
         </div>
         <RecommendedMentionTooltip

--- a/packages/shared/src/components/modals/CommentBox.tsx
+++ b/packages/shared/src/components/modals/CommentBox.tsx
@@ -164,6 +164,7 @@ function CommentBox({
             onKeyDown={handleKeydown}
             onKeyUp={onMentionKeypress}
             onClick={onInputClick}
+            onTouchEnd={onMentionKeypress}
             onPaste={onPaste}
             tabIndex={0}
             aria-label="New comment box"

--- a/packages/shared/src/components/modals/CommentBox.tsx
+++ b/packages/shared/src/components/modals/CommentBox.tsx
@@ -5,7 +5,6 @@ import React, {
   ClipboardEvent,
   MouseEvent,
   KeyboardEvent,
-  useRef,
 } from 'react';
 import classNames from 'classnames';
 import AuthContext from '../../contexts/AuthContext';
@@ -21,7 +20,6 @@ import { useUserMention } from '../../hooks/useUserMention';
 import { Post } from '../../graphql/posts';
 import AtIcon from '../icons/At';
 import { cleanupEmptySpaces } from '../../lib/strings';
-import { isTouchDevice } from '../../lib/tooltip';
 
 export interface CommentBoxProps {
   authorName: string;
@@ -54,7 +52,6 @@ function CommentBox({
   parentSelector,
   post,
 }: CommentBoxProps): ReactElement {
-  const eventRef = useRef<KeyboardEvent>();
   const { user } = useContext(AuthContext);
   const {
     onMentionClick,
@@ -95,7 +92,6 @@ function CommentBox({
   };
 
   const handleKeydown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    eventRef.current = e;
     if ((e.ctrlKey || e.metaKey) && e.keyCode === 13 && input?.length) {
       return sendComment(e);
     }
@@ -116,7 +112,6 @@ function CommentBox({
       minHeight,
     )}px`;
     onInput(cleanupEmptySpaces(e.currentTarget.value));
-    onMentionKeypress(eventRef.current);
   };
 
   return (
@@ -167,7 +162,7 @@ function CommentBox({
             placeholder="Write your comment..."
             onInput={onTextareaInput}
             onKeyDown={handleKeydown}
-            onKeyUp={!isTouchDevice() && onMentionKeypress}
+            onKeyUp={onMentionKeypress}
             onClick={onInputClick}
             onPaste={onPaste}
             tabIndex={0}

--- a/packages/shared/src/components/modals/NewCommentModal.spec.tsx
+++ b/packages/shared/src/components/modals/NewCommentModal.spec.tsx
@@ -300,7 +300,7 @@ it('should recommend users previously mentioned', async () => {
   ]);
   const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
   input.value = '@';
-  Simulate.keyDown(input, { key: '@' });
+  Simulate.keyUp(input, { key: '@' });
   await waitForNock();
   expect(queryPreviouslyMentioned).toBeTruthy();
 });
@@ -342,10 +342,10 @@ it('should recommend users based on query', async () => {
   ]);
   const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
   input.value = '@';
-  Simulate.keyDown(input, { key: '@' });
+  Simulate.keyUp(input, { key: '@' });
   await new Promise((resolve) => setTimeout(resolve, 500));
   input.value = '@l';
-  Simulate.keyDown(input, { key: 'l' });
+  Simulate.keyUp(input, { key: 'l' });
   await waitForNock();
   expect(queryMatchingNameOrUsername).toBeTruthy();
 });

--- a/packages/shared/src/components/modals/NewCommentModal.spec.tsx
+++ b/packages/shared/src/components/modals/NewCommentModal.spec.tsx
@@ -111,8 +111,8 @@ it('should disable submit button when no input', async () => {
 
 it('should enable submit button when no input', async () => {
   renderComponent();
-  const input = await screen.findByRole('textbox');
-  input.innerText = 'My new comment';
+  const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+  input.value = 'My new comment';
   input.dispatchEvent(new Event('input', { bubbles: true }));
   const el = await screen.findByText('Comment');
   expect(el.getAttribute('disabled')).toBeFalsy();
@@ -143,8 +143,8 @@ it('should send commentOnPost mutation', async () => {
       },
     },
   ]);
-  const input = await screen.findByRole('textbox');
-  input.innerText = 'comment';
+  const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+  input.value = 'comment';
   input.dispatchEvent(new Event('input', { bubbles: true }));
   const el = await screen.findByText('Comment');
   el.click();
@@ -177,8 +177,8 @@ it('should send commentOnComment mutation', async () => {
       },
     },
   ]);
-  const input = await screen.findByRole('textbox');
-  input.innerText = 'comment';
+  const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+  input.value = 'comment';
   input.dispatchEvent(new Event('input', { bubbles: true }));
   const el = await screen.findByText('Comment');
   el.click();
@@ -211,8 +211,8 @@ it('should not send comment if the input is spaces only', async () => {
       },
     },
   ]);
-  const input = await screen.findByRole('textbox');
-  input.innerText = '   ';
+  const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+  input.value = '   ';
   input.dispatchEvent(new Event('input', { bubbles: true }));
   const el = await screen.findByText('Comment');
   el.click();
@@ -234,8 +234,8 @@ it('should show alert in case of an error', async () => {
       },
     },
   ]);
-  const input = await screen.findByRole('textbox');
-  input.innerText = 'comment';
+  const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+  input.value = 'comment';
   input.dispatchEvent(new Event('input', { bubbles: true }));
   const el = await screen.findByText('Comment');
   el.click();
@@ -269,8 +269,8 @@ it('should send editComment mutation', async () => {
       },
     },
   ]);
-  const input = await screen.findByRole('textbox');
-  input.innerText = comment.content;
+  const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+  input.value = comment.content;
   input.dispatchEvent(new Event('input', { bubbles: true }));
   const el = await screen.findByText('Update');
   el.click();
@@ -298,8 +298,8 @@ it('should recommend users previously mentioned', async () => {
       },
     },
   ]);
-  const input = await screen.findByRole('textbox');
-  input.innerText = '@';
+  const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+  input.value = '@';
   Simulate.keyDown(input, { key: '@' });
   await waitForNock();
   expect(queryPreviouslyMentioned).toBeTruthy();
@@ -340,11 +340,11 @@ it('should recommend users based on query', async () => {
       },
     },
   ]);
-  const input = await screen.findByRole('textbox');
-  input.innerText = '@';
+  const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+  input.value = '@';
   Simulate.keyDown(input, { key: '@' });
   await new Promise((resolve) => setTimeout(resolve, 500));
-  input.innerText = '@l';
+  input.value = '@l';
   Simulate.keyDown(input, { key: 'l' });
   await waitForNock();
   expect(queryMatchingNameOrUsername).toBeTruthy();
@@ -388,8 +388,8 @@ it('should send previewComment query', async () => {
     },
   });
   renderComponent();
-  const input = await screen.findByRole('textbox');
-  input.innerText = '# Test';
+  const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+  input.value = '# Test';
   input.dispatchEvent(new Event('input', { bubbles: true }));
   const preview = await screen.findByText('Preview');
   preview.click();

--- a/packages/shared/src/components/modals/NewCommentModal.tsx
+++ b/packages/shared/src/components/modals/NewCommentModal.tsx
@@ -1,11 +1,4 @@
-import React, {
-  ReactElement,
-  useState,
-  MouseEvent,
-  KeyboardEvent,
-  KeyboardEventHandler,
-  useEffect,
-} from 'react';
+import React, { ReactElement, useState, MouseEvent, useEffect } from 'react';
 import { useMutation, useQuery } from 'react-query';
 import {
   Comment,
@@ -151,22 +144,6 @@ export default function NewCommentModal({
     }
   };
 
-  const onKeyDown = async (
-    event: KeyboardEvent<HTMLTextAreaElement>,
-    defaultCallback?: KeyboardEventHandler<HTMLTextAreaElement>,
-  ): Promise<void> => {
-    // Ctrl / Command + Enter
-    if (
-      (event.ctrlKey || event.metaKey) &&
-      event.keyCode === 13 &&
-      input?.length
-    ) {
-      await sendComment();
-    } else {
-      defaultCallback?.(event);
-    }
-  };
-
   useEffect(() => {
     onInputChange?.(input);
   }, [input]);
@@ -194,7 +171,6 @@ export default function NewCommentModal({
             errorMessage={errorMessage}
             sendingComment={sendingComment}
             sendComment={sendComment}
-            onKeyDown={onKeyDown}
           />
         </Tab>
         <Tab label="Preview" className="flex overflow-y-auto flex-col flex-1">

--- a/packages/shared/src/components/modals/NewCommentModal.tsx
+++ b/packages/shared/src/components/modals/NewCommentModal.tsx
@@ -152,8 +152,8 @@ export default function NewCommentModal({
   };
 
   const onKeyDown = async (
-    event: KeyboardEvent<HTMLDivElement>,
-    defaultCallback?: KeyboardEventHandler<HTMLDivElement>,
+    event: KeyboardEvent<HTMLTextAreaElement>,
+    defaultCallback?: KeyboardEventHandler<HTMLTextAreaElement>,
   ): Promise<void> => {
     // Ctrl / Command + Enter
     if (

--- a/packages/shared/src/hooks/useUserMention.ts
+++ b/packages/shared/src/hooks/useUserMention.ts
@@ -33,7 +33,7 @@ import { useRequestProtocol } from './useRequestProtocol';
 
 interface UseUserMention {
   mentionQuery?: string;
-  onMentionKeypress: (event: ReactKeyboardEvent) => unknown;
+  onMentionKeypress: (event: ReactKeyboardEvent | React.TouchEvent) => unknown;
   selected: number;
   mentions: UserShortProfile[];
   offset: CaretOffset;

--- a/packages/shared/src/hooks/useUserMention.ts
+++ b/packages/shared/src/hooks/useUserMention.ts
@@ -33,7 +33,7 @@ import { useRequestProtocol } from './useRequestProtocol';
 
 interface UseUserMention {
   mentionQuery?: string;
-  onMentionKeypress: (event: ReactKeyboardEvent | React.TouchEvent) => unknown;
+  onMentionKeypress: (event: ReactKeyboardEvent) => unknown;
   selected: number;
   mentions: UserShortProfile[];
   offset: CaretOffset;

--- a/packages/shared/src/hooks/useUserMention.ts
+++ b/packages/shared/src/hooks/useUserMention.ts
@@ -48,8 +48,16 @@ interface UseUserMentionProps {
   onInput: (content: string) => unknown;
 }
 
-const UPDOWN_ARROW_KEYS = ['ArrowUp', 'ArrowDown'];
+export const UPDOWN_ARROW_KEYS = ['ArrowUp', 'ArrowDown'];
 const LEFTRIGHT_ARROW_KEYS = ['ArrowLeft', 'ArrowRight'];
+
+/* eslint-disable no-param-reassign */
+export const fixHeight = (el: HTMLElement): void => {
+  const attr = el.getAttribute('data-min-height');
+  const minHeight = parseInt(attr, 10);
+  el.style.height = 'auto';
+  el.style.height = `${Math.max(el.scrollHeight, minHeight)}px`;
+};
 
 export function useUserMention({
   postId,
@@ -123,6 +131,7 @@ export function useUserMention({
     setQuery(undefined);
     client.setQueryData(key, []);
     onInput(element.value);
+    fixHeight(element);
   };
 
   const onArrowKey = (arrowKey: string) => {

--- a/packages/shared/src/hooks/useUserMention.ts
+++ b/packages/shared/src/hooks/useUserMention.ts
@@ -5,7 +5,6 @@ import {
   KeyboardEvent as ReactKeyboardEvent,
   useEffect,
   MutableRefObject,
-  useCallback,
   useRef,
   useMemo,
 } from 'react';
@@ -26,7 +25,7 @@ import {
   replaceWord,
   getCaretOffset,
   CaretOffset,
-  anyElementClassContains,
+  parentClassContains,
   getSelectionStart,
 } from '../lib/element';
 import { nextTick } from '../lib/func';
@@ -220,8 +219,8 @@ export function useUserMention({
     textarea.dispatchEvent(new KeyboardEvent('keydown', { key: '@' }));
   };
 
-  const userClicked = useCallback(
-    (event: MouseEvent & { path: HTMLElement[] }) => {
+  useEffect(() => {
+    const userClicked = (event: MouseEvent) => {
       event.stopPropagation();
       if (typeof query === 'undefined') {
         return;
@@ -229,24 +228,21 @@ export function useUserMention({
 
       const el = event.target as HTMLElement;
       const isTextarea = el.tagName.toLocaleLowerCase() === 'textarea';
-      const isTooltip = anyElementClassContains(event.path, 'tippy-content');
-
+      const isTooltip = parentClassContains(el, 'tippy-content');
       if (isTextarea || isTooltip) {
         return;
       }
 
       setQuery(undefined);
-    },
-    [query],
-  );
+    };
 
-  useEffect(() => {
-    document.addEventListener('mousedown', userClicked);
+    const dom = commentRef.current?.getRootNode();
+    dom.addEventListener('mousedown', userClicked);
 
     return () => {
-      document.removeEventListener('mousedown', userClicked);
+      dom.removeEventListener('mousedown', userClicked);
     };
-  }, [userClicked]);
+  }, [query]);
 
   useEffect(() => {
     setSelected(0);

--- a/packages/shared/src/lib/element.ts
+++ b/packages/shared/src/lib/element.ts
@@ -7,82 +7,26 @@ type Row = number;
 export type CaretOffset = [number, number];
 export type CaretPosition = [Column, Row];
 
-interface ShadowCompanion extends ShadowRoot {
-  getSelection: typeof window.getSelection;
-}
-
 const isFirefox = process.env.TARGET_BROWSER === 'firefox';
 
-const getRoot = (node: Node) => {
-  const root = node.getRootNode();
+export function getCaretPostition(
+  textarea: HTMLTextAreaElement,
+): CaretPosition {
+  const start = textarea.selectionStart;
+  const lines = textarea.value.substring(0, start).split('\n');
+  const row = lines.length;
+  const col = lines[lines.length - 1].length;
 
-  if (root instanceof ShadowRoot) {
-    return isFirefox ? root.ownerDocument : (root as ShadowCompanion);
-  }
-
-  if (root instanceof Window) {
-    return isFirefox ? window.document : window;
-  }
-
-  return root as Document;
-};
-
-const getRootDom = (node: Node): Document => {
-  const root = getRoot(node);
-
-  if (root instanceof Document) {
-    return root;
-  }
-
-  if (root instanceof Window) {
-    return root.document;
-  }
-
-  return root.ownerDocument;
-};
-
-export function getCaretPostition(el: Element): CaretPosition {
-  const root = getRoot(el);
-  const sel = root.getSelection();
-  let row = 0;
-  for (; row < el.childNodes.length; row += 1) {
-    const child = el.childNodes[row];
-    const node = child.nodeValue ? child : child.firstChild;
-    if (child === sel.anchorNode || sel.anchorNode === node) {
-      break;
-    }
-  }
-
-  return [sel.anchorOffset, row === -1 ? 0 : row];
+  return [col, row];
 }
 
-export const getCaretOffset = (textarea: HTMLDivElement): CaretOffset => {
+export const getCaretOffset = (textarea: HTMLTextAreaElement): CaretOffset => {
   const left = document.createElement('span');
   const right = document.createElement('span');
   const div = document.createElement('div');
-  const [col, row] = getCaretPostition(textarea);
-  const leftSum = Array.from(textarea.childNodes).reduce((sum, line, i) => {
-    if (i > row) {
-      return sum;
-    }
 
-    if (i === row) {
-      return sum + col;
-    }
-
-    if (i === 0) {
-      return sum + (line.nodeValue?.length || 0);
-    }
-
-    const el = line as HTMLElement;
-
-    return sum + el.innerText.length + 1;
-  }, 0);
-
-  const content =
-    textarea.innerText.replaceAll?.('\n\n', '\n') || textarea.innerText;
-  left.innerText = content.substring(0, leftSum);
-  right.innerText = content.substring(leftSum);
+  left.innerText = textarea.value.substring(0, textarea.selectionStart);
+  right.innerText = textarea.value.substring(textarea.selectionStart);
 
   div.className = classNames(textarea.className, 'absolute invisible');
   div.setAttribute('style', 'left: 2rem');
@@ -114,34 +58,18 @@ const getNodeText = (node: Node) => {
   return string.replaceAll('\xa0', ' ');
 };
 
-export function setCaretPosition(node: Node, col: number): void {
-  const root = getRoot(node);
-  const dom = getRootDom(node);
-  const range = dom.createRange();
-  const sel = root.getSelection();
-
-  range.setStart(node, col);
-  range.collapse(true);
-
-  sel.removeAllRanges();
-  sel.addRange(range);
-}
-
 export function getWord(
-  textarea: HTMLDivElement,
+  textarea: HTMLTextAreaElement,
   [col, row]: CaretPosition,
 ): string {
-  const node = Array.from(textarea.childNodes).find(
-    (_, index) => index === row,
-  );
-  const text = getNodeText(node || textarea);
-  const end = getEndIndex(text, col);
+  const line = textarea.value.split('\n')[row - 1];
+  const end = getEndIndex(line, col);
 
-  return text.substring(col, end) || '';
+  return line.substring(col, end);
 }
 
 export const getSplittedText = (
-  textarea: HTMLDivElement,
+  textarea: HTMLTextAreaElement,
   [col, row]: CaretPosition,
   query: string,
 ): [Node, string, string] => {
@@ -155,40 +83,26 @@ export const getSplittedText = (
   return [node, left, right];
 };
 
-const getOffset = (left: string, col: number) => {
-  const lastChar = left.charAt(left.length - 1);
-
-  if (col === 0 || lastChar === ' ') {
-    return '';
-  }
-
-  return lastChar !== '' ? '&nbsp;' : '';
-};
-
 export function replaceWord(
-  textarea: HTMLDivElement,
+  textarea: HTMLTextAreaElement,
   [col, row]: CaretPosition,
   query: string,
   replacement: string,
-  forInitialization?: boolean,
 ): void {
-  const [node, left, right] = getSplittedText(textarea, [col, row], query);
-  const additionalSpace = forInitialization ? getOffset(left, col) : '';
-  const offset = additionalSpace.length || !forInitialization ? 0 : 1;
-  const result = `${left}${additionalSpace}${replacement}&nbsp;${right}`;
+  const result = textarea.value.split('\n').map((line, index) => {
+    if (index !== row - 1) {
+      return line;
+    }
 
-  if (row === 0) {
-    // eslint-disable-next-line no-param-reassign
-    textarea.innerHTML = result;
-    Array.from(textarea.children).forEach((child) => textarea.append(child));
-    setCaretPosition(textarea.firstChild, col + replacement.length - offset);
-  } else {
-    const el = node as HTMLElement;
-    el.innerHTML = result;
-    setCaretPosition(el.firstChild, col + replacement.length - offset);
-  }
+    const left = line.substring(0, col - 1);
+    const right = line.substring(col + query.length - 1);
+
+    return `${left}${replacement} ${right}`;
+  });
+
+  // eslint-disable-next-line no-param-reassign
+  textarea.value = result.join('\n');
 }
-
 export const getSelectionStart = (
   value: string,
   [col, row]: CaretPosition,
@@ -206,25 +120,15 @@ export const getSelectionStart = (
   }, 0);
 
 export function hasSpaceBeforeWord(
-  textarea: HTMLDivElement,
+  textarea: HTMLTextAreaElement,
   [col, row]: CaretPosition,
 ): [boolean, string, number] {
-  if (isTesting) {
-    return [true, textarea.innerText.substring(1), 0];
-  }
-
   if (col === 0) {
     return [false, '', -1];
   }
 
   let position = 0;
-  const node = Array.from(textarea.childNodes).find((_, i) => i === row);
-  const line = getNodeText(node);
-
-  if (!line.charAt(col - 1).trim().length) {
-    return [false, '', -1];
-  }
-
+  const line = textarea.value.split('\n')[row - 1];
   const query = line.split(' ').find((word, index) => {
     const offset = index > 0 ? 1 : 0;
     position += word.length + offset;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- It was almost impossible to make a comment in FF previously. The root cause was the div contenteditable.
- The reason behind its usage was to natively support the dynamically changing height of the comment box.
- But since it is more important for the users to be able to make a comment, we decided to go back to using textarea.
- Moved from keydown to keyup as it is much more accurate of when we should trigger the mentions.

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-134 #done
