### PR TITLE
fix: squad feed not updating after sharing new post

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
-import useFeed, { PostItem } from '../hooks/useFeed';
+import useFeed, { PostItem, UseFeedOptionalParams } from '../hooks/useFeed';
 import { Ad, Post, PostType } from '../graphql/posts';
 import AuthContext from '../contexts/AuthContext';
 import FeedContext from '../contexts/FeedContext';
@@ -51,7 +51,8 @@ import useSidebarRendered from '../hooks/useSidebarRendered';
 import AlertContext from '../contexts/AlertContext';
 import OnboardingContext from '../contexts/OnboardingContext';
 
-export type FeedProps<T> = {
+export interface FeedProps<T>
+  extends Pick<UseFeedOptionalParams<T>, 'options'> {
   feedName: string;
   feedQueryKey: unknown[];
   query?: string;
@@ -61,7 +62,7 @@ export type FeedProps<T> = {
   emptyScreen?: ReactNode;
   header?: ReactNode;
   forceCardMode?: boolean;
-};
+}
 
 interface RankVariables {
   ranking?: string;
@@ -147,6 +148,7 @@ export default function Feed<T>({
   onEmptyFeed,
   emptyScreen,
   forceCardMode,
+  options,
 }: FeedProps<T>): ReactElement {
   const { showCommentPopover } = useContext(FeaturesContext);
   const { scrollOnboardingVersion } = useContext(FeaturesContext);
@@ -174,7 +176,7 @@ export default function Feed<T>({
       currentSettings.adSpot,
       numCards,
       showOnlyUnreadPosts,
-      { query, variables, options: { refetchOnMount: true } },
+      { query, variables, options },
     );
 
   const { ranking } = (variables as RankVariables) || {};

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -174,8 +174,7 @@ export default function Feed<T>({
       currentSettings.adSpot,
       numCards,
       showOnlyUnreadPosts,
-      query,
-      variables,
+      { query, variables, options: { refetchOnMount: true } },
     );
 
   const { ranking } = (variables as RankVariables) || {};

--- a/packages/shared/src/components/modals/PostToSquadModal.tsx
+++ b/packages/shared/src/components/modals/PostToSquadModal.tsx
@@ -11,10 +11,11 @@ import { SteppedSquadComment } from '../squads/SteppedComment';
 import { ModalState, SquadStateProps } from '../squads/utils';
 import AuthContext from '../../contexts/AuthContext';
 
-export type PostToSquadModalProps = {
+export interface PostToSquadModalProps extends LazyModalCommonProps {
   squad: Squad;
   post?: Post;
-} & LazyModalCommonProps;
+  onSharedSuccessfully?: (post: Post) => void;
+}
 
 const modalSteps: ModalStep[] = [
   {
@@ -25,6 +26,7 @@ const modalSteps: ModalStep[] = [
   },
 ];
 function PostToSquadModal({
+  onSharedSuccessfully,
   onRequestClose,
   isOpen,
   post,
@@ -54,6 +56,7 @@ function PostToSquadModal({
     if (squadPost) {
       displayToast('This post has been shared to your squad');
       await client.invalidateQueries(['sourceFeed', user.id]);
+      onSharedSuccessfully?.(squadPost);
       onRequestClose(e);
     }
   };

--- a/packages/shared/src/components/modals/ShareModal.tsx
+++ b/packages/shared/src/components/modals/ShareModal.tsx
@@ -28,6 +28,7 @@ export default function ShareModal({
   columns,
   column,
   row,
+  onRequestClose,
   ...props
 }: ShareModalProps): ReactElement {
   const isComment = !!comment;
@@ -64,7 +65,12 @@ export default function ShareModal({
   }, []);
 
   return (
-    <Modal size={Modal.Size.Small} kind={Modal.Kind.FlexibleCenter} {...props}>
+    <Modal
+      size={Modal.Size.Small}
+      kind={Modal.Kind.FlexibleCenter}
+      onRequestClose={onRequestClose}
+      {...props}
+    >
       <Modal.Header title={isComment ? 'Share comment' : 'Share post'} />
       {!isComment && (
         <PostItemCard
@@ -102,6 +108,7 @@ export default function ShareModal({
           columns={columns}
           column={column}
           row={row}
+          onSquadShare={() => onRequestClose(null)}
         />
       </Modal.Body>
     </Modal>

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -32,7 +32,9 @@ interface SocialShareProps {
   origin: Origin;
   post: Post;
   comment?: Comment;
+  onSquadShare?: (post: Post) => void;
 }
+
 export const SocialShare = ({
   post,
   comment,
@@ -40,6 +42,7 @@ export const SocialShare = ({
   columns,
   column,
   row,
+  onSquadShare,
 }: SocialShareProps & FeedItemPosition): ReactElement => {
   const { squads } = useAuthContext();
   const isComment = !!comment;
@@ -64,6 +67,7 @@ export const SocialShare = ({
       props: {
         squad,
         post,
+        onSharedSuccessfully: onSquadShare,
       },
     });
 

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -4,6 +4,7 @@ import {
   InfiniteData,
   QueryClient,
   useInfiniteQuery,
+  UseInfiniteQueryOptions,
   useQueryClient,
 } from 'react-query';
 import cloneDeep from 'lodash.clonedeep';
@@ -98,15 +99,21 @@ const findIndexOfPostInData = (
   return { pageIndex: -1, index: -1 };
 };
 
+interface UseFeedOptionalParams<T> {
+  query?: string;
+  variables?: T;
+  options?: UseInfiniteQueryOptions<FeedData>;
+}
+
 export default function useFeed<T>(
   feedQueryKey: unknown[],
   pageSize: number,
   adSpot: number,
   placeholdersPerPage: number,
   showOnlyUnreadPosts: boolean,
-  query?: string,
-  variables?: T,
+  params: UseFeedOptionalParams<T> = {},
 ): FeedReturnType {
+  const { query, variables, options = {} } = params;
   const { user, tokenRefreshed } = useContext(AuthContext);
   const queryClient = useQueryClient();
 
@@ -121,8 +128,9 @@ export default function useFeed<T>(
         unreadOnly: showOnlyUnreadPosts,
       }),
     {
-      enabled: query && tokenRefreshed,
       refetchOnMount: false,
+      ...options,
+      enabled: query && tokenRefreshed,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
       getNextPageParam: (lastPage) =>

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -99,7 +99,7 @@ const findIndexOfPostInData = (
   return { pageIndex: -1, index: -1 };
 };
 
-interface UseFeedOptionalParams<T> {
+export interface UseFeedOptionalParams<T> {
   query?: string;
   variables?: T;
   options?: UseInfiniteQueryOptions<FeedData>;

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -101,6 +101,7 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
           query={SOURCE_FEED_QUERY}
           variables={queryVariables}
           forceCardMode
+          options={{ refetchOnMount: true }}
         />
       </FeedPage>
     </ProtectedPage>

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -24,7 +24,6 @@ import { useQuery } from 'react-query';
 import { LazyModal } from '@dailydotdev/shared/src/components/modals/common/types';
 import { useLazyModal } from '@dailydotdev/shared/src/hooks/useLazyModal';
 import Custom404 from '@dailydotdev/shared/src/components/Custom404';
-import { disabledRefetch } from '@dailydotdev/shared/src/lib/func';
 import { mainFeedLayoutProps } from '../../../components/layouts/MainFeedPage';
 import { getLayout } from '../../../components/layouts/FeedLayout';
 import ProtectedPage from '../../../components/ProtectedPage';
@@ -35,15 +34,14 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
   const { isFallback } = useRouter();
   const { openModal } = useLazyModal();
   const queryKey = ['squad', handle];
-  const { data: squad, isLoading } = useQuery<Squad>(
-    queryKey,
-    () => getSquad(handle),
-    {
-      ...disabledRefetch,
-      enabled: !!handle,
-      retry: false,
-    },
-  );
+  const {
+    data: squad,
+    isLoading,
+    isFetched,
+  } = useQuery<Squad>(queryKey, () => getSquad(handle), {
+    enabled: !!handle,
+    retry: false,
+  });
 
   const squadId = squad?.id;
 
@@ -63,7 +61,9 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
     [squadId],
   );
 
-  if (isLoading) return <SquadLoading />;
+  if (isLoading && !isFetched && !squad) return <SquadLoading />;
+
+  if (!isFetched) return <></>;
 
   if (!squad) return <Custom404 />;
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since I was testing out some theory of the `refetch` could be the issue (but turns out to be not), I took the liberty of reverting the `refetch` as we always tend to prefer it enabled.
- I also tested out and it shows the loading skeleton as opposed to the current behavior of flickering 404 page.
- I checked to access it on incognito and no flicker whatsoever.
- I updated the `useFeed` hook to accept the options for enabling refetch on mount. This is unwanted for regular feeds, but feeds like `Source` should be okay.
- Automatically closes the Share modal once the transaction for sharing a post to a squad was successful.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1035 #done
