### PR TITLE
fix: comment replies avatar z-index

### DIFF
--- a/packages/shared/src/components/comments/CommentAuthor.tsx
+++ b/packages/shared/src/components/comments/CommentAuthor.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import classNames from 'classnames';
 import { Author } from '../../graphql/comments';
 import { ProfileLink } from '../profile/ProfileLink';
 import FeatherIcon from '../icons/Feather';
@@ -7,19 +8,24 @@ import { ProfileTooltip } from '../profile/ProfileTooltip';
 export interface CommentAuthorProps {
   postAuthorId: string | null;
   author: Author;
+  className?: string;
   appendTooltipTo?: () => HTMLElement;
 }
 
 export default function CommentAuthor({
   postAuthorId,
   author,
+  className,
   appendTooltipTo,
 }: CommentAuthorProps): ReactElement {
   return (
     <ProfileTooltip user={author} tooltip={{ appendTo: appendTooltipTo }}>
       <ProfileLink
         user={author}
-        className="overflow-hidden font-bold whitespace-nowrap w-fit commentAuthor text-theme-label-primary typo-callout"
+        className={classNames(
+          'overflow-hidden font-bold whitespace-nowrap w-fit commentAuthor text-theme-label-primary typo-callout',
+          className,
+        )}
       >
         {author.name}
         {author.id === postAuthorId && (

--- a/packages/shared/src/components/comments/CommentBox.tsx
+++ b/packages/shared/src/components/comments/CommentBox.tsx
@@ -71,7 +71,7 @@ function CommentBox({
           user={comment.author}
           tooltip={{ appendTo: appendTooltipTo }}
         >
-          <ProfileImageLink user={comment.author} />
+          <ProfileImageLink className="z-1" user={comment.author} />
         </ProfileTooltip>
         <div className="flex flex-col ml-3 typo-callout">
           <FlexRow>

--- a/packages/shared/src/components/comments/SubComment.tsx
+++ b/packages/shared/src/components/comments/SubComment.tsx
@@ -22,7 +22,7 @@ function SubComment({
       className={{ container: 'relative', content: 'ml-14' }}
     >
       <div
-        className="absolute top-0 bottom-0 left-8 w-0.5 bg-theme-float"
+        className="absolute top-0 bottom-0 left-9 -ml-px w-0.5 bg-theme-float"
         data-testid="subcomment"
       />
     </CommentBox>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixes the issue where the timeline is showing on top of comment replies avatars.
- Also fixes the alignment of timeline as I noticed it not being centered of the author avatar.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-997 #done
