### PR TITLE
fix: remove validation of fields on first paint

### DIFF
--- a/packages/shared/src/components/fields/PasswordField.spec.tsx
+++ b/packages/shared/src/components/fields/PasswordField.spec.tsx
@@ -38,7 +38,7 @@ it('should show password strength on input', async () => {
   const input = getInput();
   input.value = 'a';
   input.dispatchEvent(new Event('input', { bubbles: true }));
-  const el = screen.getByText('Risky');
+  const el = await screen.findByText('Risky');
   await waitFor(() => expect(el).toHaveClass('text-theme-status-error'));
 });
 
@@ -53,7 +53,7 @@ it('should show medium password strength on input', async () => {
   const input = getInput();
   input.value = 'asAS12!@';
   input.dispatchEvent(new Event('input', { bubbles: true }));
-  const el = screen.getByText(`You're almost there`);
+  const el = await screen.findByText(`You're almost there`);
   await waitFor(() => expect(el).toHaveClass('text-theme-status-warning'));
 });
 
@@ -68,7 +68,7 @@ it('should show strong password strength on input', async () => {
   const input = getInput();
   input.value = 'asAS12!@as';
   input.dispatchEvent(new Event('input', { bubbles: true }));
-  const el = screen.getByText('Strong as it gets');
+  const el = await screen.findByText('Strong as it gets');
   await waitFor(() => expect(el).toHaveClass('text-theme-status-success'));
 });
 

--- a/packages/shared/src/components/fields/PasswordField.tsx
+++ b/packages/shared/src/components/fields/PasswordField.tsx
@@ -44,7 +44,7 @@ export function PasswordField({
   const [isValid, setIsValid] = useState<boolean>(null);
   const hasUserAction = isValid !== null;
   const userActionHint = !isValid
-    ? `Password need a minimum length of ${props.minLength}`
+    ? `Password needs a minimum length of ${props.minLength}`
     : passwordStrengthStates[passwordStrengthLevel].label;
   const hint = !hasUserAction ? null : userActionHint;
   const shouldShowStrength = !!value && showStrength && hasUserAction;

--- a/packages/shared/src/components/fields/TextField.tsx
+++ b/packages/shared/src/components/fields/TextField.tsx
@@ -186,7 +186,7 @@ function TextFieldComponent(
           className="ml-2 font-bold typo-callout"
           style={{ color: 'var(--field-placeholder-color)' }}
         >
-          {maxLength - inputLength}
+          {maxLength - (inputLength || 0)}
         </div>
       )}
       {rightIcon}

--- a/packages/shared/src/components/modals/SubmitArticleModal.spec.tsx
+++ b/packages/shared/src/components/modals/SubmitArticleModal.spec.tsx
@@ -62,16 +62,6 @@ const renderComponent = (
   );
 };
 
-it('should show a message no URL was set', async () => {
-  renderComponent();
-  const btn = await screen.findByLabelText('Submit article');
-  await waitFor(() => expect(btn).toBeEnabled());
-  btn.click();
-  expect(
-    await screen.findByText('Please submit a valid URL'),
-  ).toBeInTheDocument();
-});
-
 it('should disable the button on invalid URL', async () => {
   renderComponent();
   const input = await screen.findByRole('textbox');

--- a/packages/shared/src/components/modals/SubmitArticleModal.tsx
+++ b/packages/shared/src/components/modals/SubmitArticleModal.tsx
@@ -93,12 +93,6 @@ export default function SubmitArticleModal({
     event.preventDefault();
     const data = formToJson<{ articleUrl: string }>(event.currentTarget);
 
-    trackEvent({
-      event_name: 'submit article',
-      feed_item_title: submitArticleModalButton,
-      extra: JSON.stringify({ url: data?.articleUrl }),
-    });
-
     setIsValidating(true);
 
     if (!data.articleUrl) {
@@ -106,6 +100,12 @@ export default function SubmitArticleModal({
       setIsValidating(false);
       return;
     }
+
+    trackEvent({
+      event_name: 'submit article',
+      feed_item_title: submitArticleModalButton,
+      extra: JSON.stringify({ url: data?.articleUrl }),
+    });
 
     try {
       const res = await submitArticle(data.articleUrl);

--- a/packages/shared/src/hooks/useInputField.ts
+++ b/packages/shared/src/hooks/useInputField.ts
@@ -33,7 +33,9 @@ export function useInputField<T extends ValidInputElement = HTMLInputElement>(
   };
 
   useEffect(() => {
-    setInput(value?.toString() || '');
+    if (value !== undefined) {
+      setInput(value?.toString() || '');
+    }
   }, [value]);
 
   const onFocus = () => setFocused(true);

--- a/packages/shared/src/hooks/useInputFieldFunctions.ts
+++ b/packages/shared/src/hooks/useInputFieldFunctions.ts
@@ -15,7 +15,7 @@ export interface InputFieldFunctionsProps {
 
 interface UseInputFieldFunctions<T extends ValidInputElement = HTMLInputElement>
   extends UseInputField<T> {
-  inputLength: number;
+  inputLength: number | undefined;
   validInput?: boolean;
 }
 
@@ -37,7 +37,7 @@ function useInputFieldFunctions<
     focusInput,
     setInput,
   } = useInputField<T>(value, valueChanged);
-  const [inputLength, setInputLength] = useState<number>(0);
+  const [inputLength, setInputLength] = useState<number>(undefined);
   const [validInput, setValidInput] = useState<boolean>(undefined);
   const [idleTimeout, clearIdleTimeout] = useDebounce(() => {
     setValidInput(inputRef.current.checkValidity());


### PR DESCRIPTION
## Changes

### Describe what this PR does

Remove validation of fields on the first paint

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-624 #done
