### PR TITLE
fix: my feed alert pointer

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -215,13 +215,14 @@ export default function MainFeedLayout({
   );
 
   const hasFiltered = feedName === MainFeedPage.MyFeed && !alerts?.filter;
+  const hasMyFeedAlert = alerts.myFeed;
 
   /* eslint-disable react/no-children-prop */
   const feedHeading = {
     [MainFeedPage.MyFeed]: (
       <MyFeedHeading
         hasFiltered={hasFiltered}
-        isAlertDisabled={!alerts.myFeed}
+        isAlertDisabled={!hasMyFeedAlert}
         sidebarRendered={sidebarRendered}
         onOpenFeedFilters={() => setIsFeedFiltersOpen(true)}
         onUpdateAlerts={() => updateAlerts({ myFeed: null })}
@@ -245,8 +246,8 @@ export default function MainFeedLayout({
       <div
         className={classNames(
           'flex flex-row flex-wrap gap-4 items-center mr-px w-full',
-          alerts.filter || !alerts.myFeed ? 'h-14' : 'h-32 laptop:h-16',
-          !sidebarRendered && alerts.myFeed && 'content-start',
+          alerts.filter || !hasMyFeedAlert ? 'h-14' : 'h-32 laptop:h-16',
+          !sidebarRendered && hasMyFeedAlert && 'content-start',
         )}
       >
         {feedHeading[feedName]}

--- a/packages/shared/src/components/alert/AlertPointer.tsx
+++ b/packages/shared/src/components/alert/AlertPointer.tsx
@@ -9,7 +9,6 @@ import {
   AlertPointerContainer,
 } from './common';
 import Pointer, { PointerColor } from './Pointer';
-import { isNullOrUndefined } from '../../lib/func';
 
 interface ClassName {
   container?: string;

--- a/packages/shared/src/components/alert/AlertPointer.tsx
+++ b/packages/shared/src/components/alert/AlertPointer.tsx
@@ -9,6 +9,7 @@ import {
   AlertPointerContainer,
 } from './common';
 import Pointer, { PointerColor } from './Pointer';
+import { isNullOrUndefined } from '../../lib/func';
 
 interface ClassName {
   container?: string;
@@ -39,20 +40,26 @@ const pointerClasses: Record<AlertPlacement, string> = {
   bottom: '',
 };
 
+const verticalCenter = '-translate-y-1/2';
+const horizontalCenter = '-translate-x-1/2';
+
 const alertContainerClasses: Record<AlertPlacement, string> = {
-  top: '-translate-y-full top-0 flex-col-reverse',
-  right: 'translate-x-full right-0 flex-row',
-  left: '-translate-x-full left-0 flex-row-reverse',
-  bottom: 'translate-y-full bottom-0 flex-col',
+  top: classNames('top-0 flex-col-reverse -translate-y-full', horizontalCenter),
+  right: classNames('translate-x-full right-0 flex-row', verticalCenter),
+  left: classNames('-translate-x-full left-0 flex-row-reverse', verticalCenter),
+  bottom: classNames('translate-y-full bottom-0 flex-col', horizontalCenter),
 };
 
+const getCenteredOffset = (offset: number | undefined) =>
+  isNullOrUndefined(offset) ? '50%' : `calc(50% - ${offset}px)`;
+
 const getContainerStyle = (
-  [xOffset = 0, yOffset = 0]: OffsetXY = [0, 0],
+  [xOffset, yOffset]: OffsetXY = [undefined, undefined],
 ): Record<AlertPlacement, CSSProperties> => ({
-  left: { left: xOffset, top: yOffset },
-  right: { right: xOffset, top: yOffset },
-  bottom: { bottom: yOffset, left: xOffset },
-  top: { top: yOffset, left: xOffset },
+  left: { left: xOffset, top: getCenteredOffset(yOffset) },
+  right: { right: xOffset, top: getCenteredOffset(yOffset) },
+  bottom: { bottom: yOffset, left: getCenteredOffset(xOffset) },
+  top: { top: yOffset, left: getCenteredOffset(xOffset) },
 });
 
 export interface AlertPointerProps {

--- a/packages/shared/src/components/alert/AlertPointer.tsx
+++ b/packages/shared/src/components/alert/AlertPointer.tsx
@@ -50,11 +50,10 @@ const alertContainerClasses: Record<AlertPlacement, string> = {
   bottom: classNames('translate-y-full bottom-0 flex-col', horizontalCenter),
 };
 
-const getCenteredOffset = (offset: number | undefined) =>
-  isNullOrUndefined(offset) ? '50%' : `calc(50% - ${offset}px)`;
+const getCenteredOffset = (offset: number) => `calc(50% - ${offset}px)`;
 
 const getContainerStyle = (
-  [xOffset, yOffset]: OffsetXY = [undefined, undefined],
+  [xOffset = 0, yOffset = 0]: OffsetXY = [0, 0],
 ): Record<AlertPlacement, CSSProperties> => ({
   left: { left: xOffset, top: getCenteredOffset(yOffset) },
   right: { right: xOffset, top: getCenteredOffset(yOffset) },

--- a/packages/shared/src/components/filters/MyFeedHeading.tsx
+++ b/packages/shared/src/components/filters/MyFeedHeading.tsx
@@ -23,12 +23,6 @@ function MyFeedHeading({
   onUpdateAlerts,
   onOpenFeedFilters,
 }: MyFeedHeadingProps): ReactElement {
-  if (!hasFiltered) {
-    return <FeedHeading>My feed</FeedHeading>;
-  }
-
-  // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const { trackEvent } = useContext(AnalyticsContext);
 
   const onClick = () => {
@@ -36,9 +30,13 @@ function MyFeedHeading({
     onOpenFeedFilters();
   };
 
+  if (!hasFiltered) {
+    return <FeedHeading>My feed</FeedHeading>;
+  }
+
   return (
     <AlertPointer
-      offset={[sidebarRendered ? 4 : 0, 8]}
+      offset={[sidebarRendered ? 4 : 0]}
       isAlertDisabled={isAlertDisabled}
       onClose={() => onUpdateAlerts({ myFeed: null })}
       className={{

--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -124,7 +124,7 @@ export function WriteFreeformContent({
       </ImageInput>
       <AlertPointer
         className={{ container: 'bg-theme-bg-primary' }}
-        offset={[4, -14]}
+        offset={[0, -12]}
         message={
           <div className="flex flex-col w-64">
             <h3 className="font-bold typo-headline">First time? 👋</h3>


### PR DESCRIPTION
## Changes
- After further investigation, the root cause was the inconsistency of being centered on the component being used.
- Preview of the fix based on the current implementations:

Note: in companion, everything works as intended without any change which shows the fix actually did resolve the root cause.

![Screenshot 2023-06-06 at 1 33 02 PM](https://github.com/dailydotdev/apps/assets/13744167/12637955-db55-43da-9fb2-377c8891d210)
![Screenshot 2023-06-06 at 1 45 15 PM](https://github.com/dailydotdev/apps/assets/13744167/5589658e-a6af-4399-9cff-7d2b7b552762)
![Screenshot 2023-06-06 at 1 52 27 PM](https://github.com/dailydotdev/apps/assets/13744167/54f6cf4a-f5f8-46dc-9111-5db687b844bf)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1408 #done
