### PR TITLE
refactor: feed filters creation monitoring

### DIFF
--- a/packages/shared/src/hooks/useMyFeed.ts
+++ b/packages/shared/src/hooks/useMyFeed.ts
@@ -43,7 +43,7 @@ export function useMyFeed(): UseMyFeed {
         event_name: AuthEventNames.RegistrationError,
         extra: JSON.stringify({
           error: JSON.stringify(err),
-          origin: 'window registration flow error',
+          origin: 'create my feed mutation error',
         }),
       });
     }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- After numerous retries and reproduction, we have been miserably unable to replicate the concern.
- In order to understand what could be causing the modal to persist, we are looking to monitor the logs on the area where it can only fail before sending the event for completing onboarding.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
