### PR TITLE
Wt 331 change email

### DIFF
--- a/packages/shared/src/lib/auth.ts
+++ b/packages/shared/src/lib/auth.ts
@@ -28,6 +28,13 @@ export interface ResetPasswordParameters extends AuthPostParams {
   password: string;
   method: KratosMethod;
 }
+export interface ValidateEmailParameters extends AuthPostParams {
+  'traits.email': string;
+  'traits.name': string;
+  'traits.username': string;
+  'traits.image': string;
+  method: KratosMethod;
+}
 
 export type VerificationParams = KratosFormParams<AccountRecoveryParameters>;
 
@@ -61,6 +68,7 @@ export type ValidateLoginParams = KratosFormParams<
 >;
 export type SettingsParams = KratosFormParams<SettingsParameters>;
 export type ValidateResetPassword = KratosFormParams<ResetPasswordParameters>;
+export type ValidateChangeEmail = KratosFormParams<ValidateEmailParameters>;
 
 export const errorsToJson = <T extends string>(
   data: InitializationData,

--- a/packages/shared/src/lib/boot.ts
+++ b/packages/shared/src/lib/boot.ts
@@ -47,15 +47,8 @@ export type BootCacheData = Pick<
 > & { lastModifier?: string };
 
 export async function getBootData(app: string, url?: string): Promise<Boot> {
-  const version = await import('../../../extension/package.json').then(
-    ({ version: _version }) => _version,
-  );
   const appRoute = app === 'companion' ? '/companion' : '';
-  const params = new URLSearchParams();
-  params.append('v', version);
-  if (url) {
-    params.append('url', url);
-  }
+  const params = url ? new URLSearchParams({ url }) : '';
   const res = await fetch(`${apiUrl}/boot${appRoute}?${params}`, {
     method: 'GET',
     credentials: 'include',

--- a/packages/shared/src/lib/boot.ts
+++ b/packages/shared/src/lib/boot.ts
@@ -47,8 +47,15 @@ export type BootCacheData = Pick<
 > & { lastModifier?: string };
 
 export async function getBootData(app: string, url?: string): Promise<Boot> {
+  const version = await import('../../../extension/package.json').then(
+    ({ version: _version }) => _version,
+  );
   const appRoute = app === 'companion' ? '/companion' : '';
-  const params = url ? new URLSearchParams({ url }) : '';
+  const params = new URLSearchParams();
+  params.append('v', version);
+  if (url) {
+    params.append('url', url);
+  }
   const res = await fetch(`${apiUrl}/boot${appRoute}?${params}`, {
     method: 'GET',
     credentials: 'include',

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -99,7 +99,7 @@ const AccountSecurityPage = (): ReactElement => {
     const email = input?.value?.trim();
 
     if (!email) {
-      return null;
+      return;
     }
 
     const { action, nodes } = settings.ui;
@@ -115,7 +115,7 @@ const AccountSecurityPage = (): ReactElement => {
         'traits.image': getNodeValue('traits.image', nodes),
       },
     });
-    return null;
+    return;
   };
 
   return (

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -115,7 +115,6 @@ const AccountSecurityPage = (): ReactElement => {
         'traits.image': getNodeValue('traits.image', nodes),
       },
     });
-    return;
   };
 
   return (

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -16,7 +16,6 @@ import {
   ValidateResetPassword,
 } from '@dailydotdev/shared/src/lib/auth';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
-import { Simulate } from 'react-dom/test-utils';
 import { AccountSecurityDisplay as Display } from '../../components/layouts/AccountLayout/common';
 import { getAccountLayout } from '../../components/layouts/AccountLayout';
 import AccountSecurityDefault, {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Change email flow

NOTE:
- We probably want to check if the email is still available first
- @sshanzel Noticed that the privileged action modals works, but on verification it doesn't auto continue the flow, is that intended?

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-331 #done
