### PR TITLE
fix: multiple fixes to "share post" page

### DIFF
--- a/packages/shared/src/components/post/PostSourceInfo.tsx
+++ b/packages/shared/src/components/post/PostSourceInfo.tsx
@@ -18,6 +18,7 @@ function PostSourceInfo({
   size = 'medium',
   className,
 }: SourceInfoProps): ReactElement {
+  const isUnknown = source.id === 'unknown';
   return (
     <span
       className={classNames(
@@ -25,11 +26,15 @@ function PostSourceInfo({
         className,
       )}
     >
-      <SourceButton source={source} size={size} />
-      <h3 className="ml-3">{source.handle}</h3>
+      {!isUnknown && (
+        <>
+          <SourceButton source={source} size={size} />
+          <h3 className="ml-3">{source.handle}</h3>
+        </>
+      )}
       {!!date && (
         <>
-          <Separator />
+          {!isUnknown && <Separator />}
           <time dateTime={date}>{date}</time>
         </>
       )}

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -147,7 +147,7 @@ function SquadPostContent({
           <div className="flex flex-col mt-8 rounded-16 border border-theme-divider-tertiary hover:border-theme-divider-secondary">
             <a
               href={
-                post.private
+                post.sharedPost.source.id === 'unknown'
                   ? post.sharedPost.permalink
                   : post.sharedPost.commentsPermalink
               }

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -4,7 +4,6 @@ import React, {
   ReactNode,
   useCallback,
   useContext,
-  useEffect,
   useState,
 } from 'react';
 import { useRouter } from 'next/router';

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -87,12 +87,6 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     options: { initialData, retry: false },
   });
 
-  useEffect(() => {
-    if (!post?.private || !post?.permalink) return;
-
-    globalThis?.location.replace(post.permalink);
-  }, [post]);
-
   const seo: NextSeoProps = {
     title: getTemplatedTitle(post?.title),
     description: getSeoDescription(post),


### PR DESCRIPTION
## Changes

### Describe what this PR does

* Not sure why we had this snippet there but there's no reason to redirect the user to the permalink of the post when they land on the article page. We should either show 404 or show the article page.
* Clicking on the referred post section in the "share post" page should lead to another post page unless it's from the unknown source
* We shouldn't show the image and handle of the unknown source
