### PR TITLE
fix: comment highlight and placeholder

### DIFF
--- a/packages/extension/src/companion/CompanionDiscussion.tsx
+++ b/packages/extension/src/companion/CompanionDiscussion.tsx
@@ -64,7 +64,6 @@ export function CompanionDiscussion({
         <PostComments
           post={post}
           origin={Origin.Companion}
-          applyBottomMargin={false}
           onClick={onCommentClick}
           onShare={(comment) => openShareComment(comment, post)}
           onClickUpvote={onShowUpvoted}

--- a/packages/shared/src/components/ProfilePicture.tsx
+++ b/packages/shared/src/components/ProfilePicture.tsx
@@ -46,6 +46,16 @@ const roundClasses = {
   full: 'rounded-full',
 };
 
+export const getProfilePictureClasses = (
+  size: ProfileImageSize,
+  roundSize?: ProfileImageRoundSize,
+): string =>
+  classNames(
+    'object-cover',
+    sizeClasses[size],
+    roundClasses[roundSize ?? size],
+  );
+
 let onError: ReactEventHandler<HTMLImageElement> = (e) => {
   const target = e.target as HTMLImageElement;
   target.onerror = null;
@@ -69,6 +79,11 @@ function ProfilePictureComponent(
   }: ProfilePictureProps,
   ref?: Ref<HTMLImageElement>,
 ): ReactElement {
+  const classes = classNames(
+    getProfilePictureClasses(size, rounded),
+    className,
+  );
+
   if (nativeLazyLoading) {
     return (
       <img
@@ -77,12 +92,7 @@ function ProfilePictureComponent(
         src={user.image}
         alt={`${user.username || user.id}'s profile`}
         onError={onError}
-        className={classNames(
-          'object-cover',
-          sizeClasses[size],
-          roundClasses[rounded ?? size],
-          className,
-        )}
+        className={classes}
         loading="lazy"
       />
     );
@@ -94,11 +104,7 @@ function ProfilePictureComponent(
       ref={ref}
       imgSrc={user.image}
       imgAlt={`${user.username || user.id}'s profile`}
-      className={classNames(
-        sizeClasses[size],
-        roundClasses[rounded ?? size],
-        className,
-      )}
+      className={classes}
       fallbackSrc={fallbackImages.avatar}
     />
   );

--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -30,7 +30,7 @@ export interface Props extends CommentActionProps {
   appendTooltipTo?: () => HTMLElement;
 }
 
-const MainCommentBox = classed(CommentBox, 'my-2 py-2');
+const MainCommentBox = classed(CommentBox, 'my-4');
 
 export default function MainComment({
   post,
@@ -55,8 +55,15 @@ export default function MainComment({
       ref={commentHash === getCommentHash(comment.id) ? commentRef : null}
       data-testid="comment"
     >
-      <CommentContainer className={classNames('flex-col', className)}>
-        <div className="flex items-center px-3">
+      <CommentContainer
+        className={classNames(
+          'flex-col',
+          commentHash === getCommentHash(comment.id) &&
+            'border border-theme-color-cabbage',
+          className,
+        )}
+      >
+        <div className="flex items-center">
           <ProfileTooltip
             user={comment.author}
             tooltip={{ appendTo: appendTooltipTo }}
@@ -75,13 +82,7 @@ export default function MainComment({
             <CommentPublishDate comment={comment} />
           </div>
         </div>
-        <MainCommentBox
-          className={classNames(
-            'px-3',
-            commentHash === getCommentHash(comment.id) &&
-              'border border-theme-color-cabbage rounded-8',
-          )}
-        >
+        <MainCommentBox>
           <Markdown
             content={comment.contentHtml}
             appendTooltipTo={appendTooltipTo}
@@ -97,7 +98,6 @@ export default function MainComment({
           onDelete={onDelete}
           onEdit={onEdit}
           onShowUpvotes={onShowUpvotes}
-          className="ml-2"
         />
       </CommentContainer>
       {comment.children?.edges.map((e, i) => (

--- a/packages/shared/src/components/comments/SubComment.tsx
+++ b/packages/shared/src/components/comments/SubComment.tsx
@@ -51,7 +51,11 @@ export default function SubComment({
   const { user } = useContext(AuthContext);
   return (
     <CommentContainer
-      className="flex-row items-start mt-2 scroll-mt-16"
+      className={classNames(
+        'flex-row items-start mt-2 scroll-mt-16',
+        commentHash === getCommentHash(comment.id) &&
+          'border border-theme-color-cabbage',
+      )}
       data-testid="subcomment"
       ref={commentHash === getCommentHash(comment.id) ? commentRef : null}
     >
@@ -61,9 +65,9 @@ export default function SubComment({
       >
         <ProfileImageLink user={comment.author} />
       </ProfileTooltip>
-      <div className="flex flex-col flex-1">
+      <div className="flex flex-col flex-1 ml-4">
         <CommentBox>
-          <div className="flex ml-4">
+          <div className="flex">
             <CommentAuthor
               postAuthorId={postAuthorId}
               author={comment.author}
@@ -71,14 +75,8 @@ export default function SubComment({
             />
             {comment.author?.id === postScoutId && <ScoutBadge />}
           </div>
-          <CommentPublishDate className="ml-4" comment={comment} />
-          <div
-            className={classNames(
-              'py-2 px-3 my-2 mx-1',
-              commentHash === getCommentHash(comment.id) &&
-                'border border-theme-color-cabbage rounded-8',
-            )}
-          >
+          <CommentPublishDate comment={comment} />
+          <div className="my-4">
             <Markdown
               content={comment.contentHtml}
               appendTooltipTo={appendTooltipTo}
@@ -95,7 +93,6 @@ export default function SubComment({
           onDelete={onDelete}
           onEdit={onEdit}
           onShowUpvotes={onShowUpvotes}
-          className="ml-4"
         />
         {permissionNotificationCommentId === comment.id && (
           <EnableNotification

--- a/packages/shared/src/components/comments/common.tsx
+++ b/packages/shared/src/components/comments/common.tsx
@@ -28,7 +28,7 @@ export function CommentPublishDate({
   );
 }
 
-export const CommentContainer = classed('article', 'flex py-2 rounded-16');
+export const CommentContainer = classed('article', 'flex px-3 py-2 rounded-16');
 
 export const commentBoxClassNames =
   'rounded-lg break-words-overflow typo-callout';

--- a/packages/shared/src/components/modals/CommentBox.tsx
+++ b/packages/shared/src/components/modals/CommentBox.tsx
@@ -151,7 +151,7 @@ function CommentBox({
           )}
           defaultValue={input}
           ref={commentRef}
-          placeholder="Write your comment..."
+          placeholder="Share your thoughts"
           onInput={onTextareaInput}
           onKeyDown={handleKeydown}
           onKeyUp={onMentionKeypress}

--- a/packages/shared/src/components/modals/NewCommentModal.spec.tsx
+++ b/packages/shared/src/components/modals/NewCommentModal.spec.tsx
@@ -107,7 +107,7 @@ it('should show content of parent', async () => {
 
 it('should disable submit button when no input', async () => {
   renderComponent();
-  const el = await screen.findByText('Comment');
+  const el = await screen.findByText('Post');
   // eslint-disable-next-line testing-library/no-node-access
   expect(el.parentElement).toBeDisabled();
 });
@@ -117,7 +117,7 @@ it('should enable submit button when no input', async () => {
   const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
   input.value = 'My new comment';
   input.dispatchEvent(new Event('input', { bubbles: true }));
-  const el = await screen.findByText('Comment');
+  const el = await screen.findByText('Post');
   expect(el.getAttribute('disabled')).toBeFalsy();
 });
 
@@ -149,7 +149,7 @@ it('should send commentOnPost mutation', async () => {
   const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
   input.value = 'comment';
   input.dispatchEvent(new Event('input', { bubbles: true }));
-  const el = await screen.findByText('Comment');
+  const el = await screen.findByText('Post');
   el.click();
   await waitFor(() => mutationCalled);
   await waitFor(() => expect(onComment).toBeCalledWith(newComment, true));
@@ -183,7 +183,7 @@ it('should send commentOnComment mutation', async () => {
   const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
   input.value = 'comment';
   input.dispatchEvent(new Event('input', { bubbles: true }));
-  const el = await screen.findByText('Comment');
+  const el = await screen.findByText('Post');
   el.click();
   await waitFor(() => mutationCalled);
   await waitFor(() => expect(onComment).toBeCalledWith(newComment, true));
@@ -217,7 +217,7 @@ it('should not send comment if the input is spaces only', async () => {
   const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
   input.value = '   ';
   input.dispatchEvent(new Event('input', { bubbles: true }));
-  const el = await screen.findByText('Comment');
+  const el = await screen.findByText('Post');
   el.click();
   await waitFor(() => expect(onComment).not.toBeCalled());
   expect(mutationCalled).toBeFalsy();
@@ -240,7 +240,7 @@ it('should show alert in case of an error', async () => {
   const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
   input.value = 'comment';
   input.dispatchEvent(new Event('input', { bubbles: true }));
-  const el = await screen.findByText('Comment');
+  const el = await screen.findByText('Post');
   el.click();
   await waitFor(() => mutationCalled);
   await screen.findByRole('alert');

--- a/packages/shared/src/components/modals/NewCommentModal.tsx
+++ b/packages/shared/src/components/modals/NewCommentModal.tsx
@@ -165,7 +165,7 @@ export default function NewCommentModal({
       onClick={sendComment}
       className="ml-auto btn-primary-avocado"
     >
-      {editId ? 'Update' : 'Comment'}
+      {editId ? 'Update' : 'Post'}
     </Button>
   );
   return (

--- a/packages/shared/src/components/post/NewComment.tsx
+++ b/packages/shared/src/components/post/NewComment.tsx
@@ -1,8 +1,14 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
-import { ProfileImageSize, ProfilePicture } from '../ProfilePicture';
+import {
+  getProfilePictureClasses,
+  ProfileImageSize,
+  ProfilePicture,
+} from '../ProfilePicture';
 import { LoggedUser } from '../../lib/user';
 import { Button, ButtonSize } from '../buttons/Button';
+import { Image } from '../image/Image';
+import { fallbackImages } from '../../lib/config';
 
 interface NewCommentProps {
   user?: LoggedUser;
@@ -36,15 +42,18 @@ export function NewComment({
       )}
       onClick={onNewComment}
     >
-      {user && (
-        <ProfilePicture
-          user={user}
-          size={size}
-          className="mr-4"
-          nativeLazyLoading
+      {user ? (
+        <ProfilePicture user={user} size={size} nativeLazyLoading />
+      ) : (
+        <Image
+          src={fallbackImages.avatar}
+          alt="Placeholder image for anonymous user"
+          className={getProfilePictureClasses('large')}
         />
       )}
-      <span className="text-theme-label-tertiary">Share your thoughts</span>
+      <span className="ml-4 text-theme-label-tertiary">
+        Share your thoughts
+      </span>
       <Button
         buttonSize={buttonSize[size]}
         className="ml-auto btn-secondary"

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -37,7 +37,6 @@ export interface ParentComment {
 interface PostCommentsProps {
   post: Post;
   origin: Origin;
-  applyBottomMargin?: boolean;
   permissionNotificationCommentId?: string;
   modalParentSelector?: () => HTMLElement;
   onClick?: (parent: ParentComment) => unknown;
@@ -93,7 +92,6 @@ export function PostComments({
   onClickUpvote,
   modalParentSelector,
   permissionNotificationCommentId,
-  applyBottomMargin = true,
 }: PostCommentsProps): ReactElement {
   const { id } = post;
   const { user, showLogin, tokenRefreshed } = useContext(AuthContext);
@@ -156,13 +154,12 @@ export function PostComments({
   };
   return (
     <div className="flex flex-col">
-      {comments.postComments.edges.map((e, i) => (
+      {comments.postComments.edges.map((e) => (
         <MainComment
           post={post}
           origin={origin}
           commentHash={commentHash}
           commentRef={commentRef}
-          className={i === commentsCount - 1 && applyBottomMargin && 'mb-12'}
           comment={e.node}
           key={e.node.id}
           onComment={onCommentClick}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixed comment popup copy.
- Refactored the comment highlight based on Tomer's response: https://dailydotdev.slack.com/archives/C03QZBF46JC/p1673266631899009?thread_ts=1673175579.259209&cid=C03QZBF46JC

![image](https://user-images.githubusercontent.com/13744167/211323944-2db2398b-a635-43bc-a325-1559208b96a2.png)

![image](https://user-images.githubusercontent.com/13744167/211323620-1c7e3db1-27cf-42c1-bc2c-d8fa18c9d8e2.png)

![image](https://user-images.githubusercontent.com/13744167/211323778-0d5f1a41-ecf9-4746-a4b6-9f688bb6cca7.png)

Note: anonymous user placeholder is not yet available for the comment box

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
