### PR TITLE
refactor: list priority for squad member list

### DIFF
--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -351,3 +351,13 @@ export async function editSquad(
   );
   return data.editSquad;
 }
+
+export const rolePriority: Record<SquadMemberRole, number> = {
+  member: 0,
+  owner: 10,
+};
+
+const DEFAULT_NEW_ROLES = 1;
+
+export const getRolePriority = (role: SquadMemberRole): number =>
+  rolePriority[role] ?? DEFAULT_NEW_ROLES;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Created a priority to easily identify the order in whom to display.
- Member is set at `0` since this is the most basic level, to make it backwards compatible (extension-wise), I have introduced a default value of new introductions as `1`. Most likely we will introduce moderators/admins, which are a level above members (0). The owner is the highest (10) - it is highly unlikely we will get 10 levels with roles.
- Deleted an empty file.

Preview:
![image](https://user-images.githubusercontent.com/13744167/217167397-35a09434-3ca4-435b-86d1-91d8c3ffdfbc.png)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1034 #done
