### PR TITLE
fix: aria-hidden true must still display the element

### DIFF
--- a/packages/extension/public/css/daily-companion-app.css
+++ b/packages/extension/public/css/daily-companion-app.css
@@ -12,3 +12,7 @@ daily-companion-app {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
+
+daily-companion-app[aria-hidden=true] {
+  display: block;
+}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since some sites override our styling, there are cases where `aria-hidden=true` applies a styling of `display: none` to elements.
- To override that, we provided a much stronger selector within our CSS for the Companion.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-235 #done
