### PR TITLE
fix: social icon more spacing

### DIFF
--- a/packages/shared/src/components/auth/common.tsx
+++ b/packages/shared/src/components/auth/common.tsx
@@ -33,22 +33,22 @@ export const providerMap: ProviderMap = {
   //   style: { backgroundColor: '#1D9BF0' },
   // },
   facebook: {
-    icon: <FacebookIcon />,
+    icon: <FacebookIcon className="socialIcon" />,
     provider: 'Facebook',
     style: { backgroundColor: '#4363B6' },
   },
   google: {
-    icon: <GoogleIcon secondary />,
+    icon: <GoogleIcon className="socialIcon" secondary />,
     provider: 'Google',
     style: { backgroundColor: '#FFFFFF', color: '#0E1217' },
   },
   github: {
-    icon: <GitHubIcon />,
+    icon: <GitHubIcon className="socialIcon" />,
     provider: 'GitHub',
     style: { backgroundColor: '#2D313A' },
   },
   apple: {
-    icon: <AppleIcon />,
+    icon: <AppleIcon className="socialIcon" />,
     provider: 'Apple',
     style: { backgroundColor: '#0E1217' },
   },

--- a/packages/shared/src/styles/components/buttons.css
+++ b/packages/shared/src/styles/components/buttons.css
@@ -49,6 +49,9 @@
         margin-right: -0.5rem;
       }
     }
+    & .socialIcon {
+      margin-right: 0.75rem;
+    }
   }
 
   &.iconOnly {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Due to our dynamic setup I had to resort to some unwanted classname injection, but it works
- Only social icons now have more spacing 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-656 #done
