### PR TITLE
fix: await first load of boot data

### DIFF
--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -155,8 +155,8 @@ export const BootDataProvider = ({
   return (
     <FeaturesContextProvider
       flags={flags}
+      isFlagsFetched={initialLoad}
       isFeaturesLoaded={loadedFromCache}
-      isFlagsFetched={isFetched}
     >
       <AuthContextProvider
         user={user}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Used the `firstLoad` parameter to make sure everything is loaded locally.
- The issue was that fetched was accurate, but we set the state which requires another loop, and by that time, the modal is already open.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
