### PR TITLE
feat: notification prompt after new comment

### DIFF
--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 import classNames from 'classnames';
 import { Comment, getCommentHash } from '../../graphql/comments';
 import { CommentBox, CommentPublishDate } from './common';
@@ -14,6 +14,9 @@ import { ProfileTooltip } from '../profile/ProfileTooltip';
 import ScoutBadge from './ScoutBadge';
 import { Origin } from '../../lib/analytics';
 import { Post } from '../../graphql/posts';
+import EnableNotification, {
+  NotificationPromptSource,
+} from '../notifications/EnableNotification';
 
 export interface Props extends CommentActionProps {
   post: Post;
@@ -24,6 +27,7 @@ export interface Props extends CommentActionProps {
   commentHash?: string;
   commentRef?: React.MutableRefObject<HTMLElement>;
   className?: string;
+  permissionNotificationCommentId?: string;
   appendTooltipTo?: () => HTMLElement;
 }
 
@@ -44,6 +48,7 @@ export default function MainComment({
   className,
   postAuthorId,
   postScoutId,
+  permissionNotificationCommentId,
 }: Props): ReactElement {
   return (
     <article
@@ -96,25 +101,33 @@ export default function MainComment({
         onShowUpvotes={onShowUpvotes}
       />
       {comment.children?.edges.map((e, i) => (
-        <SubComment
-          post={post}
-          origin={origin}
-          commentHash={commentHash}
-          commentRef={commentRef}
-          comment={e.node}
-          key={e.node.id}
-          firstComment={i === 0}
-          lastComment={i === comment.children.edges.length - 1}
-          parentId={comment.id}
-          onComment={onComment}
-          onShare={onShare}
-          onDelete={onDelete}
-          onEdit={(childComment) => onEdit(childComment, comment)}
-          onShowUpvotes={onShowUpvotes}
-          postAuthorId={postAuthorId}
-          postScoutId={postScoutId}
-          appendTooltipTo={appendTooltipTo}
-        />
+        <Fragment key={e.node.id}>
+          <SubComment
+            post={post}
+            origin={origin}
+            commentHash={commentHash}
+            commentRef={commentRef}
+            comment={e.node}
+            key={e.node.id}
+            firstComment={i === 0}
+            lastComment={i === comment.children.edges.length - 1}
+            parentId={comment.id}
+            onComment={onComment}
+            onShare={onShare}
+            onDelete={onDelete}
+            onEdit={(childComment) => onEdit(childComment, comment)}
+            onShowUpvotes={onShowUpvotes}
+            postAuthorId={postAuthorId}
+            postScoutId={postScoutId}
+            appendTooltipTo={appendTooltipTo}
+          />
+          {permissionNotificationCommentId === e.node.id && (
+            <EnableNotification
+              parentCommentAuthorName={e.node.author?.name}
+              source={NotificationPromptSource.NewComment}
+            />
+          )}
+        </Fragment>
       ))}
     </article>
   );

--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement } from 'react';
+import React, { Fragment, ReactElement, useContext } from 'react';
 import classNames from 'classnames';
 import { Comment, getCommentHash } from '../../graphql/comments';
 import { CommentBox, CommentPublishDate } from './common';
@@ -17,6 +17,7 @@ import { Post } from '../../graphql/posts';
 import EnableNotification, {
   NotificationPromptSource,
 } from '../notifications/EnableNotification';
+import AuthContext from '../../contexts/AuthContext';
 
 export interface Props extends CommentActionProps {
   post: Post;
@@ -50,6 +51,7 @@ export default function MainComment({
   postScoutId,
   permissionNotificationCommentId,
 }: Props): ReactElement {
+  const { user } = useContext(AuthContext);
   return (
     <article
       className={classNames(
@@ -122,13 +124,22 @@ export default function MainComment({
             appendTooltipTo={appendTooltipTo}
           />
           {permissionNotificationCommentId === e.node.id && (
-            <EnableNotification
-              parentCommentAuthorName={e.node.author?.name}
-              source={NotificationPromptSource.NewComment}
-            />
+            <div className="relative left-[2.6rem] w-[34rem]">
+              <EnableNotification
+                parentCommentAuthorName={
+                  e.node.author?.id !== user?.id
+                    ? e.node.author?.name
+                    : undefined
+                }
+                source={NotificationPromptSource.NewComment}
+              />
+            </div>
           )}
         </Fragment>
       ))}
+      {permissionNotificationCommentId === comment.id && (
+        <EnableNotification source={NotificationPromptSource.NewComment} />
+      )}
     </article>
   );
 }

--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactElement, useContext } from 'react';
+import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import { Comment, getCommentHash } from '../../graphql/comments';
 import { CommentBox, CommentPublishDate } from './common';
@@ -17,7 +17,6 @@ import { Post } from '../../graphql/posts';
 import EnableNotification, {
   NotificationPromptSource,
 } from '../notifications/EnableNotification';
-import AuthContext from '../../contexts/AuthContext';
 
 export interface Props extends CommentActionProps {
   post: Post;
@@ -51,7 +50,6 @@ export default function MainComment({
   postScoutId,
   permissionNotificationCommentId,
 }: Props): ReactElement {
-  const { user } = useContext(AuthContext);
   return (
     <article
       className={classNames(
@@ -103,39 +101,26 @@ export default function MainComment({
         onShowUpvotes={onShowUpvotes}
       />
       {comment.children?.edges.map((e, i) => (
-        <Fragment key={e.node.id}>
-          <SubComment
-            post={post}
-            origin={origin}
-            commentHash={commentHash}
-            commentRef={commentRef}
-            comment={e.node}
-            key={e.node.id}
-            firstComment={i === 0}
-            lastComment={i === comment.children.edges.length - 1}
-            parentId={comment.id}
-            onComment={onComment}
-            onShare={onShare}
-            onDelete={onDelete}
-            onEdit={(childComment) => onEdit(childComment, comment)}
-            onShowUpvotes={onShowUpvotes}
-            postAuthorId={postAuthorId}
-            postScoutId={postScoutId}
-            appendTooltipTo={appendTooltipTo}
-          />
-          {permissionNotificationCommentId === e.node.id && (
-            <div className="relative left-[2.6rem] w-[34rem]">
-              <EnableNotification
-                parentCommentAuthorName={
-                  e.node.author?.id !== user?.id
-                    ? e.node.author?.name
-                    : undefined
-                }
-                source={NotificationPromptSource.NewComment}
-              />
-            </div>
-          )}
-        </Fragment>
+        <SubComment
+          post={post}
+          origin={origin}
+          commentHash={commentHash}
+          commentRef={commentRef}
+          comment={e.node}
+          parentComment={comment}
+          key={e.node.id}
+          firstComment={i === 0}
+          lastComment={i === comment.children.edges.length - 1}
+          onComment={onComment}
+          onShare={onShare}
+          onDelete={onDelete}
+          onEdit={(childComment) => onEdit(childComment, comment)}
+          onShowUpvotes={onShowUpvotes}
+          postAuthorId={postAuthorId}
+          postScoutId={postScoutId}
+          appendTooltipTo={appendTooltipTo}
+          permissionNotificationCommentId={permissionNotificationCommentId}
+        />
       ))}
       {permissionNotificationCommentId === comment.id && (
         <EnableNotification source={NotificationPromptSource.NewComment} />

--- a/packages/shared/src/components/comments/SubComment.spec.tsx
+++ b/packages/shared/src/components/comments/SubComment.spec.tsx
@@ -6,6 +6,7 @@ import { LoggedUser } from '../../lib/user';
 import SubComment, { Props } from './SubComment';
 import loggedUser from '../../../__tests__/fixture/loggedUser';
 import comment from '../../../__tests__/fixture/comment';
+import { Origin } from '../../lib/analytics';
 
 const onComment = jest.fn();
 const onDelete = jest.fn();
@@ -23,12 +24,16 @@ const renderLayout = (
     comment,
     firstComment: false,
     lastComment: false,
-    parentId: 'c1',
+    parentComment: { ...comment, id: 'c1' },
     onComment,
     onDelete,
     onEdit,
     postAuthorId: null,
     postScoutId: null,
+    post: undefined,
+    origin: Origin.ArticleModal,
+    onShare: jest.fn(),
+    onShowUpvotes: jest.fn(),
   };
 
   const client = new QueryClient();
@@ -42,6 +47,8 @@ const renderLayout = (
           showLogin: jest.fn(),
           logout: jest.fn(),
           updateUser: jest.fn(),
+          closeLogin: jest.fn(),
+          getRedirectUri: jest.fn(),
           tokenRefreshed: true,
         }}
       >

--- a/packages/shared/src/components/comments/SubComment.tsx
+++ b/packages/shared/src/components/comments/SubComment.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import classNames from 'classnames';
 import { Comment, getCommentHash } from '../../graphql/comments';
 import { CommentBox, CommentPublishDate } from './common';
@@ -13,6 +13,10 @@ import { ProfileTooltip } from '../profile/ProfileTooltip';
 import ScoutBadge from './ScoutBadge';
 import { Post } from '../../graphql/posts';
 import { Origin } from '../../lib/analytics';
+import EnableNotification, {
+  NotificationPromptSource,
+} from '../notifications/EnableNotification';
+import AuthContext from '../../contexts/AuthContext';
 
 export interface Props extends CommentActionProps {
   post: Post;
@@ -20,10 +24,11 @@ export interface Props extends CommentActionProps {
   origin: Origin;
   firstComment: boolean;
   lastComment: boolean;
-  parentId: string;
+  parentComment: Comment;
   postAuthorId: string | null;
   postScoutId: string | null;
   commentHash?: string;
+  permissionNotificationCommentId?: string;
   commentRef?: React.MutableRefObject<HTMLElement>;
   appendTooltipTo?: () => HTMLElement;
 }
@@ -36,7 +41,7 @@ export default function SubComment({
   origin,
   firstComment,
   lastComment,
-  parentId,
+  parentComment,
   commentHash,
   commentRef,
   onComment,
@@ -47,7 +52,9 @@ export default function SubComment({
   appendTooltipTo,
   postAuthorId,
   postScoutId,
+  permissionNotificationCommentId,
 }: Props): ReactElement {
+  const { user } = useContext(AuthContext);
   return (
     <article
       className="flex items-stretch mt-4 scroll-mt-16"
@@ -100,13 +107,23 @@ export default function SubComment({
           post={post}
           origin={origin}
           comment={comment}
-          parentId={parentId}
+          parentId={parentComment.id}
           onComment={onComment}
           onShare={onShare}
           onDelete={onDelete}
           onEdit={onEdit}
           onShowUpvotes={onShowUpvotes}
         />
+        {permissionNotificationCommentId === comment.id && (
+          <EnableNotification
+            parentCommentAuthorName={
+              parentComment.author?.id !== user?.id
+                ? parentComment.author?.name
+                : undefined
+            }
+            source={NotificationPromptSource.NewComment}
+          />
+        )}
       </div>
     </article>
   );

--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -3,47 +3,106 @@ import usePersistentContext from '../../hooks/usePersistentContext';
 import { Button } from '../buttons/Button';
 import NotificationsContext from '../../contexts/NotificationsContext';
 import { cloudinary } from '../../lib/image';
+import CloseButton from '../CloseButton';
+
+export enum NotificationPromptSource {
+  NotificationList = 'notificationList',
+  NewComment = 'newComment',
+  NewSource = 'newSource',
+}
 
 const DISMISS_BROWSER_PERMISSION = 'dismissBrowserPermission';
 
-function EnableNotification(): ReactElement {
-  const { hasPermission, requestPermission } = useContext(NotificationsContext);
-  const [dismissed, setDismissed, isLoaded] = usePersistentContext(
-    DISMISS_BROWSER_PERMISSION,
-    false,
-  );
+type DismissBrowserPermissions = {
+  [NotificationPromptSource.NotificationList]: boolean;
+  [NotificationPromptSource.NewComment]: boolean;
+  [NotificationPromptSource.NewSource]: boolean;
+};
 
+const DEFAULT_CACHE_VALUE: DismissBrowserPermissions = {
+  newComment: false,
+  newSource: false,
+  notificationList: false,
+};
+
+type EnableNotificationProps = {
+  source?: NotificationPromptSource;
+  parentCommentAuthorName?: string;
+};
+
+function EnableNotification({
+  source = NotificationPromptSource.NotificationList,
+  parentCommentAuthorName,
+}: EnableNotificationProps): ReactElement {
+  const { hasPermission, requestPermission } = useContext(NotificationsContext);
+  const [dismissedCache, setDismissedCache, isLoaded] =
+    usePersistentContext<DismissBrowserPermissions>(
+      DISMISS_BROWSER_PERMISSION,
+      DEFAULT_CACHE_VALUE,
+    );
+  const dismissed = !!dismissedCache?.[source];
+  const setDismissed = (value: boolean) =>
+    setDismissedCache({ ...dismissedCache, [source]: value });
   if (!isLoaded || dismissed || hasPermission) {
     return null;
   }
-
+  if (source === NotificationPromptSource.NotificationList) {
+    return (
+      <div className="relative py-4 px-6 w-full bg-theme-float border-l typo-callout border-theme-color-cabbage">
+        <span className="mb-2 font-bold">Push notifications</span>
+        <p className="w-3/5 text-theme-label-tertiary">
+          Stay in the loop whenever you get a mention, reply and other important
+          updates.
+        </p>
+        <span className="flex flex-row gap-4 mt-4">
+          <Button
+            buttonSize="small"
+            className="w-28 text-white btn-primary-cabbage"
+            onClick={requestPermission}
+          >
+            Enable
+          </Button>
+          <Button
+            buttonSize="small"
+            className="w-28 btn-tertiary"
+            onClick={() => setDismissed(true)}
+          >
+            Dismiss
+          </Button>
+        </span>
+        <img
+          className="absolute top-2 right-0"
+          src={cloudinary.notifications.browser}
+          alt="A sample browser notification"
+        />
+      </div>
+    );
+  }
   return (
-    <div className="relative py-4 px-6 w-full bg-theme-float border-l typo-callout border-l-theme-color-cabbage">
-      <span className="font-bold">Push notifications</span>
-      <p className="mt-2 w-3/5 text-theme-label-tertiary">
-        Stay in the loop whenever you get a mention, reply and other important
-        updates.
+    <div className="overflow-hidden relative py-4 px-4 mt-3 rounded-16 border typo-callout border-theme-color-cabbage left-[2.6rem] w-[34rem]">
+      <p className="w-3/5 text-theme-label-tertiary">
+        Want to get notified when {parentCommentAuthorName} responds so you can
+        continue the conversation?
       </p>
       <span className="flex flex-row gap-4 mt-4">
         <Button
           buttonSize="small"
-          className="w-28 btn-primary-cabbage"
+          className="text-white btn-primary-cabbage"
           onClick={requestPermission}
         >
-          Enable
-        </Button>
-        <Button
-          buttonSize="small"
-          className="w-28 btn-tertiary"
-          onClick={() => setDismissed(true)}
-        >
-          Dismiss
+          Enable Notifications
         </Button>
       </span>
       <img
-        className="absolute top-2 right-0"
+        className="absolute right-4 -bottom-2"
         src={cloudinary.notifications.browser}
         alt="A sample browser notification"
+      />
+      <CloseButton
+        buttonSize="xsmall"
+        className="top-3 right-3"
+        onClick={() => setDismissed(true)}
+        position="absolute"
       />
     </div>
   );

--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -43,7 +43,7 @@ function EnableNotification({
   const dismissed = !!dismissedCache?.[source];
   const setDismissed = (value: boolean) =>
     setDismissedCache({ ...dismissedCache, [source]: value });
-  if (!isLoaded || dismissed || hasPermission) {
+  if (!isLoaded || dismissed || !hasPermission) {
     return null;
   }
   if (source === NotificationPromptSource.NotificationList) {

--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -43,7 +43,7 @@ function EnableNotification({
   const dismissed = !!dismissedCache?.[source];
   const setDismissed = (value: boolean) =>
     setDismissedCache({ ...dismissedCache, [source]: value });
-  if (!isLoaded || dismissed || !hasPermission) {
+  if (!isLoaded || dismissed || hasPermission) {
     return null;
   }
   if (source === NotificationPromptSource.NotificationList) {

--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -79,10 +79,10 @@ function EnableNotification({
     );
   }
   return (
-    <div className="overflow-hidden relative py-4 px-4 mt-3 rounded-16 border typo-callout border-theme-color-cabbage left-[2.6rem] w-[34rem]">
+    <div className="overflow-hidden relative py-4 px-4 mt-3 rounded-16 border typo-callout border-theme-color-cabbage">
       <p className="w-3/5 text-theme-label-tertiary">
-        Want to get notified when {parentCommentAuthorName} responds so you can
-        continue the conversation?
+        Want to get notified when {parentCommentAuthorName ?? 'someone'}{' '}
+        responds so you can continue the conversation?
       </p>
       <span className="flex flex-row gap-4 mt-4">
         <Button

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -38,6 +38,7 @@ interface PostCommentsProps {
   post: Post;
   origin: Origin;
   applyBottomMargin?: boolean;
+  permissionNotificationCommentId?: string;
   modalParentSelector?: () => HTMLElement;
   onClick?: (parent: ParentComment) => unknown;
   onShare?: (comment: Comment) => void;
@@ -91,6 +92,7 @@ export function PostComments({
   onShare,
   onClickUpvote,
   modalParentSelector,
+  permissionNotificationCommentId,
   applyBottomMargin = true,
 }: PostCommentsProps): ReactElement {
   const { id } = post;
@@ -152,7 +154,6 @@ export function PostComments({
     const shared = { editContent: comment.content, editId: comment.id };
     onClick(getParentComment(post, localParentComment, shared));
   };
-
   return (
     <>
       {comments.postComments.edges.map((e, i) => (
@@ -174,6 +175,7 @@ export function PostComments({
           postAuthorId={post.author?.id}
           postScoutId={post.scout?.id}
           appendTooltipTo={modalParentSelector}
+          permissionNotificationCommentId={permissionNotificationCommentId}
         />
       ))}
       {pendingComment && (

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -50,6 +50,7 @@ import { Origin } from '../../lib/analytics';
 import { useShareComment } from '../../hooks/useShareComment';
 import useOnPostClick from '../../hooks/useOnPostClick';
 import { AuthTriggers } from '../../lib/auth';
+import { Comment } from '../../graphql/comments';
 
 const UpvotedPopupModal = dynamic(
   () =>
@@ -150,6 +151,7 @@ export function PostContent({
   } = useUpvoteQuery();
   const { user, showLogin } = useContext(AuthContext);
   const { trackEvent } = useContext(AnalyticsContext);
+  const [permissionNotificationCommentId, setPermissionNotificationCommentId] = useState<string>();
   const [authorOnboarding, setAuthorOnboarding] = useState(false);
   const queryClient = useQueryClient();
   const postQueryKey = ['post', id];
@@ -253,6 +255,14 @@ export function PostContent({
     bookmarkToast(targetBookmarkState);
   };
 
+  const onComment = (comment: Comment, isNew?: boolean) => {
+    const displayNotificationBanner = isNew && !!parentComment.commentId;
+    if (displayNotificationBanner) {
+      setPermissionNotificationCommentId(comment.id);
+    }
+    updatePostComments(comment, isNew);
+  };
+
   return (
     <Wrapper
       className={className}
@@ -345,6 +355,7 @@ export function PostContent({
           onClick={onCommentClick}
           onShare={(comment) => openShareComment(comment, postById.post)}
           onClickUpvote={onShowUpvotedComment}
+          permissionNotificationCommentId={permissionNotificationCommentId}
         />
         {authorOnboarding && (
           <AuthorOnboarding
@@ -379,7 +390,7 @@ export function PostContent({
           isOpen={!!parentComment}
           onRequestClose={closeNewComment}
           {...parentComment}
-          onComment={updatePostComments}
+          onComment={onComment}
         />
       )}
       {postById && showShareNewComment && (

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -152,7 +152,7 @@ export function PostContent({
   const { user, showLogin } = useContext(AuthContext);
   const { trackEvent } = useContext(AnalyticsContext);
   const [permissionNotificationCommentId, setPermissionNotificationCommentId] =
-    useState<string>();
+    useState<string>('R3c_0TsjO');
   const [authorOnboarding, setAuthorOnboarding] = useState(false);
   const queryClient = useQueryClient();
   const postQueryKey = ['post', id];

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -152,7 +152,7 @@ export function PostContent({
   const { user, showLogin } = useContext(AuthContext);
   const { trackEvent } = useContext(AnalyticsContext);
   const [permissionNotificationCommentId, setPermissionNotificationCommentId] =
-    useState<string>('R3c_0TsjO');
+    useState<string>();
   const [authorOnboarding, setAuthorOnboarding] = useState(false);
   const queryClient = useQueryClient();
   const postQueryKey = ['post', id];

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -151,7 +151,8 @@ export function PostContent({
   } = useUpvoteQuery();
   const { user, showLogin } = useContext(AuthContext);
   const { trackEvent } = useContext(AnalyticsContext);
-  const [permissionNotificationCommentId, setPermissionNotificationCommentId] = useState<string>();
+  const [permissionNotificationCommentId, setPermissionNotificationCommentId] =
+    useState<string>();
   const [authorOnboarding, setAuthorOnboarding] = useState(false);
   const queryClient = useQueryClient();
   const postQueryKey = ['post', id];
@@ -256,8 +257,7 @@ export function PostContent({
   };
 
   const onComment = (comment: Comment, isNew?: boolean) => {
-    const displayNotificationBanner = isNew && !!parentComment.commentId;
-    if (displayNotificationBanner) {
+    if (isNew) {
       setPermissionNotificationCommentId(comment.id);
     }
     updatePostComments(comment, isNew);


### PR DESCRIPTION
## Changes

Added a notification prompt when the user creates a new comment.

<img width="669" alt="image" src="https://user-images.githubusercontent.com/1488164/206422400-70737511-9950-4934-a6be-7a6cf3a301bd.png">



### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
