### PR TITLE
feat: removing the bg color from the similar posts sidebar widget

### DIFF
--- a/packages/shared/src/components/widgets/SimilarPosts.tsx
+++ b/packages/shared/src/components/widgets/SimilarPosts.tsx
@@ -126,7 +126,7 @@ export default function SimilarPosts({
   return (
     <section
       className={classNames(
-        'flex flex-col rounded-2xl bg-theme-bg-primary border-theme-divider-quaternary border',
+        'flex flex-col rounded-2xl border-theme-divider-quaternary border',
         className,
       )}
     >


### PR DESCRIPTION
## Changes
Removing the bg-color set on the similar posts widget so it matches the rest of the widgets in the sidebar

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1461 #done
