### PR TITLE
fix: quit squad modal

### DIFF
--- a/packages/shared/src/components/squads/utils.tsx
+++ b/packages/shared/src/components/squads/utils.tsx
@@ -30,22 +30,22 @@ export type SquadStateProps = {
 };
 
 export const quitSquadModal: PromptOptions = {
-  title: 'Quit the process?',
+  title: 'Are you sure?',
   description: (
     <>
-      <p>
-        Learning is more powerful together. Are you sure you want to quit the
-        process?
-      </p>
-      <p>p.s you can create a new Squad from the left sidebar</p>
+      <p>You can always create a new Squad from the left sidebar</p>
     </>
   ),
+  className: {
+    buttons: 'flex-row-reverse',
+  },
   cancelButton: {
-    title: 'Cancel',
+    title: 'Stay',
+    className: 'btn-primary-cabbage',
   },
   okButton: {
-    title: 'Continue',
-    className: 'text-white btn-primary-ketchup',
+    title: 'Close',
+    className: 'btn-secondary',
   },
 };
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Update modal to latest sketch file.

<img width="446" alt="Screenshot 2023-01-25 at 11 10 36" src="https://user-images.githubusercontent.com/554874/214536366-4b531c0b-92fe-4d2d-8b4c-414dd878dc87.png">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-965 #done
