### PR TITLE
feat(companion): show bookmark button and support share to squad

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -47,7 +47,7 @@ const sendBootData = async (_, tab: Tabs.Tab) => {
 
   const [
     deviceId,
-    { postData, settings, flags, user, alerts, visit, accessToken },
+    { postData, settings, flags, user, alerts, visit, accessToken, squads },
   ] = await Promise.all([
     getOrGenerateDeviceId(),
     getBootData('companion', href),
@@ -67,6 +67,7 @@ const sendBootData = async (_, tab: Tabs.Tab) => {
     alerts,
     visit,
     accessToken,
+    squads,
   });
 };
 

--- a/packages/extension/src/companion/App.tsx
+++ b/packages/extension/src/companion/App.tsx
@@ -33,6 +33,7 @@ export type CompanionData = { url: string; deviceId: string } & Pick<
   | 'user'
   | 'visit'
   | 'accessToken'
+  | 'squads'
 >;
 
 const refreshTokenKey = 'refresh_token';
@@ -47,6 +48,7 @@ export default function App({
   alerts,
   visit,
   accessToken,
+  squads,
 }: CompanionData): ReactElement {
   useError();
   const [token, setToken] = useState(accessToken);
@@ -88,6 +90,7 @@ export default function App({
               tokenRefreshed
               getRedirectUri={() => browser.runtime.getURL('index.html')}
               updateUser={() => null}
+              squads={squads}
             >
               <SettingsContextProvider settings={settings}>
                 <AlertContextProvider alerts={alerts}>

--- a/packages/extension/src/companion/Companion.spec.tsx
+++ b/packages/extension/src/companion/Companion.spec.tsx
@@ -71,6 +71,7 @@ const renderComponent = (postdata, settings): RenderResult => {
       flags={{}}
       deviceId="123"
       accessToken={{ token: '', expiresIn: '' }}
+      squads={[]}
     />,
   );
 };

--- a/packages/extension/src/companion/Companion.spec.tsx
+++ b/packages/extension/src/companion/Companion.spec.tsx
@@ -136,18 +136,14 @@ describe('companion app', () => {
   it('should show bookmark icon selected', async () => {
     renderComponent({}, {});
     await screen.findByTestId('companion');
-    const [menuBtn] = await screen.findAllByLabelText('More options');
-    menuBtn.click();
-    const el = await screen.findByText('Remove from bookmarks');
+    const el = await screen.findByLabelText('Remove from bookmarks');
     expect(el).toBeInTheDocument();
   });
 
   it('should show bookmark icon unselected', async () => {
     renderComponent({ bookmarked: false }, {});
     await screen.findByTestId('companion');
-    const [menuBtn] = await screen.findAllByLabelText('More options');
-    menuBtn.click();
-    const el = await screen.findByText('Save to bookmarks');
+    const el = await screen.findByLabelText('Save to bookmarks');
     expect(el).toBeInTheDocument();
   });
 

--- a/packages/extension/src/companion/CompanionContextMenu.tsx
+++ b/packages/extension/src/companion/CompanionContextMenu.tsx
@@ -9,10 +9,8 @@ import { PostBootData } from '@dailydotdev/shared/src/lib/boot';
 import { postAnalyticsEvent } from '@dailydotdev/shared/src/lib/feed';
 import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
-import BookmarkIcon from '@dailydotdev/shared/src/components/icons/Bookmark';
 import { ShareBookmarkProps } from '@dailydotdev/shared/src/components/post/PostActions';
 import { feedback } from '@dailydotdev/shared/src/lib/constants';
-import classNames from 'classnames';
 import {
   PromptOptions,
   usePrompt,
@@ -20,7 +18,8 @@ import {
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import { getCompanionWrapper } from './common';
 
-interface CompanionContextMenuProps extends ShareBookmarkProps {
+interface CompanionContextMenuProps
+  extends Omit<ShareBookmarkProps, 'onBookmark'> {
   postData: PostBootData;
   onReport: (T) => void;
   onBlockSource: (T) => void;
@@ -32,7 +31,6 @@ export default function CompanionContextMenu({
   onReport,
   onBlockSource,
   onDisableCompanion,
-  onBookmark,
 }: CompanionContextMenuProps): ReactElement {
   const { displayToast } = useToastNotification();
   const { trackEvent } = useContext(AnalyticsContext);
@@ -89,17 +87,6 @@ export default function CompanionContextMenu({
             <CommentIcon size={IconSize.Small} className="mr-2" /> View
             discussion
           </a>
-        </Item>
-        <Item onClick={onBookmark}>
-          <BookmarkIcon
-            size={IconSize.Small}
-            className={classNames(
-              'mr-2',
-              postData?.bookmarked && 'text-theme-color-bun',
-            )}
-            secondary={postData?.bookmarked}
-          />
-          {postData?.bookmarked ? 'Remove from' : 'Save to'} bookmarks
         </Item>
         <Item onClick={() => setReportModal(true)}>
           <FlagIcon size={IconSize.Small} className="mr-2" /> Report

--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -5,6 +5,7 @@ import CommentIcon from '@dailydotdev/shared/src/components/icons/Discuss';
 import MenuIcon from '@dailydotdev/shared/src/components/icons/Menu';
 import ShareIcon from '@dailydotdev/shared/src/components/icons/Share';
 import SimpleTooltip from '@dailydotdev/shared/src/components/tooltips/SimpleTooltip';
+import BookmarkIcon from '@dailydotdev/shared/src/components/icons/Bookmark';
 import Modal from 'react-modal';
 import { useContextMenu } from '@dailydotdev/react-contexify';
 import { isTesting } from '@dailydotdev/shared/src/lib/constants';
@@ -19,12 +20,18 @@ import { useKeyboardNavigation } from '@dailydotdev/shared/src/hooks/useKeyboard
 import { useSharePost } from '@dailydotdev/shared/src/hooks/useSharePost';
 import NewCommentModal from '@dailydotdev/shared/src/components/modals/NewCommentModal';
 import ShareModal from '@dailydotdev/shared/src/components/modals/ShareModal';
+import { LazyModal } from '@dailydotdev/shared/src/components/modals/common/types';
+import PostToSquadModal, {
+  PostToSquadModalProps,
+} from '@dailydotdev/shared/src/components/modals/PostToSquadModal';
+import { useLazyModal } from '@dailydotdev/shared/src/hooks/useLazyModal';
 import CompanionContextMenu from './CompanionContextMenu';
 import '@dailydotdev/shared/src/styles/globals.css';
 import { getCompanionWrapper } from './common';
 import useCompanionActions from './useCompanionActions';
 import { useCompanionPostComment } from './useCompanionPostComment';
 import CompanionToggle from './CompanionToggle';
+import { companionRequest } from './companionRequest';
 
 if (!isTesting) {
   Modal.setAppElement('daily-companion-app');
@@ -49,6 +56,7 @@ export default function CompanionMenu({
   setCompanionState,
   onOpenComments,
 }: CompanionMenuProps): ReactElement {
+  const { modal, closeModal } = useLazyModal();
   const { trackEvent } = useContext(AnalyticsContext);
   const { user } = useContext(AuthContext);
   const [showCompanionHelper, setShowCompanionHelper] = usePersistentContext(
@@ -213,6 +221,19 @@ export default function CompanionMenu({
       </SimpleTooltip>
       <SimpleTooltip
         placement="left"
+        content={`${post?.bookmarked ? 'Remove from' : 'Save to'} bookmarks`}
+        appendTo="parent"
+        container={tooltipContainerProps}
+      >
+        <Button
+          icon={<BookmarkIcon secondary={post?.bookmarked} />}
+          pressed={post?.bookmarked}
+          onClick={toggleBookmark}
+          className="btn-tertiary-bun"
+        />
+      </SimpleTooltip>
+      <SimpleTooltip
+        placement="left"
         content="Share post"
         appendTo="parent"
         container={tooltipContainerProps}
@@ -236,7 +257,6 @@ export default function CompanionMenu({
         />
       </SimpleTooltip>
       <CompanionContextMenu
-        onBookmark={toggleBookmark}
         onShare={onShare}
         postData={post}
         onReport={report}
@@ -259,6 +279,15 @@ export default function CompanionMenu({
           post={sharePost}
           origin={Origin.Companion}
           onRequestClose={closeSharePost}
+        />
+      )}
+      {modal?.type === LazyModal.PostToSquad && (
+        <PostToSquadModal
+          isOpen
+          parentSelector={getCompanionWrapper}
+          requestMethod={companionRequest}
+          onRequestClose={closeModal}
+          {...(modal.props as PostToSquadModalProps)}
         />
       )}
     </div>

--- a/packages/extension/src/companion/index.tsx
+++ b/packages/extension/src/companion/index.tsx
@@ -34,6 +34,7 @@ browser.runtime.onMessage.addListener(
     alerts,
     visit,
     accessToken,
+    squads,
   }) => {
     if (!settings || settings?.optOutCompanion) {
       return;
@@ -50,6 +51,7 @@ browser.runtime.onMessage.addListener(
         alerts,
         visit,
         accessToken,
+        squads,
       });
     } else {
       const container = getCompanionWrapper();

--- a/packages/shared/src/components/modals/ShareModal.tsx
+++ b/packages/shared/src/components/modals/ShareModal.tsx
@@ -100,7 +100,7 @@ export default function ShareModal({
           value={link}
           readOnly
         />
-        <p className="py-2.5 font-bold typo-callout">Share via</p>
+        <p className="py-2.5 font-bold typo-callout">Share to</p>
         <SocialShare
           post={post}
           comment={comment}

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -31,7 +31,7 @@ export interface ModalProps extends ReactModal.Props {
 
 export type LazyModalCommonProps = Pick<
   ModalProps,
-  'isOpen' | 'onRequestClose'
+  'isOpen' | 'onRequestClose' | 'parentSelector'
 > & { onRequestClose: (e?: React.MouseEvent | React.KeyboardEvent) => void };
 
 const modalKindToOverlayClassName: Record<ModalKind, string> = {

--- a/packages/shared/src/components/profile/SourceProfilePicture.tsx
+++ b/packages/shared/src/components/profile/SourceProfilePicture.tsx
@@ -3,6 +3,7 @@ import { Source } from '../../graphql/sources';
 import ConditionalWrapper from '../ConditionalWrapper';
 import { ProfilePicture, ProfilePictureProps } from '../ProfilePicture';
 import { ProfileLink } from './ProfileLink';
+import { cloudinary } from '../../lib/image';
 
 interface SourceProfilePictureProps extends Omit<ProfilePictureProps, 'user'> {
   isLink?: boolean;
@@ -30,6 +31,7 @@ function SourceProfilePicture({
           image: source.image,
           username: source.handle,
         }}
+        fallbackSrc={cloudinary.squads.imageFallback}
       />
     </ConditionalWrapper>
   );

--- a/packages/shared/src/components/squads/Comment.tsx
+++ b/packages/shared/src/components/squads/Comment.tsx
@@ -1,4 +1,10 @@
-import React, { FormEvent, ReactElement, useContext, useState } from 'react';
+import React, {
+  FormEvent,
+  KeyboardEvent,
+  ReactElement,
+  useContext,
+  useState,
+} from 'react';
 import { Modal } from '../modals/common/Modal';
 import { Button } from '../buttons/Button';
 import { ProfilePicture } from '../ProfilePicture';
@@ -9,9 +15,13 @@ import AuthContext from '../../contexts/AuthContext';
 import OpenLinkIcon from '../icons/OpenLink';
 import { SquadForm } from '../../graphql/squads';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
+import { KeyboardCommand } from '../../lib/element';
 
 interface SquadCommentProps {
-  onSubmit: React.EventHandler<FormEvent>;
+  onSubmit: (
+    e?: React.MouseEvent | React.KeyboardEvent,
+    commentary?: string,
+  ) => unknown;
   form: Partial<SquadForm>;
   isLoading?: boolean;
 }
@@ -25,11 +35,22 @@ export function SquadComment({
   const { user } = useContext(AuthContext);
   const [commentary, setCommentary] = useState(form.commentary);
 
+  const handleKeydown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    const pressedSpecialkey = e.ctrlKey || e.metaKey;
+    if (
+      pressedSpecialkey &&
+      e.key === KeyboardCommand.Enter &&
+      commentary?.length
+    ) {
+      onSubmit(null, commentary);
+    }
+  };
+
   return (
     <>
       <Modal.Body className="flex flex-col">
         <form
-          onSubmit={onSubmit}
+          onSubmit={onSubmit as React.EventHandler<FormEvent>}
           className="flex flex-1 gap-4"
           id="squad-comment"
         >
@@ -38,6 +59,7 @@ export function SquadComment({
             placeholder="Share your thought and insights about the post…"
             className="flex-1 self-stretch w-full min-w-0 focus:placeholder-transparent bg-transparent focus:outline-none resize-none typo-body caret-theme-label-link text-theme-label-primary"
             value={commentary}
+            onKeyDown={handleKeydown}
             onChange={(event) => setCommentary(event.target.value)}
             ref={(el) => {
               if (!el) return;

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -290,8 +290,10 @@ export const checkExistingHandle = async (handle: string): Promise<boolean> => {
   return req.sourceHandleExists;
 };
 
-export const addPostToSquad = (data: PostToSquadProps): Promise<Post> =>
-  request(graphqlUrl, ADD_POST_TO_SQUAD_MUTATION, data);
+export const addPostToSquad =
+  (requestMethod: typeof request) =>
+  (data: PostToSquadProps): Promise<Post> =>
+    requestMethod(graphqlUrl, ADD_POST_TO_SQUAD_MUTATION, data);
 
 export async function createSquad(form: SquadForm): Promise<Squad> {
   const inputData: CreateSquadInput = {


### PR DESCRIPTION
## Changes

### Describe what this PR does

* Put bookmark button in the companion widget between comment and share
* Add support for sharing posts to squads from companion
* Bonus: Submit commenatry on CMD+Enter like we have for comments

Everything was tested locally.

Sidenote: Some sites block our images from loading but it's a known issue as far as I recall. It's relevant for squad images and user images

<img width="183" alt="image" src="https://user-images.githubusercontent.com/1993245/224558771-73368ac9-0701-4d9b-9042-078cdf04b7a4.png">
<img width="746" alt="image" src="https://user-images.githubusercontent.com/1993245/224558785-6f425cab-d549-4d56-b6e9-fc854aaeda73.png">


