### PR TITLE
refactor: move to enum for extension message type

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -3,7 +3,7 @@ import { browser, Runtime, Tabs } from 'webextension-polyfill-ts';
 import { getBootData } from '@dailydotdev/shared/src/lib/boot';
 import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
 import { parseOrDefault } from '@dailydotdev/shared/src/lib/func';
-import request, { RequestDocument } from 'graphql-request';
+import request from 'graphql-request';
 import { UPDATE_USER_SETTINGS_MUTATION } from '@dailydotdev/shared/src/graphql/settings';
 import { getLocalBootData } from '@dailydotdev/shared/src/contexts/BootProvider';
 import { getOrGenerateDeviceId } from '@dailydotdev/shared/src/hooks/analytics/useDeviceId';

--- a/packages/extension/src/companion/App.tsx
+++ b/packages/extension/src/companion/App.tsx
@@ -13,6 +13,7 @@ import { RouterContext } from 'next/dist/shared/lib/router-context';
 import useWindowEvents from '@dailydotdev/shared/src/hooks/useWindowEvents';
 import { AuthEvent } from '@dailydotdev/shared/src/lib/kratos';
 import { useError } from '@dailydotdev/shared/src/hooks/useError';
+import { ExtensionMessageType } from '@dailydotdev/shared/src/lib/extension';
 import Companion from './Companion';
 import CustomRouter from '../lib/CustomRouter';
 import { companionFetch } from './companionFetch';
@@ -58,7 +59,7 @@ export default function App({
 
   const memoizedFlags = useMemo(() => flags, [flags]);
   const refetchData = async () =>
-    browser.runtime.sendMessage({ type: 'CONTENT_LOADED' });
+    browser.runtime.sendMessage({ type: ExtensionMessageType.ContentLoaded });
 
   useRefreshToken(token, refetchData);
   useBackgroundRequest(refreshTokenKey, {

--- a/packages/extension/src/companion/companionFetch.tsx
+++ b/packages/extension/src/companion/companionFetch.tsx
@@ -1,9 +1,10 @@
+import { ExtensionMessageType } from '@dailydotdev/shared/src/lib/extension';
 import { browser } from 'webextension-polyfill-ts';
 
 const proxyFetch = {
   apply(_, __, args) {
     browser.runtime.sendMessage({
-      type: 'FETCH_REQUEST',
+      type: ExtensionMessageType.FetchRequest,
       url: args[0],
       args: args[1],
     });

--- a/packages/extension/src/companion/companionRequest.tsx
+++ b/packages/extension/src/companion/companionRequest.tsx
@@ -1,13 +1,14 @@
 import request from 'graphql-request';
 import { browser } from 'webextension-polyfill-ts';
 import { initialDataKey } from '@dailydotdev/shared/src/lib/constants';
+import { ExtensionMessageType } from '@dailydotdev/shared/src/lib/extension';
 
 const proxyRequest = {
   apply(_, __, args) {
     const { [initialDataKey]: initial, ...variables } = args?.[2];
 
     browser.runtime.sendMessage({
-      type: 'GRAPHQL_REQUEST',
+      type: ExtensionMessageType.GraphQLRequest,
       url: args?.[0],
       document: args?.[1],
       variables,

--- a/packages/extension/src/companion/useCompanionActions.ts
+++ b/packages/extension/src/companion/useCompanionActions.ts
@@ -13,6 +13,7 @@ import { ADD_FILTERS_TO_FEED_MUTATION } from '@dailydotdev/shared/src/graphql/fe
 import { UPDATE_ALERTS } from '@dailydotdev/shared/src/graphql/alerts';
 import { UPDATE_USER_SETTINGS_MUTATION } from '@dailydotdev/shared/src/graphql/settings';
 import { MutateFunc } from '@dailydotdev/shared/src/lib/query';
+import { ExtensionMessageType } from '@dailydotdev/shared/src/lib/extension';
 import { companionRequest } from './companionRequest';
 
 type UseCompanionActionsParams<T> = {
@@ -78,7 +79,11 @@ export default function useCompanionActions<
     unknown,
     T,
     (() => void) | undefined
-  >(() => browser.runtime.sendMessage({ type: 'DISABLE_COMPANION' }));
+  >(() =>
+    browser.runtime.sendMessage({
+      type: ExtensionMessageType.DisableCompanion,
+    }),
+  );
 
   const { mutateAsync: bookmark } = useMutation<
     void,

--- a/packages/extension/src/content/index.tsx
+++ b/packages/extension/src/content/index.tsx
@@ -1,5 +1,6 @@
 import { browser } from 'webextension-polyfill-ts';
 import { removeLinkTargetElement } from '@dailydotdev/shared/src/lib/strings';
+import { ExtensionMessageType } from '@dailydotdev/shared/src/lib/extension';
 
 const isRendered = !!document.querySelector('daily-companion-app');
 
@@ -17,14 +18,14 @@ if (!isRendered) {
   wrapper.id = 'daily-companion-wrapper';
   shadow.appendChild(wrapper);
 
-  browser.runtime.sendMessage({ type: 'CONTENT_LOADED' });
+  browser.runtime.sendMessage({ type: ExtensionMessageType.ContentLoaded });
 
   let lastUrl = removeLinkTargetElement(window.location.href);
   new MutationObserver(() => {
     const current = removeLinkTargetElement(window.location.href);
     if (current !== lastUrl) {
       lastUrl = current;
-      browser.runtime.sendMessage({ type: 'CONTENT_LOADED' });
+      browser.runtime.sendMessage({ type: ExtensionMessageType.ContentLoaded });
     }
   }).observe(document, { subtree: true, childList: true });
 }

--- a/packages/shared/src/hooks/analytics/useAnalyticsQueue.ts
+++ b/packages/shared/src/hooks/analytics/useAnalyticsQueue.ts
@@ -2,6 +2,7 @@ import { useMutation } from 'react-query';
 import { MutableRefObject, useMemo, useRef } from 'react';
 import { apiUrl } from '../../lib/config';
 import useDebounce from '../useDebounce';
+import { ExtensionMessageType } from '../../lib/extension';
 
 export interface AnalyticsEvent extends Record<string, unknown> {
   visit_id?: string;
@@ -81,7 +82,7 @@ export default function useAnalyticsQueue({
           if (backgroundMethod) {
             backgroundMethod?.({
               url: ANALYTICS_ENDPOINT,
-              type: 'FETCH_REQUEST',
+              type: ExtensionMessageType.FetchRequest,
               args: {
                 body: JSON.stringify(events),
                 credentials: 'include',

--- a/packages/shared/src/lib/extension.ts
+++ b/packages/shared/src/lib/extension.ts
@@ -1,0 +1,7 @@
+export enum ExtensionMessageType {
+  ContentLoaded = 'CONTENT_LOADED',
+  GraphQLRequest = 'GRAPHQL_REQUEST',
+  FetchRequest = 'FETCH_REQUEST',
+  DisableCompanion = 'DISABLE_COMPANION',
+  RequestUpdate = 'REQUEST_UPDATE',
+}

--- a/packages/shared/src/lib/extension.ts
+++ b/packages/shared/src/lib/extension.ts
@@ -3,5 +3,4 @@ export enum ExtensionMessageType {
   GraphQLRequest = 'GRAPHQL_REQUEST',
   FetchRequest = 'FETCH_REQUEST',
   DisableCompanion = 'DISABLE_COMPANION',
-  RequestUpdate = 'REQUEST_UPDATE',
 }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- In context of #1605 @sshanzel mentioned it would be cool to add `enum` for message type in extension. This will be even better if added after #733 because then we will be able to properly type `browser.runtime.sendMessage` with generic and disallow unknown message types completely. 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
