### PR TITLE
fix: read article button open new tab

### DIFF
--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -33,6 +33,7 @@ export interface ActionButtonsProps {
   postCardVersion?: string;
   postModalByDefault?: boolean;
   postEngagementNonClickable?: boolean;
+  openNewTab?: boolean;
 }
 
 const getContainer = (displayWhenHovered = false, className?: string) =>
@@ -46,6 +47,7 @@ const getContainer = (displayWhenHovered = false, className?: string) =>
   );
 
 export default function ActionButtons({
+  openNewTab,
   post,
   onUpvoteClick,
   onCommentClick,
@@ -161,6 +163,7 @@ export default function ActionButtons({
             href={post.permalink}
             className="btn-tertiary"
             onClick={onReadArticleClick}
+            openNewTab={openNewTab}
           />
         )}
         {(!insaneMode || !postModalByDefault || postEngagementNonClickable) &&

--- a/packages/shared/src/components/cards/PostCard.tsx
+++ b/packages/shared/src/components/cards/PostCard.tsx
@@ -109,6 +109,7 @@ export const PostCard = forwardRef(function PostCard(
       <CardTextContainer>
         {isV1 && (
           <PostCardHeader
+            openNewTab={openNewTab}
             source={post.source}
             postLink={post.permalink}
             onMenuClick={(event) => onMenuClick?.(event, post)}
@@ -136,6 +137,7 @@ export const PostCard = forwardRef(function PostCard(
                 ? 'relative tablet:absolute tablet:right-0 tablet:bottom-0 tablet:left-0 mt-2 tablet:mt-0 tablet:border-0 border-t border-theme-divider-tertiary'
                 : 'absolute right-0 bottom-0 left-0',
             )}
+            openNewTab={openNewTab}
             postLink={post.permalink}
             source={post.source}
             author={post.author}
@@ -170,6 +172,7 @@ export const PostCard = forwardRef(function PostCard(
           </div>
         )}
         <ActionButtons
+          openNewTab={openNewTab}
           post={post}
           onUpvoteClick={onUpvoteClick}
           onCommentClick={onCommentClick}

--- a/packages/shared/src/components/cards/PostCardHeader.tsx
+++ b/packages/shared/src/components/cards/PostCardHeader.tsx
@@ -13,6 +13,7 @@ interface CardHeaderProps extends PostCardTests {
   onMenuClick?: (e: React.MouseEvent) => void;
   onReadArticleClick?: (e: React.MouseEvent) => unknown;
   postLink: string;
+  openNewTab?: boolean;
 }
 
 const Container = getGroupedHoverContainer('span');
@@ -25,6 +26,7 @@ export const PostCardHeader = ({
   postLink,
   postModalByDefault,
   postEngagementNonClickable,
+  openNewTab,
 }: CardHeaderProps): ReactElement => {
   return (
     <CardHeader>
@@ -36,6 +38,7 @@ export const PostCardHeader = ({
             className="mr-2 btn-primary"
             href={postLink}
             onClick={onReadArticleClick}
+            openNewTab={openNewTab}
           />
         )}
         <OptionsButton onClick={onMenuClick} tooltipPlacement="top" />

--- a/packages/shared/src/components/cards/PostFooterOverlay.tsx
+++ b/packages/shared/src/components/cards/PostFooterOverlay.tsx
@@ -16,6 +16,7 @@ interface PostFooterOverlayProps extends PostCardTests {
   source: Source;
   postLink: string;
   insaneMode?: boolean;
+  openNewTab?: boolean;
   onReadArticleClick?: (e: React.MouseEvent) => unknown;
 }
 
@@ -33,6 +34,7 @@ export const PostFooterOverlay = ({
   onReadArticleClick,
   postModalByDefault,
   postEngagementNonClickable,
+  openNewTab,
 }: PostFooterOverlayProps): ReactElement => {
   return (
     <div className={classNames('flex flex-row p-2', className)}>
@@ -62,6 +64,7 @@ export const PostFooterOverlay = ({
           )}
           href={postLink}
           onClick={onReadArticleClick}
+          openNewTab={openNewTab}
         />
       )}
     </div>

--- a/packages/shared/src/components/cards/PostList.tsx
+++ b/packages/shared/src/components/cards/PostList.tsx
@@ -109,6 +109,7 @@ export const PostList = forwardRef(function PostList(
           )}
           <ActionButtons
             post={post}
+            openNewTab={openNewTab}
             onUpvoteClick={onUpvoteClick}
             onCommentClick={onCommentClick}
             onBookmarkClick={onBookmarkClick}

--- a/packages/shared/src/components/cards/ReadArticleButton.tsx
+++ b/packages/shared/src/components/cards/ReadArticleButton.tsx
@@ -5,18 +5,20 @@ import OpenLinkIcon from '../icons/OpenLink';
 interface ReadArticleButtonProps {
   href: string;
   className?: string;
+  openNewTab?: boolean;
   onClick?: (e: React.MouseEvent) => unknown;
 }
 
-export const ReadArticleButton = (
-  props: ReadArticleButtonProps,
-): ReactElement => (
+export const ReadArticleButton = ({
+  openNewTab,
+  ...props
+}: ReadArticleButtonProps): ReactElement => (
   <Button
     tag="a"
     {...props}
     buttonSize="small"
     rightIcon={<OpenLinkIcon className="ml-2" secondary />}
-    target="_blank"
+    target={openNewTab ? '_blank' : '_self'}
   >
     Read article
   </Button>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Refactored read article button to have an option of opening a new tab
- Refactor existing implementations (used search to find all).
- Tested in preview deployment and works as intended.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-306 #done
