### PR TITLE
fix: display the image in squad edit

### DIFF
--- a/packages/shared/src/components/squads/Details.tsx
+++ b/packages/shared/src/components/squads/Details.tsx
@@ -67,7 +67,7 @@ export function SquadDetails({
             </SquadTitle>
           )}
           <ImageInput
-            initialValue={form.file}
+            initialValue={form.image ?? form.file}
             id={squadImageId}
             fallbackImage={cloudinary.squads.imageFallback}
             className={{

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -22,7 +22,10 @@ export type Squads = {
   squads: Squad[];
 };
 
-export type SquadForm = Pick<Squad, 'name' | 'handle' | 'description'> & {
+export type SquadForm = Pick<
+  Squad,
+  'name' | 'handle' | 'description' | 'image'
+> & {
   file?: string;
   commentary: string;
   post: PostItem;
@@ -111,6 +114,7 @@ export const CREATE_SQUAD_MUTATION = gql`
       public
       type
       description
+      image
       members {
         edges {
           node {
@@ -163,6 +167,7 @@ export const EDIT_SQUAD_MUTATION = gql`
       public
       type
       description
+      image
     }
   }
 `;


### PR DESCRIPTION
## Changes

I was not able to test this locally, but hopefully it should be ok :)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
