### PR TITLE
feat: re-introduce comment popup as AB

### DIFF
--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -53,6 +53,7 @@ import {
 import { getFeedSettingsQueryKey } from '../hooks/useFeedSettings';
 import Toast from './notifications/Toast';
 import { FeaturesContextProvider } from '../contexts/FeaturesContext';
+import { COMMENT_ON_POST_MUTATION } from '../graphql/comments';
 
 const showLogin = jest.fn();
 let nextCallback: (value: PostsEngaged) => unknown = null;
@@ -151,7 +152,9 @@ const renderComponent = (
     toggleSidebarExpanded: jest.fn(),
   };
   return render(
-    <FeaturesContextProvider flags={{}}>
+    <FeaturesContextProvider
+      flags={{ show_comment_popover: { enabled: true } }}
+    >
       <QueryClientProvider client={queryClient}>
         <AuthContext.Provider
           value={{
@@ -572,81 +575,81 @@ it('should update feed item on subscription message', async () => {
   });
 });
 
-// it('should open comment popup on upvote', async () => {
-//   renderComponent([
-//     createFeedMock({
-//       pageInfo: defaultFeedPage.pageInfo,
-//       edges: [defaultFeedPage.edges[0]],
-//     }),
-//     {
-//       request: {
-//         query: UPVOTE_MUTATION,
-//         variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
-//       },
-//       result: () => {
-//         return { data: { _: true } };
-//       },
-//     },
-//   ]);
-//   const [el] = await screen.findAllByLabelText('Upvote');
-//   el.click();
-//   await waitFor(async () =>
-//     expect(await screen.findByRole('textbox')).toBeInTheDocument(),
-//   );
-// });
+it('should open comment popup on upvote', async () => {
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [defaultFeedPage.edges[0]],
+    }),
+    {
+      request: {
+        query: UPVOTE_MUTATION,
+        variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
+      },
+      result: () => {
+        return { data: { _: true } };
+      },
+    },
+  ]);
+  const [el] = await screen.findAllByLabelText('Upvote');
+  el.click();
+  await waitFor(async () =>
+    expect(await screen.findByRole('textbox')).toBeInTheDocument(),
+  );
+});
 
-// it('should send comment through the comment popup', async () => {
-//   let mutationCalled = false;
-//   const newComment = {
-//     __typename: 'Comment',
-//     id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
-//     content: 'comment',
-//     createdAt: new Date(2017, 1, 10, 0, 1).toISOString(),
-//     permalink: 'https://daily.dev',
-//   };
-//   renderComponent([
-//     createFeedMock({
-//       pageInfo: defaultFeedPage.pageInfo,
-//       edges: [defaultFeedPage.edges[0]],
-//     }),
-//     {
-//       request: {
-//         query: UPVOTE_MUTATION,
-//         variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
-//       },
-//       result: () => {
-//         return { data: { _: true } };
-//       },
-//     },
-//     {
-//       request: {
-//         query: COMMENT_ON_POST_MUTATION,
-//         variables: {
-//           id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
-//           content: 'comment',
-//         },
-//       },
-//       result: () => {
-//         mutationCalled = true;
-//         return {
-//           data: {
-//             comment: newComment,
-//           },
-//         };
-//       },
-//     },
-//   ]);
-//   const [upvoteBtn] = await screen.findAllByLabelText('Upvote');
-//   upvoteBtn.click();
-//   const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
-//   fireEvent.change(input, { target: { value: 'comment' } });
-//   const commentBtn = await screen.findByText('Comment');
-//   commentBtn.click();
-//   await waitFor(() => expect(mutationCalled).toBeTruthy());
-//   await waitFor(async () =>
-//     expect(screen.queryByRole('textbox')).not.toBeInTheDocument(),
-//   );
-// });
+it('should send comment through the comment popup', async () => {
+  let mutationCalled = false;
+  const newComment = {
+    __typename: 'Comment',
+    id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
+    content: 'comment',
+    createdAt: new Date(2017, 1, 10, 0, 1).toISOString(),
+    permalink: 'https://daily.dev',
+  };
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [defaultFeedPage.edges[0]],
+    }),
+    {
+      request: {
+        query: UPVOTE_MUTATION,
+        variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
+      },
+      result: () => {
+        return { data: { _: true } };
+      },
+    },
+    {
+      request: {
+        query: COMMENT_ON_POST_MUTATION,
+        variables: {
+          id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
+          content: 'comment',
+        },
+      },
+      result: () => {
+        mutationCalled = true;
+        return {
+          data: {
+            comment: newComment,
+          },
+        };
+      },
+    },
+  ]);
+  const [upvoteBtn] = await screen.findAllByLabelText('Upvote');
+  upvoteBtn.click();
+  const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+  fireEvent.change(input, { target: { value: 'comment' } });
+  const commentBtn = await screen.findByText('Post');
+  commentBtn.click();
+  await waitFor(() => expect(mutationCalled).toBeTruthy());
+  await waitFor(async () =>
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument(),
+  );
+});
 
 it('should report broken link', async () => {
   let mutationCalled = false;

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -17,7 +17,7 @@ import { Spaciness } from '../graphql/settings';
 import ScrollToTopButton from './ScrollToTopButton';
 import useFeedUpvotePost from '../hooks/feed/useFeedUpvotePost';
 import useFeedBookmarkPost from '../hooks/feed/useFeedBookmarkPost';
-// import useCommentPopup from '../hooks/feed/useCommentPopup';
+import useCommentPopup from '../hooks/feed/useCommentPopup';
 import useFeedOnPostClick, {
   FeedPostClick,
 } from '../hooks/feed/useFeedOnPostClick';
@@ -115,8 +115,12 @@ export default function Feed<T>({
   onEmptyFeed,
   emptyScreen,
 }: FeedProps<T>): ReactElement {
-  const { postCardVersion, postModalByDefault, postEngagementNonClickable } =
-    useContext(FeaturesContext);
+  const {
+    postCardVersion,
+    postModalByDefault,
+    postEngagementNonClickable,
+    showCommentPopover,
+  } = useContext(FeaturesContext);
   const { trackEvent } = useContext(AnalyticsContext);
   const currentSettings = useContext(FeedContext);
   const { user } = useContext(AuthContext);
@@ -166,17 +170,17 @@ export default function Feed<T>({
     return <></>;
   }
 
-  // const {
-  //   showCommentPopupId,
-  //   setShowCommentPopupId,
-  //   comment,
-  //   isSendingComment,
-  // } = useCommentPopup(feedName);
+  const {
+    showCommentPopupId,
+    setShowCommentPopupId,
+    comment,
+    isSendingComment,
+  } = useCommentPopup(feedName);
 
   const onUpvote = useFeedUpvotePost(
     items,
     updatePost,
-    // setShowCommentPopupId,
+    showCommentPopover && setShowCommentPopupId,
     virtualizedNumCards,
     feedName,
     ranking,
@@ -333,10 +337,10 @@ export default function Feed<T>({
             openNewTab={openNewTab}
             insaneMode={insaneMode}
             postMenuIndex={postMenuIndex}
-            // showCommentPopupId={showCommentPopupId}
-            // setShowCommentPopupId={setShowCommentPopupId}
-            // isSendingComment={isSendingComment}
-            // comment={comment}
+            showCommentPopupId={showCommentPopupId}
+            setShowCommentPopupId={setShowCommentPopupId}
+            isSendingComment={isSendingComment}
+            comment={comment}
             user={user}
             feedName={feedName}
             ranking={ranking}

--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-// import dynamic from 'next/dynamic';
+import dynamic from 'next/dynamic';
 import { FeedItem } from '../hooks/useFeed';
 import { PostList } from './cards/PostList';
 import { PostCard } from './cards/PostCard';
@@ -9,12 +9,12 @@ import { PlaceholderList } from './cards/PlaceholderList';
 import { PlaceholderCard } from './cards/PlaceholderCard';
 import { Ad, Post } from '../graphql/posts';
 import { LoggedUser } from '../lib/user';
-// import { CommentOnData } from '../graphql/comments';
+import { CommentOnData } from '../graphql/comments';
 import useTrackImpression from '../hooks/feed/useTrackImpression';
 import { FeedPostClick } from '../hooks/feed/useFeedOnPostClick';
 import { PostCardTests } from './post/common';
 
-// const CommentPopup = dynamic(() => import('./cards/CommentPopup'));
+const CommentPopup = dynamic(() => import('./cards/CommentPopup'));
 
 export type FeedItemComponentProps = {
   items: FeedItem[];
@@ -26,16 +26,16 @@ export type FeedItemComponentProps = {
   openNewTab: boolean;
   insaneMode: boolean;
   postMenuIndex: number | undefined;
-  // showCommentPopupId: string | undefined;
-  // setShowCommentPopupId: (value: string | undefined) => void;
-  // isSendingComment: boolean;
-  // comment: (variables: {
-  //   post: Post;
-  //   content: string;
-  //   row: number;
-  //   column: number;
-  //   columns: number;
-  // }) => Promise<CommentOnData>;
+  showCommentPopupId: string | undefined;
+  setShowCommentPopupId: (value: string | undefined) => void;
+  isSendingComment: boolean;
+  comment: (variables: {
+    post: Post;
+    content: string;
+    row: number;
+    column: number;
+    columns: number;
+  }) => Promise<CommentOnData>;
   user: LoggedUser | undefined;
   feedName: string;
   ranking?: string;
@@ -94,10 +94,10 @@ export default function FeedItemComponent({
   insaneMode,
   openNewTab,
   postMenuIndex,
-  // showCommentPopupId,
-  // setShowCommentPopupId,
-  // isSendingComment,
-  // comment,
+  showCommentPopupId,
+  setShowCommentPopupId,
+  isSendingComment,
+  comment,
   user,
   feedName,
   ranking,
@@ -161,20 +161,19 @@ export default function FeedItemComponent({
           postCardVersion={postCardVersion}
           postModalByDefault={postModalByDefault}
           postEngagementNonClickable={postEngagementNonClickable}
-          // >
-          //   {showCommentPopupId === item.post.id && (
-          //     <CommentPopup
-          //       onClose={() => setShowCommentPopupId(null)}
-          //       onSubmit={(content) =>
-          //         comment({ post: item.post, content, row, column, columns })
-          //       }
-          //       loading={isSendingComment}
-          //       compactCard={!useList && insaneMode}
-          //       listMode={useList}
-          //     />
-          //   )}
-          // </PostTag>
-        />
+        >
+          {showCommentPopupId === item.post.id && (
+            <CommentPopup
+              onClose={() => setShowCommentPopupId(null)}
+              onSubmit={(content) =>
+                comment({ post: item.post, content, row, column, columns })
+              }
+              loading={isSendingComment}
+              compactCard={!useList && insaneMode}
+              listMode={useList}
+            />
+          )}
+        </PostTag>
       );
     case 'ad':
       return (

--- a/packages/shared/src/components/cards/CommentPopup.tsx
+++ b/packages/shared/src/components/cards/CommentPopup.tsx
@@ -77,7 +77,7 @@ export default function CommentPopup({
           onClick={onClose}
           style={{ top: '0.5rem', right: '0.75rem' }}
         />
-        <h3 className="mr-11 ml-2 text-theme-label-primary typo-callout">
+        <h3 className="mr-11 ml-2 font-bold text-theme-label-primary typo-callout">
           {text.title}
         </h3>
         <div
@@ -103,9 +103,9 @@ export default function CommentPopup({
             onClick={() => onSubmit?.(comment)}
             disabled={!comment?.trim().length}
             loading={loading}
-            className={classNames('btn-primary', listMode && 'self-end')}
+            className={classNames('btn-primary', 'self-end')}
           >
-            Comment
+            Post
           </Button>
         </div>
       </div>

--- a/packages/shared/src/contexts/FeaturesContext.tsx
+++ b/packages/shared/src/contexts/FeaturesContext.tsx
@@ -30,6 +30,7 @@ export const FeaturesContextProvider = ({
   const features = useMemo(
     () => ({
       flags,
+      showCommentPopover: isFeaturedEnabled(Features.ShowCommentPopover, flags),
       shouldShowMyFeed: isFeaturedEnabled(Features.MyFeedOn, flags) ?? true,
       postEngagementNonClickable: isFeaturedEnabled(
         Features.PostEngagementNonClickable,

--- a/packages/shared/src/contexts/FeaturesContext.tsx
+++ b/packages/shared/src/contexts/FeaturesContext.tsx
@@ -8,6 +8,7 @@ import {
 
 export interface FeaturesData {
   flags: IFlags;
+  showCommentPopover?: boolean;
   shouldShowMyFeed?: boolean;
   postEngagementNonClickable?: boolean;
   postModalByDefault?: boolean;

--- a/packages/shared/src/hooks/feed/useFeedUpvotePost.ts
+++ b/packages/shared/src/hooks/feed/useFeedUpvotePost.ts
@@ -1,4 +1,4 @@
-// import { requestIdleCallback } from 'next/dist/client/request-idle-callback';
+import { requestIdleCallback } from 'next/dist/client/request-idle-callback';
 import { useContext } from 'react';
 import useUpvotePost from '../useUpvotePost';
 import { FeedItem } from '../useFeed';
@@ -15,7 +15,7 @@ import { postEventName } from '../../components/utilities';
 export default function useFeedUpvotePost(
   items: FeedItem[],
   updatePost: (page: number, index: number, post: Post) => void,
-  // setShowCommentPopupId: (postId: string) => void,
+  setShowCommentPopupId: (postId: string) => void,
   columns: number,
   feedName: string,
   ranking?: string,
@@ -60,9 +60,11 @@ export default function useFeedUpvotePost(
     );
     if (upvoted) {
       await upvotePost({ id: post.id, index });
-      // requestIdleCallback(() => {
-      //   setShowCommentPopupId(post.id);
-      // });
+      if (setShowCommentPopupId) {
+        requestIdleCallback(() => {
+          setShowCommentPopupId(post.id);
+        });
+      }
     } else {
       await cancelPostUpvote({ id: post.id, index });
     }

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -111,7 +111,7 @@ export class Features {
     'Activate companion',
   );
 
-  static readonly PostCardVersion = new Features('post_card_version', 'v1', [
+  static readonly PostCardVersion = new Features('post_card_version', 'v2', [
     'v1',
     'v2',
   ]);
@@ -133,6 +133,8 @@ export class Features {
     AdditionalInteractionButtons.Bookmark,
     [AdditionalInteractionButtons.Bookmark, AdditionalInteractionButtons.Share],
   );
+
+  static readonly ShowCommentPopover = new Features('show_comment_popover');
 
   private constructor(
     public readonly id: string,

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -111,7 +111,7 @@ export class Features {
     'Activate companion',
   );
 
-  static readonly PostCardVersion = new Features('post_card_version', 'v2', [
+  static readonly PostCardVersion = new Features('post_card_version', 'v1', [
     'v1',
     'v2',
   ]);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Re-introducing the comment modal popup

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-266 #done
