### PR TITLE
feat: changing the companion menu position

### DIFF
--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -201,7 +201,7 @@ export default function CompanionMenu({
   });
   const onContextOptions = (event: React.MouseEvent): void => {
     showCompanionOptionsMenu(event, {
-      position: { x: 48, y: 265 },
+      position: { x: 48, y: 318 },
     });
   };
 


### PR DESCRIPTION
## Changes
Changing the position of the menu so it doesn't go over the companion itself

<img width="263" alt="Screenshot 2023-07-11 at 12 48 05 pm" src="https://github.com/dailydotdev/apps/assets/42202149/e50e9eb3-7689-4c51-a4ac-8fa3d30605d8">


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1508 #done
