### PR TITLE
Wt 388 fix accepted marketing

### DIFF
--- a/packages/shared/src/contexts/AlertContext.tsx
+++ b/packages/shared/src/contexts/AlertContext.tsx
@@ -5,7 +5,7 @@ import { Alerts, UPDATE_ALERTS } from '../graphql/alerts';
 import { apiUrl } from '../lib/config';
 
 export const ALERT_DEFAULTS: Alerts = {
-  filter: false,
+  filter: true,
   rankLastSeen: null,
   myFeed: null,
 };

--- a/packages/webapp/__tests__/TagPage.tsx
+++ b/packages/webapp/__tests__/TagPage.tsx
@@ -25,6 +25,7 @@ import {
   mockGraphQL,
 } from '@dailydotdev/shared/__tests__/helpers/graphql';
 import { waitForNock } from '@dailydotdev/shared/__tests__/helpers/utilities';
+import { AlertContextProvider } from '@dailydotdev/shared/src/contexts/AlertContext';
 import TagPage from '../pages/tags/[tag]';
 import { FEED_SETTINGS_QUERY } from '../../shared/src/graphql/feedSettings';
 
@@ -117,9 +118,11 @@ const renderComponent = (
           getRedirectUri: jest.fn(),
         }}
       >
-        <SettingsContext.Provider value={settingsContext}>
-          <TagPage tag="react" />
-        </SettingsContext.Provider>
+        <AlertContextProvider alerts={{}} updateAlerts={jest.fn()} loadedAlerts>
+          <SettingsContext.Provider value={settingsContext}>
+            <TagPage tag="react" />
+          </SettingsContext.Provider>
+        </AlertContextProvider>
       </AuthContext.Provider>
     </QueryClientProvider>,
   );

--- a/packages/webapp/pages/account/others.tsx
+++ b/packages/webapp/pages/account/others.tsx
@@ -62,6 +62,7 @@ const AccountOthersPage = (): ReactElement => {
           name="newsletter"
           className="mt-6"
           compact={false}
+          checked={user.acceptedMarketing}
           onToggle={() =>
             updateUserProfile({ acceptedMarketing: !user.acceptedMarketing })
           }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added the checked value for the switch component
- Changed alert filter to default true, this is the database default and it caused weird sideffect where re-render got the wrong default value.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-388 #done
