### PR TITLE
fix(companion): new comment modal now closes after posting

### DIFF
--- a/packages/extension/src/companion/Companion.tsx
+++ b/packages/extension/src/companion/Companion.tsx
@@ -16,7 +16,8 @@ import '@dailydotdev/shared/src/styles/globals.css';
 import { PostBootData } from '@dailydotdev/shared/src/lib/boot';
 import useTrackPageView from '@dailydotdev/shared/src/hooks/analytics/useTrackPageView';
 import useDebounce from '@dailydotdev/shared/src/hooks/useDebounce';
-import usePostById, {
+import {
+  getPostByIdKey,
   updatePostCache,
 } from '@dailydotdev/shared/src/hooks/usePostById';
 import CompanionMenu from './CompanionMenu';
@@ -72,15 +73,15 @@ export default function Companion({
   const containerRef = useRef<HTMLDivElement>();
   const [assetsLoaded, setAssetsLoaded] = useState(isTesting);
   const client = useQueryClient();
-  const { post } = usePostById({
-    id: postData.id,
-    options: {
-      initialData: () => ({
-        post: postData,
-      }),
-      staleTime: Infinity,
+  const { data: post } = useQuery(
+    getPostByIdKey(postData.id),
+    () => ({ post: postData }),
+    {
+      select: useCallback((data) => {
+        return data.post;
+      }, []),
     },
-  });
+  );
   const setPost = useCallback(
     (newPostData: PostBootData) => {
       updatePostCache(client, newPostData.id, newPostData);

--- a/packages/extension/src/companion/Companion.tsx
+++ b/packages/extension/src/companion/Companion.tsx
@@ -80,6 +80,8 @@ export default function Companion({
       select: useCallback((data) => {
         return data.post;
       }, []),
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
     },
   );
   const setPost = useCallback(


### PR DESCRIPTION
## Changes

### Describe what this PR does
- core issue was in post data coming from boot was persisted in local state inside `Companion`, this then did not react to cache updates that usually happen during comment posting/updates
- with this changes post data is now automatically updated during cache invalidation and other side effects that happen (same as in webapp), UI also updates automatically due to this
  - comment count
  - comment list
  - post metadata
- NOTE here would be to refactor all of companion to just `useQuery` instead of props drilling but for now I just added it to the top to mimic `useState`

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1080 #done
