### PR TITLE
refactor: community link submission autofill suggestions removal

### DIFF
--- a/packages/extension/src/newtab/LinksForm.tsx
+++ b/packages/extension/src/newtab/LinksForm.tsx
@@ -33,6 +33,7 @@ export function LinksForm({
           // eslint-disable-next-line react/no-array-index-key
           key={i}
           type="url"
+          autoComplete="off"
           fieldType="tertiary"
           label="Add shortcuts"
           value={links[i]}

--- a/packages/shared/src/components/fields/SearchField.tsx
+++ b/packages/shared/src/components/fields/SearchField.tsx
@@ -32,6 +32,7 @@ export interface SearchFieldProps
     | 'disabled'
     | 'readOnly'
     | 'aria-describedby'
+    | 'autoComplete'
   > {
   inputId: string;
   valueChanged?: (value: string) => void;

--- a/packages/shared/src/components/modals/NewSourceModal.tsx
+++ b/packages/shared/src/components/modals/NewSourceModal.tsx
@@ -238,6 +238,7 @@ export default function NewSourceModal(props: ModalProps): ReactElement {
             name="url"
             placeholder="Paste blog / RSS URL"
             showIcon={false}
+            autoComplete="off"
             type="url"
             autoFocus
             aria-describedby={scrapeError && 'new-source-field-desc'}

--- a/packages/shared/src/components/modals/ShareModal.tsx
+++ b/packages/shared/src/components/modals/ShareModal.tsx
@@ -88,6 +88,7 @@ export default function ShareModal({
           inputId="postUrl"
           label="Copy URL"
           type="url"
+          autoComplete="off"
           fieldType="tertiary"
           actionButton={
             <Button

--- a/packages/shared/src/components/modals/SharedBookmarksModal.tsx
+++ b/packages/shared/src/components/modals/SharedBookmarksModal.tsx
@@ -80,6 +80,7 @@ export default function SharedBookmarksModal({
               inputId="rssUrl"
               label="Your unique RSS URL"
               type="url"
+              autoComplete="off"
               fieldType="tertiary"
               actionButton={
                 <Button

--- a/packages/shared/src/components/modals/SubmitArticleModal.tsx
+++ b/packages/shared/src/components/modals/SubmitArticleModal.tsx
@@ -225,6 +225,7 @@ export default function SubmitArticleModal({
               name="articleUrl"
               inputId="article_url"
               label="Paste post url"
+              autoComplete="off"
               disabled={!isEnabled}
               hint={urlHint}
               valid={!urlHint}

--- a/packages/shared/src/components/modals/SubmitArticleModal.tsx
+++ b/packages/shared/src/components/modals/SubmitArticleModal.tsx
@@ -220,12 +220,12 @@ export default function SubmitArticleModal({
             <TextField
               autoFocus
               type="url"
+              autoComplete="off"
               leftIcon={<LinkIcon />}
               fieldType="tertiary"
               name="articleUrl"
               inputId="article_url"
               label="Paste post url"
-              autoComplete="off"
               disabled={!isEnabled}
               hint={urlHint}
               valid={!urlHint}

--- a/packages/shared/src/components/profile/ProfileForm.tsx
+++ b/packages/shared/src/components/profile/ProfileForm.tsx
@@ -207,6 +207,7 @@ export default function ProfileForm({
         name="portfolio"
         label="Website"
         type="url"
+        autoComplete="off"
         value={user.portfolio}
       />
     </>

--- a/packages/shared/src/components/squads/Comment.tsx
+++ b/packages/shared/src/components/squads/Comment.tsx
@@ -153,6 +153,7 @@ export function SquadComment({
               inputId="url"
               name="url"
               type="url"
+              autoComplete="off"
               required
               value={link}
               onInput={onInputChange}

--- a/packages/shared/src/components/squads/InviteTextField.tsx
+++ b/packages/shared/src/components/squads/InviteTextField.tsx
@@ -43,6 +43,7 @@ const InviteText: ForwardRefRenderFunction<
       data-testid="permalink"
       label={invitation}
       type="url"
+      autoComplete="off"
       fieldType="tertiary"
       disabled
       actionButton={

--- a/packages/shared/src/components/squads/SharePostBar.tsx
+++ b/packages/shared/src/components/squads/SharePostBar.tsx
@@ -62,6 +62,7 @@ function SharePostBar({
       />
       <input
         type="url"
+        autoComplete="off"
         name="share-post-bar"
         className="flex-1 order-2 pl-1 w-24 mobileL:w-auto outline-none bg-theme-bg-transparent text-theme-label-primary focus:placeholder-theme-label-quaternary hover:placeholder-theme-label-primary typo-callout"
         placeholder="Enter link to share"


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The product has decided to remove the auto-fill suggested values when submitting a community link.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1176 #done
