### PR TITLE
fix: add tutorial for notification prompt

### DIFF
--- a/packages/shared/src/components/modals/NewSquadModal.tsx
+++ b/packages/shared/src/components/modals/NewSquadModal.tsx
@@ -58,7 +58,7 @@ function NewSquadModal({
   };
 
   const newSquadTutorial = useTutorial({
-    key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP_KEY,
+    key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP,
   });
 
   const handleClose = async () => {

--- a/packages/shared/src/components/modals/NewSquadModal.tsx
+++ b/packages/shared/src/components/modals/NewSquadModal.tsx
@@ -58,7 +58,7 @@ function NewSquadModal({
   };
 
   const newSquadTutorial = useTutorial({
-    key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP,
+    key: TutorialKey.SeenNewSquadTooltip,
   });
 
   const handleClose = async () => {

--- a/packages/shared/src/components/modals/SquadTourModal.tsx
+++ b/packages/shared/src/components/modals/SquadTourModal.tsx
@@ -3,24 +3,31 @@ import CloseButton from '../CloseButton';
 import SquadTour from '../squads/SquadTour';
 import { Modal, ModalProps } from './common/Modal';
 import { ButtonSize } from '../buttons/Button';
+import { useSquadTourClose } from '../../hooks/useSquadTourClose';
 
 function SquadTourModal({
   onRequestClose,
   ...props
 }: ModalProps): ReactElement {
+  const [onSquadTourClose] = useSquadTourClose();
+  const onModalClose: typeof onRequestClose = (param) => {
+    onSquadTourClose();
+    onRequestClose(param);
+  };
+
   return (
     <Modal
       {...props}
-      onRequestClose={onRequestClose}
+      onRequestClose={onModalClose}
       kind={Modal.Kind.FlexibleCenter}
       size={Modal.Size.Small}
       className="overflow-hidden !border-theme-color-cabbage"
     >
-      <SquadTour onClose={onRequestClose} />
+      <SquadTour onClose={onModalClose} />
       <CloseButton
         buttonSize={ButtonSize.Small}
         className="top-3 right-3 !absolute !btn-secondary"
-        onClick={onRequestClose}
+        onClick={onModalClose}
       />
     </Modal>
   );

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -86,7 +86,7 @@ export default function Sidebar({
     ? [0, 1.5 * 16]
     : [0, 1 * 16];
   const newSquadTooltipTutorial = useTutorial({
-    key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP,
+    key: TutorialKey.SeenNewSquadTooltip,
   });
 
   const [completeTutorialWithDelay] = useDebounce(() => {

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -86,7 +86,7 @@ export default function Sidebar({
     ? [0, 1.5 * 16]
     : [0, 1 * 16];
   const newSquadTooltipTutorial = useTutorial({
-    key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP_KEY,
+    key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP,
   });
 
   const [completeTutorialWithDelay] = useDebounce(() => {

--- a/packages/shared/src/components/squads/SquadHeaderBar.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderBar.tsx
@@ -39,7 +39,7 @@ export function SquadHeaderBar({
   const { sidebarRendered } = useSidebarRendered();
 
   const copyLinkTutorial = useTutorial({
-    key: TutorialKey.COPY_SQUAD_LINK,
+    key: TutorialKey.CopySquadLink,
   });
 
   return (

--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -47,10 +47,6 @@ export default function SquadHeaderMenu({
   });
   const isSquadOwner = squad?.currentMember?.role === SquadMemberRole.Owner;
 
-  const sharePostTutorial = useTutorial({
-    key: TutorialKey.ShareSquadPost,
-  });
-
   const onEditSquad = () => {
     openModal({
       type: LazyModal.EditSquad,

--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -48,7 +48,7 @@ export default function SquadHeaderMenu({
   const isSquadOwner = squad?.currentMember?.role === SquadMemberRole.Owner;
 
   const sharePostTutorial = useTutorial({
-    key: TutorialKey.SHARE_SQUAD_POST,
+    key: TutorialKey.ShareSquadPost,
   });
 
   const onEditSquad = () => {
@@ -66,11 +66,6 @@ export default function SquadHeaderMenu({
         onClick: () =>
           openModal({
             type: LazyModal.SquadTour,
-            props: {
-              onAfterClose: () => {
-                sharePostTutorial.activate();
-              },
-            },
           }),
         label: 'Learn how Squads work',
       },

--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -14,7 +14,6 @@ import { useLeaveSquad } from '../../hooks/useLeaveSquad';
 import ContextMenuItem, {
   ContextMenuItemProps,
 } from '../tooltips/ContextMenuItem';
-import { TutorialKey, useTutorial } from '../../hooks/useTutorial';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ '../fields/PortalMenu'),

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -26,8 +26,8 @@ export function SquadPageHeader({
   onNewSquadPost,
 }: SquadPageHeaderProps): ReactElement {
   const { sidebarRendered } = useSidebarRendered();
-  const squadEnableNotifications = useTutorial({
-    key: TutorialKey.SQUAD_ENABLE_NOTIFICATIONS_KEY,
+  const enableNotifications = useTutorial({
+    key: TutorialKey.SQUAD_ENABLE_NOTIFICATIONS,
   });
 
   const sharePostTutorial = useTutorial({
@@ -75,7 +75,7 @@ export function SquadPageHeader({
         onNewSquadPost={onNewSquadPost}
         className={sidebarRendered && 'absolute top-0 right-[4.5rem]'}
       />
-      {squadEnableNotifications.isActive && (
+      {enableNotifications.isActive && (
         <EnableNotification
           contentName={squad.name}
           source={NotificationPromptSource.SquadPage}

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -27,11 +27,11 @@ export function SquadPageHeader({
 }: SquadPageHeaderProps): ReactElement {
   const { sidebarRendered } = useSidebarRendered();
   const enableNotifications = useTutorial({
-    key: TutorialKey.SQUAD_ENABLE_NOTIFICATIONS,
+    key: TutorialKey.SquadEnableNotifications,
   });
 
   const sharePostTutorial = useTutorial({
-    key: TutorialKey.SHARE_SQUAD_POST,
+    key: TutorialKey.ShareSquadPost,
   });
 
   return (
@@ -75,7 +75,7 @@ export function SquadPageHeader({
         onNewSquadPost={onNewSquadPost}
         className={sidebarRendered && 'absolute top-0 right-[4.5rem]'}
       />
-      {enableNotifications.isActive && (
+      {enableNotifications.isCompleted && (
         <EnableNotification
           contentName={squad.name}
           source={NotificationPromptSource.SquadPage}

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -16,6 +16,7 @@ type SquadPageHeaderProps = {
   squad: Squad;
   members: SquadMember[];
   onNewSquadPost: () => void;
+  hasTriedOnboarding?: boolean;
 };
 
 const MAX_WIDTH = 'laptop:max-w-[38.5rem]';
@@ -24,11 +25,9 @@ export function SquadPageHeader({
   squad,
   members,
   onNewSquadPost,
+  hasTriedOnboarding,
 }: SquadPageHeaderProps): ReactElement {
   const { sidebarRendered } = useSidebarRendered();
-  const enableNotifications = useTutorial({
-    key: TutorialKey.SquadEnableNotifications,
-  });
 
   const sharePostTutorial = useTutorial({
     key: TutorialKey.ShareSquadPost,
@@ -75,7 +74,7 @@ export function SquadPageHeader({
         onNewSquadPost={onNewSquadPost}
         className={sidebarRendered && 'absolute top-0 right-[4.5rem]'}
       />
-      {enableNotifications.isCompleted && (
+      {hasTriedOnboarding && (
         <EnableNotification
           contentName={squad.name}
           source={NotificationPromptSource.SquadPage}

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -9,12 +9,12 @@ import { FlexCol } from '../utilities';
 import SquadMemberShortList from './SquadMemberShortList';
 import useSidebarRendered from '../../hooks/useSidebarRendered';
 import SharePostBar from './SharePostBar';
+import { TutorialKey, useTutorial } from '../../hooks/useTutorial';
 
 type SquadPageHeaderProps = {
   squad: Squad;
   members: SquadMember[];
   onNewSquadPost: () => void;
-  hasTriedOnboarding?: boolean;
 };
 
 const MAX_WIDTH = 'laptop:max-w-[38.5rem]';
@@ -23,9 +23,11 @@ export function SquadPageHeader({
   squad,
   members,
   onNewSquadPost,
-  hasTriedOnboarding,
 }: SquadPageHeaderProps): ReactElement {
   const { sidebarRendered } = useSidebarRendered();
+  const squadEnableNotifications = useTutorial({
+    key: TutorialKey.SQUAD_ENABLE_NOTIFICATIONS_KEY,
+  });
 
   return (
     <FlexCol className="relative items-center laptop:items-start px-6 pb-20 tablet:pb-20 laptop:pb-14 mb-6 w-full tablet:border-b laptop:px-[4.5rem] min-h-20 border-theme-divider-tertiary">
@@ -63,7 +65,7 @@ export function SquadPageHeader({
         onNewSquadPost={onNewSquadPost}
         className={sidebarRendered && 'absolute top-0 right-[4.5rem]'}
       />
-      {hasTriedOnboarding && (
+      {squadEnableNotifications.isActive && (
         <EnableNotification
           contentName={squad.name}
           source={NotificationPromptSource.SquadPage}

--- a/packages/shared/src/components/squads/SquadTourPopup.tsx
+++ b/packages/shared/src/components/squads/SquadTourPopup.tsx
@@ -14,14 +14,14 @@ function SquadTourPopup({ onClose }: SquadTourPopupProps): ReactElement {
   const sharePostTutorial = useTutorial({
     key: TutorialKey.SHARE_SQUAD_POST,
   });
-  const squadEnableNotifications = useTutorial({
-    key: TutorialKey.SQUAD_ENABLE_NOTIFICATIONS_KEY,
+  const enableNotifications = useTutorial({
+    key: TutorialKey.SQUAD_ENABLE_NOTIFICATIONS,
   });
 
   const onPopupClose = (event: MouseEvent) => {
     onClose(event);
     sharePostTutorial.activate();
-    squadEnableNotifications.activate();
+    enableNotifications.activate();
   };
 
   return (

--- a/packages/shared/src/components/squads/SquadTourPopup.tsx
+++ b/packages/shared/src/components/squads/SquadTourPopup.tsx
@@ -1,27 +1,20 @@
 import React, { MouseEvent, ReactElement } from 'react';
-import { useTutorial, TutorialKey } from '../../hooks/useTutorial';
 import CloseButton from '../CloseButton';
 import InteractivePopup, {
   InteractivePopupPosition,
 } from '../tooltips/InteractivePopup';
 import SquadTour from './SquadTour';
+import { useSquadTourClose } from '../../hooks/useSquadTourClose';
 
 interface SquadTourPopupProps {
   onClose: React.EventHandler<MouseEvent>;
 }
 
 function SquadTourPopup({ onClose }: SquadTourPopupProps): ReactElement {
-  const sharePostTutorial = useTutorial({
-    key: TutorialKey.SHARE_SQUAD_POST,
-  });
-  const enableNotifications = useTutorial({
-    key: TutorialKey.SQUAD_ENABLE_NOTIFICATIONS,
-  });
-
+  const [onSquadTourClose] = useSquadTourClose();
   const onPopupClose = (event: MouseEvent) => {
     onClose(event);
-    sharePostTutorial.activate();
-    enableNotifications.activate();
+    onSquadTourClose();
   };
 
   return (

--- a/packages/shared/src/components/squads/SquadTourPopup.tsx
+++ b/packages/shared/src/components/squads/SquadTourPopup.tsx
@@ -4,21 +4,31 @@ import InteractivePopup, {
   InteractivePopupPosition,
 } from '../tooltips/InteractivePopup';
 import SquadTour from './SquadTour';
+import { TutorialKey, useTutorial } from '../../hooks/useTutorial';
 
 interface SquadTourPopupProps {
   onClose: React.EventHandler<MouseEvent>;
 }
 
 function SquadTourPopup({ onClose }: SquadTourPopupProps): ReactElement {
+  const squadEnableNotifications = useTutorial({
+    key: TutorialKey.SQUAD_ENABLE_NOTIFICATIONS_KEY,
+  });
+
+  const onPopupClose = (event: MouseEvent) => {
+    onClose(event);
+    squadEnableNotifications.activate();
+  };
+
   return (
     <InteractivePopup
       position={InteractivePopupPosition.RightEnd}
       className="border border-theme-color-cabbage w-[26rem]"
     >
-      <SquadTour onClose={onClose} />
+      <SquadTour onClose={onPopupClose} />
       <CloseButton
         className="top-3 right-3 !absolute !btn-secondary"
-        onClick={onClose}
+        onClick={onPopupClose}
       />
     </InteractivePopup>
   );

--- a/packages/shared/src/hooks/useSquadTourClose.ts
+++ b/packages/shared/src/hooks/useSquadTourClose.ts
@@ -1,0 +1,19 @@
+import { TutorialKey, useTutorial } from './useTutorial';
+
+export function useSquadTourClose(): [() => void] {
+  const sharePostTutorial = useTutorial({
+    key: TutorialKey.ShareSquadPost,
+  });
+  const enableNotifications = useTutorial({
+    key: TutorialKey.SquadEnableNotifications,
+  });
+
+  const onClose = () => {
+    if (!sharePostTutorial.isCompleted) {
+      sharePostTutorial.activate();
+    }
+    enableNotifications.complete();
+  };
+
+  return [onClose];
+}

--- a/packages/shared/src/hooks/useSquadTourClose.ts
+++ b/packages/shared/src/hooks/useSquadTourClose.ts
@@ -4,15 +4,11 @@ export function useSquadTourClose(): [() => void] {
   const sharePostTutorial = useTutorial({
     key: TutorialKey.ShareSquadPost,
   });
-  const enableNotifications = useTutorial({
-    key: TutorialKey.SquadEnableNotifications,
-  });
 
   const onClose = () => {
     if (!sharePostTutorial.isCompleted) {
       sharePostTutorial.activate();
     }
-    enableNotifications.complete();
   };
 
   return [onClose];

--- a/packages/shared/src/hooks/useTutorial.spec.tsx
+++ b/packages/shared/src/hooks/useTutorial.spec.tsx
@@ -26,7 +26,7 @@ describe('useTutorial hook', () => {
   }) => {
     return waitFor(() => {
       const value = client.getQueryData([
-        `tutorial-${TutorialKey.SEEN_NEW_SQUAD_TOOLTIP_KEY}`,
+        `tutorial-${TutorialKey.SEEN_NEW_SQUAD_TOOLTIP}`,
         false,
       ]);
 
@@ -42,7 +42,7 @@ describe('useTutorial hook', () => {
   it('should return the tutorial state', async () => {
     const client = new QueryClient();
     const { result } = renderHook(
-      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP_KEY }),
+      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP }),
       { wrapper: createWrapper({ client }) },
     );
 
@@ -53,7 +53,7 @@ describe('useTutorial hook', () => {
   it('should activate tutorial', async () => {
     const client = new QueryClient();
     const { result, rerender } = renderHook(
-      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP_KEY }),
+      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP }),
       { wrapper: createWrapper({ client }) },
     );
 
@@ -67,7 +67,7 @@ describe('useTutorial hook', () => {
   it('should complete tutorial', async () => {
     const client = new QueryClient();
     const { result } = renderHook(
-      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP_KEY }),
+      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP }),
       { wrapper: createWrapper({ client }) },
     );
 
@@ -82,7 +82,7 @@ describe('useTutorial hook', () => {
   it('should reset tutorial', async () => {
     const client = new QueryClient();
     const { result } = renderHook(
-      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP_KEY }),
+      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP }),
       { wrapper: createWrapper({ client }) },
     );
 
@@ -100,7 +100,7 @@ describe('useTutorial hook', () => {
   it('should not activate if tutorial is completed', async () => {
     const client = new QueryClient();
     const { result, rerender } = renderHook(
-      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP_KEY }),
+      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP }),
       { wrapper: createWrapper({ client }) },
     );
 

--- a/packages/shared/src/hooks/useTutorial.spec.tsx
+++ b/packages/shared/src/hooks/useTutorial.spec.tsx
@@ -26,7 +26,7 @@ describe('useTutorial hook', () => {
   }) => {
     return waitFor(() => {
       const value = client.getQueryData([
-        `tutorial-${TutorialKey.SEEN_NEW_SQUAD_TOOLTIP}`,
+        `tutorial-${TutorialKey.SeenNewSquadTooltip}`,
         false,
       ]);
 
@@ -42,7 +42,7 @@ describe('useTutorial hook', () => {
   it('should return the tutorial state', async () => {
     const client = new QueryClient();
     const { result } = renderHook(
-      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP }),
+      () => useTutorial({ key: TutorialKey.SeenNewSquadTooltip }),
       { wrapper: createWrapper({ client }) },
     );
 
@@ -53,7 +53,7 @@ describe('useTutorial hook', () => {
   it('should activate tutorial', async () => {
     const client = new QueryClient();
     const { result, rerender } = renderHook(
-      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP }),
+      () => useTutorial({ key: TutorialKey.SeenNewSquadTooltip }),
       { wrapper: createWrapper({ client }) },
     );
 
@@ -67,7 +67,7 @@ describe('useTutorial hook', () => {
   it('should complete tutorial', async () => {
     const client = new QueryClient();
     const { result } = renderHook(
-      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP }),
+      () => useTutorial({ key: TutorialKey.SeenNewSquadTooltip }),
       { wrapper: createWrapper({ client }) },
     );
 
@@ -82,7 +82,7 @@ describe('useTutorial hook', () => {
   it('should reset tutorial', async () => {
     const client = new QueryClient();
     const { result } = renderHook(
-      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP }),
+      () => useTutorial({ key: TutorialKey.SeenNewSquadTooltip }),
       { wrapper: createWrapper({ client }) },
     );
 
@@ -100,7 +100,7 @@ describe('useTutorial hook', () => {
   it('should not activate if tutorial is completed', async () => {
     const client = new QueryClient();
     const { result, rerender } = renderHook(
-      () => useTutorial({ key: TutorialKey.SEEN_NEW_SQUAD_TOOLTIP }),
+      () => useTutorial({ key: TutorialKey.SeenNewSquadTooltip }),
       { wrapper: createWrapper({ client }) },
     );
 

--- a/packages/shared/src/hooks/useTutorial.ts
+++ b/packages/shared/src/hooks/useTutorial.ts
@@ -3,10 +3,10 @@ import { useQuery, useQueryClient } from 'react-query';
 import usePersistentContext from './usePersistentContext';
 
 export enum TutorialKey {
-  SEEN_NEW_SQUAD_TOOLTIP = 'seenNewSquadTooltip',
-  SQUAD_ENABLE_NOTIFICATIONS = 'squadEnableNotifications',
-  SHARE_SQUAD_POST = 'shareSquadPost',
-  COPY_SQUAD_LINK = 'copySquadLink',
+  SeenNewSquadTooltip = 'seenNewSquadTooltip',
+  SquadEnableNotifications = 'squadEnableNotifications',
+  ShareSquadPost = 'shareSquadPost',
+  CopySquadLink = 'copySquadLink',
 }
 
 export type UseTutorialProps = {

--- a/packages/shared/src/hooks/useTutorial.ts
+++ b/packages/shared/src/hooks/useTutorial.ts
@@ -3,8 +3,8 @@ import { useQuery, useQueryClient } from 'react-query';
 import usePersistentContext from './usePersistentContext';
 
 export enum TutorialKey {
-  SEEN_NEW_SQUAD_TOOLTIP_KEY = 'seenNewSquadTooltip',
-  SQUAD_ENABLE_NOTIFICATIONS_KEY = 'squadEnableNotifications',
+  SEEN_NEW_SQUAD_TOOLTIP = 'seenNewSquadTooltip',
+  SQUAD_ENABLE_NOTIFICATIONS = 'squadEnableNotifications',
   SHARE_SQUAD_POST = 'shareSquadPost',
   COPY_SQUAD_LINK = 'copySquadLink',
 }

--- a/packages/shared/src/hooks/useTutorial.ts
+++ b/packages/shared/src/hooks/useTutorial.ts
@@ -4,7 +4,6 @@ import usePersistentContext from './usePersistentContext';
 
 export enum TutorialKey {
   SeenNewSquadTooltip = 'seenNewSquadTooltip',
-  SquadEnableNotifications = 'squadEnableNotifications',
   ShareSquadPost = 'shareSquadPost',
   CopySquadLink = 'copySquadLink',
 }

--- a/packages/shared/src/hooks/useTutorial.ts
+++ b/packages/shared/src/hooks/useTutorial.ts
@@ -4,6 +4,7 @@ import usePersistentContext from './usePersistentContext';
 
 export enum TutorialKey {
   SEEN_NEW_SQUAD_TOOLTIP_KEY = 'seenNewSquadTooltip',
+  SQUAD_ENABLE_NOTIFICATIONS_KEY = 'squadEnableNotifications',
 }
 
 export type UseTutorialProps = {

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -134,11 +134,11 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
   if (!squad) return <Custom404 />;
 
   const sharePostTutorial = useTutorial({
-    key: TutorialKey.SHARE_SQUAD_POST,
+    key: TutorialKey.ShareSquadPost,
   });
 
   const copyLinkTutorial = useTutorial({
-    key: TutorialKey.COPY_SQUAD_LINK,
+    key: TutorialKey.CopySquadLink,
   });
 
   const onNewSquadPost = (props: NewSquadPostProps = {}) =>
@@ -149,7 +149,6 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
         squad,
         onAfterClose: () => {
           sharePostTutorial.complete();
-
           copyLinkTutorial.activate();
         },
       },

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -112,7 +112,7 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
 
   const isFinishedLoading = isFetched && !isLoading && !!squad;
 
-  const { isPopupOpen, onClosePopup } = useSquadOnboarding(
+  const { isPopupOpen, onClosePopup, hasTriedOnboarding } = useSquadOnboarding(
     isFinishedLoading && !isForbidden,
   );
 
@@ -172,6 +172,7 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
           squad={squad}
           members={squadMembers}
           onNewSquadPost={onNewSquadPost}
+          hasTriedOnboarding={hasTriedOnboarding && !isPopupOpen}
         />
         <Feed
           className="px-6 laptop:px-0 pt-14 laptop:pt-10"

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -108,7 +108,7 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
 
   const isFinishedLoading = isFetched && !isLoading && !!squad;
 
-  const { isPopupOpen, onClosePopup, hasTriedOnboarding } = useSquadOnboarding(
+  const { isPopupOpen, onClosePopup } = useSquadOnboarding(
     isFinishedLoading && !isForbidden,
   );
 
@@ -156,7 +156,6 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
           squad={squad}
           members={squadMembers}
           onNewSquadPost={onNewSquadPost}
-          hasTriedOnboarding={hasTriedOnboarding}
         />
         <Feed
           className="px-6 laptop:px-0 pt-14 laptop:pt-10"


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Prompt notifications only once tour is closed.
- @capJavert will cause some merge conflict with your one :)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1175 #done
