### PR TITLE
fix: reset password loading indicator and error management

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -31,6 +31,7 @@ import useWindowEvents from '../hooks/useWindowEvents';
 import {
   AuthEvent,
   AuthFlow,
+  ErrorData,
   ErrorEvent,
   getKratosError,
   getKratosFlow,
@@ -154,7 +155,8 @@ export default function MainLayout({
       enabled: !!router?.query.recovery && !!router?.query.flow,
       onSuccess: (data) => {
         if ('error' in data) {
-          displayErrorMessage(data.error.message);
+          const errorData = data as unknown as ErrorData;
+          displayErrorMessage(errorData.error.message);
           return;
         }
 

--- a/packages/shared/src/lib/kratos.ts
+++ b/packages/shared/src/lib/kratos.ts
@@ -191,7 +191,7 @@ interface KratosError {
   code: number;
   message: string;
   reason: string;
-  debug: string;
+  debug?: string;
 }
 
 export interface ErrorData {
@@ -231,7 +231,7 @@ export const initializeKratosFlow = async (
 export const getKratosFlow = async (
   flow: AuthFlow,
   id: string,
-): Promise<InitializationData> => {
+): Promise<InitializationData | ErrorData> => {
   const res = await fetch(`${authUrl}/self-service${flow}?flow=${id}`, {
     credentials: 'include',
     headers: { Accept: 'application/json' },
@@ -351,4 +351,8 @@ export const getKratosSession = async (): Promise<AuthSession> => {
   }
 
   return res.json();
+};
+
+export const KRATOS_ERROR = {
+  INVALID_TOKEN: 4060004,
 };

--- a/packages/shared/src/lib/kratos.ts
+++ b/packages/shared/src/lib/kratos.ts
@@ -231,7 +231,7 @@ export const initializeKratosFlow = async (
 export const getKratosFlow = async (
   flow: AuthFlow,
   id: string,
-): Promise<InitializationData | ErrorData> => {
+): Promise<InitializationData> => {
   const res = await fetch(`${authUrl}/self-service${flow}?flow=${id}`, {
     credentials: 'include',
     headers: { Accept: 'application/json' },

--- a/packages/webapp/pages/reset-password.tsx
+++ b/packages/webapp/pages/reset-password.tsx
@@ -1,4 +1,5 @@
 import React, { FormEvent, ReactElement, useState } from 'react';
+import classNames from 'classnames';
 import DailyCircle from '@dailydotdev/shared/src/components/DailyCircle';
 import Logo from '@dailydotdev/shared/src/components/Logo';
 import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
@@ -22,6 +23,8 @@ import { PasswordField } from '@dailydotdev/shared/src/components/fields/Passwor
 function ResetPassword(): ReactElement {
   const router = useRouter();
   const [hint, setHint] = useState(null);
+  const [disabledWhileRedirecting, setDisabledWhileRedirecting] =
+    useState(false);
   const { data } = useQuery(
     'settings',
     () => getKratosFlow(AuthFlow.Settings, router.query.flow as string),
@@ -31,11 +34,12 @@ function ResetPassword(): ReactElement {
       enabled: !!router.query.flow,
     },
   );
-  const { mutateAsync: reset } = useMutation(
+  const { mutateAsync: reset, isLoading } = useMutation(
     (params: ValidateRegistrationParams) => submitKratosFlow(params),
     {
       onSuccess: ({ error, data: success }) => {
         if (success) {
+          setDisabledWhileRedirecting(true);
           return window.location.replace(process.env.NEXT_PUBLIC_WEBAPP_URL);
         }
 
@@ -91,7 +95,14 @@ function ResetPassword(): ReactElement {
           onChange={() => hint && setHint('')}
           hint={hint}
         />
-        <Button className="mt-7 w-full bg-theme-color-cabbage" type="submit">
+        <Button
+          className={classNames(
+            'mt-7 w-full btn-primary',
+            !isLoading && 'bg-theme-color-cabbage',
+          )}
+          type="submit"
+          disabled={isLoading || disabledWhileRedirecting}
+        >
           Change password
         </Button>
       </form>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Disable the submit button while the request is loading and was successful.
- Error management for when the token expired, kratos redirects to our page and should display a toast message.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-472 #done
