### PR TITLE
fix: downvote option modal state

### DIFF
--- a/packages/shared/src/hooks/useUpdatePost.ts
+++ b/packages/shared/src/hooks/useUpdatePost.ts
@@ -16,6 +16,13 @@ export default function useUpdatePost(): UseBookmarkPostRet {
       const postQueryKey = ['post', props.id];
       await client.cancelQueries(postQueryKey);
       const oldPost = client.getQueryData<PostData>(postQueryKey);
+
+      if (!oldPost) {
+        // nothing in cache so we skip any update
+
+        return () => undefined;
+      }
+
       client.setQueryData<PostData>(postQueryKey, {
         post: {
           ...oldPost.post,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- when clicking downvote from modal option menu mutation handlers were missing and state would go out of sync with upvote/downvote buttons in the post modal actions

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
