### PR TITLE
fix: replying to long comment scroll

### DIFF
--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -58,7 +58,8 @@ const modalKindAndSizeToClassName: Partial<
   Record<ModalKind, Partial<Record<ModalSize, string>>>
 > = {
   [ModalKind.FlexibleTop]: {
-    [ModalSize.Medium]: 'h-full mobileL:h-auto min-h-[25rem]',
+    [ModalSize.Medium]:
+      'h-full mobileL:h-auto min-h-[25rem] max-h-[calc(100vh-10rem)]',
     [ModalSize.Large]: 'laptop:mt-14 laptop:mb-10',
     [ModalSize.XLarge]: 'laptop:mt-14 laptop:mb-10',
   },


### PR DESCRIPTION
## Changes

### Describe what this PR does
- With the migration of modals, we missed fixing the scrolling on long comments which had a discussion in the past already.
- For reference, this was the accepted design:
https://dailydotdev.slack.com/archives/C02AA18RD1D/p1651499956941809?thread_ts=1651144522.037189&cid=C02AA18RD1D

Preview:

![image](https://github.com/dailydotdev/apps/assets/13744167/1c79c900-a48a-4ff7-8acf-39121c0fb295)

![image](https://github.com/dailydotdev/apps/assets/13744167/cbbd8255-4a01-49b8-a8bd-7bb84bb3a8d3)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1330 #done
