### PR TITLE
fix: missing container class for squad post page

### DIFF
--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -46,13 +46,6 @@ function SquadPostContent({
   onClose,
   onRemovePost,
 }: PostContentProps): ReactElement {
-  if (isLoading)
-    return (
-      <PostContentContainer hasNavigation>
-        <PostLoadingPlaceholder shouldShowWidgets={false} />
-      </PostContentContainer>
-    );
-
   const { mutateAsync: onSendViewPost } = useMutation(sendViewPost);
   const { openNewTab } = useContext(SettingsContext);
   const hasNavigation = !!onPreviousPost || !!onNextPost;
@@ -86,6 +79,16 @@ function SquadPostContent({
 
   const containerClass =
     sidebarRendered && modalSizeToClassName[ModalSize.Large];
+
+  if (isLoading)
+    return (
+      <PostContentContainer
+        className={classNames(containerClass, 'm-auto')}
+        hasNavigation
+      >
+        <PostLoadingPlaceholder shouldShowWidgets={false} />
+      </PostContentContainer>
+    );
 
   return (
     <>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We set the with to occupy all space but only works on modal as we set its max width.
- To fix the issue above, we should also apply the max width we have for the modal, which was missing in the first place.

Preview:

![image](https://user-images.githubusercontent.com/13744167/231108883-990f35e4-82b0-45ed-8fa7-f0df4ce119d4.png)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1230 #done
