### PR TITLE
fix: option to only return public posts for select article

### DIFF
--- a/packages/shared/src/components/squads/SelectArticle.tsx
+++ b/packages/shared/src/components/squads/SelectArticle.tsx
@@ -32,6 +32,9 @@ export function SquadSelectArticle({
   const queryProps = {
     key,
     query: READING_HISTORY_QUERY,
+    variables: {
+      isPublic: true,
+    },
   };
   const { hasData, data, isInitialLoading, isLoading, queryResult } =
     useInfiniteReadingHistory(queryProps);

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -245,8 +245,8 @@ export const SEARCH_READING_HISTORY_QUERY = gql`
 
 export const READING_HISTORY_QUERY = gql`
   ${READING_HISTORY_CONNECTION_FRAGMENT}
-  query ReadHistory($after: String, $first: Int) {
-    readHistory(after: $after, first: $first) {
+  query ReadHistory($after: String, $first: Int, $isPublic: Boolean) {
+    readHistory(after: $after, first: $first, isPublic: $isPublic) {
       ...ReadingHistoryConnectionFragment
     }
   }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Optional function to only return public posts for reading history.
- See API as well: https://github.com/dailydotdev/daily-api/pull/1164

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-996 #done
