### PR TITLE
fix: stretched image in profile

### DIFF
--- a/packages/shared/src/components/auth/SocialRegistrationForm.tsx
+++ b/packages/shared/src/components/auth/SocialRegistrationForm.tsx
@@ -134,7 +134,7 @@ export const SocialRegistrationForm = ({
         data-testid="registration_form"
       >
         <ImageInput
-          className="mb-4"
+          className={{ container: 'mb-4' }}
           initialValue={user?.image}
           size="medium"
           viewOnly

--- a/packages/shared/src/components/fields/ImageInput.tsx
+++ b/packages/shared/src/components/fields/ImageInput.tsx
@@ -12,8 +12,13 @@ import EditIcon from '../icons/Edit';
 
 type Size = 'medium' | 'large';
 
+interface ClassName {
+  container?: string;
+  img?: string;
+}
+
 interface ImageInputProps {
-  className?: string;
+  className?: ClassName;
   initialValue?: string;
   onChange?: (base64: string) => void;
   name?: string;
@@ -35,7 +40,7 @@ function ImageInput({
   initialValue,
   name = 'file',
   id,
-  className,
+  className = {},
   onChange,
   size = 'medium',
   viewOnly,
@@ -78,7 +83,7 @@ function ImageInput({
       className={classNames(
         'relative flex justify-center items-center group overflow-hidden border border-theme-divider-primary',
         componentSize[size],
-        className,
+        className?.container,
       )}
       disabled={viewOnly}
     >
@@ -96,6 +101,7 @@ function ImageInput({
       <img
         className={classNames(
           'w-full h-full',
+          className?.img,
           !viewOnly && 'mouse:group-hover:opacity-64',
         )}
         src={image}

--- a/packages/webapp/pages/account/profile.tsx
+++ b/packages/webapp/pages/account/profile.tsx
@@ -71,7 +71,7 @@ const AccountProfilePage = (): ReactElement => {
         >
           <ImageInput
             id={id}
-            className="mt-6"
+            className={{ container: 'mt-6', img: 'object-cover' }}
             initialValue={user.image}
             hoverIcon={<CameraIcon size="xlarge" />}
           />


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

Before the fix:
![image](https://user-images.githubusercontent.com/13744167/193740582-688c41f6-48a6-494c-888f-31ae9eb6db2f.png)


Result:
![image](https://user-images.githubusercontent.com/13744167/193740596-9d767fc8-b4cc-4e85-b70d-8804fcb2709e.png)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-632 #done
