### PR TITLE
Wt 1215 blocked squad member

### DIFF
--- a/packages/shared/__tests__/fixture/squads.ts
+++ b/packages/shared/__tests__/fixture/squads.ts
@@ -1,19 +1,17 @@
 import { GraphQLResult } from '../helpers/graphql';
 import { Edge } from '../../src/graphql/common';
-import { SourceType } from '../../src/graphql/sources';
 import {
-  Squad,
-  SquadData,
-  SquadEdgesData,
-  SquadMember,
-  SquadMemberRole,
-} from '../../src/graphql/squads';
+  SourceType,
+  SourceMember,
+  SourceMemberRole,
+} from '../../src/graphql/sources';
+import { Squad, SquadData, SquadEdgesData } from '../../src/graphql/squads';
 
 export const defaultSquadToken = 'ki3YLcxvSZ2Q6KgMBZvMbly1gnrZ6JnIrhTpUML-Hua';
 
 export const generateTestOwner = (
-  members: Edge<SquadMember>[] = [],
-): SquadMember => ({
+  members: Edge<SourceMember>[] = [],
+): SourceMember => ({
   user: {
     id: 'Se4LmwLU0q6aVDpX1MkqX',
     name: 'Lee Hansel Solevilla',
@@ -47,7 +45,7 @@ export const generateTestOwner = (
             },
             source: null,
             referralToken: defaultSquadToken,
-            role: SquadMemberRole.Owner,
+            role: SourceMemberRole.Owner,
           },
         },
         ...members,
@@ -55,11 +53,11 @@ export const generateTestOwner = (
     },
   },
   referralToken: defaultSquadToken,
-  role: SquadMemberRole.Owner,
+  role: SourceMemberRole.Owner,
 });
 
 export const generateMembersResult = (
-  members: Edge<SquadMember>[] = [
+  members: Edge<SourceMember>[] = [
     {
       node: {
         role: 'owner',
@@ -141,7 +139,7 @@ export const generateMembersResult = (
 export const generateTestMember = (
   i: string | number,
   token = defaultSquadToken,
-): SquadMember => ({
+): SourceMember => ({
   user: {
     id: `Se4LmwLU0q6aVDpX1MkqX${i}`,
     name: `Lee Hansel Solevilla - ${i}`,
@@ -151,7 +149,7 @@ export const generateTestMember = (
   },
   source: null,
   referralToken: `${token}${i}`,
-  role: SquadMemberRole.Member,
+  role: SourceMemberRole.Member,
 });
 
 export const generateTestSquad = (props: Partial<Squad> = {}): Squad => ({
@@ -167,7 +165,7 @@ export const generateTestSquad = (props: Partial<Squad> = {}): Squad => ({
     'https://daily-now-res.cloudinary.com/image/upload/v1675848308/squads/343f82f0-85f0-4f10-a666-aa331d8d7a1b.png',
   membersCount: 12,
   currentMember: {
-    role: SquadMemberRole.Member,
+    role: SourceMemberRole.Member,
     referralToken: '3ZvloDmEbgiCKLF_eDg72JKLRPgp6MOpGDkh6qTRFr8',
     user: {
       id: 'u1',
@@ -201,8 +199,8 @@ export const generateNotFoundSquadResult = (): GraphQLResult<SquadData> => ({
 });
 
 export const generateMembersList = (
-  members: Edge<SquadMember>[] = [],
-): Edge<SquadMember>[] => [
+  members: Edge<SourceMember>[] = [],
+): Edge<SourceMember>[] => [
   {
     node: {
       role: 'owner',

--- a/packages/shared/src/components/cards/SourceButton.tsx
+++ b/packages/shared/src/components/cards/SourceButton.tsx
@@ -6,7 +6,7 @@ import { ProfileImageSize } from '../ProfilePicture';
 import { Source } from '../../graphql/sources';
 
 interface SourceButtonProps {
-  source: Omit<Source, 'type'>;
+  source: Pick<Source, 'id' | 'name' | 'handle' | 'image' | 'permalink'>;
   className?: string;
   style?: CSSProperties;
   size?: ProfileImageSize;

--- a/packages/shared/src/components/modals/EditSquadModal.tsx
+++ b/packages/shared/src/components/modals/EditSquadModal.tsx
@@ -1,7 +1,8 @@
 import React, { ReactElement } from 'react';
 import { useQueryClient } from 'react-query';
 import { LazyModalCommonProps, Modal } from './common/Modal';
-import { Squad, editSquad } from '../../graphql/squads';
+import { editSquad } from '../../graphql/squads';
+import { Squad } from '../../graphql/sources';
 import { SquadDetails } from '../squads/Details';
 import { ModalHeaderKind } from './common/types';
 import { useToastNotification } from '../../hooks/useToastNotification';

--- a/packages/shared/src/components/modals/PostToSquadModal.tsx
+++ b/packages/shared/src/components/modals/PostToSquadModal.tsx
@@ -57,7 +57,7 @@ function PostToSquadModal({
     if (squadPost) onSharedSuccessfully?.(squadPost);
 
     displayToast(
-      'This post is being processed and will be shared with you Squad shortly',
+      'This post is being processed and will be shared with your Squad shortly',
     );
     await client.invalidateQueries(['sourceFeed', user.id]);
     onRequestClose(null);

--- a/packages/shared/src/components/modals/PostToSquadModal.tsx
+++ b/packages/shared/src/components/modals/PostToSquadModal.tsx
@@ -2,7 +2,8 @@ import React, { ReactElement, useContext, useState } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
 import request from 'graphql-request';
 import { LazyModalCommonProps, Modal } from './common/Modal';
-import { addPostToSquad, Squad, SquadForm } from '../../graphql/squads';
+import { addPostToSquad, SquadForm } from '../../graphql/squads';
+import { Squad } from '../../graphql/sources';
 import { SquadComment, SubmitSharePostFunc } from '../squads/Comment';
 import { ModalStep } from './common/types';
 import { Post, submitExternalLink } from '../../graphql/posts';
@@ -57,8 +58,11 @@ function PostToSquadModal({
     if (squadPost) onSharedSuccessfully?.(squadPost);
 
     displayToast(
-      'This post is being processed and will be shared with your Squad shortly',
+      isLink
+        ? 'This post is being processed and will be shared with your Squad shortly'
+        : 'This post has been shared to your Squad',
     );
+
     await client.invalidateQueries(['sourceFeed', user.id]);
     onRequestClose(null);
   };

--- a/packages/shared/src/components/modals/SquadInviteModal.tsx
+++ b/packages/shared/src/components/modals/SquadInviteModal.tsx
@@ -4,7 +4,8 @@ import { Button } from '../buttons/Button';
 import { Modal, ModalProps } from './common/Modal';
 import Alert, { AlertType } from '../widgets/Alert';
 import LinkIcon from '../icons/Link';
-import { getSquad, Squad } from '../../graphql/squads';
+import { getSquad } from '../../graphql/squads';
+import { Squad } from '../../graphql/sources';
 import {
   InviteTextField,
   InviteTextFieldHandle,

--- a/packages/shared/src/components/modals/SquadMemberModal.tsx
+++ b/packages/shared/src/components/modals/SquadMemberModal.tsx
@@ -3,12 +3,8 @@ import { useInfiniteQuery } from 'react-query';
 import request from 'graphql-request';
 import { graphqlUrl } from '../../lib/config';
 import { ModalProps } from './common/Modal';
-import {
-  Squad,
-  SQUAD_MEMBERS_QUERY,
-  SquadEdgesData,
-  SquadMemberRole,
-} from '../../graphql/squads';
+import { SQUAD_MEMBERS_QUERY, SquadEdgesData } from '../../graphql/squads';
+import { Squad, SourceMemberRole } from '../../graphql/sources';
 import UserListModal from './UserListModal';
 import { checkFetchMore } from '../containers/InfiniteScrolling';
 import { Button, ButtonSize } from '../buttons/Button';
@@ -96,7 +92,7 @@ export function SquadMemberModal({
           .flat()}
         additionalContent={(user) => {
           const role = getSquadMembersUserRole(queryResult, user);
-          if (role === SquadMemberRole.Owner) {
+          if (role === SourceMemberRole.Owner) {
             return (
               <span
                 className="flex gap-1 items-center font-bold typo-footnote text-theme-color-cabbage"

--- a/packages/shared/src/components/sidebar/SquadsList.tsx
+++ b/packages/shared/src/components/sidebar/SquadsList.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Squad } from '../../graphql/squads';
+import { Squad } from '../../graphql/sources';
 import DefaultSquadIcon from '../icons/DefaultSquad';
 import NewSquadIcon from '../icons/NewSquad';
 import { SquadImage } from '../squads/SquadImage';

--- a/packages/shared/src/components/squads/InviteTextField.tsx
+++ b/packages/shared/src/components/squads/InviteTextField.tsx
@@ -7,7 +7,7 @@ import React, {
 import { Button } from '../buttons/Button';
 import { TextField } from '../fields/TextField';
 import CopyIcon from '../icons/Copy';
-import { Squad } from '../../graphql/squads';
+import { Squad } from '../../graphql/sources';
 import { Origin } from '../../lib/analytics';
 import { useSquadInvitation } from '../../hooks/useSquadInvitation';
 

--- a/packages/shared/src/components/squads/ModalHeader.tsx
+++ b/packages/shared/src/components/squads/ModalHeader.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Squad } from '../../graphql/squads';
+import { Squad } from '../../graphql/sources';
 import { cloudinary } from '../../lib/image';
 import DailyCircle from '../DailyCircle';
 import { Image } from '../image/Image';

--- a/packages/shared/src/components/squads/Ready.tsx
+++ b/packages/shared/src/components/squads/Ready.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useContext, useRef } from 'react';
 import { Modal } from '../modals/common/Modal';
 import { Button } from '../buttons/Button';
 import LinkIcon from '../icons/Link';
-import { Squad } from '../../graphql/squads';
+import { Squad } from '../../graphql/sources';
 import SquadReadySvg from '../../svg/SquadReady';
 import Alert, { AlertType } from '../widgets/Alert';
 import {

--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -5,7 +5,7 @@ import AuthContext from '../../contexts/AuthContext';
 import EditIcon from '../icons/Edit';
 import TourIcon from '../icons/Tour';
 import ExitIcon from '../icons/Exit';
-import { Squad, SquadMemberRole } from '../../graphql/squads';
+import { Squad, SourceMemberRole } from '../../graphql/sources';
 import TrashIcon from '../icons/Trash';
 import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
@@ -44,7 +44,7 @@ export default function SquadHeaderMenu({
     squad,
     callback: () => router.replace('/'),
   });
-  const isSquadOwner = squad?.currentMember?.role === SquadMemberRole.Owner;
+  const isSquadOwner = squad?.currentMember?.role === SourceMemberRole.Owner;
 
   const onEditSquad = () => {
     openModal({

--- a/packages/shared/src/components/squads/SquadImage.tsx
+++ b/packages/shared/src/components/squads/SquadImage.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
-import { Squad } from '../../graphql/squads';
+import { Squad } from '../../graphql/sources';
 import { Image } from '../image/Image';
 import { cloudinary } from '../../lib/image';
 

--- a/packages/shared/src/components/squads/SquadMemberShortList.tsx
+++ b/packages/shared/src/components/squads/SquadMemberShortList.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import React, { ReactElement } from 'react';
-import { Squad, SquadMember } from '../../graphql/squads';
+import { Squad, SourceMember } from '../../graphql/sources';
 import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
 import { ProfilePicture } from '../ProfilePicture';
@@ -8,7 +8,7 @@ import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 
 export interface SquadMemberShortListProps {
   squad: Squad;
-  members: SquadMember[];
+  members: SourceMember[];
   memberCount: number;
   className?: string;
 }

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
-import { Squad, SquadMember } from '../../graphql/squads';
+import { Squad, SourceMember } from '../../graphql/sources';
 import { SquadHeaderBar } from './SquadHeaderBar';
 import { SquadImage } from './SquadImage';
 import EnableNotification from '../notifications/EnableNotification';
@@ -16,7 +16,7 @@ import { useSquadTour } from '../../hooks/useSquadTour';
 
 interface SquadPageHeaderProps {
   squad: Squad;
-  members: SquadMember[];
+  members: SourceMember[];
   onNewSquadPost: () => void;
   hasTriedOnboarding?: boolean;
 }

--- a/packages/shared/src/components/squads/utils.tsx
+++ b/packages/shared/src/components/squads/utils.tsx
@@ -2,11 +2,8 @@ import React from 'react';
 import { UseInfiniteQueryResult } from 'react-query';
 import classed from '../../lib/classed';
 import { PromptOptions } from '../../hooks/usePrompt';
-import {
-  SquadEdgesData,
-  SquadForm,
-  SquadMemberRole,
-} from '../../graphql/squads';
+import { SquadEdgesData, SquadForm } from '../../graphql/squads';
+import { SourceMemberRole } from '../../graphql/sources';
 import { UserShortProfile } from '../../lib/user';
 
 export enum ModalState {
@@ -57,7 +54,7 @@ export const quitSquadModal: PromptOptions = {
 export const getSquadMembersUserRole = (
   input: UseInfiniteQueryResult<SquadEdgesData>,
   user: UserShortProfile,
-): SquadMemberRole => {
+): SourceMemberRole => {
   return input.data?.pages
     .map((page) =>
       page.sourceMembers.edges.filter(({ node }) => node.user.id === user.id),

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -25,7 +25,7 @@ import { Comment, getCommentHash } from '../../graphql/comments';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
-import { Squad } from '../../graphql/squads';
+import { Squad } from '../../graphql/sources';
 import SourceProfilePicture from '../profile/SourceProfilePicture';
 
 interface SocialShareProps {

--- a/packages/shared/src/contexts/AuthContext.tsx
+++ b/packages/shared/src/contexts/AuthContext.tsx
@@ -15,7 +15,7 @@ import {
 import { AccessToken, Boot, Visit } from '../lib/boot';
 import { isCompanionActivated } from '../lib/element';
 import { AuthTriggers, AuthTriggersOrString } from '../lib/auth';
-import { Squad } from '../graphql/squads';
+import { Squad } from '../graphql/sources';
 
 export interface LoginState {
   trigger: AuthTriggersOrString;

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -1,7 +1,7 @@
 import request, { gql } from 'graphql-request';
 import { Author, Comment, Scout } from './comments';
 import { Connection, Upvote } from './common';
-import { Source } from './sources';
+import { Source, Squad } from './sources';
 import { EmptyResponse } from './emptyResponse';
 import { graphqlUrl } from '../lib/config';
 import {
@@ -37,7 +37,7 @@ export interface Post {
   createdAt?: string;
   readTime?: number;
   tags?: string[];
-  source?: Source;
+  source?: Source | Squad;
   upvoted?: boolean;
   commented?: boolean;
   commentsPermalink: string;

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -1,8 +1,35 @@
 import { gql } from 'graphql-request';
+import { UserShortProfile } from '../lib/user';
+import { Connection } from './common';
+
+export enum SourceMemberRole {
+  Member = 'member',
+  Moderator = 'moderator',
+  Owner = 'owner',
+}
+
+export interface SourceMember {
+  role: SourceMemberRole;
+  user: UserShortProfile;
+  source: Squad;
+  referralToken: string;
+}
 
 export enum SourceType {
   Machine = 'machine',
   Squad = 'squad',
+}
+
+export interface Squad extends Source {
+  active: boolean;
+  permalink: string;
+  public: boolean;
+  type: SourceType.Squad;
+  owners?: string[];
+  moderators?: string[];
+  members?: Connection<SourceMember>;
+  membersCount: number;
+  description: string;
 }
 
 export interface Source {
@@ -13,6 +40,7 @@ export interface Source {
   handle: string;
   type: SourceType;
   permalink: string;
+  currentMember?: SourceMember;
 }
 
 export type SourceData = { source: Source };

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -32,6 +32,7 @@ export type SquadForm = Pick<
 export enum SquadMemberRole {
   Member = 'member',
   Owner = 'owner',
+  Blocked = 'blocked',
 }
 
 export type SquadMember = {

--- a/packages/shared/src/hooks/useBoot.ts
+++ b/packages/shared/src/hooks/useBoot.ts
@@ -1,6 +1,6 @@
 import { useQueryClient } from 'react-query';
 import { BOOT_QUERY_KEY } from '../contexts/common';
-import { Squad } from '../graphql/squads';
+import { Squad } from '../graphql/sources';
 import { Boot } from '../lib/boot';
 
 type UseBoot = {

--- a/packages/shared/src/hooks/useDeleteSquad.ts
+++ b/packages/shared/src/hooks/useDeleteSquad.ts
@@ -1,5 +1,6 @@
 import { useContext, useMemo } from 'react';
-import { deleteSquad, Squad } from '../graphql/squads';
+import { deleteSquad } from '../graphql/squads';
+import { Squad } from '../graphql/sources';
 import { PromptOptions, usePrompt } from './usePrompt';
 import { useBoot } from './useBoot';
 import AnalyticsContext from '../contexts/AnalyticsContext';

--- a/packages/shared/src/hooks/useLeaveSquad.ts
+++ b/packages/shared/src/hooks/useLeaveSquad.ts
@@ -1,5 +1,6 @@
 import { useContext, useMemo } from 'react';
-import { leaveSquad, Squad } from '../graphql/squads';
+import { leaveSquad } from '../graphql/squads';
+import { Squad } from '../graphql/sources';
 import { PromptOptions, usePrompt } from './usePrompt';
 import { useBoot } from './useBoot';
 import AnalyticsContext from '../contexts/AnalyticsContext';

--- a/packages/shared/src/hooks/useSquadInvitation.ts
+++ b/packages/shared/src/hooks/useSquadInvitation.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { CopyNotifyFunction, useCopyLink } from './useCopyLink';
 import { useAnalyticsContext } from '../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../lib/analytics';
-import { Squad } from '../graphql/squads';
+import { Squad } from '../graphql/sources';
 
 export interface UseSquadInvitationProps {
   squad: Squad;

--- a/packages/shared/src/lib/boot.ts
+++ b/packages/shared/src/lib/boot.ts
@@ -4,7 +4,7 @@ import { apiUrl } from './config';
 import { Alerts } from '../graphql/alerts';
 import { RemoteSettings } from '../graphql/settings';
 import { Post } from '../graphql/posts';
-import { Squad } from '../graphql/squads';
+import { Squad } from '../graphql/sources';
 
 interface NotificationsBootData {
   unreadNotificationsCount: number;

--- a/packages/webapp/__tests__/SquadFeedPage.tsx
+++ b/packages/webapp/__tests__/SquadFeedPage.tsx
@@ -32,13 +32,15 @@ import {
   generateMembersList,
 } from '@dailydotdev/shared/__tests__/fixture/squads';
 import {
-  Squad,
   SquadData,
   SquadEdgesData,
-  SquadMemberRole,
   SQUAD_MEMBERS_QUERY,
   SQUAD_QUERY,
 } from '@dailydotdev/shared/src/graphql/squads';
+import {
+  Squad,
+  SourceMemberRole,
+} from '@dailydotdev/shared/src/graphql/sources';
 import { NotificationsContextProvider } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import { BootApp } from '@dailydotdev/shared/src/lib/boot';
 import { squadFeedback } from '@dailydotdev/shared/src/lib/constants';
@@ -288,7 +290,7 @@ describe('squad members modal', () => {
   it('should show the owner on top of the list', async () => {
     const fullMembers = await openedMembersModal();
     const [first] = fullMembers;
-    expect(first.node.role).toEqual(SquadMemberRole.Owner);
+    expect(first.node.role).toEqual(SourceMemberRole.Owner);
     const owner = await screen.findByText('Owner');
     expect(owner).toHaveAttribute('data-testvalue', first.node.user.username);
   });

--- a/packages/webapp/__tests__/SquadTokenPage.tsx
+++ b/packages/webapp/__tests__/SquadTokenPage.tsx
@@ -23,10 +23,10 @@ import OnboardingContext from '@dailydotdev/shared/src/contexts/OnboardingContex
 import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import {
   SquadInvitation,
-  SquadMember,
   SQUAD_INVITATION_QUERY,
   SQUAD_JOIN_MUTATION,
 } from '@dailydotdev/shared/src/graphql/squads';
+import { SourceMember } from '@dailydotdev/shared/src/graphql/sources';
 import { BOOT_QUERY_KEY } from '@dailydotdev/shared/src/contexts/common';
 import SquadPage, {
   SquadReferralProps,
@@ -56,7 +56,7 @@ let client: QueryClient;
 
 const createInvitationMock = (
   token: string = defaultSquadToken,
-  member: SquadMember = generateTestOwner(),
+  member: SourceMember = generateTestOwner(),
 ): MockedGraphQLResponse<SquadInvitation> => ({
   request: {
     query: SQUAD_INVITATION_QUERY,

--- a/packages/webapp/pages/squads/[handle]/[token].tsx
+++ b/packages/webapp/pages/squads/[handle]/[token].tsx
@@ -6,6 +6,7 @@ import {
   getSquadInvitation,
   joinSquadInvitation,
   SquadMember,
+  SquadMemberRole,
   validateSourceHandle,
 } from '@dailydotdev/shared/src/graphql/squads';
 import { Edge } from '@dailydotdev/shared/src/graphql/common';
@@ -86,10 +87,13 @@ const SquadReferral = ({
 
         if (!isValid) return router.replace(webappUrl);
 
-        const isMember = response.source.members.edges.some(
-          ({ node }) => node.user.id === loggedUser.id,
-        );
-        if (isMember) return router.replace(squadsUrl);
+        const { currentMember } = response.source;
+        if (currentMember) {
+          const { role } = currentMember;
+          if (role !== SquadMemberRole.Blocked) {
+            return router.replace(squadsUrl);
+          }
+        }
 
         return null;
       },

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -22,9 +22,8 @@ import { BaseFeedPage } from '@dailydotdev/shared/src/components/utilities';
 import {
   getSquad,
   getSquadMembers,
-  Squad,
-  SquadMember,
 } from '@dailydotdev/shared/src/graphql/squads';
+import { Squad, SourceMember } from '@dailydotdev/shared/src/graphql/sources';
 import Unauthorized from '@dailydotdev/shared/src/components/errors/Unauthorized';
 import SquadLoading from '@dailydotdev/shared/src/components/errors/SquadLoading';
 import { useQuery } from 'react-query';
@@ -95,7 +94,7 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
     setTrackedImpression(true);
   }, [squadId, trackedImpression]);
 
-  const { data: squadMembers } = useQuery<SquadMember[]>(
+  const { data: squadMembers } = useQuery<SourceMember[]>(
     ['squadMembersInitial', handle],
     () => getSquadMembers(squadId),
     { enabled: isBootFetched && !!squadId },


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Introduces a fix to support blocked members seeing the token page 
- Changed the evaluation there to current member as it contains all info.
- Still needs the toast message so pointing to intermediate branch

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1215 #done
