### PR TITLE
fix: we removed search params on the companion side

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -32,7 +32,7 @@ const isExcluded = (origin: string) => {
 };
 
 const sendBootData = async (_, tab: Tabs.Tab) => {
-  const { origin, pathname } = new URL(tab.url);
+  const { origin, pathname, search } = new URL(tab.url);
   if (isExcluded(origin)) {
     return;
   }
@@ -42,7 +42,7 @@ const sendBootData = async (_, tab: Tabs.Tab) => {
     return;
   }
 
-  const href = origin + pathname;
+  const href = origin + pathname + search;
 
   const [
     deviceId,

--- a/packages/shared/src/lib/strings.ts
+++ b/packages/shared/src/lib/strings.ts
@@ -12,7 +12,7 @@ export const cleanupEmptySpaces = (text: string): string =>
   text.replaceAll?.('\xa0', ' ') || text;
 
 export const removeLinkTargetElement = (link: string): string => {
-  const { origin, pathname } = new URL(link);
+  const { origin, pathname, search } = new URL(link);
 
-  return origin + pathname;
+  return origin + pathname + search;
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- In this commit we removed the search params
- This was not intended, we only wanted to remove `#` and other weird symbols not the search params
- This fix introduces the whole search string

Edge case:
If the page has multiple search params for these allowed domains it won't be able to find them.
For instance:

```js
https://news.ycombinator.com/item?id=32069418 = valid
https://news.ycombinator.com/item?id=32069418&utm=blabla = not valid
```

Personally think it's good enough for now.
(It only affects domains where we allow querystrings)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-240 #done 
