### PR TITLE
fix: pin mariadb version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - "6379:6379"
 
   daily-mysql:
-    image: mariadb
+    image: mariadb:10.8.2
     healthcheck:
       test: mysql --user=root --password=$$MYSQL_ROOT_PASSWORD -e 'SHOW DATABASES;'
       interval: 1s


### PR DESCRIPTION
## Changes

### Describe what this PR does
- There is a running issue where 10.8.3 runs on `jammy` but not all the testing environment can run this yet.
- The solution for now is to pin 10.8.2

This is not the recommend solution according to MariaBD you should pin a new package for development use, but this does not reflect our environment and gives innoDB issues.

Thus 10.8.2 is a safe option for now, especially seeing we only run this for GitPod really.

[Maria DB post](https://mariadb.org/new-service-quay-io-mariadb-foundation-mariadb-devel/)
[Issue on GitHub](https://stackoverflow.com/a/72417962)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-256 #done
