### PR TITLE
fix: add tracking event to squad invite

### DIFF
--- a/packages/shared/src/components/squads/InviteTextField.tsx
+++ b/packages/shared/src/components/squads/InviteTextField.tsx
@@ -35,7 +35,7 @@ const InviteText: ForwardRefRenderFunction<
   const trackAndCopyLink = () => {
     trackEvent({
       event_name: AnalyticsEvent.ShareSquadInvitation,
-      extra: JSON.stringify({ origin }),
+      extra: JSON.stringify({ origin, squad: squad?.id }),
     });
     return copyLink();
   };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Add tracking event for squad sharing

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change| share squad invitation  | extra: { squad: "squad.id" } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1091 #done
