### PR TITLE
fix: missing unblock modal

### DIFF
--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -13,20 +13,14 @@ import CloseButton from '../modals/CloseButton';
 import styles from './FeedFilters.module.css';
 import ArrowIcon from '../icons/Arrow';
 import { Button } from '../buttons/Button';
+import { UnblockItem } from './FilterMenu';
+import UnblockModal from '../modals/UnblockModal';
 
-const items = [
-  {
-    title: 'Manage tags',
-    icon: <HashtagIcon />,
-    component: <TagsFilter tagCategoryLayout={TagCategoryLayout.Settings} />,
-  },
-  {
-    title: 'Advanced',
-    icon: <FilterIcon />,
-    component: <AdvancedSettingsFilter />,
-  },
-  { title: 'Blocked items', icon: <BlockIcon />, component: <BlockedFilter /> },
-];
+enum FilterMenuTitle {
+  Tags = 'Manage tags',
+  Advanced = 'Advanced',
+  Blocked = 'Blocked items',
+}
 
 export const filterAlertMessage = 'Edit your personal feed preferences here';
 
@@ -36,8 +30,25 @@ export default function FeedFilters({
   ...props
 }: ModalProps): ReactElement {
   const [isNavOpen, setIsNavOpen] = useState(false);
-  const [display, setDisplay] = useState<string>(items[0].title);
-
+  const [display, setDisplay] = useState<string>(FilterMenuTitle.Tags);
+  const [unblockItem, setUnblockItem] = useState<UnblockItem>();
+  const items = [
+    {
+      title: FilterMenuTitle.Tags,
+      icon: <HashtagIcon />,
+      component: <TagsFilter tagCategoryLayout={TagCategoryLayout.Settings} />,
+    },
+    {
+      title: FilterMenuTitle.Advanced,
+      icon: <FilterIcon />,
+      component: <AdvancedSettingsFilter />,
+    },
+    {
+      title: FilterMenuTitle.Blocked,
+      icon: <BlockIcon />,
+      component: <BlockedFilter onUnblockItem={setUnblockItem} />,
+    },
+  ];
   const onNavClick = (active: string) => {
     setDisplay(active);
     if (isNavOpen) {
@@ -88,6 +99,14 @@ export default function FeedFilters({
           </div>
         </div>
       </div>
+      {unblockItem && (
+        <UnblockModal
+          item={unblockItem}
+          isOpen={!!unblockItem}
+          onConfirm={unblockItem.action}
+          onRequestClose={() => setUnblockItem(null)}
+        />
+      )}
     </StyledModal>
   );
 }

--- a/packages/shared/src/components/filters/FilterMenu.tsx
+++ b/packages/shared/src/components/filters/FilterMenu.tsx
@@ -14,7 +14,7 @@ import { Source } from '../../graphql/sources';
 
 const NewSourceModal = dynamic(() => import('../modals/NewSourceModal'));
 
-interface UnblockItem {
+export interface UnblockItem {
   tag?: string;
   source?: Source;
   action?: () => unknown;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- I missed adding the unblocking modal for confirmation 🤦 
- Should be fixed in this PR.

Preview:
![image](https://user-images.githubusercontent.com/13744167/195854956-15e1e9ae-2187-46d6-aeaf-0544423ccd88.png)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
