### PR TITLE
fix: added v4 related tracking events

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -487,6 +487,7 @@ export default function Feed<T>({
           postIndex={postMenuIndex}
           onHidden={() => setPostMenuIndex(null)}
           onRemovePost={onRemovePost}
+          origin={Origin.Feed}
         />
         <ShareOptionsMenu
           {...commonMenuItems}

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -19,7 +19,7 @@ import MainComment from '../comments/MainComment';
 import PlaceholderCommentList from '../comments/PlaceholderCommentList';
 import { useRequestProtocol } from '../../hooks/useRequestProtocol';
 import { initialDataKey } from '../../lib/constants';
-import { Origin } from '../../lib/analytics';
+import { AnalyticsEvent, Origin } from '../../lib/analytics';
 import { AuthTriggers } from '../../lib/auth';
 import { PromptOptions, usePrompt } from '../../hooks/usePrompt';
 import {
@@ -28,6 +28,9 @@ import {
   usePostComment,
 } from '../../hooks/usePostComment';
 import { useToastNotification } from '../../hooks/useToastNotification';
+import AnalyticsContext from '../../contexts/AnalyticsContext';
+import { ExperimentWinner } from '../../lib/featureValues';
+import { postAnalyticsEvent } from '../../lib/feed';
 
 interface PostCommentsProps {
   post: Post;
@@ -51,6 +54,7 @@ export function PostComments({
   const { id } = post;
   const container = useRef<HTMLDivElement>();
   const { user, showLogin, tokenRefreshed } = useContext(AuthContext);
+  const { trackEvent } = useContext(AnalyticsContext);
   const { displayToast } = useToastNotification();
   const { requestMethod } = useRequestProtocol();
   const { showPrompt } = usePrompt();
@@ -88,6 +92,7 @@ export function PostComments({
       },
     };
     if (await showPrompt(options)) {
+      trackEvent(postAnalyticsEvent(AnalyticsEvent.DeleteComment, post));
       await deleteComment(commentId, requestMethod);
       displayToast('The comment has been deleted');
       deleteCommentCache(commentId, parentId);

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -29,7 +29,6 @@ import {
 } from '../../hooks/usePostComment';
 import { useToastNotification } from '../../hooks/useToastNotification';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
-import { ExperimentWinner } from '../../lib/featureValues';
 import { postAnalyticsEvent } from '../../lib/feed';
 
 interface PostCommentsProps {

--- a/packages/shared/src/components/post/PostModalActions.tsx
+++ b/packages/shared/src/components/post/PostModalActions.tsx
@@ -20,6 +20,7 @@ import PostOptionsMenu, { PostOptionsMenuProps } from '../PostOptionsMenu';
 import { ShareBookmarkProps } from './PostActions';
 import { PromptOptions, usePrompt } from '../../hooks/usePrompt';
 import SettingsContext from '../../contexts/SettingsContext';
+import { Origin } from '../../lib/analytics';
 
 export interface PostModalActionsProps extends ShareBookmarkProps {
   post: Post;
@@ -119,6 +120,7 @@ export function PostModalActions({
         onRemovePost={onRemovePost}
         setShowBanPost={isModerator ? () => banPostPrompt() : null}
         contextId={contextMenuId}
+        origin={Origin.ArticleModal}
       />
     </Container>
   );

--- a/packages/shared/src/hooks/usePostMenuActions.ts
+++ b/packages/shared/src/hooks/usePostMenuActions.ts
@@ -11,6 +11,7 @@ interface UsePostMenuActions {
 }
 
 interface DeletePostProps {
+  post: Post;
   id: string;
   index?: number;
 }
@@ -43,7 +44,7 @@ export const usePostMenuActions = ({
     { onSuccess: (_, vars) => onPostDeleted(vars) },
   );
   const deletePostPrompt = async () => {
-    const param = { id: post.id, index: postIndex };
+    const param = { id: post.id, index: postIndex, post };
 
     if (await showPrompt(deletePromptOptions)) {
       await onDeletePost(param);

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -56,6 +56,8 @@ export enum AnalyticsEvent {
   CompleteSquadCreation = 'complete squad creation',
   StartShareToSquad = 'start share to squad',
   ShareToSquad = 'share to squad',
+  DeletePost = 'delete post',
+  DeleteComment = 'delete comment',
   // squads - end
   EligibleScrollBlock = 'eligible scroll block',
 }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Awaiting Sab/Ido confirmation on using the post tracking in favor of adding manual sources

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
|New | delete post  | extra: { origin } |
|New | delete comment  |  |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1331 #done
