### PR TITLE
fix: stale squad response after join/leave

### DIFF
--- a/packages/shared/src/components/squads/SquadJoinButton.tsx
+++ b/packages/shared/src/components/squads/SquadJoinButton.tsx
@@ -109,7 +109,15 @@ export const SquadJoinButton = ({
         displayToast('👋 You have left the Squad.');
 
         const queryKey = generateQueryKey(RequestKey.Squad, user, squad.handle);
-        queryClient.invalidateQueries(queryKey);
+        const currenSquad = queryClient.getQueryData<Squad>(queryKey);
+
+        if (currenSquad) {
+          queryClient.setQueryData(queryKey, {
+            ...currenSquad,
+            currentMember: null,
+            membersCount: currenSquad.membersCount - 1,
+          });
+        }
         queryClient.invalidateQueries(['squadMembersInitial', squad.handle]);
       },
       onError: () => {

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -250,6 +250,7 @@ export const SQUAD_JOIN_MUTATION = gql`
   mutation JoinSquad($sourceId: ID!, $token: String) {
     source: joinSource(sourceId: $sourceId, token: $token) {
       ...SourceBaseInfo
+      referralUrl
     }
   }
   ${SOURCE_BASE_FRAGMENT}

--- a/packages/shared/src/hooks/useJoinSquad.ts
+++ b/packages/shared/src/hooks/useJoinSquad.ts
@@ -5,7 +5,7 @@ import { useAnalyticsContext } from '../contexts/AnalyticsContext';
 import { Squad } from '../graphql/sources';
 import { AnalyticsEvent } from '../lib/analytics';
 import { useBoot } from './useBoot';
-import { RequestKey } from '../lib/query';
+import { generateQueryKey, RequestKey } from '../lib/query';
 
 type UseJoinSquadProps = {
   squad: Pick<Squad, 'id' | 'handle'>;
@@ -42,7 +42,13 @@ export const useJoinSquad = ({
     });
 
     addSquad(result);
-    queryClient.invalidateQueries([RequestKey.Squad]);
+
+    const queryKey = generateQueryKey(
+      RequestKey.Squad,
+      result.currentMember.user,
+      result.handle,
+    );
+    queryClient.setQueryData(queryKey, result);
     queryClient.invalidateQueries(['squadMembersInitial', squad.handle]);
 
     return result;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- we had an edge case where sometimes after user joining or leaving squad the next Source API request would return stale data with `currentMember` as if user was still part of the squad.
Following flow would fail:
- join squad
- join mutation passes
- we invalidate source data locally (react query)
- source query fires API request for Source to refetch
  - API request returns the stale data (like user is not a member)

I checked that order of requests on the frontend is valid and that join mutation request finishes before the Source request is made. So I don't think it is a frontend race condition.

This PR fixes the above where we actually reuse the response from join squad mutation. As bonus we make one less network request which is even better.

This fixes the issue but we are still not sure why API sometimes returns the stale response.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
