### PR TITLE
fix: wait freeform draft and copy change

### DIFF
--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -14,7 +14,6 @@ import { Button } from '../../../buttons/Button';
 import { WritePageMain } from './common';
 import { useNotificationToggle } from '../../../../hooks/notifications';
 import { EditPostProps, Post } from '../../../../graphql/posts';
-import usePersistentContext from '../../../../hooks/usePersistentContext';
 import { formToJson } from '../../../../lib/form';
 import useDebounce from '../../../../hooks/useDebounce';
 import AlertPointer, { AlertPlacement } from '../../../alert/AlertPointer';

--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -96,7 +96,7 @@ export function WriteFreeformContent({
       >
         <CameraIcon secondary />
         <span className="flex flex-row ml-1.5 font-bold typo-callout">
-          Cover image
+          Thumbnail
         </span>
       </ImageInput>
       <AlertPointer

--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -29,6 +29,8 @@ export interface WriteFreeformContentProps {
   post?: Post;
   enableUpload?: boolean;
   formRef?: MutableRefObject<HTMLFormElement>;
+  draft?: Partial<WriteForm>;
+  updateDraft?: (props: Partial<WriteForm>) => Promise<void>;
 }
 
 export interface WriteForm {
@@ -53,6 +55,8 @@ export function WriteFreeformContent({
   isPosting,
   squadId,
   post,
+  draft,
+  updateDraft,
   formRef: propRef,
 }: WriteFreeformContentProps): ReactElement {
   const formRef = useRef<HTMLFormElement>();
@@ -61,11 +65,6 @@ export function WriteFreeformContent({
   const { sidebarRendered } = useSidebarRendered();
   const { shouldShowCta, isEnabled, onToggle, onSubmitted } =
     useNotificationToggle();
-  const key = generateWritePostKey(post?.id);
-  const [draft, updateDraft] = usePersistentContext<Partial<WriteForm>>(
-    key,
-    {},
-  );
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
     completeAction(ActionType.WritePost);

--- a/packages/shared/src/hooks/input/useDiscardPost.ts
+++ b/packages/shared/src/hooks/input/useDiscardPost.ts
@@ -5,6 +5,7 @@ import {
   checkSavedProperty,
   generateWritePostKey,
   WriteForm,
+  WriteFreeformContentProps,
 } from '../../components/post/freeform';
 import {
   UseExitConfirmation,
@@ -16,8 +17,11 @@ interface UseDiscardPostProps {
   post?: Post;
 }
 
-interface UseDiscardPost extends UseExitConfirmation {
+interface UseDiscardPost
+  extends UseExitConfirmation,
+    Pick<WriteFreeformContentProps, 'draft' | 'updateDraft'> {
   formRef: MutableRefObject<HTMLFormElement>;
+  isDraftReady: boolean;
 }
 
 export const useDiscardPost = ({
@@ -25,7 +29,8 @@ export const useDiscardPost = ({
 }: UseDiscardPostProps = {}): UseDiscardPost => {
   const formRef = useRef<HTMLFormElement>();
   const draftKey = generateWritePostKey();
-  const [draft] = usePersistentContext<WriteForm>(draftKey);
+  const [draft, updateDraft, isDraftReady] =
+    usePersistentContext<WriteForm>(draftKey);
   const onValidateAction = useCallback(() => {
     const form = formToJson<EditPostProps>(formRef.current);
     const isTitleSaved = checkSavedProperty('title', form, draft, post);
@@ -35,5 +40,5 @@ export const useDiscardPost = ({
 
   const { onAskConfirmation } = useExitConfirmation({ onValidateAction });
 
-  return { onAskConfirmation, formRef };
+  return { onAskConfirmation, draft, updateDraft, isDraftReady, formRef };
 };

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -26,7 +26,8 @@ function EditPost(): ReactElement {
     [id, handle].includes(post?.source?.id),
   );
   const { displayToast } = useToastNotification();
-  const { onAskConfirmation, formRef } = useDiscardPost({ post });
+  const { onAskConfirmation, draft, updateDraft, isDraftReady, formRef } =
+    useDiscardPost({ post });
   const { mutateAsync: onCreatePost, isLoading: isPosting } = useMutation(
     editPost,
     {
@@ -63,10 +64,12 @@ function EditPost(): ReactElement {
       formRef={formRef}
       isPosting={isPosting}
       onSubmitForm={onClickSubmit}
-      isLoading={!isReady || !isFetched}
+      isLoading={!isReady || !isFetched || !isDraftReady}
       isForbidden={post?.author.id !== user?.id}
       squad={squad}
       post={post}
+      draft={draft}
+      updateDraft={updateDraft}
     />
   );
 }

--- a/packages/webapp/pages/squads/[handle]/create.tsx
+++ b/packages/webapp/pages/squads/[handle]/create.tsx
@@ -22,7 +22,8 @@ function CreatePost(): ReactElement {
     [id, handle].includes(query?.handle as string),
   );
   const { displayToast } = useToastNotification();
-  const { onAskConfirmation } = useDiscardPost();
+  const { onAskConfirmation, draft, updateDraft, isDraftReady } =
+    useDiscardPost();
   const { mutateAsync: onCreatePost, isLoading: isPosting } = useMutation(
     createPost,
     {
@@ -56,9 +57,11 @@ function CreatePost(): ReactElement {
   return (
     <WritePage
       onSubmitForm={onClickSubmit}
-      isLoading={!isReady}
+      isLoading={!isReady || !isDraftReady}
       formRef={formRef}
       squad={squad}
+      draft={draft}
+      updateDraft={updateDraft}
     />
   );
 }


### PR DESCRIPTION
## Changes
- Updated the copy for the cover image to Thumbnail.
- Fixed the freeform draft to wait for the cache to be loaded first.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
