### PR TITLE
fix: missing query params on redirect

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -158,7 +158,7 @@ export default function MainLayout({
   useEffect(() => {
     if (!shouldRedirectOnboarding) return;
 
-    router.push(`${webappUrl}/onboarding`);
+    router.push({ pathname: `${webappUrl}/onboarding`, query: router.query });
   }, [shouldRedirectOnboarding, router]);
 
   if (

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -158,13 +158,21 @@ export default function MainLayout({
   useEffect(() => {
     if (!shouldRedirectOnboarding) return;
 
-    const url = new URLSearchParams();
+    const onboarding = `${webappUrl}/onboarding`;
+    const entries = Object.entries(router.query);
 
-    Object.entries(router.query).forEach(([key, value]) => {
-      url.append(key, value as string);
+    if (entries.length === 0) {
+      router.push(onboarding);
+      return;
+    }
+
+    const params = new URLSearchParams();
+
+    entries.forEach(([key, value]) => {
+      params.append(key, value as string);
     });
 
-    router.push(`${webappUrl}/onboarding?${url.toString()}`);
+    router.push(`${webappUrl}/onboarding?${params.toString()}`);
   }, [shouldRedirectOnboarding, router]);
 
   if (

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -172,7 +172,7 @@ export default function MainLayout({
       params.append(key, value as string);
     });
 
-    router.push(`${webappUrl}/onboarding?${params.toString()}`);
+    router.push(`${onboarding}?${params.toString()}`);
   }, [shouldRedirectOnboarding, router]);
 
   if (

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -158,7 +158,13 @@ export default function MainLayout({
   useEffect(() => {
     if (!shouldRedirectOnboarding) return;
 
-    router.push({ pathname: `${webappUrl}/onboarding`, query: router.query });
+    const url = new URLSearchParams();
+
+    Object.entries(router.query).forEach(([key, value]) => {
+      url.append(key, value as string);
+    });
+
+    router.push(`${webappUrl}/onboarding?${url.toString()}`);
   }, [shouldRedirectOnboarding, router]);
 
   if (


### PR DESCRIPTION
## Changes
- Keep query params when redirecting for onboarding.
- Tested and tried to include the parameters. Also checked on extension and verified to be working.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
