### PR TITLE
feat: added irrelevant tags option to report post modal

### DIFF
--- a/packages/extension/src/companion/CompanionContextMenu.tsx
+++ b/packages/extension/src/companion/CompanionContextMenu.tsx
@@ -48,8 +48,9 @@ export default function CompanionContextMenu({
     reason,
     comment,
     blockSource,
+    tags,
   ): Promise<void> => {
-    onReport({ id: reportedPost.id, reason, comment });
+    onReport({ id: reportedPost.id, reason, comment, tags });
     if (blockSource) {
       onBlockSource({ id: reportedPost?.source?.id });
     }

--- a/packages/extension/src/companion/useCompanionActions.ts
+++ b/packages/extension/src/companion/useCompanionActions.ts
@@ -47,6 +47,7 @@ interface UseCompanionActionsProps {
   reason?: string;
   comment?: string;
   companionExpandedValue?: boolean;
+  tags?: string[];
 }
 export default function useCompanionActions<
   T extends UseCompanionActionsProps,
@@ -63,11 +64,12 @@ export default function useCompanionActions<
     unknown,
     T,
     (() => void) | undefined
-  >(({ id, reason, comment }) =>
+  >(({ id, reason, comment, tags }) =>
     companionRequest(graphqlUrl, REPORT_POST_MUTATION, {
       id,
       reason,
       comment,
+      tags,
     }),
   );
 

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -603,7 +603,11 @@ it('should report broken link', async () => {
     {
       request: {
         query: REPORT_POST_MUTATION,
-        variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf', reason: 'BROKEN' },
+        variables: {
+          id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
+          reason: 'BROKEN',
+          tags: [],
+        },
       },
       result: () => {
         mutationCalled = true;
@@ -644,6 +648,7 @@ it('should report broken link with comment', async () => {
           id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
           reason: 'BROKEN',
           comment: 'comment',
+          tags: [],
         },
       },
       result: () => {
@@ -684,7 +689,11 @@ it('should report nsfw', async () => {
     {
       request: {
         query: REPORT_POST_MUTATION,
-        variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf', reason: 'NSFW' },
+        variables: {
+          id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
+          reason: 'NSFW',
+          tags: [],
+        },
       },
       result: () => {
         mutationCalled = true;

--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -64,6 +64,7 @@ type ReportPostAsync = (
   reason: ReportReason,
   comment: string,
   blockSource: boolean,
+  tags: string[],
 ) => Promise<unknown>;
 
 export default function PostOptionsMenu({
@@ -158,11 +159,13 @@ export default function PostOptionsMenu({
     reason,
     comment,
     blockSource,
+    tags,
   ): Promise<void> => {
     const { successful } = await reportPost({
       id: reportedPost?.id,
       reason,
       comment,
+      tags,
     });
 
     if (!successful) {

--- a/packages/shared/src/components/fields/Radio.tsx
+++ b/packages/shared/src/components/fields/Radio.tsx
@@ -6,6 +6,7 @@ export interface RadioOption<T = string> {
   label: ReactNode;
   value: T;
   id?: string;
+  afterElement?: ReactNode;
 }
 
 interface ClassName {
@@ -44,6 +45,7 @@ export function Radio({
           checked={value === option.value}
           onChange={() => onChange(option.value)}
           className={classNames('my-0.5 truncate', className.content)}
+          afterElement={option.afterElement}
         >
           {option.label}
         </RadioItem>

--- a/packages/shared/src/components/fields/RadioItem.tsx
+++ b/packages/shared/src/components/fields/RadioItem.tsx
@@ -1,49 +1,55 @@
-import React, { InputHTMLAttributes, ReactElement } from 'react';
+import React, { InputHTMLAttributes, ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
 import styles from './RadioItem.module.css';
 
 export type RadioItemProps = Omit<
   InputHTMLAttributes<HTMLInputElement>,
   'type'
->;
+> & {
+  afterElement?: ReactNode;
+};
 
 export function RadioItem({
   children,
   className,
   checked,
+  afterElement,
   ...props
 }: RadioItemProps): ReactElement {
   const { id } = props;
   return (
-    <label
-      className={classNames(
-        styles.item,
-        { [styles.checked]: checked },
-        'relative flex flex-row items-center typo-footnote text-theme-label-tertiary pointer font-bold cursor-pointer select-none hover:text-theme-label-primary focus-within:text-theme-label-primary pr-3',
-        className,
-      )}
-      htmlFor={id}
-    >
-      <input
-        type="radio"
-        className="absolute w-0 h-0 opacity-0"
-        checked={checked}
-        {...props}
-      />
-      <span
+    <>
+      <label
         className={classNames(
-          'w-8 h-8 p-1.5 rounded-10 mr-1.5',
-          styles.checkmark,
+          styles.item,
+          { [styles.checked]: checked },
+          'relative flex flex-row items-center typo-footnote text-theme-label-tertiary pointer font-bold cursor-pointer select-none hover:text-theme-label-primary focus-within:text-theme-label-primary pr-3',
+          className,
         )}
+        htmlFor={id}
       >
+        <input
+          type="radio"
+          className="absolute w-0 h-0 opacity-0"
+          checked={checked}
+          {...props}
+        />
         <span
           className={classNames(
-            'w-full h-full flex rounded-full border-2 border-theme-label-tertiary',
-            styles.innerRing,
+            'w-8 h-8 p-1.5 rounded-10 mr-1.5',
+            styles.checkmark,
           )}
-        />
-      </span>
-      {children}
-    </label>
+        >
+          <span
+            className={classNames(
+              'w-full h-full flex rounded-full border-2 border-theme-label-tertiary',
+              styles.innerRing,
+            )}
+          />
+        </span>
+        {children}
+      </label>
+      {afterElement}
+    </>
   );
 }

--- a/packages/shared/src/components/modals/ReportPostModal.tsx
+++ b/packages/shared/src/components/modals/ReportPostModal.tsx
@@ -82,7 +82,6 @@ export default function ReportPostModal({
   const [comment, setComment] = useState<string>();
   const inputRef = useRef<HTMLInputElement>();
   const [selectedTags, setSelectedTags] = useState<string[]>(() => []);
-  const showTextArea = reason !== 'IRRELEVANT';
   const reportOptionsForActiveReason = useMemo<RadioOption[]>(() => {
     return reportReasons.map((reportReason) => {
       const LabelComponent =
@@ -137,13 +136,11 @@ export default function ReportPostModal({
           value={reason}
           onChange={setReason}
         />
-        {showTextArea && (
-          <textarea
-            onChange={(event) => setComment(event.target.value)}
-            className="self-stretch p-2 mb-4 w-full h-20 bg-theme-float rounded-10 resize-none typo-body"
-            data-testid="report_comment"
-          />
-        )}
+        <textarea
+          onChange={(event) => setComment(event.target.value)}
+          className="self-stretch p-2 mb-4 w-full h-20 bg-theme-float rounded-10 resize-none typo-body"
+          data-testid="report_comment"
+        />
         <Checkbox ref={inputRef} name="blockSource" className="font-normal">
           Don&apos;t show posts from {post?.source?.name}
         </Checkbox>

--- a/packages/shared/src/components/modals/ReportPostModal.tsx
+++ b/packages/shared/src/components/modals/ReportPostModal.tsx
@@ -46,8 +46,8 @@ const reportReasonsMap: Partial<
 > = {
   IRRELEVANT: ({ post, selectedTags, setSelectedTags }) => {
     return (
-      <FlexRow className="gap-2 my-4">
-        {post.tags.map((tag) => {
+      <FlexRow className="flex-wrap gap-2 my-4">
+        {post.tags?.map((tag) => {
           const isSelected = selectedTags.includes(tag);
 
           return (

--- a/packages/shared/src/components/modals/ReportPostModal.tsx
+++ b/packages/shared/src/components/modals/ReportPostModal.tsx
@@ -53,7 +53,7 @@ const reportReasonsMap: Partial<
           return (
             <Button
               key={tag}
-              className={isSelected ? 'btn-primary' : 'btn-tag'}
+              className={isSelected ? 'btn-primary' : 'btn-tertiaryFloat'}
               buttonSize={ButtonSize.Small}
               onClick={() => {
                 if (isSelected) {

--- a/packages/shared/src/components/modals/ReportPostModal.tsx
+++ b/packages/shared/src/components/modals/ReportPostModal.tsx
@@ -1,24 +1,76 @@
-import React, { ReactElement, MouseEvent, useState, useRef } from 'react';
-import { Radio } from '../fields/Radio';
+import React, {
+  ReactElement,
+  MouseEvent,
+  useState,
+  useRef,
+  useMemo,
+  SetStateAction,
+  Dispatch,
+} from 'react';
+import { Radio, RadioOption } from '../fields/Radio';
 import { Post } from '../../graphql/posts';
 import { Checkbox } from '../fields/Checkbox';
-import { Button } from '../buttons/Button';
+import { Button, ButtonSize } from '../buttons/Button';
 import { PostBootData } from '../../lib/boot';
 import { Modal, ModalProps } from './common/Modal';
+import { FlexRow } from '../utilities';
 
 export interface Props extends ModalProps {
   postIndex: number;
   post: Post | PostBootData;
-  onReport: (postIndex, postId, reason, comment, blockSource) => unknown;
+  onReport: (postIndex, postId, reason, comment, blockSource, tags) => unknown;
 }
 
 const reportReasons: { value: string; label: string }[] = [
+  { value: 'IRRELEVANT', label: 'The post is not about...' },
   { value: 'BROKEN', label: 'Broken link' },
   { value: 'CLICKBAIT', label: 'Clickbait' },
   { value: 'LOW', label: 'Low-quality content' },
   { value: 'NSFW', label: 'NSFW' },
   { value: 'OTHER', label: 'Other' },
 ];
+
+const reportReasonsMap: Partial<
+  Record<
+    string,
+    ({
+      post,
+      selectedTags,
+      setSelectedTags,
+    }: {
+      post: Post;
+      selectedTags: string[];
+      setSelectedTags: Dispatch<SetStateAction<string[]>>;
+    }) => ReactElement
+  >
+> = {
+  IRRELEVANT: ({ post, selectedTags, setSelectedTags }) => {
+    return (
+      <FlexRow className="gap-2 my-4">
+        {post.tags.map((tag) => {
+          const isSelected = selectedTags.includes(tag);
+
+          return (
+            <Button
+              key={tag}
+              className={isSelected ? 'btn-primary' : 'btn-tag'}
+              buttonSize={ButtonSize.Small}
+              onClick={() => {
+                if (isSelected) {
+                  setSelectedTags(selectedTags.filter((t) => t !== tag));
+                } else {
+                  setSelectedTags([...selectedTags, tag]);
+                }
+              }}
+            >
+              #{tag}
+            </Button>
+          );
+        })}
+      </FlexRow>
+    );
+  },
+};
 
 export default function ReportPostModal({
   postIndex,
@@ -29,9 +81,39 @@ export default function ReportPostModal({
   const [reason, setReason] = useState(null);
   const [comment, setComment] = useState<string>();
   const inputRef = useRef<HTMLInputElement>();
+  const [selectedTags, setSelectedTags] = useState<string[]>(() => []);
+  const showTextArea = reason !== 'IRRELEVANT';
+  const reportOptionsForActiveReason = useMemo<RadioOption[]>(() => {
+    return reportReasons.map((reportReason) => {
+      const LabelComponent =
+        reportReason.value === reason && reportReasonsMap[reportReason.value];
+
+      if (LabelComponent) {
+        return {
+          ...reportReason,
+          afterElement: (
+            <LabelComponent
+              post={post}
+              selectedTags={selectedTags}
+              setSelectedTags={setSelectedTags}
+            />
+          ),
+        };
+      }
+
+      return reportReason;
+    });
+  }, [reason, post, selectedTags]);
 
   const onReportPost = async (event: MouseEvent): Promise<void> => {
-    onReport(postIndex, post, reason, comment, inputRef.current?.checked);
+    onReport(
+      postIndex,
+      post,
+      reason,
+      comment,
+      inputRef.current?.checked,
+      selectedTags,
+    );
     props.onRequestClose(event);
   };
 
@@ -51,23 +133,18 @@ export default function ReportPostModal({
         <Radio
           className={{ container: 'mt-2 mb-4' }}
           name="report_reason"
-          options={reportReasons}
+          options={reportOptionsForActiveReason}
           value={reason}
           onChange={setReason}
         />
-        <p className="px-2 mt-6 mb-1 font-bold typo-caption1">
-          Anything else you&apos;d like to add?
-        </p>
-        <textarea
-          onChange={(event) => setComment(event.target.value)}
-          className="self-stretch p-2 mb-4 w-full h-20 bg-theme-float rounded-10 resize-none typo-body"
-          data-testid="report_comment"
-        />
-        <Checkbox
-          ref={inputRef}
-          name="blockSource"
-          className="self-center font-normal"
-        >
+        {showTextArea && (
+          <textarea
+            onChange={(event) => setComment(event.target.value)}
+            className="self-stretch p-2 mb-4 w-full h-20 bg-theme-float rounded-10 resize-none typo-body"
+            data-testid="report_comment"
+          />
+        )}
+        <Checkbox ref={inputRef} name="blockSource" className="font-normal">
           Don&apos;t show posts from {post?.source?.name}
         </Checkbox>
       </Modal.Body>

--- a/packages/shared/src/components/modals/ReportPostModal.tsx
+++ b/packages/shared/src/components/modals/ReportPostModal.tsx
@@ -148,7 +148,11 @@ export default function ReportPostModal({
       <Modal.Footer>
         <Button
           className="btn-primary"
-          disabled={!reason || (reason === 'OTHER' && !comment)}
+          disabled={
+            !reason ||
+            (reason === 'OTHER' && !comment) ||
+            (reason === 'IRRELEVANT' && selectedTags.length === 0)
+          }
           onClick={onReportPost}
         >
           Submit report

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -290,8 +290,13 @@ export const POSTS_ENGAGED_SUBSCRIPTION = gql`
 `;
 
 export const REPORT_POST_MUTATION = gql`
-  mutation ReportPost($id: ID!, $reason: ReportReason!, $comment: String) {
-    reportPost(id: $id, reason: $reason, comment: $comment) {
+  mutation ReportPost(
+    $id: ID!
+    $reason: ReportReason!
+    $comment: String
+    $tags: [String!]
+  ) {
+    reportPost(id: $id, reason: $reason, comment: $comment, tags: $tags) {
       _
     }
   }

--- a/packages/shared/src/hooks/useReportPost.ts
+++ b/packages/shared/src/hooks/useReportPost.ts
@@ -17,6 +17,7 @@ type UseReportPostRet = {
     id: string;
     reason: ReportReason;
     comment?: string;
+    tags?: string[];
   }) => BooleanPromise;
   hidePost: (id: string) => BooleanPromise;
   unhidePost: (id: string) => BooleanPromise;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Add another option to `ReportPostModal`
- Extend `RadioItem` to support `afterElement` (needed to render tags selection below radio)
- Update report post mutation to support tags as per https://github.com/dailydotdev/daily-api/pull/1319

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1446 #done
