### PR TITLE
fix: encode tag when using it as a link

### DIFF
--- a/packages/shared/src/components/TagLinks.tsx
+++ b/packages/shared/src/components/TagLinks.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import Link from 'next/link';
 import { Button } from './buttons/Button';
+import { getTagPageLink } from '../lib/links';
 
 interface TagLinkProps {
   tag: string;
@@ -10,11 +11,7 @@ interface TagLinkProps {
 
 export function TagLink({ tag, className }: TagLinkProps): ReactElement {
   return (
-    <Link
-      href={`${process.env.NEXT_PUBLIC_WEBAPP_URL}tags/${tag}`}
-      passHref
-      key={tag}
-    >
+    <Link href={getTagPageLink(tag)} passHref key={tag}>
       <Button
         tag="a"
         className={classNames('btn-tertiaryFloat xsmall', className)}

--- a/packages/shared/src/components/filters/TagOptionsMenu.tsx
+++ b/packages/shared/src/components/filters/TagOptionsMenu.tsx
@@ -3,6 +3,7 @@ import dynamic from 'next/dynamic';
 import { Item } from '@dailydotdev/react-contexify';
 import Link from 'next/link';
 import { Tag } from '../../graphql/feedSettings';
+import { getTagPageLink } from '../../lib/links';
 
 const PortalMenu = dynamic(() => import('../fields/PortalMenu'), {
   ssr: false,
@@ -36,11 +37,7 @@ export default function TagOptionsMenu({
     >
       {tag && (
         <Item>
-          <Link
-            href={`${process.env.NEXT_PUBLIC_WEBAPP_URL}tags/${tag}`}
-            passHref
-            prefetch={false}
-          >
+          <Link href={getTagPageLink(tag.name)} passHref prefetch={false}>
             <a className="w-full">View</a>
           </Link>
         </Item>

--- a/packages/shared/src/lib/links.ts
+++ b/packages/shared/src/lib/links.ts
@@ -1,0 +1,2 @@
+export const getTagPageLink = (tag: string): string =>
+  `${process.env.NEXT_PUBLIC_WEBAPP_URL}tags/${encodeURIComponent(tag)}`;


### PR DESCRIPTION
## Changes

### Describe what this PR does

Some tags are not URL friendly (such as C#) and must be encoded before used as links

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
