### PR TITLE
feat: close block panel on upvote

### DIFF
--- a/packages/shared/src/components/post/PostActions.tsx
+++ b/packages/shared/src/components/post/PostActions.tsx
@@ -47,6 +47,10 @@ export function PostActions({
   const { updatePost } = useUpdatePost();
   const { data, onShowPanel, onClose } = useBlockPostPanel(post);
   const { showTagsPanel } = data;
+  const onUpvotePostMutate = updatePost({
+    id: post.id,
+    update: mutationHandlers.upvote(post),
+  });
   const onDownvoteMutate = updatePost({
     id: post.id,
     update: mutationHandlers.downvote(post),
@@ -57,10 +61,10 @@ export function PostActions({
   });
   const { upvotePost, cancelPostUpvote, downvotePost, cancelPostDownvote } =
     useVotePost({
-      onUpvotePostMutate: updatePost({
-        id: post.id,
-        update: mutationHandlers.upvote(post),
-      }),
+      onUpvotePostMutate: (params) => {
+        onClose(true);
+        return onUpvotePostMutate(params);
+      },
       onCancelPostUpvoteMutate: updatePost({
         id: post.id,
         update: mutationHandlers.cancelUpvote(post),


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Just noticed an edge case where after downvoting and then clicking upvote the downvote is reversed but the post block panel is not hidden.
- Since panel is hidden if you undo downvote I think it should be hidden on upvote as well (since it undo's downvote under the hood)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
