### PR TITLE
feat: introduces squad tracking events

### DIFF
--- a/packages/shared/src/components/ShareOptionsMenu.tsx
+++ b/packages/shared/src/components/ShareOptionsMenu.tsx
@@ -8,7 +8,7 @@ import { postAnalyticsEvent } from '../lib/feed';
 import { MenuIcon } from './MenuIcon';
 import { ShareBookmarkProps } from './post/PostActions';
 import BookmarkIcon from './icons/Bookmark';
-import { Origin } from '../lib/analytics';
+import { AnalyticsEvent, Origin } from '../lib/analytics';
 import { ShareProvider } from '../lib/share';
 import { useCopyPostLink } from '../hooks/useCopyPostLink';
 import LinkIcon from './icons/Link';
@@ -109,14 +109,19 @@ export default function ShareOptionsMenu({
             <MenuIcon Icon={DefaultSquadIcon} />
           ),
           text: `Share to ${squad.name}`,
-          action: () =>
+          action: () => {
+            trackEvent({ event_name: AnalyticsEvent.StartShareToSquad });
             openModal({
               type: LazyModal.PostToSquad,
               props: {
                 squad,
                 post,
+                onSharedSuccessfully: () => {
+                  trackEvent({ event_name: AnalyticsEvent.ShareToSquad });
+                },
               },
-            }),
+            });
+          },
         }),
     );
   }

--- a/packages/shared/src/components/ShareOptionsMenu.tsx
+++ b/packages/shared/src/components/ShareOptionsMenu.tsx
@@ -94,7 +94,7 @@ export default function ShareOptionsMenu({
         action: () =>
           openModal({
             type: LazyModal.NewSquad,
-            props: { post },
+            props: { post, origin: Origin.Share },
           }),
       });
     }

--- a/packages/shared/src/components/ShareOptionsMenu.tsx
+++ b/packages/shared/src/components/ShareOptionsMenu.tsx
@@ -110,14 +110,18 @@ export default function ShareOptionsMenu({
           ),
           text: `Share to ${squad.name}`,
           action: () => {
-            trackEvent({ event_name: AnalyticsEvent.StartShareToSquad });
+            trackEvent(
+              postAnalyticsEvent(AnalyticsEvent.StartShareToSquad, post),
+            );
             openModal({
               type: LazyModal.PostToSquad,
               props: {
                 squad,
                 post,
                 onSharedSuccessfully: () => {
-                  trackEvent({ event_name: AnalyticsEvent.ShareToSquad });
+                  trackEvent(
+                    postAnalyticsEvent(AnalyticsEvent.ShareToSquad, post),
+                  );
                 },
               },
             });

--- a/packages/shared/src/components/modals/NewSquadModal.tsx
+++ b/packages/shared/src/components/modals/NewSquadModal.tsx
@@ -1,9 +1,14 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useContext, useEffect, useState } from 'react';
 import { Modal } from './common/Modal';
 import { Squad, SquadForm } from '../../graphql/squads';
 import { SquadSelectArticle } from '../squads/SelectArticle';
 import { SquadReady } from '../squads/Ready';
-import { ModalState, quitSquadModal, SquadStateProps } from '../squads/utils';
+import {
+  ModalState,
+  modalStateToScreenValue,
+  quitSquadModal,
+  SquadStateProps,
+} from '../squads/utils';
 import { usePrompt } from '../../hooks/usePrompt';
 import { ModalStep } from './common/types';
 import { SteppedSquadComment } from '../squads/SteppedComment';
@@ -11,39 +16,47 @@ import { SteppedSquadDetails } from '../squads/SteppedDetails';
 import { Post } from '../../graphql/posts';
 import { useBoot } from '../../hooks/useBoot';
 import SquadAccessIntro from '../sidebar/SquadAccessIntro';
-
-export const modalStateOrder = [
-  ModalState.Details,
-  ModalState.SelectArticle,
-  ModalState.WriteComment,
-  ModalState.Ready,
-];
+import { AnalyticsEvent, Origin, TargetType } from '../../lib/analytics';
+import AnalyticsContext from '../../contexts/AnalyticsContext';
 
 export type NewSquadModalProps = {
   onRequestClose: () => void;
-  onPreviousState?: () => void;
   isOpen: boolean;
+  origin: Origin;
   post?: Post;
   shouldShowIntro?: boolean;
 };
 
 let activeView;
 function NewSquadModal({
-  onPreviousState,
   onRequestClose,
   isOpen,
   post,
   shouldShowIntro = false,
+  origin,
 }: NewSquadModalProps): ReactElement {
+  const { trackEvent } = useContext(AnalyticsContext);
   const [squad, setSquad] = useState<Squad>();
   const { showPrompt } = usePrompt();
   const { addSquad } = useBoot();
   const [shouldShowBetaModal, setShouldShowBetaModal] =
     useState(shouldShowIntro);
   const [form, setForm] = useState<Partial<SquadForm>>({ post: { post } });
+
+  useEffect(() => {
+    trackEvent({
+      event_name: AnalyticsEvent.Impression,
+      target_type: TargetType.CreateSquadPopup,
+      extra: JSON.stringify({ origin }),
+    });
+  }, []);
+
   const onNext = async (squadForm?: SquadForm) =>
     squadForm && setForm(squadForm);
   const onCreate = (newSquad: Squad) => {
+    trackEvent({
+      event_name: AnalyticsEvent.CompleteSquadCreation,
+    });
     addSquad(newSquad);
     setSquad(newSquad);
   };
@@ -54,22 +67,48 @@ function NewSquadModal({
     onRequestClose,
   };
 
+  const onBetaNext = () => {
+    trackEvent({
+      event_name: AnalyticsEvent.ClickSquadCreationNext,
+      extra: JSON.stringify({ screen_value: 'intro' }),
+    });
+    setShouldShowBetaModal(false);
+  };
+
+  const onBetaBack = () => {
+    trackEvent({
+      event_name: AnalyticsEvent.ClickSquadCreationBack,
+      extra: JSON.stringify({
+        screen_value: modalStateToScreenValue[ModalState.Details],
+      }),
+    });
+    setShouldShowBetaModal(true);
+  };
+
   const modalSteps: ModalStep[] = [
     {
       key: ModalState.Details,
+      screen_value: modalStateToScreenValue[ModalState.Details],
       title: (
         <>
-          {onPreviousState && (
-            <Modal.Header.StepsButton onClick={onPreviousState} />
-          )}
+          {shouldShowIntro && <Modal.Header.StepsButton onClick={onBetaBack} />}
           <Modal.Header.Subtitle>{ModalState.Details}</Modal.Header.Subtitle>
         </>
       ),
     },
-    !post ? { key: ModalState.SelectArticle } : undefined,
-    { key: ModalState.WriteComment },
+    !post
+      ? {
+          key: ModalState.SelectArticle,
+          screen_value: modalStateToScreenValue[ModalState.SelectArticle],
+        }
+      : undefined,
+    {
+      key: ModalState.WriteComment,
+      screen_value: modalStateToScreenValue[ModalState.WriteComment],
+    },
     {
       key: ModalState.Ready,
+      screen_value: modalStateToScreenValue[ModalState.Ready],
       title: <Modal.Header.Title>{ModalState.Ready}</Modal.Header.Title>,
     },
   ].filter((step) => step);
@@ -91,10 +130,7 @@ function NewSquadModal({
         size={Modal.Size.Small}
         onRequestClose={handleClose}
       >
-        <SquadAccessIntro
-          onClose={handleClose}
-          onCreateSquad={() => setShouldShowBetaModal(false)}
-        />
+        <SquadAccessIntro onClose={handleClose} onCreateSquad={onBetaNext} />
       </Modal>
     );
   }
@@ -106,6 +142,8 @@ function NewSquadModal({
       kind={Modal.Kind.FixedCenter}
       size={Modal.Size.Small}
       onRequestClose={handleClose}
+      onTrackNext={AnalyticsEvent.ClickSquadCreationNext}
+      onTrackPrev={AnalyticsEvent.ClickSquadCreationBack}
       onViewChange={(view) => {
         activeView = view;
       }}

--- a/packages/shared/src/components/modals/SquadInviteModal.tsx
+++ b/packages/shared/src/components/modals/SquadInviteModal.tsx
@@ -10,6 +10,7 @@ import {
   InviteTextFieldHandle,
 } from '../squads/InviteTextField';
 import { SquadModalHeader } from '../squads/ModalHeader';
+import { Origin } from '../../lib/analytics';
 
 type SquadInviteModalProps = {
   initialSquad: Squad;
@@ -40,6 +41,7 @@ function SquadInviteModal({
           isLoading={isLoading}
           squad={squad}
           ref={inviteTextRef}
+          origin={Origin.SquadPage}
         />
         <Alert
           className="mt-4"

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -15,6 +15,7 @@ import {
 } from './types';
 import classed from '../../../lib/classed';
 import { ModalStepsWrapper } from './ModalStepsWrapper';
+import { AnalyticsEvent } from '../../../lib/analytics';
 
 export interface ModalProps extends ReactModal.Props {
   children?: React.ReactNode;
@@ -24,6 +25,8 @@ export interface ModalProps extends ReactModal.Props {
   steps?: ModalStep[];
   defaultView?: string;
   onViewChange?: (view: string) => void;
+  onTrackNext?: AnalyticsEvent;
+  onTrackPrev?: AnalyticsEvent;
 }
 
 export type LazyModalCommonProps = Pick<
@@ -76,6 +79,8 @@ export function Modal({
   kind = ModalKind.FlexibleCenter,
   size = ModalSize.Medium,
   onViewChange,
+  onTrackNext,
+  onTrackPrev,
   onRequestClose,
   tabs,
   steps,
@@ -122,6 +127,8 @@ export function Modal({
           setActiveView,
           steps,
           tabs,
+          onTrackNext,
+          onTrackPrev,
         }}
       >
         {children}

--- a/packages/shared/src/components/modals/common/ModalStepsWrapper.tsx
+++ b/packages/shared/src/components/modals/common/ModalStepsWrapper.tsx
@@ -6,6 +6,7 @@ import {
 } from 'react';
 import { isNullOrUndefined } from '../../../lib/func';
 import { ModalPropsContext } from './types';
+import AnalyticsContext from '../../../contexts/AnalyticsContext';
 
 export interface StepComponentProps<
   T extends ReactEventHandler = MouseEventHandler,
@@ -23,17 +24,39 @@ export function ModalStepsWrapper({
   view,
   children,
 }: ModalStepsProps): ReactElement {
-  const { activeView, steps, setActiveView } = useContext(ModalPropsContext);
+  const { trackEvent } = useContext(AnalyticsContext);
+  const { activeView, steps, setActiveView, onTrackNext, onTrackPrev } =
+    useContext(ModalPropsContext);
   const activeStepIndex = steps.findIndex(({ key }) => activeView === key);
   const activeStep = steps[activeStepIndex];
   if (!activeStep) return null;
   const previousStep =
     activeStepIndex > 0
-      ? () => setActiveView(steps[activeStepIndex - 1]?.key)
+      ? () => {
+          if (onTrackPrev) {
+            trackEvent({
+              event_name: onTrackPrev,
+              extra: JSON.stringify({
+                screen_value: steps[activeStepIndex]?.screen_value,
+              }),
+            });
+          }
+          return setActiveView(steps[activeStepIndex - 1]?.key);
+        }
       : undefined;
   const nextStep =
     activeStepIndex < steps.length
-      ? () => setActiveView(steps[activeStepIndex + 1]?.key)
+      ? () => {
+          if (onTrackNext) {
+            trackEvent({
+              event_name: onTrackNext,
+              extra: JSON.stringify({
+                screen_value: steps[activeStepIndex]?.screen_value,
+              }),
+            });
+          }
+          return setActiveView(steps[activeStepIndex + 1]?.key);
+        }
       : undefined;
 
   if (!isNullOrUndefined(view) && view !== activeView) {

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -1,4 +1,5 @@
 import { KeyboardEvent, MouseEvent, createContext, ReactNode } from 'react';
+import { AnalyticsEvent } from '../../../lib/analytics';
 
 export enum ModalHeaderKind {
   Primary = 'primary',
@@ -38,6 +39,7 @@ export type ModalTabItem = {
 
 export type ModalStep = {
   key: string;
+  screen_value?: string;
   title?: string | ReactNode;
   hideProgress?: boolean;
 };
@@ -51,6 +53,8 @@ export type ModalContextProps = {
   size: ModalSize;
   steps?: ModalStep[];
   tabs?: string[] | ModalTabItem[];
+  onTrackNext?: AnalyticsEvent;
+  onTrackPrev?: AnalyticsEvent;
 };
 
 export const ModalPropsContext = createContext<ModalContextProps>({

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -22,6 +22,7 @@ import { BasePostContent, PostContentClassName } from './BasePostContent';
 import { PostLoadingPlaceholder } from './PostLoadingPlaceholder';
 import classed from '../../lib/classed';
 import { cloudinary } from '../../lib/image';
+import { combinedClicks } from '../../lib/click';
 
 export interface PostContentProps
   extends Pick<PostModalActionsProps, 'onClose' | 'inlineActions'>,
@@ -155,7 +156,7 @@ export function PostContent({
             title="Go to post"
             target="_blank"
             rel="noopener"
-            onClick={onReadArticle}
+            {...combinedClicks(onReadArticle)}
             className="block overflow-hidden mb-10 rounded-2xl cursor-pointer"
             style={{ maxWidth: '25.625rem' }}
           >

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -146,7 +146,8 @@ function SquadPostContent({
           <div className="flex flex-col mt-8 rounded-16 border border-theme-divider-tertiary hover:border-theme-divider-secondary">
             <a
               href={post.sharedPost.commentsPermalink}
-              title="Go to article"
+              title="Go to post"
+              target="_blank"
               rel="noopener"
               className="flex flex-col-reverse laptop:flex-row p-4 max-w-full"
               onClick={onReadArticle}
@@ -166,6 +167,7 @@ function SquadPostContent({
                   className="mt-5 btn-secondary w-fit"
                   href={post.sharedPost.permalink}
                   openNewTab={openNewTab}
+                  onClick={onReadArticle}
                 />
               </div>
               <div className="block overflow-hidden w-70 rounded-2xl cursor-pointer h-fit">

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -29,6 +29,7 @@ import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
 import { Squad } from '../../graphql/squads';
 import { useCreateSquadModal } from '../../hooks/useCreateSquadModal';
+import { Origin } from '../../lib/analytics';
 
 const UserSettingsModal = dynamic(
   () =>
@@ -68,7 +69,7 @@ export default function Sidebar({
     popularFeedCopy,
     isFlagsFetched,
   } = useContext(FeaturesContext);
-  const { openSquadBetaModal } = useCreateSquadModal({
+  const { openNewSquadModal, openSquadBetaModal } = useCreateSquadModal({
     hasSquads: !!squads?.length,
     hasAccess: hasSquadAccess,
     isFlagsFetched,
@@ -131,25 +132,25 @@ export default function Sidebar({
         <SidebarScrollWrapper>
           <Nav>
             <SidebarUserButton sidebarRendered={sidebarRendered} />
-            {newSquadButtonVisible && (
-              <div className="flex">
-                <Button
-                  buttonSize="small"
-                  icon={<PlusIcon />}
-                  iconOnly={!sidebarExpanded}
-                  className={classNames(
-                    'mt-0 laptop:mt-2 mb-4 btn-primary-cabbage flex flex-1',
-                    sidebarExpanded ? 'mx-3' : 'mx-1.5',
-                  )}
-                  textPosition={
-                    sidebarExpanded ? 'justify-start' : 'justify-center'
-                  }
-                  onClick={openSquadBetaModal}
-                >
-                  {sidebarExpanded && 'New Squad'}
-                </Button>
-              </div>
-            )}
+            {/* {newSquadButtonVisible && ( */}
+            <div className="flex">
+              <Button
+                buttonSize="small"
+                icon={<PlusIcon />}
+                iconOnly={!sidebarExpanded}
+                className={classNames(
+                  'mt-0 laptop:mt-2 mb-4 btn-primary-cabbage flex flex-1',
+                  sidebarExpanded ? 'mx-3' : 'mx-1.5',
+                )}
+                textPosition={
+                  sidebarExpanded ? 'justify-start' : 'justify-center'
+                }
+                onClick={() => openSquadBetaModal({ origin: Origin.Sidebar })}
+              >
+                {sidebarExpanded && 'New Squad'}
+              </Button>
+            </div>
+            {/* )} */}
             {!alerts?.filter && (
               <MyFeedButton
                 {...defaultRenderSectionProps}
@@ -164,7 +165,7 @@ export default function Sidebar({
                 {...defaultRenderSectionProps}
                 activePage={activePageProp}
                 squads={squads}
-                onNewSquad={openSquadBetaModal}
+                onNewSquad={() => openNewSquadModal({ origin: Origin.Sidebar })}
                 onOpenLockedSquad={openLockedSquadModal}
               />
             )}

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -132,25 +132,25 @@ export default function Sidebar({
         <SidebarScrollWrapper>
           <Nav>
             <SidebarUserButton sidebarRendered={sidebarRendered} />
-            {/* {newSquadButtonVisible && ( */}
-            <div className="flex">
-              <Button
-                buttonSize="small"
-                icon={<PlusIcon />}
-                iconOnly={!sidebarExpanded}
-                className={classNames(
-                  'mt-0 laptop:mt-2 mb-4 btn-primary-cabbage flex flex-1',
-                  sidebarExpanded ? 'mx-3' : 'mx-1.5',
-                )}
-                textPosition={
-                  sidebarExpanded ? 'justify-start' : 'justify-center'
-                }
-                onClick={() => openSquadBetaModal({ origin: Origin.Sidebar })}
-              >
-                {sidebarExpanded && 'New Squad'}
-              </Button>
-            </div>
-            {/* )} */}
+            {newSquadButtonVisible && (
+              <div className="flex">
+                <Button
+                  buttonSize="small"
+                  icon={<PlusIcon />}
+                  iconOnly={!sidebarExpanded}
+                  className={classNames(
+                    'mt-0 laptop:mt-2 mb-4 btn-primary-cabbage flex flex-1',
+                    sidebarExpanded ? 'mx-3' : 'mx-1.5',
+                  )}
+                  textPosition={
+                    sidebarExpanded ? 'justify-start' : 'justify-center'
+                  }
+                  onClick={() => openSquadBetaModal({ origin: Origin.Sidebar })}
+                >
+                  {sidebarExpanded && 'New Squad'}
+                </Button>
+              </div>
+            )}
             {!alerts?.filter && (
               <MyFeedButton
                 {...defaultRenderSectionProps}

--- a/packages/shared/src/components/squads/Ready.tsx
+++ b/packages/shared/src/components/squads/Ready.tsx
@@ -13,6 +13,7 @@ import {
 } from './utils';
 import { ModalPropsContext } from '../modals/common/types';
 import { InviteTextField, InviteTextFieldHandle } from './InviteTextField';
+import { Origin } from '../../lib/analytics';
 
 interface SquadReadyProps extends SquadStateProps {
   squad?: Squad;
@@ -33,7 +34,11 @@ export function SquadReady({ squad }: SquadReadyProps): ReactElement {
         <SquadReadySvg className="mt-6 mb-4" />
         <h3 className="font-bold typo-title2">{name}</h3>
         <h4>@{handle}</h4>
-        <InviteTextField squad={squad} ref={inviteTextRef} />
+        <InviteTextField
+          squad={squad}
+          ref={inviteTextRef}
+          origin={Origin.SquadCreation}
+        />
         <Alert
           className="mt-4"
           type={AlertType.Info}

--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -6,17 +6,12 @@ import AuthContext from '../../contexts/AuthContext';
 import EditIcon from '../icons/Edit';
 // import TourIcon from '../icons/Tour';
 import ExitIcon from '../icons/Exit';
-import { PromptOptions, usePrompt } from '../../hooks/usePrompt';
-import {
-  deleteSquad,
-  leaveSquad,
-  Squad,
-  SquadMemberRole,
-} from '../../graphql/squads';
+import { Squad, SquadMemberRole } from '../../graphql/squads';
 import TrashIcon from '../icons/Trash';
 import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
-import { useBoot } from '../../hooks/useBoot';
+import { useDeleteSquad } from '../../hooks/useDeleteSquad';
+import { useLeaveSquad } from '../../hooks/useLeaveSquad';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ '../fields/PortalMenu'),
@@ -31,62 +26,21 @@ export default function SquadHeaderMenu({
   squad: Squad;
 }): ReactElement {
   const router = useRouter();
-  const { deleteSquad: deleteSquadFromList } = useBoot();
   const { user } = useContext(AuthContext);
-  const { showPrompt } = usePrompt();
   const { openModal } = useLazyModal();
 
   if (!user) {
     return <></>;
   }
-
+  const { onDeleteSquad } = useDeleteSquad({
+    squad,
+    callback: () => router.replace('/'),
+  });
+  const { onLeaveSquad } = useLeaveSquad({
+    squad,
+    callback: () => router.replace('/'),
+  });
   const isSquadOwner = squad?.currentMember?.role === SquadMemberRole.Owner;
-
-  const onLeaveSquad = async () => {
-    const options: PromptOptions = {
-      title: `Leave ${squad.name}`,
-      description: `Leaving ${squad.name} means that you will lose your access to all posts that were shared in the Squad`,
-      okButton: {
-        title: 'Leave',
-        className: 'btn-secondary',
-      },
-      cancelButton: {
-        title: 'Stay',
-        className: 'btn-primary-cabbage',
-      },
-      className: {
-        buttons: 'flex-row-reverse',
-      },
-    };
-    if (await showPrompt(options)) {
-      await leaveSquad(squad.id);
-      deleteSquadFromList(squad.id);
-      await router.replace('/');
-    }
-  };
-
-  const onDeleteSquad = async () => {
-    const options: PromptOptions = {
-      title: `Delete ${squad.name}`,
-      description: `Deleting ${squad.name} means you and all squad members will lose access to all posts that were shared in the Squad. Are you sure?`,
-      okButton: {
-        title: 'Delete',
-        className: 'btn-secondary',
-      },
-      cancelButton: {
-        title: 'No, keep it',
-        className: 'btn-primary-cabbage',
-      },
-      className: {
-        buttons: 'flex-row-reverse',
-      },
-    };
-    if (await showPrompt(options)) {
-      await deleteSquad(squad.id);
-      deleteSquadFromList(squad.id);
-      await router.replace('/');
-    }
-  };
 
   const onEditSquad = () => {
     openModal({

--- a/packages/shared/src/components/squads/utils.tsx
+++ b/packages/shared/src/components/squads/utils.tsx
@@ -15,7 +15,12 @@ export enum ModalState {
   WriteComment = 'Post article',
   Ready = 'Almost there!',
 }
-
+export const modalStateToScreenValue: Record<ModalState, string> = {
+  [ModalState.Details]: 'squad details',
+  [ModalState.SelectArticle]: 'share article',
+  [ModalState.WriteComment]: 'comment',
+  [ModalState.Ready]: 'invitation',
+};
 export const SquadTitle = classed(
   'h3',
   'text-center typo-large-title font-bold',

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -62,14 +62,14 @@ export const SocialShare = ({
     );
 
   const onShareToSquad = (squad: Squad) => {
-    trackEvent({ event_name: AnalyticsEvent.StartShareToSquad });
+    trackEvent(postAnalyticsEvent(AnalyticsEvent.StartShareToSquad, post));
     openModal({
       type: LazyModal.PostToSquad,
       props: {
         squad,
         post,
         onSharedSuccessfully: () => {
-          trackEvent({ event_name: AnalyticsEvent.ShareToSquad });
+          trackEvent(postAnalyticsEvent(AnalyticsEvent.ShareToSquad, post));
           return onSquadShare;
         },
       },

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -19,7 +19,7 @@ import RedditIcon from '../icons/Reddit';
 import LinkedInIcon from '../icons/LinkedIn';
 import TelegramIcon from '../icons/Telegram';
 import { FeedItemPosition, postAnalyticsEvent } from '../../lib/feed';
-import { Origin } from '../../lib/analytics';
+import { AnalyticsEvent, Origin } from '../../lib/analytics';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 import { Comment, getCommentHash } from '../../graphql/comments';
 import { useAuthContext } from '../../contexts/AuthContext';
@@ -61,15 +61,20 @@ export const SocialShare = ({
       }),
     );
 
-  const onShareToSquad = (squad: Squad) =>
+  const onShareToSquad = (squad: Squad) => {
+    trackEvent({ event_name: AnalyticsEvent.StartShareToSquad });
     openModal({
       type: LazyModal.PostToSquad,
       props: {
         squad,
         post,
-        onSharedSuccessfully: onSquadShare,
+        onSharedSuccessfully: () => {
+          trackEvent({ event_name: AnalyticsEvent.ShareToSquad });
+          return onSquadShare;
+        },
       },
     });
+  };
 
   return (
     <section className="grid grid-cols-5 gap-4 pt-2 w-fit">

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -101,7 +101,8 @@ export type ReadHistoryPost = Pick<
   | 'trending'
   | 'tags'
   | 'sharedPost'
-> & { source?: Pick<Source, 'image' | 'id'> } & {
+  | 'type'
+> & { source?: Pick<Source, 'image' | 'id' | 'type'> } & {
   author?: Pick<Author, 'id'>;
 } & {
   scout?: Pick<Scout, 'id'>;

--- a/packages/shared/src/hooks/useDeleteSquad.ts
+++ b/packages/shared/src/hooks/useDeleteSquad.ts
@@ -1,0 +1,55 @@
+import { useContext, useMemo } from 'react';
+import { deleteSquad, Squad } from '../graphql/squads';
+import { PromptOptions, usePrompt } from './usePrompt';
+import { useBoot } from './useBoot';
+import AnalyticsContext from '../contexts/AnalyticsContext';
+import { AnalyticsEvent } from '../lib/analytics';
+
+interface UseDeleteSquadModal {
+  onDeleteSquad: () => void;
+}
+
+type UseDeleteSquadProps = {
+  squad: Squad;
+  callback?: (params?: unknown) => void;
+};
+
+export const useDeleteSquad = ({
+  squad,
+  callback,
+}: UseDeleteSquadProps): UseDeleteSquadModal => {
+  const { trackEvent } = useContext(AnalyticsContext);
+  const { showPrompt } = usePrompt();
+  const { deleteSquad: deleteCachedSquad } = useBoot();
+
+  const onDeleteSquad = async () => {
+    const options: PromptOptions = {
+      title: `Delete ${squad.name}`,
+      description: squad.active
+        ? `Deleting ${squad.name} means you and all squad members will lose access to all posts that were shared in the Squad. Are you sure?`
+        : `Deleting your Squad will free up your handle and members you invited will not be able to join`,
+      okButton: {
+        title: 'Delete',
+        className: 'btn-secondary',
+      },
+      cancelButton: {
+        title: 'No, keep it',
+        className: 'btn-primary-cabbage',
+      },
+      className: {
+        buttons: 'flex-row-reverse',
+      },
+    };
+    if (await showPrompt(options)) {
+      trackEvent({
+        event_name: AnalyticsEvent.DeleteSquad,
+        extra: JSON.stringify({ squad: squad.id }),
+      });
+      await deleteSquad(squad.id);
+      deleteCachedSquad(squad.id);
+      await callback?.();
+    }
+  };
+
+  return useMemo(() => ({ onDeleteSquad }), [onDeleteSquad]);
+};

--- a/packages/shared/src/hooks/useLeaveSquad.ts
+++ b/packages/shared/src/hooks/useLeaveSquad.ts
@@ -1,0 +1,53 @@
+import { useContext, useMemo } from 'react';
+import { leaveSquad, Squad } from '../graphql/squads';
+import { PromptOptions, usePrompt } from './usePrompt';
+import { useBoot } from './useBoot';
+import AnalyticsContext from '../contexts/AnalyticsContext';
+import { AnalyticsEvent } from '../lib/analytics';
+
+interface UseLeaveSquad {
+  onLeaveSquad: () => void;
+}
+
+type UseLeaveSquadProps = {
+  squad: Squad;
+  callback?: (params?: unknown) => void;
+};
+
+export const useLeaveSquad = ({
+  squad,
+  callback,
+}: UseLeaveSquadProps): UseLeaveSquad => {
+  const { trackEvent } = useContext(AnalyticsContext);
+  const { showPrompt } = usePrompt();
+  const { deleteSquad: deleteCachedSquad } = useBoot();
+
+  const onLeaveSquad = async () => {
+    const options: PromptOptions = {
+      title: `Leave ${squad.name}`,
+      description: `Leaving ${squad.name} means that you will lose your access to all posts that were shared in the Squad`,
+      okButton: {
+        title: 'Leave',
+        className: 'btn-secondary',
+      },
+      cancelButton: {
+        title: 'Stay',
+        className: 'btn-primary-cabbage',
+      },
+      className: {
+        buttons: 'flex-row-reverse',
+      },
+    };
+    if (await showPrompt(options)) {
+      trackEvent({
+        event_name: AnalyticsEvent.LeaveSquad,
+        extra: JSON.stringify({ squad: squad.id }),
+      });
+      await leaveSquad(squad.id);
+      deleteCachedSquad(squad.id);
+      await callback?.();
+    }
+  };
+
+  return useMemo(() => ({ onLeaveSquad }), [onLeaveSquad]);
+};

--- a/packages/shared/src/hooks/useOnPostClick.ts
+++ b/packages/shared/src/hooks/useOnPostClick.ts
@@ -7,6 +7,7 @@ import { Origin } from '../lib/analytics';
 
 interface PostClickOptionalProps {
   skipPostUpdate?: boolean;
+  parent_id?: string;
 }
 
 export type FeedPostClick = ({
@@ -46,7 +47,14 @@ export default function useOnPostClick({
             columns,
             column,
             row,
-            ...feedAnalyticsExtra(feedName, ranking, null, origin),
+            ...feedAnalyticsExtra(
+              feedName,
+              ranking,
+              null,
+              origin,
+              null,
+              optional?.parent_id,
+            ),
           }),
         );
 

--- a/packages/shared/src/hooks/usePostContent.ts
+++ b/packages/shared/src/hooks/usePostContent.ts
@@ -41,7 +41,11 @@ const usePostContent = ({
   const { trackEvent } = useAnalyticsContext();
   const { updatePost } = useUpdatePost();
   const onPostClick = useOnPostClick({ origin });
-  const onReadArticle = () => onPostClick({ post });
+  const onReadArticle = () =>
+    onPostClick({
+      post: post?.sharedPost || post,
+      optional: { parent_id: post.sharedPost && post.id },
+    });
   const { bookmark, bookmarkToast, removeBookmark } = useBookmarkPost({
     onBookmarkMutate: updatePost({ id, update: { bookmarked: true } }),
     onRemoveBookmarkMutate: updatePost({ id, update: { bookmarked: false } }),

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -10,6 +10,15 @@ export enum Origin {
   TagsSearch = 'tags search',
   RealTime = 'realtime',
   NonRealTime = 'nonrealtime',
+  // squads - start
+  SquadCreation = 'squad creation',
+  LockedSquad = 'locked squad',
+  SquadPage = 'squad page',
+  Auto = 'auto',
+  Sidebar = 'sidebar',
+  Share = 'share',
+  Notification = 'notification',
+  // squads - end
 }
 
 export enum LoginTrigger {
@@ -35,6 +44,18 @@ export enum AnalyticsEvent {
   ClickNotificationDismiss = 'click notification dismiss',
   DisableNotification = 'disable notification',
   // notifications - end
+  // squads - start
+  ViewSquadInvitation = 'view squad invitation',
+  ClickJoinSquad = 'click join squad',
+  CompleteJoiningSquad = 'complete joining the squad',
+  DeleteSquad = 'delete squad',
+  LeaveSquad = 'leave squad',
+  ShareSquadInvitation = 'share squad invitation',
+  ViewSquadPage = 'view squad page',
+  CompleteSquadCreation = 'complete squad creation',
+  ClickSquadCreationNext = 'click squad creation next',
+  ClickSquadCreationBack = 'click squad creation back',
+  // squads - end
 }
 
 export enum TargetType {
@@ -42,6 +63,7 @@ export enum TargetType {
   ArticleAnonymousCTA = 'article anonymous cta',
   ScrollBlock = 'scroll block',
   EnableNotifications = 'enable notifications',
+  CreateSquadPopup = 'create squad popup',
 }
 
 export enum TargetId {

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -47,7 +47,7 @@ export enum AnalyticsEvent {
   // squads - start
   ViewSquadInvitation = 'view squad invitation',
   ClickJoinSquad = 'click join squad',
-  CompleteJoiningSquad = 'complete joining the squad',
+  CompleteJoiningSquad = 'complete joining squad',
   DeleteSquad = 'delete squad',
   LeaveSquad = 'leave squad',
   ShareSquadInvitation = 'share squad invitation',
@@ -55,6 +55,8 @@ export enum AnalyticsEvent {
   CompleteSquadCreation = 'complete squad creation',
   ClickSquadCreationNext = 'click squad creation next',
   ClickSquadCreationBack = 'click squad creation back',
+  StartShareToSquad = 'start share to squad',
+  ShareToSquad = 'share to squad',
   // squads - end
 }
 

--- a/packages/shared/src/lib/feed.ts
+++ b/packages/shared/src/lib/feed.ts
@@ -54,6 +54,7 @@ interface FeedAnalyticsExtra {
     feed: string;
     ranking?: string;
     variant?: string;
+    parent_id?: string;
   };
 }
 
@@ -65,6 +66,7 @@ export function feedAnalyticsExtra(
   },
   origin?: Origin,
   variant?: string,
+  parent_id?: string,
 ): FeedAnalyticsExtra {
   return {
     extra: {
@@ -73,6 +75,7 @@ export function feedAnalyticsExtra(
       variant,
       ...(ranking && { ranking }),
       ...(extra && extra),
+      ...(parent_id && { parent_id }),
     },
   };
 }

--- a/packages/shared/src/lib/feed.ts
+++ b/packages/shared/src/lib/feed.ts
@@ -108,6 +108,8 @@ export function postAnalyticsEvent(
     post_upvotes_count: post.numUpvotes,
     target_id: post.id,
     target_type: 'post',
+    post_type: post.type,
+    post_source_type: post.source?.type,
     extra: opts?.extra ? JSON.stringify(opts.extra) : undefined,
   };
 }

--- a/packages/webapp/pages/squads/[handle]/[token].tsx
+++ b/packages/webapp/pages/squads/[handle]/[token].tsx
@@ -85,25 +85,22 @@ const SquadReferral = ({ token, handle }: SquadReferralProps): ReactElement => {
     },
   );
 
-  useEffect(() => {
-    if (trackedImpression || !member) return;
-
-    trackEvent({
-      event_name: AnalyticsEvent.ViewSquadInvitation,
-      extra: JSON.stringify({
-        inviter: member.user.id,
-        squad: member.source.id,
-      }),
-    });
-    setTrackedImpression(true);
-  }, [member, trackedImpression]);
-
   const joinSquadAnalyticsExtra = () => {
     return JSON.stringify({
       inviter: member.user.id,
       squad: member.source.id,
     });
   };
+
+  useEffect(() => {
+    if (trackedImpression || !member) return;
+
+    trackEvent({
+      event_name: AnalyticsEvent.ViewSquadInvitation,
+      extra: joinSquadAnalyticsExtra(),
+    });
+    setTrackedImpression(true);
+  }, [member, trackedImpression]);
 
   const sourceId = member?.source?.id;
   const { mutateAsync: onJoinSquad } = useMutation(

--- a/packages/webapp/pages/squads/[handle]/[token].tsx
+++ b/packages/webapp/pages/squads/[handle]/[token].tsx
@@ -15,7 +15,7 @@ import Link from 'next/link';
 import SourceButton from '@dailydotdev/shared/src/components/cards/SourceButton';
 import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
 import { useBoot } from '@dailydotdev/shared/src/hooks/useBoot';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useContext, useEffect, useState } from 'react';
 import { ParsedUrlQuery } from 'querystring';
 import {
   GetStaticPathsResult,
@@ -25,6 +25,8 @@ import {
 import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import { NextSeo } from 'next-seo';
 import { disabledRefetch } from '@dailydotdev/shared/src/lib/func';
+import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext';
+import { AnalyticsEvent } from '@dailydotdev/shared/src/lib/analytics';
 import { getLayout } from '../../../components/layouts/MainLayout';
 
 const getOthers = (others: Edge<SquadMember>[]) => {
@@ -51,8 +53,11 @@ export interface SquadReferralProps {
 
 const SquadReferral = ({ token, handle }: SquadReferralProps): ReactElement => {
   const router = useRouter();
+  const { trackEvent } = useContext(AnalyticsContext);
   const { addSquad } = useBoot();
   const { showLogin, user: loggedUser, squads } = useAuthContext();
+  const [trackedImpression, setTrackedImpression] = useState(false);
+
   const { data: member } = useQuery(
     ['squad_referral', token, loggedUser?.id],
     () => getSquadInvitation(token),
@@ -79,11 +84,37 @@ const SquadReferral = ({ token, handle }: SquadReferralProps): ReactElement => {
       },
     },
   );
+
+  useEffect(() => {
+    if (trackedImpression || !member) return;
+
+    trackEvent({
+      event_name: AnalyticsEvent.ViewSquadInvitation,
+      extra: JSON.stringify({
+        inviter: member.user.id,
+        squad: member.source.id,
+      }),
+    });
+    setTrackedImpression(true);
+  }, [member, trackedImpression]);
+
+  const joinSquadAnalyticsExtra = () => {
+    return JSON.stringify({
+      inviter: member.user.id,
+      squad: member.source.id,
+    });
+  };
+
   const sourceId = member?.source?.id;
   const { mutateAsync: onJoinSquad } = useMutation(
     () => joinSquadInvitation({ sourceId, token }),
     {
       onSuccess: (data) => {
+        trackEvent({
+          event_name: AnalyticsEvent.CompleteJoiningSquad,
+          extra: joinSquadAnalyticsExtra(),
+        });
+
         const squad = squads.find(({ id }) => id === data.id);
         if (squad) return router.replace(squad.permalink);
 
@@ -94,6 +125,11 @@ const SquadReferral = ({ token, handle }: SquadReferralProps): ReactElement => {
   );
 
   const onJoinClick = async () => {
+    trackEvent({
+      event_name: AnalyticsEvent.ClickJoinSquad,
+      extra: joinSquadAnalyticsExtra(),
+    });
+
     if (loggedUser) return onJoinSquad();
 
     return showLogin('join squad', {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Introduces new tracking events for the squads beta
- Introduced a new way to track optional prev/next on stepped modals, would love to hear your thoughts. After this PR we can modify the other implementation as well.

## Events

There are a bunch of new events, without noting them down here, I refer to the taxonomy sheet:
https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=2069206456

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-951 #done
