### PR TITLE
fix: hidden options button when moderator

### DIFF
--- a/packages/shared/src/components/comments/CommentActionButtons.spec.tsx
+++ b/packages/shared/src/components/comments/CommentActionButtons.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, RenderResult, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import AuthContext from '../../contexts/AuthContext';
-import { LoggedUser } from '../../lib/user';
+import { LoggedUser, Roles } from '../../lib/user';
 import CommentActionButtons, { Props } from './CommentActionButtons';
 import {
   CANCEL_COMMENT_UPVOTE_MUTATION,
@@ -140,6 +140,20 @@ it('should call onComment callback', async () => {
 
 it('should call onDelete callback', async () => {
   renderComponent({}, loggedUser);
+  const el = await screen.findByLabelText('Options');
+  el.click();
+  const [, remove] = await screen.findAllByRole('menuitem');
+  remove.click();
+  expect(onDelete).toBeCalledWith(comment, 'c1');
+});
+
+it('should allow delete for moderators', async () => {
+  const user: LoggedUser = {
+    ...loggedUser,
+    id: 'other user',
+    roles: [Roles.Moderator],
+  };
+  renderComponent({}, user);
   const el = await screen.findByLabelText('Options');
   el.click();
   const [, remove] = await screen.findAllByRole('menuitem');

--- a/packages/shared/src/components/comments/CommentActionButtons.tsx
+++ b/packages/shared/src/components/comments/CommentActionButtons.tsx
@@ -134,6 +134,8 @@ export default function CommentActionButtons({
     return undefined;
   };
 
+  const isModerator = user?.roles?.includes(Roles.Moderator);
+
   return (
     <div className={classNames('flex flex-row items-center', className)}>
       <SimpleTooltip content="Upvote">
@@ -162,7 +164,7 @@ export default function CommentActionButtons({
           className="mr-3 btn-tertiary-cabbage"
         />
       </SimpleTooltip>
-      {user?.id === comment.author.id && (
+      {(user?.id === comment.author.id || isModerator) && (
         <OptionsButton
           tooltipPlacement="top"
           onClick={(e) => show(e, { position: getContextBottomPosition(e) })}
@@ -189,8 +191,7 @@ export default function CommentActionButtons({
             <EditIcon size="small" /> Edit
           </ContextItem>
         </Item>
-        {(user?.id === comment.author.id ||
-          user?.roles?.includes(Roles.Moderator)) && (
+        {(user?.id === comment.author.id || isModerator) && (
           <Item onClick={() => onDelete(comment, parentId)}>
             <ContextItem className="flex items-center w-full">
               <TrashIcon size="small" /> Delete


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We made the delete option inside a context menu which should also be shown when the user is a moderator.
- Also added a test case for it.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
