### PR TITLE
feat: send feed metadata with analytics events

### DIFF
--- a/packages/shared/src/graphql/feed.ts
+++ b/packages/shared/src/graphql/feed.ts
@@ -40,6 +40,7 @@ export const FEED_POST_FRAGMENT = gql`
     tags
     type
     private
+    feedMeta
   }
   ${SHARED_POST_INFO_FRAGMENT}
 `;

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -60,6 +60,7 @@ export interface Post {
   sharedPost?: SharedPost;
   type: PostType;
   private?: boolean;
+  feedMeta?: string;
 }
 
 export interface Ad {

--- a/packages/shared/src/lib/feed.ts
+++ b/packages/shared/src/lib/feed.ts
@@ -25,6 +25,7 @@ interface FeedItemAnalyticsEvent extends AnalyticsEvent {
   feed_grid_columns?: number;
   feed_item_grid_column?: number;
   feed_item_grid_row?: number;
+  feed_item_meta?: string;
   feed_item_image: string;
   feed_item_target_url: string;
   feed_item_title: string;
@@ -100,6 +101,7 @@ export function postAnalyticsEvent(
     feed_item_image: post.image,
     feed_item_target_url: post.permalink,
     feed_item_title: post.title,
+    feed_item_meta: (post as Post).feedMeta,
     post_author_id: post.author?.id,
     post_scout_id: post.scout?.id,
     post_created_at: post.createdAt,


### PR DESCRIPTION
## Changes

### Describe what this PR does

`feedMeta` is a new property provided by the feed service and used for analytics purposes.

## Events

Add a new property `feed_item_meta`

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
