### PR TITLE
refactor: post context menu removing post label

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -234,7 +234,7 @@ export default function PostOptionsMenu({
   if (onConfirmDeletePost) {
     postOptions.push({
       icon: <MenuIcon Icon={TrashIcon} />,
-      text: 'Remove',
+      text: 'Delete post',
       action: onConfirmDeletePost,
     });
   }

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -122,12 +122,12 @@ export function PostComments({
     parentId: string | null,
   ) => {
     const options: PromptOptions = {
-      title: 'Delete comment',
+      title: 'Delete comment?',
       description:
         'Are you sure you want to delete your comment? This action cannot be undone.',
       okButton: {
         title: 'Delete',
-        className: 'btn-primary-ketchup',
+        className: 'btn-primary-cabbage',
       },
     };
     if (await showPrompt(options)) {

--- a/packages/shared/src/hooks/usePostMenuActions.ts
+++ b/packages/shared/src/hooks/usePostMenuActions.ts
@@ -23,7 +23,8 @@ interface UsePostMenuActionsProps {
 
 const deletePromptOptions: PromptOptions = {
   title: 'Delete post?',
-  description: 'Are you sure you want to delete this post?',
+  description:
+    'Are you sure you want to delete this post? This action cannot be undone.',
   okButton: {
     title: 'Delete',
     className: 'btn-primary-cabbage',


### PR DESCRIPTION
## Changes

- Updated the post context menu label for deleting a post and prompt description.
- Updated the delete comment prompt's title and confirm color.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1239 #done
WT-1240 #done