### PR TITLE
fix: not showing forbidden squad pages

### DIFF
--- a/packages/shared/src/components/Custom404.tsx
+++ b/packages/shared/src/components/Custom404.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, ReactNode } from 'react';
 import HelloWorldSvg from '../svg/HelloWorldSvg';
+import { PageContainer } from './utilities';
 
 interface Custom404Props {
   children?: ReactNode;
@@ -7,18 +8,18 @@ interface Custom404Props {
 
 export default function Custom404({ children }: Custom404Props): ReactElement {
   return (
-    <div
-      className="flex flex-col justify-center items-center mx-auto min-h-page"
+    <PageContainer
+      className="justify-center items-center min-h-page"
       data-testid="notFound"
     >
       {children}
       <HelloWorldSvg
         style={{ width: '55%', maxWidth: '32.75rem' }}
-        className="self-center mb-10"
+        className="self-center -mt-20 laptop:-mt-10 mb-10"
       />
       <h1 className="mx-9 font-bold text-center break-words-overflow typo-title1">
         Oops, this page couldn’t be found
       </h1>
-    </div>
+    </PageContainer>
   );
 }

--- a/packages/shared/src/graphql/common.ts
+++ b/packages/shared/src/graphql/common.ts
@@ -78,3 +78,8 @@ export const isQueryKeySame = (left: QueryKey, right: QueryKey): boolean => {
 
   return false;
 };
+
+export enum ApiError {
+  Forbidden = 'FORBIDDEN',
+  NotFound = 'NOT_FOUND',
+}

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -34,6 +34,7 @@ import SquadPostContent from '@dailydotdev/shared/src/components/post/SquadPostC
 import SquadPostPageNavigation from '@dailydotdev/shared/src/components/post/SquadPostPageNavigation';
 import useWindowEvents from '@dailydotdev/shared/src/hooks/useWindowEvents';
 import usePostById from '@dailydotdev/shared/src/hooks/usePostById';
+import { ApiError } from '@dailydotdev/shared/src/graphql/common';
 import { getLayout as getMainLayout } from '../../components/layouts/MainLayout';
 import { getTemplatedTitle } from '../../components/layouts/utils';
 
@@ -171,11 +172,8 @@ export async function getStaticProps({
     };
   } catch (err) {
     const clientError = err as ClientError;
-    if (
-      ['FORBIDDEN', 'NOT_FOUND'].includes(
-        clientError?.response?.errors?.[0]?.extensions?.code,
-      )
-    ) {
+    const errors = Object.values(ApiError);
+    if (errors.includes(clientError?.response?.errors?.[0]?.extensions?.code)) {
       return {
         props: { id },
         revalidate: 60,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We never get the Forbidden page since we never provide any information if the Squad actually exists except the error thrown by the API, which I agree is the best way.
- I have consolidated the errors to easily manage returned error codes.
- Also fixed the 404 page responsiveness.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
