### PR TITLE
feat: disable event pings during development

### DIFF
--- a/packages/shared/src/hooks/analytics/useAnalyticsQueue.ts
+++ b/packages/shared/src/hooks/analytics/useAnalyticsQueue.ts
@@ -32,6 +32,13 @@ export default function useAnalyticsQueue({
   const enabledRef = useRef(false);
   const { mutateAsync: sendEvents } = useMutation(
     async (events: AnalyticsEvent[]) => {
+      if (process.env.NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        console.log('useAnalyticsQueue.sendEvents', { events });
+
+        return;
+      }
+
       const res = await fetchMethod(ANALYTICS_ENDPOINT, {
         method: 'POST',
         body: JSON.stringify({ events }),
@@ -78,6 +85,14 @@ export default function useAnalyticsQueue({
           const blob = new Blob([JSON.stringify({ events })], {
             type: 'application/json',
           });
+
+          if (process.env.NODE_ENV === 'development') {
+            // eslint-disable-next-line no-console
+            console.log('useAnalyticsQueue.sendBeacon', { events });
+
+            return;
+          }
+
           if (backgroundMethod) {
             backgroundMethod?.({
               url: ANALYTICS_ENDPOINT,

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -139,7 +139,8 @@ export default function useFeed<T>(
     },
     {
       getNextPageParam: () => Date.now(),
-      enabled: query && tokenRefreshed,
+      enabled:
+        process.env.NODE_ENV !== 'development' && query && tokenRefreshed,
       refetchOnMount: false,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,


### PR DESCRIPTION
## Changes

### Describe what this PR does

Talking to Chris I noticed that during development there are lot of periodical or navigation based pings that will always fail with `503` because analytics service is not available in development. Specifically it disables these pings:
- active ping inside useFeed hook
- sendEvents and sendBeacon pings from useAnalyticsQueue hook (replaced by console.log)

All of this results in a lot of console.error logs and failed network requests (in chrome network tab) which IMO clutter those places when looking for stuff that actually matters.

I am aware that this could also be solved with filters in console/network tab but those are not so easy to persist across tabs/urls etc.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
