### PR TITLE
fix: forgot password

### DIFF
--- a/packages/shared/src/components/auth/LoginForm.tsx
+++ b/packages/shared/src/components/auth/LoginForm.tsx
@@ -73,7 +73,7 @@ function LoginForm({
         {onForgotPassword && (
           <ClickableText
             type="button"
-            className="flex-1 underline btn-primary"
+            className="flex-1 underline grow-[2] btn-primary"
             onClick={onForgotPassword}
           >
             Forgot password?


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Password was pushed to two lines because double flex-1 on two elements.
- Flex grow to 2 on the password helps.

![Screenshot 2022-09-21 at 09 20 42](https://user-images.githubusercontent.com/554874/191440916-99667f99-6391-45af-a33a-c631c4db42e0.png)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-556 #done
