### PR TITLE
fix: verify session modal background

### DIFF
--- a/packages/shared/src/components/auth/VerifySessionModal.module.css
+++ b/packages/shared/src/components/auth/VerifySessionModal.module.css
@@ -9,7 +9,6 @@
     flex-direction: column;
     align-items: center;
     overflow: hidden;
-    background: var(--theme-background-primary);
 
     @screen laptop {
       max-width: 25.75rem;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The background color is inaccurate for the verify session modal. We should keep the default `tertiary`.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-614 #done
