### PR TITLE
feat: make squad image and name/handle clickable

### DIFF
--- a/packages/shared/src/components/sources/SourceCard.tsx
+++ b/packages/shared/src/components/sources/SourceCard.tsx
@@ -84,17 +84,19 @@ export const SourceCard = ({
       </div>
       <div className="flex flex-col flex-1 p-4 -mt-12 rounded-t-2xl bg-theme-bg-secondary">
         <div className="flex justify-between items-end mb-3">
-          {source?.image ? (
-            <img
-              className="-mt-14 w-24 h-24 rounded-full z-10"
-              src={source?.image}
-              alt={`${title} source`}
-            />
-          ) : (
-            <div className="flex justify-center items-center -mt-14 w-24 h-24 rounded-full bg-theme-bg-pepper40 z-10">
-              {icon}
-            </div>
-          )}
+          <a href={source?.permalink}>
+            {source?.image ? (
+              <img
+                className="-mt-14 w-24 h-24 rounded-full z-10"
+                src={source?.image}
+                alt={`${title} source`}
+              />
+            ) : (
+              <div className="flex justify-center items-center -mt-14 w-24 h-24 rounded-full bg-theme-bg-pepper40 z-10">
+                {icon}
+              </div>
+            )}
+          </a>
           {source?.membersCount > 0 && (
             <SquadMemberShortList
               squad={{
@@ -110,10 +112,12 @@ export const SourceCard = ({
         </div>
         <div className="flex flex-col flex-1 justify-between">
           <div className="flex-auto mb-5">
-            <div className="font-bold typo-title3">{title}</div>
-            {subtitle && (
-              <div className="text-theme-label-secondary">{subtitle}</div>
-            )}
+            <a href={source?.permalink}>
+              <div className="font-bold typo-title3">{title}</div>
+              {subtitle && (
+                <div className="text-theme-label-secondary">{subtitle}</div>
+              )}
+            </a>
             {description ||
               (source?.description && (
                 <div className="mt-1 line-clamp-5 text-theme-label-secondary multi-truncate">


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Link image, name and handle to squad from `SourceCard`

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1594 #done
