### PR TITLE
feat: add ssr seo to squad page

### DIFF
--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -197,6 +197,17 @@ export const SQUAD_QUERY = gql`
   ${SOURCE_BASE_FRAGMENT}
 `;
 
+export const SQUAD_STATIC_FIELDS_QUERY = gql`
+  query Source($handle: ID!) {
+    source(id: $handle) {
+      name
+      public
+      description
+      image
+    }
+  }
+`;
+
 export const SQUAD_HANDE_AVAILABILITY_QUERY = gql`
   query SourceHandleExists($handle: String!) {
     sourceHandleExists(handle: $handle)

--- a/packages/webapp/next-seo.ts
+++ b/packages/webapp/next-seo.ts
@@ -1,3 +1,5 @@
+import { Source } from '@dailydotdev/shared/src/graphql/sources';
+import { cloudinary } from '@dailydotdev/shared/src/lib/image';
 import { DefaultSeoProps, NextSeoProps, OpenGraph } from 'next-seo/lib/types';
 
 const config: DefaultSeoProps = {
@@ -25,3 +27,14 @@ export const defaultOpenGraph: Partial<OpenGraph> = {
     },
   ],
 };
+
+export const getSquadOpenGraph = ({
+  squad,
+}: {
+  squad?: Pick<Source, 'image'>;
+}): Partial<OpenGraph> => ({
+  images:
+    squad?.image && squad.image !== cloudinary.squads.imageFallback
+      ? [{ url: squad.image }]
+      : defaultOpenGraph.images,
+});

--- a/packages/webapp/pages/squads/[handle]/[token].tsx
+++ b/packages/webapp/pages/squads/[handle]/[token].tsx
@@ -43,7 +43,7 @@ import useMedia from '@dailydotdev/shared/src/hooks/useMedia';
 import { tablet } from '@dailydotdev/shared/src/styles/media';
 import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
 import { getLayout } from '../../../components/layouts/MainLayout';
-import { defaultOpenGraph } from '../../../next-seo';
+import { getSquadOpenGraph } from '../../../next-seo';
 
 const getOthers = (others: Edge<SourceMember>[], total: number) => {
   const { length } = others;
@@ -184,9 +184,7 @@ const SquadReferral = ({
   const seo: NextSeoProps = {
     title: `${user.name} invited you to ${source.name}`,
     description: source.description,
-    openGraph: {
-      images: source?.image ? [{ url: source.image }] : defaultOpenGraph.images,
-    },
+    openGraph: getSquadOpenGraph({ squad: source }),
   };
 
   if (!initialData && (isFallback || !isFetched)) {

--- a/packages/webapp/pages/squads/[handle]/[token].tsx
+++ b/packages/webapp/pages/squads/[handle]/[token].tsx
@@ -43,6 +43,7 @@ import useMedia from '@dailydotdev/shared/src/hooks/useMedia';
 import { tablet } from '@dailydotdev/shared/src/styles/media';
 import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
 import { getLayout } from '../../../components/layouts/MainLayout';
+import { defaultOpenGraph } from '../../../next-seo';
 
 const getOthers = (others: Edge<SourceMember>[], total: number) => {
   const { length } = others;
@@ -184,7 +185,7 @@ const SquadReferral = ({
     title: `${user.name} invited you to ${source.name}`,
     description: source.description,
     openGraph: {
-      images: [{ url: source?.image }],
+      images: source?.image ? [{ url: source.image }] : defaultOpenGraph.images,
     },
   };
 

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -226,7 +226,7 @@ export async function getServerSideProps({
   const setCacheHeader = () => {
     res.setHeader(
       'Cache-Control',
-      `public, max-age=0, must-revalidate, s-maxage=${oneHour}`,
+      `public, max-age=0, must-revalidate, s-maxage=${oneHour}, stale-while-revalidate=${oneHour}`,
     );
   };
 

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -39,7 +39,7 @@ import { getLayout } from '../../../components/layouts/FeedLayout';
 import ProtectedPage, {
   ProtectedPageProps,
 } from '../../../components/ProtectedPage';
-import { defaultOpenGraph } from '../../../next-seo';
+import { getSquadOpenGraph } from '../../../next-seo';
 
 const Custom404 = dynamic(
   () => import(/* webpackChunkName: "404" */ '../../404'),
@@ -144,11 +144,7 @@ const SquadPage = ({
           : `${seoData.name} posts on daily.dev`
       }
       description={seoData.description}
-      openGraph={{
-        images: seoData.image
-          ? [{ url: seoData.image }]
-          : defaultOpenGraph.images,
-      }}
+      openGraph={getSquadOpenGraph({ squad: seoData })}
       nofollow={!seoData.public}
       noindex={!seoData.public}
     />

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -19,7 +19,7 @@ import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { SquadPageHeader } from '@dailydotdev/shared/src/components/squads/SquadPageHeader';
 import { BaseFeedPage } from '@dailydotdev/shared/src/components/utilities';
 import {
-  SQUAD_QUERY,
+  SQUAD_STATIC_FIELDS_QUERY,
   getSquadMembers,
 } from '@dailydotdev/shared/src/graphql/squads';
 import { SourceMember, Squad } from '@dailydotdev/shared/src/graphql/sources';
@@ -61,7 +61,10 @@ const SquadChecklistCard = dynamic(
     ),
 );
 
-type SourcePageProps = { handle: string; initialData?: Squad };
+type SourcePageProps = {
+  handle: string;
+  initialData?: Pick<Squad, 'name' | 'public' | 'description' | 'image'>;
+};
 
 const PageComponent = (props: ProtectedPageProps & { squad: Squad }) => {
   const { squad, seo, children, ...restProtectedPageProps } = props;
@@ -217,13 +220,11 @@ export async function getStaticProps({
   const { handle } = params;
 
   try {
-    const { source: squad } = await request<{ source: Squad }>(
-      graphqlUrl,
-      SQUAD_QUERY,
-      {
-        handle,
-      },
-    );
+    const { source: squad } = await request<{
+      source: SourcePageProps['initialData'];
+    }>(graphqlUrl, SQUAD_STATIC_FIELDS_QUERY, {
+      handle,
+    });
 
     return {
       props: {

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -39,6 +39,7 @@ import { getLayout } from '../../../components/layouts/FeedLayout';
 import ProtectedPage, {
   ProtectedPageProps,
 } from '../../../components/ProtectedPage';
+import { defaultOpenGraph } from '../../../next-seo';
 
 const Custom404 = dynamic(
   () => import(/* webpackChunkName: "404" */ '../../404'),
@@ -144,7 +145,9 @@ const SquadPage = ({
       }
       description={seoData.description}
       openGraph={{
-        images: seoData.image ? [{ url: seoData.image }] : undefined,
+        images: seoData.image
+          ? [{ url: seoData.image }]
+          : defaultOpenGraph.images,
       }}
       nofollow={!seoData.public}
       noindex={!seoData.public}


### PR DESCRIPTION
## Changes

### Describe what this PR does

- [x] - Add seo data fetch for public squads
- [x] - Private squads query will just fail since private squads need user auth and will behave as they do currently
- [x] - Add custom seo if squad page is accessed from open squad invitation

Page is not `getServerSideProps` page. Caching is the same as `getStaticProps` only through cache header. This was needed to take into account query params `userid` and `cid` when squad page is shared as invitation. 

regular:
<img width="600" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/b4196f58-3f1f-4b1d-8f9a-c5ef790345c9">

invite:
<img width="602" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/35ca2644-c848-4b83-b955-76378ec34bd1">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
