### PR TITLE
fix: duplicate comments by keeping submit disabled

### DIFF
--- a/packages/extension/src/companion/useCompanionSettings.ts
+++ b/packages/extension/src/companion/useCompanionSettings.ts
@@ -19,5 +19,7 @@ export const useCompanionSettings = (origin: string): void => {
     }
 
     registerBrowserContentScripts();
+    // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [optOutCompanion, loadedSettings]);
 };

--- a/packages/shared/src/components/fields/MarkdownInput/CommentMarkdownInput.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/CommentMarkdownInput.tsx
@@ -137,7 +137,11 @@ export function CommentMarkdownInput({
   const mutation = parentCommentId
     ? COMMENT_ON_COMMENT_MUTATION
     : COMMENT_ON_POST_MUTATION;
-  const { mutateAsync: onComment, isLoading: isCommenting } = useMutation(
+  const {
+    mutateAsync: onComment,
+    isLoading: isCommenting,
+    isSuccess,
+  } = useMutation(
     (variables: SubmitComment) =>
       requestMethod(graphqlUrl, mutation, variables, {
         requestKey: JSON.stringify(key),
@@ -199,6 +203,7 @@ export function CommentMarkdownInput({
         sourceId={sourceId}
         showUserAvatar
         isLoading={isCommenting || isEditing}
+        disabledSubmit={isSuccess}
         initialContent={initialContent}
         textareaProps={{
           name: 'content',

--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -58,6 +58,7 @@ interface MarkdownInputProps
   isUpdatingDraft?: boolean;
   timeline?: ReactNode;
   isLoading?: boolean;
+  disabledSubmit?: boolean;
 }
 
 enum CommentTab {
@@ -88,6 +89,7 @@ function MarkdownInput(
     footer,
     timeline,
     isLoading,
+    disabledSubmit,
   }: MarkdownInputProps,
   ref: MutableRefObject<MarkdownRef>,
 ): ReactElement {
@@ -319,7 +321,7 @@ function MarkdownInput(
             <Button
               className="ml-auto btn-primary-cabbage"
               type="submit"
-              disabled={isLoading}
+              disabled={isLoading || disabledSubmit}
               loading={isLoading}
             >
               {submitCopy}


### PR DESCRIPTION
## Changes
- One of the few things we adopted recently is to disable the submit button when the submission succeeded.
- I am unable to reproduce the case, so I instead apply our common code principle on forms.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
