### PR TITLE
fix: valid user flow

### DIFF
--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -2,6 +2,7 @@ import React, {
   MutableRefObject,
   ReactElement,
   useContext,
+  useEffect,
   useRef,
   useState,
 } from 'react';
@@ -77,14 +78,26 @@ function AuthOptions({
     storage.getItem(SIGNIN_METHOD_KEY) ? Display.SignBack : defaultDisplay,
   );
   const [isForgotPasswordReturn, setIsForgotPasswordReturn] = useState(false);
+  const [handleLoginCheck, setHandleLoginCheck] = useState<boolean>(null);
   const [chosenProvider, setChosenProvider] = useState<string>(null);
   const onLoginCheck = () => {
-    if (user && user?.infoConfirmed) {
-      onSuccessfulLogin();
+    if (!user || handleLoginCheck === false) {
+      return;
     }
 
-    setActiveDisplay(Display.SocialRegistration);
+    setHandleLoginCheck(handleLoginCheck === null);
+
+    if (user.infoConfirmed) {
+      onSuccessfulLogin();
+    } else {
+      setActiveDisplay(Display.SocialRegistration);
+    }
   };
+
+  useEffect(() => {
+    onLoginCheck();
+  }, [user]);
+
   const { loginHint, onPasswordLogin, isPasswordLoginLoading } = useLogin({
     onSuccessfulLogin: onLoginCheck,
   });


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Previously we didn't wait for the user to be valid so we could never continue the flow.
- Now we wait for the user and evaluate the action 
- Did have to use useEffect :(

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-596 #done
