### PR TITLE
fix: on password login, close modal

### DIFF
--- a/packages/shared/src/components/auth/AuthModal.tsx
+++ b/packages/shared/src/components/auth/AuthModal.tsx
@@ -9,6 +9,7 @@ import useAuthForms from '../../hooks/useAuthForms';
 import FeaturesContext from '../../contexts/FeaturesContext';
 import { AuthVersion } from '../../lib/featureValues';
 import DailyCircle from '../DailyCircle';
+import AuthContext from '../../contexts/AuthContext';
 
 export type AuthModalProps = ModalProps;
 
@@ -28,6 +29,7 @@ export default function AuthModal({
   ...props
 }: AuthModalProps): ReactElement {
   const { authVersion } = useContext(FeaturesContext);
+  const { closeLogin } = useContext(AuthContext);
   const {
     onDiscardAttempt,
     onDiscardCancelled,
@@ -80,6 +82,7 @@ export default function AuthModal({
         className={classNames('h-full', containerMargin[authVersion])}
         onClose={onDiscardAttempt}
         formRef={formRef}
+        onSuccessfulLogin={closeLogin}
       />
       {isDiscardOpen && (
         <DiscardActionModal

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -55,7 +55,7 @@ function AuthOptions({
   const [registrationHints, setRegistrationHints] = useState<RegistrationError>(
     {},
   );
-  const { refetchBoot, referral, closeLogin } = useContext(AuthContext);
+  const { refetchBoot, referral } = useContext(AuthContext);
   const { loginHint, onPasswordLogin } = useLogin({ onSuccessfulLogin });
   const { authVersion } = useContext(FeaturesContext);
   const isV2 = authVersion === AuthVersion.V2;
@@ -88,7 +88,7 @@ function AuthOptions({
     async (e) => {
       if (!e.data?.social_registration) {
         await refetchBoot();
-        closeLogin();
+        onSuccessfulLogin?.();
         return;
       }
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- This AuthOptions component is reused at the v3 (dedicated login page), where there is no concept of modal, so we will have to use the props whenever the login was successful.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-483 #done
