### PR TITLE
fix: uneven margins on v2 cards

### DIFF
--- a/packages/shared/src/components/cards/PostCard.tsx
+++ b/packages/shared/src/components/cards/PostCard.tsx
@@ -119,8 +119,7 @@ export const PostCard = forwardRef(function PostCard(
         )}
         <CardTitle>{post.title}</CardTitle>
       </CardTextContainer>
-      <Containter className="mb-8 tablet:mb-0">
-        <CardSpace />
+      <Containter className="mb-5">
         <PostMetadata
           createdAt={post.createdAt}
           readTime={post.readTime}
@@ -133,7 +132,7 @@ export const PostCard = forwardRef(function PostCard(
             className={classNames(
               'rounded-b-12',
               insaneMode
-                ? 'relative tablet:absolute tablet:right-0 tablet:bottom-0 tablet:left-0 mt-2 tablet:mt-0 tablet:border-0 border-t border-theme-divider-tertiary'
+                ? 'relative tablet:absolute tablet:right-0 tablet:bottom-0 tablet:left-0 mt-2.5 tablet:mt-0 tablet:border-0 border-t border-theme-divider-tertiary'
                 : 'absolute right-0 bottom-0 left-0',
             )}
             postLink={post.permalink}
@@ -184,9 +183,9 @@ export const PostCard = forwardRef(function PostCard(
             additionalInteractionButtonFeature
           }
           className={classNames(
-            'mx-4',
+            'mx-2',
             !postEngagementNonClickable && 'justify-between',
-            !showImage && 'my-4 laptop:mb-0',
+            !showImage && 'laptop:mb-0',
           )}
         />
       </Containter>

--- a/packages/shared/src/components/cards/PostCard.tsx
+++ b/packages/shared/src/components/cards/PostCard.tsx
@@ -11,7 +11,6 @@ import {
   Card,
   CardButton,
   CardImage,
-  CardSpace,
   CardTextContainer,
   CardTitle,
   getPostClassNames,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- There where some uneven margins that didn't correspond with the design.
- Only open question is the mobile margin below the date (awaiting merge)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-268 #done
