### PR TITLE
refactor: boot data type to include notifications data

### DIFF
--- a/packages/extension/src/newtab/ShortcutLinks.spec.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.spec.tsx
@@ -101,6 +101,7 @@ const defaultBootData: BootCacheData = {
   alerts: defaultAlerts,
   user: defaultUser,
   settings: defaultSettings,
+  notifications: { unreadNotificationsCount: 0 },
   flags: {},
 };
 

--- a/packages/shared/src/components/buttons/Button.tsx
+++ b/packages/shared/src/components/buttons/Button.tsx
@@ -74,11 +74,12 @@ function ButtonComponent<TagName extends AllowedTags>(
     position = 'relative',
     textPosition = 'justify-center',
     readOnly,
+    iconOnly: showIconOnly,
     ...props
   }: StyledButtonProps & ButtonProps<TagName>,
   ref?: Ref<ButtonElementType<TagName>>,
 ): ReactElement {
-  const iconOnly = icon && !children && !rightIcon;
+  const iconOnly = (icon && !children && !rightIcon) || showIconOnly;
 
   const getIconWithSize = useGetIconWithSize(buttonSize, iconOnly);
 

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -101,7 +101,7 @@ function MainLayoutHeader({
               href={`${webappUrl}/notifications`}
             >
               <Button
-                className="mr-4 btn-tertiary"
+                className="hidden laptop:flex mr-4 btn-tertiary"
                 buttonSize="small"
                 iconOnly
                 icon={

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -8,6 +8,7 @@ import BellIcon from '../icons/Bell';
 import HamburgerIcon from '../icons/Hamburger';
 import LoginButton from '../LoginButton';
 import MobileHeaderRankProgress from '../MobileHeaderRankProgress';
+import { checkAtNotificationsPage } from '../notifications/utils';
 import ProfileButton from '../profile/ProfileButton';
 import { LinkWithTooltip } from '../tooltips/LinkWithTooltip';
 import { Bubble } from '../tooltips/utils';
@@ -34,11 +35,6 @@ const shouldShowLogo = ({
 }: ShouldShowLogoProps) => {
   return !mobileTitle ? true : mobileTitle && sidebarRendered;
 };
-
-const notificationsUrl = `${webappUrl}/notifications`;
-
-const checkAtNotificationsPage = () =>
-  notificationsUrl === globalThis.window?.location.href;
 
 function MainLayoutHeader({
   greeting,

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, { ReactElement, ReactNode, useContext } from 'react';
 import AuthContext from '../../contexts/AuthContext';
+import { useNotificationContext } from '../../contexts/NotificationsContext';
 import { webappUrl } from '../../lib/constants';
 import { Button } from '../buttons/Button';
 import BellIcon from '../icons/Bell';
@@ -9,6 +10,7 @@ import LoginButton from '../LoginButton';
 import MobileHeaderRankProgress from '../MobileHeaderRankProgress';
 import ProfileButton from '../profile/ProfileButton';
 import { LinkWithTooltip } from '../tooltips/LinkWithTooltip';
+import { Bubble } from '../tooltips/utils';
 import HeaderLogo from './HeaderLogo';
 
 interface ShouldShowLogoProps {
@@ -33,6 +35,11 @@ const shouldShowLogo = ({
   return !mobileTitle ? true : mobileTitle && sidebarRendered;
 };
 
+const notificationsUrl = `${webappUrl}/notifications`;
+
+const checkAtNotificationsPage = () =>
+  notificationsUrl === globalThis.window?.location.href;
+
 function MainLayoutHeader({
   greeting,
   hasBanner,
@@ -44,6 +51,7 @@ function MainLayoutHeader({
   onLogoClick,
   onMobileSidebarToggle,
 }: MainLayoutHeaderProps): ReactElement {
+  const { unreadCount } = useNotificationContext();
   const { user, loadingUser } = useContext(AuthContext);
   const hideButton = showOnlyLogo || loadingUser;
 
@@ -58,6 +66,9 @@ function MainLayoutHeader({
 
     return <LoginButton className="hidden laptop:block" />;
   })();
+
+  const hasNotification = !!unreadCount;
+  const atNotificationsPage = checkAtNotificationsPage();
 
   return (
     <header
@@ -96,8 +107,20 @@ function MainLayoutHeader({
               <Button
                 className="mr-4 btn-tertiary"
                 buttonSize="small"
-                icon={<BellIcon />}
-              />
+                iconOnly
+                icon={
+                  <BellIcon
+                    className={
+                      atNotificationsPage && 'text-theme-label-primary'
+                    }
+                    secondary={hasNotification}
+                  />
+                }
+              >
+                {hasNotification && (
+                  <Bubble className="-top-2 -right-3">{unreadCount}</Bubble>
+                )}
+              </Button>
             </LinkWithTooltip>
           )}
           {additionalButtons}

--- a/packages/shared/src/components/notifications/FirstNotification.tsx
+++ b/packages/shared/src/components/notifications/FirstNotification.tsx
@@ -1,0 +1,29 @@
+import React, { ReactElement, useEffect } from 'react';
+import { NotificationType } from '../../graphql/notifications';
+import usePersistentContext from '../../hooks/usePersistentContext';
+import NotificationItem from './NotificationItem';
+import { NotificationIcon } from './utils';
+
+const READ_KEY = 'FIRST_NOTIFICATION_READ';
+
+function FirstNotification(): ReactElement {
+  const [isUnread, setIsUnread] = usePersistentContext(READ_KEY, true);
+
+  useEffect(() => {
+    return () => {
+      setIsUnread(false);
+    };
+  }, []);
+
+  return (
+    <NotificationItem
+      isUnread={isUnread}
+      type={NotificationType.System}
+      icon={NotificationIcon.Bell}
+      title="Welcome to your new notification center!"
+      description="The notification system notifies you of important events such as replies, mentions, updates etc."
+    />
+  );
+}
+
+export default FirstNotification;

--- a/packages/shared/src/components/notifications/utils.ts
+++ b/packages/shared/src/components/notifications/utils.ts
@@ -1,5 +1,6 @@
 import { ComponentType } from 'react';
 import classed from '../../lib/classed';
+import { webappUrl } from '../../lib/constants';
 import { IconProps } from '../Icon';
 import BellIcon from '../icons/Bell';
 import CommunityPicksIcon from '../icons/CommunityPicksIcon';
@@ -50,3 +51,8 @@ export const notificationDefaultTheme: Record<NotificationIcon, string> = {
   [NotificationIcon.Upvote]: 'text-theme-color-blueCheese',
   [NotificationIcon.Bell]: '',
 };
+
+const notificationsUrl = `${webappUrl}/notifications`;
+
+export const checkAtNotificationsPage = (): boolean =>
+  notificationsUrl === globalThis.window?.location.href;

--- a/packages/shared/src/components/tooltips/utils.ts
+++ b/packages/shared/src/components/tooltips/utils.ts
@@ -1,0 +1,6 @@
+import classed from '../../lib/classed';
+
+export const Bubble = classed(
+  'span',
+  'absolute flex justify-center items-center min-w-[1.25rem] min-h-[1.25rem] font-normal text-white rounded-8 bg-theme-color-cabbage typo-subhead',
+);

--- a/packages/shared/src/contexts/BootProvider.spec.tsx
+++ b/packages/shared/src/contexts/BootProvider.spec.tsx
@@ -66,6 +66,7 @@ const defaultBootData: BootCacheData = {
   alerts: defaultAlerts,
   user: defaultUser,
   settings: defaultSettings,
+  notifications: { unreadNotificationsCount: 0 },
   flags: {},
 };
 

--- a/packages/shared/src/contexts/BootProvider.spec.tsx
+++ b/packages/shared/src/contexts/BootProvider.spec.tsx
@@ -60,6 +60,7 @@ const defaultSettings: RemoteSettings = {
   sortingEnabled: false,
   optOutWeeklyGoal: true,
   autoDismissNotifications: true,
+  optOutCompanion: false,
 };
 
 const defaultBootData: BootCacheData = {

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -183,7 +183,11 @@ export const BootDataProvider = ({
             updateAlerts={updateAlerts}
             loadedAlerts={loadedFromCache}
           >
-            <NotificationsContextProvider>
+            <NotificationsContextProvider
+              unreadCount={
+                cachedBootData?.notifications?.unreadNotificationsCount
+              }
+            >
               {children}
             </NotificationsContextProvider>
           </AlertContextProvider>

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -58,6 +58,7 @@ const updateLocalBootData = (
     'alerts',
     'flags',
     'settings',
+    'notifications',
     'user',
     'lastModifier',
   ]);
@@ -80,7 +81,13 @@ export const BootDataProvider = ({
     useState<Partial<BootCacheData>>();
   const [initialLoad, setInitialLoad] = useState<boolean>(null);
   const loadedFromCache = cachedBootData !== undefined;
-  const { user, settings, flags = {}, alerts } = cachedBootData || {};
+  const {
+    user,
+    settings,
+    flags = {},
+    alerts,
+    notifications,
+  } = cachedBootData || {};
   const {
     data: bootRemoteData,
     refetch,
@@ -184,9 +191,7 @@ export const BootDataProvider = ({
             loadedAlerts={loadedFromCache}
           >
             <NotificationsContextProvider
-              unreadCount={
-                cachedBootData?.notifications?.unreadNotificationsCount
-              }
+              unreadCount={notifications?.unreadNotificationsCount}
             >
               {children}
             </NotificationsContextProvider>

--- a/packages/shared/src/contexts/NotificationsContext.tsx
+++ b/packages/shared/src/contexts/NotificationsContext.tsx
@@ -50,7 +50,7 @@ export const NotificationsContextProvider = ({
   };
 
   useEffect(() => {
-    setCurrentUnreadCount(0);
+    setCurrentUnreadCount(unreadCount);
   }, [unreadCount]);
 
   const data = useMemo(() => {

--- a/packages/shared/src/contexts/NotificationsContext.tsx
+++ b/packages/shared/src/contexts/NotificationsContext.tsx
@@ -32,7 +32,7 @@ export const NotificationsContextProvider = ({
   unreadCount = 0,
 }: NotificationsContextProviderProps): ReactElement => {
   const { user } = useContext(AuthContext);
-  const [currentUnreadCount, setCurrentUnreadCount] = useState(0);
+  const [currentUnreadCount, setCurrentUnreadCount] = useState(unreadCount);
   const [hasPermission, setHasPermission] = useState(
     globalThis.window?.Notification?.permission === 'granted',
   );
@@ -55,15 +55,15 @@ export const NotificationsContextProvider = ({
 
   const data = useMemo(() => {
     return {
-      unreadCount,
       hasPermission,
+      unreadCount: currentUnreadCount,
       clearUnreadCount: () => setCurrentUnreadCount(0),
       incrementUnreadCount: (value = 1) =>
         setCurrentUnreadCount((current) => current + value),
       notificationsAvailable,
       requestPermission,
     };
-  }, [hasPermission, currentUnreadCount, user]);
+  }, [hasPermission, currentUnreadCount, unreadCount, user]);
 
   return (
     <NotificationsContext.Provider value={data}>

--- a/packages/shared/src/contexts/NotificationsContext.tsx
+++ b/packages/shared/src/contexts/NotificationsContext.tsx
@@ -2,6 +2,7 @@ import React, {
   ReactElement,
   ReactNode,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -10,6 +11,8 @@ import AuthContext from './AuthContext';
 interface NotificationsContextData {
   unreadCount: number;
   hasPermission: boolean;
+  clearUnreadCount: () => void;
+  incrementUnreadCount: () => void;
   notificationsAvailable: () => boolean;
   requestPermission: () => Promise<NotificationPermission>;
 }
@@ -29,6 +32,7 @@ export const NotificationsContextProvider = ({
   unreadCount = 0,
 }: NotificationsContextProviderProps): ReactElement => {
   const { user } = useContext(AuthContext);
+  const [currentUnreadCount, setCurrentUnreadCount] = useState(0);
   const [hasPermission, setHasPermission] = useState(
     globalThis.window?.Notification?.permission === 'granted',
   );
@@ -45,14 +49,21 @@ export const NotificationsContextProvider = ({
     return result;
   };
 
+  useEffect(() => {
+    setCurrentUnreadCount(0);
+  }, [unreadCount]);
+
   const data = useMemo(() => {
     return {
       unreadCount,
       hasPermission,
+      clearUnreadCount: () => setCurrentUnreadCount(0),
+      incrementUnreadCount: (value = 1) =>
+        setCurrentUnreadCount((current) => current + value),
       notificationsAvailable,
       requestPermission,
     };
-  }, [hasPermission, user]);
+  }, [hasPermission, currentUnreadCount, user]);
 
   return (
     <NotificationsContext.Provider value={data}>
@@ -60,3 +71,6 @@ export const NotificationsContextProvider = ({
     </NotificationsContext.Provider>
   );
 };
+
+export const useNotificationContext = (): NotificationsContextData =>
+  useContext(NotificationsContext);

--- a/packages/shared/src/lib/boot.ts
+++ b/packages/shared/src/lib/boot.ts
@@ -5,6 +5,10 @@ import { Alerts } from '../graphql/alerts';
 import { RemoteSettings } from '../graphql/settings';
 import { Post } from '../graphql/posts';
 
+interface NotificationsBootData {
+  unreadNotificationsCount: number;
+}
+
 export type PostBootData = Pick<
   Post,
   | 'id'
@@ -37,6 +41,7 @@ export type Boot = {
   alerts: Alerts;
   visit: Visit;
   flags: IFlags;
+  notifications: NotificationsBootData;
   settings: RemoteSettings;
   postData?: PostBootData;
   isLegacyLogout?: boolean;
@@ -44,7 +49,7 @@ export type Boot = {
 
 export type BootCacheData = Pick<
   Boot,
-  'user' | 'alerts' | 'settings' | 'flags' | 'postData'
+  'user' | 'alerts' | 'settings' | 'flags' | 'postData' | 'notifications'
 > & { lastModifier?: string };
 
 export async function getBootData(app: string, url?: string): Promise<Boot> {

--- a/packages/webapp/__tests__/BookmarksPage.tsx
+++ b/packages/webapp/__tests__/BookmarksPage.tsx
@@ -20,6 +20,7 @@ import {
   mockGraphQL,
 } from '@dailydotdev/shared/__tests__/helpers/graphql';
 import { waitForNock } from '@dailydotdev/shared/__tests__/helpers/utilities';
+import { NotificationsContextProvider } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import BookmarksPage from '../pages/bookmarks';
 
 const showLogin = jest.fn();
@@ -115,11 +116,13 @@ const renderComponent = (
         }}
       >
         <SettingsContext.Provider value={settingsContext}>
-          {BookmarksPage.getLayout(
-            <BookmarksPage />,
-            {},
-            BookmarksPage.layoutProps,
-          )}
+          <NotificationsContextProvider>
+            {BookmarksPage.getLayout(
+              <BookmarksPage />,
+              {},
+              BookmarksPage.layoutProps,
+            )}
+          </NotificationsContextProvider>
         </SettingsContext.Provider>
       </AuthContext.Provider>
     </QueryClientProvider>,

--- a/packages/webapp/__tests__/MainLayout.tsx
+++ b/packages/webapp/__tests__/MainLayout.tsx
@@ -6,6 +6,7 @@ import SettingsContext, {
   SettingsContextData,
 } from '@dailydotdev/shared/src/contexts/SettingsContext';
 import { LoggedUser } from '@dailydotdev/shared/src/lib/user';
+import { NotificationsContextProvider } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import MainLayout from '../components/layouts/MainLayout';
 
 const showLogin = jest.fn();
@@ -48,10 +49,11 @@ const renderLayout = (user: LoggedUser = null): RenderResult => {
         }}
       >
         <SettingsContext.Provider value={settingsContext}>
-          <MainLayout />
+          <NotificationsContextProvider>
+            <MainLayout />
+          </NotificationsContextProvider>
         </SettingsContext.Provider>
       </AuthContext.Provider>
-      ,
     </QueryClientProvider>,
   );
 };

--- a/packages/webapp/__tests__/MostDiscussedPage.tsx
+++ b/packages/webapp/__tests__/MostDiscussedPage.tsx
@@ -18,6 +18,7 @@ import {
   MockedGraphQLResponse,
   mockGraphQL,
 } from '@dailydotdev/shared/__tests__/helpers/graphql';
+import { NotificationsContextProvider } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import Discussed from '../pages/discussed';
 
 const showLogin = jest.fn();
@@ -94,7 +95,9 @@ const renderComponent = (
         }}
       >
         <SettingsContext.Provider value={settingsContext}>
-          {Discussed.getLayout(<Discussed />, {}, Discussed.layoutProps)}
+          <NotificationsContextProvider>
+            {Discussed.getLayout(<Discussed />, {}, Discussed.layoutProps)}
+          </NotificationsContextProvider>
         </SettingsContext.Provider>
       </AuthContext.Provider>
     </QueryClientProvider>,

--- a/packages/webapp/__tests__/MostUpvotedPage.tsx
+++ b/packages/webapp/__tests__/MostUpvotedPage.tsx
@@ -18,6 +18,7 @@ import {
   MockedGraphQLResponse,
   mockGraphQL,
 } from '@dailydotdev/shared/__tests__/helpers/graphql';
+import { NotificationsContextProvider } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import Upvoted from '../pages/upvoted';
 
 const showLogin = jest.fn();
@@ -94,7 +95,9 @@ const renderComponent = (
         }}
       >
         <SettingsContext.Provider value={settingsContext}>
-          {Upvoted.getLayout(<Upvoted />, {}, Upvoted.layoutProps)}
+          <NotificationsContextProvider>
+            {Upvoted.getLayout(<Upvoted />, {}, Upvoted.layoutProps)}
+          </NotificationsContextProvider>
         </SettingsContext.Provider>
       </AuthContext.Provider>
     </QueryClientProvider>,

--- a/packages/webapp/__tests__/MyFeedPage.tsx
+++ b/packages/webapp/__tests__/MyFeedPage.tsx
@@ -26,6 +26,7 @@ import {
   MockedGraphQLResponse,
   mockGraphQL,
 } from '@dailydotdev/shared/__tests__/helpers/graphql';
+import { NotificationsContextProvider } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import MyFeed from '../pages/my-feed';
 
 jest.mock('next/router', () => ({
@@ -118,7 +119,9 @@ const renderComponent = (
             }}
           >
             <SettingsContext.Provider value={settingsContext}>
-              {MyFeed.getLayout(<MyFeed />, {}, MyFeed.layoutProps)}
+              <NotificationsContextProvider>
+                {MyFeed.getLayout(<MyFeed />, {}, MyFeed.layoutProps)}
+              </NotificationsContextProvider>
             </SettingsContext.Provider>
           </AuthContext.Provider>
         </AlertContextProvider>

--- a/packages/webapp/__tests__/NotificationsPage.tsx
+++ b/packages/webapp/__tests__/NotificationsPage.tsx
@@ -130,10 +130,10 @@ it('should not show the welcome notification if we are not at the last page', as
   data.notifications.pageInfo.endCursor = 'end';
   renderComponent([fetchNotificationsMock(data)]);
   await waitForNock();
-  await waitForElementToBeRemoved(
-    () => screen.queryByText('Welcome to your new notification center!'),
-    { timeout: 10 },
+  const welcome = screen.queryByText(
+    'Welcome to your new notification center!',
   );
+  expect(welcome).not.toBeInTheDocument();
   globalThis.window.Notification = temp;
 });
 

--- a/packages/webapp/__tests__/NotificationsPage.tsx
+++ b/packages/webapp/__tests__/NotificationsPage.tsx
@@ -13,11 +13,7 @@ import {
   MockedGraphQLResponse,
   mockGraphQL,
 } from '@dailydotdev/shared/__tests__/helpers/graphql';
-import {
-  render,
-  screen,
-  waitForElementToBeRemoved,
-} from '@testing-library/preact';
+import { render, screen } from '@testing-library/preact';
 import NotificationsContext from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { waitForNock } from '@dailydotdev/shared/__tests__/helpers/utilities';

--- a/packages/webapp/__tests__/PopularPage.tsx
+++ b/packages/webapp/__tests__/PopularPage.tsx
@@ -21,6 +21,7 @@ import {
   MockedGraphQLResponse,
   mockGraphQL,
 } from '@dailydotdev/shared/__tests__/helpers/graphql';
+import { NotificationsContextProvider } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import Popular from '../pages/popular';
 
 const showLogin = jest.fn();
@@ -97,7 +98,9 @@ const renderComponent = (
         }}
       >
         <SettingsContext.Provider value={settingsContext}>
-          {Popular.getLayout(<Popular />, {}, Popular.layoutProps)}
+          <NotificationsContextProvider>
+            {Popular.getLayout(<Popular />, {}, Popular.layoutProps)}
+          </NotificationsContextProvider>
         </SettingsContext.Provider>
       </AuthContext.Provider>
     </QueryClientProvider>,

--- a/packages/webapp/__tests__/SearchPage.tsx
+++ b/packages/webapp/__tests__/SearchPage.tsx
@@ -23,6 +23,7 @@ import {
   mockGraphQL,
 } from '@dailydotdev/shared/__tests__/helpers/graphql';
 import { waitForNock } from '@dailydotdev/shared/__tests__/helpers/utilities';
+import { NotificationsContextProvider } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import SearchPage from '../pages/search';
 
 const showLogin = jest.fn();
@@ -106,7 +107,9 @@ const renderComponent = (
         }}
       >
         <SettingsContext.Provider value={settingsContext}>
-          {SearchPage.getLayout(<SearchPage />, {}, SearchPage.layoutProps)}
+          <NotificationsContextProvider>
+            {SearchPage.getLayout(<SearchPage />, {}, SearchPage.layoutProps)}
+          </NotificationsContextProvider>
         </SettingsContext.Provider>
       </AuthContext.Provider>
     </QueryClientProvider>,

--- a/packages/webapp/__tests__/register.tsx
+++ b/packages/webapp/__tests__/register.tsx
@@ -10,6 +10,7 @@ import { mocked } from 'ts-jest/utils';
 import { NextRouter, useRouter } from 'next/router';
 import { getUserDefaultTimezone } from '@dailydotdev/shared/src/lib/timezones';
 import user from '@dailydotdev/shared/__tests__/fixture/loggedUser';
+import { NotificationsContextProvider } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import Page from '../pages/register';
 
 jest.mock('next/router', () => ({
@@ -69,7 +70,9 @@ const renderComponent = (
         }}
       >
         <SettingsContext.Provider value={settingsContext}>
-          <Page />
+          <NotificationsContextProvider>
+            <Page />
+          </NotificationsContextProvider>
         </SettingsContext.Provider>
       </AuthContext.Provider>
     </QueryClientProvider>,

--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -51,7 +51,9 @@ export const tabs: Tab[] = [
     title: 'Notifications',
     icon: (active: boolean, unreadCount) => (
       <span className="relative">
-        <Bubble className="top-0 -right-1 px-1">{unreadCount}</Bubble>
+        <Bubble className="top-0 px-1 left-[calc(100%-0.75rem)]">
+          {unreadCount}
+        </Bubble>
         <BellIcon secondary={active} size="xxlarge" />
       </span>
     ),

--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -16,6 +16,7 @@ import {
 } from '@dailydotdev/shared/src/components/buttons/Button';
 import classNames from 'classnames';
 import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
+import { Bubble } from '@dailydotdev/shared/src/components/tooltips/utils';
 import styles from './FooterNavBar.module.css';
 
 type Tab = {
@@ -47,7 +48,12 @@ export const tabs: Tab[] = [
   {
     path: '/notifications',
     title: 'Notifications',
-    icon: (active: boolean) => <BellIcon secondary={active} size="xxlarge" />,
+    icon: (active: boolean) => (
+      <span className="relative">
+        <Bubble className="top-0 -right-1">1</Bubble>
+        <BellIcon secondary={active} size="xxlarge" />
+      </span>
+    ),
   },
   {
     path: '/filters',

--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -17,12 +17,13 @@ import {
 import classNames from 'classnames';
 import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
 import { Bubble } from '@dailydotdev/shared/src/components/tooltips/utils';
+import { useNotificationContext } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import styles from './FooterNavBar.module.css';
 
 type Tab = {
   path: string;
   title: string;
-  icon: (active: boolean) => ReactElement;
+  icon: (active: boolean, unread?: number) => ReactElement;
   requiresLogin?: boolean;
 };
 
@@ -48,9 +49,9 @@ export const tabs: Tab[] = [
   {
     path: '/notifications',
     title: 'Notifications',
-    icon: (active: boolean) => (
+    icon: (active: boolean, unreadCount) => (
       <span className="relative">
-        <Bubble className="top-0 -right-1">1</Bubble>
+        <Bubble className="top-0 -right-1 px-1">{unreadCount}</Bubble>
         <BellIcon secondary={active} size="xxlarge" />
       </span>
     ),
@@ -64,6 +65,7 @@ export const tabs: Tab[] = [
 
 export default function FooterNavBar(): ReactElement {
   const { user, showLogin } = useContext(AuthContext);
+  const { unreadCount } = useNotificationContext();
   const router = useRouter();
   const selectedTab = tabs.findIndex((tab) => tab.path === router?.pathname);
 
@@ -97,7 +99,7 @@ export default function FooterNavBar(): ReactElement {
               <Button
                 {...buttonProps}
                 tag="a"
-                icon={tab.icon(index === selectedTab)}
+                icon={tab.icon(index === selectedTab, unreadCount)}
                 pressed={index === selectedTab}
               />
             </LinkWithTooltip>
@@ -105,7 +107,7 @@ export default function FooterNavBar(): ReactElement {
             <SimpleTooltip content={tab.title}>
               <Button
                 {...buttonProps}
-                icon={tab.icon(index === selectedTab)}
+                icon={tab.icon(index === selectedTab, unreadCount)}
                 onClick={() => showLogin(AuthTriggers.Bookmark)}
               />
             </SimpleTooltip>

--- a/packages/webapp/pages/notifications.tsx
+++ b/packages/webapp/pages/notifications.tsx
@@ -17,6 +17,7 @@ import { apiUrl } from '@dailydotdev/shared/src/lib/config';
 import NotificationItem from '@dailydotdev/shared/src/components/notifications/NotificationItem';
 import EnableNotification from '@dailydotdev/shared/src/components/notifications/EnableNotification';
 import { NotificationIcon } from '@dailydotdev/shared/src/components/notifications/utils';
+import { useNotificationContext } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import InfiniteScrolling from '@dailydotdev/shared/src/components/containers/InfiniteScrolling';
 import { getLayout } from '../components/layouts/FooterNavBarLayout';
 import { getLayout as getFooterNavBarLayout } from '../components/layouts/MainLayout';
@@ -30,8 +31,10 @@ const hasUnread = (data: InfiniteData<NotificationsData>) =>
 
 const Notifications = (): ReactElement => {
   const seo = <NextSeo title="Notifications" nofollow noindex />;
-  const { mutateAsync: readNotifications } = useMutation(() =>
-    request(`${apiUrl}/graphql`, READ_NOTIFICATIONS_MUTATION),
+  const { clearUnreadCount } = useNotificationContext();
+  const { mutateAsync: readNotifications } = useMutation(
+    () => request(`${apiUrl}/graphql`, READ_NOTIFICATIONS_MUTATION),
+    { onSuccess: clearUnreadCount },
   );
   const queryResult = useInfiniteQuery<NotificationsData>(
     ['notifications'],

--- a/packages/webapp/pages/notifications.tsx
+++ b/packages/webapp/pages/notifications.tsx
@@ -4,7 +4,6 @@ import { NextSeo } from 'next-seo';
 import { useInfiniteQuery, InfiniteData, useMutation } from 'react-query';
 import {
   NotificationsData,
-  NotificationType,
   NOTIFICATIONS_QUERY,
   READ_NOTIFICATIONS_MUTATION,
 } from '@dailydotdev/shared/src/graphql/notifications';
@@ -15,8 +14,8 @@ import {
 import request from 'graphql-request';
 import { apiUrl } from '@dailydotdev/shared/src/lib/config';
 import NotificationItem from '@dailydotdev/shared/src/components/notifications/NotificationItem';
+import FirstNotification from '@dailydotdev/shared/src/components/notifications/FirstNotification';
 import EnableNotification from '@dailydotdev/shared/src/components/notifications/EnableNotification';
-import { NotificationIcon } from '@dailydotdev/shared/src/components/notifications/utils';
 import { useNotificationContext } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import InfiniteScrolling from '@dailydotdev/shared/src/components/containers/InfiniteScrolling';
 import { getLayout } from '../components/layouts/FooterNavBarLayout';
@@ -77,15 +76,7 @@ const Notifications = (): ReactElement => {
                 ),
               ),
             )}
-          {(!length || !queryResult.hasNextPage) && (
-            <NotificationItem
-              isUnread
-              type={NotificationType.System}
-              icon={NotificationIcon.Bell}
-              title="Welcome to your new notification center!"
-              description="The notification system notifies you of important events such as replies, mentions, updates etc."
-            />
-          )}
+          {(!length || !queryResult.hasNextPage) && <FirstNotification />}
         </InfiniteScrolling>
       </main>
     </ProtectedPage>

--- a/packages/webapp/pages/notifications.tsx
+++ b/packages/webapp/pages/notifications.tsx
@@ -66,7 +66,12 @@ const Notifications = (): ReactElement => {
         )}
       >
         <EnableNotification />
-        <h2 className="p-6 font-bold typo-headline">Notifications</h2>
+        <h2
+          className="p-6 font-bold typo-headline"
+          data-testid="notification_page-title"
+        >
+          Notifications
+        </h2>
         <InfiniteScrolling queryResult={queryResult}>
           {length > 0 &&
             queryResult.data.pages.map((page) =>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Boot provider to pass down unread count.
- Bubble component and usage on bell icon for the unread count.
- Unread count local data mutation.
- Fixed the first notification to be readable state.

Currently deployed at preview 1. You should be able to see the bubble text on header.
https://preview.app.daily.dev/

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
