### PR TITLE
feat: preload onboarding image

### DIFF
--- a/packages/shared/src/hooks/useAssetPreload.ts
+++ b/packages/shared/src/hooks/useAssetPreload.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+export enum AssetType {
+  image = 'image',
+}
+
+export const useAssetPreload = (type: AssetType, asset: string): void => {
+  useEffect(() => {
+    const link = document.createElement('link');
+    link.setAttribute('rel', 'preload');
+    link.setAttribute('href', asset);
+    link.setAttribute('as', type);
+    document.head.append(link);
+
+    return () => {
+      link.remove();
+    };
+  }, [type, asset]);
+};

--- a/packages/shared/src/hooks/useAssetPreload.ts
+++ b/packages/shared/src/hooks/useAssetPreload.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 
 export enum AssetType {
-  image = 'image',
+  Image = 'image',
 }
 
 export const useAssetPreload = (type: AssetType, asset: string): void => {

--- a/packages/shared/src/hooks/useOnboardingModal.ts
+++ b/packages/shared/src/hooks/useOnboardingModal.ts
@@ -7,6 +7,7 @@ import { AnalyticsEvent } from '../lib/analytics';
 import { OnboardingVersion } from '../lib/featureValues';
 import { cloudinary } from '../lib/image';
 import { LoggedUser } from '../lib/user';
+import { AssetType, useAssetPreload } from './useAssetPreload';
 import { useMyFeed } from './useMyFeed';
 import usePersistentContext from './usePersistentContext';
 
@@ -38,6 +39,7 @@ export const useOnboardingModal = ({
   onboardingVersion,
   onFeedPageChanged,
 }: UseOnboardingModalProps): UseOnboardingModal => {
+  useAssetPreload(AssetType.image, cloudinary.feedFilters.yourFeed);
   const { trackEvent } = useContext(AnalyticsContext);
   const { registerLocalFilters } = useMyFeed();
   const [shouldUpdateFilters, setShouldUpdateFilters] = useState(false);
@@ -87,18 +89,6 @@ export const useOnboardingModal = ({
     setOnboardingMode(OnboardingMode.Auto);
     modalStateCommand[onboardingVersion]?.(true);
   }, [hasOnboardingLoaded, user]);
-
-  useEffect(() => {
-    const link = document.createElement('link');
-    link.setAttribute('rel', 'preload');
-    link.setAttribute('href', cloudinary.feedFilters.yourFeed);
-    link.setAttribute('as', 'image');
-    document.head.append(link);
-
-    return () => {
-      link.remove();
-    };
-  }, []);
 
   return useMemo(
     () => ({

--- a/packages/shared/src/hooks/useOnboardingModal.ts
+++ b/packages/shared/src/hooks/useOnboardingModal.ts
@@ -5,6 +5,7 @@ import { Alerts } from '../graphql/alerts';
 import { OnboardingMode } from '../graphql/feed';
 import { AnalyticsEvent } from '../lib/analytics';
 import { OnboardingVersion } from '../lib/featureValues';
+import { cloudinary } from '../lib/image';
 import { LoggedUser } from '../lib/user';
 import { useMyFeed } from './useMyFeed';
 import usePersistentContext from './usePersistentContext';
@@ -86,6 +87,18 @@ export const useOnboardingModal = ({
     setOnboardingMode(OnboardingMode.Auto);
     modalStateCommand[onboardingVersion]?.(true);
   }, [hasOnboardingLoaded, user]);
+
+  useEffect(() => {
+    const link = document.createElement('link');
+    link.setAttribute('rel', 'preload');
+    link.setAttribute('href', cloudinary.feedFilters.yourFeed);
+    link.setAttribute('as', 'image');
+    document.head.append(link);
+
+    return () => {
+      link.remove();
+    };
+  }, []);
 
   return useMemo(
     () => ({

--- a/packages/shared/src/hooks/useOnboardingModal.ts
+++ b/packages/shared/src/hooks/useOnboardingModal.ts
@@ -39,7 +39,7 @@ export const useOnboardingModal = ({
   onboardingVersion,
   onFeedPageChanged,
 }: UseOnboardingModalProps): UseOnboardingModal => {
-  useAssetPreload(AssetType.image, cloudinary.feedFilters.yourFeed);
+  useAssetPreload(AssetType.Image, cloudinary.feedFilters.yourFeed);
   const { trackEvent } = useContext(AnalyticsContext);
   const { registerLocalFilters } = useMyFeed();
   const [shouldUpdateFilters, setShouldUpdateFilters] = useState(false);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Created a hook for preloading assets
- Preloaded the onboarding intro image

Tested through:
Preview deployment for onboarding feed filters -> clear cache -> reload -> skip -> set feature onboarding v2 -> refresh -> open onboarding -> result is a bit slow

Deployment of this PR -> clear cache -> reload -> skip -> set feature onboarding v2 -> refresh -> open onboarding -> result is noticeable.

This won't also block any form of rendering as part of having `ref="preload"` attribute.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
