### PR TITLE
fix: do not display when the notification request again when dismissed

### DIFF
--- a/packages/shared/src/components/modals/PushNotificationModal.tsx
+++ b/packages/shared/src/components/modals/PushNotificationModal.tsx
@@ -48,9 +48,9 @@ function PushNotificationModal(modalProps: ModalProps): ReactElement {
     >
       <Modal.Header />
       <Modal.Body>
-        <Modal.Title>Push notifications</Modal.Title>
+        <Modal.Title>Enable Push Notifications</Modal.Title>
         <Modal.Text className="text-center">
-          Get notified on the status of your source submissions in real time
+          Get notified of the status of your source submissions
         </Modal.Text>
         <img
           className="my-14 mx-auto"

--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -14,7 +14,7 @@ import {
   useEnableNotification,
 } from '../../hooks/useEnableNotification';
 
-const DISMISS_PERMISSION_BANNER = 'DISMISS_PERMISSION_BANNER';
+export const DISMISS_PERMISSION_BANNER = 'DISMISS_PERMISSION_BANNER';
 
 type EnableNotificationProps = {
   source?: NotificationPromptSource;

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -17,7 +17,7 @@ export const cloudinary = {
       'https://daily-now-res.cloudinary.com/image/upload/v1671199935/public/scroll_feed_filters.svg',
   },
   notifications: {
-    big: 'https://daily-now-res.cloudinary.com/image/upload/v1671199897/public/notification_big.svg',
+    big: 'https://daily-now-res.cloudinary.com/image/upload/public/notification_big.svg',
     browser:
       'https://daily-now-res.cloudinary.com/image/upload/v1670512489/public/notification_animated.gif',
     browser_enabled:


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Note: when you dismiss the enable permission widget on comments (and other places), you won't see this too. Goes the same when you dismissed this popup.
- Updated the copy based on the discussion in Slack: https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1674036243515409?thread_ts=1673854401.136469&cid=C01L0QXQJNB

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-960 #done
