### PR TITLE
Wt 1378 stop showing the checklist until information is loaded

### DIFF
--- a/packages/shared/src/components/checklist/SquadChecklistCard.tsx
+++ b/packages/shared/src/components/checklist/SquadChecklistCard.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement, useContext, useEffect } from 'react';
-import classNames from 'classnames';
 import { ChecklistCard } from './ChecklistCard';
 import { useSquadChecklist } from '../../hooks/useSquadChecklist';
 import { Squad } from '../../graphql/sources';
@@ -14,10 +13,9 @@ import AnalyticsContext from '../../contexts/AnalyticsContext';
 import { AnalyticsEvent, TargetType } from '../../lib/analytics';
 
 const SquadChecklistCard = ({ squad }: { squad: Squad }): ReactElement => {
-  const { steps, isChecklistVisible, setChecklistVisible, isChecklistReady } =
-    useSquadChecklist({
-      squad,
-    });
+  const { steps, isChecklistVisible, setChecklistVisible } = useSquadChecklist({
+    squad,
+  });
   const { sidebarRendered } = useSidebarRendered();
   const { isDone } = useChecklist({ steps });
   const { trackEvent } = useContext(AnalyticsContext);
@@ -50,7 +48,6 @@ const SquadChecklistCard = ({ squad }: { squad: Squad }): ReactElement => {
       description="5 simple steps to squad greatness!"
       steps={steps}
       onRequestClose={onRequestClose}
-      className={classNames(isChecklistReady ? 'flex' : 'hidden')}
     />
   );
 

--- a/packages/shared/src/components/checklist/SquadChecklistCard.tsx
+++ b/packages/shared/src/components/checklist/SquadChecklistCard.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useContext, useEffect } from 'react';
+import classNames from 'classnames';
 import { ChecklistCard } from './ChecklistCard';
 import { useSquadChecklist } from '../../hooks/useSquadChecklist';
 import { Squad } from '../../graphql/sources';
@@ -13,9 +14,10 @@ import AnalyticsContext from '../../contexts/AnalyticsContext';
 import { AnalyticsEvent, TargetType } from '../../lib/analytics';
 
 const SquadChecklistCard = ({ squad }: { squad: Squad }): ReactElement => {
-  const { steps, isChecklistVisible, setChecklistVisible } = useSquadChecklist({
-    squad,
-  });
+  const { steps, isChecklistVisible, setChecklistVisible, isChecklistReady } =
+    useSquadChecklist({
+      squad,
+    });
   const { sidebarRendered } = useSidebarRendered();
   const { isDone } = useChecklist({ steps });
   const { trackEvent } = useContext(AnalyticsContext);
@@ -48,6 +50,7 @@ const SquadChecklistCard = ({ squad }: { squad: Squad }): ReactElement => {
       description="5 simple steps to squad greatness!"
       steps={steps}
       onRequestClose={onRequestClose}
+      className={classNames(isChecklistReady ? 'flex' : 'hidden')}
     />
   );
 

--- a/packages/shared/src/components/squads/SquadHeaderBar.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderBar.tsx
@@ -48,8 +48,13 @@ export function SquadHeaderBar({
     key: TutorialKey.CopySquadLink,
   });
 
-  const { steps, completedSteps, isChecklistVisible, setChecklistVisible } =
-    useSquadChecklist({ squad });
+  const {
+    steps,
+    completedSteps,
+    isChecklistVisible,
+    setChecklistVisible,
+    isChecklistReady,
+  } = useSquadChecklist({ squad });
 
   const completedStepsCount = completedSteps.length;
   const totalStepsCount = steps.length;
@@ -99,7 +104,7 @@ export function SquadHeaderBar({
       )}
       <SimpleTooltip
         forceLoad={!isTesting}
-        visible={completedStepsCount < totalStepsCount}
+        visible={isChecklistReady && completedStepsCount < totalStepsCount}
         container={{
           className: '-mb-4 bg-theme-color-onion !text-white',
         }}

--- a/packages/shared/src/hooks/useActions.ts
+++ b/packages/shared/src/hooks/useActions.ts
@@ -13,12 +13,13 @@ interface UseActions {
   actions: Action[];
   checkHasCompleted: (type: ActionType) => boolean;
   completeAction: (type: ActionType) => Promise<void>;
+  isActionsFetched: boolean;
 }
 
 export const useActions = (): UseActions => {
   const client = useQueryClient();
   const { user } = useAuthContext();
-  const { data: actions } = useQuery(
+  const { data: actions, isFetched: isActionsFetched } = useQuery(
     generateQueryKey(RequestKey.Actions, user),
     getUserActions,
     { enabled: !!user },
@@ -70,6 +71,7 @@ export const useActions = (): UseActions => {
         return completeAction(type);
       },
       checkHasCompleted,
+      isActionsFetched,
     };
-  }, [actions, completeAction, checkHasCompleted]);
+  }, [actions, completeAction, checkHasCompleted, isActionsFetched]);
 };

--- a/packages/shared/src/hooks/useSquadChecklist.tsx
+++ b/packages/shared/src/hooks/useSquadChecklist.tsx
@@ -26,12 +26,13 @@ type UseSquadChecklistProps = {
 type UseSquadChecklist = UseChecklist & {
   isChecklistVisible: boolean;
   setChecklistVisible: (value: boolean) => void;
+  isChecklistReady: boolean;
 };
 
 const useSquadChecklist = ({
   squad,
 }: UseSquadChecklistProps): UseSquadChecklist => {
-  const { actions } = useActions();
+  const { actions, isActionsFetched: isChecklistReady } = useActions();
   const { showArticleOnboarding } = useContext(OnboardingContext);
 
   const stepsMap = useMemo<
@@ -150,6 +151,7 @@ const useSquadChecklist = ({
     ...checklist,
     isChecklistVisible,
     setChecklistVisible,
+    isChecklistReady,
   };
 };
 


### PR DESCRIPTION
## Changes
Using the new isChecklistReady to render the Checklist card only once the data has been fetched.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
