### PR TITLE
refactor: direct changelog click to article page

### DIFF
--- a/packages/shared/src/components/tooltips/ChangelogTooltip.spec.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.spec.tsx
@@ -150,7 +150,7 @@ describe('ChangelogTooltip component', () => {
     expect(changelogReleaseNotesBtn).toBeInTheDocument();
     expect(changelogReleaseNotesBtn).toHaveAttribute(
       'href',
-      defaultPost.permalink,
+      defaultPost.commentsPermalink,
     );
 
     const changelogExtensionBtn = screen.queryByTestId('changelogExtensionBtn');

--- a/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
@@ -173,7 +173,7 @@ function ChangelogTooltip<TRef extends HTMLElement>({
                 className="btn-tertiary"
                 onClick={dismissChangelog}
                 tag="a"
-                href={post.permalink}
+                href={post.commentsPermalink}
                 data-testid="changelogReleaseNotesBtn"
               >
                 Release notes

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -346,7 +346,7 @@ export const LATEST_CHANGELOG_POST_QUERY = gql`
           title
           createdAt
           image
-          permalink
+          commentsPermalink
           numComments
           numUpvotes
           summary


### PR DESCRIPTION
## Changes

### Describe what this PR does

Change the changelog tooltip to direct to article page

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
