### PR TITLE
fix: delay loading of pages which applicable for onboarding

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -161,7 +161,11 @@ export default function MainLayout({
     router.push(`${webappUrl}/onboarding`);
   }, [shouldRedirectOnboarding, router]);
 
-  if ((!isPageReady && isPageApplicableForOnboarding) || shouldRedirectOnboarding) return null;
+  if (
+    (!isPageReady && isPageApplicableForOnboarding) ||
+    shouldRedirectOnboarding
+  )
+    return null;
 
   return (
     <div {...handlers}>

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -52,6 +52,8 @@ export interface MainLayoutProps
 const mainLayoutClass = (sidebarExpanded: boolean) =>
   sidebarExpanded ? 'laptop:pl-60' : 'laptop:pl-11';
 
+const feeds = Object.values(MainFeedPage);
+
 export default function MainLayout({
   children,
   showOnlyLogo,
@@ -141,15 +143,16 @@ export default function MainLayout({
   };
 
   const router = useRouter();
-  const feeds = Object.values(MainFeedPage);
   const page = router?.route?.substring(1).trim() as MainFeedPage;
   const isPageReady =
     (isFeaturesLoaded && router?.isReady && isAuthReady) || isTesting;
+
+  const isPageApplicableForOnboarding = !page || feeds.includes(page);
   const shouldRedirectOnboarding =
     !user &&
     isPageReady &&
     onboardingV2 !== OnboardingV2.Control &&
-    (!page || feeds.includes(page)) &&
+    isPageApplicableForOnboarding &&
     !isTesting;
 
   useEffect(() => {
@@ -158,7 +161,7 @@ export default function MainLayout({
     router.push(`${webappUrl}/onboarding`);
   }, [shouldRedirectOnboarding, router]);
 
-  if (!isPageReady || shouldRedirectOnboarding) return null;
+  if ((!isPageReady && isPageApplicableForOnboarding) || shouldRedirectOnboarding) return null;
 
   return (
     <div {...handlers}>


### PR DESCRIPTION
## Changes

### Describe what this PR does

Instead of delaying all the pages, this fix delay only the feed pages. The rest are not applicable for onboarding.
This fixes the preview issue when sharing links. I also validated that the onboarding wall still works.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
