### PR TITLE
fix: modal height issue on ios

### DIFF
--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -23,30 +23,31 @@ export type ModalProps = ReactModal.Props & {
 };
 
 const modalKindToOverlayClassName: Record<ModalKind, string> = {
-  [ModalKind.FixedCenter]: 'mobileL:justify-center',
+  [ModalKind.FixedCenter]: 'mobileL:justify-center pt-10 mobileL:pt-0',
   [ModalKind.FlexibleCenter]: 'justify-center',
-  [ModalKind.FlexibleTop]: 'm-0',
+  [ModalKind.FlexibleTop]: 'pt-10',
 };
 const modalKindAndSizeToOverlayClassName: Partial<
   Record<ModalKind, Partial<Record<ModalSize, string>>>
 > = {
   [ModalKind.FlexibleTop]: {
-    [ModalSize.Medium]: 'mobileL:pt-10',
+    [ModalSize.Small]: 'mobileL:pt-20',
+    [ModalSize.Medium]: 'mobileL:pt-14',
   },
 };
 const modalKindToClassName: Record<ModalKind, string> = {
   [ModalKind.FixedCenter]:
-    'h-full max-h-[calc(100vh-2.5rem)] mobileL:h-[40rem] mobileL:max-h-[calc(100vh-5rem)] mt-10 mobileL:mt-0',
+    'h-full max-h-[calc(100vh-2.5rem)] mobileL:h-[40rem] mobileL:max-h-[calc(100vh-5rem)]',
   [ModalKind.FlexibleCenter]:
     'mx-4 max-w-[calc(100vw-2rem)] max-h-[min(calc(100vh),40rem)] mobileL:max-h-[min(calc(100vh-5rem),40rem)]',
-  [ModalKind.FlexibleTop]: 'm-0 mobileL:mt-10 mobileL:h-auto',
+  [ModalKind.FlexibleTop]: 'max-h-full h-full mobileL:h-auto',
 };
 const modalKindAndSizeToClassName: Partial<
   Record<ModalKind, Partial<Record<ModalSize, string>>>
 > = {
   [ModalKind.FlexibleTop]: {
     [ModalSize.Medium]:
-      'mt-10 mobileL:max-h-[calc(100vh-7.5rem)] max-h-[calc(100vh-2.5rem)] h-auto',
+      'mobileL:max-h-[calc(100vh-7.5rem)] max-h-[calc(100vh-2.5rem)] h-auto',
     [ModalSize.Large]:
       'mobileL:mt-14 mobileL:max-h-[calc(100vh-5rem)] max-h-[100vh]',
   },


### PR DESCRIPTION
## Changes

<img width="508" alt="Screenshot 2022-12-09 at 16 03 26" src="https://user-images.githubusercontent.com/1488164/206708728-9a74fea1-befe-419b-a2c6-e555f7dc56b6.png">


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
