### PR TITLE
fix: remember email from register to login

### DIFF
--- a/packages/shared/src/components/auth/AuthDefault.tsx
+++ b/packages/shared/src/components/auth/AuthDefault.tsx
@@ -42,6 +42,7 @@ const AuthDefault = ({
   title = 'Sign up to daily.dev',
 }: AuthDefaultProps): ReactElement => {
   const [shouldLogin, setShouldLogin] = useState(isV2);
+  const [registerEmail, setRegisterEmail] = useState<string>(null);
   const { mutateAsync: checkEmail } = useMutation((emailParam: string) =>
     checkKratosEmail(emailParam),
   );
@@ -61,6 +62,7 @@ const AuthDefault = ({
     const res = await checkEmail(email);
 
     if (res?.result) {
+      setRegisterEmail(email);
       return setShouldLogin(true);
     }
 
@@ -80,6 +82,7 @@ const AuthDefault = ({
     if (!disablePassword && (shouldLogin || disableRegistration)) {
       return (
         <LoginForm
+          email={registerEmail}
           loginHint={loginHint}
           onPasswordLogin={onPasswordLogin}
           onForgotPassword={onForgotPassword}

--- a/packages/shared/src/components/auth/LoginForm.tsx
+++ b/packages/shared/src/components/auth/LoginForm.tsx
@@ -12,6 +12,7 @@ import { AuthForm } from './common';
 interface LoginFormProps {
   onForgotPassword?: () => unknown;
   onPasswordLogin?: (params: LoginFormParams) => void;
+  email?: string;
   loginHint: ReturnType<typeof useState>;
   className?: string;
 }
@@ -28,6 +29,7 @@ export interface LoginSocialFormParams {
 function LoginForm({
   onForgotPassword,
   onPasswordLogin,
+  email,
   loginHint: [hint, setHint],
   className,
 }: LoginFormProps): ReactElement {
@@ -49,6 +51,7 @@ function LoginForm({
         name="identifier"
         label="Email"
         type="email"
+        value={email}
         data-testid="login_email"
         saveHintSpace
         hint={hint as string}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added a state to pass email from register to login screen

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-433 #done
