### PR TITLE
fix: source submission icons

### DIFF
--- a/packages/extension/src/newtab/DndModal.tsx
+++ b/packages/extension/src/newtab/DndModal.tsx
@@ -68,7 +68,7 @@ export default function DndModal({
               valueChanged={(text) => setLink(text)}
             />
             <Radio
-              className="mt-8"
+              className={{ container: 'mt-8' }}
               name="timeOff"
               value={dndTime}
               options={timeFormatOptions}

--- a/packages/shared/src/components/fields/Radio.tsx
+++ b/packages/shared/src/components/fields/Radio.tsx
@@ -8,12 +8,17 @@ export interface RadioOption<T = string> {
   id?: string;
 }
 
+interface ClassName {
+  container?: string;
+  content?: string;
+}
+
 export type RadioProps = {
   name: string;
   options: RadioOption[];
   value?: string;
   onChange: (value: string) => unknown;
-  className?: string;
+  className?: ClassName;
 };
 
 export function Radio({
@@ -21,10 +26,15 @@ export function Radio({
   options,
   value,
   onChange,
-  className,
+  className = {},
 }: RadioProps): ReactElement {
   return (
-    <div className={classNames('flex flex-col -my-0.5 items-start', className)}>
+    <div
+      className={classNames(
+        'flex flex-col -my-0.5 items-start',
+        className.container,
+      )}
+    >
       {options.map((option) => (
         <RadioItem
           key={option.value}
@@ -33,7 +43,7 @@ export function Radio({
           value={option.value}
           checked={value === option.value}
           onChange={() => onChange(option.value)}
-          className="my-0.5 truncate"
+          className={classNames('my-0.5 truncate', className.content)}
         >
           {option.label}
         </RadioItem>

--- a/packages/shared/src/components/modals/NewSourceModal.tsx
+++ b/packages/shared/src/components/modals/NewSourceModal.tsx
@@ -60,7 +60,7 @@ type ScrapeSourceResponse =
   | ScrapeSourceUnavailable;
 
 const getFeedLabel = (label: string, link: string) => (
-  <span className="flex justify-between items-center w-full">
+  <span className="flex flex-1 justify-between items-center w-full">
     {label}
     <Button
       className="btn-tertiary"
@@ -278,7 +278,7 @@ export default function NewSourceModal(props: ModalProps): ReactElement {
                 value={selectedFeed}
                 className={{
                   container: 'self-start w-full',
-                  content: 'w-full',
+                  content: 'w-full pr-0',
                 }}
               />
             </form>

--- a/packages/shared/src/components/modals/NewSourceModal.tsx
+++ b/packages/shared/src/components/modals/NewSourceModal.tsx
@@ -65,6 +65,7 @@ const getFeedLabel = (label: string, link: string) => (
     <Button
       className="btn-tertiary"
       tag="a"
+      target="_blank"
       href={link}
       icon={<OpenLinkIcon />}
     />

--- a/packages/shared/src/components/modals/NewSourceModal.tsx
+++ b/packages/shared/src/components/modals/NewSourceModal.tsx
@@ -276,7 +276,10 @@ export default function NewSourceModal(props: ModalProps): ReactElement {
                 options={feeds}
                 onChange={setSelectedFeed}
                 value={selectedFeed}
-                className="self-start"
+                className={{
+                  container: 'self-start w-full',
+                  content: 'w-full',
+                }}
               />
             </form>
           </>

--- a/packages/shared/src/components/modals/ReportPostModal.tsx
+++ b/packages/shared/src/components/modals/ReportPostModal.tsx
@@ -49,7 +49,7 @@ export default function RepostPostModal({
           &quot;{post?.title}&quot;
         </p>
         <Radio
-          className="mt-2 mb-4"
+          className={{ container: 'mt-2 mb-4' }}
           name="report_reason"
           options={reportReasons}
           value={reason}


### PR DESCRIPTION
## Changes

This is also deployed at preview2. Should now flex as intended.

Preview:

![image](https://user-images.githubusercontent.com/13744167/222367523-a31b41f1-9895-4554-abbb-01d1a54f02c8.png)

### Describe what this PR does
- There was a missing flex: 1

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
