### PR TITLE
fix: upvote icon color

### DIFF
--- a/packages/shared/src/components/notifications/utils.ts
+++ b/packages/shared/src/components/notifications/utils.ts
@@ -47,7 +47,7 @@ export const notificationDefaultTheme: Record<NotificationIcon, string> = {
   [NotificationIcon.DailyDev]: '',
   [NotificationIcon.CommunityPicks]: '',
   [NotificationIcon.Comment]: 'text-theme-color-blueCheese',
-  [NotificationIcon.Upvote]: 'text-theme-color-blueCheese',
+  [NotificationIcon.Upvote]: 'text-theme-color-avocado',
   [NotificationIcon.Bell]: '',
 };
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Change the upvote icon color to green

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-930 #done
