### PR TITLE
fix: devcard page responsiveness

### DIFF
--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -345,7 +345,7 @@ const DevCardPage = (): ReactElement => {
   return (
     <div
       className={classNames(
-        'page flex min-h-screen flex-col items-center px-6 py-10 laptop:-mt-12 max-w-full laptop:justify-center mx-auto',
+        'page flex min-h-page flex-col justify-center items-center px-6 py-10 tablet:-mt-12 max-w-full mx-auto',
         step === 1 && 'laptop:flex-row laptop:gap-20',
       )}
     >


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The page was not consuming the whole space, hence, the devcard is at the top most.
- Also applied easy centering classes.

Preview:
![Screenshot 2023-02-09 at 4 53 54 PM](https://user-images.githubusercontent.com/13744167/217763552-a2d3da54-c49f-4acf-9c7f-ef3233a2e23c.png)
![Screenshot 2023-02-09 at 4 54 05 PM](https://user-images.githubusercontent.com/13744167/217763592-3f7bf485-0a93-4825-9358-4c1ce0d14b2f.png)
![Screenshot 2023-02-09 at 4 54 16 PM](https://user-images.githubusercontent.com/13744167/217763643-e9b8298e-a049-4cea-89ef-a58dc94d9daf.png)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
