### PR TITLE
fix: middle click for list mode

### DIFF
--- a/packages/shared/src/components/ConditionalWrapper.tsx
+++ b/packages/shared/src/components/ConditionalWrapper.tsx
@@ -1,15 +1,15 @@
-import { ReactElement } from 'react';
+import { ReactElement, ReactNode } from 'react';
 
 interface ConditionalWrapperProps {
   condition: boolean;
-  wrapper: (children: ReactElement) => ReactElement;
-  children: ReactElement;
+  wrapper: (children: ReactNode) => ReactElement;
+  children: ReactNode;
 }
 const ConditionalWrapper = ({
   condition,
   wrapper,
   children,
 }: ConditionalWrapperProps): ReactElement =>
-  condition ? wrapper(children) : children;
+  condition ? wrapper(children) : (children as ReactElement);
 
 export default ConditionalWrapper;

--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -10,9 +10,10 @@ import CommentIcon from '../icons/Discuss';
 import { Button, ButtonProps } from '../buttons/Button';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import OptionsButton from '../buttons/OptionsButton';
-import classed from '../../lib/classed';
 import { ReadArticleButton } from './ReadArticleButton';
 import { visibleOnGroupHover } from './common';
+import ConditionalWrapper from '../ConditionalWrapper';
+import classed from '../../lib/classed';
 
 const ShareIcon = dynamic(
   () => import(/* webpackChunkName: "share" */ '../icons/Share'),
@@ -32,16 +33,6 @@ export interface ActionButtonsProps {
   insaneMode?: boolean;
   openNewTab?: boolean;
 }
-
-const getContainer = (displayWhenHovered = false, className?: string) =>
-  classed(
-    'div',
-    classNames(
-      'flex justify-between',
-      displayWhenHovered && visibleOnGroupHover,
-      className,
-    ),
-  );
 
 type LastActionButtonProps = {
   onBookmarkClick?: (post: Post, bookmarked: boolean) => unknown;
@@ -78,10 +69,6 @@ export default function ActionButtons({
   children,
   insaneMode,
 }: ActionButtonsProps): ReactElement {
-  const LeftContainer = insaneMode ? getContainer() : React.Fragment;
-  const RightContainer = insaneMode
-    ? getContainer(true, 'ml-auto')
-    : React.Fragment;
   const upvoteCommentProps: ButtonProps<'button'> = {
     buttonSize: 'small',
   };
@@ -93,6 +80,8 @@ export default function ActionButtons({
     onShareClick,
   });
 
+  const Container = classed('div', 'flex justify-between', className);
+
   return (
     <div
       className={classNames(
@@ -102,7 +91,10 @@ export default function ActionButtons({
         className,
       )}
     >
-      <LeftContainer>
+      <ConditionalWrapper
+        condition={insaneMode}
+        wrapper={(leftChildren) => <Container>{leftChildren}</Container>}
+      >
         <SimpleTooltip content={post.upvoted ? 'Remove upvote' : 'Upvote'}>
           <QuaternaryButton
             id={`post-${post.id}-upvote-btn`}
@@ -132,12 +124,17 @@ export default function ActionButtons({
           </QuaternaryButton>
         </SimpleTooltip>
         {insaneMode && lastActionButton}
-      </LeftContainer>
-      <RightContainer>
+      </ConditionalWrapper>
+      <ConditionalWrapper
+        condition={insaneMode}
+        wrapper={(rightChildren) => (
+          <Container className={visibleOnGroupHover}>{rightChildren}</Container>
+        )}
+      >
         {insaneMode && (
           <ReadArticleButton
+            className="mr-2 btn-primary"
             href={post.permalink}
-            className="btn-tertiary"
             onClick={onReadArticleClick}
             openNewTab={openNewTab}
           />
@@ -151,7 +148,7 @@ export default function ActionButtons({
           />
         )}
         {children}
-      </RightContainer>
+      </ConditionalWrapper>
     </div>
   );
 }

--- a/packages/shared/src/components/cards/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.tsx
@@ -14,7 +14,7 @@ import PostMetadata from './PostMetadata';
 import ActionButtons from './ActionButtons';
 import { PostCardHeader } from './PostCardHeader';
 import { PostCardFooter } from './PostCardFooter';
-import { Containter, PostCardProps } from './common';
+import { Container, PostCardProps } from './common';
 
 export const ArticlePostCard = forwardRef(function PostCard(
   {
@@ -60,15 +60,15 @@ export const ArticlePostCard = forwardRef(function PostCard(
         />
         <CardTitle>{post.title}</CardTitle>
       </CardTextContainer>
-      <Containter className="mb-8 tablet:mb-0">
+      <Container className="mb-8 tablet:mb-0">
         <CardSpace />
         <PostMetadata
           createdAt={post.createdAt}
           readTime={post.readTime}
           className="mx-4"
         />
-      </Containter>
-      <Containter>
+      </Container>
+      <Container>
         <PostCardFooter
           insaneMode={insaneMode}
           openNewTab={openNewTab}
@@ -91,7 +91,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
             !showImage && 'my-4 laptop:mb-0',
           )}
         />
-      </Containter>
+      </Container>
       {children}
     </Card>
   );

--- a/packages/shared/src/components/cards/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.tsx
@@ -4,7 +4,7 @@ import ActionButtons from './ActionButtons';
 import { SharedPostCardHeader } from './SharedPostCardHeader';
 import { SharedPostText } from './SharedPostText';
 import { SharedPostCardFooter } from './SharedPostCardFooter';
-import { Containter, PostCardProps } from './common';
+import { Container, PostCardProps } from './common';
 import OptionsButton from '../buttons/OptionsButton';
 
 export const SharePostCard = forwardRef(function SharePostCard(
@@ -61,7 +61,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
         title={post.title}
         onHeightChange={onSharedPostTextHeightChange}
       />
-      <Containter ref={containerRef}>
+      <Container ref={containerRef}>
         <SharedPostCardFooter
           sharedPost={post.sharedPost}
           isShort={isSharedPostShort}
@@ -78,7 +78,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
           onReadArticleClick={onReadArticleClick}
           className="justify-between mx-4"
         />
-      </Containter>
+      </Container>
       {children}
     </Card>
   );

--- a/packages/shared/src/components/cards/common.tsx
+++ b/packages/shared/src/components/cards/common.tsx
@@ -18,7 +18,7 @@ export const getGroupedHoverContainer = <
 
 export type Callback = (post: Post) => unknown;
 
-export const Containter = classed('div', 'relative flex flex-1 flex-col');
+export const Container = classed('div', 'relative flex flex-1 flex-col');
 
 export type PostCardProps = {
   post: Post;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- For some reason classed + the functional evaluation was not working for middle-clicks
- Decided to make it more inline with our existing systems and use the `ConditionalWrapper` component
- Verified both layouts still work
- List now fires middle click + opens the article
- Also fixed a small typo

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1108 #done
