### PR TITLE
Wt 1519 changelog below sidebar

### DIFF
--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -71,7 +71,7 @@ export const SidebarBackdrop = classed(
 );
 export const SidebarAside = classed(
   'aside',
-  'flex flex-col z-sidebar laptop:z-3 w-70 laptop:-translate-x-0 left-0 bg-theme-bg-primary border-r border-theme-divider-tertiary transition-[width,transform] duration-300 ease-in-out group fixed top-0  h-full ',
+  'flex flex-col z-sidebar w-70 laptop:-translate-x-0 left-0 bg-theme-bg-primary border-r border-theme-divider-tertiary transition-[width,transform] duration-300 ease-in-out group fixed top-0  h-full ',
 );
 export const SidebarScrollWrapper = classed(
   'div',


### PR DESCRIPTION
## Changes
Fixing the z-index for the sidebar / changelog popup so it doesn't go behind the account settings sidbarnav.

@sshanzel, @capJavert, @rebelchris - Iv'e done some regression, and can't find anything that will be negatively effected by this z-index change but if you guys know of any reason this might be an issue please let me know so i can test that area.

![WT-1519](https://github.com/dailydotdev/apps/assets/42202149/a459837b-e8fc-4550-b451-041360d76849)


### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1519 #done
