### PR TITLE
fix: checklist after joining squad

### DIFF
--- a/packages/shared/src/hooks/useActions.ts
+++ b/packages/shared/src/hooks/useActions.ts
@@ -22,7 +22,7 @@ export const useActions = (): UseActions => {
   const { data: actions, isFetched: isActionsFetched } = useQuery(
     generateQueryKey(RequestKey.Actions, user),
     getUserActions,
-    { enabled: !!user },
+    { enabled: !!user, refetchOnMount: false },
   );
   const { mutateAsync: completeAction } = useMutation(completeUserAction, {
     onMutate: (type) => {

--- a/packages/shared/src/hooks/useJoinSquad.ts
+++ b/packages/shared/src/hooks/useJoinSquad.ts
@@ -53,7 +53,6 @@ export const useJoinSquad = ({
       RequestKey.Actions,
       result.currentMember.user,
     );
-    queryClient.setQueryData(queryKey, result);
     queryClient.setQueryData<Action[]>(actionsKey, (data) => {
       if (data?.some(({ type }) => type === ActionType.JoinSquad)) return data;
 

--- a/packages/shared/src/hooks/useJoinSquad.ts
+++ b/packages/shared/src/hooks/useJoinSquad.ts
@@ -6,7 +6,6 @@ import { Squad } from '../graphql/sources';
 import { AnalyticsEvent } from '../lib/analytics';
 import { useBoot } from './useBoot';
 import { generateQueryKey, RequestKey } from '../lib/query';
-import { useActions } from './useActions';
 import { Action, ActionType } from '../graphql/actions';
 
 type UseJoinSquadProps = {
@@ -23,7 +22,6 @@ export const useJoinSquad = ({
   const queryClient = useQueryClient();
   const { addSquad } = useBoot();
   const { trackEvent } = useAnalyticsContext();
-  const {} = useActions();
 
   const joinSquad = useCallback(async () => {
     const payload: SquadInvitationProps = {

--- a/packages/shared/src/hooks/useJoinSquad.ts
+++ b/packages/shared/src/hooks/useJoinSquad.ts
@@ -6,6 +6,8 @@ import { Squad } from '../graphql/sources';
 import { AnalyticsEvent } from '../lib/analytics';
 import { useBoot } from './useBoot';
 import { generateQueryKey, RequestKey } from '../lib/query';
+import { useActions } from './useActions';
+import { Action, ActionType } from '../graphql/actions';
 
 type UseJoinSquadProps = {
   squad: Pick<Squad, 'id' | 'handle'>;
@@ -21,6 +23,7 @@ export const useJoinSquad = ({
   const queryClient = useQueryClient();
   const { addSquad } = useBoot();
   const { trackEvent } = useAnalyticsContext();
+  const {} = useActions();
 
   const joinSquad = useCallback(async () => {
     const payload: SquadInvitationProps = {
@@ -48,6 +51,18 @@ export const useJoinSquad = ({
       result.currentMember.user,
       result.handle,
     );
+    const actionsKey = generateQueryKey(
+      RequestKey.Actions,
+      result.currentMember.user,
+    );
+    queryClient.setQueryData(queryKey, result);
+    queryClient.setQueryData<Action[]>(actionsKey, (data) => {
+      if (data?.some(({ type }) => type === ActionType.JoinSquad)) return data;
+
+      const action = { type: ActionType.JoinSquad, completedAt: new Date() };
+
+      return data ? [...data, action] : [action];
+    });
     queryClient.setQueryData(queryKey, result);
     queryClient.invalidateQueries(['squadMembersInitial', squad.handle]);
 

--- a/packages/webapp/pages/squads/[handle]/edit.tsx
+++ b/packages/webapp/pages/squads/[handle]/edit.tsx
@@ -73,7 +73,6 @@ const EditSquad = ({ handle }: EditSquadPageProps): ReactElement => {
         user,
         editedSquad.handle,
       );
-      queryClient.invalidateQueries(queryKey);
       await queryClient.invalidateQueries(queryKey);
       updateSquad(editedSquad);
       displayToast('The Squad has been updated');


### PR DESCRIPTION
## Changes
- There can be a difference between the invalidation of cache for us to fetch the user's completed actions over the background worker's finishing time.
- We instead push the finished action than relying on the API as we already expect this to happen.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1583 #done
