### PR TITLE
feat: change instance ref for react query

### DIFF
--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -6,7 +6,13 @@
 // }
 
 import '@dailydotdev/shared/src/lib/lazysizesImport';
-import React, { ReactElement, ReactNode, useContext, useEffect } from 'react';
+import React, {
+  ReactElement,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 import { AppProps } from 'next/app';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
@@ -181,7 +187,7 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
 }
 
 export default function App(props: AppProps): ReactElement {
-  const [queryClient] = React.useState(() => new QueryClient());
+  const [queryClient] = useState(() => new QueryClient());
   const version = useWebappVersion();
   const deviceId = useDeviceId();
 

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -35,8 +35,6 @@ import useWebappVersion from '../hooks/useWebappVersion';
 //   { ssr: false },
 // );
 
-const queryClient = new QueryClient();
-
 const LoginModal = dynamic(
   () =>
     import(
@@ -183,6 +181,7 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
 }
 
 export default function App(props: AppProps): ReactElement {
+  const [queryClient] = React.useState(() => new QueryClient());
   const version = useWebappVersion();
   const deviceId = useDeviceId();
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- After discussing this with Dominik, our current setup can actually share data across users on the server side
- By moving the ref inside the app via state it's bound to a single user
- Read more: [React Query Hydration](https://tanstack.com/query/v4/docs/guides/ssr#using-hydration)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-277 #done
