### PR TITLE
feat: block panel on article post cards

### DIFF
--- a/packages/shared/src/components/cards/ArticlePostCard.spec.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.spec.tsx
@@ -11,6 +11,7 @@ import { ArticlePostCard } from './ArticlePostCard';
 import { FeaturesContextProvider } from '../../contexts/FeaturesContext';
 import post from '../../../__tests__/fixture/post';
 import { PostCardProps, visibleOnGroupHover } from './common';
+import { AuthContextProvider } from '../../contexts/AuthContext';
 
 const defaultProps: PostCardProps = {
   post,
@@ -30,9 +31,16 @@ beforeEach(() => {
 const renderComponent = (props: Partial<PostCardProps> = {}): RenderResult => {
   return render(
     <FeaturesContextProvider flags={{}}>
-      <QueryClientProvider client={new QueryClient()}>
-        <ArticlePostCard {...defaultProps} {...props} />
-      </QueryClientProvider>
+      <AuthContextProvider
+        user={null}
+        updateUser={jest.fn()}
+        tokenRefreshed={false}
+        getRedirectUri={jest.fn()}
+      >
+        <QueryClientProvider client={new QueryClient()}>
+          <ArticlePostCard {...defaultProps} {...props} />
+        </QueryClientProvider>
+      </AuthContextProvider>
     </FeaturesContextProvider>,
   );
 };

--- a/packages/shared/src/components/cards/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.tsx
@@ -13,6 +13,8 @@ import { PostCardHeader } from './PostCardHeader';
 import { PostCardFooter } from './PostCardFooter';
 import { Container, PostCardProps } from './common';
 import FeedItemContainer from './FeedItemContainer';
+import { useBlockPost } from '../../hooks/post/useBlockPost';
+import { PostTagsPanel } from '../post/block/PostTagsPanel';
 
 export const ArticlePostCard = forwardRef(function PostCard(
   {
@@ -37,9 +39,19 @@ export const ArticlePostCard = forwardRef(function PostCard(
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ): ReactElement {
+  const { data } = useBlockPost(post);
   const onPostCardClick = () => onPostClick(post);
   const { trending, pinnedAt } = post;
   const customStyle = !showImage ? { minHeight: '15.125rem' } : {};
+
+  if (data?.showTagsPanel && post.tags.length > 0) {
+    return (
+      <PostTagsPanel
+        className="overflow-hidden h-full max-h-[23.5rem]"
+        post={post}
+      />
+    );
+  }
 
   return (
     <FeedItemContainer

--- a/packages/shared/src/components/cards/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.tsx
@@ -49,6 +49,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
       <PostTagsPanel
         className="overflow-hidden h-full max-h-[23.5rem]"
         post={post}
+        toastOnSuccess
       />
     );
   }

--- a/packages/shared/src/components/cards/PostList.tsx
+++ b/packages/shared/src/components/cards/PostList.tsx
@@ -13,6 +13,8 @@ import ActionButtons from './ActionButtons';
 import SourceButton from './SourceButton';
 import PostAuthor from './PostAuthor';
 import FeedItemContainer from './FeedItemContainer';
+import { PostTagsPanel } from '../post/block/PostTagsPanel';
+import { useBlockPost } from '../../hooks/post/useBlockPost';
 
 export const PostList = forwardRef(function PostList(
   {
@@ -34,8 +36,18 @@ export const PostList = forwardRef(function PostList(
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ): ReactElement {
+  const { data } = useBlockPost(post);
   const onPostCardClick = () => onPostClick(post);
   const { trending, pinnedAt } = post;
+
+  if (data?.showTagsPanel && post.tags.length > 0) {
+    return (
+      <PostTagsPanel
+        className="overflow-hidden h-full max-h-[23.5rem]"
+        post={post}
+      />
+    );
+  }
 
   return (
     <FeedItemContainer

--- a/packages/shared/src/components/notifications/Toast.tsx
+++ b/packages/shared/src/components/notifications/Toast.tsx
@@ -104,7 +104,7 @@ const Toast = ({
             onClick={undoAction}
             aria-label="Undo action"
           >
-            Undo
+            {toast?.undoCopy ?? 'Undo'}
           </Button>
         )}
         <Button

--- a/packages/shared/src/components/post/block/PostTagsPanel.tsx
+++ b/packages/shared/src/components/post/block/PostTagsPanel.tsx
@@ -83,7 +83,7 @@ export function PostTagsPanel({
         Pick all the topics you are not interested to see on your feed
       </p>
       <span
-        className="flex overflow-auto flex-row flex-wrap flex-1 gap-2 mt-4"
+        className="flex overflow-auto flex-row flex-wrap flex-1 gap-2 content-start mt-4"
         role="list"
       >
         <Button

--- a/packages/shared/src/components/post/block/PostTagsPanel.tsx
+++ b/packages/shared/src/components/post/block/PostTagsPanel.tsx
@@ -76,12 +76,16 @@ export function PostTagsPanel({
         className="top-3 right-3"
         position="absolute"
         onClick={() => onClose()}
+        buttonSize={ButtonSize.Small}
       />
       <h4 className="font-bold typo-body">Don&apos;t show me posts from...</h4>
       <p className="mt-1 typo-callout text-theme-label-tertiary">
         Pick all the topics you are not interested to see on your feed
       </p>
-      <span className="flex flex-row flex-wrap gap-2 mt-4" role="list">
+      <span
+        className="flex overflow-auto flex-row flex-wrap flex-1 gap-2 mt-4"
+        role="list"
+      >
         <Button
           className={shouldBlockSource ? 'btn-primary' : 'btn-tertiaryFloat'}
           buttonSize={ButtonSize.Small}

--- a/packages/shared/src/hooks/post/useBlockPost.ts
+++ b/packages/shared/src/hooks/post/useBlockPost.ts
@@ -66,7 +66,7 @@ export const useBlockPost = (
   const { onBlockTags, onUnfollowSource, onUnblockTags, onFollowSource } =
     useTagAndSource({
       origin: Origin.TagsFilter,
-      postId: post.id,
+      postId: post?.id,
     });
   const client = useQueryClient();
   const { user } = useAuthContext();

--- a/packages/shared/src/hooks/usePostMenuActions.ts
+++ b/packages/shared/src/hooks/usePostMenuActions.ts
@@ -10,6 +10,7 @@ import { postAnalyticsEvent } from '../lib/feed';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { AnalyticsEvent, Origin } from '../lib/analytics';
 import useUpdatePost from './useUpdatePost';
+import { useBlockPost } from './post/useBlockPost';
 
 interface UsePostMenuActions {
   onConfirmDeletePost: () => Promise<void>;
@@ -83,19 +84,29 @@ export const usePostMenuActions = ({
     { onSuccess: onPinSuccessful },
   );
 
+  const { onClose, onShowPanel } = useBlockPost(post);
+
+  const onDownvoteMutate =
+    post &&
+    updatePost({
+      id: post.id,
+      update: mutationHandlers.downvote(post),
+    });
+  const onCancelDownvoteMutate =
+    post &&
+    updatePost({
+      id: post.id,
+      update: mutationHandlers.cancelDownvote(post),
+    });
   const { downvotePost, cancelPostDownvote } = useVotePost({
-    onDownvotePostMutate:
-      !!post &&
-      updatePost({
-        id: post.id,
-        update: mutationHandlers.downvote(post),
-      }),
-    onCancelPostDownvoteMutate:
-      !!post &&
-      updatePost({
-        id: post.id,
-        update: mutationHandlers.cancelDownvote(post),
-      }),
+    onDownvotePostMutate: (params) => {
+      onShowPanel();
+      return onDownvoteMutate(params);
+    },
+    onCancelPostDownvoteMutate: (params) => {
+      onClose(true);
+      return onCancelDownvoteMutate(params);
+    },
   });
 
   return {

--- a/packages/shared/src/hooks/useToastNotification.ts
+++ b/packages/shared/src/hooks/useToastNotification.ts
@@ -19,15 +19,14 @@ export interface ToastNotification {
   timer: number;
   subject?: ToastSubject;
   onUndo?: AnyFunction;
+  undoCopy?: string;
 }
 
 export const TOAST_NOTIF_KEY = 'toast_notif';
 
-export interface NotifyOptionalProps {
-  timer?: number;
-  subject?: ToastSubject;
-  onUndo?: AnyFunction;
-}
+export type NotifyOptionalProps = Partial<
+  Pick<ToastNotification, 'timer' | 'subject' | 'onUndo' | 'undoCopy'>
+>;
 
 export const useToastNotification = (): UseToastNotification => {
   const client = useQueryClient();


### PR DESCRIPTION
## Changes
- With the introduction of a reusable panel and actions for downvoting a post, implementation on cards became easy as expected.
- After downvoting, the panel to allow blocking or reporting of post should be displayed. 

Preview:

![Screenshot 2023-06-29 at 12 06 46 AM](https://github.com/dailydotdev/apps/assets/13744167/1808f08b-3ed7-42b2-844c-8d4be7c0cb68)

![Screenshot 2023-06-29 at 12 07 04 AM](https://github.com/dailydotdev/apps/assets/13744167/6e5f276a-7dce-4995-a99c-3263f5abbafa)

Currently deployed at preview2:

https://preview2.app.daily.dev/

![Screenshot 2023-06-29 at 12 08 29 AM](https://github.com/dailydotdev/apps/assets/13744167/1fd9fd47-31e7-49a6-b808-3fef16ec0aa5)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1442 #done
