### PR TITLE
fix: squad post commentary breakline

### DIFF
--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -142,7 +142,7 @@ function SquadPostContent({
               </a>
             </ProfileTooltip>
           </span>
-          <p className="mt-6 typo-title3">{post.title}</p>
+          <p className="mt-6 whitespace-pre-line typo-title3">{post.title}</p>
           <div className="flex flex-col mt-8 rounded-16 border border-theme-divider-tertiary hover:border-theme-divider-secondary">
             <a
               href={


### PR DESCRIPTION
## Changes

Since our input form accepts new line on its content, we should also be able to display the user's commentary with break lines.

Have deployed on preview2. Feel free to test it out 🥳 

https://preview2.app.daily.dev/

Sample post:

![image](https://github.com/dailydotdev/apps/assets/13744167/24a63d8c-4d92-4006-ad2a-8bba72f09e6b)

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
