### PR TITLE
fix: missing context menu items on feed cards

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -39,7 +39,6 @@ export interface PostOptionsMenuProps extends ShareBookmarkProps {
   feedName?: string;
   onHidden?: () => unknown;
   onRemovePost?: (postIndex: number) => Promise<unknown>;
-  canDeletePost?: boolean;
   setShowBanPost?: () => unknown;
   contextId?: string;
 }
@@ -60,7 +59,6 @@ export default function PostOptionsMenu({
   onHidden,
   onRemovePost,
   setShowBanPost,
-  canDeletePost,
   contextId = 'post-context',
 }: PostOptionsMenuProps): ReactElement {
   const client = useQueryClient();
@@ -101,8 +99,9 @@ export default function PostOptionsMenu({
   };
   const { onConfirmDeletePost } = usePostMenuActions({
     post,
-    onPostDeleted: () =>
-      showMessageAndRemovePost('The post has been deleted', postIndex, null),
+    postIndex,
+    onPostDeleted: ({ index }) =>
+      showMessageAndRemovePost('The post has been deleted', index, null),
   });
 
   const onReportPost: ReportPostAsync = async (
@@ -232,7 +231,7 @@ export default function PostOptionsMenu({
     text: 'Report',
     action: async () => setReportModal({ index: postIndex, post }),
   });
-  if (canDeletePost) {
+  if (onConfirmDeletePost) {
     postOptions.push({
       icon: <MenuIcon Icon={TrashIcon} />,
       text: 'Remove',

--- a/packages/shared/src/components/post/PostModalActions.tsx
+++ b/packages/shared/src/components/post/PostModalActions.tsx
@@ -20,7 +20,6 @@ import PostOptionsMenu, { PostOptionsMenuProps } from '../PostOptionsMenu';
 import { ShareBookmarkProps } from './PostActions';
 import { PromptOptions, usePrompt } from '../../hooks/usePrompt';
 import SettingsContext from '../../contexts/SettingsContext';
-import { SourcePermissions, SourceType } from '../../graphql/sources';
 
 export interface PostModalActionsProps extends ShareBookmarkProps {
   post: Post;

--- a/packages/shared/src/components/post/PostModalActions.tsx
+++ b/packages/shared/src/components/post/PostModalActions.tsx
@@ -61,15 +61,7 @@ export function PostModalActions({
     });
   };
 
-  const isSharedPostAuthor =
-    post.source.type === SourceType.Squad && post.author?.id === user.id;
   const isModerator = user?.roles?.includes(Roles.Moderator);
-  const canDelete =
-    isModerator ||
-    isSharedPostAuthor ||
-    post.source.currentMember?.permissions?.includes(
-      SourcePermissions.PostDelete,
-    );
 
   const banPostPrompt = async () => {
     const options: PromptOptions = {
@@ -126,7 +118,6 @@ export function PostModalActions({
         onShare={onShare}
         post={post}
         onRemovePost={onRemovePost}
-        canDeletePost={canDelete}
         setShowBanPost={isModerator ? () => banPostPrompt() : null}
         contextId={contextMenuId}
       />

--- a/packages/shared/src/graphql/feed.ts
+++ b/packages/shared/src/graphql/feed.ts
@@ -15,31 +15,11 @@ export const SUPPORTED_TYPES = `$supportedTypes: [String!] = ["article", "share"
 
 export const FEED_POST_FRAGMENT = gql`
   fragment FeedPost on Post {
-    id
-    title
-    createdAt
-    image
-    readTime
-    source {
-      ...SourceShortInfo
-    }
+    ...SharedPostInfo
     sharedPost {
       ...SharedPostInfo
     }
-    permalink
-    numComments
-    numUpvotes
-    commentsPermalink
-    scout {
-      ...UserShortInfo
-    }
-    author {
-      ...UserShortInfo
-    }
     trending
-    tags
-    type
-    private
     feedMeta
   }
   ${SHARED_POST_INFO_FRAGMENT}

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -24,33 +24,6 @@ export const SOURCE_SHORT_INFO_FRAGMENT = gql`
   }
 `;
 
-export const SHARED_POST_INFO_FRAGMENT = gql`
-  fragment SharedPostInfo on Post {
-    id
-    title
-    image
-    readTime
-    permalink
-    commentsPermalink
-    summary
-    createdAt
-    private
-    scout {
-      ...UserShortInfo
-    }
-    author {
-      ...UserShortInfo
-    }
-    type
-    tags
-    source {
-      ...SourceShortInfo
-    }
-  }
-  ${SOURCE_SHORT_INFO_FRAGMENT}
-  ${USER_SHORT_INFO_FRAGMENT}
-`;
-
 export const SOURCE_BASE_FRAGMENT = gql`
   fragment SourceBaseInfo on Source {
     id
@@ -66,8 +39,41 @@ export const SOURCE_BASE_FRAGMENT = gql`
     currentMember {
       role
       referralToken
+      permissions
     }
   }
+`;
+
+export const SHARED_POST_INFO_FRAGMENT = gql`
+  fragment SharedPostInfo on Post {
+    id
+    title
+    image
+    readTime
+    permalink
+    commentsPermalink
+    summary
+    createdAt
+    private
+    upvoted
+    commented
+    bookmarked
+    numUpvotes
+    numComments
+    scout {
+      ...UserShortInfo
+    }
+    author {
+      ...UserShortInfo
+    }
+    type
+    tags
+    source {
+      ...SourceBaseInfo
+    }
+  }
+  ${SOURCE_BASE_FRAGMENT}
+  ${USER_SHORT_INFO_FRAGMENT}
 `;
 
 export const COMMENT_FRAGMENT = gql`

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -48,9 +48,10 @@ export const SOURCE_BASE_FRAGMENT = gql`
     image
     membersCount
     currentMember {
-       ...CurrentMember
+      ...CurrentMember
     }
   }
+  ${CURRENT_MEMBER_FRAGMENT}
 `;
 
 export const SHARED_POST_INFO_FRAGMENT = gql`

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -128,38 +128,11 @@ export interface PostUpvote extends Upvote {
 export const POST_BY_ID_QUERY = gql`
   query Post($id: ID!) {
     post(id: $id) {
-      id
-      title
-      permalink
-      image
-      placeholder
-      createdAt
-      readTime
-      tags
-      bookmarked
+      ...SharedPostInfo
       trending
-      upvoted
-      commented
-      private
-      commentsPermalink
-      numUpvotes
-      numComments
       views
       sharedPost {
         ...SharedPostInfo
-      }
-      source {
-        ...SourceShortInfo
-        currentMember {
-          permissions
-          role
-        }
-      }
-      scout {
-        ...UserShortInfo
-      }
-      author {
-        ...UserShortInfo
       }
       description
       summary
@@ -167,7 +140,6 @@ export const POST_BY_ID_QUERY = gql`
         text
         id
       }
-      type
     }
   }
   ${SHARED_POST_INFO_FRAGMENT}

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -5,7 +5,6 @@ import { Source, Squad } from './sources';
 import { EmptyResponse } from './emptyResponse';
 import { graphqlUrl } from '../lib/config';
 import {
-  CURRENT_MEMBER_FRAGMENT,
   SHARED_POST_INFO_FRAGMENT,
   SOURCE_SHORT_INFO_FRAGMENT,
   USER_SHORT_INFO_FRAGMENT,
@@ -144,7 +143,6 @@ export const POST_BY_ID_QUERY = gql`
     }
   }
   ${SHARED_POST_INFO_FRAGMENT}
-  ${CURRENT_MEMBER_FRAGMENT}
 `;
 
 export const POST_UPVOTES_BY_ID_QUERY = gql`

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -166,35 +166,14 @@ export const USER_READING_HISTORY_QUERY = gql`
 `;
 
 const READING_HISTORY_FRAGMENT = gql`
-  fragment ReadingHistoryFrament on ReadingHistory {
+  fragment ReadingHistoryFragment on ReadingHistory {
     timestamp
     timestampDb
     post {
-      id
-      title
-      image
-      permalink
-      commentsPermalink
-      trending
-      tags
-      readTime
-      numUpvotes
-      bookmarked
-      numComments
-      private
+      ...SharedPostInfo
       sharedPost {
         ...SharedPostInfo
       }
-      source {
-        ...SourceShortInfo
-      }
-      scout {
-        ...UserShortInfo
-      }
-      author {
-        ...UserShortInfo
-      }
-      type
     }
   }
   ${SHARED_POST_INFO_FRAGMENT}
@@ -209,7 +188,7 @@ const READING_HISTORY_CONNECTION_FRAGMENT = gql`
     }
     edges {
       node {
-        ...ReadingHistoryFrament
+        ...ReadingHistoryFragment
       }
     }
   }

--- a/packages/shared/src/hooks/usePostMenuActions.ts
+++ b/packages/shared/src/hooks/usePostMenuActions.ts
@@ -22,12 +22,11 @@ interface UsePostMenuActionsProps {
 }
 
 const deletePromptOptions: PromptOptions = {
-  title: 'Delete post 🚫',
-  description:
-    'Are you sure you want to delete this post? This action cannot be undone.',
+  title: 'Delete post?',
+  description: 'Are you sure you want to delete this post?',
   okButton: {
     title: 'Delete',
-    className: 'btn-primary-ketchup',
+    className: 'btn-primary-cabbage',
   },
 };
 

--- a/packages/shared/src/hooks/usePostMenuActions.ts
+++ b/packages/shared/src/hooks/usePostMenuActions.ts
@@ -2,14 +2,23 @@ import { useMutation } from 'react-query';
 import { useMemo } from 'react';
 import { PromptOptions, usePrompt } from './usePrompt';
 import { deletePost, Post } from '../graphql/posts';
+import { SourcePermissions, SourceType } from '../graphql/sources';
+import { Roles } from '../lib/user';
+import { useAuthContext } from '../contexts/AuthContext';
 
 interface UsePostMenuActions {
   onConfirmDeletePost: () => Promise<void>;
 }
 
+interface DeletePostProps {
+  id: string;
+  index?: number;
+}
+
 interface UsePostMenuActionsProps {
   post: Post;
-  onPostDeleted?: () => void;
+  postIndex?: number;
+  onPostDeleted?: (args: DeletePostProps) => void;
 }
 
 const deletePromptOptions: PromptOptions = {
@@ -24,17 +33,35 @@ const deletePromptOptions: PromptOptions = {
 
 export const usePostMenuActions = ({
   post,
+  postIndex,
   onPostDeleted,
 }: UsePostMenuActionsProps): UsePostMenuActions => {
+  const { user } = useAuthContext();
   const { showPrompt } = usePrompt();
-  const { mutateAsync: onDeletePost } = useMutation(() => deletePost(post.id), {
-    onSuccess: onPostDeleted,
-  });
+  const { mutateAsync: onDeletePost } = useMutation(
+    ({ id }: DeletePostProps) => deletePost(id),
+    { onSuccess: (_, vars) => onPostDeleted(vars) },
+  );
   const deletePostPrompt = async () => {
+    const param = { id: post.id, index: postIndex };
+
     if (await showPrompt(deletePromptOptions)) {
-      await onDeletePost();
+      await onDeletePost(param);
     }
   };
 
-  return useMemo(() => ({ onConfirmDeletePost: deletePostPrompt }), [post]);
+  const isSharedPostAuthor =
+    post?.source.type === SourceType.Squad && post?.author?.id === user.id;
+  const isModerator = user?.roles?.includes(Roles.Moderator);
+  const canDelete =
+    isModerator ||
+    isSharedPostAuthor ||
+    post?.source.currentMember?.permissions?.includes(
+      SourcePermissions.PostDelete,
+    );
+
+  return useMemo(
+    () => ({ onConfirmDeletePost: canDelete ? deletePostPrompt : null }),
+    [onDeletePost, canDelete],
+  );
 };


### PR DESCRIPTION
## Changes

The context menu for post modal and the feed card was not unified in terms of behavior but using the same component.

Note: pointed to main as removing post is already available.

### Describe what this PR does
- Since both areas were using the same context menu component, we've updated how we identify allowing deletion of post.
- Also refactored the fragment to be unified so nothing will be missed out when looking for the information needed to identify whether the user can delete a post in the regular feed.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1218 #done
