### PR TITLE
feat: making title and read more buttons link to the correct place

### DIFF
--- a/packages/shared/src/components/cards/ReadArticleButton.tsx
+++ b/packages/shared/src/components/cards/ReadArticleButton.tsx
@@ -8,6 +8,8 @@ interface ReadArticleButtonProps {
   openNewTab?: boolean;
   buttonSize?: ButtonSize;
   onClick?: (e: React.MouseEvent) => unknown;
+  title?: string;
+  rel?: string;
 }
 
 export const ReadArticleButton = ({

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -150,7 +150,15 @@ export function PostContent({
             className="my-6 font-bold break-words typo-large-title"
             data-testid="post-modal-title"
           >
-            {post.title}
+            <a
+              href={post.permalink}
+              title="Go to post"
+              target="_blank"
+              rel="noopener"
+              {...combinedClicks(onReadArticle)}
+            >
+              {post.title}
+            </a>
           </h1>
           {post.summary && (
             <PostSummary className="mb-6" summary={post.summary} />

--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -10,6 +10,7 @@ import ArrowIcon from '../icons/Arrow';
 import { Post } from '../../graphql/posts';
 import SettingsContext from '../../contexts/SettingsContext';
 import { SharePostTitle } from './share';
+import { combinedClicks } from '../../lib/click';
 
 interface SharePostContentProps {
   post: Post;
@@ -69,7 +70,10 @@ function SharePostContent({
                 className="mt-5 btn-secondary w-fit"
                 href={post.sharedPost.permalink}
                 openNewTab={openNewTab}
-                onClick={onReadArticle}
+                title="Go to post"
+                rel="noopener"
+                onClick={(e) => e.stopPropagation()}
+                {...combinedClicks(onReadArticle)}
               />
             </div>
             <div className="block overflow-hidden ml-2 w-70 rounded-2xl cursor-pointer h-fit">

--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -33,6 +33,11 @@ function SharePostContent({
 
   const isUnknownSource = post.sharedPost.source.id === 'unknown';
 
+  const openArticle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onReadArticle();
+  };
+
   return (
     <>
       <SharePostTitle post={post} />
@@ -72,8 +77,7 @@ function SharePostContent({
                 openNewTab={openNewTab}
                 title="Go to post"
                 rel="noopener"
-                onClick={(e) => e.stopPropagation()}
-                {...combinedClicks(onReadArticle)}
+                {...combinedClicks(openArticle)}
               />
             </div>
             <div className="block overflow-hidden ml-2 w-70 rounded-2xl cursor-pointer h-fit">


### PR DESCRIPTION
## Changes
I have made titles link on the article page/modal as well as when you share a post to a squad the Read post button now links to the external article correctly

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1576 #done
