### PR TITLE
fix: missing notification toggle on sharing post

### DIFF
--- a/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
+++ b/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
@@ -11,10 +11,12 @@ import SourceButton from '../../cards/SourceButton';
 import { Squad } from '../../../graphql/sources';
 import { formToJson } from '../../../lib/form';
 import { useDebouncedUrl } from '../../../hooks/input';
+import { useNotificationToggle } from '../../../hooks/notifications';
+import { Switch } from '../../fields/Switch';
 
 export interface CreateSharedPostModalProps extends ModalProps {
   preview: ExternalLinkPreview;
-  onSharedSuccessfully?: () => void;
+  onSharedSuccessfully?: (enableNotification?: boolean) => void;
   squad: Squad;
 }
 
@@ -26,6 +28,8 @@ export function CreateSharedPostModal({
 }: CreateSharedPostModalProps): ReactElement {
   const markdownRef = useRef<MarkdownRef>();
   const [link, setLink] = useState(preview?.permalink ?? preview?.url ?? '');
+  const { shouldShowCta, isEnabled, onToggle, onSubmitted } =
+    useNotificationToggle();
   const {
     getLinkPreview,
     isLoadingPreview,
@@ -36,6 +40,7 @@ export function CreateSharedPostModal({
     initialPreview: preview,
     onPostSuccess: () => {
       if (onSharedSuccessfully) onSharedSuccessfully();
+      onSubmitted();
       props.onRequestClose(null);
     },
   });
@@ -90,6 +95,20 @@ export function CreateSharedPostModal({
             )
           }
         />
+        {/* {shouldShowCta && ( */}
+        <Switch
+          data-testId="push_notification-switch"
+          inputId="push_notification-switch"
+          name="push_notification"
+          labelClassName="flex-1 font-normal"
+          className="py-3"
+          compact={false}
+          checked={isEnabled}
+          onToggle={onToggle}
+        >
+          Receive updates whenever your Squad members engage with your post
+        </Switch>
+        {/* )} */}
       </form>
       <Modal.Footer className="typo-caption1">
         <Button

--- a/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
+++ b/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
@@ -118,20 +118,20 @@ export function CreateSharedPostModal({
             )
           }
         />
-        {/* {shouldShowCta && ( */}
-        <Switch
-          data-testId="push_notification-switch"
-          inputId="push_notification-switch"
-          name="push_notification"
-          labelClassName="flex-1 font-normal"
-          className="py-3"
-          compact={false}
-          checked={isEnabled}
-          onToggle={onToggle}
-        >
-          Receive updates whenever your Squad members engage with your post
-        </Switch>
-        {/* )} */}
+        {shouldShowCta && (
+          <Switch
+            data-testId="push_notification-switch"
+            inputId="push_notification-switch"
+            name="push_notification"
+            labelClassName="flex-1 font-normal"
+            className="py-3"
+            compact={false}
+            checked={isEnabled}
+            onToggle={onToggle}
+          >
+            Receive updates whenever your Squad members engage with your post
+          </Switch>
+        )}
       </form>
       <Modal.Footer className="typo-caption1" justify={Justify.Start}>
         <Button


### PR DESCRIPTION
## Changes
- Fix the missing toggle after migrating the sharing of post to a new modal.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
