### PR TITLE
fix: registration stuck issue

### DIFF
--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -240,8 +240,18 @@ function AuthOptions({
 
         return displayToast('An error occurred, please refresh the page.');
       }
+      const bootResponse = await refetchBoot();
+      if (!bootResponse.data.user || !('email' in bootResponse.data.user)) {
+        trackEvent({
+          event_name: AuthEventNames.SubmitSignUpFormError,
+          extra: JSON.stringify({
+            error: 'Could not find email on social registration',
+          }),
+        });
+        return displayToast('An error occurred, please refresh and try again.');
+      }
+
       if (!e.data?.social_registration) {
-        await refetchBoot();
         return onSuccessfulLogin?.();
       }
 
@@ -250,7 +260,7 @@ function AuthOptions({
   );
 
   const onEmailRegistration = (emailAd: string) => {
-    // before displaying registration, ensure the email doesn't exists
+    // before displaying registration, ensure the email doesn't exist
     onSetActiveDisplay(AuthDisplay.Registration);
     setEmail(emailAd);
   };

--- a/packages/shared/src/contexts/AuthContext.tsx
+++ b/packages/shared/src/contexts/AuthContext.tsx
@@ -5,13 +5,14 @@ import React, {
   useMemo,
   useState,
 } from 'react';
+import { QueryObserverResult } from 'react-query';
 import {
   AnonymousUser,
   deleteAccount,
   LoggedUser,
   logout as dispatchLogout,
 } from '../lib/user';
-import { AccessToken, Visit } from '../lib/boot';
+import { AccessToken, Boot, Visit } from '../lib/boot';
 import { isCompanionActivated } from '../lib/element';
 import { AuthTriggers, AuthTriggersOrString } from '../lib/auth';
 import { Squad } from '../graphql/squads';
@@ -44,7 +45,7 @@ export interface AuthContextData {
   visit?: Visit;
   isFirstVisit?: boolean;
   deleteAccount?: () => Promise<void>;
-  refetchBoot?: () => Promise<unknown>;
+  refetchBoot?: () => Promise<QueryObserverResult<Boot>>;
   accessToken?: AccessToken;
   squads?: Squad[];
 }
@@ -87,7 +88,7 @@ export type AuthContextProviderProps = {
   isFetched?: boolean;
   isLegacyLogout?: boolean;
   firstLoad?: boolean;
-  refetchBoot?: () => Promise<unknown>;
+  refetchBoot?: () => Promise<QueryObserverResult<Boot>>;
   children?: ReactNode;
 } & Pick<
   AuthContextData,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- There was a chance for the registration flow to be stuck because of the user reefch not happening.
- Moved the refetch and actually log if it returns no user.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1134 #done
