### PR TITLE
feat: add global listener to history change to close lazy modal

### DIFF
--- a/packages/shared/src/hooks/useLazyModal.ts
+++ b/packages/shared/src/hooks/useLazyModal.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useQuery, useQueryClient } from 'react-query';
 import { LazyModalType, ModalsType } from '../components/modals/common';
 
@@ -18,8 +18,14 @@ export function useLazyModal<
   const { data: modal } = useQuery<T>(MODAL_KEY, () =>
     client.getQueryData<T>(MODAL_KEY),
   );
-  const openModal = (data: T) => client.setQueryData(MODAL_KEY, data);
-  const closeModal = () => client.setQueryData(MODAL_KEY, null);
+  const openModal = useCallback(
+    (data: T) => client.setQueryData(MODAL_KEY, data),
+    [client],
+  );
+  const closeModal = useCallback(
+    () => client.setQueryData(MODAL_KEY, null),
+    [client],
+  );
 
   return useMemo(
     () => ({
@@ -27,6 +33,6 @@ export function useLazyModal<
       closeModal,
       modal,
     }),
-    [modal],
+    [openModal, closeModal, modal],
   );
 }

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -80,11 +80,27 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
 
   useTrackPageView();
   useInAppNotification();
-  useLazyModal();
+  const { modal, closeModal } = useLazyModal();
   usePrompt();
   useEffect(() => {
     updateCookieBanner(user);
   }, [user]);
+
+  useEffect(() => {
+    if (!modal) {
+      return undefined;
+    }
+
+    const onBeforeHistoryChange = () => {
+      closeModal();
+    };
+
+    router.events.on('beforeHistoryChange', onBeforeHistoryChange);
+
+    return () => {
+      router.events.off('beforeHistoryChange', onBeforeHistoryChange);
+    };
+  }, [modal, closeModal, router.events]);
 
   const getLayout =
     (Component as ComponentGetLayout).getLayout || ((page) => page);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added global listener per comments here https://dailydotdev.slack.com/archives/C02E2C3C13R/p1681299753422359
- Added it to _app due to router not being available for extension and we do not really have any route changes that happen in extensions (anything that changes route goes to app.daily.dev)
  - `popstate` event does not really work since it is not triggered for route changes
- My concern with this is that we are adding this for all lazy modals, we might want specific behaviour of not closing for specific modals
  - I would alternatively implement calling `closeModal` inside event handlers eg. when clicking item `UserListModal`

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
