### PR TITLE
fix: account details responsiveness

### DIFF
--- a/packages/shared/src/components/modals/CloseButton.tsx
+++ b/packages/shared/src/components/modals/CloseButton.tsx
@@ -1,0 +1,24 @@
+import classNames from 'classnames';
+import React, { forwardRef, ReactElement, Ref } from 'react';
+import { Button, ButtonProps } from '../buttons/Button';
+import CloseIcon from '../icons/Close';
+
+function CloseButtonComponent(
+  { className, style, ...props }: ButtonProps<'button'>,
+  ref: Ref<HTMLButtonElement>,
+): ReactElement {
+  return (
+    <Button
+      {...props}
+      ref={ref}
+      className={classNames('btn-tertiary', className)}
+      buttonSize="small"
+      title="Close"
+      icon={<CloseIcon />}
+    />
+  );
+}
+
+const CloseButton = forwardRef(CloseButtonComponent);
+
+export default CloseButton;

--- a/packages/shared/src/components/modals/ModalCloseButton.tsx
+++ b/packages/shared/src/components/modals/ModalCloseButton.tsx
@@ -1,20 +1,17 @@
 import React, { forwardRef, ReactElement, Ref } from 'react';
 import classNames from 'classnames';
-import { Button, ButtonProps } from '../buttons/Button';
-import XIcon from '../icons/Close';
+import { ButtonProps } from '../buttons/Button';
+import CloseButton from './CloseButton';
 
 function ModalCloseButtonComponent(
   { className, style, ...props }: ButtonProps<'button'>,
   ref: Ref<HTMLButtonElement>,
 ): ReactElement {
   return (
-    <Button
+    <CloseButton
       {...props}
       ref={ref}
-      className={classNames('btn-tertiary right-4 z-1', className)}
-      buttonSize="small"
-      title="Close"
-      icon={<XIcon />}
+      className={classNames('right-4 z-1', className)}
       style={{ position: 'absolute', ...style }}
     />
   );

--- a/packages/webapp/components/layouts/AccountLayout/AccountPageContainer.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/AccountPageContainer.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, ReactNode } from 'react';
+import { useQueryClient } from 'react-query';
 import classNames from 'classnames';
 import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
 import ArrowIcon from '@dailydotdev/shared/src/components/icons/Arrow';
@@ -32,9 +33,18 @@ export const AccountPageContainer = ({
   className = {},
   onBack,
 }: AccountPageContainerProps): ReactElement => {
+  const client = useQueryClient();
+  const openSideNav = () => client.setQueryData(['account_nav_open'], true);
+
   return (
     <AccountPageContent className={classNames('relative', className.container)}>
       <AccountPageHeading className={classNames('sticky', className.heading)}>
+        <Button
+          className="flex tablet:hidden mr-2 btn-tertiary"
+          icon={<ArrowIcon className="-rotate-90" />}
+          buttonSize="xsmall"
+          onClick={openSideNav}
+        />
         {onBack && (
           <Button
             className="mr-2 btn-tertiary"

--- a/packages/webapp/components/layouts/AccountLayout/SidebarNav.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/SidebarNav.tsx
@@ -5,6 +5,8 @@ import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import CloseButton from '@dailydotdev/shared/src/components/modals/CloseButton';
 import { disabledRefetch } from '@dailydotdev/shared/src/lib/func';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { isTouchDevice } from '@dailydotdev/shared/src/lib/tooltip';
 import SidebarNavItem from './SidebarNavItem';
 import {
   AccountPage,
@@ -12,8 +14,6 @@ import {
   accountSidebarPages,
   AccountSidebarPagesSection,
 } from './common';
-import { useRouter } from 'next/router';
-import { isTouchDevice } from '@dailydotdev/shared/src/lib/tooltip';
 
 interface SidebarNavProps {
   className?: string;

--- a/packages/webapp/components/layouts/AccountLayout/SidebarNav.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/SidebarNav.tsx
@@ -1,6 +1,9 @@
 import React, { ReactElement, useContext } from 'react';
+import { useQuery, useQueryClient } from 'react-query';
 import classNames from 'classnames';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import CloseButton from '@dailydotdev/shared/src/components/modals/CloseButton';
+import { disabledRefetch } from '@dailydotdev/shared/src/lib/func';
 import Link from 'next/link';
 import SidebarNavItem from './SidebarNavItem';
 import {
@@ -21,6 +24,11 @@ function SidebarNav({
   className,
   basePath = '',
 }: SidebarNavProps): ReactElement {
+  const client = useQueryClient();
+  const closeSideNav = () => client.setQueryData(['account_nav_open'], false);
+  const { data: isOpen } = useQuery(['account_nav_open'], () => false, {
+    ...disabledRefetch,
+  });
   const { user } = useContext(AuthContext);
 
   if (!user) {
@@ -28,37 +36,49 @@ function SidebarNav({
   }
 
   return (
-    <div className={classNames('flex flex-col items-center', className)}>
-      {pageKeys.map((key) => {
-        const href = `/${basePath}${accountPage[key].href}`;
-        const isActive = window.location.pathname === href;
+    <div
+      className={classNames(
+        'flex flex-col tablet:items-center tablet:px-6 tablet:pt-6 ease-in-out transition-transform tablet:translate-x-[unset]',
+        isOpen ? 'translate-x-0' : ' -translate-x-full',
+        className,
+      )}
+    >
+      <span className="flex tablet:hidden flex-row justify-between items-center p-2 mb-6 w-full border-b border-theme-divider-tertiary">
+        <span className="ml-4 font-bold typo-title3">Account Settings</span>
+        <CloseButton onClick={closeSideNav} />
+      </span>
+      <div className="px-6 tablet:px-0">
+        {pageKeys.map((key) => {
+          const href = `/${basePath}${accountPage[key].href}`;
+          const isActive = window.location.pathname === href;
 
-        return (
-          <SidebarNavItem
-            key={key}
-            title={accountPage[key].title}
-            href={href}
-            isActive={isActive}
-            icon={accountPage[key].getIcon({ user, isActive })}
-          />
-        );
-      })}
-      <AccountSidebarPagesSection>
-        {accountSidebarPages.map((accountSidebarPage) => (
-          <Link
-            href={accountSidebarPage.href}
-            passHref
-            key={accountSidebarPage.title}
-          >
-            <a
-              className="my-3 w-full typo-callout text-theme-label-tertiary"
-              target={accountSidebarPage.target}
+          return (
+            <SidebarNavItem
+              key={key}
+              title={accountPage[key].title}
+              href={href}
+              isActive={isActive}
+              icon={accountPage[key].getIcon({ user, isActive })}
+            />
+          );
+        })}
+        <AccountSidebarPagesSection>
+          {accountSidebarPages.map((accountSidebarPage) => (
+            <Link
+              href={accountSidebarPage.href}
+              passHref
+              key={accountSidebarPage.title}
             >
-              {accountSidebarPage.title}
-            </a>
-          </Link>
-        ))}
-      </AccountSidebarPagesSection>
+              <a
+                className="my-3 w-full typo-callout text-theme-label-tertiary"
+                target={accountSidebarPage.target}
+              >
+                {accountSidebarPage.title}
+              </a>
+            </Link>
+          ))}
+        </AccountSidebarPagesSection>
+      </div>
     </div>
   );
 }

--- a/packages/webapp/components/layouts/AccountLayout/SidebarNavItem.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/SidebarNavItem.tsx
@@ -22,7 +22,7 @@ function SidebarNavItem({
     <Link href={href}>
       <a
         className={classNames(
-          'flex flex-row p-4 rounded-16 w-64',
+          'flex flex-row p-4 rounded-16 w-full tablet:w-64',
           isActive && 'border border-theme-divider-tertiary bg-theme-active',
           isActive && 'p-[0.9375rem]', // to avoid layout shift for when the border (1px) is displayed being active
           className,

--- a/packages/webapp/components/layouts/AccountLayout/common.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/common.tsx
@@ -95,7 +95,7 @@ export const accountPage: Record<AccountPage, AccountPageProps> = {
 export const AccountPageContent = classed(
   'div',
   pageBorders,
-  'flex flex-col w-full max-w-[calc(100vw-19.75rem)] laptop:max-w-[calc(100vw-36rem)] laptopL:max-w-[40rem] tablet:border-l mr-auto',
+  'flex flex-col w-full laptop:max-w-[calc(100vw-19.75rem)] laptop:max-w-[calc(100vw-36rem)] laptopL:max-w-[40rem] tablet:border-l mr-auto',
 );
 export const AccountPageSection = classed('section', 'flex flex-col p-6');
 export const AccountPageHeading = classed(

--- a/packages/webapp/components/layouts/AccountLayout/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/index.tsx
@@ -52,7 +52,7 @@ export default function AccountLayout({
       <NextSeo {...Seo} />
       <main className="flex relative flex-row flex-1 items-stretch pt-0 mx-auto w-full laptop:max-w-[calc(100vw-17.5rem)]">
         <SidebarNav
-          className="px-6 pt-6 ml-auto border-l border-theme-divider-tertiary"
+          className="absolute tablet:relative z-3 ml-auto w-full h-full border-l tablet:w-[unset] bg-theme-bg-primary border-theme-divider-tertiary"
           basePath="account"
         />
         {children}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- In our account details page, for when the width is for mobile devices, the side navigation should be toggleable.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-417 #done
WT-419 #done
