### PR TITLE
refactor: spacing on squad invitation page

### DIFF
--- a/packages/webapp/pages/squads/[handle]/[token].tsx
+++ b/packages/webapp/pages/squads/[handle]/[token].tsx
@@ -213,7 +213,7 @@ const SquadReferral = ({
   }
 
   return (
-    <PageContainer className="relative justify-center items-center pt-24">
+    <PageContainer className="relative items-center pt-10 tablet:pt-20">
       <NextSeo {...seo} />
       <div className="absolute -top-4 right-0 tablet:-right-20 left-0 tablet:-left-20 h-40 rounded-26 max-w-[100vw] squad-background-fade" />
       <h1 className="typo-title1">You are invited to join {source.name}</h1>
@@ -222,7 +222,7 @@ const SquadReferral = ({
         squad members can share knowledge and content in one place. Join now to
         start collaborating.
       </BodyParagraph>
-      <span className="flex flex-row items-center mt-10" data-testid="inviter">
+      <span className="flex flex-row items-center mt-8" data-testid="inviter">
         <ProfileImageLink user={user} />
         <BodyParagraph className="flex-1 ml-4">
           <HighlightedText>{user.name}</HighlightedText>{' '}
@@ -232,7 +232,7 @@ const SquadReferral = ({
           has invited you to <HighlightedText>{source.name}</HighlightedText>
         </BodyParagraph>
       </span>
-      <div className="flex flex-col p-6 my-10 w-full rounded-24 border border-theme-color-cabbage">
+      <div className="flex flex-col p-6 my-8 w-full rounded-24 border border-theme-color-cabbage">
         <span className="flex flex-row items-center">
           <SourceButton source={source} size="xxlarge" />
           <div className="flex flex-col ml-4">


### PR DESCRIPTION
## Changes
- Mostly just spacing changes based on [the Sketch](https://www.sketch.com/s/2867ec63-0966-4647-b1d7-b6fe696ba251/a/lRK9Akd#Inspect)

Feel free to test it out here: https://daily-webapp-p18tuwyst-dailydotdev.vercel.app/squads/dailydev2/dDJYWNPj2hSj8Y5kT0Kto_9O2SKa3pG8d8rLbwNmFog

Previews:
![Screenshot 2023-06-06 at 4 58 03 PM](https://github.com/dailydotdev/apps/assets/13744167/802fbd7d-b624-48bf-8dfa-5969c67694c5)
![Screenshot 2023-06-06 at 4 57 53 PM](https://github.com/dailydotdev/apps/assets/13744167/69e9b0c4-30bb-4fd8-a30c-64e68dac14d6)
![Screenshot 2023-06-06 at 4 58 24 PM](https://github.com/dailydotdev/apps/assets/13744167/82bdec81-faf1-4ce3-8840-d1f4a38733d6)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1398 #done
