### PR TITLE
fix: sidebar z-index

### DIFF
--- a/packages/shared/src/components/modals/Prompt.tsx
+++ b/packages/shared/src/components/modals/Prompt.tsx
@@ -35,7 +35,7 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement {
       size={promptSize}
       onRequestClose={onFail}
       className={className.modal}
-      overlayClassName="!z-[100]"
+      overlayClassName="!z-max"
       {...props}
     >
       <Modal.Body>

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -99,7 +99,7 @@ export function Modal({
     setView(view);
   };
   const modalOverlayClassName = classNames(
-    'overlay flex fixed flex-col inset-0 items-center bg-overlay-quaternary-onion z-[10]',
+    'overlay flex fixed flex-col inset-0 items-center bg-overlay-quaternary-onion z-modal',
     modalKindAndSizeToOverlayClassName[kind]?.[size],
     modalKindToOverlayClassName[kind],
     overlayClassName,

--- a/packages/shared/src/components/notifications/InAppNotification.tsx
+++ b/packages/shared/src/components/notifications/InAppNotification.tsx
@@ -23,7 +23,7 @@ const Container = classed(
   classNames(
     styles.inAppNotificationContainer,
     'animate-bounce',
-    'fixed right-1/2 translate-x-1/2 laptop:translate-x-0 laptop:right-10 bg-theme-bg-notification border border-theme-active rounded-16 in-app-notification slide-in z-[100] w-[22.5rem] h-22',
+    'fixed right-1/2 translate-x-1/2 laptop:translate-x-0 laptop:right-10 bg-theme-bg-notification border border-theme-active rounded-16 in-app-notification slide-in z-max w-[22.5rem] h-22',
   ),
 );
 

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -70,7 +70,7 @@ export const SidebarBackdrop = classed(
 );
 export const SidebarAside = classed(
   'aside',
-  'flex flex-col w-70 laptop:-translate-x-0 left-0 bg-theme-bg-primary z-3 border-r border-theme-divider-tertiary transition-[width,transform] duration-300 ease-in-out group fixed top-0  h-full ',
+  'flex flex-col z-sidebar w-70 laptop:-translate-x-0 left-0 bg-theme-bg-primary z-3 border-r border-theme-divider-tertiary transition-[width,transform] duration-300 ease-in-out group fixed top-0  h-full ',
 );
 export const SidebarScrollWrapper = classed(
   'div',

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -70,7 +70,7 @@ export const SidebarBackdrop = classed(
 );
 export const SidebarAside = classed(
   'aside',
-  'flex flex-col z-sidebar w-70 laptop:-translate-x-0 left-0 bg-theme-bg-primary z-3 border-r border-theme-divider-tertiary transition-[width,transform] duration-300 ease-in-out group fixed top-0  h-full ',
+  'flex flex-col z-max laptop:z-3 w-70 laptop:-translate-x-0 left-0 bg-theme-bg-primary border-r border-theme-divider-tertiary transition-[width,transform] duration-300 ease-in-out group fixed top-0  h-full ',
 );
 export const SidebarScrollWrapper = classed(
   'div',

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -70,7 +70,7 @@ export const SidebarBackdrop = classed(
 );
 export const SidebarAside = classed(
   'aside',
-  'flex flex-col z-max laptop:z-3 w-70 laptop:-translate-x-0 left-0 bg-theme-bg-primary border-r border-theme-divider-tertiary transition-[width,transform] duration-300 ease-in-out group fixed top-0  h-full ',
+  'flex flex-col z-sidebar laptop:z-3 w-70 laptop:-translate-x-0 left-0 bg-theme-bg-primary border-r border-theme-divider-tertiary transition-[width,transform] duration-300 ease-in-out group fixed top-0  h-full ',
 );
 export const SidebarScrollWrapper = classed(
   'div',

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -137,7 +137,8 @@ module.exports = {
       2: '2',
       3: '3',
       rank: '3',
-      sidebar: '100',
+      modal: '10',
+      max: '100',
       '-1': '-1',
     },
     maxHeight: {

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -139,6 +139,7 @@ module.exports = {
       rank: '3',
       sidebar: '9',
       modal: '10',
+      max: '100',
       '-1': '-1',
     },
     maxHeight: {

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -137,8 +137,8 @@ module.exports = {
       2: '2',
       3: '3',
       rank: '3',
+      sidebar: '9',
       modal: '10',
-      max: '100',
       '-1': '-1',
     },
     maxHeight: {

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -137,6 +137,7 @@ module.exports = {
       2: '2',
       3: '3',
       rank: '3',
+      sidebar: '100',
       '-1': '-1',
     },
     maxHeight: {

--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -165,7 +165,7 @@ const Step2 = ({
     <div className="flex flex-col self-stretch laptop:self-center mx-2 mt-5">
       <h1 className="mx-3 mb-8 font-bold typo-title1">Share your #DevCard</h1>
       <main className="flex flex-col laptop:flex-row gap-10 laptopL:gap-20">
-        <section className="flex flex-col">
+        <section className="flex z-2 flex-col">
           <Tilt
             className="overflow-hidden relative self-stretch w-fit"
             glareEnable

--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -164,8 +164,8 @@ const Step2 = ({
   return (
     <div className="flex flex-col self-stretch laptop:self-center mx-2 mt-5">
       <h1 className="mx-3 mb-8 font-bold typo-title1">Share your #DevCard</h1>
-      <main className="flex flex-col laptop:flex-row gap-10 laptopL:gap-20">
-        <section className="flex z-2 flex-col">
+      <main className="flex z-2 flex-col laptop:flex-row gap-10 laptopL:gap-20">
+        <section className="flex flex-col">
           <Tilt
             className="overflow-hidden relative self-stretch w-fit"
             glareEnable

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -51,7 +51,7 @@ const maxAuthWidth = 'tablet:max-w-[30rem]';
 
 const Container = classed(
   'div',
-  'flex flex-col overflow-x-hidden items-center min-h-[100vh] w-full h-full max-h-[100vh] flex-1 z-[100] bg-theme-bg-primary',
+  'flex flex-col overflow-x-hidden items-center min-h-[100vh] w-full h-full max-h-[100vh] flex-1 z-max bg-theme-bg-primary',
 );
 
 const seo: NextSeoProps = {


### PR DESCRIPTION
## Changes
- Introduced a z-index for the sidebar. The sidebar is meant to be on top of everything to allow user to navigate wherever they are.
- Issue was they were at z-index 3.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1579 #done
