### PR TITLE
fix: comment mention click handlers

### DIFF
--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -48,6 +48,8 @@ function MarkdownInput({
     onUploadCommand,
     onMentionCommand,
     onApplyMention,
+    onCloseMention,
+    checkMention,
     mentions,
   } = useMarkdownInput({
     postId,
@@ -76,6 +78,7 @@ function MarkdownInput({
         className="m-4 bg-transparent outline-none typo-body placeholder-theme-label-quaternary"
         placeholder="Start a discussion, ask a question or write about anything that you believe would benefit the squad. (Optional)"
         value={input}
+        onClick={() => checkMention()}
         onDragOver={(e) => e.preventDefault()} // for better experience and stop opening the file with browser
         rows={10}
       />
@@ -86,6 +89,7 @@ function MarkdownInput({
         selected={selected}
         query={query}
         onMentionClick={onApplyMention}
+        onClickOutside={onCloseMention}
       />
       <span className="flex flex-row items-center p-3 px-4 border-t border-theme-divider-tertiary">
         {enableUpload && (

--- a/packages/shared/src/components/tooltips/BaseTooltip.tsx
+++ b/packages/shared/src/components/tooltips/BaseTooltip.tsx
@@ -36,6 +36,7 @@ export interface TooltipProps
     | 'sticky'
     | 'plugins'
     | 'zIndex'
+    | 'onClickOutside'
   > {
   container?: Omit<
     BaseTooltipContainerProps,

--- a/packages/shared/src/components/tooltips/RecommendedMentionTooltip.tsx
+++ b/packages/shared/src/components/tooltips/RecommendedMentionTooltip.tsx
@@ -10,6 +10,7 @@ interface RecommendedMentionTooltipProps {
   mentions?: UserShortProfile[];
   offset?: number[];
   onMentionClick?: (username: string) => unknown;
+  onClickOutside?: () => void;
   appendTo?: () => HTMLElement;
   elementRef: MutableRefObject<HTMLElement>;
 }
@@ -25,6 +26,7 @@ export function RecommendedMentionTooltip({
   onMentionClick,
   appendTo,
   elementRef,
+  onClickOutside,
 }: RecommendedMentionTooltipProps): ReactElement {
   if (isTesting) {
     return null;
@@ -44,6 +46,7 @@ export function RecommendedMentionTooltip({
         />
       }
       offset={[offsetX, (offsetY + lines + EXTRA_SPACES) * -1]}
+      onClickOutside={onClickOutside}
       interactive
       container={{
         className: 'shadow',

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -272,7 +272,7 @@ export const useMarkdownInput = ({
     startUploading();
   };
 
-  const onCloseMention = useCallback(() => setQuery(undefined), [setQuery]);
+  const onCloseMention = useCallback(() => setQuery(undefined), []);
 
   return {
     input,

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -5,6 +5,7 @@ import {
   HTMLAttributes,
   KeyboardEventHandler,
   MutableRefObject,
+  useCallback,
   useEffect,
   useMemo,
   useState,
@@ -65,6 +66,7 @@ interface UseMarkdownInput {
   onUploadCommand: (files: FileList) => void;
   onApplyMention: (username: string) => Promise<void>;
   checkMention: (position?: number[]) => void;
+  onCloseMention: () => void;
   mentions: UserShortProfile[];
   callbacks: InputCallbacks;
   uploadingCount: number;
@@ -270,6 +272,8 @@ export const useMarkdownInput = ({
     startUploading();
   };
 
+  const onCloseMention = useCallback(() => setQuery(undefined), [setQuery]);
+
   return {
     input,
     query,
@@ -278,6 +282,7 @@ export const useMarkdownInput = ({
     uploadedCount,
     uploadingCount: queueCount,
     checkMention,
+    onCloseMention,
     onLinkCommand,
     onUploadCommand,
     onMentionCommand,


### PR DESCRIPTION
## Changes
- When a user clicks the textarea and points directly at a mention word, we should initialize back the mention for better UX.
- Also when the user clicks outside the tooltip, we should close it.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
