### PR TITLE
feat: make sure correct draft key is created after post creation

### DIFF
--- a/packages/shared/src/hooks/input/useDiscardPost.ts
+++ b/packages/shared/src/hooks/input/useDiscardPost.ts
@@ -1,4 +1,5 @@
 import { MutableRefObject, useCallback, useRef } from 'react';
+import { del as deleteCache } from 'idb-keyval';
 import { formToJson } from '../../lib/form';
 import { EditPostProps, Post } from '../../graphql/posts';
 import {
@@ -23,6 +24,7 @@ interface UseDiscardPost
     Pick<WriteFreeformContentProps, 'draft' | 'updateDraft'> {
   formRef: MutableRefObject<HTMLFormElement>;
   isDraftReady: boolean;
+  clearDraft: () => void;
 }
 
 export const useDiscardPost = ({
@@ -43,5 +45,16 @@ export const useDiscardPost = ({
 
   const { onAskConfirmation } = useExitConfirmation({ onValidateAction });
 
-  return { onAskConfirmation, draft, updateDraft, isDraftReady, formRef };
+  const clearDraft = useCallback(async () => {
+    await deleteCache(draftKey);
+  }, [draftKey]);
+
+  return {
+    onAskConfirmation,
+    draft,
+    updateDraft,
+    isDraftReady,
+    formRef,
+    clearDraft,
+  };
 };

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -1,10 +1,6 @@
 import React, { FormEvent, ReactElement } from 'react';
 import { useRouter } from 'next/router';
-import { del as deleteCache } from 'idb-keyval';
-import {
-  generateWritePostKey,
-  WritePage,
-} from '@dailydotdev/shared/src/components/post/freeform';
+import { WritePage } from '@dailydotdev/shared/src/components/post/freeform';
 import { editPost } from '@dailydotdev/shared/src/graphql/posts';
 import usePostById from '@dailydotdev/shared/src/hooks/usePostById';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
@@ -24,8 +20,14 @@ function EditPost(): ReactElement {
     [id, handle].includes(post?.source?.id),
   );
   const { displayToast } = useToastNotification();
-  const { onAskConfirmation, draft, updateDraft, isDraftReady, formRef } =
-    useDiscardPost({ post });
+  const {
+    onAskConfirmation,
+    draft,
+    updateDraft,
+    isDraftReady,
+    formRef,
+    clearDraft,
+  } = useDiscardPost({ post });
   const {
     mutateAsync: onUpdatePost,
     isLoading: isPosting,
@@ -35,8 +37,7 @@ function EditPost(): ReactElement {
       onAskConfirmation(false);
     },
     onSuccess: async () => {
-      const key = generateWritePostKey(post.id);
-      await deleteCache(key);
+      clearDraft();
       await push(post.commentsPermalink);
     },
     onError: (data: ApiErrorResult) => {

--- a/packages/webapp/pages/squads/[handle]/create.tsx
+++ b/packages/webapp/pages/squads/[handle]/create.tsx
@@ -39,7 +39,7 @@ function CreatePost(): ReactElement {
       onAskConfirmation(false);
     },
     onSuccess: async (post) => {
-      const key = generateWritePostKey();
+      const key = generateWritePostKey(squad?.id);
       await deleteCache(key);
       await push(post.commentsPermalink);
     },

--- a/packages/webapp/pages/squads/[handle]/create.tsx
+++ b/packages/webapp/pages/squads/[handle]/create.tsx
@@ -1,11 +1,7 @@
 import React, { FormEvent, ReactElement } from 'react';
 import { NextSeo, NextSeoProps } from 'next-seo';
 import { useRouter } from 'next/router';
-import { del as deleteCache } from 'idb-keyval';
-import {
-  generateWritePostKey,
-  WritePage,
-} from '@dailydotdev/shared/src/components/post/freeform';
+import { WritePage } from '@dailydotdev/shared/src/components/post/freeform';
 import { useMutation } from 'react-query';
 import { createPost } from '@dailydotdev/shared/src/graphql/posts';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
@@ -28,8 +24,14 @@ function CreatePost(): ReactElement {
     [id, handle].includes(query?.handle as string),
   );
   const { displayToast } = useToastNotification();
-  const { onAskConfirmation, draft, updateDraft, isDraftReady, formRef } =
-    useDiscardPost({ draftIdentifier: squad?.id });
+  const {
+    onAskConfirmation,
+    draft,
+    updateDraft,
+    isDraftReady,
+    formRef,
+    clearDraft,
+  } = useDiscardPost({ draftIdentifier: squad?.id });
   const {
     mutateAsync: onCreatePost,
     isLoading: isPosting,
@@ -39,8 +41,7 @@ function CreatePost(): ReactElement {
       onAskConfirmation(false);
     },
     onSuccess: async (post) => {
-      const key = generateWritePostKey(squad?.id);
-      await deleteCache(key);
+      clearDraft();
       await push(post.commentsPermalink);
     },
     onError: (data: ApiErrorResult) => {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- squad.id is default identifier in draft inside `useDiscardPost` so this makes sure that correct one is used

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
