### PR TITLE
feat: fixing layout overlap on mobile join for lego referral

### DIFF
--- a/packages/shared/src/components/Logo.tsx
+++ b/packages/shared/src/components/Logo.tsx
@@ -5,12 +5,26 @@ import { LinkWithTooltip } from './tooltips/LinkWithTooltip';
 import LogoText from '../svg/LogoText';
 import LogoIcon from '../svg/LogoIcon';
 
+export enum LogoPosition {
+  Absolute = 'absolute',
+  Relative = 'relative',
+}
+
+const logoPositionToClassName: Record<LogoPosition, string> = {
+  [LogoPosition.Absolute]: classNames(
+    'absolute left-1/2 -translate-x-1/2 top-4 mt-0.5',
+    'laptop:relative laptop:left-[unset] laptop:top-[unset] laptop:translate-x-[unset] laptop:mt-0',
+  ),
+  [LogoPosition.Relative]: classNames('relative mt-0.5', 'laptop:mt-0'),
+};
+
 interface LogoProps {
   className?: string;
   logoClassName?: string;
   showGreeting?: boolean;
   onLogoClick?: (e: React.MouseEvent) => unknown;
   hideTextMobile?: boolean;
+  position?: LogoPosition;
 }
 
 export default function Logo({
@@ -19,6 +33,7 @@ export default function Logo({
   showGreeting,
   onLogoClick,
   hideTextMobile = false,
+  position = LogoPosition.Absolute,
 }: LogoProps): ReactElement {
   return (
     <LinkWithTooltip
@@ -31,8 +46,7 @@ export default function Logo({
       <a
         className={classNames(
           'flex items-center',
-          'absolute left-1/2 -translate-x-1/2 top-4 mt-0.5',
-          'laptop:relative laptop:left-[unset] laptop:top-[unset] laptop:translate-x-[unset] laptop:mt-0',
+          logoPositionToClassName[position],
           className,
         )}
         onClick={onLogoClick}

--- a/packages/webapp/pages/join.tsx
+++ b/packages/webapp/pages/join.tsx
@@ -1,4 +1,4 @@
-import Logo from '@dailydotdev/shared/src/components/Logo';
+import Logo, { LogoPosition } from '@dailydotdev/shared/src/components/Logo';
 import { ProfilePicture } from '@dailydotdev/shared/src/components/ProfilePicture';
 import {
   Button,
@@ -96,6 +96,7 @@ const Page = ({ referringUser, campaign }: PageProps): ReactElement => {
       >
         <Logo
           className="mx-auto laptop:mx-0 mb-8 laptop:mb-16 h-6"
+          position={LogoPosition.Relative}
           logoClassName="h-6"
         />
         {!!referringUser && (


### PR DESCRIPTION
## Changes
On the lego referral join page there was content overlapping with teh logo and image of the person that sent the invite.
Below is how it now looks for mobile and desktop

![mobile](https://github.com/dailydotdev/apps/assets/42202149/4e0d5ca6-d181-4e32-8c8a-e5efc3537d3b)
![desktop](https://github.com/dailydotdev/apps/assets/42202149/9d3addef-c461-4fc5-b164-bd99664b45bf)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1453 #done
