### PR TITLE
fix: existing private links to still be submitted

### DIFF
--- a/packages/shared/src/components/squads/SharePostBar.tsx
+++ b/packages/shared/src/components/squads/SharePostBar.tsx
@@ -19,6 +19,8 @@ interface SharePostBarProps {
   onNewSquadPost?: (props?: NewSquadPostProps) => void;
 }
 
+const allowedSubmissionErrors = [ApiError.NotFound, ApiError.Forbidden];
+
 function SharePostBar({
   className,
   onNewSquadPost,
@@ -32,7 +34,9 @@ function SharePostBar({
     onError: (err: ApiErrorResult, link) => {
       if (
         link === '' ||
-        err?.response?.errors?.[0].extensions.code === ApiError.NotFound
+        allowedSubmissionErrors.includes(
+          err?.response?.errors?.[0].extensions.code,
+        )
       ) {
         onNewSquadPost({ url, onSharedSuccessfully });
       }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- For the temporary fix of allowing existing private links and continuing the support for the Companion, we will make the change on FE only.
- If the error is FORBIDDEN, it means it exist, hence, continue with the process.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1182 #done
