### PR TITLE
fix: show tooltip for stepped modal error state

### DIFF
--- a/packages/shared/src/components/modals/SteppedModal.tsx
+++ b/packages/shared/src/components/modals/SteppedModal.tsx
@@ -194,6 +194,7 @@ function SteppedModal({
             {backCopy[step] || getBackwardsLabel({ step })}
           </Button>
           <SimpleTooltip
+            forceLoad
             content={invalidMessage}
             visible={!!invalidMessage}
             container={{

--- a/packages/shared/src/components/tooltips/BaseTooltip.tsx
+++ b/packages/shared/src/components/tooltips/BaseTooltip.tsx
@@ -30,12 +30,12 @@ export interface TooltipProps
     | 'onHide'
     | 'duration'
     | 'visible'
-    | 'appendTo'
     | 'offset'
     | 'trigger'
     | 'disabled'
   > {
   container?: Omit<BaseTooltipContainerProps, 'placement' | 'children'>;
+  forceLoad?: boolean;
 }
 
 export interface BaseTooltipProps extends TippyProps {

--- a/packages/shared/src/components/tooltips/SimpleTooltip.tsx
+++ b/packages/shared/src/components/tooltips/SimpleTooltip.tsx
@@ -15,6 +15,7 @@ export function SimpleTooltip({
   content,
   onTrigger,
   onShow,
+  forceLoad,
   ...props
 }: TooltipProps): ReactElement {
   /**
@@ -62,7 +63,7 @@ export function SimpleTooltip({
   return (
     <TippyTooltip
       {...props}
-      shouldLoad={getShouldLoadTooltip()}
+      shouldLoad={forceLoad || getShouldLoadTooltip()}
       content={content}
       onTrigger={onTooltipTrigger}
       onUntrigger={onUntrigger}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Currently we don't show the tooltips on touch devices, however for the stepped modal this blocks the user flow, thus we force load it there.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
