### PR TITLE
fix: processing toast only show if private link submitted

### DIFF
--- a/packages/shared/src/components/modals/PostToSquadModal.tsx
+++ b/packages/shared/src/components/modals/PostToSquadModal.tsx
@@ -56,11 +56,11 @@ function PostToSquadModal({
   const onPostSuccess = async (squadPost?: Post) => {
     if (squadPost) onSharedSuccessfully?.(squadPost);
 
-    if (isLink) {
-      displayToast(
-        'This post is being processed and will be shared with your Squad shortly',
-      );
-    }
+    displayToast(
+      isLink
+        ? 'This post is being processed and will be shared with your Squad shortly'
+        : 'This post has been shared to your Squad',
+    );
 
     await client.invalidateQueries(['sourceFeed', user.id]);
     onRequestClose(null);

--- a/packages/shared/src/components/modals/PostToSquadModal.tsx
+++ b/packages/shared/src/components/modals/PostToSquadModal.tsx
@@ -56,9 +56,12 @@ function PostToSquadModal({
   const onPostSuccess = async (squadPost?: Post) => {
     if (squadPost) onSharedSuccessfully?.(squadPost);
 
-    displayToast(
-      'This post is being processed and will be shared with your Squad shortly',
-    );
+    if (isLink) {
+      displayToast(
+        'This post is being processed and will be shared with your Squad shortly',
+      );
+    }
+
     await client.invalidateQueries(['sourceFeed', user.id]);
     onRequestClose(null);
   };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- As mentioned here https://github.com/dailydotdev/apps/pull/1703#discussion_r1150726244
- this should only show toast for processing if link is being shared

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
