### PR TITLE
fix: avoid modal close on tags/source block

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -96,6 +96,7 @@ export default function PostOptionsMenu({
   } = useTagAndSource({
     origin: Origin.PostContextMenu,
     postId: post?.id,
+    shouldInvalidateQueries: false,
   });
   const [reportModal, setReportModal] = useState<{
     index?: number;

--- a/packages/shared/src/hooks/post/useBlockPost.ts
+++ b/packages/shared/src/hooks/post/useBlockPost.ts
@@ -70,6 +70,7 @@ export const useBlockPost = (
     useTagAndSource({
       origin: Origin.TagsFilter,
       postId: post?.id,
+      shouldInvalidateQueries: false,
     });
   const client = useQueryClient();
   const { user } = useAuthContext();


### PR DESCRIPTION
## Changes

### Describe what this PR does

So the issue with article modal auto closing was only happening on "My feed" when blocking tag or source from the modal. All other actions like hide and report do not close modal (which is good ✅ ).

This PR does below changes to enable selective invalidation of feed queries when blocking tags/sources:
- move logic to invalidate feed queries on tags/settings change to `useTagAndSource` hook
  - this proved to be smallest footprint change which fixes the underlying issue
- remove `useFeedSettings` useEffect that was triggering too often (and unused options/state related to it)
  - invalidation is called from actions inside `useTagAndSource` directly
- add `shouldInvalidateQueries` to `useTagAndSource` since that hook is responsible for actual actions execution
- disable feed queries invalidation from `PostOptionsMenu` to prevent modal close on blocking

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
