### PR TITLE
fix: close login modal when user is already available

### DIFF
--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -2,7 +2,6 @@ import React, {
   MutableRefObject,
   ReactElement,
   useContext,
-  useEffect,
   useState,
 } from 'react';
 import classNames from 'classnames';
@@ -56,7 +55,7 @@ function AuthOptions({
   const [registrationHints, setRegistrationHints] = useState<RegistrationError>(
     {},
   );
-  const { refetchBoot, referral, user, closeLogin } = useContext(AuthContext);
+  const { refetchBoot, referral, closeLogin } = useContext(AuthContext);
   const { loginHint, onPasswordLogin } = useLogin({ onSuccessfulLogin });
   const { authVersion } = useContext(FeaturesContext);
   const isV2 = authVersion === AuthVersion.V2;
@@ -88,6 +87,8 @@ function AuthOptions({
     AuthEvent.SocialRegistration,
     async (e) => {
       if (!e.data?.social_registration) {
+        await refetchBoot();
+        closeLogin();
         return;
       }
 
@@ -119,15 +120,6 @@ function AuthOptions({
     logout();
     onClose(e, true);
   };
-
-  useEffect(() => {
-    const isLoginDisplay =
-      activeDisplay === Display.Default || activeDisplay === Display.SignBack;
-
-    if (user && isLoginDisplay) {
-      closeLogin();
-    }
-  }, [user, activeDisplay]);
 
   return (
     <div

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -2,6 +2,7 @@ import React, {
   MutableRefObject,
   ReactElement,
   useContext,
+  useEffect,
   useState,
 } from 'react';
 import classNames from 'classnames';
@@ -55,7 +56,7 @@ function AuthOptions({
   const [registrationHints, setRegistrationHints] = useState<RegistrationError>(
     {},
   );
-  const { refetchBoot, referral } = useContext(AuthContext);
+  const { refetchBoot, referral, user, closeLogin } = useContext(AuthContext);
   const { loginHint, onPasswordLogin } = useLogin({ onSuccessfulLogin });
   const { authVersion } = useContext(FeaturesContext);
   const isV2 = authVersion === AuthVersion.V2;
@@ -118,6 +119,15 @@ function AuthOptions({
     logout();
     onClose(e, true);
   };
+
+  useEffect(() => {
+    const isLoginDisplay =
+      activeDisplay === Display.Default || activeDisplay === Display.SignBack;
+
+    if (user && isLoginDisplay) {
+      closeLogin();
+    }
+  }, [user, activeDisplay]);
 
   return (
     <div


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Sometimes when you hit the provider and the callback closes, the user gets logged in but not closing the modal.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-440 #done
