### PR TITLE
fix: hot label text color

### DIFF
--- a/packages/shared/src/components/cards/TrendingFlag.tsx
+++ b/packages/shared/src/components/cards/TrendingFlag.tsx
@@ -28,7 +28,9 @@ export default function TrendingFlag({
               : 'w-10 h-full flex-col mouse:translate-y-4 rounded-t',
           )}
         >
-          <span className="font-bold uppercase typo-caption2">Hot</span>
+          <span className="font-bold text-white uppercase typo-caption2">
+            Hot
+          </span>
         </div>
       </SimpleTooltip>
       {!listMode && (

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -167,7 +167,7 @@ export const TLDRText = classed(
 );
 
 export const HotLabel = (): ReactElement => (
-  <div className="py-px px-2 font-bold uppercase rounded typo-caption2 bg-theme-status-error text-theme-label-primary">
+  <div className="py-px px-2 font-bold text-white uppercase rounded typo-caption2 bg-theme-status-error">
     Hot
   </div>
 );


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The hot label should always render in white, regardless of the theme

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

<img width="175" alt="Screenshot 2022-07-08 at 13 17 11" src="https://user-images.githubusercontent.com/554874/177984925-f4fe83de-bcbc-4b73-a40e-0ccb3b36dd10.png">
<img width="183" alt="Screenshot 2022-07-08 at 13 18 15" src="https://user-images.githubusercontent.com/554874/177984930-ed83383b-2172-494b-93be-af5eae3879d2.png">
<img width="331" alt="Screenshot 2022-07-08 at 13 29 51" src="https://user-images.githubusercontent.com/554874/177984933-11edde1c-9a64-4804-97b6-69c07229a770.png">
<img width="324" alt="Screenshot 2022-07-08 at 13 30 17" src="https://user-images.githubusercontent.com/554874/177984936-f96b50c2-0566-4d5b-b3b8-1759af2c2686.png">


### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-203 #done
