### PR TITLE
feat: store last sign-in method

### DIFF
--- a/packages/shared/src/components/auth/AuthDefault.tsx
+++ b/packages/shared/src/components/auth/AuthDefault.tsx
@@ -1,8 +1,10 @@
 import React, { ReactElement, ReactNode, useState } from 'react';
+import { storageWrapper as storage } from '../../lib/storageWrapper';
 import { CloseModalFunc } from '../modals/common';
 import AuthModalFooter from './AuthModalFooter';
 import AuthModalHeader from './AuthModalHeader';
 import AuthModalHeading from './AuthModalHeading';
+import { SIGNIN_METHOD_KEY } from './AuthSignBack';
 import { ColumnContainer, providers } from './common';
 import EmailSignupForm from './EmailSignupForm';
 import LoginForm from './LoginForm';
@@ -51,6 +53,11 @@ const AuthDefault = ({
     return onSignup(input.value.trim());
   };
 
+  const onSocialClick = (provider: string) => {
+    storage.setItem(SIGNIN_METHOD_KEY, provider);
+    onProviderClick(provider);
+  };
+
   return (
     <>
       <AuthModalHeader title="Sign up to daily.dev" onClose={onClose} />
@@ -69,14 +76,14 @@ const AuthDefault = ({
               key={provider}
               provider={provider}
               label="Connect with"
-              onClick={() => onProviderClick(provider.toLowerCase())}
+              onClick={() => onSocialClick(provider.toLowerCase())}
               {...props}
             />
           ))}
         {!isV2 && <OrDivider />}
         {shouldLogin ? (
           <LoginForm
-            onSuccessfulLogin={(e) => onClose(e)}
+            onSuccessfulLogin={onClose}
             onForgotPassword={onForgotPassword}
           />
         ) : (

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -5,13 +5,13 @@ import React, {
   useState,
 } from 'react';
 import classNames from 'classnames';
-import AuthContext, { getQueryParams } from '../../contexts/AuthContext';
+import AuthContext from '../../contexts/AuthContext';
 import FeaturesContext from '../../contexts/FeaturesContext';
 import { AuthVersion } from '../../lib/featureValues';
 import { CloseModalFunc } from '../modals/common';
 import TabContainer, { Tab } from '../tabs/TabContainer';
 import AuthDefault from './AuthDefault';
-import { AuthSignBack } from './AuthSignBack';
+import { AuthSignBack, SIGNIN_METHOD_KEY } from './AuthSignBack';
 import ForgotPasswordForm from './ForgotPasswordForm';
 import LoginForm from './LoginForm';
 import {
@@ -26,6 +26,7 @@ import EmailVerificationSent from './EmailVerificationSent';
 import AuthModalHeader from './AuthModalHeader';
 import { AuthFlow, getKratosFlow } from '../../lib/kratos';
 import { fallbackImages } from '../../lib/config';
+import { storageWrapper as storage } from '../../lib/storageWrapper';
 
 export enum Display {
   Default = 'default',
@@ -34,12 +35,6 @@ export enum Display {
   ForgotPassword = 'forgot_password',
   EmailSent = 'email_sent',
 }
-
-const hasLoggedOut = () => {
-  const params = getQueryParams();
-
-  return params?.logged_out !== undefined;
-};
 
 export interface AuthOptionsProps {
   onClose?: CloseModalFunc;
@@ -65,8 +60,8 @@ function AuthOptions({
   const { authVersion } = useContext(FeaturesContext);
   const isV2 = authVersion === AuthVersion.V2;
   const [email, setEmail] = useState('');
-  const [activeDisplay, setActiveDisplay] = useState(
-    hasLoggedOut() ? Display.SignBack : defaultDisplay,
+  const [activeDisplay, setActiveDisplay] = useState(() =>
+    storage.getItem(SIGNIN_METHOD_KEY) ? Display.SignBack : defaultDisplay,
   );
   const { registration, validateRegistration, onSocialRegistration } =
     useRegistration({

--- a/packages/shared/src/components/auth/AuthSignBack.tsx
+++ b/packages/shared/src/components/auth/AuthSignBack.tsx
@@ -1,7 +1,8 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React, { ReactElement, ReactNode, useState } from 'react';
+import { storageWrapper as storage } from '../../lib/storageWrapper';
 import { CloseModalFunc } from '../modals/common';
 import AuthModalHeader from './AuthModalHeader';
-import { ColumnContainer, providerMap } from './common';
+import { ColumnContainer, Provider, providerMap } from './common';
 import OrDivider from './OrDivider';
 import ProviderButton from './ProviderButton';
 
@@ -10,32 +11,41 @@ interface AuthSignBackProps {
   onClose?: CloseModalFunc;
 }
 
-const { twitter, ...rest } = providerMap;
-const providers = Object.values(rest);
+const providers = Object.values(providerMap);
+
+export const SIGNIN_METHOD_KEY = 'signin_method';
 
 export const AuthSignBack = ({
   children,
   onClose,
 }: AuthSignBackProps): ReactElement => {
+  const [signback] = useState<Provider>(() => {
+    const method = storage.getItem(SIGNIN_METHOD_KEY);
+    storage.removeItem(SIGNIN_METHOD_KEY);
+    return providerMap[method];
+  });
+
   return (
     <>
       <AuthModalHeader title="Login to daily.dev" onClose={onClose} />
       <ColumnContainer>
         <ProviderButton
-          provider={twitter.provider}
+          provider={signback.provider}
           label="Login with"
-          {...twitter}
+          {...signback}
         />
         <OrDivider />
         <div className="grid grid-cols-4 gap-3 w-fit">
-          {providers.map(({ provider, style, ...props }) => (
-            <ProviderButton
-              key={provider}
-              provider={provider}
-              style={{ ...style, width: '3.875rem' }}
-              {...props}
-            />
-          ))}
+          {providers
+            .filter(({ provider }) => provider !== signback.provider)
+            .map(({ provider, style, ...props }) => (
+              <ProviderButton
+                key={provider}
+                provider={provider}
+                style={{ ...style, width: '3.875rem' }}
+                {...props}
+              />
+            ))}
         </div>
         {children}
       </ColumnContainer>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Store the last clicked provider used.
- When the user opens the modal that is only when it will be checked for which one was used the last one.
- Once the user has seen the "sign back in" form, it will remove the storage value so next signin will include allowing of registration.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-341 #done
