### PR TITLE
fix: refetch of bookmarks to update

### DIFF
--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -14,6 +14,7 @@ import Feed, { FeedProps } from './Feed';
 import BookmarkEmptyScreen from './BookmarkEmptyScreen';
 import { Button } from './buttons/Button';
 import ShareIcon from './icons/Share';
+import { generateQueryKey, RequestKey } from '../lib/query';
 
 export type BookmarkFeedLayoutProps = {
   searchQuery?: string;
@@ -37,12 +38,12 @@ export default function BookmarkFeedLayout({
   const { user, tokenRefreshed } = useContext(AuthContext);
   const [showEmptyScreen, setShowEmptyScreen] = useState(false);
   const [showSharedBookmarks, setShowSharedBookmarks] = useState(false);
-
+  const defaultKey = generateQueryKey(RequestKey.Bookmarks, user);
   const feedProps = useMemo<FeedProps<unknown>>(() => {
     if (searchQuery) {
       return {
         feedName: 'search-bookmarks',
-        feedQueryKey: ['bookmarks', user?.id ?? 'anonymous', searchQuery],
+        feedQueryKey: defaultKey.concat(searchQuery),
         query: SEARCH_BOOKMARKS_QUERY,
         variables: { query: searchQuery },
         emptyScreen: <SearchEmptyScreen />,
@@ -50,7 +51,7 @@ export default function BookmarkFeedLayout({
     }
     return {
       feedName: 'bookmarks',
-      feedQueryKey: ['bookmarks', user?.id ?? 'anonymous'],
+      feedQueryKey: defaultKey,
       query: BOOKMARKS_FEED_QUERY,
       onEmptyFeed: () => setShowEmptyScreen(true),
       options: { refetchOnMount: true },

--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -53,6 +53,7 @@ export default function BookmarkFeedLayout({
       feedQueryKey: ['bookmarks', user?.id ?? 'anonymous'],
       query: BOOKMARKS_FEED_QUERY,
       onEmptyFeed: () => setShowEmptyScreen(true),
+      options: { refetchOnMount: true },
     };
   }, [searchQuery, user]);
 

--- a/packages/shared/src/hooks/useBookmarkPost.ts
+++ b/packages/shared/src/hooks/useBookmarkPost.ts
@@ -9,7 +9,7 @@ import {
 } from '../graphql/posts';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import {
-  filterCache,
+  filterInfiniteCache,
   generateQueryKey,
   MutateFunc,
   RequestKey,
@@ -77,12 +77,14 @@ export default function useBookmarkPost<
         if (onRemoveBookmarkTrackObject)
           trackEvent(onRemoveBookmarkTrackObject());
 
-        filterCache<FeedData>({
-          client,
-          prop: 'page',
-          queryKey: generateQueryKey(RequestKey.Bookmarks, user),
-          condition: ({ node }) => node.id !== id,
-        });
+        filterInfiniteCache<FeedData>(
+          {
+            client,
+            prop: 'page',
+            queryKey: generateQueryKey(RequestKey.Bookmarks, user),
+          },
+          ({ node }) => node.id !== id,
+        );
       },
     },
   );

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -1,5 +1,6 @@
 import { InfiniteData, QueryClient, QueryKey } from 'react-query';
 import { Connection } from '../graphql/common';
+import { EmptyObjectLiteral } from './kratos';
 import { LoggedUser } from './user';
 
 export type MutateFunc<T> = (variables: T) => Promise<(() => void) | undefined>;
@@ -21,28 +22,30 @@ export type HasConnection<
   TKey extends keyof TEntity = keyof TEntity,
 > = Partial<Record<TKey, Connection<unknown>>>;
 
-interface UpdateCacheProps<
-  T extends HasConnection<T>,
-  K extends keyof T = keyof T,
+interface InfiniteCacheProps<
+  TEntity extends HasConnection<TEntity>,
+  TKey extends keyof TEntity = keyof TEntity,
 > {
-  prop: K;
+  prop: TKey;
   queryKey: QueryKey;
   client: QueryClient;
-  condition: (param: T[K]['edges'][0]) => boolean;
 }
 
-export const filterCache = <T extends HasConnection<T>>({
-  client,
-  prop,
-  queryKey,
-  condition,
-}: UpdateCacheProps<T>): InfiniteData<T> => {
-  return client.setQueryData<InfiniteData<T>>(queryKey, (feed) => {
-    if (!feed) return null;
+export const filterInfiniteCache = <
+  TEntity extends HasConnection<TEntity>,
+  TKey extends keyof TEntity = keyof TEntity,
+  TData extends TEntity[TKey]['edges'][0] = TEntity[TKey]['edges'][0],
+  TReturn extends InfiniteData<TEntity> = InfiniteData<TEntity>,
+>(
+  { client, prop, queryKey }: InfiniteCacheProps<TEntity>,
+  condition: (param: TData) => boolean,
+): TReturn => {
+  return client.setQueryData<TReturn>(queryKey, (data) => {
+    if (!data) return null;
 
     return {
-      ...feed,
-      pages: feed?.pages?.map((edge) => ({
+      ...data,
+      pages: data?.pages?.map((edge) => ({
         ...edge,
         [prop]: {
           ...edge[prop],
@@ -50,5 +53,40 @@ export const filterCache = <T extends HasConnection<T>>({
         },
       })),
     };
+  });
+};
+
+interface UpdateInfiniteCacheProps<
+  TEntity extends HasConnection<TEntity>,
+  TData extends TEntity[TKey]['edges'][0]['node'],
+  TKey extends keyof TEntity = keyof TEntity,
+> extends InfiniteCacheProps<TEntity, TKey> {
+  page: number;
+  edge: number;
+  entity: Partial<TData>;
+}
+
+export const updateInfiniteCache = <
+  TEntity extends HasConnection<TEntity>,
+  TKey extends keyof TEntity = keyof TEntity,
+  TData extends TEntity[TKey]['edges'][0]['node'] = TEntity[TKey]['edges'][0]['node'],
+  TReturn extends InfiniteData<TEntity> = InfiniteData<TEntity>,
+>({
+  client,
+  prop,
+  queryKey,
+  page,
+  edge,
+  entity,
+}: UpdateInfiniteCacheProps<TEntity, TData>): TReturn => {
+  return client.setQueryData<TReturn>(queryKey, (data) => {
+    if (!data) return null;
+
+    const updated = { ...data };
+    const item = updated.pages[page][prop].edges[edge]
+      .node as EmptyObjectLiteral;
+    updated.pages[page][prop].edges[edge].node = { ...item, ...entity };
+
+    return updated;
   });
 };

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -3,9 +3,13 @@ import { LoggedUser } from './user';
 export type MutateFunc<T> = (variables: T) => Promise<(() => void) | undefined>;
 
 export const generateQueryKey = (
-  name: string,
+  name: string | RequestKey,
   user: Pick<LoggedUser, 'id'> | null,
   ...additional: unknown[]
 ): unknown[] => {
   return [name, user?.id ?? 'anonymous', ...additional];
 };
+
+export enum RequestKey {
+  Bookmarks = 'bookmarks',
+}

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -1,3 +1,5 @@
+import { InfiniteData, QueryClient, QueryKey } from 'react-query';
+import { Connection } from '../graphql/common';
 import { LoggedUser } from './user';
 
 export type MutateFunc<T> = (variables: T) => Promise<(() => void) | undefined>;
@@ -13,3 +15,40 @@ export const generateQueryKey = (
 export enum RequestKey {
   Bookmarks = 'bookmarks',
 }
+
+export type HasConnection<
+  TEntity,
+  TKey extends keyof TEntity = keyof TEntity,
+> = Partial<Record<TKey, Connection<unknown>>>;
+
+interface UpdateCacheProps<
+  T extends HasConnection<T>,
+  K extends keyof T = keyof T,
+> {
+  prop: K;
+  queryKey: QueryKey;
+  client: QueryClient;
+  condition: (param: T[K]['edges'][0]) => boolean;
+}
+
+export const filterCache = <T extends HasConnection<T>>({
+  client,
+  prop,
+  queryKey,
+  condition,
+}: UpdateCacheProps<T>): InfiniteData<T> => {
+  return client.setQueryData<InfiniteData<T>>(queryKey, (feed) => {
+    if (!feed) return null;
+
+    return {
+      ...feed,
+      pages: feed?.pages?.map((edge) => ({
+        ...edge,
+        [prop]: {
+          ...edge[prop],
+          edges: edge[prop].edges.filter(condition),
+        },
+      })),
+    };
+  });
+};


### PR DESCRIPTION
## Changes

We had two options, update the data locally or allow refetch when the cache is stale.

The reason we didn't go for the first one is, there could be instances when you bookmark a post, you might not have all the necessary information when you toggled the bookmark (i.e. in reading history) which will then update the cache (of bookmarks feed), we will have to fetch to ensure the data is complete, else, the bookmarks feed might malfunction.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
