### PR TITLE
fix: companion discussion horizontal scroll 

### DIFF
--- a/packages/extension/src/companion/CompanionDiscussion.tsx
+++ b/packages/extension/src/companion/CompanionDiscussion.tsx
@@ -51,7 +51,7 @@ export function CompanionDiscussion({
         user={user}
         onNewComment={() => openNewComment('start discussion button')}
       />
-      <div className="overflow-auto flex-1 px-6 mt-7 border-t border-theme-divider-tertiary">
+      <div className="overflow-x-hidden overflow-y-auto flex-1 px-6 mt-7 border-t border-theme-divider-tertiary">
         <h3 className="my-3.5 font-bold typo-callout">Discussion</h3>
         <PostComments
           post={post}


### PR DESCRIPTION
## Changes

### Describe what this PR does

Now we have `overflow-x: hidden`, so there is no horizontal scroll, it also resolved an issue with start discussion button on a tabled resolution (check screenshots below)

Before:
<img width="1512" alt="Screenshot 2022-07-13 at 14 35 15" src="https://user-images.githubusercontent.com/58859242/178724623-7ec0cacc-2363-4ef2-a713-f61352a920dd.png">

After:
<img width="1512" alt="Screenshot 2022-07-13 at 14 35 48" src="https://user-images.githubusercontent.com/58859242/178724686-938450d8-509d-41d6-96fa-65d0362d8316.png">



## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-245 #done
