### PR TITLE
fix: share options menu icon size consistency

### DIFF
--- a/packages/shared/src/components/ShareOptionsMenu.tsx
+++ b/packages/shared/src/components/ShareOptionsMenu.tsx
@@ -89,7 +89,7 @@ export default function ShareOptionsMenu({
   if (hasSquadAccess && !post?.private) {
     if (!squads?.length) {
       shareOptions.push({
-        icon: <MenuIcon Icon={SquadIcon} />,
+        icon: <MenuIcon Icon={SquadIcon} size="medium" />,
         text: 'Post to new squad',
         action: () =>
           openModal({
@@ -104,9 +104,9 @@ export default function ShareOptionsMenu({
         squad.active &&
         shareOptions.push({
           icon: squad.image ? (
-            <SquadImage className="mr-2.5 w-5 h-5 text-2xl" {...squad} />
+            <SquadImage className="mr-2.5 w-6 h-6" {...squad} />
           ) : (
-            <MenuIcon Icon={DefaultSquadIcon} />
+            <MenuIcon Icon={DefaultSquadIcon} size="medium" />
           ),
           text: `Share to ${squad.name}`,
           action: () =>

--- a/packages/shared/src/components/ShareOptionsMenu.tsx
+++ b/packages/shared/src/components/ShareOptionsMenu.tsx
@@ -89,7 +89,7 @@ export default function ShareOptionsMenu({
   if (hasSquadAccess && !post?.private) {
     if (!squads?.length) {
       shareOptions.push({
-        icon: <MenuIcon Icon={SquadIcon} size="medium" />,
+        icon: <MenuIcon Icon={SquadIcon} />,
         text: 'Post to new squad',
         action: () =>
           openModal({
@@ -106,7 +106,7 @@ export default function ShareOptionsMenu({
           icon: squad.image ? (
             <SquadImage className="mr-2.5 w-6 h-6" {...squad} />
           ) : (
-            <MenuIcon Icon={DefaultSquadIcon} size="medium" />
+            <MenuIcon Icon={DefaultSquadIcon} />
           ),
           text: `Share to ${squad.name}`,
           action: () =>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The icon size set for Squad image was inconsistent with what we have for our existing items.
- All should now follow the `24px` box size.

Preview:
![image](https://user-images.githubusercontent.com/13744167/217172173-fd418153-874c-42fa-b54e-fbc0e61c708e.png)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1040 #done
