### PR TITLE
fix: notification tracking

### DIFF
--- a/packages/shared/src/contexts/AnalyticsContext.tsx
+++ b/packages/shared/src/contexts/AnalyticsContext.tsx
@@ -20,6 +20,7 @@ const AnalyticsContext = createContext<AnalyticsContextData>({
   trackEvent: () => {},
   trackEventStart: () => {},
   trackEventEnd: () => {},
+  sendBeacon: () => {},
 });
 export default AnalyticsContext;
 
@@ -57,6 +58,7 @@ export const AnalyticsContextProvider = ({
     sharedPropsRef,
     getPage,
     durationEventsQueue,
+    sendBeacon,
   );
   useBackfillPendingEvents(
     sharedPropsRef,

--- a/packages/shared/src/hooks/analytics/useAnalyticsContextData.ts
+++ b/packages/shared/src/hooks/analytics/useAnalyticsContextData.ts
@@ -7,6 +7,7 @@ export type AnalyticsContextData = {
   trackEvent: (event: AnalyticsEvent) => void;
   trackEventStart: (id: string, event: AnalyticsEvent) => void;
   trackEventEnd: (id: string, now?: Date) => void;
+  sendBeacon: () => void;
 };
 
 const generateEventId = (now = new Date()): string => {
@@ -45,6 +46,7 @@ export default function useAnalyticsContextData(
   sharedPropsRef: MutableRefObject<Partial<AnalyticsEvent>>,
   getPage: () => string,
   durationEventsQueue: MutableRefObject<Map<string, AnalyticsEvent>>,
+  sendBeacon: () => void,
 ): AnalyticsContextData {
   return useMemo<AnalyticsContextData>(
     () => ({
@@ -71,7 +73,8 @@ export default function useAnalyticsContextData(
           pushToQueue([event]);
         }
       },
+      sendBeacon,
     }),
-    [sharedPropsRef, getPage, pushToQueue, durationEventsQueue],
+    [sharedPropsRef, getPage, pushToQueue, durationEventsQueue, sendBeacon],
   );
 }

--- a/packages/webapp/pages/popup/notifications/enable.tsx
+++ b/packages/webapp/pages/popup/notifications/enable.tsx
@@ -8,6 +8,7 @@ import React, { useEffect } from 'react';
 import { ENABLE_NOTIFICATION_WINDOW_KEY } from '@dailydotdev/shared/src/hooks/useNotificationPermissionPopup';
 import { useRouter } from 'next/router';
 import { NotificationPromptSource } from '@dailydotdev/shared/src/lib/analytics';
+import { useAnalyticsContext } from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 
 const InstructionContainer = classed(
   'div',
@@ -22,6 +23,7 @@ function Enable(): React.ReactElement {
   const router = useRouter();
   const { isSubscribed, isInitialized, onTogglePermission } =
     useNotificationContext();
+  const { sendBeacon } = useAnalyticsContext();
   const { source } = router.query;
 
   useEffect(() => {
@@ -44,7 +46,10 @@ function Enable(): React.ReactElement {
       postWindowMessage(ENABLE_NOTIFICATION_WINDOW_KEY, { permission });
 
       if (permission === 'granted') {
-        setTimeout(window.close, 2000);
+        setTimeout(() => {
+          sendBeacon();
+          window.close();
+        }, 2000);
       }
     };
 


### PR DESCRIPTION
## Changes

### Describe what this PR does

Use OneSignal events to trigger proper tracking of events. I also made sure the popup sends all the events before closing by utilizing `sendBeacon`. Unfortunately, there is no way for me to test beside production because of OneSignal limitations.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
