### PR TITLE
chore: fix bookmark tests

### DIFF
--- a/packages/extension/src/companion/Companion.spec.tsx
+++ b/packages/extension/src/companion/Companion.spec.tsx
@@ -135,15 +135,19 @@ describe('companion app', () => {
   it('should show bookmark icon selected', async () => {
     renderComponent({}, {});
     await screen.findByTestId('companion');
-    const button = await screen.findByLabelText('Remove bookmark');
-    expect(button).toHaveAttribute('aria-pressed', 'true');
+    const [menuBtn] = await screen.findAllByLabelText('More options');
+    menuBtn.click();
+    const el = await screen.findByText('Remove from bookmarks');
+    expect(el).toBeInTheDocument();
   });
 
   it('should show bookmark icon unselected', async () => {
     renderComponent({ bookmarked: false }, {});
     await screen.findByTestId('companion');
-    const button = await screen.findByLabelText('Bookmark');
-    expect(button).toHaveAttribute('aria-pressed', 'false');
+    const [menuBtn] = await screen.findAllByLabelText('More options');
+    menuBtn.click();
+    const el = await screen.findByText('Save to bookmarks');
+    expect(el).toBeInTheDocument();
   });
 
   it('should show report menu', async () => {

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -180,7 +180,6 @@ const renderComponent = (
           </SettingsContext.Provider>
         </AuthContext.Provider>
       </QueryClientProvider>
-      ,
     </FeaturesContextProvider>,
   );
 };

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -497,8 +497,15 @@ it('should send bookmark mutation', async () => {
       },
     },
   ]);
-  const el = await screen.findByText('Bookmark');
+
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const [menuBtn] = await screen.findAllByLabelText('Options');
+  menuBtn.click();
+
+  const el = await screen.findByText('Save to bookmarks');
   el.click();
+
   await waitFor(() => mutationCalled);
 });
 
@@ -518,8 +525,14 @@ it('should send cancel upvote mutation', async () => {
       },
     },
   ]);
-  const el = await screen.findByText('Bookmark');
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  const [menuBtn] = await screen.findAllByLabelText('Options');
+  menuBtn.click();
+
+  const el = await screen.findByText('Remove from bookmarks');
   el.click();
+
   await waitFor(() => mutationCalled);
 });
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We had some issues with test cases for the post page, we have to await the renders

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android