### PR TITLE
fix: unnecessary content query

### DIFF
--- a/packages/shared/src/components/cards/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCard.tsx
@@ -52,7 +52,7 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
   const clamp = (() => {
     if (post.image) return 'line-clamp-3';
 
-    return post.content ? 'line-clamp-4' : 'line-clamp-9';
+    return post.contentHtml ? 'line-clamp-4' : 'line-clamp-9';
   })();
 
   return (

--- a/packages/shared/src/components/cards/WelcomePostCardFooter.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCardFooter.tsx
@@ -28,7 +28,7 @@ export const WelcomePostCardFooter = ({
       />
     );
   }
-  if (post.content) {
+  if (content) {
     return (
       <p className="px-2 break-words line-clamp-6 typo-callout">{content}</p>
     );

--- a/packages/shared/src/graphql/feed.ts
+++ b/packages/shared/src/graphql/feed.ts
@@ -111,7 +111,7 @@ export const FEED_QUERY = gql`
       ...FeedPostConnection
     }
   }
-  ${getFeedPostFragment('content contentHtml')}
+  ${getFeedPostFragment('contentHtml')}
 `;
 
 export const MOST_UPVOTED_FEED_QUERY = gql`
@@ -178,7 +178,7 @@ export const SOURCE_FEED_QUERY = gql`
       ...FeedPostConnection
     }
   }
-  ${getFeedPostFragment('pinnedAt content contentHtml')}
+  ${getFeedPostFragment('pinnedAt contentHtml')}
 `;
 
 export const BOOKMARKS_FEED_QUERY = gql`


### PR DESCRIPTION
## Changes
- The primary goal here was to sanitize all HTML outputs but after further investigation, it seems all of our implementation of HTML outputs are already sanitizing the content. Most of the implementations are using our `Markdown` component for displaying the HTML content (which does it out of the box).
- One rare instance is on the FeedCard, where we manually sanitize it to strip all the tags (recent implementation).
- With that in mind, I have come to realize that we don't need the `content` property on the `feed` anymore since we rely on the `contentHtml` property for feed display. I have also verified that it is not used elsewhere in the feed. This reduces the response size for the feed.

@idoshamun - tagged for visibility.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1421 #done
