### PR TITLE
fix: usage of state on context menu

### DIFF
--- a/packages/shared/src/components/tooltips/notifications/NotificationPreferenceMenu.tsx
+++ b/packages/shared/src/components/tooltips/notifications/NotificationPreferenceMenu.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement } from 'react';
 import { Item } from '@dailydotdev/react-contexify';
 import PortalMenu from '../../fields/PortalMenu';
 import { Loader } from '../../Loader';

--- a/packages/shared/src/components/tooltips/notifications/NotificationPreferenceMenu.tsx
+++ b/packages/shared/src/components/tooltips/notifications/NotificationPreferenceMenu.tsx
@@ -15,12 +15,14 @@ import { useNotificationPreference } from '../../../hooks/notifications';
 interface NotificationPreferenceMenuProps {
   contextId: string;
   notification: Notification;
+  onClose(): void;
 }
 
 export const NotificationPreferenceMenu = ({
   contextId,
+  notification,
+  onClose,
 }: NotificationPreferenceMenuProps): ReactElement => {
-  const [notification, setNotification] = useState<Notification>();
   const {
     preferences,
     isFetching,
@@ -77,7 +79,7 @@ export const NotificationPreferenceMenu = ({
       id={contextId}
       className="menu-primary"
       animation="fade"
-      onHidden={() => setNotification(undefined)}
+      onHidden={onClose}
     >
       <Item className="py-1 w-64 typo-callout" onClick={onItemClick}>
         <span className="flex flex-row gap-1 items-center w-full">

--- a/packages/webapp/pages/notifications.tsx
+++ b/packages/webapp/pages/notifications.tsx
@@ -32,7 +32,6 @@ import { useContextMenu } from '@dailydotdev/react-contexify';
 import { NotificationPreferenceMenu } from '@dailydotdev/shared/src/components/tooltips/notifications';
 import { getLayout as getFooterNavBarLayout } from '../components/layouts/FooterNavBarLayout';
 import { getLayout } from '../components/layouts/MainLayout';
-
 import ProtectedPage from '../components/ProtectedPage';
 
 const hasUnread = (data: InfiniteData<NotificationsData>) =>
@@ -171,6 +170,7 @@ const Notifications = (): ReactElement => {
       <NotificationPreferenceMenu
         contextId={contextId}
         notification={notification}
+        onClose={() => setNotification(undefined)}
       />
     </ProtectedPage>
   );


### PR DESCRIPTION
## Changes
- After the refactor, I mistakenly included the state inside the component when should be passed from top to down.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1571 #done
