### PR TITLE
fix: boot and squad race condition

### DIFF
--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -46,6 +46,7 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
   const { isFallback } = useRouter();
   const [isForbidden, setIsForbidden] = useState(false);
   const { openModal } = useLazyModal();
+  const { user, isFetched: isBootFetched } = useContext(AuthContext);
   const [trackedImpression, setTrackedImpression] = useState(false);
   const queryKey = ['squad', handle];
   const {
@@ -53,7 +54,7 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
     isLoading,
     isFetched,
   } = useQuery<Squad, ClientError>(queryKey, () => getSquad(handle), {
-    enabled: !!handle && !isForbidden,
+    enabled: isBootFetched && !!handle && !isForbidden,
     retry: false,
     onError: (err) => {
       const isErrorForbidden =
@@ -77,10 +78,9 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
   const { data: squadMembers } = useQuery<SquadMember[]>(
     ['squadMembersInitial', handle],
     () => getSquadMembers(squadId),
-    { enabled: !!squadId },
+    { enabled: isBootFetched && !!squadId },
   );
 
-  const { user } = useContext(AuthContext);
   // Must be memoized to prevent refreshing the feed
   const queryVariables = useMemo(
     () => ({


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Wait for the boot to be fetched before triggering the load of Squad related requests.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1079 #done
