### PR TITLE
feat: lego referral option is hidden from profile menu while off

### DIFF
--- a/packages/shared/src/components/ProfileMenu.tsx
+++ b/packages/shared/src/components/ProfileMenu.tsx
@@ -13,7 +13,7 @@ import { Image } from './image/Image';
 import { cloudinary } from '../lib/image';
 import { LazyModal } from './modals/common/types';
 import { useLazyModal } from '../hooks/useLazyModal';
-import { ReferralCampaignKey } from '../hooks';
+import { ReferralCampaignKey, useReferralCampaign } from '../hooks';
 import usePersistentContext from '../hooks/usePersistentContext';
 import { LEGO_REFERRAL_CAMPAIGN_MAY_2023_HIDDEN_FROM_HEADER_KEY } from '../lib/storage';
 
@@ -31,6 +31,9 @@ export default function ProfileMenu(): ReactElement {
     false,
   );
   const { openModal } = useLazyModal();
+  const { isReady } = useReferralCampaign({
+    campaignKey: ReferralCampaignKey.LegoMay2023,
+  });
 
   if (!user) {
     return <></>;
@@ -71,7 +74,7 @@ export default function ProfileMenu(): ReactElement {
           </a>
         </Link>
       </Item>
-      {isHiddenFromHeader && (
+      {isReady && isHiddenFromHeader && (
         <Item>
           <button
             type="button"
@@ -91,7 +94,7 @@ export default function ProfileMenu(): ReactElement {
               height={24}
               src={cloudinary.referralCampaign.lego.piece}
             />
-            Referral campagin
+            Referral campaign
             <TimerIcon className="ml-auto" size={IconSize.Small} />
           </button>
         </Item>


### PR DESCRIPTION
## Changes

### Describe what this PR does
This one was still showing (even though we turned off the campaign) since it was not looking `isReady` param from hook.
<img width="304" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/2279918d-5c98-45f4-9300-920072e9f2f4">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
