### PR TITLE
fix: squad issues

### DIFF
--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -98,10 +98,7 @@ export const FeedContainer = ({
     >
       <ScrollToTopButton />
 
-      <div
-        className="flex flex-col px-6 laptop:px-0 pt-2 laptopL:mx-auto w-full"
-        style={style}
-      >
+      <div className="flex flex-col pt-2 laptopL:mx-auto w-full" style={style}>
         {!inlineHeader && header}
 
         <div

--- a/packages/shared/src/components/squads/SquadJoinButton.tsx
+++ b/packages/shared/src/components/squads/SquadJoinButton.tsx
@@ -144,21 +144,19 @@ export const SquadJoinButton = ({
       disabled={!isMemberBlocked}
       content={blockedTooltipText}
     >
-      <div className="flex flex-1">
-        <SimpleSquadJoinButton
-          {...rest}
-          className={classNames(
-            isCurrentMember ? 'btn-secondary' : 'btn-primary',
-            className,
-          )}
-          squad={squad}
-          disabled={isMemberBlocked || isLoading}
-          onClick={onLeaveSquad}
-          origin={origin}
-        >
-          {isCurrentMember ? leaveText : joinText}
-        </SimpleSquadJoinButton>
-      </div>
+      <SimpleSquadJoinButton
+        {...rest}
+        className={classNames(
+          isCurrentMember ? 'btn-secondary' : 'btn-primary',
+          className,
+        )}
+        squad={squad}
+        disabled={isMemberBlocked || isLoading}
+        onClick={onLeaveSquad}
+        origin={origin}
+      >
+        {isCurrentMember ? leaveText : joinText}
+      </SimpleSquadJoinButton>
     </SimpleTooltip>
   );
 };

--- a/packages/shared/src/components/squads/SquadMemberShortList.tsx
+++ b/packages/shared/src/components/squads/SquadMemberShortList.tsx
@@ -5,6 +5,7 @@ import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
 import { ProfilePicture } from '../ProfilePicture';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
+import useSidebarRendered from '../../hooks/useSidebarRendered';
 
 export interface SquadMemberShortListProps {
   squad: Squad;
@@ -17,6 +18,7 @@ function SquadMemberShortList({
   members,
   className,
 }: SquadMemberShortListProps): ReactElement {
+  const { sidebarRendered } = useSidebarRendered();
   const { openModal } = useLazyModal();
   const openMemberListModal = () =>
     openModal({
@@ -45,7 +47,7 @@ function SquadMemberShortList({
             ? `${Math.floor(squad.membersCount / 1000)}K`
             : squad.membersCount}
         </span>
-        {members?.map(({ user }) => (
+        {members?.slice(0, sidebarRendered ? 5 : 3).map(({ user }) => (
           <ProfilePicture
             className="-ml-2"
             size="medium"

--- a/packages/webapp/pages/squads/index.tsx
+++ b/packages/webapp/pages/squads/index.tsx
@@ -70,11 +70,7 @@ const SquadsPage = (): ReactElement => {
                 queryResult.data.pages.map((page) =>
                   page.sources.edges.reduce(
                     (nodes, { node: { name, permalink, id, ...props } }) => {
-                      const isMember =
-                        user &&
-                        props?.members?.edges.find(
-                          (member) => member?.node?.user.id === user.id,
-                        );
+                      const isMember = user && props?.currentMember;
 
                       nodes.push(
                         <SourceCard


### PR DESCRIPTION
## Changes

### Describe what this PR does
- With the recent feed wrapper changes we accidental added padding twice
- I added a strict limit on the squad member card to render 3 on mobile and 5 max on desktop
- - Not sure it had impact on other places, but this fix should work reliable.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1577 #done
