### PR TITLE
hotfix: issue with profile page

### DIFF
--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -1,5 +1,4 @@
 import React, { HTMLAttributes, ReactElement, ReactHTML } from 'react';
-import classNames from 'classnames';
 import classed, { ClassedHTML } from '../lib/classed';
 import styles from './utilities.module.css';
 import ArrowIcon from './icons/Arrow';
@@ -109,24 +108,15 @@ export const postEventName = (
   return !update.bookmarked ? 'remove post bookmark' : 'bookmark post';
 };
 
-export const LegalNotice = classed(
-  'div',
-  'text-theme-label-quaternary text-center typo-caption1',
-  styles.legal,
-);
-
 export const pageBorders =
   'laptop:border-r laptop:border-l border-theme-divider-tertiary';
 const pagePaddings = 'px-4 tablet:px-8';
 
-export const pageContainerClassNames = classNames(
-  styles.pageContainer,
-  'relative flex flex-col w-full items-stretch z-1 tablet:self-center',
-);
 export const PageContainer = classed(
   'main',
+  styles.pageContainer,
   pagePaddings,
-  pageContainerClassNames,
+  'relative flex flex-col w-full items-stretch z-1 tablet:self-center',
 );
 
 export const PageWidgets = classed(

--- a/packages/shared/src/components/utilities.tsx
+++ b/packages/shared/src/components/utilities.tsx
@@ -1,4 +1,5 @@
 import React, { HTMLAttributes, ReactElement, ReactHTML } from 'react';
+import classNames from 'classnames';
 import classed, { ClassedHTML } from '../lib/classed';
 import styles from './utilities.module.css';
 import ArrowIcon from './icons/Arrow';
@@ -112,11 +113,14 @@ export const pageBorders =
   'laptop:border-r laptop:border-l border-theme-divider-tertiary';
 const pagePaddings = 'px-4 tablet:px-8';
 
+export const pageContainerClassNames = classNames(
+  styles.pageContainer,
+  'relative flex flex-col w-full items-stretch z-1 tablet:self-center',
+);
 export const PageContainer = classed(
   'main',
-  styles.pageContainer,
   pagePaddings,
-  'relative flex flex-col w-full items-stretch z-1 tablet:self-center',
+  pageContainerClassNames,
 );
 
 export const PageWidgets = classed(

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -142,7 +142,7 @@ export default function ProfileLayout({
         <link rel="preload" as="image" href={profile.image} />
       </Head>
       <NextSeo {...Seo} />
-      <ResponsivePageContainer className="overflow-x-hidden flex-1 px-6 max-w-full">
+      <ResponsivePageContainer>
         <section
           className={classNames(
             'flex flex-col self-start tablet:flex-row tablet:-ml-4 tablet:-mr-4 tablet:self-stretch tablet:overflow-x-hidden',


### PR DESCRIPTION
## Changes

### Describe what this PR does
-  Hotfix for profile page, we introduced a wrong load of style names and added a overwrite on max-width
- Also removed a unused class

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
