### PR TITLE
fix: cookie banner was never initialized

### DIFF
--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -74,11 +74,13 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
     loginState,
   } = useContext(AuthContext);
   const { registerLocalFilters } = useMyFeed();
-  const [showCookie, acceptCookies] = useCookieBanner();
+  const [showCookie, acceptCookies, updateCookieBanner] = useCookieBanner();
 
   useTrackPageView();
 
   useEffect(() => {
+    updateCookieBanner(user);
+
     if (!tokenRefreshed || !user) {
       return;
     }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- With the removal of a useEffect in the new auth system we accidentally removed the init function for the cookie banner.
- We now use the existing useEffect to always call it.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-692 #done
