### PR TITLE
fix: add object cover to profile images

### DIFF
--- a/packages/shared/src/components/ProfilePicture.tsx
+++ b/packages/shared/src/components/ProfilePicture.tsx
@@ -76,6 +76,7 @@ function ProfilePictureComponent(
         alt={`${user.username}'s profile`}
         onError={onError}
         className={classNames(
+          'object-cover',
           sizeClasses[size],
           roundClasses[rounded ?? size],
           className,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- When moving to native lazy loading we forgot to add the `object-cover` class to images.
- I went over the other native lazy loading modification, which all seem to have the class

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing
<img width="231" alt="Screenshot 2022-07-08 at 15 17 48" src="https://user-images.githubusercontent.com/554874/178000037-cb877fa8-65cc-49a3-bc06-63ba51deb9a8.png">
<img width="217" alt="Screenshot 2022-07-08 at 15 17 56" src="https://user-images.githubusercontent.com/554874/178000046-d7c22b61-5b3b-4a97-b40e-b86b9065fcee.png">

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-224 #done
