### PR TITLE
feat: only show active squads

### DIFF
--- a/packages/shared/src/components/ShareOptionsMenu.tsx
+++ b/packages/shared/src/components/ShareOptionsMenu.tsx
@@ -99,23 +99,25 @@ export default function ShareOptionsMenu({
       });
     }
 
-    squads?.map((squad) =>
-      shareOptions.push({
-        icon: squad.image ? (
-          <SquadImage className="mr-2.5 w-5 h-5 text-2xl" {...squad} />
-        ) : (
-          <MenuIcon Icon={DefaultSquadIcon} />
-        ),
-        text: squad.name,
-        action: () =>
-          openModal({
-            type: LazyModal.PostToSquad,
-            props: {
-              squad,
-              post,
-            },
-          }),
-      }),
+    squads?.map(
+      (squad) =>
+        squad.active &&
+        shareOptions.push({
+          icon: squad.image ? (
+            <SquadImage className="mr-2.5 w-5 h-5 text-2xl" {...squad} />
+          ) : (
+            <MenuIcon Icon={DefaultSquadIcon} />
+          ),
+          text: squad.name,
+          action: () =>
+            openModal({
+              type: LazyModal.PostToSquad,
+              props: {
+                squad,
+                post,
+              },
+            }),
+        }),
     );
   }
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Only show active squads in the share context

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-940 #done
