### PR TITLE
fix: catch username

### DIFF
--- a/packages/shared/src/hooks/useProfileForm.ts
+++ b/packages/shared/src/hooks/useProfileForm.ts
@@ -1,7 +1,7 @@
 import { GraphQLError } from 'graphql-request/dist/types';
 import request from 'graphql-request';
 import { FormEvent, useContext, useMemo, useState } from 'react';
-import { UseMutateAsyncFunction, useMutation } from 'react-query';
+import { useMutation } from 'react-query';
 import { UseMutateFunction } from 'react-query/types/react/types';
 import AuthContext from '../contexts/AuthContext';
 import { UPDATE_USER_PROFILE_MUTATION } from '../graphql/users';

--- a/packages/shared/src/hooks/useProfileForm.ts
+++ b/packages/shared/src/hooks/useProfileForm.ts
@@ -2,6 +2,7 @@ import { GraphQLError } from 'graphql-request/dist/types';
 import request from 'graphql-request';
 import { FormEvent, useContext, useMemo, useState } from 'react';
 import { UseMutateAsyncFunction, useMutation } from 'react-query';
+import { UseMutateFunction } from 'react-query/types/react/types';
 import AuthContext from '../contexts/AuthContext';
 import { UPDATE_USER_PROFILE_MUTATION } from '../graphql/users';
 import { apiUrl } from '../lib/config';
@@ -33,7 +34,7 @@ interface UseProfileForm {
   hint: ProfileFormHint;
   onUpdateHint?: (hint: Partial<ProfileFormHint>) => void;
   isLoading?: boolean;
-  updateUserProfile: UseMutateAsyncFunction<
+  updateUserProfile: UseMutateFunction<
     LoggedUser,
     ResponseError,
     Partial<UpdateProfileParameters & { event: FormEvent }>
@@ -64,7 +65,7 @@ const useProfileForm = ({
 }: UseProfileFormProps = {}): UseProfileForm => {
   const { user, updateUser } = useContext(AuthContext);
   const [hint, setHint] = useState<ProfileFormHint>({});
-  const { isLoading, mutateAsync: updateUserProfile } = useMutation<
+  const { isLoading, mutate: updateUserProfile } = useMutation<
     LoggedUser,
     ResponseError,
     Partial<UpdateProfileParameters & { event: ModalEvent }>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We where using mutateAsync which does NOT handle errors on it's own.
- I decided to switch to mutate itself which is recommend by react query.
- More info on mutation promise: https://tanstack.com/query/v4/docs/guides/mutations#promises

Side note: Production it was visually half-working, but still throwing a unhandled error under the hood.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-555 #done
