### PR TITLE
fix: twitter field

### DIFF
--- a/packages/shared/src/components/profile/PostsSection.tsx
+++ b/packages/shared/src/components/profile/PostsSection.tsx
@@ -169,7 +169,7 @@ export default function PostsSection({
           daily.dev. Set up your Twitter handle and we'll do the rest 🙌`}
         </EmptyMessage>
         <form
-          className="flex flex-col items-start mt-6"
+          className="flex flex-col items-stretch mt-6 max-w-sm"
           ref={formRef}
           onSubmit={onSubmit}
         >
@@ -182,7 +182,7 @@ export default function PostsSection({
             value={user.twitter}
           />
           <Button
-            className="w-28 btn-primary"
+            className="mt-4 w-28 btn-primary"
             type="submit"
             disabled={isLoading}
           >


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The profile twitter field was off due to new textfield changes

New:
![Screenshot 2022-10-06 at 11 49 18](https://user-images.githubusercontent.com/554874/194282851-bd97eaaa-e3c6-4d26-8d20-29659c29a424.png)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-641 #done
