### PR TITLE
fix: color consistency on buttons

### DIFF
--- a/packages/extension/src/companion/CompanionContextMenu.tsx
+++ b/packages/extension/src/companion/CompanionContextMenu.tsx
@@ -12,6 +12,7 @@ import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNoti
 import BookmarkIcon from '@dailydotdev/shared/src/components/icons/Bookmark';
 import { OnShareOrBookmarkProps } from '@dailydotdev/shared/src/components/post/PostActions';
 import { feedback } from '@dailydotdev/shared/src/lib/constants';
+import classNames from 'classnames';
 import {
   PromptOptions,
   usePrompt,
@@ -90,7 +91,10 @@ export default function CompanionContextMenu({
         <Item onClick={onBookmark}>
           <BookmarkIcon
             size="medium"
-            className="mr-2"
+            className={classNames(
+              'mr-2',
+              postData?.bookmarked && 'text-theme-color-bun',
+            )}
             secondary={postData?.bookmarked}
           />
           {postData?.bookmarked ? 'Remove from' : 'Save to'} bookmarks

--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -207,7 +207,8 @@ export default function CompanionMenu({
       >
         <Button
           buttonSize="medium"
-          className="btn-tertiary"
+          className="btn-tertiary-blueCheese"
+          pressed={post?.commented}
           icon={<CommentIcon />}
           onClick={() => openNewComment('comment button')}
         />

--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -191,7 +191,13 @@ export default function PostOptionsMenu({
       action: onHidePost,
     },
     {
-      icon: <MenuIcon secondary={post?.bookmarked} Icon={BookmarkIcon} />,
+      icon: (
+        <MenuIcon
+          secondary={post?.bookmarked}
+          Icon={BookmarkIcon}
+          className={post?.bookmarked && 'text-theme-color-bun'}
+        />
+      ),
       text: `${post?.bookmarked ? 'Remove from' : 'Save to'} bookmarks`,
       action: onBookmark,
     },

--- a/packages/shared/src/components/PostOptionsReadingHistoryMenu.tsx
+++ b/packages/shared/src/components/PostOptionsReadingHistoryMenu.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useContext } from 'react';
+import classNames from 'classnames';
 import { Item } from '@dailydotdev/react-contexify';
 import dynamic from 'next/dynamic';
 import { QueryClient, QueryKey, useQueryClient } from 'react-query';
@@ -63,7 +64,14 @@ const getBookmarkIconAndMenuText = (bookmarked: boolean) => (
   <>
     <MenuIcon
       Icon={({ secondary, ...props }) => (
-        <BookmarkIcon secondary={bookmarked} {...props} />
+        <BookmarkIcon
+          secondary={bookmarked}
+          {...props}
+          className={classNames(
+            props.className,
+            bookmarked && 'text-theme-color-bun',
+          )}
+        />
       )}
     />
     {bookmarked ? 'Remove from bookmarks' : 'Save to bookmarks'}

--- a/packages/shared/src/components/ShareMobile.tsx
+++ b/packages/shared/src/components/ShareMobile.tsx
@@ -14,7 +14,7 @@ export function ShareMobile({ share, link }: Props): ReactElement {
   const [copying, copyLink] = useCopyPostLink(link);
 
   return (
-    <WidgetContainer className="flex laptop:hidden flex-col gap-2 items-start py-3 px-1">
+    <WidgetContainer className="flex laptop:hidden flex-col gap-2 items-start p-3">
       <Button
         buttonSize="small"
         onClick={() => copyLink()}
@@ -28,7 +28,7 @@ export function ShareMobile({ share, link }: Props): ReactElement {
         buttonSize="small"
         onClick={share}
         icon={<ShareIcon />}
-        className="btn-tertiary"
+        className="btn-tertiary-cabbage"
       >
         Share with your friends
       </Button>

--- a/packages/shared/src/components/ShareOptionsMenu.tsx
+++ b/packages/shared/src/components/ShareOptionsMenu.tsx
@@ -60,7 +60,13 @@ export default function ShareOptionsMenu({
       action: onShare,
     },
     {
-      icon: <MenuIcon secondary={post?.bookmarked} Icon={BookmarkIcon} />,
+      icon: (
+        <MenuIcon
+          secondary={post?.bookmarked}
+          Icon={BookmarkIcon}
+          className={post?.bookmarked && 'text-theme-color-bun'}
+        />
+      ),
       text: `${post?.bookmarked ? 'Remove from' : 'Save to'} bookmarks`,
       action: onBookmark,
     },

--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -94,11 +94,8 @@ export default function ActionButtons({
   const upvoteCommentProps: ButtonProps<'button'> = {
     readOnly: postEngagementNonClickable,
     buttonSize: 'small',
-    className: classNames(
-      'btn-tertiary-avocado',
-      !postEngagementNonClickable && 'w-[4.875rem]',
-    ),
   };
+  const buttonClass = !postEngagementNonClickable && 'w-[4.875rem]';
 
   const lastActionButton = LastActionButton({
     post,
@@ -132,6 +129,7 @@ export default function ActionButtons({
             pressed={post.upvoted}
             onClick={() => onUpvoteClick?.(post, !post.upvoted)}
             {...upvoteCommentProps}
+            className={classNames('btn-tertiary-avocado', buttonClass)}
           >
             {postEngagementNonClickable && !post.numUpvotes ? null : (
               <InteractionCounter
@@ -151,6 +149,7 @@ export default function ActionButtons({
             pressed={post.commented}
             onClick={() => onCommentClick?.(post)}
             {...upvoteCommentProps}
+            className={classNames('btn-tertiary-blueCheese', buttonClass)}
           >
             <InteractionCounter
               value={post.numComments > 0 && post.numComments}

--- a/packages/shared/src/components/comments/CommentActionButtons.tsx
+++ b/packages/shared/src/components/comments/CommentActionButtons.tsx
@@ -151,7 +151,7 @@ export default function CommentActionButtons({
           buttonSize="small"
           onClick={() => onComment(comment, parentId)}
           icon={<CommentIcon />}
-          className="mr-3 btn-tertiary-avocado"
+          className="mr-3 btn-tertiary-blueCheese"
         />
       </SimpleTooltip>
       <SimpleTooltip content="Share comment">

--- a/packages/shared/src/components/post/PostActions.tsx
+++ b/packages/shared/src/components/post/PostActions.tsx
@@ -95,7 +95,7 @@ export function PostActions({
         icon={<CommentIcon secondary={post.commented} />}
         aria-label="Comment"
         responsiveLabelClass={actionsClassName}
-        className="btn-tertiary-avocado"
+        className="btn-tertiary-blueCheese"
       >
         Comment
       </QuaternaryButton>

--- a/packages/shared/src/lib/boot.ts
+++ b/packages/shared/src/lib/boot.ts
@@ -28,6 +28,7 @@ export type PostBootData = Pick<
   | 'permalink'
   | 'author'
   | 'scout'
+  | 'commented'
 >;
 
 export enum BootApp {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Sifted through the code base for any implementations of comment/bookmark/share that are still using `avocado` for color and updated those.
- Updated some old implementations, such as the CompanionDiscussion area.

Guideline:
- Upvote - Avocado
- Comment - Blue cheese
- Bookmarks - Bun
- Share - Cabbage

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-934 #done
