### PR TITLE
fix: redirect race condition

### DIFF
--- a/packages/webapp/components/layouts/AccountLayout/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/index.tsx
@@ -2,7 +2,6 @@ import React, { ReactElement, ReactNode, useContext } from 'react';
 import { PublicProfile } from '@dailydotdev/shared/src/lib/user';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { NextSeoProps } from 'next-seo/lib/types';
-import { useRouter } from 'next/router';
 import Head from 'next/head';
 import { NextSeo } from 'next-seo';
 import { getLayout as getMainLayout } from '../MainLayout';
@@ -16,14 +15,9 @@ export interface AccountLayoutProps {
 export default function AccountLayout({
   children,
 }: AccountLayoutProps): ReactElement {
-  const router = useRouter();
   const { user: profile, isFetched } = useContext(AuthContext);
 
-  if (isFetched && !profile) {
-    router.replace('/');
-  }
-
-  if (!profile || !Object.keys(profile).length) {
+  if (!profile || !Object.keys(profile).length || (isFetched && !profile)) {
     return null;
   }
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- A race condition happens when the request just finished but the data for `profile` parameter is not yet reflecting the updated one.
- We instead wait until all is resolved.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-635 #done
