### PR TITLE
feat: handling granting scout access notification

### DIFF
--- a/packages/shared/src/components/sidebar/ContributeSection.tsx
+++ b/packages/shared/src/components/sidebar/ContributeSection.tsx
@@ -1,8 +1,8 @@
 import dynamic from 'next/dynamic';
-import { useRouter } from 'next/router';
-import React, { ReactElement, useContext, useEffect, useState } from 'react';
+import React, { ReactElement, useContext, useState } from 'react';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 import { FeaturesData } from '../../contexts/FeaturesContext';
+import { useSubmitArticle } from '../../hooks/useSubmitArticle';
 import EmbedIcon from '../icons/Embed';
 import LinkIcon from '../icons/Link';
 import { ListIcon, SidebarMenuItem } from './common';
@@ -35,9 +35,9 @@ export function ContributeSection({
   submitArticleModalButton,
   ...props
 }: SectionCommonProps & SubmitFlags): ReactElement {
-  const router = useRouter();
   const { trackEvent } = useContext(AnalyticsContext);
-  const [showSubmitArticle, setShowSubmitArticle] = useState(false);
+  const { isOpen: showSubmitArticle, onIsOpen: setShowSubmitArticle } =
+    useSubmitArticle();
   const [showNewSourceModal, setShowNewSourceModal] = useState(false);
   const contributeMenuItems: SidebarMenuItem[] = [
     {
@@ -70,19 +70,6 @@ export function ContributeSection({
     };
     contributeMenuItems.unshift(submitArticleMenuItem);
   }
-
-  useEffect(() => {
-    const search = new URLSearchParams(window.location.search);
-    const query = Object.fromEntries(search);
-    if (!query?.scout) {
-      return;
-    }
-
-    const { origin, pathname } = window.location;
-    setShowSubmitArticle(true);
-    router.replace(origin + pathname);
-  }, []);
-
   return (
     <>
       <Section

--- a/packages/shared/src/components/sidebar/ContributeSection.tsx
+++ b/packages/shared/src/components/sidebar/ContributeSection.tsx
@@ -1,5 +1,6 @@
 import dynamic from 'next/dynamic';
-import React, { ReactElement, useContext, useState } from 'react';
+import { useRouter } from 'next/router';
+import React, { ReactElement, useContext, useEffect, useState } from 'react';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 import { FeaturesData } from '../../contexts/FeaturesContext';
 import EmbedIcon from '../icons/Embed';
@@ -34,6 +35,7 @@ export function ContributeSection({
   submitArticleModalButton,
   ...props
 }: SectionCommonProps & SubmitFlags): ReactElement {
+  const router = useRouter();
   const { trackEvent } = useContext(AnalyticsContext);
   const [showSubmitArticle, setShowSubmitArticle] = useState(false);
   const [showNewSourceModal, setShowNewSourceModal] = useState(false);
@@ -68,6 +70,18 @@ export function ContributeSection({
     };
     contributeMenuItems.unshift(submitArticleMenuItem);
   }
+
+  useEffect(() => {
+    const search = new URLSearchParams(window.location.search);
+    const query = Object.fromEntries(search);
+    if (!query?.scout) {
+      return;
+    }
+
+    const { origin, pathname } = window.location;
+    setShowSubmitArticle(true);
+    router.replace(origin + pathname);
+  }, []);
 
   return (
     <>

--- a/packages/shared/src/components/sidebar/ContributeSection.tsx
+++ b/packages/shared/src/components/sidebar/ContributeSection.tsx
@@ -22,15 +22,11 @@ const NewSourceModal = dynamic(
 
 type SubmitFlags = Pick<
   FeaturesData,
-  | 'canSubmitArticle'
-  | 'submitArticleOn'
-  | 'submitArticleSidebarButton'
-  | 'submitArticleModalButton'
+  'canSubmitArticle' | 'submitArticleSidebarButton' | 'submitArticleModalButton'
 >;
 
 export function ContributeSection({
   canSubmitArticle,
-  submitArticleOn,
   submitArticleSidebarButton,
   submitArticleModalButton,
   ...props
@@ -39,7 +35,24 @@ export function ContributeSection({
   const { isOpen: showSubmitArticle, onIsOpen: setShowSubmitArticle } =
     useSubmitArticle();
   const [showNewSourceModal, setShowNewSourceModal] = useState(false);
+  const trackAndShowSubmitArticle = () => {
+    trackEvent({
+      event_name: 'start submit article',
+      feed_item_title: submitArticleSidebarButton,
+      extra: JSON.stringify({ has_access: canSubmitArticle }),
+    });
+    setShowSubmitArticle(true);
+  };
+
   const contributeMenuItems: SidebarMenuItem[] = [
+    {
+      icon: (active: boolean) => (
+        <ListIcon Icon={() => <LinkIcon secondary={active} />} />
+      ),
+      title: submitArticleSidebarButton,
+      action: trackAndShowSubmitArticle,
+      active: showSubmitArticle,
+    },
     {
       icon: (active) => (
         <ListIcon Icon={() => <EmbedIcon secondary={active} />} />
@@ -50,26 +63,6 @@ export function ContributeSection({
     },
   ];
 
-  const trackAndShowSubmitArticle = () => {
-    trackEvent({
-      event_name: 'start submit article',
-      feed_item_title: submitArticleSidebarButton,
-      extra: JSON.stringify({ has_access: canSubmitArticle }),
-    });
-    setShowSubmitArticle(true);
-  };
-
-  if (submitArticleOn) {
-    const submitArticleMenuItem = {
-      icon: (active: boolean) => (
-        <ListIcon Icon={() => <LinkIcon secondary={active} />} />
-      ),
-      title: submitArticleSidebarButton,
-      action: trackAndShowSubmitArticle,
-      active: showSubmitArticle,
-    };
-    contributeMenuItems.unshift(submitArticleMenuItem);
-  }
   return (
     <>
       <Section

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -64,7 +64,6 @@ export default function Sidebar({
   const [showSettings, setShowSettings] = useState(false);
   const {
     canSubmitArticle,
-    submitArticleOn,
     submitArticleSidebarButton,
     submitArticleModalButton,
     popularFeedCopy,
@@ -202,7 +201,6 @@ export default function Sidebar({
             <ContributeSection
               {...defaultRenderSectionProps}
               canSubmitArticle={canSubmitArticle}
-              submitArticleOn={submitArticleOn}
               submitArticleSidebarButton={submitArticleSidebarButton}
               submitArticleModalButton={submitArticleModalButton}
             />

--- a/packages/shared/src/contexts/FeaturesContext.tsx
+++ b/packages/shared/src/contexts/FeaturesContext.tsx
@@ -25,7 +25,6 @@ interface Experiments {
   onboardingVersion?: OnboardingVersion;
   onboardingFiltersLayout?: OnboardingFiltersLayout;
   popularFeedCopy?: string;
-  submitArticleOn?: boolean;
   canSubmitArticle?: boolean;
   submitArticleSidebarButton?: string;
   submitArticleModalButton?: string;
@@ -80,7 +79,6 @@ const getFeatures = (flags: IFlags): FeaturesData => {
       Features.PostEngagementNonClickable,
       flags,
     ),
-    submitArticleOn: isFeaturedEnabled(Features.SubmitArticleOn, flags),
     canSubmitArticle: isFeaturedEnabled(Features.SubmitArticle, flags),
     submitArticleSidebarButton: getFeatureValue(
       Features.SubmitArticleSidebarButton,

--- a/packages/shared/src/graphql/notifications.ts
+++ b/packages/shared/src/graphql/notifications.ts
@@ -22,6 +22,19 @@ export interface NotificationAttachment {
 
 export enum NotificationType {
   System = 'system',
+  CommunityPicksFailed = 'community_picks_failed',
+  CommunityPicksSucceeded = 'community_picks_succeeded',
+  CommunityPicksGranted = 'community_picks_granted',
+  ArticlePicked = 'article_picked',
+  ArticleNewComment = 'article_new_comment',
+  ArticleUpvoteMilestone = 'article_upvote_milestone',
+  ArticleReportApproved = 'article_report_approved',
+  ArticleAnalytics = 'article_analytics',
+  SourceApproved = 'source_approved',
+  SourceRejected = 'source_rejected',
+  CommentMention = 'comment_mention',
+  CommentReply = 'comment_reply',
+  CommentUpvoteMilestone = 'comment_upvote_milestone',
 }
 
 export interface Notification {

--- a/packages/shared/src/graphql/notifications.ts
+++ b/packages/shared/src/graphql/notifications.ts
@@ -22,19 +22,6 @@ export interface NotificationAttachment {
 
 export enum NotificationType {
   System = 'system',
-  CommunityPicksFailed = 'community_picks_failed',
-  CommunityPicksSucceeded = 'community_picks_succeeded',
-  CommunityPicksGranted = 'community_picks_granted',
-  ArticlePicked = 'article_picked',
-  ArticleNewComment = 'article_new_comment',
-  ArticleUpvoteMilestone = 'article_upvote_milestone',
-  ArticleReportApproved = 'article_report_approved',
-  ArticleAnalytics = 'article_analytics',
-  SourceApproved = 'source_approved',
-  SourceRejected = 'source_rejected',
-  CommentMention = 'comment_mention',
-  CommentReply = 'comment_reply',
-  CommentUpvoteMilestone = 'comment_upvote_milestone',
 }
 
 export interface Notification {

--- a/packages/shared/src/hooks/useSubmitArticle.ts
+++ b/packages/shared/src/hooks/useSubmitArticle.ts
@@ -1,0 +1,26 @@
+import { useRouter } from 'next/router';
+import { useEffect, useMemo, useState } from 'react';
+
+interface UseSubmitArticle {
+  isOpen: boolean;
+  onIsOpen: (value: boolean) => void;
+}
+
+export const useSubmitArticle = (): UseSubmitArticle => {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    const search = new URLSearchParams(window.location.search);
+    const query = Object.fromEntries(search);
+    if (!query?.scout) {
+      return;
+    }
+
+    const { origin, pathname } = window.location;
+    setIsOpen(true);
+    router.replace(origin + pathname);
+  }, []);
+
+  return useMemo(() => ({ isOpen, onIsOpen: setIsOpen }), [isOpen]);
+};


### PR DESCRIPTION
## Changes

### Describe what this PR does
- In the preview below, I just replaced the URL of the first notification locally just to simulate how it would look like.

https://user-images.githubusercontent.com/13744167/209301517-4344feaa-f789-418c-9374-a966ab3c76a8.mov


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-802 #done
