### PR TITLE
fix: make the header part of the feed independant

### DIFF
--- a/packages/shared/src/components/Feed.module.css
+++ b/packages/shared/src/components/Feed.module.css
@@ -1,7 +1,11 @@
 .feed {
   grid-template-columns: 100%;
 }
-
+.container {
+  @screen laptopL {
+    max-width: calc(20rem * var(--num-cards) + var(--feed-gap) * (var(--num-cards) - 1));
+  }
+}
 .cards {
   @screen mobileL {
     max-width: calc(20rem * var(--num-cards) + var(--feed-gap) * (var(--num-cards) - 1));

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -267,8 +267,8 @@ export default function Feed<T>({
   const style = {
     '--num-cards': numCards,
     '--feed-gap': `${feedGapPx / 16}rem`,
-    ...getStyle(useList, spaciness),
   };
+  const cardContainerStye = { ...getStyle(useList, spaciness) };
 
   if (emptyScreen && emptyFeed) {
     return <>{emptyScreen}</>;
@@ -292,7 +292,13 @@ export default function Feed<T>({
   }, [selectedPost]);
 
   return (
-    <div className="flex flex-col laptopL:mx-auto w-full laptopL:w-auto">
+    <div
+      className={classNames(
+        'flex flex-col laptopL:mx-auto w-full',
+        styles.container,
+      )}
+      style={style}
+    >
       {header}
       <div
         className={classNames(
@@ -301,11 +307,10 @@ export default function Feed<T>({
           styles.feed,
           !useList && styles.cards,
         )}
-        style={style}
+        style={cardContainerStye}
         aria-live={subject === ToastSubject.Feed ? 'assertive' : 'off'}
         data-testid="posts-feed"
       >
-
         {selectedPost && (
           <PostModal
             isOpen
@@ -314,42 +319,6 @@ export default function Feed<T>({
             onPreviousPost={onPrevious}
             onNextPost={onNext}
             isFetchingNextPage={isFetchingNextPage}
-  />
-        )}
-        {items.map((item, index) => (
-          <FeedItemComponent
-            additionalInteractionButtonFeature={
-              additionalInteractionButtonFeature
-            }
-            items={items}
-            index={index}
-            row={calculateRow(index, numCards)}
-            column={calculateColumn(index, numCards)}
-            columns={virtualizedNumCards}
-            key={getFeedItemKey(items, index)}
-            useList={useList}
-            openNewTab={openNewTab}
-            insaneMode={insaneMode}
-            postMenuIndex={postMenuIndex}
-            showCommentPopupId={showCommentPopupId}
-            setShowCommentPopupId={setShowCommentPopupId}
-            isSendingComment={isSendingComment}
-            comment={comment}
-            user={user}
-            feedName={feedName}
-            ranking={ranking}
-            onUpvote={onUpvote}
-            onBookmark={onBookmark}
-            onPostClick={onPostCardClick}
-            onShare={onShareClick}
-            onMenuClick={onMenuClick}
-            onCommentClick={onCommentClick}
-            onAdClick={onAdClick}
-            onReadArticleClick={onReadArticleClick}
-            postCardVersion={postCardVersion}
-            postModalByDefault={postModalByDefault}
-            postEngagementNonClickable={postEngagementNonClickable}
-
           />
         )}
         <ScrollToTopButton />
@@ -375,10 +344,10 @@ export default function Feed<T>({
               openNewTab={openNewTab}
               insaneMode={insaneMode}
               postMenuIndex={postMenuIndex}
-              // showCommentPopupId={showCommentPopupId}
-              // setShowCommentPopupId={setShowCommentPopupId}
-              // isSendingComment={isSendingComment}
-              // comment={comment}
+              showCommentPopupId={showCommentPopupId}
+              setShowCommentPopupId={setShowCommentPopupId}
+              isSendingComment={isSendingComment}
+              comment={comment}
               user={user}
               feedName={feedName}
               ranking={ranking}

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -267,7 +267,7 @@ export default function Feed<T>({
   const style = {
     '--num-cards': numCards,
     '--feed-gap': `${feedGapPx / 16}rem`,
-  };
+  } as React.CSSProperties;
   const cardContainerStye = { ...getStyle(useList, spaciness) };
 
   if (emptyScreen && emptyFeed) {

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -288,107 +288,111 @@ export default function Feed<T>({
   }, [selectedPost]);
 
   return (
-    <div
-      className={classNames(
-        'relative mx-auto w-full',
-        className,
-        styles.feed,
-        !useList && styles.cards,
-      )}
-      style={style}
-      aria-live={subject === ToastSubject.Feed ? 'assertive' : 'off'}
-      data-testid="posts-feed"
-    >
-      {selectedPost && (
-        <PostModal
-          isOpen
-          id={selectedPost.id}
-          onRequestClose={() => onCloseModal(false)}
-          onPreviousPost={onPrevious}
-          onNextPost={onNext}
-          isFetchingNextPage={isFetchingNextPage}
-        />
-      )}
+    <div className="flex flex-col laptopL:mx-auto w-full laptopL:w-auto">
       {header}
-      <ScrollToTopButton />
       <div
         className={classNames(
-          'grid',
-          gapClass(useList, spaciness),
-          cardClass(useList, numCards),
+          'relative mx-auto w-full',
+          className,
+          styles.feed,
+          !useList && styles.cards,
         )}
+        style={style}
+        aria-live={subject === ToastSubject.Feed ? 'assertive' : 'off'}
+        data-testid="posts-feed"
       >
-        {items.map((item, index) => (
-          <FeedItemComponent
-            additionalInteractionButtonFeature={
-              additionalInteractionButtonFeature
-            }
-            items={items}
-            index={index}
-            row={calculateRow(index, numCards)}
-            column={calculateColumn(index, numCards)}
-            columns={virtualizedNumCards}
-            key={getFeedItemKey(items, index)}
-            useList={useList}
-            openNewTab={openNewTab}
-            insaneMode={insaneMode}
-            postMenuIndex={postMenuIndex}
-            // showCommentPopupId={showCommentPopupId}
-            // setShowCommentPopupId={setShowCommentPopupId}
-            // isSendingComment={isSendingComment}
-            // comment={comment}
-            user={user}
-            feedName={feedName}
-            ranking={ranking}
-            onUpvote={onUpvote}
-            onBookmark={onBookmark}
-            onPostClick={onPostCardClick}
-            onShare={onShareClick}
-            onMenuClick={onMenuClick}
-            onCommentClick={onCommentClick}
-            onAdClick={onAdClick}
-            onReadArticleClick={onReadArticleClick}
-            postCardVersion={postCardVersion}
-            postModalByDefault={postModalByDefault}
-            postEngagementNonClickable={postEngagementNonClickable}
+        {selectedPost && (
+          <PostModal
+            isOpen
+            id={selectedPost.id}
+            onRequestClose={() => onCloseModal(false)}
+            onPreviousPost={onPrevious}
+            onNextPost={onNext}
+            isFetchingNextPage={isFetchingNextPage}
           />
-        ))}
-      </div>
-      <InfiniteScrollScreenOffset ref={infiniteScrollRef} />
-      <PostOptionsMenu
-        additionalInteractionButtonFeature={additionalInteractionButtonFeature}
-        onShare={() =>
-          openSharePost(
-            (items[postMenuIndex] as PostItem)?.post,
-            virtualizedNumCards,
-            postMenuLocation.row,
-            postMenuLocation.column,
-          )
-        }
-        onBookmark={() =>
-          onBookmark(
-            (items[postMenuIndex] as PostItem)?.post,
-            postMenuIndex,
-            postMenuLocation.row,
-            postMenuLocation.column,
-            !(items[postMenuIndex] as PostItem)?.post?.bookmarked,
-          )
-        }
-        feedName={feedName}
-        postIndex={postMenuIndex}
-        post={(items[postMenuIndex] as PostItem)?.post}
-        onHidden={() => setPostMenuIndex(null)}
-        onRemovePost={onRemovePost}
-      />
-      {sharePost && (
-        <SharePostModal
-          isOpen={!!sharePost}
-          post={sharePost}
-          origin={Origin.Feed}
-          {...sharePostFeedLocation}
-          onRequestClose={closeSharePost}
+        )}
+        <ScrollToTopButton />
+        <div
+          className={classNames(
+            'grid',
+            gapClass(useList, spaciness),
+            cardClass(useList, numCards),
+          )}
+        >
+          {items.map((item, index) => (
+            <FeedItemComponent
+              additionalInteractionButtonFeature={
+                additionalInteractionButtonFeature
+              }
+              items={items}
+              index={index}
+              row={calculateRow(index, numCards)}
+              column={calculateColumn(index, numCards)}
+              columns={virtualizedNumCards}
+              key={getFeedItemKey(items, index)}
+              useList={useList}
+              openNewTab={openNewTab}
+              insaneMode={insaneMode}
+              postMenuIndex={postMenuIndex}
+              // showCommentPopupId={showCommentPopupId}
+              // setShowCommentPopupId={setShowCommentPopupId}
+              // isSendingComment={isSendingComment}
+              // comment={comment}
+              user={user}
+              feedName={feedName}
+              ranking={ranking}
+              onUpvote={onUpvote}
+              onBookmark={onBookmark}
+              onPostClick={onPostCardClick}
+              onShare={onShareClick}
+              onMenuClick={onMenuClick}
+              onCommentClick={onCommentClick}
+              onAdClick={onAdClick}
+              onReadArticleClick={onReadArticleClick}
+              postCardVersion={postCardVersion}
+              postModalByDefault={postModalByDefault}
+              postEngagementNonClickable={postEngagementNonClickable}
+            />
+          ))}
+        </div>
+        <InfiniteScrollScreenOffset ref={infiniteScrollRef} />
+        <PostOptionsMenu
+          additionalInteractionButtonFeature={
+            additionalInteractionButtonFeature
+          }
+          onShare={() =>
+            openSharePost(
+              (items[postMenuIndex] as PostItem)?.post,
+              virtualizedNumCards,
+              postMenuLocation.row,
+              postMenuLocation.column,
+            )
+          }
+          onBookmark={() =>
+            onBookmark(
+              (items[postMenuIndex] as PostItem)?.post,
+              postMenuIndex,
+              postMenuLocation.row,
+              postMenuLocation.column,
+              !(items[postMenuIndex] as PostItem)?.post?.bookmarked,
+            )
+          }
+          feedName={feedName}
+          postIndex={postMenuIndex}
+          post={(items[postMenuIndex] as PostItem)?.post}
+          onHidden={() => setPostMenuIndex(null)}
+          onRemovePost={onRemovePost}
         />
-      )}
+        {sharePost && (
+          <SharePostModal
+            isOpen={!!sharePost}
+            post={sharePost}
+            origin={Origin.Feed}
+            {...sharePostFeedLocation}
+            onRequestClose={closeSharePost}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -84,7 +84,7 @@ const LogoAndGreeting = ({
 };
 
 const mainLayoutClass = (sidebarExpanded: boolean) =>
-  sidebarExpanded ? 'laptop:pl-70' : 'laptop:pl-11';
+  sidebarExpanded ? 'laptop:pl-60' : 'laptop:pl-11';
 
 export default function MainLayout({
   children,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Our current header was always aligned with the feed size.
- On some sizes this really cut down the header.

Before and current laptopL and above
<img width="1140" alt="Screenshot 2022-07-20 at 16 05 28" src="https://user-images.githubusercontent.com/554874/180004544-b2a61d95-b76f-4c09-8200-24c797ec0d86.png">

New smaller than laptopL
<img width="1060" alt="Screenshot 2022-07-20 at 16 05 42" src="https://user-images.githubusercontent.com/554874/180004619-029a5182-665f-40ca-974f-06bc5a4dee8b.png">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-210 #done
