### PR TITLE
fix: don't recall browser login for logged users

### DIFF
--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -131,6 +131,7 @@ function AuthOptions({
   }, [user]);
 
   const { loginHint, onPasswordLogin, isPasswordLoginLoading } = useLogin({
+    queryEnabled: !user,
     onSuccessfulLogin: onLoginCheck,
     trigger,
   });

--- a/packages/shared/src/components/auth/LoginForm.spec.tsx
+++ b/packages/shared/src/components/auth/LoginForm.spec.tsx
@@ -23,7 +23,10 @@ import { AuthContextProvider } from '../../contexts/AuthContext';
 import { formToJson } from '../../lib/form';
 import AuthOptions, { AuthOptionsProps } from './AuthOptions';
 
+let user = null;
+
 beforeEach(() => {
+  nock.cleanAll();
   jest.clearAllMocks();
 });
 
@@ -58,15 +61,15 @@ const renderComponent = (
   props: AuthOptionsProps = {
     onSuccessfulLogin,
     formRef: null,
+    trigger: 'test',
   },
 ): RenderResult => {
   const client = new QueryClient();
-  mockLoginFlow();
   mockRegistraitonFlow();
   return render(
     <QueryClientProvider client={client}>
       <AuthContextProvider
-        user={{ id: '123', infoConfirmed: true, providers: [] }}
+        user={user}
         updateUser={jest.fn()}
         tokenRefreshed
         getRedirectUri={jest.fn()}
@@ -82,7 +85,6 @@ const renderComponent = (
 
 const renderLogin = async (email: string) => {
   renderComponent();
-  await waitForNock();
   mockEmailCheck(email, true);
   fireEvent.input(screen.getByPlaceholderText('Email'), {
     target: { value: email },
@@ -103,6 +105,7 @@ const renderLogin = async (email: string) => {
 
 it('should post login including token', async () => {
   const email = 'sshanzel@yahoo.com';
+  user = { id: '123', infoConfirmed: true, providers: [] };
   await renderLogin(email);
   fireEvent.input(screen.getByLabelText('Password'), {
     target: { value: '#123xAbc' },
@@ -118,6 +121,8 @@ it('should post login including token', async () => {
 
 it('should display error messages', async () => {
   const email = 'sshanzel@yahoo.com';
+  user = null;
+  await mockLoginFlow();
   await renderLogin(email);
 
   fireEvent.input(screen.getByLabelText('Password'), {

--- a/packages/shared/src/hooks/useLogin.ts
+++ b/packages/shared/src/hooks/useLogin.ts
@@ -64,7 +64,7 @@ const useLogin = ({
     [{ type: 'login', params: queryParams }],
     ({ queryKey: [{ params }] }) =>
       initializeKratosFlow(AuthFlow.Login, params),
-    { enabled: queryEnabled },
+    { enabled: queryEnabled, refetchOnWindowFocus: false },
   );
   const { mutateAsync: onPasswordLogin, isLoading } = useMutation(
     (params: ValidateLoginParams) => {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We currently always recall the login flow, but this should not be the case for logged users. (Only in privileged actions)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-650 #done
