### PR TITLE
feat: restore scroll position after lazy modal close

### DIFF
--- a/packages/shared/src/hooks/useLazyModal.ts
+++ b/packages/shared/src/hooks/useLazyModal.ts
@@ -10,6 +10,8 @@ type UseLazyModal<K extends keyof ModalsType, T extends LazyModalType<K>> = {
   modal: T;
 };
 
+let scrollPosition = 0;
+
 export function useLazyModal<
   K extends keyof ModalsType,
   T extends LazyModalType<K> = LazyModalType<K>,
@@ -19,13 +21,19 @@ export function useLazyModal<
     client.getQueryData<T>(MODAL_KEY),
   );
   const openModal = useCallback(
-    (data: T) => client.setQueryData(MODAL_KEY, data),
+    (data: T) => {
+      scrollPosition = window.scrollY;
+
+      client.setQueryData(MODAL_KEY, data);
+    },
     [client],
   );
-  const closeModal = useCallback(
-    () => client.setQueryData(MODAL_KEY, null),
-    [client],
-  );
+  const closeModal = useCallback(() => {
+    window.scrollTo(0, scrollPosition);
+    scrollPosition = 0;
+
+    client.setQueryData(MODAL_KEY, null);
+  }, [client]);
 
   return useMemo(
     () => ({


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Building on logic that was implemented for new post modal https://github.com/dailydotdev/apps/pull/1763 I implemented similar logic into our `useLazyModal` hook

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
