### PR TITLE
refactor: squad tour viewed device sync

### DIFF
--- a/packages/shared/src/contexts/AlertContext.tsx
+++ b/packages/shared/src/contexts/AlertContext.tsx
@@ -8,10 +8,12 @@ export const ALERT_DEFAULTS: Alerts = {
   filter: true,
   rankLastSeen: null,
   myFeed: null,
+  showSquadTour: true,
 };
 
 export interface AlertContextData {
   alerts: Alerts;
+  isFetched?: boolean;
   loadedAlerts?: boolean;
   updateAlerts?: UseMutateAsyncFunction<
     unknown,
@@ -31,6 +33,7 @@ const AlertContext = React.createContext<AlertContextData>({
 interface AlertContextProviderProps {
   children: ReactNode;
   alerts?: Alerts;
+  isFetched?: boolean;
   loadedAlerts?: boolean;
   updateAlerts?: (alerts: Alerts) => unknown;
 }
@@ -39,6 +42,7 @@ export const AlertContextProvider = ({
   children,
   alerts = ALERT_DEFAULTS,
   loadedAlerts,
+  isFetched,
   updateAlerts,
 }: AlertContextProviderProps): ReactElement => {
   const { mutateAsync: updateRemoteAlerts } = useMutation<
@@ -66,10 +70,11 @@ export const AlertContextProvider = ({
   const alertContextData = useMemo<AlertContextData>(
     () => ({
       alerts,
+      isFetched,
       loadedAlerts,
       updateAlerts: updateRemoteAlerts,
     }),
-    [alerts, updateRemoteAlerts],
+    [alerts, loadedAlerts, isFetched, updateRemoteAlerts],
   );
 
   return (

--- a/packages/shared/src/contexts/AlertContext.tsx
+++ b/packages/shared/src/contexts/AlertContext.tsx
@@ -8,7 +8,7 @@ export const ALERT_DEFAULTS: Alerts = {
   filter: true,
   rankLastSeen: null,
   myFeed: null,
-  showSquadTour: true,
+  squadTour: true,
 };
 
 export interface AlertContextData {

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -189,6 +189,7 @@ export const BootDataProvider = ({
         >
           <AlertContextProvider
             alerts={alerts}
+            isFetched={isFetched}
             updateAlerts={updateAlerts}
             loadedAlerts={loadedFromCache}
           >

--- a/packages/shared/src/graphql/alerts.ts
+++ b/packages/shared/src/graphql/alerts.ts
@@ -15,6 +15,7 @@ export const UPDATE_ALERTS = gql`
       rankLastSeen
       myFeed
       companionHelper
+      showSquadTour
     }
   }
 `;

--- a/packages/shared/src/graphql/alerts.ts
+++ b/packages/shared/src/graphql/alerts.ts
@@ -4,7 +4,7 @@ export type Alerts = {
   filter?: boolean;
   rankLastSeen?: Date;
   myFeed?: string;
-  showSquadTour?: boolean;
+  squadTour?: boolean;
   companionHelper?: boolean;
 };
 
@@ -15,7 +15,7 @@ export const UPDATE_ALERTS = gql`
       rankLastSeen
       myFeed
       companionHelper
-      showSquadTour
+      squadTour
     }
   }
 `;

--- a/packages/shared/src/graphql/alerts.ts
+++ b/packages/shared/src/graphql/alerts.ts
@@ -4,6 +4,7 @@ export type Alerts = {
   filter?: boolean;
   rankLastSeen?: Date;
   myFeed?: string;
+  showSquadTour?: boolean;
   companionHelper?: boolean;
 };
 

--- a/packages/shared/src/hooks/useSquadOnboarding.ts
+++ b/packages/shared/src/hooks/useSquadOnboarding.ts
@@ -31,14 +31,14 @@ export const useSquadOnboarding = (
 
     if (hasTriedOnboarding) {
       // to update sync - backwards compatibility
-      if (alerts.showSquadTour) updateAlerts({ showSquadTour: false });
+      if (alerts.squadTour) updateAlerts({ squadTour: false });
 
       return;
     }
 
-    if (isPopupOpen || !alerts.showSquadTour) return;
+    if (isPopupOpen || !alerts.squadTour) return;
 
-    updateAlerts({ showSquadTour: false });
+    updateAlerts({ squadTour: false });
     setHasTriedOnboarding(true);
     if (sidebarRendered) {
       setIsPopupOpen(true);

--- a/packages/shared/src/hooks/useSquadOnboarding.ts
+++ b/packages/shared/src/hooks/useSquadOnboarding.ts
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import { LazyModal } from '../components/modals/common/types';
+import AlertContext from '../contexts/AlertContext';
 import { generateStorageKey, StorageTopic } from '../lib/storage';
 import { useLazyModal } from './useLazyModal';
 import usePersistentContext from './usePersistentContext';
@@ -15,15 +16,29 @@ interface UseSquadOnboarding {
 export const useSquadOnboarding = (
   isPageReady: boolean,
 ): UseSquadOnboarding => {
+  const { alerts, isFetched, updateAlerts } = useContext(AlertContext);
   const { sidebarRendered } = useSidebarRendered();
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const { openModal } = useLazyModal<LazyModal.SquadTour>();
-  const [hasTriedOnboarding, setHasTriedOnboarding, isFetched] =
+  const [hasTriedOnboarding, setHasTriedOnboarding, isCacheFetched] =
     usePersistentContext(SQUAD_ONBOARDING_KEY, false);
 
   useEffect(() => {
-    if (!isPageReady || !isFetched || hasTriedOnboarding || isPopupOpen) return;
+    const conditions = [isPageReady, isFetched, isCacheFetched];
+    const isReady = conditions.every((isMet) => isMet);
 
+    if (!isReady) return;
+
+    if (hasTriedOnboarding) {
+      // to update sync - backwards compatibility
+      if (alerts.showSquadTour) updateAlerts({ showSquadTour: false });
+
+      return;
+    }
+
+    if (isPopupOpen || !alerts.showSquadTour) return;
+
+    updateAlerts({ showSquadTour: false });
     setHasTriedOnboarding(true);
     if (sidebarRendered) {
       setIsPopupOpen(true);
@@ -33,7 +48,9 @@ export const useSquadOnboarding = (
   }, [
     hasTriedOnboarding,
     isFetched,
+    isCacheFetched,
     isPageReady,
+    alerts,
     isPopupOpen,
     sidebarRendered,
   ]);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Applied the newly introduced property in the backend for `Alerts` entity.
- Has backwards compatibility for those who viewed the tour already to update API.
- API PR: https://github.com/dailydotdev/daily-api/pull/1185

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1097 #done
