### PR TITLE
fix: onboarding scroll block placement

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -366,6 +366,13 @@ export default function Feed<T>({
       forceCardMode={forceCardMode}
       header={header}
       className={className}
+      afterFeed={
+        showScrollOnboardingVersion ? (
+          <ScrollFeedFiltersOnboarding
+            onInitializeOnboarding={onInitializeOnboardingClick}
+          />
+        ) : null
+      }
     >
       {items.map((item, index) => (
         <FeedItemComponent
@@ -397,11 +404,6 @@ export default function Feed<T>({
           onReadArticleClick={onReadArticleClick}
         />
       ))}
-      {showScrollOnboardingVersion && (
-        <ScrollFeedFiltersOnboarding
-          onInitializeOnboarding={onInitializeOnboardingClick}
-        />
-      )}
       <InfiniteScrollScreenOffset ref={infiniteScrollRef} />
       <PostOptionsMenu
         {...commonMenuItems}

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -23,6 +23,50 @@ export interface FeedContainerProps {
   inlineHeader?: boolean;
 }
 
+const listGaps = {
+  cozy: 'gap-5',
+  roomy: 'gap-3',
+};
+
+const gridGaps = {
+  cozy: 'gap-14',
+  roomy: 'gap-12',
+};
+
+const cardListClass = {
+  1: 'grid-cols-1',
+  2: 'grid-cols-2',
+  3: 'grid-cols-3',
+  4: 'grid-cols-4',
+  5: 'grid-cols-5',
+  6: 'grid-cols-6',
+  7: 'grid-cols-7',
+};
+
+const getFeedGapPx = {
+  'gap-2': 8,
+  'gap-3': 12,
+  'gap-5': 20,
+  'gap-8': 32,
+  'gap-12': 48,
+  'gap-14': 56,
+};
+
+const gapClass = (isList: boolean, space: Spaciness) =>
+  isList ? listGaps[space] ?? 'gap-2' : gridGaps[space] ?? 'gap-8';
+
+const cardClass = (isList: boolean, numberOfCards: number): string =>
+  isList ? 'grid-cols-1' : cardListClass[numberOfCards];
+
+const getStyle = (isList: boolean, space: Spaciness): CSSProperties => {
+  if (isList && space !== 'eco') {
+    return space === 'cozy'
+      ? { maxWidth: '48.75rem' }
+      : { maxWidth: '63.75rem' };
+  }
+  return {};
+};
+
 export const FeedContainer = ({
   children,
   forceCardMode,
@@ -39,50 +83,13 @@ export const FeedContainer = ({
   } = useContext(SettingsContext);
   const numCards = currentSettings.numCards[spaciness ?? 'eco'];
   const insaneMode = !forceCardMode && listMode;
-  const useList = insaneMode && numCards > 1;
-  const listGaps = {
-    cozy: 'gap-5',
-    roomy: 'gap-3',
-  };
-  const gridGaps = {
-    cozy: 'gap-14',
-    roomy: 'gap-12',
-  };
-  const cardListClass = {
-    1: 'grid-cols-1',
-    2: 'grid-cols-2',
-    3: 'grid-cols-3',
-    4: 'grid-cols-4',
-    5: 'grid-cols-5',
-    6: 'grid-cols-6',
-    7: 'grid-cols-7',
-  };
-  const getFeedGapPx = {
-    'gap-2': 8,
-    'gap-3': 12,
-    'gap-5': 20,
-    'gap-8': 32,
-    'gap-12': 48,
-    'gap-14': 56,
-  };
-  const gapClass = (isList: boolean, space: Spaciness) =>
-    isList ? listGaps[space] ?? 'gap-2' : gridGaps[space] ?? 'gap-8';
-  const cardClass = (isList: boolean, numberOfCards: number): string =>
-    isList ? 'grid-cols-1' : cardListClass[numberOfCards];
-  const feedGapPx = getFeedGapPx[gapClass(useList, spaciness)];
+  const isList = insaneMode && numCards > 1;
+  const feedGapPx = getFeedGapPx[gapClass(isList, spaciness)];
   const style = {
     '--num-cards': numCards,
     '--feed-gap': `${feedGapPx / 16}rem`,
   } as CSSProperties;
-  const getStyle = (isList: boolean, space: Spaciness): CSSProperties => {
-    if (isList && space !== 'eco') {
-      return space === 'cozy'
-        ? { maxWidth: '48.75rem' }
-        : { maxWidth: '63.75rem' };
-    }
-    return {};
-  };
-  const cardContainerStyle = { ...getStyle(useList, spaciness) };
+  const cardContainerStyle = { ...getStyle(isList, spaciness) };
 
   if (!loadedSettings) {
     return <></>;
@@ -97,27 +104,24 @@ export const FeedContainer = ({
       )}
     >
       <ScrollToTopButton />
-
       <div className="flex flex-col pt-2 laptopL:mx-auto w-full" style={style}>
         {!inlineHeader && header}
-
         <div
           className={classNames(
             'relative mx-auto w-full',
             styles.feed,
-            !useList && styles.cards,
+            !isList && styles.cards,
           )}
           style={cardContainerStyle}
           aria-live={subject === ToastSubject.Feed ? 'assertive' : 'off'}
           data-testid="posts-feed"
         >
           {inlineHeader && header}
-
           <div
             className={classNames(
               'grid',
-              gapClass(useList, spaciness),
-              cardClass(useList, numCards),
+              gapClass(isList, spaciness),
+              cardClass(isList, numCards),
             )}
           >
             {children}

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -21,6 +21,7 @@ export interface FeedContainerProps {
   header?: ReactNode;
   className?: string;
   inlineHeader?: boolean;
+  afterFeed?: ReactNode;
 }
 
 const listGaps = {
@@ -73,6 +74,7 @@ export const FeedContainer = ({
   header,
   className,
   inlineHeader = false,
+  afterFeed,
 }: FeedContainerProps): ReactElement => {
   const currentSettings = useContext(FeedContext);
   const { subject } = useToastNotification();
@@ -126,6 +128,7 @@ export const FeedContainer = ({
           >
             {children}
           </div>
+          {afterFeed}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Changes
- Did a refactor to move out certain const to keep the render function lean.
- Introduced a property on the container to place certain elements after the feed's grid. Everything about the fix should only be in this commit https://github.com/dailydotdev/apps/commit/b49ba3ca13da4c2eba4626f98e3063ef00d3ddb5

Preview:

![Screenshot 2023-08-02 at 5 13 43 PM](https://github.com/dailydotdev/apps/assets/13744167/53f69ac0-5e37-49ba-9d36-144b930c804b)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1612 #done
