### PR TITLE
fix: hide notifications tab on anonymous

### DIFF
--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -31,6 +31,7 @@ type Tab = {
   title: string;
   icon: (active: boolean, unread?: number) => ReactElement;
   requiresLogin?: boolean;
+  shouldShowLogin?: boolean;
   onClick?: () => void;
 };
 
@@ -47,7 +48,7 @@ export const tabs: Tab[] = [
     icon: (active: boolean) => (
       <BookmarkIcon secondary={active} size="xxlarge" />
     ),
-    requiresLogin: true,
+    shouldShowLogin: true,
   },
   {
     path: '/search',
@@ -56,6 +57,7 @@ export const tabs: Tab[] = [
   },
   {
     requiresLogin: true,
+    shouldShowLogin: true,
     path: notificationsPath,
     title: 'Notifications',
     icon: (active: boolean, unreadCount) => (
@@ -113,42 +115,44 @@ export default function FooterNavBar(): ReactElement {
         styles.footerNavBar,
       )}
     >
-      {tabs.map((tab, index) => (
-        <div key={tab.path} className="relative">
-          {!tab.requiresLogin || user ? (
-            <LinkWithTooltip
-              href={tab.path}
-              prefetch={false}
-              passHref
-              tooltip={{ content: tab.title }}
-            >
-              <Button
-                {...buttonProps}
-                tag="a"
-                icon={tab.icon(index === selectedTab, unreadCount)}
-                pressed={index === selectedTab}
-                onClick={onItemClick[tab.path]}
-              />
-            </LinkWithTooltip>
-          ) : (
-            <SimpleTooltip content={tab.title}>
-              <Button
-                {...buttonProps}
-                icon={tab.icon(index === selectedTab, unreadCount)}
-                onClick={() => showLogin(AuthTriggers.Bookmark)}
-              />
-            </SimpleTooltip>
-          )}
-          <Flipped flipId="activeTabIndicator">
-            {selectedTab === index && (
-              <ActiveTabIndicator
-                className="w-12"
-                style={{ top: '-0.125rem' }}
-              />
+      {tabs.map((tab, index) =>
+        tab.requiresLogin && !user ? null : (
+          <div key={tab.path} className="relative">
+            {!tab.shouldShowLogin || user ? (
+              <LinkWithTooltip
+                href={tab.path}
+                prefetch={false}
+                passHref
+                tooltip={{ content: tab.title }}
+              >
+                <Button
+                  {...buttonProps}
+                  tag="a"
+                  icon={tab.icon(index === selectedTab, unreadCount)}
+                  pressed={index === selectedTab}
+                  onClick={onItemClick[tab.path]}
+                />
+              </LinkWithTooltip>
+            ) : (
+              <SimpleTooltip content={tab.title}>
+                <Button
+                  {...buttonProps}
+                  icon={tab.icon(index === selectedTab, unreadCount)}
+                  onClick={() => showLogin(AuthTriggers.Bookmark)}
+                />
+              </SimpleTooltip>
             )}
-          </Flipped>
-        </div>
-      ))}
+            <Flipped flipId="activeTabIndicator">
+              {selectedTab === index && (
+                <ActiveTabIndicator
+                  className="w-12"
+                  style={{ top: '-0.125rem' }}
+                />
+              )}
+            </Flipped>
+          </div>
+        ),
+      )}
     </Flipper>
   );
 }

--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -55,6 +55,7 @@ export const tabs: Tab[] = [
     icon: (active: boolean) => <SearchIcon secondary={active} size="xxlarge" />,
   },
   {
+    requiresLogin: true,
     path: notificationsPath,
     title: 'Notifications',
     icon: (active: boolean, unreadCount) => (


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
