### PR TITLE
fix: checklist status on touch devices

### DIFF
--- a/packages/shared/src/components/squads/SquadHeaderBar.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderBar.tsx
@@ -96,6 +96,7 @@ export function SquadHeaderBar({
         />
       )}
       <SimpleTooltip
+        forceLoad
         visible={completedStepsCount < totalStepsCount}
         container={{
           className: '-mb-4 bg-theme-color-onion !text-white',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Realised that we have tooltips disabled by default on touch devices
- Since this is a specific case where we wanna show checklist status (eg. 0/5) `forceLoad` is used

<img width="373" alt="image" src="https://user-images.githubusercontent.com/9803078/236790343-09d98e17-c174-4d10-ae15-c75eb693d4c4.png">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
