### PR TITLE
fix: invite overflow issue

### DIFF
--- a/packages/webapp/pages/squads/[handle]/[token].tsx
+++ b/packages/webapp/pages/squads/[handle]/[token].tsx
@@ -183,7 +183,7 @@ const SquadReferral = ({
   }
 
   return (
-    <PageContainer className="overflow-hidden relative justify-center items-center pt-24">
+    <PageContainer className="relative justify-center items-center pt-24">
       <NextSeo {...seo} />
       <div className="absolute -top-4 -right-20 -left-20 h-40 rounded-26 squad-background-fade" />
       <h1 className="typo-title1">You are invited to join {source.name}</h1>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixed overflow issue cutting off the gradient.

@sshanzel Not quite sure why you introduced it, did it have a specific use-case I missed?
Added screenshot of the new flow here:

![Screenshot 2023-03-23 at 15 11 36](https://user-images.githubusercontent.com/554874/227214889-aa45a3dd-e482-4b5b-be61-86110ae5779d.png)
![Screenshot 2023-03-23 at 15 11 43](https://user-images.githubusercontent.com/554874/227214904-81e4607a-06e0-45ca-a550-e89fe074f8e8.png)
![Screenshot 2023-03-23 at 15 11 49](https://user-images.githubusercontent.com/554874/227214914-f92e0fc1-e82a-45f7-a69e-186275e40456.png)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1171 #done
