### PR TITLE
fix: only show edit post for logged users

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -268,7 +268,7 @@ export default function PostOptionsMenu({
         },
       }),
   });
-  if (post?.author?.id === user?.id) {
+  if (user?.id && post?.author?.id === user?.id) {
     postOptions.push({
       icon: <MenuIcon Icon={EditIcon} />,
       text: 'Edit post',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Currently edit post option would show and break the app if you are anonymous

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1511 #done
