### PR TITLE
feat: disable next/prev buttons on post modal

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -184,6 +184,7 @@ export default function Feed<T>({
     onCloseModal,
     onPrevious,
     onNext,
+    postPosition,
     selectedPost,
     isFetchingNextPage,
   } = usePostModalNavigation(items, fetchPage, updatePost);
@@ -480,6 +481,7 @@ export default function Feed<T>({
             onPreviousPost={onPrevious}
             onNextPost={onNext}
             isFetchingNextPage={isFetchingNextPage}
+            postPosition={postPosition}
           />
         )}
         {sharePost && (

--- a/packages/shared/src/components/modals/ArticlePostModal.tsx
+++ b/packages/shared/src/components/modals/ArticlePostModal.tsx
@@ -10,7 +10,10 @@ import OnboardingContext from '../../contexts/OnboardingContext';
 
 interface ArticlePostModalProps
   extends ModalProps,
-    Pick<PostNavigationProps, 'onPreviousPost' | 'onNextPost'> {
+    Pick<
+      PostNavigationProps,
+      'onPreviousPost' | 'onNextPost' | 'postPosition'
+    > {
   id: string;
   isFetchingNextPage?: boolean;
 }
@@ -25,6 +28,7 @@ export default function ArticlePostModal({
   onRequestClose,
   onPreviousPost,
   onNextPost,
+  postPosition,
   ...props
 }: ArticlePostModalProps): ReactElement {
   const { showArticleOnboarding } = useContext(OnboardingContext);
@@ -40,6 +44,7 @@ export default function ArticlePostModal({
       <PostContent
         position={position}
         post={post}
+        postPosition={postPosition}
         onPreviousPost={onPreviousPost}
         onNextPost={onNextPost}
         inlineActions

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -11,7 +11,10 @@ import { ONBOARDING_OFFSET } from '../post/BasePostContent';
 
 interface PostModalProps
   extends ModalProps,
-    Pick<PostNavigationProps, 'onPreviousPost' | 'onNextPost'> {
+    Pick<
+      PostNavigationProps,
+      'onPreviousPost' | 'onNextPost' | 'postPosition'
+    > {
   id: string;
   isFetchingNextPage?: boolean;
 }
@@ -23,6 +26,7 @@ export default function PostModal({
   onRequestClose,
   onPreviousPost,
   onNextPost,
+  postPosition,
   ...props
 }: PostModalProps): ReactElement {
   const { showArticleOnboarding } = useContext(OnboardingContext);
@@ -44,6 +48,7 @@ export default function PostModal({
         post={post}
         onPreviousPost={onPreviousPost}
         onNextPost={onNextPost}
+        postPosition={postPosition}
         inlineActions
         onClose={onRequestClose}
         isLoading={isLoading}

--- a/packages/shared/src/components/post/FixedPostNavigation.tsx
+++ b/packages/shared/src/components/post/FixedPostNavigation.tsx
@@ -5,6 +5,7 @@ import PostNavigation, { PostNavigationProps } from './PostNavigation';
 function FixedPostNavigation({
   onPreviousPost,
   onNextPost,
+  postPosition,
   post,
   className = {},
   ...props
@@ -31,6 +32,7 @@ function FixedPostNavigation({
       }}
       onPreviousPost={onPreviousPost}
       onNextPost={onNextPost}
+      postPosition={postPosition}
     >
       <div
         className={classNames(

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -25,7 +25,7 @@ import { cloudinary } from '../../lib/image';
 
 export interface PostContentProps
   extends Pick<PostModalActionsProps, 'onClose' | 'inlineActions'>,
-    Pick<PostNavigationProps, 'onNextPost' | 'onPreviousPost'>,
+    Pick<PostNavigationProps, 'onNextPost' | 'onPreviousPost' | 'postPosition'>,
     UsePostCommentOptionalProps {
   post?: Post;
   isFallback?: boolean;
@@ -56,6 +56,7 @@ export function PostContent({
   onPreviousPost,
   onNextPost,
   onClose,
+  postPosition,
   isLoading,
   isFallback,
   customNavigation,
@@ -78,6 +79,7 @@ export function PostContent({
   );
 
   const navigationProps: PostNavigationProps = {
+    postPosition,
     onPreviousPost,
     onNextPost,
     post,

--- a/packages/shared/src/components/post/PostNavigation.tsx
+++ b/packages/shared/src/components/post/PostNavigation.tsx
@@ -4,6 +4,7 @@ import { Button } from '../buttons/Button';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import ArrowIcon from '../icons/Arrow';
 import { PostModalActions, PostModalActionsProps } from './PostModalActions';
+import { PostPosition } from '../../hooks/usePostModalNavigation';
 
 type PostActions = Pick<
   PostModalActionsProps,
@@ -22,6 +23,7 @@ export interface PostNavigationClassName {
 }
 
 export interface PostNavigationProps extends PostActions {
+  postPosition?: PostPosition;
   onPreviousPost?: () => unknown;
   onNextPost?: () => unknown;
   className?: PostNavigationClassName;
@@ -29,6 +31,7 @@ export interface PostNavigationProps extends PostActions {
 }
 
 function PostNavigation({
+  postPosition,
   onPreviousPost,
   onNextPost,
   className = {},
@@ -49,6 +52,9 @@ function PostNavigation({
             className="-rotate-90 btn-secondary"
             icon={<ArrowIcon />}
             onClick={onPreviousPost}
+            disabled={[PostPosition.First, PostPosition.Only].includes(
+              postPosition,
+            )}
           />
         </SimpleTooltip>
       )}
@@ -58,6 +64,9 @@ function PostNavigation({
             className="rotate-90 btn-secondary"
             icon={<ArrowIcon />}
             onClick={onNextPost}
+            disabled={[PostPosition.Last, PostPosition.Only].includes(
+              postPosition,
+            )}
           />
         </SimpleTooltip>
       )}

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -37,6 +37,7 @@ function SquadPostContent({
   isLoading,
   origin,
   position,
+  postPosition,
   inlineActions,
   className,
   customNavigation,
@@ -66,6 +67,7 @@ function SquadPostContent({
     onPreviousPost,
     onNextPost,
     onShare: onSharePost,
+    postPosition,
     onClose,
     inlineActions,
   };

--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -7,7 +7,15 @@ import { FeedItem, PostItem, UpdateFeedPost } from './useFeed';
 import { useKeyboardNavigation } from './useKeyboardNavigation';
 import { Origin } from '../lib/analytics';
 
+export enum PostPosition {
+  First = 'first',
+  Only = 'only',
+  Middle = 'middle',
+  Last = 'last',
+}
+
 interface UsePostModalNavigation {
+  postPosition: PostPosition;
   onPrevious: () => void;
   onNext: () => Promise<void>;
   onOpenModal: (index: number, fromPopState?: boolean) => void;
@@ -106,8 +114,18 @@ export const usePostModalNavigation = (
     };
   }, [items]);
 
+  const getPostPosition = () => {
+    const isPost = (item: FeedItem) => item.type === 'post';
+    const firstPost = items.findIndex(isPost);
+    const lastPost = [...items].reverse().findIndex(isPost);
+    const isLast = items.length - lastPost - 1 === openedPostIndex;
+    if (firstPost === openedPostIndex)
+      return isLast ? PostPosition.Only : PostPosition.First;
+    return isLast ? PostPosition.Last : PostPosition.Middle;
+  };
   const ret = useMemo<UsePostModalNavigation>(
     () => ({
+      postPosition: getPostPosition(),
       isFetchingNextPage,
       onCloseModal,
       onOpenModal,

--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -117,11 +117,11 @@ export const usePostModalNavigation = (
   const getPostPosition = () => {
     const isPost = (item: FeedItem) => item.type === 'post';
     const firstPost = items.findIndex(isPost);
-    const lastPost = [...items].reverse().findIndex(isPost);
-    const isLast = items.length - lastPost - 1 === openedPostIndex;
     if (firstPost === openedPostIndex)
-      return isLast ? PostPosition.Only : PostPosition.First;
-    return isLast ? PostPosition.Last : PostPosition.Middle;
+      return items.length - 1 === openedPostIndex
+        ? PostPosition.Only
+        : PostPosition.First;
+    return PostPosition.Middle;
   };
   const ret = useMemo<UsePostModalNavigation>(
     () => ({

--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -121,6 +121,8 @@ export const usePostModalNavigation = (
       return items.length - 1 === openedPostIndex
         ? PostPosition.Only
         : PostPosition.First;
+    // We do not set the Last position because the local last might not be the actual last.
+    // The setting can be updated once we update the API to return the information if the page is last or not.
     return PostPosition.Middle;
   };
   const ret = useMemo<UsePostModalNavigation>(


### PR DESCRIPTION
## Changes
first post:
<img width="603" alt="SCR-20230203-nwn" src="https://user-images.githubusercontent.com/1488164/216624880-99bbbb77-b4bf-429a-992b-52e293275ef4.png">

last post:
<img width="555" alt="SCR-20230203-nwu" src="https://user-images.githubusercontent.com/1488164/216624918-e22c9e22-b60b-486f-be8e-67e40424865b.png">

only post:
<img width="473" alt="SCR-20230203-nx3" src="https://user-images.githubusercontent.com/1488164/216624969-81c6078a-4416-43fd-b8b7-1f2cc1271976.png">

middle post:
<img width="446" alt="SCR-20230203-nxd" src="https://user-images.githubusercontent.com/1488164/216625039-d8847935-5cd5-4f33-a955-68fa6592baa6.png">


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
