### PR TITLE
fix: fallback is now triggered only if user has no bookmarks

### DIFF
--- a/packages/webapp/pages/history.tsx
+++ b/packages/webapp/pages/history.tsx
@@ -3,7 +3,9 @@ import dynamic from 'next/dynamic';
 import { NextSeo } from 'next-seo';
 import { ResponsivePageContainer } from '@dailydotdev/shared/src/components/utilities';
 import useReadingHistory from '@dailydotdev/shared/src/hooks/useReadingHistory';
-import useInfiniteReadingHistory from '@dailydotdev/shared/src/hooks/useInfiniteReadingHistory';
+import useInfiniteReadingHistory, {
+  ReadHistoryInfiniteData,
+} from '@dailydotdev/shared/src/hooks/useInfiniteReadingHistory';
 import ReadingHistoryList from '@dailydotdev/shared/src/components/history/ReadingHistoryList';
 import ReadingHistoryPlaceholder from '@dailydotdev/shared/src/components/history/ReadingHistoryPlaceholder';
 import ReadingHistoryEmptyScreen from '@dailydotdev/shared/src/components/history/ReadingHistoryEmptyScreen';
@@ -54,14 +56,16 @@ const History = (): ReactElement => {
   const { data, isInitialLoading, isLoading, hasData, infiniteScrollRef } =
     useInfiniteReadingHistory({ ...queryProps });
 
-  const hasReadingHistory = !!client.getQueryData(key) && !isLoading;
+  const hasReadingHistory = client
+    .getQueryData<ReadHistoryInfiniteData>(key)
+    ?.pages?.some((page) => page.readHistory.edges.length > 0);
   const shouldShowEmptyScreen = !hasData && !isLoading;
 
   return (
     <ProtectedPage
       seo={seo}
       fallback={<ReadingHistoryEmptyScreen />}
-      shouldFallback={hasReadingHistory}
+      shouldFallback={!hasReadingHistory && !isLoading}
     >
       <ResponsivePageContainer
         className={isInitialLoading && 'h-screen overflow-hidden'}

--- a/packages/webapp/pages/history.tsx
+++ b/packages/webapp/pages/history.tsx
@@ -10,6 +10,7 @@ import ReadingHistoryEmptyScreen from '@dailydotdev/shared/src/components/histor
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { useRouter } from 'next/router';
 import { useQueryClient } from 'react-query';
+import SearchEmptyScreen from '@dailydotdev/shared/src/components/SearchEmptyScreen';
 import { getLayout } from '../components/layouts/MainLayout';
 import {
   READING_HISTORY_QUERY,
@@ -50,10 +51,11 @@ const History = (): ReactElement => {
   }, [searchQuery, key]);
 
   const { hideReadHistory } = useReadingHistory(key);
-  const { data, isInitialLoading, isLoading, infiniteScrollRef } =
+  const { data, isInitialLoading, isLoading, hasData, infiniteScrollRef } =
     useInfiniteReadingHistory({ ...queryProps });
 
   const hasReadingHistory = !!client.getQueryData(key) && !isLoading;
+  const shouldShowEmptyScreen = !hasData && !isLoading;
 
   return (
     <ProtectedPage
@@ -75,14 +77,17 @@ const History = (): ReactElement => {
             suggestionType="searchReadingHistorySuggestions"
           />
         </div>
-        <ReadingHistoryList
-          data={data}
-          onHide={hideReadHistory}
-          infiniteScrollRef={infiniteScrollRef}
-        />
+        {hasData && (
+          <ReadingHistoryList
+            data={data}
+            onHide={hideReadHistory}
+            infiniteScrollRef={infiniteScrollRef}
+          />
+        )}
         {isLoading && (
           <ReadingHistoryPlaceholder amount={isInitialLoading ? 15 : 1} />
         )}
+        {shouldShowEmptyScreen && <SearchEmptyScreen />}
       </ResponsivePageContainer>
     </ProtectedPage>
   );

--- a/packages/webapp/pages/history.tsx
+++ b/packages/webapp/pages/history.tsx
@@ -9,6 +9,7 @@ import ReadingHistoryPlaceholder from '@dailydotdev/shared/src/components/histor
 import ReadingHistoryEmptyScreen from '@dailydotdev/shared/src/components/history/ReadingHistoryEmptyScreen';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { useRouter } from 'next/router';
+import { useQueryClient } from 'react-query';
 import { getLayout } from '../components/layouts/MainLayout';
 import {
   READING_HISTORY_QUERY,
@@ -32,6 +33,7 @@ const History = (): ReactElement => {
   const { user } = useContext(AuthContext);
   const searchQuery = router.query?.q?.toString();
   const key = ['readHistory', user?.id];
+  const client = useQueryClient();
 
   const queryProps = useMemo(() => {
     if (searchQuery) {
@@ -48,14 +50,16 @@ const History = (): ReactElement => {
   }, [searchQuery, key]);
 
   const { hideReadHistory } = useReadingHistory(key);
-  const { data, isInitialLoading, isLoading, hasData, infiniteScrollRef } =
+  const { data, isInitialLoading, isLoading, infiniteScrollRef } =
     useInfiniteReadingHistory({ ...queryProps });
+
+  const hasReadingHistory = !!client.getQueryData(key) && !isLoading;
 
   return (
     <ProtectedPage
       seo={seo}
       fallback={<ReadingHistoryEmptyScreen />}
-      shouldFallback={!hasData && !isLoading}
+      shouldFallback={hasReadingHistory}
     >
       <ResponsivePageContainer
         className={isInitialLoading && 'h-screen overflow-hidden'}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Show fallback empty page only if user has no bookmarks
- Show search results empty component if bookmark search has no results
- Fixes https://github.com/dailydotdev/daily/issues/765

### Screenshot references

#### Webapp
* [No search results](https://user-images.githubusercontent.com/9803078/224854571-abc4b1b2-def2-4521-9052-ce9cfd842720.png)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-741 #done
