### PR TITLE
fix: squad header bar responsiveness

### DIFF
--- a/packages/shared/src/components/squads/SquadHeaderBar.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderBar.tsx
@@ -2,21 +2,18 @@ import classNames from 'classnames';
 import React, { HTMLAttributes, ReactElement } from 'react';
 import { Button } from '../buttons/Button';
 import MenuIcon from '../icons/Menu';
-import AddUserIcon from '../icons/AddUser';
-import { ProfilePicture } from '../ProfilePicture';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import SquadHeaderMenu from './SquadHeaderMenu';
-import { Squad, SquadMember } from '../../graphql/squads';
-import { useLazyModal } from '../../hooks/useLazyModal';
-import { LazyModal } from '../modals/common/types';
 import useContextMenu from '../../hooks/useContextMenu';
+import SquadMemberShortList, {
+  SquadMemberShortListProps,
+} from './SquadMemberShortList';
 
-type SquadHeaderBarProps = {
-  squad: Squad;
-  members: SquadMember[];
-  memberCount: number;
+interface SquadHeaderBarProps
+  extends SquadMemberShortListProps,
+    HTMLAttributes<HTMLDivElement> {
   onNewSquadPost: () => void;
-} & HTMLAttributes<HTMLDivElement>;
+}
 
 export function SquadHeaderBar({
   squad,
@@ -27,76 +24,30 @@ export function SquadHeaderBar({
   ...props
 }: SquadHeaderBarProps): ReactElement {
   const { onMenuClick } = useContextMenu({ id: 'squad-menu-context' });
-  const { openModal } = useLazyModal();
-  const openMemberListModal = () =>
-    openModal({
-      type: LazyModal.SquadMember,
-      props: {
-        squad,
-        placeholderAmount: squad?.membersCount,
-      },
-    });
-  const openSquadInviteModal = () =>
-    openModal({
-      type: LazyModal.SquadInvite,
-      props: {
-        initialSquad: squad,
-      },
-    });
 
   return (
     <div
       {...props}
       className={classNames(
-        'flex flex-row flex-wrap items-center gap-4',
+        'flex flex-row flex-wrap justify-center items-center gap-4 w-full',
         className,
       )}
     >
-      <div className="flex overflow-hidden items-center rounded-14 border border-theme-divider-secondary">
-        <SimpleTooltip placement="top" content="Members list">
-          <button
-            type="button"
-            className="flex flex-row-reverse items-center p-1 pl-3 hover:bg-theme-hover active:bg-theme-active border-r border-theme-divider-tertiary"
-            onClick={openMemberListModal}
-          >
-            <span
-              className="mr-1 ml-2 min-w-[1rem]"
-              aria-label="squad-members-count"
-            >
-              {memberCount}
-            </span>
-            {members?.map(({ user }, index) => (
-              <ProfilePicture
-                className={classNames(
-                  '-ml-2 border-2 border-theme-bg-primary',
-                  index > 2 && 'hidden tablet:flex',
-                )}
-                size="medium"
-                key={user.username}
-                user={user}
-              />
-            ))}
-          </button>
-        </SimpleTooltip>
-        <Button
-          className="m-1 active:bg-theme-active btn-tertiary"
-          buttonSize="small"
-          onClick={openSquadInviteModal}
-          icon={<AddUserIcon className="text-theme-label-secondary" />}
-        >
-          Invite
-        </Button>
-      </div>
+      <SquadMemberShortList
+        squad={squad}
+        members={members}
+        memberCount={memberCount}
+      />
       <SimpleTooltip placement="top" content="Squad options">
         <Button
-          className="mobileL:order-2 btn btn-secondary"
+          className="tablet:order-2 btn btn-secondary"
           icon={<MenuIcon size="medium" />}
           onClick={onMenuClick}
           aria-label="Squad options"
         />
       </SimpleTooltip>
       <Button
-        className="w-full mobileL:w-auto btn btn-primary"
+        className="w-full mobileL:max-w-[18rem] tablet:w-fit btn btn-primary"
         onClick={onNewSquadPost}
       >
         Create new post

--- a/packages/shared/src/components/squads/SquadMemberShortList.tsx
+++ b/packages/shared/src/components/squads/SquadMemberShortList.tsx
@@ -1,0 +1,78 @@
+import classNames from 'classnames';
+import React, { ReactElement } from 'react';
+import { Squad, SquadMember } from '../../graphql/squads';
+import { useLazyModal } from '../../hooks/useLazyModal';
+import { Button } from '../buttons/Button';
+import AddUserIcon from '../icons/AddUser';
+import { LazyModal } from '../modals/common/types';
+import { ProfilePicture } from '../ProfilePicture';
+import { SimpleTooltip } from '../tooltips/SimpleTooltip';
+
+export interface SquadMemberShortListProps {
+  squad: Squad;
+  members: SquadMember[];
+  memberCount: number;
+}
+
+function SquadMemberShortList({
+  squad,
+  members,
+  memberCount,
+}: SquadMemberShortListProps): ReactElement {
+  const { openModal } = useLazyModal();
+  const openMemberListModal = () =>
+    openModal({
+      type: LazyModal.SquadMember,
+      props: {
+        squad,
+        placeholderAmount: squad?.membersCount,
+      },
+    });
+  const openSquadInviteModal = () =>
+    openModal({
+      type: LazyModal.SquadInvite,
+      props: {
+        initialSquad: squad,
+      },
+    });
+
+  return (
+    <div className="flex overflow-hidden items-center rounded-14 border border-theme-divider-secondary">
+      <SimpleTooltip placement="top" content="Members list">
+        <button
+          type="button"
+          className="flex flex-row-reverse items-center p-1 pl-3 hover:bg-theme-hover active:bg-theme-active border-r border-theme-divider-tertiary"
+          onClick={openMemberListModal}
+        >
+          <span
+            className="mr-1 ml-2 min-w-[1rem]"
+            aria-label="squad-members-count"
+          >
+            {memberCount}
+          </span>
+          {members?.map(({ user }, index) => (
+            <ProfilePicture
+              className={classNames(
+                '-ml-2 border-2 border-theme-bg-primary',
+                index > 2 && 'hidden tablet:flex',
+              )}
+              size="medium"
+              key={user.username}
+              user={user}
+            />
+          ))}
+        </button>
+      </SimpleTooltip>
+      <Button
+        className="m-1 active:bg-theme-active btn-tertiary"
+        buttonSize="small"
+        onClick={openSquadInviteModal}
+        icon={<AddUserIcon className="text-theme-label-secondary" />}
+      >
+        Invite
+      </Button>
+    </div>
+  );
+}
+
+export default SquadMemberShortList;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Apologies for some of the changes, it was pretty tough to read through the elements of the `SquadHeaderBar` as there are many things going on, so I have decided to extract it to a new component.
- The actual changes that fixed the responsiveness issue are:
  - Line 32: https://github.com/dailydotdev/apps/pull/1640/files#diff-13db82f69e64251bf61f24b0ae6b2d856e78937dc7817993ed6053655599ad49R32
  - Line 43: https://github.com/dailydotdev/apps/pull/1640/files#diff-13db82f69e64251bf61f24b0ae6b2d856e78937dc7817993ed6053655599ad49R43
  - Line 50: https://github.com/dailydotdev/apps/pull/1640/files#diff-13db82f69e64251bf61f24b0ae6b2d856e78937dc7817993ed6053655599ad49R50

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1114 #done
