### PR TITLE
fix: clean up experiment winner for scroll block

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -42,10 +42,7 @@ import {
 import { useSharePost } from '../hooks/useSharePost';
 import { AnalyticsEvent, Origin } from '../lib/analytics';
 import ShareOptionsMenu from './ShareOptionsMenu';
-import {
-  ExperimentWinner,
-  ScrollOnboardingVersion,
-} from '../lib/featureValues';
+import { ExperimentWinner } from '../lib/featureValues';
 import useSidebarRendered from '../hooks/useSidebarRendered';
 import AlertContext from '../contexts/AlertContext';
 import OnboardingContext from '../contexts/OnboardingContext';
@@ -151,7 +148,6 @@ export default function Feed<T>({
   options,
 }: FeedProps<T>): ReactElement {
   const { showCommentPopover } = useContext(FeaturesContext);
-  const { scrollOnboardingVersion } = useContext(FeaturesContext);
   const { alerts } = useContext(AlertContext);
   const { onInitializeOnboarding } = useContext(OnboardingContext);
   const { trackEvent } = useContext(AnalyticsContext);
@@ -205,23 +201,17 @@ export default function Feed<T>({
     feedName === MainFeedPage.Popular &&
     !isLoading &&
     alerts?.filter &&
-    !user?.id &&
-    Object.values(ScrollOnboardingVersion).includes(scrollOnboardingVersion);
-  const shouldScrollBlock =
-    showScrollOnboardingVersion &&
-    [ScrollOnboardingVersion.V1, ScrollOnboardingVersion.V2].includes(
-      scrollOnboardingVersion,
-    );
+    !user?.id;
 
   const infiniteScrollRef = useFeedInfiniteScroll({
     fetchPage,
-    canFetchMore: canFetchMore && !shouldScrollBlock,
+    canFetchMore: canFetchMore && !showScrollOnboardingVersion,
   });
 
   const onInitializeOnboardingClick = () => {
     trackEvent({
       event_name: AnalyticsEvent.ClickScrollBlock,
-      target_id: scrollOnboardingVersion,
+      target_id: ExperimentWinner.ScrollOnboardingVersion,
     });
     onInitializeOnboarding(undefined, true);
   };
@@ -467,7 +457,6 @@ export default function Feed<T>({
         </div>
         {showScrollOnboardingVersion && (
           <ScrollFeedFiltersOnboarding
-            version={scrollOnboardingVersion}
             onInitializeOnboarding={onInitializeOnboardingClick}
           />
         )}

--- a/packages/shared/src/components/ScrollFeedFiltersOnboarding.tsx
+++ b/packages/shared/src/components/ScrollFeedFiltersOnboarding.tsx
@@ -4,7 +4,13 @@ import { ExperimentWinner } from '../lib/featureValues';
 import { cloudinary } from '../lib/image';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../lib/analytics';
+import SuperchargeIcon from '../../icons/supercharge.svg';
 
+const GaussianBlur = (): ReactElement => {
+  return (
+    <div className="absolute w-48 h-48 rounded-full blur-2xl opacity-[0.2] bg-theme-color-cabbage" />
+  );
+};
 interface ScrollFeedFiltersOnboardingProps {
   onInitializeOnboarding: () => void;
 }
@@ -39,6 +45,10 @@ export default function ScrollFeedFiltersOnboarding({
       }}
     >
       <div className="flex flex-col items-center">
+        <div className="flex relative justify-center items-center mb-10">
+          <GaussianBlur />
+          <SuperchargeIcon className="w-[4.625rem] h-[4.625rem]" />
+        </div>
         <h2 className="mb-6 font-bold typo-title2">
           Supercharge your feed with
           <br /> content you&apos;ll love reading!

--- a/packages/shared/src/components/ScrollFeedFiltersOnboarding.tsx
+++ b/packages/shared/src/components/ScrollFeedFiltersOnboarding.tsx
@@ -1,79 +1,31 @@
 import React, { ReactElement, useContext, useEffect } from 'react';
-import classNames from 'classnames';
 import { Button, ButtonSize } from './buttons/Button';
-import { ScrollOnboardingVersion } from '../lib/featureValues';
+import { ExperimentWinner } from '../lib/featureValues';
 import { cloudinary } from '../lib/image';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../lib/analytics';
-import SuperchargeIcon from '../../icons/supercharge.svg';
-
-type ScrollOnboardingVersionMap = Partial<
-  Record<ScrollOnboardingVersion, string>
->;
-
-const versionToContainerClassName: ScrollOnboardingVersionMap = {
-  [ScrollOnboardingVersion.V1]: 'h-48 my-5',
-  [ScrollOnboardingVersion.V2]: 'h-80 m-10',
-};
-const versionToButtonClassName: ScrollOnboardingVersionMap = {
-  [ScrollOnboardingVersion.V1]: 'w-[16.25rem]',
-  [ScrollOnboardingVersion.V2]: 'w-40',
-};
-const versionToButtonText: ScrollOnboardingVersionMap = {
-  [ScrollOnboardingVersion.V1]: 'Customize your feed',
-  [ScrollOnboardingVersion.V2]: 'Start',
-};
-
-const versionToGaussianBlurClassName: ScrollOnboardingVersionMap = {
-  [ScrollOnboardingVersion.V1]: 'top-0 right-0 bottom-0 left-0 m-auto',
-  [ScrollOnboardingVersion.V2]: '',
-};
-
-const GaussianBlur = ({
-  version,
-}: {
-  version: ScrollOnboardingVersion;
-}): ReactElement => {
-  return (
-    <div
-      className={classNames(
-        'absolute w-48 h-48 rounded-full blur-2xl opacity-[0.2] bg-theme-color-cabbage',
-        versionToGaussianBlurClassName[version],
-      )}
-    />
-  );
-};
 
 interface ScrollFeedFiltersOnboardingProps {
-  version: ScrollOnboardingVersion;
   onInitializeOnboarding: () => void;
 }
 export default function ScrollFeedFiltersOnboarding({
-  version,
   onInitializeOnboarding,
 }: ScrollFeedFiltersOnboardingProps): ReactElement {
   const { trackEvent } = useContext(AnalyticsContext);
   useEffect(() => {
     trackEvent({
       event_name: AnalyticsEvent.EligibleScrollBlock,
-      target_id: version,
+      target_id: ExperimentWinner.ScrollOnboardingVersion,
     });
-  }, [version]);
-
-  if (version === ScrollOnboardingVersion.Control) {
-    return null;
-  }
+  }, []);
 
   return (
     <div
       onClick={onInitializeOnboarding}
       role="button"
       tabIndex={0}
-      aria-label={versionToButtonText[version]}
-      className={classNames(
-        'flex flex-1 justify-center items-center relative',
-        versionToContainerClassName[version],
-      )}
+      aria-label="Start"
+      className="flex relative flex-1 justify-center items-center m-10 h-80"
       onKeyDown={(event) => {
         if (event.key !== 'Enter') {
           return;
@@ -87,38 +39,23 @@ export default function ScrollFeedFiltersOnboarding({
       }}
     >
       <div className="flex flex-col items-center">
-        {version === ScrollOnboardingVersion.V1 ? (
-          <GaussianBlur version={version} />
-        ) : (
-          <div className="flex relative justify-center items-center mb-10">
-            <GaussianBlur version={version} />
-            <SuperchargeIcon className="w-[4.625rem] h-[4.625rem]" />
-          </div>
-        )}
-        {version === ScrollOnboardingVersion.V2 && (
-          <h2 className="mb-6 font-bold typo-title2">
-            Supercharge your feed with
-            <br /> content you&apos;ll love reading!
-          </h2>
-        )}
+        <h2 className="mb-6 font-bold typo-title2">
+          Supercharge your feed with
+          <br /> content you&apos;ll love reading!
+        </h2>
         <Button
-          className={classNames(
-            'btn-primary-cabbage',
-            versionToButtonClassName[version],
-          )}
+          className="w-40 btn-primary-cabbage"
           buttonSize={ButtonSize.Large}
           tabIndex={-1}
         >
-          {versionToButtonText[version]}
+          Start
         </Button>
       </div>
-      {version === ScrollOnboardingVersion.V2 && (
-        <img
-          src={cloudinary.feedFilters.scroll}
-          alt="example topics for your feed"
-          className="laptop:hidden laptopL:block ml-2"
-        />
-      )}
+      <img
+        src={cloudinary.feedFilters.scroll}
+        alt="example topics for your feed"
+        className="laptop:hidden laptopL:block ml-2"
+      />
     </div>
   );
 }

--- a/packages/shared/src/contexts/FeaturesContext.tsx
+++ b/packages/shared/src/contexts/FeaturesContext.tsx
@@ -9,7 +9,6 @@ import {
 import {
   InAppNotificationPosition,
   OnboardingFiltersLayout,
-  ScrollOnboardingVersion,
 } from '../lib/featureValues';
 import { OnboardingStep } from '../components/onboarding/common';
 import { getCookieFeatureFlags, updateFeatureFlags } from '../lib/cookie';
@@ -25,7 +24,6 @@ interface Experiments {
   submitArticleModalButton?: string;
   showCommentPopover?: boolean;
   inAppNotificationPosition?: InAppNotificationPosition;
-  scrollOnboardingVersion?: ScrollOnboardingVersion;
   hasSquadAccess?: boolean;
   showHiring?: boolean;
 }
@@ -73,10 +71,6 @@ const getFeatures = (flags: IFlags): FeaturesData => {
     ),
     inAppNotificationPosition: getFeatureValue(
       Features.InAppNotificationPosition,
-      flags,
-    ),
-    scrollOnboardingVersion: getFeatureValue(
-      Features.ScrollOnboardingVersion,
       flags,
     ),
     hasSquadAccess: isFeaturedEnabled(Features.HasSquadAccess, flags),

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -3,7 +3,6 @@ import { OnboardingStep } from '../components/onboarding/common';
 import {
   OnboardingFiltersLayout as OnboardingFiltersLayoutEnum,
   InAppNotificationPosition as InAppNotificationPositionEnum,
-  ScrollOnboardingVersion,
 } from './featureValues';
 
 export type FeatureValue = string | number | boolean;
@@ -139,16 +138,6 @@ export class Features<T extends FeatureValue = string> {
   );
 
   static readonly ShowCommentPopover = new Features('show_comment_popover');
-
-  static readonly ScrollOnboardingVersion = new Features(
-    'anonymous_users_scroll_home_page',
-    ScrollOnboardingVersion.Control,
-    [
-      ScrollOnboardingVersion.Control,
-      ScrollOnboardingVersion.V1,
-      ScrollOnboardingVersion.V2,
-    ],
-  );
 
   static readonly HasSquadAccess = new Features('squad');
 

--- a/packages/shared/src/lib/featureValues.ts
+++ b/packages/shared/src/lib/featureValues.ts
@@ -8,15 +8,10 @@ export enum OnboardingFiltersLayout {
   List = 'list',
 }
 
-export enum ScrollOnboardingVersion {
-  Control = 'control',
-  V1 = 'v1',
-  V2 = 'v2',
-}
-
 export enum ExperimentWinner {
   ArticleOnboarding = 'v3',
   PostCardShareVersion = 'v2',
   AuthVersion = 'v4',
   OnboardingVersion = 'v2',
+  ScrollOnboardingVersion = 'v2',
 }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Cleanup experiment winner for scroll block
- Left analytics intact with winner value

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1306 #done
