### PR TITLE
fix: squad join page responsiveness

### DIFF
--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -170,7 +170,7 @@ function SquadPostContent({
                   onClick={onReadArticle}
                 />
               </div>
-              <div className="block overflow-hidden w-70 rounded-2xl cursor-pointer h-fit">
+              <div className="block overflow-hidden ml-2 w-70 rounded-2xl cursor-pointer h-fit">
                 <LazyImage
                   imgSrc={post.sharedPost.image}
                   imgAlt="Post cover image"

--- a/packages/webapp/__tests__/SquadTokenPage.tsx
+++ b/packages/webapp/__tests__/SquadTokenPage.tsx
@@ -205,6 +205,15 @@ describe('squad details', () => {
     await waitForNock();
     expect(replaced).toEqual(owner.source.permalink);
   });
+
+  it('should have two join squad one is displayed on desktop and one on mobile', async () => {
+    client.setQueryData(BOOT_QUERY_KEY, { squads: [] });
+    const owner = generateTestOwner();
+    renderComponent([createInvitationMock(defaultToken, owner)]);
+    const [desktop, mobile] = await screen.findAllByText('Join Squad');
+    expect(desktop).toHaveClass('hidden tablet:flex');
+    expect(mobile).toHaveClass('flex tablet:hidden');
+  });
 });
 
 describe('invalid token', () => {

--- a/packages/webapp/__tests__/SquadTokenPage.tsx
+++ b/packages/webapp/__tests__/SquadTokenPage.tsx
@@ -200,7 +200,7 @@ describe('squad details', () => {
       },
       result: () => ({ data: { source: owner.source } }),
     });
-    const [btn] = await screen.findAllByAltText('Join Squad');
+    const [btn] = await screen.findAllByText('Join Squad');
     btn.click();
     await waitForNock();
     expect(replaced).toEqual(owner.source.permalink);

--- a/packages/webapp/__tests__/SquadTokenPage.tsx
+++ b/packages/webapp/__tests__/SquadTokenPage.tsx
@@ -228,7 +228,7 @@ describe('squad details', () => {
     client.setQueryData(BOOT_QUERY_KEY, { squads: [] });
     const owner = generateTestOwner();
     renderComponent([createInvitationMock(defaultToken, owner)]);
-    const [desktop, mobile] = await screen.findAllByText('Join Squad');
+    const [desktop, mobile] = await screen.findAllByRole('button');
     expect(desktop).toHaveClass('hidden tablet:flex');
     expect(mobile).toHaveClass('flex tablet:hidden');
   });

--- a/packages/webapp/__tests__/SquadTokenPage.tsx
+++ b/packages/webapp/__tests__/SquadTokenPage.tsx
@@ -188,7 +188,7 @@ describe('squad details', () => {
     expect(result.length).toEqual(members.length);
   });
 
-  it('should join squad', async () => {
+  it('should join squad on the first button', async () => {
     client.setQueryData(BOOT_QUERY_KEY, { squads: [] });
     const owner = generateTestOwner();
     renderComponent([createInvitationMock(defaultToken, owner)]);
@@ -200,8 +200,26 @@ describe('squad details', () => {
       },
       result: () => ({ data: { source: owner.source } }),
     });
-    const [btn] = await screen.findAllByText('Join Squad');
-    btn.click();
+    const [desktop] = await screen.findAllByText('Join Squad');
+    desktop.click();
+    await waitForNock();
+    expect(replaced).toEqual(owner.source.permalink);
+  });
+
+  it('should join squad on the second button', async () => {
+    client.setQueryData(BOOT_QUERY_KEY, { squads: [] });
+    const owner = generateTestOwner();
+    renderComponent([createInvitationMock(defaultToken, owner)]);
+    await waitForNock();
+    mockGraphQL({
+      request: {
+        query: SQUAD_JOIN_MUTATION,
+        variables: { token: owner.referralToken, sourceId: owner.source.id },
+      },
+      result: () => ({ data: { source: owner.source } }),
+    });
+    const [, mobile] = await screen.findAllByText('Join Squad');
+    mobile.click();
     await waitForNock();
     expect(replaced).toEqual(owner.source.permalink);
   });

--- a/packages/webapp/__tests__/SquadTokenPage.tsx
+++ b/packages/webapp/__tests__/SquadTokenPage.tsx
@@ -200,7 +200,7 @@ describe('squad details', () => {
       },
       result: () => ({ data: { source: owner.source } }),
     });
-    const btn = await screen.findByText('Join Squad');
+    const [btn] = await screen.findAllByAltText('Join Squad');
     btn.click();
     await waitForNock();
     expect(replaced).toEqual(owner.source.permalink);

--- a/packages/webapp/pages/squads/[handle]/[token].tsx
+++ b/packages/webapp/pages/squads/[handle]/[token].tsx
@@ -149,7 +149,7 @@ const SquadReferral = ({ token, handle }: SquadReferralProps): ReactElement => {
   );
 
   return (
-    <PageContainer className="relative justify-center items-center pt-24">
+    <PageContainer className="overflow-hidden relative justify-center items-center pt-24">
       <NextSeo
         title={`Invitation to ${source.name}`}
         titleTemplate="%s | daily.dev"
@@ -179,21 +179,30 @@ const SquadReferral = ({ token, handle }: SquadReferralProps): ReactElement => {
             <BodyParagraph className="mt-2">@{source.handle}</BodyParagraph>
           </div>
           <Button
-            className="ml-auto btn-primary"
+            className="hidden tablet:flex ml-auto btn-primary"
             buttonSize="large"
             onClick={onJoinClick}
           >
             Join Squad
           </Button>
         </span>
-        <BodyParagraph className="mt-3 ml-[4.5rem]">
-          {source.description}
-        </BodyParagraph>
+        {source.description && (
+          <BodyParagraph className="mt-4 ml-[4.5rem]">
+            {source.description}
+          </BodyParagraph>
+        )}
+        <Button
+          className="flex tablet:hidden mt-4 ml-auto w-full btn-primary"
+          buttonSize="large"
+          onClick={onJoinClick}
+        >
+          Join Squad
+        </Button>
       </div>
       <BodyParagraph data-testid="waiting-users">
         {user.name} {othersLabel} waiting for you inside. Join them now!
       </BodyParagraph>
-      <span className="flex flex-row gap-2 mt-6">
+      <span className="flex flex-row flex-wrap gap-2 mt-6">
         {others.slice(0, 10).map(({ node }) => (
           <ProfileImageLink key={node.user.id} user={node.user} />
         ))}

--- a/packages/webapp/pages/squads/[handle]/[token].tsx
+++ b/packages/webapp/pages/squads/[handle]/[token].tsx
@@ -1,5 +1,6 @@
 import { PageContainer } from '@dailydotdev/shared/src/components/utilities';
 import { useQuery, useMutation } from 'react-query';
+import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import {
   getSquadInvitation,
@@ -148,6 +149,16 @@ const SquadReferral = ({ token, handle }: SquadReferralProps): ReactElement => {
     source.members.edges.filter(({ node }) => node.user.id !== user.id),
   );
 
+  const renderJoinButton = (className?: string) => (
+    <Button
+      className={classNames('btn-primary', className)}
+      buttonSize="large"
+      onClick={onJoinClick}
+    >
+      Join Squad
+    </Button>
+  );
+
   return (
     <PageContainer className="overflow-hidden relative justify-center items-center pt-24">
       <NextSeo
@@ -178,26 +189,14 @@ const SquadReferral = ({ token, handle }: SquadReferralProps): ReactElement => {
             <h2 className="flex flex-col typo-headline">{source.name}</h2>
             <BodyParagraph className="mt-2">@{source.handle}</BodyParagraph>
           </div>
-          <Button
-            className="hidden tablet:flex ml-auto btn-primary"
-            buttonSize="large"
-            onClick={onJoinClick}
-          >
-            Join Squad
-          </Button>
+          {renderJoinButton('hidden tablet:flex ml-auto')}
         </span>
         {source.description && (
           <BodyParagraph className="mt-4 ml-[4.5rem]">
             {source.description}
           </BodyParagraph>
         )}
-        <Button
-          className="flex tablet:hidden mt-4 ml-auto w-full btn-primary"
-          buttonSize="large"
-          onClick={onJoinClick}
-        >
-          Join Squad
-        </Button>
+        {renderJoinButton('flex tablet:hidden mt-4 w-full')}
       </div>
       <BodyParagraph data-testid="waiting-users">
         {user.name} {othersLabel} waiting for you inside. Join them now!


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Responsiveness of the Squad join page was missed. There should be a button under the description when it is mobile.
- This also fixes the wrap (overflow) issue on the "members waiting" list.
- I also fixed the missing left margin on the shared post content's cover image.

Preview:
![image](https://user-images.githubusercontent.com/13744167/217720088-b0ae2bb6-5428-421a-ba27-1f4a455c6691.png)

![image](https://user-images.githubusercontent.com/13744167/217720143-e46d5e7f-0b6d-402e-9707-41158f421175.png)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1058 #done
