### PR TITLE
fix: loading state when sharing a post

### DIFF
--- a/packages/shared/src/components/squads/Comment.tsx
+++ b/packages/shared/src/components/squads/Comment.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext, useState } from 'react';
+import React, { FormEvent, ReactElement, useContext, useState } from 'react';
 import { Modal } from '../modals/common/Modal';
 import { Button } from '../buttons/Button';
 import { ProfilePicture } from '../ProfilePicture';
@@ -10,13 +10,17 @@ import OpenLinkIcon from '../icons/OpenLink';
 import { SquadForm } from '../../graphql/squads';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 
+interface SquadCommentProps {
+  onSubmit: React.EventHandler<FormEvent>;
+  form: Partial<SquadForm>;
+  isLoading?: boolean;
+}
+
 export function SquadComment({
   onSubmit,
   form,
-}: {
-  onSubmit: (e) => void;
-  form: Partial<SquadForm>;
-}): ReactElement {
+  isLoading,
+}: SquadCommentProps): ReactElement {
   const { post } = form.post;
   const { user } = useContext(AuthContext);
   const [commentary, setCommentary] = useState(form.commentary);
@@ -80,7 +84,8 @@ export function SquadComment({
               form="squad-comment"
               className="btn-primary-cabbage"
               type="submit"
-              disabled={!commentary}
+              loading={isLoading}
+              disabled={!commentary || isLoading}
             >
               Done
             </Button>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Refactored to use `useMutation` to handle loading OOTB.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1081 #done
