### PR TITLE
fix: onboarding intro image

### DIFF
--- a/packages/shared/src/components/onboarding/IntroductionOnboarding.tsx
+++ b/packages/shared/src/components/onboarding/IntroductionOnboarding.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import classNames from 'classnames';
 import { Button } from '../buttons/Button';
 import { Modal } from '../modals/common/Modal';
 import { StepComponentProps } from '../modals/common/ModalStepsWrapper';
@@ -27,7 +28,7 @@ function IntroductionOnboarding({
   onClose,
 }: OnboardingStepProps): ReactElement {
   const { user, showLogin } = useAuthContext();
-  const { onboardingIntroduction } = useThemedAsset();
+  const { onboardingIntroduction, isLight } = useThemedAsset();
 
   return (
     <Modal.StepsWrapper view={OnboardingStep.Intro}>
@@ -46,7 +47,10 @@ function IntroductionOnboarding({
               style={{
                 backgroundImage: `url(${onboardingIntroduction})`,
               }}
-              className="absolute -top-4 w-full h-full bg-cover"
+              className={classNames(
+                'absolute w-full bg-cover',
+                isLight ? 'scale-75 -top-16 h-full' : 'h-full -top-4',
+              )}
             />
             {!user && (
               <MemberAlready

--- a/packages/shared/src/hooks/utils/useThemedAsset.ts
+++ b/packages/shared/src/hooks/utils/useThemedAsset.ts
@@ -5,6 +5,7 @@ import { cloudinary } from '../../lib/image';
 interface UseCloudinaryAsset {
   onboardingIntroduction: string;
   scrollBlock: string;
+  isLight: boolean;
 }
 
 export const useThemedAsset = (): UseCloudinaryAsset => {
@@ -19,6 +20,7 @@ export const useThemedAsset = (): UseCloudinaryAsset => {
   }, [themeMode]);
 
   return {
+    isLight,
     onboardingIntroduction: isLight
       ? cloudinary.feedFilters.yourFeed.light
       : cloudinary.feedFilters.yourFeed.dark,


### PR DESCRIPTION
## Changes
- When it is light mode, the image is not the same size or ratio of the dark mode image.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
