### PR TITLE
fix: show unlink confirmation modal before unlinking

### DIFF
--- a/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
@@ -189,7 +189,7 @@ function AccountSecurityDefault({
       <AccountLoginSection
         title="Connected accounts"
         description="Remove the connection between daily.dev and authorized login providers."
-        providerAction={manageSocialProviders}
+        providerAction={({ provider }) => setUnlinkProvider(provider)}
         providerActionType="unlink"
         providers={removeProviderList.filter(({ provider }) =>
           userProviders?.result.includes(provider.toLowerCase()),
@@ -233,7 +233,7 @@ function AccountSecurityDefault({
         <UnlinkModal
           provider={unlinkProvider}
           onConfirm={() => {
-            manageSocialProviders({ type: 'link', provider: unlinkProvider });
+            manageSocialProviders({ type: 'unlink', provider: unlinkProvider });
           }}
           onRequestClose={() => setUnlinkProvider(null)}
           isOpen={!!unlinkProvider}


### PR DESCRIPTION
## Changes

### Describe what this PR does

We ignored the unlinked confirmation modal and unlinked the user immediately on button click

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
