### PR TITLE
fix: clickable tos pp

### DIFF
--- a/packages/shared/src/components/auth/EmailSignupForm.tsx
+++ b/packages/shared/src/components/auth/EmailSignupForm.tsx
@@ -4,6 +4,8 @@ import { TextField } from '../fields/TextField';
 import ArrowIcon from '../icons/Arrow';
 import MailIcon from '../icons/Mail';
 import { AuthForm } from './common';
+import { privacyPolicy, termsOfService } from '../../lib/constants';
+import { ClickableText } from '../buttons/ClickableText';
 
 interface EmailSignupFormProps {
   onSubmit: (e: React.FormEvent) => unknown;
@@ -44,7 +46,25 @@ function EmailSignupForm({
         </Button>
       )}
       <p className="text-center text-theme-label-quaternary typo-caption1">
-        By signing in I accept the Terms of Service and the Privacy Policy.
+        By signing up I accept the{' '}
+        <a
+          href={termsOfService}
+          target="_blank"
+          rel="noopener"
+          className="font-bold underline"
+        >
+          Terms of Service
+        </a>{' '}
+        and the{' '}
+        <a
+          href={privacyPolicy}
+          target="_blank"
+          rel="noopener"
+          className="font-bold underline"
+        >
+          Privacy Policy
+        </a>
+        .
       </p>
     </AuthForm>
   );

--- a/packages/shared/src/components/auth/EmailSignupForm.tsx
+++ b/packages/shared/src/components/auth/EmailSignupForm.tsx
@@ -5,7 +5,6 @@ import ArrowIcon from '../icons/Arrow';
 import MailIcon from '../icons/Mail';
 import { AuthForm } from './common';
 import { privacyPolicy, termsOfService } from '../../lib/constants';
-import { ClickableText } from '../buttons/ClickableText';
 
 interface EmailSignupFormProps {
   onSubmit: (e: React.FormEvent) => unknown;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Make TOS and PP clickable and styled

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-466 #done
