### PR TITLE
fix: optional data for when modal loading

### DIFF
--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -57,8 +57,8 @@ function SquadPostContent({
   const engagementActions = usePostContent({ origin, post });
   const { onReadArticle, onSharePost, onToggleBookmark } = engagementActions;
   const { role } = useMemberRoleForSource({
-    source: post.source,
-    user: post.author,
+    source: post?.source,
+    user: post?.author,
   });
 
   const navigationProps: PostNavigationProps = {

--- a/packages/shared/src/hooks/useMemberRoleForSource.ts
+++ b/packages/shared/src/hooks/useMemberRoleForSource.ts
@@ -16,7 +16,7 @@ export const useMemberRoleForSource = ({
   user,
 }: UseMemberRoleForSourceProps): UseMemberRoleForSourceResult => {
   return useMemo(() => {
-    const role = source.privilegedMembers?.find(
+    const role = source?.privilegedMembers?.find(
       (member) => member.user.id === user?.id,
     )?.role;
 

--- a/packages/shared/src/hooks/useMemberRoleForSource.ts
+++ b/packages/shared/src/hooks/useMemberRoleForSource.ts
@@ -3,7 +3,7 @@ import { Source, SourceMemberRole } from '../graphql/sources';
 import { PublicProfile } from '../lib/user';
 
 export type UseMemberRoleForSourceProps = {
-  source: Source;
+  source?: Source;
   user?: Pick<PublicProfile, 'id'>;
 };
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- With new later return we need to make props optional to not-break rendering.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1250 #done
