### PR TITLE
refactor: cleanup of my feed experiment

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -175,10 +175,6 @@ export default function MainFeedLayout({
     getFeatureValue(Features.FeedVersion, flags),
     10,
   );
-  const myFeedOnboardingVersion = getFeatureValue(
-    Features.MyFeedOnboardingVersion,
-    flags,
-  );
   const feedName = feedNameProp === 'default' ? defaultFeed : feedNameProp;
   const isMyFeed = feedName === MainFeedPage.MyFeed;
 
@@ -189,11 +185,7 @@ export default function MainFeedLayout({
     if (user) {
       setIsFirstSession(false);
       setMyFeedMode(MyFeedMode.Manual);
-    } else if (
-      isFirstSession &&
-      isSessionLoaded &&
-      myFeedOnboardingVersion !== 'control'
-    ) {
+    } else if (isFirstSession && isSessionLoaded) {
       setIsFirstSession(true);
       setMyFeedMode(MyFeedMode.Auto);
       setCreateMyFeed(true);
@@ -394,7 +386,6 @@ export default function MainFeedLayout({
       )}
       {createMyFeed && (
         <CreateMyFeedModal
-          version={myFeedOnboardingVersion}
           mode={myFeedMode}
           hasUser={!!user}
           isOpen={createMyFeed}

--- a/packages/shared/src/components/modals/CreateMyFeedModal.spec.tsx
+++ b/packages/shared/src/components/modals/CreateMyFeedModal.spec.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { render, RenderResult, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  RenderResult,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import CreateMyFeedModal from './CreateMyFeedModal';
 import AuthContext from '../../contexts/AuthContext';
 import {
@@ -64,6 +70,7 @@ const renderComponent = (
       >
         <CreateMyFeedModal
           isOpen
+          hasUser={false}
           onRequestClose={onRequestClose}
           ariaHideApp={false}
         />
@@ -74,12 +81,16 @@ const renderComponent = (
 
 it('should show create feed button', async () => {
   renderComponent();
+  const next = await screen.findByText('Continue');
+  fireEvent.click(next);
   const el = await screen.findByText('Create');
   expect(el).toBeVisible();
 });
 
 it('should show tag categories', async () => {
   const { baseElement } = renderComponent();
+  const next = await screen.findByText('Continue');
+  fireEvent.click(next);
   await waitFor(() => expect(baseElement).not.toHaveAttribute('aria-busy'));
 
   const {

--- a/packages/shared/src/components/modals/CreateMyFeedModal.tsx
+++ b/packages/shared/src/components/modals/CreateMyFeedModal.tsx
@@ -55,7 +55,6 @@ const getFooterButton = ({
 };
 
 interface CreateMyFeedModalProps extends ModalProps {
-  version?: string;
   mode?: string;
   hasUser: boolean;
 }

--- a/packages/shared/src/components/modals/CreateMyFeedModal.tsx
+++ b/packages/shared/src/components/modals/CreateMyFeedModal.tsx
@@ -11,55 +11,48 @@ import { MyFeedIntro } from '../MyFeedIntro';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 import { MyFeedMode } from '../../graphql/feed';
 
+const MY_FEED_VERSION_WINNER = 'v3';
+
 interface GetFooterButtonProps {
   hasUser: boolean;
   showIntro: boolean;
-  version: string;
   onSkip?: React.MouseEventHandler;
   onContinue: () => void;
 }
 const getFooterButton = ({
   showIntro,
-  version,
   hasUser,
   onSkip,
   onContinue,
 }: GetFooterButtonProps): ReactElement => {
-  if (!showIntro) {
-    return hasUser ? (
-      <Button className="btn-primary-cabbage" onClick={onSkip}>
-        Done
-      </Button>
-    ) : (
-      <CreateFeedFilterButton
-        className="w-40 btn-primary-cabbage"
-        feedFilterModalType="v4"
-      />
+  if (showIntro) {
+    return (
+      <>
+        <Button className="btn-tertiary" onClick={onSkip}>
+          Skip
+        </Button>
+        <Button className="btn-primary-cabbage" onClick={onContinue}>
+          Continue
+        </Button>
+      </>
     );
   }
 
-  if (version === 'v2') {
+  if (hasUser) {
     return (
-      <Button className="btn-primary-cabbage" onClick={onContinue}>
-        Create my feed
+      <Button className="btn-primary-cabbage" onClick={onSkip}>
+        Done
       </Button>
     );
   }
 
   return (
-    <>
-      <Button className="btn-tertiary" onClick={onSkip}>
-        Skip
-      </Button>
-      <Button className="btn-primary-cabbage" onClick={onContinue}>
-        Continue
-      </Button>
-    </>
+    <CreateFeedFilterButton
+      className="w-40 btn-primary-cabbage"
+      feedFilterModalType="v4"
+    />
   );
 };
-
-const introVariants = ['v2', 'v3'];
-const closableVariants = ['control', 'v3'];
 
 interface CreateMyFeedModalProps extends ModalProps {
   version?: string;
@@ -68,22 +61,19 @@ interface CreateMyFeedModalProps extends ModalProps {
 }
 export default function CreateMyFeedModal({
   mode = MyFeedMode.Manual,
-  version = 'control',
   hasUser,
   className,
   onRequestClose,
   ...modalProps
 }: CreateMyFeedModalProps): ReactElement {
   const { trackEvent } = useContext(AnalyticsContext);
-  const [showIntro, setShowIntro] = useState<boolean>(
-    introVariants.includes(version),
-  );
+  const [showIntro, setShowIntro] = useState<boolean>(true);
 
   useEffect(() => {
     trackEvent({
       event_name: 'impression',
       target_type: 'my feed modal',
-      target_id: version,
+      target_id: MY_FEED_VERSION_WINNER,
       extra: JSON.stringify({
         origin: mode,
       }),
@@ -99,20 +89,18 @@ export default function CreateMyFeedModal({
           height: '100%',
         },
       }}
-      onRequestClose={closableVariants.includes(version) && onRequestClose}
+      onRequestClose={onRequestClose}
     >
       {!showIntro && (
         <header className="flex fixed responsiveModalBreakpoint:sticky top-0 left-0 z-3 flex-row justify-between items-center py-4 px-6 w-full border-b border-theme-divider-tertiary bg-theme-bg-tertiary">
           <h3 className="font-bold typo-title3">Feed filters</h3>
-          {closableVariants.includes(version) && (
-            <Button
-              className="btn-tertiary"
-              buttonSize="small"
-              title="Close"
-              icon={<XIcon />}
-              onClick={onRequestClose}
-            />
-          )}
+          <Button
+            className="btn-tertiary"
+            buttonSize="small"
+            title="Close"
+            icon={<XIcon />}
+            onClick={onRequestClose}
+          />
         </header>
       )}
       <section
@@ -124,15 +112,9 @@ export default function CreateMyFeedModal({
       >
         {showIntro ? <MyFeedIntro /> : <TagsFilter />}
       </section>
-      <footer
-        className={classNames(
-          'flex w-full fixed responsiveModalBreakpoint:sticky bottom-0 left-0 items-center border-t border-theme-divider-tertiary bg-theme-bg-tertiary py-3',
-          version === 'v3' ? 'justify-between px-4' : 'justify-center',
-        )}
-      >
+      <footer className="flex fixed responsiveModalBreakpoint:sticky bottom-0 left-0 justify-between items-center py-3 px-4 w-full border-t border-theme-divider-tertiary bg-theme-bg-tertiary">
         {getFooterButton({
           showIntro,
-          version,
           hasUser,
           onSkip: onRequestClose,
           onContinue: () => setShowIntro(false),

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -120,12 +120,6 @@ export class Features {
     'post_engagement_non_clickable',
   );
 
-  static readonly MyFeedOnboardingVersion = new Features(
-    'my_feed_onboarding_version',
-    'control',
-    ['control', 'v1', 'v2', 'v3'],
-  );
-
   static readonly AuthenticationVersion = new Features(
     'auth_version',
     AuthVersion.V1,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- For the `v3` being concluded as the winner of the "my feed onboarding" experiment, this contains a code cleanup as part of our routine for when an experiment is concluded.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
