### PR TITLE
feat: add member invite option to squad create and edit

### DIFF
--- a/packages/shared/src/components/fields/Radio.tsx
+++ b/packages/shared/src/components/fields/Radio.tsx
@@ -39,7 +39,7 @@ export function Radio({
         <RadioItem
           key={option.value}
           name={name}
-          id={option.id || option.value}
+          id={`${name}-${option.id || option.value}`}
           value={option.value}
           checked={value === option.value}
           onChange={() => onChange(option.value)}

--- a/packages/shared/src/components/modals/EditSquadModal.tsx
+++ b/packages/shared/src/components/modals/EditSquadModal.tsx
@@ -28,6 +28,7 @@ function EditSquadModal({
       handle: form.handle,
       file: form.file,
       memberPostingRole: form.memberPostingRole,
+      memberInviteRole: form.memberInviteRole,
     };
     const editedSquad = await editSquad(squad.id, formJson);
     if (editedSquad) {

--- a/packages/shared/src/components/squads/Details.tsx
+++ b/packages/shared/src/components/squads/Details.tsx
@@ -199,6 +199,7 @@ export function SquadDetails({
             <h4 className="mb-2 typo-headline">Post permissions</h4>
             <p className="mb-4 text-theme-label-tertiary typo-callout">
               Choose who is allowed to post new content in this Squad.
+              {createMode && ' You can always change this setting later.'}
             </p>
             <Radio
               name="memberPostingRole"
@@ -213,6 +214,7 @@ export function SquadDetails({
             <h4 className="mb-2 typo-headline">Invitation permissions</h4>
             <p className="mb-4 text-theme-label-tertiary typo-callout">
               Choose who is allowed to invite new members to this squad.
+              {createMode && ' You can always change this setting later.'}
             </p>
             <Radio
               name="memberInviteRole"

--- a/packages/shared/src/components/squads/Details.tsx
+++ b/packages/shared/src/components/squads/Details.tsx
@@ -44,7 +44,7 @@ const getFormData = async (
   return { ...current, file: base64 };
 };
 
-const memberPostingRoleOptions = [
+const memberRoleOptions = [
   {
     label: 'All members (recommended)',
     value: SourceMemberRole.Member,
@@ -66,6 +66,7 @@ export function SquadDetails({
     handle,
     description,
     memberPostingRole: initialMemberPostingRole,
+    memberInviteRole: initialMemberInviteRole,
   } = form;
   const [activeHandle, setActiveHandle] = useState(handle);
   const [imageChanged, setImageChanged] = useState(false);
@@ -73,6 +74,9 @@ export function SquadDetails({
   const [canSubmit, setCanSubmit] = useState(!!name && !!activeHandle);
   const [memberPostingRole, setMemberPostingRole] = useState(
     () => initialMemberPostingRole || SourceMemberRole.Member,
+  );
+  const [memberInviteRole, setMemberInviteRole] = useState(
+    () => initialMemberInviteRole || SourceMemberRole.Member,
   );
   const { mutateAsync: onValidateHandle } = useMutation(checkExistingHandle, {
     onError: (err) => {
@@ -198,10 +202,24 @@ export function SquadDetails({
             </p>
             <Radio
               name="memberPostingRole"
-              options={memberPostingRoleOptions}
+              options={memberRoleOptions}
               value={memberPostingRole}
               onChange={(value) =>
                 setMemberPostingRole(value as SourceMemberRole)
+              }
+            />
+          </div>
+          <div className="flex flex-col">
+            <h4 className="mb-2 typo-headline">Invitation permissions</h4>
+            <p className="mb-4 text-theme-label-tertiary typo-callout">
+              Choose who is allowed to invite new members to this squad.
+            </p>
+            <Radio
+              name="memberInviteRole"
+              options={memberRoleOptions}
+              value={memberInviteRole}
+              onChange={(value) =>
+                setMemberInviteRole(value as SourceMemberRole)
               }
             />
           </div>

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -51,6 +51,7 @@ export const SOURCE_BASE_FRAGMENT = gql`
       ...CurrentMember
     }
     memberPostingRole
+    memberInviteRole
   }
   ${CURRENT_MEMBER_FRAGMENT}
 `;

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -18,7 +18,7 @@ export enum SourcePermissions {
   PostDelete = 'post_delete',
   MemberRoleUpdate = 'member_role_update',
   MemberRemove = 'member_remove',
-  InviteDisable = 'invite_disable',
+  Invite = 'invite',
   Leave = 'leave',
   Delete = 'delete',
   Edit = 'edit',

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -46,6 +46,7 @@ export interface Squad extends Source {
   membersCount: number;
   description: string;
   memberPostingRole: SourceMemberRole;
+  memberInviteRole: SourceMemberRole;
 }
 
 export interface SourcePrivilegedMembers extends Pick<SourceMember, 'role'> {

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -23,6 +23,7 @@ export type SquadForm = Pick<
   post: PostItem;
   buttonText?: string;
   memberPostingRole?: SourceMemberRole;
+  memberInviteRole?: SourceMemberRole;
 };
 
 type SharedSquadInput = {
@@ -31,6 +32,7 @@ type SharedSquadInput = {
   description: string;
   image?: File;
   memberPostingRole?: SourceMemberRole;
+  memberInviteRole?: SourceMemberRole;
 };
 
 type EditSquadInput = SharedSquadInput & {
@@ -92,6 +94,7 @@ export const CREATE_SQUAD_MUTATION = gql`
     $description: String
     $image: Upload
     $memberPostingRole: String
+    $memberInviteRole: String
   ) {
     createSquad(
       name: $name
@@ -99,6 +102,7 @@ export const CREATE_SQUAD_MUTATION = gql`
       description: $description
       image: $image
       memberPostingRole: $memberPostingRole
+      memberInviteRole: $memberInviteRole
     ) {
       ...SourceBaseInfo
       members {
@@ -121,6 +125,7 @@ export const EDIT_SQUAD_MUTATION = gql`
     $description: String
     $image: Upload
     $memberPostingRole: String
+    $memberInviteRole: String
   ) {
     editSquad(
       sourceId: $sourceId
@@ -129,6 +134,7 @@ export const EDIT_SQUAD_MUTATION = gql`
       description: $description
       image: $image
       memberPostingRole: $memberPostingRole
+      memberInviteRole: $memberInviteRole
     ) {
       ...SourceBaseInfo
     }
@@ -339,6 +345,7 @@ export async function createSquad(form: SquadForm): Promise<Squad> {
     name: form.name,
     image: form.file ? await base64ToFile(form.file, 'image.jpg') : undefined,
     memberPostingRole: form.memberPostingRole,
+    memberInviteRole: form.memberInviteRole,
   };
   const data = await request<CreateSquadOutput>(
     graphqlUrl,
@@ -353,6 +360,7 @@ type EditSquadForm = Pick<
   'name' | 'description' | 'handle' | 'file'
 > & {
   memberPostingRole?: SourceMemberRole;
+  memberInviteRole?: SourceMemberRole;
 };
 
 export async function editSquad(
@@ -366,6 +374,7 @@ export async function editSquad(
     name: form.name,
     image: form.file ? await base64ToFile(form.file, 'image.jpg') : undefined,
     memberPostingRole: form.memberPostingRole,
+    memberInviteRole: form.memberInviteRole,
   };
   const data = await request<EditSquadOutput>(
     graphqlUrl,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Add memberInviteRole to squad create
- Add memberInviteRole to squad settings
- Update permissions to include new `Invite` permission
- Update fragments/mutations to accept `memberInviteRole` field
- update copy per design
- API implementation here https://github.com/dailydotdev/daily-api/pull/1240

Also includes WT-1265 since changes are closely related.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1264 #done
