### PR TITLE
fix: notification toggle

### DIFF
--- a/packages/shared/src/components/modals/NewSourceModal.tsx
+++ b/packages/shared/src/components/modals/NewSourceModal.tsx
@@ -26,10 +26,10 @@ import { Modal, ModalProps } from './common/Modal';
 import NotificationsContext from '../../contexts/NotificationsContext';
 import PushNotificationModal from './PushNotificationModal';
 import usePersistentContext from '../../hooks/usePersistentContext';
-import { DISMISS_PERMISSION_BANNER } from '../notifications/EnableNotification';
 import Alert, { AlertType } from '../widgets/Alert';
 import SourceProfilePicture from '../profile/SourceProfilePicture';
 import OpenLinkIcon from '../icons/OpenLink';
+import { DISMISS_PERMISSION_BANNER } from '../../hooks/useEnableNotification';
 
 interface RSS {
   url: string;

--- a/packages/shared/src/hooks/useEnableNotification.ts
+++ b/packages/shared/src/hooks/useEnableNotification.ts
@@ -1,0 +1,103 @@
+import { useContext, useEffect } from 'react';
+import { useAnalyticsContext } from '../contexts/AnalyticsContext';
+import NotificationsContext from '../contexts/NotificationsContext';
+import usePersistentContext from './usePersistentContext';
+import {
+  AnalyticsEvent,
+  NotificationPromptSource,
+  TargetType,
+} from '../lib/analytics';
+
+export const DISMISS_PERMISSION_BANNER = 'DISMISS_PERMISSION_BANNER';
+
+interface UseEnableNotificationProps {
+  source: NotificationPromptSource;
+}
+
+interface UseEnableNotification {
+  isEnabled: boolean;
+  hasEnabled: boolean;
+  shouldShowCta: boolean;
+  onDismiss: () => void;
+  onEnable: () => Promise<void>;
+}
+
+export const useEnableNotification = ({
+  source = NotificationPromptSource.NotificationsPage,
+}: UseEnableNotificationProps): UseEnableNotification => {
+  const { trackEvent } = useAnalyticsContext();
+  const {
+    isInitialized,
+    isSubscribed,
+    isNotificationSupported,
+    hasPermissionCache,
+    acceptedPermissionJustNow: isEnabled,
+    onAcceptedPermissionJustNow,
+    onTogglePermission,
+  } = useContext(NotificationsContext);
+  const [isDismissed, setIsDismissed, isLoaded] = usePersistentContext(
+    DISMISS_PERMISSION_BANNER,
+    false,
+  );
+  const onDismiss = () => {
+    trackEvent({
+      event_name: AnalyticsEvent.ClickNotificationDismiss,
+      extra: JSON.stringify({ origin: source }),
+    });
+    setIsDismissed(true);
+  };
+
+  const onEnable = async () => {
+    const permission = await onTogglePermission(source);
+
+    if (permission === null) {
+      return;
+    }
+
+    const isGranted = permission === 'granted';
+
+    onAcceptedPermissionJustNow?.(isGranted);
+  };
+
+  const hasEnabled = (isSubscribed || hasPermissionCache) && isEnabled;
+
+  const conditions = [
+    !isLoaded,
+    isDismissed,
+    !isInitialized,
+    !isNotificationSupported,
+    (isSubscribed || hasPermissionCache) && !isEnabled,
+    hasEnabled && source === NotificationPromptSource.SquadPostModal,
+  ];
+  const shouldShowCta = !conditions.some((passed) => passed);
+
+  useEffect(() => {
+    if (!shouldShowCta) {
+      return;
+    }
+
+    trackEvent({
+      event_name: AnalyticsEvent.Impression,
+      target_type: TargetType.EnableNotifications,
+      extra: JSON.stringify({ origin: source }),
+    });
+    // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldShowCta]);
+
+  useEffect(() => {
+    return () => {
+      if (onAcceptedPermissionJustNow) {
+        onAcceptedPermissionJustNow(false);
+      }
+    };
+  }, [onAcceptedPermissionJustNow]);
+
+  return {
+    isEnabled,
+    hasEnabled,
+    shouldShowCta,
+    onDismiss,
+    onEnable,
+  };
+};


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Have unified the process on whether to display the toggle or not. Feel free to check the difference between preview and preview2.
- Also, I think the toggle/banners won't show since we don't have a OneSignal dedicated for preview deployments.

https://preview.app.daily.dev/squads/newsquad123
https://preview2.app.daily.dev/squads/newsquad123

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
