### PR TITLE
fix: feedback url was missing user id

### DIFF
--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -1,5 +1,16 @@
 import { gql } from 'graphql-request';
 
+export const CURRENT_MEMBER_FRAGMENT = gql`
+  fragment CurrentMember on SourceMember {
+    user {
+      id
+    }
+    permissions
+    role
+    referralToken
+  }
+`;
+
 export const USER_SHORT_INFO_FRAGMENT = gql`
   fragment UserShortInfo on User {
     id
@@ -64,10 +75,10 @@ export const SOURCE_BASE_FRAGMENT = gql`
     image
     membersCount
     currentMember {
-      role
-      referralToken
+      ...CurrentMember
     }
   }
+  ${CURRENT_MEMBER_FRAGMENT}
 `;
 
 export const COMMENT_FRAGMENT = gql`

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -5,6 +5,7 @@ import { Source, Squad } from './sources';
 import { EmptyResponse } from './emptyResponse';
 import { graphqlUrl } from '../lib/config';
 import {
+  CURRENT_MEMBER_FRAGMENT,
   SHARED_POST_INFO_FRAGMENT,
   SOURCE_SHORT_INFO_FRAGMENT,
   USER_SHORT_INFO_FRAGMENT,
@@ -151,8 +152,7 @@ export const POST_BY_ID_QUERY = gql`
       source {
         ...SourceShortInfo
         currentMember {
-          permissions
-          role
+          ...CurrentMember
         }
       }
       scout {
@@ -171,6 +171,7 @@ export const POST_BY_ID_QUERY = gql`
     }
   }
   ${SHARED_POST_INFO_FRAGMENT}
+  ${CURRENT_MEMBER_FRAGMENT}
 `;
 
 export const POST_UPVOTES_BY_ID_QUERY = gql`


### PR DESCRIPTION
## Changes

### Describe what this PR does
- CurrentMember was evaluating user?.id and this was missing from the fragment.
- Can't seem to find when it went missing, but added a fragment to avoid it in future. (This also uniforms currentMember needs)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1222 #done
