### PR TITLE
feat: remember scroll position and restore after post modal close

### DIFF
--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { Post, PostType } from '../graphql/posts';
 import { postAnalyticsEvent } from '../lib/feed';
@@ -37,6 +37,7 @@ export const usePostModalNavigation = (
   const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
   const { trackEvent } = useContext(AnalyticsContext);
   const router = useRouter();
+  const scrollPositionOnFeed = useRef(0);
 
   const changeHistory = (data: unknown, title: string, url: string) => {
     if (!isExtension) {
@@ -67,6 +68,8 @@ export const usePostModalNavigation = (
 
   const onOpenModal = (index: number, fromPopState = false) => {
     if (!currentPage) {
+      scrollPositionOnFeed.current = window.scrollY;
+
       setCurrentPage(window.location.pathname);
     }
     onChangeSelected(index, fromPopState);
@@ -76,8 +79,12 @@ export const usePostModalNavigation = (
     setOpenedPostIndex(null);
     setCurrentPage(undefined);
     if (!fromPopState) {
+      window.scrollTo(0, scrollPositionOnFeed.current);
+
       changeHistory({}, `Feed`, currentPage);
     }
+
+    scrollPositionOnFeed.current = 0;
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- I could not really get anything concrete on this so wanted to propose a different approach
  - I also checked and this does not happen on Android phones I have on me Android 12 and 13
  - As said in tasks and reports seems like iOS only issue when clicking "X" close button
  - Also, if user just uses back button (instead of "X") scroll restoration works and they do not get jumped to top 
- To fix this I implemented a ref to save scroll position on feed when post modal gets opened, I keep it and when modal is closed by clicking on "X" I just restore that position and that works
  - also it does not break desktop/other platforms since they just retain scroll normally
  
I know this does not fix the core issue but if iOS browser was conforming to the spec this would not even be the problem so I think if this works and brings a lot of value to our users it should be enough.
  
It can be tested on [preview2](https://preview2.app.daily.dev)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-812 #done
