### PR TITLE
fix: changelog browser polyfill in production extension bundle

### DIFF
--- a/packages/shared/package-lock.json
+++ b/packages/shared/package-lock.json
@@ -20,7 +20,9 @@
         "lodash.clonedeep": "^4.5.0",
         "node-fetch": "^2.6.6",
         "react-onesignal": "^2.0.4",
-        "uuid": "^8.3.2"
+        "tippy.js": "^6.3.1",
+        "uuid": "^8.3.2",
+        "webextension-polyfill-ts": "^0.22.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.16.0",
@@ -15714,6 +15716,20 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/webextension-polyfill": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz",
+      "integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw=="
+    },
+    "node_modules/webextension-polyfill-ts": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.22.0.tgz",
+      "integrity": "sha512-3P33ClMwZ/qiAT7UH1ROrkRC1KM78umlnPpRhdC/292UyoTTW9NcjJEqDsv83HbibcTB6qCtpVeuB2q2/oniHQ==",
+      "deprecated": "This project has moved to @types/webextension-polyfill",
+      "dependencies": {
+        "webextension-polyfill": "^0.7.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -27625,6 +27641,19 @@
       "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "webextension-polyfill": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz",
+      "integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw=="
+    },
+    "webextension-polyfill-ts": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill-ts/-/webextension-polyfill-ts-0.22.0.tgz",
+      "integrity": "sha512-3P33ClMwZ/qiAT7UH1ROrkRC1KM78umlnPpRhdC/292UyoTTW9NcjJEqDsv83HbibcTB6qCtpVeuB2q2/oniHQ==",
+      "requires": {
+        "webextension-polyfill": "^0.7.0"
       }
     },
     "webidl-conversions": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -118,6 +118,7 @@
     "node-fetch": "^2.6.6",
     "react-onesignal": "^2.0.4",
     "tippy.js": "^6.3.1",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "webextension-polyfill-ts": "^0.22.0"
   }
 }

--- a/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
@@ -62,17 +62,14 @@ function ChangelogTooltip<TRef extends HTMLElement>({
         return;
       }
 
-      const sendMessage = globalThis?.browser?.runtime?.sendMessage;
+      const browser = await import('webextension-polyfill-ts').then(
+        (mod) => mod.browser,
+      );
 
-      if (typeof sendMessage !== 'function') {
-        toast.displayToast(toastMessageMap.error);
-
-        return;
-      }
-
-      const updateResponse: { status: string } = await sendMessage({
-        type: ExtensionMessageType.RequestUpdate,
-      });
+      const updateResponse: { status: string } =
+        await browser.runtime.sendMessage({
+          type: ExtensionMessageType.RequestUpdate,
+        });
 
       const toastMessage = toastMessageMap[updateResponse.status];
 

--- a/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
@@ -30,9 +30,10 @@ interface ChangelogTooltipProps<TRef> extends BaseTooltipProps {
 
 const toastMessageMap = {
   error: 'Something went wrong, try again later',
-  throttled: 'There is no update available, try again later',
-  no_update: 'You are already on the latest available version',
-  update_available: 'Browser extension updated',
+  throttled: 'There is no extension update available, try again later',
+  no_update:
+    "Your extension is already the latest and greatest. You're awesome 🎉",
+  update_available: 'Browser extension updated 🎉',
 };
 
 function ChangelogTooltip<TRef extends HTMLElement>({


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixes issue where extension update button would always result in error
- Browser polyfill was not loaded in production extension bundle (while it is loaded during development and exposed in `globalThis`)
- While I could not find core reason for this (looking at webpack configs and build script), I think it is due to this being the only place where polyfill is required inside the shared package
- To fix I added polyfill as shared dependency and lazy load it when extension update is requested
- I also checked other places and all of them are from extension package and already use polyfill so this bug is not present

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
