### PR TITLE
fix: missing referral token on locked squad for invitation link

### DIFF
--- a/packages/shared/src/components/modals/LockedSquadModal.tsx
+++ b/packages/shared/src/components/modals/LockedSquadModal.tsx
@@ -32,17 +32,17 @@ const options: PromptOptions = {
 };
 
 type LockedSquadModalProps = {
-  squad: Squad;
+  initialSqual: Squad;
 } & ModalProps;
 
 function LockedSquadModal({
-  squad: squadProp,
+  initialSqual,
   onRequestClose,
 }: LockedSquadModalProps): ReactElement {
   const { data: squad, isLoading } = useQuery(
-    [{ type: 'squad_locked', id: squadProp.id }],
+    [{ type: 'squad_locked', id: initialSqual.id }],
     ({ queryKey: [{ id }] }) => getSquad(id),
-    { initialData: squadProp },
+    { initialData: initialSqual },
   );
   const { showPrompt } = usePrompt();
   const token = squad?.currentMember?.referralToken ?? '';
@@ -58,8 +58,6 @@ function LockedSquadModal({
       onRequestClose(e);
     }
   };
-
-  if (isLoading && !squad) return <></>;
 
   return (
     <Modal
@@ -86,6 +84,7 @@ function LockedSquadModal({
         <h3 className="font-bold typo-title2">{squad.name}</h3>
         <h4 className="text-theme-label-tertiary">@{squad.handle}</h4>
         <TextField
+          aria-busy={isLoading}
           className={{ container: 'w-full mt-10' }}
           name="permalink"
           inputId="permalink"

--- a/packages/shared/src/components/modals/LockedSquadModal.tsx
+++ b/packages/shared/src/components/modals/LockedSquadModal.tsx
@@ -44,7 +44,7 @@ function LockedSquadModal({
     ({ queryKey: [{ squadId: id }] }) => getSquad(id),
   );
   const { showPrompt } = usePrompt();
-  const token = squad?.currentMember?.referralToken ?? '';
+  const token = squad?.currentMember.referralToken ?? '';
   const invitation = `${squad?.permalink}/${token}`;
   const [copying, copyLink] = useCopyLink(() => invitation);
   const onCopy = () => {

--- a/packages/shared/src/components/modals/LockedSquadModal.tsx
+++ b/packages/shared/src/components/modals/LockedSquadModal.tsx
@@ -7,7 +7,7 @@ import { TextField } from '../fields/TextField';
 import CopyIcon from '../icons/Copy';
 import Alert, { AlertType } from '../widgets/Alert';
 import LinkIcon from '../icons/Link';
-import { deleteSquad, getSquad } from '../../graphql/squads';
+import { deleteSquad, getSquad, Squad } from '../../graphql/squads';
 import { useCopyLink } from '../../hooks/useCopyLink';
 import { Image } from '../image/Image';
 import { cloudinary } from '../../lib/image';
@@ -32,19 +32,20 @@ const options: PromptOptions = {
 };
 
 type LockedSquadModalProps = {
-  squadId: string;
+  squad: Squad;
 } & ModalProps;
 
 function LockedSquadModal({
-  squadId,
+  squad: squadProp,
   onRequestClose,
 }: LockedSquadModalProps): ReactElement {
   const { data: squad, isLoading } = useQuery(
-    [{ type: 'squad_locked', squadId }],
-    ({ queryKey: [{ squadId: id }] }) => getSquad(id),
+    [{ type: 'squad_locked', id: squadProp.id }],
+    ({ queryKey: [{ id }] }) => getSquad(id),
+    { initialData: squadProp },
   );
   const { showPrompt } = usePrompt();
-  const token = squad?.currentMember.referralToken ?? '';
+  const token = squad?.currentMember?.referralToken ?? '';
   const invitation = `${squad?.permalink}/${token}`;
   const [copying, copyLink] = useCopyLink(() => invitation);
   const onCopy = () => {

--- a/packages/shared/src/components/modals/LockedSquadModal.tsx
+++ b/packages/shared/src/components/modals/LockedSquadModal.tsx
@@ -32,17 +32,17 @@ const options: PromptOptions = {
 };
 
 type LockedSquadModalProps = {
-  initialSqual: Squad;
+  initialSquad: Squad;
 } & ModalProps;
 
 function LockedSquadModal({
-  initialSqual,
+  initialSquad,
   onRequestClose,
 }: LockedSquadModalProps): ReactElement {
   const { data: squad, isLoading } = useQuery(
-    [{ type: 'squad_locked', id: initialSqual.id }],
+    [{ type: 'squad_locked', id: initialSquad.id }],
     ({ queryKey: [{ id }] }) => getSquad(id),
-    { initialData: initialSqual },
+    { initialData: initialSquad },
   );
   const { showPrompt } = usePrompt();
   const token = squad?.currentMember?.referralToken ?? '';

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -106,7 +106,7 @@ export default function Sidebar({
   const openLockedSquadModal = (squad: Squad) => {
     openModal({
       type: LazyModal.LockedSquad,
-      props: { initialSqual: squad },
+      props: { initialSquad: squad },
     });
   };
 

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -106,9 +106,7 @@ export default function Sidebar({
   const openLockedSquadModal = (squad: Squad) => {
     openModal({
       type: LazyModal.LockedSquad,
-      props: {
-        squad,
-      },
+      props: { squadId: squad.id },
     });
   };
 

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -106,7 +106,7 @@ export default function Sidebar({
   const openLockedSquadModal = (squad: Squad) => {
     openModal({
       type: LazyModal.LockedSquad,
-      props: { squadId: squad.id },
+      props: { squad },
     });
   };
 

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -106,7 +106,7 @@ export default function Sidebar({
   const openLockedSquadModal = (squad: Squad) => {
     openModal({
       type: LazyModal.LockedSquad,
-      props: { squad },
+      props: { initialSqual: squad },
     });
   };
 

--- a/packages/shared/src/components/squads/Ready.tsx
+++ b/packages/shared/src/components/squads/Ready.tsx
@@ -63,7 +63,7 @@ export function SquadReady({
               data-testid="textfield-action-icon"
             />
           }
-          value={permalink}
+          value={invitation}
           readOnly
         />
         <Alert

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -136,6 +136,7 @@ const SOURCE_BASE_FRAGMENT = gql`
     membersCount
     currentMember {
       role
+      referralToken
     }
   }
 `;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The referral token was missing on the copy field for invitation link.
- We instead fetch the Squad data on LockedModal open.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-958 #done
