### PR TITLE
fix: stale post when navigating from reading history

### DIFF
--- a/packages/shared/src/hooks/usePostById.ts
+++ b/packages/shared/src/hooks/usePostById.ts
@@ -4,6 +4,7 @@ import { QueryObserverOptions, useQuery } from 'react-query';
 import { graphqlUrl } from '../lib/config';
 import { useAuthContext } from '../contexts/AuthContext';
 import { Post, PostData, POST_BY_ID_QUERY } from '../graphql/posts';
+import { isNullOrUndefined } from '../lib/func';
 
 interface UsePostByIdProps {
   id: string;
@@ -22,6 +23,7 @@ const usePostById = ({
   options = {},
 }: UsePostByIdProps): UsePostById => {
   const { tokenRefreshed } = useAuthContext();
+  const isEnabled = !!id && tokenRefreshed;
   const {
     data: postById,
     isLoading,
@@ -29,7 +31,12 @@ const usePostById = ({
   } = useQuery<PostData>(
     ['post', id],
     () => request(graphqlUrl, POST_BY_ID_QUERY, { id }),
-    { ...options, enabled: !!id && tokenRefreshed },
+    {
+      ...options,
+      enabled: isNullOrUndefined(options.enabled)
+        ? isEnabled
+        : isEnabled && options.enabled,
+    },
   );
 
   const post = postById || (options?.initialData as PostData);
@@ -39,7 +46,7 @@ const usePostById = ({
       post: post?.post,
       isLoading: isLoading || !isFetched || isFetchingNextPage,
     }),
-    [postById, isLoading],
+    [id, postById, isLoading, options, isFetchingNextPage],
   );
 };
 

--- a/packages/shared/src/hooks/usePostById.ts
+++ b/packages/shared/src/hooks/usePostById.ts
@@ -4,7 +4,6 @@ import { QueryObserverOptions, useQuery } from 'react-query';
 import { graphqlUrl } from '../lib/config';
 import { useAuthContext } from '../contexts/AuthContext';
 import { Post, PostData, POST_BY_ID_QUERY } from '../graphql/posts';
-import { isNullOrUndefined } from '../lib/func';
 
 interface UsePostByIdProps {
   id: string;
@@ -24,7 +23,6 @@ const usePostById = ({
   options = {},
 }: UsePostByIdProps): UsePostById => {
   const { tokenRefreshed } = useAuthContext();
-  const isEnabled = !!id && tokenRefreshed;
   const {
     data: postById,
     isLoading,
@@ -34,9 +32,7 @@ const usePostById = ({
     () => request(graphqlUrl, POST_BY_ID_QUERY, { id }),
     {
       ...options,
-      enabled: isNullOrUndefined(options.enabled)
-        ? isEnabled
-        : isEnabled && options.enabled,
+      enabled: !!id && tokenRefreshed,
     },
   );
 

--- a/packages/shared/src/hooks/usePostById.ts
+++ b/packages/shared/src/hooks/usePostById.ts
@@ -15,6 +15,7 @@ interface UsePostByIdProps {
 interface UsePostById {
   post: Post;
   isLoading: boolean;
+  isFetched: boolean;
 }
 
 const usePostById = ({
@@ -44,9 +45,10 @@ const usePostById = ({
   return useMemo(
     () => ({
       post: post?.post,
-      isLoading: isLoading || !isFetched || isFetchingNextPage,
+      isFetched,
+      isLoading: isLoading || isFetchingNextPage,
     }),
-    [id, postById, isLoading, options, isFetchingNextPage],
+    [id, postById, isLoading, options, isFetched, isFetchingNextPage],
   );
 };
 

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -114,7 +114,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
   };
   const customNavigation = navigation[post?.type] ?? navigation.article;
 
-  if (!Content && (!isFallback || !isFetched)) return <Custom404 />;
+  if (!Content && (!isFallback || isFetched)) return <Custom404 />;
 
   return (
     <>

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -76,7 +76,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     false,
   );
 
-  const { post, isLoading, isFetched } = usePostById({
+  const { post, isFetched } = usePostById({
     id,
     options: { initialData, retry: false },
   });
@@ -114,7 +114,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
   };
   const customNavigation = navigation[post?.type] ?? navigation.article;
 
-  if (!Content && (!isFallback || !isLoading)) return <Custom404 />;
+  if (!Content && (!isFallback || !isFetched)) return <Custom404 />;
 
   return (
     <>

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -34,7 +34,6 @@ import SquadPostContent from '@dailydotdev/shared/src/components/post/SquadPostC
 import SquadPostPageNavigation from '@dailydotdev/shared/src/components/post/SquadPostPageNavigation';
 import useWindowEvents from '@dailydotdev/shared/src/hooks/useWindowEvents';
 import usePostById from '@dailydotdev/shared/src/hooks/usePostById';
-import { disabledRefetch } from '@dailydotdev/shared/src/lib/func';
 import { getLayout as getMainLayout } from '../../components/layouts/MainLayout';
 import { getTemplatedTitle } from '../../components/layouts/utils';
 
@@ -79,7 +78,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
 
   const { post, isLoading } = usePostById({
     id,
-    options: { initialData, retry: false, ...disabledRefetch },
+    options: { initialData, retry: false, enabled: !!initialData },
   });
 
   const seo: NextSeoProps = {
@@ -100,8 +99,8 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     scrollProperty: 'scrollY',
   });
 
-  if (!initialData && (isFallback || isLoading)) {
-    return <></>;
+  if (!initialData) {
+    return <Custom404 />;
   }
 
   const Content = CONTENT_MAP[post?.type];

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -126,7 +126,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
         position={position}
         post={post}
         isFallback={isFallback}
-        isLoading={isLoading || !isFetched}
+        isLoading={!isFetched}
         customNavigation={customNavigation}
         shouldOnboardAuthor={!!router.query?.author}
         enableShowShareNewComment={!!router?.query.new}

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -76,9 +76,9 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     false,
   );
 
-  const { post, isLoading } = usePostById({
+  const { post, isLoading, isFetched } = usePostById({
     id,
-    options: { initialData, retry: false, enabled: !!initialData },
+    options: { initialData, retry: false },
   });
 
   const seo: NextSeoProps = {
@@ -99,8 +99,8 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     scrollProperty: 'scrollY',
   });
 
-  if (!initialData) {
-    return <Custom404 />;
+  if (!initialData && (isFallback || !isFetched)) {
+    return <></>;
   }
 
   const Content = CONTENT_MAP[post?.type];
@@ -126,7 +126,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
         position={position}
         post={post}
         isFallback={isFallback}
-        isLoading={isLoading}
+        isLoading={isLoading || !isFetched}
         customNavigation={customNavigation}
         shouldOnboardAuthor={!!router.query?.author}
         enableShowShareNewComment={!!router?.query.new}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- For some reason, the post is always considered `stale`.
- This is being fixed by refetching the data since the sole purpose of that is to check the cache if it is stale.
- Since we have decided to bring back refetching, I have fixed it here.
- With that in mind, I have also ensured to fix the issue we have that repeatedly loads NOT_FOUND article by disabling the fetch itself when the `initialData` is not found.
- The `initialData` is always null when an error has occurred (including NOT_FOUND), so I believe that is a right fix.
 
## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1037 #done
