### PR TITLE
fix: garden dependencies to point to main

### DIFF
--- a/project.garden.yml
+++ b/project.garden.yml
@@ -1,13 +1,13 @@
 kind: Project
 name: apps
-dotIgnoreFiles: [ .gitignore ]
+dotIgnoreFiles: [.gitignore]
 sources:
   - name: db-services
     repositoryUrl: git@github.com:dailydotdev/garden-dependencies.git#main
   - name: api
-    repositoryUrl: git@github.com:dailydotdev/daily-api.git#master
+    repositoryUrl: git@github.com:dailydotdev/daily-api.git#main
   - name: gateway
-    repositoryUrl: git@github.com:dailydotdev/daily-gateway.git#master
+    repositoryUrl: git@github.com:dailydotdev/daily-gateway.git#main
   - name: heimdall
     repositoryUrl: git@github.com:dailydotdev/heimdall.git#main
 environments:


### PR DESCRIPTION
## Changes

### Describe what this PR does
- As we moved from `master` to `main` - when updating remote dependencies, it fails due to the config still pointing to master.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
