### PR TITLE
fix: update companion new comment placement

### DIFF
--- a/packages/extension/src/companion/CompanionDiscussion.tsx
+++ b/packages/extension/src/companion/CompanionDiscussion.tsx
@@ -46,7 +46,8 @@ export function CompanionDiscussion({
       )}
     >
       <NewComment
-        className="laptop:px-6 laptop:pb-2"
+        responsive={false}
+        className="px-6 pt-0 pb-2"
         user={user}
         onNewComment={() => openNewComment('start discussion button')}
       />

--- a/packages/shared/src/components/post/NewComment.tsx
+++ b/packages/shared/src/components/post/NewComment.tsx
@@ -6,18 +6,26 @@ import { LoggedUser } from '../../lib/user';
 import styles from './NewComment.module.css';
 
 interface NewCommentProps {
+  responsive?: boolean;
   user?: LoggedUser;
   className?: string;
   onNewComment: () => unknown;
 }
 
 export function NewComment({
+  responsive = true,
   user,
   className,
   onNewComment,
 }: NewCommentProps): ReactElement {
   return (
-    <NewCommentContainer className={className}>
+    <NewCommentContainer
+      className={classNames(
+        className,
+        responsive &&
+          'fixed right-0 py-3 px-4 bottom-0 left-0 z-2 laptop:relative laptop:p-0 laptop:bg-none',
+      )}
+    >
       <button
         type="button"
         className={classNames(

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -112,8 +112,7 @@ export const PageWidgets = classed(
 
 export const NewCommentContainer = classed(
   'div',
-  'flex fixed right-0 bottom-0 left-0 z-2 flex-col items-stretch py-3 px-4 w-full bg-theme-bg-primary',
-  'laptop:relative laptop:p-0 laptop:bg-none ',
+  'flex flex-col items-stretch w-full bg-theme-bg-primary',
 );
 
 export const ResponsivePageContainer = classed(


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The companion new comment bar was using responsive styles
- This affected the behaviour, as it supposed to show non-responsive inside the companion at all screen sizes

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

Before:
<img width="455" alt="Screenshot 2022-07-08 at 16 00 07" src="https://user-images.githubusercontent.com/554874/178007563-42bcffd7-dd79-4f57-99e6-9f338260515c.png">
<img width="218" alt="Screenshot 2022-07-08 at 16 00 02" src="https://user-images.githubusercontent.com/554874/178007570-bfdc92ee-6d63-4a22-ac8a-e01bd333f070.png">

After:
<img width="458" alt="Screenshot 2022-07-08 at 16 00 39" src="https://user-images.githubusercontent.com/554874/178007548-36892967-1019-4a5a-aaec-c3fe3f908d0f.png">
<img width="162" alt="Screenshot 2022-07-08 at 16 00 33" src="https://user-images.githubusercontent.com/554874/178007560-7b8246b2-2924-4c13-a73e-cb92c02ff785.png">

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-191 #done
