### PR TITLE
feat: removing the bg color to the table of contents widget

### DIFF
--- a/packages/shared/src/components/widgets/PostToc.tsx
+++ b/packages/shared/src/components/widgets/PostToc.tsx
@@ -54,7 +54,7 @@ export default function PostToc({
 
   const titleClass =
     'flex items-center py-3 px-4 typo-body text-theme-label-tertiary border border-theme-divider-quaternary';
-  if (!collapsible) {
+  if (collapsible) {
     return (
       <details
         className={classNames(

--- a/packages/shared/src/components/widgets/PostToc.tsx
+++ b/packages/shared/src/components/widgets/PostToc.tsx
@@ -57,7 +57,7 @@ export default function PostToc({
     return (
       <details
         className={classNames(
-          'flex-col rounded-2xl bg-theme-bg-secondary overflow-hidden select-none',
+          'flex-col rounded-2xl overflow-hidden select-none',
           styles.details,
           className,
         )}

--- a/packages/shared/src/components/widgets/PostToc.tsx
+++ b/packages/shared/src/components/widgets/PostToc.tsx
@@ -6,6 +6,7 @@ import { Summary, SummaryArrow } from '../utilities';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 import { postAnalyticsEvent } from '../../lib/feed';
 import styles from './PostToc.module.css';
+import { WidgetContainer } from './common';
 
 export type PostTocProps = {
   post: Post;
@@ -52,8 +53,8 @@ export default function PostToc({
   );
 
   const titleClass =
-    'flex items-center py-3 px-4 typo-body text-theme-label-tertiary';
-  if (collapsible) {
+    'flex items-center py-3 px-4 typo-body text-theme-label-tertiary border border-theme-divider-quaternary';
+  if (!collapsible) {
     return (
       <details
         className={classNames(
@@ -75,9 +76,9 @@ export default function PostToc({
     );
   }
   return (
-    <section
+    <WidgetContainer
       className={classNames(
-        'flex-col rounded-2xl pb-3 bg-theme-bg-secondary overflow-hidden',
+        'flex-col rounded-2xl pb-3 overflow-hidden border border-theme-divider-quaternary',
         className,
       )}
     >
@@ -87,6 +88,6 @@ export default function PostToc({
       </h4>
       {Separator}
       {items}
-    </section>
+    </WidgetContainer>
   );
 }


### PR DESCRIPTION
## Changes
Removed the bg color on the table of contents widget to bring it inline with the other widgets

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1476 #done
