### PR TITLE
fix: hover on comment author z-index

### DIFF
--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -12,6 +12,7 @@ export interface MainCommentProps extends CommentBoxProps {
 export default function MainComment({
   className,
   comment,
+  appendTooltipTo,
   permissionNotificationCommentId,
   ...props
 }: MainCommentProps): ReactElement {
@@ -32,6 +33,7 @@ export default function MainComment({
         comment={comment}
         parentId={comment.id}
         className={{ container: 'border-b' }}
+        appendTooltipTo={appendTooltipTo}
       />
       {comment.children?.edges.map(({ node }) => (
         <SubComment
@@ -39,6 +41,7 @@ export default function MainComment({
           key={node.id}
           comment={node}
           parentComment={comment}
+          appendTooltipTo={appendTooltipTo}
         />
       ))}
       {shouldShowBanner && (


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Missing append tooltip to property.
- In the preview deployment, you can see the fix.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
