### PR TITLE
fix: whoami refresh

### DIFF
--- a/packages/shared/__tests__/fixture/auth.ts
+++ b/packages/shared/__tests__/fixture/auth.ts
@@ -793,8 +793,8 @@ const whoamiMockData = {
 };
 
 export const mockWhoAmIFlow = (result: Partial<AuthSession> = {}): void => {
-  nock(authUrl)
-    .get('/sessions/whoami')
+  nock(heimdallUrl)
+    .get('/api/whoami')
     .reply(200, { ...whoamiMockData, ...result });
 };
 

--- a/packages/shared/__tests__/fixture/auth.ts
+++ b/packages/shared/__tests__/fixture/auth.ts
@@ -792,8 +792,7 @@ const getWhoamiMockData = (email = 'lee@daily.dev') => ({
 });
 
 export const mockWhoAmIFlow = (email?: string): void => {
-  nock(heimdallUrl)
-    .get('/api/whoami').reply(200, getWhoamiMockData(email));
+  nock(heimdallUrl).get('/api/whoami').reply(200, getWhoamiMockData(email));
 };
 
 export const socialProviderRedirectMock = {

--- a/packages/shared/src/lib/kratos.ts
+++ b/packages/shared/src/lib/kratos.ts
@@ -345,7 +345,7 @@ export const submitKratosFlow = async <
 };
 
 export const getKratosSession = async (): Promise<AuthSession> => {
-  const res = await fetch(`${authUrl}/sessions/whoami`, {
+  const res = await fetch(`${heimdallUrl}/api/whoami`, {
     credentials: 'include',
   });
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Change from kratos whoami to heimdall whoami

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-609 #done
