### PR TITLE
feat: new tab experience update

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -7,7 +7,7 @@ import request from 'graphql-request';
 import { UPDATE_USER_SETTINGS_MUTATION } from '@dailydotdev/shared/src/graphql/settings';
 import { getLocalBootData } from '@dailydotdev/shared/src/contexts/BootProvider';
 import { getOrGenerateDeviceId } from '@dailydotdev/shared/src/hooks/analytics/useDeviceId';
-import { uninstall } from '@dailydotdev/shared/src/lib/constants';
+import { install, uninstall } from '@dailydotdev/shared/src/lib/constants';
 import { BOOT_LOCAL_KEY } from '@dailydotdev/shared/src/contexts/common';
 import { ExtensionMessageType } from '@dailydotdev/shared/src/lib/extension';
 import { getContentScriptPermissionAndRegister } from '../companion/useExtensionPermission';
@@ -173,6 +173,10 @@ browser.runtime.onInstalled.addListener(async (details) => {
 
   if (details.reason === 'update') {
     await getContentScriptPermissionAndRegister();
+  }
+
+  if (details.reason === 'install') {
+    browser.tabs.create({ url: install, active: true });
   }
 });
 

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -18,6 +18,7 @@ export const companionPermissionGrantedLink =
 export const initialDataKey = 'initial';
 export const submissionGuidelineDocsLink =
   'https://r.daily.dev/submission-guidelines';
+export const install = 'https://r.daily.dev/install';
 export const uninstall = 'https://r.daily.dev/uninstall';
 export const weeklyGoal = 'https://r.daily.dev/weekly-goal';
 export const sharingBookmarks = 'https://r.daily.dev/sharing-bookmarks';


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Open web app homepage after extension install
- Due to technical difficulties we can not add an overlay reliably ([details here](https://dailydotdev.slack.com/archives/C054E1B3JLT/p1685361293185909)) so skipping it here
  - we did add `?ref=install` to the homepage URL that is opened on extension install so we will be able to add stuff for users after install if needed in the future without need to update an extension. 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

COM-55 #done
