### PR TITLE
refactor: history page to be tabbed

### DIFF
--- a/packages/shared/src/components/PostsSearch.tsx
+++ b/packages/shared/src/components/PostsSearch.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement, useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { useQuery } from 'react-query';
 import request from 'graphql-request';
+import classNames from 'classnames';
 import { SearchField } from './fields/SearchField';
 import { useAutoComplete } from '../hooks/useAutoComplete';
 import { graphqlUrl } from '../lib/config';
@@ -20,13 +21,14 @@ const AutoCompleteMenu = dynamic(
   },
 );
 
-export type PostsSearchProps = {
+export interface PostsSearchProps {
   initialQuery?: string;
   placeholder?: string;
   suggestionType?: string;
   autoFocus?: boolean;
+  className?: string;
   onSubmitQuery: (query: string) => Promise<unknown>;
-};
+}
 
 const SEARCH_TYPES = {
   searchPostSuggestions: SEARCH_POST_SUGGESTIONS,
@@ -39,6 +41,7 @@ export default function PostsSearch({
   autoFocus = true,
   placeholder,
   onSubmitQuery,
+  className,
   suggestionType = 'searchPostSuggestions',
 }: PostsSearchProps): ReactElement {
   const searchBoxRef = useRef<HTMLDivElement>();
@@ -131,7 +134,7 @@ export default function PostsSearch({
   return (
     <>
       <SearchField
-        className="flex-1 compact"
+        className={classNames('flex-1 compact', className)}
         inputId="posts-search"
         fieldSize="medium"
         placeholder={placeholder}

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 import AuthContext from '../../contexts/AuthContext';
-import TabContainer, { Tab } from '../tabs/TabContainer';
+import { Tab, TabContainer } from '../tabs/TabContainer';
 import AuthDefault from './AuthDefault';
 import { AuthSignBack, SIGNIN_METHOD_KEY } from './AuthSignBack';
 import ForgotPasswordForm from './ForgotPasswordForm';

--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -26,7 +26,7 @@ import { MarkdownUploadLabel } from './MarkdownUploadLabel';
 import { markdownGuide } from '../../../lib/constants';
 import useSidebarRendered from '../../../hooks/useSidebarRendered';
 import ConditionalWrapper from '../../ConditionalWrapper';
-import TabContainer, { Tab } from '../../tabs/TabContainer';
+import { TabContainer, Tab } from '../../tabs/TabContainer';
 import MarkdownPreview from '../MarkdownPreview';
 import { isNullOrUndefined } from '../../../lib/func';
 import { SavingLabel } from './SavingLabel';

--- a/packages/shared/src/components/fields/SearchField.tsx
+++ b/packages/shared/src/components/fields/SearchField.tsx
@@ -86,16 +86,13 @@ export const SearchField = forwardRef(function SearchField(
 
   const isPrimary = fieldType === 'primary';
   const isSecondary = fieldType === 'secondary';
+  const sizeClass =
+    fieldSize === 'medium' ? 'h-10 rounded-12' : 'h-12 rounded-14';
 
   return (
     <BaseField
       {...props}
-      className={classNames(
-        'items-center',
-        fieldSize === 'medium' ? 'h-10 rounded-12' : 'h-12 rounded-14',
-        className,
-        { focused },
-      )}
+      className={classNames('items-center', sizeClass, className, { focused })}
       onClick={focusInput}
       data-testid="searchField"
       ref={ref}
@@ -146,6 +143,7 @@ export const SearchField = forwardRef(function SearchField(
         autoComplete="off"
         className={classNames(
           'flex-1',
+          sizeClass,
           getFieldFontColor({ readOnly, disabled, hasInput, focused }),
         )}
         required

--- a/packages/shared/src/components/history/ReadingHistoryEmptyScreen.tsx
+++ b/packages/shared/src/components/history/ReadingHistoryEmptyScreen.tsx
@@ -2,35 +2,31 @@ import Link from 'next/link';
 import React, { ReactElement } from 'react';
 import {
   EmptyScreenButton,
-  EmptyScreenContainer,
   EmptyScreenDescription,
   EmptyScreenIcon,
   EmptyScreenTitle,
 } from '../EmptyScreen';
 import EyeIcon from '../icons/Eye';
-import { PageContainer } from '../utilities';
 import { ButtonSize } from '../buttons/Button';
 
 function ReadingHistoryEmptyScreen(): ReactElement {
   return (
-    <PageContainer className="mx-auto">
-      <EmptyScreenContainer>
-        <EyeIcon
-          className={EmptyScreenIcon.className}
-          style={EmptyScreenIcon.style}
-        />
-        <EmptyScreenTitle>Your reading history is empty.</EmptyScreenTitle>
-        <EmptyScreenDescription>
-          Go back to your feed and read posts that spark your interest. Each
-          post you read will be listed here.
-        </EmptyScreenDescription>
-        <Link href={process.env.NEXT_PUBLIC_WEBAPP_URL}>
-          <EmptyScreenButton buttonSize={ButtonSize.Large}>
-            Back to feed
-          </EmptyScreenButton>
-        </Link>
-      </EmptyScreenContainer>
-    </PageContainer>
+    <div className="flex flex-col flex-1 justify-center items-center px-6 mt-20">
+      <EyeIcon
+        className={EmptyScreenIcon.className}
+        style={EmptyScreenIcon.style}
+      />
+      <EmptyScreenTitle>Your reading history is empty.</EmptyScreenTitle>
+      <EmptyScreenDescription>
+        Go back to your feed and read posts that spark your interest. Each post
+        you read will be listed here.
+      </EmptyScreenDescription>
+      <Link href={process.env.NEXT_PUBLIC_WEBAPP_URL}>
+        <EmptyScreenButton buttonSize={ButtonSize.Large}>
+          Back to feed
+        </EmptyScreenButton>
+      </Link>
+    </div>
   );
 }
 

--- a/packages/shared/src/components/tabs/TabContainer.spec.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.spec.tsx
@@ -6,7 +6,7 @@ import {
   screen,
 } from '@testing-library/preact';
 import nock from 'nock';
-import TabContainer, { Tab, TabContainerProps } from './TabContainer';
+import { Tab, TabContainer, TabContainerProps } from './TabContainer';
 
 beforeEach(() => {
   nock.cleanAll();

--- a/packages/shared/src/components/tabs/TabContainer.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.tsx
@@ -46,7 +46,7 @@ export interface TabContainerProps<T extends string> {
   tabListProps?: Pick<TabListProps, 'className'>;
 }
 
-function TabContainer<T extends string = string>({
+export function TabContainer<T extends string = string>({
   children,
   shouldMountInactive = false,
   onActiveChange,

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -24,6 +24,7 @@ export enum RequestKey {
   PostCommentsMutations = 'post_comments_mutations',
   Actions = 'actions',
   Squad = 'squad',
+  ReadingHistory = 'readingHistory',
   ReferralCampaigns = 'referral_campaigns',
   NotificationPreference = 'notification_preference',
 }

--- a/packages/webapp/__tests__/HistoryPage.spec.tsx
+++ b/packages/webapp/__tests__/HistoryPage.spec.tsx
@@ -91,16 +91,16 @@ const renderComponent = (
 
 it('should show appropriate loading attributes', async () => {
   renderComponent();
-  const initialBusyState = (await screen.findByRole('main')).getAttribute(
-    'aria-busy',
-  );
+  const initialBusyState = (
+    await screen.findByTestId('reading-history-container')
+  ).getAttribute('aria-busy');
   expect(JSON.parse(initialBusyState)).toEqual(true);
 
   await waitForNock();
 
-  const afterFetchingBusyState = (await screen.findByRole('main')).getAttribute(
-    'aria-busy',
-  );
+  const afterFetchingBusyState = (
+    await screen.findByTestId('reading-history-container')
+  ).getAttribute('aria-busy');
   expect(JSON.parse(afterFetchingBusyState)).toEqual(false);
 });
 

--- a/packages/webapp/components/RouterPostsSearch.tsx
+++ b/packages/webapp/components/RouterPostsSearch.tsx
@@ -1,18 +1,12 @@
 import React, { ReactElement } from 'react';
-import PostsSearch from '@dailydotdev/shared/src/components/PostsSearch';
+import PostsSearch, {
+  PostsSearchProps,
+} from '@dailydotdev/shared/src/components/PostsSearch';
 import { useRouter } from 'next/router';
 
-export type RouterPostsSearchProps = {
-  suggestionType?: string;
-  placeholder?: string;
-  autoFocus?: boolean;
-};
-
-export default function RouterPostsSearch({
-  suggestionType,
-  placeholder,
-  autoFocus,
-}: RouterPostsSearchProps): ReactElement {
+export default function RouterPostsSearch(
+  props: Omit<PostsSearchProps, 'onSubmitQuery'>,
+): ReactElement {
   const router = useRouter();
 
   const onSubmitQuery = (query: string): Promise<boolean> =>
@@ -23,11 +17,9 @@ export default function RouterPostsSearch({
 
   return (
     <PostsSearch
-      suggestionType={suggestionType}
-      placeholder={placeholder}
+      {...props}
       initialQuery={router.query.q?.toString()}
       onSubmitQuery={onSubmitQuery}
-      autoFocus={autoFocus}
     />
   );
 }

--- a/packages/webapp/components/history/common.ts
+++ b/packages/webapp/components/history/common.ts
@@ -1,0 +1,4 @@
+export enum HistoryType {
+  Reading = 'Reading history',
+  Search = 'Search history',
+}

--- a/packages/webapp/components/history/index.ts
+++ b/packages/webapp/components/history/index.ts
@@ -1,0 +1,3 @@
+export * from './search';
+export * from './reading';
+export * from './common';

--- a/packages/webapp/components/history/reading.tsx
+++ b/packages/webapp/components/history/reading.tsx
@@ -51,7 +51,11 @@ export function ReadingHistory(): ReactElement {
   if (!hasReadingHistory && !isLoading) return <ReadingHistoryEmptyScreen />;
 
   return (
-    <div className="flex flex-col">
+    <div
+      className="flex flex-col"
+      aria-busy={isLoading}
+      data-testId="reading-history-container"
+    >
       <PostsSearch
         autoFocus={false}
         placeholder="Search reading history"

--- a/packages/webapp/components/history/reading.tsx
+++ b/packages/webapp/components/history/reading.tsx
@@ -1,0 +1,74 @@
+import React, { ReactElement, useContext, useMemo } from 'react';
+import { useRouter } from 'next/router';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import {
+  READING_HISTORY_QUERY,
+  SEARCH_READING_HISTORY_QUERY,
+} from '@dailydotdev/shared/src/graphql/users';
+import useReadingHistory from '@dailydotdev/shared/src/hooks/useReadingHistory';
+import useInfiniteReadingHistory from '@dailydotdev/shared/src/hooks/useInfiniteReadingHistory';
+import ReadingHistoryPlaceholder from '@dailydotdev/shared/src/components/history/ReadingHistoryPlaceholder';
+import SearchEmptyScreen from '@dailydotdev/shared/src/components/SearchEmptyScreen';
+import ReadingHistoryList from '@dailydotdev/shared/src/components/history/ReadingHistoryList';
+import dynamic from 'next/dynamic';
+import {
+  generateQueryKey,
+  RequestKey,
+} from '@dailydotdev/shared/src/lib/query';
+import ReadingHistoryEmptyScreen from '@dailydotdev/shared/src/components/history/ReadingHistoryEmptyScreen';
+
+const PostsSearch = dynamic(
+  () =>
+    import(/* webpackChunkName: "routerPostsSearch" */ '../RouterPostsSearch'),
+  { ssr: false },
+);
+
+export function ReadingHistory(): ReactElement {
+  const router = useRouter();
+  const { user } = useContext(AuthContext);
+  const searchQuery = router.query?.q?.toString();
+  const key = generateQueryKey(RequestKey.ReadingHistory, user);
+  const queryProps = useMemo(() => {
+    if (searchQuery) {
+      return {
+        key: [...key, searchQuery],
+        query: SEARCH_READING_HISTORY_QUERY,
+        variables: { query: searchQuery },
+      };
+    }
+
+    return { key, query: READING_HISTORY_QUERY };
+  }, [searchQuery, key]);
+
+  const { hideReadHistory } = useReadingHistory(key);
+  const { data, isInitialLoading, isLoading, hasData, infiniteScrollRef } =
+    useInfiniteReadingHistory({ ...queryProps });
+  const hasReadingHistory = data?.pages?.some(
+    (page) => page.readHistory.edges.length > 0,
+  );
+  const shouldShowEmptyScreen = !hasData && !isLoading;
+
+  if (!hasReadingHistory && !isLoading) return <ReadingHistoryEmptyScreen />;
+
+  return (
+    <div className="flex flex-col">
+      <PostsSearch
+        autoFocus={false}
+        placeholder="Search reading history"
+        suggestionType="searchReadingHistorySuggestions"
+        className="m-4"
+      />
+      {hasData && (
+        <ReadingHistoryList
+          data={data}
+          onHide={hideReadHistory}
+          infiniteScrollRef={infiniteScrollRef}
+        />
+      )}
+      {isLoading && (
+        <ReadingHistoryPlaceholder amount={isInitialLoading ? 15 : 1} />
+      )}
+      {shouldShowEmptyScreen && <SearchEmptyScreen />}
+    </div>
+  );
+}

--- a/packages/webapp/components/history/search.tsx
+++ b/packages/webapp/components/history/search.tsx
@@ -1,0 +1,5 @@
+import React, { ReactElement } from 'react';
+
+export function SearchHistory(): ReactElement {
+  return <div className="flex flex-col gap-3">SearchHistoryList</div>;
+}

--- a/packages/webapp/pages/history.tsx
+++ b/packages/webapp/pages/history.tsx
@@ -1,99 +1,48 @@
-import React, { ReactElement, useContext, useMemo } from 'react';
-import dynamic from 'next/dynamic';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { NextSeo } from 'next-seo';
 import { ResponsivePageContainer } from '@dailydotdev/shared/src/components/utilities';
-import useReadingHistory from '@dailydotdev/shared/src/hooks/useReadingHistory';
-import useInfiniteReadingHistory, {
-  ReadHistoryInfiniteData,
-} from '@dailydotdev/shared/src/hooks/useInfiniteReadingHistory';
-import ReadingHistoryList from '@dailydotdev/shared/src/components/history/ReadingHistoryList';
-import ReadingHistoryPlaceholder from '@dailydotdev/shared/src/components/history/ReadingHistoryPlaceholder';
-import ReadingHistoryEmptyScreen from '@dailydotdev/shared/src/components/history/ReadingHistoryEmptyScreen';
-import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { useRouter } from 'next/router';
-import { useQueryClient } from 'react-query';
-import SearchEmptyScreen from '@dailydotdev/shared/src/components/SearchEmptyScreen';
-import { getLayout } from '../components/layouts/MainLayout';
 import {
-  READING_HISTORY_QUERY,
-  SEARCH_READING_HISTORY_QUERY,
-} from '../../shared/src/graphql/users';
+  Tab,
+  TabContainer,
+} from '@dailydotdev/shared/src/components/tabs/TabContainer';
+import { getLayout } from '../components/layouts/MainLayout';
 import ProtectedPage from '../components/ProtectedPage';
-
-const PostsSearch = dynamic(
-  () =>
-    import(
-      /* webpackChunkName: "routerPostsSearch" */ '../components/RouterPostsSearch'
-    ),
-  {
-    ssr: false,
-  },
-);
+import {
+  HistoryType,
+  ReadingHistory,
+  SearchHistory,
+} from '../components/history';
 
 const History = (): ReactElement => {
   const seo = <NextSeo title="Reading History" nofollow noindex />;
   const router = useRouter();
-  const { user } = useContext(AuthContext);
-  const searchQuery = router.query?.q?.toString();
-  // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const key = ['readHistory', user?.id];
-  const client = useQueryClient();
+  const tabQuery = router.query?.t?.toString() as HistoryType;
+  const [page, setPage] = useState(HistoryType.Reading);
 
-  const queryProps = useMemo(() => {
-    if (searchQuery) {
-      return {
-        key: [...key, searchQuery],
-        query: SEARCH_READING_HISTORY_QUERY,
-        variables: { query: searchQuery },
-      };
-    }
-    return {
-      key,
-      query: READING_HISTORY_QUERY,
-    };
-  }, [searchQuery, key]);
+  useEffect(() => {
+    const pages = Object.values(HistoryType);
 
-  const { hideReadHistory } = useReadingHistory(key);
-  const { data, isInitialLoading, isLoading, hasData, infiniteScrollRef } =
-    useInfiniteReadingHistory({ ...queryProps });
+    if (!tabQuery || !pages.includes(tabQuery)) return;
 
-  const hasReadingHistory = client
-    .getQueryData<ReadHistoryInfiniteData>(key)
-    ?.pages?.some((page) => page.readHistory.edges.length > 0);
-  const shouldShowEmptyScreen = !hasData && !isLoading;
+    setPage(tabQuery);
+  }, [tabQuery]);
 
   return (
-    <ProtectedPage
-      seo={seo}
-      fallback={<ReadingHistoryEmptyScreen />}
-      shouldFallback={!hasReadingHistory && !isLoading}
-    >
-      <ResponsivePageContainer
-        className={isInitialLoading && 'h-screen overflow-hidden'}
-        style={{ paddingLeft: 0, paddingRight: 0 }}
-        aria-busy={isLoading}
-        role="main"
-      >
-        <div className="px-6 mb-10">
-          <h1 className="mb-4 font-bold typo-headline">Reading History</h1>
-          <PostsSearch
-            autoFocus={false}
-            placeholder="Search reading history"
-            suggestionType="searchReadingHistorySuggestions"
-          />
-        </div>
-        {hasData && (
-          <ReadingHistoryList
-            data={data}
-            onHide={hideReadHistory}
-            infiniteScrollRef={infiniteScrollRef}
-          />
-        )}
-        {isLoading && (
-          <ReadingHistoryPlaceholder amount={isInitialLoading ? 15 : 1} />
-        )}
-        {shouldShowEmptyScreen && <SearchEmptyScreen />}
+    <ProtectedPage seo={seo}>
+      <ResponsivePageContainer className="!p-0" role="main">
+        <TabContainer<HistoryType>
+          controlledActive={page}
+          onActiveChange={setPage}
+          className={{ container: 'max-h-page h-full' }}
+        >
+          <Tab label={HistoryType.Reading}>
+            <ReadingHistory />
+          </Tab>
+          <Tab label={HistoryType.Search}>
+            <SearchHistory />
+          </Tab>
+        </TabContainer>
       </ResponsivePageContainer>
     </ProtectedPage>
   );


### PR DESCRIPTION
## Changes
- Major change from the history page is to have the tabs option.
- Applied a useEffect to work with redirection if the primary opened tab should be the search history.
- Refactored the SearchField to apply the correct height (not sure why it suddenly shrinks in after the refactor but fixed now - preview are available for existing implementations).
- Since the history is not just a full page anymore, I have also updated the placeholder component.

Preview:
The search tab is pretty empty as we don't have yet the components and page to redirect to.

https://github.com/dailydotdev/apps/assets/13744167/cf2182d7-836a-4007-89b1-466c7bb98d7b

Existing implementations of the updated SearchField

![Screenshot 2023-08-03 at 7 29 17 PM](https://github.com/dailydotdev/apps/assets/13744167/d505a8f3-7ecb-4525-baca-9a56bf1ef517)
![Screenshot 2023-08-03 at 7 29 06 PM](https://github.com/dailydotdev/apps/assets/13744167/72566a43-375d-477c-9c8f-98fb36f784f6)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1555 #done
