### PR TITLE
fix: always center selected comment into view

### DIFF
--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -113,7 +113,7 @@ export function PostComments({
     );
   const { hash: commentHash } = window.location;
   const commentsCount = comments?.postComments?.edges?.length || 0;
-  const commentRef = useRef(null);
+  const commentRef = useRef<HTMLElement>(null);
   const { deleteCommentCache } = usePostComment(post);
   const deleteCommentPrompt = async (
     commentId: string,
@@ -137,7 +137,7 @@ export function PostComments({
   const [scrollToComment, setScrollToComment] = useState(!!commentHash);
   useEffect(() => {
     if (commentsCount > 0 && scrollToComment && commentRef.current) {
-      commentRef.current.scrollIntoView();
+      commentRef.current.scrollIntoView({ block: 'center', inline: 'nearest' });
       setScrollToComment(false);
     }
   }, [commentsCount, scrollToComment]);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Comment link is now always be visible inside the view (without sticky header overlap)
- Current implementation uses `scrollIntoViewOptions` to center comment into view
  - `block: center` means center vertically
  - `inline: nearest` is default value for horizontal alignment, since we do not have horizontal scroll it will always center of course
- check screenshots below for how it looks for different comment positions
  
### Additional thoughts
- I think current method works well and fixes issue with sticky header by always positioning comment into center of view as best as it fits. It also uses `scrollIntoView` function which is made for this kind of thing.
- If we want to put scroll position just few px above comment box we could use `block: start` but the same issue with overlapping sticky header would happen (this is also default for `scrolInfoView` which is why this happened in the first place)
- If we do wish to position on the top of comment box we can use [scroll-margin-top](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top) property but again, I think center position works well especially on mobile and with out coloured outline for linked comment
  
## Screenshot references

Screenshots showing different comment positions.

### Desktop
- [Top comment](https://user-images.githubusercontent.com/9803078/225485996-c00ca746-cad6-4eab-87dd-216b8ad00c2c.png)
- [Middle comment](https://user-images.githubusercontent.com/9803078/225485994-612941e5-e1e0-482b-aad9-f79683fa2f51.png)
- [Bottom comment](https://user-images.githubusercontent.com/9803078/225485993-ed9045d8-dfed-4cbc-8396-4e2ca9c07891.png)

### Mobile
- [Top comment](https://user-images.githubusercontent.com/9803078/225486267-9f6a2db2-32af-461a-a10c-8010c5da6ff1.png)
- [Middle comment](https://user-images.githubusercontent.com/9803078/225486262-dcc8ba31-125f-4067-8474-196f34d658c7.png)
- [Bottom comment](https://user-images.githubusercontent.com/9803078/225486257-1c039509-3354-4b79-8cea-3d4fa043fd47.png)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-275 #done
