### PR TITLE
feat: show toast when an error occurs when unlinking

### DIFF
--- a/packages/shared/src/lib/kratos.ts
+++ b/packages/shared/src/lib/kratos.ts
@@ -359,4 +359,5 @@ export const getKratosSession = async (): Promise<AuthSession> => {
 export const KRATOS_ERROR = {
   INVALID_TOKEN: 4060004,
   EXISTING_USER: 4000007,
+  SINGLE_OIDC: 4000001,
 };

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -151,7 +151,7 @@ const AccountSecurityPage = (): ReactElement => {
 
         if (error) {
           if (error.ui?.messages?.[0].id === KRATOS_ERROR.SINGLE_OIDC) {
-            displayToast('You cannot unlink this provider');
+            displayToast('You must have at least one provider');
           }
           return;
         }

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -150,7 +150,7 @@ const AccountSecurityPage = (): ReactElement => {
         }
 
         if (error) {
-          if (error.ui?.messages?.[0].id === 4000001) {
+          if (error.ui?.messages?.[0].id === KRATOS_ERROR.SINGLE_OIDC) {
             displayToast('You cannot unlink this provider');
           }
           return;

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -150,6 +150,9 @@ const AccountSecurityPage = (): ReactElement => {
         }
 
         if (error) {
+          if (error.ui?.messages?.[0].id === 4000001) {
+            displayToast('You cannot unlink this provider');
+          }
           return;
         }
 


### PR DESCRIPTION
## Changes

### Describe what this PR does

When the account has only one oidc provider, kratos will throw an error when trying to unlink it. We display a toast if it happens

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-622 #done
