### PR TITLE
fix: update local viewed post based on type

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -61,7 +61,6 @@ export type FeedProps<T> = {
   emptyScreen?: ReactNode;
   header?: ReactNode;
   forceCardMode?: boolean;
-  updatePostWhenViewed?: boolean;
 };
 
 interface RankVariables {
@@ -148,7 +147,6 @@ export default function Feed<T>({
   onEmptyFeed,
   emptyScreen,
   forceCardMode,
-  updatePostWhenViewed,
 }: FeedProps<T>): ReactElement {
   const { showCommentPopover } = useContext(FeaturesContext);
   const { scrollOnboardingVersion } = useContext(FeaturesContext);
@@ -188,11 +186,7 @@ export default function Feed<T>({
     onNext,
     selectedPost,
     isFetchingNextPage,
-  } = usePostModalNavigation(
-    items,
-    fetchPage,
-    updatePostWhenViewed ? updatePost : null,
-  );
+  } = usePostModalNavigation(items, fetchPage, updatePost);
 
   useEffect(() => {
     if (emptyFeed) {

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -61,6 +61,7 @@ export type FeedProps<T> = {
   emptyScreen?: ReactNode;
   header?: ReactNode;
   forceCardMode?: boolean;
+  updatePostWhenViewed?: boolean;
 };
 
 interface RankVariables {
@@ -147,6 +148,7 @@ export default function Feed<T>({
   onEmptyFeed,
   emptyScreen,
   forceCardMode,
+  updatePostWhenViewed,
 }: FeedProps<T>): ReactElement {
   const { showCommentPopover } = useContext(FeaturesContext);
   const { scrollOnboardingVersion } = useContext(FeaturesContext);
@@ -186,7 +188,11 @@ export default function Feed<T>({
     onNext,
     selectedPost,
     isFetchingNextPage,
-  } = usePostModalNavigation(items, fetchPage);
+  } = usePostModalNavigation(
+    items,
+    fetchPage,
+    updatePostWhenViewed ? updatePost : null,
+  );
 
   useEffect(() => {
     if (emptyFeed) {

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -29,10 +29,12 @@ export type AdItem = { type: 'ad'; ad: Ad };
 export type PlaceholderItem = { type: 'placeholder' };
 export type FeedItem = PostItem | AdItem | PlaceholderItem;
 
+export type UpdateFeedPost = (page: number, index: number, post: Post) => void;
+
 export type FeedReturnType = {
   items: FeedItem[];
   fetchPage: () => Promise<void>;
-  updatePost: (page: number, index: number, post: Post) => void;
+  updatePost: UpdateFeedPost;
   removePost: (page: number, index: number) => void;
   canFetchMore: boolean;
   emptyFeed: boolean;

--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -1,7 +1,7 @@
 import { useRouter } from 'next/router';
 import { useContext, useEffect, useMemo, useState } from 'react';
 import AnalyticsContext from '../contexts/AnalyticsContext';
-import { Post } from '../graphql/posts';
+import { Post, PostType } from '../graphql/posts';
 import { postAnalyticsEvent } from '../lib/feed';
 import { FeedItem, PostItem, UpdateFeedPost } from './useFeed';
 import { useKeyboardNavigation } from './useKeyboardNavigation';
@@ -19,7 +19,7 @@ interface UsePostModalNavigation {
 export const usePostModalNavigation = (
   items: FeedItem[],
   fetchPage: () => Promise<unknown>,
-  updatePost?: UpdateFeedPost,
+  updatePost: UpdateFeedPost,
 ): UsePostModalNavigation => {
   const [currentPage, setCurrentPage] = useState<string>();
   const isExtension = !!process.env.TARGET_BROWSER;
@@ -49,7 +49,7 @@ export const usePostModalNavigation = (
     if (post) {
       changeHistory({}, `Post: ${post.id}`, `/posts/${post.id}`);
     }
-    if (updatePost) {
+    if (post?.type === PostType.Share) {
       const item = getPostItem(index);
       updatePost(item.page, item.index, { ...post, read: true });
     }

--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -3,7 +3,7 @@ import { useContext, useEffect, useMemo, useState } from 'react';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { Post } from '../graphql/posts';
 import { postAnalyticsEvent } from '../lib/feed';
-import { FeedItem, PostItem } from './useFeed';
+import { FeedItem, PostItem, UpdateFeedPost } from './useFeed';
 import { useKeyboardNavigation } from './useKeyboardNavigation';
 import { Origin } from '../lib/analytics';
 
@@ -19,6 +19,7 @@ interface UsePostModalNavigation {
 export const usePostModalNavigation = (
   items: FeedItem[],
   fetchPage: () => Promise<unknown>,
+  updatePost?: UpdateFeedPost,
 ): UsePostModalNavigation => {
   const [currentPage, setCurrentPage] = useState<string>();
   const isExtension = !!process.env.TARGET_BROWSER;
@@ -33,7 +34,11 @@ export const usePostModalNavigation = (
     }
   };
 
-  const getPost = (index) =>
+  const getPostItem = (index: number) =>
+    index !== null && items[index].type === 'post'
+      ? (items[index] as PostItem)
+      : null;
+  const getPost = (index: number) =>
     index !== null && items[index].type === 'post'
       ? (items[index] as PostItem).post
       : null;
@@ -43,6 +48,10 @@ export const usePostModalNavigation = (
     const post = !fromPopState && getPost(index);
     if (post) {
       changeHistory({}, `Post: ${post.id}`, `/posts/${post.id}`);
+    }
+    if (updatePost) {
+      const item = getPostItem(index);
+      updatePost(item.page, item.index, { ...post, read: true });
     }
   };
 

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -100,7 +100,6 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
           query={SOURCE_FEED_QUERY}
           variables={queryVariables}
           forceCardMode
-          updatePostWhenViewed
         />
       </FeedPage>
     </ProtectedPage>

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -100,6 +100,7 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
           query={SOURCE_FEED_QUERY}
           variables={queryVariables}
           forceCardMode
+          updatePostWhenViewed
         />
       </FeedPage>
     </ProtectedPage>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The viewed mutation is successfully sent but the local data in the feed where it indicates being viewed was not getting updated.
- This PR should fix the decision whether to locally make it viewed based on post type.
- Feel free to test it in preview deployment vs our production deployment.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1012 #done
