### PR TITLE
fix: squad tracking events

### DIFF
--- a/packages/shared/src/components/sidebar/ClickableNavItem.tsx
+++ b/packages/shared/src/components/sidebar/ClickableNavItem.tsx
@@ -34,6 +34,7 @@ export function ClickableNavItem({
     return (
       <Link href={item.path} passHref prefetch={false}>
         <a
+          {...(item.action && { onClick: item.action })}
           {...props}
           target={item?.target}
           className={navBtnClass}

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -73,7 +73,8 @@ export default function Sidebar({
     squadForm,
     squadButton,
   } = useContext(FeaturesContext);
-  const squadVisible = sidebarRendered && user;
+  const squadVisible = sidebarRendered && !user;
+  const [trackedSquadImpression, setTrackedSquadImpression] = useState(false);
   const activePage =
     activePageProp === '/' ? `/${defaultFeed}` : activePageProp;
 
@@ -111,6 +112,9 @@ export default function Sidebar({
   );
 
   useEffect(() => {
+    if (trackedSquadImpression) {
+      return;
+    }
     if (squadVersion !== SquadVersion.Off && squadVisible) {
       trackEvent({
         event_name: 'impression',
@@ -119,8 +123,15 @@ export default function Sidebar({
         feed_item_title: squadButton,
         feed_item_target_url: squadForm,
       });
+      setTrackedSquadImpression(true);
     }
-  }, [squadVersion, squadButton, squadForm, squadVisible]);
+  }, [
+    squadVersion,
+    squadButton,
+    squadForm,
+    squadVisible,
+    trackedSquadImpression,
+  ]);
 
   if (!loadedSettings) {
     return <></>;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fix two issues with tracking events
- Ensure impression only triggers once
- Ensure link tracking happens (wasn't passed on the nav item)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
