### PR TITLE
refactor: add active query param to ad request

### DIFF
--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -125,7 +125,7 @@ const renderComponent = (
   queryClient = new QueryClient();
 
   mocks.forEach(mockGraphQL);
-  nock('http://localhost:3000').get('/v1/a').reply(200, [ad]);
+  nock('http://localhost:3000').get('/v1/a?active=false').reply(200, [ad]);
   const settingsContext: SettingsContextData = {
     spaciness: 'eco',
     showOnlyUnreadPosts: false,

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -130,8 +130,8 @@ export default function useFeed<T>(
 
   const adsQuery = useInfiniteQuery<Ad>(
     ['ads', ...feedQueryKey],
-    async () => {
-      const res = await fetch(`${apiUrl}/v1/a`);
+    async ({ pageParam }) => {
+      const res = await fetch(`${apiUrl}/v1/a?active=${!!pageParam}`);
       const ads: Ad[] = await res.json();
       return ads[0];
     },


### PR DESCRIPTION
## Changes

### Describe what this PR does

The second page of the feed onward should set the `active` query param to `true`

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
