### PR TITLE
fix: resend email verification timer set to a minute

### DIFF
--- a/packages/shared/src/components/auth/EmailVerificationSent.tsx
+++ b/packages/shared/src/components/auth/EmailVerificationSent.tsx
@@ -44,7 +44,7 @@ function EmailVerificationSent({
     (params: VerificationParams) => submitKratosFlow(params),
     {
       onSuccess: () => {
-        setTimer(12);
+        setTimer(60);
         runTimer();
         setSentCount((value) => value + 1);
       },


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The forgot password resend timer is already a minute.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-457 #done
