### PR TITLE
fix: redirect from register to home page or parameter if no session

### DIFF
--- a/packages/webapp/pages/register.tsx
+++ b/packages/webapp/pages/register.tsx
@@ -45,9 +45,7 @@ export default function Register(): ReactElement {
       return;
     }
 
-    if (!user) {
-      router?.replace((router.query.redirect_uri as string) || '/');
-    }
+    router?.replace((router.query.redirect_uri as string) || '/');
   }, [user, loadedUserFromCache, loadingUser]);
 
   const onSuccessfulSubmit = async (optionalFields: boolean) => {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- It feels stuck since we don't do anything when there is no session available on the register page.
- We redirect for easy fix to the query parameter or homepage if none.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
