### PR TITLE
feat: dynamically show notification and join banners

### DIFF
--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -32,6 +32,7 @@ interface PostCommentsProps {
   post: Post;
   origin: Origin;
   permissionNotificationCommentId?: string;
+  joinNotificationCommentId?: string;
   modalParentSelector?: () => HTMLElement;
   onShare?: (comment: Comment) => void;
   onClickUpvote?: (commentId: string, upvotes: number) => unknown;
@@ -46,6 +47,7 @@ export function PostComments({
   onClickUpvote,
   modalParentSelector,
   permissionNotificationCommentId,
+  joinNotificationCommentId,
   className = {},
   onCommented,
 }: PostCommentsProps): ReactElement {
@@ -137,6 +139,7 @@ export function PostComments({
           postScoutId={post.scout?.id}
           appendTooltipTo={modalParentSelector ?? (() => container?.current)}
           permissionNotificationCommentId={permissionNotificationCommentId}
+          joinNotificationCommentId={joinNotificationCommentId}
           onCommented={onCommented}
         />
       ))}

--- a/packages/shared/src/components/squads/SquadCommentJoinBanner.tsx
+++ b/packages/shared/src/components/squads/SquadCommentJoinBanner.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import { useMutation, useQueryClient } from 'react-query';
+import classNames from 'classnames';
 import { Origin } from '../../lib/analytics';
 import { Button } from '../buttons/Button';
 import { SimpleSquadJoinButton } from './SquadJoinButton';
@@ -15,12 +16,14 @@ import { SQUAD_COMMENT_JOIN_BANNER_KEY } from '../../graphql/squads';
 import { Post } from '../../graphql/posts';
 
 export type SquadCommentJoinBannerProps = {
+  className?: string;
   squad: Squad;
   analyticsOrigin: Origin;
   post?: Pick<Post, 'id'>;
 };
 
 export const SquadCommentJoinBanner = ({
+  className,
   squad,
   analyticsOrigin,
   post,
@@ -56,7 +59,12 @@ export const SquadCommentJoinBanner = ({
   }
 
   return (
-    <div className="flex flex-row flex-1 gap-4 justify-between items-start p-4 mx-3 mb-3 rounded-16 border border-theme-color-cabbage">
+    <div
+      className={classNames(
+        'flex flex-row flex-1 gap-4 justify-between items-start p-4 mx-3 mb-3 rounded-16 border border-theme-color-cabbage',
+        className,
+      )}
+    >
       <div className="flex flex-col flex-1">
         <p className="flex flex-1 text-theme-label-tertiary typo-callout">
           Join {squad.name} to see more posts like this one, contribute to


### PR DESCRIPTION
## Changes

### Describe what this PR does
  - [x] join banner needs to show on any comment
  - [x] notification banner must not show if join banner is showing
  - [x] clicking join squad on banner or dismissing show notification banner (if notifications not already accepted)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1567 #done
