### PR TITLE
fix: unstable mention navigation

### DIFF
--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -73,7 +73,7 @@ export function WriteFreeformContent({
 
   const onUpdate = async () => {
     const { title, content } = formToJson(formRef.current);
-    await updateDraft({ title, content, image: draft.image });
+    await updateDraft({ title, content, image: draft?.image });
   };
 
   const [onFormUpdate] = useDebounce(onUpdate, 3000);

--- a/packages/shared/src/hooks/input/useDiscardPost.ts
+++ b/packages/shared/src/hooks/input/useDiscardPost.ts
@@ -29,8 +29,9 @@ export const useDiscardPost = ({
 }: UseDiscardPostProps = {}): UseDiscardPost => {
   const formRef = useRef<HTMLFormElement>();
   const draftKey = generateWritePostKey();
-  const [draft, updateDraft, isDraftReady] =
-    usePersistentContext<WriteForm>(draftKey);
+  const [draft, updateDraft, isDraftReady] = usePersistentContext<
+    Partial<WriteForm>
+  >(draftKey, {});
   const onValidateAction = useCallback(() => {
     const form = formToJson<EditPostProps>(formRef.current);
     const isTitleSaved = checkSavedProperty('title', form, draft, post);


### PR DESCRIPTION
## Changes
- After further investigation, it seems the issue was not directly the keyboard navigation on mention but rather on the debounced function.
- When we try to mention someone, we type the `@` character where we trigger a debounce to update the draft, and during the process of selecting users to mention, the debounce await has finished and triggered the update of cache but it throws an error internally. It was due to the `draft` being nullable when referencing the `image` property to not be overwritten.

![Screenshot 2023-05-31 at 9 36 39 AM](https://github.com/dailydotdev/apps/assets/13744167/ad519a56-3fdc-4516-b2f3-5a66f906b474)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1409 #done
