### PR TITLE
fix: reset password edge case

### DIFF
--- a/packages/shared/src/lib/kratos.ts
+++ b/packages/shared/src/lib/kratos.ts
@@ -231,7 +231,7 @@ export const initializeKratosFlow = async (
 export const getKratosFlow = async (
   flow: AuthFlow,
   id: string,
-): Promise<InitializationData> => {
+): Promise<InitializationData | KratosError> => {
   const res = await fetch(`${authUrl}/self-service${flow}?flow=${id}`, {
     credentials: 'include',
     headers: { Accept: 'application/json' },

--- a/packages/shared/src/lib/kratos.ts
+++ b/packages/shared/src/lib/kratos.ts
@@ -187,7 +187,7 @@ export interface SuccessfulRegistrationData {
   identity: Identity;
 }
 
-interface KratosError {
+export interface KratosError {
   code: number;
   message: string;
   reason: string;
@@ -228,10 +228,10 @@ export const initializeKratosFlow = async (
   return res.json();
 };
 
-export const getKratosFlow = async (
+export const getKratosFlow = async <T = InitializationData>(
   flow: AuthFlow,
   id: string,
-): Promise<InitializationData | KratosError> => {
+): Promise<T> => {
   const res = await fetch(`${authUrl}/self-service${flow}?flow=${id}`, {
     credentials: 'include',
     headers: { Accept: 'application/json' },

--- a/packages/webapp/pages/reset-password.tsx
+++ b/packages/webapp/pages/reset-password.tsx
@@ -27,13 +27,20 @@ function ResetPassword(): ReactElement {
   const [hint, setHint] = useState(null);
   const [disabledWhileRedirecting, setDisabledWhileRedirecting] =
     useState(false);
-  const { data } = useQuery(
+  const { data: settings } = useQuery(
     'settings',
     () => getKratosFlow(AuthFlow.Settings, router.query.flow as string),
     {
       ...disabledRefetch,
       retry: false,
       enabled: !!router.query.flow,
+      onSuccess: (data) => {
+        if ('code' in data && data.code === 401) {
+          setHint(
+            `An error occurred. Kindly send us a report and include the follow id: ${router.query.flow}`,
+          );
+        }
+      },
     },
   );
   const { mutateAsync: reset, isLoading } = useMutation(
@@ -61,14 +68,14 @@ function ResetPassword(): ReactElement {
     const { password } = formToJson<{ password: string }>(e.currentTarget);
     const params: RegistrationParameters = {
       method: 'password',
-      csrf_token: getNodeValue('csrf_token', data.ui.nodes),
-      'traits.email': getNodeValue('traits.email', data.ui.nodes),
-      'traits.name': getNodeValue('traits.name', data.ui.nodes),
-      'traits.username': getNodeValue('traits.username', data.ui.nodes),
-      'traits.image': getNodeValue('traits.image', data.ui.nodes),
+      csrf_token: getNodeValue('csrf_token', settings.ui.nodes),
+      'traits.email': getNodeValue('traits.email', settings.ui.nodes),
+      'traits.name': getNodeValue('traits.name', settings.ui.nodes),
+      'traits.username': getNodeValue('traits.username', settings.ui.nodes),
+      'traits.image': getNodeValue('traits.image', settings.ui.nodes),
       password,
     };
-    reset({ params, action: data.ui.action });
+    reset({ params, action: settings.ui.action });
   };
 
   return (

--- a/packages/webapp/pages/reset-password.tsx
+++ b/packages/webapp/pages/reset-password.tsx
@@ -39,7 +39,7 @@ function ResetPassword(): ReactElement {
       onSuccess: (data) => {
         if ('code' in data && data.code === 401) {
           setHint(
-            `An error occurred. Kindly send us a report and include the follow id: ${router.query.flow}`,
+            `An error occurred. Kindly send us a report and include the following id: ${router.query.flow}`,
           );
         }
       },

--- a/packages/webapp/pages/reset-password.tsx
+++ b/packages/webapp/pages/reset-password.tsx
@@ -16,6 +16,8 @@ import { formToJson } from '@dailydotdev/shared/src/lib/form';
 import {
   AuthFlow,
   getKratosFlow,
+  InitializationData,
+  KratosError,
   submitKratosFlow,
 } from '@dailydotdev/shared/src/lib/kratos';
 import { PasswordField } from '@dailydotdev/shared/src/components/fields/PasswordField';
@@ -27,7 +29,7 @@ function ResetPassword(): ReactElement {
   const [hint, setHint] = useState(null);
   const [disabledWhileRedirecting, setDisabledWhileRedirecting] =
     useState(false);
-  const { data: settings } = useQuery(
+  const { data: settings } = useQuery<InitializationData | KratosError>(
     'settings',
     () => getKratosFlow(AuthFlow.Settings, router.query.flow as string),
     {
@@ -65,6 +67,10 @@ function ResetPassword(): ReactElement {
 
   const onSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    if ('code' in settings) {
+      return;
+    }
+
     const { password } = formToJson<{ password: string }>(e.currentTarget);
     const params: RegistrationParameters = {
       method: 'password',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fix edge case where there is a mismatch with the `identities` user id and the `api` db user id but the same email. The user automatically gets logged out (our internal function for user not found).
- To be able to investigate easily, we ask the user to include the flow ID for sending feedback as this requires internal fix for matching their IDs.
- 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-604 #done
