### PR TITLE
fix: hide unnecessary notification

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -25,6 +25,7 @@ import { useNotificationContext } from '../contexts/NotificationsContext';
 import { AnalyticsEvent, NotificationTarget } from '../lib/analytics';
 import { LazyModalElement } from './modals/LazyModalElement';
 import { PromptElement } from './modals/Prompt';
+import { useNotificationParams } from '../hooks/useNotificationParams';
 
 export interface MainLayoutProps
   extends Omit<MainLayoutHeaderProps, 'onMobileSidebarToggle'>,
@@ -74,6 +75,7 @@ export default function MainLayout({
   const { isNotificationsReady, unreadCount } = useNotificationContext();
   useAuthErrors();
   useAuthVerificationRecovery();
+  useNotificationParams();
   const handlers = useSwipeableSidebar({
     sidebarRendered,
     openMobileSidebar,

--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -28,6 +28,7 @@ const containerClassName: Record<NotificationPromptSource, string> = {
   [NotificationPromptSource.NewComment]: 'rounded-16 border px-4 mx-3 mb-3',
   [NotificationPromptSource.CommunityPicks]: 'rounded-16 border px-4 mt-3',
   [NotificationPromptSource.NewSourceModal]: '',
+  [NotificationPromptSource.NotificationItem]: '',
   [NotificationPromptSource.SquadPage]: 'rounded-16 border px-4 mt-6',
 };
 
@@ -37,6 +38,7 @@ const sourceRenderTextCloseButton: Record<NotificationPromptSource, boolean> = {
   [NotificationPromptSource.CommunityPicks]: false,
   [NotificationPromptSource.NewSourceModal]: false,
   [NotificationPromptSource.SquadPage]: true,
+  [NotificationPromptSource.NotificationItem]: false,
 };
 
 function EnableNotification({
@@ -124,6 +126,7 @@ function EnableNotification({
     [NotificationPromptSource.NotificationsPage]:
       'Stay in the loop whenever you get a mention, reply and other important updates.',
     [NotificationPromptSource.NewSourceModal]: '',
+    [NotificationPromptSource.NotificationItem]: '',
     [NotificationPromptSource.SquadPage]: `Get notified whenever something important happens on ${contentName}.`,
   };
   const message = sourceToMessage[source];

--- a/packages/shared/src/components/notifications/InAppNotification.tsx
+++ b/packages/shared/src/components/notifications/InAppNotification.tsx
@@ -18,6 +18,7 @@ import { NotificationType } from './utils';
 import FeaturesContext from '../../contexts/FeaturesContext';
 import { InAppNotificationPosition } from '../../lib/featureValues';
 import { ButtonSize } from '../buttons/Button';
+import { useNotificationContext } from '../../contexts/NotificationsContext';
 
 const Container = classed(
   'div',
@@ -36,6 +37,7 @@ export function InAppNotificationElement(): ReactElement {
   const { trackEvent } = useAnalyticsContext();
   const { clearNotifications, dismissNotification } = useInAppNotification();
   const [isExit, setIsExit] = useState(false);
+  const { isSubscribed } = useNotificationContext();
   const closeNotification = () => {
     setIsExit(true);
     setTimeout(() => {
@@ -89,7 +91,10 @@ export function InAppNotificationElement(): ReactElement {
     });
   };
 
-  if (!payload?.notification) {
+  const isNotifTypeSubscribe =
+    payload?.notification?.type === NotificationType.SquadSubscribeNotification;
+
+  if (!payload?.notification || (isSubscribed && isNotifTypeSubscribe)) {
     return null;
   }
 

--- a/packages/shared/src/components/notifications/utils.ts
+++ b/packages/shared/src/components/notifications/utils.ts
@@ -36,6 +36,7 @@ export enum NotificationType {
   PromotedToAdmin = 'promoted_to_admin',
   PromotedToModerator = 'promoted_to_moderator',
   DemotedToMember = 'demoted_to_member',
+  SquadSubscribeNotification = 'squad_subscribe_to_notification',
 }
 
 export enum NotificationIconType {
@@ -86,6 +87,7 @@ export const notificationTypeTheme: Record<NotificationType, string> = {
   [NotificationType.PromotedToModerator]: 'text-theme-color-cabbage',
   [NotificationType.PromotedToAdmin]: 'text-theme-color-cabbage',
   [NotificationType.SquadBlocked]: 'text-theme-color-cabbage',
+  [NotificationType.SquadSubscribeNotification]: 'text-theme-color-cabbage',
 };
 
 const notificationsUrl = `/notifications`;

--- a/packages/shared/src/hooks/useAuthVerificationRecovery.ts
+++ b/packages/shared/src/hooks/useAuthVerificationRecovery.ts
@@ -12,6 +12,7 @@ import { useToastNotification } from './useToastNotification';
 import { disabledRefetch } from '../lib/func';
 import AuthContext from '../contexts/AuthContext';
 import { AuthTriggers } from '../lib/auth';
+import { stripLinkParameters } from '../lib/links';
 
 export function useAuthVerificationRecovery(): void {
   const router = useRouter();
@@ -20,8 +21,8 @@ export function useAuthVerificationRecovery(): void {
   const { displayToast } = useToastNotification();
 
   const displayErrorMessage = (text: string) => {
-    const { origin, pathname } = new URL(window.location.href);
-    router.replace(origin + pathname);
+    const link = stripLinkParameters(window.location.href);
+    router.replace(link);
     setTimeout(() => displayToast(text), 100);
   };
 

--- a/packages/shared/src/hooks/useNotificationParams.ts
+++ b/packages/shared/src/hooks/useNotificationParams.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { NotificationPromptSource } from '../lib/analytics';
+import { useNotificationContext } from '../contexts/NotificationsContext';
+import { stripLinkParameters } from '../lib/links';
+
+export const useNotificationParams = (): void => {
+  const router = useRouter();
+  const { isSubscribed, onTogglePermission } = useNotificationContext();
+
+  useEffect(() => {
+    if (isSubscribed || !router?.query.notify) return;
+
+    onTogglePermission(NotificationPromptSource.NotificationItem).then(
+      (permission) => {
+        const isGranted = permission === 'granted';
+
+        if (!isGranted) return;
+
+        const link = stripLinkParameters(window.location.href);
+        router.replace(link);
+      },
+    );
+  }, [onTogglePermission, isSubscribed, router]);
+};

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -89,4 +89,5 @@ export enum NotificationPromptSource {
   CommunityPicks = 'community picks modal',
   NewSourceModal = 'new source modal',
   SquadPage = 'squad page',
+  NotificationItem = 'notification item',
 }

--- a/packages/shared/src/lib/links.ts
+++ b/packages/shared/src/lib/links.ts
@@ -34,3 +34,9 @@ export function isValidHttpUrl(link: string): boolean {
     return false;
   }
 }
+
+export const stripLinkParameters = (link: string): string => {
+  const { origin, pathname } = new URL(link);
+
+  return origin + pathname;
+};

--- a/packages/webapp/pages/notifications.tsx
+++ b/packages/webapp/pages/notifications.tsx
@@ -1,15 +1,15 @@
 import React, { ReactElement, useEffect } from 'react';
 import classNames from 'classnames';
 import { NextSeo } from 'next-seo';
-import { useInfiniteQuery, InfiniteData, useMutation } from 'react-query';
+import { InfiniteData, useInfiniteQuery, useMutation } from 'react-query';
 import {
-  NotificationsData,
   NOTIFICATIONS_QUERY,
+  NotificationsData,
   READ_NOTIFICATIONS_MUTATION,
 } from '@dailydotdev/shared/src/graphql/notifications';
 import {
-  pageContainerClassNames,
   pageBorders,
+  pageContainerClassNames,
 } from '@dailydotdev/shared/src/components/utilities';
 import request from 'graphql-request';
 import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
@@ -43,7 +43,7 @@ const Notifications = (): ReactElement => {
     />
   );
   const { trackEvent } = useAnalyticsContext();
-  const { clearUnreadCount } = useNotificationContext();
+  const { clearUnreadCount, isSubscribed } = useNotificationContext();
   const { mutateAsync: readNotifications } = useMutation(
     () => request(graphqlUrl, READ_NOTIFICATIONS_MUTATION),
     { onSuccess: clearUnreadCount },
@@ -107,16 +107,28 @@ const Notifications = (): ReactElement => {
         >
           {length > 0 &&
             queryResult.data.pages.map((page) =>
-              page.notifications.edges.map(
-                ({ node: { id, readAt, type, ...props } }) => (
-                  <NotificationItem
-                    key={id}
-                    {...props}
-                    type={type}
-                    isUnread={!readAt}
-                    onClick={() => onNotificationClick(id, type)}
-                  />
-                ),
+              page.notifications.edges.reduce(
+                (nodes, { node: { id, readAt, type, ...props } }) => {
+                  if (
+                    isSubscribed &&
+                    type === NotificationType.SquadSubscribeNotification
+                  ) {
+                    return nodes;
+                  }
+
+                  nodes.push(
+                    <NotificationItem
+                      key={id}
+                      {...props}
+                      type={type}
+                      isUnread={!readAt}
+                      onClick={() => onNotificationClick(id, type)}
+                    />,
+                  );
+
+                  return nodes;
+                },
+                [],
               ),
             )}
           {(!length || !hasNextPage) && isFetched && <FirstNotification />}


### PR DESCRIPTION
## Changes

@rebelchris since we have merged the new notification type, I realized that it will now show up for everyone since we don't have yet an idea if people have subscribed since we just introduced the actions table.

This is basically the same PR of this https://github.com/dailydotdev/apps/pull/1775 but pointed to main,

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
