### PR TITLE
feat: should not redirect to register endpoint if not confirmed

### DIFF
--- a/packages/extension/src/newtab/App.tsx
+++ b/packages/extension/src/newtab/App.tsx
@@ -53,14 +53,8 @@ function InternalApp({
 }: {
   pageRef: MutableRefObject<string>;
 }): ReactElement {
-  const {
-    user,
-    tokenRefreshed,
-    closeLogin,
-    loadingUser,
-    shouldShowLogin,
-    loginState,
-  } = useContext(AuthContext);
+  const { user, closeLogin, loadingUser, shouldShowLogin, loginState } =
+    useContext(AuthContext);
   const { contentScriptGranted } = useExtensionPermission({
     origin: 'on extension load',
   });
@@ -70,16 +64,6 @@ function InternalApp({
     shouldShowConsent ? null : true,
   );
   const routeChangedCallbackRef = useTrackPageView();
-
-  useEffect(() => {
-    if (tokenRefreshed && user && !user.infoConfirmed) {
-      window.location.replace(
-        `${process.env.NEXT_PUBLIC_WEBAPP_URL}register?redirect_uri=${encodeURI(
-          browser.runtime.getURL('index.html'),
-        )}`,
-      );
-    }
-  }, [user, loadingUser, tokenRefreshed]);
 
   useEffect(() => {
     if (routeChangedCallbackRef.current) {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Extension should not call register endpoint on reload

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
