### PR TITLE
fix: add promote/demote option for moderators

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -33,6 +33,7 @@ import EditIcon from './icons/Edit';
 import DownvoteIcon from './icons/Downvote';
 import { useLazyModal } from '../hooks/useLazyModal';
 import { LazyModal } from './modals/common/types';
+import UpvoteIcon from './icons/Upvote';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ './fields/PortalMenu'),
@@ -55,6 +56,7 @@ export interface PostOptionsMenuProps extends ShareBookmarkProps {
   feedQueryKey?: QueryKey;
   onRemovePost?: (postIndex: number) => Promise<unknown>;
   setShowBanPost?: () => unknown;
+  setShowPromotePost?: () => unknown;
   contextId?: string;
   origin: Origin;
   allowPin?: boolean;
@@ -68,6 +70,7 @@ export default function PostOptionsMenu({
   onHidden,
   onRemovePost,
   setShowBanPost,
+  setShowPromotePost,
   feedQueryKey,
   origin,
   allowPin,
@@ -296,6 +299,15 @@ export default function PostOptionsMenu({
       action: setShowBanPost,
     });
   }
+  if (setShowPromotePost) {
+    const promoteFlag = post.flags?.promoteToPublic;
+    postOptions.push({
+      icon: <MenuIcon Icon={promoteFlag ? DownvoteIcon : UpvoteIcon} />,
+      text: promoteFlag ? 'Demote' : 'Promote',
+      action: setShowPromotePost,
+    });
+  }
+
   return (
     <>
       <PortalMenu

--- a/packages/shared/src/components/post/PostModalActions.tsx
+++ b/packages/shared/src/components/post/PostModalActions.tsx
@@ -11,7 +11,12 @@ import CloseIcon from '../icons/MiniClose';
 import OpenLinkIcon from '../icons/OpenLink';
 import { Roles } from '../../lib/user';
 import AuthContext from '../../contexts/AuthContext';
-import { banPost, internalReadTypes, Post } from '../../graphql/posts';
+import {
+  banPost,
+  internalReadTypes,
+  Post,
+  promotePost,
+} from '../../graphql/posts';
 import useReportPostMenu from '../../hooks/useReportPostMenu';
 import classed from '../../lib/classed';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
@@ -78,6 +83,23 @@ export function PostModalActions({
     }
   };
 
+  const promotePostPrompt = async () => {
+    const promoteFlag = post.flags?.promoteToPublic;
+
+    const options: PromptOptions = {
+      title: promoteFlag ? 'Demote post' : 'Promote post',
+      description: `Do you want to ${
+        promoteFlag ? 'demote' : 'promote'
+      } this post ${promoteFlag ? 'from' : 'to'} the public?`,
+      okButton: {
+        title: promoteFlag ? 'Demote' : 'Promote',
+      },
+    };
+    if (await showPrompt(options)) {
+      await promotePost(post.id, !promoteFlag);
+    }
+  };
+
   return (
     <Container {...props} className={classNames('gap-2', className)}>
       {!isInternalReadType && onReadArticle && (
@@ -120,6 +142,7 @@ export function PostModalActions({
         post={post}
         onRemovePost={onRemovePost}
         setShowBanPost={isModerator ? () => banPostPrompt() : null}
+        setShowPromotePost={isModerator ? () => promotePostPrompt() : null}
         contextId={contextMenuId}
         origin={Origin.ArticleModal}
       />

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -84,6 +84,9 @@ export const SHARED_POST_INFO_FRAGMENT = gql`
       ...SourceBaseInfo
     }
     downvoted
+    flags {
+      promoteToPublic
+    }
   }
   ${SOURCE_BASE_FRAGMENT}
   ${USER_SHORT_INFO_FRAGMENT}

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -39,6 +39,16 @@ export const supportedTypesForPrivateSources = [
   PostType.Freeform,
 ];
 
+type PostFlags = {
+  sentAnalyticsReport: boolean;
+  banned: boolean;
+  deleted: boolean;
+  private: boolean;
+  visible: boolean;
+  showOnFeed: boolean;
+  promoteToPublic: boolean;
+};
+
 export interface Post {
   __typename?: string;
   id: string;
@@ -77,6 +87,7 @@ export interface Post {
   private?: boolean;
   feedMeta?: string;
   downvoted?: boolean;
+  flags: PostFlags;
 }
 
 export interface Ad {
@@ -255,6 +266,14 @@ export const BAN_POST_MUTATION = gql`
   }
 `;
 
+export const PROMOTE_TO_PUBLIC_MUTATION = gql`
+  mutation UpdatePromoteToPublic($id: ID!, $promoteToPublic: Boolean!) {
+    updatePromoteToPublic(id: $id, promoteToPublic: $promoteToPublic) {
+      _
+    }
+  }
+`;
+
 export const ADD_BOOKMARKS_MUTATION = gql`
   mutation AddBookmarks($data: AddBookmarkInput!) {
     addBookmarks(data: $data) {
@@ -321,6 +340,16 @@ export const UNHIDE_POST_MUTATION = gql`
 export const banPost = (id: string): Promise<EmptyResponse> => {
   return request(graphqlUrl, BAN_POST_MUTATION, {
     id,
+  });
+};
+
+export const promotePost = (
+  id: string,
+  value: boolean,
+): Promise<EmptyResponse> => {
+  return request(graphqlUrl, PROMOTE_TO_PUBLIC_MUTATION, {
+    id,
+    promoteToPublic: value,
   });
 };
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added option to promote/demote on the frontend (see changes to expose flag in API [here](https://github.com/dailydotdev/daily-api/pull/1336/commits/089a6b71f6c78a4308e42db04d53bc264d10dac1))

@idoshamun Will this suffice or did you want a more explicit to only show this when it's a open squad?

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1503 #done
