### PR TITLE
fix: create cache key for pnpm lock file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,14 +12,14 @@ jobs:
           command: npm i --prefix=$HOME/.local -g pnpm
       - restore_cache:
           keys:
-            - deps-v5-{{ checksum "pnpm-lock.yaml" }}
-            - deps-v5-{{ .Branch }}
-            - deps-v5-
+            - deps-v6-{{ checksum "pnpm-lock.yaml" }}
+            - deps-v6-{{ .Branch }}
+            - deps-v6-
       - run:
           name: Install dependencies
           command: pnpm install
       - save_cache:
-          key: deps-v5-{{ checksum "pnpm-lock.yaml" }}
+          key: deps-v6-{{ checksum "pnpm-lock.yaml" }}
           paths:
             - ./node_modules
             - ./packages/eslint-config/node_modules
@@ -43,14 +43,14 @@ jobs:
           command: npm i --prefix=$HOME/.local -g pnpm
       - restore_cache:
           keys:
-            - deps-v5-{{ checksum "pnpm-lock.yaml" }}
-            - deps-v5-{{ .Branch }}
-            - deps-v5-
+            - deps-v6-{{ checksum "pnpm-lock.yaml" }}
+            - deps-v6-{{ .Branch }}
+            - deps-v6-
       - run:
           name: Install dependencies
           command: pnpm install
       - save_cache:
-          key: deps-v5-{{ checksum "pnpm-lock.yaml" }}
+          key: deps-v6-{{ checksum "pnpm-lock.yaml" }}
           paths:
             - ./node_modules
             - ./packages/eslint-config/node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,14 @@ jobs:
           command: npm i --prefix=$HOME/.local -g pnpm
       - restore_cache:
           keys:
+            - deps-v5-{{ checksum "pnpm-lock.yaml" }}
             - deps-v5-{{ .Branch }}
             - deps-v5-
       - run:
           name: Install dependencies
           command: pnpm install
       - save_cache:
-          key: deps-v5-{{ .Branch }}
+          key: deps-v5-{{ checksum "pnpm-lock.yaml" }}
           paths:
             - ./node_modules
             - ./packages/eslint-config/node_modules
@@ -42,13 +43,14 @@ jobs:
           command: npm i --prefix=$HOME/.local -g pnpm
       - restore_cache:
           keys:
+            - - deps-v5-{{ checksum "pnpm-lock.yaml" }}
             - deps-v5-{{ .Branch }}
             - deps-v5-
       - run:
           name: Install dependencies
           command: pnpm install
       - save_cache:
-          key: deps-v5-{{ .Branch }}
+          key: deps-v5-{{ checksum "pnpm-lock.yaml" }}
           paths:
             - ./node_modules
             - ./packages/eslint-config/node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
           keys:
             - deps-v6-{{ checksum "pnpm-lock.yaml" }}
             - deps-v6-{{ .Branch }}
-            - deps-v6-
       - run:
           name: Install dependencies
           command: pnpm install
@@ -45,7 +44,6 @@ jobs:
           keys:
             - deps-v6-{{ checksum "pnpm-lock.yaml" }}
             - deps-v6-{{ .Branch }}
-            - deps-v6-
       - run:
           name: Install dependencies
           command: pnpm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           command: npm i --prefix=$HOME/.local -g pnpm
       - restore_cache:
           keys:
-            - - deps-v5-{{ checksum "pnpm-lock.yaml" }}
+            - deps-v5-{{ checksum "pnpm-lock.yaml" }}
             - deps-v5-{{ .Branch }}
             - deps-v5-
       - run:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "daily-apps",
   "private": true,
   "dependencies": {
+    "@babel/runtime": "^7.17.9",
     "postcss-rem-to-responsive-pixel": "^5.1.1"
   }
 }

--- a/packages/shared/src/components/modals/comment/NewCommentModal.spec.tsx
+++ b/packages/shared/src/components/modals/comment/NewCommentModal.spec.tsx
@@ -418,7 +418,7 @@ it('should send previewComment query', async () => {
   input.dispatchEvent(new Event('input', { bubbles: true }));
   const preview = await screen.findByText('Preview');
   preview.click();
-  await new Promise((resolve) => setTimeout(resolve, 10));
+  await new Promise((resolve) => setTimeout(resolve, 1000));
   await waitForNock();
   expect(queryCalled).toBeTruthy();
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@babel/runtime':
+        specifier: ^7.17.9
+        version: 7.17.9
       postcss-rem-to-responsive-pixel:
         specifier: ^5.1.1
         version: 5.1.1


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Make cache dependant on pnpm lock file
## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
