### PR TITLE
feat: error message now reflects file size limit

### DIFF
--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -9,7 +9,11 @@ import CameraIcon from '../../../icons/Camera';
 import { TextField } from '../../../fields/TextField';
 import MarkdownInput from '../../../fields/MarkdownInput';
 import { WritePageMain } from './common';
-import { EditPostProps, Post } from '../../../../graphql/posts';
+import {
+  EditPostProps,
+  Post,
+  imageSizeLimitMB,
+} from '../../../../graphql/posts';
 import { formToJson } from '../../../../lib/form';
 import useDebounce from '../../../../hooks/useDebounce';
 import AlertPointer, { AlertPlacement } from '../../../alert/AlertPointer';
@@ -87,7 +91,7 @@ export function WriteFreeformContent({
         enableHover={false}
         fallbackImage={null}
         closeable
-        fileSizeLimitMB={5}
+        fileSizeLimitMB={imageSizeLimitMB}
         name="image"
         initialValue={draft?.image ?? post?.image}
         onChange={(base64, file) =>

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -542,7 +542,7 @@ export const UPLOAD_IMAGE_MUTATION = gql`
   }
 `;
 
-const imageSizeLimitMB = 5;
+export const imageSizeLimitMB = 5;
 export const allowedFileSize = imageSizeLimitMB * MEGABYTE;
 export const allowedContentImage = [...acceptedTypesList, 'image/gif'];
 
@@ -551,7 +551,7 @@ export const uploadContentImage = async (
   onProcessing?: (file: File) => void,
 ): Promise<string> => {
   if (image.size > allowedFileSize) {
-    throw new Error('File size exceeds the limit');
+    throw new Error(`File size exceeds the limit of ${imageSizeLimitMB} MB`);
   }
 
   if (!allowedContentImage.includes(image.type)) {

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -39,7 +39,11 @@ import { getLinkReplacement, getMentionReplacement } from '../../lib/markdown';
 import { handleRegex } from '../../graphql/users';
 import { UploadState, useSyncUploader } from './useSyncUploader';
 import { useToastNotification } from '../useToastNotification';
-import { allowedContentImage, allowedFileSize } from '../../graphql/posts';
+import {
+  allowedContentImage,
+  allowedFileSize,
+  imageSizeLimitMB,
+} from '../../graphql/posts';
 
 export enum MarkdownCommand {
   Upload = 'upload',
@@ -127,7 +131,7 @@ export const useMarkdownInput = ({
       onFinish: async (status, file, url) => {
         if (status === UploadState.Failed) {
           return displayToast(
-            'File type is not allowed or the size exceeded the limit',
+            `File type is not allowed or the size exceeded the limit of ${imageSizeLimitMB} MB`,
           );
         }
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- message is now `File size exceeds the limit of 5 MB`
- updated props to use const export

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1426 #done
