### PR TITLE
feat: show connected accounts

### DIFF
--- a/packages/shared/__tests__/fixture/auth.ts
+++ b/packages/shared/__tests__/fixture/auth.ts
@@ -1376,6 +1376,6 @@ export const mockListProviders = (
   result: string[] = ['facebook', 'github', 'apple'],
 ): void => {
   nock(heimdallUrl)
-    .post('/api/list_providers')
+    .post('/api/list_providers?')
     .reply(200, { ok: true, result });
 };

--- a/packages/shared/src/components/auth/AuthModal.module.css
+++ b/packages/shared/src/components/auth/AuthModal.module.css
@@ -35,7 +35,7 @@
     }
   }
 
-  & :global(.auth.v4) {
+  & :global(.auth.hiddenHeadings) {
     @screen laptop {
       max-width: 25.75rem;
     }

--- a/packages/shared/src/components/auth/AuthModal.tsx
+++ b/packages/shared/src/components/auth/AuthModal.tsx
@@ -88,7 +88,7 @@ export default function AuthModal({
         onClose={onDiscardAttempt}
         formRef={formRef}
         onSuccessfulLogin={closeLogin}
-        onShowOptionsOnly={() => setShowOptionsOnly(true)}
+        onShowOptionsOnly={(value: boolean) => setShowOptionsOnly(value)}
       />
       {isDiscardOpen && (
         <DiscardActionModal

--- a/packages/shared/src/components/auth/AuthModal.tsx
+++ b/packages/shared/src/components/auth/AuthModal.tsx
@@ -49,7 +49,11 @@ export default function AuthModal({
       overlayRef={onContainerChange}
       onRequestClose={onDiscardAttempt}
       className={classNames(styles.authModal, className)}
-      contentClassName={classNames('auth', authVersion)}
+      contentClassName={classNames(
+        'auth',
+        authVersion,
+        (authVersion === 'v4' || showOptionsOnly) && 'hiddenHeadings',
+      )}
       style={{}}
     >
       {isV1 && !showOptionsOnly && (

--- a/packages/shared/src/components/auth/AuthModal.tsx
+++ b/packages/shared/src/components/auth/AuthModal.tsx
@@ -28,7 +28,7 @@ export default function AuthModal({
   children,
   ...props
 }: AuthModalProps): ReactElement {
-  const [isVerificationSent, setIsVerificationSent] = useState(false);
+  const [showOptionsOnly, setShowOptionsOnly] = useState(false);
   const { authVersion } = useContext(FeaturesContext);
   const { closeLogin } = useContext(AuthContext);
   const {
@@ -52,7 +52,7 @@ export default function AuthModal({
       contentClassName={classNames('auth', authVersion)}
       style={{}}
     >
-      {isV1 && !isVerificationSent && (
+      {isV1 && !showOptionsOnly && (
         <>
           <div className="hidden laptop:flex z-1 flex-col flex-1 gap-5 p-10 h-full">
             <AuthModalHeading className="typo-giga1">
@@ -84,7 +84,7 @@ export default function AuthModal({
         onClose={onDiscardAttempt}
         formRef={formRef}
         onSuccessfulLogin={closeLogin}
-        onVerificationSent={() => setIsVerificationSent(true)}
+        onShowOptionsOnly={() => setShowOptionsOnly(true)}
       />
       {isDiscardOpen && (
         <DiscardActionModal

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -19,7 +19,12 @@ import useWindowEvents from '../../hooks/useWindowEvents';
 import useRegistration from '../../hooks/useRegistration';
 import EmailVerificationSent from './EmailVerificationSent';
 import AuthModalHeader from './AuthModalHeader';
-import { AuthEvent, SocialRegistrationFlow } from '../../lib/kratos';
+import {
+  AuthEvent,
+  AuthFlow,
+  getKratosFlow,
+  SocialRegistrationFlow,
+} from '../../lib/kratos';
 import { storageWrapper as storage } from '../../lib/storageWrapper';
 import { providers } from './common';
 import useLogin from '../../hooks/useLogin';
@@ -27,6 +32,9 @@ import { SocialRegistrationForm } from './SocialRegistrationForm';
 import useProfileForm from '../../hooks/useProfileForm';
 import { CloseAuthModalFunc } from '../../hooks/useAuthForms';
 import { logout } from '../../lib/user';
+import ConnectedUserModal, {
+  ConnectedUser as RegistrationConnectedUser,
+} from '../modals/ConnectedUser';
 
 export enum Display {
   Default = 'default',
@@ -35,12 +43,13 @@ export enum Display {
   SignBack = 'sign_back',
   ForgotPassword = 'forgot_password',
   EmailSent = 'email_sent',
+  ConnectedUser = 'connected_user',
 }
 
 export interface AuthOptionsProps {
   onClose?: CloseAuthModalFunc;
   onSuccessfulLogin?: () => unknown;
-  onShowOptionsOnly?: () => unknown;
+  onShowOptionsOnly?: (value: boolean) => unknown;
   formRef: MutableRefObject<HTMLFormElement>;
   defaultDisplay?: Display;
   className?: string;
@@ -64,6 +73,8 @@ function AuthOptions({
   const { authVersion } = useContext(FeaturesContext);
   const isV2 = authVersion === AuthVersion.V2;
   const [email, setEmail] = useState('');
+  const [connectedUser, setConnectedUser] =
+    useState<RegistrationConnectedUser>();
   const [activeDisplay, setActiveDisplay] = useState(() =>
     storage.getItem(SIGNIN_METHOD_KEY) ? Display.SignBack : defaultDisplay,
   );
@@ -81,7 +92,7 @@ function AuthOptions({
       key: 'registration_form',
       onValidRegistration: () => {
         refetchBoot();
-        onShowOptionsOnly();
+        onShowOptionsOnly(true);
         setActiveDisplay(Display.EmailSent);
       },
       onInvalidRegistration: setRegistrationHints,
@@ -97,13 +108,26 @@ function AuthOptions({
     'message',
     AuthEvent.SocialRegistration,
     async (e) => {
+      if (e.data?.flow) {
+        const connected = await getKratosFlow(
+          AuthFlow.Registration,
+          e.data.flow,
+        );
+        const user = {
+          name: getNodeValue('traits.name', connected.ui.nodes),
+          email: getNodeValue('traits.email', connected.ui.nodes),
+          image: getNodeValue('traits.image', connected.ui.nodes),
+        };
+        onShowOptionsOnly(true);
+        setConnectedUser(user);
+        return setActiveDisplay(Display.ConnectedUser);
+      }
       if (!e.data?.social_registration) {
         await refetchBoot();
-        onSuccessfulLogin?.();
-        return;
+        return onSuccessfulLogin?.();
       }
 
-      setActiveDisplay(Display.SocialRegistration);
+      return setActiveDisplay(Display.SocialRegistration);
     },
   );
 
@@ -135,6 +159,11 @@ function AuthOptions({
   const onForgotPasswordBack = () => {
     setIsForgotPasswordReturn(true);
     setActiveDisplay(defaultDisplay);
+  };
+
+  const onShowLogin = () => {
+    onShowOptionsOnly(false);
+    setActiveDisplay(Display.Default);
   };
 
   return (
@@ -219,6 +248,16 @@ function AuthOptions({
             onClose={onClose}
           />
           <EmailVerificationSent email={email} />
+        </Tab>
+        <Tab label={Display.ConnectedUser}>
+          <AuthModalHeader title="Account already exists" onClose={onClose} />
+          {connectedUser && (
+            <ConnectedUserModal
+              flowId={email}
+              user={connectedUser}
+              onLogin={onShowLogin}
+            />
+          )}
         </Tab>
       </TabContainer>
     </div>

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -118,7 +118,7 @@ function AuthOptions({
           email: getNodeValue('traits.email', connected.ui.nodes),
           image: getNodeValue('traits.image', connected.ui.nodes),
         };
-        onShowOptionsOnly(true);
+        onShowOptionsOnly?.(true);
         setConnectedUser(user);
         return setActiveDisplay(Display.ConnectedUser);
       }

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -114,6 +114,7 @@ function AuthOptions({
           e.data.flow,
         );
         const user = {
+          provider: chosenProvider,
           name: getNodeValue('traits.name', connected.ui.nodes),
           email: getNodeValue('traits.email', connected.ui.nodes),
           image: getNodeValue('traits.image', connected.ui.nodes),

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -40,7 +40,7 @@ export enum Display {
 export interface AuthOptionsProps {
   onClose?: CloseAuthModalFunc;
   onSuccessfulLogin?: () => unknown;
-  onVerificationSent?: () => unknown;
+  onShowOptionsOnly?: () => unknown;
   formRef: MutableRefObject<HTMLFormElement>;
   defaultDisplay?: Display;
   className?: string;
@@ -51,7 +51,7 @@ function AuthOptions({
   onSuccessfulLogin,
   className,
   formRef,
-  onVerificationSent,
+  onShowOptionsOnly,
   defaultDisplay = Display.Default,
 }: AuthOptionsProps): ReactElement {
   const [registrationHints, setRegistrationHints] = useState<RegistrationError>(
@@ -81,7 +81,7 @@ function AuthOptions({
       key: 'registration_form',
       onValidRegistration: () => {
         refetchBoot();
-        onVerificationSent();
+        onShowOptionsOnly();
         setActiveDisplay(Display.EmailSent);
       },
       onInvalidRegistration: setRegistrationHints,

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -92,7 +92,7 @@ function AuthOptions({
       key: 'registration_form',
       onValidRegistration: () => {
         refetchBoot();
-        onVerificationSent?.(true);
+        onShowOptionsOnly?.(true);
         setActiveDisplay(Display.EmailSent);
       },
       onInvalidRegistration: setRegistrationHints,

--- a/packages/shared/src/components/auth/RegistrationForm.spec.tsx
+++ b/packages/shared/src/components/auth/RegistrationForm.spec.tsx
@@ -57,10 +57,8 @@ const mockRegistraitonValidationFlow = (
     .reply(responseCode, result);
 };
 
-const onSelectedProvider = jest.fn();
 const renderComponent = (
   props: AuthOptionsProps = {
-    onSelectedProvider,
     formRef: null,
   },
 ): RenderResult => {

--- a/packages/shared/src/components/modals/ConnectedUser.tsx
+++ b/packages/shared/src/components/modals/ConnectedUser.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { useQuery } from 'react-query';
 import { getKratosProviders } from '../../lib/kratos';
+import { capitalize } from '../../lib/strings';
 import { Button } from '../buttons/Button';
 import ImageInput from '../fields/ImageInput';
 
@@ -36,8 +37,9 @@ function ConnectedUserModal({
           Connected log in methods: {data?.result?.join(', ')}
         </span>
         <p className="mt-12 text-center text-theme-label-secondary typo-body">
-          You previously logged in to daily.dev. If you want to add Facebook as
-          another login option, you will need to login again.
+          You previously logged in to daily.dev. If you want to add{' '}
+          {capitalize(user.provider)} as another login option, you will need to
+          login again.
         </p>
       </div>
       <span className="flex flex-row justify-center p-3 mt-auto w-full border-t border-theme-divider-tertiary">

--- a/packages/shared/src/components/modals/ConnectedUser.tsx
+++ b/packages/shared/src/components/modals/ConnectedUser.tsx
@@ -1,0 +1,54 @@
+import React, { ReactElement } from 'react';
+import { useQuery } from 'react-query';
+import { getKratosProviders } from '../../lib/kratos';
+import { Button } from '../buttons/Button';
+import ImageInput from '../fields/ImageInput';
+
+export interface ConnectedUser {
+  name: string;
+  email: string;
+  image: string;
+}
+
+interface ConnectedUserModalProps {
+  user: ConnectedUser;
+  flowId: string;
+  onLogin: () => void;
+}
+
+function ConnectedUserModal({
+  user,
+  flowId,
+  onLogin,
+}: ConnectedUserModalProps): ReactElement {
+  const { data } = useQuery(
+    [{ type: 'registration', flowId }],
+    ({ queryKey: [{ flowId: flow }] }) => getKratosProviders(flow),
+  );
+
+  return (
+    <>
+      <div className="flex flex-col flex-1 items-center px-10 pt-8 w-full">
+        <ImageInput viewOnly initialValue={user.image} size="large" />
+        <span className="mt-5 typo-title3">{user.email}</span>
+        <span className="mt-1 typo-footnote text-theme-label-tertiary">
+          Connected log in methods: {data?.result?.join(', ')}
+        </span>
+        <p className="mt-12 text-center text-theme-label-secondary typo-body">
+          You previously logged in to daily.dev. If you want to add Facebook as
+          another login option, you will need to login again.
+        </p>
+      </div>
+      <span className="flex flex-row justify-center p-3 mt-auto w-full border-t border-theme-divider-tertiary">
+        <Button
+          className="btn-primary bg-theme-color-cabbage"
+          onClick={onLogin}
+        >
+          Log in
+        </Button>
+      </span>
+    </>
+  );
+}
+
+export default ConnectedUserModal;

--- a/packages/shared/src/components/modals/ConnectedUser.tsx
+++ b/packages/shared/src/components/modals/ConnectedUser.tsx
@@ -8,6 +8,7 @@ export interface ConnectedUser {
   name: string;
   email: string;
   image: string;
+  provider: string;
 }
 
 interface ConnectedUserModalProps {

--- a/packages/shared/src/lib/kratos.ts
+++ b/packages/shared/src/lib/kratos.ts
@@ -295,7 +295,7 @@ export interface KratosProviderData {
 export const getKratosProviders = async (
   flow?: string,
 ): Promise<KratosProviderData> => {
-  const search = new URLSearchParams({ flow });
+  const search = flow ? new URLSearchParams({ flow }) : '';
   const res = await fetch(`${heimdallUrl}/api/list_providers?${search}`, {
     credentials: 'include',
     method: flow ? 'GET' : 'POST',

--- a/packages/shared/src/lib/kratos.ts
+++ b/packages/shared/src/lib/kratos.ts
@@ -292,10 +292,13 @@ export interface KratosProviderData {
   result: string[];
 }
 
-export const getKratosProviders = async (): Promise<KratosProviderData> => {
-  const res = await fetch(`${heimdallUrl}/api/list_providers`, {
+export const getKratosProviders = async (
+  flow?: string,
+): Promise<KratosProviderData> => {
+  const search = new URLSearchParams({ flow });
+  const res = await fetch(`${heimdallUrl}/api/list_providers?${search}`, {
     credentials: 'include',
-    method: 'POST',
+    method: flow ? 'GET' : 'POST',
   });
   return res.json();
 };

--- a/packages/shared/src/lib/strings.ts
+++ b/packages/shared/src/lib/strings.ts
@@ -16,3 +16,6 @@ export const removeLinkTargetElement = (link: string): string => {
 
   return origin + pathname + search;
 };
+
+export const capitalize = (value: string): string =>
+  (value && value[0].toUpperCase() + value.slice(1)) || '';

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -33,7 +33,7 @@ const AccountSecurityPage = (): ReactElement => {
   const [activeDisplay, setActiveDisplay] = useState(Display.Default);
   const { data: userProviders, refetch: refetchProviders } = useQuery(
     'providers',
-    getKratosProviders,
+    () => getKratosProviders(),
   );
   const { data: settings } = useQuery(['settings'], () =>
     initializeKratosFlow(AuthFlow.Settings),


### PR DESCRIPTION
## Changes

### Describe what this PR does
- This also fixes the issue of not hiding the left-side graphics (headings).
- Should show connected accounts

Preview (the connected log-in methods aren't shown in the preview as it was only running locally):
![image](https://user-images.githubusercontent.com/13744167/190607991-b18c1ae3-0af7-4394-9a9f-ebfe6eadce47.png)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-446 #done
