### PR TITLE
feat: support local draft

### DIFF
--- a/packages/shared/src/components/fields/BaseFieldContainer.tsx
+++ b/packages/shared/src/components/fields/BaseFieldContainer.tsx
@@ -17,6 +17,7 @@ interface FieldStateProps {
   hasActionIcon?: boolean;
   isTertiaryField?: boolean;
   isSecondaryField?: boolean;
+  isPrimaryField?: boolean;
 }
 
 export interface FieldClassName {
@@ -34,8 +35,14 @@ export const getFieldLabelColor = ({
   hasInput,
   disabled,
   focused,
+  isPrimaryField,
 }: FieldStateProps): string => {
-  if (readOnly || isLocked || (hasInput && !focused)) {
+  if (
+    readOnly ||
+    isLocked ||
+    (hasInput && !focused) ||
+    (isPrimaryField && hasInput)
+  ) {
     return 'text-theme-label-tertiary';
   }
 

--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -24,6 +24,7 @@ function MarkdownInput({
   postId,
   sourceId,
   onSubmit,
+  onValueUpdate,
   initialContent,
   textareaProps = {},
 }: MarkdownInputProps): ReactElement {
@@ -46,6 +47,7 @@ function MarkdownInput({
     initialContent,
     onSubmit,
     textareaRef,
+    onValueUpdate,
   });
 
   return (

--- a/packages/shared/src/components/fields/TextField.tsx
+++ b/packages/shared/src/components/fields/TextField.tsx
@@ -73,6 +73,7 @@ function TextFieldComponent(
   const isSecondaryField = fieldType === 'secondary';
   const isTertiaryField = fieldType === 'tertiary';
   const invalid = validInput === false || (required && inputLength === 0);
+  const hasValue = hasInput || !!inputRef?.current?.value?.length;
 
   return (
     <BaseFieldContainer
@@ -125,16 +126,17 @@ function TextFieldComponent(
           actionButton && 'mr-2',
         )}
       >
-        {isPrimaryField && (focused || hasInput) && (
+        {isPrimaryField && (focused || hasValue) && (
           <label
             className={classNames(
               'typo-caption1',
               getFieldLabelColor({
                 readOnly,
                 isLocked,
-                hasInput,
+                hasInput: hasValue,
                 focused,
                 disabled,
+                isPrimaryField: true,
               }),
             )}
             htmlFor={inputId}
@@ -169,7 +171,7 @@ function TextFieldComponent(
             getFieldFontColor({
               readOnly,
               disabled,
-              hasInput,
+              hasInput: hasValue,
               focused,
               hasActionIcon: !!rightIcon,
             }),

--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -25,7 +25,7 @@ interface WriteForm {
   image: string;
 }
 
-export const generateWritePostKey = (reference = 'create') =>
+export const generateWritePostKey = (reference = 'create'): string =>
   `write:post:${reference}`;
 
 export function WriteFreeformContent({

--- a/packages/shared/src/components/post/freeform/write/WritePage.tsx
+++ b/packages/shared/src/components/post/freeform/write/WritePage.tsx
@@ -19,12 +19,10 @@ interface WritePageProps extends Omit<WriteFreeformContentProps, 'squadId'> {
 
 export function WritePage({
   isEdit,
-  isPosting,
-  onSubmitForm,
   squad,
   isLoading,
   isForbidden,
-  post,
+  ...props
 }: WritePageProps): ReactElement {
   const isVerified = verifyPermission(squad, SourcePermissions.Post);
 
@@ -35,12 +33,7 @@ export function WritePage({
   return (
     <WritePageContainer>
       <WritePostHeader squad={squad} isEdit={isEdit} />
-      <WriteFreeformContent
-        onSubmitForm={onSubmitForm}
-        isPosting={isPosting}
-        squadId={squad.id}
-        post={post}
-      />
+      <WriteFreeformContent {...props} squadId={squad.id} />
     </WritePageContainer>
   );
 }

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -33,6 +33,7 @@ export interface UseMarkdownInputProps
   postId?: string;
   sourceId?: string;
   initialContent?: string;
+  onValueUpdate?: (value: string) => void;
 }
 
 interface UseMarkdownInput
@@ -57,6 +58,7 @@ export const useMarkdownInput = ({
   postId,
   sourceId,
   onSubmit,
+  onValueUpdate,
   initialContent = '',
 }: UseMarkdownInputProps): UseMarkdownInput => {
   const textarea = textareaRef?.current;
@@ -67,6 +69,11 @@ export const useMarkdownInput = ({
   const { requestMethod } = useRequestProtocol();
   const key = ['user', query, postId, sourceId];
   const { user } = useAuthContext();
+
+  const onUpdate = (value: string) => {
+    setInput(value);
+    if (onValueUpdate) onValueUpdate(value);
+  };
 
   const { data = { recommendedMentions: [] } } =
     useQuery<RecommendedMentionsData>(
@@ -99,18 +106,18 @@ export const useMarkdownInput = ({
   const onApplyMention = async (username: string) => {
     const command = new TextareaCommand(textarea, CursorType.Adjacent);
     const getUsernameReplacement = () => ({ replacement: `@${username} ` });
-    await command.replaceWord(getUsernameReplacement, setInput);
+    await command.replaceWord(getUsernameReplacement, onUpdate);
     updateQuery(undefined);
   };
 
   const onLinkCommand = async () => {
     const command = new TextareaCommand(textarea);
-    await command.replaceWord(getLinkReplacement, setInput);
+    await command.replaceWord(getLinkReplacement, onUpdate);
   };
 
   const onMentionCommand = async () => {
     const command = new TextareaCommand(textarea);
-    const replaced = await command.replaceWord(getMentionReplacement, setInput);
+    const replaced = await command.replaceWord(getMentionReplacement, onUpdate);
     const mention = replaced.trim().substring(1);
     setQuery(mention);
   };
@@ -182,7 +189,7 @@ export const useMarkdownInput = ({
 
     if (!target) return;
 
-    setInput(target.value);
+    onUpdate(target.value);
     checkMention();
   };
 

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -90,12 +90,12 @@ export const useMarkdownInput = ({
   const key = ['user', query, postId, sourceId];
   const { user } = useAuthContext();
   const { displayToast } = useToastNotification();
-  
+
   const onUpdate = (value: string) => {
     setInput(value);
     if (onValueUpdate) onValueUpdate(value);
   };
-  
+
   const { uploadedCount, queueCount, pushUpload, startUploading } =
     useSyncUploader({
       onStarted: async (file) => {
@@ -159,7 +159,7 @@ export const useMarkdownInput = ({
     updateQuery(undefined);
   };
 
-  const onLinkCommand = () => command.replaceWord(getLinkReplacement, onUpdate)
+  const onLinkCommand = () => command.replaceWord(getLinkReplacement, onUpdate);
 
   const onMentionCommand = async () => {
     const replaced = await command.replaceWord(getMentionReplacement, onUpdate);

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -1,6 +1,10 @@
 import React, { FormEventHandler, ReactElement } from 'react';
 import { useRouter } from 'next/router';
-import { WritePage } from '@dailydotdev/shared/src/components/post/freeform';
+import { del as deleteCache } from 'idb-keyval';
+import {
+  generateWritePostKey,
+  WritePage,
+} from '@dailydotdev/shared/src/components/post/freeform';
 import {
   CreatePostProps,
   editPost,
@@ -25,6 +29,8 @@ function EditPost(): ReactElement {
     editPost,
     {
       onSuccess: async () => {
+        const key = generateWritePostKey(post.id);
+        await deleteCache(key);
         await push(post.commentsPermalink);
       },
       onError: (data: ApiErrorResult) => {

--- a/packages/webapp/pages/squads/[handle]/create.tsx
+++ b/packages/webapp/pages/squads/[handle]/create.tsx
@@ -1,4 +1,4 @@
-import React, { FormEventHandler, ReactElement } from 'react';
+import React, { FormEventHandler, ReactElement, useRef } from 'react';
 import { useRouter } from 'next/router';
 import { WritePage } from '@dailydotdev/shared/src/components/post/freeform';
 import { useMutation } from 'react-query';

--- a/packages/webapp/pages/squads/[handle]/create.tsx
+++ b/packages/webapp/pages/squads/[handle]/create.tsx
@@ -1,4 +1,4 @@
-import React, { FormEventHandler, ReactElement, useRef } from 'react';
+import React, { FormEventHandler, ReactElement } from 'react';
 import { useRouter } from 'next/router';
 import { WritePage } from '@dailydotdev/shared/src/components/post/freeform';
 import { useMutation } from 'react-query';

--- a/packages/webapp/pages/squads/[handle]/create.tsx
+++ b/packages/webapp/pages/squads/[handle]/create.tsx
@@ -1,6 +1,10 @@
 import React, { FormEventHandler, ReactElement } from 'react';
 import { useRouter } from 'next/router';
-import { WritePage } from '@dailydotdev/shared/src/components/post/freeform';
+import { del as deleteCache } from 'idb-keyval';
+import {
+  generateWritePostKey,
+  WritePage,
+} from '@dailydotdev/shared/src/components/post/freeform';
 import { useMutation } from 'react-query';
 import {
   createPost,
@@ -22,7 +26,11 @@ function CreatePost(): ReactElement {
   const { mutateAsync: onCreatePost, isLoading: isPosting } = useMutation(
     createPost,
     {
-      onSuccess: (post) => push(post.commentsPermalink),
+      onSuccess: async (post) => {
+        const key = generateWritePostKey();
+        await deleteCache(key);
+        await push(post.commentsPermalink);
+      },
       onError: (data: ApiErrorResult) => {
         if (data?.response?.errors?.[0]) {
           displayToast(data?.response?.errors?.[0].message);


### PR DESCRIPTION
## Changes
- Usage of persistent context would allow saving the changes on a local cache state.
- This also fixes the issue with the guideline for input on primary fields with uncontrolled states.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1350 #done
