### PR TITLE
fix: enabled message temporary state

### DIFF
--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -1,34 +1,56 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement, useContext, useState } from 'react';
 import usePersistentContext from '../../hooks/usePersistentContext';
 import { Button } from '../buttons/Button';
 import NotificationsContext from '../../contexts/NotificationsContext';
 import { cloudinary } from '../../lib/image';
+import VIcon from '../icons/V';
+import { webappUrl } from '../../lib/constants';
 
 const DISMISS_BROWSER_PERMISSION = 'dismissBrowserPermission';
 
 function EnableNotification(): ReactElement {
+  const [isEnabled, setIsEnabled] = useState(false);
   const { hasPermission, requestPermission } = useContext(NotificationsContext);
   const [dismissed, setDismissed, isLoaded] = usePersistentContext(
     DISMISS_BROWSER_PERMISSION,
     false,
   );
 
-  if (!isLoaded || dismissed || hasPermission) {
+  const onEnable = async () => {
+    const permission = await requestPermission();
+
+    setIsEnabled(permission === 'granted');
+  };
+
+  if (!isLoaded || dismissed || (hasPermission && !isEnabled)) {
     return null;
   }
 
   return (
     <div className="relative py-4 px-6 w-full bg-theme-float border-l typo-callout border-l-theme-color-cabbage">
-      <span className="font-bold">Push notifications</span>
-      <p className="mt-2 w-3/5 text-theme-label-tertiary">
-        Stay in the loop whenever you get a mention, reply and other important
-        updates.
-      </p>
+      <span className="flex flex-row font-bold">
+        {isEnabled && <VIcon className="mr-2" />}
+        {`Push notifications${isEnabled ? ' successfully enabled' : ''}`}
+      </span>
+      {isEnabled ? (
+        <p>
+          Changing your{' '}
+          <a href={`${webappUrl}account/notifications`}>
+            notification settings
+          </a>{' '}
+          can be done anytime through your account details
+        </p>
+      ) : (
+        <p className="mt-2 w-3/5 text-theme-label-tertiary">
+          Stay in the loop whenever you get a mention, reply and other important
+          updates.
+        </p>
+      )}
       <span className="flex flex-row gap-4 mt-4">
         <Button
           buttonSize="small"
           className="w-28 btn-primary-cabbage"
-          onClick={requestPermission}
+          onClick={onEnable}
         >
           Enable
         </Button>

--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -104,7 +104,7 @@ function EnableNotification({
       <span className="flex flex-row gap-4 mt-4">
         <Button
           buttonSize="small"
-          className="min-w-[7rem] btn-primary-cabbage"
+          className="text-white min-w-[7rem] btn-primary-cabbage"
           onClick={onEnable}
         >
           Enable Notifications

--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -41,7 +41,7 @@ function EnableNotification(): ReactElement {
           can be done anytime through your account details
         </p>
       ) : (
-        <p className="mt-2 w-3/5 text-theme-label-tertiary">
+        <p className="mt-2 w-full tablet:w-3/5 text-theme-label-tertiary">
           Stay in the loop whenever you get a mention, reply and other important
           updates.
         </p>
@@ -63,7 +63,7 @@ function EnableNotification(): ReactElement {
         </Button>
       </span>
       <img
-        className="absolute top-2 right-0"
+        className="hidden tablet:flex absolute top-2 right-0"
         src={cloudinary.notifications.browser}
         alt="A sample browser notification"
       />

--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -30,9 +30,9 @@ type EnableNotificationProps = {
 };
 
 const containerClassName: Record<NotificationPromptSource, string> = {
-  notificationList: 'px-6 w-full border-l border-theme-color-cabbage',
-  newComment: 'border border-theme-color-cabbage px-4 mt-3',
-  newSource: 'border border-theme-color-cabbage px-4 mt-3',
+  notificationList: 'px-6 w-full border-l',
+  newComment: 'border px-4 mt-3',
+  newSource: 'border px-4 mt-3',
 };
 
 function EnableNotification({
@@ -75,7 +75,7 @@ function EnableNotification({
   return (
     <div
       className={classNames(
-        'overflow-hidden relative py-4 rounded-16 typo-callout',
+        'overflow-hidden relative py-4 rounded-16 typo-callout border-theme-color-cabbage',
         classes,
       )}
     >

--- a/packages/shared/src/styles/components/buttons.css
+++ b/packages/shared/src/styles/components/buttons.css
@@ -39,7 +39,7 @@
     color: var(--theme-label-primary);
   }
 
-  &.bg-theme-color-cabbage {
+  &.bg-theme-color-cabbage, &.btn-primary-cabbage {
     color: #FFFFFF;
   }
 

--- a/packages/webapp/pages/account/notifications.tsx
+++ b/packages/webapp/pages/account/notifications.tsx
@@ -87,7 +87,7 @@ const AccountNotificationsPage = (): ReactElement => {
               discussions, upvotes, replies or mentions on daily.dev!
             </p>
             <img
-              className="absolute top-0 right-10"
+              className="absolute top-4 right-14"
               src={cloudinary.notifications.browser}
               alt="A sample browser notification"
             />


### PR DESCRIPTION
## Changes

I didn't realize I was not able to create the PR last week.

### Describe what this PR does
- The design was if the user accepts, the banner should temporarily still be visible, and when they go back it should be gone. This is on "enabled" process.

Note: will fix merge conflict once in a while. Just doing some setups.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
