### PR TITLE
feat: Fixing the border color for Similar posts

### DIFF
--- a/packages/shared/src/components/widgets/SimilarPosts.tsx
+++ b/packages/shared/src/components/widgets/SimilarPosts.tsx
@@ -126,7 +126,7 @@ export default function SimilarPosts({
   return (
     <section
       className={classNames(
-        'flex flex-col rounded-2xl border-theme-divider-quaternary border',
+        'flex flex-col rounded-2xl border border-theme-divider-tertiary',
         className,
       )}
     >


### PR DESCRIPTION
## Changes
The Similar Posts component had a different border color to the other components on the post sidebar so I updated it to match the others. Below is the screenshots for before and after.
![Screenshot 2023-07-03 at 2 06 13 pm](https://github.com/dailydotdev/apps/assets/42202149/6fef9512-c03b-44a2-8d30-10c0db024ebb)
![Screenshot 2023-07-03 at 2 05 47 pm](https://github.com/dailydotdev/apps/assets/42202149/793d8dcd-1cd5-49f4-9a96-9686c32ae0ce)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1507 #done
