### PR TITLE
Without next plugin preact

### DIFF
--- a/packages/webapp/next.config.js
+++ b/packages/webapp/next.config.js
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
-const withPreact = require('next-plugin-preact');
+const withPreact = (config) => config
 const withPWA = require('next-pwa');
 const withTM = require('next-transpile-modules')(['@dailydotdev/shared']);
 const sharedPackage = require('../shared/package.json');

--- a/packages/webapp/next.config.js
+++ b/packages/webapp/next.config.js
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
-const withPreact = (config) => config
 const withPWA = require('next-pwa');
 const withTM = require('next-transpile-modules')(['@dailydotdev/shared']);
 const sharedPackage = require('../shared/package.json');
@@ -16,8 +15,7 @@ module.exports = withTM(
       dest: 'public',
       disable: process.env.NODE_ENV === 'development',
     },
-    ...withPreact(
-      withBundleAnalyzer({
+    ...withBundleAnalyzer({
         i18n: {
           locales: ["en"],
           defaultLocale: "en",
@@ -87,6 +85,5 @@ module.exports = withTM(
         reactStrictMode: false,
         productionBrowserSourceMaps: process.env.SOURCE_MAPS === 'true',
       }),
-    ),
   }),
 );

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -27,7 +27,6 @@
     "graphql-request": "^3.7.0",
     "idb-keyval": "^5.1.5",
     "next": "^12.2.2",
-    "next-plugin-preact": "^3.0.7",
     "next-pwa": "^5.5.4",
     "next-seo": "^5.4.0",
     "preact": "^10.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -703,9 +703,6 @@ importers:
       next:
         specifier: ^12.2.2
         version: 12.2.2(@babel/core@7.17.9)(@preact/compat@17.0.2)(@preact/compat@17.0.2)(sass@1.53.0)
-      next-plugin-preact:
-        specifier: ^3.0.7
-        version: 3.0.7(@prefresh/babel-plugin@0.4.4)(next@12.2.2)(preact-render-to-string@5.2.0)(preact-ssr-prepass@1.2.0)(preact@10.8.2)(webpack@5.72.0)
       next-pwa:
         specifier: ^5.5.4
         version: 5.5.4(@babel/core@7.17.9)(next@12.2.2)(webpack@5.72.0)
@@ -2639,6 +2636,7 @@ packages:
 
   /@prefresh/babel-plugin@0.4.4:
     resolution: {integrity: sha512-/EvgIFMDL+nd20WNvMO0JQnzIl1EJPgmSaSYrZUww7A+aSdKsi37aL07TljrZR1cBMuzFxcr4xvqsUQLFJEukw==}
+    dev: true
 
   /@prefresh/core@1.5.1(preact@10.8.2):
     resolution: {integrity: sha512-e0mB0Oxtog6ZpKPDBYbzFniFJDIktuKMzOHp7sguntU+ot0yi6dbhJRE9Css1qf0u16wdSZjpL2W2ODWuU05Cw==}
@@ -2692,6 +2690,7 @@ packages:
       '@prefresh/utils': 1.2.0
       preact: 10.8.2
       webpack: 5.72.0(webpack-cli@4.9.2)
+    dev: true
 
   /@reach/observe-rect@1.2.0:
     resolution: {integrity: sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ==}
@@ -4091,22 +4090,6 @@ packages:
       normalize-range: 0.1.2
       picocolors: 1.0.0
       postcss: 8.4.12
-      postcss-value-parser: 4.2.0
-    dev: true
-
-  /autoprefixer@10.4.5(postcss@8.4.24):
-    resolution: {integrity: sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==}
-    engines: {node: ^10 || ^12 || >=14}
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.1.0
-    dependencies:
-      browserslist: 4.21.8
-      caniuse-lite: 1.0.30001502
-      fraction.js: 4.2.0
-      normalize-range: 0.1.2
-      picocolors: 1.0.0
-      postcss: 8.4.24
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -8896,10 +8879,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /module-alias@2.2.3:
-    resolution: {integrity: sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==}
-    dev: false
-
   /mrmime@1.0.1:
     resolution: {integrity: sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==}
     engines: {node: '>=10'}
@@ -8954,26 +8933,6 @@ packages:
   /nested-error-stacks@2.1.1:
     resolution: {integrity: sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==}
     dev: true
-
-  /next-plugin-preact@3.0.7(@prefresh/babel-plugin@0.4.4)(next@12.2.2)(preact-render-to-string@5.2.0)(preact-ssr-prepass@1.2.0)(preact@10.8.2)(webpack@5.72.0):
-    resolution: {integrity: sha512-8Xl+SJT3FCZHS7R/6Gana6e95o09UpiyCsK0cw8P/KW2M+lQcYIwIt4ZLZd+K9TW3JZx6KJDLqVbq0Kd6KZsIg==}
-    requiresBuild: true
-    peerDependencies:
-      preact: '>=10'
-      preact-render-to-string: '>=5'
-      preact-ssr-prepass: '>=1'
-    dependencies:
-      '@prefresh/next': 1.5.2(next@12.2.2)(preact@10.8.2)(webpack@5.72.0)
-      '@prefresh/webpack': 3.3.3(@prefresh/babel-plugin@0.4.4)(preact@10.8.2)(webpack@5.72.0)
-      module-alias: 2.2.3
-      preact: 10.8.2
-      preact-render-to-string: 5.2.0(preact@10.8.2)
-      preact-ssr-prepass: 1.2.0(preact@10.8.2)
-    transitivePeerDependencies:
-      - '@prefresh/babel-plugin'
-      - next
-      - webpack
-    dev: false
 
   /next-pwa@5.5.4(@babel/core@7.17.9)(next@12.2.2)(webpack@5.72.0):
     resolution: {integrity: sha512-EgB2MQWGR8oZDzY6US+/D0LOCUhPZYCgeqRVBYDxQWNi0N6XfQOoZPw2COIrg/eMt/rB0M+/mquhAQACs5v4Ag==}
@@ -10219,14 +10178,6 @@ packages:
     dependencies:
       preact: 10.8.2
       pretty-format: 3.8.0
-    dev: false
-
-  /preact-ssr-prepass@1.2.0(preact@10.8.2):
-    resolution: {integrity: sha512-UKz6FB2+KepjHQ6aGqiTUMZfGgdoTunxtByczdUNho9UvSRTJw31Np9J+wUSAlJ1kALJGX1BpcBLvO3iohQUSA==}
-    peerDependencies:
-      preact: '>=10 || ^10.0.0-beta.0 || ^10.0.0-alpha.0'
-    dependencies:
-      preact: 10.8.2
     dev: false
 
   /preact@10.8.2:
@@ -11720,7 +11671,7 @@ packages:
       postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
-      autoprefixer: 10.4.5(postcss@8.4.24)
+      autoprefixer: 10.4.5(postcss@8.4.12)
       bytes: 3.1.2
       chalk: 4.1.2
       chokidar: 3.5.3


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since we are manually switching preact we don't need this plugin.
- Should make local environment faster
- Note: When enabling preact debug it get's slower again

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
