### PR TITLE
refactor: comment boxes to make font to typo body

### DIFF
--- a/packages/shared/src/components/modals/CommentBox.tsx
+++ b/packages/shared/src/components/modals/CommentBox.tsx
@@ -180,7 +180,7 @@ function CommentBox({
         )}
         <textarea
           className={classNames(
-            'flex-1 text-theme-label-primary bg-transparent border-none caret-theme-label-link break-words typo-subhead resize-none',
+            'flex-1 text-theme-label-primary bg-transparent border-none caret-theme-label-link break-words typo-body resize-none',
             styles.textarea,
             isComment && 'ml-3',
           )}

--- a/packages/shared/src/components/squads/SharePostBar.tsx
+++ b/packages/shared/src/components/squads/SharePostBar.tsx
@@ -84,7 +84,7 @@ function SharePostBar({
           name="share-post-bar"
           placeholder={`Enter URL${isMobile ? '' : ' / Choose from'}`}
           className={classNames(
-            'pl-1 tablet:min-w-[11rem] w-auto outline-none bg-theme-bg-transparent text-theme-label-primary focus:placeholder-theme-label-quaternary hover:placeholder-theme-label-primary typo-callout',
+            'pl-1 tablet:min-w-[11rem] w-auto outline-none bg-theme-bg-transparent text-theme-label-primary focus:placeholder-theme-label-quaternary hover:placeholder-theme-label-primary typo-body',
             url !== undefined && 'flex-1 pr-2',
           )}
           onInput={(e) => setUrl(e.currentTarget.value)}


### PR DESCRIPTION
## Changes

- Our input boxes have been decided to be `17px`. Since the `MarkdownInput` and `SquadComment` is already up to date, below are only what's left:
   - `CommentBox` when making comments.
   - `SharePostBar` when submitting external links.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1430 #done
