### PR TITLE
fix: change similar post links to be interanl

### DIFF
--- a/packages/shared/src/components/widgets/SimilarPosts.tsx
+++ b/packages/shared/src/components/widgets/SimilarPosts.tsx
@@ -45,9 +45,7 @@ const ListItem = ({
     )}
   >
     <CardLink
-      href={post.permalink}
-      target="_blank"
-      rel="noopener"
+      href={post.commentsPermalink}
       title={post.title}
       onClick={() => onLinkClick(post)}
       onMouseUp={(event) => event.button === 1 && onLinkClick(post)}

--- a/packages/shared/src/graphql/furtherReading.ts
+++ b/packages/shared/src/graphql/furtherReading.ts
@@ -20,6 +20,7 @@ export const FURTHER_READING_QUERY = gql`
       id
       title
       permalink
+      commentsPermalink
       bookmarked @include(if: $loggedIn)
       source {
         id
@@ -45,6 +46,7 @@ export const FURTHER_READING_QUERY = gql`
       id
       title
       permalink
+      commentsPermalink
       bookmarked @include(if: $loggedIn)
       source {
         id


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Link similar posts to internal links

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-276 #done
