### PR TITLE
fix: fallback resolve for share post card

### DIFF
--- a/packages/shared/src/components/cards/SharedPostCardFooter.tsx
+++ b/packages/shared/src/components/cards/SharedPostCardFooter.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, { ReactElement } from 'react';
 import { Post } from '../../graphql/posts';
+import { cloudinary } from '../../lib/image';
 
 type SharedPostCardFooterProps = {
   isShort: boolean;
@@ -30,7 +31,9 @@ export const SharedPostCardFooter = ({
           'rounded-xl',
           isShort ? 'h-full aspect-square' : 'flex-1',
         )}
-        style={{ background: `url(${sharedPost.image}) center center / cover` }}
+        style={{
+          background: `url(${sharedPost.image}) center center / cover, url(${cloudinary.post.imageCoverPlaceholder}) center center / cover`,
+        }}
       />
     </div>
   );


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixed a fallback for our share post card
- Since we load this as a background image (needed for the 3 different render sizes) we can only rely on secondary notation for background-image. 
- Downside of the above: It loads the fallback image even when it's not shown (see image)
- **Do let me know what you think of this.**

![Screenshot 2023-04-25 at 09 38 21](https://user-images.githubusercontent.com/554874/234207676-ed723231-bac6-49f5-ab85-91ac4caa914b.png)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1275 #done
