### PR TITLE
fix: refresh feed

### DIFF
--- a/packages/shared/src/components/modals/PostToSquadModal.tsx
+++ b/packages/shared/src/components/modals/PostToSquadModal.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useContext, useState } from 'react';
+import { useQueryClient } from 'react-query';
 import { LazyModalCommonProps, Modal } from './common/Modal';
 import { addPostToSquad, Squad, SquadForm } from '../../graphql/squads';
 import { SquadComment } from '../squads/Comment';
@@ -8,6 +9,7 @@ import { useToastNotification } from '../../hooks/useToastNotification';
 import { SquadSelectArticle } from '../squads/SelectArticle';
 import { SteppedSquadComment } from '../squads/SteppedComment';
 import { ModalState, SquadStateProps } from '../squads/utils';
+import AuthContext from '../../contexts/AuthContext';
 
 export type PostToSquadModalProps = {
   squad: Squad;
@@ -28,6 +30,8 @@ function PostToSquadModal({
   post,
   squad,
 }: PostToSquadModalProps): ReactElement {
+  const client = useQueryClient();
+  const { user } = useContext(AuthContext);
   const { displayToast } = useToastNotification();
   const [form, setForm] = useState<Partial<SquadForm>>({
     post: { post },
@@ -49,6 +53,7 @@ function PostToSquadModal({
     });
     if (squadPost) {
       displayToast('This post has been shared to your squad');
+      await client.invalidateQueries(['sourceFeed', user.id]);
       onRequestClose(e);
     }
   };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Invalidate squad feeds on posting new article
- Decided to invalidate because other content might have been added as well.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-969 #done
