### PR TITLE
fix: introduced a combined click handler

### DIFF
--- a/packages/shared/src/components/buttons/Button.tsx
+++ b/packages/shared/src/components/buttons/Button.tsx
@@ -89,13 +89,13 @@ function ButtonComponent<TagName extends AllowedTags>(
   ref?: Ref<ButtonElementType<TagName>>,
 ): ReactElement {
   const iconOnly = (icon && !children && !rightIcon) || showIconOnly;
-
   const getIconWithSize = useGetIconWithSize(buttonSize, iconOnly);
+  const isAnchor = Tag === 'a';
 
   return (
     <Tag
       {...(props as StyledButtonProps)}
-      {...combinedClicks(onClick)}
+      {...(isAnchor ? combinedClicks(onClick) : { onClick })}
       aria-busy={loading}
       aria-pressed={pressed}
       ref={ref}

--- a/packages/shared/src/components/buttons/Button.tsx
+++ b/packages/shared/src/components/buttons/Button.tsx
@@ -8,6 +8,7 @@ import React, {
 import classNames from 'classnames';
 import { Size, IconProps } from '../Icon';
 import { Loader } from '../Loader';
+import { combinedClicks } from '../../lib/click';
 
 export type ButtonSize =
   | 'xxsmall'
@@ -82,6 +83,7 @@ function ButtonComponent<TagName extends AllowedTags>(
     textPosition = 'justify-center',
     readOnly,
     iconOnly: showIconOnly,
+    onClick,
     ...props
   }: StyledButtonProps & ButtonProps<TagName>,
   ref?: Ref<ButtonElementType<TagName>>,
@@ -93,6 +95,7 @@ function ButtonComponent<TagName extends AllowedTags>(
   return (
     <Tag
       {...(props as StyledButtonProps)}
+      {...combinedClicks(onClick)}
       aria-busy={loading}
       aria-pressed={pressed}
       ref={ref}

--- a/packages/shared/src/lib/click.ts
+++ b/packages/shared/src/lib/click.ts
@@ -1,6 +1,6 @@
 export const combinedClicks = (func) => {
   return {
-    onMouseUp: (event) => event.button === 1 && func,
+    onMouseUp: (event) => event.button === 1 && func(event),
     onClick: func,
   };
 };

--- a/packages/shared/src/lib/click.ts
+++ b/packages/shared/src/lib/click.ts
@@ -1,0 +1,6 @@
+export const combinedClicks = (func) => {
+  return {
+    onMouseUp: (event) => event.button === 1 && func,
+    onClick: func,
+  };
+};

--- a/packages/shared/src/lib/click.ts
+++ b/packages/shared/src/lib/click.ts
@@ -1,4 +1,12 @@
-export const combinedClicks = (func) => {
+import React from 'react';
+
+type CombinedClicks = {
+  onMouseUp: React.MouseEventHandler<HTMLAnchorElement>;
+  onClick: React.MouseEventHandler<HTMLAnchorElement>;
+};
+export const combinedClicks = (
+  func: React.MouseEventHandler,
+): CombinedClicks => {
   return {
     onMouseUp: (event) => event.button === 1 && func(event),
     onClick: func,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Introducing a generic onClick handler that applies onClick + onMouseUp (for auxiliary input)
## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-961 #done
