### PR TITLE
fix: password strength hints rendering

### DIFF
--- a/packages/shared/src/components/fields/PasswordField.tsx
+++ b/packages/shared/src/components/fields/PasswordField.tsx
@@ -64,10 +64,12 @@ export function PasswordField({
       leftIcon={<LockIcon />}
       hint={!!value && showStrength ? hint : props.hint}
       validityChanged={setIsValid}
-      valid={isValid}
+      valid={isValid || !props.hint}
       className={{
         ...className,
-        hint: passwordStrengthStates[passwordStrengthLevel].className,
+        hint: shouldShowStrength
+          ? passwordStrengthStates[passwordStrengthLevel].className
+          : 'text-theme-status-error',
         baseField: shouldShowStrength && `password-${passwordStrengthLevel}`,
       }}
       progress={

--- a/packages/webapp/pages/reset-password.tsx
+++ b/packages/webapp/pages/reset-password.tsx
@@ -103,12 +103,15 @@ function ResetPassword(): ReactElement {
           you if your password is strong enough.
         </p>
         <PasswordField
+          required
+          minLength={6}
+          hint={hint}
+          showStrength={!hint}
+          onChange={() => hint && setHint('')}
           label="Create new password"
           inputId="password"
           type="password"
           name="password"
-          onChange={() => hint && setHint('')}
-          hint={hint}
         />
         <Button
           className={classNames(


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The reset-password page was never showing the custom hints, due to strength priority.
- This fix will allow both options to work.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-649 #done
