### PR TITLE
fix: show correct member role for user

### DIFF
--- a/packages/shared/src/components/squads/SquadPostListItem.tsx
+++ b/packages/shared/src/components/squads/SquadPostListItem.tsx
@@ -11,6 +11,7 @@ import SquadPostAuthor from '../post/SquadPostAuthor';
 import { CardLink } from '../cards/Card';
 import { postDateFormat } from '../../lib/dateFormat';
 import { combinedClicks } from '../../lib/click';
+import { useMemberRoleForSource } from '../../hooks/useMemberRoleForSource';
 
 type PostProps = {
   post: Post;
@@ -22,45 +23,51 @@ export const SquadPostListItem = ({
   post,
   onLinkClick,
   onBookmark,
-}: PostProps): ReactElement => (
-  <article
-    className={classNames(
-      'relative flex py-2 pl-4 pr-2 group items-start hover:bg-theme-hover',
-      styles.card,
-    )}
-  >
-    <CardLink
-      href={post.commentsPermalink}
-      title={post.title}
-      {...combinedClicks(() => onLinkClick(post))}
-    />
-    <div className="flex flex-col flex-1">
-      <SquadPostAuthor
-        className={{
-          container: 'mt-0',
-          name: 'typo-callout text-theme-label-primary',
-          handle: 'typo-callout text-theme-label-quaternary',
-        }}
-        author={post.author}
-        role={post.source.currentMember?.role}
-        size="large"
-        date={postDateFormat(post.createdAt)}
+}: PostProps): ReactElement => {
+  const { role } = useMemberRoleForSource({
+    source: post?.source,
+    user: post?.author,
+  });
+  return (
+    <article
+      className={classNames(
+        'relative flex py-2 pl-4 pr-2 group items-start hover:bg-theme-hover',
+        styles.card,
+      )}
+    >
+      <CardLink
+        href={post.commentsPermalink}
+        title={post.title}
+        {...combinedClicks(() => onLinkClick(post))}
       />
-      <p className="mt-2 line-clamp-3 typo-callout text-theme-label-primary">
-        {post.title}
-      </p>
-    </div>
-    <SimpleTooltip content={post.bookmarked ? 'Remove bookmark' : 'Bookmark'}>
-      <Button
-        className="group-hover:visible mouse:invisible mt-1 btn-tertiary-bun"
-        pressed={post.bookmarked}
-        buttonSize={ButtonSize.Small}
-        icon={<BookmarkIcon secondary={post.bookmarked} />}
-        onClick={() => onBookmark(post)}
-      />
-    </SimpleTooltip>
-  </article>
-);
+      <div className="flex flex-col flex-1">
+        <SquadPostAuthor
+          className={{
+            container: 'mt-0',
+            name: 'typo-callout text-theme-label-primary',
+            handle: 'typo-callout text-theme-label-quaternary',
+          }}
+          author={post.author}
+          role={role}
+          size="large"
+          date={postDateFormat(post.createdAt)}
+        />
+        <p className="mt-2 line-clamp-3 typo-callout text-theme-label-primary">
+          {post.title}
+        </p>
+      </div>
+      <SimpleTooltip content={post.bookmarked ? 'Remove bookmark' : 'Bookmark'}>
+        <Button
+          className="group-hover:visible mouse:invisible mt-1 btn-tertiary-bun"
+          pressed={post.bookmarked}
+          buttonSize={ButtonSize.Small}
+          icon={<BookmarkIcon secondary={post.bookmarked} />}
+          onClick={() => onBookmark(post)}
+        />
+      </SimpleTooltip>
+    </article>
+  );
+};
 
 const SquadPostListItemPlaceholder = (): ReactElement => (
   <article aria-busy className="flex relative flex-col py-2 px-4">

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -50,6 +50,12 @@ export const SOURCE_BASE_FRAGMENT = gql`
     description
     image
     membersCount
+    privilegedMembers {
+      user {
+        id
+      }
+      role
+    }
     currentMember {
       ...CurrentMember
     }

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -167,12 +167,6 @@ export const POST_BY_ID_QUERY = gql`
       }
       source {
         ...SourceBaseInfo
-        privilegedMembers {
-          user {
-            id
-          }
-          role
-        }
       }
       description
       summary


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Currently we showed the current member role for each similar post, this should be based on the role the author of set posts has
- Added the privileged member query to base info as we use it in multiple places to resolve roles

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1609 #done
