### PR TITLE
fix: navigator share server side

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -4,6 +4,7 @@ import React, {
   ReactNode,
   useContext,
   useEffect,
+  useState,
 } from 'react';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
@@ -124,9 +125,13 @@ export default function Feed<T>({
     postEngagementNonClickable,
     showCommentPopover,
   } = useContext(FeaturesContext);
-  const postCardShareVersion = navigator?.share
-    ? ShareVersion.V2
-    : shareVersion;
+  const [postCardShareVersion, setPostCardShareVersion] =
+    useState<ShareVersion>(shareVersion);
+  useEffect(() => {
+    if (navigator?.share) {
+      setPostCardShareVersion(ShareVersion.V2);
+    }
+  }, []);
   const { trackEvent } = useContext(AnalyticsContext);
   const currentSettings = useContext(FeedContext);
   const { user } = useContext(AuthContext);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- navigator is a window object, we should wait till client side is active to invoke them.
- wrapping set code in useEffect is the proven way to interact with them in server side rendered components

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
