### PR TITLE
feat: do not show devcard popup when on squad pages

### DIFF
--- a/packages/shared/src/components/RankProgressWrapper.tsx
+++ b/packages/shared/src/components/RankProgressWrapper.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useContext, useState } from 'react';
 import dynamic from 'next/dynamic';
 import classNames from 'classnames';
+import { useRouter } from 'next/router';
 import { RankProgress } from './RankProgress';
 import useReadingRank from '../hooks/useReadingRank';
 import AuthContext from '../contexts/AuthContext';
@@ -27,6 +28,9 @@ export default function RankProgressWrapper({
   sidebarExpanded,
   className,
 }: RankProgressWrapperProps): ReactElement {
+  const router = useRouter();
+  const isSquadPage = (router.asPath || router.pathname).startsWith('/squads/');
+
   const { user } = useContext(AuthContext);
   const [showRanksModal, setShowRanksModal] = useState(false);
   const {
@@ -38,7 +42,7 @@ export default function RankProgressWrapper({
     shouldShowRankModal,
     levelUp,
     confirmLevelUp,
-  } = useReadingRank(disableNewRankPopup);
+  } = useReadingRank(disableNewRankPopup || isSquadPage);
 
   const [levelUpAnimation] = useDebounce(() => {
     confirmLevelUp(true);

--- a/packages/shared/src/components/SidebarRankProgress.spec.tsx
+++ b/packages/shared/src/components/SidebarRankProgress.spec.tsx
@@ -3,6 +3,8 @@ import { render, RenderResult, screen, waitFor } from '@testing-library/preact';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import nock from 'nock';
 import { set as setCache } from 'idb-keyval';
+import { useRouter, NextRouter } from 'next/router';
+import { mocked } from 'ts-jest/utils';
 import {
   MockedGraphQLResponse,
   mockGraphQL,
@@ -29,6 +31,15 @@ beforeEach(() => {
   jest.restoreAllMocks();
   jest.clearAllMocks();
   nock.cleanAll();
+  mocked(useRouter).mockImplementation(
+    () =>
+      ({
+        pathname: '/',
+        query: {},
+        replace: jest.fn(),
+        push: jest.fn(),
+      } as unknown as NextRouter),
+  );
 });
 
 const createRankMock = (


### PR DESCRIPTION
## Changes

### Describe what this PR does
- do not show devcard popup when on squad pages

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1595 #done
