### PR TITLE
feat: sidebar support for the new modal structure

### DIFF
--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -15,6 +15,7 @@ import ArrowIcon from '../icons/Arrow';
 import { Button } from '../buttons/Button';
 import { UnblockItem } from './FilterMenu';
 import UnblockModal from '../modals/UnblockModal';
+// import { Modal } from '../modals/common/Modal';
 
 enum FilterMenuTitle {
   Tags = 'Manage tags',
@@ -55,6 +56,62 @@ export default function FeedFilters({
       setIsNavOpen(false);
     }
   };
+
+  // if (setIsNavOpen) {
+  //   const tabs = [
+  //     {
+  //       title: FilterMenuTitle.Tags,
+  //       options: { icon: <HashtagIcon /> },
+  //     },
+  //     {
+  //       title: FilterMenuTitle.Advanced,
+  //       options: { icon: <FilterIcon /> },
+  //     },
+  //     {
+  //       title: FilterMenuTitle.Blocked,
+  //       options: { icon: <BlockIcon /> },
+  //     },
+  //   ];
+  //   return (
+  //     <Modal
+  //       className="h-full mb-8 flex-1"
+  //       isOpen
+  //       kind={Modal.Kind.FlexibleTop}
+  //       size={Modal.Size.Large}
+  //       onRequestClose={onRequestClose}
+  //       tabs={tabs}
+  //     >
+  //       <Modal.Sidebar>
+  //         <Modal.Sidebar.List
+  //           className='w-74'
+  //           title="Feed filters"
+  //           isNavOpen={isNavOpen}
+  //           onTabChange={onNavClick}
+  //           setIsNavOpen={setIsNavOpen}
+  //         />
+  //         <Modal.Sidebar.Inner>
+  //           <Modal.Header>
+  //             <Button
+  //               buttonSize="small"
+  //               className="flex tablet:hidden mr-2 -rotate-90"
+  //               icon={<ArrowIcon />}
+  //               onClick={() => setIsNavOpen(true)}
+  //             />
+  //           </Modal.Header>
+  //           <Modal.Body tab={FilterMenuTitle.Tags}>
+  //             <TagsFilter tagCategoryLayout={TagCategoryLayout.Settings} />
+  //           </Modal.Body>
+  //           <Modal.Body tab={FilterMenuTitle.Advanced}>
+  //             <AdvancedSettingsFilter />
+  //           </Modal.Body>
+  //           <Modal.Body tab={FilterMenuTitle.Blocked}>
+  //             <BlockedFilter onUnblockItem={setUnblockItem} />
+  //           </Modal.Body>
+  //         </Modal.Sidebar.Inner>
+  //       </Modal.Sidebar>
+  //     </Modal>
+  //   );
+  // }
 
   return (
     <StyledModal

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -4,14 +4,20 @@ import classNames from 'classnames';
 import { ModalHeader } from './ModalHeader';
 import { ModalBody } from './ModalBody';
 import { ModalFooter } from './ModalFooter';
-import { ModalSidebar } from './ModalSidebar';
-import { ModalKind, ModalPropsContext, ModalSize } from './types';
+import { ModalSidebar, ModalSidebarList } from './ModalSidebar';
+import {
+  ModalKind,
+  ModalPropsContext,
+  ModalSize,
+  ModalTabItem,
+  modalTabTitle,
+} from './types';
 
 export type ModalProps = ReactModal.Props & {
   children: React.ReactNode;
   kind?: ModalKind;
   size?: ModalSize;
-  tabs?: string[];
+  tabs?: string[] | ModalTabItem[];
   defaultTab?: string;
 };
 
@@ -32,8 +38,7 @@ const modalKindToClassName: Record<ModalKind, string> = {
     'h-full max-h-[calc(100vh-2.5rem)] mobileL:h-[40rem] mobileL:max-h-[calc(100vh-5rem)] mt-10 mobileL:mt-0',
   [ModalKind.FlexibleCenter]:
     'mx-4 max-w-[calc(100vw-2rem)] max-h-[min(calc(100vh),40rem)] mobileL:max-h-[min(calc(100vh-5rem),40rem)]',
-  [ModalKind.FlexibleTop]:
-    'm-0 mobileL:mt-10 mobileL:h-auto mobileL:max-h-[calc(100vh-2.5rem)]',
+  [ModalKind.FlexibleTop]: 'm-0 mobileL:mt-10 mobileL:h-auto',
 };
 const modalKindAndSizeToClassName: Partial<
   Record<ModalKind, Partial<Record<ModalSize, string>>>
@@ -42,7 +47,7 @@ const modalKindAndSizeToClassName: Partial<
     [ModalSize.Medium]:
       'mt-10 mobileL:max-h-[calc(100vh-7.5rem)] max-h-[calc(100vh-2.5rem)] h-auto',
     [ModalSize.Large]:
-      'mobileL:mt-7 mobileL:max-h-[calc(100vh-10rem)] max-h-[100vh]',
+      'mobileL:mt-14 mobileL:max-h-[calc(100vh-5rem)] max-h-[100vh]',
   },
 };
 const modalSizeToClassName: Record<ModalSize, string> = {
@@ -62,8 +67,8 @@ export function Modal({
   onRequestClose,
   tabs,
 }: ModalProps): ReactElement {
-  const [activeTab, onTabChange] = useState<string | undefined>(
-    tabs ? defaultTab ?? tabs[0] : undefined,
+  const [activeTab, setActiveTab] = useState<string | undefined>(
+    tabs ? defaultTab ?? modalTabTitle(tabs[0]) : undefined,
   );
   const modalOverlayClassName = classNames(
     'overlay flex fixed flex-col inset-0 items-center bg-gradient-to-r to-theme-overlay-to from-theme-overlay-from z-[10]',
@@ -86,7 +91,7 @@ export function Modal({
       className={modalClassName}
     >
       <ModalPropsContext.Provider
-        value={{ activeTab, size, kind, onRequestClose, onTabChange, tabs }}
+        value={{ activeTab, size, kind, onRequestClose, setActiveTab, tabs }}
       >
         {children}
       </ModalPropsContext.Provider>

--- a/packages/shared/src/components/modals/common/ModalHeader.tsx
+++ b/packages/shared/src/components/modals/common/ModalHeader.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, ReactNode, useContext } from 'react';
+import classNames from 'classnames';
 import classed from '../../../lib/classed';
 import { ModalTabs } from './ModalTabs';
 import { ModalClose } from './ModalClose';
@@ -10,20 +11,38 @@ export type ModalHeaderProps = {
 };
 
 const ModalHeaderTitle = classed('h3', 'font-bold typo-title3');
+const ModalHeaderOuter = classed(
+  'header',
+  'flex items-center py-4 px-6 w-full h-14',
+);
 
 export function ModalHeader({
   children,
   title,
 }: ModalHeaderProps): ReactElement {
-  const { onRequestClose, tabs } = useContext(ModalPropsContext);
+  const { activeTab, onRequestClose } = useContext(ModalPropsContext);
+  const modalTitle = title ?? activeTab;
   return (
-    <header className="flex justify-between items-center py-4 px-6 w-full h-14 border-b border-theme-divider-tertiary">
-      {!!title && <ModalHeaderTitle>{title}</ModalHeaderTitle>}
-      {tabs && <ModalTabs />}
+    <ModalHeaderOuter
+      className={classNames(
+        (!children || !modalTitle) && 'justify-between',
+        (modalTitle || children) && 'border-b border-theme-divider-tertiary',
+      )}
+    >
       {children}
+      {!!modalTitle && <ModalHeaderTitle>{modalTitle}</ModalHeaderTitle>}
       {onRequestClose && <ModalClose onClick={onRequestClose} />}
-    </header>
+    </ModalHeaderOuter>
+  );
+}
+
+export function ModalHeaderTabs(): ReactElement {
+  return (
+    <ModalHeaderOuter className="border-b border-theme-divider-tertiary">
+      <ModalTabs />
+    </ModalHeaderOuter>
   );
 }
 
 ModalHeader.Title = ModalHeaderTitle;
+ModalHeader.Tabs = ModalHeaderTabs;

--- a/packages/shared/src/components/modals/common/ModalSidebar.tsx
+++ b/packages/shared/src/components/modals/common/ModalSidebar.tsx
@@ -1,8 +1,67 @@
-import React, { ReactElement, ReactNode } from 'react';
+import classNames from 'classnames';
+import React, { ReactElement, ReactNode, useContext } from 'react';
+import classed from '../../../lib/classed';
+import SidebarList from '../../sidebar/SidebarList';
+import { ModalPropsContext, ModalTabItem } from './types';
 
 export type ModalSidebarProps = {
   children?: ReactNode;
+  className?: string;
 };
-export function ModalSidebar({ children }: ModalSidebarProps): ReactElement {
-  return <div>{children}</div>;
+
+export type ModalSidebarListProps = {
+  className?: string;
+  title: string;
+  isNavOpen: boolean;
+  setIsNavOpen: (open: boolean) => void;
+  onTabChange?: (tab: string) => void;
+};
+
+export function ModalSidebarList({
+  className,
+  isNavOpen,
+  onTabChange,
+  setIsNavOpen,
+  title,
+}: ModalSidebarListProps): ReactElement {
+  const { activeTab, tabs, setActiveTab } = useContext(ModalPropsContext);
+  return (
+    <nav className={classNames('bg-theme-bg-primary z-2', className)}>
+      <SidebarList
+        className="z-1 pb-6"
+        active={activeTab}
+        title={title}
+        onItemClick={(tab) => {
+          setActiveTab(tab);
+          onTabChange && onTabChange(tab);
+        }}
+        items={tabs.map((tab: string | ModalTabItem) =>
+          typeof tab === 'string'
+            ? { title: tab, icon: <></> }
+            : { title: tab.title, ...tab.options },
+        )}
+        isOpen={isNavOpen}
+        onClose={() => setIsNavOpen(false)}
+      />
+    </nav>
+  );
 }
+
+export const ModalSidebarInner = classed(
+  'div',
+  'flex flex-1 flex-col border-l border-theme-divider-tertiary',
+);
+
+export function ModalSidebar({
+  children,
+  className,
+}: ModalSidebarProps): ReactElement {
+  return (
+    <div className={classNames('flex flex-row w-full h-full', className)}>
+      {children}
+    </div>
+  );
+}
+
+ModalSidebar.Inner = ModalSidebarInner;
+ModalSidebar.List = ModalSidebarList;

--- a/packages/shared/src/components/modals/common/ModalTabs.tsx
+++ b/packages/shared/src/components/modals/common/ModalTabs.tsx
@@ -1,33 +1,36 @@
 import classNames from 'classnames';
 import React, { ReactElement, useContext } from 'react';
-import { ModalPropsContext } from './types';
+import { ModalPropsContext, ModalTabItem, modalTabTitle } from './types';
 
 export function ModalTabs(): ReactElement {
-  const { activeTab, onTabChange, tabs } = useContext(ModalPropsContext);
+  const { activeTab, setActiveTab, tabs } = useContext(ModalPropsContext);
   return (
     <ul className="flex flex-row gap-4">
-      {tabs.map((tab) => (
-        <button
-          key={tab}
-          className={classNames(
-            'relative py-1.5 px-3 text-center typo-callout rounded-6',
-            tab === activeTab
-              ? 'bg-theme-bg-pepper font-bold'
-              : 'text-theme-label-tertiary',
-          )}
-          onClick={() => onTabChange(tab)}
-          type="button"
-          role="menuitem"
-        >
-          {tab}
-          {tab === activeTab && (
-            <div
-              className="absolute mx-auto w-4 h-px bg-theme-label-primary"
-              style={{ bottom: '-0.75rem', left: 'calc(50% - 0.5rem)' }}
-            />
-          )}
-        </button>
-      ))}
+      {tabs.map((tab: string | ModalTabItem) => {
+        const tabTitle = modalTabTitle(tab);
+        return (
+          <button
+            key={tabTitle}
+            className={classNames(
+              'relative py-1.5 px-3 text-center typo-callout rounded-6',
+              tab === activeTab
+                ? 'bg-theme-bg-pepper font-bold'
+                : 'text-theme-label-tertiary',
+            )}
+            onClick={() => setActiveTab(tabTitle)}
+            type="button"
+            role="menuitem"
+          >
+            {tabTitle}
+            {tabTitle === activeTab && (
+              <div
+                className="absolute mx-auto w-4 h-px bg-theme-label-primary"
+                style={{ bottom: '-0.75rem', left: 'calc(50% - 0.5rem)' }}
+              />
+            )}
+          </button>
+        );
+      })}
     </ul>
   );
 }

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -13,13 +13,18 @@ export enum ModalSize {
   Large = 'large',
 }
 
+export type ModalTabItem = {
+  title: string;
+  options: Record<string, unknown>;
+};
+
 export type ModalContextProps = {
   onRequestClose: null | ((event: MouseEvent | KeyboardEvent) => void);
   kind: ModalKind;
   size: ModalSize;
-  onTabChange?: (tab: string) => void;
   activeTab?: string;
-  tabs?: string[];
+  setActiveTab?: (tab: string) => void;
+  tabs?: string[] | ModalTabItem[];
 };
 
 export const ModalPropsContext = createContext<ModalContextProps>({
@@ -27,3 +32,7 @@ export const ModalPropsContext = createContext<ModalContextProps>({
   kind: ModalKind.FlexibleCenter,
   size: ModalSize.Medium,
 });
+
+export function modalTabTitle(tab: string | ModalTabItem): string {
+  return typeof tab === 'string' ? tab : tab.title;
+}

--- a/packages/shared/src/components/sidebar/SidebarListItem.tsx
+++ b/packages/shared/src/components/sidebar/SidebarListItem.tsx
@@ -6,7 +6,7 @@ import ArrowIcon from '../icons/Arrow';
 export interface SidebarListItemProps
   extends HTMLAttributes<HTMLButtonElement | HTMLAnchorElement> {
   title: string;
-  icon: ReactNode;
+  icon?: ReactNode;
   href?: string;
   isActive?: boolean;
   className?: string;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Sidebar support for modals


### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-732 #done
