### PR TITLE
fix: reading history overlap with metadata

### DIFF
--- a/packages/shared/src/components/post/PostItemCard.tsx
+++ b/packages/shared/src/components/post/PostItemCard.tsx
@@ -79,9 +79,9 @@ export default function PostItemCard({
             {post.title}
           </h3>
           <PostMetadata
+            className="text-theme-label-tertiary"
             readTime={post.readTime}
             numUpvotes={post.numUpvotes}
-            typoClassName="typo-footnote text-theme-label-tertiary"
           />
         </div>
         {showButtons && onHide && (

--- a/packages/shared/src/components/post/PostItemCard.tsx
+++ b/packages/shared/src/components/post/PostItemCard.tsx
@@ -74,14 +74,16 @@ export default function PostItemCard({
           }}
           nativeLazyLoading
         />
-        <h3 className="flex flex-wrap flex-1 mr-6 ml-4 text-left line-clamp-2 typo-callout">
-          {post.title}
+        <div className="flex flex-col flex-1 ml-4">
+          <h3 className="flex flex-1 mr-6 text-left break-words line-clamp-2 typo-callout">
+            {post.title}
+          </h3>
           <PostMetadata
             readTime={post.readTime}
             numUpvotes={post.numUpvotes}
-            typoClassName="typo-callout"
+            typoClassName="typo-footnote text-theme-label-tertiary"
           />
-        </h3>
+        </div>
         {showButtons && onHide && (
           <Button
             buttonSize="small"


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The metadata was contained and the line-clamp was not working since there were two elements to consider.
- Sketch reference used: https://www.sketch.com/s/2bc42f67-3e55-4c07-bcf6-90ecdf74182b/a/kaOkrGo#Inspect
- Preview on local development:

![image](https://user-images.githubusercontent.com/13744167/218909659-28de2519-e521-4633-a8c8-384692203992.png)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [x] iOS (Chrome and Safari)
- [ ] Android

WT-1077 #done
