### PR TITLE
fix: injecting companion scripts on update

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -141,10 +141,14 @@ browser.browserAction.onClicked.addListener(() => {
   browser.tabs.create({ url, active: true });
 });
 
-browser.runtime.onInstalled.addListener(async () => {
+browser.runtime.onInstalled.addListener(async (details) => {
   await Promise.all([
     browser.runtime.setUninstallURL('https://daily.dev/uninstall'),
   ]);
+
+  if (details.reason === 'update') {
+    await getContentScriptPermissionAndRegister();
+  }
 });
 
 browser.runtime.onStartup.addListener(async () => {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Re-inject script on updates only.
- The reason it is not part on a new install, is it would mean the permissions are always not granted when after a new installation.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-227 #done
