### PR TITLE
fix: cleanup navigator use with it's own function

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -4,7 +4,6 @@ import React, {
   ReactNode,
   useContext,
   useEffect,
-  useState,
 } from 'react';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
@@ -44,6 +43,7 @@ import { useSharePost } from '../hooks/useSharePost';
 import { Origin } from '../lib/analytics';
 import ShareOptionsMenu from './ShareOptionsMenu';
 import { ShareVersion } from '../lib/featureValues';
+import { getNavigator } from '../lib/navigator';
 
 export type FeedProps<T> = {
   feedName: string;
@@ -125,13 +125,9 @@ export default function Feed<T>({
     postEngagementNonClickable,
     showCommentPopover,
   } = useContext(FeaturesContext);
-  const [postCardShareVersion, setPostCardShareVersion] =
-    useState<ShareVersion>(shareVersion);
-  useEffect(() => {
-    if (navigator?.share) {
-      setPostCardShareVersion(ShareVersion.V2);
-    }
-  }, []);
+  const postCardShareVersion = getNavigator()?.share
+    ? ShareVersion.V2
+    : shareVersion;
   const { trackEvent } = useContext(AnalyticsContext);
   const currentSettings = useContext(FeedContext);
   const { user } = useContext(AuthContext);

--- a/packages/shared/src/lib/navigator.ts
+++ b/packages/shared/src/lib/navigator.ts
@@ -1,0 +1,7 @@
+export const getNavigator = (): Navigator => {
+  if (typeof navigator === 'undefined') {
+    return null;
+  }
+
+  return navigator;
+};


### PR DESCRIPTION
## Changes

### Describe what this PR does
- It seems impossible to test the full static behaviour so I couldn't add specific test cases for this.
- However decided to create a new `getNavigator` function which can be used on the Next static side to get the navigator.
- This removes the need for the useEffect hook.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-727 #done
