### PR TITLE
feat: fix onboarding pill size

### DIFF
--- a/packages/shared/src/components/MyFeedIntro.tsx
+++ b/packages/shared/src/components/MyFeedIntro.tsx
@@ -17,11 +17,20 @@ const Pill = classed(
 );
 const FeedFiltersIntroModalTagsContainer = classed('div', 'w-[160%]');
 
-type TagPillProps = HTMLAttributes<HTMLSpanElement>;
-const TagPill = ({ className, children }: TagPillProps): ReactElement => {
+type TagPillProps = { autoWidth: boolean } & HTMLAttributes<HTMLSpanElement>;
+const TagPill = ({
+  className,
+  children,
+  autoWidth,
+}: TagPillProps): ReactElement => {
+  if (autoWidth) {
+    return <Pill className={className}>{children}</Pill>;
+  }
+
   const [pillWidth] = useState(
     () => emptyWidths[Math.floor(Math.random() * emptyWidths.length)],
   );
+
   return <Pill className={classNames(className, pillWidth)}>{children}</Pill>;
 };
 
@@ -39,6 +48,7 @@ export const MyFeedIntro = (): ReactElement => {
           <ul className="flex gap-3 mb-3" key={i}>
             {row.map((tag, j) => (
               <TagPill
+                autoWidth={!!tag.length}
                 className={classNames(
                   (j === 0 || j === row.length - 1) && 'flex-1',
                   !tag.length


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The onboarding pill always overruled the `w-auto`
- Now we evaluate if a random width is needed, else we don't even invoke the state

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-222 #done 
