### PR TITLE
Wt 439 safari bug

### DIFF
--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -2,6 +2,7 @@ import React, {
   MutableRefObject,
   ReactElement,
   useContext,
+  useRef,
   useState,
 } from 'react';
 import classNames from 'classnames';
@@ -86,6 +87,7 @@ function AuthOptions({
     onUpdateHint,
     isLoading: isProfileUpdateLoading,
   } = useProfileForm();
+  const windowPopup = useRef<Window>(null);
 
   const { registration, validateRegistration, onSocialRegistration } =
     useRegistration({
@@ -96,10 +98,13 @@ function AuthOptions({
         setActiveDisplay(Display.EmailSent);
       },
       onInvalidRegistration: setRegistrationHints,
-      onRedirect: (redirect) => window.open(redirect),
+      onRedirect: (redirect) => {
+        windowPopup.current.location.href = redirect;
+      },
     });
 
   const onProviderClick = (provider: string) => {
+    windowPopup.current = window.open();
     setChosenProvider(provider);
     onSocialRegistration(provider);
   };
@@ -224,7 +229,7 @@ function AuthOptions({
         <Tab label={Display.SignBack}>
           <AuthSignBack
             onRegister={() => setActiveDisplay(Display.Default)}
-            onProviderClick={onSocialRegistration}
+            onProviderClick={onProviderClick}
             onClose={onClose}
           >
             <LoginForm

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -123,6 +123,7 @@ function AuthOptions({
           name: getNodeValue('traits.name', connected.ui.nodes),
           email: getNodeValue('traits.email', connected.ui.nodes),
           image: getNodeValue('traits.image', connected.ui.nodes),
+          flowId: connected.id,
         };
         onShowOptionsOnly?.(true);
         setConnectedUser(user);

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -118,7 +118,6 @@ function AuthOptions({
           name: getNodeValue('traits.name', connected.ui.nodes),
           email: getNodeValue('traits.email', connected.ui.nodes),
           image: getNodeValue('traits.image', connected.ui.nodes),
-          flowId: connected.id,
         };
         onShowOptionsOnly?.(true);
         setConnectedUser(user);
@@ -254,7 +253,11 @@ function AuthOptions({
         <Tab label={Display.ConnectedUser}>
           <AuthModalHeader title="Account already exists" onClose={onClose} />
           {connectedUser && (
-            <ConnectedUserModal user={connectedUser} onLogin={onShowLogin} />
+            <ConnectedUserModal
+              flowId={registration?.id}
+              user={connectedUser}
+              onLogin={onShowLogin}
+            />
           )}
         </Tab>
       </TabContainer>

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -258,11 +258,7 @@ function AuthOptions({
         <Tab label={Display.ConnectedUser}>
           <AuthModalHeader title="Account already exists" onClose={onClose} />
           {connectedUser && (
-            <ConnectedUserModal
-              flowId={registration?.id}
-              user={connectedUser}
-              onLogin={onShowLogin}
-            />
+            <ConnectedUserModal user={connectedUser} onLogin={onShowLogin} />
           )}
         </Tab>
       </TabContainer>

--- a/packages/shared/src/components/modals/ConnectedUser.tsx
+++ b/packages/shared/src/components/modals/ConnectedUser.tsx
@@ -9,22 +9,23 @@ export interface ConnectedUser {
   name: string;
   email: string;
   image: string;
-  flowId: string;
   provider: string;
 }
 
 interface ConnectedUserModalProps {
   user: ConnectedUser;
+  flowId: string;
   onLogin: () => void;
 }
 
 function ConnectedUserModal({
   user,
+  flowId,
   onLogin,
 }: ConnectedUserModalProps): ReactElement {
   const { data } = useQuery(
-    [{ type: 'registration', flowId: user.flowId }],
-    ({ queryKey: [{ flowId }] }) => getKratosProviders(flowId),
+    [{ type: 'registration', flowId }],
+    ({ queryKey: [{ flowId: flow }] }) => getKratosProviders(flow),
   );
 
   return (

--- a/packages/shared/src/components/modals/ConnectedUser.tsx
+++ b/packages/shared/src/components/modals/ConnectedUser.tsx
@@ -9,23 +9,22 @@ export interface ConnectedUser {
   name: string;
   email: string;
   image: string;
+  flowId: string;
   provider: string;
 }
 
 interface ConnectedUserModalProps {
   user: ConnectedUser;
-  flowId: string;
   onLogin: () => void;
 }
 
 function ConnectedUserModal({
   user,
-  flowId,
   onLogin,
 }: ConnectedUserModalProps): ReactElement {
   const { data } = useQuery(
-    [{ type: 'registration', flowId }],
-    ({ queryKey: [{ flowId: flow }] }) => getKratosProviders(flow),
+    [{ type: 'registration', flowId: user.flowId }],
+    ({ queryKey: [{ flowId }] }) => getKratosProviders(flowId),
   );
 
   return (


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Safari has to open the window outside any async calls, this way the window is not considered a blocking popup

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-439 #done
