### PR TITLE
fix: companion prompt issue

### DIFF
--- a/packages/extension/src/companion/App.tsx
+++ b/packages/extension/src/companion/App.tsx
@@ -15,11 +15,13 @@ import { AuthEvent } from '@dailydotdev/shared/src/lib/kratos';
 import { useError } from '@dailydotdev/shared/src/hooks/useError';
 import { ExtensionMessageType } from '@dailydotdev/shared/src/lib/extension';
 import { defaultQueryClientConfig } from '@dailydotdev/shared/src/lib/query';
+import { PromptElement } from '@dailydotdev/shared/src/components/modals/Prompt';
 import Companion from './Companion';
 import CustomRouter from '../lib/CustomRouter';
 import { companionFetch } from './companionFetch';
 import { version } from '../../package.json';
 import { useBackgroundRequest } from './useBackgroundRequest';
+import { getCompanionWrapper } from './common';
 
 const queryClient = new QueryClient(defaultQueryClientConfig);
 const router = new CustomRouter();
@@ -108,6 +110,7 @@ export default function App({
                       companionExpanded={settings?.companionExpanded}
                       onOptOut={() => setIsOptOutCompanion(true)}
                     />
+                    <PromptElement parentSelector={getCompanionWrapper} />
                     <Toast
                       autoDismissNotifications={
                         settings?.autoDismissNotifications


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The companion was missing the prompt element thus disable was never working.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1146 #done
