### PR TITLE
feat: Making commentary optional for sharePost

### DIFF
--- a/packages/shared/src/components/squads/Comment.tsx
+++ b/packages/shared/src/components/squads/Comment.tsx
@@ -108,8 +108,9 @@ export function SquadComment({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const onSubmitForm = (e?: FormEvent<HTMLFormElement>) =>
+  const onSubmitForm = (e?: FormEvent<HTMLFormElement>) => {
     onSubmit(e, commentary);
+  };
 
   const handleKeydown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     const pressedSpecialkey = e.ctrlKey || e.metaKey;
@@ -144,6 +145,7 @@ export function SquadComment({
               ref={textinput}
             />
           </span>
+          123
           <PostPreview
             className="mb-4"
             preview={preview}
@@ -212,9 +214,7 @@ export function SquadComment({
                 className="btn-primary-cabbage"
                 type="submit"
                 loading={isLoading}
-                disabled={
-                  !commentary || isLoading || isLoadingPreview || !preview.title
-                }
+                disabled={isLoading || isLoadingPreview || !preview.title}
               >
                 Done
               </Button>

--- a/packages/shared/src/components/squads/Comment.tsx
+++ b/packages/shared/src/components/squads/Comment.tsx
@@ -108,9 +108,8 @@ export function SquadComment({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const onSubmitForm = (e?: FormEvent<HTMLFormElement>) => {
+  const onSubmitForm = (e?: FormEvent<HTMLFormElement>) => 
     onSubmit(e, commentary);
-  };
 
   const handleKeydown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     const pressedSpecialkey = e.ctrlKey || e.metaKey;
@@ -145,7 +144,6 @@ export function SquadComment({
               ref={textinput}
             />
           </span>
-          123
           <PostPreview
             className="mb-4"
             preview={preview}

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -142,7 +142,7 @@ export const EDIT_SQUAD_MUTATION = gql`
 `;
 
 export const ADD_POST_TO_SQUAD_MUTATION = gql`
-  mutation AddPostToSquad($id: ID!, $sourceId: ID!, $commentary: String!) {
+  mutation AddPostToSquad($id: ID!, $sourceId: ID!, $commentary: String) {
     sharePost(id: $id, sourceId: $sourceId, commentary: $commentary) {
       id
     }


### PR DESCRIPTION
## Changes
I made the commentary field option for AddPostToSquad mutation and ability to submit share of article to a squad without adding a title (commentary)

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1385 #done
