### PR TITLE
feat: introducing feed filter scroll experiment

### DIFF
--- a/packages/shared/src/components/ScrollFeedFiltersOnboarding.tsx
+++ b/packages/shared/src/components/ScrollFeedFiltersOnboarding.tsx
@@ -50,7 +50,7 @@ export default function scrollFeedFiltersOnboarding({
       )}
       style={{
         background:
-          'linear-gradient(90deg, rgba(4, 19, 30, 1) 0%, rgba(4, 19, 30, 0.605797) 100%)',
+          'linear-gradient(180deg, #04131e00 0%, #04131eb3 20%, #0e1217 100%)',
       }}
     >
       <div className="flex flex-col items-center">

--- a/packages/shared/src/components/ScrollFeedFiltersOnboarding.tsx
+++ b/packages/shared/src/components/ScrollFeedFiltersOnboarding.tsx
@@ -1,0 +1,95 @@
+import React, { ReactElement, useContext, useEffect } from 'react';
+import classNames from 'classnames';
+import { Button } from './buttons/Button';
+import { ScrollOnboardingVersion } from '../lib/featureValues';
+import { cloudinary } from '../lib/image';
+import AnalyticsContext from '../contexts/AnalyticsContext';
+import { AnalyticsEvent, TargetType } from '../lib/analytics';
+
+const GaussianBlur = (): ReactElement => {
+  return (
+    <div className="absolute w-52 h-52 rounded-full opacity-32 blur-2xl bg-theme-color-cabbage" />
+  );
+};
+
+const versionToContainerClassName: Record<ScrollOnboardingVersion, string> = {
+  [ScrollOnboardingVersion.V1]: 'h-60',
+  [ScrollOnboardingVersion.V2]: 'h-[36rem]',
+};
+const versionToButtonClassName: Record<ScrollOnboardingVersion, string> = {
+  [ScrollOnboardingVersion.V1]: 'w-[16.25rem]',
+  [ScrollOnboardingVersion.V2]: 'w-40',
+};
+const versionToButtonText: Record<ScrollOnboardingVersion, string> = {
+  [ScrollOnboardingVersion.V1]: 'Customize your feed',
+  [ScrollOnboardingVersion.V2]: 'Start',
+};
+
+interface ScrollFeedFiltersOnboardingProps {
+  version: ScrollOnboardingVersion;
+  onInitializeOnboarding: () => void;
+}
+export default function scrollFeedFiltersOnboarding({
+  version,
+  onInitializeOnboarding,
+}: ScrollFeedFiltersOnboardingProps): ReactElement {
+  const { trackEvent } = useContext(AnalyticsContext);
+  useEffect(() => {
+    trackEvent({
+      event_name: AnalyticsEvent.Impression,
+      target_type: TargetType.ScrollBlock,
+      target_id: version,
+    });
+  }, []);
+
+  return (
+    <div
+      className={classNames(
+        'flex fixed bottom-0 left-60 z-3 gap-16 justify-center items-center w-full pr-40',
+        versionToContainerClassName[version],
+      )}
+      style={{
+        background:
+          'linear-gradient(90deg, rgba(4, 19, 30, 1) 0%, rgba(4, 19, 30, 0.605797) 100%)',
+      }}
+    >
+      <div className="flex flex-col items-center">
+        {version === ScrollOnboardingVersion.V1 ? (
+          <GaussianBlur />
+        ) : (
+          <div className="flex relative justify-center items-center mb-10">
+            <GaussianBlur />
+            <img
+              className="w-[4.625rem] h-[4.625rem]"
+              src={cloudinary.feedFilters.supercharge}
+              alt="supercharge your feed"
+            />
+          </div>
+        )}
+        {version === ScrollOnboardingVersion.V2 && (
+          <h2 className="mb-6 font-bold typo-title2">
+            Supercharge your feed with
+            <br /> content you&apos;ll love reading!
+          </h2>
+        )}
+        <Button
+          className={classNames(
+            'text-white btn-primary-cabbage ',
+            versionToButtonClassName[version],
+          )}
+          buttonSize="large"
+          onClick={onInitializeOnboarding}
+        >
+          {versionToButtonText[version]}
+        </Button>
+      </div>
+      {version === ScrollOnboardingVersion.V2 && (
+        <img
+          src={cloudinary.feedFilters.scroll}
+          alt="example topics for your feed"
+          className="ml-2 laptop:w-2/5 laptopL:w-[40rem]"
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/shared/src/components/ScrollFeedFiltersOnboarding.tsx
+++ b/packages/shared/src/components/ScrollFeedFiltersOnboarding.tsx
@@ -87,7 +87,7 @@ export default function scrollFeedFiltersOnboarding({
         <img
           src={cloudinary.feedFilters.scroll}
           alt="example topics for your feed"
-          className="ml-2 laptop:w-2/5 laptopL:w-[40rem]"
+          className="laptop:hidden laptopL:block ml-2"
         />
       )}
     </div>

--- a/packages/shared/src/contexts/FeaturesContext.tsx
+++ b/packages/shared/src/contexts/FeaturesContext.tsx
@@ -10,6 +10,7 @@ import {
   ArticleOnboardingVersion,
   OnboardingFiltersLayout,
   OnboardingVersion,
+  ScrollOnboardingVersion,
   ShareVersion,
   SquadVersion,
 } from '../lib/featureValues';
@@ -37,6 +38,7 @@ interface Experiments {
   squadForm?: string;
   squadButton?: string;
   articleOnboardingVersion?: ArticleOnboardingVersion;
+  scrollOnboardingVersion?: ScrollOnboardingVersion;
 }
 
 export interface FeaturesData extends Experiments {
@@ -95,6 +97,10 @@ const getFeatures = (flags: IFlags): FeaturesData => {
     squadButton: getFeatureValue(Features.SquadButton, flags),
     articleOnboardingVersion: getFeatureValue(
       Features.ArticleOnboardingVersion,
+      flags,
+    ),
+    scrollOnboardingVersion: getFeatureValue(
+      Features.ScrollOnboardingVersion,
       flags,
     ),
   };

--- a/packages/shared/src/hooks/feed/useFeedInfiniteScroll.ts
+++ b/packages/shared/src/hooks/feed/useFeedInfiniteScroll.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import classed from '../../lib/classed';
 
 export interface UseFeedInfiniteScrollProps {
-  fetchPage: () => Promise<unknown>;
+  fetchPage: () => Promise<unknown> | void;
   canFetchMore: boolean;
 }
 

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -24,11 +24,13 @@ export enum AnalyticsEvent {
   CompleteOnboarding = 'complete onboarding',
   GlobalError = 'global error',
   ClickArticleAnonymousCTA = 'click article anonymous cta',
+  ClickScrollBlock = 'click scroll block',
 }
 
 export enum TargetType {
   MyFeedModal = 'my feed modal',
   ArticleAnonymousCTA = 'article anonymous cta',
+  ScrollBlock = 'scroll block',
 }
 
 export enum TargetId {

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -7,6 +7,7 @@ import {
   OnboardingVersion,
   OnboardingFiltersLayout as OnboardingFiltersLayoutEnum,
   ArticleOnboardingVersion,
+  ScrollOnboardingVersion,
 } from './featureValues';
 
 export type FeatureValue = string | number | boolean;
@@ -190,6 +191,12 @@ export class Features<T extends FeatureValue = string> {
       ArticleOnboardingVersion.V2,
       ArticleOnboardingVersion.V3,
     ],
+  );
+
+  static readonly ScrollOnboardingVersion = new Features(
+    'scroll_onboarding_version',
+    null,
+    [ScrollOnboardingVersion.V1, ScrollOnboardingVersion.V2],
   );
 
   private constructor(

--- a/packages/shared/src/lib/featureValues.ts
+++ b/packages/shared/src/lib/featureValues.ts
@@ -35,3 +35,8 @@ export enum ArticleOnboardingVersion {
   V2 = 'v2',
   V3 = 'v3',
 }
+
+export enum ScrollOnboardingVersion {
+  V1 = 'v1',
+  V2 = 'v2',
+}

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -14,6 +14,6 @@ export const cloudinary = {
     topicsV3:
       'https://daily-now-res.cloudinary.com/image/upload/v1670321759/public/feed_filters_v3.svg',
     scroll:
-      'https://daily-now-res.cloudinary.com/image/upload/v1671184101/public/scroll_feed_filters.svg',
+      'https://daily-now-res.cloudinary.com/image/upload/v1671199935/public/scroll_feed_filters.svg',
   },
 };

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -13,5 +13,7 @@ export const cloudinary = {
       'https://daily-now-res.cloudinary.com/image/upload/v1670321759/public/feed_filters_v2.svg',
     topicsV3:
       'https://daily-now-res.cloudinary.com/image/upload/v1670321759/public/feed_filters_v3.svg',
+    scroll:
+      'https://daily-now-res.cloudinary.com/image/upload/v1671184101/public/scroll_feed_filters.svg',
   },
 };

--- a/packages/webapp/__tests__/TagPage.tsx
+++ b/packages/webapp/__tests__/TagPage.tsx
@@ -1,5 +1,8 @@
 import { FeedData } from '@dailydotdev/shared/src/graphql/posts';
-import { TAG_FEED_QUERY } from '@dailydotdev/shared/src/graphql/feed';
+import {
+  OnboardingMode,
+  TAG_FEED_QUERY,
+} from '@dailydotdev/shared/src/graphql/feed';
 import nock from 'nock';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import React from 'react';
@@ -26,6 +29,7 @@ import {
 } from '@dailydotdev/shared/__tests__/helpers/graphql';
 import { waitForNock } from '@dailydotdev/shared/__tests__/helpers/utilities';
 import { AlertContextProvider } from '@dailydotdev/shared/src/contexts/AlertContext';
+import OnboardingContext from '@dailydotdev/shared/src/contexts/OnboardingContext';
 import TagPage from '../pages/tags/[tag]';
 import { FEED_SETTINGS_QUERY } from '../../shared/src/graphql/feedSettings';
 
@@ -120,7 +124,17 @@ const renderComponent = (
       >
         <AlertContextProvider alerts={{}} updateAlerts={jest.fn()} loadedAlerts>
           <SettingsContext.Provider value={settingsContext}>
-            <TagPage tag="react" />
+            <OnboardingContext.Provider
+              value={{
+                myFeedMode: OnboardingMode.Manual,
+                isOnboardingOpen: false,
+                onCloseOnboardingModal: jest.fn(),
+                onInitializeOnboarding: jest.fn(),
+                onShouldUpdateFilters: jest.fn(),
+              }}
+            >
+              <TagPage tag="react" />
+            </OnboardingContext.Provider>
           </SettingsContext.Provider>
         </AlertContextProvider>
       </AuthContext.Provider>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Introduces the new scroll feed filter experiment
- In the current implementation it technically means it always shows directly on the feed (due to how we assign the new load)

Version 1:
![Screenshot 2022-12-16 at 13 13 09](https://user-images.githubusercontent.com/554874/208093324-9815081d-6fd9-44a6-92be-35652eede4e3.png)

Version 2:
![Screenshot 2022-12-16 at 13 13 32](https://user-images.githubusercontent.com/554874/208093341-42bc9f27-e078-4499-a71f-af6ce25a31e2.png)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| New | impression  | target_type: scroll block, target_id: [V1, V2] |
| New | click scroll block  | target_id: [V1, V2] |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

> Note: Only shows up on desktop sizes

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-806 #done
