### PR TITLE
fix: prompt styling

### DIFF
--- a/packages/shared/src/components/profile/UserShortInfo.tsx
+++ b/packages/shared/src/components/profile/UserShortInfo.tsx
@@ -20,7 +20,10 @@ type PropsOf<Tag> = Tag extends keyof JSX.IntrinsicElements
 interface UserShortInfoProps<Tag extends AnyTag> {
   user: Author;
   imageSize?: ProfileImageSize;
-  className?: string;
+  className?: {
+    container?: string;
+    textWrapper?: string;
+  };
   tag?: Tag;
   disableTooltip?: boolean;
   scrollingContainer?: HTMLElement;
@@ -34,7 +37,10 @@ export function UserShortInfo<Tag extends AnyTag>({
   imageSize = 'xlarge',
   tag,
   user,
-  className = 'py-3 px-6 hover:bg-theme-hover',
+  className = {
+    container: 'py-3 px-6 hover:bg-theme-hover',
+    textWrapper: 'flex-1',
+  },
   disableTooltip,
   scrollingContainer,
   appendTooltipTo,
@@ -49,7 +55,10 @@ export function UserShortInfo<Tag extends AnyTag>({
   };
 
   return (
-    <Element {...props} className={classNames('flex flex-row', className)}>
+    <Element
+      {...props}
+      className={classNames('flex flex-row', className.container)}
+    >
       <ProfileTooltip
         user={user}
         tooltip={tooltipProps}
@@ -62,7 +71,12 @@ export function UserShortInfo<Tag extends AnyTag>({
         tooltip={tooltipProps}
         scrollingContainer={scrollingContainer}
       >
-        <div className="flex overflow-hidden flex-col flex-1 ml-4 typo-callout">
+        <div
+          className={classNames(
+            'flex overflow-hidden flex-col ml-4 typo-callout',
+            className.textWrapper,
+          )}
+        >
           <TextEllipsis className="font-bold">{name}</TextEllipsis>
           <TextEllipsis className="text-theme-label-secondary">
             @{username}

--- a/packages/shared/src/components/squads/SquadMemberItemAdditionalContent.tsx
+++ b/packages/shared/src/components/squads/SquadMemberItemAdditionalContent.tsx
@@ -32,7 +32,13 @@ function SquadMemberItemAdditionalContent({
       title: 'Unblock member?',
       description: `${user.name} will now have access to join your Squad and can then post, upvote and comment`,
       okButton: { title: 'Unblock', className: 'btn-primary-cabbage' },
-      content: <UserShortInfo user={user} />,
+      content: (
+        <UserShortInfo
+          disableTooltip
+          user={user}
+          className={{ container: 'py-3 px-6 justify-center' }}
+        />
+      ),
       promptSize: ModalSize.Small,
       className: { buttons: 'mt-6' },
     };

--- a/packages/shared/src/components/squads/SquadMemberMenu.tsx
+++ b/packages/shared/src/components/squads/SquadMemberMenu.tsx
@@ -117,7 +117,13 @@ export default function SquadMemberMenu({
       title: `${title}?`,
       description: promptDescription[title](member.user.name, squad.name),
       okButton: { title, className: 'btn-primary-cabbage' },
-      content: <UserShortInfo user={member.user} />,
+      content: (
+        <UserShortInfo
+          user={member.user}
+          disableTooltip
+          className={{ container: 'py-3 px-6 justify-center' }}
+        />
+      ),
       promptSize: ModalSize.Small,
       className: { buttons: 'mt-6' },
     });


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Remove hover state on prompt styling
- Ensure it's centered in the block

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1228 #done
