### PR TITLE
feat: adding border to google buttons on light mode

### DIFF
--- a/packages/shared/src/components/auth/AuthDefault.tsx
+++ b/packages/shared/src/components/auth/AuthDefault.tsx
@@ -155,17 +155,18 @@ const AuthDefault = ({
     <>
       {!simplified && <AuthModalHeader title={title} />}
       <AuthContainer className={disableRegistration && 'mb-6'}>
-        {providers.map(({ provider, ...props }) => (
-          <ProviderButton
-            key={provider}
-            provider={provider}
-            label={shouldLogin ? 'Log in with' : 'Sign up with'}
-            className="mb-1 border-0"
-            onClick={() => onSocialClick(provider.toLowerCase())}
-            loading={!isReady}
-            {...props}
-          />
-        ))}
+        <div className="flex flex-col gap-4">
+          {providers.map(({ provider, ...props }) => (
+            <ProviderButton
+              key={provider}
+              provider={provider}
+              label={shouldLogin ? 'Log in with' : 'Sign up with'}
+              onClick={() => onSocialClick(provider.toLowerCase())}
+              loading={!isReady}
+              {...props}
+            />
+          ))}
+        </div>
         {getOrDivider()}
         {getForm()}
       </AuthContainer>

--- a/packages/shared/src/components/auth/AuthDefault.tsx
+++ b/packages/shared/src/components/auth/AuthDefault.tsx
@@ -160,7 +160,7 @@ const AuthDefault = ({
             key={provider}
             provider={provider}
             label={shouldLogin ? 'Log in with' : 'Sign up with'}
-            className="mb-1"
+            className="border-0 mb-1"
             onClick={() => onSocialClick(provider.toLowerCase())}
             loading={!isReady}
             {...props}

--- a/packages/shared/src/components/auth/AuthDefault.tsx
+++ b/packages/shared/src/components/auth/AuthDefault.tsx
@@ -160,7 +160,7 @@ const AuthDefault = ({
             key={provider}
             provider={provider}
             label={shouldLogin ? 'Log in with' : 'Sign up with'}
-            className="border-0 mb-1"
+            className="mb-1 border-0"
             onClick={() => onSocialClick(provider.toLowerCase())}
             loading={!isReady}
             {...props}

--- a/packages/shared/src/components/auth/ProviderButton.tsx
+++ b/packages/shared/src/components/auth/ProviderButton.tsx
@@ -14,7 +14,7 @@ function ProviderButton({
   label,
   provider,
   style,
-  className,
+  className = 'border-0',
   ...props
 }: ProviderButtonProps): ReactElement {
   return (
@@ -24,7 +24,6 @@ function ProviderButton({
       style={{
         justifyContent: label ? 'flex-start' : 'center',
         color: '#FFFFFF',
-        border: 0,
         fontWeight: 'normal',
         ...style,
       }}

--- a/packages/shared/src/components/auth/common.tsx
+++ b/packages/shared/src/components/auth/common.tsx
@@ -41,7 +41,7 @@ export const providerMap: ProviderMap = {
     icon: <GoogleIcon className="socialIcon" secondary />,
     provider: 'Google',
     style: { backgroundColor: '#FFFFFF', color: '#0E1217' },
-    className: 'border border-theme-divider-tertiary'
+    className: 'border border-theme-divider-tertiary',
   },
   github: {
     icon: <GitHubIcon className="socialIcon" />,

--- a/packages/shared/src/components/auth/common.tsx
+++ b/packages/shared/src/components/auth/common.tsx
@@ -41,6 +41,7 @@ export const providerMap: ProviderMap = {
     icon: <GoogleIcon className="socialIcon" secondary />,
     provider: 'Google',
     style: { backgroundColor: '#FFFFFF', color: '#0E1217' },
+    className: 'border border-theme-divider-tertiary'
   },
   github: {
     icon: <GitHubIcon className="socialIcon" />,


### PR DESCRIPTION
## Changes
Adding a border so the google button is more visible on light mode. Screenshots added below

![dark-mode](https://github.com/dailydotdev/apps/assets/42202149/e4457796-eaee-4f57-acf9-6311a620c9b7)
![light-mode](https://github.com/dailydotdev/apps/assets/42202149/19cb8fec-9dc3-44d5-8afc-7d20dea10b2e)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1560 #done
