### PR TITLE
fix: new modal backdrop

### DIFF
--- a/packages/eslint-rules/lib/rules/no-custom-color.js
+++ b/packages/eslint-rules/lib/rules/no-custom-color.js
@@ -9,6 +9,7 @@ const alwaysValidClasses = [
   'text-xl',
   'text-ellipsis',
   'bg-none',
+  'bg-gradient-to-r',
 ];
 const findTargetClassNames = (classNames) => {
   if (!classNames) {

--- a/packages/shared/src/components/modals/StyledModal.tsx
+++ b/packages/shared/src/components/modals/StyledModal.tsx
@@ -18,7 +18,7 @@ export function StyledModal({
     <Modal
       portalClassName={className?.toString()}
       overlayClassName={classNames(
-        'overlay flex fixed flex-col justify-center inset-0 max-h-[100vh] items-center px-5 bg-theme-overlay-quaternary z-[10]',
+        'overlay flex fixed flex-col justify-center inset-0 max-h-[100vh] items-center px-5 bg-gradient-to-r to-theme-overlay-to from-theme-overlay-from z-[10]',
         overlayClassName,
       )}
       className={classNames(

--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -78,6 +78,8 @@ body {
   --theme-overlay-quaternary: theme('colors.overlay.quaternary.white');
   --theme-overlay-water: theme('colors.overlay.quaternary.water');
   --theme-overlay-cabbage: theme('colors.overlay.quaternary.cabbage');
+  --theme-overlay-from: theme('colors.onion.40')30;
+  --theme-overlay-to: theme('colors.cabbage.40')30;
 
   --theme-rank-highlight: theme('colors.salt.10');
 
@@ -180,6 +182,8 @@ body {
   --theme-overlay-quaternary: theme('colors.overlay.quaternary.pepper');
   --theme-overlay-water: theme('colors.overlay.quaternary.water');
   --theme-overlay-cabbage: theme('colors.overlay.quaternary.cabbage');
+  --theme-overlay-from: theme('colors.onion.40')30;
+  --theme-overlay-to: theme('colors.cabbage.40')30;
 
   --theme-rank-highlight: theme('colors.salt.10');
 

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -55,6 +55,8 @@ module.exports = {
           quaternary: 'var(--theme-overlay-quaternary)',
           water: 'var(--theme-overlay-water)',
           cabbage: 'var(--theme-overlay-cabbage)',
+          from: 'var(--theme-overlay-from)',
+          to: 'var(--theme-overlay-to)',
         },
         status: {
           error: 'var(--theme-status-error)',

--- a/packages/webapp/pages/reset-password.tsx
+++ b/packages/webapp/pages/reset-password.tsx
@@ -65,8 +65,7 @@ function ResetPassword(): ReactElement {
   };
 
   return (
-    // eslint-disable-next-line @dailydotdev/daily-dev-eslint-rules/no-custom-color
-    <div className="flex overflow-hidden relative flex-col items-center w-screen max-w-full h-screen bg-gradient-to-bl from-[#EF43FD32] to-[#6451F332]">
+    <div className="flex overflow-hidden relative flex-col items-center w-screen max-w-full h-screen bg-gradient-to-r to-theme-overlay-to from-theme-overlay-from">
       <DailyCircle className="hidden laptop:block absolute left-20" />
       <Logo className="mt-16 h-fit" logoClassName="h-logo-big" />
       <form


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Add the new modal colors and added a new eslint rule exception for background gradient.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-527 #done
