### PR TITLE
fix: squad post content no longer breaks while loading post

### DIFF
--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -74,8 +74,12 @@ function SquadPostContent({
   }, [shoudShowSummary, height]);
 
   useEffect(() => {
+    if (!post?.id) {
+      return;
+    }
+
     onSendViewPost(post.id);
-  }, [post.id]);
+  }, [post?.id]);
 
   const containerClass =
     sidebarRendered && modalSizeToClassName[ModalSize.Large];


### PR DESCRIPTION
## Changes

### Describe what this PR does
- squad post content no longer breaks while loading post

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
