### PR TITLE
fix: mobile in-app notification

### DIFF
--- a/packages/shared/src/components/notifications/InAppNotification.module.css
+++ b/packages/shared/src/components/notifications/InAppNotification.module.css
@@ -13,11 +13,31 @@
   }
 }
 
+@keyframes mobileInAppNotificationAnimationEntry {
+  0% {
+    transform: translate(50%, -200%);
+    opacity: 0;
+  }
+  50% {
+    transform: translate(50%, -200%);
+    opacity: 0.8;
+  }
+  100% {
+    transform: translate(50%, 0);
+    opacity: 1;
+  }
+}
+
+
 .inAppNotificationContainer {
-  animation: inAppNotificationAnimationEntry 0.80s ease-in-out;
+  animation: mobileInAppNotificationAnimationEntry 0.80s ease-in-out;
   transition: opacity 0.14s ease-in-out;
 
   &:global(.exit) {
     opacity: 0;
+  }
+  
+  @screen laptop {
+    animation: inAppNotificationAnimationEntry 0.80s ease-in-out;
   }
 }

--- a/packages/shared/src/components/notifications/InAppNotification.tsx
+++ b/packages/shared/src/components/notifications/InAppNotification.tsx
@@ -23,7 +23,7 @@ const Container = classed(
   classNames(
     styles.inAppNotificationContainer,
     'animate-bounce',
-    'fixed right-3 laptop:right-10 bg-theme-bg-notification border border-theme-active rounded-16 in-app-notification slide-in z-[100] w-[22.5rem] h-22',
+    'fixed right-1/2 translate-x-1/2 laptop:translate-x-0 laptop:right-10 bg-theme-bg-notification border border-theme-active rounded-16 in-app-notification slide-in z-[100] w-[22.5rem] h-22',
   ),
 );
 
@@ -95,10 +95,10 @@ export function InAppNotificationElement(): ReactElement {
   return (
     <Container
       className={classNames(
+        'top-16',
         isExit && 'exit',
-        inAppNotificationPosition === InAppNotificationPosition.Bottom
-          ? 'bottom-16 laptop:bottom-10'
-          : 'top-16',
+        inAppNotificationPosition === InAppNotificationPosition.Bottom &&
+          'laptop:bottom-10 laptop:top-[unset]',
       )}
       role="alert"
       onMouseEnter={stopTimer}

--- a/packages/shared/src/components/notifications/InAppNotification.tsx
+++ b/packages/shared/src/components/notifications/InAppNotification.tsx
@@ -23,7 +23,7 @@ const Container = classed(
   classNames(
     styles.inAppNotificationContainer,
     'animate-bounce',
-    'fixed right-10 bg-theme-bg-notification border border-theme-active rounded-16 in-app-notification slide-in z-[100] w-[22.5rem] h-22',
+    'fixed right-3 laptop:right-10 bg-theme-bg-notification border border-theme-active rounded-16 in-app-notification slide-in z-[100] w-[22.5rem] h-22',
   ),
 );
 

--- a/packages/shared/src/components/notifications/InAppNotification.tsx
+++ b/packages/shared/src/components/notifications/InAppNotification.tsx
@@ -97,7 +97,7 @@ export function InAppNotificationElement(): ReactElement {
       className={classNames(
         isExit && 'exit',
         inAppNotificationPosition === InAppNotificationPosition.Bottom
-          ? 'bottom-10'
+          ? 'bottom-16 laptop:bottom-10'
           : 'top-16',
       )}
       role="alert"


### PR DESCRIPTION
## Changes

### Describe what this PR does
Note: I just hacked the notification for demo purposes. So it never goes out and just used refresh to animate

https://user-images.githubusercontent.com/13744167/210529607-989f9600-aa34-4fa0-a722-41307b687769.mov

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-903 #done
