### PR TITLE
feat: show image errors in toast

### DIFF
--- a/packages/shared/src/components/fields/ImageInput.tsx
+++ b/packages/shared/src/components/fields/ImageInput.tsx
@@ -10,6 +10,7 @@ import { blobToBase64 } from '../../lib/blob';
 import { fallbackImages } from '../../lib/config';
 import EditIcon from '../icons/Edit';
 import { IconSize } from '../Icon';
+import { useToastNotification } from '../../hooks/useToastNotification';
 
 type Size = 'medium' | 'large';
 
@@ -55,7 +56,7 @@ function ImageInput({
   fallbackImage = fallbackImages.avatar,
 }: ImageInputProps): ReactElement {
   const inputRef = useRef<HTMLInputElement>();
-  const [error, setError] = useState('');
+  const toast = useToastNotification();
   const [image, setImage] = useState(initialValue || fallbackImage);
   const onClick = () => {
     inputRef.current.click();
@@ -71,12 +72,13 @@ function ImageInput({
     }
 
     if (file.size > TWO_MEGABYTES) {
-      setError('Maximum image size is 2 MB');
+      toast.displayToast('Maximum image size is 2 MB');
+
       return;
     }
 
     const base64 = await blobToBase64(file);
-    setError(null);
+    toast.dismissToast();
     setImage(base64);
     onChange?.(base64);
   };
@@ -123,11 +125,6 @@ function ImageInput({
         )}
       >
         {hoverIcon || <EditIcon size={sizeToIconSize[size]} secondary />}
-      </span>
-      <span
-        className={classNames('typo-footnote', error ? 'visible' : 'invisible')}
-      >
-        {error}
       </span>
     </button>
   );


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Replace footnote error with toast in ImageInput, since former broke the UI in most cases

![image](https://user-images.githubusercontent.com/9803078/224288304-d6de4d6a-8d15-487a-b35f-5bb3f01bf95a.png)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{1137} #done
