### PR TITLE
feat: upload images on markdown

### DIFF
--- a/packages/shared/src/components/Loader.tsx
+++ b/packages/shared/src/components/Loader.tsx
@@ -4,11 +4,13 @@ import styles from './Loader.module.css';
 
 export interface LoaderProps extends HTMLAttributes<HTMLDivElement> {
   invertColor?: boolean;
+  innerClassName?: string;
 }
 
 export function Loader({
   className,
   invertColor,
+  innerClassName,
   ...props
 }: LoaderProps): ReactElement {
   return (
@@ -22,7 +24,11 @@ export function Loader({
       )}
     >
       <span
-        className={classNames(styles.inner, invertColor && styles.invert)}
+        className={classNames(
+          styles.inner,
+          invertColor && styles.invert,
+          innerClassName,
+        )}
       />
     </div>
   );

--- a/packages/shared/src/components/fields/ImageInput.tsx
+++ b/packages/shared/src/components/fields/ImageInput.tsx
@@ -48,7 +48,7 @@ const sizeToIconSize: Record<Size, IconSize> = {
   medium: IconSize.Small,
   large: IconSize.Medium,
 };
-const ACCEPTED_TYPES = 'image/png,image/jpeg';
+export const ACCEPTED_TYPES = 'image/png,image/jpeg';
 export const acceptedTypesList = ACCEPTED_TYPES.split(',');
 
 function ImageInput({

--- a/packages/shared/src/components/fields/ImageInput.tsx
+++ b/packages/shared/src/components/fields/ImageInput.tsx
@@ -38,7 +38,7 @@ interface ImageInputProps {
   fileSizeLimitMB?: number;
 }
 
-const MEGABYTE = 1024 * 1024;
+export const MEGABYTE = 1024 * 1024;
 
 const componentSize: Record<Size, string> = {
   medium: 'w-24 h-24 rounded-26',
@@ -49,6 +49,7 @@ const sizeToIconSize: Record<Size, IconSize> = {
   large: IconSize.Medium,
 };
 const ACCEPTED_TYPES = 'image/png,image/jpeg';
+export const acceptedTypesList = ACCEPTED_TYPES.split(',');
 
 function ImageInput({
   initialValue,
@@ -87,7 +88,7 @@ function ImageInput({
       return;
     }
 
-    if (!ACCEPTED_TYPES.split(',').includes(file.type)) {
+    if (!acceptedTypesList.includes(file.type)) {
       toast.displayToast(`File type is not allowed`);
       return;
     }

--- a/packages/shared/src/components/fields/MarkdownInput/MarkdownUploadLabel.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/MarkdownUploadLabel.tsx
@@ -1,0 +1,33 @@
+import React, { ReactElement } from 'react';
+import { ImageIcon } from '../../icons';
+import { Loader } from '../../Loader';
+
+interface MarkdownInputFooterProps {
+  uploadingCount: number;
+  uploadedCount: number;
+}
+
+export function MarkdownUploadLabel({
+  uploadingCount,
+  uploadedCount,
+}: MarkdownInputFooterProps): ReactElement {
+  if (uploadingCount === 0) {
+    return (
+      <>
+        <ImageIcon className="mr-2" />
+        Attach images by dragging & dropping
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Loader
+        className="mr-2 btn-loader"
+        innerClassName="before:border-t-theme-color-cabbage after:border-theme-color-cabbage"
+      />
+      Uploading in progress
+      {uploadedCount > 1 ? ` (${uploadedCount}/${uploadingCount})` : ''}
+    </>
+  );
+}

--- a/packages/shared/src/components/fields/MarkdownInput/MarkdownUploadLabel.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/MarkdownUploadLabel.tsx
@@ -27,7 +27,7 @@ export function MarkdownUploadLabel({
         innerClassName="before:border-t-theme-color-cabbage after:border-theme-color-cabbage"
       />
       Uploading in progress
-      {uploadedCount > 1 ? ` (${uploadedCount}/${uploadingCount})` : ''}
+      {uploadingCount > 1 ? ` (${uploadedCount}/${uploadingCount})` : ''}
     </>
   );
 }

--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -5,10 +5,8 @@ import { Button, ButtonSize } from '../../buttons/Button';
 import LinkIcon from '../../icons/Link';
 import AtIcon from '../../icons/At';
 import { RecommendedMentionTooltip } from '../../tooltips/RecommendedMentionTooltip';
-import {
-  useMarkdownInput,
-  UseMarkdownInputProps,
-} from '../../../hooks/input/useMarkdownInput';
+import { useMarkdownInput, UseMarkdownInputProps } from '../../../hooks/input';
+import { Loader } from '../../Loader';
 
 interface MarkdownInputProps
   extends Omit<UseMarkdownInputProps, 'textareaRef'> {
@@ -24,18 +22,19 @@ function MarkdownInput({
   postId,
   sourceId,
   onSubmit,
+  enableUpload,
   initialContent,
   textareaProps = {},
 }: MarkdownInputProps): ReactElement {
   const textareaRef = useRef<HTMLTextAreaElement>();
   const {
-    onInput,
     input,
     query,
     offset,
     selected,
-    onKeyUp,
-    onKeyDown,
+    callbacks,
+    uploadingCount,
+    uploadedCount,
     onLinkCommand,
     onMentionCommand,
     onApplyMention,
@@ -46,7 +45,43 @@ function MarkdownInput({
     initialContent,
     onSubmit,
     textareaRef,
+    enableUpload,
   });
+
+  const footerLabel = (() => {
+    if (uploadingCount === 0) {
+      return (
+        <>
+          <ImageIcon className="mr-2" />
+          Attach images by dragging & dropping
+        </>
+      );
+    }
+
+    const content = 'Uploading in progress';
+    const loader = (
+      <Loader
+        className="mr-2 btn-loader"
+        innerClassName="before:border-t-theme-color-cabbage after:border-theme-color-cabbage"
+      />
+    );
+
+    if (uploadingCount === 1) {
+      return (
+        <>
+          {loader}
+          {content}
+        </>
+      );
+    }
+
+    return (
+      <>
+        {loader}
+        {`${content} (${uploadedCount}/${uploadingCount})`}
+      </>
+    );
+  })();
 
   return (
     <div
@@ -57,13 +92,11 @@ function MarkdownInput({
     >
       <textarea
         {...textareaProps}
+        {...callbacks}
         ref={textareaRef}
         className="m-4 bg-transparent outline-none typo-body placeholder-theme-label-quaternary"
         placeholder="Start a discussion, ask a question or write about anything that you believe would benefit the squad. (Optional)"
         value={input}
-        onInput={onInput}
-        onKeyUp={onKeyUp}
-        onKeyDown={onKeyDown}
         rows={10}
       />
       <RecommendedMentionTooltip
@@ -75,25 +108,37 @@ function MarkdownInput({
         onMentionClick={onApplyMention}
       />
       <span className="flex flex-row items-center p-3 px-4 border-t border-theme-divider-tertiary">
-        <button
-          type="button"
-          className="flex relative flex-row typo-callout text-theme-label-quaternary"
-        >
-          <ImageIcon className="mr-2" />
-          Attach images by dragging & dropping
-        </button>
+        {enableUpload && (
+          <button
+            type="button"
+            className={classNames(
+              'flex relative flex-row typo-callout',
+              uploadingCount
+                ? 'text-theme-color-cabbage'
+                : 'text-theme-label-quaternary',
+            )}
+          >
+            {footerLabel}
+          </button>
+        )}
         <span className="grid grid-cols-3 gap-3 ml-auto text-theme-label-tertiary">
           <Button
+            type="button"
             buttonSize={ButtonSize.Small}
             icon={<LinkIcon secondary />}
             onClick={onLinkCommand}
           />
           <Button
+            type="button"
             buttonSize={ButtonSize.Small}
             icon={<AtIcon />}
             onClick={onMentionCommand}
           />
-          <Button buttonSize={ButtonSize.Small} icon={<MarkdownIcon />} />
+          <Button
+            type="button"
+            buttonSize={ButtonSize.Small}
+            icon={<MarkdownIcon />}
+          />
         </span>
       </span>
     </div>

--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -1,4 +1,9 @@
-import React, { ReactElement, TextareaHTMLAttributes, useRef } from 'react';
+import React, {
+  ChangeEventHandler,
+  ReactElement,
+  TextareaHTMLAttributes,
+  useRef,
+} from 'react';
 import classNames from 'classnames';
 import { ImageIcon, MarkdownIcon } from '../../icons';
 import { Button, ButtonSize } from '../../buttons/Button';
@@ -7,6 +12,7 @@ import AtIcon from '../../icons/At';
 import { RecommendedMentionTooltip } from '../../tooltips/RecommendedMentionTooltip';
 import { useMarkdownInput, UseMarkdownInputProps } from '../../../hooks/input';
 import { Loader } from '../../Loader';
+import { ACCEPTED_TYPES } from '../ImageInput';
 
 interface MarkdownInputProps
   extends Omit<UseMarkdownInputProps, 'textareaRef'> {
@@ -27,6 +33,7 @@ function MarkdownInput({
   textareaProps = {},
 }: MarkdownInputProps): ReactElement {
   const textareaRef = useRef<HTMLTextAreaElement>();
+  const uploadRef = useRef<HTMLInputElement>();
   const {
     input,
     query,
@@ -36,6 +43,7 @@ function MarkdownInput({
     uploadingCount,
     uploadedCount,
     onLinkCommand,
+    onUploadCommand,
     onMentionCommand,
     onApplyMention,
     mentions,
@@ -83,6 +91,9 @@ function MarkdownInput({
     );
   })();
 
+  const onUpload: ChangeEventHandler<HTMLInputElement> = (e) =>
+    onUploadCommand(e.currentTarget.files);
+
   return (
     <div
       className={classNames(
@@ -117,8 +128,17 @@ function MarkdownInput({
                 ? 'text-theme-color-cabbage'
                 : 'text-theme-label-quaternary',
             )}
+            onClick={() => uploadRef?.current?.click()}
           >
             {footerLabel}
+            <input
+              type="file"
+              className="hidden"
+              name="content_upload"
+              ref={uploadRef}
+              accept={ACCEPTED_TYPES}
+              onInput={onUpload}
+            />
           </button>
         )}
         <span className="grid grid-cols-3 gap-3 ml-auto text-theme-label-tertiary">

--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -5,14 +5,14 @@ import React, {
   useRef,
 } from 'react';
 import classNames from 'classnames';
-import { ImageIcon, MarkdownIcon } from '../../icons';
+import { MarkdownIcon } from '../../icons';
 import { Button, ButtonSize } from '../../buttons/Button';
 import LinkIcon from '../../icons/Link';
 import AtIcon from '../../icons/At';
 import { RecommendedMentionTooltip } from '../../tooltips/RecommendedMentionTooltip';
 import { useMarkdownInput, UseMarkdownInputProps } from '../../../hooks/input';
-import { Loader } from '../../Loader';
 import { ACCEPTED_TYPES } from '../ImageInput';
+import { MarkdownUploadLabel } from './MarkdownUploadLabel';
 
 interface MarkdownInputProps
   extends Omit<UseMarkdownInputProps, 'textareaRef'> {
@@ -56,41 +56,6 @@ function MarkdownInput({
     enableUpload,
   });
 
-  const footerLabel = (() => {
-    if (uploadingCount === 0) {
-      return (
-        <>
-          <ImageIcon className="mr-2" />
-          Attach images by dragging & dropping
-        </>
-      );
-    }
-
-    const content = 'Uploading in progress';
-    const loader = (
-      <Loader
-        className="mr-2 btn-loader"
-        innerClassName="before:border-t-theme-color-cabbage after:border-theme-color-cabbage"
-      />
-    );
-
-    if (uploadingCount === 1) {
-      return (
-        <>
-          {loader}
-          {content}
-        </>
-      );
-    }
-
-    return (
-      <>
-        {loader}
-        {`${content} (${uploadedCount}/${uploadingCount})`}
-      </>
-    );
-  })();
-
   const onUpload: ChangeEventHandler<HTMLInputElement> = (e) =>
     onUploadCommand(e.currentTarget.files);
 
@@ -130,7 +95,10 @@ function MarkdownInput({
             )}
             onClick={() => uploadRef?.current?.click()}
           >
-            {footerLabel}
+            <MarkdownUploadLabel
+              uploadingCount={uploadingCount}
+              uploadedCount={uploadedCount}
+            />
             <input
               type="file"
               className="hidden"

--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -73,6 +73,7 @@ function MarkdownInput({
         className="m-4 bg-transparent outline-none typo-body placeholder-theme-label-quaternary"
         placeholder="Start a discussion, ask a question or write about anything that you believe would benefit the squad. (Optional)"
         value={input}
+        onDragOver={(e) => e.preventDefault()} // for better experience and stop opening the file with browser
         rows={10}
       />
       <RecommendedMentionTooltip

--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -1,4 +1,4 @@
-import React, { FormEventHandler, ReactElement, ReactNode } from 'react';
+import React, { FormEventHandler, ReactElement } from 'react';
 import ImageInput from '../../../fields/ImageInput';
 import CameraIcon from '../../../icons/Camera';
 import { TextField } from '../../../fields/TextField';

--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -1,4 +1,4 @@
-import React, { FormEventHandler, ReactElement } from 'react';
+import React, { FormEventHandler, ReactElement, ReactNode } from 'react';
 import ImageInput from '../../../fields/ImageInput';
 import CameraIcon from '../../../icons/Camera';
 import { TextField } from '../../../fields/TextField';
@@ -14,6 +14,7 @@ export interface WriteFreeformContentProps {
   isPosting?: boolean;
   squadId: string;
   post?: Post;
+  enableUpload?: boolean;
 }
 
 export function WriteFreeformContent({
@@ -62,7 +63,11 @@ export function WriteFreeformContent({
         onSubmit={() => {}}
         sourceId={squadId}
         initialContent={post?.content}
-        textareaProps={{ name: 'content', required: true }}
+        enableUpload
+        textareaProps={{
+          name: 'content',
+          required: true,
+        }}
       />
       <span className="flex flex-row items-center mt-4">
         {shouldShowCta && (

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -536,17 +536,18 @@ export const UPLOAD_IMAGE_MUTATION = gql`
 `;
 
 const imageSizeLimitMB = 5;
-const maxSize = imageSizeLimitMB * MEGABYTE;
+export const allowedFileSize = imageSizeLimitMB * MEGABYTE;
+export const allowedContentImage = [...acceptedTypesList, 'image/gif'];
 
 export const uploadContentImage = async (
   image: File,
   onProcessing?: (file: File) => void,
 ): Promise<string> => {
-  if (image.size > maxSize) {
+  if (image.size > allowedFileSize) {
     throw new Error('File size exceeds the limit');
   }
 
-  if (!acceptedTypesList.includes(image.type)) {
+  if (!allowedContentImage.includes(image.type)) {
     throw new Error('File type is not allowed');
   }
 

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -9,6 +9,7 @@ import {
   SOURCE_SHORT_INFO_FRAGMENT,
   USER_SHORT_INFO_FRAGMENT,
 } from './fragments';
+import { acceptedTypesList, MEGABYTE } from '../components/fields/ImageInput';
 
 export type ReportReason = 'BROKEN' | 'NSFW' | 'CLICKBAIT' | 'LOW';
 
@@ -526,4 +527,32 @@ export const createPost = async (
   const res = await request(graphqlUrl, CREATE_POST_MUTATION, variables);
 
   return res.createFreeformPost;
+};
+
+export const UPLOAD_IMAGE_MUTATION = gql`
+  mutation UploadContentImage($image: Upload!) {
+    uploadContentImage(image: $image)
+  }
+`;
+
+const imageSizeLimitMB = 5;
+const maxSize = imageSizeLimitMB * MEGABYTE;
+
+export const uploadContentImage = async (
+  image: File,
+  onProcessing?: (file: File) => void,
+): Promise<string> => {
+  if (image.size > maxSize) {
+    throw new Error('File size exceeds the limit');
+  }
+
+  if (!acceptedTypesList.includes(image.type)) {
+    throw new Error('File type is not allowed');
+  }
+
+  if (onProcessing) onProcessing(image);
+
+  const res = await request(graphqlUrl, UPLOAD_IMAGE_MUTATION, { image });
+
+  return res.uploadContentImage;
 };

--- a/packages/shared/src/hooks/input/index.ts
+++ b/packages/shared/src/hooks/input/index.ts
@@ -1,0 +1,2 @@
+export * from './useSyncUploader';
+export * from './useMarkdownInput';

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -39,6 +39,7 @@ import {
   MEGABYTE,
 } from '../../components/fields/ImageInput';
 import { UploadState, useSyncUploader } from './useSyncUploader';
+import { useToastNotification } from '../useToastNotification';
 
 export interface UseMarkdownInputProps
   extends Pick<HTMLAttributes<HTMLTextAreaElement>, 'onSubmit'> {
@@ -90,6 +91,7 @@ export const useMarkdownInput = ({
   const { requestMethod } = useRequestProtocol();
   const key = ['user', query, postId, sourceId];
   const { user } = useAuthContext();
+  const { displayToast } = useToastNotification();
   const { uploadedCount, queueCount, pushUpload, startUploading } =
     useSyncUploader({
       onStarted: async (file) => {
@@ -100,9 +102,13 @@ export const useMarkdownInput = ({
         await command.replaceWord(replace, setInput, CursorType.Isolated);
       },
       onFinish: async (status, file, url) => {
-        if (status === UploadState.Failed) return; // toast?
+        if (status === UploadState.Failed) {
+          return displayToast(
+            'File type is not allowed or the size exceeded the limit',
+          );
+        }
 
-        setInput(command.onReplaceUpload(url, file.name));
+        return setInput(command.onReplaceUpload(url, file.name));
       },
     });
 

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -1,4 +1,5 @@
 import {
+  ClipboardEventHandler,
   DragEventHandler,
   FormEventHandler,
   HTMLAttributes,
@@ -50,7 +51,7 @@ export interface UseMarkdownInputProps
 
 type InputCallbacks = Pick<
   HTMLAttributes<HTMLTextAreaElement>,
-  'onSubmit' | 'onKeyDown' | 'onKeyUp' | 'onDrop' | 'onInput'
+  'onSubmit' | 'onKeyDown' | 'onKeyUp' | 'onDrop' | 'onInput' | 'onPaste'
 >;
 
 interface UseMarkdownInput {
@@ -253,6 +254,14 @@ export const useMarkdownInput = ({
     startUploading();
   };
 
+  const onPaste: ClipboardEventHandler<HTMLTextAreaElement> = (e) => {
+    e.preventDefault();
+
+    Array.from(e.clipboardData.files).forEach(verifyFile);
+
+    startUploading();
+  };
+
   return {
     input,
     query,
@@ -269,6 +278,7 @@ export const useMarkdownInput = ({
       onInput,
       onKeyUp,
       onKeyDown,
+      onPaste,
       onDrop: enableUpload && onDrop,
     },
     mentions: useMemo(() => data?.recommendedMentions ?? [], [data]),

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -258,6 +258,8 @@ export const useMarkdownInput = ({
   };
 
   const onPaste: ClipboardEventHandler<HTMLTextAreaElement> = (e) => {
+    if (!e.clipboardData.files?.length) return;
+
     e.preventDefault();
 
     Array.from(e.clipboardData.files).forEach(verifyFile);

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -34,12 +34,10 @@ import {
 import { UserShortProfile } from '../../lib/user';
 import { getLinkReplacement, getMentionReplacement } from '../../lib/markdown';
 import { handleRegex } from '../../graphql/users';
-import {
-  acceptedTypesList,
-  MEGABYTE,
-} from '../../components/fields/ImageInput';
+import { MEGABYTE } from '../../components/fields/ImageInput';
 import { UploadState, useSyncUploader } from './useSyncUploader';
 import { useToastNotification } from '../useToastNotification';
+import { allowedContentImage, allowedFileSize } from '../../graphql/posts';
 
 export interface UseMarkdownInputProps
   extends Pick<HTMLAttributes<HTMLTextAreaElement>, 'onSubmit'> {
@@ -70,9 +68,6 @@ interface UseMarkdownInput {
   uploadingCount: number;
   uploadedCount: number;
 }
-
-const imageSizeLimitMB = 5;
-const maxSize = imageSizeLimitMB * MEGABYTE;
 
 export const useMarkdownInput = ({
   textareaRef,
@@ -234,7 +229,9 @@ export const useMarkdownInput = ({
   };
 
   const verifyFile = (file: File) => {
-    if (file.size > maxSize || !acceptedTypesList.includes(file.type)) return;
+    const isValidType = allowedContentImage.includes(file.type);
+
+    if (file.size > allowedFileSize || !isValidType) return;
 
     pushUpload(file);
   };

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -13,6 +13,7 @@ import { useQuery } from 'react-query';
 import {
   CursorType,
   getCloseWord,
+  getCursorType,
   GetReplacementFn,
   getTemporaryUploadString,
   TextareaCommand,
@@ -35,7 +36,6 @@ import {
 import { UserShortProfile } from '../../lib/user';
 import { getLinkReplacement, getMentionReplacement } from '../../lib/markdown';
 import { handleRegex } from '../../graphql/users';
-import { MEGABYTE } from '../../components/fields/ImageInput';
 import { UploadState, useSyncUploader } from './useSyncUploader';
 import { useToastNotification } from '../useToastNotification';
 import { allowedContentImage, allowedFileSize } from '../../graphql/posts';
@@ -95,7 +95,10 @@ export const useMarkdownInput = ({
         const replace: GetReplacementFn = (_, { trailingChar }) => ({
           replacement: `${!trailingChar ? '' : '\n\n'}${temporary}\n\n`,
         });
-        await command.replaceWord(replace, setInput, CursorType.Isolated);
+        const type = getCursorType(textarea);
+        const allowedType =
+          type === CursorType.Adjacent ? CursorType.Isolated : type;
+        await command.replaceWord(replace, setInput, allowedType);
       },
       onFinish: async (status, file, url) => {
         if (status === UploadState.Failed) {

--- a/packages/shared/src/hooks/input/useSyncUploader.ts
+++ b/packages/shared/src/hooks/input/useSyncUploader.ts
@@ -41,8 +41,7 @@ export const useSyncUploader = ({
         }
 
         setUploadedCount(uploadedCount + 1);
-        const upload = filesRef.current.pop();
-        uploadImage(upload);
+        uploadImage(filesRef.current.pop());
       });
   };
 
@@ -51,10 +50,7 @@ export const useSyncUploader = ({
 
     setQueueCount(filesRef.current.length);
 
-    if (!queueCount) {
-      const file = filesRef.current.pop();
-      uploadImage(file);
-    }
+    if (!queueCount) uploadImage(filesRef.current.pop());
   };
 
   const pushUpload = (file: File) => {

--- a/packages/shared/src/hooks/input/useSyncUploader.ts
+++ b/packages/shared/src/hooks/input/useSyncUploader.ts
@@ -1,0 +1,62 @@
+import { useRef, useState } from 'react';
+import { uploadContentImage } from '../../graphql/posts';
+import { nextTick } from '../../lib/func';
+
+interface UseSyncUploaderProps {
+  onStarted: (file: File) => void;
+  onFinish: (status: UploadState, file: File, url?: string) => void;
+}
+
+interface UseSyncUploader {
+  queueCount: number;
+  uploadedCount: number;
+  startUploading: () => void;
+  pushUpload: (file: File) => void;
+}
+
+export enum UploadState {
+  Failed = 'failed',
+  Ok = 'ok',
+}
+
+export const useSyncUploader = ({
+  onStarted,
+  onFinish,
+}: UseSyncUploaderProps): UseSyncUploader => {
+  const filesRef = useRef<File[]>([]);
+  const [queueCount, setQueueCount] = useState(0);
+  const [uploadedCount, setUploadedCount] = useState(0);
+
+  const uploadImage = (file: File) => {
+    uploadContentImage(file, onStarted)
+      .then((url) => onFinish(UploadState.Ok, file, url))
+      .catch(() => onFinish(UploadState.Failed, file))
+      .finally(async () => {
+        await nextTick();
+
+        if (!filesRef.current.length) {
+          setUploadedCount(0);
+          setQueueCount(0);
+          return;
+        }
+
+        setUploadedCount(uploadedCount + 1);
+        const upload = filesRef.current.pop();
+        uploadImage(upload);
+      });
+  };
+
+  const startUploading = () => {
+    if (!filesRef.current.length) return;
+
+    setQueueCount(filesRef.current.length);
+    const file = filesRef.current.pop();
+    uploadImage(file);
+  };
+
+  const pushUpload = (file: File) => {
+    filesRef.current.push(file);
+  };
+
+  return { queueCount, uploadedCount, pushUpload, startUploading };
+};

--- a/packages/shared/src/hooks/input/useSyncUploader.ts
+++ b/packages/shared/src/hooks/input/useSyncUploader.ts
@@ -50,8 +50,11 @@ export const useSyncUploader = ({
     if (!filesRef.current.length) return;
 
     setQueueCount(filesRef.current.length);
-    const file = filesRef.current.pop();
-    uploadImage(file);
+
+    if (!queueCount) {
+      const file = filesRef.current.pop();
+      uploadImage(file);
+    }
   };
 
   const pushUpload = (file: File) => {

--- a/packages/shared/src/lib/textarea.ts
+++ b/packages/shared/src/lib/textarea.ts
@@ -211,42 +211,4 @@ export class TextareaCommand {
 
     return concatReplacement(this.textarea, position, replacement);
   }
-
-  // private async uploadImage(
-  //   file: File,
-  //   onUploading: ReplacedFn,
-  //   onFinish: (state: UploadImage) => void,
-  // ): Promise<void> {
-  //   const temporary = `![${file.name}]()`;
-  //
-  //   const replace: GetReplacementFn = (_, { trailingChar }) => ({
-  //     replacement: `${!trailingChar ? '' : '\n\n'}${temporary}\n\n`,
-  //   });
-  //
-  //   uploadContentImage(file, () => this.replaceWord(replace, onUploading))
-  //     .then((url) => {
-  //       const result = this.onReplaceUpload(url, file.name);
-  //       onFinish({ status: UploadState.Ok, result });
-  //     })
-  //     .catch(() => {
-  //       onFinish({ status: UploadState.Failed });
-  //     })
-  //     .finally(async () => {
-  //       await nextTick();
-  //       if (this.files.length) {
-  //         const upload = this.files.pop();
-  //         this.uploadImage(upload, onUploading, onFinish);
-  //       }
-  //     });
-  // }
-  //
-  // initializeUpload(
-  //   onUploading: ReplacedFn,
-  //   onFinish: (state: UploadImage) => void,
-  // ): void {
-  //   if (!this.files.length) return;
-  //
-  //   const file = this.files.pop();
-  //   this.uploadImage(file, onUploading, onFinish);
-  // }
 }

--- a/packages/shared/src/lib/textarea.ts
+++ b/packages/shared/src/lib/textarea.ts
@@ -77,7 +77,7 @@ export enum CursorType {
   Highlighted = 'highlighted',
 }
 
-const getCursorType = (textarea: HTMLTextAreaElement) => {
+export const getCursorType = (textarea: HTMLTextAreaElement): CursorType => {
   const [start, end] = [textarea.selectionStart, textarea.selectionEnd];
   const [highlighted, trailing] = getSelectedString(textarea);
 

--- a/packages/shared/src/lib/textarea.ts
+++ b/packages/shared/src/lib/textarea.ts
@@ -2,7 +2,7 @@ import { MutableRefObject } from 'react';
 import { nextTick } from './func';
 
 export const isFalsyOrSpace = (value: string): boolean =>
-  !value || value === ' ';
+  !value || value === ' ' || value === '\n';
 
 const getSelectedString = (textarea: HTMLTextAreaElement) => {
   const [start, end] = [textarea.selectionStart, textarea.selectionEnd];

--- a/packages/shared/src/lib/textarea.ts
+++ b/packages/shared/src/lib/textarea.ts
@@ -1,3 +1,4 @@
+import { MutableRefObject } from 'react';
 import { nextTick } from './func';
 
 export const isFalsyOrSpace = (value: string): boolean =>
@@ -104,27 +105,35 @@ type TypeReplacementFn = (
   getReplacement: GetReplacementFn,
 ) => [string, number[]];
 
+type ReplacedFn = (result: string) => void;
+
 export type GetReplacementFn = (
   type: CursorType,
   props: GetReplacementOptionalProps,
 ) => GetReplacement;
 
+export const getTemporaryUploadString = (filename: string): string =>
+  `![${filename}]()`;
+
 export class TextareaCommand {
-  private type: CursorType;
+  private textareaRef: MutableRefObject<HTMLTextAreaElement>;
 
-  private textarea: HTMLTextAreaElement;
+  constructor(textareaRef: MutableRefObject<HTMLTextAreaElement>) {
+    this.textareaRef = textareaRef;
+  }
 
-  constructor(textarea: HTMLTextAreaElement, type?: CursorType) {
-    this.type = type ?? getCursorType(textarea);
-    this.textarea = textarea;
+  get textarea(): HTMLTextAreaElement {
+    return this.textareaRef.current;
   }
 
   private getIsolatedReplacement: TypeReplacementFn = (getReplacement) => {
     const start = this.textarea.selectionStart;
-    const selection = [start, this.textarea.selectionEnd];
+    const selection = [start, start];
     const { replacement, offset } = getReplacement(CursorType.Isolated, {
       word: '',
       selection,
+      trailingChar: this.textarea.value[start - 1],
+      leadingChar: this.textarea.value[start + 1],
     });
     const result = concatReplacement(this.textarea, selection, replacement);
     const index = start + replacement.length;
@@ -166,12 +175,14 @@ export class TextareaCommand {
     return [result, offset ?? [end, end]];
   };
 
-  private getResult(getReplacement: GetReplacementFn) {
-    if (this.type === CursorType.Isolated) {
+  private getResult(getReplacement: GetReplacementFn, forcedType?: CursorType) {
+    const type = forcedType ?? getCursorType(this.textarea);
+
+    if (type === CursorType.Isolated) {
       return this.getIsolatedReplacement(getReplacement);
     }
 
-    if (this.type === CursorType.Highlighted) {
+    if (type === CursorType.Highlighted) {
       return this.getHighlightedReplacement(getReplacement);
     }
 
@@ -180,11 +191,62 @@ export class TextareaCommand {
 
   async replaceWord(
     getReplacement: GetReplacementFn,
-    onReplaced: (result: string) => void,
+    onReplaced: ReplacedFn,
+    forcedType?: CursorType,
   ): Promise<string> {
-    const [result, position] = this.getResult(getReplacement);
+    const [result, position] = this.getResult(getReplacement, forcedType);
     onReplaced(result);
     await focusInput(this.textarea, position);
     return result;
   }
+
+  onReplaceUpload(url: string, filename: string): string {
+    const temporary = getTemporaryUploadString(filename);
+    const start = this.textarea.value.indexOf(temporary);
+    const file = filename.split('.');
+    file.pop();
+    const position = [start, start + temporary.length];
+    const alt = file.join('.');
+    const replacement = `![${alt}](${url})`;
+
+    return concatReplacement(this.textarea, position, replacement);
+  }
+
+  // private async uploadImage(
+  //   file: File,
+  //   onUploading: ReplacedFn,
+  //   onFinish: (state: UploadImage) => void,
+  // ): Promise<void> {
+  //   const temporary = `![${file.name}]()`;
+  //
+  //   const replace: GetReplacementFn = (_, { trailingChar }) => ({
+  //     replacement: `${!trailingChar ? '' : '\n\n'}${temporary}\n\n`,
+  //   });
+  //
+  //   uploadContentImage(file, () => this.replaceWord(replace, onUploading))
+  //     .then((url) => {
+  //       const result = this.onReplaceUpload(url, file.name);
+  //       onFinish({ status: UploadState.Ok, result });
+  //     })
+  //     .catch(() => {
+  //       onFinish({ status: UploadState.Failed });
+  //     })
+  //     .finally(async () => {
+  //       await nextTick();
+  //       if (this.files.length) {
+  //         const upload = this.files.pop();
+  //         this.uploadImage(upload, onUploading, onFinish);
+  //       }
+  //     });
+  // }
+  //
+  // initializeUpload(
+  //   onUploading: ReplacedFn,
+  //   onFinish: (state: UploadImage) => void,
+  // ): void {
+  //   if (!this.files.length) return;
+  //
+  //   const file = this.files.pop();
+  //   this.uploadImage(file, onUploading, onFinish);
+  // }
 }

--- a/packages/webapp/pages/squads/[handle]/create.tsx
+++ b/packages/webapp/pages/squads/[handle]/create.tsx
@@ -2,10 +2,7 @@ import React, { FormEventHandler, ReactElement } from 'react';
 import { useRouter } from 'next/router';
 import { WritePage } from '@dailydotdev/shared/src/components/post/freeform';
 import { useMutation } from 'react-query';
-import {
-  createPost,
-  CreatePostProps,
-} from '@dailydotdev/shared/src/graphql/posts';
+import { createPost } from '@dailydotdev/shared/src/graphql/posts';
 import { formToJson } from '@dailydotdev/shared/src/lib/form';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
 import { ApiErrorResult } from '@dailydotdev/shared/src/graphql/common';

--- a/packages/webapp/pages/squads/[handle]/create.tsx
+++ b/packages/webapp/pages/squads/[handle]/create.tsx
@@ -36,9 +36,9 @@ function CreatePost(): ReactElement {
 
     if (isPosting) return null;
 
-    const data = formToJson<CreatePostProps>(e.currentTarget);
+    const { title, content, image } = formToJson(e.currentTarget);
 
-    return onCreatePost({ ...data, sourceId: squad.id });
+    return onCreatePost({ title, content, image, sourceId: squad.id });
   };
 
   return (


### PR DESCRIPTION
## Changes

File upload by dropping files on the textarea or clicking the footer of the textarea itself.

The process flow is taken from the current behavior of GitHub's markdown input support for files. The upload process can be done with multiple files but each file is processed one after the other.

Have refactored to make the instance of the command class be created only once.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1336 #done
