### PR TITLE
fix: comment share button space

### DIFF
--- a/packages/shared/src/components/comments/CommentActionButtons.tsx
+++ b/packages/shared/src/components/comments/CommentActionButtons.tsx
@@ -140,7 +140,7 @@ export default function CommentActionButtons({
             buttonSize="small"
             onClick={() => onDelete(comment, parentId)}
             icon={<TrashIcon />}
-            className="btn-tertiary"
+            className="mr-3 btn-tertiary"
           />
         </SimpleTooltip>
       )}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The delete button was not having enough space on the right

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-274 #done
