### PR TITLE
feat: useOnPostClick hook to refactor modal clicks

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -206,7 +206,6 @@ export default function Feed<T>({
     virtualizedNumCards,
     feedName,
     ranking,
-    'go to link',
   );
 
   const onPostModalOpen = (index: number, callback?: () => unknown) => {

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -49,6 +49,7 @@ import { useSharePost } from '../../hooks/useSharePost';
 import FeaturesContext from '../../contexts/FeaturesContext';
 import { Origin } from '../../lib/analytics';
 import { useShareComment } from '../../hooks/useShareComment';
+import useOnPostClick from '../../hooks/useOnPostClick';
 
 const UpvotedPopupModal = dynamic(() => import('../modals/UpvotedPopupModal'));
 const NewCommentModal = dynamic(() => import('../modals/NewCommentModal'));
@@ -195,13 +196,10 @@ export function PostContent({
     return <Custom404 />;
   }
 
-  const onLinkClick = async () => {
-    trackEvent(
-      postAnalyticsEvent('click', postById.post, {
-        extra: { origin: analyticsOrigin },
-      }),
-    );
-  };
+  const onPostClick = useOnPostClick({ origin: analyticsOrigin });
+  const onReadArticle = () => onPostClick({ post: postById.post });
+  const onLinkClick = () =>
+    onPostClick({ post: postById.post, event: 'click' });
 
   const postLinkProps = {
     href: postById?.post.permalink,
@@ -261,6 +259,7 @@ export function PostContent({
           )}
           shouldDisplayTitle={isFixed}
           post={postById.post}
+          onReadArticle={onReadArticle}
           onClose={onClose}
           isModal={isModal}
           additionalInteractionButtonFeature={
@@ -345,6 +344,7 @@ export function PostContent({
         additionalInteractionButtonFeature={additionalInteractionButtonFeature}
         onBookmark={toggleBookmark}
         onShare={onShare}
+        onReadArticle={onReadArticle}
         post={postById.post}
         isNavigationFixed={hasNavigation && isFixed}
         className="pb-20"

--- a/packages/shared/src/components/post/PostModalActions.tsx
+++ b/packages/shared/src/components/post/PostModalActions.tsx
@@ -19,19 +19,15 @@ import classed from '../../lib/classed';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import { Button } from '../buttons/Button';
 import PostOptionsMenu from '../PostOptionsMenu';
-import AnalyticsContext from '../../contexts/AnalyticsContext';
-import { postAnalyticsEvent } from '../../lib/feed';
-import { PostOrigin } from '../../hooks/analytics/useAnalyticsContextData';
 import { OnShareOrBookmarkProps } from './PostActions';
-import { Origin } from '../../lib/analytics';
 
 export interface PostModalActionsProps extends OnShareOrBookmarkProps {
   post: Post;
+  onReadArticle?: () => void;
   onClose?: MouseEventHandler | KeyboardEventHandler;
   className?: string;
   style?: CSSProperties;
   inlineActions?: boolean;
-  origin?: PostOrigin;
   notificactionClassName?: string;
 }
 
@@ -43,17 +39,16 @@ const DeletePostModal = dynamic(() => import('../modals/DeletePostModal'));
 
 export function PostModalActions({
   additionalInteractionButtonFeature,
+  onReadArticle,
   onShare,
   onBookmark,
   post,
   onClose,
   inlineActions,
   className,
-  origin = Origin.ArticlePage,
   notificactionClassName,
   ...props
 }: PostModalActionsProps): ReactElement {
-  const { trackEvent } = useContext(AnalyticsContext);
   const { user } = useContext(AuthContext);
   const { showReportMenu } = useReportPostMenu();
   const [showBanPost, setShowBanPost] = useState(false);
@@ -64,14 +59,6 @@ export function PostModalActions({
     showReportMenu(e, {
       position: { x: right, y: bottom + 4 },
     });
-  };
-
-  const onReadArticle = () => {
-    trackEvent(
-      postAnalyticsEvent('go to link', post, {
-        extra: { origin },
-      }),
-    );
   };
 
   const isModerator = user?.roles?.indexOf(Roles.Moderator) > -1;

--- a/packages/shared/src/components/post/PostNavigation.tsx
+++ b/packages/shared/src/components/post/PostNavigation.tsx
@@ -11,7 +11,7 @@ const SimpleTooltip = dynamic(() => import('../tooltips/SimpleTooltip'));
 export interface PostNavigationProps
   extends Pick<
     PostModalActionsProps,
-    'post' | 'onClose' | 'onShare' | 'onBookmark'
+    'post' | 'onClose' | 'onShare' | 'onBookmark' | 'onReadArticle'
   > {
   onPreviousPost: () => unknown;
   onNextPost: () => unknown;
@@ -28,6 +28,7 @@ export function PostNavigation({
   className,
   isModal,
   post,
+  onReadArticle,
   onClose,
   onShare,
   onBookmark,
@@ -88,13 +89,13 @@ export function PostNavigation({
       <PostModalActions
         onShare={onShare}
         onBookmark={onBookmark}
+        onReadArticle={onReadArticle}
         additionalInteractionButtonFeature={additionalInteractionButtonFeature}
         post={post}
         onClose={onClose}
         inlineActions={shouldDisplayTitle || isModal}
         className={getClasses()}
         notificactionClassName="ml-4"
-        origin={isModal ? Origin.ArticleModal : Origin.ArticleModal}
       />
     </div>
   );

--- a/packages/shared/src/components/post/PostWidgets.tsx
+++ b/packages/shared/src/components/post/PostWidgets.tsx
@@ -22,6 +22,7 @@ export function PostWidgets({
   additionalInteractionButtonFeature,
   onShare,
   onBookmark,
+  onReadArticle,
   post,
   className,
   isNavigationFixed,
@@ -62,11 +63,11 @@ export function PostWidgets({
           }
           onBookmark={onBookmark}
           onShare={onShare}
+          onReadArticle={onReadArticle}
           inlineActions={isNavigationFixed}
           post={post}
           onClose={onClose}
           className="hidden tablet:flex pt-6"
-          origin={origin}
         />
       )}
       <PostUsersHighlights post={post} />

--- a/packages/shared/src/hooks/feed/useFeedOnPostClick.ts
+++ b/packages/shared/src/hooks/feed/useFeedOnPostClick.ts
@@ -1,9 +1,6 @@
-import { useContext } from 'react';
 import { Post } from '../../graphql/posts';
 import { FeedItem, PostItem } from '../useFeed';
-import useIncrementReadingRank from '../useIncrementReadingRank';
-import AnalyticsContext from '../../contexts/AnalyticsContext';
-import { feedAnalyticsExtra, postAnalyticsEvent } from '../../lib/feed';
+import useOnPostClick from '../useOnPostClick';
 
 interface PostClickOptionalProps {
   skipPostUpdate?: boolean;
@@ -23,28 +20,16 @@ export default function useFeedOnPostClick(
   columns: number,
   feedName: string,
   ranking?: string,
-  event = 'click',
 ): FeedPostClick {
-  const { incrementReadingRank } = useIncrementReadingRank();
-  const { trackEvent } = useContext(AnalyticsContext);
+  const onPostClick = useOnPostClick({ columns, feedName, ranking });
 
   return async (post, index, row, column, optional): Promise<void> => {
-    trackEvent(
-      postAnalyticsEvent(event, post, {
-        columns,
-        column,
-        row,
-        ...feedAnalyticsExtra(feedName, ranking),
-      }),
-    );
+    await onPostClick({ post, row, column, optional });
 
     if (optional?.skipPostUpdate) {
       return;
     }
 
-    if (!post.read) {
-      await incrementReadingRank();
-    }
     const item = items[index] as PostItem;
     updatePost(item.page, item.index, { ...post, read: true });
   };

--- a/packages/shared/src/hooks/useOnPostClick.ts
+++ b/packages/shared/src/hooks/useOnPostClick.ts
@@ -1,0 +1,65 @@
+import { useContext } from 'react';
+import useIncrementReadingRank from './useIncrementReadingRank';
+import AnalyticsContext from '../contexts/AnalyticsContext';
+import { feedAnalyticsExtra, postAnalyticsEvent } from '../lib/feed';
+import { Post } from '../graphql/posts';
+import { Origin } from '../lib/analytics';
+
+interface PostClickOptionalProps {
+  skipPostUpdate?: boolean;
+}
+
+export type FeedPostClick = ({
+  event,
+  post,
+  row,
+  column,
+  optional,
+}: {
+  event?: string;
+  post: Post;
+  row?: number;
+  column?: number;
+  optional?: PostClickOptionalProps;
+}) => Promise<void>;
+
+interface UseOnPostClickProps {
+  columns?: number;
+  feedName?: string;
+  ranking?: string;
+  origin?: Origin;
+}
+export default function useOnPostClick({
+  columns,
+  feedName,
+  ranking,
+  origin,
+}: UseOnPostClickProps): FeedPostClick {
+  const { trackEvent } = useContext(AnalyticsContext);
+  const { incrementReadingRank } = useIncrementReadingRank();
+
+  return async ({
+    event = 'go to link',
+    post,
+    row,
+    column,
+    optional,
+  }): Promise<void> => {
+    trackEvent(
+      postAnalyticsEvent(event, post, {
+        columns,
+        column,
+        row,
+        ...feedAnalyticsExtra(feedName, ranking, null, origin),
+      }),
+    );
+
+    if (optional?.skipPostUpdate) {
+      return;
+    }
+
+    if (!post.read) {
+      await incrementReadingRank();
+    }
+  };
+}

--- a/packages/shared/src/lib/feed.ts
+++ b/packages/shared/src/lib/feed.ts
@@ -62,10 +62,11 @@ export function feedAnalyticsExtra(
   extra?: {
     scroll_y?: number;
   },
+  origin?: Origin,
 ): FeedAnalyticsExtra {
   return {
     extra: {
-      origin: Origin.Feed,
+      origin: origin ?? Origin.Feed,
       feed: feedName,
       ...(ranking && { ranking }),
       ...(extra && extra),


### PR DESCRIPTION
## Changes

### Describe what this PR does
- New useOnPostClick hook to leverage reading rank and click tracking
- Modify feed hook to use this version
- Drill down the prop to the modal and feedpage

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

No new introductions, but good to keep a close eye on analytics after merge (CC: @idoshamun )

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-292 #done
