### PR TITLE
feat: show an indicator when draft is saved and is saving

### DIFF
--- a/packages/shared/src/components/fields/MarkdownInput/SavingLabel.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/SavingLabel.tsx
@@ -17,17 +17,17 @@ export function SavingLabel({
 }: SavingLabelProps): ReactElement {
   if (!isUptoDate && !isUpdating) return null;
 
-  const label = (() => {
+  const getLabel = () => {
     if (isUpdating) return 'Saving changes';
 
     return isUptoDate ? 'All changes saved' : '';
-  })();
+  };
 
-  const icon = (() => {
+  const getIcon = () => {
     if (isUpdating) return <Loader />;
 
     return isUptoDate ? <VIcon size={IconSize.Medium} /> : '';
-  })();
+  };
 
   return (
     <span
@@ -36,8 +36,8 @@ export function SavingLabel({
         className,
       )}
     >
-      {icon}
-      {label}
+      {getIcon()}
+      {getLabel()}
     </span>
   );
 }

--- a/packages/shared/src/components/fields/MarkdownInput/SavingLabel.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/SavingLabel.tsx
@@ -1,0 +1,43 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import { Loader } from '../../Loader';
+import VIcon from '../../icons/V';
+import { IconSize } from '../../Icon';
+
+interface SavingLabelProps {
+  isUptoDate?: boolean;
+  isUpdating?: boolean;
+  className?: string;
+}
+
+export function SavingLabel({
+  isUptoDate,
+  isUpdating,
+  className,
+}: SavingLabelProps): ReactElement {
+  if (!isUptoDate && !isUpdating) return null;
+
+  const label = (() => {
+    if (isUpdating) return 'Saving changes';
+
+    return isUptoDate ? 'All changes saved' : '';
+  })();
+
+  const icon = (() => {
+    if (isUpdating) return <Loader />;
+
+    return isUptoDate ? <VIcon size={IconSize.Medium} /> : '';
+  })();
+
+  return (
+    <span
+      className={classNames(
+        'flex flex-row items-center gap-1 typo-callout font-bold text-theme-label-tertiary',
+        className,
+      )}
+    >
+      {icon}
+      {label}
+    </span>
+  );
+}

--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -86,6 +86,7 @@ function MarkdownInput({
         <SavingLabel
           className="absolute top-3 right-3"
           isUpdating={isUpdatingDraft}
+          isUptoDate={initialContent === input}
         />
       )}
       <TabContainer

--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -18,6 +18,8 @@ import useSidebarRendered from '../../../hooks/useSidebarRendered';
 import ConditionalWrapper from '../../ConditionalWrapper';
 import TabContainer, { Tab } from '../../tabs/TabContainer';
 import MarkdownPreview from '../MarkdownPreview';
+import { isNullOrUndefined } from '../../../lib/func';
+import { SavingLabel } from './SavingLabel';
 
 interface MarkdownInputProps
   extends Omit<UseMarkdownInputProps, 'textareaRef'> {
@@ -27,6 +29,7 @@ interface MarkdownInputProps
     'className'
   >;
   showMarkdownGuide?: boolean;
+  isUpdatingDraft?: boolean;
 }
 
 function MarkdownInput({
@@ -39,6 +42,7 @@ function MarkdownInput({
   textareaProps = {},
   enabledCommand,
   showMarkdownGuide = true,
+  isUpdatingDraft,
 }: MarkdownInputProps): ReactElement {
   const { sidebarRendered } = useSidebarRendered();
   const textareaRef = useRef<HTMLTextAreaElement>();
@@ -74,10 +78,16 @@ function MarkdownInput({
   return (
     <div
       className={classNames(
-        'flex flex-col bg-theme-float rounded-16',
+        'relative flex flex-col bg-theme-float rounded-16',
         className,
       )}
     >
+      {!isNullOrUndefined(isUpdatingDraft) && (
+        <SavingLabel
+          className="absolute top-3 right-3"
+          isUpdating={isUpdatingDraft}
+        />
+      )}
       <TabContainer
         shouldMountInactive={false}
         className={{ header: 'px-1', container: 'min-h-[20.5rem]' }}
@@ -135,8 +145,8 @@ function MarkdownInput({
         )}
         <ConditionalWrapper
           condition={sidebarRendered}
-          wrapper={(children) => (
-            <span className="flex flex-row gap-3 ml-auto">{children}</span>
+          wrapper={(component) => (
+            <span className="flex flex-row gap-3 ml-auto">{component}</span>
           )}
         >
           {onLinkCommand && (

--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -48,6 +48,7 @@ export function WriteFreeformContent({
     post,
     draft,
     updateDraft,
+    isUpdatingDraft,
     formRef: propRef,
   } = useWritePostContext();
   const formRef = useRef<HTMLFormElement>();
@@ -141,6 +142,7 @@ export function WriteFreeformContent({
         initialContent={draft?.content ?? post?.content}
         textareaProps={{ name: 'content' }}
         enabledCommand={{ ...defaultMarkdownCommands, upload: true }}
+        isUpdatingDraft={isUpdatingDraft}
       />
       <WriteFooter isLoading={isPosting} />
     </WritePageMain>

--- a/packages/shared/src/contexts/WritePostContext.ts
+++ b/packages/shared/src/contexts/WritePostContext.ts
@@ -21,6 +21,7 @@ export interface WritePostProps {
   formRef?: MutableRefObject<HTMLFormElement>;
   draft?: Partial<WriteForm>;
   updateDraft?: (props: Partial<WriteForm>) => Promise<void>;
+  isUpdatingDraft?: boolean;
 }
 
 export const WritePostContext = React.createContext<WritePostProps>({

--- a/packages/shared/src/hooks/input/useDiscardPost.ts
+++ b/packages/shared/src/hooks/input/useDiscardPost.ts
@@ -24,6 +24,7 @@ interface UseDiscardPost
   formRef: MutableRefObject<HTMLFormElement>;
   isDraftReady: boolean;
   clearDraft: () => void;
+  isUpdatingDraft: boolean;
 }
 
 export const useDiscardPost = ({
@@ -32,9 +33,8 @@ export const useDiscardPost = ({
 }: UseDiscardPostProps = {}): UseDiscardPost => {
   const formRef = useRef<HTMLFormElement>();
   const draftKey = generateWritePostKey(draftIdentifier ?? post?.id);
-  const [draft, updateDraft, isDraftReady] = usePersistentContext<
-    Partial<WriteForm>
-  >(draftKey, {});
+  const [draft, updateDraft, isDraftReady, isUpdatingDraft] =
+    usePersistentContext<Partial<WriteForm>>(draftKey, {});
   const onValidateAction = useCallback(() => {
     if (!formRef.current) return true;
 
@@ -57,5 +57,6 @@ export const useDiscardPost = ({
     isDraftReady,
     formRef,
     clearDraft,
+    isUpdatingDraft,
   };
 };

--- a/packages/shared/src/hooks/usePersistentContext.ts
+++ b/packages/shared/src/hooks/usePersistentContext.ts
@@ -22,15 +22,15 @@ export default function usePersistentContext<T>(
   valueWhenCacheEmpty?: T,
   validValues?: T[],
   fallbackValue?: T,
-): [T, (value: T) => Promise<void>, boolean] {
+): [T, (value: T) => Promise<void>, boolean, boolean] {
   const queryKey = [key, valueWhenCacheEmpty];
   const queryClient = useQueryClient();
 
-  const { data, isFetched } = useQuery<unknown, unknown, T>(queryKey, () =>
+  const { data, isFetched } = useQuery(queryKey, () =>
     getAsyncCache<T>(key, valueWhenCacheEmpty, validValues),
   );
 
-  const { mutateAsync: updateValue } = useMutation<void, unknown, unknown, T>(
+  const { mutateAsync: updateValue, isLoading } = useMutation(
     (value: T) => setCache(key, value),
     {
       onMutate: (mutatedData) => {
@@ -44,5 +44,5 @@ export default function usePersistentContext<T>(
     },
   );
 
-  return [data ?? fallbackValue, updateValue, isFetched];
+  return [data ?? fallbackValue, updateValue, isFetched, isLoading];
 }

--- a/packages/webapp/pages/squads/create.tsx
+++ b/packages/webapp/pages/squads/create.tsx
@@ -42,8 +42,14 @@ function CreatePost(): ReactElement {
   const squad = squads?.[selected];
   const [display, setDisplay] = useState(WriteFormTab.Share);
   const { displayToast } = useToastNotification();
-  const { onAskConfirmation, draft, updateDraft, formRef, clearDraft } =
-    useDiscardPost({ draftIdentifier: squad?.id });
+  const {
+    onAskConfirmation,
+    draft,
+    updateDraft,
+    formRef,
+    clearDraft,
+    isUpdatingDraft,
+  } = useDiscardPost({ draftIdentifier: squad?.id });
   const {
     mutateAsync: onCreatePost,
     isLoading: isPosting,
@@ -85,6 +91,7 @@ function CreatePost(): ReactElement {
         draft,
         updateDraft,
         formRef,
+        isUpdatingDraft,
         onSubmitForm: onClickSubmit,
         squad,
         isPosting: isPosting || isSuccess,


### PR DESCRIPTION
## Changes
- Add a label based on whether the draft is being saved or if it is up to date.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
