### PR TITLE
fix: svg module resolution error in shared

### DIFF
--- a/packages/shared/custom.d.ts
+++ b/packages/shared/custom.d.ts
@@ -1,1 +1,8 @@
 declare module '*.css';
+
+type SvgrComponent = React.FC<React.SVGAttributes<SVGElement>>;
+
+declare module '*.svg' {
+  const value: SvgrComponent;
+  export default value;
+}


### PR DESCRIPTION
## Changes

### Describe what this PR does
Noticed svg module resolution not working in shared so just added missing definition.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
