### PR TITLE
fix: draft image

### DIFF
--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -74,7 +74,7 @@ export function WriteFreeformContent({
     useNotificationToggle();
 
   const getDraftImage = () => {
-    if (!draft.image) return null;
+    if (!draft?.image) return null;
 
     return base64ToFile(draft.image, draft.filename ?? defaultFilename);
   };
@@ -90,7 +90,7 @@ export function WriteFreeformContent({
 
   const onUpdate = async () => {
     const { title, content } = formToJson(formRef.current);
-    await updateDraft({ title, content, image: draft.image });
+    await updateDraft({ title, content, image: draft?.image });
   };
 
   const [onFormUpdate] = useDebounce(onUpdate, 3000);

--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -1,4 +1,5 @@
 import React, {
+  FormEvent,
   FormEventHandler,
   MutableRefObject,
   ReactElement,
@@ -20,9 +21,13 @@ import AlertPointer, { AlertPlacement } from '../../../alert/AlertPointer';
 import { useActions } from '../../../../hooks/useActions';
 import { ActionType } from '../../../../graphql/actions';
 import useSidebarRendered from '../../../../hooks/useSidebarRendered';
+import { base64ToFile } from '../../../../lib/base64';
 
 export interface WriteFreeformContentProps {
-  onSubmitForm: FormEventHandler<HTMLFormElement>;
+  onSubmitForm: (
+    e: FormEvent<HTMLFormElement>,
+    prop: WriteForm,
+  ) => Promise<Post>;
   isPosting?: boolean;
   squadId: string;
   post?: Post;
@@ -65,10 +70,18 @@ export function WriteFreeformContent({
   const { shouldShowCta, isEnabled, onToggle, onSubmitted } =
     useNotificationToggle();
 
+  const getImage = () => {
+    if (!draft.image) return null;
+
+    return base64ToFile(draft.image, 'thumbnail.png');
+  };
+
   const handleSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
     completeAction(ActionType.WritePost);
     await onSubmitted();
-    await onSubmitForm(e);
+    const { title, content, image: files } = formToJson(e.currentTarget);
+    const image = files?.[0] ?? (await getImage());
+    await onSubmitForm(e, { title, content, image });
   };
 
   const onUpdate = async () => {

--- a/packages/shared/src/hooks/input/useDiscardPost.ts
+++ b/packages/shared/src/hooks/input/useDiscardPost.ts
@@ -15,6 +15,7 @@ import usePersistentContext from '../usePersistentContext';
 
 interface UseDiscardPostProps {
   post?: Post;
+  draftIdentifier?: string;
 }
 
 interface UseDiscardPost
@@ -26,9 +27,10 @@ interface UseDiscardPost
 
 export const useDiscardPost = ({
   post,
+  draftIdentifier,
 }: UseDiscardPostProps = {}): UseDiscardPost => {
   const formRef = useRef<HTMLFormElement>();
-  const draftKey = generateWritePostKey(post?.id);
+  const draftKey = generateWritePostKey(draftIdentifier ?? post?.id);
   const [draft, updateDraft, isDraftReady] = usePersistentContext<
     Partial<WriteForm>
   >(draftKey, {});

--- a/packages/shared/src/hooks/input/useDiscardPost.ts
+++ b/packages/shared/src/hooks/input/useDiscardPost.ts
@@ -28,7 +28,7 @@ export const useDiscardPost = ({
   post,
 }: UseDiscardPostProps = {}): UseDiscardPost => {
   const formRef = useRef<HTMLFormElement>();
-  const draftKey = generateWritePostKey();
+  const draftKey = generateWritePostKey(post?.id);
   const [draft, updateDraft, isDraftReady] = usePersistentContext<
     Partial<WriteForm>
   >(draftKey, {});

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -48,8 +48,6 @@ function EditPost(): ReactElement {
   });
 
   const onClickSubmit = (e: FormEvent<HTMLFormElement>, params) => {
-    e.preventDefault();
-
     if (isPosting || isSuccess) return null;
 
     return onUpdatePost({ ...params, id: post.id });

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -1,15 +1,11 @@
-import React, { FormEventHandler, ReactElement } from 'react';
+import React, { FormEvent, ReactElement } from 'react';
 import { useRouter } from 'next/router';
 import { del as deleteCache } from 'idb-keyval';
 import {
   generateWritePostKey,
   WritePage,
 } from '@dailydotdev/shared/src/components/post/freeform';
-import {
-  CreatePostProps,
-  editPost,
-} from '@dailydotdev/shared/src/graphql/posts';
-import { formToJson } from '@dailydotdev/shared/src/lib/form';
+import { editPost } from '@dailydotdev/shared/src/graphql/posts';
 import usePostById from '@dailydotdev/shared/src/hooks/usePostById';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import { useMutation } from 'react-query';
@@ -31,7 +27,7 @@ function EditPost(): ReactElement {
   const { onAskConfirmation, draft, updateDraft, isDraftReady, formRef } =
     useDiscardPost({ post });
   const {
-    mutateAsync: onCreatePost,
+    mutateAsync: onUpdatePost,
     isLoading: isPosting,
     isSuccess,
   } = useMutation(editPost, {
@@ -51,17 +47,12 @@ function EditPost(): ReactElement {
     },
   });
 
-  const onClickSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+  const onClickSubmit = (e: FormEvent<HTMLFormElement>, params) => {
     e.preventDefault();
 
-    if (isPosting) return null;
+    if (isPosting || isSuccess) return null;
 
-    const data = formToJson<CreatePostProps & { image: File[] }>(
-      e.currentTarget,
-    );
-    const image = data.image ? data.image[0] : null;
-
-    return onCreatePost({ ...data, image, id: post.id });
+    return onUpdatePost({ ...params, id: post.id });
   };
 
   const seo: NextSeoProps = {

--- a/packages/webapp/pages/squads/[handle]/create.tsx
+++ b/packages/webapp/pages/squads/[handle]/create.tsx
@@ -1,4 +1,4 @@
-import React, { FormEventHandler, ReactElement } from 'react';
+import React, { FormEvent, ReactElement } from 'react';
 import { NextSeo, NextSeoProps } from 'next-seo';
 import { useRouter } from 'next/router';
 import { del as deleteCache } from 'idb-keyval';
@@ -8,7 +8,6 @@ import {
 } from '@dailydotdev/shared/src/components/post/freeform';
 import { useMutation } from 'react-query';
 import { createPost } from '@dailydotdev/shared/src/graphql/posts';
-import { formToJson } from '@dailydotdev/shared/src/lib/form';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
 import { ApiErrorResult } from '@dailydotdev/shared/src/graphql/common';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
@@ -52,15 +51,12 @@ function CreatePost(): ReactElement {
     },
   });
 
-  const onClickSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+  const onClickSubmit = (e: FormEvent<HTMLFormElement>, params) => {
     e.preventDefault();
 
-    if (isPosting) return null;
+    if (isPosting || isSuccess) return null;
 
-    const { title, content, image: files } = formToJson(e.currentTarget);
-    const image = files ? files[0] : null;
-
-    return onCreatePost({ title, content, image, sourceId: squad.id });
+    return onCreatePost({ ...params, sourceId: squad.id });
   };
 
   return (

--- a/packages/webapp/pages/squads/[handle]/create.tsx
+++ b/packages/webapp/pages/squads/[handle]/create.tsx
@@ -52,8 +52,6 @@ function CreatePost(): ReactElement {
   });
 
   const onClickSubmit = (e: FormEvent<HTMLFormElement>, params) => {
-    e.preventDefault();
-
     if (isPosting || isSuccess) return null;
 
     return onCreatePost({ ...params, sourceId: squad.id });

--- a/packages/webapp/pages/squads/[handle]/create.tsx
+++ b/packages/webapp/pages/squads/[handle]/create.tsx
@@ -29,7 +29,7 @@ function CreatePost(): ReactElement {
   );
   const { displayToast } = useToastNotification();
   const { onAskConfirmation, draft, updateDraft, isDraftReady, formRef } =
-    useDiscardPost();
+    useDiscardPost({ draftIdentifier: squad?.id });
   const {
     mutateAsync: onCreatePost,
     isLoading: isPosting,


### PR DESCRIPTION
## Changes
- When a draft image is saved locally, we are displaying it when the user comes back, but since we don't apply the value to the element on load, we should properly check if there is anything available in the draft.
- Also refactored the submit function to simplify and to just receive the params then change it if necessary.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
