### PR TITLE
fix: awaiting the cache load, currently could be null

### DIFF
--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -77,7 +77,7 @@ export const BootDataProvider = ({
   const [lastAppliedChange, setLastAppliedChange] =
     useState<Partial<BootCacheData>>();
   const [initialLoad, setInitialLoad] = useState<boolean>(null);
-  const loadedFromCache = cachedBootData !== undefined;
+  const loadedFromCache = !!cachedBootData;
   const { user, settings, flags = {}, alerts } = cachedBootData || {};
   const {
     data: bootRemoteData,

--- a/packages/shared/src/contexts/OnboardingContext.tsx
+++ b/packages/shared/src/contexts/OnboardingContext.tsx
@@ -51,7 +51,7 @@ export const OnboardingContextProvider = ({
 }: OnboardingContextProviderProps): ReactElement => {
   const { pathname } = useRouter() ?? {};
   const { user } = useContext(AuthContext);
-  const { alerts } = useContext(AlertContext);
+  const { loadedAlerts, alerts } = useContext(AlertContext);
   const { trackEvent } = useContext(AnalyticsContext);
   const { registerLocalFilters } = useMyFeed();
   const [isOnboarding, setIsOnboarding] = useState(false);
@@ -76,6 +76,7 @@ export const OnboardingContextProvider = ({
   useEffect(() => {
     const isHome = !pathname || pathname === '/';
     const conditions = [
+      !loadedAlerts,
       !hasOnboardingLoaded,
       hasTriedOnboarding,
       !alerts.filter,
@@ -89,7 +90,7 @@ export const OnboardingContextProvider = ({
     setHasTriedOnboarding(false);
     setOnboardingMode(OnboardingMode.Auto);
     setIsOnboarding(true);
-  }, [hasOnboardingLoaded, user, pathname]);
+  }, [hasOnboardingLoaded, user, pathname, loadedAlerts]);
 
   const onCloseOnboardingModal = () => {
     if (onboardingMode === OnboardingMode.Auto) {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- In the current implementation we wait for the cache to be existing, however we never checked against `null` value, only undefined.
- This might even fix some other edge-cases we have seen before.
- Also modified the modal to wait for this loaded state

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-900 #done
