### PR TITLE
fix: redirect url should be valid for view all button on extension wi…

### DIFF
--- a/packages/shared/src/components/widgets/SimilarPosts.tsx
+++ b/packages/shared/src/components/widgets/SimilarPosts.tsx
@@ -154,7 +154,7 @@ export default function SimilarPosts({
       )}
 
       {Separator}
-      <Link href="/" passHref>
+      <Link href={process.env.NEXT_PUBLIC_WEBAPP_URL} passHref>
         <Button
           className="self-start my-2 ml-2 btn-tertiary"
           buttonSize="small"


### PR DESCRIPTION

<img width="2660" alt="image" src="https://user-images.githubusercontent.com/38607460/187119313-9a0cea59-52a3-48a2-b251-c5c0ae4d8c0b.png">
<img width="1383" alt="image" src="https://user-images.githubusercontent.com/38607460/187119351-ddc2e76e-5653-4174-a576-fc5262a001c1.png">


## Changes

Specific valid URL for `View all` button on extension widget.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
