### PR TITLE
fix: set correct tag links

### DIFF
--- a/packages/shared/src/components/filters/TagOptionsMenu.tsx
+++ b/packages/shared/src/components/filters/TagOptionsMenu.tsx
@@ -37,7 +37,7 @@ export default function TagOptionsMenu({
     >
       {tag && (
         <Item>
-          <Link href={getTagPageLink(tag.name)} passHref prefetch={false}>
+          <Link href={getTagPageLink(tag as string)} passHref prefetch={false}>
             <a className="w-full">View</a>
           </Link>
         </Item>

--- a/packages/shared/src/components/filters/TagOptionsMenu.tsx
+++ b/packages/shared/src/components/filters/TagOptionsMenu.tsx
@@ -37,7 +37,11 @@ export default function TagOptionsMenu({
     >
       {tag && (
         <Item>
-          <Link href={getTagPageLink(tag as string)} passHref prefetch={false}>
+          <Link
+            href={getTagPageLink(tag.name ? tag.name : (tag as string))}
+            passHref
+            prefetch={false}
+          >
             <a className="w-full">View</a>
           </Link>
         </Item>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Hotfix for linking to the right tag
- We no longer support the tag.name type in this format (but it's supported as a interface elsewhere)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-720 #done
