### PR TITLE
fix: sidebar top margin issue

### DIFF
--- a/packages/shared/src/components/sidebar/MyFeedButton.tsx
+++ b/packages/shared/src/components/sidebar/MyFeedButton.tsx
@@ -36,7 +36,7 @@ function MyFeedButton({
   const isActive = activePage === myFeedMenuItem.path;
 
   return (
-    <NavItem className="mt-6" active={isActive}>
+    <NavItem className="mt-0 laptop:mt-2" active={isActive}>
       <ClickableNavItem item={myFeedMenuItem} isButton={isButton}>
         <ItemInner
           item={myFeedMenuItem}

--- a/packages/shared/src/components/sidebar/SquadButton.tsx
+++ b/packages/shared/src/components/sidebar/SquadButton.tsx
@@ -37,7 +37,7 @@ function SquadButton({
           rel="noopener"
           iconOnly={!sidebarExpanded}
           className={classNames(
-            'my-4 btn-primary-cabbage',
+            'mt-0 laptop:mt-2 mb-4 btn-primary-cabbage',
             sidebarExpanded ? 'mx-3' : 'mx-1.5',
           )}
           textPosition={sidebarExpanded ? 'justify-start' : 'justify-center'}

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -72,7 +72,7 @@ export const SidebarScrollWrapper = classed(
   'div',
   'flex overflow-x-hidden overflow-y-auto flex-col h-full no-scrollbar',
 );
-export const Nav = classed('nav', 'my-4 mt-10');
+export const Nav = classed('nav', 'my-4 mt-10 laptop:mt-8');
 export const NavSection = classed('ul', 'mt-0 laptop:mt-2');
 export const NavHeader = classed(
   'li',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The sidebar top margin was not consistent and in some cases too big.
- Now it's always 40px regardless of the rendered first element

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-772 #done
