### PR TITLE
fix: notifications page inaccuracies

### DIFF
--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -30,7 +30,7 @@ type EnableNotificationProps = {
 };
 
 const containerClassName: Record<NotificationPromptSource, string> = {
-  notificationList: 'px-6 w-full border-l',
+  notificationList: 'px-6 w-full border-l bg-theme-float',
   newComment: 'rounded-16 border px-4 mt-3',
   newSource: 'rounded-16 border px-4 mt-3',
 };

--- a/packages/shared/src/components/notifications/FirstNotification.tsx
+++ b/packages/shared/src/components/notifications/FirstNotification.tsx
@@ -20,6 +20,7 @@ function FirstNotification(): ReactElement {
       isUnread={isUnread}
       type={NotificationType.System}
       icon={NotificationIcon.Bell}
+      targetUrl="#"
       title="Welcome to your new notification center!"
       description="The notification system notifies you of important events such as replies, mentions, updates etc."
     />

--- a/packages/shared/src/components/notifications/NotificationItem.spec.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.spec.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import NotificationItem, { NotificationItemProps } from './NotificationItem';
 import {
   NotificationAvatarType,
@@ -38,10 +39,17 @@ const sampleNotification: NotificationItemProps = {
   ],
 };
 
+const renderComponent = (component: ReactNode) => {
+  const client = new QueryClient();
+  render(
+    <QueryClientProvider client={client}>{component}</QueryClientProvider>,
+  );
+};
+
 describe('notification attachment', () => {
   it('should display image', async () => {
     const [attachment] = sampleNotification.attachments;
-    render(<NotificationItem {...sampleNotification} />);
+    renderComponent(<NotificationItem {...sampleNotification} />);
     const img = await screen.findByAltText(
       `Cover preview of: ${attachment.title}`,
     );
@@ -50,7 +58,7 @@ describe('notification attachment', () => {
 
   it('should have a title', async () => {
     const [attachment] = sampleNotification.attachments;
-    render(<NotificationItem {...sampleNotification} />);
+    renderComponent(<NotificationItem {...sampleNotification} />);
     await screen.findByText(attachment.title);
   });
 });
@@ -58,14 +66,14 @@ describe('notification attachment', () => {
 describe('notification avatars', () => {
   it('should display the avatar of the source', async () => {
     const [source] = sampleNotification.avatars;
-    render(<NotificationItem {...sampleNotification} />);
+    renderComponent(<NotificationItem {...sampleNotification} />);
     const img = await screen.findByAltText(`${source.referenceId}'s profile`);
     expect(img).toHaveAttribute('src', source.image);
   });
 
   it('should display the avatar of the user', async () => {
     const [, user] = sampleNotification.avatars;
-    render(<NotificationItem {...sampleNotification} />);
+    renderComponent(<NotificationItem {...sampleNotification} />);
     const img = await screen.findByAltText(`${user.referenceId}'s profile`);
     expect(img).toHaveAttribute('src', user.image);
   });
@@ -75,7 +83,7 @@ describe('notification avatars', () => {
     const notif = { ...sampleNotification } as any;
     notif.avatars[1].type = 'Test';
     const [, user] = sampleNotification.avatars;
-    render(<NotificationItem {...sampleNotification} />);
+    renderComponent(<NotificationItem {...sampleNotification} />);
     const img = screen.queryByAltText(`${user.referenceId}'s profile`);
     expect(img).not.toBeInTheDocument();
   });
@@ -83,7 +91,7 @@ describe('notification avatars', () => {
 
 describe('notification item', () => {
   it('should display the icon of the notification', async () => {
-    render(<NotificationItem {...sampleNotification} />);
+    renderComponent(<NotificationItem {...sampleNotification} />);
     const testid = `notification-${sampleNotification.icon}`;
     const img = await screen.findByTestId(testid);
     expect(img).toBeInTheDocument();
@@ -93,19 +101,19 @@ describe('notification item', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const notification = { ...sampleNotification } as any; // using any to validate unknown icon
     notification.icon = 'new notif';
-    render(<NotificationItem {...notification} />);
+    renderComponent(<NotificationItem {...notification} />);
     const testid = `notification-${notification.icon}`;
     const img = await screen.findByTestId(testid);
     expect(img).toHaveAttribute('data-testvalue', NotificationIcon.DailyDev);
   });
 
   it('should have a title that supports html', async () => {
-    render(<NotificationItem {...sampleNotification} />);
+    renderComponent(<NotificationItem {...sampleNotification} />);
     await screen.findByText(sampleNotificationTitle);
   });
 
   it('should have a description that supports html', async () => {
-    render(<NotificationItem {...sampleNotification} />);
+    renderComponent(<NotificationItem {...sampleNotification} />);
     await screen.findByText(sampleNotificationDescription);
   });
 });

--- a/packages/shared/src/components/notifications/NotificationItem.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.tsx
@@ -60,7 +60,7 @@ function NotificationItem({
       type="button"
       onClick={onClick}
       className={classNames(
-        'flex flex-row py-4 pl-6 pr-4 hover:bg-theme-hover focus:bg-theme-active',
+        'flex flex-row py-4 pl-6 pr-4 hover:bg-theme-hover focus:bg-theme-active border-y border-theme-bg-primary',
         isUnread && 'bg-theme-float',
       )}
     >

--- a/packages/shared/src/components/notifications/NotificationItem.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.tsx
@@ -1,6 +1,6 @@
-import classNames from 'classnames';
-import { useRouter } from 'next/router';
 import React, { ReactElement, useMemo } from 'react';
+import classNames from 'classnames';
+import Link from 'next/link';
 import { Notification } from '../../graphql/notifications';
 import { useDomPurify } from '../../hooks/useDomPurify';
 import NotificationItemIcon from './NotificationIcon';
@@ -13,7 +13,8 @@ export interface NotificationItemProps
     'type' | 'icon' | 'title' | 'description' | 'avatars' | 'attachments'
   > {
   isUnread?: boolean;
-  targetUrl?: string;
+  targetUrl: string;
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
 function NotificationItem({
@@ -24,9 +25,9 @@ function NotificationItem({
   avatars,
   attachments,
   targetUrl,
+  onClick,
 }: NotificationItemProps): ReactElement {
   const purify = useDomPurify();
-  const router = useRouter();
   const { title: memoizedTitle, description: memoizedDescription } =
     useMemo(() => {
       if (!purify?.sanitize) {
@@ -51,47 +52,45 @@ function NotificationItem({
       .filter((avatar) => avatar) ?? [];
   const hasAvatar = avatarComponents.length > 0;
 
-  const onClick = () => {
-    router.push(targetUrl);
-  };
-
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={classNames(
-        'flex flex-row py-4 pl-6 pr-4 hover:bg-theme-hover focus:bg-theme-active border-y border-theme-bg-primary',
-        isUnread && 'bg-theme-float',
-      )}
-    >
-      <NotificationItemIcon icon={icon} />
-      <div className="flex flex-col flex-1 ml-4 w-full text-left typo-callout">
-        {hasAvatar && (
-          <span className="flex flex-row gap-2 mb-4">{avatarComponents}</span>
+    <Link href={targetUrl} passHref>
+      <a
+        href="#"
+        onClick={onClick}
+        className={classNames(
+          'flex flex-row py-4 pl-6 pr-4 hover:bg-theme-hover focus:bg-theme-active border-y border-theme-bg-primary',
+          isUnread && 'bg-theme-float',
         )}
-        <span
-          className="break-words"
-          dangerouslySetInnerHTML={{
-            __html: memoizedTitle,
-          }}
-        />
-        {description && (
-          <p
-            className="mt-2 w-4/5 break-words text-theme-label-quaternary"
+      >
+        <NotificationItemIcon icon={icon} />
+        <div className="flex flex-col flex-1 ml-4 w-full text-left typo-callout">
+          {hasAvatar && (
+            <span className="flex flex-row gap-2 mb-4">{avatarComponents}</span>
+          )}
+          <span
+            className="break-words"
             dangerouslySetInnerHTML={{
-              __html: memoizedDescription,
+              __html: memoizedTitle,
             }}
           />
-        )}
-        {attachments?.map(({ image, title: attachment }) => (
-          <NotificationItemAttachment
-            key={attachment}
-            image={image}
-            title={attachment}
-          />
-        ))}
-      </div>
-    </button>
+          {description && (
+            <p
+              className="mt-2 w-4/5 break-words text-theme-label-quaternary"
+              dangerouslySetInnerHTML={{
+                __html: memoizedDescription,
+              }}
+            />
+          )}
+          {attachments?.map(({ image, title: attachment }) => (
+            <NotificationItemAttachment
+              key={attachment}
+              image={image}
+              title={attachment}
+            />
+          ))}
+        </div>
+      </a>
+    </Link>
   );
 }
 

--- a/packages/shared/src/components/notifications/NotificationItemAvatar.tsx
+++ b/packages/shared/src/components/notifications/NotificationItemAvatar.tsx
@@ -3,7 +3,6 @@ import {
   NotificationAvatar,
   NotificationAvatarType,
 } from '../../graphql/notifications';
-import { webappUrl } from '../../lib/constants';
 import SourceButton from '../cards/SourceButton';
 import { ProfileTooltip } from '../profile/ProfileTooltip';
 import { ProfilePicture } from '../ProfilePicture';
@@ -12,6 +11,7 @@ function NotificationItemAvatar({
   type,
   image,
   name,
+  targetUrl,
   referenceId,
 }: NotificationAvatar): ReactElement {
   if (type === NotificationAvatarType.Source) {
@@ -20,10 +20,7 @@ function NotificationItemAvatar({
 
   if (type === NotificationAvatarType.User) {
     return (
-      <ProfileTooltip
-        link={{ href: `${webappUrl}/${referenceId}` }}
-        user={{ id: referenceId }}
-      >
+      <ProfileTooltip link={{ href: targetUrl }} user={{ id: referenceId }}>
         <ProfilePicture
           user={{ image, id: referenceId }}
           nativeLazyLoading

--- a/packages/shared/src/components/notifications/NotificationItemAvatar.tsx
+++ b/packages/shared/src/components/notifications/NotificationItemAvatar.tsx
@@ -3,7 +3,9 @@ import {
   NotificationAvatar,
   NotificationAvatarType,
 } from '../../graphql/notifications';
+import { webappUrl } from '../../lib/constants';
 import SourceButton from '../cards/SourceButton';
+import { ProfileTooltip } from '../profile/ProfileTooltip';
 import { ProfilePicture } from '../ProfilePicture';
 
 function NotificationItemAvatar({
@@ -18,7 +20,12 @@ function NotificationItemAvatar({
 
   if (type === NotificationAvatarType.User) {
     return (
-      <ProfilePicture user={{ image, id: referenceId }} nativeLazyLoading />
+      <ProfileTooltip
+        link={{ href: `${webappUrl}/${referenceId}` }}
+        user={{ id: referenceId }}
+      >
+        <ProfilePicture user={{ image, id: referenceId }} nativeLazyLoading />
+      </ProfileTooltip>
     );
   }
 

--- a/packages/shared/src/components/notifications/NotificationItemAvatar.tsx
+++ b/packages/shared/src/components/notifications/NotificationItemAvatar.tsx
@@ -24,7 +24,11 @@ function NotificationItemAvatar({
         link={{ href: `${webappUrl}/${referenceId}` }}
         user={{ id: referenceId }}
       >
-        <ProfilePicture user={{ image, id: referenceId }} nativeLazyLoading />
+        <ProfilePicture
+          user={{ image, id: referenceId }}
+          nativeLazyLoading
+          size="medium"
+        />
       </ProfileTooltip>
     );
   }

--- a/packages/shared/src/components/notifications/utils.ts
+++ b/packages/shared/src/components/notifications/utils.ts
@@ -56,7 +56,7 @@ const notificationsUrl = `/notifications`;
 export const checkAtNotificationsPage = (): boolean =>
   notificationsUrl === globalThis.window?.location.pathname;
 
-const MAX_UNREAD_DISPLAY = 99;
+const MAX_UNREAD_DISPLAY = 20;
 
 export const getUnreadText = (unread: number): string =>
-  unread > MAX_UNREAD_DISPLAY ? '99+' : unread.toString();
+  unread > MAX_UNREAD_DISPLAY ? `${MAX_UNREAD_DISPLAY}+` : unread.toString();

--- a/packages/shared/src/graphql/notifications.ts
+++ b/packages/shared/src/graphql/notifications.ts
@@ -59,6 +59,7 @@ export const NOTIFICATIONS_QUERY = gql`
           type
           description
           avatars {
+            referenceId
             type
             image
             name


### PR DESCRIPTION
## Changes

### Describe what this PR does
- [x] notification permission banner is missing its BG
- [x] avatars are bigger than expected and the tooltip doesn’t work
- [x] the notification item is supposed to be a link to be middle clickable
- [x] border between notification items

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
