### PR TITLE
feat: enable react query devtools

### DIFF
--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -38,13 +38,9 @@ import { useNotificationContext } from '@dailydotdev/shared/src/contexts/Notific
 import { getUnreadText } from '@dailydotdev/shared/src/components/notifications/utils';
 import { useLazyModal } from '@dailydotdev/shared/src/hooks/useLazyModal';
 import { usePrompt } from '@dailydotdev/shared/src/hooks/usePrompt';
+import { ReactQueryDevtools } from 'react-query/devtools';
 import Seo from '../next-seo';
 import useWebappVersion from '../hooks/useWebappVersion';
-
-// const ReactQueryDevtools = dynamic(
-//   () => import('react-query/devtools').then((mod) => mod.ReactQueryDevtools),
-//   { ssr: false },
-// );
 
 const AuthModal = dynamic(
   () =>
@@ -184,6 +180,7 @@ export default function App(props: AppProps): ReactElement {
             </AnalyticsContextProvider>
           </SubscriptionContextProvider>
         </BootDataProvider>
+        <ReactQueryDevtools />
       </QueryClientProvider>
     </ProgressiveEnhancementContextProvider>
   );


### PR DESCRIPTION
## Changes

### Describe what this PR does
Just enabling react query devtools. Devtools are automatically excluded from production bundle by `react-query`. 
- https://tanstack.com/query/v4/docs/react/devtools#install-and-import-the-devtools
- https://github.com/TanStack/query/blob/main/packages/react-query-devtools/src/index.ts

Also, there is no need to `dynamic` import because in production devtools component is empty so import breaks.

 I think they are really useful to just see all the active queries on the page and then working back and finding them inside the codebase. Especially when someone is just starting.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
