### PR TITLE
feat: use referralUrl for squad invite

### DIFF
--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -49,6 +49,7 @@ export interface Squad extends Source {
   description: string;
   memberPostingRole: SourceMemberRole;
   memberInviteRole: SourceMemberRole;
+  referralUrl: string;
 }
 
 export interface SourcePrivilegedMembers extends Pick<SourceMember, 'role'> {

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -153,6 +153,7 @@ export const SQUAD_QUERY = gql`
   query Source($handle: ID!) {
     source(id: $handle) {
       ...SourceBaseInfo
+      referralUrl
     }
   }
   ${SOURCE_BASE_FRAGMENT}

--- a/packages/shared/src/hooks/useSquadInvitation.ts
+++ b/packages/shared/src/hooks/useSquadInvitation.ts
@@ -25,14 +25,7 @@ export const useSquadInvitation = ({
   const { completeAction } = useActions();
 
   const invitation = useMemo(() => {
-    const permalink = squad?.permalink;
-    const token = squad?.currentMember?.referralToken;
-
-    if (!permalink || !token) {
-      return undefined;
-    }
-
-    return `${permalink}/${token}`;
+    return squad.referralUrl;
   }, [squad]);
   const [copying, copyLink] = useCopyLink(() => invitation);
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- use new `referralUrl` for squad invite
- it automatically supports public and private squads
- API implementation https://github.com/dailydotdev/daily-api/pull/1341

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1502 #done
