### PR TITLE
fix: turn off restart tour

### DIFF
--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -108,12 +108,12 @@ export default function SquadHeaderMenu({
           </span>
         </Item>
       )}
-      <Item className="typo-callout">
-        <span className="flex items-center w-full typo-callout">
-          <TourIcon size="medium" secondary={false} className="mr-2" /> Learn
-          how Squads work
-        </span>
-      </Item>
+      {/* <Item className="typo-callout"> */}
+      {/*  <span className="flex items-center w-full typo-callout"> */}
+      {/*    <TourIcon size="medium" secondary={false} className="mr-2" /> Learn */}
+      {/*    how Squads work */}
+      {/*  </span> */}
+      {/* </Item> */}
       {isSquadOwner ? (
         <Item className="typo-callout" onClick={onDeleteSquad}>
           <span className="flex items-center w-full typo-callout">

--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -4,7 +4,7 @@ import { Item } from '@dailydotdev/react-contexify';
 import { useRouter } from 'next/router';
 import AuthContext from '../../contexts/AuthContext';
 import EditIcon from '../icons/Edit';
-import TourIcon from '../icons/Tour';
+// import TourIcon from '../icons/Tour';
 import ExitIcon from '../icons/Exit';
 import { PromptOptions, usePrompt } from '../../hooks/usePrompt';
 import {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Temporary remove restart tour 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-949 #done
