### PR TITLE
fix: introducing new login flow state

### DIFF
--- a/packages/shared/src/components/auth/AuthDefault.tsx
+++ b/packages/shared/src/components/auth/AuthDefault.tsx
@@ -30,7 +30,7 @@ interface AuthDefaultProps {
   onProviderClick?: (provider: string, login?: boolean) => unknown;
   onForgotPassword?: () => unknown;
   isV2?: boolean;
-  isForgotPasswordReturn?: boolean;
+  isLoginFlow?: boolean;
   title?: string;
   providers: Provider[];
   trigger: string;
@@ -48,7 +48,7 @@ const AuthDefault = ({
   onForgotPassword,
   onPasswordLogin,
   isV2,
-  isForgotPasswordReturn,
+  isLoginFlow,
   providers,
   disableRegistration,
   disablePassword,
@@ -58,9 +58,7 @@ const AuthDefault = ({
   loginButton,
 }: AuthDefaultProps): ReactElement => {
   const { trackEvent } = useContext(AnalyticsContext);
-  const [shouldLogin, setShouldLogin] = useState(
-    isForgotPasswordReturn || isV2,
-  );
+  const [shouldLogin, setShouldLogin] = useState(isLoginFlow || isV2);
 
   const useTitle = shouldLogin ? 'Log in to daily.dev' : title;
 

--- a/packages/shared/src/components/auth/AuthModal.tsx
+++ b/packages/shared/src/components/auth/AuthModal.tsx
@@ -124,6 +124,7 @@ export default function AuthModal({
         onSuccessfulLogin={closeLogin}
         onShowOptionsOnly={(value: boolean) => setShowOptionsOnly(value)}
         trigger={trigger}
+        isLoginFlow={isLogoutFlow}
         onDisplayChange={(display: Display) => setScreenValue(display)}
       />
       {isDiscardOpen && (

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -63,6 +63,7 @@ export interface AuthOptionsProps {
   trigger: string;
   defaultDisplay?: Display;
   className?: string;
+  isLoginFlow?: boolean;
   onDisplayChange?: (value: string) => void;
 }
 
@@ -75,6 +76,7 @@ function AuthOptions({
   trigger,
   defaultDisplay = Display.Default,
   onDisplayChange,
+  isLoginFlow,
 }: AuthOptionsProps): ReactElement {
   const { trackEvent } = useContext(AnalyticsContext);
   const [registrationHints, setRegistrationHints] = useState<RegistrationError>(
@@ -261,7 +263,7 @@ function AuthOptions({
             loginHint={loginHint}
             isV2={isV2}
             isLoading={isPasswordLoginLoading}
-            isForgotPasswordReturn={isForgotPasswordReturn}
+            isLoginFlow={isForgotPasswordReturn || isLoginFlow}
             trigger={trigger}
           />
         </Tab>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added a isLogin state so we can easily determine which view to render for the default screen

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-634 #done
