### PR TITLE
fix: line-break bug for mobile screens

### DIFF
--- a/packages/shared/src/components/widgets/Alert.tsx
+++ b/packages/shared/src/components/widgets/Alert.tsx
@@ -61,7 +61,7 @@ function Alert({
         <Icon size="medium" className={classNames('mr-2', fontColor[type])} />
         <span
           className={classNames(
-            'typo-callout',
+            'typo-callout flex-1',
             children && 'font-bold',
             children && fontColor[type],
           )}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Small fix for mobile versions of the alert div

New:
<img width="410" alt="Screenshot 2022-09-19 at 13 48 50" src="https://user-images.githubusercontent.com/554874/191011028-0caad175-1b6b-4ee1-aaf8-17f5067ac292.png">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-530 #done
