### PR TITLE
fix: event names click/modal

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -206,6 +206,7 @@ export default function Feed<T>({
     virtualizedNumCards,
     feedName,
     ranking,
+    'go to link',
   );
 
   const onPostModalOpen = (index: number, callback?: () => unknown) => {

--- a/packages/shared/src/hooks/feed/useFeedOnPostClick.ts
+++ b/packages/shared/src/hooks/feed/useFeedOnPostClick.ts
@@ -21,8 +21,14 @@ export default function useFeedOnPostClick(
   columns: number,
   feedName: string,
   ranking?: string,
+  eventName = 'click',
 ): FeedPostClick {
-  const onPostClick = useOnPostClick({ columns, feedName, ranking });
+  const onPostClick = useOnPostClick({
+    eventName,
+    columns,
+    feedName,
+    ranking,
+  });
 
   return useMemo(
     () =>

--- a/packages/shared/src/hooks/useOnPostClick.ts
+++ b/packages/shared/src/hooks/useOnPostClick.ts
@@ -22,12 +22,14 @@ export type FeedPostClick = ({
 }) => Promise<void>;
 
 interface UseOnPostClickProps {
+  eventName?: string;
   columns?: number;
   feedName?: string;
   ranking?: string;
   origin?: Origin;
 }
 export default function useOnPostClick({
+  eventName = 'go to link',
   columns,
   feedName,
   ranking,
@@ -40,7 +42,7 @@ export default function useOnPostClick({
     () =>
       async ({ post, row, column, optional }): Promise<void> => {
         trackEvent(
-          postAnalyticsEvent('go to link', post, {
+          postAnalyticsEvent(eventName, post, {
             columns,
             column,
             row,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Modify default actions to be click
- Side actions defined as what they intend to be

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-366 #done
