### PR TITLE
chore: cleanup winner experiment

### DIFF
--- a/packages/extension/src/companion/CompanionContextMenu.tsx
+++ b/packages/extension/src/companion/CompanionContextMenu.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useContext, useState } from 'react';
 import CommentIcon from '@dailydotdev/shared/src/components/icons/Discuss';
-import ShareIcon from '@dailydotdev/shared/src/components/icons/Share';
 import FlagIcon from '@dailydotdev/shared/src/components/icons/Flag';
 import FeedbackIcon from '@dailydotdev/shared/src/components/icons/Feedback';
 import EyeIcon from '@dailydotdev/shared/src/components/icons/Eye';
@@ -12,13 +11,11 @@ import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext'
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
 import BookmarkIcon from '@dailydotdev/shared/src/components/icons/Bookmark';
 import { OnShareOrBookmarkProps } from '@dailydotdev/shared/src/components/post/PostActions';
-import { AdditionalInteractionButtons } from '@dailydotdev/shared/src/lib/featureValues';
 import { getCompanionWrapper } from './common';
 import DisableCompanionModal from './DisableCompanionModal';
 
 interface CompanionContextMenuProps extends OnShareOrBookmarkProps {
   postData: PostBootData;
-  additionalInteractionButtonFeature: string;
   onReport: (T) => void;
   onBlockSource: (T) => void;
   onDisableCompanion: () => void;
@@ -26,12 +23,10 @@ interface CompanionContextMenuProps extends OnShareOrBookmarkProps {
 
 export default function CompanionContextMenu({
   postData,
-  additionalInteractionButtonFeature,
   onReport,
   onBlockSource,
   onDisableCompanion,
   onBookmark,
-  onShare,
 }: CompanionContextMenuProps): ReactElement {
   const { displayToast } = useToastNotification();
   const { trackEvent } = useContext(AnalyticsContext);
@@ -75,21 +70,14 @@ export default function CompanionContextMenu({
             <CommentIcon size="medium" className="mr-2" /> View discussion
           </a>
         </Item>
-        {additionalInteractionButtonFeature ===
-        AdditionalInteractionButtons.Bookmark ? (
-          <Item onClick={onShare}>
-            <ShareIcon size="medium" className="mr-2" /> Share article via...
-          </Item>
-        ) : (
-          <Item onClick={onBookmark}>
-            <BookmarkIcon
-              size="medium"
-              className="mr-2"
-              secondary={postData?.bookmarked}
-            />
-            {postData?.bookmarked ? 'Remove from' : 'Save to'} bookmarks
-          </Item>
-        )}
+        <Item onClick={onBookmark}>
+          <BookmarkIcon
+            size="medium"
+            className="mr-2"
+            secondary={postData?.bookmarked}
+          />
+          {postData?.bookmarked ? 'Remove from' : 'Save to'} bookmarks
+        </Item>
         <Item onClick={() => setReportModal(true)}>
           <FlagIcon size="medium" className="mr-2" /> Report
         </Item>

--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -2,7 +2,6 @@ import React, { ReactElement, useContext, useEffect } from 'react';
 import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
 import UpvoteIcon from '@dailydotdev/shared/src/components/icons/Upvote';
 import CommentIcon from '@dailydotdev/shared/src/components/icons/Discuss';
-import BookmarkIcon from '@dailydotdev/shared/src/components/icons/Bookmark';
 import MenuIcon from '@dailydotdev/shared/src/components/icons/Menu';
 import ShareIcon from '@dailydotdev/shared/src/components/icons/Share';
 import SimpleTooltip from '@dailydotdev/shared/src/components/tooltips/SimpleTooltip';
@@ -18,8 +17,6 @@ import { postAnalyticsEvent } from '@dailydotdev/shared/src/lib/feed';
 import { postEventName } from '@dailydotdev/shared/src/components/utilities';
 import { useKeyboardNavigation } from '@dailydotdev/shared/src/hooks/useKeyboardNavigation';
 import { useSharePost } from '@dailydotdev/shared/src/hooks/useSharePost';
-import FeaturesContext from '@dailydotdev/shared/src/contexts/FeaturesContext';
-import { AdditionalInteractionButtons } from '@dailydotdev/shared/src/lib/featureValues';
 import NewCommentModal from '@dailydotdev/shared/src/components/modals/NewCommentModal';
 import ShareModal from '@dailydotdev/shared/src/components/modals/ShareModal';
 import CompanionContextMenu from './CompanionContextMenu';
@@ -54,7 +51,6 @@ export default function CompanionMenu({
 }: CompanionMenuProps): ReactElement {
   const { trackEvent } = useContext(AnalyticsContext);
   const { user } = useContext(AuthContext);
-  const { additionalInteractionButtonFeature } = useContext(FeaturesContext);
   const [showCompanionHelper, setShowCompanionHelper] = usePersistentContext(
     'companion_helper',
     companionHelper,
@@ -216,37 +212,19 @@ export default function CompanionMenu({
           onClick={() => openNewComment('comment button')}
         />
       </SimpleTooltip>
-      {additionalInteractionButtonFeature ===
-      AdditionalInteractionButtons.Bookmark ? (
-        <SimpleTooltip
-          placement="left"
-          content={post?.bookmarked ? 'Remove bookmark' : 'Bookmark'}
-          appendTo="parent"
-          container={tooltipContainerProps}
-        >
-          <Button
-            buttonSize="medium"
-            pressed={post?.bookmarked}
-            className="btn-tertiary-bun"
-            onClick={toggleBookmark}
-            icon={<BookmarkIcon secondary={post?.bookmarked} />}
-          />
-        </SimpleTooltip>
-      ) : (
-        <SimpleTooltip
-          placement="left"
-          content="Share post"
-          appendTo="parent"
-          container={tooltipContainerProps}
-        >
-          <Button
-            buttonSize="medium"
-            className="btn-tertiary-cabbage"
-            onClick={onShare}
-            icon={<ShareIcon />}
-          />
-        </SimpleTooltip>
-      )}
+      <SimpleTooltip
+        placement="left"
+        content="Share post"
+        appendTo="parent"
+        container={tooltipContainerProps}
+      >
+        <Button
+          buttonSize="medium"
+          className="btn-tertiary-cabbage"
+          onClick={onShare}
+          icon={<ShareIcon />}
+        />
+      </SimpleTooltip>
       <SimpleTooltip
         placement="left"
         content="More options"
@@ -261,7 +239,6 @@ export default function CompanionMenu({
         />
       </SimpleTooltip>
       <CompanionContextMenu
-        additionalInteractionButtonFeature={additionalInteractionButtonFeature}
         onBookmark={toggleBookmark}
         onShare={onShare}
         postData={post}

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -330,7 +330,9 @@ it('should send add bookmark mutation', async () => {
       },
     },
   ]);
-  const [el] = await screen.findAllByLabelText('Bookmark');
+  const [menuBtn] = await screen.findAllByLabelText('Options');
+  menuBtn.click();
+  const el = await screen.findByText('Save to bookmarks');
   el.click();
   await waitFor(() => expect(mutationCalled).toBeTruthy());
 });
@@ -358,7 +360,9 @@ it('should send remove bookmark mutation', async () => {
       },
     },
   ]);
-  const [el] = await screen.findAllByLabelText('Remove bookmark');
+  const [menuBtn] = await screen.findAllByLabelText('Options');
+  menuBtn.click();
+  const el = await screen.findByText('Remove from bookmarks');
   el.click();
   await waitFor(() => expect(mutationCalled).toBeTruthy());
 });
@@ -381,7 +385,9 @@ it('should open login modal on anonymous bookmark', async () => {
     ],
     null,
   );
-  const [el] = await screen.findAllByLabelText('Bookmark');
+  const [menuBtn] = await screen.findAllByLabelText('Options');
+  menuBtn.click();
+  const el = await screen.findByText('Save to bookmarks');
   el.click();
   await waitFor(() => expect(showLogin).toBeCalledWith('bookmark'));
 });

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -154,7 +154,6 @@ export default function Feed<T>({
     selectedPost,
     isFetchingNextPage,
   } = usePostModalNavigation(items, fetchPage);
-  const { additionalInteractionButtonFeature } = useContext(FeaturesContext);
 
   useEffect(() => {
     if (emptyFeed) {
@@ -326,7 +325,6 @@ export default function Feed<T>({
     }
   }, [selectedPost]);
   const commonMenuItems = {
-    additionalInteractionButtonFeature,
     onShare: () =>
       openSharePost(
         (items[postMenuIndex] as PostItem)?.post,
@@ -386,9 +384,6 @@ export default function Feed<T>({
         >
           {items.map((item, index) => (
             <FeedItemComponent
-              additionalInteractionButtonFeature={
-                additionalInteractionButtonFeature
-              }
               items={items}
               index={index}
               row={calculateRow(index, virtualizedNumCards)}

--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -13,7 +13,6 @@ import { CommentOnData } from '../graphql/comments';
 import useTrackImpression from '../hooks/feed/useTrackImpression';
 import { FeedPostClick } from '../hooks/feed/useFeedOnPostClick';
 import { PostCardTests } from './post/common';
-import { AdditionalInteractionButtons } from '../lib/featureValues';
 
 const CommentPopup = dynamic(() => import('./cards/CommentPopup'));
 
@@ -77,7 +76,6 @@ export type FeedItemComponentProps = {
     column: number,
   ) => unknown;
   onAdClick: (ad: Ad, index: number, row: number, column: number) => void;
-  additionalInteractionButtonFeature: AdditionalInteractionButtons;
 } & PostCardTests;
 
 export function getFeedItemKey(items: FeedItem[], index: number): string {
@@ -117,7 +115,6 @@ export default function FeedItemComponent({
   onMenuClick,
   onCommentClick,
   onAdClick,
-  additionalInteractionButtonFeature,
   onReadArticleClick,
   postCardShareVersion,
   postCardVersion,
@@ -142,9 +139,6 @@ export default function FeedItemComponent({
     case 'post':
       return (
         <PostTag
-          additionalInteractionButtonFeature={
-            additionalInteractionButtonFeature
-          }
           ref={inViewRef}
           post={{
             ...item.post,

--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -10,7 +10,6 @@ import HammerIcon from './icons/Hammer';
 import EyeIcon from './icons/Eye';
 import BlockIcon from './icons/Block';
 import FlagIcon from './icons/Flag';
-import ShareIcon from './icons/Share';
 import RepostPostModal from './modals/ReportPostModal';
 import useTagAndSource from '../hooks/useTagAndSource';
 import AnalyticsContext from '../contexts/AnalyticsContext';
@@ -24,7 +23,6 @@ import { generateQueryKey } from '../lib/query';
 import AuthContext from '../contexts/AuthContext';
 import { OnShareOrBookmarkProps } from './post/PostActions';
 import BookmarkIcon from './icons/Bookmark';
-import { AdditionalInteractionButtons } from '../lib/featureValues';
 import { Origin } from '../lib/analytics';
 
 const PortalMenu = dynamic(() => import('./fields/PortalMenu'), {
@@ -51,8 +49,6 @@ type ReportPostAsync = (
 ) => Promise<unknown>;
 
 export default function PostOptionsMenu({
-  additionalInteractionButtonFeature,
-  onShare,
   onBookmark,
   postIndex,
   post,
@@ -192,27 +188,16 @@ export default function PostOptionsMenu({
       action: onHidePost,
     },
     {
+      icon: <MenuIcon secondary={post?.bookmarked} Icon={BookmarkIcon} />,
+      text: `${post?.bookmarked ? 'Remove from' : 'Save to'} bookmarks`,
+      action: onBookmark,
+    },
+    {
       icon: <MenuIcon Icon={BlockIcon} />,
       text: `Don't show articles from ${post?.source?.name}`,
       action: onBlockSource,
     },
   ];
-
-  if (
-    additionalInteractionButtonFeature === AdditionalInteractionButtons.Bookmark
-  ) {
-    postOptions.splice(1, 0, {
-      icon: <MenuIcon Icon={ShareIcon} />,
-      text: 'Share article via...',
-      action: onShare,
-    });
-  } else {
-    postOptions.splice(1, 0, {
-      icon: <MenuIcon secondary={post?.bookmarked} Icon={BookmarkIcon} />,
-      text: `${post?.bookmarked ? 'Remove from' : 'Save to'} bookmarks`,
-      action: onBookmark,
-    });
-  }
 
   post?.tags?.forEach((tag) => {
     if (tag.length) {

--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -7,17 +7,13 @@ import InteractionCounter from '../InteractionCounter';
 import { QuaternaryButton } from '../buttons/QuaternaryButton';
 import UpvoteIcon from '../icons/Upvote';
 import CommentIcon from '../icons/Discuss';
-import BookmarkIcon from '../icons/Bookmark';
 import { Button, ButtonProps } from '../buttons/Button';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import OptionsButton from '../buttons/OptionsButton';
 import classed from '../../lib/classed';
 import { ReadArticleButton } from './ReadArticleButton';
 import { visibleOnGroupHover } from './common';
-import {
-  AdditionalInteractionButtons,
-  ShareVersion,
-} from '../../lib/featureValues';
+import { ShareVersion } from '../../lib/featureValues';
 
 const ShareIcon = dynamic(() => import('../icons/Share'));
 
@@ -32,7 +28,6 @@ export interface ActionButtonsProps {
   onReadArticleClick?: (e: React.MouseEvent) => unknown;
   className?: string;
   children?: ReactNode;
-  additionalInteractionButtonFeature?: AdditionalInteractionButtons;
   insaneMode?: boolean;
   postCardShareVersion?: ShareVersion;
   postCardVersion?: string;
@@ -53,36 +48,13 @@ const getContainer = (displayWhenHovered = false, className?: string) =>
 
 type LastActionButtonProps = {
   postCardShareVersion: ShareVersion;
-  additionalInteractionButtonFeature: AdditionalInteractionButtons;
   onBookmarkClick?: (post: Post, bookmarked: boolean) => unknown;
   onShare?: (post: Post) => unknown;
   onShareClick?: (event: React.MouseEvent, post: Post) => unknown;
   post: Post;
 };
 function LastActionButton(props: LastActionButtonProps) {
-  const {
-    additionalInteractionButtonFeature,
-    onBookmarkClick,
-    onShare,
-    onShareClick,
-    post,
-    postCardShareVersion,
-  } = props;
-  if (
-    additionalInteractionButtonFeature === AdditionalInteractionButtons.Bookmark
-  ) {
-    return (
-      <SimpleTooltip content={post.bookmarked ? 'Remove bookmark' : 'Bookmark'}>
-        <Button
-          icon={<BookmarkIcon secondary={post.bookmarked} />}
-          buttonSize="small"
-          pressed={post.bookmarked}
-          onClick={() => onBookmarkClick?.(post, !post.bookmarked)}
-          className="btn-tertiary-bun"
-        />
-      </SimpleTooltip>
-    );
-  }
+  const { onShare, onShareClick, post, postCardShareVersion } = props;
   const onClickShare =
     !postCardShareVersion || postCardShareVersion === ShareVersion.V1
       ? () => onShare?.(post)
@@ -116,7 +88,6 @@ export default function ActionButtons({
   postCardShareVersion,
   postModalByDefault,
   postEngagementNonClickable,
-  additionalInteractionButtonFeature,
 }: ActionButtonsProps): ReactElement {
   const isV2 = postCardVersion === 'v2';
   const separatedActions =
@@ -135,7 +106,6 @@ export default function ActionButtons({
   };
 
   const lastActionButton = LastActionButton({
-    additionalInteractionButtonFeature,
     post,
     postCardShareVersion,
     onBookmarkClick,

--- a/packages/shared/src/components/cards/PostCard.spec.tsx
+++ b/packages/shared/src/components/cards/PostCard.spec.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import { render, RenderResult, screen, waitFor } from '@testing-library/react';
 import { PostCard, PostCardProps } from './PostCard';
-import { AdditionalInteractionButtons } from '../../lib/featureValues';
 import { FeaturesContextProvider } from '../../contexts/FeaturesContext';
 import post from '../../../__tests__/fixture/post';
 
 const defaultProps: PostCardProps = {
   post,
-  additionalInteractionButtonFeature: AdditionalInteractionButtons.Bookmark,
   onPostClick: jest.fn(),
   onUpvoteClick: jest.fn(),
   onCommentClick: jest.fn(),
@@ -67,9 +65,7 @@ it('should call on bookmark click on bookmark button click', async () => {
 });
 
 it('should call on share click on share button click', async () => {
-  renderComponent({
-    additionalInteractionButtonFeature: AdditionalInteractionButtons.Share,
-  });
+  renderComponent({});
   const el = await screen.findByLabelText('Share post');
   el.click();
   await waitFor(() => expect(defaultProps.onShare).toBeCalledWith(post));

--- a/packages/shared/src/components/cards/PostCard.tsx
+++ b/packages/shared/src/components/cards/PostCard.tsx
@@ -28,7 +28,6 @@ import { PostCardHeader } from './PostCardHeader';
 import classed from '../../lib/classed';
 import { PostFooterOverlay } from './PostFooterOverlay';
 import { PostCardTests } from '../post/common';
-import { AdditionalInteractionButtons } from '../../lib/featureValues';
 
 type Callback = (post: Post) => unknown;
 
@@ -46,7 +45,6 @@ export type PostCardProps = {
   enableMenu?: boolean;
   menuOpened?: boolean;
   showImage?: boolean;
-  additionalInteractionButtonFeature?: AdditionalInteractionButtons;
   insaneMode?: boolean;
 } & HTMLAttributes<HTMLDivElement> &
   PostCardTests;
@@ -68,7 +66,6 @@ export const PostCard = forwardRef(function PostCard(
     children,
     showImage = true,
     style,
-    additionalInteractionButtonFeature,
     insaneMode,
     onReadArticleClick,
     postCardShareVersion,
@@ -188,9 +185,6 @@ export const PostCard = forwardRef(function PostCard(
           postCardVersion={postCardVersion}
           postModalByDefault={postModalByDefault}
           postEngagementNonClickable={postEngagementNonClickable}
-          additionalInteractionButtonFeature={
-            additionalInteractionButtonFeature
-          }
           className={classNames(
             'mx-4',
             !postEngagementNonClickable && 'justify-between',

--- a/packages/shared/src/components/cards/PostList.tsx
+++ b/packages/shared/src/components/cards/PostList.tsx
@@ -34,7 +34,6 @@ export const PostList = forwardRef(function PostList(
     openNewTab,
     enableMenu,
     menuOpened,
-    additionalInteractionButtonFeature,
     className,
     children,
     postCardShareVersion,
@@ -125,9 +124,6 @@ export const PostList = forwardRef(function PostList(
             postCardShareVersion={postCardShareVersion}
             postModalByDefault={postModalByDefault}
             postEngagementNonClickable={postEngagementNonClickable}
-            additionalInteractionButtonFeature={
-              additionalInteractionButtonFeature
-            }
           />
         </ActionsContainer>
       </ListCardMain>

--- a/packages/shared/src/components/post/PostActions.tsx
+++ b/packages/shared/src/components/post/PostActions.tsx
@@ -2,7 +2,6 @@ import React, { ReactElement, useContext } from 'react';
 import { QueryKey } from 'react-query';
 import UpvoteIcon from '../icons/Upvote';
 import CommentIcon from '../icons/Discuss';
-import BookmarkIcon from '../icons/Bookmark';
 import { Post } from '../../graphql/posts';
 import { QuaternaryButton } from '../buttons/QuaternaryButton';
 import useUpvotePost from '../../hooks/useUpvotePost';
@@ -13,11 +12,9 @@ import { PostOrigin } from '../../hooks/analytics/useAnalyticsContextData';
 import { postEventName } from '../utilities';
 import ShareIcon from '../icons/Share';
 import useUpdatePost from '../../hooks/useUpdatePost';
-import { AdditionalInteractionButtons } from '../../lib/featureValues';
 import { Origin } from '../../lib/analytics';
 
 export type OnShareOrBookmarkProps = {
-  additionalInteractionButtonFeature: string;
   onShare: () => void;
   onBookmark: () => void;
 };
@@ -31,9 +28,7 @@ interface PostActionsProps extends OnShareOrBookmarkProps {
 }
 
 export function PostActions({
-  additionalInteractionButtonFeature,
   onShare,
-  onBookmark,
   post,
   actionsClassName = 'hidden mobileL:flex',
   onComment,
@@ -101,29 +96,15 @@ export function PostActions({
       >
         Comment
       </QuaternaryButton>
-      {additionalInteractionButtonFeature ===
-      AdditionalInteractionButtons.Bookmark ? (
-        <QuaternaryButton
-          id="bookmark-post-btn"
-          pressed={post.bookmarked}
-          onClick={onBookmark}
-          icon={<BookmarkIcon secondary={post.bookmarked} />}
-          responsiveLabelClass={actionsClassName}
-          className="btn-tertiary-bun"
-        >
-          Bookmark
-        </QuaternaryButton>
-      ) : (
-        <QuaternaryButton
-          id="share-post-btn"
-          onClick={onShare}
-          icon={<ShareIcon />}
-          responsiveLabelClass={actionsClassName}
-          className="btn-tertiary-cabbage"
-        >
-          Share
-        </QuaternaryButton>
-      )}
+      <QuaternaryButton
+        id="share-post-btn"
+        onClick={onShare}
+        icon={<ShareIcon />}
+        responsiveLabelClass={actionsClassName}
+        className="btn-tertiary-cabbage"
+      >
+        Share
+      </QuaternaryButton>
     </div>
   );
 }

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -46,7 +46,6 @@ import { postEventName } from '../utilities';
 import useBookmarkPost from '../../hooks/useBookmarkPost';
 import useUpdatePost from '../../hooks/useUpdatePost';
 import { useSharePost } from '../../hooks/useSharePost';
-import FeaturesContext from '../../contexts/FeaturesContext';
 import { Origin } from '../../lib/analytics';
 import { useShareComment } from '../../hooks/useShareComment';
 import useOnPostClick from '../../hooks/useOnPostClick';
@@ -62,11 +61,7 @@ const Custom404 = dynamic(() => import('../Custom404'));
 export interface PostContentProps
   extends Omit<
       PostModalActionsProps,
-      | 'post'
-      | 'onShare'
-      | 'onBookmark'
-      | 'contextMenuId'
-      | 'additionalInteractionButtonFeature'
+      'post' | 'onShare' | 'onBookmark' | 'contextMenuId'
     >,
     Partial<Pick<PostNavigationProps, 'onPreviousPost' | 'onNextPost'>>,
     UsePostCommentOptionalProps {
@@ -133,7 +128,6 @@ export function PostContent({
     onShowUpvotedComment,
   } = useUpvoteQuery();
   const { user, showLogin } = useContext(AuthContext);
-  const { additionalInteractionButtonFeature } = useContext(FeaturesContext);
   const { trackEvent } = useContext(AnalyticsContext);
   const [authorOnboarding, setAuthorOnboarding] = useState(false);
   const queryClient = useQueryClient();
@@ -265,9 +259,6 @@ export function PostContent({
           onReadArticle={onReadArticle}
           onClose={onClose}
           isModal={isModal}
-          additionalInteractionButtonFeature={
-            additionalInteractionButtonFeature
-          }
           onBookmark={toggleBookmark}
           onShare={onShare}
         />
@@ -317,9 +308,6 @@ export function PostContent({
           }
         />
         <PostActions
-          additionalInteractionButtonFeature={
-            additionalInteractionButtonFeature
-          }
           onBookmark={toggleBookmark}
           onShare={onShare}
           post={postById.post}
@@ -344,7 +332,6 @@ export function PostContent({
         />
       </PostContainer>
       <PostWidgets
-        additionalInteractionButtonFeature={additionalInteractionButtonFeature}
         onBookmark={toggleBookmark}
         onShare={onShare}
         onReadArticle={onReadArticle}

--- a/packages/shared/src/components/post/PostModalActions.tsx
+++ b/packages/shared/src/components/post/PostModalActions.tsx
@@ -39,7 +39,6 @@ const BanPostModal = dynamic(() => import('../modals/BanPostModal'));
 const DeletePostModal = dynamic(() => import('../modals/DeletePostModal'));
 
 export function PostModalActions({
-  additionalInteractionButtonFeature,
   onReadArticle,
   onShare,
   onBookmark,
@@ -100,7 +99,6 @@ export function PostModalActions({
         </SimpleTooltip>
       )}
       <PostOptionsMenu
-        additionalInteractionButtonFeature={additionalInteractionButtonFeature}
         onBookmark={onBookmark}
         onShare={onShare}
         post={post}

--- a/packages/shared/src/components/post/PostNavigation.tsx
+++ b/packages/shared/src/components/post/PostNavigation.tsx
@@ -17,7 +17,6 @@ export interface PostNavigationProps
   shouldDisplayTitle?: boolean;
   isModal?: boolean;
   className?: string;
-  additionalInteractionButtonFeature: string;
 }
 
 export function PostNavigation({
@@ -31,7 +30,6 @@ export function PostNavigation({
   onClose,
   onShare,
   onBookmark,
-  additionalInteractionButtonFeature,
 }: PostNavigationProps): ReactElement {
   const published = `Published on ${post?.source.name}`;
   const subtitle = !post?.author
@@ -89,7 +87,6 @@ export function PostNavigation({
         onShare={onShare}
         onBookmark={onBookmark}
         onReadArticle={onReadArticle}
-        additionalInteractionButtonFeature={additionalInteractionButtonFeature}
         post={post}
         onClose={onClose}
         inlineActions={shouldDisplayTitle || isModal}

--- a/packages/shared/src/components/post/PostWidgets.tsx
+++ b/packages/shared/src/components/post/PostWidgets.tsx
@@ -20,7 +20,6 @@ interface PostWidgetsProps
 }
 
 export function PostWidgets({
-  additionalInteractionButtonFeature,
   onShare,
   onBookmark,
   onReadArticle,
@@ -59,9 +58,6 @@ export function PostWidgets({
     >
       {!isNavigationFixed && (
         <PostModalActions
-          additionalInteractionButtonFeature={
-            additionalInteractionButtonFeature
-          }
           onBookmark={onBookmark}
           onShare={onShare}
           onReadArticle={onReadArticle}

--- a/packages/shared/src/contexts/FeaturesContext.tsx
+++ b/packages/shared/src/contexts/FeaturesContext.tsx
@@ -5,10 +5,7 @@ import {
   getFeatureValue,
   isFeaturedEnabled,
 } from '../lib/featureManagement';
-import {
-  AdditionalInteractionButtons,
-  ShareVersion,
-} from '../lib/featureValues';
+import { ShareVersion } from '../lib/featureValues';
 
 export interface FeaturesData {
   flags: IFlags;
@@ -23,7 +20,6 @@ export interface FeaturesData {
   postCardVersion?: string;
   postCardShareVersion?: ShareVersion;
   authVersion?: string;
-  additionalInteractionButtonFeature?: AdditionalInteractionButtons;
 }
 
 const FeaturesContext = React.createContext<FeaturesData>({ flags: {} });
@@ -64,10 +60,6 @@ export const FeaturesContextProvider = ({
         flags,
       ) as ShareVersion,
       authVersion: getFeatureValue(Features.AuthenticationVersion, flags),
-      additionalInteractionButtonFeature: getFeatureValue(
-        Features.AdditionalInteractionButton,
-        flags,
-      ) as AdditionalInteractionButtons,
     }),
     [flags],
   );

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -1,9 +1,5 @@
 import { IFlags } from 'flagsmith';
-import {
-  AdditionalInteractionButtons,
-  AuthVersion,
-  ShareVersion,
-} from './featureValues';
+import { AuthVersion, ShareVersion } from './featureValues';
 
 export class Features {
   static readonly SignupButtonCopy = new Features(
@@ -134,12 +130,6 @@ export class Features {
     'auth_version',
     AuthVersion.V1,
     [AuthVersion.V1, AuthVersion.V2, AuthVersion.V3, AuthVersion.V4],
-  );
-
-  static readonly AdditionalInteractionButton = new Features(
-    'additional_interaction_button',
-    AdditionalInteractionButtons.Bookmark,
-    [AdditionalInteractionButtons.Bookmark, AdditionalInteractionButtons.Share],
   );
 
   static readonly ShowCommentPopover = new Features('show_comment_popover');

--- a/packages/shared/src/lib/featureValues.ts
+++ b/packages/shared/src/lib/featureValues.ts
@@ -1,8 +1,3 @@
-export enum AdditionalInteractionButtons {
-  Bookmark = 'bookmark',
-  Share = 'share',
-}
-
 export enum AuthVersion {
   V1 = 'v1',
   V2 = 'v2',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We decided on a winner for the bookmark vs share (share in card won) 
- This means we can cleanup and remove all the conditional rendering
- I opted to keep the new onShare/onBookmark passing as it's way more extendable for future proofing

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-711 #done
