### PR TITLE
fix: squads and feed page padding

### DIFF
--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -152,7 +152,7 @@ const SquadPage = ({ handle }: SourcePageProps): ReactElement => {
         <SquadPageHeader squad={squad} members={squadMembers} />
         <SquadChecklistCard squad={squad} />
         <Feed
-          className="px-6 laptop:px-0 pt-14 laptop:pt-10"
+          className="px-6 pt-14 laptop:pt-10"
           feedName="squad"
           feedQueryKey={[
             'sourceFeed',

--- a/packages/webapp/pages/squads/index.tsx
+++ b/packages/webapp/pages/squads/index.tsx
@@ -62,7 +62,7 @@ const SquadsPage = (): ReactElement => {
           >
             <FeedContainer
               header={<SquadsDirectoryHeader />}
-              className="px-6 laptop:px-0"
+              className="px-6"
               inlineHeader
               forceCardMode
             >


### PR DESCRIPTION
## Changes
- Removed the custom padding of `0` on laptop size.
- Not sure if there was any reasoning behind this, if anyone has, please let us know.

Previews:

_Before the fix_
![Screenshot 2023-07-29 at 2 12 49 PM](https://github.com/dailydotdev/apps/assets/13744167/887970cb-7fd5-4f37-80d5-1a96c8c179e4)

![Screenshot 2023-07-29 at 2 13 46 PM](https://github.com/dailydotdev/apps/assets/13744167/af619dd5-0e5e-451e-a57a-79103e8be6b0)

_After the fix_


![Screenshot 2023-07-29 at 2 13 28 PM](https://github.com/dailydotdev/apps/assets/13744167/df8a4346-2951-4363-90b5-ba54fe4afab9)
![Screenshot 2023-07-29 at 2 13 54 PM](https://github.com/dailydotdev/apps/assets/13744167/ae8cc46b-793a-4258-bc68-6d12c0960879)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1584 #done
