### PR TITLE
fix(squads): invite permission tests

### DIFF
--- a/packages/shared/src/components/squads/SquadHeaderBar.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderBar.tsx
@@ -21,6 +21,7 @@ import { verifyPermission } from '../../graphql/squads';
 import { SourcePermissions } from '../../graphql/sources';
 import ChecklistBIcon from '../icons/ChecklistB';
 import { useSquadChecklist } from '../../hooks/useSquadChecklist';
+import { isTesting } from '../../lib/constants';
 
 interface SquadHeaderBarProps
   extends SquadMemberShortListProps,
@@ -96,7 +97,7 @@ export function SquadHeaderBar({
         />
       )}
       <SimpleTooltip
-        forceLoad
+        forceLoad={!isTesting}
         visible={completedStepsCount < totalStepsCount}
         container={{
           className: '-mb-4 bg-theme-color-onion !text-white',

--- a/packages/webapp/__tests__/SquadFeedPage.tsx
+++ b/packages/webapp/__tests__/SquadFeedPage.tsx
@@ -44,6 +44,10 @@ import {
 } from '@dailydotdev/shared/src/graphql/sources';
 import { NotificationsContextProvider } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import { BootApp } from '@dailydotdev/shared/src/lib/boot';
+import {
+  ActionType,
+  COMPLETE_ACTION_MUTATION,
+} from '@dailydotdev/shared/src/graphql/actions';
 import SquadPage from '../pages/squads/[handle]';
 
 const showLogin = jest.fn();
@@ -275,7 +279,17 @@ describe('squad header bar', () => {
     };
     renderComponent();
     const invite = await screen.findByText('Copy invitation link');
+
+    mockGraphQL({
+      request: {
+        query: COMPLETE_ACTION_MUTATION,
+        variables: { type: ActionType.SquadInvite },
+      },
+      result: { data: { _: true } },
+    });
     invite.click();
+    await waitForNock();
+
     const invitation = `https://app.daily.dev/squads/webteam/3ZvloDmEbgiCKLF_eDg72JKLRPgp6MOpGDkh6qTRFr8`;
     await waitFor(() =>
       expect(window.navigator.clipboard.writeText).toBeCalledWith(invitation),

--- a/packages/webapp/__tests__/SquadFeedPage.tsx
+++ b/packages/webapp/__tests__/SquadFeedPage.tsx
@@ -6,7 +6,13 @@ import {
 import nock from 'nock';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import React from 'react';
-import { render, RenderResult, screen, waitFor } from '@testing-library/preact';
+import {
+  fireEvent,
+  render,
+  RenderResult,
+  screen,
+  waitFor,
+} from '@testing-library/preact';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { LoggedUser } from '@dailydotdev/shared/src/lib/user';
 import { NextRouter } from 'next/router';
@@ -287,8 +293,8 @@ describe('squad header bar', () => {
       },
       result: { data: { _: true } },
     });
-    invite.click();
-    await waitForNock();
+    fireEvent.click(invite);
+    await new Promise(process.nextTick);
 
     const invitation = `https://app.daily.dev/squads/webteam/3ZvloDmEbgiCKLF_eDg72JKLRPgp6MOpGDkh6qTRFr8`;
     await waitFor(() =>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Latest changes introduced some possibly flaky test cases
- Added missing completeAction nock when copying invite link since https://github.com/dailydotdev/apps/pull/1783 introduced it

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
