### PR TITLE
fix: changelog header styling

### DIFF
--- a/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
@@ -108,13 +108,9 @@ function ChangelogTooltip<TRef extends HTMLElement>({
             data-testid="changelog"
           >
             <header className="flex flex-1 items-center py-3 px-4 border-b border-theme-divider-tertiary">
-              <Button
-                disabled
-                className="font-normal text-white bg-theme-color-water btn-primary small"
-                data-testid="changelogNewReleaseTag"
-              >
+              <h3 className="ml-2 font-bold typo-title3 text-theme-label-primary">
                 New release
-              </Button>
+              </h3>
               <ModalClose
                 className="right-4"
                 onClick={onModalCloseClick}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- New changelog header style (see extra margin on header as intended)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1274 #done
