### PR TITLE
fix: title for ABs and register button for V2

### DIFF
--- a/packages/shared/src/components/auth/AuthDefault.tsx
+++ b/packages/shared/src/components/auth/AuthDefault.tsx
@@ -55,13 +55,15 @@ const AuthDefault = ({
   disablePassword,
   isLoading,
   trigger,
-  title = isV2 ? 'Log in to daily.dev' : 'Sign up to daily.dev',
+  title,
   loginButton,
 }: AuthDefaultProps): ReactElement => {
   const { trackEvent } = useContext(AnalyticsContext);
   const [shouldLogin, setShouldLogin] = useState(isLoginFlow || isV2);
 
-  const useTitle = shouldLogin ? 'Log in to daily.dev' : title;
+  const useTitle = shouldLogin
+    ? 'Log in to daily.dev'
+    : title || 'Sign up to daily.dev';
 
   const [registerEmail, setRegisterEmail] = useState<string>(null);
   const { mutateAsync: checkEmail } = useMutation((emailParam: string) =>

--- a/packages/shared/src/components/auth/EmailSignupForm.tsx
+++ b/packages/shared/src/components/auth/EmailSignupForm.tsx
@@ -40,8 +40,8 @@ function EmailSignupForm({
         }
       />
       {isV2 && (
-        <Button className="mt-4 bg-theme-color-avocado btn-primary">
-          Register
+        <Button className="mt-4 btn-primary text-theme-label-primary bg-theme-color-cabbage">
+          Sign up
         </Button>
       )}
       <p className="text-center text-theme-label-quaternary typo-caption1">


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We had a mismatch in the design of the button for V2, should be the purple one.
- Also adjusted the title usage to reflect wanted behaviour

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-661 #done
