### PR TITLE
refactor: notification type for squads and theme

### DIFF
--- a/packages/shared/src/components/notifications/FirstNotification.tsx
+++ b/packages/shared/src/components/notifications/FirstNotification.tsx
@@ -1,9 +1,8 @@
 import React, { ReactElement, useEffect } from 'react';
-import { NotificationType } from '../../graphql/notifications';
 import usePersistentContext from '../../hooks/usePersistentContext';
 import { firstNotificationLink } from '../../lib/constants';
 import NotificationItem from './NotificationItem';
-import { NotificationIcon } from './utils';
+import { NotificationType, NotificationIconType } from './utils';
 
 const READ_KEY = 'FIRST_NOTIFICATION_READ';
 
@@ -20,7 +19,7 @@ function FirstNotification(): ReactElement {
     <NotificationItem
       isUnread={isUnread}
       type={NotificationType.System}
-      icon={NotificationIcon.Bell}
+      icon={NotificationIconType.Bell}
       targetUrl={firstNotificationLink}
       title="Welcome to your new notification center!"
       description="The notification system notifies you of important events such as replies, mentions, updates etc."

--- a/packages/shared/src/components/notifications/InAppNotification.tsx
+++ b/packages/shared/src/components/notifications/InAppNotification.tsx
@@ -14,7 +14,7 @@ import { InAppNotificationItem } from './InAppNotificationItem';
 import styles from './InAppNotification.module.css';
 import { useAnalyticsContext } from '../../contexts/AnalyticsContext';
 import { AnalyticsEvent, Origin } from '../../lib/analytics';
-import { NotificationType } from '../../graphql/notifications';
+import { NotificationType } from './utils';
 import FeaturesContext from '../../contexts/FeaturesContext';
 import { InAppNotificationPosition } from '../../lib/featureValues';
 

--- a/packages/shared/src/components/notifications/NotificationIcon.tsx
+++ b/packages/shared/src/components/notifications/NotificationIcon.tsx
@@ -1,28 +1,30 @@
 import React, { ReactElement } from 'react';
 import {
-  notificationDefaultTheme,
   notificationIcon,
-  NotificationIcon,
+  NotificationIconType,
+  notificationIconTypeTheme,
 } from './utils';
 
 const noBackgroundIcons = [
-  NotificationIcon.DailyDev,
-  NotificationIcon.CommunityPicks,
+  NotificationIconType.DailyDev,
+  NotificationIconType.CommunityPicks,
 ];
 
 interface NotificationItemIconProps {
-  icon: NotificationIcon;
+  icon: NotificationIconType;
+  iconTheme?: string;
 }
 
 function NotificationItemIcon({
   icon,
+  iconTheme,
 }: NotificationItemIconProps): ReactElement {
   const Icon = notificationIcon[icon] ?? notificationIcon.DailyDev;
   const testId = `notification-${icon}`;
 
   if (!notificationIcon[icon] || noBackgroundIcons.includes(icon)) {
     const testValue = !notificationIcon[icon]
-      ? NotificationIcon.DailyDev
+      ? NotificationIconType.DailyDev
       : icon;
     return (
       <Icon
@@ -34,16 +36,11 @@ function NotificationItemIcon({
     );
   }
 
-  const iconTheme = notificationDefaultTheme[icon];
+  const theme = iconTheme ?? notificationIconTypeTheme[icon];
 
   return (
     <span className="overflow-hidden p-1 bg-theme-float rounded-8 typo-callout h-fit">
-      <Icon
-        size="medium"
-        secondary
-        className={iconTheme}
-        data-testid={testId}
-      />
+      <Icon size="medium" secondary className={theme} data-testid={testId} />
     </span>
   );
 }

--- a/packages/shared/src/components/notifications/NotificationItem.spec.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.spec.tsx
@@ -2,18 +2,15 @@ import React, { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import NotificationItem, { NotificationItemProps } from './NotificationItem';
-import {
-  NotificationAvatarType,
-  NotificationType,
-} from '../../graphql/notifications';
-import { NotificationIcon } from './utils';
+import { NotificationAvatarType } from '../../graphql/notifications';
+import { NotificationType, NotificationIconType } from './utils';
 
 const sampleNotificationTitle = 'Welcome to your new notification center!';
 const sampleNotificationDescription =
   'The notification system notifies you of important events such as replies, mentions, updates etc.';
 const sampleNotification: NotificationItemProps = {
   isUnread: true,
-  icon: NotificationIcon.Comment,
+  icon: NotificationIconType.Comment,
   title: `<p>${sampleNotificationTitle}</p>`,
   description: `<p>${sampleNotificationDescription}</p>`,
   type: NotificationType.System,
@@ -104,7 +101,10 @@ describe('notification item', () => {
     renderComponent(<NotificationItem {...notification} />);
     const testid = `notification-${notification.icon}`;
     const img = await screen.findByTestId(testid);
-    expect(img).toHaveAttribute('data-testvalue', NotificationIcon.DailyDev);
+    expect(img).toHaveAttribute(
+      'data-testvalue',
+      NotificationIconType.DailyDev,
+    );
   });
 
   it('should have a title that supports html', async () => {

--- a/packages/shared/src/components/notifications/NotificationItem.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.tsx
@@ -6,6 +6,7 @@ import { useObjectPurify } from '../../hooks/useDomPurify';
 import NotificationItemIcon from './NotificationIcon';
 import NotificationItemAttachment from './NotificationItemAttachment';
 import NotificationItemAvatar from './NotificationItemAvatar';
+import { notificationTypeTheme } from './utils';
 
 export interface NotificationItemProps
   extends Pick<
@@ -19,6 +20,7 @@ export interface NotificationItemProps
 
 function NotificationItem({
   icon,
+  type,
   title,
   isUnread,
   description,
@@ -55,7 +57,10 @@ function NotificationItem({
           isUnread && 'bg-theme-float',
         )}
       >
-        <NotificationItemIcon icon={icon} />
+        <NotificationItemIcon
+          icon={icon}
+          iconTheme={notificationTypeTheme[type]}
+        />
         <div className="flex flex-col flex-1 ml-4 w-full text-left typo-callout">
           {hasAvatar && (
             <span className="flex flex-row gap-2 mb-4">{avatarComponents}</span>

--- a/packages/shared/src/components/notifications/utils.ts
+++ b/packages/shared/src/components/notifications/utils.ts
@@ -5,6 +5,7 @@ import BellIcon from '../icons/Bell';
 import CommunityPicksIcon from '../icons/CommunityPicksIcon';
 import DailyIcon from '../icons/DailyIcon';
 import DiscussIcon from '../icons/Discuss';
+import EyeIcon from '../icons/Eye';
 import UpvoteIcon from '../icons/Upvote';
 
 export const NotifContainer = classed(
@@ -24,31 +25,46 @@ export const NotifProgress = classed(
   'absolute -bottom-2 h-1 ease-in-out bg-theme-status-cabbage rounded-full',
 );
 
-export enum NotificationIcon {
+export enum NotificationType {
+  System = 'system',
+  SquaPostAdded = 'squad_post_added',
+  SquadMemberJoined = 'squad_member_joined',
+}
+
+export enum NotificationIconType {
   DailyDev = 'DailyDev',
   CommunityPicks = 'CommunityPicks',
   Comment = 'Comment',
   Upvote = 'Upvote',
   Bell = 'Bell',
+  View = 'View',
 }
 
 export const notificationIcon: Record<
-  NotificationIcon,
+  NotificationIconType,
   ComponentType<IconProps>
 > = {
-  [NotificationIcon.DailyDev]: DailyIcon,
-  [NotificationIcon.CommunityPicks]: CommunityPicksIcon,
-  [NotificationIcon.Comment]: DiscussIcon,
-  [NotificationIcon.Upvote]: UpvoteIcon,
-  [NotificationIcon.Bell]: BellIcon,
+  [NotificationIconType.DailyDev]: DailyIcon,
+  [NotificationIconType.CommunityPicks]: CommunityPicksIcon,
+  [NotificationIconType.Comment]: DiscussIcon,
+  [NotificationIconType.Upvote]: UpvoteIcon,
+  [NotificationIconType.Bell]: BellIcon,
+  [NotificationIconType.View]: EyeIcon,
 };
 
-export const notificationDefaultTheme: Record<NotificationIcon, string> = {
-  [NotificationIcon.DailyDev]: '',
-  [NotificationIcon.CommunityPicks]: '',
-  [NotificationIcon.Comment]: 'text-theme-color-blueCheese',
-  [NotificationIcon.Upvote]: 'text-theme-color-avocado',
-  [NotificationIcon.Bell]: '',
+export const notificationIconTypeTheme: Record<NotificationIconType, string> = {
+  [NotificationIconType.DailyDev]: '',
+  [NotificationIconType.CommunityPicks]: '',
+  [NotificationIconType.Comment]: 'text-theme-color-blueCheese',
+  [NotificationIconType.Upvote]: 'text-theme-color-avocado',
+  [NotificationIconType.Bell]: '',
+  [NotificationIconType.View]: 'text-theme-color-blueCheese',
+};
+
+export const notificationTypeTheme: Record<NotificationType, string> = {
+  [NotificationType.System]: '',
+  [NotificationType.SquaPostAdded]: 'text-theme-color-cabbage',
+  [NotificationType.SquadMemberJoined]: 'text-theme-color-cabbage',
 };
 
 const notificationsUrl = `/notifications`;

--- a/packages/shared/src/graphql/notifications.ts
+++ b/packages/shared/src/graphql/notifications.ts
@@ -1,5 +1,8 @@
 import { gql } from 'graphql-request';
-import { NotificationIcon } from '../components/notifications/utils';
+import {
+  NotificationIconType,
+  NotificationType,
+} from '../components/notifications/utils';
 import { Connection } from './common';
 
 export enum NotificationAvatarType {
@@ -20,16 +23,12 @@ export interface NotificationAttachment {
   title: string;
 }
 
-export enum NotificationType {
-  System = 'system',
-}
-
 export interface Notification {
   id: string;
   userId: string;
   createdAt: Date;
   readAt?: Date;
-  icon: NotificationIcon;
+  icon: NotificationIconType;
   title: string;
   type: NotificationType;
   description?: string;

--- a/packages/webapp/__tests__/NotificationsPage.tsx
+++ b/packages/webapp/__tests__/NotificationsPage.tsx
@@ -3,7 +3,6 @@ import nock from 'nock';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import {
   Notification,
-  NotificationType,
   NotificationsData,
   NOTIFICATIONS_QUERY,
   READ_NOTIFICATIONS_MUTATION,
@@ -17,6 +16,7 @@ import { render, screen } from '@testing-library/preact';
 import NotificationsContext from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { waitForNock } from '@dailydotdev/shared/__tests__/helpers/utilities';
+import { NotificationType } from '@dailydotdev/shared/src/components/notifications/utils';
 import { mocked } from 'ts-jest/utils';
 import { NextRouter, useRouter } from 'next/router';
 import NotificationsPage from '../pages/notifications';

--- a/packages/webapp/pages/notifications.tsx
+++ b/packages/webapp/pages/notifications.tsx
@@ -5,7 +5,6 @@ import { useInfiniteQuery, InfiniteData, useMutation } from 'react-query';
 import {
   NotificationsData,
   NOTIFICATIONS_QUERY,
-  NotificationType,
   READ_NOTIFICATIONS_MUTATION,
 } from '@dailydotdev/shared/src/graphql/notifications';
 import {
@@ -23,6 +22,7 @@ import InfiniteScrolling, {
 } from '@dailydotdev/shared/src/components/containers/InfiniteScrolling';
 import { useAnalyticsContext } from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 import { AnalyticsEvent, Origin } from '@dailydotdev/shared/src/lib/analytics';
+import { NotificationType } from '@dailydotdev/shared/src/components/notifications/utils';
 import { getLayout as getFooterNavBarLayout } from '../components/layouts/FooterNavBarLayout';
 import { getLayout } from '../components/layouts/MainLayout';
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- This introduces the new notification type `View`.
- Applied specific themes for new squad posts and member notifications.

Preview: 
<img width="627" alt="image" src="https://user-images.githubusercontent.com/13744167/215963706-4046db9b-2c9e-43ab-b0da-f9ec2d7a03ff.png">


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-897 #done
