### PR TITLE
fix: add bottom spacing if there is no post summary

### DIFF
--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -270,10 +270,7 @@ export function PostContent({
           onShare={onShare}
         />
         <h1
-          className={classNames(
-            'mt-6 font-bold break-words typo-large-title',
-            !postById.post.summary && 'mb-6',
-          )}
+          className="my-6 font-bold break-words typo-large-title"
           data-testid="post-modal-title"
         >
           {postById.post.title}

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -270,7 +270,10 @@ export function PostContent({
           onShare={onShare}
         />
         <h1
-          className="mt-6 font-bold break-words typo-large-title"
+          className={classNames(
+            'mt-6 font-bold break-words typo-large-title',
+            !postById.post.summary && 'mb-6',
+          )}
           data-testid="post-modal-title"
         >
           {postById.post.title}

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -160,7 +160,7 @@ export const SummaryArrow = classed(ArrowIcon, 'icon arrow ml-auto text-xl');
 
 export const SummaryContainer = classed(
   'div',
-  'text-theme-label-secondary multi-truncate my-6 border-l border-theme-status-cabbage pl-4',
+  'text-theme-label-secondary multi-truncate mb-6 border-l border-theme-status-cabbage pl-4',
 );
 
 export const TLDRText = classed(


### PR DESCRIPTION
## Changes

### Describe what this PR does
Tags were too close to article title if there is no TLDR. No bottom margin will be added to title in this case to keep correct spacing  

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{293} #done
