### PR TITLE
fix: refactor owner to admin

### DIFF
--- a/packages/shared/__tests__/fixture/squads.ts
+++ b/packages/shared/__tests__/fixture/squads.ts
@@ -1,15 +1,15 @@
 import { GraphQLResult } from '../helpers/graphql';
 import { Edge } from '../../src/graphql/common';
 import {
-  SourceType,
   SourceMember,
   SourceMemberRole,
+  SourceType,
 } from '../../src/graphql/sources';
 import { Squad, SquadData, SquadEdgesData } from '../../src/graphql/squads';
 
 export const defaultSquadToken = 'ki3YLcxvSZ2Q6KgMBZvMbly1gnrZ6JnIrhTpUML-Hua';
 
-export const generateTestOwner = (
+export const generateTestAdmin = (
   members: Edge<SourceMember>[] = [],
 ): SourceMember => ({
   user: {
@@ -45,7 +45,7 @@ export const generateTestOwner = (
             },
             source: null,
             referralToken: defaultSquadToken,
-            role: SourceMemberRole.Owner,
+            role: SourceMemberRole.Admin,
           },
         },
         ...members,
@@ -53,14 +53,14 @@ export const generateTestOwner = (
     },
   },
   referralToken: defaultSquadToken,
-  role: SourceMemberRole.Owner,
+  role: SourceMemberRole.Admin,
 });
 
 export const generateMembersResult = (
   members: Edge<SourceMember>[] = [
     {
       node: {
-        role: 'owner',
+        role: SourceMemberRole.Admin,
         user: {
           id: 'F8G694HAObSoebZRzeKKa',
           name: 'Eliz Kılıç',
@@ -74,7 +74,7 @@ export const generateMembersResult = (
     },
     {
       node: {
-        role: 'member',
+        role: SourceMemberRole.Member,
         user: {
           id: 'LJSkpBexOSCWc8INyu3Eu',
           name: 'Ante Barić',
@@ -88,7 +88,7 @@ export const generateMembersResult = (
     },
     {
       node: {
-        role: 'member',
+        role: SourceMemberRole.Member,
         user: {
           id: 'QgTYreBqt',
           name: 'Francesco Ciulla',
@@ -102,7 +102,7 @@ export const generateMembersResult = (
     },
     {
       node: {
-        role: 'member',
+        role: SourceMemberRole.Member,
         user: {
           id: 'twmsvOCVr4s9JjlwIKGqI',
           name: 'Vas N',
@@ -116,7 +116,7 @@ export const generateMembersResult = (
     },
     {
       node: {
-        role: 'member',
+        role: SourceMemberRole.Member,
         user: {
           id: 'vqsMiP21barzohGfVjLFx',
           name: 'Hanzel',
@@ -203,7 +203,7 @@ export const generateMembersList = (
 ): Edge<SourceMember>[] => [
   {
     node: {
-      role: 'owner',
+      role: SourceMemberRole.Admin,
       user: {
         id: 'F8G694HAObSoebZRzeKKa',
         name: 'Eliz Kılıç',
@@ -217,7 +217,7 @@ export const generateMembersList = (
   },
   {
     node: {
-      role: 'member',
+      role: SourceMemberRole.Member,
       user: {
         id: 'LJSkpBexOSCWc8INyu3Eu',
         name: 'Ante Barić',
@@ -231,7 +231,7 @@ export const generateMembersList = (
   },
   {
     node: {
-      role: 'member',
+      role: SourceMemberRole.Member,
       user: {
         id: 'QgTYreBqt',
         name: 'Francesco Ciulla',
@@ -245,7 +245,7 @@ export const generateMembersList = (
   },
   {
     node: {
-      role: 'member',
+      role: SourceMemberRole.Member,
       user: {
         id: 'twmsvOCVr4s9JjlwIKGqI',
         name: 'Vas N',
@@ -259,7 +259,7 @@ export const generateMembersList = (
   },
   {
     node: {
-      role: 'member',
+      role: SourceMemberRole.Member,
       user: {
         id: 'vqsMiP21barzohGfVjLFx',
         name: 'Hanzel',
@@ -273,7 +273,7 @@ export const generateMembersList = (
   },
   {
     node: {
-      role: 'member',
+      role: SourceMemberRole.Member,
       user: {
         id: 'EEO0c1ol7u5IpOuykRZ1K',
         name: 'Sab',
@@ -287,7 +287,7 @@ export const generateMembersList = (
   },
   {
     node: {
-      role: 'member',
+      role: SourceMemberRole.Member,
       user: {
         id: 'yRuVFf6IbfTylBjx9Dzvt',
         name: 'Denis Bolkovskis',
@@ -301,7 +301,7 @@ export const generateMembersList = (
   },
   {
     node: {
-      role: 'member',
+      role: SourceMemberRole.Member,
       user: {
         id: 'IfGXaLUgpCHFaqiGEQQtp',
         name: 'Sabarinath Selvam',
@@ -315,7 +315,7 @@ export const generateMembersList = (
   },
   {
     node: {
-      role: 'member',
+      role: SourceMemberRole.Member,
       user: {
         id: 'k7eIkWOKPsTKc2SLpUB6v',
         name: 'Deniz Gunsav',
@@ -329,7 +329,7 @@ export const generateMembersList = (
   },
   {
     node: {
-      role: 'member',
+      role: SourceMemberRole.Member,
       user: {
         id: 'ab02e61b958d49d88c8420b431a4d91c',
         name: 'Lee Hansel Solevilla Jr',
@@ -343,7 +343,7 @@ export const generateMembersList = (
   },
   {
     node: {
-      role: 'member',
+      role: SourceMemberRole.Member,
       user: {
         id: '5e0af68445e04c02b0656c3530664aff',
         name: 'Tsahi Matsliah',
@@ -357,7 +357,7 @@ export const generateMembersList = (
   },
   {
     node: {
-      role: 'member',
+      role: SourceMemberRole.Member,
       user: {
         id: '28849d86070e4c099c877ab6837c61f0',
         name: 'Ido Shamun',
@@ -371,7 +371,7 @@ export const generateMembersList = (
   },
   {
     node: {
-      role: 'member',
+      role: SourceMemberRole.Member,
       user: {
         id: 'JUNiIGCV-',
         name: 'Chris Bongers',

--- a/packages/shared/src/components/notifications/utils.ts
+++ b/packages/shared/src/components/notifications/utils.ts
@@ -33,7 +33,7 @@ export enum NotificationType {
   SquadPostAdded = 'squad_post_added',
   SquadMemberJoined = 'squad_member_joined',
   SquadBlocked = 'squad_blocked',
-  PromotedToOwner = 'promoted_to_owner',
+  PromotedToAdmin = 'promoted_to_admin',
   PromotedToModerator = 'promoted_to_moderator',
   DemotedToMember = 'demoted_to_member',
 }
@@ -84,7 +84,7 @@ export const notificationTypeTheme: Record<NotificationType, string> = {
   [NotificationType.SquadMemberJoined]: 'text-theme-color-cabbage',
   [NotificationType.DemotedToMember]: 'text-theme-color-cabbage',
   [NotificationType.PromotedToModerator]: 'text-theme-color-cabbage',
-  [NotificationType.PromotedToOwner]: 'text-theme-color-cabbage',
+  [NotificationType.PromotedToAdmin]: 'text-theme-color-cabbage',
   [NotificationType.SquadBlocked]: 'text-theme-color-cabbage',
 };
 

--- a/packages/shared/src/components/squads/SquadMemberBadge.tsx
+++ b/packages/shared/src/components/squads/SquadMemberBadge.tsx
@@ -23,7 +23,7 @@ const RoleToIconMap: Partial<
   Record<SourceMemberRole, FunctionComponent<IconProps>>
 > = {
   [SourceMemberRole.Moderator]: UserIcon,
-  [SourceMemberRole.Owner]: StarIcon,
+  [SourceMemberRole.Admin]: StarIcon,
 };
 
 const SquadMemberBadge = ({

--- a/packages/shared/src/components/squads/SquadMemberMenu.tsx
+++ b/packages/shared/src/components/squads/SquadMemberMenu.tsx
@@ -27,7 +27,7 @@ interface SquadMemberMenuProps extends Pick<UseSquadActions, 'onUpdateRole'> {
 }
 
 enum MenuItemTitle {
-  AddAsOwner = 'Add as co-owner',
+  AddAsAdmin = 'Add as admin',
   PromoteToModerator = 'Promote to moderator',
   DemoteToModerator = 'Demote to moderator',
   DemoteToMember = 'Demote to member',
@@ -38,12 +38,12 @@ const promptDescription: Record<
   MenuItemTitle,
   (memberName: string, squadName: string) => string
 > = {
-  [MenuItemTitle.AddAsOwner]: (memberName, squadName) =>
-    `${memberName} will get the same permissions as you have. Adding as co-owner will not replace you as the owner of ${squadName}.`,
+  [MenuItemTitle.AddAsAdmin]: (memberName, squadName) =>
+    `${memberName} will get the same permissions as you have. Adding as admin will not replace you as the admin of ${squadName}.`,
   [MenuItemTitle.PromoteToModerator]: (memberName) =>
     `${memberName} will now get moderator permissions and be able to remove posts and members from your Squad. You can reverse this decision later.`,
   [MenuItemTitle.DemoteToModerator]: (memberName) =>
-    `${memberName} will no longer have owner permissions. You can always reverse this decision later.`,
+    `${memberName} will no longer have admin permissions. You can always reverse this decision later.`,
   [MenuItemTitle.DemoteToMember]: (memberName) =>
     `${memberName} will lose the moderator permissions and become a regular member.`,
   [MenuItemTitle.BlockMember]: (memberName, squadName) =>
@@ -66,10 +66,10 @@ const getUpdateRoleOptions = (
     title: MenuItemTitle,
   ) => UpdateRoleFn,
 ): ContextMenuItemProps[] => {
-  const promoteToOwner = {
-    text: MenuItemTitle.AddAsOwner,
+  const promoteToAdmin = {
+    text: MenuItemTitle.AddAsAdmin,
     icon: <StarIcon size={IconSize.Small} />,
-    action: getUpdateRoleFn(SourceMemberRole.Owner, MenuItemTitle.AddAsOwner),
+    action: getUpdateRoleFn(SourceMemberRole.Admin, MenuItemTitle.AddAsAdmin),
   };
   const promoteToModerator = {
     text: MenuItemTitle.PromoteToModerator,
@@ -96,15 +96,15 @@ const getUpdateRoleOptions = (
     ),
   };
 
-  if (member.role === SourceMemberRole.Owner) {
+  if (member.role === SourceMemberRole.Admin) {
     return [demoteToModerator, demoteToMember];
   }
 
   if (member.role === SourceMemberRole.Moderator) {
-    return [promoteToOwner, demoteToMember];
+    return [promoteToAdmin, demoteToMember];
   }
 
-  return [promoteToOwner, promoteToModerator];
+  return [promoteToAdmin, promoteToModerator];
 };
 
 export default function SquadMemberMenu({

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -5,7 +5,7 @@ import { Connection } from './common';
 export enum SourceMemberRole {
   Member = 'member',
   Moderator = 'moderator',
-  Owner = 'owner',
+  Admin = 'admin',
   Blocked = 'blocked',
 }
 
@@ -42,7 +42,7 @@ export interface Squad extends Source {
   permalink: string;
   public: boolean;
   type: SourceType.Squad;
-  owners?: string[];
+  admins?: string[];
   moderators?: string[];
   members?: Connection<SourceMember>;
   membersCount: number;

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -42,8 +42,6 @@ export interface Squad extends Source {
   permalink: string;
   public: boolean;
   type: SourceType.Squad;
-  admins?: string[];
-  moderators?: string[];
   members?: Connection<SourceMember>;
   membersCount: number;
   description: string;

--- a/packages/webapp/__tests__/SquadFeedPage.tsx
+++ b/packages/webapp/__tests__/SquadFeedPage.tsx
@@ -295,10 +295,10 @@ describe('squad members modal', () => {
     return members;
   };
 
-  it('should show the owner on top of the list', async () => {
+  it('should show the admin on top of the list', async () => {
     const fullMembers = await openedMembersModal();
     const [first] = fullMembers;
-    expect(first.node.role).toEqual(SourceMemberRole.Owner);
+    expect(first.node.role).toEqual(SourceMemberRole.Admin);
   });
 
   it('should show all members of the squad', async () => {
@@ -321,7 +321,7 @@ describe('squad members modal', () => {
 
   it('should show all blocked members of the squad when privileged', async () => {
     requestedSquad.currentMember = {
-      role: SourceMemberRole.Owner,
+      role: SourceMemberRole.Admin,
       permissions: [SourcePermissions.ViewBlockedMembers],
     };
     await openedMembersModal();

--- a/packages/webapp/__tests__/SquadTokenPage.tsx
+++ b/packages/webapp/__tests__/SquadTokenPage.tsx
@@ -12,7 +12,7 @@ import defaultUser from '@dailydotdev/shared/__tests__/fixture/loggedUser';
 import {
   defaultSquadToken,
   generateTestMember,
-  generateTestOwner,
+  generateTestAdmin,
 } from '@dailydotdev/shared/__tests__/fixture/squads';
 import {
   MockedGraphQLResponse,
@@ -60,7 +60,7 @@ let client: QueryClient;
 
 const createInvitationMock = (
   token: string = defaultSquadToken,
-  member: SourceMember = generateTestOwner(),
+  member: SourceMember = generateTestAdmin(),
 ): MockedGraphQLResponse<SquadInvitation> => ({
   request: {
     query: SQUAD_INVITATION_QUERY,
@@ -114,7 +114,7 @@ const renderComponent = (
 };
 
 describe('inviter', () => {
-  const member = generateTestOwner();
+  const member = generateTestAdmin();
   it('should show profile image', async () => {
     renderComponent();
     await waitForNock();
@@ -136,7 +136,7 @@ describe('inviter', () => {
 });
 
 describe('squad details', () => {
-  const member = generateTestOwner();
+  const member = generateTestAdmin();
   it('should show page heading that includes squad name', async () => {
     renderComponent();
     await waitForNock();
@@ -166,24 +166,24 @@ describe('squad details', () => {
   });
 
   it('should show accurate waiting label when there is 2 members', async () => {
-    const owner = generateTestOwner();
+    const admin = generateTestAdmin();
     const newMember = generateTestMember('u1');
-    owner.source.members.edges.push({ node: newMember });
-    renderComponent([createInvitationMock(defaultToken, owner)]);
+    admin.source.members.edges.push({ node: newMember });
+    renderComponent([createInvitationMock(defaultToken, admin)]);
     await waitForNock();
-    const label = `${owner.user.name} and ${newMember.user.name} are waiting for you inside. Join them now`;
+    const label = `${admin.user.name} and ${newMember.user.name} are waiting for you inside. Join them now`;
     const text = await screen.findByTestId('waiting-users');
     expect(text).toHaveTextContent(label);
   });
 
   it('should show accurate waiting label when there is 3 or more members', async () => {
-    const owner = generateTestOwner();
+    const admin = generateTestAdmin();
     const members = [generateTestMember('u1'), generateTestMember('u2')];
-    owner.source.members.edges.push({ node: members[0] }, { node: members[1] });
-    owner.source.membersCount = 3;
-    renderComponent([createInvitationMock(defaultToken, owner)]);
+    admin.source.members.edges.push({ node: members[0] }, { node: members[1] });
+    admin.source.membersCount = 3;
+    renderComponent([createInvitationMock(defaultToken, admin)]);
     await waitForNock();
-    const label = `${owner.user.name} and 2 others are waiting for you inside. Join them now`;
+    const label = `${admin.user.name} and 2 others are waiting for you inside. Join them now`;
     const text = await screen.findByTestId('waiting-users');
     expect(text).toHaveTextContent(label);
     const result = await Promise.all(
@@ -196,44 +196,44 @@ describe('squad details', () => {
 
   it('should join squad on the first button', async () => {
     client.setQueryData(BOOT_QUERY_KEY, { squads: [] });
-    const owner = generateTestOwner();
-    renderComponent([createInvitationMock(defaultToken, owner)]);
+    const admin = generateTestAdmin();
+    renderComponent([createInvitationMock(defaultToken, admin)]);
     await waitForNock();
     mockGraphQL({
       request: {
         query: SQUAD_JOIN_MUTATION,
-        variables: { token: owner.referralToken, sourceId: owner.source.id },
+        variables: { token: admin.referralToken, sourceId: admin.source.id },
       },
-      result: () => ({ data: { source: owner.source } }),
+      result: () => ({ data: { source: admin.source } }),
     });
     const [desktop] = await screen.findAllByText('Join Squad');
     desktop.click();
     await waitForNock();
-    expect(replaced).toEqual(owner.source.permalink);
+    expect(replaced).toEqual(admin.source.permalink);
   });
 
   it('should join squad on the second button', async () => {
     client.setQueryData(BOOT_QUERY_KEY, { squads: [] });
-    const owner = generateTestOwner();
-    renderComponent([createInvitationMock(defaultToken, owner)]);
+    const admin = generateTestAdmin();
+    renderComponent([createInvitationMock(defaultToken, admin)]);
     await waitForNock();
     mockGraphQL({
       request: {
         query: SQUAD_JOIN_MUTATION,
-        variables: { token: owner.referralToken, sourceId: owner.source.id },
+        variables: { token: admin.referralToken, sourceId: admin.source.id },
       },
-      result: () => ({ data: { source: owner.source } }),
+      result: () => ({ data: { source: admin.source } }),
     });
     const [, mobile] = await screen.findAllByText('Join Squad');
     mobile.click();
     await waitForNock();
-    expect(replaced).toEqual(owner.source.permalink);
+    expect(replaced).toEqual(admin.source.permalink);
   });
 
   it('should have two join squad one is displayed on desktop and one on mobile', async () => {
     client.setQueryData(BOOT_QUERY_KEY, { squads: [] });
-    const owner = generateTestOwner();
-    renderComponent([createInvitationMock(defaultToken, owner)]);
+    const admin = generateTestAdmin();
+    renderComponent([createInvitationMock(defaultToken, admin)]);
     const [desktop, mobile] = await screen.findAllByRole('button');
     expect(desktop).toHaveClass('hidden tablet:flex');
     expect(mobile).toHaveClass('flex tablet:hidden');
@@ -248,8 +248,8 @@ describe('invalid token', () => {
   });
 
   it('should redirect to home page when invitation source id does not match route squad id', async () => {
-    const owner = generateTestOwner();
-    renderComponent([createInvitationMock(defaultToken, owner)], {
+    const admin = generateTestAdmin();
+    renderComponent([createInvitationMock(defaultToken, admin)], {
       handle: 'not your squad',
       token: defaultToken,
     });
@@ -258,22 +258,22 @@ describe('invalid token', () => {
   });
 
   it('should redirect to squads page when member is already part of the squad', async () => {
-    const owner = generateTestOwner();
+    const admin = generateTestAdmin();
     const member = generateTestMember(1);
     member.user.id = defaultUser.id;
-    owner.source.currentMember = member;
-    renderComponent([createInvitationMock(defaultToken, owner)]);
+    admin.source.currentMember = member;
+    renderComponent([createInvitationMock(defaultToken, admin)]);
     await waitForNock();
-    expect(replaced).toEqual(`/squads/${owner.source.handle}`);
+    expect(replaced).toEqual(`/squads/${admin.source.handle}`);
   });
 
   it('should show toast is blocked user tries to join', async () => {
-    const owner = generateTestOwner();
+    const admin = generateTestAdmin();
     const member = generateTestMember(1);
     member.role = SourceMemberRole.Blocked;
     member.user.id = defaultUser.id;
-    owner.source.currentMember = member;
-    renderComponent([createInvitationMock(defaultToken, owner)]);
+    admin.source.currentMember = member;
+    renderComponent([createInvitationMock(defaultToken, admin)]);
     await waitForNock();
     const [desktop] = await screen.findAllByText('Join Squad');
     desktop.click();


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Change all owner texts to admin

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1236 #done
