### PR TITLE
fix: use dvh instead of vh to account for dynamic url bar on ios

### DIFF
--- a/packages/webapp/components/layouts/AccountLayout/AccountPageContainer.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/AccountPageContainer.tsx
@@ -63,8 +63,8 @@ export const AccountPageContainer = ({
         className={classNames(
           'h-full overflow-y-scroll',
           footer
-            ? 'min-h-[calc(100dvh-11.25rem)] max-h-[calc(100dvh-11.25rem)] min-h-[calc(100vh-11.25rem)] max-h-[calc(100vh-11.25rem)]'
-            : 'min-h-[calc(100dvh-7.25rem)] max-h-[calc(100dvh-7.25rem)] min-h-[calc(100vh-7.25rem)] max-h-[calc(100vh-7.25rem)]',
+            ? '!min-h-[calc(100dvh-11.25rem)] !max-h-[calc(100dvh-11.25rem)] min-h-[calc(100vh-11.25rem)] max-h-[calc(100vh-11.25rem)]'
+            : '!min-h-[calc(100dvh-7.25rem)] !max-h-[calc(100dvh-7.25rem)] min-h-[calc(100vh-7.25rem)] max-h-[calc(100vh-7.25rem)]',
           className.section,
         )}
       >

--- a/packages/webapp/components/layouts/AccountLayout/AccountPageContainer.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/AccountPageContainer.tsx
@@ -63,8 +63,8 @@ export const AccountPageContainer = ({
         className={classNames(
           'h-full overflow-y-scroll',
           footer
-            ? 'min-h-[calc(100vh-11.25rem)] max-h-[calc(100vh-11.25rem)]'
-            : 'min-h-[calc(100vh-7.25rem)] max-h-[calc(100vh-7.25rem)]',
+            ? 'min-h-[calc(100dvh-11.25rem)] max-h-[calc(100dvh-11.25rem)] min-h-[calc(100vh-11.25rem)] max-h-[calc(100vh-11.25rem)]'
+            : 'min-h-[calc(100dvh-7.25rem)] max-h-[calc(100dvh-7.25rem)] min-h-[calc(100vh-7.25rem)] max-h-[calc(100vh-7.25rem)]',
           className.section,
         )}
       >

--- a/packages/webapp/components/layouts/AccountLayout/AccountPageContainer.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/AccountPageContainer.tsx
@@ -63,8 +63,8 @@ export const AccountPageContainer = ({
         className={classNames(
           'h-full overflow-y-scroll',
           footer
-            ? '!min-h-[calc(100dvh-11.25rem)] !max-h-[calc(100dvh-11.25rem)] min-h-[calc(100vh-11.25rem)] max-h-[calc(100vh-11.25rem)]'
-            : '!min-h-[calc(100dvh-7.25rem)] !max-h-[calc(100dvh-7.25rem)] min-h-[calc(100vh-7.25rem)] max-h-[calc(100vh-7.25rem)]',
+            ? 'min-h-[calc(100dvh-11.25rem)] max-h-[calc(100dvh-11.25rem)] min-h-[calc(100vh-11.25rem)] max-h-[calc(100vh-11.25rem)]'
+            : 'min-h-[calc(100dvh-7.25rem)] max-h-[calc(100dvh-7.25rem)] min-h-[calc(100vh-7.25rem)] max-h-[calc(100vh-7.25rem)]',
           className.section,
         )}
       >


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The issue mainly comes because of the dynamic url bar that shows/hides while scrolling on iOS
- `dvh` unit solves this because it accounts for those dynamic changes https://developer.mozilla.org/en-US/docs/Learn/CSS/Building_blocks/Values_and_units
- left the fallback to `vh` for browsers that do not support dynamic units

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1252 #done
