### PR TITLE
feat: setting a max height for the MarkdownInput

### DIFF
--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -211,7 +211,7 @@ function MarkdownInput(
                 {...callbacks}
                 ref={textareaRef}
                 className={classNames(
-                  'flex flex-1 bg-transparent outline-none typo-body placeholder-theme-label-quaternary max-h-textarea',
+                  'flex flex-1 bg-transparent outline-none typo-body placeholder-theme-label-quaternary max-h-commentBox',
                   showUserAvatar ? 'm-3' : 'm-4',
                   className?.input,
                 )}

--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -211,7 +211,7 @@ function MarkdownInput(
                 {...callbacks}
                 ref={textareaRef}
                 className={classNames(
-                  'flex flex-1 bg-transparent outline-none typo-body placeholder-theme-label-quaternary',
+                  'flex flex-1 bg-transparent outline-none typo-body placeholder-theme-label-quaternary max-h-textarea',
                   showUserAvatar ? 'm-3' : 'm-4',
                   className?.input,
                 )}

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -134,6 +134,7 @@ module.exports = {
       'img-mobile': '280px',
       'rank-modal': 'calc(100vh - 5rem)',
       page: 'calc(100vh - 3.5rem)',
+      textarea: '292px',
     },
     minHeight: {
       page: 'calc(100vh - 3.5rem)',

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -134,7 +134,7 @@ module.exports = {
       'img-mobile': '280px',
       'rank-modal': 'calc(100vh - 5rem)',
       page: 'calc(100vh - 3.5rem)',
-      textarea: '292px',
+      commentBox: '18.25rem',
     },
     minHeight: {
       page: 'calc(100vh - 3.5rem)',


### PR DESCRIPTION
## Changes
Currently there isn't a max-height for the MarkdownInput so it would break out of the modal container, so a max height has been added to the textarea

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
