### PR TITLE
fix: remove pin option in my feed

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -59,6 +59,7 @@ export interface FeedProps<T>
   emptyScreen?: ReactNode;
   header?: ReactNode;
   forceCardMode?: boolean;
+  allowPin?: boolean;
 }
 
 interface RankVariables {
@@ -147,6 +148,7 @@ export default function Feed<T>({
   emptyScreen,
   forceCardMode,
   options,
+  allowPin,
 }: FeedProps<T>): ReactElement {
   const { showCommentPopover } = useContext(FeaturesContext);
   const { alerts } = useContext(AlertContext);
@@ -490,6 +492,7 @@ export default function Feed<T>({
           onHidden={() => setPostMenuIndex(null)}
           onRemovePost={onRemovePost}
           origin={Origin.Feed}
+          allowPin={allowPin}
         />
         <ShareOptionsMenu
           {...commonMenuItems}

--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -51,6 +51,7 @@ export interface PostOptionsMenuProps extends ShareBookmarkProps {
   setShowBanPost?: () => unknown;
   contextId?: string;
   origin: Origin;
+  allowPin?: boolean;
 }
 
 type ReportPostAsync = (
@@ -71,6 +72,7 @@ export default function PostOptionsMenu({
   setShowBanPost,
   feedQueryKey,
   origin,
+  allowPin,
   contextId = 'post-context',
 }: PostOptionsMenuProps): ReactElement {
   const client = useQueryClient();
@@ -269,7 +271,7 @@ export default function PostOptionsMenu({
       action: onConfirmDeletePost,
     });
   }
-  if (onPinPost) {
+  if (allowPin && onPinPost) {
     postOptions.unshift({
       icon: <MenuIcon Icon={PinIcon} secondary={!!post.pinnedAt} />,
       text: post.pinnedAt ? 'Unpin from top' : 'Pin to top',

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -212,6 +212,7 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
           forceCardMode
           emptyScreen={<SquadEmptyScreen />}
           options={{ refetchOnMount: true }}
+          allowPin
         />
       </BaseFeedPage>
     </ProtectedPage>


### PR DESCRIPTION
## Changes
- Pinning of posts option should only be seen in Squad feed as it is irrelevant in any other feed.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1378 #done
