### PR TITLE
fix: added temporary role assignment for moving API over

### DIFF
--- a/packages/shared/src/components/modals/SquadMemberModal.tsx
+++ b/packages/shared/src/components/modals/SquadMemberModal.tsx
@@ -92,7 +92,7 @@ export function SquadMemberModal({
           .flat()}
         additionalContent={(user) => {
           const role = getSquadMembersUserRole(queryResult, user);
-          if (role === SourceMemberRole.Owner) {
+          if ([SourceMemberRole.Owner, SourceMemberRole.Admin].includes(role)) {
             return (
               <span
                 className="flex gap-1 items-center font-bold typo-footnote text-theme-color-cabbage"

--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -44,7 +44,10 @@ export default function SquadHeaderMenu({
     squad,
     callback: () => router.replace('/'),
   });
-  const isSquadOwner = squad?.currentMember?.role === SourceMemberRole.Owner;
+  const isSquadOwner = [
+    SourceMemberRole.Owner,
+    SourceMemberRole.Admin,
+  ].includes(squad?.currentMember?.role);
 
   const onEditSquad = () => {
     openModal({

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -6,6 +6,7 @@ export enum SourceMemberRole {
   Member = 'member',
   Moderator = 'moderator',
   Owner = 'owner',
+  Admin = 'admin',
 }
 
 export enum SourcePermissions {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added a temporary fix to allow both Admin and Owner role to be valid while we move API over to Admin

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1236
