### PR TITLE
fix: consistency of using the same flow id for list providers query

### DIFF
--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -118,6 +118,7 @@ function AuthOptions({
           name: getNodeValue('traits.name', connected.ui.nodes),
           email: getNodeValue('traits.email', connected.ui.nodes),
           image: getNodeValue('traits.image', connected.ui.nodes),
+          flowId: connected.id,
         };
         onShowOptionsOnly?.(true);
         setConnectedUser(user);
@@ -253,11 +254,7 @@ function AuthOptions({
         <Tab label={Display.ConnectedUser}>
           <AuthModalHeader title="Account already exists" onClose={onClose} />
           {connectedUser && (
-            <ConnectedUserModal
-              flowId={registration?.id}
-              user={connectedUser}
-              onLogin={onShowLogin}
-            />
+            <ConnectedUserModal user={connectedUser} onLogin={onShowLogin} />
           )}
         </Tab>
       </TabContainer>

--- a/packages/shared/src/components/modals/ConnectedUser.tsx
+++ b/packages/shared/src/components/modals/ConnectedUser.tsx
@@ -9,23 +9,22 @@ export interface ConnectedUser {
   name: string;
   email: string;
   image: string;
+  flowId: string;
   provider: string;
 }
 
 interface ConnectedUserModalProps {
   user: ConnectedUser;
-  flowId: string;
   onLogin: () => void;
 }
 
 function ConnectedUserModal({
   user,
-  flowId,
   onLogin,
 }: ConnectedUserModalProps): ReactElement {
   const { data } = useQuery(
-    [{ type: 'registration', flowId }],
-    ({ queryKey: [{ flowId: flow }] }) => getKratosProviders(flow),
+    [{ type: 'registration', flowId: user.flowId }],
+    ({ queryKey: [{ flowId }] }) => getKratosProviders(flowId),
   );
 
   return (


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
