### PR TITLE
feat: auto pick article on post card share new squad

### DIFF
--- a/packages/shared/src/components/ShareOptionsMenu.tsx
+++ b/packages/shared/src/components/ShareOptionsMenu.tsx
@@ -88,6 +88,7 @@ export default function ShareOptionsMenu({
         action: () =>
           openModal({
             type: LazyModal.NewSquad,
+            props: { post },
           }),
       });
     }

--- a/packages/shared/src/components/modals/NewSquadModal.tsx
+++ b/packages/shared/src/components/modals/NewSquadModal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { Modal } from './common/Modal';
 import { createSquad, Squad, SquadForm } from '../../graphql/squads';
 import { SquadSelectArticle } from '../squads/SelectArticle';
@@ -47,31 +47,25 @@ function NewSquadModal({
     onRequestClose,
   };
 
-  const modalSteps = useMemo(() => {
-    const steps: ModalStep[] = [
-      {
-        key: ModalState.Details,
-        title: (
-          <>
-            {onPreviousState && (
-              <Modal.Header.StepsButton onClick={onPreviousState} />
-            )}
-            <Modal.Header.Subtitle>{ModalState.Details}</Modal.Header.Subtitle>
-          </>
-        ),
-      },
-    ];
-
-    if (!post) steps.push({ key: ModalState.SelectArticle });
-
-    return steps.concat(
-      { key: ModalState.WriteComment },
-      {
-        key: ModalState.Ready,
-        title: <Modal.Header.Title>{ModalState.Ready}</Modal.Header.Title>,
-      },
-    );
-  }, [onPreviousState, post]);
+  const modalSteps: ModalStep[] = [
+    {
+      key: ModalState.Details,
+      title: (
+        <>
+          {onPreviousState && (
+            <Modal.Header.StepsButton onClick={onPreviousState} />
+          )}
+          <Modal.Header.Subtitle>{ModalState.Details}</Modal.Header.Subtitle>
+        </>
+      ),
+    },
+    !post ? { key: ModalState.SelectArticle } : undefined,
+    { key: ModalState.WriteComment },
+    {
+      key: ModalState.Ready,
+      title: <Modal.Header.Title>{ModalState.Ready}</Modal.Header.Title>,
+    },
+  ].filter((step) => step);
 
   const handleClose = async () => {
     if (activeView === ModalState.Ready) return onRequestClose();


### PR DESCRIPTION
## Changes

### Describe what this PR does
- auto pick an article when the share button on the post card is clicked then selected "Post to your Squad".

Note: In the preview below, I manually made the menu item available even when the user already has Squads.

https://user-images.githubusercontent.com/13744167/213085847-51570497-006b-460d-bf4d-a7b80f545fba.mov


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-922 #done
