### PR TITLE
feat: first time writing post alert

### DIFF
--- a/packages/shared/src/components/alert/AlertPointer.tsx
+++ b/packages/shared/src/components/alert/AlertPointer.tsx
@@ -49,10 +49,10 @@ const alertContainerClasses: Record<AlertPlacement, string> = {
 const getContainerStyle = (
   [xOffset = 0, yOffset = 0]: OffsetXY = [0, 0],
 ): Record<AlertPlacement, CSSProperties> => ({
-  left: { left: xOffset },
-  right: { right: xOffset },
+  left: { left: xOffset, top: yOffset },
+  right: { right: xOffset, top: yOffset },
   bottom: { bottom: yOffset, left: xOffset },
-  top: { top: yOffset },
+  top: { top: yOffset, left: xOffset },
 });
 
 export interface AlertPointerProps {

--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -8,6 +8,9 @@ import { Button } from '../../../buttons/Button';
 import { WritePageMain } from './common';
 import { useNotificationToggle } from '../../../../hooks/notifications';
 import { Post } from '../../../../graphql/posts';
+import AlertPointer, { AlertPlacement } from '../../../alert/AlertPointer';
+import { useActions } from '../../../../hooks/useActions';
+import { ActionType } from '../../../../graphql/actions';
 
 export interface WriteFreeformContentProps {
   onSubmitForm: FormEventHandler<HTMLFormElement>;
@@ -22,13 +25,16 @@ export function WriteFreeformContent({
   squadId,
   post,
 }: WriteFreeformContentProps): ReactElement {
+  const { isFetched, checkHasCompleted, completeAction } = useActions();
   const { shouldShowCta, isEnabled, onToggle, onSubmitted } =
     useNotificationToggle();
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
+    completeAction(ActionType.WritePost);
     await onSubmitted();
     await onSubmitForm(e);
   };
+
   return (
     <WritePageMain onSubmit={handleSubmit}>
       <ImageInput
@@ -48,15 +54,31 @@ export function WriteFreeformContent({
           Cover image
         </span>
       </ImageInput>
-      <TextField
-        className={{ container: 'mt-6' }}
-        inputId="title"
-        name="title"
-        label="Post Title*"
-        placeholder="Give your post a title"
-        required
-        defaultValue={post?.title}
-      />
+      <AlertPointer
+        message={
+          <div className="flex flex-col w-64">
+            <h3 className="font-bold typo-headline">First time? 👋</h3>
+            <p className="mt-1 typo-subhead">
+              It looks like this is your first time sharing a post with the
+              squad! This is a community we build together. Please be welcoming
+              and open-minded.
+            </p>
+          </div>
+        }
+        isAlertDisabled={!isFetched || checkHasCompleted(ActionType.WritePost)}
+        onClose={() => completeAction(ActionType.WritePost)}
+        placement={AlertPlacement.Right}
+      >
+        <TextField
+          className={{ container: 'mt-6 w-full' }}
+          inputId="title"
+          name="title"
+          label="Post Title*"
+          placeholder="Give your post a title"
+          required
+          defaultValue={post?.title}
+        />
+      </AlertPointer>
       <MarkdownInput
         className="mt-4"
         onSubmit={() => {}}

--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -11,6 +11,7 @@ import { Post } from '../../../../graphql/posts';
 import AlertPointer, { AlertPlacement } from '../../../alert/AlertPointer';
 import { useActions } from '../../../../hooks/useActions';
 import { ActionType } from '../../../../graphql/actions';
+import useSidebarRendered from '../../../../hooks/useSidebarRendered';
 
 export interface WriteFreeformContentProps {
   onSubmitForm: FormEventHandler<HTMLFormElement>;
@@ -26,6 +27,7 @@ export function WriteFreeformContent({
   post,
 }: WriteFreeformContentProps): ReactElement {
   const { isFetched, checkHasCompleted, completeAction } = useActions();
+  const { sidebarRendered } = useSidebarRendered();
   const { shouldShowCta, isEnabled, onToggle, onSubmitted } =
     useNotificationToggle();
 
@@ -55,6 +57,8 @@ export function WriteFreeformContent({
         </span>
       </ImageInput>
       <AlertPointer
+        className={{ container: 'bg-theme-bg-primary' }}
+        offset={[4, -14]}
         message={
           <div className="flex flex-col w-64">
             <h3 className="font-bold typo-headline">First time? 👋</h3>
@@ -65,7 +69,11 @@ export function WriteFreeformContent({
             </p>
           </div>
         }
-        isAlertDisabled={!isFetched || checkHasCompleted(ActionType.WritePost)}
+        isAlertDisabled={
+          !isFetched ||
+          !sidebarRendered ||
+          checkHasCompleted(ActionType.WritePost)
+        }
         onClose={() => completeAction(ActionType.WritePost)}
         placement={AlertPlacement.Right}
       >

--- a/packages/shared/src/graphql/actions.ts
+++ b/packages/shared/src/graphql/actions.ts
@@ -11,6 +11,7 @@ export enum ActionType {
   SquadInvite = 'squad_invite',
   BrowserExtension = 'browser_extension',
   EnableNotification = 'enable_notification',
+  WritePost = 'write_post',
 }
 
 export interface Action {

--- a/packages/shared/src/hooks/useActions.ts
+++ b/packages/shared/src/hooks/useActions.ts
@@ -73,5 +73,5 @@ export const useActions = (): UseActions => {
       },
       checkHasCompleted,
     };
-  }, [actions, completeAction, checkHasCompleted]);
+  }, [actions, isFetched, completeAction, checkHasCompleted]);
 };

--- a/packages/shared/src/hooks/useActions.ts
+++ b/packages/shared/src/hooks/useActions.ts
@@ -11,6 +11,7 @@ import { generateQueryKey, RequestKey } from '../lib/query';
 
 interface UseActions {
   actions: Action[];
+  isFetched: boolean;
   checkHasCompleted: (type: ActionType) => boolean;
   completeAction: (type: ActionType) => Promise<void>;
 }
@@ -18,7 +19,7 @@ interface UseActions {
 export const useActions = (): UseActions => {
   const client = useQueryClient();
   const { user } = useAuthContext();
-  const { data: actions } = useQuery(
+  const { data: actions, isFetched } = useQuery(
     generateQueryKey(RequestKey.Actions, user),
     getUserActions,
     { enabled: !!user },
@@ -62,6 +63,7 @@ export const useActions = (): UseActions => {
   return useMemo<UseActions>(() => {
     return {
       actions,
+      isFetched,
       completeAction: (type: ActionType) => {
         if (checkHasCompleted(type)) {
           return undefined;


### PR DESCRIPTION
## Changes
- For first time users writing a post, whether editing (welcome post) or writing a new one, we should display an alert pointer.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1352 #done
