### PR TITLE
refactor: accounts page placeholder

### DIFF
--- a/packages/shared/src/contexts/AuthContext.tsx
+++ b/packages/shared/src/contexts/AuthContext.tsx
@@ -20,6 +20,7 @@ export interface AuthContextData {
   logout: () => Promise<void>;
   updateUser: (user: LoggedUser) => Promise<void>;
   loadingUser?: boolean;
+  isFetched?: boolean;
   tokenRefreshed: boolean;
   loadedUserFromCache?: boolean;
   getRedirectUri: () => string;
@@ -60,6 +61,7 @@ const logout = async (): Promise<void> => {
 
 export type AuthContextProviderProps = {
   user: LoggedUser | AnonymousUser | undefined;
+  isFetched?: boolean;
   refetchBoot?: () => Promise<unknown>;
   children?: ReactNode;
 } & Pick<
@@ -76,6 +78,7 @@ export const AuthContextProvider = ({
   children,
   user,
   updateUser,
+  isFetched,
   loadingUser,
   tokenRefreshed,
   loadedUserFromCache,
@@ -105,10 +108,19 @@ export const AuthContextProvider = ({
       getRedirectUri,
       anonymous: user,
       visit,
+      isFetched,
       refetchBoot,
       deleteAccount,
     }),
-    [user, loginState, loadingUser, tokenRefreshed, loadedUserFromCache, visit],
+    [
+      user,
+      loginState,
+      isFetched,
+      loadingUser,
+      tokenRefreshed,
+      loadedUserFromCache,
+      visit,
+    ],
   );
 
   return (

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -83,6 +83,7 @@ export const BootDataProvider = ({
     data: bootRemoteData,
     refetch,
     dataUpdatedAt,
+    isFetched,
   } = useQuery(BOOT_QUERY_KEY, () => getBootData(app));
 
   useEffect(() => {
@@ -160,6 +161,7 @@ export const BootDataProvider = ({
         loadedUserFromCache={loadedFromCache}
         visit={bootRemoteData?.visit}
         refetchBoot={refetch}
+        isFetched={isFetched}
       >
         <SettingsContextProvider
           settings={settings}

--- a/packages/webapp/components/layouts/AccountLayout/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/index.tsx
@@ -2,13 +2,11 @@ import React, { ReactElement, ReactNode, useContext } from 'react';
 import { PublicProfile } from '@dailydotdev/shared/src/lib/user';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { NextSeoProps } from 'next-seo/lib/types';
+import { useRouter } from 'next/router';
 import Head from 'next/head';
 import { NextSeo } from 'next-seo';
-import dynamic from 'next/dynamic';
 import { getLayout as getMainLayout } from '../MainLayout';
 import SidebarNav from './SidebarNav';
-
-const Custom404 = dynamic(() => import('../../../pages/404'));
 
 export interface AccountLayoutProps {
   profile: PublicProfile;
@@ -18,14 +16,15 @@ export interface AccountLayoutProps {
 export default function AccountLayout({
   children,
 }: AccountLayoutProps): ReactElement {
-  const { user: profile } = useContext(AuthContext);
+  const router = useRouter();
+  const { user: profile, isFetched } = useContext(AuthContext);
 
-  if (!profile) {
-    return <Custom404 />;
+  if (isFetched && !profile) {
+    router.replace('/');
   }
 
-  if (!Object.keys(profile).length) {
-    return <></>; // should be a loading screen
+  if (!profile || !Object.keys(profile).length) {
+    return null;
   }
 
   const Seo: NextSeoProps = profile


### PR DESCRIPTION
## Changes

### Describe what this PR does
- As per Ido, an empty screen should be okay for a placeholder on the profile pages.
- I also applied a redirect if the data is fetched already and user is not logged in.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-450 #done
