### PR TITLE
feat: setting the overlay bg to the correct color for mobile sidebar

### DIFF
--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -66,7 +66,7 @@ export const navBtnClass =
   'flex flex-1 items-center pl-2 laptop:pl-0 pr-5 laptop:pr-3 h-10 laptop:h-7';
 export const SidebarBackdrop = classed(
   'div',
-  'fixed w-full h-full bg-theme-overlay-quaternary z-3 cursor-pointer inset-0',
+  'fixed w-full h-full bg-overlay-quaternary-onion z-3 cursor-pointer inset-0',
 );
 export const SidebarAside = classed(
   'aside',


### PR DESCRIPTION
## Changes
Changing the overlay bg from grey for the mobile sidebar to the quaternary onion as per other overlays

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
