### PR TITLE
feat: change to the use notifications logic to show subscribe banner

### DIFF
--- a/packages/shared/src/hooks/useEnableNotification.ts
+++ b/packages/shared/src/hooks/useEnableNotification.ts
@@ -72,7 +72,6 @@ export const useEnableNotification = ({
     !isInitialized,
     !isNotificationSupported,
     (isSubscribed || hasPermissionCache) && !isEnabled,
-    hasEnabled,
   ];
   const shouldShowCta = !conditions.some((passed) => passed);
 

--- a/packages/shared/src/hooks/useEnableNotification.ts
+++ b/packages/shared/src/hooks/useEnableNotification.ts
@@ -72,7 +72,7 @@ export const useEnableNotification = ({
     !isInitialized,
     !isNotificationSupported,
     (isSubscribed || hasPermissionCache) && !isEnabled,
-    hasEnabled && source === NotificationPromptSource.SquadPostModal,
+    hasEnabled,
   ];
   const shouldShowCta = !conditions.some((passed) => passed);
 


### PR DESCRIPTION
## Changes
Changed the logic to show the subscribe banner in squads as the banner was showing even if you were subscribed

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1513 #done
