### PR TITLE
fix: invalid if required and empty

### DIFF
--- a/packages/shared/src/components/auth/LoginForm.tsx
+++ b/packages/shared/src/components/auth/LoginForm.tsx
@@ -61,6 +61,7 @@ function LoginForm({
         hint={hint as string}
         onChange={() => hint && setHint(null)}
         valid={!hint}
+        required
       />
       <PasswordField
         data-testid="login_password"

--- a/packages/shared/src/components/fields/TextField.tsx
+++ b/packages/shared/src/components/fields/TextField.tsx
@@ -47,6 +47,7 @@ function TextFieldComponent(
     actionButton,
     disabled,
     rightIcon,
+    required,
     ...props
   }: TextFieldProps,
   ref?: MutableRefObject<HTMLDivElement>,
@@ -70,7 +71,8 @@ function TextFieldComponent(
   const isPrimaryField = fieldType === 'primary';
   const isSecondaryField = fieldType === 'secondary';
   const isTertiaryField = fieldType === 'tertiary';
-  const invalid = validInput === false;
+  const invalid =
+    validInput === false || (required && inputLength === 0 && !!hint);
 
   return (
     <BaseFieldContainer

--- a/packages/shared/src/components/fields/TextField.tsx
+++ b/packages/shared/src/components/fields/TextField.tsx
@@ -169,6 +169,7 @@ function TextFieldComponent(
             }),
           )}
           disabled={disabled}
+          required={required}
           {...props}
         />
         {progress && (

--- a/packages/shared/src/components/fields/TextField.tsx
+++ b/packages/shared/src/components/fields/TextField.tsx
@@ -71,8 +71,7 @@ function TextFieldComponent(
   const isPrimaryField = fieldType === 'primary';
   const isSecondaryField = fieldType === 'secondary';
   const isTertiaryField = fieldType === 'tertiary';
-  const invalid =
-    validInput === false || (required && inputLength === 0 && !!hint);
+  const invalid = validInput === false || (required && inputLength === 0);
 
   return (
     <BaseFieldContainer


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The hint turns red once submitted but only when it has value
- This should fix the requirement for when the hint should also turn red if empty but must be a required field.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-619 #done
