### PR TITLE
Wt 249 reading history share

### DIFF
--- a/packages/extension/package-lock.json
+++ b/packages/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "extension",
-	"version": "3.16.8",
+	"version": "3.16.9",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "extension",
-			"version": "3.16.8",
+			"version": "3.16.9",
 			"dependencies": {
 				"@babel/runtime": "^7.17.9",
 				"@dailydotdev/react-contexify": "^5.0.2",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extension",
-  "version": "3.16.8",
+  "version": "3.16.9",
   "scripts": {
     "dev:chrome": "cross-env NODE_ENV=development cross-env TARGET_BROWSER=chrome webpack --watch",
     "dev:firefox": "cross-env NODE_ENV=development cross-env TARGET_BROWSER=firefox webpack --watch",

--- a/packages/shared/src/components/PostOptionsReadingHistoryMenu.tsx
+++ b/packages/shared/src/components/PostOptionsReadingHistoryMenu.tsx
@@ -11,10 +11,8 @@ import AuthContext from '../contexts/AuthContext';
 import { ReadHistoryInfiniteData } from '../hooks/useInfiniteReadingHistory';
 import { MenuIcon } from './MenuIcon';
 import { QueryIndexes } from '../hooks/useReadingHistory';
-import { useShareOrCopyLink } from '../hooks/useShareOrCopyLink';
 import { postAnalyticsEvent } from '../lib/feed';
 import { postEventName } from './utilities';
-import { Origin } from '../lib/analytics';
 
 const PortalMenu = dynamic(() => import('./fields/PortalMenu'), {
   ssr: false,
@@ -22,6 +20,7 @@ const PortalMenu = dynamic(() => import('./fields/PortalMenu'), {
 
 export type PostOptionsReadingHistoryMenuProps = {
   post: ReadHistoryPost;
+  onShare?: () => void;
   onHiddenMenu?: () => unknown;
   displayCopiedMessageFunc?: () => void;
   onHideHistoryPost?: (postId: string) => unknown;
@@ -68,6 +67,7 @@ const getBookmarkIconAndMenuText = (bookmarked: boolean) => (
 
 export default function PostOptionsReadingHistoryMenu({
   post,
+  onShare,
   onHiddenMenu,
   onHideHistoryPost,
   indexes,
@@ -75,14 +75,6 @@ export default function PostOptionsReadingHistoryMenu({
   const { user } = useContext(AuthContext);
   const queryClient = useQueryClient();
   const historyQueryKey = ['readHistory', user?.id];
-  const [, onShareOrCopyLink] = useShareOrCopyLink({
-    link: post?.commentsPermalink,
-    text: post?.title,
-    trackObject: (provider) =>
-      postAnalyticsEvent('share post', post, {
-        extra: { origin: Origin.ReadingHistoryContextMenu, provider },
-      }),
-  });
 
   const { bookmark, removeBookmark } = useBookmarkPost({
     onBookmarkMutate: updateReadingHistoryPost(
@@ -127,14 +119,14 @@ export default function PostOptionsReadingHistoryMenu({
         animation="fade"
         onHidden={onHiddenMenu}
       >
+        <Item className="typo-callout" onClick={onShare}>
+          <span className="flex w-full typo-callout">
+            <MenuIcon Icon={ShareIcon} /> Share article via...
+          </span>
+        </Item>
         <Item className="typo-callout" onClick={onBookmarkReadingHistoryPost}>
           <span className="flex w-full typo-callout">
             {getBookmarkIconAndMenuText(post?.bookmarked)}
-          </span>
-        </Item>
-        <Item className="typo-callout" onClick={() => onShareOrCopyLink()}>
-          <span className="flex w-full typo-callout">
-            <MenuIcon Icon={ShareIcon} /> Share article
           </span>
         </Item>
         <Item

--- a/packages/shared/src/components/history/ReadingHistoryList.tsx
+++ b/packages/shared/src/components/history/ReadingHistoryList.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useCallback } from 'react';
 import classNames from 'classnames';
+import dynamic from 'next/dynamic';
 import { HideReadHistory } from '../../hooks/useReadingHistory';
 import classed from '../../lib/classed';
 import {
@@ -11,6 +12,8 @@ import { ReadHistoryInfiniteData } from '../../hooks/useInfiniteReadingHistory';
 import { InfiniteScrollScreenOffset } from '../../hooks/feed/useFeedInfiniteScroll';
 import PostOptionsReadingHistoryMenu from '../PostOptionsReadingHistoryMenu';
 import useReadingHistoryContextMenu from '../../hooks/useReadingHistoryContextMenu';
+import { useSharePost } from '../../hooks/useSharePost';
+import { Origin } from '../../lib/analytics';
 
 const DateTitle = classed('h2', 'typo-body text-theme-label-tertiary');
 
@@ -23,6 +26,8 @@ const getDateGroup = (date: Date) => {
     </DateTitle>
   );
 };
+
+const SharePostModal = dynamic(() => import('../modals/SharePostModal'));
 
 export interface ReadHistoryListProps {
   data: ReadHistoryInfiniteData;
@@ -41,6 +46,9 @@ export default function ReadHistoryList({
     onReadingHistoryContextOptions,
     queryIndexes,
   } = useReadingHistoryContextMenu();
+  const analyticsOrigin = Origin.ReadingHistoryContextMenu;
+  const { sharePost, openSharePost, closeSharePost } =
+    useSharePost(analyticsOrigin);
 
   const renderList = useCallback(() => {
     let currentDate: Date;
@@ -79,6 +87,7 @@ export default function ReadHistoryList({
       <InfiniteScrollScreenOffset ref={infiniteScrollRef} />
       <PostOptionsReadingHistoryMenu
         post={readingHistoryContextItem?.post}
+        onShare={() => openSharePost(readingHistoryContextItem.post)}
         onHiddenMenu={() => setReadingHistoryContextItem(null)}
         onHideHistoryPost={(postId) =>
           onHide({
@@ -89,6 +98,14 @@ export default function ReadHistoryList({
         }
         indexes={queryIndexes}
       />
+      {sharePost && (
+        <SharePostModal
+          isOpen={!!sharePost}
+          post={sharePost}
+          origin={analyticsOrigin}
+          onRequestClose={closeSharePost}
+        />
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Post share modal for reading history

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-249 #done
