### PR TITLE
refactor: promotion notification to show modal

### DIFF
--- a/packages/shared/src/components/icons/Star/index.tsx
+++ b/packages/shared/src/components/icons/Star/index.tsx
@@ -3,7 +3,7 @@ import Icon, { IconProps } from '../../Icon';
 import OutlinedIcon from './outlined.svg';
 import FilledIcon from './filled.svg';
 
-const StarIcon = (props: IconProps): ReactElement => (
+export const StarIcon = (props: IconProps): ReactElement => (
   <Icon {...props} IconPrimary={OutlinedIcon} IconSecondary={FilledIcon} />
 );
 

--- a/packages/shared/src/components/icons/User/index.tsx
+++ b/packages/shared/src/components/icons/User/index.tsx
@@ -3,7 +3,7 @@ import Icon, { IconProps } from '../../Icon';
 import OutlinedIcon from './outlined.svg';
 import FilledIcon from './filled.svg';
 
-const UserIcon = (props: IconProps): ReactElement => (
+export const UserIcon = (props: IconProps): ReactElement => (
   <Icon {...props} IconPrimary={OutlinedIcon} IconSecondary={FilledIcon} />
 );
 

--- a/packages/shared/src/components/icons/index.ts
+++ b/packages/shared/src/components/icons/index.ts
@@ -1,3 +1,5 @@
 export * from './Pin';
 export * from './Markdown';
 export * from './Image';
+export * from './User';
+export * from './Star';

--- a/packages/shared/src/components/modals/common.tsx
+++ b/packages/shared/src/components/modals/common.tsx
@@ -25,6 +25,12 @@ const UpvotedPopupModal = dynamic(
 const SquadTourModal = dynamic(
   () => import(/* webpackChunkName: "squadTourModal" */ './SquadTourModal'),
 );
+const SquadPromotionModal = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "squadPromotionModal" */ './squads/SquadPromotionModal'
+    ),
+);
 
 const EditWelcomePostModal = dynamic(
   () =>
@@ -41,6 +47,7 @@ export const modals = {
   [LazyModal.UpvotedPopup]: UpvotedPopupModal,
   [LazyModal.SquadTour]: SquadTourModal,
   [LazyModal.EditWelcomePost]: EditWelcomePostModal,
+  [LazyModal.SquadPromotion]: SquadPromotionModal,
 };
 
 type GetComponentProps<T> = T extends

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -30,6 +30,7 @@ export enum LazyModal {
   SquadTour = 'squadTour',
   UpvotedPopup = 'upvotedPopup',
   EditWelcomePost = 'editWelcomePost',
+  SquadPromotion = 'squadPromotion',
 }
 
 export type ModalTabItem = {

--- a/packages/shared/src/components/modals/squads/SquadPromotionModal.tsx
+++ b/packages/shared/src/components/modals/squads/SquadPromotionModal.tsx
@@ -1,0 +1,47 @@
+import React, { ReactElement } from 'react';
+import { Modal, ModalProps } from '../common/Modal';
+import CloseButton from '../../CloseButton';
+import { ButtonSize } from '../../buttons/Button';
+import PromotionTour from '../../squads/PromotionTour';
+import { Source } from '../../../graphql/sources';
+import { useSquad } from '../../../hooks';
+
+interface SquadPromotionModalProps extends ModalProps {
+  handle: string;
+}
+
+export function SquadPromotionModal({
+  onRequestClose,
+  handle,
+  ...props
+}: SquadPromotionModalProps): ReactElement {
+  const { squad, isFetched } = useSquad({ handle });
+  const onClose = () => {
+    console.log('on close');
+    onRequestClose(null);
+  };
+
+  console.log(squad, isFetched);
+
+  if (!isFetched) return null;
+
+  return (
+    <Modal
+      {...props}
+      isOpen
+      onRequestClose={onClose}
+      kind={Modal.Kind.FlexibleCenter}
+      size={Modal.Size.Small}
+      className="overflow-hidden !border-theme-color-cabbage"
+    >
+      <PromotionTour onClose={onClose} source={squad} />
+      <CloseButton
+        buttonSize={ButtonSize.Small}
+        className="top-3 right-3 !absolute !btn-secondary"
+        onClick={onClose}
+      />
+    </Modal>
+  );
+}
+
+export default SquadPromotionModal;

--- a/packages/shared/src/components/squads/PromotionTour.tsx
+++ b/packages/shared/src/components/squads/PromotionTour.tsx
@@ -1,0 +1,158 @@
+import React, { ReactElement, useMemo } from 'react';
+import { cloudinary } from '../../lib/image';
+import { Button } from '../buttons/Button';
+import { FlexCentered, Justify } from '../utilities';
+import Carousel from '../containers/Carousel';
+import { ModalFooter } from '../modals/common/ModalFooter';
+import SquadTourCard from './SquadTourCard';
+import classed from '../../lib/classed';
+import { Source, SourceMemberRole } from '../../graphql/sources';
+import { StarIcon, UserIcon } from '../icons';
+import { capitalize } from '../../lib/strings';
+import { ProfilePicture } from '../ProfilePicture';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { IconSize } from '../Icon';
+import SourceButton from '../cards/SourceButton';
+
+interface PromotionTourProps {
+  onClose: React.EventHandler<React.MouseEvent>;
+  source: Source;
+}
+
+const bannerClass = 'h-60 bg-cover';
+
+const FooterButton = classed(Button, 'w-22');
+const iconMap = {
+  [SourceMemberRole.Moderator]: UserIcon,
+  [SourceMemberRole.Admin]: StarIcon,
+};
+const roleDescription = {
+  [SourceMemberRole.Moderator]:
+    'As a moderator, you will have the opportunity to help guide and shape the squad, ensuring that all members have a positive and productive experience.',
+  [SourceMemberRole.Admin]:
+    'As an admin, you will have full permissions to manage and guide the squad, ensuring that all members and moderators have a positive and productive experience.',
+};
+const firstStep = {
+  [SourceMemberRole.Moderator]: (
+    <SquadTourCard
+      key="step1"
+      bannerAsBg
+      className={{ banner: bannerClass }}
+      banner={cloudinary.squads.promotion.remove}
+      title="Manage squad members"
+      description="Maintain a harmonious squad by overseeing membership and removing those no longer contributing positively."
+    />
+  ),
+  [SourceMemberRole.Admin]: (
+    <SquadTourCard
+      key="step1"
+      bannerAsBg
+      className={{ banner: bannerClass }}
+      banner={cloudinary.squads.promotion.promote}
+      title="Manage roles and permissions"
+      description="Take charge of your squad by promoting or demoting members and moderators according to their engagement and contributions."
+    />
+  ),
+};
+
+function PromotionTour({ onClose, source }: PromotionTourProps): ReactElement {
+  const { user } = useAuthContext();
+  const items = useMemo(() => {
+    const { role } = source.currentMember;
+    const tour = [];
+    const Icon = iconMap[role];
+
+    tour.push(
+      <SquadTourCard
+        key="intro"
+        bannerAsBg
+        className={{ container: 'relative', banner: bannerClass }}
+        banner={cloudinary.squads.promotion.banner}
+        title="You have been promoted"
+        description={roleDescription[role]}
+      >
+        <FlexCentered className="absolute top-20 left-1/2 gap-1 justify-center -translate-x-1/2">
+          <span className="relative">
+            <ProfilePicture user={user} size="xxxxlarge" />
+            <SourceButton
+              className="absolute -right-4 -bottom-4"
+              source={source}
+              size="xlarge"
+            />
+          </span>
+          <Icon size={IconSize.XLarge} className="ml-3" secondary />
+          <span className="font-bold typo-title1">{capitalize(role)}</span>
+        </FlexCentered>
+      </SquadTourCard>,
+    );
+
+    tour.push(firstStep[role]);
+
+    tour.push(
+      <SquadTourCard
+        key="step2"
+        bannerAsBg
+        className={{ banner: bannerClass }}
+        banner={cloudinary.squads.promotion.remove}
+        title="Remove posts and comments"
+        description="Uphold your squad’s standards by removing off-topic or inappropriate content."
+      />,
+    );
+
+    if (role === SourceMemberRole.Admin) {
+      tour.push(
+        <SquadTourCard
+          key="step2"
+          bannerAsBg
+          className={{ banner: bannerClass }}
+          banner={cloudinary.squads.promotion.settings}
+          title="Customize squad settings"
+          description="Tailor your community experience by managing posting rights, member invitation privileges, and editing squad details."
+        />,
+      );
+    }
+
+    tour.push(
+      <SquadTourCard
+        key="step2"
+        bannerAsBg
+        className={{ banner: bannerClass }}
+        banner={cloudinary.squads.promotion.invite}
+        title="Grow your squad"
+        description="Strengthen your squad's network by bringing in new members to collaborate and exchange insights."
+      />,
+    );
+
+    return tour;
+  }, [source, user]);
+
+  return (
+    <Carousel
+      hasCustomIndicator
+      items={items}
+      className={{ wrapper: 'w-full' }}
+      onClose={() => onClose?.(null)}
+      onEnd={() => onClose?.(null)}
+    >
+      {({ onSwipedLeft, onSwipedRight, index }, indicator) => (
+        <ModalFooter justify={Justify.Between}>
+          <FooterButton
+            className="btn-tertiary"
+            onClick={(e) => onSwipedRight(e)}
+          >
+            {index === 0 ? 'Close' : 'Back'}
+          </FooterButton>
+          {indicator}
+          <FooterButton
+            className="btn-primary-cabbage"
+            onClick={(e) => onSwipedLeft(e)}
+          >
+            {index === items.length - 1 ? 'Close' : 'Next'}
+          </FooterButton>
+        </ModalFooter>
+      )}
+    </Carousel>
+  );
+}
+
+export default PromotionTour;

--- a/packages/shared/src/components/squads/SquadTourCard.tsx
+++ b/packages/shared/src/components/squads/SquadTourCard.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { Badge } from '../tooltips/utils';
-import { FlexCentered, FlexCol } from '../utilities';
+import { FlexCol } from '../utilities';
 
 interface ClassName {
   container?: string;
@@ -11,30 +11,47 @@ interface ClassName {
 interface SquadTourCardProps {
   banner: string;
   title: string;
-  badge?: string;
+  badge?: ReactNode;
+  children?: ReactNode;
   description?: string;
   className?: ClassName;
+  bannerAsBg?: boolean;
 }
 
 function SquadTourCard({
   banner,
+  bannerAsBg,
   title,
   description,
   badge,
+  children,
   className,
 }: SquadTourCardProps): ReactElement {
   return (
     <FlexCol className={className?.container}>
-      <FlexCentered className="h-80 bg-gradient-to-l from-cabbage-90 to-cabbage-50">
-        <img
-          className={classNames(
-            'w-full max-w-[23.5rem] pt-14',
-            className?.banner,
-          )}
-          src={banner}
-          alt={`${title} banner`}
-        />
-      </FlexCentered>
+      <FlexCol
+        className={classNames(
+          'relative',
+          !bannerAsBg &&
+            'h-80 justify-center items-center bg-gradient-to-l from-cabbage-90 to-cabbage-50',
+        )}
+      >
+        {bannerAsBg ? (
+          <div
+            className={classNames('w-full ', className?.banner)}
+            style={{ backgroundImage: `url(${banner})` }}
+          />
+        ) : (
+          <img
+            className={classNames(
+              'w-full max-w-[23.5rem] pt-14',
+              className?.banner,
+            )}
+            src={banner}
+            alt={`${title} banner`}
+          />
+        )}
+      </FlexCol>
       <FlexCol className="p-6">
         <h3
           className={classNames(
@@ -42,7 +59,7 @@ function SquadTourCard({
             description ? 'typo-title3' : 'typo-title1',
           )}
         >
-          {badge && <Badge>{badge}</Badge>}
+          {typeof badge === 'string' ? <Badge>{badge}</Badge> : badge}
           {title}
         </h3>
         {description && (
@@ -51,6 +68,7 @@ function SquadTourCard({
           </p>
         )}
       </FlexCol>
+      {children}
     </FlexCol>
   );
 }

--- a/packages/shared/src/hooks/notifications/usePromotionModal.ts
+++ b/packages/shared/src/hooks/notifications/usePromotionModal.ts
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useLazyModal } from '../useLazyModal';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { LazyModal } from '../../components/modals/common/types';
+
+export const usePromotionModal = (): void => {
+  const { query, replace } = useRouter();
+  const { squads } = useAuthContext();
+  const { openModal } = useLazyModal();
+
+  useEffect(() => {
+    if (!query || !query.promoted || !query.sid || !squads) return;
+
+    const squad = squads.find(({ id, handle }) =>
+      [id, handle].includes(query.sid as string),
+    );
+    if (!squad) {
+      const { origin, pathname } = window.location;
+      replace(origin + pathname);
+      return;
+    }
+
+    openModal({
+      type: LazyModal.SquadPromotion,
+      props: { handle: squad.handle },
+    });
+  }, [query, squads, replace, openModal]);
+};

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -53,6 +53,14 @@ export const cloudinary = {
       banner4_v2:
         'https://daily-now-res.cloudinary.com/image/upload/f_auto/public/squad_tour4_v2',
     },
+    promotion: {
+      settings: '/squad_promotion_settings.png',
+      remove: '/squad_promotion_remove.png',
+      delete: '/squad_promotion_delete.png',
+      banner: '/squad_promotion_banner.png',
+      invite: '/squad_promotion_invite.png',
+      promote: '/squad_promotion_promote.png',
+    },
     emptySquad:
       'https://daily-now-res.cloudinary.com/image/upload/f_auto/public/empty-squad',
     emptySquadLight:

--- a/packages/webapp/pages/notifications.tsx
+++ b/packages/webapp/pages/notifications.tsx
@@ -23,6 +23,7 @@ import InfiniteScrolling, {
 import { useAnalyticsContext } from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 import { AnalyticsEvent, Origin } from '@dailydotdev/shared/src/lib/analytics';
 import { NotificationType } from '@dailydotdev/shared/src/components/notifications/utils';
+import { usePromotionModal } from '@dailydotdev/shared/src/hooks/notifications/usePromotionModal';
 import { getLayout as getFooterNavBarLayout } from '../components/layouts/FooterNavBarLayout';
 import { getLayout } from '../components/layouts/MainLayout';
 
@@ -87,6 +88,8 @@ const Notifications = (): ReactElement => {
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFetchedAfterMount]);
+
+  usePromotionModal();
 
   return (
     <ProtectedPage seo={seo}>


### PR DESCRIPTION
## Changes
- Carousel tour for promoting a moderator or admin.

Note: I used the first notification as a placeholder to test the supposed notification.

Preview:

https://github.com/dailydotdev/apps/assets/13744167/5a3e3ef5-c87b-4e51-893d-86ecb92d2a7c


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1396 #done
