### PR TITLE
feat(dev): alert clipboard content to avoid app crash

### DIFF
--- a/packages/shared/src/hooks/useCopyLink.ts
+++ b/packages/shared/src/hooks/useCopyLink.ts
@@ -3,6 +3,7 @@ import {
   NotifyOptionalProps,
   useToastNotification,
 } from './useToastNotification';
+import { isDevelopment } from '../lib/constants';
 
 type CopyNotifyFunctionProps = NotifyOptionalProps & {
   message?: string;
@@ -25,10 +26,7 @@ export function useCopyLink(
     const link = getLink();
 
     if (link) {
-      if (
-        process.env.NODE_ENV === 'development' &&
-        !window.location.origin.includes('localhost')
-      ) {
+      if (isDevelopment) {
         // since we are using custom domain in dev, we can't use the clipboard API
         // this is a workaround to not crash the app in development and still be able
         // to test other stuff while working with clipboard

--- a/packages/shared/src/hooks/useCopyLink.ts
+++ b/packages/shared/src/hooks/useCopyLink.ts
@@ -25,7 +25,20 @@ export function useCopyLink(
     const link = getLink();
 
     if (link) {
-      await navigator.clipboard.writeText(link);
+      if (
+        process.env.NODE_ENV === 'development' &&
+        !window.location.origin.includes('localhost')
+      ) {
+        // since we are using custom domain in dev, we can't use the clipboard API
+        // this is a workaround to not crash the app in development and still be able
+        // to test other stuff while working with clipboard
+        // more info here https://web.dev/async-clipboard
+        // eslint-disable-next-line no-alert
+        alert(`Dev copied: ${link}`);
+      } else {
+        await navigator.clipboard.writeText(link);
+      }
+
       displayToast(props.message || defaultMessage, props);
     } else {
       displayToast(noLinkErrorMessage, props);


### PR DESCRIPTION
## Changes

### Describe what this PR does
In `WT-792` I noticed that navigator.clipboard is also undefined in development since our custom domain `webapp.local.com` is not served over HTTPS

Info from here [Unblocking clipboard access](https://web.dev/async-clipboard) 
> As with many new APIs, the Clipboard API is only supported for pages served over HTTPS. To help prevent abuse, clipboard access is only allowed when a page is the active tab. Pages in active tabs can write to the clipboard without requesting permission, but reading from the clipboard always requires permission.

serving on localhost  is the only way to have `navigator.clipboard` available without https. Since we we need our custom domain for local authentication to work we need an alternative.

To not crash the app in development and allow us to test those features easily I added development only check to `alert` the clipboard contents instead. I think it is an ok alternative for local DX.
<img width="1231" alt="image" src="https://user-images.githubusercontent.com/9803078/230603665-e319dac7-8412-4e20-969d-1877fe171774.png">


Also, since it is wrapped in development check bundler will automatically remove it from production bundle so no overhead there.

Interested to see what you think or have other ideas.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
