### PR TITLE
fix: nullable source on preview

### DIFF
--- a/packages/shared/src/components/post/write/WriteLinkPreview.tsx
+++ b/packages/shared/src/components/post/write/WriteLinkPreview.tsx
@@ -48,20 +48,21 @@ export function WriteLinkPreview({
         <WritePreviewContent className={isMinimized && '!py-2 !px-3'}>
           <div className="flex flex-col flex-1 typo-footnote">
             <span className="font-bold line-clamp-2">{preview.title}</span>
-            {preview.source && isMinimized ? (
-              <SourceAvatar
-                size="small"
-                source={preview.source}
-                className="absolute right-24 mt-1 mr-4"
-              />
-            ) : (
-              <span className="flex flex-row items-center mt-1">
-                <SourceAvatar size="small" source={preview.source} />
-                <span className="text-theme-label-tertiary">
-                  {preview.source.name}
+            {preview.source &&
+              (isMinimized ? (
+                <SourceAvatar
+                  size="small"
+                  source={preview.source}
+                  className="absolute right-24 mt-1 mr-4"
+                />
+              ) : (
+                <span className="flex flex-row items-center mt-1">
+                  <SourceAvatar size="small" source={preview.source} />
+                  <span className="text-theme-label-tertiary">
+                    {preview.source.name}
+                  </span>
                 </span>
-              </span>
-            )}
+              ))}
           </div>
           <Image
             className={previewImageClass}


### PR DESCRIPTION
## Changes
- The condition should only proceed when the Source is available then there will be two states, minimized and the normal one. The parenthesis should ensure the source availability first.

Also tested locally and works now.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
