### PR TITLE
fix: share modal content

### DIFF
--- a/packages/shared/src/components/modals/ShareModal.tsx
+++ b/packages/shared/src/components/modals/ShareModal.tsx
@@ -31,9 +31,12 @@ export default function ShareModal({
   ...props
 }: ShareModalProps): ReactElement {
   const isComment = !!comment;
+  const permalink = isComment
+    ? post?.commentsPermalink
+    : post?.sharedPost?.commentsPermalink ?? post?.commentsPermalink;
   const link = isComment
-    ? `${post?.commentsPermalink}${getCommentHash(comment.id)}`
-    : post?.commentsPermalink;
+    ? `${permalink}${getCommentHash(comment.id)}`
+    : permalink;
   const { trackEvent } = useContext(AnalyticsContext);
   const [, copyUrl] = useCopyLink(() => link);
 
@@ -63,13 +66,15 @@ export default function ShareModal({
     return () => baseTrackingEvent('close share');
   }, []);
 
+  const article = post?.sharedPost ?? post;
+
   return (
     <Modal size={Modal.Size.Small} kind={Modal.Kind.FlexibleCenter} {...props}>
       <Modal.Header title={isComment ? 'Share comment' : 'Share article'} />
       {!isComment && (
         <PostItemCard
           className="mt-2"
-          postItem={{ post }}
+          postItem={{ post: article }}
           showButtons={false}
           clickable={false}
         />
@@ -96,7 +101,7 @@ export default function ShareModal({
         />
         <p className="py-2.5 font-bold typo-callout">Share via</p>
         <SocialShare
-          post={post}
+          post={article}
           comment={comment}
           origin={origin}
           columns={columns}

--- a/packages/shared/src/components/modals/ShareModal.tsx
+++ b/packages/shared/src/components/modals/ShareModal.tsx
@@ -74,7 +74,7 @@ export default function ShareModal({
       {!isComment && (
         <PostItemCard
           className="mt-2"
-          postItem={{ post: article }}
+          postItem={{ post }}
           showButtons={false}
           clickable={false}
         />

--- a/packages/shared/src/components/post/PostItemCard.tsx
+++ b/packages/shared/src/components/post/PostItemCard.tsx
@@ -40,6 +40,7 @@ export default function PostItemCard({
     e.stopPropagation();
     onHide({ postId: post.id, timestamp: timestampDb });
   };
+  const article = post?.sharedPost ?? post;
 
   return (
     <ConditionalWrapper
@@ -56,7 +57,7 @@ export default function PostItemCard({
         )}
       >
         <Image
-          src={post.image}
+          src={article.image}
           alt={post.title}
           className="object-cover w-16 laptop:w-24 h-16 rounded-16"
           loading="lazy"
@@ -68,7 +69,7 @@ export default function PostItemCard({
           rounded="full"
           className="absolute left-6"
           user={{
-            image: post.source?.image,
+            image: post.source.image,
             username: `source of ${post.title}`,
           }}
           nativeLazyLoading

--- a/packages/shared/src/graphql/comments.ts
+++ b/packages/shared/src/graphql/comments.ts
@@ -1,6 +1,6 @@
 import request, { gql } from 'graphql-request';
 import { Connection, Upvote } from './common';
-import { UPVOTER_FRAGMENT } from './users';
+import { USER_SHORT_INFO_FRAGMENT } from './fragments';
 import { EmptyResponse } from './emptyResponse';
 import { UserShortProfile } from '../lib/user';
 import { apiUrl } from '../lib/config';
@@ -144,7 +144,7 @@ export const USER_COMMENTS_QUERY = gql`
 `;
 
 export const COMMENT_UPVOTES_BY_ID_QUERY = gql`
-  ${UPVOTER_FRAGMENT}
+  ${USER_SHORT_INFO_FRAGMENT}
   query CommentUpvotes($id: String!, $after: String, $first: Int) {
     upvotes: commentUpvotes(id: $id, after: $after, first: $first) {
       pageInfo {

--- a/packages/shared/src/graphql/feed.ts
+++ b/packages/shared/src/graphql/feed.ts
@@ -1,6 +1,8 @@
 import { gql } from 'graphql-request';
-import { SHARED_POST_INFO_FRAGMENT } from './posts';
-import { USER_SHORT_INFO_FRAGMENT } from './users';
+import {
+  SHARED_POST_INFO_FRAGMENT,
+  USER_SHORT_INFO_FRAGMENT,
+} from './fragments';
 
 export enum RankingAlgorithm {
   Popularity = 'POPULARITY',

--- a/packages/shared/src/graphql/feed.ts
+++ b/packages/shared/src/graphql/feed.ts
@@ -1,5 +1,6 @@
 import { gql } from 'graphql-request';
-import { SOURCE_SHORT_INFO_FRAGMENT } from './sources';
+import { SHARED_POST_INFO_FRAGMENT } from './posts';
+import { USER_SHORT_INFO_FRAGMENT } from './users';
 
 export enum RankingAlgorithm {
   Popularity = 'POPULARITY',
@@ -19,41 +20,27 @@ export const FEED_POST_FRAGMENT = gql`
     image
     readTime
     source {
-      ...SourceShortInfoFragment
+      ...SourceShortInfo
     }
     sharedPost {
-      id
-      title
-      image
-      readTime
-      summary
-      permalink
-      source {
-        ...SourceShortInfoFragment
-      }
+      ...SharedPostInfo
     }
     permalink
     numComments
     numUpvotes
     commentsPermalink
     scout {
-      id
-      name
-      image
-      username
+      ...UserShortInfo
     }
     author {
-      id
-      name
-      image
-      username
-      permalink
+      ...UserShortInfo
     }
     trending
     tags
     type
   }
-  ${SOURCE_SHORT_INFO_FRAGMENT}
+  ${SHARED_POST_INFO_FRAGMENT}
+  ${USER_SHORT_INFO_FRAGMENT}
 `;
 
 export const USER_POST_FRAGMENT = gql`

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -1,0 +1,59 @@
+import { gql } from 'graphql-request';
+
+export const USER_SHORT_INFO_FRAGMENT = gql`
+  fragment UserShortInfo on User {
+    id
+    name
+    image
+    permalink
+    username
+    bio
+  }
+`;
+
+export const SOURCE_SHORT_INFO_FRAGMENT = gql`
+  fragment SourceShortInfo on Source {
+    id
+    handle
+    name
+    permalink
+    description
+    image
+    type
+  }
+`;
+
+export const SHARED_POST_INFO_FRAGMENT = gql`
+  fragment SharedPostInfo on Post {
+    id
+    title
+    image
+    readTime
+    permalink
+    commentsPermalink
+    summary
+    source {
+      ...SourceShortInfo
+    }
+  }
+  ${SOURCE_SHORT_INFO_FRAGMENT}
+`;
+
+export const SOURCE_BASE_FRAGMENT = gql`
+  fragment SourceBaseInfo on Source {
+    id
+    active
+    handle
+    name
+    permalink
+    public
+    type
+    description
+    image
+    membersCount
+    currentMember {
+      role
+      referralToken
+    }
+  }
+`;

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -1,10 +1,14 @@
 import request, { gql } from 'graphql-request';
 import { Author, Comment, Scout } from './comments';
 import { Connection, Upvote } from './common';
-import { UPVOTER_FRAGMENT, USER_SHORT_INFO_FRAGMENT } from './users';
-import { Source, SOURCE_SHORT_INFO_FRAGMENT } from './sources';
+import { Source } from './sources';
 import { EmptyResponse } from './emptyResponse';
 import { apiUrl } from '../lib/config';
+import {
+  SHARED_POST_INFO_FRAGMENT,
+  SOURCE_SHORT_INFO_FRAGMENT,
+  USER_SHORT_INFO_FRAGMENT,
+} from './fragments';
 
 export type ReportReason = 'BROKEN' | 'NSFW' | 'CLICKBAIT' | 'LOW';
 
@@ -22,22 +26,6 @@ export enum PostType {
   Article = 'article',
   Share = 'share',
 }
-
-export const SHARED_POST_INFO_FRAGMENT = gql`
-  fragment SharedPostInfo on Post {
-    id
-    title
-    image
-    readTime
-    permalink
-    commentsPermalink
-    summary
-    source {
-      ...SourceShortInfo
-    }
-  }
-  ${SOURCE_SHORT_INFO_FRAGMENT}
-`;
 
 export interface Post {
   __typename?: string;
@@ -111,6 +99,7 @@ export type ReadHistoryPost = Pick<
   | 'numComments'
   | 'trending'
   | 'tags'
+  | 'sharedPost'
 > & { source?: Pick<Source, 'image' | 'id'> } & {
   author?: Pick<Author, 'id'>;
 } & {
@@ -180,7 +169,7 @@ export const POST_BY_ID_QUERY = gql`
 `;
 
 export const POST_UPVOTES_BY_ID_QUERY = gql`
-  ${UPVOTER_FRAGMENT}
+  ${USER_SHORT_INFO_FRAGMENT}
   query PostUpvotes($id: String!, $after: String, $first: Int) {
     upvotes: postUpvotes(id: $id, after: $after, first: $first) {
       pageInfo {

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -1,7 +1,7 @@
 import request, { gql } from 'graphql-request';
 import { Author, Comment, Scout } from './comments';
 import { Connection, Upvote } from './common';
-import { UPVOTER_FRAGMENT } from './users';
+import { UPVOTER_FRAGMENT, USER_SHORT_INFO_FRAGMENT } from './users';
 import { Source, SOURCE_SHORT_INFO_FRAGMENT } from './sources';
 import { EmptyResponse } from './emptyResponse';
 import { apiUrl } from '../lib/config';
@@ -22,6 +22,22 @@ export enum PostType {
   Article = 'article',
   Share = 'share',
 }
+
+export const SHARED_POST_INFO_FRAGMENT = gql`
+  fragment SharedPostInfo on Post {
+    id
+    title
+    image
+    readTime
+    permalink
+    commentsPermalink
+    summary
+    source {
+      ...SourceShortInfo
+    }
+  }
+  ${SOURCE_SHORT_INFO_FRAGMENT}
+`;
 
 export interface Post {
   __typename?: string;
@@ -139,32 +155,16 @@ export const POST_BY_ID_QUERY = gql`
       numComments
       views
       sharedPost {
-        id
-        title
-        image
-        readTime
-        permalink
-        summary
-        source {
-          ...SourceShortInfoFragment
-        }
+        ...SharedPostInfo
       }
       source {
-        ...SourceShortInfoFragment
+        ...SourceShortInfo
       }
       scout {
-        id
-        image
-        name
-        permalink
-        username
+        ...UserShortInfo
       }
       author {
-        id
-        image
-        name
-        permalink
-        username
+        ...UserShortInfo
       }
       description
       summary
@@ -175,7 +175,8 @@ export const POST_BY_ID_QUERY = gql`
       type
     }
   }
-  ${SOURCE_SHORT_INFO_FRAGMENT}
+  ${SHARED_POST_INFO_FRAGMENT}
+  ${USER_SHORT_INFO_FRAGMENT}
 `;
 
 export const POST_UPVOTES_BY_ID_QUERY = gql`
@@ -212,7 +213,7 @@ export const POST_BY_ID_STATIC_FIELDS_QUERY = gql`
       numUpvotes
       numComments
       source {
-        ...SourceShortInfoFragment
+        ...SourceShortInfo
       }
       description
       summary
@@ -305,7 +306,7 @@ export const AUTHOR_FEED_QUERY = gql`
           commentsPermalink
           image
           source {
-            ...SourceShortInfoFragment
+            ...SourceShortInfo
           }
           numUpvotes
           numComments

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -17,37 +17,6 @@ export interface Source {
 
 export type SourceData = { source: Source };
 
-export const SOURCE_BASE_FRAGMENT = gql`
-  fragment SourceBaseInfo on Source {
-    id
-    active
-    handle
-    name
-    permalink
-    public
-    type
-    description
-    image
-    membersCount
-    currentMember {
-      role
-      referralToken
-    }
-  }
-`;
-
-export const SOURCE_SHORT_INFO_FRAGMENT = gql`
-  fragment SourceShortInfo on Source {
-    id
-    handle
-    name
-    permalink
-    description
-    image
-    type
-  }
-`;
-
 export const SOURCE_QUERY = gql`
   query Source($id: ID!) {
     source(id: $id) {

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -18,7 +18,7 @@ export interface Source {
 export type SourceData = { source: Source };
 
 export const SOURCE_BASE_FRAGMENT = gql`
-  fragment SourceBaseFragment on Source {
+  fragment SourceBaseInfo on Source {
     id
     active
     handle
@@ -37,7 +37,7 @@ export const SOURCE_BASE_FRAGMENT = gql`
 `;
 
 export const SOURCE_SHORT_INFO_FRAGMENT = gql`
-  fragment SourceShortInfoFragment on Source {
+  fragment SourceShortInfo on Source {
     id
     handle
     name

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -1,15 +1,9 @@
 import request, { gql } from 'graphql-request';
-import { USER_SHORT_INFO_FRAGMENT } from './users';
+import { SOURCE_BASE_FRAGMENT, USER_SHORT_INFO_FRAGMENT } from './fragments';
 import { apiUrl } from '../lib/config';
 import { UserShortProfile } from '../lib/user';
 import { Connection } from './common';
-import {
-  Source,
-  SourceType,
-  SourceData,
-  SOURCE_BASE_FRAGMENT,
-  SOURCE_QUERY,
-} from './sources';
+import { Source, SourceType, SourceData, SOURCE_QUERY } from './sources';
 import { Post, PostItem } from './posts';
 import { base64ToFile } from '../lib/base64';
 

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -113,7 +113,7 @@ export const CREATE_SQUAD_MUTATION = gql`
       commentary: $commentary
       image: $image
     ) {
-      ...SourceBaseFragment
+      ...SourceBaseInfo
       members {
         edges {
           node {
@@ -141,7 +141,7 @@ export const EDIT_SQUAD_MUTATION = gql`
       description: $description
       image: $image
     ) {
-      ...SourceBaseFragment
+      ...SourceBaseInfo
     }
   }
   ${SOURCE_BASE_FRAGMENT}
@@ -158,7 +158,7 @@ export const ADD_POST_TO_SQUAD_MUTATION = gql`
 export const SQUAD_QUERY = gql`
   query Source($handle: ID!) {
     source(id: $handle) {
-      ...SourceBaseFragment
+      ...SourceBaseInfo
     }
   }
   ${SOURCE_BASE_FRAGMENT}
@@ -181,7 +181,7 @@ export const SQUAD_MEMBERS_QUERY = gql`
         node {
           role
           user {
-            ...UserShortInfoFragment
+            ...UserShortInfo
           }
         }
       }
@@ -194,15 +194,15 @@ export const SQUAD_INVITATION_QUERY = gql`
   query SourceInvitationQuery($token: String!) {
     member: sourceMemberByToken(token: $token) {
       user {
-        ...UserShortInfoFragment
+        ...UserShortInfo
       }
       source {
-        ...SourceBaseFragment
+        ...SourceBaseInfo
         members {
           edges {
             node {
               user {
-                ...UserShortInfoFragment
+                ...UserShortInfo
               }
             }
           }
@@ -217,7 +217,7 @@ export const SQUAD_INVITATION_QUERY = gql`
 export const SQUAD_JOIN_MUTATION = gql`
   mutation JoinSquad($sourceId: ID!, $token: String!) {
     joinSource(sourceId: $sourceId, token: $token) {
-      ...SourceBaseFragment
+      ...SourceBaseInfo
     }
   }
   ${SOURCE_BASE_FRAGMENT}

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -82,7 +82,7 @@ export const USER_TOOLTIP_CONTENT_QUERY = gql`
 `;
 
 export const USER_SHORT_INFO_FRAGMENT = gql`
-  fragment UserShortInfoFragment on User {
+  fragment UserShortInfo on User {
     id
     name
     image

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -1,4 +1,5 @@
 import { gql } from 'graphql-request';
+import { SHARED_POST_INFO_FRAGMENT } from './fragments';
 
 type PostStats = {
   numPosts: number;
@@ -78,17 +79,6 @@ export const USER_TOOLTIP_CONTENT_QUERY = gql`
       bio
       permalink
     }
-  }
-`;
-
-export const USER_SHORT_INFO_FRAGMENT = gql`
-  fragment UserShortInfo on User {
-    id
-    name
-    image
-    permalink
-    username
-    bio
   }
 `;
 
@@ -175,17 +165,6 @@ export const USER_READING_HISTORY_QUERY = gql`
   }
 `;
 
-export const UPVOTER_FRAGMENT = gql`
-  fragment UpvoterFragment on User {
-    id
-    name
-    username
-    bio
-    image
-    permalink
-  }
-`;
-
 const READING_HISTORY_FRAGMENT = gql`
   fragment ReadingHistoryFrament on ReadingHistory {
     timestamp
@@ -202,6 +181,9 @@ const READING_HISTORY_FRAGMENT = gql`
       numUpvotes
       bookmarked
       numComments
+      sharedPost {
+        ...SharedPostInfo
+      }
       source {
         id
         image
@@ -215,6 +197,7 @@ const READING_HISTORY_FRAGMENT = gql`
       type
     }
   }
+  ${SHARED_POST_INFO_FRAGMENT}
 `;
 
 const READING_HISTORY_CONNECTION_FRAGMENT = gql`


### PR DESCRIPTION
## Changes

### Describe what this PR does
- As discussed, when the user tries to share a Squad post, the link should be directed towards the original article.
- I have also refactored the fragments to be contained in a single `fragments` file as I was having some deps issues.
- I have also checked previous implementations of `Fragments` and the word `Fragment` itself should not be part of the name.
- Note: still waiting for Sab's response on which title should we display in the reading history. Title of the actual article or the user's commentary but feel free to review.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-999 #done
