### PR TITLE
fix: subscribe checklist

### DIFF
--- a/packages/shared/src/components/checklist/NotificationChecklistStep.tsx
+++ b/packages/shared/src/components/checklist/NotificationChecklistStep.tsx
@@ -1,23 +1,19 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement } from 'react';
 import { ChecklistStepProps } from '../../lib/checklist';
 import { Button } from '../buttons/Button';
 import { ChecklistStep } from './ChecklistStep';
 import BellIcon from '../icons/Bell';
-import NotificationsContext from '../../contexts/NotificationsContext';
 import { NotificationPromptSource } from '../../lib/analytics';
+import { useEnableNotification } from '../../hooks/useEnableNotification';
 
 const NotificationChecklistStep = (props: ChecklistStepProps): ReactElement => {
-  const { onTogglePermission } = useContext(NotificationsContext);
+  const { onEnable } = useEnableNotification({
+    source: NotificationPromptSource.SquadChecklist,
+  });
 
   return (
     <ChecklistStep {...props}>
-      <Button
-        icon={<BellIcon />}
-        className="btn-primary"
-        onClick={() => {
-          onTogglePermission(NotificationPromptSource.SquadChecklist);
-        }}
-      >
+      <Button icon={<BellIcon />} className="btn-primary" onClick={onEnable}>
         Subscribe
       </Button>
     </ChecklistStep>

--- a/packages/shared/src/contexts/NotificationsContext.tsx
+++ b/packages/shared/src/contexts/NotificationsContext.tsx
@@ -17,8 +17,6 @@ import { checkIsExtension } from '../lib/func';
 import AuthContext from './AuthContext';
 import { AnalyticsEvent, NotificationPromptSource } from '../lib/analytics';
 import { useAnalyticsContext } from './AnalyticsContext';
-import { useActions } from '../hooks/useActions';
-import { ActionType } from '../graphql/actions';
 
 export interface NotificationsContextData
   extends UseNotificationPermissionPopup {
@@ -59,7 +57,6 @@ export const NotificationsContextProvider = ({
   const isExtension = checkIsExtension();
   const { trackEvent } = useAnalyticsContext();
   const { user } = useContext(AuthContext);
-  const { actions, completeAction, checkHasCompleted } = useActions();
   const [OneSignal, setOneSignal] = useState(null);
   const [isInitializing, setIsInitializing] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
@@ -208,14 +205,6 @@ export const NotificationsContextProvider = ({
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isInitialized, isInitializing, user]);
-
-  // we could have make this trigger when the permission is once accepted
-  // but did this instead so we won't have to do retroactive checks in the BE
-  useEffect(() => {
-    if (!actions || !isSubscribed) return;
-
-    completeAction(ActionType.EnableNotification);
-  }, [actions, isSubscribed, completeAction, checkHasCompleted]);
 
   const data: NotificationsContextData = useMemo(
     () => ({

--- a/packages/shared/src/hooks/useEnableNotification.ts
+++ b/packages/shared/src/hooks/useEnableNotification.ts
@@ -7,6 +7,8 @@ import {
   NotificationPromptSource,
   TargetType,
 } from '../lib/analytics';
+import { useActions } from './useActions';
+import { ActionType } from '../graphql/actions';
 
 export const DISMISS_PERMISSION_BANNER = 'DISMISS_PERMISSION_BANNER';
 
@@ -25,6 +27,7 @@ interface UseEnableNotification {
 export const useEnableNotification = ({
   source = NotificationPromptSource.NotificationsPage,
 }: UseEnableNotificationProps): UseEnableNotification => {
+  const { completeAction } = useActions();
   const { trackEvent } = useAnalyticsContext();
   const {
     isInitialized,
@@ -57,6 +60,8 @@ export const useEnableNotification = ({
     const isGranted = permission === 'granted';
 
     onAcceptedPermissionJustNow?.(isGranted);
+
+    if (isGranted) completeAction(ActionType.EnableNotification);
   };
 
   const hasEnabled = (isSubscribed || hasPermissionCache) && isEnabled;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since we did an actual retro check from the BE, we don't need the use effect to identify whether the user is not yet subscribed.
- Made the checklist step to utilize our unified actions for notifications.
- Instead of relying on the use effect, we now explicitly complete the action once permission is granted.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
