### PR TITLE
refactor: disabling whoami call when unnecessary

### DIFF
--- a/packages/shared/src/hooks/useLogin.ts
+++ b/packages/shared/src/hooks/useLogin.ts
@@ -27,6 +27,7 @@ interface UseLogin {
 }
 
 interface UseLoginProps {
+  enableSessionVerification?: boolean;
   queryEnabled?: boolean;
   queryParams?: EmptyObjectLiteral;
   onSuccessfulLogin?: (() => Promise<void>) | (() => void);
@@ -36,10 +37,13 @@ const useLogin = ({
   onSuccessfulLogin,
   queryEnabled = true,
   queryParams = {},
+  enableSessionVerification = false,
 }: UseLoginProps = {}): UseLogin => {
   const { refetchBoot } = useContext(AuthContext);
   const [hint, setHint] = useState('Enter your password to login');
-  const { data: session } = useQuery(['current_session'], getKratosSession);
+  const { data: session } = useQuery(['current_session'], getKratosSession, {
+    enabled: enableSessionVerification,
+  });
   const { data: login } = useQuery(
     [{ type: 'login', params: queryParams }],
     ({ queryKey: [{ params }] }) =>

--- a/packages/shared/src/hooks/usePrivilegedSession.ts
+++ b/packages/shared/src/hooks/usePrivilegedSession.ts
@@ -29,6 +29,7 @@ const usePrivilegedSession = ({
 
   const { loginFlowData, loginHint, onSocialLogin, onPasswordLogin } = useLogin(
     {
+      enableSessionVerification: true,
       queryEnabled: !!verifySessionId,
       queryParams: { refresh: 'true' },
       onSuccessfulLogin: () => {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- whoami call is not needed almost everytime but only at verifying sessions.
- Create a condition to let the query not execute.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-447 #done
