### PR TITLE
fix: share post loading

### DIFF
--- a/packages/shared/src/hooks/usePostById.ts
+++ b/packages/shared/src/hooks/usePostById.ts
@@ -32,9 +32,11 @@ const usePostById = ({
     { ...options, enabled: !!id && tokenRefreshed },
   );
 
+  const post = postById || (options?.initialData as PostData);
+
   return useMemo(
     () => ({
-      post: postById?.post,
+      post: post?.post,
       isLoading: isLoading || !isFetched || isFetchingNextPage,
     }),
     [postById, isLoading],

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -68,14 +68,18 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
   } = useQuery<PostData>(
     ['post', id],
     () => request(`${apiUrl}/graphql`, POST_BY_ID_QUERY, { id }),
-    { initialData, enabled: !!id && tokenRefreshed },
+    { initialData, enabled: !!id && tokenRefreshed, retry: false },
   );
 
   // Need this as sometimes client side might still be loading, but we already have initial data.
   const post = fetchedPost ?? initialData;
 
-  if ((!isFallback && !id) || (isFetched && !post.post.id)) {
+  if ((!isFallback && !id) || (isFetched && !post?.post.title)) {
     return <Custom404 />;
+  }
+
+  if (isFallback && !initialData) {
+    return <></>;
   }
 
   const seo: NextSeoProps = {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Changed loading state for posts.
- If Server side succeeds (normal posts) we simply show that as initialData
- If Server side fails (auth posts, squads) we fallback to client side rendering
- Modified how we show the data merge

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-979 #done
