### PR TITLE
fix: locked squad access

### DIFF
--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -40,6 +40,11 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
       enabled: !!handle,
     },
   );
+
+  if (!squad && isLoading) return <SquadLoading />;
+
+  if (isFallback || !squad.active) return <Unauthorized />;
+
   const squadId = squad?.id;
 
   const { data: squadMembers } = useQuery<SquadMember[]>(
@@ -57,10 +62,6 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
     }),
     [squadId],
   );
-
-  if (!squad && isLoading) return <SquadLoading />;
-
-  if (isFallback) return <Unauthorized />;
 
   const onNewSquadPost = () =>
     openModal({


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Show 404 if squad is still locked
- Also decided to pre show it so we don't waste other queries

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-993 #done
