### PR TITLE
fix: changed feed header height to remove scroll

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -265,7 +265,7 @@ export default function MainFeedLayout({
           flags={flags}
         />
       )}
-      <div className="flex flex-row flex-wrap gap-4 items-center mr-px w-full h-12">
+      <div className="flex flex-row flex-wrap gap-4 items-center mr-px w-full h-[3.125rem]">
         <h3 className="flex flex-1 typo-headline">{feedTitles[feedName]}</h3>
         {navChildren}
         {isUpvoted && (


### PR DESCRIPTION
## Changes

### Describe what this PR does

Shorcuts block is 50px (48px + 2px for border) and header size was 48px. Now header size is 50px, so no scroll on header and no cut offs for shortcuts block

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

DD-645 #done
