### PR TITLE
fix: className so value is converted to pixels

### DIFF
--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -66,7 +66,7 @@ export default function SharePostModal({
     <ResponsiveModal
       padding={false}
       {...props}
-      style={{ content: { maxWidth: '26.25rem' } }}
+      contentClassName="!max-w-[26.25rem]"
     >
       <header className="flex fixed responsiveModalBreakpoint:sticky top-0 left-0 z-3 flex-row justify-between items-center px-6 w-full h-14 border-b border-theme-divider-tertiary bg-theme-bg-tertiary">
         <h3 className="font-bold typo-title3">Share article</h3>


### PR DESCRIPTION
## Changes

### Describe what this PR does
Share post modal can be of the wrong width on the companion because of style with width set in rem. Now classNames is used, so value is converted to pixels, but we need to use !important to override the rule of the responsive modal used under the hood of share post modal 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
