### PR TITLE
fix: copy changes to be more inline and line-break fix

### DIFF
--- a/packages/shared/src/components/squads/SquadMemberItemAdditionalContent.tsx
+++ b/packages/shared/src/components/squads/SquadMemberItemAdditionalContent.tsx
@@ -38,7 +38,10 @@ function SquadMemberItemAdditionalContent({
         <UserShortInfo
           disableTooltip
           user={user}
-          className={{ container: 'py-3 px-6 justify-center' }}
+          className={{
+            container: 'py-3 px-6 justify-center',
+            textWrapper: 'max-w-fit',
+          }}
         />
       ),
       promptSize: ModalSize.Small,

--- a/packages/shared/src/components/squads/SquadMemberMenu.tsx
+++ b/packages/shared/src/components/squads/SquadMemberMenu.tsx
@@ -27,7 +27,7 @@ interface SquadMemberMenuProps extends Pick<UseSquadActions, 'onUpdateRole'> {
 }
 
 enum MenuItemTitle {
-  AddAsAdmin = 'Add as admin',
+  PromoteToAdmin = 'Make admin',
   PromoteToModerator = 'Promote to moderator',
   DemoteToModerator = 'Demote to moderator',
   DemoteToMember = 'Demote to member',
@@ -38,7 +38,7 @@ const promptDescription: Record<
   MenuItemTitle,
   (memberName: string, squadName: string) => string
 > = {
-  [MenuItemTitle.AddAsAdmin]: (memberName, squadName) =>
+  [MenuItemTitle.PromoteToAdmin]: (memberName, squadName) =>
     `${memberName} will get the same permissions as you have. Adding as admin will not replace you as the admin of ${squadName}.`,
   [MenuItemTitle.PromoteToModerator]: (memberName) =>
     `${memberName} will now get moderator permissions and be able to remove posts and members from your Squad. You can reverse this decision later.`,
@@ -67,9 +67,12 @@ const getUpdateRoleOptions = (
   ) => UpdateRoleFn,
 ): ContextMenuItemProps[] => {
   const promoteToAdmin = {
-    text: MenuItemTitle.AddAsAdmin,
+    text: MenuItemTitle.PromoteToAdmin,
     icon: <StarIcon size={IconSize.Small} />,
-    action: getUpdateRoleFn(SourceMemberRole.Admin, MenuItemTitle.AddAsAdmin),
+    action: getUpdateRoleFn(
+      SourceMemberRole.Admin,
+      MenuItemTitle.PromoteToAdmin,
+    ),
   };
   const promoteToModerator = {
     text: MenuItemTitle.PromoteToModerator,
@@ -127,7 +130,10 @@ export default function SquadMemberMenu({
         <UserShortInfo
           user={member.user}
           disableTooltip
-          className={{ container: 'py-3 px-6 justify-center' }}
+          className={{
+            container: 'py-3 px-6 justify-center',
+            textWrapper: 'max-w-fit',
+          }}
         />
       ),
       promptSize: ModalSize.Small,

--- a/packages/shared/src/components/squads/SquadMemberMenu.tsx
+++ b/packages/shared/src/components/squads/SquadMemberMenu.tsx
@@ -39,7 +39,7 @@ const promptDescription: Record<
   (memberName: string, squadName: string) => string
 > = {
   [MenuItemTitle.PromoteToAdmin]: (memberName, squadName) =>
-    `${memberName} will get the same permissions as you have. Adding as admin will not replace you as the admin of ${squadName}.`,
+    `${memberName} will get the same permissions as you have. Making someone an admin will not replace you as the admin of ${squadName}. You can reverse this decision later.`,
   [MenuItemTitle.PromoteToModerator]: (memberName) =>
     `${memberName} will now get moderator permissions and be able to remove posts and members from your Squad. You can reverse this decision later.`,
   [MenuItemTitle.DemoteToModerator]: (memberName) =>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Small copy change see here: https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1681479731311269?thread_ts=1681479342.294069&cid=C01L0QXQJNB
- And line break issue on the prompt

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1257 #done
