### PR TITLE
fix: account details page sidebar

### DIFF
--- a/packages/shared/src/components/fields/ImageInput.tsx
+++ b/packages/shared/src/components/fields/ImageInput.tsx
@@ -1,5 +1,11 @@
 import classNames from 'classnames';
-import React, { ChangeEvent, ReactElement, useRef, useState } from 'react';
+import React, {
+  ChangeEvent,
+  ReactElement,
+  ReactNode,
+  useRef,
+  useState,
+} from 'react';
 import { blobToBase64 } from '../../lib/blob';
 import { fallbackImages } from '../../lib/config';
 import EditIcon from '../icons/Edit';
@@ -15,6 +21,7 @@ interface ImageInputProps {
   id?: string;
   viewOnly?: boolean;
   fallbackImage?: string;
+  hoverIcon?: ReactNode;
 }
 
 const TWO_MEGABYTES = 2 * 1024 * 1024;
@@ -32,6 +39,7 @@ function ImageInput({
   onChange,
   size = 'medium',
   viewOnly,
+  hoverIcon,
   fallbackImage = fallbackImages.avatar,
 }: ImageInputProps): ReactElement {
   const inputRef = useRef<HTMLInputElement>();
@@ -94,14 +102,14 @@ function ImageInput({
         alt="File upload preview"
         onError={onError}
       />
-      <EditIcon
+      <span
         className={classNames(
           'hidden',
           !viewOnly && 'mouse:group-hover:block absolute',
         )}
-        size={size}
-        secondary
-      />
+      >
+        {hoverIcon || <EditIcon size={size} secondary />}
+      </span>
       <span
         className={classNames('typo-footnote', error ? 'visible' : 'invisible')}
       >

--- a/packages/webapp/components/layouts/AccountLayout/SidebarNav.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/SidebarNav.tsx
@@ -89,7 +89,7 @@ function SidebarNav({
               key={accountSidebarPage.title}
             >
               <a
-                className="my-3 w-full typo-callout text-theme-label-tertiary"
+                className="w-full typo-callout text-theme-label-tertiary"
                 target={accountSidebarPage.target}
               >
                 {accountSidebarPage.title}

--- a/packages/webapp/components/layouts/AccountLayout/SidebarNavItem.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/SidebarNavItem.tsx
@@ -29,7 +29,14 @@ function SidebarNavItem({
         )}
       >
         {icon}
-        <span className="ml-2 typo-callout">{title}</span>
+        <span
+          className={classNames(
+            'ml-2 typo-callout',
+            !isActive && 'text-theme-label-tertiary',
+          )}
+        >
+          {title}
+        </span>
         <ArrowIcon className="ml-auto rotate-90" />
       </a>
     </Link>

--- a/packages/webapp/components/layouts/AccountLayout/common.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/common.tsx
@@ -107,5 +107,5 @@ export const CommonTextField = classed(TextField, 'max-w-sm');
 export const AccountTextField = classed(CommonTextField, 'mt-6');
 export const AccountSidebarPagesSection = classed(
   'div',
-  'flex flex-col py-1.5 px-6 mt-10 w-full rounded-16 border border-theme-divider-tertiary',
+  'flex flex-col py-4 px-5 gap-3 mt-10 w-full rounded-16 border border-theme-divider-tertiary',
 );

--- a/packages/webapp/pages/account/profile.tsx
+++ b/packages/webapp/pages/account/profile.tsx
@@ -12,6 +12,7 @@ import React, { ReactElement, useContext, useRef } from 'react';
 import useProfileForm, {
   UpdateProfileParameters,
 } from '@dailydotdev/shared/src/hooks/useProfileForm';
+import CameraIcon from '@dailydotdev/shared/src/components/icons/Camera';
 import { getAccountLayout } from '../../components/layouts/AccountLayout';
 import AccountContentSection from '../../components/layouts/AccountLayout/AccountContentSection';
 import { AccountPageContainer } from '../../components/layouts/AccountLayout/AccountPageContainer';
@@ -64,7 +65,12 @@ const AccountProfilePage = (): ReactElement => {
           description="Upload a picture to make your profile stand out and let people recognise
         your comments and contributions easily!"
         >
-          <ImageInput id={id} className="mt-6" initialValue={user.image} />
+          <ImageInput
+            id={id}
+            className="mt-6"
+            initialValue={user.image}
+            hoverIcon={<CameraIcon size="xlarge" />}
+          />
         </AccountContentSection>
         <AccountContentSection title="Account Information">
           <AccountTextField


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixes sidebar inactive items
- Fixes the account pages list spacing
- Refactored the ImageInput to include hover icon as props

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-565 #done
WT-566 #done
WT-567 #done
