### PR TITLE
fix: profile picture vertical line

### DIFF
--- a/packages/shared/src/components/comments/CommentBox.tsx
+++ b/packages/shared/src/components/comments/CommentBox.tsx
@@ -66,7 +66,7 @@ function CommentBox({
       data-testid="comment"
     >
       {children}
-      <header className="flex flex-row">
+      <header className="flex flex-row z-1">
         <ProfileTooltip
           user={comment.author}
           tooltip={{ appendTo: appendTooltipTo }}

--- a/packages/shared/src/components/comments/CommentBox.tsx
+++ b/packages/shared/src/components/comments/CommentBox.tsx
@@ -66,7 +66,7 @@ function CommentBox({
       data-testid="comment"
     >
       {children}
-      <header className="flex flex-row z-1">
+      <header className="flex z-1 flex-row">
         <ProfileTooltip
           user={comment.author}
           tooltip={{ appendTo: appendTooltipTo }}


### PR DESCRIPTION
## Changes

before: (changed the line color temporarily to make it seen on preview)
<img width="297" alt="SCR-20230131-g3g" src="https://user-images.githubusercontent.com/1488164/215709402-698b98f8-acad-4609-a4c4-626dd50f9897.png">
after:
<img width="255" alt="SCR-20230131-g4b" src="https://user-images.githubusercontent.com/1488164/215709625-67156af9-183f-4805-8bd0-52daaab2f76f.png">


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
