### PR TITLE
fix: link on similar posts

### DIFF
--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -33,11 +33,11 @@ function SquadPostAuthor({
         className?.container,
       )}
     >
-      <ProfileTooltip user={author}>
+      <ProfileTooltip user={author} link={{ href: author.permalink }}>
         <ProfilePicture user={author} size={size} nativeLazyLoading />
       </ProfileTooltip>
       <ProfileTooltip user={author} link={{ href: author.permalink }}>
-        <a className="flex flex-col ml-4">
+        <a href={author.permalink} className="flex flex-col ml-4">
           <div className="flex items-center">
             <span className={classNames('font-bold', className?.name)}>
               {author.name}


### PR DESCRIPTION
## Changes
- Fix the missing links for SimilarPost section when it is a Squad post.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1575 #done
