### PR TITLE
fix: post button size was too big

### DIFF
--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -70,7 +70,7 @@ export default function ActionButtons({
     : React.Fragment;
   const upvoteCommentProps: ButtonProps<'button'> = {
     readOnly: postEngagementNonClickable,
-    buttonSize: postEngagementNonClickable ? 'small' : 'medium',
+    buttonSize: 'small',
     className: classNames(
       'btn-tertiary-avocado',
       !postEngagementNonClickable && 'w-[4.875rem]',
@@ -83,7 +83,7 @@ export default function ActionButtons({
       <SimpleTooltip content={post.bookmarked ? 'Remove bookmark' : 'Bookmark'}>
         <Button
           icon={<BookmarkIcon secondary={post.bookmarked} />}
-          buttonSize={postEngagementNonClickable ? 'small' : 'medium'}
+          buttonSize="small"
           pressed={post.bookmarked}
           onClick={() => onBookmarkClick?.(post, !post.bookmarked)}
           className="btn-tertiary-bun"
@@ -93,7 +93,7 @@ export default function ActionButtons({
       <SimpleTooltip content="Share post">
         <Button
           icon={<ShareIcon />}
-          buttonSize={postEngagementNonClickable ? 'small' : 'medium'}
+          buttonSize="small"
           onClick={() => onShare?.(post)}
           className="btn-tertiary-cabbage"
         />


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We used `medium` buttons, but they should always be `small`.

New v1 and v2:
<img width="350" alt="Screenshot 2022-07-24 at 13 51 58" src="https://user-images.githubusercontent.com/554874/180645713-d94d9d21-000d-4588-8b42-252fa0df22c9.png">
<img width="350" alt="Screenshot 2022-07-24 at 13 52 12" src="https://user-images.githubusercontent.com/554874/180645715-758c4bbe-7288-4e87-b838-8467a793ab15.png">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-271 #done
