### PR TITLE
fix: return traits when name is empty

### DIFF
--- a/packages/webapp/pages/account/profile.tsx
+++ b/packages/webapp/pages/account/profile.tsx
@@ -81,6 +81,8 @@ const AccountProfilePage = (): ReactElement => {
             label="Full Name"
             inputId="name"
             name="name"
+            hint={hint.name}
+            valid={!hint.name}
             leftIcon={<UserIcon />}
             value={user.name}
           />


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Ensure that we show the trait when name is not submitted.
![Screenshot 2022-12-08 at 15 50 50](https://user-images.githubusercontent.com/554874/206463960-07e3c147-5f4c-4a98-a737-0e8ce0bcfe6b.png)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-807 #done
