### PR TITLE
feat: making the beta tag offset for the squad directory header

### DIFF
--- a/packages/shared/src/components/squads/SquadsDirectoryHeader.tsx
+++ b/packages/shared/src/components/squads/SquadsDirectoryHeader.tsx
@@ -28,7 +28,7 @@ export const SquadsDirectoryHeader = (): ReactElement => {
         <SourceBetaIcon
           width="auto"
           height="3rem"
-          className="mb-4 text-white"
+          className="mb-4 text-white translate-x-[1.125rem]"
         />
         <div className="flex justify-center items-center mb-3 text-white typo-large-title">
           Introducing Squads


### PR DESCRIPTION
## Changes
The squad directory header icon currently has an icon but the beta text is also in the icon so we needed to offset the icon so that the icon itself is centered and not icon with beta text.

![WT-1588](https://github.com/dailydotdev/apps/assets/42202149/5ad0d131-f84f-4fb2-8cde-9b2bc6c6c2f2)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1588 #done


[WT-1588]: https://dailydotdev.atlassian.net/browse/WT-1588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ