### PR TITLE
refactor: auth modal hiding graphics on verification sent

### DIFF
--- a/packages/shared/src/components/auth/AuthModal.tsx
+++ b/packages/shared/src/components/auth/AuthModal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement, useContext, useState } from 'react';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
 import { StyledModal, ModalProps } from '../modals/StyledModal';
@@ -28,6 +28,7 @@ export default function AuthModal({
   children,
   ...props
 }: AuthModalProps): ReactElement {
+  const [isVerificationSent, setIsVerificationSent] = useState(false);
   const { authVersion } = useContext(FeaturesContext);
   const { closeLogin } = useContext(AuthContext);
   const {
@@ -51,7 +52,7 @@ export default function AuthModal({
       contentClassName={classNames('auth', authVersion)}
       style={{}}
     >
-      {isV1 && (
+      {isV1 && !isVerificationSent && (
         <>
           <div className="hidden laptop:flex z-1 flex-col flex-1 gap-5 p-10 h-full">
             <AuthModalHeading className="typo-giga1">
@@ -83,6 +84,7 @@ export default function AuthModal({
         onClose={onDiscardAttempt}
         formRef={formRef}
         onSuccessfulLogin={closeLogin}
+        onVerificationSent={() => setIsVerificationSent(true)}
       />
       {isDiscardOpen && (
         <DiscardActionModal

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -40,6 +40,7 @@ export enum Display {
 export interface AuthOptionsProps {
   onClose?: CloseAuthModalFunc;
   onSuccessfulLogin?: () => unknown;
+  onVerificationSent?: () => unknown;
   formRef: MutableRefObject<HTMLFormElement>;
   defaultDisplay?: Display;
   className?: string;
@@ -50,6 +51,7 @@ function AuthOptions({
   onSuccessfulLogin,
   className,
   formRef,
+  onVerificationSent,
   defaultDisplay = Display.Default,
 }: AuthOptionsProps): ReactElement {
   const [registrationHints, setRegistrationHints] = useState<RegistrationError>(
@@ -79,6 +81,7 @@ function AuthOptions({
       key: 'registration_form',
       onValidRegistration: () => {
         refetchBoot();
+        onVerificationSent();
         setActiveDisplay(Display.EmailSent);
       },
       onInvalidRegistration: setRegistrationHints,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-498 #done
