### PR TITLE
fix: new comment latency updating local data

### DIFF
--- a/packages/shared/src/hooks/usePostComment.ts
+++ b/packages/shared/src/hooks/usePostComment.ts
@@ -9,6 +9,7 @@ import AnalyticsContext from '../contexts/AnalyticsContext';
 import { postAnalyticsEvent } from '../lib/feed';
 import useDebounce from './useDebounce';
 import { AuthTriggers } from '../lib/auth';
+import { updatePostCache } from './usePostById';
 
 export interface UsePostCommentOptionalProps {
   enableShowShareNewComment?: boolean;
@@ -94,6 +95,11 @@ export const usePostComment = (
     }
   };
 
+  const updatePostCommentsCount = (increment: number) =>
+    updatePostCache(client, post.id, {
+      numComments: post.numComments + increment,
+    });
+
   const getCommentEdge = (comment: Comment, isNew = true): Edge<Comment> => {
     if (isNew) {
       return { node: { ...comment, children: { edges: [], pageInfo: null } } };
@@ -126,6 +132,7 @@ export const usePostComment = (
       return null;
     }
 
+    updatePostCommentsCount(-1);
     if (parentId === commentId) {
       const index = edges.findIndex((e) => e.node.id === commentId);
       const count = edges[index].node.children?.edges?.length || 0;
@@ -156,6 +163,7 @@ export const usePostComment = (
     const parentId = parentComment.commentId;
 
     if (isNew) {
+      updatePostCommentsCount(1);
       if (!parentId) {
         cached.postComments.edges.push(comment);
         return client.setQueryData(key, cached);

--- a/packages/shared/src/hooks/usePostContent.ts
+++ b/packages/shared/src/hooks/usePostContent.ts
@@ -4,7 +4,6 @@ import { useAuthContext } from '../contexts/AuthContext';
 import { useSharePost } from './useSharePost';
 import {
   Post,
-  PostData,
   PostsEngaged,
   POSTS_ENGAGED_SUBSCRIPTION,
 } from '../graphql/posts';
@@ -17,6 +16,7 @@ import { postEventName } from '../components/utilities';
 import useOnPostClick from './useOnPostClick';
 import useSubscription from './useSubscription';
 import { PostOrigin } from './analytics/useAnalyticsContextData';
+import { updatePostCache } from './usePostById';
 
 export interface UsePostContent {
   sharePost: Post;
@@ -36,7 +36,6 @@ const usePostContent = ({
   post,
 }: UsePostContentProps): UsePostContent => {
   const id = post?.id;
-  const postQueryKey = ['post', id];
   const queryClient = useQueryClient();
   const { user, showLogin } = useAuthContext();
   const { trackEvent } = useAnalyticsContext();
@@ -80,12 +79,7 @@ const usePostContent = ({
     {
       next: (data: PostsEngaged) => {
         if (data.postsEngaged.id === id) {
-          queryClient.setQueryData<PostData>(postQueryKey, (oldPost) => ({
-            post: {
-              ...oldPost.post,
-              ...data.postsEngaged,
-            },
-          }));
+          updatePostCache(queryClient, post.id, data.postsEngaged);
         }
       },
     },


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The issue from the new comment latency is not actually the request time.
- After further investigation, we don't show the comments list component when the `post.numComments` is at 0.
- It happens to update (after some time, thinking it is after mutation latency) due to our real-time updates through `useSubscription`. That is why it only happens on a post's very first comment.
- To fix the issue, I have created a utility function to update the post cache.
- Also created a function to generate a post query key as it is used in a lot of areas but didn't want to update everything in this PR.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1021 #done
