### PR TITLE
feat: adding option to hide role in SquadPostAuthor

### DIFF
--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -14,10 +14,9 @@ interface SquadPostAuthorProps {
     handle: string;
   }>;
   author: Author;
-  role: SourceMemberRole;
+  role?: SourceMemberRole;
   size?: ProfileImageSize;
   date?: string;
-  showRole?: boolean;
 }
 
 function SquadPostAuthor({
@@ -26,7 +25,6 @@ function SquadPostAuthor({
   role,
   size = 'xxxlarge',
   date,
-  showRole = true,
 }: SquadPostAuthorProps): ReactElement {
   return (
     <span
@@ -44,7 +42,7 @@ function SquadPostAuthor({
             <span className={classNames('font-bold', className?.name)}>
               {author.name}
             </span>
-            {showRole && <SquadMemberBadge key="squadMemberRole" role={role} />}
+            {role && <SquadMemberBadge key="squadMemberRole" role={role} />}
           </div>
           <span
             className={classNames(

--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -42,7 +42,7 @@ function SquadPostAuthor({
             <span className={classNames('font-bold', className?.name)}>
               {author.name}
             </span>
-            {role && <SquadMemberBadge key="squadMemberRole" role={role} />}
+            {!!role && <SquadMemberBadge key="squadMemberRole" role={role} />}
           </div>
           <span
             className={classNames(

--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -17,6 +17,7 @@ interface SquadPostAuthorProps {
   role: SourceMemberRole;
   size?: ProfileImageSize;
   date?: string;
+  showRole?: boolean;
 }
 
 function SquadPostAuthor({
@@ -25,6 +26,7 @@ function SquadPostAuthor({
   role,
   size = 'xxxlarge',
   date,
+  showRole = true,
 }: SquadPostAuthorProps): ReactElement {
   return (
     <span
@@ -42,7 +44,7 @@ function SquadPostAuthor({
             <span className={classNames('font-bold', className?.name)}>
               {author.name}
             </span>
-            <SquadMemberBadge key="squadMemberRole" role={role} />
+            {showRole && <SquadMemberBadge key="squadMemberRole" role={role} />}
           </div>
           <span
             className={classNames(

--- a/packages/shared/src/components/squads/SquadPostListItem.tsx
+++ b/packages/shared/src/components/squads/SquadPostListItem.tsx
@@ -51,6 +51,7 @@ export const SquadPostListItem = ({
           role={role}
           size="large"
           date={postDateFormat(post.createdAt)}
+          showRole={false}
         />
         <p className="mt-2 line-clamp-3 typo-callout text-theme-label-primary">
           {post.title}

--- a/packages/shared/src/components/squads/SquadPostListItem.tsx
+++ b/packages/shared/src/components/squads/SquadPostListItem.tsx
@@ -11,7 +11,6 @@ import SquadPostAuthor from '../post/SquadPostAuthor';
 import { CardLink } from '../cards/Card';
 import { postDateFormat } from '../../lib/dateFormat';
 import { combinedClicks } from '../../lib/click';
-import { useMemberRoleForSource } from '../../hooks/useMemberRoleForSource';
 
 type PostProps = {
   post: Post;
@@ -24,10 +23,6 @@ export const SquadPostListItem = ({
   onLinkClick,
   onBookmark,
 }: PostProps): ReactElement => {
-  const { role } = useMemberRoleForSource({
-    source: post?.source,
-    user: post?.author,
-  });
   return (
     <article
       className={classNames(
@@ -48,10 +43,8 @@ export const SquadPostListItem = ({
             handle: 'typo-callout text-theme-label-quaternary',
           }}
           author={post.author}
-          role={role}
           size="large"
           date={postDateFormat(post.createdAt)}
-          showRole={false}
         />
         <p className="mt-2 line-clamp-3 typo-callout text-theme-label-primary">
           {post.title}


### PR DESCRIPTION
## Changes
The role was showing in the similar posts for squads, but it was removed in this location only to reduce the information in this widget


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1618 #done
