### PR TITLE
fix: stacked my feed heading

### DIFF
--- a/packages/shared/src/components/alert/AlertPointer.tsx
+++ b/packages/shared/src/components/alert/AlertPointer.tsx
@@ -94,7 +94,7 @@ export default function AlertPointer({
   }
 
   return (
-    <AlertPointerWrapper>
+    <AlertPointerWrapper className={className.wrapper}>
       {children}
       <AlertPointerContainer
         style={getContainerStyle(offset)[placement]}

--- a/packages/shared/src/components/filters/MyFeedHeading.tsx
+++ b/packages/shared/src/components/filters/MyFeedHeading.tsx
@@ -30,12 +30,12 @@ function MyFeedHeading({
       offset={[4, 8]}
       isAlertDisabled={isAlertDisabled}
       onClose={() => onUpdateAlerts({ myFeed: null })}
-      className={{ label: 'w-44', message: 'ml-4' }}
+      className={{ label: 'w-44', message: 'ml-4', wrapper: 'mr-auto' }}
       message={filterAlertMessage}
       placement={sidebarRendered ? AlertPlacement.Right : AlertPlacement.Bottom}
     >
       <Button
-        className="btn-tertiary headline"
+        className="mr-auto btn-tertiary headline"
         onClick={onOpenFeedFilters}
         rightIcon={<FilterIcon />}
       >


### PR DESCRIPTION
## Changes

### Describe what this PR does
Before:
![image](https://user-images.githubusercontent.com/13744167/199420239-c25b87c2-13ba-4eaa-b110-0498ff3b540b.png)

After:
![image](https://user-images.githubusercontent.com/13744167/199420280-63870f43-814e-43bc-8f1f-37342fc8f5fd.png)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
