### PR TITLE
fix: web push displayed toggle only when supported

### DIFF
--- a/packages/webapp/pages/account/notifications.tsx
+++ b/packages/webapp/pages/account/notifications.tsx
@@ -1,6 +1,7 @@
 import { Checkbox } from '@dailydotdev/shared/src/components/fields/Checkbox';
 import { Switch } from '@dailydotdev/shared/src/components/fields/Switch';
 import React, { ReactElement, useContext } from 'react';
+import classNames from 'classnames';
 import { cloudinary } from '@dailydotdev/shared/src/lib/image';
 import CloseButton from '@dailydotdev/shared/src/components/CloseButton';
 import Pointer, {
@@ -129,7 +130,12 @@ const AccountNotificationsPage = (): ReactElement => {
         </div>
       )}
       {isNotificationSupported && isAlertShown && (
-        <div className="relative mt-6 w-full rounded-16 border border-theme-color-cabbage">
+        <div
+          className={classNames(
+            'relative w-full rounded-16 border border-theme-color-cabbage',
+            isNotificationSupported && 'mt-6',
+          )}
+        >
           <Pointer
             className="absolute -top-5 right-8"
             color={PointerColor.Cabbage}

--- a/packages/webapp/pages/account/notifications.tsx
+++ b/packages/webapp/pages/account/notifications.tsx
@@ -130,12 +130,7 @@ const AccountNotificationsPage = (): ReactElement => {
         </div>
       )}
       {isNotificationSupported && isAlertShown && (
-        <div
-          className={classNames(
-            'relative w-full rounded-16 border border-theme-color-cabbage',
-            isNotificationSupported && 'mt-6',
-          )}
-        >
+        <div className="relative mt-6 w-full rounded-16 border border-theme-color-cabbage">
           <Pointer
             className="absolute -top-5 right-8"
             color={PointerColor.Cabbage}
@@ -158,7 +153,12 @@ const AccountNotificationsPage = (): ReactElement => {
           </div>
         </div>
       )}
-      <div className="flex flex-row mt-6">
+      <div
+        className={classNames(
+          'flex flex-row',
+          isNotificationSupported && 'mt-6',
+        )}
+      >
         <AccountContentSection
           className={{
             heading: 'mt-0',

--- a/packages/webapp/pages/account/notifications.tsx
+++ b/packages/webapp/pages/account/notifications.tsx
@@ -23,8 +23,12 @@ import AccountContentSection from '../../components/layouts/AccountLayout/Accoun
 const ALERT_PUSH_KEY = 'alert_push_key';
 
 const AccountNotificationsPage = (): ReactElement => {
-  const { onTogglePermission, isSubscribed, isInitialized } =
-    useContext(NotificationsContext);
+  const {
+    onTogglePermission,
+    isSubscribed,
+    isInitialized,
+    isNotificationSupported,
+  } = useContext(NotificationsContext);
   const [isAlertShown, setIsAlertShown] = usePersistentContext(
     ALERT_PUSH_KEY,
     true,
@@ -99,30 +103,32 @@ const AccountNotificationsPage = (): ReactElement => {
 
   return (
     <AccountPageContainer title="Notifications">
-      <div className="flex flex-row">
-        <AccountContentSection
-          className={{
-            heading: 'mt-0',
-            container: 'flex flex-col flex-1 w-full',
-          }}
-          title="Push notifications"
-          description="The daily.dev notification system notifies you of important events such as replies, mentions, updates, etc."
-        />
-        <div className="mx-4 w-px h-full bg-theme-divider-tertiary" />
-        <Switch
-          data-testId="push_notification-switch"
-          inputId="push_notification-switch"
-          name="push_notification"
-          className="w-20"
-          compact={false}
-          checked={isSubscribed}
-          onToggle={onTogglePush}
-          disabled={!isInitialized}
-        >
-          {isSubscribed ? 'On' : 'Off'}
-        </Switch>
-      </div>
-      {isAlertShown && (
+      {isNotificationSupported && (
+        <div className="flex flex-row">
+          <AccountContentSection
+            className={{
+              heading: 'mt-0',
+              container: 'flex flex-col flex-1 w-full',
+            }}
+            title="Push notifications"
+            description="The daily.dev notification system notifies you of important events such as replies, mentions, updates, etc."
+          />
+          <div className="mx-4 w-px h-full bg-theme-divider-tertiary" />
+          <Switch
+            data-testId="push_notification-switch"
+            inputId="push_notification-switch"
+            name="push_notification"
+            className="w-20"
+            compact={false}
+            checked={isSubscribed}
+            onToggle={onTogglePush}
+            disabled={!isInitialized}
+          >
+            {isSubscribed ? 'On' : 'Off'}
+          </Switch>
+        </div>
+      )}
+      {isNotificationSupported && isAlertShown && (
         <div className="relative mt-6 w-full rounded-16 border border-theme-color-cabbage">
           <Pointer
             className="absolute -top-5 right-8"


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
