### PR TITLE
feat: added comment highlight to active comment

### DIFF
--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -73,7 +73,12 @@ export default function MainComment({
           <CommentPublishDate comment={comment} />
         </div>
       </div>
-      <MainCommentBox>
+      <MainCommentBox
+        className={
+          commentHash === getCommentHash(comment.id) &&
+          'border border-theme-color-cabbage'
+        }
+      >
         <Markdown content={comment.contentHtml} />
       </MainCommentBox>
       <CommentActionButtons

--- a/packages/shared/src/components/comments/SubComment.tsx
+++ b/packages/shared/src/components/comments/SubComment.tsx
@@ -74,7 +74,12 @@ export default function SubComment({
         </ProfileTooltip>
       </div>
       <div className="flex flex-col flex-1 items-stretch ml-2">
-        <SubCommentBox>
+        <SubCommentBox
+          className={
+            commentHash === getCommentHash(comment.id) &&
+            'border border-theme-color-cabbage'
+          }
+        >
           <div className="flex">
             <CommentAuthor
               postAuthorId={postAuthorId}

--- a/packages/shared/src/components/comments/common.tsx
+++ b/packages/shared/src/components/comments/common.tsx
@@ -22,12 +22,12 @@ export const commentBoxClassNames =
 
 const StyledCommentBox = classed('div', commentBoxClassNames);
 
+export interface CommentBoxProps extends HTMLAttributes<HTMLDivElement> {
+  children?: ReactNode;
+}
 export const CommentBox = ({
   children,
   ...props
-}: {
-  children?: ReactNode;
-  props?: HTMLAttributes<HTMLDivElement>;
-}): ReactElement => {
+}: CommentBoxProps): ReactElement => {
   return <StyledCommentBox {...props}>{children}</StyledCommentBox>;
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added a active border to the highlighted comments

![Screenshot 2022-09-09 at 15 49 38](https://user-images.githubusercontent.com/554874/189365517-b0a9b2f1-b3dd-4839-a1c8-825744f90cf8.png)
![Screenshot 2022-09-09 at 15 49 26](https://user-images.githubusercontent.com/554874/189365536-cad93df2-9a5e-4c1b-aa9c-fcf80e459d6d.png)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-308 #done
