### PR TITLE
fix: submitting comment from preview tab

### DIFF
--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -8,6 +8,7 @@ import React, {
   TextareaHTMLAttributes,
   useImperativeHandle,
   useRef,
+  useState,
 } from 'react';
 import classNames from 'classnames';
 import { ImageIcon, MarkdownIcon } from '../../icons';
@@ -59,6 +60,11 @@ interface MarkdownInputProps
   isLoading?: boolean;
 }
 
+enum CommentTab {
+  Write = 'Write',
+  Preview = 'Preview',
+}
+
 export interface MarkdownRef
   extends Pick<UseMarkdownInput, 'onMentionCommand'> {
   textareaRef: MutableRefObject<HTMLTextAreaElement>;
@@ -91,6 +97,7 @@ function MarkdownInput(
   const { sidebarRendered } = useSidebarRendered();
   const textareaRef = useRef<HTMLTextAreaElement>();
   const uploadRef = useRef<HTMLInputElement>();
+  const [active, setActive] = useState(CommentTab.Write);
   const {
     input,
     query,
@@ -157,19 +164,21 @@ function MarkdownInput(
         condition={allowPreview}
         wrapper={(children) => (
           <TabContainer
-            shouldMountInactive={false}
+            shouldMountInactive
+            onActiveChange={(tab: CommentTab) => setActive(tab)}
             className={{
               header: 'px-1',
               container: classNames('min-h-[20.5rem]', className?.tab),
             }}
             tabListProps={{ className: { indicator: '!w-6' } }}
           >
-            <Tab label="Write">{children}</Tab>
-            <Tab label="Preview" className="p-4">
+            <Tab label={CommentTab.Write}>{children}</Tab>
+            <Tab label={CommentTab.Preview} className="p-4">
               <MarkdownPreview
                 input={input}
                 sourceId={sourceId}
                 parentSelector={parentSelector}
+                enabled={allowPreview && CommentTab.Preview === active}
               />
             </Tab>
           </TabContainer>


### PR DESCRIPTION
## Changes
- In the initial implementation, we had `shouldMountInactive={false}` so that it won't send a mutation request for the preview on each type since the parameter of the query changes by not rendering the other tab when it is not opened.
- So when you click the submit button when the preview tab is opened, we tried to fetch the data from the Form for which the textarea is not rendered anymore due to the above condition.
- To fix it, we now render both ends anytime, but we will enable the query only when the `Preview` tab is active, and in that case, we have to track it through the state. Tested it locally, and works as normal now.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1539 #done
