### PR TITLE
refactor: feed should only show visible posts, ads, and placeholders

### DIFF
--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -60,6 +60,7 @@ export interface Post {
   sharedPost?: SharedPost;
   type: PostType;
   private?: boolean;
+  visible?: boolean;
 }
 
 export interface Ad {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Should show only visible posts.
- Backwards compatible by using the condition `post.visible !== false` as the current value could be undefined or null based on what GraphQL will fallback to.
- Introduced enum for `PostItemType`.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1118 #done
