### PR TITLE
fix: ensure pulse only on welcome post type

### DIFF
--- a/packages/shared/src/components/cards/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCard.tsx
@@ -10,6 +10,7 @@ import { useSquadChecklist } from '../../hooks/useSquadChecklist';
 import { Squad } from '../../graphql/sources';
 import { ActionType } from '../../graphql/actions';
 import FeedItemContainer from './FeedItemContainer';
+import { PostType } from '../../graphql/posts';
 
 export const WelcomePostCard = forwardRef(function SharePostCard(
   {
@@ -31,7 +32,7 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ): ReactElement {
-  const { pinnedAt } = post;
+  const { pinnedAt, type: postType } = post;
   const onPostCardClick = () => onPostClick(post);
   const containerRef = useRef<HTMLDivElement>();
 
@@ -40,6 +41,7 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
   });
 
   const shouldShowHighlightPulse =
+    postType === PostType.Welcome &&
     isChecklistVisible &&
     [ActionType.SquadFirstComment, ActionType.EditWelcomePost].includes(
       openStep,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- As freeform and welcome both render as welcome post cards, we needed to ensure only welcome actually pulses on animation open

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1585 #done
