### PR TITLE
fix: missing queryFn console error in useQuery usages

### DIFF
--- a/packages/shared/src/hooks/useInAppNotification.ts
+++ b/packages/shared/src/hooks/useInAppNotification.ts
@@ -41,6 +41,7 @@ export const useInAppNotification = (): UseInAppNotification => {
   const { incrementUnreadCount } = useNotificationContext();
   const { data: notification } = useQuery<InAppNotification>(
     IN_APP_NOTIFICATION_KEY,
+    () => client.getQueryData<InAppNotification>(IN_APP_NOTIFICATION_KEY),
   );
   const hasNotification = (): boolean =>
     !!client.getQueryData(IN_APP_NOTIFICATION_KEY);

--- a/packages/shared/src/hooks/useLazyModal.ts
+++ b/packages/shared/src/hooks/useLazyModal.ts
@@ -15,7 +15,9 @@ export function useLazyModal<
   T extends LazyModalType<K> = LazyModalType<K>,
 >(): UseLazyModal<K, T> {
   const client = useQueryClient();
-  const { data: modal } = useQuery<T>(MODAL_KEY);
+  const { data: modal } = useQuery<T>(MODAL_KEY, () =>
+    client.getQueryData<T>(MODAL_KEY),
+  );
   const openModal = (data: T) => client.setQueryData(MODAL_KEY, data);
   const closeModal = () => client.setQueryData(MODAL_KEY, null);
 

--- a/packages/shared/src/hooks/usePrivilegedSession.ts
+++ b/packages/shared/src/hooks/usePrivilegedSession.ts
@@ -26,8 +26,10 @@ export const VERIFY_SESSION_KEY = 'verify_session';
 const usePrivilegedSession = (): UsePrivilegedSession => {
   const onVerification = useRef<Func>();
   const { displayToast } = useToastNotification();
-  const { data: verifySessionId } = useQuery(VERIFY_SESSION_KEY);
   const client = useQueryClient();
+  const { data: verifySessionId } = useQuery(VERIFY_SESSION_KEY, () =>
+    client.getQueryData(VERIFY_SESSION_KEY),
+  );
   const setVerifySessionId = (value: string) =>
     client.setQueryData(VERIFY_SESSION_KEY, value);
 

--- a/packages/shared/src/hooks/usePrompt.ts
+++ b/packages/shared/src/hooks/usePrompt.ts
@@ -37,7 +37,9 @@ type UsePromptRet = {
 
 export function usePrompt(): UsePromptRet {
   const client = useQueryClient();
-  const { data: prompt } = useQuery<Prompt>(PROMPT_KEY);
+  const { data: prompt } = useQuery<Prompt>(PROMPT_KEY, () =>
+    client.getQueryData<Prompt>(PROMPT_KEY),
+  );
   const setPrompt = (data: Prompt) => client.setQueryData(PROMPT_KEY, data);
 
   const showPrompt = (promptOptions: PromptOptions): Promise<boolean> =>

--- a/packages/shared/src/hooks/useToastNotification.ts
+++ b/packages/shared/src/hooks/useToastNotification.ts
@@ -31,7 +31,9 @@ export interface NotifyOptionalProps {
 
 export const useToastNotification = (): UseToastNotification => {
   const client = useQueryClient();
-  const { data: toast } = useQuery<ToastNotification>(TOAST_NOTIF_KEY);
+  const { data: toast } = useQuery<ToastNotification>(TOAST_NOTIF_KEY, () =>
+    client.getQueryData<ToastNotification>(TOAST_NOTIF_KEY),
+  );
   const setToastNotification = (data: ToastNotification) =>
     client.setQueryData(TOAST_NOTIF_KEY, data);
 


### PR DESCRIPTION
## Changes

### Describe what this PR does

While trying to cleanup console clutter during development in #1573 I noticed another error that happens passively while clicking through the app `Error: Missing queryFn` coming from `useQuery` usages.

This happens in pattern when using useQuery as state hook. Valid fix should be to add queryFn that just loads up the current data of the query (if exists). I looked at the rest of the code and I can see that on some other places it is using the same pattern (eg. `packages/shared/src/components/notifications/Toast.tsx`) so I think these were just missed accidentally.

As far as I can see this does not break anything because all of the hooks fallback and handle when data is present or `undefined`.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
