### PR TITLE
feat: add tracking event for forbidden squad

### DIFF
--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -52,6 +52,7 @@ export enum AnalyticsEvent {
   LeaveSquad = 'leave squad',
   ShareSquadInvitation = 'share squad invitation',
   ViewSquadPage = 'view squad page',
+  ViewSquadForbiddenPage = 'view squad forbidden',
   CompleteSquadCreation = 'complete squad creation',
   ClickSquadCreationNext = 'click squad creation next',
   ClickSquadCreationBack = 'click squad creation back',

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -59,6 +59,8 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
   const { openModal } = useLazyModal();
   const { user, isFetched: isBootFetched } = useContext(AuthContext);
   const [trackedImpression, setTrackedImpression] = useState(false);
+  const [trackedForbiddenImpression, setTrackedForbiddenImpression] =
+    useState(false);
   const queryKey = ['squad', handle];
   const {
     data: squad,
@@ -112,7 +114,16 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
 
   if (!isFetched) return <></>;
 
-  if (isFallback || isInactive || isForbidden) return <Unauthorized />;
+  if (isFallback || isInactive || isForbidden) {
+    if (!trackedForbiddenImpression) {
+      trackEvent({
+        event_name: AnalyticsEvent.ViewSquadForbiddenPage,
+        extra: JSON.stringify({ squad: squadId ?? handle }),
+      });
+      setTrackedForbiddenImpression(true);
+    }
+    return <Unauthorized />;
+  }
 
   if (!squad) return <Custom404 />;
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Add once-off tracking for forbidden squad page.
- Determine either squadId or fallback to handle if unauthorised request (for logging purpose)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| New | view squad forbidden  | extra: { squad: [squadId or handle] } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1096 #done
