### PR TITLE
fix: onboarding trap

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -183,7 +183,7 @@ export default function MainFeedLayout({
     hasFiltered: !alerts?.filter,
     hasUser: !!user,
   });
-  const { flags, popularFeedCopy, onboardingVersion, isFeaturesLoaded } =
+  const { flags, popularFeedCopy, onboardingVersion, isFlagsFetched } =
     useContext(FeaturesContext);
   const [isFeedFiltersOpen, setIsFeedFiltersOpen] = useState(false);
   const feedVersion = parseInt(
@@ -237,7 +237,7 @@ export default function MainFeedLayout({
     user,
     alerts,
     isFirstVisit,
-    isFeaturesLoaded,
+    isFeaturesLoaded: isFlagsFetched,
     onboardingVersion,
     onFeedPageChanged,
   });

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -153,7 +153,11 @@ export const BootDataProvider = ({
   );
 
   return (
-    <FeaturesContextProvider flags={flags} isFeaturesLoaded={loadedFromCache}>
+    <FeaturesContextProvider
+      flags={flags}
+      isFeaturesLoaded={loadedFromCache}
+      isFlagsFetched={isFetched}
+    >
       <AuthContextProvider
         user={user}
         updateUser={updateUser}

--- a/packages/shared/src/contexts/FeaturesContext.tsx
+++ b/packages/shared/src/contexts/FeaturesContext.tsx
@@ -39,6 +39,7 @@ interface Experiments {
 
 export interface FeaturesData extends Experiments {
   flags: IFlags;
+  isFlagsFetched?: boolean;
   isFeaturesLoaded?: boolean;
 }
 
@@ -46,7 +47,7 @@ const FeaturesContext = React.createContext<FeaturesData>({ flags: {} });
 export default FeaturesContext;
 
 export interface FeaturesContextProviderProps
-  extends Pick<FeaturesData, 'flags' | 'isFeaturesLoaded'> {
+  extends Pick<FeaturesData, 'flags' | 'isFlagsFetched' | 'isFeaturesLoaded'> {
   children?: ReactNode;
 }
 
@@ -95,14 +96,16 @@ const getFeatures = (flags: IFlags): FeaturesData => {
 
 export const FeaturesContextProvider = ({
   isFeaturesLoaded,
+  isFlagsFetched,
   children,
   flags,
 }: FeaturesContextProviderProps): ReactElement => {
   const featuresFlags: FeaturesData = useMemo(() => {
     const features = getFeatures(flags);
+    const props = { isFeaturesLoaded, isFlagsFetched };
 
     if (!isPreviewDeployment) {
-      return { ...features, isFeaturesLoaded };
+      return { ...features, ...props };
     }
 
     const featuresCookie = getCookieFeatureFlags();
@@ -111,8 +114,8 @@ export const FeaturesContextProvider = ({
 
     globalThis.getFeatureKeys = () => Object.keys(features);
 
-    return { ...result, isFeaturesLoaded };
-  }, [flags, isFeaturesLoaded]);
+    return { ...result, ...props };
+  }, [flags, isFeaturesLoaded, isFlagsFetched]);
 
   return (
     <FeaturesContext.Provider value={featuresFlags}>

--- a/packages/shared/src/hooks/useOnboardingModal.ts
+++ b/packages/shared/src/hooks/useOnboardingModal.ts
@@ -56,14 +56,14 @@ export const useOnboardingModal = ({
     v2: setIsOnboardingOpen,
   };
 
-  const onCloseOnboardingModal = () => {
+  const onCloseOnboardingModal = async () => {
     if (
       onboardingMode === OnboardingMode.Auto &&
       onboardingVersion === OnboardingVersion.V1
     ) {
       trackEvent({ event_name: AnalyticsEvent.OnboardingSkip });
     }
-    setHasTriedOnboarding(true);
+    await setHasTriedOnboarding(true);
     modalStateCommand[onboardingVersion]?.(false);
     if (user && !alerts.filter) {
       onFeedPageChanged(MainFeedPage.MyFeed);

--- a/packages/shared/src/hooks/useOnboardingModal.ts
+++ b/packages/shared/src/hooks/useOnboardingModal.ts
@@ -64,7 +64,8 @@ export const useOnboardingModal = ({
       trackEvent({ event_name: AnalyticsEvent.OnboardingSkip });
     }
     await setHasTriedOnboarding(true);
-    modalStateCommand[onboardingVersion]?.(false);
+    const commands = Object.values(modalStateCommand);
+    commands.forEach((onShowModal) => onShowModal?.(false));
     if (user && !alerts.filter) {
       onFeedPageChanged(MainFeedPage.MyFeed);
     }

--- a/packages/shared/src/hooks/useOnboardingModal.ts
+++ b/packages/shared/src/hooks/useOnboardingModal.ts
@@ -63,9 +63,10 @@ export const useOnboardingModal = ({
     ) {
       trackEvent({ event_name: AnalyticsEvent.OnboardingSkip });
     }
-    await setHasTriedOnboarding(true);
-    const commands = Object.values(modalStateCommand);
-    commands.forEach((onShowModal) => onShowModal?.(false));
+    if (!hasTriedOnboarding) {
+      await setHasTriedOnboarding(true);
+    }
+    modalStateCommand[onboardingVersion]?.(false);
     if (user && !alerts.filter) {
       onFeedPageChanged(MainFeedPage.MyFeed);
     }
@@ -98,7 +99,7 @@ export const useOnboardingModal = ({
     setHasTriedOnboarding(false);
     setOnboardingMode(OnboardingMode.Auto);
     modalStateCommand[onboardingVersion]?.(true);
-  }, [hasOnboardingLoaded, isFeaturesLoaded, user]);
+  }, [hasOnboardingLoaded, hasTriedOnboarding, isFeaturesLoaded, user]);
 
   return useMemo(
     () => ({

--- a/packages/shared/src/hooks/useOnboardingModal.ts
+++ b/packages/shared/src/hooks/useOnboardingModal.ts
@@ -56,17 +56,20 @@ export const useOnboardingModal = ({
     v2: setIsOnboardingOpen,
   };
 
-  const onCloseOnboardingModal = async () => {
+  const onCloseOnboardingModal = () => {
     if (
       onboardingMode === OnboardingMode.Auto &&
       onboardingVersion === OnboardingVersion.V1
     ) {
       trackEvent({ event_name: AnalyticsEvent.OnboardingSkip });
     }
+
     if (!hasTriedOnboarding) {
-      await setHasTriedOnboarding(true);
+      setHasTriedOnboarding(true);
     }
+
     modalStateCommand[onboardingVersion]?.(false);
+
     if (user && !alerts.filter) {
       onFeedPageChanged(MainFeedPage.MyFeed);
     }

--- a/packages/shared/src/hooks/useOnboardingModal.ts
+++ b/packages/shared/src/hooks/useOnboardingModal.ts
@@ -102,7 +102,7 @@ export const useOnboardingModal = ({
     setHasTriedOnboarding(false);
     setOnboardingMode(OnboardingMode.Auto);
     modalStateCommand[onboardingVersion]?.(true);
-  }, [hasOnboardingLoaded, hasTriedOnboarding, isFeaturesLoaded, user]);
+  }, [hasOnboardingLoaded, isFeaturesLoaded, user]);
 
   return useMemo(
     () => ({


### PR DESCRIPTION
## Changes

### Describe what this PR does
- One issue could be a race condition where we were not awaiting the variable we use when updating them, then the useEffect gets triggered to open the modal again. This would ensure setting the value has happened first before closing them modal.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
