### PR TITLE
fix: use the correct number of columns when calculating row and column

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -336,8 +336,8 @@ export default function Feed<T>({
               }
               items={items}
               index={index}
-              row={calculateRow(index, numCards)}
-              column={calculateColumn(index, numCards)}
+              row={calculateRow(index, virtualizedNumCards)}
+              column={calculateColumn(index, virtualizedNumCards)}
               columns={virtualizedNumCards}
               key={getFeedItemKey(items, index)}
               useList={useList}


### PR DESCRIPTION
## Changes

### Describe what this PR does

When we track feed events, we attach the item row and column but they are calculated based on the wrong number of columns

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
