### PR TITLE
fix: reading history grouping

### DIFF
--- a/packages/shared/src/components/history/ReadingHistoryList.tsx
+++ b/packages/shared/src/components/history/ReadingHistoryList.tsx
@@ -54,6 +54,8 @@ export default function ReadHistoryList({
 
   const renderList = useCallback(() => {
     let currentDate: Date;
+    let previousGroup: string;
+    const now = new Date();
 
     return data?.pages.map((page, pageIndex) =>
       page.readHistory.edges.reduce((dom, { node: history }, edgeIndex) => {
@@ -62,7 +64,12 @@ export default function ReadHistoryList({
 
         if (!currentDate || !isDateOnlyEqual(currentDate, date)) {
           currentDate = date;
-          dom.push(getDateGroup(date));
+          const dateToGroup = currentDate > now ? now : date;
+          const group = getReadHistoryDateFormat(dateToGroup);
+          if (previousGroup !== group) {
+            previousGroup = group;
+            dom.push(getDateGroup(dateToGroup));
+          }
         }
 
         const indexes = { page: pageIndex, edge: edgeIndex };


### PR DESCRIPTION
## Changes
- When the user's timezone is above over the current country/timezone they are at, it groups the day for tomorrow even though it happened technically "Today".
- So to avoid confusion, since it happened "Today", we will list the item as "Today" instead of "Tomorrow".
- Though it was discussed that we can use this mechanism to identify whether the user must change their timezone and we must show a popup, but that is still in progress under the product team.

Before:
![image](https://user-images.githubusercontent.com/13744167/228140061-2890b608-3c45-4432-97c7-e48acfad6c58.png)

After:
![image](https://user-images.githubusercontent.com/13744167/228140095-69c5f603-751f-4872-a4d6-74a0718996a1.png)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-369 #done
