### PR TITLE
refactor: user mention allowing hyphens to be used

### DIFF
--- a/packages/shared/src/lib/strings.ts
+++ b/packages/shared/src/lib/strings.ts
@@ -1,10 +1,10 @@
 export const isAlphaNumeric = (key: string): boolean => {
-  const match = key.match(/^[a-z0-9]+$/i);
+  const match = key.match(/^[a-z0-9-]+$/i);
 
   return match && match[0].length === 1;
 };
 
-const specialCharsFormat = /[ `!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~]/;
+const specialCharsFormat = /[ `!@#$%^&*()_+=[\]{};':"\\|,.<>/?~]/;
 export const isSpecialCharacter = (key: string): boolean =>
   specialCharsFormat.test(key);
 


### PR DESCRIPTION
## Changes
- Whitelist hyphens when mentioning a user.
- The function updated here are only used by the user mention feature.

Preview:

![image](https://user-images.githubusercontent.com/13744167/228117682-a18aad69-a224-4798-b939-913ba489cd7e.png)

![image](https://user-images.githubusercontent.com/13744167/228117760-51702cfe-eeec-4c2e-95c2-9c1d5240f813.png)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1179 #done
