### PR TITLE
refactor: merging of finished actions

### DIFF
--- a/packages/shared/src/components/sources/SourceCard.spec.tsx
+++ b/packages/shared/src/components/sources/SourceCard.spec.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../graphql/squads';
 import { waitForNock } from '../../../__tests__/helpers/utilities';
 import { cloudinary } from '../../lib/image';
+import { ActionType, COMPLETE_ACTION_MUTATION } from '../../graphql/actions';
 
 const onClickTest = jest.fn();
 const routerReplace = jest.fn();
@@ -214,6 +215,17 @@ it('should render the component with a join squad button', async () => {
     request: {
       query: SQUAD_JOIN_MUTATION,
       variables: { sourceId: admin.source.id },
+    },
+    result: () => {
+      queryCalled = true;
+      return { data: { source: admin.source } };
+    },
+  });
+
+  mockGraphQL({
+    request: {
+      query: COMPLETE_ACTION_MUTATION,
+      variables: { type: ActionType.JoinSquad },
     },
     result: () => {
       queryCalled = true;

--- a/packages/shared/src/components/sources/SourceCard.spec.tsx
+++ b/packages/shared/src/components/sources/SourceCard.spec.tsx
@@ -228,8 +228,7 @@ it('should render the component with a join squad button', async () => {
       variables: { type: ActionType.JoinSquad },
     },
     result: () => {
-      queryCalled = true;
-      return { data: { source: admin.source } };
+      return { data: { _: null } };
     },
   });
 

--- a/packages/shared/src/hooks/useActions.ts
+++ b/packages/shared/src/hooks/useActions.ts
@@ -19,35 +19,40 @@ interface UseActions {
 export const useActions = (): UseActions => {
   const client = useQueryClient();
   const { user } = useAuthContext();
+  const actionsKey = generateQueryKey(RequestKey.Actions, user);
   const { data: actions, isFetched: isActionsFetched } = useQuery(
-    generateQueryKey(RequestKey.Actions, user),
-    getUserActions,
-    { enabled: !!user, refetchOnMount: false },
+    actionsKey,
+    async () => {
+      const current = client.getQueryData<Action[]>(actionsKey);
+      const data = await getUserActions();
+
+      if (!current || !Array.isArray(current)) return data;
+
+      const filtered = data.filter(({ type }) =>
+        current.every((action) => action.type !== type),
+      );
+
+      return [...current, ...filtered];
+    },
+    { enabled: !!user },
   );
   const { mutateAsync: completeAction } = useMutation(completeUserAction, {
     onMutate: (type) => {
-      client.setQueryData<Action[]>(
-        generateQueryKey(RequestKey.Actions, user),
-        (data) => {
-          const optimisticAction = {
-            userId: user.id,
-            type,
-            completedAt: new Date(),
-          };
+      client.setQueryData<Action[]>(actionsKey, (data) => {
+        const optimisticAction = {
+          userId: user.id,
+          type,
+          completedAt: new Date(),
+        };
 
-          if (!Array.isArray(data)) {
-            return [optimisticAction];
-          }
+        if (!Array.isArray(data)) {
+          return [optimisticAction];
+        }
 
-          return [...data, optimisticAction];
-        },
-      );
+        return [...data, optimisticAction];
+      });
 
-      return () =>
-        client.setQueryData<Action[]>(
-          generateQueryKey(RequestKey.Actions, user),
-          actions,
-        );
+      return () => client.setQueryData<Action[]>(actionsKey, actions);
     },
     onError: (_, __, rollback: () => void) => {
       if (rollback) rollback();

--- a/packages/webapp/__tests__/SquadTokenPage.tsx
+++ b/packages/webapp/__tests__/SquadTokenPage.tsx
@@ -39,6 +39,10 @@ import {
 import { BOOT_QUERY_KEY } from '@dailydotdev/shared/src/contexts/common';
 import Toast from '@dailydotdev/shared/src/components/notifications/Toast';
 import { labels } from '@dailydotdev/shared/src/lib';
+import {
+  ActionType,
+  COMPLETE_ACTION_MUTATION,
+} from '@dailydotdev/shared/src/graphql/actions';
 import SquadPage, {
   SquadReferralProps,
 } from '../pages/squads/[handle]/[token]';
@@ -202,9 +206,9 @@ describe('squad details', () => {
   });
 
   it('should join squad on button click', async () => {
-    client.setQueryData(BOOT_QUERY_KEY, { squads: [] });
     const admin = generateTestAdmin();
     renderComponent([createInvitationMock(defaultToken, admin)]);
+    client.setQueryData(BOOT_QUERY_KEY, { squads: [] });
     await waitForNock();
     mockGraphQL({
       request: {
@@ -212,6 +216,15 @@ describe('squad details', () => {
         variables: { token: admin.referralToken, sourceId: admin.source.id },
       },
       result: () => ({ data: { source: admin.source } }),
+    });
+    mockGraphQL({
+      request: {
+        query: COMPLETE_ACTION_MUTATION,
+        variables: { type: ActionType.JoinSquad },
+      },
+      result: () => {
+        return { data: { _: null } };
+      },
     });
     const button = await screen.findByText('Join Squad');
     fireEvent.click(button);

--- a/packages/webapp/__tests__/SquadTokenPage.tsx
+++ b/packages/webapp/__tests__/SquadTokenPage.tsx
@@ -220,9 +220,9 @@ describe('squad details', () => {
   });
 
   it('should have join squad button', async () => {
-    client.setQueryData(BOOT_QUERY_KEY, { squads: [] });
     const admin = generateTestAdmin();
     renderComponent([createInvitationMock(defaultToken, admin)]);
+    client.setQueryData(BOOT_QUERY_KEY, { squads: [] });
     await waitFor(() => screen.findAllByText('Join Squad'));
   });
 });


### PR DESCRIPTION
## Changes
- UserActions are immutable, we don't delete any data on this entity in any scenario, but since there can be some latency issues with background workers updating the finished actions, we need to keep the manually stored cache to avoid discrepancies with some checklists.
- We have two options, either merge it or disable the `refetchOnMount`. The latter is a good option too, though we will have to manually add to FE cache every actions that are registered in an async manner in the BE.

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
