### PR TITLE
fix: boot data always undefined

### DIFF
--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -136,7 +136,7 @@ export const BootDataProvider = ({
       setCachedBootData(updated);
       await queryClient.invalidateQueries(generateQueryKey('profile', newUser));
     },
-    [queryClient],
+    [queryClient, cachedBootData],
   );
 
   const updateSettings = useCallback(


### PR DESCRIPTION
## Changes

### Describe what this PR does
- After further investigation, it seems the `cachedData` is always undefined when executing from use profile form.
- To make it always up to date, it was missing a critical dependency.
- I'm actually wondering why on current production it behaves as intended.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-448 #done
