### PR TITLE
refactor: resend verification always shown if not verified

### DIFF
--- a/packages/shared/__tests__/fixture/auth.ts
+++ b/packages/shared/__tests__/fixture/auth.ts
@@ -739,7 +739,7 @@ export const settingsFlowMockData: InitializationData & { identity: Identity } =
     state: 'show_form',
   };
 
-const whoamiMockData = {
+const getWhoamiMockData = (email = 'lee@daily.dev') => ({
   id: 'c005cab5-e770-4337-a3b3-7903b79abc61',
   active: true,
   expires_at: '2022-09-01T06:19:36.095759Z',
@@ -761,7 +761,7 @@ const whoamiMockData = {
     state_changed_at: '2022-08-24T03:30:19.668093Z',
     traits: {
       name: 'Lee Hansel Solevilla',
-      email: 'lee@daily.dev',
+      email: email,
       image:
         'https://lh3.googleusercontent.com/a-/AFdZucrCRkShFtfp4KDx2ipH0cgIzKmD7fcDYfwLqX8Q=s96-c',
       username: 'lee',
@@ -769,7 +769,7 @@ const whoamiMockData = {
     verifiable_addresses: [
       {
         id: '99a84554-56a8-4a1c-b269-869ddd0b4b8d',
-        value: 'lee@daily.dev',
+        value: email,
         verified: false,
         via: 'email',
         status: 'sent',
@@ -780,7 +780,7 @@ const whoamiMockData = {
     recovery_addresses: [
       {
         id: 'a530e776-6a87-4b19-9523-4eef4a01b0dd',
-        value: 'lee@daily.dev',
+        value: email,
         via: 'email',
         created_at: '2022-08-24T03:30:19.714243Z',
         updated_at: '2022-08-31T03:48:02.423298Z',
@@ -790,12 +790,10 @@ const whoamiMockData = {
     created_at: '2022-08-24T03:30:19.690974Z',
     updated_at: '2022-08-24T03:30:19.690974Z',
   },
-};
+});
 
-export const mockWhoAmIFlow = (result: Partial<AuthSession> = {}): void => {
-  nock(authUrl)
-    .get('/sessions/whoami')
-    .reply(200, { ...whoamiMockData, ...result });
+export const mockWhoAmIFlow = (email?: string): void => {
+  nock(authUrl).get('/sessions/whoami').reply(200, getWhoamiMockData(email));
 };
 
 export const socialProviderRedirectMock = {

--- a/packages/shared/__tests__/fixture/auth.ts
+++ b/packages/shared/__tests__/fixture/auth.ts
@@ -1,7 +1,6 @@
 import nock from 'nock';
 import { authUrl, heimdallUrl } from '../../src/lib/constants';
 import {
-  AuthSession,
   EmptyObjectLiteral,
   Identity,
   InitializationData,

--- a/packages/shared/__tests__/fixture/auth.ts
+++ b/packages/shared/__tests__/fixture/auth.ts
@@ -760,7 +760,7 @@ const getWhoamiMockData = (email = 'lee@daily.dev') => ({
     state_changed_at: '2022-08-24T03:30:19.668093Z',
     traits: {
       name: 'Lee Hansel Solevilla',
-      email: email,
+      email,
       image:
         'https://lh3.googleusercontent.com/a-/AFdZucrCRkShFtfp4KDx2ipH0cgIzKmD7fcDYfwLqX8Q=s96-c',
       username: 'lee',

--- a/packages/shared/src/hooks/useLogin.ts
+++ b/packages/shared/src/hooks/useLogin.ts
@@ -25,6 +25,7 @@ interface UseLogin {
   isPasswordLoginLoading?: boolean;
   loginFlowData: InitializationData;
   loginHint?: ReturnType<typeof useState>;
+  refetchSession?: () => Promise<unknown>;
   onSocialLogin: (provider: string) => void;
   onPasswordLogin: (params: LoginFormParams) => void;
 }
@@ -44,9 +45,11 @@ const useLogin = ({
 }: UseLoginProps = {}): UseLogin => {
   const { refetchBoot } = useContext(AuthContext);
   const [hint, setHint] = useState('Enter your password to login');
-  const { data: session } = useQuery(['current_session'], getKratosSession, {
-    enabled: enableSessionVerification,
-  });
+  const { data: session, refetch: refetchSession } = useQuery(
+    ['current_session'],
+    getKratosSession,
+    { enabled: enableSessionVerification },
+  );
   const { data: login } = useQuery(
     [{ type: 'login', params: queryParams }],
     ({ queryKey: [{ params }] }) =>
@@ -129,6 +132,7 @@ const useLogin = ({
 
   return useMemo(
     () => ({
+      refetchSession,
       session,
       loginFlowData: login,
       loginHint: [hint, setHint],

--- a/packages/shared/src/hooks/useLogin.ts
+++ b/packages/shared/src/hooks/useLogin.ts
@@ -11,6 +11,7 @@ import {
 import {
   AuthEvent,
   AuthFlow,
+  AuthSession,
   EmptyObjectLiteral,
   getKratosSession,
   InitializationData,
@@ -20,6 +21,7 @@ import {
 import useWindowEvents from './useWindowEvents';
 
 interface UseLogin {
+  session: AuthSession;
   isPasswordLoginLoading?: boolean;
   loginFlowData: InitializationData;
   loginHint?: ReturnType<typeof useState>;
@@ -127,13 +129,14 @@ const useLogin = ({
 
   return useMemo(
     () => ({
+      session,
       loginFlowData: login,
       loginHint: [hint, setHint],
       isPasswordLoginLoading: isLoading,
       onSocialLogin: onSubmitSocialLogin,
       onPasswordLogin: onSubmitPasswordLogin,
     }),
-    [queryEnabled, queryParams, hint, login, isLoading],
+    [session, queryEnabled, queryParams, hint, login, isLoading],
   );
 };
 

--- a/packages/shared/src/hooks/usePrivilegedSession.ts
+++ b/packages/shared/src/hooks/usePrivilegedSession.ts
@@ -9,6 +9,7 @@ interface UsePrivilegedSession {
   session: AuthSession;
   showVerifySession?: boolean;
   onCloseVerifySession: () => void;
+  refetchSession?: () => Promise<unknown>;
   onPasswordLogin?: (params: LoginFormParams) => void;
   onSocialLogin?: (provider: string) => void;
   initializePrivilegedSession?: (redirect: string) => void;
@@ -29,20 +30,26 @@ const usePrivilegedSession = ({
   const setVerifySessionId = (value: string) =>
     client.setQueryData(VERIFY_SESSION_KEY, value);
 
-  const { session, loginFlowData, loginHint, onSocialLogin, onPasswordLogin } =
-    useLogin({
-      enableSessionVerification: true,
-      queryEnabled: !!verifySessionId,
-      queryParams: { refresh: 'true' },
-      onSuccessfulLogin: () => {
-        setVerifySessionId(null);
-        if (onSessionVerified) {
-          onSessionVerified();
-        } else {
-          displayToast('Session successfully verified!');
-        }
-      },
-    });
+  const {
+    session,
+    loginFlowData,
+    loginHint,
+    onSocialLogin,
+    onPasswordLogin,
+    refetchSession,
+  } = useLogin({
+    enableSessionVerification: true,
+    queryEnabled: !!verifySessionId,
+    queryParams: { refresh: 'true' },
+    onSuccessfulLogin: () => {
+      setVerifySessionId(null);
+      if (onSessionVerified) {
+        onSessionVerified();
+      } else {
+        displayToast('Session successfully verified!');
+      }
+    },
+  });
 
   const initializePrivilegedSession = (redirect: string) => {
     const url = new URL(redirect);
@@ -67,6 +74,7 @@ const usePrivilegedSession = ({
       onCloseVerifySession: () => setVerifySessionId(null),
       onPasswordLogin,
       onSocialLogin,
+      refetchSession,
     }),
     [session, verifySessionId, loginHint, loginFlowData],
   );

--- a/packages/shared/src/hooks/usePrivilegedSession.ts
+++ b/packages/shared/src/hooks/usePrivilegedSession.ts
@@ -1,10 +1,12 @@
 import { useMemo } from 'react';
 import { useQuery, useQueryClient } from 'react-query';
 import { LoginFormParams } from '../components/auth/LoginForm';
+import { AuthSession } from '../lib/kratos';
 import useLogin from './useLogin';
 import { useToastNotification } from './useToastNotification';
 
 interface UsePrivilegedSession {
+  session: AuthSession;
   showVerifySession?: boolean;
   onCloseVerifySession: () => void;
   onPasswordLogin?: (params: LoginFormParams) => void;
@@ -27,8 +29,8 @@ const usePrivilegedSession = ({
   const setVerifySessionId = (value: string) =>
     client.setQueryData(VERIFY_SESSION_KEY, value);
 
-  const { loginFlowData, loginHint, onSocialLogin, onPasswordLogin } = useLogin(
-    {
+  const { session, loginFlowData, loginHint, onSocialLogin, onPasswordLogin } =
+    useLogin({
       enableSessionVerification: true,
       queryEnabled: !!verifySessionId,
       queryParams: { refresh: 'true' },
@@ -40,8 +42,7 @@ const usePrivilegedSession = ({
           displayToast('Session successfully verified!');
         }
       },
-    },
-  );
+    });
 
   const initializePrivilegedSession = (redirect: string) => {
     const url = new URL(redirect);
@@ -60,13 +61,14 @@ const usePrivilegedSession = ({
 
   return useMemo(
     () => ({
+      session,
       showVerifySession: !!verifySessionId,
       initializePrivilegedSession,
       onCloseVerifySession: () => setVerifySessionId(null),
       onPasswordLogin,
       onSocialLogin,
     }),
-    [verifySessionId, loginHint, loginFlowData],
+    [session, verifySessionId, loginHint, loginFlowData],
   );
 };
 

--- a/packages/webapp/__tests__/AccountSecurityPage.tsx
+++ b/packages/webapp/__tests__/AccountSecurityPage.tsx
@@ -56,7 +56,7 @@ const renderComponent = (): RenderResult => {
   const client = new QueryClient();
   mockSettingsFlow();
   mockListProviders();
-  mockWhoAmIFlow();
+  mockWhoAmIFlow(defaultLoggedUser.email);
 
   return render(
     <QueryClientProvider client={client}>

--- a/packages/webapp/__tests__/AccountSecurityPage.tsx
+++ b/packages/webapp/__tests__/AccountSecurityPage.tsx
@@ -136,6 +136,7 @@ it('should allow changing of email', async () => {
     'traits.username': getNodeValue('traits.username', nodes),
     'traits.image': getNodeValue('traits.image', nodes),
   };
+  mockVerificationFlow();
   mockWhoAmIFlow(email);
   mockSettingsValidation(params);
   const submitChanges = await screen.findByText('Save changes');
@@ -237,6 +238,7 @@ it('should allow linking social providers', async () => {
   const { nodes } = settingsFlowMockData.ui;
   const token = getNodeValue('csrf_token', nodes);
   const params = { link: 'google', csrf_token: token };
+  mockListProviders();
   mockSettingsValidation(params);
   fireEvent.click(connect);
   await waitForNock();

--- a/packages/webapp/__tests__/AccountSecurityPage.tsx
+++ b/packages/webapp/__tests__/AccountSecurityPage.tsx
@@ -52,10 +52,16 @@ const defaultLoggedUser: LoggedUser = {
 const updateUser = jest.fn();
 const refetchBoot = jest.fn();
 
+const waitAllRenderMocks = async () => {
+  await waitForNock();
+  await act(() => new Promise((resolve) => setTimeout(resolve, 100)));
+};
+
 const renderComponent = (): RenderResult => {
   const client = new QueryClient();
   mockSettingsFlow();
   mockListProviders();
+  mockVerificationFlow();
   mockWhoAmIFlow(defaultLoggedUser.email);
 
   return render(
@@ -104,13 +110,14 @@ const verifySession = async (email = defaultLoggedUser.email) => {
 
 it('should show current email', async () => {
   renderComponent();
+  await waitAllRenderMocks();
   const el = await screen.findByTestId('current_email');
   expect(el).toHaveValue(defaultLoggedUser.email);
 });
 
 it('should allow changing of email', async () => {
   renderComponent();
-  await waitForNock();
+  await waitAllRenderMocks();
   const el = await screen.findByTestId('current_email');
   expect(el).toHaveValue(defaultLoggedUser.email);
   const displayForm = await screen.findByText('Change email');
@@ -140,7 +147,7 @@ it('should allow changing of email', async () => {
 
 it('should allow changing of email but require verification', async () => {
   renderComponent();
-  await waitForNock();
+  await waitAllRenderMocks();
   const el = await screen.findByTestId('current_email');
   expect(el).toHaveValue(defaultLoggedUser.email);
   const displayForm = await screen.findByText('Change email');
@@ -176,7 +183,7 @@ it('should allow changing of email but require verification', async () => {
 
 it('should allow setting new password', async () => {
   renderComponent();
-  await waitForNock();
+  await waitAllRenderMocks();
   const password = '#123xAbc';
   fireEvent.input(screen.getByPlaceholderText('Password'), {
     target: { value: password },
@@ -198,7 +205,7 @@ it('should allow setting new password', async () => {
 
 it('should allow setting new password but require to verify session', async () => {
   renderComponent();
-  await waitForNock();
+  await waitAllRenderMocks();
   const password = '#123xAbc';
   fireEvent.input(screen.getByPlaceholderText('Password'), {
     target: { value: password },
@@ -225,7 +232,7 @@ it('should allow setting new password but require to verify session', async () =
 
 it('should allow linking social providers', async () => {
   renderComponent();
-  await waitForNock();
+  await waitAllRenderMocks();
   const connect = await screen.findByText('Connect with Google');
   const { nodes } = settingsFlowMockData.ui;
   const token = getNodeValue('csrf_token', nodes);
@@ -237,7 +244,7 @@ it('should allow linking social providers', async () => {
 
 it('should allow linking social providers but require to verify session', async () => {
   renderComponent();
-  await waitForNock();
+  await waitAllRenderMocks();
   const connect = await screen.findByText('Connect with Google');
   const { nodes } = settingsFlowMockData.ui;
   const token = getNodeValue('csrf_token', nodes);

--- a/packages/webapp/__tests__/AccountSecurityPage.tsx
+++ b/packages/webapp/__tests__/AccountSecurityPage.tsx
@@ -129,6 +129,7 @@ it('should allow changing of email', async () => {
     'traits.username': getNodeValue('traits.username', nodes),
     'traits.image': getNodeValue('traits.image', nodes),
   };
+  mockWhoAmIFlow(email);
   mockSettingsValidation(params);
   const submitChanges = await screen.findByText('Save changes');
   fireEvent.click(submitChanges);
@@ -163,6 +164,7 @@ it('should allow changing of email but require verification', async () => {
   fireEvent.click(submitChanges);
   await waitForNock();
   await verifySession();
+  mockWhoAmIFlow(email);
   mockSettingsValidation(params);
   const reSubmitChanges = await screen.findByText('Save changes');
   fireEvent.click(reSubmitChanges);

--- a/packages/webapp/components/layouts/AccountLayout/EmailSentSection.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/EmailSentSection.tsx
@@ -1,37 +1,24 @@
 import AlertContainer from '@dailydotdev/shared/src/components/alert/AlertContainer';
 import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
 import React, { ReactElement } from 'react';
-import { useQuery } from 'react-query';
 import classNames from 'classnames';
 import useAccountEmailFlow from '@dailydotdev/shared/src/hooks/useAccountEmailFlow';
-import { AuthFlow, getKratosSession } from '@dailydotdev/shared/src/lib/kratos';
+import { AuthFlow } from '@dailydotdev/shared/src/lib/kratos';
 
 interface EmailSentSectionProps {
   onCancel?: (e: React.MouseEvent) => void;
   className?: string;
+  email: string;
 }
 
 function EmailSentSection({
   onCancel,
+  email,
   className,
 }: EmailSentSectionProps): ReactElement {
-  const { data } = useQuery(['whoami'], getKratosSession);
   const { sendEmail, resendTimer, isLoading } = useAccountEmailFlow(
     AuthFlow.Verification,
   );
-  const email = data?.identity?.traits?.email;
-
-  if (!email) {
-    return null;
-  }
-
-  const verifyable = data.identity.verifiable_addresses.find(
-    (address) => address.value === email,
-  );
-
-  if (verifyable?.verified) {
-    return null;
-  }
 
   return (
     <AlertContainer
@@ -46,7 +33,7 @@ function EmailSentSection({
       </p>
       <span className="flex flex-row gap-4 mt-4">
         <Button
-          onClick={() => sendEmail(data?.identity?.traits?.email)}
+          onClick={() => sendEmail(email)}
           buttonSize="xsmall"
           className="w-fit btn-primary"
           disabled={isLoading || resendTimer > 0}

--- a/packages/webapp/components/layouts/AccountLayout/EmailSentSection.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/EmailSentSection.tsx
@@ -19,6 +19,19 @@ function EmailSentSection({
   const { sendEmail, resendTimer, isLoading } = useAccountEmailFlow(
     AuthFlow.Verification,
   );
+  const email = data?.identity?.traits?.email;
+
+  if (!email) {
+    return null;
+  }
+
+  const verifyable = data.identity.verifiable_addresses.find(
+    (address) => address.value === email,
+  );
+
+  if (verifyable?.verified) {
+    return null;
+  }
 
   return (
     <AlertContainer

--- a/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
@@ -69,6 +69,7 @@ const removeProviderList = Object.values(removeProvider).map(
 );
 
 interface AccountSecurityDefaultProps {
+  email?: string;
   session: AuthSession;
   isEmailSent?: boolean;
   userProviders?: KratosProviderData;
@@ -79,6 +80,7 @@ interface AccountSecurityDefaultProps {
 }
 
 function AccountSecurityDefault({
+  email,
   session,
   userProviders,
   updatePasswordRef,
@@ -91,7 +93,6 @@ function AccountSecurityDefault({
   const [alreadyLinkedProvider, setAlreadyLinkedProvider] = useState(false);
   const [linkProvider, setLinkProvider] = useState(null);
   const [unlinkProvider, setUnlinkProvider] = useState(null);
-  const [, setEmail] = useState<string>(null);
   const hasPassword = userProviders?.result?.includes('password');
 
   useWindowEvents<SocialRegistrationFlow>(
@@ -127,10 +128,11 @@ function AccountSecurityDefault({
     onUpdatePassword(form);
   };
 
-  const email = session?.identity?.traits?.email;
-  const verifyable = session?.identity?.verifiable_addresses?.find(
-    (address) => address.value === email,
-  );
+  const verifyable =
+    email &&
+    session?.identity?.verifiable_addresses?.find(
+      (address) => address.value === email,
+    );
 
   return (
     <AccountPageContainer title="Security">
@@ -152,7 +154,6 @@ function AccountSecurityDefault({
           <AccountTextField
             fieldType="tertiary"
             value={user.email}
-            onChange={(e) => setEmail(e.currentTarget.value)}
             label="Email"
             inputId="email"
             data-testid="current_email"

--- a/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
@@ -77,7 +77,6 @@ interface AccountSecurityDefaultProps {
 }
 
 function AccountSecurityDefault({
-  isEmailSent,
   userProviders,
   updatePasswordRef,
   onSwitchDisplay,
@@ -125,20 +124,6 @@ function AccountSecurityDefault({
     onUpdatePassword(form);
   };
 
-  const emailAction = isEmailSent ? (
-    <EmailSentSection className="max-w-sm" />
-  ) : (
-    hasPassword && (
-      <Button
-        buttonSize="small"
-        className="mt-6 w-fit btn-secondary"
-        onClick={() => onSwitchDisplay(Display.ChangeEmail)}
-      >
-        Change email
-      </Button>
-    )
-  );
-
   return (
     <AccountPageContainer title="Security">
       <AccountContentSection
@@ -168,7 +153,18 @@ function AccountSecurityDefault({
             isLocked
           />
         </SimpleTooltip>
-        {emailAction}
+        {!hasPassword && (
+          <>
+            <EmailSentSection className="max-w-sm" />
+            <Button
+              buttonSize="small"
+              className="mt-6 w-fit btn-secondary"
+              onClick={() => onSwitchDisplay(Display.ChangeEmail)}
+            >
+              Change email
+            </Button>
+          </>
+        )}
       </AccountContentSection>
       <AccountLoginSection
         title="Add login account"

--- a/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
@@ -88,7 +88,7 @@ function AccountSecurityDefault({
   onUpdatePassword,
   onUpdateProviders,
 }: AccountSecurityDefaultProps): ReactElement {
-  const { user, deleteAccount } = useContext(AuthContext);
+  const { deleteAccount } = useContext(AuthContext);
   const [showDeleteAccount, setShowDeleteAccount] = useState(false);
   const [alreadyLinkedProvider, setAlreadyLinkedProvider] = useState(false);
   const [linkProvider, setLinkProvider] = useState(null);
@@ -153,7 +153,7 @@ function AccountSecurityDefault({
         >
           <AccountTextField
             fieldType="tertiary"
-            value={user.email}
+            value={email}
             label="Email"
             inputId="email"
             data-testid="current_email"

--- a/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
@@ -16,6 +16,7 @@ import React, {
 import {
   AuthEvent,
   AuthFlow,
+  AuthSession,
   getKratosSettingsFlow,
   KratosProviderData,
   SocialRegistrationFlow,
@@ -68,6 +69,7 @@ const removeProviderList = Object.values(removeProvider).map(
 );
 
 interface AccountSecurityDefaultProps {
+  session: AuthSession;
   isEmailSent?: boolean;
   userProviders?: KratosProviderData;
   updatePasswordRef: MutableRefObject<HTMLFormElement>;
@@ -77,6 +79,7 @@ interface AccountSecurityDefaultProps {
 }
 
 function AccountSecurityDefault({
+  session,
   userProviders,
   updatePasswordRef,
   onSwitchDisplay,
@@ -124,6 +127,11 @@ function AccountSecurityDefault({
     onUpdatePassword(form);
   };
 
+  const email = session?.identity?.traits?.email;
+  const verifyable = session?.identity?.verifiable_addresses?.find(
+    (address) => address.value === email,
+  );
+
   return (
     <AccountPageContainer title="Security">
       <AccountContentSection
@@ -153,17 +161,17 @@ function AccountSecurityDefault({
             isLocked
           />
         </SimpleTooltip>
-        {!hasPassword && (
-          <>
-            <EmailSentSection className="max-w-sm" />
-            <Button
-              buttonSize="small"
-              className="mt-6 w-fit btn-secondary"
-              onClick={() => onSwitchDisplay(Display.ChangeEmail)}
-            >
-              Change email
-            </Button>
-          </>
+        {hasPassword && email && verifyable && !verifyable.verified && (
+          <EmailSentSection email={email} className="max-w-sm" />
+        )}
+        {hasPassword && (
+          <Button
+            buttonSize="small"
+            className="mt-6 w-fit btn-secondary"
+            onClick={() => onSwitchDisplay(Display.ChangeEmail)}
+          >
+            Change email
+          </Button>
         )}
       </AccountContentSection>
       <AccountLoginSection

--- a/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
@@ -154,6 +154,7 @@ function AccountSecurityDefault({
           <AccountTextField
             fieldType="tertiary"
             value={email}
+            defaultValue={email}
             label="Email"
             inputId="email"
             data-testid="current_email"

--- a/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
@@ -154,7 +154,6 @@ function AccountSecurityDefault({
           <AccountTextField
             fieldType="tertiary"
             value={email}
-            defaultValue={email}
             label="Email"
             inputId="email"
             data-testid="current_email"

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -165,10 +165,6 @@ const AccountSecurityPage = (): ReactElement => {
     updateSettings({ action, params });
   };
 
-  if (!session) {
-    return null;
-  }
-
   return (
     <>
       <TabContainer showHeader={false} controlledActive={activeDisplay}>

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -29,7 +29,6 @@ import EmailFormPage from '../../components/layouts/AccountLayout/Security/Email
 
 const AccountSecurityPage = (): ReactElement => {
   const updatePasswordRef = useRef<HTMLFormElement>();
-  const [email, setEmail] = useState<string>(null);
   const { displayToast } = useToastNotification();
   const [activeDisplay, setActiveDisplay] = useState(Display.Default);
   const [hint, setHint] = useState<string>(null);
@@ -88,7 +87,7 @@ const AccountSecurityPage = (): ReactElement => {
       return submitKratosFlow(params);
     },
     {
-      onSuccess: async ({ redirect, error, code }, { params }) => {
+      onSuccess: async ({ redirect, error, code }) => {
         if (redirect && code === 403) {
           initializePrivilegedSession(redirect);
           return;
@@ -102,7 +101,6 @@ const AccountSecurityPage = (): ReactElement => {
           return;
         }
 
-        setEmail(params['traits.email']);
         setActiveDisplay(Display.Default);
         await refetchSession();
       },
@@ -172,7 +170,7 @@ const AccountSecurityPage = (): ReactElement => {
       <TabContainer showHeader={false} controlledActive={activeDisplay}>
         <Tab label={Display.Default}>
           <AccountSecurityDefault
-            email={email || session?.identity?.traits?.email}
+            email={session?.identity?.traits?.email}
             session={session}
             userProviders={userProviders}
             updatePasswordRef={updatePasswordRef}

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -165,6 +165,10 @@ const AccountSecurityPage = (): ReactElement => {
     updateSettings({ action, params });
   };
 
+  if (!session) {
+    return null;
+  }
+
   return (
     <>
       <TabContainer showHeader={false} controlledActive={activeDisplay}>

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -138,7 +138,7 @@ const AccountSecurityPage = (): ReactElement => {
   const { mutateAsync: updateSettings } = useMutation(
     (params: SettingsParams) => submitKratosFlow(params),
     {
-      onSuccess: ({ redirect, error, code }) => {
+      onSuccess: ({ redirect, error, code }, { params }) => {
         if (redirect) {
           if (code === 403) {
             initializePrivilegedSession(redirect);
@@ -153,7 +153,9 @@ const AccountSecurityPage = (): ReactElement => {
           return;
         }
 
-        refetchProviders();
+        if ('link' in params || 'unlink' in params) {
+          refetchProviders();
+        }
       },
     },
   );

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -46,6 +46,7 @@ const AccountSecurityPage = (): ReactElement => {
   };
 
   const {
+    session,
     showVerifySession,
     initializePrivilegedSession,
     onPasswordLogin,
@@ -167,6 +168,7 @@ const AccountSecurityPage = (): ReactElement => {
       <TabContainer showHeader={false} controlledActive={activeDisplay}>
         <Tab label={Display.Default}>
           <AccountSecurityDefault
+            session={session}
             userProviders={userProviders}
             updatePasswordRef={updatePasswordRef}
             onSwitchDisplay={setActiveDisplay}

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -30,7 +30,6 @@ import EmailFormPage from '../../components/layouts/AccountLayout/Security/Email
 const AccountSecurityPage = (): ReactElement => {
   const updatePasswordRef = useRef<HTMLFormElement>();
   const { displayToast } = useToastNotification();
-  const [isEmailSent, setIsEmailSent] = useState(false);
   const [activeDisplay, setActiveDisplay] = useState(Display.Default);
   const [hint, setHint] = useState<string>(null);
   const { data: userProviders, refetch: refetchProviders } = useQuery(
@@ -99,7 +98,6 @@ const AccountSecurityPage = (): ReactElement => {
           return null;
         }
 
-        setIsEmailSent(true);
         setActiveDisplay(Display.Default);
         return null;
       },
@@ -169,7 +167,6 @@ const AccountSecurityPage = (): ReactElement => {
       <TabContainer showHeader={false} controlledActive={activeDisplay}>
         <Tab label={Display.Default}>
           <AccountSecurityDefault
-            isEmailSent={isEmailSent}
             userProviders={userProviders}
             updatePasswordRef={updatePasswordRef}
             onSwitchDisplay={setActiveDisplay}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Allow unverified email of users to resend and not only when they changed email.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-609 #done
