### PR TITLE
feat(checklist): pulse animation on squad page depending on active step

### DIFF
--- a/packages/shared/src/components/cards/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCard.tsx
@@ -12,6 +12,9 @@ import { Container, PostCardProps } from './common';
 import OptionsButton from '../buttons/OptionsButton';
 import { WelcomePostCardHeader } from './WelcomePostCardHeader';
 import { WelcomePostCardFooter } from './WelcomePostCardFooter';
+import { useSquadChecklist } from '../../hooks/useSquadChecklist';
+import { Squad } from '../../graphql/sources';
+import { ActionType } from '../../graphql/actions';
 
 export const WelcomePostCard = forwardRef(function SharePostCard(
   {
@@ -35,10 +38,22 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
   const onPostCardClick = () => onPostClick(post);
   const containerRef = useRef<HTMLDivElement>();
 
+  const { activeStep, isChecklistVisible } = useSquadChecklist({
+    squad: post.source as Squad,
+  });
+
+  const shouldShowHighlightPulse =
+    isChecklistVisible && activeStep === ActionType.SquadFirstComment;
+
   return (
     <Card
       {...props}
-      className={getPostClassNames(post, className, 'min-h-[22.5rem]')}
+      className={getPostClassNames(
+        post,
+        className,
+        'min-h-[22.5rem]',
+        shouldShowHighlightPulse && 'highlight-pulse',
+      )}
       style={style}
       ref={ref}
     >

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -14,6 +14,8 @@ import { TourScreenIndex } from './SquadTour';
 import { useSquadTour } from '../../hooks/useSquadTour';
 import { verifyPermission } from '../../graphql/squads';
 import { NotificationPromptSource } from '../../lib/analytics';
+import { useSquadChecklist } from '../../hooks/useSquadChecklist';
+import { ActionType } from '../../graphql/actions';
 
 interface SquadPageHeaderProps {
   squad: Squad;
@@ -36,6 +38,12 @@ export function SquadPageHeader({
   const sharePostTutorial = useTutorial({
     key: TutorialKey.ShareSquadPost,
   });
+
+  const { activeStep, isChecklistVisible } = useSquadChecklist({ squad });
+
+  const shouldShowHighlightPulse =
+    tourIndex === TourScreenIndex.Post ||
+    (isChecklistVisible && activeStep === ActionType.SquadFirstPost);
 
   return (
     <FlexCol
@@ -90,7 +98,7 @@ export function SquadPageHeader({
       <div
         className={classNames(
           'absolute bottom-0 w-full translate-y-1/2 px-6 laptop:px-0 bg-theme-bg-primary',
-          tourIndex === TourScreenIndex.Post && 'highlight-pulse',
+          shouldShowHighlightPulse && 'highlight-pulse',
           MAX_WIDTH,
         )}
       >


### PR DESCRIPTION
## Changes

### Describe what this PR does
- add pulse animation when squad first post is active
- add pulse animation when squad first comment is active

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1335 #done
