### PR TITLE
feat: delete post as a moderator/owner or author of shared post

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -192,6 +192,7 @@ export default function Feed<T>({
     postPosition,
     selectedPost,
     isFetchingNextPage,
+    selectedPostIndex,
   } = usePostModalNavigation(items, fetchPage, updatePost, canFetchMore);
 
   useEffect(() => {
@@ -492,6 +493,7 @@ export default function Feed<T>({
             onNextPost={onNext}
             isFetchingNextPage={isFetchingNextPage}
             postPosition={postPosition}
+            onRemovePost={() => onRemovePost(selectedPostIndex)}
           />
         )}
         {sharePost && (

--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -232,7 +232,7 @@ export default function PostOptionsMenu({
     text: 'Report',
     action: async () => setReportModal({ index: postIndex, post }),
   });
-  if (canDeletePost && !post.deleted) {
+  if (canDeletePost) {
     postOptions.push({
       icon: <MenuIcon Icon={TrashIcon} />,
       text: 'Remove',

--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -24,6 +24,7 @@ import AuthContext from '../contexts/AuthContext';
 import { ShareBookmarkProps } from './post/PostActions';
 import BookmarkIcon from './icons/Bookmark';
 import { Origin } from '../lib/analytics';
+import { usePostMenuActions } from '../hooks/usePostMenuActions';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ './fields/PortalMenu'),
@@ -32,13 +33,13 @@ const PortalMenu = dynamic(
   },
 );
 
-interface PostOptionsMenuProps extends ShareBookmarkProps {
+export interface PostOptionsMenuProps extends ShareBookmarkProps {
   postIndex?: number;
   post: Post;
   feedName?: string;
   onHidden?: () => unknown;
   onRemovePost?: (postIndex: number) => Promise<unknown>;
-  setShowDeletePost?: () => unknown;
+  canDeletePost?: boolean;
   setShowBanPost?: () => unknown;
   contextId?: string;
 }
@@ -58,8 +59,8 @@ export default function PostOptionsMenu({
   feedName,
   onHidden,
   onRemovePost,
-  setShowDeletePost,
   setShowBanPost,
+  canDeletePost,
   contextId = 'post-context',
 }: PostOptionsMenuProps): ReactElement {
   const client = useQueryClient();
@@ -92,9 +93,17 @@ export default function PostOptionsMenu({
       await undo?.();
       client.invalidateQueries(generateQueryKey(feedName, user));
     };
-    displayToast(message, { subject: ToastSubject.Feed, onUndo });
+    displayToast(message, {
+      subject: ToastSubject.Feed,
+      onUndo: undo !== null ? onUndo : null,
+    });
     onRemovePost?.(_postIndex);
   };
+  const { onConfirmDeletePost } = usePostMenuActions({
+    post,
+    onPostDeleted: () =>
+      showMessageAndRemovePost('The post has been deleted', postIndex, null),
+  });
 
   const onReportPost: ReportPostAsync = async (
     reportPostIndex,
@@ -223,11 +232,11 @@ export default function PostOptionsMenu({
     text: 'Report',
     action: async () => setReportModal({ index: postIndex, post }),
   });
-  if (setShowDeletePost) {
+  if (canDeletePost && !post.deleted) {
     postOptions.push({
       icon: <MenuIcon Icon={TrashIcon} />,
       text: 'Remove',
-      action: setShowDeletePost,
+      action: onConfirmDeletePost,
     });
   }
   if (setShowBanPost) {

--- a/packages/shared/src/components/modals/ArticlePostModal.tsx
+++ b/packages/shared/src/components/modals/ArticlePostModal.tsx
@@ -1,19 +1,17 @@
 import React, { ReactElement, useContext } from 'react';
 import { Modal, ModalProps, modalSizeToClassName } from './common/Modal';
-import { ONBOARDING_OFFSET, PostContent } from '../post/PostContent';
-import { PostNavigationProps } from '../post/PostNavigation';
+import {
+  ONBOARDING_OFFSET,
+  PassedPostNavigationProps,
+  PostContent,
+} from '../post/PostContent';
 import { Origin } from '../../lib/analytics';
 import usePostNavigationPosition from '../../hooks/usePostNavigationPosition';
 import usePostById from '../../hooks/usePostById';
 import BasePostModal from './BasePostModal';
 import OnboardingContext from '../../contexts/OnboardingContext';
 
-interface ArticlePostModalProps
-  extends ModalProps,
-    Pick<
-      PostNavigationProps,
-      'onPreviousPost' | 'onNextPost' | 'postPosition'
-    > {
+interface ArticlePostModalProps extends ModalProps, PassedPostNavigationProps {
   id: string;
   isFetchingNextPage?: boolean;
 }
@@ -26,6 +24,7 @@ export default function ArticlePostModal({
   onPreviousPost,
   onNextPost,
   postPosition,
+  onRemovePost,
   ...props
 }: ArticlePostModalProps): ReactElement {
   const { showArticleOnboarding } = useContext(OnboardingContext);
@@ -57,6 +56,7 @@ export default function ArticlePostModal({
         onClose={onRequestClose}
         isLoading={isLoading}
         origin={Origin.ArticleModal}
+        onRemovePost={onRemovePost}
       />
     </BasePostModal>
   );

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useContext } from 'react';
 import { Modal, ModalProps } from './common/Modal';
-import { PostNavigationProps } from '../post/PostNavigation';
 import BasePostModal from './BasePostModal';
 import { Origin } from '../../lib/analytics';
 import usePostById from '../../hooks/usePostById';
@@ -8,13 +7,9 @@ import usePostNavigationPosition from '../../hooks/usePostNavigationPosition';
 import SquadPostContent from '../post/SquadPostContent';
 import OnboardingContext from '../../contexts/OnboardingContext';
 import { ONBOARDING_OFFSET } from '../post/BasePostContent';
+import { PassedPostNavigationProps } from '../post/PostContent';
 
-interface PostModalProps
-  extends ModalProps,
-    Pick<
-      PostNavigationProps,
-      'onPreviousPost' | 'onNextPost' | 'postPosition'
-    > {
+interface PostModalProps extends ModalProps, PassedPostNavigationProps {
   id: string;
   isFetchingNextPage?: boolean;
 }
@@ -27,6 +22,7 @@ export default function PostModal({
   onPreviousPost,
   onNextPost,
   postPosition,
+  onRemovePost,
   ...props
 }: PostModalProps): ReactElement {
   const { showArticleOnboarding } = useContext(OnboardingContext);
@@ -53,6 +49,7 @@ export default function PostModal({
         onClose={onRequestClose}
         isLoading={isLoading}
         origin={Origin.ArticleModal}
+        onRemovePost={onRemovePost}
         className={{
           container: 'post-content',
           fixedNavigation: { container: 'w-[inherit]', actions: 'ml-auto' },

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -24,9 +24,14 @@ import classed from '../../lib/classed';
 import { cloudinary } from '../../lib/image';
 import { combinedClicks } from '../../lib/click';
 
+export type PassedPostNavigationProps = Pick<
+  PostNavigationProps,
+  'onNextPost' | 'onPreviousPost' | 'postPosition' | 'onRemovePost'
+>;
+
 export interface PostContentProps
   extends Pick<PostModalActionsProps, 'onClose' | 'inlineActions'>,
-    Pick<PostNavigationProps, 'onNextPost' | 'onPreviousPost' | 'postPosition'>,
+    PassedPostNavigationProps,
     UsePostCommentOptionalProps {
   post?: Post;
   isFallback?: boolean;
@@ -61,6 +66,7 @@ export function PostContent({
   isLoading,
   isFallback,
   customNavigation,
+  onRemovePost,
 }: PostContentProps): ReactElement {
   const { subject } = useToastNotification();
   const engagementActions = usePostContent({
@@ -89,6 +95,7 @@ export function PostContent({
     onClose,
     onShare,
     inlineActions,
+    onRemovePost,
   };
 
   if (isLoading) {

--- a/packages/shared/src/components/post/PostModalActions.tsx
+++ b/packages/shared/src/components/post/PostModalActions.tsx
@@ -11,7 +11,7 @@ import CloseIcon from '../icons/MiniClose';
 import OpenLinkIcon from '../icons/OpenLink';
 import { Roles } from '../../lib/user';
 import AuthContext from '../../contexts/AuthContext';
-import { Post, banPost, deletePost } from '../../graphql/posts';
+import { banPost, deletePost, Post } from '../../graphql/posts';
 import useReportPostMenu from '../../hooks/useReportPostMenu';
 import classed from '../../lib/classed';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
@@ -20,6 +20,7 @@ import PostOptionsMenu from '../PostOptionsMenu';
 import { ShareBookmarkProps } from './PostActions';
 import { PromptOptions, usePrompt } from '../../hooks/usePrompt';
 import SettingsContext from '../../contexts/SettingsContext';
+import { SourcePermissions, SourceType } from '../../graphql/sources';
 
 export interface PostModalActionsProps extends ShareBookmarkProps {
   post: Post;
@@ -58,7 +59,15 @@ export function PostModalActions({
     });
   };
 
-  const isModerator = user?.roles?.indexOf(Roles.Moderator) > -1;
+  const isSharedPostAuthor =
+    post.source.type === SourceType.Squad && post.author?.id === user.id;
+  const isModerator = user?.roles?.includes(Roles.Moderator);
+  const canDelete =
+    isModerator ||
+    isSharedPostAuthor ||
+    post.source.currentMember?.permissions?.includes(
+      SourcePermissions.PostDelete,
+    );
 
   const banPostPrompt = async () => {
     const options: PromptOptions = {
@@ -130,7 +139,7 @@ export function PostModalActions({
         onShare={onShare}
         post={post}
         setShowBanPost={isModerator ? () => banPostPrompt() : null}
-        setShowDeletePost={isModerator ? () => deletePostPrompt() : null}
+        setShowDeletePost={canDelete ? () => deletePostPrompt() : null}
         contextId={contextMenuId}
       />
     </Container>

--- a/packages/shared/src/components/post/PostModalActions.tsx
+++ b/packages/shared/src/components/post/PostModalActions.tsx
@@ -11,12 +11,12 @@ import CloseIcon from '../icons/MiniClose';
 import OpenLinkIcon from '../icons/OpenLink';
 import { Roles } from '../../lib/user';
 import AuthContext from '../../contexts/AuthContext';
-import { banPost, deletePost, Post } from '../../graphql/posts';
+import { banPost, Post } from '../../graphql/posts';
 import useReportPostMenu from '../../hooks/useReportPostMenu';
 import classed from '../../lib/classed';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import { Button } from '../buttons/Button';
-import PostOptionsMenu from '../PostOptionsMenu';
+import PostOptionsMenu, { PostOptionsMenuProps } from '../PostOptionsMenu';
 import { ShareBookmarkProps } from './PostActions';
 import { PromptOptions, usePrompt } from '../../hooks/usePrompt';
 import SettingsContext from '../../contexts/SettingsContext';
@@ -31,6 +31,7 @@ export interface PostModalActionsProps extends ShareBookmarkProps {
   inlineActions?: boolean;
   notificactionClassName?: string;
   contextMenuId: string;
+  onRemovePost?: PostOptionsMenuProps['onRemovePost'];
 }
 
 const Container = classed('div', 'flex flex-row items-center');
@@ -45,6 +46,7 @@ export function PostModalActions({
   className,
   notificactionClassName,
   contextMenuId,
+  onRemovePost,
   ...props
 }: PostModalActionsProps): ReactElement {
   const { openNewTab } = useContext(SettingsContext);
@@ -80,21 +82,6 @@ export function PostModalActions({
     };
     if (await showPrompt(options)) {
       await banPost(post.id);
-    }
-  };
-
-  const deletePostPrompt = async () => {
-    const options: PromptOptions = {
-      title: 'Delete post 🚫',
-      description:
-        'Are you sure you want to delete this post? This action cannot be undone.',
-      okButton: {
-        title: 'Delete',
-        className: 'btn-primary-ketchup',
-      },
-    };
-    if (await showPrompt(options)) {
-      await deletePost(post.id);
     }
   };
 
@@ -138,8 +125,9 @@ export function PostModalActions({
         onBookmark={onBookmark}
         onShare={onShare}
         post={post}
+        onRemovePost={onRemovePost}
+        canDeletePost={canDelete}
         setShowBanPost={isModerator ? () => banPostPrompt() : null}
-        setShowDeletePost={canDelete ? () => deletePostPrompt() : null}
         contextId={contextMenuId}
       />
     </Container>

--- a/packages/shared/src/components/post/PostNavigation.tsx
+++ b/packages/shared/src/components/post/PostNavigation.tsx
@@ -14,6 +14,7 @@ type PostActions = Pick<
   | 'onBookmark'
   | 'onReadArticle'
   | 'inlineActions'
+  | 'onRemovePost'
 >;
 
 export interface PostNavigationClassName {

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -44,6 +44,7 @@ function SquadPostContent({
   onPreviousPost,
   onNextPost,
   onClose,
+  onRemovePost,
 }: PostContentProps): ReactElement {
   if (isLoading)
     return (
@@ -70,6 +71,7 @@ function SquadPostContent({
     postPosition,
     onClose,
     inlineActions,
+    onRemovePost,
   };
 
   const tldrHeight = useMemo(() => {

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -149,6 +149,10 @@ export const POST_BY_ID_QUERY = gql`
       }
       source {
         ...SourceShortInfo
+        currentMember {
+          permissions
+          role
+        }
       }
       scout {
         ...UserShortInfo

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -8,11 +8,26 @@ export enum SourceMemberRole {
   Owner = 'owner',
 }
 
+export enum SourcePermissions {
+  View = 'view',
+  Post = 'post',
+  PostLimit = 'post_limit',
+  PostDelete = 'post_delete',
+  MemberRemove = 'member_remove',
+  ModeratorAdd = 'moderator_add',
+  ModeratorRemove = 'moderator_remove',
+  InviteDisable = 'invite_disable',
+  Leave = 'leave',
+  Delete = 'delete',
+  Edit = 'edit',
+}
+
 export interface SourceMember {
   role: SourceMemberRole;
   user: UserShortProfile;
   source: Squad;
   referralToken: string;
+  permissions?: SourcePermissions[];
 }
 
 export enum SourceType {

--- a/packages/shared/src/hooks/usePostMenuActions.ts
+++ b/packages/shared/src/hooks/usePostMenuActions.ts
@@ -1,0 +1,40 @@
+import { useMutation } from 'react-query';
+import { useMemo } from 'react';
+import { PromptOptions, usePrompt } from './usePrompt';
+import { deletePost, Post } from '../graphql/posts';
+
+interface UsePostMenuActions {
+  onConfirmDeletePost: () => Promise<void>;
+}
+
+interface UsePostMenuActionsProps {
+  post: Post;
+  onPostDeleted?: () => void;
+}
+
+const deletePromptOptions: PromptOptions = {
+  title: 'Delete post 🚫',
+  description:
+    'Are you sure you want to delete this post? This action cannot be undone.',
+  okButton: {
+    title: 'Delete',
+    className: 'btn-primary-ketchup',
+  },
+};
+
+export const usePostMenuActions = ({
+  post,
+  onPostDeleted,
+}: UsePostMenuActionsProps): UsePostMenuActions => {
+  const { showPrompt } = usePrompt();
+  const { mutateAsync: onDeletePost } = useMutation(() => deletePost(post.id), {
+    onSuccess: onPostDeleted,
+  });
+  const deletePostPrompt = async () => {
+    if (await showPrompt(deletePromptOptions)) {
+      await onDeletePost();
+    }
+  };
+
+  return useMemo(() => ({ onConfirmDeletePost: deletePostPrompt }), [post]);
+};

--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -22,6 +22,7 @@ interface UsePostModalNavigation {
   onCloseModal: (fromPopState?: boolean) => void;
   isFetchingNextPage?: boolean;
   selectedPost: Post | null;
+  selectedPostIndex: number;
 }
 
 export const usePostModalNavigation = (
@@ -184,6 +185,7 @@ export const usePostModalNavigation = (
         onChangeSelected(index);
       },
       selectedPost: getPost(openedPostIndex),
+      selectedPostIndex: openedPostIndex,
     }),
     [items, openedPostIndex, isFetchingNextPage],
   );


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Return the current member and the permissions to check whether access is valid for deleting a post.
- Allow shared post author to delete their own posts.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1202 #done
