### PR TITLE
feat: Adding prop to hide description in UserShortInfo

### DIFF
--- a/packages/shared/src/components/RecommendedMention.tsx
+++ b/packages/shared/src/components/RecommendedMention.tsx
@@ -46,6 +46,7 @@ export function RecommendedMention({
           aria-selected={index === selected}
           role="option"
           disableTooltip
+          showDescription={false}
         />
       ))}
     </ul>

--- a/packages/shared/src/components/profile/UserShortInfo.tsx
+++ b/packages/shared/src/components/profile/UserShortInfo.tsx
@@ -88,7 +88,9 @@ export function UserShortInfo<Tag extends AnyTag>({
           <TextEllipsis className="text-theme-label-secondary">
             @{username}
           </TextEllipsis>
-          {bio && showDescription && <span className="mt-1 text-theme-label-tertiary">{bio}</span>}
+          {bio && showDescription && (
+            <span className="mt-1 text-theme-label-tertiary">{bio}</span>
+          )}
         </div>
       </ProfileTooltip>
       {children}

--- a/packages/shared/src/components/profile/UserShortInfo.tsx
+++ b/packages/shared/src/components/profile/UserShortInfo.tsx
@@ -29,6 +29,7 @@ interface UserShortInfoProps<Tag extends AnyTag> {
   scrollingContainer?: HTMLElement;
   appendTooltipTo?: HTMLElement;
   children?: ReactNode;
+  showDescription?: boolean;
 }
 
 const TextEllipsis = getTextEllipsis();
@@ -47,6 +48,7 @@ export function UserShortInfo<Tag extends AnyTag>({
   scrollingContainer,
   appendTooltipTo,
   children,
+  showDescription = true,
   ...props
 }: UserShortInfoProps<Tag> & Omit<PropsOf<Tag>, 'className'>): ReactElement {
   const Element = (tag || 'a') as React.ElementType;
@@ -86,7 +88,7 @@ export function UserShortInfo<Tag extends AnyTag>({
           <TextEllipsis className="text-theme-label-secondary">
             @{username}
           </TextEllipsis>
-          {bio && <span className="mt-1 text-theme-label-tertiary">{bio}</span>}
+          {bio && showDescription && <span className="mt-1 text-theme-label-tertiary">{bio}</span>}
         </div>
       </ProfileTooltip>
       {children}


### PR DESCRIPTION
## Changes
Adding this prop to make the description optional, this has been added for mentions popup to exclude the description in this one location

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1365 #done
