### PR TITLE
fix: add v5 tracking events

### DIFF
--- a/packages/shared/src/components/checklist/SquadChecklistCard.tsx
+++ b/packages/shared/src/components/checklist/SquadChecklistCard.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useContext, useEffect } from 'react';
 import { ChecklistCard } from './ChecklistCard';
 import { useSquadChecklist } from '../../hooks/useSquadChecklist';
 import { Squad } from '../../graphql/sources';
@@ -9,6 +9,8 @@ import useSidebarRendered from '../../hooks/useSidebarRendered';
 import { Modal } from '../modals/common/Modal';
 import { ModalKind } from '../modals/common/types';
 import { useChecklist } from '../../hooks/useChecklist';
+import AnalyticsContext from '../../contexts/AnalyticsContext';
+import { AnalyticsEvent, TargetType } from '../../lib/analytics';
 
 const SquadChecklistCard = ({ squad }: { squad: Squad }): ReactElement => {
   const { steps, isChecklistVisible, setChecklistVisible } = useSquadChecklist({
@@ -16,12 +18,27 @@ const SquadChecklistCard = ({ squad }: { squad: Squad }): ReactElement => {
   });
   const { sidebarRendered } = useSidebarRendered();
   const { isDone } = useChecklist({ steps });
+  const { trackEvent } = useContext(AnalyticsContext);
+
+  useEffect(() => {
+    trackEvent({
+      event_name: AnalyticsEvent.Impression,
+      target_type: TargetType.OnboardingChecklist,
+      extra: JSON.stringify({ squad: squad.id }),
+    });
+    // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!isChecklistVisible) {
     return null;
   }
 
   const onRequestClose = () => {
+    trackEvent({
+      event_name: AnalyticsEvent.ChecklistClose,
+      extra: JSON.stringify({ squad: squad.id }),
+    });
     setChecklistVisible(false);
   };
 

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -56,6 +56,7 @@ export enum AnalyticsEvent {
   CompleteSquadCreation = 'complete squad creation',
   StartShareToSquad = 'start share to squad',
   ShareToSquad = 'share to squad',
+  ChecklistClose = 'checklist close',
   // squads - end
   EligibleScrollBlock = 'eligible scroll block',
 }
@@ -65,6 +66,7 @@ export enum TargetType {
   ArticleAnonymousCTA = 'article anonymous cta',
   EnableNotifications = 'enable notifications',
   CreateSquadPopup = 'create squad popup',
+  OnboardingChecklist = 'onboarding checklist',
 }
 
 export enum NotificationChannel {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- @capJavert as we don't have the new hook yet I still used the old useEffect hack to only fire once.
- The only one missing is `checklist completion` we need to find a way to unique identify it 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| New | impression (onboarding checklist) | extra: { squad } |
| New | checklist close | extra: { squad } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1328 #done
