### PR TITLE
feat: modal tabs and footer changes

### DIFF
--- a/packages/shared/src/components/modals/NewCommentModal.tsx
+++ b/packages/shared/src/components/modals/NewCommentModal.tsx
@@ -19,6 +19,7 @@ import { Post } from '../../graphql/posts';
 import { ModalCloseButton } from './ModalCloseButton';
 import DiscardActionModal from './DiscardActionModal';
 import { useRequestProtocol } from '../../hooks/useRequestProtocol';
+// import { Modal } from './common/Modal';
 
 interface CommentVariables {
   id: string;
@@ -147,6 +148,55 @@ export default function NewCommentModal({
   useEffect(() => {
     onInputChange?.(input);
   }, [input]);
+
+  // return (
+  //   <Modal
+  //     contentRef={modalRef}
+  //     onRequestClose={confirmClose}
+  //     kind={Modal.Kind.FlexibleCenter}
+  //     size={Modal.Size.Small}
+  //     tabs={['Write', 'Preview']}
+  //     {...props}
+  //   >
+  //     <Modal.Header />
+  //     <Modal.Body tab="Write">
+  //       <CommentBox
+  //         {...props}
+  //         onInput={setInput}
+  //         input={input}
+  //         editId={editId}
+  //         errorMessage={errorMessage}
+  //         sendingComment={sendingComment}
+  //         sendComment={sendComment}
+  //       />
+  //     </Modal.Body>
+  //     <Modal.Body tab="Preview">
+  //       {isPreview && previewContent?.preview && (
+  //         <Markdown
+  //           content={previewContent.preview}
+  //           appendTooltipTo={props.parentSelector}
+  //         />
+  //       )}
+  //     </Modal.Body>
+  //     <Modal.Footer>
+  //       <Button
+  //         disabled={!input?.trim().length || input === props.editContent}
+  //         loading={sendingComment}
+  //         onClick={sendComment}
+  //         className="mt-auto ml-auto btn-primary-avocado"
+  //       >
+  //         {editId ? 'Update' : 'Comment'}
+  //       </Button>
+  //     </Modal.Footer>
+  //     <DiscardActionModal
+  //       isOpen={showDiscardModal}
+  //       onRequestClose={() => setShowDiscardModal(false)}
+  //       rightButtonAction={onRequestClose}
+  //       shouldCloseOnOverlayClick={false}
+  //       parentSelector={props.parentSelector}
+  //     />
+  //   </Modal>
+  // );
 
   return (
     <ResponsiveModal

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import ReactModal from 'react-modal';
 import classNames from 'classnames';
 import { ModalHeader } from './ModalHeader';
@@ -11,6 +11,8 @@ export type ModalProps = ReactModal.Props & {
   children: React.ReactNode;
   kind?: ModalKind;
   size?: ModalSize;
+  tabs?: string[];
+  defaultTab?: string;
 };
 
 const modalKindToOverlayClassName: Record<ModalKind, string> = {
@@ -51,13 +53,18 @@ const modalSizeToClassName: Record<ModalSize, string> = {
 };
 
 export function Modal({
+  defaultTab,
   className,
   overlayClassName,
   children,
   kind = ModalKind.FlexibleCenter,
   size = ModalSize.Medium,
   onRequestClose,
+  tabs,
 }: ModalProps): ReactElement {
+  const [activeTab, onTabChange] = useState<string | undefined>(
+    tabs ? defaultTab ?? tabs[0] : undefined,
+  );
   const modalOverlayClassName = classNames(
     'overlay flex fixed flex-col inset-0 items-center bg-gradient-to-r to-theme-overlay-to from-theme-overlay-from z-[10]',
     modalKindAndSizeToOverlayClassName[kind]?.[size],
@@ -78,7 +85,9 @@ export function Modal({
       overlayClassName={modalOverlayClassName}
       className={modalClassName}
     >
-      <ModalPropsContext.Provider value={{ size, kind, onRequestClose }}>
+      <ModalPropsContext.Provider
+        value={{ activeTab, size, kind, onRequestClose, onTabChange, tabs }}
+      >
         {children}
       </ModalPropsContext.Provider>
     </ReactModal>

--- a/packages/shared/src/components/modals/common/ModalBody.tsx
+++ b/packages/shared/src/components/modals/common/ModalBody.tsx
@@ -4,13 +4,15 @@ import { ModalKind, ModalPropsContext, ModalSize } from './types';
 
 export type ModalBodyProps = {
   children?: ReactNode;
+  tab?: string;
 };
 
-export function ModalBody({ children }: ModalBodyProps): ReactElement {
-  const { kind, size } = useContext(ModalPropsContext);
+export function ModalBody({ children, tab }: ModalBodyProps): ReactElement {
+  const { activeTab, kind, size } = useContext(ModalPropsContext);
   const className = classNames(
     'overflow-auto relative w-full h-full shrink max-h-full p-6',
     kind === ModalKind.FlexibleTop && size === ModalSize.Large && 'mobileL:p-8',
   );
+  if (tab && tab !== activeTab) return null;
   return <section className={className}>{children}</section>;
 }

--- a/packages/shared/src/components/modals/common/ModalFooter.tsx
+++ b/packages/shared/src/components/modals/common/ModalFooter.tsx
@@ -1,12 +1,30 @@
-import React, { ReactElement, ReactNode } from 'react';
+import classNames from 'classnames';
+import React, { ReactElement, ReactNode, useContext } from 'react';
+import { ModalPropsContext } from './types';
 
 export type ModalFooterProps = {
   children?: ReactNode;
+  className?: string;
+  justify?: 'end' | 'center' | 'between';
+  tab?: string;
 };
 
-export function ModalFooter({ children }: ModalFooterProps): ReactElement {
+export function ModalFooter({
+  children,
+  className,
+  justify = 'end',
+  tab,
+}: ModalFooterProps): ReactElement {
+  const { activeTab } = useContext(ModalPropsContext);
+  if (tab && tab !== activeTab) return null;
   return (
-    <footer className="flex gap-3 justify-end items-center py-4 px-2 w-full h-14 border-t border-theme-divider-tertiary">
+    <footer
+      className={classNames(
+        'flex gap-3 items-center py-4 px-2 w-full h-14 border-t border-theme-divider-tertiary',
+        `justify-${justify}`,
+        className,
+      )}
+    >
       {children}
     </footer>
   );

--- a/packages/shared/src/components/modals/common/ModalHeader.tsx
+++ b/packages/shared/src/components/modals/common/ModalHeader.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, ReactNode, useContext } from 'react';
 import classed from '../../../lib/classed';
+import { ModalTabs } from './ModalTabs';
 import { ModalClose } from './ModalClose';
 import { ModalPropsContext } from './types';
 
@@ -14,10 +15,11 @@ export function ModalHeader({
   children,
   title,
 }: ModalHeaderProps): ReactElement {
-  const { onRequestClose } = useContext(ModalPropsContext);
+  const { onRequestClose, tabs } = useContext(ModalPropsContext);
   return (
     <header className="flex justify-between items-center py-4 px-6 w-full h-14 border-b border-theme-divider-tertiary">
       {!!title && <ModalHeaderTitle>{title}</ModalHeaderTitle>}
+      {tabs && <ModalTabs />}
       {children}
       {onRequestClose && <ModalClose onClick={onRequestClose} />}
     </header>

--- a/packages/shared/src/components/modals/common/ModalTabs.tsx
+++ b/packages/shared/src/components/modals/common/ModalTabs.tsx
@@ -1,0 +1,33 @@
+import classNames from 'classnames';
+import React, { ReactElement, useContext } from 'react';
+import { ModalPropsContext } from './types';
+
+export function ModalTabs(): ReactElement {
+  const { activeTab, onTabChange, tabs } = useContext(ModalPropsContext);
+  return (
+    <ul className="flex flex-row gap-4">
+      {tabs.map((tab) => (
+        <button
+          key={tab}
+          className={classNames(
+            'relative py-1.5 px-3 text-center typo-callout rounded-6',
+            tab === activeTab
+              ? 'bg-theme-bg-pepper font-bold'
+              : 'text-theme-label-tertiary',
+          )}
+          onClick={() => onTabChange(tab)}
+          type="button"
+          role="menuitem"
+        >
+          {tab}
+          {tab === activeTab && (
+            <div
+              className="absolute mx-auto w-4 h-px bg-theme-label-primary"
+              style={{ bottom: '-0.75rem', left: 'calc(50% - 0.5rem)' }}
+            />
+          )}
+        </button>
+      ))}
+    </ul>
+  );
+}

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -17,6 +17,9 @@ export type ModalContextProps = {
   onRequestClose: null | ((event: MouseEvent | KeyboardEvent) => void);
   kind: ModalKind;
   size: ModalSize;
+  onTabChange?: (tab: string) => void;
+  activeTab?: string;
+  tabs?: string[];
 };
 
 export const ModalPropsContext = createContext<ModalContextProps>({


### PR DESCRIPTION
## Changes

- Add support for tabs to the modals


## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-731 #done
