### PR TITLE
fix: refresh token causing boot to refetch

### DIFF
--- a/packages/shared/src/hooks/useRefreshToken.ts
+++ b/packages/shared/src/hooks/useRefreshToken.ts
@@ -2,7 +2,6 @@ import { useEffect } from 'react';
 import { differenceInMilliseconds } from 'date-fns';
 import { AccessToken } from '../lib/boot';
 import useDebounce from './useDebounce';
-import { nextTick } from '../lib/func';
 
 export function useRefreshToken(
   accessToken: AccessToken,
@@ -16,9 +15,7 @@ export function useRefreshToken(
 
   useEffect(() => {
     if (accessToken) {
-      nextTick().then(() => {
-        useRefresh();
-      });
+      useRefresh();
     }
   }, [accessToken, refresh]);
 }

--- a/packages/shared/src/hooks/useRefreshToken.ts
+++ b/packages/shared/src/hooks/useRefreshToken.ts
@@ -1,23 +1,24 @@
-import { useRef, useEffect } from 'react';
+import { useEffect } from 'react';
 import { differenceInMilliseconds } from 'date-fns';
 import { AccessToken } from '../lib/boot';
 import useDebounce from './useDebounce';
+import { nextTick } from '../lib/func';
 
 export function useRefreshToken(
   accessToken: AccessToken,
   refresh: () => Promise<unknown>,
 ): void {
-  const timeout = useRef<number>();
-  const [useRefresh] = useDebounce(refresh, timeout.current - 1000 * 60 * 2);
+  const difference = differenceInMilliseconds(
+    new Date(accessToken?.expiresIn),
+    new Date(),
+  );
+  const [useRefresh] = useDebounce(refresh, difference - 1000 * 60 * 2);
 
   useEffect(() => {
     if (accessToken) {
-      timeout.current = differenceInMilliseconds(
-        new Date(accessToken.expiresIn),
-        new Date(),
-      );
-      useRefresh();
+      nextTick().then(() => {
+        useRefresh();
+      });
     }
-    return () => clearTimeout(timeout.current);
   }, [accessToken, refresh]);
 }

--- a/packages/shared/src/lib/boot.ts
+++ b/packages/shared/src/lib/boot.ts
@@ -47,15 +47,12 @@ export type BootCacheData = Pick<
 > & { lastModifier?: string };
 
 export async function getBootData(app: string, url?: string): Promise<Boot> {
-  const res = await fetch(
-    `${apiUrl}/boot${app === 'companion' ? '/companion' : ''}?${
-      url && new URLSearchParams({ url })
-    }`,
-    {
-      method: 'GET',
-      credentials: 'include',
-      headers: { app, 'Content-Type': 'application/json' },
-    },
-  );
+  const appRoute = app === 'companion' ? '/companion' : '';
+  const params = url ? new URLSearchParams({ url }) : '';
+  const res = await fetch(`${apiUrl}/boot${appRoute}?${params}`, {
+    method: 'GET',
+    credentials: 'include',
+    headers: { app, 'Content-Type': 'application/json' },
+  });
   return res.json();
 }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The value we use to check how much it should wait for our refresh token to be requested was `undefined` at initialization.
- It produces `NaN` due to arithmetic operation on `undefined`, so the setTimeout was thinking to fire at will.
- Also took the chance to remove the undefined search query parameter in the boot request.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-232 #done
