### PR TITLE
fix: companion popups

### DIFF
--- a/packages/extension/src/companion/App.tsx
+++ b/packages/extension/src/companion/App.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentType, ReactElement, useMemo, useState } from 'react';
+import React, { ReactElement, useMemo, useState } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { browser } from 'webextension-polyfill-ts';
 import { Boot, BootApp } from '@dailydotdev/shared/src/lib/boot';

--- a/packages/extension/src/companion/App.tsx
+++ b/packages/extension/src/companion/App.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo, useState } from 'react';
+import React, { ComponentType, ReactElement, useMemo, useState } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { browser } from 'webextension-polyfill-ts';
 import { Boot, BootApp } from '@dailydotdev/shared/src/lib/boot';
@@ -17,6 +17,9 @@ import { ExtensionMessageType } from '@dailydotdev/shared/src/lib/extension';
 import { defaultQueryClientConfig } from '@dailydotdev/shared/src/lib/query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { PromptElement } from '@dailydotdev/shared/src/components/modals/Prompt';
+import { LazyModalElement } from '@dailydotdev/shared/src/components/modals/LazyModalElement';
+import { LazyModal } from '@dailydotdev/shared/src/components/modals/common/types';
+import UpvotedPopupModal from '@dailydotdev/shared/src/components/modals/UpvotedPopupModal';
 import Companion from './Companion';
 import CustomRouter from '../lib/CustomRouter';
 import { companionFetch } from './companionFetch';
@@ -40,6 +43,10 @@ export type CompanionData = { url: string; deviceId: string } & Pick<
 >;
 
 const refreshTokenKey = 'refresh_token';
+
+const companionModals = {
+  [LazyModal.UpvotedPopup]: UpvotedPopupModal,
+};
 
 export default function App({
   deviceId,
@@ -111,6 +118,7 @@ export default function App({
                       companionExpanded={settings?.companionExpanded}
                       onOptOut={() => setIsOptOutCompanion(true)}
                     />
+                    <LazyModalElement modalSelection={companionModals} />
                     <PromptElement parentSelector={getCompanionWrapper} />
                     <Toast
                       autoDismissNotifications={

--- a/packages/extension/src/companion/CompanionContent.tsx
+++ b/packages/extension/src/companion/CompanionContent.tsx
@@ -19,6 +19,7 @@ import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext'
 import { CompanionEngagements } from './CompanionEngagements';
 import { CompanionDiscussion } from './CompanionDiscussion';
 import { useBackgroundPaginatedRequest } from './useBackgroundPaginatedRequest';
+import { getCompanionWrapper } from './common';
 
 type CompanionContentProps = {
   post: PostBootData;
@@ -32,7 +33,9 @@ export default function CompanionContent({
   const { trackEvent } = useContext(AnalyticsContext);
   const [copying, copyLink] = useCopyLink(() => post.commentsPermalink);
   const [heightPx, setHeightPx] = useState('0');
-  const { queryKey, onShowUpvoted } = useUpvoteQuery();
+  const { queryKey, onShowUpvoted } = useUpvoteQuery({
+    appendModalTo: getCompanionWrapper,
+  });
   useBackgroundPaginatedRequest(queryKey);
 
   const trackAndCopyLink = () => {

--- a/packages/shared/src/components/comments/CommentActionButtons.tsx
+++ b/packages/shared/src/components/comments/CommentActionButtons.tsx
@@ -45,6 +45,7 @@ export interface Props extends CommentActionProps {
   origin: Origin;
   parentId: string | null;
   className?: string;
+  appendTooltipTo?: () => HTMLElement;
 }
 
 export default function CommentActionButtons({
@@ -58,6 +59,7 @@ export default function CommentActionButtons({
   onDelete,
   onEdit,
   onShowUpvotes,
+  appendTooltipTo,
 }: Props): ReactElement {
   const id = `comment-actions-menu-${comment.id}`;
   const { show } = useContextMenu({ id });
@@ -185,6 +187,7 @@ export default function CommentActionButtons({
         id={id}
         className="menu-primary typo-callout"
         animation="fade"
+        appendTo={appendTooltipTo}
       >
         <Item onClick={() => onEdit(comment)}>
           <ContextItem>

--- a/packages/shared/src/components/comments/CommentBox.tsx
+++ b/packages/shared/src/components/comments/CommentBox.tsx
@@ -112,6 +112,7 @@ function CommentBox({
           onEdit={onEdit}
           onShowUpvotes={onShowUpvotes}
           className="mt-3"
+          appendTooltipTo={appendTooltipTo}
         />
       </div>
     </article>

--- a/packages/shared/src/components/fields/PortalMenu.tsx
+++ b/packages/shared/src/components/fields/PortalMenu.tsx
@@ -1,10 +1,13 @@
 import React, { ReactElement } from 'react';
 import { Menu, MenuProps } from '@dailydotdev/react-contexify';
-import Portal from '../tooltips/Portal';
+import Portal, { PortalProps } from '../tooltips/Portal';
 
-export default function PortalMenu(props: MenuProps): ReactElement {
+export default function PortalMenu({
+  appendTo,
+  ...props
+}: MenuProps & PortalProps): ReactElement {
   return (
-    <Portal>
+    <Portal appendTo={appendTo}>
       <Menu {...props} />
     </Portal>
   );

--- a/packages/shared/src/components/modals/LazyModalElement.tsx
+++ b/packages/shared/src/components/modals/LazyModalElement.tsx
@@ -1,12 +1,18 @@
-import React, { ReactElement } from 'react';
+import React, { ComponentType, ReactElement } from 'react';
 import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyPropTypes, modals } from './common';
 
-export function LazyModalElement(): ReactElement {
+interface LazyModalElementProps {
+  modalSelection?: Record<string, ComponentType>;
+}
+
+export function LazyModalElement({
+  modalSelection = modals,
+}: LazyModalElementProps): ReactElement {
   const { modal, closeModal } = useLazyModal();
   if (!modal) return null;
 
   const { type, props } = modal;
-  const ActiveModal = modals[type] as React.FC<LazyPropTypes>;
+  const ActiveModal = modalSelection[type] as React.FC<LazyPropTypes>;
   return <ActiveModal isOpen onRequestClose={closeModal} {...props} />;
 }

--- a/packages/shared/src/components/modals/UpvotedPopupModal.tsx
+++ b/packages/shared/src/components/modals/UpvotedPopupModal.tsx
@@ -46,7 +46,8 @@ export function UpvotedPopupModal({
         fetchNextPage: queryResult.fetchNextPage,
       }}
       users={queryResult.data?.pages
-        .map((p) => p.upvotes.edges.map(({ node }) => node.user))
+        .filter((p) => !!p)
+        .map((p) => p?.upvotes.edges.map(({ node }) => node.user))
         .flat()}
     />
   );

--- a/packages/shared/src/components/tooltips/Portal.tsx
+++ b/packages/shared/src/components/tooltips/Portal.tsx
@@ -1,12 +1,19 @@
 import { ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
-interface PortalProps {
+export interface PortalProps {
   children: ReactNode;
+  appendTo?: Document | HTMLElement | (() => HTMLElement);
 }
 
-function Portal({ children }: PortalProps): ReturnType<typeof createPortal> {
-  return createPortal(children, document.body);
+function Portal({
+  children,
+  appendTo = document.body,
+}: PortalProps): ReturnType<typeof createPortal> {
+  return createPortal(
+    children,
+    typeof appendTo === 'function' ? appendTo() : appendTo,
+  );
 }
 
 export default Portal;

--- a/packages/shared/src/hooks/useUpvoteQuery.ts
+++ b/packages/shared/src/hooks/useUpvoteQuery.ts
@@ -4,12 +4,17 @@ import { LazyModal } from '../components/modals/common/types';
 import { COMMENT_UPVOTES_BY_ID_QUERY } from '../graphql/comments';
 import { POST_UPVOTES_BY_ID_QUERY } from '../graphql/posts';
 import { useLazyModal } from './useLazyModal';
+import { ModalProps } from '../components/modals/common/Modal';
 
 type UpvoteType = 'post' | 'comment';
 
 interface UseUpvoteQuery {
   queryKey: QueryKey;
   onShowUpvoted: (id: string, upvotes: number, type?: UpvoteType) => unknown;
+}
+
+interface UseUpvoteQueryProps {
+  appendModalTo?: ModalProps['parentSelector'];
 }
 
 const DEFAULT_UPVOTES_PER_PAGE = 50;
@@ -24,7 +29,9 @@ const QUERY_MAP = {
   comment: COMMENT_UPVOTES_BY_ID_QUERY,
 };
 
-export const useUpvoteQuery = (): UseUpvoteQuery => {
+export const useUpvoteQuery = ({
+  appendModalTo,
+}: UseUpvoteQueryProps = {}): UseUpvoteQuery => {
   const { modal, openModal } = useLazyModal<LazyModal.UpvotedPopup>();
   const onShowUpvoted = (
     id: string,
@@ -34,6 +41,7 @@ export const useUpvoteQuery = (): UseUpvoteQuery => {
     openModal({
       type: LazyModal.UpvotedPopup,
       props: {
+        parentSelector: appendModalTo,
         placeholderAmount: upvotes,
         requestQuery: {
           queryKey: [KEY_MAP[type], id],
@@ -46,6 +54,6 @@ export const useUpvoteQuery = (): UseUpvoteQuery => {
 
   return useMemo(
     () => ({ onShowUpvoted, queryKey: modal?.props?.requestQuery?.queryKey }),
-    [modal],
+    [modal, appendModalTo],
   );
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Usage of `Portal` must allow to which place in the DOM it must be appended.
- LazyModalElement was not included in the Companion's rendered components.
- After long hours of battling with the LazyLoading, the issue is, the resource fetch is being pointed to the site we are currently at, instead of pointing to the resources of the `chrome-extension://id`. Haven't found a way to manually point the calls to that.
- Refactored the LazyModalElement to accept a list of modals to use to have more options.
- Fixed the upvoted modal usage on Companion where the initial state is the first node being null.
- I have also verified the tooltips/popups in the Companion and all seem to be covered now.

@capJavert just some early background info while I am still on my way to writing the doc page for the Companion, in order for our styles to work, we must append the popup/tooltip to the base container of our shadow root. We have a function to fetch the said element, it is named `getCompanionWrapper` as utilized in this PR.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1177 #done
