### PR TITLE
fix: hide push notification alert on settings when enabled

### DIFF
--- a/packages/webapp/pages/account/notifications.tsx
+++ b/packages/webapp/pages/account/notifications.tsx
@@ -7,7 +7,6 @@ import CloseButton from '@dailydotdev/shared/src/components/CloseButton';
 import Pointer, {
   PointerColor,
 } from '@dailydotdev/shared/src/components/alert/Pointer';
-import usePersistentContext from '@dailydotdev/shared/src/hooks/usePersistentContext';
 import NotificationsContext from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import useProfileForm from '@dailydotdev/shared/src/hooks/useProfileForm';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
@@ -21,19 +20,15 @@ import { getAccountLayout } from '../../components/layouts/AccountLayout';
 import { AccountPageContainer } from '../../components/layouts/AccountLayout/AccountPageContainer';
 import AccountContentSection from '../../components/layouts/AccountLayout/AccountContentSection';
 
-const ALERT_PUSH_KEY = 'alert_push_key';
-
 const AccountNotificationsPage = (): ReactElement => {
   const {
+    shouldShowSettingsAlert,
+    onShouldShowSettingsAlert,
     onTogglePermission,
     isSubscribed,
     isInitialized,
     isNotificationSupported,
   } = useContext(NotificationsContext);
-  const [isAlertShown, setIsAlertShown] = usePersistentContext(
-    ALERT_PUSH_KEY,
-    true,
-  );
   const { updateUserProfile } = useProfileForm();
   const { trackEvent } = useAnalyticsContext();
   const { user } = useContext(AuthContext);
@@ -129,7 +124,7 @@ const AccountNotificationsPage = (): ReactElement => {
           </Switch>
         </div>
       )}
-      {isNotificationSupported && isAlertShown && (
+      {isNotificationSupported && shouldShowSettingsAlert && isInitialized && (
         <div className="relative mt-6 w-full rounded-16 border border-theme-color-cabbage">
           <Pointer
             className="absolute -top-5 right-8"
@@ -148,7 +143,7 @@ const AccountNotificationsPage = (): ReactElement => {
             <CloseButton
               buttonSize="xsmall"
               className="ml-auto laptopL:ml-32"
-              onClick={() => setIsAlertShown(false)}
+              onClick={() => onShouldShowSettingsAlert(false)}
             />
           </div>
         </div>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-905 #done


[WT-905]: https://dailydotdev.atlassian.net/browse/WT-905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ