### PR TITLE
feat: hiding create new squad for anon users

### DIFF
--- a/packages/shared/src/components/squads/SquadsToShare.tsx
+++ b/packages/shared/src/components/squads/SquadsToShare.tsx
@@ -55,6 +55,7 @@ export function SquadsToShare({
     [squads, isLoading, onClick, size, squadAvatarSize],
   );
 
+  if (!hasSquadAccess) return null;
   if (list.length) return <>{list}</>;
 
   return (

--- a/packages/shared/src/components/widgets/SocialShareIcon.tsx
+++ b/packages/shared/src/components/widgets/SocialShareIcon.tsx
@@ -57,7 +57,7 @@ export const SocialShareIcon = ({
       />
       <ShareText
         className={classNames(
-          'mt-1.5 max-w-[4rem] overflow-hidden overflow-ellipsis',
+          'mt-1.5 max-w-[4rem] overflow-hidden overflow-ellipsis text-center',
           sizeToText[size],
         )}
         onClick={() => button?.current?.click()}


### PR DESCRIPTION
## Changes
Setting logic to hide the create squad button in the SquadsToShare component so nothing renders related to squads if the user doesn't have squads access
![Screenshot 2023-06-26 at 10 57 11 am](https://github.com/dailydotdev/apps/assets/42202149/4440cab5-173b-490a-9b4a-fac4782d153d)
![Screenshot 2023-06-26 at 10 58 54 am](https://github.com/dailydotdev/apps/assets/42202149/ae97fd16-38e3-4c37-887e-d8915baa1db1)



### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1477 #done
