### PR TITLE
fix: add option to go back to squad from article

### DIFF
--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -39,6 +39,7 @@ export interface PostContentProps
   shouldOnboardAuthor?: boolean;
   customNavigation?: ReactNode;
   position?: CSSProperties['position'];
+  backToSquad?: boolean;
 }
 
 export const SCROLL_OFFSET = 80;
@@ -64,6 +65,7 @@ export function PostContent({
   isFallback,
   customNavigation,
   onRemovePost,
+  backToSquad,
 }: PostContentProps): ReactElement {
   const { subject } = useToastNotification();
   const engagementActions = usePostContent({
@@ -111,6 +113,7 @@ export function PostContent({
         <BasePostContent
           className={{
             ...className,
+            onboarding: backToSquad && 'mb-6',
             navigation: {
               actions: className?.navigation?.actions,
               container: classNames('pt-6', className?.navigation?.container),

--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -39,7 +39,7 @@ function SharePostContent({
           href={
             isUnknownSource
               ? post.sharedPost.permalink
-              : `${post.sharedPost.commentsPermalink}?squad=${post.source.name}`
+              : `${post.sharedPost.commentsPermalink}?squad=${post.source.handle}&n=${post.source.name}`
           }
           as={isUnknownSource ? undefined : post.sharedPost.commentsPermalink}
         >

--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -36,7 +36,7 @@ function SharePostContent({
           href={
             post.sharedPost.source.id === 'unknown'
               ? post.sharedPost.permalink
-              : post.sharedPost.commentsPermalink
+              : `${post.sharedPost.commentsPermalink}?squad=${post.source.id}&n=${post.source.name}`
           }
           title="Go to post"
           target="_blank"

--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -29,25 +29,25 @@ function SharePostContent({
     return shouldShowSummary ? height : 0;
   }, [shouldShowSummary, height]);
 
+  const isUnknownSource = post.sharedPost.source.id === 'unknown';
+
   return (
     <>
       <p className="mt-6 whitespace-pre-line typo-title3">{post.title}</p>
       <div className="flex flex-col mt-8 rounded-16 border border-theme-divider-tertiary hover:border-theme-divider-secondary">
         <Link
           href={
-            post.sharedPost.source.id === 'unknown'
+            isUnknownSource
               ? post.sharedPost.permalink
               : `${post.sharedPost.commentsPermalink}?squad=${post.source.name}`
           }
-          as={
-            post.sharedPost.source.id === 'unknown'
-              ? undefined
-              : post.sharedPost.commentsPermalink
-          }
+          as={isUnknownSource ? undefined : post.sharedPost.commentsPermalink}
         >
           {/* eslint-disable-next-line react/jsx-no-comment-textnodes, jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
           <a
             title="Go to post"
+            target={isUnknownSource ? '_blank' : undefined}
+            rel={isUnknownSource ? 'noopener' : undefined}
             className="flex flex-col-reverse laptop:flex-row p-4 max-w-full"
             onClick={onReadArticle}
           >

--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, useContext, useMemo, useState } from 'react';
 import classNames from 'classnames';
+import Link from 'next/link';
 import PostSourceInfo from './PostSourceInfo';
 import { ReadArticleButton } from '../cards/ReadArticleButton';
 import { LazyImage } from '../LazyImage';
@@ -32,48 +33,55 @@ function SharePostContent({
     <>
       <p className="mt-6 whitespace-pre-line typo-title3">{post.title}</p>
       <div className="flex flex-col mt-8 rounded-16 border border-theme-divider-tertiary hover:border-theme-divider-secondary">
-        <a
+        <Link
           href={
             post.sharedPost.source.id === 'unknown'
               ? post.sharedPost.permalink
-              : `${post.sharedPost.commentsPermalink}?squad=${post.source.id}&n=${post.source.name}`
+              : `${post.sharedPost.commentsPermalink}?squad=${post.source.name}`
           }
-          title="Go to post"
-          target="_blank"
-          rel="noopener"
-          className="flex flex-col-reverse laptop:flex-row p-4 max-w-full"
-          onClick={onReadArticle}
+          as={
+            post.sharedPost.source.id === 'unknown'
+              ? undefined
+              : post.sharedPost.commentsPermalink
+          }
         >
-          <div className="flex flex-col flex-1">
-            <h2 className="flex flex-wrap mt-4 laptop:mt-0 mb-4 font-bold typo-body">
-              {post.sharedPost.title}
-            </h2>
-            <PostSourceInfo
-              date={
-                post.sharedPost.readTime
-                  ? `${post.sharedPost.readTime}m read time`
-                  : undefined
-              }
-              source={post.sharedPost.source}
-              size="small"
-            />
-            <ReadArticleButton
-              className="mt-5 btn-secondary w-fit"
-              href={post.sharedPost.permalink}
-              openNewTab={openNewTab}
-              onClick={onReadArticle}
-            />
-          </div>
-          <div className="block overflow-hidden ml-2 w-70 rounded-2xl cursor-pointer h-fit">
-            <LazyImage
-              imgSrc={post.sharedPost.image}
-              imgAlt="Post cover image"
-              ratio="52%"
-              eager
-              fallbackSrc={cloudinary.post.imageCoverPlaceholder}
-            />
-          </div>
-        </a>
+          {/* eslint-disable-next-line react/jsx-no-comment-textnodes, jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+          <a
+            title="Go to post"
+            className="flex flex-col-reverse laptop:flex-row p-4 max-w-full"
+            onClick={onReadArticle}
+          >
+            <div className="flex flex-col flex-1">
+              <h2 className="flex flex-wrap mt-4 laptop:mt-0 mb-4 font-bold typo-body">
+                {post.sharedPost.title}
+              </h2>
+              <PostSourceInfo
+                date={
+                  post.sharedPost.readTime
+                    ? `${post.sharedPost.readTime}m read time`
+                    : undefined
+                }
+                source={post.sharedPost.source}
+                size="small"
+              />
+              <ReadArticleButton
+                className="mt-5 btn-secondary w-fit"
+                href={post.sharedPost.permalink}
+                openNewTab={openNewTab}
+                onClick={onReadArticle}
+              />
+            </div>
+            <div className="block overflow-hidden ml-2 w-70 rounded-2xl cursor-pointer h-fit">
+              <LazyImage
+                imgSrc={post.sharedPost.image}
+                imgAlt="Post cover image"
+                ratio="52%"
+                eager
+                fallbackSrc={cloudinary.post.imageCoverPlaceholder}
+              />
+            </div>
+          </a>
+        </Link>
         {post.sharedPost.summary && (
           <>
             <PostSummary

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -149,7 +149,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
       <Link href={`/squads/${router.query.squad}`}>
         <a className="flex flex-row items-center font-bold text-theme-label-tertiary typo-callout">
           <ArrowIcon size={IconSize.Medium} className="mr-2 -rotate-90" />
-          Back to {router.query.squad || 'Squad'}
+          Back to {router.query.n || 'Squad'}
         </a>
       </Link>
     ),

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -145,11 +145,11 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     <SquadPostPageNavigation squadLink={post.source.permalink} />
   );
   const navigation: Record<PostType, ReactNode> = {
-    article: router?.query?.squad && (
+    article: !!router?.query?.squad && (
       <Link href={`/squads/${router.query.squad}`}>
         <a className="flex flex-row items-center font-bold text-theme-label-tertiary typo-callout">
           <ArrowIcon size={IconSize.Medium} className="mr-2 -rotate-90" />
-          Back to {router?.query?.n || 'Squad'}
+          Back to {router.query.squad || 'Squad'}
         </a>
       </Link>
     ),

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -43,6 +43,9 @@ import { ModalSize } from '@dailydotdev/shared/src/components/modals/common/type
 import useSidebarRendered from '@dailydotdev/shared/src/hooks/useSidebarRendered';
 import PostLoadingSkeleton from '@dailydotdev/shared/src/components/post/PostLoadingSkeleton';
 import classNames from 'classnames';
+import ArrowIcon from '@dailydotdev/shared/src/components/icons/Arrow';
+import { IconSize } from '@dailydotdev/shared/src/components/Icon';
+import Link from 'next/link';
 import { getTemplatedTitle } from '../../../components/layouts/utils';
 import { getLayout as getMainLayout } from '../../../components/layouts/MainLayout';
 
@@ -142,7 +145,14 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     <SquadPostPageNavigation squadLink={post.source.permalink} />
   );
   const navigation: Record<PostType, ReactNode> = {
-    article: null,
+    article: router?.query?.squad && (
+      <Link href={`/squads/${router.query.squad}`}>
+        <a className="flex flex-row items-center font-bold text-theme-label-tertiary typo-callout">
+          <ArrowIcon size={IconSize.Medium} className="mr-2 -rotate-90" />
+          Back to {router?.query?.n || 'Squad'}
+        </a>
+      </Link>
+    ),
     share: shareNavigation,
     welcome: shareNavigation,
     freeform: shareNavigation,
@@ -150,7 +160,6 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
   const customNavigation = navigation[post?.type] ?? navigation.article;
 
   if (!Content || isError) return <Custom404 />;
-
   return (
     <>
       <Head>
@@ -162,6 +171,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
         post={post}
         isFallback={isFallback}
         customNavigation={customNavigation}
+        backToSquad={!!router?.query?.squad}
         shouldOnboardAuthor={!!router.query?.author}
         enableShowShareNewComment={!!router?.query.new}
         origin={Origin.ArticlePage}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added a option to go back to a squad on a article if the origin of flow was squad's
- Used query params as it should only flow if user moves via this flow
- Design is slightly adjusted to make things easier for now (will refactor in later stage, see discussion [here](https://dailydotdev.slack.com/archives/C051TNXSXR8/p1686750909746819))

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1395 #done
