### PR TITLE
fix: added range for changelog width to not span to full width

### DIFF
--- a/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
@@ -99,7 +99,7 @@ function ChangelogTooltip<TRef extends HTMLElement>({
       content={
         !!post && (
           <div
-            className="flex flex-col whitespace-normal break-words rounded-16 border shadow-2 focus:outline-none min-w-[22.5rem] changelog bg-theme-bg-tertiary border-theme-color-cabbage"
+            className="flex relative flex-col whitespace-normal break-words rounded-16 border shadow-2 focus:outline-none w-[24rem] changelog bg-theme-bg-tertiary border-theme-color-cabbage"
             data-testid="changelog"
           >
             <header className="flex flex-1 items-center py-3 px-4 border-b border-theme-divider-tertiary">
@@ -164,7 +164,7 @@ function ChangelogTooltip<TRef extends HTMLElement>({
                 </span>
               </div>
             </section>
-            <footer className="flex gap-3 items-center py-3 px-4 w-full h-16 border-t border-theme-divider-tertiary">
+            <footer className="flex gap-3 justify-between items-center py-3 px-4 w-full h-16 border-t border-theme-divider-tertiary">
               <Button
                 className="btn-tertiary"
                 onClick={dismissChangelog}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- changelog would span full width due to absolute positioned element not wrapping by default

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done

### Screenshot references

#### Webapp
* [Long summary text (max 300 chars)](https://user-images.githubusercontent.com/9803078/224270051-82e5e9e9-d06b-45dc-96f6-5de6c3cca8e1.png)
* [Short summary text](https://user-images.githubusercontent.com/9803078/224270046-36fe5e9e-4a78-48e0-9399-5adcad90931b.png)
* [No summary](https://user-images.githubusercontent.com/9803078/224270044-c9983e0c-687b-421f-8fd8-0d23800c8500.png)

#### Extension
* [Long summary text (max 300 chars)](https://user-images.githubusercontent.com/9803078/224270048-6baf4d94-6907-47cd-ada1-97baac0ecb11.png)
* [Short summary text](https://user-images.githubusercontent.com/9803078/224270045-05a35d70-c961-48a9-9ef5-a1d762da8044.png)
* [No summary](https://user-images.githubusercontent.com/9803078/224270040-2b417d10-444e-4a06-bd47-5e55938c9730.png)

### Testing steps
Update `lastChangelog` column in the `alerts` table for your user to some date in the past. For seeded db content locally anything in `2017` works.