### PR TITLE
fix: timezone order and offset

### DIFF
--- a/packages/shared/src/lib/timezones.ts
+++ b/packages/shared/src/lib/timezones.ts
@@ -3,7 +3,13 @@ import { SVGAttributes } from 'react';
 import DaytimeIcon from '../../icons/timezone_daytime.svg';
 import NighttimeIcon from '../../icons/timezone_nighttime.svg';
 
-const TIME_ZONES = [
+interface TimeZoneItem {
+  value: string;
+  label: string;
+  offset?: number;
+}
+
+const TIME_ZONES: TimeZoneItem[] = [
   {
     value: 'Pacific/Midway',
     label: 'Midway Island, American Samoa',
@@ -498,10 +504,7 @@ const TIME_ZONES = [
   },
 ];
 
-const timeZoneCurrentOffsetLabel = (timeZone: {
-  value: string;
-  label: string;
-}) => {
+const timeZoneCurrentOffsetLabel = (timeZone: TimeZoneItem) => {
   const date = new Date();
   date.setMilliseconds(0);
   const userOffset = (date.getTimezoneOffset() / 60) * -1;
@@ -512,15 +515,18 @@ const timeZoneCurrentOffsetLabel = (timeZone: {
   const diffHrs =
     (localTimeZoneDate.getTime() - date.getTime()) / 1000 / 60 / 60;
   const timeZoneOffset = userOffset + diffHrs;
-  return `(UTC ${timeZoneOffset > 0 ? '+' : ''}${timeZoneOffset}) ${
-    timeZone.label
-  }`;
+  const offset = timeZoneOffset >= 24 ? timeZoneOffset - 24 : timeZoneOffset;
+  return {
+    label: `(UTC ${timeZoneOffset > 0 ? '+' : ''}${offset}) ${timeZone.label}`,
+    offset,
+  };
 };
 
-export const getTimeZoneOptions = (): { value: string; label: string }[] => {
+export const getTimeZoneOptions = (): TimeZoneItem[] => {
   return TIME_ZONES.map((timeZone) => {
-    return { ...timeZone, label: timeZoneCurrentOffsetLabel(timeZone) };
-  });
+    const labelOffset = timeZoneCurrentOffsetLabel(timeZone);
+    return { ...timeZone, ...labelOffset };
+  }).sort((a, b) => a.offset - b.offset);
 };
 
 export const getUserDefaultTimezone = (): string => {


### PR DESCRIPTION
## Changes
- The offsets having a value of greater than 24 have exactly an excess of 24 on the offset itself.
- Refactored the function fetching the offset to also return the numerical value to be used for sorting.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-651 #done
WT-291 #done
