### PR TITLE
hotfix: empty image fallback on profile

### DIFF
--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -1,6 +1,3 @@
-export const smallPostImage = (url: string): string =>
-  url.replace('/f_auto,q_auto/', '/c_fill,f_auto,q_auto,w_192/');
-
 export const cloudinary = {
   post: {
     imageCoverPlaceholder:
@@ -86,4 +83,12 @@ export const cloudinary = {
     purpleEdgeGlow:
       'https://daily-now-res.cloudinary.com/image/upload/s--Va9xODJM--/v1686074969/Glow_fjelt5.svg',
   },
+};
+
+export const smallPostImage = (url: string): string => {
+  if (!url) {
+    return cloudinary.post.imageCoverPlaceholder;
+  }
+
+  return url.replace('/f_auto,q_auto/', '/c_fill,f_auto,q_auto,w_192/');
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- With the introduction of public posts there is a change images are empty for posts.
- I added a fallback to the fallback image, as it technically would never error state

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
