### PR TITLE
fix: version mismatch webapp

### DIFF
--- a/packages/extension/package-lock.json
+++ b/packages/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "extension",
-	"version": "3.16.16",
+	"version": "3.17.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "extension",
-			"version": "3.16.16",
+			"version": "3.17.1",
 			"dependencies": {
 				"@babel/runtime": "^7.17.9",
 				"@dailydotdev/react-contexify": "^5.0.2",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extension",
-  "version": "3.16.16",
+  "version": "3.17.1",
   "scripts": {
     "dev:chrome": "cross-env NODE_ENV=development cross-env TARGET_BROWSER=chrome webpack --watch",
     "dev:firefox": "cross-env NODE_ENV=development cross-env TARGET_BROWSER=firefox webpack --watch",


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Set the logout version for the boot query

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
