### PR TITLE
fix: light mode white color issue

### DIFF
--- a/packages/shared/src/components/filters/UnblockCopy.tsx
+++ b/packages/shared/src/components/filters/UnblockCopy.tsx
@@ -8,8 +8,8 @@ export type CopyProps = {
 export const UnblockTagCopy = ({ name }: CopyProps): ReactElement => {
   return (
     <p>
-      Unblocking <strong className="text-white">#{name}</strong> means that you
-      might see posts containing this tag in your feed.
+      Unblocking <strong className="text-theme-label-primary">#{name}</strong>{' '}
+      means that you might see posts containing this tag in your feed.
     </p>
   );
 };
@@ -17,8 +17,8 @@ export const UnblockTagCopy = ({ name }: CopyProps): ReactElement => {
 export const UnblockSourceCopy = ({ name }: CopyProps): ReactElement => {
   return (
     <p>
-      Unblocking <strong className="text-white">{name}</strong> means that you
-      might see posts from this source in your feed.
+      Unblocking <strong className="text-theme-label-primary">{name}</strong>{' '}
+      means that you might see posts from this source in your feed.
     </p>
   );
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We had a small light mode color issue when using `text-white` it should be `text-theme-label-primary` in this case (white as well)
- I checked code base other implementation of `text-white` where good as they always on purple backgrounds

![Screenshot 2023-06-30 at 09 44 04](https://github.com/dailydotdev/apps/assets/554874/66fd3368-7b58-4fd6-8a9f-a570cd6019db)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1504 #done
