### PR TITLE
fix: double social registration form

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -117,7 +117,8 @@ export default function MainLayout({
   const { displayToast } = useToastNotification();
   const [isIncompleteRegistration, setIsIncompleteRegistration] =
     useState(false);
-  const { user, loadingUser, logout, refetchBoot } = useContext(AuthContext);
+  const { user, loadingUser, shouldShowLogin, logout, refetchBoot } =
+    useContext(AuthContext);
   const { trackEvent } = useContext(AnalyticsContext);
   const { sidebarRendered } = useSidebarRendered();
   const { bannerData, setLastSeen } = usePromotionalBanner();
@@ -247,7 +248,7 @@ export default function MainLayout({
           onRequestClose={() => setIsIncompleteRegistration(false)}
         />
       )}
-      {user && !user.infoConfirmed && (
+      {!shouldShowLogin && user && !user.infoConfirmed && (
         <StyledModal isOpen onRequestClose={() => logout()}>
           <SocialRegistrationForm
             className="mb-6"


### PR DESCRIPTION
## Changes

### Describe what this PR does
- When the social registration form is present, we should not show the standalone social registration form.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-456 #done
