### PR TITLE
fix: submit button styling when email is filled

### DIFF
--- a/packages/shared/src/components/auth/EmailSignupForm.tsx
+++ b/packages/shared/src/components/auth/EmailSignupForm.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { Button } from '../buttons/Button';
 import { TextField } from '../fields/TextField';
 import ArrowIcon from '../icons/Arrow';
@@ -14,6 +14,8 @@ function EmailSignupForm({
   onSubmit,
   isV2,
 }: EmailSignupFormProps): ReactElement {
+  const [email, setEmail] = useState(null);
+
   return (
     <AuthForm className="gap-2" onSubmit={onSubmit} action="#">
       <TextField
@@ -22,14 +24,16 @@ function EmailSignupForm({
         label="Email"
         type="email"
         name="email"
+        onInput={(e) => setEmail(e.currentTarget.value)}
         actionButton={
           !isV2 && (
             <Button
               buttonSize="small"
-              className="btn-tertiary"
+              className="btn-primary"
               icon={<ArrowIcon className="rotate-90" />}
               type="submit"
               data-testid="email_signup_submit"
+              disabled={!email}
             />
           )
         }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- From the image below (attached to the ticket), the button seems primary and disabled when the email is empty. As also explained in the ticket itself.

![image](https://user-images.githubusercontent.com/13744167/189643073-8d86353a-1bf4-4fd0-ad00-706c96a9156a.png)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
