### PR TITLE
fix: last open icon changes from design feedback

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -310,9 +310,9 @@ export default function Feed<T>({
   } as React.CSSProperties;
   const cardContainerStye = { ...getStyle(useList, spaciness) };
 
-  // if (emptyScreen && emptyFeed) {
-  //   return <>{emptyScreen}</>;
-  // }
+  if (emptyScreen && emptyFeed) {
+    return <>{emptyScreen}</>;
+  }
   const { sharePost, sharePostFeedLocation, openSharePost, closeSharePost } =
     useSharePost(Origin.Feed);
   const onShareClick = (post: Post, row?: number, column?: number) =>

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -310,9 +310,9 @@ export default function Feed<T>({
   } as React.CSSProperties;
   const cardContainerStye = { ...getStyle(useList, spaciness) };
 
-  if (emptyScreen && emptyFeed) {
-    return <>{emptyScreen}</>;
-  }
+  // if (emptyScreen && emptyFeed) {
+  //   return <>{emptyScreen}</>;
+  // }
   const { sharePost, sharePostFeedLocation, openSharePost, closeSharePost } =
     useSharePost(Origin.Feed);
   const onShareClick = (post: Post, row?: number, column?: number) =>

--- a/packages/shared/src/components/Settings.tsx
+++ b/packages/shared/src/components/Settings.tsx
@@ -119,7 +119,7 @@ export default function Settings({
           inputId="layout-switch"
           name="insaneMode"
           leftContent={<CardIcon secondary={!insaneMode} />}
-          rightContent={<LineIcon secondary={!insaneMode} />}
+          rightContent={<LineIcon secondary={insaneMode} />}
           checked={insaneMode}
           className="mx-1.5"
           onToggle={toggleInsaneMode}

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -127,7 +127,8 @@ export function Dropdown({
         aria-haspopup="true"
         aria-expanded={isVisible}
       >
-        {React.cloneElement(icon as ReactElement, { secondary: isVisible })}
+        {icon &&
+          React.cloneElement(icon as ReactElement, { secondary: isVisible })}
         <span
           className={classNames('flex flex-1 mr-1 truncate', className.label)}
         >

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -127,7 +127,7 @@ export function Dropdown({
         aria-haspopup="true"
         aria-expanded={isVisible}
       >
-        {icon}
+        {React.cloneElement(icon as ReactElement, { secondary: isVisible })}
         <span
           className={classNames('flex flex-1 mr-1 truncate', className.label)}
         >

--- a/packages/shared/src/components/sidebar/SidebarListItem.tsx
+++ b/packages/shared/src/components/sidebar/SidebarListItem.tsx
@@ -28,7 +28,10 @@ function SidebarListItem({
   );
   const content = (
     <>
-      {React.cloneElement(icon as ReactElement, { secondary: isActive })}
+      {React.cloneElement(icon as ReactElement, {
+        secondary: isActive,
+        className: !isActive && 'text-theme-label-secondary',
+      })}
       <span
         className={classNames(
           'ml-2 typo-callout',
@@ -37,7 +40,12 @@ function SidebarListItem({
       >
         {title}
       </span>
-      <ArrowIcon className="ml-auto rotate-90" />
+      <ArrowIcon
+        className={classNames(
+          'ml-auto rotate-90',
+          !isActive && 'text-theme-label-secondary',
+        )}
+      />
     </>
   );
 

--- a/packages/webapp/components/layouts/AccountLayout/common.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/common.tsx
@@ -88,12 +88,22 @@ export const accountPage: Record<AccountPage, AccountPageProps> = {
   security: {
     title: 'Security',
     href: '/security',
-    getIcon: ({ isActive }) => <LockIcon secondary={isActive} />,
+    getIcon: ({ isActive }) => (
+      <LockIcon
+        secondary={isActive}
+        className={!isActive && 'text-theme-label-secondary'}
+      />
+    ),
   },
   others: {
     title: 'Other Settings',
     href: '/others',
-    getIcon: ({ isActive }) => <SettingsIcon secondary={isActive} />,
+    getIcon: ({ isActive }) => (
+      <SettingsIcon
+        secondary={isActive}
+        className={!isActive && 'text-theme-label-secondary'}
+      />
+    ),
   },
 };
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Design found a couple remaining issues that are now addressed.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-789 #done
