### PR TITLE
fix: notification bugs

### DIFF
--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -137,7 +137,7 @@ function EnableNotification({
       )}
       <img
         className={classNames(
-          'hidden tablet:flex absolute right-4',
+          'hidden tablet:flex absolute right-4 w-[7.5rem]',
           isEnabled ? '-bottom-8' : '-bottom-2',
         )}
         src={

--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -149,7 +149,7 @@ function EnableNotification({
       />
       <CloseButton
         buttonSize="xsmall"
-        className="top-3 right-3"
+        className="top-1 laptop:top-3 right-1 laptop:right-3"
         onClick={() => setDismissed(true)}
         position="absolute"
       />

--- a/packages/shared/src/components/notifications/NotificationIcon.tsx
+++ b/packages/shared/src/components/notifications/NotificationIcon.tsx
@@ -38,7 +38,12 @@ function NotificationItemIcon({
 
   return (
     <span className="overflow-hidden p-1 bg-theme-float rounded-8 typo-callout h-fit">
-      <Icon secondary className={iconTheme} data-testid={testId} />
+      <Icon
+        size="medium"
+        secondary
+        className={iconTheme}
+        data-testid={testId}
+      />
     </span>
   );
 }

--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -52,9 +52,11 @@ export const tabs: Tab[] = [
     title: 'Notifications',
     icon: (active: boolean, unreadCount) => (
       <span className="relative">
-        <Bubble className="top-0 px-1 left-[calc(100%-0.75rem)]">
-          {getUnreadText(unreadCount)}
-        </Bubble>
+        {unreadCount && (
+          <Bubble className="top-0 px-1 left-[calc(100%-0.75rem)]">
+            {getUnreadText(unreadCount)}
+          </Bubble>
+        )}
         <BellIcon secondary={active} size="xxlarge" />
       </span>
     ),

--- a/packages/webapp/pages/account/notifications.tsx
+++ b/packages/webapp/pages/account/notifications.tsx
@@ -72,13 +72,13 @@ const AccountNotificationsPage = (): ReactElement => {
               discussions, upvotes, replies or mentions on daily.dev!
             </p>
             <img
-              className="absolute top-4 right-14"
+              className="hidden laptopL:flex absolute top-4 right-14"
               src={cloudinary.notifications.browser}
               alt="A sample browser notification"
             />
             <CloseButton
               buttonSize="xsmall"
-              className="ml-32"
+              className="ml-auto laptopL:ml-32"
               onClick={() => setIsAlertShown(false)}
             />
           </div>

--- a/packages/webapp/pages/account/notifications.tsx
+++ b/packages/webapp/pages/account/notifications.tsx
@@ -1,6 +1,6 @@
 import { Checkbox } from '@dailydotdev/shared/src/components/fields/Checkbox';
 import { Switch } from '@dailydotdev/shared/src/components/fields/Switch';
-import React, { ReactElement, useContext, useState } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import { cloudinary } from '@dailydotdev/shared/src/lib/image';
 import CloseButton from '@dailydotdev/shared/src/components/CloseButton';
 import Pointer, {
@@ -26,16 +26,13 @@ const AccountNotificationsPage = (): ReactElement => {
   const { updateUserProfile } = useProfileForm();
   const { user } = useContext(AuthContext);
   const { acceptedMarketing, notificationEmail } = user ?? {};
-  const [emailNotification, setEmailNotification] = useState(
-    acceptedMarketing || notificationEmail,
-  );
+  const emailNotification = acceptedMarketing || notificationEmail;
   const onToggleEmailNotification = () => {
     const value = !emailNotification;
     updateUserProfile({
       acceptedMarketing: value,
       notificationEmail: value,
     });
-    setEmailNotification(value);
   };
 
   return (


### PR DESCRIPTION
## Changes

### Fixes the items below:
- Bell icon not to show when zero on mobile.
- Margin between banner image and text (should not be shown on laptop below [based on Sketch](https://www.sketch.com/s/2867ec63-0966-4647-b1d7-b6fe696ba251/a/xr3m8WA)).
- Required additional margin between the close button and contents.
- Notification icons are not the same sizes.
- Email notification settings not showing accurate value.
- Using the wrong GIF on Enable Notification banner and size when enabled.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-869#done
WT-870#done
WT-877#done
WT-878#done
WT-879#done
WT-880#done

