### PR TITLE
fix: forbidden page throwing error

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -191,7 +191,6 @@ export default function Feed<T>({
     onNext,
     postPosition,
     selectedPost,
-    isFetchingNextPage,
     selectedPostIndex,
   } = usePostModalNavigation(items, fetchPage, updatePost, canFetchMore);
 

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -491,7 +491,6 @@ export default function Feed<T>({
             onRequestClose={() => onCloseModal(false)}
             onPreviousPost={onPrevious}
             onNextPost={onNext}
-            isFetchingNextPage={isFetchingNextPage}
             postPosition={postPosition}
             onRemovePost={() => onRemovePost(selectedPostIndex)}
           />

--- a/packages/shared/src/components/modals/ArticlePostModal.tsx
+++ b/packages/shared/src/components/modals/ArticlePostModal.tsx
@@ -14,7 +14,6 @@ import { PostType } from '../../graphql/posts';
 
 interface ArticlePostModalProps extends ModalProps, PassedPostNavigationProps {
   id: string;
-  isFetchingNextPage?: boolean;
 }
 
 const containerClass = 'border border-theme-divider-tertiary rounded-16';
@@ -22,7 +21,6 @@ const containerClass = 'border border-theme-divider-tertiary rounded-16';
 export default function ArticlePostModal({
   id,
   className,
-  isFetchingNextPage,
   onRequestClose,
   onPreviousPost,
   onNextPost,

--- a/packages/shared/src/components/modals/ArticlePostModal.tsx
+++ b/packages/shared/src/components/modals/ArticlePostModal.tsx
@@ -10,6 +10,7 @@ import usePostNavigationPosition from '../../hooks/usePostNavigationPosition';
 import usePostById from '../../hooks/usePostById';
 import BasePostModal from './BasePostModal';
 import OnboardingContext from '../../contexts/OnboardingContext';
+import { PostType } from '../../graphql/posts';
 
 interface ArticlePostModalProps extends ModalProps, PassedPostNavigationProps {
   id: string;
@@ -28,15 +29,26 @@ export default function ArticlePostModal({
   ...props
 }: ArticlePostModalProps): ReactElement {
   const { showArticleOnboarding } = useContext(OnboardingContext);
-  const { post, isLoading } = usePostById({ id, isFetchingNextPage });
+  const {
+    post,
+    query: { isLoading, isFetching },
+  } = usePostById({ id });
+  const isPostLoading = isLoading || isFetchingNextPage || isFetching;
   const position = usePostNavigationPosition({
-    isLoading,
+    isLoading: isPostLoading,
     isDisplayed: props.isOpen,
     offset: showArticleOnboarding ? ONBOARDING_OFFSET : 0,
   });
+  const containerClass = 'border border-theme-divider-tertiary rounded-16';
 
   return (
-    <BasePostModal {...props} onRequestClose={onRequestClose}>
+    <BasePostModal
+      {...props}
+      onRequestClose={onRequestClose}
+      loadingClassName={containerClass}
+      postType={PostType.Article}
+      isLoading={isPostLoading}
+    >
       <PostContent
         position={position}
         post={post}
@@ -46,7 +58,7 @@ export default function ArticlePostModal({
         inlineActions
         className={{
           onboarding: 'mt-8',
-          container: 'border border-theme-divider-tertiary rounded-16',
+          container: containerClass,
           navigation: { actions: 'tablet:hidden ml-auto' },
           fixedNavigation: {
             container: modalSizeToClassName[Modal.Size.XLarge],
@@ -54,7 +66,6 @@ export default function ArticlePostModal({
           },
         }}
         onClose={onRequestClose}
-        isLoading={isLoading}
         origin={Origin.ArticleModal}
         onRemovePost={onRemovePost}
       />

--- a/packages/shared/src/components/modals/ArticlePostModal.tsx
+++ b/packages/shared/src/components/modals/ArticlePostModal.tsx
@@ -31,13 +31,9 @@ export default function ArticlePostModal({
   ...props
 }: ArticlePostModalProps): ReactElement {
   const { showArticleOnboarding } = useContext(OnboardingContext);
-  const {
-    post,
-    query: { isLoading, isFetching },
-  } = usePostById({ id });
-  const isPostLoading = isLoading || isFetchingNextPage || isFetching;
+  const { post, isPostLoadingOrFetching } = usePostById({ id });
   const position = usePostNavigationPosition({
-    isLoading: isPostLoading,
+    isLoading: isPostLoadingOrFetching,
     isDisplayed: props.isOpen,
     offset: showArticleOnboarding ? ONBOARDING_OFFSET : 0,
   });
@@ -48,7 +44,7 @@ export default function ArticlePostModal({
       onRequestClose={onRequestClose}
       loadingClassName={containerClass}
       postType={PostType.Article}
-      isLoading={isPostLoading}
+      isLoading={isPostLoadingOrFetching}
     >
       <PostContent
         position={position}

--- a/packages/shared/src/components/modals/ArticlePostModal.tsx
+++ b/packages/shared/src/components/modals/ArticlePostModal.tsx
@@ -17,6 +17,8 @@ interface ArticlePostModalProps extends ModalProps, PassedPostNavigationProps {
   isFetchingNextPage?: boolean;
 }
 
+const containerClass = 'border border-theme-divider-tertiary rounded-16';
+
 export default function ArticlePostModal({
   id,
   className,
@@ -39,7 +41,6 @@ export default function ArticlePostModal({
     isDisplayed: props.isOpen,
     offset: showArticleOnboarding ? ONBOARDING_OFFSET : 0,
   });
-  const containerClass = 'border border-theme-divider-tertiary rounded-16';
 
   return (
     <BasePostModal

--- a/packages/shared/src/components/modals/BasePostModal.tsx
+++ b/packages/shared/src/components/modals/BasePostModal.tsx
@@ -2,12 +2,23 @@ import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import { Modal, ModalProps } from './common/Modal';
 import styles from './BasePostModal.module.css';
+import PostLoadingSkeleton from '../post/PostLoadingSkeleton';
+import { PostType } from '../../graphql/posts';
+
+interface BasePostModalProps extends ModalProps {
+  postType: PostType;
+  isLoading?: boolean;
+  loadingClassName?: string;
+}
 
 function BasePostModal({
   className,
   children,
+  isLoading,
+  postType,
+  loadingClassName,
   ...props
-}: ModalProps): ReactElement {
+}: BasePostModalProps): ReactElement {
   return (
     <Modal
       size={Modal.Size.XLarge}
@@ -18,7 +29,15 @@ function BasePostModal({
       className={classNames(className, 'post-modal focus:outline-none')}
       overlayClassName="post-modal-overlay bg-overlay-quaternary-onion"
     >
-      {children}
+      {isLoading ? (
+        <PostLoadingSkeleton
+          hasNavigation
+          type={postType}
+          className={loadingClassName}
+        />
+      ) : (
+        children
+      )}
     </Modal>
   );
 }

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -27,13 +27,9 @@ export default function PostModal({
   ...props
 }: PostModalProps): ReactElement {
   const { showArticleOnboarding } = useContext(OnboardingContext);
-  const {
-    post,
-    query: { isLoading, isFetching },
-  } = usePostById({ id });
-  const isPostLoading = isLoading || isFetchingNextPage || isFetching;
+  const { post, isPostLoadingOrFetching } = usePostById({ id });
   const position = usePostNavigationPosition({
-    isLoading: isPostLoading,
+    isLoading: isPostLoadingOrFetching,
     isDisplayed: props.isOpen,
     offset: showArticleOnboarding ? ONBOARDING_OFFSET : 0,
   });
@@ -45,7 +41,7 @@ export default function PostModal({
       size={Modal.Size.Large}
       onRequestClose={onRequestClose}
       postType={PostType.Share}
-      isLoading={isPostLoading}
+      isLoading={isPostLoadingOrFetching}
       loadingClassName={containerClass}
     >
       <SquadPostContent

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -8,6 +8,8 @@ import SquadPostContent from '../post/SquadPostContent';
 import OnboardingContext from '../../contexts/OnboardingContext';
 import { ONBOARDING_OFFSET } from '../post/BasePostContent';
 import { PassedPostNavigationProps } from '../post/PostContent';
+import PostLoadingSkeleton from '../post/PostLoadingSkeleton';
+import { PostType } from '../../graphql/posts';
 
 interface PostModalProps extends ModalProps, PassedPostNavigationProps {
   id: string;
@@ -26,18 +28,26 @@ export default function PostModal({
   ...props
 }: PostModalProps): ReactElement {
   const { showArticleOnboarding } = useContext(OnboardingContext);
-  const { post, isLoading } = usePostById({ id, isFetchingNextPage });
+  const {
+    post,
+    query: { isLoading, isFetching },
+  } = usePostById({ id });
+  const isPostLoading = isLoading || isFetchingNextPage || isFetching;
   const position = usePostNavigationPosition({
-    isLoading,
+    isLoading: isPostLoading,
     isDisplayed: props.isOpen,
     offset: showArticleOnboarding ? ONBOARDING_OFFSET : 0,
   });
+  const containerClass = 'post-content';
 
   return (
     <BasePostModal
       {...props}
       size={Modal.Size.Large}
       onRequestClose={onRequestClose}
+      postType={PostType.Share}
+      isLoading={isPostLoading}
+      loadingClassName={containerClass}
     >
       <SquadPostContent
         position={position}
@@ -47,11 +57,10 @@ export default function PostModal({
         postPosition={postPosition}
         inlineActions
         onClose={onRequestClose}
-        isLoading={isLoading}
         origin={Origin.ArticleModal}
         onRemovePost={onRemovePost}
         className={{
-          container: 'post-content',
+          container: containerClass,
           fixedNavigation: { container: 'w-[inherit]', actions: 'ml-auto' },
           navigation: { actions: 'tablet:hidden ml-auto' },
         }}

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -8,7 +8,6 @@ import SquadPostContent from '../post/SquadPostContent';
 import OnboardingContext from '../../contexts/OnboardingContext';
 import { ONBOARDING_OFFSET } from '../post/BasePostContent';
 import { PassedPostNavigationProps } from '../post/PostContent';
-import PostLoadingSkeleton from '../post/PostLoadingSkeleton';
 import { PostType } from '../../graphql/posts';
 
 interface PostModalProps extends ModalProps, PassedPostNavigationProps {

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -12,13 +12,11 @@ import { PostType } from '../../graphql/posts';
 
 interface PostModalProps extends ModalProps, PassedPostNavigationProps {
   id: string;
-  isFetchingNextPage?: boolean;
 }
 
 export default function PostModal({
   id,
   className,
-  isFetchingNextPage,
   onRequestClose,
   onPreviousPost,
   onNextPost,

--- a/packages/shared/src/components/post/BasePostContent.tsx
+++ b/packages/shared/src/components/post/BasePostContent.tsx
@@ -35,7 +35,6 @@ export interface PostContentClassName {
 export interface BasePostContentProps extends UsePostContentProps {
   post: Post;
   children: ReactNode;
-  isLoading?: boolean;
   isFallback?: boolean;
   className?: PostContentClassName;
   navigationProps?: PostNavigationProps;
@@ -51,7 +50,6 @@ export const ONBOARDING_OFFSET = 120;
 export function BasePostContent({
   post,
   isFallback,
-  isLoading,
   origin,
   children,
   className = {},
@@ -63,29 +61,12 @@ export function BasePostContent({
 }: BasePostContentProps): ReactElement {
   const { id } = post ?? {};
 
-  if (!id && !isFallback && !isLoading) return <Custom404 />;
+  if (!id && !isFallback) return <Custom404 />;
 
   const { onCloseShare, sharePost, onSharePost, onToggleBookmark } =
     engagementProps;
-  const { onPreviousPost, onNextPost } = navigationProps ?? {};
   const { onStartArticleOnboarding, showArticleOnboarding } =
     useContext(OnboardingContext);
-  const hasNavigation = !!onPreviousPost || !!onNextPost;
-  const containerClass = classNames(
-    'tablet:pb-0 tablet:flex-row',
-    className?.container,
-  );
-
-  if (isLoading) {
-    return (
-      <PostContentContainer
-        hasNavigation={hasNavigation}
-        className={containerClass}
-      >
-        <PostLoadingPlaceholder />
-      </PostContentContainer>
-    );
-  }
 
   return (
     <>

--- a/packages/shared/src/components/post/BasePostContent.tsx
+++ b/packages/shared/src/components/post/BasePostContent.tsx
@@ -1,4 +1,3 @@
-import classNames from 'classnames';
 import dynamic from 'next/dynamic';
 import React, { ReactElement, ReactNode, useContext } from 'react';
 import { Post } from '../../graphql/posts';
@@ -6,10 +5,8 @@ import PostNavigation, {
   PostNavigationClassName,
   PostNavigationProps,
 } from './PostNavigation';
-import { PostLoadingPlaceholder } from './PostLoadingPlaceholder';
 import { PostFeedFiltersOnboarding } from './PostFeedFiltersOnboarding';
 import PostEngagements from './PostEngagements';
-import PostContentContainer from './PostContentContainer';
 import {
   UsePostContent,
   UsePostContentProps,

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -19,7 +19,6 @@ import { PostOrigin } from '../../hooks/analytics/useAnalyticsContextData';
 import usePostContent from '../../hooks/usePostContent';
 import FixedPostNavigation from './FixedPostNavigation';
 import { BasePostContent, PostContentClassName } from './BasePostContent';
-import { PostLoadingPlaceholder } from './PostLoadingPlaceholder';
 import classed from '../../lib/classed';
 import { cloudinary } from '../../lib/image';
 import { combinedClicks } from '../../lib/click';
@@ -38,7 +37,6 @@ export interface PostContentProps
   className?: PostContentClassName;
   origin: PostOrigin;
   shouldOnboardAuthor?: boolean;
-  isLoading?: boolean;
   customNavigation?: ReactNode;
   position?: CSSProperties['position'];
 }
@@ -63,7 +61,6 @@ export function PostContent({
   onNextPost,
   onClose,
   postPosition,
-  isLoading,
   isFallback,
   customNavigation,
   onRemovePost,
@@ -98,17 +95,6 @@ export function PostContent({
     onRemovePost,
   };
 
-  if (isLoading) {
-    return (
-      <PostContentContainer
-        hasNavigation={hasNavigation}
-        className={containerClass}
-      >
-        <PostLoadingPlaceholder className="tablet:border-r tablet:border-theme-divider-tertiary" />
-      </PostContentContainer>
-    );
-  }
-
   return (
     <PostContentContainer
       hasNavigation={hasNavigation}
@@ -130,7 +116,6 @@ export function PostContent({
               container: classNames('pt-6', className?.navigation?.container),
             },
           }}
-          isLoading={isLoading}
           isFallback={isFallback}
           customNavigation={customNavigation}
           enableShowShareNewComment={enableShowShareNewComment}

--- a/packages/shared/src/components/post/PostContentContainer.tsx
+++ b/packages/shared/src/components/post/PostContentContainer.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, ReactNode } from 'react';
 import classed from '../../lib/classed';
 
 interface PostContentContainerProps {
-  hasNavigation: boolean;
+  hasNavigation?: boolean;
   className?: string;
   children: ReactNode;
 }

--- a/packages/shared/src/components/post/PostLoadingSkeleton.tsx
+++ b/packages/shared/src/components/post/PostLoadingSkeleton.tsx
@@ -1,0 +1,44 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import { PostType } from '../../graphql/posts';
+import { PostLoadingPlaceholder } from './PostLoadingPlaceholder';
+import PostContentContainer from './PostContentContainer';
+
+interface PostLoadingSkeletonProps {
+  type: PostType;
+  className?: string;
+  hasNavigation?: boolean;
+}
+
+function PostLoadingSkeleton({
+  type,
+  className,
+  hasNavigation,
+}: PostLoadingSkeletonProps): ReactElement {
+  if (!type) return null;
+
+  if (type === PostType.Share) {
+    return (
+      <PostContentContainer
+        className={classNames(className, 'm-auto')}
+        hasNavigation={hasNavigation}
+      >
+        <PostLoadingPlaceholder shouldShowWidgets={false} />
+      </PostContentContainer>
+    );
+  }
+
+  return (
+    <PostContentContainer
+      hasNavigation={hasNavigation}
+      className={classNames(
+        className,
+        'tablet:pb-0 tablet:flex-row bg-theme-bg-primary',
+      )}
+    >
+      <PostLoadingPlaceholder className="tablet:border-r tablet:border-theme-divider-tertiary" />
+    </PostContentContainer>
+  );
+}
+
+export default PostLoadingSkeleton;

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -7,12 +7,10 @@ import React, {
 } from 'react';
 import { useMutation } from 'react-query';
 import classNames from 'classnames';
-import { modalSizeToClassName } from '../modals/common/Modal';
 import { PostNavigationProps } from './PostNavigation';
 import { postDateFormat } from '../../lib/dateFormat';
 import PostContentContainer from './PostContentContainer';
 import usePostContent from '../../hooks/usePostContent';
-import { ModalSize } from '../modals/common/types';
 import FixedPostNavigation from './FixedPostNavigation';
 import PostSummary from '../cards/PostSummary';
 import { LazyImage } from '../LazyImage';
@@ -21,12 +19,10 @@ import ArrowIcon from '../icons/Arrow';
 import PostSourceInfo from './PostSourceInfo';
 import { PostContentProps } from './PostContent';
 import { BasePostContent } from './BasePostContent';
-import useSidebarRendered from '../../hooks/useSidebarRendered';
 import { cloudinary } from '../../lib/image';
 import SettingsContext from '../../contexts/SettingsContext';
 import { ProfilePicture } from '../ProfilePicture';
 import { ProfileTooltip } from '../profile/ProfileTooltip';
-import { PostLoadingPlaceholder } from './PostLoadingPlaceholder';
 import { sendViewPost } from '../../graphql/posts';
 
 function SquadPostContent({
@@ -34,7 +30,6 @@ function SquadPostContent({
   isFallback,
   shouldOnboardAuthor,
   enableShowShareNewComment,
-  isLoading,
   origin,
   position,
   postPosition,
@@ -50,8 +45,7 @@ function SquadPostContent({
   const { openNewTab } = useContext(SettingsContext);
   const hasNavigation = !!onPreviousPost || !!onNextPost;
   const [height, setHeight] = useState<number>(null);
-  const { sidebarRendered } = useSidebarRendered();
-  const [shoudShowSummary, setShouldShowSummary] = useState(true);
+  const [shouldShowSummary, setShouldShowSummary] = useState(true);
   const engagementActions = usePostContent({ origin, post });
   const { onReadArticle, onSharePost, onToggleBookmark } = engagementActions;
 
@@ -70,8 +64,8 @@ function SquadPostContent({
   const tldrHeight = useMemo(() => {
     if (height === null) return 'auto';
 
-    return shoudShowSummary ? height : 0;
-  }, [shoudShowSummary, height]);
+    return shouldShowSummary ? height : 0;
+  }, [shouldShowSummary, height]);
 
   useEffect(() => {
     if (!post?.id) {
@@ -80,19 +74,6 @@ function SquadPostContent({
 
     onSendViewPost(post.id);
   }, [post?.id]);
-
-  const containerClass =
-    sidebarRendered && modalSizeToClassName[ModalSize.Large];
-
-  if (isLoading)
-    return (
-      <PostContentContainer
-        className={classNames(containerClass, 'm-auto')}
-        hasNavigation
-      >
-        <PostLoadingPlaceholder shouldShowWidgets={false} />
-      </PostContentContainer>
-    );
 
   return (
     <>
@@ -106,7 +87,6 @@ function SquadPostContent({
       <PostContentContainer
         className={classNames(
           'relative py-8 px-6 post-content',
-          containerClass,
           className?.container,
         )}
         hasNavigation={hasNavigation}
@@ -117,7 +97,6 @@ function SquadPostContent({
             onboarding: 'mb-6',
             navigation: { actions: 'ml-auto', container: 'mb-6' },
           }}
-          isLoading={isLoading}
           isFallback={isFallback}
           customNavigation={customNavigation}
           enableShowShareNewComment={enableShowShareNewComment}
@@ -207,20 +186,20 @@ function SquadPostContent({
                   style={{ height: tldrHeight }}
                   className={classNames(
                     'mx-4 transition-all duration-300 ease-in-out',
-                    shoudShowSummary && 'mb-4',
+                    shouldShowSummary && 'mb-4',
                   )}
                   summary={post.sharedPost.summary}
                 />
                 <button
                   type="button"
                   className="flex flex-row justify-center py-2 w-full font-bold hover:underline border-t border-theme-divider-tertiary typo-callout"
-                  onClick={() => setShouldShowSummary(!shoudShowSummary)}
+                  onClick={() => setShouldShowSummary(!shouldShowSummary)}
                 >
-                  {shoudShowSummary ? 'Hide' : 'Show'} TLDR{' '}
+                  {shouldShowSummary ? 'Hide' : 'Show'} TLDR{' '}
                   <ArrowIcon
                     className={classNames(
                       'ml-2 transition-transform ease-in-out duration-300',
-                      !shoudShowSummary && 'rotate-180',
+                      !shouldShowSummary && 'rotate-180',
                     )}
                   />
                 </button>

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -16,9 +16,9 @@ import {
 import { ParsedUrlQuery } from 'querystring';
 import { NextSeo } from 'next-seo';
 import {
+  Post,
   POST_BY_ID_STATIC_FIELDS_QUERY,
   PostData,
-  Post,
   PostType,
 } from '@dailydotdev/shared/src/graphql/posts';
 import { NextSeoProps } from 'next-seo/lib/types';
@@ -38,8 +38,13 @@ import useWindowEvents from '@dailydotdev/shared/src/hooks/useWindowEvents';
 import usePostById from '@dailydotdev/shared/src/hooks/usePostById';
 import { ApiError } from '@dailydotdev/shared/src/graphql/common';
 import { ONBOARDING_OFFSET } from '@dailydotdev/shared/src/components/post/BasePostContent';
-import { getLayout as getMainLayout } from '../../components/layouts/MainLayout';
+import { modalSizeToClassName } from '@dailydotdev/shared/src/components/modals/common/Modal';
+import { ModalSize } from '@dailydotdev/shared/src/components/modals/common/types';
+import useSidebarRendered from '@dailydotdev/shared/src/hooks/useSidebarRendered';
+import PostLoadingSkeleton from '@dailydotdev/shared/src/components/post/PostLoadingSkeleton';
+import classNames from 'classnames';
 import { getTemplatedTitle } from '../../components/layouts/utils';
+import { getLayout as getMainLayout } from '../../components/layouts/MainLayout';
 
 const Custom404 = dynamic(() => import(/* webpackChunkName: "404" */ '../404'));
 
@@ -73,6 +78,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
   const [position, setPosition] =
     useState<CSSProperties['position']>('relative');
   const router = useRouter();
+  const { sidebarRendered } = useSidebarRendered();
   const { isFallback } = router;
   useWindowEvents(
     'popstate',
@@ -81,11 +87,18 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     false,
   );
 
-  const { post, isFetched } = usePostById({
+  const { post, query } = usePostById({
     id,
     options: { initialData, retry: false },
   });
-
+  const containerClass = classNames(
+    'pb-20 laptop:pb-6 laptopL:pb-0 max-w-screen-laptop border-r laptop:min-h-page',
+    post?.type === PostType.Share &&
+      sidebarRendered &&
+      modalSizeToClassName[ModalSize.Large],
+  );
+  const { isLoading, isFetching, isFetched, isError } = query;
+  const isPostLoading = isFetching || isLoading;
   const seo: NextSeoProps = {
     title: getTemplatedTitle(post?.title),
     description: getSeoDescription(post),
@@ -104,7 +117,11 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     scrollProperty: 'scrollY',
   });
 
-  if (!initialData && (isFallback || !isFetched)) {
+  if (isPostLoading) {
+    return <PostLoadingSkeleton className={containerClass} type={post?.type} />;
+  }
+
+  if (isFallback || !isFetched) {
     return <></>;
   }
 
@@ -119,7 +136,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
   };
   const customNavigation = navigation[post?.type] ?? navigation.article;
 
-  if (!Content && (!isFallback || isFetched)) return <Custom404 />;
+  if (!Content || isError) return <Custom404 />;
 
   return (
     <>
@@ -131,14 +148,12 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
         position={position}
         post={post}
         isFallback={isFallback}
-        isLoading={!isFetched}
         customNavigation={customNavigation}
         shouldOnboardAuthor={!!router.query?.author}
         enableShowShareNewComment={!!router?.query.new}
         origin={Origin.ArticlePage}
         className={{
-          container:
-            'pb-20 laptop:pb-6 laptopL:pb-0 max-w-screen-laptop border-r laptop:min-h-page',
+          container: containerClass,
           fixedNavigation: { container: 'flex laptop:hidden' },
           navigation: {
             container: 'flex tablet:hidden',

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -87,7 +87,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     false,
   );
 
-  const { post, query } = usePostById({
+  const { post, isError, isFetched, isPostLoadingOrFetching } = usePostById({
     id,
     options: { initialData, retry: false },
   });
@@ -97,8 +97,6 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
       sidebarRendered &&
       modalSizeToClassName[ModalSize.Large],
   );
-  const { isLoading, isFetching, isFetched, isError } = query;
-  const isPostLoading = isFetching || isLoading;
   const seo: NextSeoProps = {
     title: getTemplatedTitle(post?.title),
     description: getSeoDescription(post),
@@ -117,7 +115,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     scrollProperty: 'scrollY',
   });
 
-  if (isPostLoading) {
+  if (isPostLoadingOrFetching) {
     return <PostLoadingSkeleton className={containerClass} type={post?.type} />;
   }
 


### PR DESCRIPTION
## Changes
- Fixes the issue where forbidden throws an error instead of showing the 404 page. Since we now support requesting the static information to fill the page, our previous condition doesn't work anymore.
- Also saw some discrepancies on the loading page when the error happens. Since there are two kinds (page and modal) of when to display it, I have refactored it to render from where it needs to happen (page and modal) than fitting to all 4 cases (all combinations).
- Fixed some typos.
- Have tested all four cases thoroughly. Will test it in preview once a deployment gets free tomorrow.
- Code-wise though this should be reviewable. Feedback would be highly appreciated, had to test all 4 cases every change, so I might have missed something.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1238 #done
