### PR TITLE
chore: upgrade chunk names to company standard

### DIFF
--- a/packages/extension/src/newtab/App.tsx
+++ b/packages/extension/src/newtab/App.tsx
@@ -30,7 +30,12 @@ import {
   useExtensionPermission,
 } from '../companion/useExtensionPermission';
 
-const AnalyticsConsentModal = dynamic(() => import('./AnalyticsConsentModal'));
+const AnalyticsConsentModal = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "analyticsConsentModal" */ './AnalyticsConsentModal'
+    ),
+);
 
 const router = new CustomRouter();
 const queryClient = new QueryClient();

--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -24,12 +24,12 @@ import { useCompanionSettings } from '../companion/useCompanionSettings';
 const PostsSearch = dynamic(
   () =>
     import(
-      /* webpackChunkName: "search" */ '@dailydotdev/shared/src/components/PostsSearch'
+      /* webpackChunkName: "postsSearch" */ '@dailydotdev/shared/src/components/PostsSearch'
     ),
 );
 
 const DndModal = dynamic(
-  () => import(/* webpackChunkName: "dnd" */ './DndModal'),
+  () => import(/* webpackChunkName: "dndModal" */ './DndModal'),
 );
 
 export type MainFeedPageProps = {

--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -25,7 +25,7 @@ export type BookmarkFeedLayoutProps = {
 const SharedBookmarksModal = dynamic(
   () =>
     import(
-      /* webpackChunkName: "SharedBookmarksModal" */ './modals/SharedBookmarksModal'
+      /* webpackChunkName: "sharedBookmarksModal" */ './modals/SharedBookmarksModal'
     ),
 );
 

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -60,8 +60,12 @@ interface RankVariables {
   ranking?: string;
 }
 
-const SharePostModal = dynamic(() => import('./modals/ShareModal'));
-const PostModal = dynamic(() => import('./modals/PostModal'));
+const SharePostModal = dynamic(
+  () => import(/* webpackChunkName: "shareModal" */ './modals/ShareModal'),
+);
+const PostModal = dynamic(
+  () => import(/* webpackChunkName: "postModal" */ './modals/PostModal'),
+);
 
 const listGaps = {
   cozy: 'gap-5',

--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -14,7 +14,9 @@ import useTrackImpression from '../hooks/feed/useTrackImpression';
 import { FeedPostClick } from '../hooks/feed/useFeedOnPostClick';
 import { PostCardTests } from './post/common';
 
-const CommentPopup = dynamic(() => import('./cards/CommentPopup'));
+const CommentPopup = dynamic(
+  () => import(/* webpackChunkName: "commentPopup" */ './cards/CommentPopup'),
+);
 
 export type FeedItemComponentProps = {
   items: FeedItem[];

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -39,15 +39,15 @@ import MyFeedHeading from './filters/MyFeedHeading';
 import SortIcon from './icons/Sort';
 
 const SearchEmptyScreen = dynamic(
-  () => import(/* webpackChunkName: "emptySearch" */ './SearchEmptyScreen'),
+  () =>
+    import(/* webpackChunkName: "searchEmptyScreen" */ './SearchEmptyScreen'),
 );
 const FeedEmptyScreen = dynamic(
-  () => import(/* webpackChunkName: "feedEmpty" */ './FeedEmptyScreen'),
+  () => import(/* webpackChunkName: "feedEmptyScreen" */ './FeedEmptyScreen'),
 );
 
 const FeedFilters = dynamic(
-  () =>
-    import(/* webpackChunkName: "feedFiltersModal" */ './filters/FeedFilters'),
+  () => import(/* webpackChunkName: "feedFilters" */ './filters/FeedFilters'),
 );
 
 type FeedQueryProps = {

--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -25,9 +25,12 @@ import { OnShareOrBookmarkProps } from './post/PostActions';
 import BookmarkIcon from './icons/Bookmark';
 import { Origin } from '../lib/analytics';
 
-const PortalMenu = dynamic(() => import('./fields/PortalMenu'), {
-  ssr: false,
-});
+const PortalMenu = dynamic(
+  () => import(/* webpackChunkName: "portalMenu" */ './fields/PortalMenu'),
+  {
+    ssr: false,
+  },
+);
 
 interface PostOptionsMenuProps extends OnShareOrBookmarkProps {
   postIndex?: number;

--- a/packages/shared/src/components/PostOptionsReadingHistoryMenu.tsx
+++ b/packages/shared/src/components/PostOptionsReadingHistoryMenu.tsx
@@ -14,9 +14,12 @@ import { QueryIndexes } from '../hooks/useReadingHistory';
 import { postAnalyticsEvent } from '../lib/feed';
 import { postEventName } from './utilities';
 
-const PortalMenu = dynamic(() => import('./fields/PortalMenu'), {
-  ssr: false,
-});
+const PortalMenu = dynamic(
+  () => import(/* webpackChunkName: "portalMenu" */ './fields/PortalMenu'),
+  {
+    ssr: false,
+  },
+);
 
 export type PostOptionsReadingHistoryMenuProps = {
   post: ReadHistoryPost;

--- a/packages/shared/src/components/PostsSearch.tsx
+++ b/packages/shared/src/components/PostsSearch.tsx
@@ -10,9 +10,15 @@ import { SEARCH_POST_SUGGESTIONS } from '../graphql/search';
 import { SEARCH_BOOKMARKS_SUGGESTIONS } from '../graphql/feed';
 import { SEARCH_READING_HISTORY_SUGGESTIONS } from '../graphql/users';
 
-const AutoCompleteMenu = dynamic(() => import('./fields/AutoCompleteMenu'), {
-  ssr: false,
-});
+const AutoCompleteMenu = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "autoCompleteMenu" */ './fields/AutoCompleteMenu'
+    ),
+  {
+    ssr: false,
+  },
+);
 
 export type PostsSearchProps = {
   initialQuery?: string;

--- a/packages/shared/src/components/ProfileMenu.tsx
+++ b/packages/shared/src/components/ProfileMenu.tsx
@@ -8,9 +8,12 @@ import UserIcon from './icons/User';
 import DevCardIcon from './icons/DevCard';
 import SettingsIcon from './icons/Settings';
 
-const PortalMenu = dynamic(() => import('./fields/PortalMenu'), {
-  ssr: false,
-});
+const PortalMenu = dynamic(
+  () => import(/* webpackChunkName: "portalMenu" */ './fields/PortalMenu'),
+  {
+    ssr: false,
+  },
+);
 
 export default function ProfileMenu(): ReactElement {
   const { user, logout } = useContext(AuthContext);

--- a/packages/shared/src/components/auth/AuthModal.tsx
+++ b/packages/shared/src/components/auth/AuthModal.tsx
@@ -16,7 +16,10 @@ import AnalyticsContext from '../../contexts/AnalyticsContext';
 export type AuthModalProps = { trigger?: AuthTriggersOrString } & ModalProps;
 
 const DiscardActionModal = dynamic(
-  () => import('../modals/DiscardActionModal'),
+  () =>
+    import(
+      /* webpackChunkName: "discardActionModal" */ '../modals/DiscardActionModal'
+    ),
 );
 
 const containerMargin = {

--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -15,7 +15,9 @@ import { ReadArticleButton } from './ReadArticleButton';
 import { visibleOnGroupHover } from './common';
 import { ShareVersion } from '../../lib/featureValues';
 
-const ShareIcon = dynamic(() => import('../icons/Share'));
+const ShareIcon = dynamic(
+  () => import(/* webpackChunkName: "share" */ '../icons/Share'),
+);
 
 export interface ActionButtonsProps {
   post: Post;

--- a/packages/shared/src/components/filters/FilterMenu.tsx
+++ b/packages/shared/src/components/filters/FilterMenu.tsx
@@ -12,7 +12,10 @@ import AdvancedSettingsFilter from './AdvancedSettings';
 import UnblockModal from '../modals/UnblockModal';
 import { Source } from '../../graphql/sources';
 
-const NewSourceModal = dynamic(() => import('../modals/NewSourceModal'));
+const NewSourceModal = dynamic(
+  () =>
+    import(/* webpackChunkName: "newSourceModal" */ '../modals/NewSourceModal'),
+);
 
 export interface UnblockItem {
   tag?: string;

--- a/packages/shared/src/components/filters/TagOptionsMenu.tsx
+++ b/packages/shared/src/components/filters/TagOptionsMenu.tsx
@@ -5,9 +5,12 @@ import Link from 'next/link';
 import { Tag } from '../../graphql/feedSettings';
 import { getTagPageLink } from '../../lib/links';
 
-const PortalMenu = dynamic(() => import('../fields/PortalMenu'), {
-  ssr: false,
-});
+const PortalMenu = dynamic(
+  () => import(/* webpackChunkName: "portalMenu" */ '../fields/PortalMenu'),
+  {
+    ssr: false,
+  },
+);
 
 export type TagOptionsMenuProps = {
   onHidden?: () => unknown;

--- a/packages/shared/src/components/history/ReadingHistoryList.tsx
+++ b/packages/shared/src/components/history/ReadingHistoryList.tsx
@@ -27,7 +27,9 @@ const getDateGroup = (date: Date) => {
   );
 };
 
-const SharePostModal = dynamic(() => import('../modals/ShareModal'));
+const SharePostModal = dynamic(
+  () => import(/* webpackChunkName: "shareModal" */ '../modals/ShareModal'),
+);
 
 export interface ReadHistoryListProps {
   data: ReadHistoryInfiniteData;

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -51,13 +51,33 @@ import { useShareComment } from '../../hooks/useShareComment';
 import useOnPostClick from '../../hooks/useOnPostClick';
 import { AuthTriggers } from '../../lib/auth';
 
-const UpvotedPopupModal = dynamic(() => import('../modals/UpvotedPopupModal'));
-const NewCommentModal = dynamic(() => import('../modals/NewCommentModal'));
-const ShareNewCommentPopup = dynamic(() => import('../ShareNewCommentPopup'), {
-  ssr: false,
-});
-const SharePostModal = dynamic(() => import('../modals/ShareModal'));
-const Custom404 = dynamic(() => import('../Custom404'));
+const UpvotedPopupModal = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "upvotedPopupModal" */ '../modals/UpvotedPopupModal'
+    ),
+);
+const NewCommentModal = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "newCommentModal" */ '../modals/NewCommentModal'
+    ),
+);
+const ShareNewCommentPopup = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "shareNewCommentPopup" */ '../ShareNewCommentPopup'
+    ),
+  {
+    ssr: false,
+  },
+);
+const SharePostModal = dynamic(
+  () => import(/* webpackChunkName: "shareModal" */ '../modals/ShareModal'),
+);
+const Custom404 = dynamic(
+  () => import(/* webpackChunkName: "custom404" */ '../Custom404'),
+);
 
 export interface PostContentProps
   extends Omit<

--- a/packages/shared/src/components/post/PostModalActions.tsx
+++ b/packages/shared/src/components/post/PostModalActions.tsx
@@ -34,9 +34,16 @@ export interface PostModalActionsProps extends OnShareOrBookmarkProps {
 
 const Container = classed('div', 'flex flex-row items-center');
 
-const BanPostModal = dynamic(() => import('../modals/BanPostModal'));
+const BanPostModal = dynamic(
+  () => import(/* webpackChunkName: "banPostModal" */ '../modals/BanPostModal'),
+);
 
-const DeletePostModal = dynamic(() => import('../modals/DeletePostModal'));
+const DeletePostModal = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "deletePostModal" */ '../modals/DeletePostModal'
+    ),
+);
 
 export function PostModalActions({
   onReadArticle,

--- a/packages/shared/src/components/post/PostNavigation.tsx
+++ b/packages/shared/src/components/post/PostNavigation.tsx
@@ -5,7 +5,10 @@ import ArrowIcon from '../icons/Arrow';
 import { Button } from '../buttons/Button';
 import { PostModalActions, PostModalActionsProps } from './PostModalActions';
 
-const SimpleTooltip = dynamic(() => import('../tooltips/SimpleTooltip'));
+const SimpleTooltip = dynamic(
+  () =>
+    import(/* webpackChunkName: "simpleTooltip" */ '../tooltips/SimpleTooltip'),
+);
 
 export interface PostNavigationProps
   extends Pick<

--- a/packages/webapp/components/layouts/FooterNavBarLayout.tsx
+++ b/packages/webapp/components/layouts/FooterNavBarLayout.tsx
@@ -4,7 +4,7 @@ import ProgressiveEnhancementContext from '@dailydotdev/shared/src/contexts/Prog
 import useSidebarRendered from '@dailydotdev/shared/src/hooks/useSidebarRendered';
 
 const FooterNavBar = dynamic(
-  () => import(/* webpackChunkName: "Sidebar" */ '../FooterNavBar'),
+  () => import(/* webpackChunkName: "footerNavBar" */ '../FooterNavBar'),
 );
 
 type FooterNavBarLayoutProps = { children?: ReactNode };

--- a/packages/webapp/components/layouts/MainFeedPage.tsx
+++ b/packages/webapp/components/layouts/MainFeedPage.tsx
@@ -15,7 +15,8 @@ import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { getLayout } from './FeedLayout';
 
 const PostsSearch = dynamic(
-  () => import(/* webpackChunkName: "search" */ '../RouterPostsSearch'),
+  () =>
+    import(/* webpackChunkName: "routerPostsSearch" */ '../RouterPostsSearch'),
   { ssr: false },
 );
 

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -47,7 +47,9 @@ import styles from './index.module.css';
 import NavBar, { tabs } from './NavBar';
 import { getLayout as getMainLayout } from '../MainLayout';
 
-const Custom404 = dynamic(() => import('../../../pages/404'));
+const Custom404 = dynamic(
+  () => import(/* webpackChunkName: "404" */ '../../../pages/404'),
+);
 
 export interface ProfileLayoutProps {
   profile: PublicProfile;

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -46,7 +46,10 @@ const AuthModal = dynamic(
       /* webpackChunkName: "authModal" */ '@dailydotdev/shared/src/components/auth/AuthModal'
     ),
 );
-const CookieBanner = dynamic(() => import('../components/CookieBanner'));
+const CookieBanner = dynamic(
+  () =>
+    import(/* webpackChunkName: "cookieBanner" */ '../components/CookieBanner'),
+);
 
 Modal.setAppElement('#__next');
 Modal.defaultStyles = {};

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -32,7 +32,7 @@ import {
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { getLayout as getMainLayout } from '../../components/layouts/MainLayout';
 
-const Custom404 = dynamic(() => import('../404'));
+const Custom404 = dynamic(() => import(/* webpackChunkName: "404" */ '../404'));
 
 export const getSeoDescription = (post: Post): string => {
   if (post?.summary) {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Modified all existing imports to use the company defined chunk name standard

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-693 #done
