### PR TITLE
feat: reply to user when comment button is clicked

### DIFF
--- a/packages/shared/src/components/modals/CommentBox.tsx
+++ b/packages/shared/src/components/modals/CommentBox.tsx
@@ -69,17 +69,20 @@ function CommentBox({
     onInputClick,
   } = useUserMentionOptions;
   useEffect(() => {
-    commentRef.current?.focus();
-    if (commentRef.current) {
-      if (editContent) {
-        // eslint-disable-next-line no-param-reassign
-        commentRef.current.value = input || editContent;
-      }
-      commentRef.current.setAttribute(
-        'data-min-height',
-        commentRef.current.offsetHeight.toString(),
-      );
+    const element = commentRef.current;
+
+    if (!element) return;
+
+    element.focus();
+    const value = input || editContent;
+
+    if (value) {
+      // eslint-disable-next-line no-param-reassign
+      element.value = value;
+      element.setSelectionRange(element.value.length, element.value.length);
     }
+
+    element.setAttribute('data-min-height', element.offsetHeight.toString());
   }, []);
 
   const onPaste = (event: ClipboardEvent): void => {

--- a/packages/shared/src/components/modals/NewCommentModal.spec.tsx
+++ b/packages/shared/src/components/modals/NewCommentModal.spec.tsx
@@ -287,6 +287,13 @@ it('should send editComment mutation', async () => {
   await waitFor(() => expect(onComment).toBeCalledWith(comment, false));
 });
 
+it('should pre-populate comment box with the author username when', async () => {
+  const replyTo = '@sshanzel ';
+  renderComponent({ commentId: 'c1', replyTo });
+  const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+  expect(input).toHaveValue(replyTo);
+});
+
 const simulateTextboxInput = (el: HTMLTextAreaElement, key: string) => {
   Simulate.input(el, { data: key } as unknown);
   // eslint-disable-next-line no-param-reassign

--- a/packages/shared/src/components/modals/NewCommentModal.tsx
+++ b/packages/shared/src/components/modals/NewCommentModal.tsx
@@ -46,6 +46,7 @@ export interface NewCommentModalProps extends ModalProps, CommentProps {
   editContent?: string;
   editId?: string;
   onInputChange?: (value: string) => void;
+  replyTo?: string;
 }
 
 enum CommentTabs {
@@ -70,9 +71,11 @@ export default function NewCommentModal({
   editId,
   onComment,
   onInputChange,
+  replyTo,
+  editContent,
   ...props
 }: NewCommentModalProps): ReactElement {
-  const [input, setInput] = useState<string>(props.editContent || '');
+  const [input, setInput] = useState<string>(editContent || replyTo);
   const [sendingComment, setSendingComment] = useState<boolean>(false);
   const [errorMessage, setErrorMessage] = useState<string>(null);
   const { showPrompt } = usePrompt();
@@ -92,8 +95,8 @@ export default function NewCommentModal({
 
   const confirmClose = async (event: MouseEvent): Promise<void> => {
     if (
-      ((!props.editContent && input?.length) ||
-        (props.editContent && props.editContent !== input)) &&
+      ((!editContent && input?.length) ||
+        (editContent && editContent !== input)) &&
       !(await showPrompt(promptOptions))
     ) {
       return;
@@ -181,6 +184,7 @@ export default function NewCommentModal({
       {editId ? 'Update' : 'Post'}
     </Button>
   );
+
   return (
     <Modal
       contentRef={modalRef}
@@ -196,6 +200,7 @@ export default function NewCommentModal({
       <Modal.Body view={CommentTabs.Write}>
         <CommentBox
           {...props}
+          editContent={editContent}
           useUserMentionOptions={useUserMentionOptions}
           onInput={setInput}
           input={input}

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -85,6 +85,7 @@ export interface ParentComment {
   post: Post;
   editContent?: string;
   editId?: string;
+  replyTo?: string;
 }
 
 export type ReadHistoryPost = Pick<

--- a/packages/shared/src/hooks/usePostComment.ts
+++ b/packages/shared/src/hooks/usePostComment.ts
@@ -19,7 +19,7 @@ export interface UsePostComment {
   commentsNum: number;
   closeNewComment: () => void;
   openNewComment: (origin: string) => void;
-  onCommentClick: (parent: ParentComment) => void;
+  onCommentClick: (parent: ParentComment, replyTo: string) => void;
   onShowShareNewComment: (value: boolean) => void;
   updatePostComments: (comment: Comment, isNew?: boolean) => void;
   deleteCommentCache: (commentId: string, parentId?: string) => void;
@@ -68,9 +68,9 @@ export const usePostComment = (
     }
   };
 
-  const onCommentClick = (parent: ParentComment) => {
+  const onCommentClick = (parent: ParentComment, replyTo: string) => {
     setLastScroll(window.scrollY);
-    setParentComment(parent);
+    setParentComment({ ...parent, replyTo });
   };
 
   const openNewComment = (origin: string) => {


### PR DESCRIPTION
## Changes

I started my day with this task and was already half way through when I switched to fixing comments from my open PRs so I have decided to finish this off since it was almost done already.

Currently deployed at: https://preview2.app.daily.dev/

Feel free to click the comment button on the user you want to reply to!

This also fixes the issue with "edit comment" to focus the cursor on the very last character automatically.

Recording from preview deployment:

https://user-images.githubusercontent.com/13744167/222039676-d616c9a3-b88e-4270-bb2f-96f64550e868.mov

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1074 #done
