### PR TITLE
fix: post context menu ids

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -39,6 +39,7 @@ interface PostOptionsMenuProps extends OnShareOrBookmarkProps {
   onRemovePost?: (postIndex: number) => Promise<unknown>;
   setShowDeletePost?: () => unknown;
   setShowBanPost?: () => unknown;
+  contextId?: string;
 }
 
 type ReportPostAsync = (
@@ -60,6 +61,7 @@ export default function PostOptionsMenu({
   onRemovePost,
   setShowDeletePost,
   setShowBanPost,
+  contextId = 'post-context',
 }: PostOptionsMenuProps): ReactElement {
   const client = useQueryClient();
   const { user } = useContext(AuthContext);
@@ -246,7 +248,7 @@ export default function PostOptionsMenu({
     <>
       <PortalMenu
         disableBoundariesCheck
-        id="post-context"
+        id={contextId}
         className="menu-primary"
         animation="fade"
         onHidden={onHidden}

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -62,7 +62,11 @@ const Custom404 = dynamic(() => import('../Custom404'));
 export interface PostContentProps
   extends Omit<
       PostModalActionsProps,
-      'post' | 'onShare' | 'onBookmark' | 'additionalInteractionButtonFeature'
+      | 'post'
+      | 'onShare'
+      | 'onBookmark'
+      | 'contextMenuId'
+      | 'additionalInteractionButtonFeature'
     >,
     Partial<Pick<PostNavigationProps, 'onPreviousPost' | 'onNextPost'>>,
     UsePostCommentOptionalProps {

--- a/packages/shared/src/components/post/PostModalActions.tsx
+++ b/packages/shared/src/components/post/PostModalActions.tsx
@@ -29,6 +29,7 @@ export interface PostModalActionsProps extends OnShareOrBookmarkProps {
   style?: CSSProperties;
   inlineActions?: boolean;
   notificactionClassName?: string;
+  contextMenuId: string;
 }
 
 const Container = classed('div', 'flex flex-row items-center');
@@ -47,10 +48,11 @@ export function PostModalActions({
   inlineActions,
   className,
   notificactionClassName,
+  contextMenuId,
   ...props
 }: PostModalActionsProps): ReactElement {
   const { user } = useContext(AuthContext);
-  const { showReportMenu } = useReportPostMenu();
+  const { showReportMenu } = useReportPostMenu(contextMenuId);
   const [showBanPost, setShowBanPost] = useState(false);
   const [showDeletePost, setShowDeletePost] = useState(false);
 
@@ -104,6 +106,7 @@ export function PostModalActions({
         post={post}
         setShowBanPost={isModerator ? () => setShowBanPost(true) : null}
         setShowDeletePost={isModerator ? () => setShowDeletePost(true) : null}
+        contextId={contextMenuId}
       />
       {showBanPost && (
         <BanPostModal

--- a/packages/shared/src/components/post/PostNavigation.tsx
+++ b/packages/shared/src/components/post/PostNavigation.tsx
@@ -95,6 +95,7 @@ export function PostNavigation({
         inlineActions={shouldDisplayTitle || isModal}
         className={getClasses()}
         notificactionClassName="ml-4"
+        contextMenuId="post-navigation-context"
       />
     </div>
   );

--- a/packages/shared/src/components/post/PostWidgets.tsx
+++ b/packages/shared/src/components/post/PostWidgets.tsx
@@ -68,6 +68,7 @@ export function PostWidgets({
           post={post}
           onClose={onClose}
           className="hidden tablet:flex pt-6"
+          contextMenuId="post-widgets-context"
         />
       )}
       <PostUsersHighlights post={post} />

--- a/packages/shared/src/components/post/PostWidgets.tsx
+++ b/packages/shared/src/components/post/PostWidgets.tsx
@@ -13,7 +13,8 @@ import { PostOrigin } from '../../hooks/analytics/useAnalyticsContextData';
 import { ShareProvider } from '../../lib/share';
 import { Origin } from '../../lib/analytics';
 
-interface PostWidgetsProps extends PostModalActionsProps {
+interface PostWidgetsProps
+  extends Omit<PostModalActionsProps, 'contextMenuId'> {
   isNavigationFixed?: boolean;
   origin?: PostOrigin;
 }

--- a/packages/shared/src/hooks/useReportPostMenu.ts
+++ b/packages/shared/src/hooks/useReportPostMenu.ts
@@ -1,13 +1,13 @@
 import { TriggerEvent, useContextMenu } from '@dailydotdev/react-contexify';
 import { ContextMenuParams } from '@dailydotdev/react-contexify/dist/types';
 
-export default function useReportPostMenu(): {
+export default function useReportPostMenu(id = 'post-context'): {
   showReportMenu: (
     event: TriggerEvent,
     params?: Pick<ContextMenuParams, 'id' | 'props' | 'position'> | undefined,
   ) => void;
 } {
-  const { show } = useContextMenu({ id: 'post-context' });
+  const { show } = useContextMenu({ id });
 
   return {
     showReportMenu: show,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The IDs of the reusable post-context menu were conflicting with different instances.
- Pass the ID as param to avoid conflict.

Have confirmed, there are no more multiple instances on opening the options at the modal (used to be 3 elements).

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-297 #done
