### PR TITLE
fix: readtime is no longer show in squad post if falsy/null

### DIFF
--- a/packages/shared/src/components/post/PostSourceInfo.tsx
+++ b/packages/shared/src/components/post/PostSourceInfo.tsx
@@ -27,8 +27,12 @@ function PostSourceInfo({
     >
       <SourceButton source={source} size={size} />
       <h3 className="ml-3">{source.handle}</h3>
-      <Separator />
-      <time dateTime={date}>{date}</time>
+      {!!date && (
+        <>
+          <Separator />
+          <time dateTime={date}>{date}</time>
+        </>
+      )}
     </span>
   );
 }

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -158,7 +158,11 @@ function SquadPostContent({
                   {post.sharedPost.title}
                 </h2>
                 <PostSourceInfo
-                  date={`${post.sharedPost.readTime}m read time`}
+                  date={
+                    post.sharedPost.readTime
+                      ? `${post.sharedPost.readTime}m read time`
+                      : undefined
+                  }
                   source={post.sharedPost.source}
                   size="small"
                 />


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Don't render readtime if it's falsy for source sub

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{1145} #done
