### PR TITLE
feat: changing welcome image to max-width and not fixed

### DIFF
--- a/packages/shared/src/components/post/WelcomePostContent.tsx
+++ b/packages/shared/src/components/post/WelcomePostContent.tsx
@@ -15,7 +15,7 @@ function WelcomePostContent({ post }: WelcomePostContentProps): ReactElement {
         {post.title}
       </h1>
       <Markdown content={post.contentHtml} />
-      <div className="block overflow-hidden mt-8 w-96 rounded-2xl cursor-pointer h-fit">
+      <div className="block overflow-hidden mt-8 max-w-sm rounded-2xl cursor-pointer h-fit">
         <LazyImage
           imgSrc={post.image}
           imgAlt="Post cover image"


### PR DESCRIPTION
## Changes
The welcome post was using a fixed width image so was breaking mobile i changed this to a max-width instead

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1372 #done
