### PR TITLE
fix: welcome post modal width

### DIFF
--- a/packages/shared/src/components/post/PostFeedFiltersOnboarding.tsx
+++ b/packages/shared/src/components/post/PostFeedFiltersOnboarding.tsx
@@ -31,7 +31,7 @@ export function PostFeedFiltersOnboarding({
   return (
     <div
       className={classNames(
-        'flex relative rounded-16 border border-theme-color-cabbage',
+        'flex relative rounded-16 border border-theme-color-cabbage items-center',
         className,
       )}
       onClick={onInitializeOnboarding}

--- a/packages/webapp/pages/posts/[id].tsx
+++ b/packages/webapp/pages/posts/[id].tsx
@@ -96,7 +96,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
   });
   const containerClass = classNames(
     'pb-20 laptop:pb-6 laptopL:pb-0 max-w-screen-laptop border-r laptop:min-h-page',
-    post?.type === PostType.Share &&
+    [PostType.Share, PostType.Welcome].includes(post?.type) &&
       sidebarRendered &&
       modalSizeToClassName[ModalSize.Large],
   );


### PR DESCRIPTION
## Changes

### Describe what this PR does
- While implementing checklist step for welcome post I noticed some display issues

Before (too much width and notification image not aligned):
<img width="1493" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/9cef6073-dbe8-458f-be2c-d29125c81df1">

After:
<img width="1500" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/1da64877-b853-4e57-a39e-11502a07db5c">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
