### PR TITLE
fix: squad link when coming from notification avatar

### DIFF
--- a/packages/shared/src/components/cards/SourceButton.tsx
+++ b/packages/shared/src/components/cards/SourceButton.tsx
@@ -7,6 +7,7 @@ import { ProfileImageSize } from '../ProfilePicture';
 
 interface SourceButtonProps {
   source: Source;
+  link?: string;
   className?: string;
   style?: CSSProperties;
   size?: ProfileImageSize;
@@ -15,13 +16,14 @@ interface SourceButtonProps {
 
 export default function SourceButton({
   source,
+  link,
   tooltipPosition = 'bottom',
   size = 'medium',
   ...props
 }: SourceButtonProps): ReactElement {
   return source ? (
     <LinkWithTooltip
-      href={getSourcePermalink(source.id)}
+      href={link || getSourcePermalink(source.id)}
       prefetch={false}
       tooltip={{ content: source.name, placement: tooltipPosition }}
     >
@@ -32,7 +34,7 @@ export default function SourceButton({
           id: source.id,
           name: source.name,
           image: source.image,
-          permalink: getSourcePermalink(source.id),
+          permalink: link || getSourcePermalink(source.id),
           username: source.handle,
         }}
       />

--- a/packages/shared/src/components/notifications/NotificationItemAvatar.tsx
+++ b/packages/shared/src/components/notifications/NotificationItemAvatar.tsx
@@ -17,6 +17,7 @@ function NotificationItemAvatar({
   if (type === NotificationAvatarType.Source) {
     return (
       <SourceButton
+        link={targetUrl}
         source={{ id: referenceId, handle: referenceId, name, image }}
       />
     );


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fix source targetURL when coming from notification avatar

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-968 #done
