### PR TITLE
feat: squad page loading

### DIFF
--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -78,6 +78,8 @@ export interface Source {
   currentMember?: SourceMember;
   privilegedMembers?: SourcePrivilegedMembers[];
   public: boolean;
+  headerImage?: string;
+  color?: string;
 }
 
 export type SourceData = { source: Source };

--- a/packages/webapp/pages/squads/index.tsx
+++ b/packages/webapp/pages/squads/index.tsx
@@ -66,62 +66,65 @@ const SquadsPage = (): ReactElement => {
               inlineHeader
               forceCardMode
             >
-              {queryResult?.data?.pages?.length > 0 &&
-                queryResult.data.pages.map((page) =>
-                  page.sources.edges.reduce(
-                    (nodes, { node: { name, permalink, id, ...props } }) => {
-                      const isMember = user && props?.currentMember;
+              {queryResult?.data?.pages?.length > 0 && (
+                <>
+                  {queryResult.data.pages.map((page) =>
+                    page.sources.edges.reduce(
+                      (nodes, { node: { name, permalink, id, ...props } }) => {
+                        const isMember = user && props?.currentMember;
 
-                      nodes.push(
-                        <SourceCard
-                          title={name}
-                          subtitle={`@${props.handle}`}
-                          action={{
-                            text: isMember ? 'View Squad' : 'Join Squad',
-                            type: isMember ? 'link' : 'action',
-                            href: isMember ? permalink : undefined,
-                          }}
-                          source={{
-                            name,
-                            active: props.active,
-                            description: props.description,
-                            public: props.public,
-                            membersCount: props.membersCount,
-                            permalink,
-                            id,
-                            type: props.type,
-                            handle: props.handle,
-                            image: props.image,
-                            memberInviteRole: props.memberInviteRole,
-                            memberPostingRole: props.memberPostingRole,
-                            borderColor: props.color,
-                            banner: props.headerImage,
-                            ...props,
-                          }}
-                        />,
-                      );
-                      return nodes;
-                    },
-                    [],
-                  ),
-                )}
-              <SourceCard
-                title="Which squads would you like to see next?"
-                action={{
-                  type: 'link',
-                  text: 'Submit your idea',
-                  href: squadsPublicSuggestion,
-                  target: '_blank',
-                }}
-                icon={
-                  <EditIcon
-                    size={IconSize.XXLarge}
-                    className="text-theme-label-tertiary"
+                        nodes.push(
+                          <SourceCard
+                            title={name}
+                            subtitle={`@${props.handle}`}
+                            action={{
+                              text: isMember ? 'View Squad' : 'Join Squad',
+                              type: isMember ? 'link' : 'action',
+                              href: isMember ? permalink : undefined,
+                            }}
+                            source={{
+                              name,
+                              active: props.active,
+                              description: props.description,
+                              public: props.public,
+                              membersCount: props.membersCount,
+                              permalink,
+                              id,
+                              type: props.type,
+                              handle: props.handle,
+                              image: props.image,
+                              memberInviteRole: props.memberInviteRole,
+                              memberPostingRole: props.memberPostingRole,
+                              borderColor: props.color,
+                              banner: props.headerImage,
+                              ...props,
+                            }}
+                          />,
+                        );
+                        return nodes;
+                      },
+                      [],
+                    ),
+                  )}
+                  <SourceCard
+                    title="Which squads would you like to see next?"
+                    action={{
+                      type: 'link',
+                      text: 'Submit your idea',
+                      href: squadsPublicSuggestion,
+                      target: '_blank',
+                    }}
+                    icon={
+                      <EditIcon
+                        size={IconSize.XXLarge}
+                        className="text-theme-label-tertiary"
+                      />
+                    }
+                    description="We're thrilled to see how our community has grown and evolved, thanks to your incredible support. Let your voice be heard and be part of the decision-making process."
+                    borderColor={SourceCardBorderColor.Pepper}
                   />
-                }
-                description="We're thrilled to see how our community has grown and evolved, thanks to your incredible support. Let your voice be heard and be part of the decision-making process."
-                borderColor={SourceCardBorderColor.Pepper}
-              />
+                </>
+              )}
             </FeedContainer>
           </InfiniteScrolling>
         </BaseFeedPage>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- do not show last card if squads data is not fetched
- added squads fetch in SSR (1 hour cache)
- updated types for the page

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
