### PR TITLE
fix: edit comment height

### DIFF
--- a/packages/shared/src/components/modals/common/ModalBody.tsx
+++ b/packages/shared/src/components/modals/common/ModalBody.tsx
@@ -18,7 +18,7 @@ function ModalBodyComponent({
 }: ModalBodyProps): ReactElement {
   const { activeView, kind, size } = useContext(ModalPropsContext);
   const sectionClassName = classNames(
-    'overflow-auto relative w-full h-full shrink max-h-full p-6',
+    'overflow-auto relative w-full h-full shrink max-h-full p-6 flex flex-col',
     kind === ModalKind.FlexibleTop && bigModals.includes(size) && 'mobileL:p-8',
     className,
   );


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We where using `flex-1` on the textfield, but the parent was not actually a flex item so no flexing applied.
- Added it now to the modal body. (Tested various modals non seem breaking)
- The small bottom part is reserved space for the error message

<img width="677" alt="Screenshot 2023-04-13 at 14 55 44" src="https://user-images.githubusercontent.com/554874/231765567-d1ba1fed-a5dc-4548-9d0f-a1c1addbc239.png">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1255 #done
