### PR TITLE
fix: companion comment mention hover tooltip

### DIFF
--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -79,7 +79,10 @@ export default function MainComment({
           'border border-theme-color-cabbage'
         }
       >
-        <Markdown content={comment.contentHtml} />
+        <Markdown
+          content={comment.contentHtml}
+          appendTooltipTo={appendTooltipTo}
+        />
       </MainCommentBox>
       <CommentActionButtons
         post={post}

--- a/packages/shared/src/components/comments/SubComment.tsx
+++ b/packages/shared/src/components/comments/SubComment.tsx
@@ -90,7 +90,10 @@ export default function SubComment({
           </div>
           <CommentPublishDate comment={comment} />
           <div className="mt-2">
-            <Markdown content={comment.contentHtml} />
+            <Markdown
+              content={comment.contentHtml}
+              appendTooltipTo={appendTooltipTo}
+            />
           </div>
         </SubCommentBox>
         <CommentActionButtons


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The appending of the tooltip was not passed. Hence it was getting appended on the body where styles got adjusted.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-586 #done
