### PR TITLE
fix: added fully qualified type for justify modal footers

### DIFF
--- a/packages/shared/src/components/modals/common/ModalFooter.tsx
+++ b/packages/shared/src/components/modals/common/ModalFooter.tsx
@@ -1,18 +1,19 @@
 import classNames from 'classnames';
 import React, { ReactElement, ReactNode, useContext } from 'react';
 import { ModalPropsContext } from './types';
+import { Justify } from '../../utilities';
 
 export type ModalFooterProps = {
   children?: ReactNode;
   className?: string;
-  justify?: 'end' | 'center' | 'between';
+  justify?: Justify;
   tab?: string;
 };
 
 export function ModalFooter({
   children,
   className,
-  justify = 'end',
+  justify = Justify.End,
   tab,
 }: ModalFooterProps): ReactElement {
   const { activeTab } = useContext(ModalPropsContext);
@@ -21,7 +22,7 @@ export function ModalFooter({
     <footer
       className={classNames(
         'flex gap-3 items-center p-3 w-full h-16 border-t border-theme-divider-tertiary',
-        `justify-${justify}`,
+        justify,
         className,
       )}
     >

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -16,6 +16,12 @@ export enum Theme {
   Lettuce = 'lettuce',
 }
 
+export enum Justify {
+  End = 'justify-end',
+  Center = 'justify-center',
+  Between = 'justify-between',
+}
+
 export interface ThemeColor {
   border: string;
   shadow: string;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added Justify enum for fully qualified classnames and ease of import for the modal footer

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-771 #done #1386 
