### PR TITLE
fix: missing comment tracking

### DIFF
--- a/packages/shared/src/components/post/PostEngagements.tsx
+++ b/packages/shared/src/components/post/PostEngagements.tsx
@@ -12,6 +12,7 @@ import { PostComments } from './PostComments';
 import { PostUpvotesCommentsCount } from './PostUpvotesCommentsCount';
 import { Comment } from '../../graphql/comments';
 import { Origin } from '../../lib/analytics';
+import { postAnalyticsEvent } from '../../lib/feed';
 
 const AuthorOnboarding = dynamic(
   () => import(/* webpackChunkName: "authorOnboarding" */ './AuthorOnboarding'),
@@ -61,6 +62,9 @@ function PostEngagements({
 
   const onCommented = (comment: Comment, isNew?: boolean) => {
     if (isNew) {
+      postAnalyticsEvent('comment post', post, {
+        extra: { commentId: comment.id, origin: 'comment modal' },
+      });
       setPermissionNotificationCommentId(comment.id);
       onShowShareNewComment(comment.id);
     }

--- a/packages/shared/src/components/post/PostEngagements.tsx
+++ b/packages/shared/src/components/post/PostEngagements.tsx
@@ -11,7 +11,7 @@ import { PostActions, ShareBookmarkProps } from './PostActions';
 import { PostComments } from './PostComments';
 import { PostUpvotesCommentsCount } from './PostUpvotesCommentsCount';
 import { Comment } from '../../graphql/comments';
-import { Origin } from '../../lib/analytics';
+import { AnalyticsEvent, Origin } from '../../lib/analytics';
 import { postAnalyticsEvent } from '../../lib/feed';
 
 const AuthorOnboarding = dynamic(
@@ -62,7 +62,7 @@ function PostEngagements({
 
   const onCommented = (comment: Comment, isNew?: boolean) => {
     if (isNew) {
-      postAnalyticsEvent('comment post', post, {
+      postAnalyticsEvent(AnalyticsEvent.CommentPost, post, {
         extra: { commentId: comment.id, origin: 'comment modal' },
       });
       setPermissionNotificationCommentId(comment.id);

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -30,6 +30,7 @@ export enum LoginTrigger {
 }
 
 export enum AnalyticsEvent {
+  CommentPost = 'comment post',
   Impression = 'impression',
   ManageTags = 'click manage tags',
   SearchTags = 'search tags',


### PR DESCRIPTION
## Changes
- After further investigation, it seems what we were missing is the code block below:

https://github.com/dailydotdev/apps/blob/10b9383df0e53219f19d21929afdfe8e46541b61/packages/shared/src/hooks/usePostComment.ts#L251-L255

This is what tracks new comments in the past coming from the hook that was reused when making comments.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
