### PR TITLE
fix: signback key mismatch with github

### DIFF
--- a/packages/shared/src/components/auth/common.tsx
+++ b/packages/shared/src/components/auth/common.tsx
@@ -23,7 +23,7 @@ enum SocialProvider {
   // Twitter = 'twitter',
   Facebook = 'facebook',
   Google = 'google',
-  GitHub = 'gitHub',
+  GitHub = 'github',
   Apple = 'apple',
 }
 
@@ -45,7 +45,7 @@ export const providerMap: ProviderMap = {
     provider: 'Google',
     style: { backgroundColor: '#FFFFFF', color: '#0E1217' },
   },
-  gitHub: {
+  github: {
     icon: <GitHubIcon />,
     provider: 'GitHub',
     style: { backgroundColor: '#2D313A' },

--- a/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
@@ -39,7 +39,7 @@ import EmailSentSection from '../EmailSentSection';
 import AccountLoginSection from './AccountLoginSection';
 
 const socialProvider = getProviderMapClone();
-socialProvider.gitHub.style = { backgroundColor: '#383C47' };
+socialProvider.github.style = { backgroundColor: '#383C47' };
 socialProvider.apple.style = { backgroundColor: '#404551' };
 const providers = Object.values(socialProvider);
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- There was an issue with the mismatch of keys to check for GitHub provider.
- The object had `gitHub` - the saved key was `github`. To keep things simple, I lowercased everything.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-631 #done
