### PR TITLE
fix: feedback button overlapping with title

### DIFF
--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useContext } from 'react';
 import dynamic from 'next/dynamic';
-import { Item } from '@dailydotdev/react-contexify';
 import { useRouter } from 'next/router';
 import AuthContext from '../../contexts/AuthContext';
 import EditIcon from '../icons/Edit';
@@ -12,6 +11,11 @@ import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
 import { useDeleteSquad } from '../../hooks/useDeleteSquad';
 import { useLeaveSquad } from '../../hooks/useLeaveSquad';
+import FeedbackIcon from '../icons/Feedback';
+import { squadFeedback } from '../../lib/constants';
+import ContextMenuItem, {
+  ContextMenuItemProps,
+} from '../tooltips/ContextMenuItem';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ '../fields/PortalMenu'),
@@ -20,11 +24,13 @@ const PortalMenu = dynamic(
   },
 );
 
+interface SquadHeaderMenuProps {
+  squad: Squad;
+}
+
 export default function SquadHeaderMenu({
   squad,
-}: {
-  squad: Squad;
-}): ReactElement {
+}: SquadHeaderMenuProps): ReactElement {
   const router = useRouter();
   const { user } = useContext(AuthContext);
   const { openModal } = useLazyModal();
@@ -50,6 +56,10 @@ export default function SquadHeaderMenu({
       },
     });
   };
+  const feedbackLink = `${squadFeedback}#user_id=${user.id}&squad_id=${squad.id}`;
+  const removeSquadProps: ContextMenuItemProps = isSquadOwner
+    ? { Icon: TrashIcon, onClick: onDeleteSquad, label: 'Delete Squad' }
+    : { Icon: ExitIcon, onClick: onLeaveSquad, label: 'Leave Squad' };
 
   return (
     <PortalMenu
@@ -59,12 +69,11 @@ export default function SquadHeaderMenu({
       animation="fade"
     >
       {isSquadOwner && (
-        <Item className="typo-callout" onClick={onEditSquad}>
-          <span className="flex items-center w-full typo-callout">
-            <EditIcon size="medium" secondary={false} className="mr-2" /> Edit
-            Squad details
-          </span>
-        </Item>
+        <ContextMenuItem
+          Icon={EditIcon}
+          onClick={onEditSquad}
+          label="Edit Squad details"
+        />
       )}
       {/* <Item className="typo-callout"> */}
       {/*  <span className="flex items-center w-full typo-callout"> */}
@@ -72,21 +81,12 @@ export default function SquadHeaderMenu({
       {/*    how Squads work */}
       {/*  </span> */}
       {/* </Item> */}
-      {isSquadOwner ? (
-        <Item className="typo-callout" onClick={onDeleteSquad}>
-          <span className="flex items-center w-full typo-callout">
-            <TrashIcon size="medium" secondary={false} className="mr-2" />{' '}
-            Delete Squad
-          </span>
-        </Item>
-      ) : (
-        <Item className="typo-callout" onClick={onLeaveSquad}>
-          <span className="flex items-center w-full typo-callout">
-            <ExitIcon size="medium" secondary={false} className="mr-2" /> Leave
-            Squad
-          </span>
-        </Item>
-      )}
+      <ContextMenuItem
+        Icon={FeedbackIcon}
+        label="Feedback"
+        href={feedbackLink}
+      />
+      <ContextMenuItem {...removeSquadProps} />
     </PortalMenu>
   );
 }

--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement, useContext, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import AuthContext from '../../contexts/AuthContext';
@@ -56,10 +56,31 @@ export default function SquadHeaderMenu({
       },
     });
   };
-  const feedbackLink = `${squadFeedback}#user_id=${user.id}&squad_id=${squad.id}`;
-  const removeSquadProps: ContextMenuItemProps = isSquadOwner
-    ? { Icon: TrashIcon, onClick: onDeleteSquad, label: 'Delete Squad' }
-    : { Icon: ExitIcon, onClick: onLeaveSquad, label: 'Leave Squad' };
+  const items = useMemo(() => {
+    const feedbackLink = `${squadFeedback}#user_id=${user.id}&squad_id=${squad.id}`;
+    const list: ContextMenuItemProps[] = [
+      // { Icon: TourIcon, onClick: console.log, label: 'Learn how Squads work' },
+      {
+        className: 'flex tablet:hidden',
+        Icon: FeedbackIcon,
+        label: 'Feedback',
+        href: feedbackLink,
+      },
+      isSquadOwner
+        ? { Icon: TrashIcon, onClick: onDeleteSquad, label: 'Delete Squad' }
+        : { Icon: ExitIcon, onClick: onLeaveSquad, label: 'Leave Squad' },
+    ];
+
+    if (isSquadOwner) {
+      list.unshift({
+        Icon: EditIcon,
+        onClick: onEditSquad,
+        label: 'Edit Squad details',
+      });
+    }
+
+    return list;
+  }, [isSquadOwner, squad, user, onDeleteSquad, onLeaveSquad]);
 
   return (
     <PortalMenu
@@ -68,26 +89,9 @@ export default function SquadHeaderMenu({
       className="menu-primary"
       animation="fade"
     >
-      {isSquadOwner && (
-        <ContextMenuItem
-          Icon={EditIcon}
-          onClick={onEditSquad}
-          label="Edit Squad details"
-        />
-      )}
-      {/* <Item className="typo-callout"> */}
-      {/*  <span className="flex items-center w-full typo-callout"> */}
-      {/*    <TourIcon size="medium" secondary={false} className="mr-2" /> Learn */}
-      {/*    how Squads work */}
-      {/*  </span> */}
-      {/* </Item> */}
-      <ContextMenuItem
-        className="flex tablet:hidden"
-        Icon={FeedbackIcon}
-        label="Feedback"
-        href={feedbackLink}
-      />
-      <ContextMenuItem {...removeSquadProps} />
+      {items.map((props) => (
+        <ContextMenuItem key={props.label} {...props} />
+      ))}
     </PortalMenu>
   );
 }

--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -82,6 +82,7 @@ export default function SquadHeaderMenu({
       {/*  </span> */}
       {/* </Item> */}
       <ContextMenuItem
+        className="flex tablet:hidden"
         Icon={FeedbackIcon}
         label="Feedback"
         href={feedbackLink}

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -35,7 +35,7 @@ export function SquadPageHeader({
       >
         Feedback
       </Button>
-      <div className="flex flex-row mobileL:flex-col gap-4 mobileL:gap-6 mobileL:items-center w-full">
+      <div className="flex flex-row mobileL:flex-col gap-4 mobileL:gap-6 mobileL:items-center mt-6 tablet:mt-0 w-full">
         <SquadImage
           className="mobileL:mt-2 w-16 mobileL:w-24 h-16 mobileL:h-24"
           {...squad}

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -35,7 +35,7 @@ export function SquadPageHeader({
       >
         Feedback
       </Button>
-      <div className="flex flex-row mobileL:flex-col gap-4 mobileL:gap-6 mobileL:items-center mt-6 tablet:mt-0 w-full">
+      <div className="flex flex-row mobileL:flex-col gap-4 mobileL:gap-6 mobileL:items-center w-full">
         <SquadImage
           className="mobileL:mt-2 w-16 mobileL:w-24 h-16 mobileL:h-24"
           {...squad}

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -28,7 +28,7 @@ export function SquadPageHeader({
         target="_blank"
         rel="noopener noreferrer"
         href={`${squadFeedback}#user_id=${userId}&squad_id=${squad.id}`}
-        className="-top-4 right-4 btn btn-secondary"
+        className="hidden tablet:flex -top-4 right-4 btn btn-secondary"
         position="absolute"
         icon={<FeedbackIcon size="medium" />}
         buttonSize="small"

--- a/packages/shared/src/components/tooltips/ContextMenuItem.tsx
+++ b/packages/shared/src/components/tooltips/ContextMenuItem.tsx
@@ -1,4 +1,5 @@
 import { Item, ItemProps } from '@dailydotdev/react-contexify';
+import classNames from 'classnames';
 import Link from 'next/link';
 import React, { ReactElement } from 'react';
 import ConditionalWrapper from '../ConditionalWrapper';
@@ -15,6 +16,8 @@ function ContextMenuItem({
   label,
   onClick,
   Icon,
+  className,
+  ...props
 }: ContextMenuItemProps): ReactElement {
   return (
     <ConditionalWrapper
@@ -25,7 +28,11 @@ function ContextMenuItem({
         </Link>
       )}
     >
-      <Item className="typo-callout" onClick={onClick}>
+      <Item
+        {...props}
+        className={classNames('typo-callout', className)}
+        onClick={onClick}
+      >
         <span className="flex items-center w-full">
           <Icon size="medium" className="mr-2" />
           {label}

--- a/packages/shared/src/components/tooltips/ContextMenuItem.tsx
+++ b/packages/shared/src/components/tooltips/ContextMenuItem.tsx
@@ -1,0 +1,38 @@
+import { Item, ItemProps } from '@dailydotdev/react-contexify';
+import Link from 'next/link';
+import React, { ReactElement } from 'react';
+import ConditionalWrapper from '../ConditionalWrapper';
+import { IconProps } from '../Icon';
+
+export interface ContextMenuItemProps extends Omit<ItemProps, 'children'> {
+  href?: string;
+  label: string;
+  Icon: React.ComponentType<IconProps>;
+}
+
+function ContextMenuItem({
+  href,
+  label,
+  onClick,
+  Icon,
+}: ContextMenuItemProps): ReactElement {
+  return (
+    <ConditionalWrapper
+      condition={!!href}
+      wrapper={(children) => (
+        <Link href={href}>
+          <a href={href}>{children}</a>
+        </Link>
+      )}
+    >
+      <Item className="typo-callout" onClick={onClick}>
+        <span className="flex items-center w-full">
+          <Icon size="medium" className="mr-2" />
+          {label}
+        </span>
+      </Item>
+    </ConditionalWrapper>
+  );
+}
+
+export default ContextMenuItem;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Apply 24px padding when it is on mobile.

Preview:
![image](https://user-images.githubusercontent.com/13744167/217721594-41d503c0-8653-45e1-a18d-620eda5000e8.png)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1052 #done
