### PR TITLE
fix: squad page cache after login

### DIFF
--- a/packages/shared/src/hooks/useJoinSquad.ts
+++ b/packages/shared/src/hooks/useJoinSquad.ts
@@ -5,8 +5,7 @@ import { useAnalyticsContext } from '../contexts/AnalyticsContext';
 import { Squad } from '../graphql/sources';
 import { AnalyticsEvent } from '../lib/analytics';
 import { useBoot } from './useBoot';
-import { generateQueryKey, RequestKey } from '../lib/query';
-import { useAuthContext } from '../contexts/AuthContext';
+import { RequestKey } from '../lib/query';
 
 type UseJoinSquadProps = {
   squad: Pick<Squad, 'id' | 'handle'>;
@@ -21,7 +20,6 @@ export const useJoinSquad = ({
 }: UseJoinSquadProps): UseJoinSquad => {
   const queryClient = useQueryClient();
   const { addSquad } = useBoot();
-  const { user } = useAuthContext();
   const { trackEvent } = useAnalyticsContext();
 
   const joinSquad = useCallback(async () => {
@@ -44,12 +42,18 @@ export const useJoinSquad = ({
     });
 
     addSquad(result);
-    const queryKey = generateQueryKey(RequestKey.Squad, user, squad.handle);
-    queryClient.invalidateQueries(queryKey);
+    queryClient.invalidateQueries([RequestKey.Squad]);
     queryClient.invalidateQueries(['squadMembersInitial', squad.handle]);
 
     return result;
-  }, [addSquad, queryClient, squad, user, trackEvent, referralToken]);
+  }, [
+    squad.id,
+    squad.handle,
+    referralToken,
+    trackEvent,
+    addSquad,
+    queryClient,
+  ]);
 
   return joinSquad;
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
In `SquadJoinButton` we pass `joinSquad` to `showLogin`, but since in that function reference user is still for anonymous it actually clears the cache for `[squad, anonymous, handle]` and the new key (because user is logged) is `[squad, user.id, handle]`. Which then shows stale page like user is not part of squad. If you refresh the page he is of course. 

In this PR I clear all squad cache by `RequestKey.Squad` to make sure caches are cleared and user see proper join state after login.

Downside is that all the squad source query data (not the feed) will be invalidated in react query but since we do refetch that data on each visit to squad page it does not make any difference performance wise.

Alternative would be to provide [predicate function to invalidateQueries](https://tanstack.com/query/v4/docs/react/guides/query-invalidation) to check each query key manually but I think complication in this case. 

- Original discussion https://github.com/dailydotdev/apps/pull/1970#discussion_r1276018108

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
