### PR TITLE
fix: comment share icon style

### DIFF
--- a/packages/shared/src/components/ShareNewCommentPopup.tsx
+++ b/packages/shared/src/components/ShareNewCommentPopup.tsx
@@ -60,7 +60,7 @@ export default function ShareNewCommentPopup({
             href={getTwitterShareLink(href, post.title)}
             target="_blank"
             rel="noopener"
-            icon={<TwitterIcon secondary />}
+            icon={<TwitterIcon />}
             className="btn-primary-twitter"
             buttonSize="small"
           >
@@ -73,7 +73,7 @@ export default function ShareNewCommentPopup({
             href={getWhatsappShareLink(href)}
             target="_blank"
             rel="noopener"
-            icon={<WhatsappIcon secondary />}
+            icon={<WhatsappIcon />}
             className="btn-primary-whatsapp"
             buttonSize="small"
           >


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We used two secondary icons that should be primary for this case

New:
![Screenshot 2022-07-25 at 11 37 56](https://user-images.githubusercontent.com/554874/180747183-2bb2176e-c4a3-4b3d-9d52-813b42a8288e.png)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-268 #done
