### PR TITLE
refactor: sidebar nav padding avoiding layout shift

### DIFF
--- a/packages/webapp/components/layouts/AccountLayout/SidebarNav.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/SidebarNav.tsx
@@ -12,7 +12,6 @@ import {
 
 interface SidebarNavProps {
   className?: string;
-  activePage?: AccountPage;
   basePath?: string;
 }
 
@@ -21,7 +20,6 @@ const pageKeys = Object.keys(accountPage) as AccountPage[];
 function SidebarNav({
   className,
   basePath = '',
-  activePage = AccountPage.Profile,
 }: SidebarNavProps): ReactElement {
   const { user } = useContext(AuthContext);
 
@@ -31,17 +29,20 @@ function SidebarNav({
 
   return (
     <div className={classNames('flex flex-col items-center', className)}>
-      {pageKeys.map((key) => (
-        <SidebarNavItem
-          key={key}
-          title={accountPage[key].title}
-          href={`/${basePath}${accountPage[key].href}`}
-          icon={accountPage[key].getIcon({
-            user,
-            isActive: key === activePage,
-          })}
-        />
-      ))}
+      {pageKeys.map((key) => {
+        const href = `/${basePath}${accountPage[key].href}`;
+        const isActive = window.location.pathname === href;
+
+        return (
+          <SidebarNavItem
+            key={key}
+            title={accountPage[key].title}
+            href={href}
+            isActive={isActive}
+            icon={accountPage[key].getIcon({ user, isActive })}
+          />
+        );
+      })}
       <AccountSidebarPagesSection>
         {accountSidebarPages.map((accountSidebarPage) => (
           <Link

--- a/packages/webapp/components/layouts/AccountLayout/SidebarNavItem.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/SidebarNavItem.tsx
@@ -7,6 +7,7 @@ interface SidebarNavItemProps {
   title: string;
   icon: ReactNode;
   href: string;
+  isActive?: boolean;
   className?: string;
 }
 
@@ -14,16 +15,16 @@ function SidebarNavItem({
   icon,
   href,
   title,
+  isActive,
   className,
 }: SidebarNavItemProps): ReactElement {
-  const isActive = window.location.pathname === href;
-
   return (
     <Link href={href}>
       <a
         className={classNames(
           'flex flex-row p-4 rounded-16 w-64',
           isActive && 'border border-theme-divider-tertiary bg-theme-active',
+          isActive && 'p-[0.9375rem]', // to avoid layout shift for when the border (1px) is displayed being active
           className,
         )}
       >

--- a/packages/webapp/components/layouts/AccountLayout/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/index.tsx
@@ -7,18 +7,15 @@ import { NextSeo } from 'next-seo';
 import dynamic from 'next/dynamic';
 import { getLayout as getMainLayout } from '../MainLayout';
 import SidebarNav from './SidebarNav';
-import { AccountPage } from './common';
 
 const Custom404 = dynamic(() => import('../../../pages/404'));
 
 export interface AccountLayoutProps {
   profile: PublicProfile;
   children?: ReactNode;
-  activePage?: AccountPage;
 }
 
 export default function AccountLayout({
-  activePage,
   children,
 }: AccountLayoutProps): ReactElement {
   const { user: profile } = useContext(AuthContext);
@@ -56,7 +53,6 @@ export default function AccountLayout({
       <main className="flex relative flex-row flex-1 pt-0 mx-auto w-[calc(100vw-17.5rem)]">
         <SidebarNav
           className="px-6 pt-6 ml-auto border-l border-theme-divider-tertiary"
-          activePage={activePage}
           basePath="account"
         />
         {children}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Reduce the padding based on how much border is being produced to keep the size consistent.
- Tried to apply border-box but didn't work

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-383 #done
