### PR TITLE
feat: do not optimistically hide post from feed during post actions

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -103,6 +103,7 @@ export default function PostOptionsMenu({
     message: string,
     _postIndex: number,
     undo?: () => unknown,
+    callback?: (index: number) => Promise<unknown>,
   ) => {
     const onUndo = async () => {
       await undo?.();
@@ -112,7 +113,7 @@ export default function PostOptionsMenu({
       subject: ToastSubject.Feed,
       onUndo: undo !== null ? onUndo : null,
     });
-    onRemovePost?.(_postIndex);
+    callback?.(_postIndex);
   };
   const { onConfirmDeletePost, onPinPost } = usePostMenuActions({
     post,
@@ -140,7 +141,12 @@ export default function PostOptionsMenu({
           extra: { origin },
         }),
       );
-      return showMessageAndRemovePost('The post has been deleted', index, null);
+      return showMessageAndRemovePost(
+        'The post has been deleted',
+        index,
+        null,
+        onRemovePost,
+      );
     },
   });
 


### PR DESCRIPTION
## Changes

**WIP! needs some more work to handle tags blocking**

### Describe what this PR does
- This no longer hides post optimistically during block, hide and report
  - this fixes modal auto closing for users without giving option to keep interacting with article
- edge case is that user could click on the above options again thus submitting multiple times which API should handle gracefully

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
