### PR TITLE
fix: revert squad option toggle

### DIFF
--- a/packages/shared/src/components/modals/squads/SquadNotificationsModal.tsx
+++ b/packages/shared/src/components/modals/squads/SquadNotificationsModal.tsx
@@ -119,7 +119,7 @@ export function SquadNotificationsModal({
           name="notify_new_posts"
           className="w-20"
           compact={false}
-          checked={mutedNewPosts}
+          checked={!mutedNewPosts}
           onToggle={onToggleNotifyNewPosts}
         >
           Notify me about new posts
@@ -131,7 +131,7 @@ export function SquadNotificationsModal({
             name="notify_new_members"
             className="w-20"
             compact={false}
-            checked={mutedNewMembers}
+            checked={!mutedNewMembers}
             onToggle={onToggleNotifyNewMembers}
           >
             Notify me about new members


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Squad settings toggles should work opposite ways

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1607 #done
