### PR TITLE
fix: await features flags availability

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -183,7 +183,7 @@ export default function MainFeedLayout({
     hasFiltered: !alerts?.filter,
     hasUser: !!user,
   });
-  const { flags, popularFeedCopy, onboardingVersion } =
+  const { flags, popularFeedCopy, onboardingVersion, isFeaturesLoaded } =
     useContext(FeaturesContext);
   const [isFeedFiltersOpen, setIsFeedFiltersOpen] = useState(false);
   const feedVersion = parseInt(
@@ -237,6 +237,7 @@ export default function MainFeedLayout({
     user,
     alerts,
     isFirstVisit,
+    isFeaturesLoaded,
     onboardingVersion,
     onFeedPageChanged,
   });

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -153,7 +153,7 @@ export const BootDataProvider = ({
   );
 
   return (
-    <FeaturesContextProvider flags={flags}>
+    <FeaturesContextProvider flags={flags} isFeaturesLoaded={loadedFromCache}>
       <AuthContextProvider
         user={user}
         updateUser={updateUser}

--- a/packages/shared/src/contexts/FeaturesContext.tsx
+++ b/packages/shared/src/contexts/FeaturesContext.tsx
@@ -35,11 +35,11 @@ interface Experiments {
   squadVersion?: SquadVersion;
   squadForm?: string;
   squadButton?: string;
-  isFeaturesLoaded?: boolean;
 }
 
 export interface FeaturesData extends Experiments {
   flags: IFlags;
+  isFeaturesLoaded?: boolean;
 }
 
 const FeaturesContext = React.createContext<FeaturesData>({ flags: {} });
@@ -50,10 +50,7 @@ export interface FeaturesContextProviderProps
   children?: ReactNode;
 }
 
-const getFeatures = (
-  flags: IFlags,
-  isFeaturesLoaded: boolean,
-): FeaturesData => {
+const getFeatures = (flags: IFlags): FeaturesData => {
   const steps = getFeatureValue(Features.OnboardingSteps, flags);
   const onboardingSteps = (steps?.split?.('/') || []) as OnboardingStep[];
   const minimumTopics = getFeatureValue(
@@ -63,7 +60,6 @@ const getFeatures = (
 
   return {
     flags,
-    isFeaturesLoaded,
     onboardingSteps,
     onboardingMinimumTopics: getNumberValue(minimumTopics, 0),
     onboardingVersion: getFeatureValue(Features.UserOnboardingVersion, flags),
@@ -103,20 +99,20 @@ export const FeaturesContextProvider = ({
   flags,
 }: FeaturesContextProviderProps): ReactElement => {
   const featuresFlags: FeaturesData = useMemo(() => {
-    const features = getFeatures(flags, isFeaturesLoaded);
+    const features = getFeatures(flags);
 
     if (!isPreviewDeployment) {
-      return features;
+      return { ...features, isFeaturesLoaded };
     }
 
     const featuresCookie = getCookieFeatureFlags();
     const updated = updateFeatureFlags(flags, featuresCookie);
-    const result = getFeatures(updated, isFeaturesLoaded);
+    const result = getFeatures(updated);
 
     globalThis.getFeatureKeys = () => Object.keys(features);
 
-    return result;
-  }, [flags]);
+    return { ...result, isFeaturesLoaded };
+  }, [flags, isFeaturesLoaded]);
 
   return (
     <FeaturesContext.Provider value={featuresFlags}>

--- a/packages/shared/src/hooks/useOnboardingModal.ts
+++ b/packages/shared/src/hooks/useOnboardingModal.ts
@@ -25,6 +25,7 @@ interface UseOnboardingModalProps {
   alerts: Alerts;
   isFirstVisit: boolean;
   onboardingVersion: OnboardingVersion;
+  isFeaturesLoaded: boolean;
   onFeedPageChanged: (page: MainFeedPage) => unknown;
 }
 
@@ -36,6 +37,7 @@ export const useOnboardingModal = ({
   user,
   alerts,
   isFirstVisit,
+  isFeaturesLoaded,
   onboardingVersion,
   onFeedPageChanged,
 }: UseOnboardingModalProps): UseOnboardingModal => {
@@ -81,14 +83,21 @@ export const useOnboardingModal = ({
   }, [user, shouldUpdateFilters]);
 
   useEffect(() => {
-    if (!hasOnboardingLoaded || hasTriedOnboarding || !alerts.filter) {
+    const conditions = [
+      !hasOnboardingLoaded,
+      hasTriedOnboarding,
+      !alerts.filter,
+      !isFeaturesLoaded,
+    ];
+
+    if (conditions.some((condition) => !!condition)) {
       return;
     }
 
     setHasTriedOnboarding(false);
     setOnboardingMode(OnboardingMode.Auto);
     modalStateCommand[onboardingVersion]?.(true);
-  }, [hasOnboardingLoaded, user]);
+  }, [hasOnboardingLoaded, isFeaturesLoaded, user]);
 
   return useMemo(
     () => ({

--- a/packages/shared/src/lib/links.ts
+++ b/packages/shared/src/lib/links.ts
@@ -1,8 +1,14 @@
+import { isDevelopment } from './constants';
+
 export const getTagPageLink = (tag: string): string =>
   `${process.env.NEXT_PUBLIC_WEBAPP_URL}tags/${encodeURIComponent(tag)}`;
 
 export const isPreviewDeployment = (() => {
   const value = process.env.NEXT_PUBLIC_PREVIEW_DEPLOYMENT;
+
+  if (isDevelopment) {
+    return true;
+  }
 
   if (!value) {
     return false;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Issue was onboarding is loaded very quickly and does not wait for the boot data to finish yet.
- Fix is to include a variable to check whether the data was fetched already.

Tagged @idoshamun for raising the issue.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
