### PR TITLE
fix: move pulse states to react query and on OpenState

### DIFF
--- a/packages/shared/src/components/cards/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCard.tsx
@@ -38,12 +38,15 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
   const onPostCardClick = () => onPostClick(post);
   const containerRef = useRef<HTMLDivElement>();
 
-  const { activeStep, isChecklistVisible } = useSquadChecklist({
+  const { openStep, isChecklistVisible } = useSquadChecklist({
     squad: post.source as Squad,
   });
 
   const shouldShowHighlightPulse =
-    isChecklistVisible && activeStep === ActionType.SquadFirstComment;
+    isChecklistVisible &&
+    [ActionType.SquadFirstComment, ActionType.EditWelcomePost].includes(
+      openStep,
+    );
 
   return (
     <Card

--- a/packages/shared/src/components/checklist/ChecklistCard.spec.tsx
+++ b/packages/shared/src/components/checklist/ChecklistCard.spec.tsx
@@ -5,6 +5,7 @@ import {
   RenderResult,
   screen,
 } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { ChecklistCardProps } from '../../lib/checklist';
 import { ChecklistCard } from './ChecklistCard';
 import { defaultSteps, updateStep } from '../../hooks/useChecklist.spec';
@@ -17,7 +18,12 @@ describe('ChecklistCard component', () => {
   });
 
   const renderComponent = (props: ChecklistCardProps): RenderResult => {
-    return render(<ChecklistCard {...props} />);
+    const client = new QueryClient();
+    return render(
+      <QueryClientProvider client={client}>
+        <ChecklistCard {...props} />
+      </QueryClientProvider>,
+    );
   };
 
   it('should render', async () => {

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -39,11 +39,11 @@ export function SquadPageHeader({
     key: TutorialKey.ShareSquadPost,
   });
 
-  const { activeStep, isChecklistVisible } = useSquadChecklist({ squad });
+  const { openStep, isChecklistVisible } = useSquadChecklist({ squad });
 
   const shouldShowHighlightPulse =
     tourIndex === TourScreenIndex.Post ||
-    (isChecklistVisible && activeStep === ActionType.SquadFirstPost);
+    (isChecklistVisible && openStep === ActionType.SquadFirstPost);
 
   return (
     <FlexCol

--- a/packages/shared/src/hooks/useChecklist.ts
+++ b/packages/shared/src/hooks/useChecklist.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from 'react-query';
 import { ChecklistStepType } from '../lib/checklist';
 import { Action, ActionType } from '../graphql/actions';
+
+const CHECKLIST_OPEN_STEP_KEY = 'checklistOpenStepKey';
 
 export type UseChecklistProps = {
   steps: ChecklistStepType[];
@@ -8,7 +11,7 @@ export type UseChecklistProps = {
 
 export type UseChecklist = {
   steps: ChecklistStepType[];
-  openStep: string | undefined;
+  openStep: ActionType | undefined;
   onToggleStep: (action: Action) => void;
   isDone: boolean;
   activeStep: ActionType | undefined;
@@ -16,25 +19,40 @@ export type UseChecklist = {
 };
 
 const useChecklist = ({ steps }: UseChecklistProps): UseChecklist => {
+  const client = useQueryClient();
   const activeStep = useMemo(
     () => steps.find((item) => !item.action.completedAt)?.action.type,
     [steps],
   );
-  const [openStep, setOpenStep] = useState<string>(activeStep);
+  // const [openStep, setOpenStep] = useState<ActionType>(activeStep);
+  const { data: openStep } = useQuery<ActionType | undefined>(
+    CHECKLIST_OPEN_STEP_KEY,
+    () => client.getQueryData(CHECKLIST_OPEN_STEP_KEY),
+    { initialData: undefined },
+  );
 
   useEffect(() => {
-    setOpenStep(activeStep);
-  }, [activeStep]);
+    client.setQueryData<ActionType | undefined>(
+      CHECKLIST_OPEN_STEP_KEY,
+      activeStep,
+    );
+  }, [client, activeStep]);
 
-  const onToggleStep = useCallback((action: Action) => {
-    setOpenStep((currentCheckedStep) => {
-      if (currentCheckedStep === action.type) {
-        return undefined;
-      }
+  const onToggleStep = useCallback(
+    (action: Action) => {
+      client.setQueryData<ActionType | undefined>(
+        CHECKLIST_OPEN_STEP_KEY,
+        (currentCheckedStep) => {
+          if (currentCheckedStep === action.type) {
+            return undefined;
+          }
 
-      return action.type;
-    });
-  }, []);
+          return action.type;
+        },
+      );
+    },
+    [client],
+  );
 
   const isDone = useMemo(() => {
     return steps.every((item) => !!item.action.completedAt);

--- a/packages/shared/src/hooks/useChecklist.ts
+++ b/packages/shared/src/hooks/useChecklist.ts
@@ -28,7 +28,7 @@ const useChecklist = ({ steps }: UseChecklistProps): UseChecklist => {
   const { data: openStep } = useQuery<ActionType | undefined>(
     CHECKLIST_OPEN_STEP_KEY,
     () => client.getQueryData(CHECKLIST_OPEN_STEP_KEY),
-    { initialData: undefined },
+    { initialData: undefined, ...disabledRefetch },
   );
   const setOpenStep = useCallback(
     (step: ActionType) => {

--- a/packages/shared/src/hooks/useChecklist.ts
+++ b/packages/shared/src/hooks/useChecklist.ts
@@ -28,30 +28,29 @@ const useChecklist = ({ steps }: UseChecklistProps): UseChecklist => {
   const { data: openStep } = useQuery<ActionType | undefined>(
     CHECKLIST_OPEN_STEP_KEY,
     () => client.getQueryData(CHECKLIST_OPEN_STEP_KEY),
-    { initialData: undefined, ...disabledRefetch },
+    { initialData: undefined },
+  );
+  const setOpenStep = useCallback(
+    (step: ActionType) => {
+      client.setQueryData<ActionType | undefined>(
+        CHECKLIST_OPEN_STEP_KEY,
+        () => step,
+      );
+      client.invalidateQueries(CHECKLIST_OPEN_STEP_KEY);
+    },
+    [client],
   );
 
   useEffect(() => {
-    client.setQueryData<ActionType | undefined>(
-      CHECKLIST_OPEN_STEP_KEY,
-      activeStep,
-    );
-  }, [client, activeStep]);
+    setOpenStep(activeStep);
+  }, [client, setOpenStep, activeStep]);
 
   const onToggleStep = useCallback(
     (action: Action) => {
-      client.setQueryData<ActionType | undefined>(
-        CHECKLIST_OPEN_STEP_KEY,
-        (currentCheckedStep) => {
-          if (currentCheckedStep === action.type) {
-            return undefined;
-          }
-
-          return action.type;
-        },
-      );
+      const step = openStep === action.type ? undefined : action.type;
+      setOpenStep(step);
     },
-    [client],
+    [openStep, setOpenStep],
   );
 
   const isDone = useMemo(() => {

--- a/packages/shared/src/hooks/useChecklist.ts
+++ b/packages/shared/src/hooks/useChecklist.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from 'react-query';
 import { ChecklistStepType } from '../lib/checklist';
 import { Action, ActionType } from '../graphql/actions';
+import { disabledRefetch } from '../lib/func';
 
 const CHECKLIST_OPEN_STEP_KEY = 'checklistOpenStepKey';
 
@@ -24,11 +25,10 @@ const useChecklist = ({ steps }: UseChecklistProps): UseChecklist => {
     () => steps.find((item) => !item.action.completedAt)?.action.type,
     [steps],
   );
-  // const [openStep, setOpenStep] = useState<ActionType>(activeStep);
   const { data: openStep } = useQuery<ActionType | undefined>(
     CHECKLIST_OPEN_STEP_KEY,
     () => client.getQueryData(CHECKLIST_OPEN_STEP_KEY),
-    { initialData: undefined },
+    { initialData: undefined, ...disabledRefetch },
   );
 
   useEffect(() => {

--- a/packages/shared/src/hooks/useChecklist.ts
+++ b/packages/shared/src/hooks/useChecklist.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useQuery, useQueryClient } from 'react-query';
 import { ChecklistStepType } from '../lib/checklist';
 import { Action, ActionType } from '../graphql/actions';


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Moved from useState to react query to have better control as multiple subscribers go to the same state
- Moved from active state to openState

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1360 WT-1363 #done
