### PR TITLE
feat: report modal and modal footer

### DIFF
--- a/packages/shared/src/components/modals/ReportPostModal.tsx
+++ b/packages/shared/src/components/modals/ReportPostModal.tsx
@@ -12,6 +12,7 @@ import {
   ReportButtonsCenter,
 } from './ReportModal';
 import { PostBootData } from '../../lib/boot';
+// import { Modal } from './common/Modal';
 
 export interface Props extends ModalProps {
   postIndex: number;
@@ -41,6 +42,53 @@ export default function RepostPostModal({
     onReport(postIndex, post, reason, comment, inputRef.current?.checked);
     props.onRequestClose(event);
   };
+
+  // return (
+  //   <Modal
+  //     isOpen
+  //     kind={Modal.Kind.FlexibleCenter}
+  //     size={Modal.Size.Small}
+  //     onRequestClose={props.onRequestClose}
+  //     {...props}
+  //   >
+  //     <Modal.Header title="Report article" />
+  //     <Modal.Body>
+  //       <p className="mt-2 mb-6 text-theme-label-secondary typo-callout">
+  //         &quot;{post?.title}&quot;
+  //       </p>
+  //       <Radio
+  //         className="mt-2 mb-4"
+  //         name="report_reason"
+  //         options={reportReasons}
+  //         value={reason}
+  //         onChange={setReason}
+  //       />
+  //       <p className="px-2 mt-6 mb-1 font-bold typo-caption1">
+  //         Anything else you&apos;d like to add?
+  //       </p>
+  //       <textarea
+  //         onChange={(event) => setComment(event.target.value)}
+  //         className="self-stretch p-2 mb-4 w-full h-20 bg-theme-float rounded-10 resize-none typo-body"
+  //       />
+  //       <Checkbox
+  //         ref={inputRef}
+  //         name="blockSource"
+  //         className="self-center font-normal"
+  //       >
+  //         Don&apos;t show articles from {post?.source?.name}
+  //       </Checkbox>
+  //     </Modal.Body>
+  //     <Modal.Footer>
+  //       <Button
+  //         className="btn-primary"
+  //         disabled={!reason || (reason === 'OTHER' && !comment)}
+  //         onClick={onReportPost}
+  //       >
+  //         Submit report
+  //       </Button>
+  //     </Modal.Footer>
+  //   </Modal>
+  // );
 
   return (
     <ReportModal {...props}>

--- a/packages/shared/src/components/modals/common/ModalFooter.tsx
+++ b/packages/shared/src/components/modals/common/ModalFooter.tsx
@@ -5,5 +5,9 @@ export type ModalFooterProps = {
 };
 
 export function ModalFooter({ children }: ModalFooterProps): ReactElement {
-  return <footer>{children}</footer>;
+  return (
+    <footer className="flex gap-3 justify-end items-center py-4 px-2 w-full h-14 border-t border-theme-divider-tertiary">
+      {children}
+    </footer>
+  );
 }


### PR DESCRIPTION
## Changes
Adds support for Modal footer and replicates the Report Article modal

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-730 #done
