### PR TITLE
fix: hashnode profile not showing on daily.dev account

### DIFF
--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -21,6 +21,7 @@ export const USER_BY_ID_STATIC_FIELDS_QUERY = `
       bio
       twitter
       github
+      hashnode
       timezone
       portfolio
       reputation


### PR DESCRIPTION
## Changes

Fixes dailydotdev/daily#861

### Describe what this PR does
Fix the hashnode profile not showing on account profile.
- Screenshots if applicable can also help
Not able to take screenshots as we cant run auth in Gitpod.


### **Please make sure existing components are not breaking/affected by this PR**

