### PR TITLE
feat: adding login check for report comment

### DIFF
--- a/packages/shared/src/components/comments/CommentActionButtons.tsx
+++ b/packages/shared/src/components/comments/CommentActionButtons.tsx
@@ -152,7 +152,9 @@ export default function CommentActionButtons({
     );
 
   const openReportCommentModal = () => {
-    openModal({
+    if (!user) return showLogin(AuthTriggers.ReportComment);
+
+    return openModal({
       type: LazyModal.ReportComment,
       props: {
         onReport: () => displayToast(labels.reporting.reportFeedbackText),

--- a/packages/shared/src/lib/auth.ts
+++ b/packages/shared/src/lib/auth.ts
@@ -44,6 +44,7 @@ export enum AuthTriggers {
   SubmitNewSource = 'submit new source',
   Downvote = 'downvote',
   CreateSquad = 'create squad',
+  ReportComment = 'report comment',
 }
 
 // Needed for the AB flagged Sidebar items


### PR DESCRIPTION
## Changes
Adding a check for report comment to see if you are logged in. If not you are presented with the login modal

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1568 #done
