### PR TITLE
fix: add correct image component for fallback loading

### DIFF
--- a/packages/shared/src/components/notifications/NotificationItemAttachment.tsx
+++ b/packages/shared/src/components/notifications/NotificationItemAttachment.tsx
@@ -1,5 +1,7 @@
 import React, { ReactElement } from 'react';
 import { NotificationAttachment } from '../../graphql/notifications';
+import { cloudinary } from '../../lib/image';
+import { Image } from '../image/Image';
 
 function NotificationItemAttachment({
   image,
@@ -7,10 +9,12 @@ function NotificationItemAttachment({
 }: NotificationAttachment): ReactElement {
   return (
     <div className="flex flex-row items-center p-4 mt-2 rounded-16 border border-theme-divider-tertiary">
-      <img
-        className="object-cover w-24 h-16 rounded-16"
+      <Image
         src={image}
         alt={`Cover preview of: ${title}`}
+        className="object-cover w-24 h-16 rounded-16"
+        loading="lazy"
+        fallbackSrc={cloudinary.post.imageCoverPlaceholder}
       />
       <span className="flex-1 ml-4 break-words typo-callout">{title}</span>
     </div>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We weren't using the `Image` component which leverages fallback images.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1260 #done
