### PR TITLE
fix: my feed modal mobile was having some width issues and overflow scroll

### DIFF
--- a/garden.yml
+++ b/garden.yml
@@ -26,3 +26,5 @@ services:
       NEXT_PUBLIC_SUBS_URL: "ws://${var.api-hostname}/graphql"
       NEXT_PUBLIC_DOMAIN: "${var.hostname}"
       NEXT_PUBLIC_WEBAPP_URL: /
+      NEXT_PUBLIC_AUTH_URL: "http://${var.kratos-hostname}"
+      NEXT_PUBLIC_HEIMDALL_URL: "http://${var.heimdall-hostname}"

--- a/packages/shared/src/components/MyFeedIntro.tsx
+++ b/packages/shared/src/components/MyFeedIntro.tsx
@@ -36,7 +36,7 @@ const TagPill = ({
 
 export const MyFeedIntro = (): ReactElement => {
   return (
-    <div className="flex overflow-hidden flex-col justify-center items-center p-6 mobileL:px-10 h-full">
+    <div className="flex overflow-hidden absolute flex-col justify-center items-center p-6 mobileL:px-10 w-full h-full">
       <UserIcon size="xxxxlarge" />
       <h3 className="mt-4 font-bold typo-large-title">Create my feed</h3>
       <p className="mt-3 mb-16 text-center typo-title3 text-theme-label-tertiary">

--- a/packages/shared/src/components/modals/AccountDetailsModal.module.css
+++ b/packages/shared/src/components/modals/AccountDetailsModal.module.css
@@ -9,13 +9,13 @@
   }
 }
 .myFeedModal {
-& :global(.modal) {
+  & :global(.modal) {
     padding: 3rem 0 4.0625rem 0;
 
-@screen responsiveModalBreakpoint {
-  max-height: 40rem;
-  padding-top: 0;
-  padding-bottom: 0;
-}
-}
+    @screen responsiveModalBreakpoint {
+      max-height: 40rem;
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+  }
 }

--- a/packages/shared/src/components/modals/AccountDetailsModal.module.css
+++ b/packages/shared/src/components/modals/AccountDetailsModal.module.css
@@ -8,3 +8,14 @@
     }
   }
 }
+.myFeedModal {
+& :global(.modal) {
+    padding: 3rem 0 4.0625rem 0;
+
+@screen responsiveModalBreakpoint {
+  max-height: 40rem;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+}
+}

--- a/packages/shared/src/components/modals/AccountDetailsModal.module.css
+++ b/packages/shared/src/components/modals/AccountDetailsModal.module.css
@@ -10,7 +10,7 @@
 }
 .myFeedModal {
   & :global(.modal) {
-    padding: 3rem 0 4.0625rem 0;
+    padding: 4.0625rem 0 4.0625rem 0;
 
     @screen responsiveModalBreakpoint {
       max-height: 40rem;

--- a/packages/shared/src/components/modals/CreateMyFeedModal.tsx
+++ b/packages/shared/src/components/modals/CreateMyFeedModal.tsx
@@ -88,7 +88,7 @@ export default function CreateMyFeedModal({
       {...modalProps}
       style={{
         content: {
-          height: '100%',
+          height: '180rem',
         },
       }}
       onRequestClose={closableVariants.includes(version) && onRequestClose}

--- a/packages/shared/src/components/modals/CreateMyFeedModal.tsx
+++ b/packages/shared/src/components/modals/CreateMyFeedModal.tsx
@@ -88,7 +88,7 @@ export default function CreateMyFeedModal({
       {...modalProps}
       style={{
         content: {
-          height: '180rem',
+          height: '100%',
         },
       }}
       onRequestClose={closableVariants.includes(version) && onRequestClose}

--- a/packages/shared/src/components/modals/CreateMyFeedModal.tsx
+++ b/packages/shared/src/components/modals/CreateMyFeedModal.tsx
@@ -88,7 +88,7 @@ export default function CreateMyFeedModal({
       {...modalProps}
       style={{
         content: {
-          height: '180rem',
+          height: '100%',
         },
       }}
       onRequestClose={closableVariants.includes(version) && onRequestClose}
@@ -118,7 +118,7 @@ export default function CreateMyFeedModal({
       </section>
       <footer
         className={classNames(
-          'flex w-full fixed responsiveModalBreakpoint:sticky bottom-0 items-center border-t border-theme-divider-tertiary bg-theme-bg-tertiary py-3',
+          'flex w-full fixed responsiveModalBreakpoint:sticky bottom-0 left-0 items-center border-t border-theme-divider-tertiary bg-theme-bg-tertiary py-3',
           version === 'v3' ? 'justify-between px-4' : 'justify-center',
         )}
       >

--- a/packages/shared/src/components/modals/CreateMyFeedModal.tsx
+++ b/packages/shared/src/components/modals/CreateMyFeedModal.tsx
@@ -84,7 +84,7 @@ export default function CreateMyFeedModal({
 
   return (
     <ResponsiveModal
-      className={classNames(className, styles.accountDetailsModal)}
+      className={classNames(className, styles.myFeedModal)}
       {...modalProps}
       style={{
         content: {
@@ -107,12 +107,18 @@ export default function CreateMyFeedModal({
           )}
         </header>
       )}
-      <section className={classNames('flex-1', !showIntro && 'mt-6')}>
+      <section
+        className={classNames(
+          ' flex-1',
+          showIntro && 'flex items-center justify-center',
+          !showIntro && 'mt-6',
+        )}
+      >
         {showIntro ? <MyFeedIntro /> : <TagsFilter />}
       </section>
       <footer
         className={classNames(
-          'flex fixed responsiveModalBreakpoint:sticky bottom-0 items-center border-t border-theme-divider-tertiary bg-theme-bg-tertiary py-3',
+          'flex w-full fixed responsiveModalBreakpoint:sticky bottom-0 items-center border-t border-theme-divider-tertiary bg-theme-bg-tertiary py-3',
           version === 'v3' ? 'justify-between px-4' : 'justify-center',
         )}
       >

--- a/packages/shared/src/components/modals/ResponsiveModal.module.css
+++ b/packages/shared/src/components/modals/ResponsiveModal.module.css
@@ -2,6 +2,9 @@
   & :global(.overlay) {
     position: relative;
     min-height: 100vh;
+    min-height: -moz-available;
+    min-height: -webkit-fill-available;
+    min-height: fill-available;
     padding: 0;
 
     &:global(.fixed-position) {

--- a/packages/shared/src/components/modals/ResponsiveModal.module.css
+++ b/packages/shared/src/components/modals/ResponsiveModal.module.css
@@ -1,10 +1,10 @@
 .responsiveModal {
   & :global(.overlay) {
     position: relative;
-    min-height: 100vh;
     min-height: -moz-available;
     min-height: -webkit-fill-available;
     min-height: fill-available;
+    min-height: 100vh;
     padding: 0;
 
     &:global(.fixed-position) {

--- a/packages/shared/src/components/modals/ResponsiveModal.module.css
+++ b/packages/shared/src/components/modals/ResponsiveModal.module.css
@@ -1,10 +1,11 @@
 .responsiveModal {
   & :global(.overlay) {
     position: relative;
+    min-height: 100vh;
     min-height: -moz-available;
     min-height: -webkit-fill-available;
     min-height: fill-available;
-    min-height: 100vh;
+    height: 100vh;
     padding: 0;
 
     &:global(.fixed-position) {

--- a/packages/shared/src/components/modals/StyledModal.module.css
+++ b/packages/shared/src/components/modals/StyledModal.module.css
@@ -10,8 +10,6 @@
     right: 0;
     bottom: 0;
     max-height: 100vh;
-    padding-left: 1.25rem;
-    padding-right: 1.25rem;
     background: var(--theme-overlay-quaternary);
     z-index: 10;
   }

--- a/packages/shared/src/components/modals/StyledModal.module.css
+++ b/packages/shared/src/components/modals/StyledModal.module.css
@@ -20,8 +20,6 @@
     display: flex;
     position: relative;
     width: 100%;
-    max-width: 26.25rem;
-    max-height: 100%;
     overflow-y: auto;
     flex-direction: column;
     align-items: center;

--- a/packages/shared/src/components/modals/StyledModal.tsx
+++ b/packages/shared/src/components/modals/StyledModal.tsx
@@ -21,7 +21,7 @@ export function ReactModalAdapter({
       portalClassName={className.toString()}
       overlayClassName={classNames('overlay', overlayClassName)}
       style={{
-        // stylelint-disable-next-line property-no-unknown
+        // stylelint-disable-next-line selector-type-no-unknown
         overlay: {
           paddingLeft: '1.25rem',
           paddingRight: '1.25rem',

--- a/packages/shared/src/components/modals/StyledModal.tsx
+++ b/packages/shared/src/components/modals/StyledModal.tsx
@@ -21,6 +21,7 @@ export function ReactModalAdapter({
       portalClassName={className.toString()}
       overlayClassName={classNames('overlay', overlayClassName)}
       style={{
+        // stylelint-disable-next-line property-no-unknown
         overlay: {
           paddingLeft: '1.25rem',
           paddingRight: '1.25rem',

--- a/packages/shared/src/components/modals/StyledModal.tsx
+++ b/packages/shared/src/components/modals/StyledModal.tsx
@@ -21,6 +21,10 @@ export function ReactModalAdapter({
       portalClassName={className.toString()}
       overlayClassName={classNames('overlay', overlayClassName)}
       style={{
+        overlay: {
+          paddingLeft: '1.25rem',
+          paddingRight: '1.25rem',
+        },
         content: {
           maxHeight: '100%',
           maxWidth: '26.25rem',

--- a/packages/shared/src/components/modals/StyledModal.tsx
+++ b/packages/shared/src/components/modals/StyledModal.tsx
@@ -20,6 +20,12 @@ export function ReactModalAdapter({
     <Modal
       portalClassName={className.toString()}
       overlayClassName={classNames('overlay', overlayClassName)}
+      style={{
+        content: {
+          maxHeight: '100%',
+          maxWidth: '26.25rem',
+        },
+      }}
       className={classNames('focus:outline-none modal', contentClassName)}
       {...props}
     />

--- a/project.garden.yml
+++ b/project.garden.yml
@@ -34,6 +34,8 @@ variables:
   kratos-hostname: sso.apps.local.app.garden
   kratos-ui-hostname: kratos-ui.apps.local.app.garden
   kratos-database: kratos
+  heimdall-hostname: heimdall.apps.local.app.garden
+  kratos-cookie-domain: apps.local.app.garden
   # Common
   postgres-databases: api,kratos
   postgres-username: postgres


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The mobile my feed modal had bottom spacing for the footer which caused overscroll
- It was also not positioned at full-width on mobile
- Tested on desktop/mobile changes, yet to try on physical device (based on preview URL)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-391 #done
