### PR TITLE
fix: overflow issue for squad invite page

### DIFF
--- a/packages/webapp/pages/squads/[handle]/[token].tsx
+++ b/packages/webapp/pages/squads/[handle]/[token].tsx
@@ -214,9 +214,9 @@ const SquadReferral = ({
       </span>
       <div className="flex flex-col p-6 my-8 w-full rounded-24 border border-theme-color-cabbage">
         <span className="flex flex-col tablet:flex-row items-start tablet:items-center">
-          <div className="flex flex-row items-start">
+          <div className="flex flex-row flex-1 items-start">
             <SourceButton source={source} size="xxlarge" />
-            <div className="flex flex-col ml-4">
+            <div className="flex flex-col flex-1 mr-0 tablet:mr-4 ml-4">
               <h2 className="flex flex-col typo-headline">{source.name}</h2>
               <BodyParagraph className="mt-2">@{source.handle}</BodyParagraph>
               {source.description && (


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We had a small overflow text issue on the squad token page.

Before:
![Screenshot 2023-08-07 at 14 59 22](https://github.com/dailydotdev/apps/assets/554874/a468822c-706c-4286-805e-366576e8ad22)

After:
![Screenshot 2023-08-07 at 15 05 49](https://github.com/dailydotdev/apps/assets/554874/c7b35d7f-f2ab-447c-9d47-326152efa583)

Also tested mobile version :)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1629 #done
