### PR TITLE
fix: page seo and loading

### DIFF
--- a/packages/shared/src/hooks/usePostById.ts
+++ b/packages/shared/src/hooks/usePostById.ts
@@ -64,7 +64,7 @@ const usePostById = ({ id, options = {} }: UsePostByIdProps): UsePostById => {
       isFetched,
       isPostLoadingOrFetching: (isLoading || isFetching) && !isRefetching,
     }),
-    [post?.post, isError, isFetched, isLoading, isFetching],
+    [post?.post, isError, isFetched, isLoading, isFetching, isRefetching],
   );
 };
 

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -115,11 +115,11 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     scrollProperty: 'scrollY',
   });
 
-  if (isPostLoadingOrFetching) {
+  if (isPostLoadingOrFetching || isFallback) {
     return <PostLoadingSkeleton className={containerClass} type={post?.type} />;
   }
 
-  if (isFallback || !isFetched) {
+  if (!isFetched) {
     return <></>;
   }
 

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -115,12 +115,8 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     scrollProperty: 'scrollY',
   });
 
-  if (isPostLoadingOrFetching || isFallback) {
+  if (isPostLoadingOrFetching || isFallback || !isFetched) {
     return <PostLoadingSkeleton className={containerClass} type={post?.type} />;
-  }
-
-  if (!isFetched) {
-    return <></>;
   }
 
   const Content = CONTENT_MAP[post?.type];

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -108,6 +108,9 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
       },
     },
   };
+
+  const seoComponent = <NextSeo {...seo} />;
+
   useScrollTopOffset(() => globalThis.window, {
     onOverOffset: () => position !== 'fixed' && setPosition('fixed'),
     onUnderOffset: () => position !== 'relative' && setPosition('relative'),
@@ -116,7 +119,12 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
   });
 
   if (isPostLoadingOrFetching || isFallback || !isFetched) {
-    return <PostLoadingSkeleton className={containerClass} type={post?.type} />;
+    return (
+      <>
+        {seoComponent}
+        <PostLoadingSkeleton className={containerClass} type={post?.type} />
+      </>
+    );
   }
 
   const Content = CONTENT_MAP[post?.type];
@@ -137,7 +145,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
       <Head>
         <link rel="preload" as="image" href={post?.image} />
       </Head>
-      <NextSeo {...seo} />
+      {seoComponent}
       <Content
         position={position}
         post={post}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- I fixed this earlier while waiting on some reviews but forgot to raise the PR 😅 
- Fixes the SEO preview.
- Fixes the loading not being seen.
- `isFallback` is NextJS telling that the getStaticProps is still loading.

Feel free to copy paste the link below on Slack and see if a preview shows up. Also visiting the link you should see the loading placeholder.
Quick link: https://daily-webapp-pe9dxfcqo-dailydotdev.vercel.app/posts/XlISrsqLo

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
