### PR TITLE
fix: auto prompt to beta members only

### DIFF
--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -58,7 +58,6 @@ export default function Sidebar({
     loadedSettings,
     optOutWeeklyGoal,
   } = useContext(SettingsContext);
-  const { openSquadBetaModal } = useCreateSquadModal();
   const { openModal } = useLazyModal();
   const [showSettings, setShowSettings] = useState(false);
   const {
@@ -68,6 +67,10 @@ export default function Sidebar({
     submitArticleModalButton,
     popularFeedCopy,
   } = useContext(FeaturesContext);
+  const { openSquadBetaModal } = useCreateSquadModal({
+    hasSquads: !!squads?.length,
+    hasAccess: hasSquadAccess,
+  });
   const newSquadButtonVisible =
     sidebarRendered && hasSquadAccess && !squads?.length;
   const feedName = getFeedName(activePageProp, {

--- a/packages/shared/src/hooks/useCreateSquadModal.ts
+++ b/packages/shared/src/hooks/useCreateSquadModal.ts
@@ -11,12 +11,19 @@ interface UseCreateSquadModal {
 
 const SQUAD_ONBOARDING = 'hasTriedSquadOnboarding';
 
-export const useCreateSquadModal = (): UseCreateSquadModal => {
+type UseCreateSquadModalProps = {
+  hasSquads: boolean;
+  hasAccess: boolean;
+};
+export const useCreateSquadModal = ({
+  hasSquads = false,
+  hasAccess = false,
+}: UseCreateSquadModalProps): UseCreateSquadModal => {
   const router = useRouter();
   const { openModal } = useLazyModal();
   const previousRef = useRef(null);
   const [hasTriedOnboarding, setHasTriedOnboarding, isLoaded] =
-    usePersistentContext<boolean>(SQUAD_ONBOARDING, false);
+    usePersistentContext<boolean>(SQUAD_ONBOARDING, hasSquads);
 
   const openNewSquadModal = () =>
     openModal({
@@ -47,13 +54,13 @@ export const useCreateSquadModal = (): UseCreateSquadModal => {
   }, [router.pathname]);
 
   useEffect(() => {
-    if (!isLoaded || hasTriedOnboarding) {
+    if (!isLoaded || hasTriedOnboarding || hasSquads || !hasAccess) {
       return;
     }
 
     openSquadBetaModal();
     setHasTriedOnboarding(true);
-  }, [hasTriedOnboarding, isLoaded]);
+  }, [hasTriedOnboarding, isLoaded, hasSquads, hasAccess]);
 
   return useMemo(
     () => ({ openNewSquadModal, openSquadBetaModal }),


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Introduced both the fact that users can have squads or have access to the feature to the auto show modal.
- Users who get access to the feature and **don't** have a squad yet get to see it
- Users who gain access but **are** part of a squad don`t get to see it.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-976 #done
