### PR TITLE
fix: squad title and handle must be centered

### DIFF
--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -46,8 +46,10 @@ export function SquadPageHeader({
       <div className="flex flex-col laptop:flex-row items-center">
         <SquadImage className="w-16 tablet:w-24 h-16 tablet:h-24" {...squad} />
         <FlexCol className="mt-4 laptop:mt-0 ml-6">
-          <h3 className="font-bold typo-title2">{squad.name}</h3>
-          <h4 className="mt-1 tablet:mt-2 typo-body text-theme-label-tertiary">
+          <h3 className="font-bold text-center laptop:text-left typo-title2">
+            {squad.name}
+          </h3>
+          <h4 className="mt-1 tablet:mt-2 text-center laptop:text-left typo-body text-theme-label-tertiary">
             @{squad.handle}
           </h4>
         </FlexCol>


### PR DESCRIPTION
## Changes

Note: pointing to main as this is a small UI bug.

### Describe what this PR does
- Fix handle and name centered on mobile/tablet size.

Preview:

laptop:
![image](https://user-images.githubusercontent.com/13744167/229719835-acf034fd-7621-4ba1-a9d4-224079b98477.png)

tablet:
![image](https://user-images.githubusercontent.com/13744167/229719769-ea33d249-c2db-4983-9aad-df176c5a359a.png)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1205 #done
