### PR TITLE
refactor: use window events to require key

### DIFF
--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -20,13 +20,16 @@ import {
   SocialProviderAccount,
 } from './RegistrationForm';
 import { getNodeValue, RegistrationError } from '../../lib/auth';
-import useWindowEvents, {
-  SocialRegistrationFlow,
-} from '../../hooks/useWindowEvents';
+import useWindowEvents from '../../hooks/useWindowEvents';
 import useRegistration from '../../hooks/useRegistration';
 import EmailVerificationSent from './EmailVerificationSent';
 import AuthModalHeader from './AuthModalHeader';
-import { AuthEvent, AuthFlow, getKratosFlow } from '../../lib/kratos';
+import {
+  AuthEvent,
+  AuthFlow,
+  getKratosFlow,
+  SocialRegistrationFlow,
+} from '../../lib/kratos';
 import { fallbackImages } from '../../lib/config';
 import { storageWrapper as storage } from '../../lib/storageWrapper';
 import { providers } from './common';

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -20,7 +20,10 @@ import {
   SocialProviderAccount,
 } from './RegistrationForm';
 import { getNodeValue, RegistrationError } from '../../lib/auth';
-import { EventData, useKeyedWindowEvent } from '../../hooks/useWindowEvents';
+import {
+  SocialRegistrationFlow,
+  useKeyedWindowEvent,
+} from '../../hooks/useWindowEvents';
 import useRegistration from '../../hooks/useRegistration';
 import EmailVerificationSent from './EmailVerificationSent';
 import AuthModalHeader from './AuthModalHeader';
@@ -46,10 +49,6 @@ export interface AuthOptionsProps {
   socialAccount?: SocialProviderAccount;
   defaultDisplay?: Display;
   className?: string;
-}
-
-interface SocialRegistrationFlow extends EventData {
-  flow: string;
 }
 
 function AuthOptions({
@@ -88,7 +87,7 @@ function AuthOptions({
 
   useKeyedWindowEvent<SocialRegistrationFlow>(
     'message',
-    AuthEvent.Registration,
+    AuthEvent.SocialRegistration,
     async (e) => {
       if (!e.data?.flow) {
         return;

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -20,9 +20,8 @@ import {
   SocialProviderAccount,
 } from './RegistrationForm';
 import { getNodeValue, RegistrationError } from '../../lib/auth';
-import {
+import useWindowEvents, {
   SocialRegistrationFlow,
-  useKeyedWindowEvent,
 } from '../../hooks/useWindowEvents';
 import useRegistration from '../../hooks/useRegistration';
 import EmailVerificationSent from './EmailVerificationSent';
@@ -85,7 +84,7 @@ function AuthOptions({
       onRedirect: (redirect) => window.open(redirect),
     });
 
-  useKeyedWindowEvent<SocialRegistrationFlow>(
+  useWindowEvents<SocialRegistrationFlow>(
     'message',
     AuthEvent.SocialRegistration,
     async (e) => {

--- a/packages/shared/src/hooks/useLogin.ts
+++ b/packages/shared/src/hooks/useLogin.ts
@@ -9,6 +9,7 @@ import {
   ValidateLoginParams,
 } from '../lib/auth';
 import {
+  AuthEvent,
   AuthFlow,
   EmptyObjectLiteral,
   getKratosSession,
@@ -16,7 +17,7 @@ import {
   initializeKratosFlow,
   submitKratosFlow,
 } from '../lib/kratos';
-import useWindowEvents from './useWindowEvents';
+import { useKeyedWindowEvent } from './useWindowEvents';
 
 interface UseLogin {
   loginFlowData: InitializationData;
@@ -97,12 +98,17 @@ const useLogin = ({
     onPasswordLogin({ action, params });
   };
 
-  useWindowEvents('message', async (e) => {
-    if (!e.data?.flow) {
+  useKeyedWindowEvent('message', AuthEvent.Login, async () => {
+    if (!session) {
       return;
     }
 
     const verified = await getKratosSession();
+
+    if (!verified) {
+      return;
+    }
+
     const hasRenewedSession =
       session.authenticated_at !== verified.authenticated_at;
 

--- a/packages/shared/src/hooks/useLogin.ts
+++ b/packages/shared/src/hooks/useLogin.ts
@@ -17,7 +17,7 @@ import {
   initializeKratosFlow,
   submitKratosFlow,
 } from '../lib/kratos';
-import { useKeyedWindowEvent } from './useWindowEvents';
+import useWindowEvents from './useWindowEvents';
 
 interface UseLogin {
   loginFlowData: InitializationData;
@@ -98,7 +98,7 @@ const useLogin = ({
     onPasswordLogin({ action, params });
   };
 
-  useKeyedWindowEvent('message', AuthEvent.Login, async () => {
+  useWindowEvents('message', AuthEvent.Login, async () => {
     if (!session) {
       return;
     }

--- a/packages/shared/src/hooks/usePrivilegedSession.ts
+++ b/packages/shared/src/hooks/usePrivilegedSession.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
+import { useQuery, useQueryClient } from 'react-query';
 import { LoginFormParams } from '../components/auth/LoginForm';
 import useLogin from './useLogin';
-import usePersistentContext from './usePersistentContext';
 import { useToastNotification } from './useToastNotification';
 
 interface UsePrivilegedSession {
@@ -22,8 +22,10 @@ const usePrivilegedSession = ({
   onSessionVerified,
 }: UsePrivilegedSessionProps = {}): UsePrivilegedSession => {
   const { displayToast } = useToastNotification();
-  const [verifySessionId, setVerifySessionId] =
-    usePersistentContext(VERIFY_SESSION_KEY);
+  const { data: verifySessionId } = useQuery(VERIFY_SESSION_KEY);
+  const client = useQueryClient();
+  const setVerifySessionId = (value: string) =>
+    client.setQueryData(VERIFY_SESSION_KEY, value);
 
   const { loginFlowData, loginHint, onSocialLogin, onPasswordLogin } = useLogin(
     {

--- a/packages/shared/src/hooks/useWindowEvents.ts
+++ b/packages/shared/src/hooks/useWindowEvents.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
 import { AuthEvent } from '../lib/kratos';
 
 interface EventData {
@@ -14,31 +14,21 @@ export interface SocialRegistrationFlow extends EventData {
 
 const useWindowEvents = <T extends EventData = EventData>(
   event: EventParameter,
-  func: KeyedWindowEventHandler<T>,
-): void => {
-  useEffect(() => {
-    window.addEventListener(event, func);
-    return () => window.removeEventListener(event, func);
-  }, [event, func]);
-};
-
-export const useKeyedWindowEvent = <T extends EventData = EventData>(
-  event: EventParameter,
   key: string,
   func: KeyedWindowEventHandler<T>,
 ): void => {
-  useWindowEvents(
-    event,
-    useCallback(
-      (e: MessageEvent<T>) => {
-        if (!e.data?.eventKey || e.data.eventKey !== key) {
-          return;
-        }
-        func(e);
-      },
-      [event, key, func],
-    ),
-  );
+  useEffect(() => {
+    const handler = (e: MessageEvent<T>) => {
+      if (!e.data?.eventKey || e.data.eventKey !== key) {
+        return;
+      }
+
+      func(e);
+    };
+
+    window.addEventListener(event, handler);
+    return () => window.removeEventListener(event, handler);
+  }, [event, func]);
 };
 
 export default useWindowEvents;

--- a/packages/shared/src/hooks/useWindowEvents.ts
+++ b/packages/shared/src/hooks/useWindowEvents.ts
@@ -1,12 +1,16 @@
 import { useCallback, useEffect } from 'react';
 import { AuthEvent } from '../lib/kratos';
 
-export interface EventData {
+interface EventData {
   eventKey?: AuthEvent | string;
 }
 
 type EventParameter = keyof WindowEventMap;
 type KeyedWindowEventHandler<T = unknown> = (e: MessageEvent<T>) => void;
+
+export interface SocialRegistrationFlow extends EventData {
+  flow: string;
+}
 
 const useWindowEvents = <T extends EventData = EventData>(
   event: EventParameter,

--- a/packages/shared/src/hooks/useWindowEvents.ts
+++ b/packages/shared/src/hooks/useWindowEvents.ts
@@ -1,18 +1,13 @@
 import { useEffect } from 'react';
-import { AuthEvent } from '../lib/kratos';
 
-interface EventData {
-  eventKey?: AuthEvent | string;
+export interface MessageEventData {
+  eventKey?: string;
 }
 
 type EventParameter = keyof WindowEventMap;
 type KeyedWindowEventHandler<T = unknown> = (e: MessageEvent<T>) => void;
 
-export interface SocialRegistrationFlow extends EventData {
-  flow: string;
-}
-
-const useWindowEvents = <T extends EventData = EventData>(
+const useWindowEvents = <T extends MessageEventData = MessageEventData>(
   event: EventParameter,
   key: string,
   func: KeyedWindowEventHandler<T>,

--- a/packages/shared/src/hooks/useWindowEvents.ts
+++ b/packages/shared/src/hooks/useWindowEvents.ts
@@ -1,14 +1,40 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
+import { AuthEvent } from '../lib/kratos';
 
-// to make intellisense work on the first parameter
-const useWindowEvents: typeof window.addEventListener = (
-  event: string,
-  func: (e: Event) => void,
+export interface EventData {
+  eventKey?: AuthEvent | string;
+}
+
+type EventParameter = keyof WindowEventMap;
+type KeyedWindowEventHandler<T = unknown> = (e: MessageEvent<T>) => void;
+
+const useWindowEvents = <T extends EventData = EventData>(
+  event: EventParameter,
+  func: KeyedWindowEventHandler<T>,
 ): void => {
   useEffect(() => {
     window.addEventListener(event, func);
     return () => window.removeEventListener(event, func);
   }, [event, func]);
+};
+
+export const useKeyedWindowEvent = <T extends EventData = EventData>(
+  event: EventParameter,
+  key: string,
+  func: KeyedWindowEventHandler<T>,
+): void => {
+  useWindowEvents(
+    event,
+    useCallback(
+      (e: MessageEvent<T>) => {
+        if (!e.data?.eventKey || e.data.eventKey !== key) {
+          return;
+        }
+        func(e);
+      },
+      [event, key, func],
+    ),
+  );
 };
 
 export default useWindowEvents;

--- a/packages/shared/src/lib/func.ts
+++ b/packages/shared/src/lib/func.ts
@@ -26,6 +26,4 @@ export const postWindowMessage = (
   eventKey: string,
   params: EmptyObjectLiteral,
   attributes = '*',
-): void => {
-  window.opener.postMessage({ ...params, eventKey }, attributes);
-};
+): void => window.opener.postMessage({ ...params, eventKey }, attributes);

--- a/packages/shared/src/lib/func.ts
+++ b/packages/shared/src/lib/func.ts
@@ -1,3 +1,4 @@
+import { EmptyObjectLiteral } from './kratos';
 export const nextTick = (): Promise<unknown> =>
   new Promise((resolve) => setTimeout(resolve));
 
@@ -20,3 +21,11 @@ export const disabledRefetch = {
 };
 
 Object.freeze(disabledRefetch);
+
+export const postWindowMessage = (
+  eventKey: string,
+  params: EmptyObjectLiteral,
+  attributes = '*',
+): void => {
+  window.opener.postMessage({ ...params, eventKey }, attributes);
+};

--- a/packages/shared/src/lib/func.ts
+++ b/packages/shared/src/lib/func.ts
@@ -1,4 +1,5 @@
 import { EmptyObjectLiteral } from './kratos';
+
 export const nextTick = (): Promise<unknown> =>
   new Promise((resolve) => setTimeout(resolve));
 

--- a/packages/shared/src/lib/kratos.ts
+++ b/packages/shared/src/lib/kratos.ts
@@ -177,6 +177,11 @@ export interface SuccessfulRegistrationData {
   identity: Identity;
 }
 
+export enum AuthEvent {
+  Login = 'login',
+  Registration = 'registration',
+}
+
 export enum AuthFlow {
   Login = '/login',
   Registration = '/registration',

--- a/packages/shared/src/lib/kratos.ts
+++ b/packages/shared/src/lib/kratos.ts
@@ -1,6 +1,11 @@
+import { MessageEventData } from '../hooks/useWindowEvents';
 import { authUrl, heimdallUrl } from './constants';
 
 export type EmptyObjectLiteral = Record<string, never | string>;
+
+export interface SocialRegistrationFlow extends MessageEventData {
+  flow: string;
+}
 
 interface InitializationNodeAttribute {
   name: string;

--- a/packages/shared/src/lib/kratos.ts
+++ b/packages/shared/src/lib/kratos.ts
@@ -179,7 +179,7 @@ export interface SuccessfulRegistrationData {
 
 export enum AuthEvent {
   Login = 'login',
-  Registration = 'registration',
+  SocialRegistration = 'social_registration',
 }
 
 export enum AuthFlow {

--- a/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
@@ -25,9 +25,8 @@ import UnlinkModal from '@dailydotdev/shared/src/components/modals/UnlinkModal';
 import { getNodeByKey, SettingsParams } from '@dailydotdev/shared/src/lib/auth';
 import DeleteAccountModal from '@dailydotdev/shared/src/components/modals/DeleteAccountModal';
 import DeletedAccountConfirmationModal from '@dailydotdev/shared/src/components/modals/DeletedAccountConfirmationModal';
-import {
+import useWindowEvents, {
   SocialRegistrationFlow,
-  useKeyedWindowEvent,
 } from '@dailydotdev/shared/src/hooks/useWindowEvents';
 import AlreadyLinkedModal from '@dailydotdev/shared/src/components/modals/AlreadyLinkedModal';
 import { PasswordField } from '@dailydotdev/shared/src/components/fields/PasswordField';
@@ -81,7 +80,7 @@ function AccountSecurityDefault({
     initializeKratosFlow(AuthFlow.Settings),
   );
 
-  useKeyedWindowEvent<SocialRegistrationFlow>(
+  useWindowEvents<SocialRegistrationFlow>(
     'message',
     AuthEvent.SocialRegistration,
     async (e) => {

--- a/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
@@ -19,15 +19,14 @@ import {
   getKratosProviders,
   getKratosSettingsFlow,
   initializeKratosFlow,
+  SocialRegistrationFlow,
   submitKratosFlow,
 } from '@dailydotdev/shared/src/lib/kratos';
 import UnlinkModal from '@dailydotdev/shared/src/components/modals/UnlinkModal';
 import { getNodeByKey, SettingsParams } from '@dailydotdev/shared/src/lib/auth';
 import DeleteAccountModal from '@dailydotdev/shared/src/components/modals/DeleteAccountModal';
 import DeletedAccountConfirmationModal from '@dailydotdev/shared/src/components/modals/DeletedAccountConfirmationModal';
-import useWindowEvents, {
-  SocialRegistrationFlow,
-} from '@dailydotdev/shared/src/hooks/useWindowEvents';
+import useWindowEvents from '@dailydotdev/shared/src/hooks/useWindowEvents';
 import AlreadyLinkedModal from '@dailydotdev/shared/src/components/modals/AlreadyLinkedModal';
 import { PasswordField } from '@dailydotdev/shared/src/components/fields/PasswordField';
 import { formToJson } from '@dailydotdev/shared/src/lib/form';

--- a/packages/webapp/pages/callback.tsx
+++ b/packages/webapp/pages/callback.tsx
@@ -1,10 +1,12 @@
+import { AuthEvent } from '@dailydotdev/shared/src/lib/kratos';
 import { ReactElement, useEffect } from 'react';
 
 function CallbackPage(): ReactElement {
   useEffect(() => {
     const urlSearchParams = new URLSearchParams(window.location.search);
     const params = Object.fromEntries(urlSearchParams.entries());
-    window.opener.postMessage(params, '*');
+    const eventKey = params.flow ? AuthEvent.Registration : AuthEvent.Login;
+    window.opener.postMessage({ ...params, eventKey }, '*');
     window.close();
   }, []);
 

--- a/packages/webapp/pages/callback.tsx
+++ b/packages/webapp/pages/callback.tsx
@@ -6,7 +6,9 @@ function CallbackPage(): ReactElement {
   useEffect(() => {
     const urlSearchParams = new URLSearchParams(window.location.search);
     const params = Object.fromEntries(urlSearchParams.entries());
-    const eventKey = params.flow ? AuthEvent.Registration : AuthEvent.Login;
+    const eventKey = params.flow
+      ? AuthEvent.SocialRegistration
+      : AuthEvent.Login;
     postWindowMessage(eventKey, params);
     window.close();
   }, []);

--- a/packages/webapp/pages/callback.tsx
+++ b/packages/webapp/pages/callback.tsx
@@ -1,3 +1,4 @@
+import { postWindowMessage } from '@dailydotdev/shared/src/lib/func';
 import { AuthEvent } from '@dailydotdev/shared/src/lib/kratos';
 import { ReactElement, useEffect } from 'react';
 
@@ -6,7 +7,7 @@ function CallbackPage(): ReactElement {
     const urlSearchParams = new URLSearchParams(window.location.search);
     const params = Object.fromEntries(urlSearchParams.entries());
     const eventKey = params.flow ? AuthEvent.Registration : AuthEvent.Login;
-    window.opener.postMessage({ ...params, eventKey }, '*');
+    postWindowMessage(eventKey, params);
     window.close();
   }, []);
 

--- a/packages/webapp/pages/callback.tsx
+++ b/packages/webapp/pages/callback.tsx
@@ -6,9 +6,9 @@ function CallbackPage(): ReactElement {
   useEffect(() => {
     const urlSearchParams = new URLSearchParams(window.location.search);
     const params = Object.fromEntries(urlSearchParams.entries());
-    const eventKey = params.flow
-      ? AuthEvent.SocialRegistration
-      : AuthEvent.Login;
+    const eventKey = params.login
+      ? AuthEvent.Login
+      : AuthEvent.SocialRegistration;
     postWindowMessage(eventKey, params);
     window.close();
   }, []);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Create a hook that wraps the usage of window event to utilize an event key in determining if the call should proceed.
- Refactor old usage of window event to use the new one.
- Enforce sending an event key on post message function.
- Fix persisting the session verification modal on reload by making it live through current session only.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-378 #done
