### PR TITLE
fix: return null if object is null

### DIFF
--- a/packages/shared/src/components/ProfilePicture.tsx
+++ b/packages/shared/src/components/ProfilePicture.tsx
@@ -84,6 +84,8 @@ function ProfilePictureComponent(
     className,
   );
 
+  if (!user) return null;
+
   if (nativeLazyLoading) {
     return (
       <img


### PR DESCRIPTION
## Changes

### Describe what this PR does
- From the screenshot of the error, the issue seems to be coming from this component when the passed value is null.

Reference image:
![image](https://user-images.githubusercontent.com/13744167/233561604-da79c2a0-9318-429f-9527-f4a27822d15f.png)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
