### PR TITLE
fix: close button not passing style property

### DIFF
--- a/packages/shared/src/components/modals/CloseButton.tsx
+++ b/packages/shared/src/components/modals/CloseButton.tsx
@@ -4,7 +4,7 @@ import { Button, ButtonProps } from '../buttons/Button';
 import CloseIcon from '../icons/Close';
 
 function CloseButtonComponent(
-  { className, style, ...props }: ButtonProps<'button'>,
+  { className, ...props }: ButtonProps<'button'>,
   ref: Ref<HTMLButtonElement>,
 ): ReactElement {
   return (


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We spread the props to the button component, but then the `style` property was destructured and unused.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-454 #done
