### PR TITLE
fix: updated say hi comment default

### DIFF
--- a/packages/shared/src/components/checklist/SquadFirstCommentChecklistStep.tsx
+++ b/packages/shared/src/components/checklist/SquadFirstCommentChecklistStep.tsx
@@ -22,9 +22,11 @@ const SquadFirstCommentChecklistStep = ({
         disabled={!welcomePost}
         onClick={() => {
           router.push(
-            `/posts/${welcomePost.id}?comment=Hi my name is ${
-              user?.name || user.username
-            } happy to be here! I joined ${squad.name} because…`,
+            `/posts/${welcomePost.id}?comment=${encodeURIComponent(
+              `Hi my name is ${
+                user?.name || user.username
+              } happy to be here! I joined ${squad.name} because…`,
+            )}`,
           );
         }}
       >

--- a/packages/shared/src/components/checklist/SquadFirstCommentChecklistStep.tsx
+++ b/packages/shared/src/components/checklist/SquadFirstCommentChecklistStep.tsx
@@ -5,12 +5,14 @@ import { Button } from '../buttons/Button';
 import { ChecklistStep } from './ChecklistStep';
 import { Squad } from '../../graphql/sources';
 import { useFindSquadWelcomePost } from '../../hooks/useFindSquadWelcomePost';
+import { useAuthContext } from '../../contexts/AuthContext';
 
 const SquadFirstCommentChecklistStep = ({
   squad,
   ...props
 }: ChecklistStepProps & { squad: Squad }): ReactElement => {
   const router = useRouter();
+  const { user } = useAuthContext();
   const welcomePost = useFindSquadWelcomePost(squad);
 
   return (
@@ -19,7 +21,11 @@ const SquadFirstCommentChecklistStep = ({
         className="btn-primary"
         disabled={!welcomePost}
         onClick={() => {
-          router.push(`/posts/${welcomePost.id}?comment=Say hi 👋`);
+          router.push(
+            `/posts/${welcomePost.id}?comment=Hi my name is ${
+              user?.name || user.username
+            } happy to be here! I joined ${squad.name} because…`,
+          );
         }}
       >
         Say hi 👋

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -1,6 +1,3 @@
-export const smallPostImage = (url: string): string =>
-  url.replace('/f_auto,q_auto/', '/c_fill,f_auto,q_auto,w_192/');
-
 export const cloudinary = {
   post: {
     imageCoverPlaceholder:
@@ -86,4 +83,12 @@ export const cloudinary = {
     purpleEdgeGlow:
       'https://daily-now-res.cloudinary.com/image/upload/s--Va9xODJM--/v1686074969/Glow_fjelt5.svg',
   },
+};
+
+export const smallPostImage = (url: string): string => {
+  if (!url) {
+    return cloudinary.post.imageCoverPlaceholder;
+  }
+
+  return url.replace('/f_auto,q_auto/', '/c_fill,f_auto,q_auto,w_192/');
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We needed to update the say hi default comment
- As we don't have all the data on currentMember I decided to locally use the authContext

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1581 #done
