### PR TITLE
fix: second notification tracking

### DIFF
--- a/packages/shared/src/contexts/NotificationsContext.tsx
+++ b/packages/shared/src/contexts/NotificationsContext.tsx
@@ -33,6 +33,7 @@ export interface NotificationsContextData
   onTogglePermission: (
     source: NotificationPromptSource,
   ) => Promise<NotificationPermission>;
+  trackPermissionGranted: () => void;
 }
 
 const NotificationsContext =
@@ -231,6 +232,7 @@ export const NotificationsContextProvider = ({
       get isNotificationSupported() {
         return !!globalThis.window?.Notification;
       },
+      trackPermissionGranted: () => subscriptionCallbackRef.current?.(true),
     }),
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -244,6 +246,7 @@ export const NotificationsContextProvider = ({
       isAlertShown,
       acceptedPermissionJustNow,
       hasPermissionCache,
+      subscriptionCallbackRef,
     ],
   );
 

--- a/packages/webapp/pages/popup/notifications/enable.tsx
+++ b/packages/webapp/pages/popup/notifications/enable.tsx
@@ -21,8 +21,12 @@ const Description = classed('p', 'typo-callout text-theme-label-tertiary');
 
 function Enable(): React.ReactElement {
   const router = useRouter();
-  const { isSubscribed, isInitialized, onTogglePermission } =
-    useNotificationContext();
+  const {
+    isSubscribed,
+    isInitialized,
+    onTogglePermission,
+    trackPermissionGranted,
+  } = useNotificationContext();
   const { sendBeacon } = useAnalyticsContext();
   const { source } = router.query;
 
@@ -32,11 +36,17 @@ function Enable(): React.ReactElement {
     }
 
     const checkPermission = async () => {
+      const closeWindow = () => {
+        sendBeacon();
+        window.close();
+      };
+
       if (isSubscribed) {
         postWindowMessage(ENABLE_NOTIFICATION_WINDOW_KEY, {
           permission: 'granted',
         });
-        window.close();
+        trackPermissionGranted();
+        closeWindow();
         return;
       }
 
@@ -46,10 +56,7 @@ function Enable(): React.ReactElement {
       postWindowMessage(ENABLE_NOTIFICATION_WINDOW_KEY, { permission });
 
       if (permission === 'granted') {
-        setTimeout(() => {
-          sendBeacon();
-          window.close();
-        }, 2000);
+        setTimeout(closeWindow, 1000);
       }
     };
 


### PR DESCRIPTION
## Changes

### Describe what this PR does

I found an edge case where permission is already granted on the device, but a new user is asking for push notifications

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
