### PR TITLE
refactor: post modal removing edit post button

### DIFF
--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -104,29 +104,13 @@ function SquadPostContent({
           className={{
             ...className,
             onboarding: 'mb-6',
-            navigation: { actions: !canEdit && 'ml-auto', container: 'mb-6' },
+            navigation: { actions: 'ml-auto', container: 'mb-6' },
           }}
           isFallback={isFallback}
           customNavigation={customNavigation}
           enableShowShareNewComment={enableShowShareNewComment}
           shouldOnboardAuthor={shouldOnboardAuthor}
-          navigationProps={{
-            ...navigationProps,
-            children: canEdit && (
-              <Button
-                icon={<EditIcon />}
-                className="ml-auto btn-primary"
-                onClick={() =>
-                  openModal({
-                    type: LazyModal.EditWelcomePost,
-                    props: { post },
-                  })
-                }
-              >
-                Edit post
-              </Button>
-            ),
-          }}
+          navigationProps={navigationProps}
           engagementProps={engagementActions}
           origin={origin}
           post={post}

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -14,13 +14,6 @@ import { useMemberRoleForSource } from '../../hooks/useMemberRoleForSource';
 import SquadPostAuthor from './SquadPostAuthor';
 import SharePostContent from './SharePostContent';
 import MarkdownPostContent from './MarkdownPostContent';
-import { Button } from '../buttons/Button';
-import { useLazyModal } from '../../hooks/useLazyModal';
-import { LazyModal } from '../modals/common/types';
-import { useAuthContext } from '../../contexts/AuthContext';
-import { verifyPermission } from '../../graphql/squads';
-import { SourcePermissions, Squad } from '../../graphql/sources';
-import EditIcon from '../icons/Edit';
 
 const ContentMap = {
   [PostType.Freeform]: MarkdownPostContent,
@@ -46,8 +39,6 @@ function SquadPostContent({
 }: PostContentProps): ReactElement {
   const { mutateAsync: onSendViewPost } = useMutation(sendViewPost);
   const hasNavigation = !!onPreviousPost || !!onNextPost;
-  const { openModal } = useLazyModal();
-  const { user } = useAuthContext();
   const engagementActions = usePostContent({ origin, post });
   const { onReadArticle, onSharePost, onToggleBookmark } = engagementActions;
   const { role } = useMemberRoleForSource({
@@ -76,13 +67,6 @@ function SquadPostContent({
   }, [post?.id, onSendViewPost]);
 
   const Content = ContentMap[post?.type];
-  const canEdit =
-    post.author.id === user?.id ||
-    (post.type === PostType.Welcome &&
-      verifyPermission(
-        post.source as Squad,
-        SourcePermissions.WelcomePostEdit,
-      ));
 
   return (
     <>


### PR DESCRIPTION
## Changes
- Now that we have a dedicated page for editing a post, we don't need the button in the modal header anymore as we already have one option in the post options menu that redirects to the said editing post page.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
