### PR TITLE
fix: missing private property in reading history query

### DIFF
--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -78,7 +78,8 @@ export const SocialShare = ({
 
   return (
     <section className="grid grid-cols-5 gap-4 pt-2 w-fit">
-      {!isComment &&
+      {!post.sharedPost &&
+        !isComment &&
         !post.private &&
         squads?.map((squad) => (
           <button

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -78,8 +78,7 @@ export const SocialShare = ({
 
   return (
     <section className="grid grid-cols-5 gap-4 pt-2 w-fit">
-      {!post.sharedPost &&
-        !isComment &&
+      {!isComment &&
         !post.private &&
         squads
           ?.filter(({ active }) => active)

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -81,17 +81,21 @@ export const SocialShare = ({
       {!post.sharedPost &&
         !isComment &&
         !post.private &&
-        squads?.map((squad) => (
-          <button
-            type="button"
-            className="flex flex-col items-center"
-            key={squad.id}
-            onClick={() => onShareToSquad(squad)}
-          >
-            <SourceProfilePicture source={squad} />
-            <ShareText className="mt-2 break-words">@{squad.handle}</ShareText>
-          </button>
-        ))}
+        squads
+          ?.filter(({ active }) => active)
+          ?.map((squad) => (
+            <button
+              type="button"
+              className="flex flex-col items-center"
+              key={squad.id}
+              onClick={() => onShareToSquad(squad)}
+            >
+              <SourceProfilePicture source={squad} />
+              <ShareText className="mt-2 break-words">
+                @{squad.handle}
+              </ShareText>
+            </button>
+          ))}
       <SocialShareIcon
         href={getTwitterShareLink(link, post?.title)}
         icon={<TwitterIcon />}

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -181,6 +181,7 @@ const READING_HISTORY_FRAGMENT = gql`
       numUpvotes
       bookmarked
       numComments
+      private
       sharedPost {
         ...SharedPostInfo
       }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The reading history query was missing the private property.
- Also fixed the selections of Squad to be the active ones only.
- Let's open a ticket to consolidating our queries to use a Fragment for better maintenance I think.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
