### PR TITLE
feat: checking if toast isAnimating before starting again

### DIFF
--- a/packages/shared/src/components/notifications/Toast.tsx
+++ b/packages/shared/src/components/notifications/Toast.tsx
@@ -42,7 +42,7 @@ const Toast = ({
     {
       enabled: false,
       onSuccess: async (data) => {
-        if (!data) {
+        if (!data || isAnimating) {
           return;
         }
 

--- a/packages/shared/src/components/notifications/Toast.tsx
+++ b/packages/shared/src/components/notifications/Toast.tsx
@@ -32,10 +32,11 @@ const Toast = ({
   const router = useRouter();
   const client = useQueryClient();
   const testRef = useRef(null);
-  const { isAnimating, endAnimation, startAnimation } = useTimedAnimation({
-    autoEndAnimation: autoDismissNotifications,
-    onAnimationEnd: () => client.setQueryData(TOAST_NOTIF_KEY, null),
-  });
+  const { timer, isAnimating, endAnimation, startAnimation } =
+    useTimedAnimation({
+      autoEndAnimation: autoDismissNotifications,
+      onAnimationEnd: () => client.setQueryData(TOAST_NOTIF_KEY, null),
+    });
   const { data: toast } = useQuery<ToastNotification>(
     TOAST_NOTIF_KEY,
     () => client.getQueryData(TOAST_NOTIF_KEY),

--- a/packages/shared/src/components/notifications/Toast.tsx
+++ b/packages/shared/src/components/notifications/Toast.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useQuery, useQueryClient } from 'react-query';
+import classNames from 'classnames';
 import {
   ToastNotification,
   TOAST_NOTIF_KEY,
@@ -10,12 +11,7 @@ import { Button, ButtonSize } from '../buttons/Button';
 import styles from './Toast.module.css';
 import XIcon from '../icons/MiniClose';
 import { isTouchDevice } from '../../lib/tooltip';
-import {
-  NotifContainer,
-  NotifContent,
-  NotifMessage,
-  NotifProgress,
-} from './utils';
+import { NotifContainer, NotifContent, NotifMessage } from './utils';
 import { useTimedAnimation } from '../../hooks/useTimedAnimation';
 import { nextTick } from '../../lib/func';
 
@@ -24,18 +20,16 @@ interface ToastProps {
 }
 
 const Container = classed(NotifContainer, styles.toastContainer);
-const Progress = classed(NotifProgress, styles.toastProgress);
 
 const Toast = ({
   autoDismissNotifications = false,
 }: ToastProps): ReactElement => {
   const router = useRouter();
   const client = useQueryClient();
-  const { timer, isAnimating, endAnimation, startAnimation } =
-    useTimedAnimation({
-      autoEndAnimation: autoDismissNotifications,
-      onAnimationEnd: () => client.setQueryData(TOAST_NOTIF_KEY, null),
-    });
+  const { isAnimating, endAnimation, startAnimation } = useTimedAnimation({
+    autoEndAnimation: autoDismissNotifications,
+    onAnimationEnd: () => client.setQueryData(TOAST_NOTIF_KEY, null),
+  });
   const { data: toast } = useQuery<ToastNotification>(
     TOAST_NOTIF_KEY,
     () => client.getQueryData(TOAST_NOTIF_KEY),
@@ -91,8 +85,6 @@ const Toast = ({
     return null;
   }
 
-  const progress = (timer / toast.timer) * 100;
-
   return (
     <Container className={isAnimating && 'slide-in'} role="alert">
       <NotifContent>
@@ -115,7 +107,17 @@ const Toast = ({
           aria-label="Dismiss toast notification"
         />
         {autoDismissNotifications && (
-          <Progress style={{ width: `${progress}%` }} />
+          <div className="flex absolute -bottom-2 left-0 justify-center w-full ease-in-out">
+            <div
+              className={classNames(
+                'h-1 bg-theme-status-cabbage rounded-full transition-all ease-linear',
+                isAnimating ? 'w-0' : 'w-full',
+              )}
+              style={{
+                transitionDuration: `${toast.timer}ms`,
+              }}
+            />
+          </div>
         )}
       </NotifContent>
     </Container>

--- a/packages/shared/src/components/notifications/Toast.tsx
+++ b/packages/shared/src/components/notifications/Toast.tsx
@@ -48,6 +48,7 @@ const Toast = ({
     toastRef.current = toast;
     startAnimation(toast.timer);
   } else if (toastRef.current && toastRef.current !== toast && toast?.message) {
+    endAnimation();
     toastRef.current = toast;
     startAnimation(toast.timer);
   }

--- a/packages/shared/src/components/notifications/Toast.tsx
+++ b/packages/shared/src/components/notifications/Toast.tsx
@@ -17,7 +17,6 @@ import {
   NotifProgress,
 } from './utils';
 import { useTimedAnimation } from '../../hooks/useTimedAnimation';
-import { nextTick } from '../../lib/func';
 
 interface ToastProps {
   autoDismissNotifications?: boolean;
@@ -31,7 +30,7 @@ const Toast = ({
 }: ToastProps): ReactElement => {
   const router = useRouter();
   const client = useQueryClient();
-  const testRef = useRef(null);
+  const toastRef = useRef(null);
   const { timer, isAnimating, endAnimation, startAnimation } =
     useTimedAnimation({
       autoEndAnimation: autoDismissNotifications,
@@ -42,22 +41,14 @@ const Toast = ({
     () => client.getQueryData(TOAST_NOTIF_KEY),
     {
       enabled: false,
-      onSuccess: async (data) => {
-        if (!data) {
-          return;
-        }
-
-        await nextTick(); // wait (1ms) for the component to render so animation can be seen
-      },
     },
   );
 
-  if (!testRef.current && toast?.message) {
-    testRef.current = toast;
+  if (!toastRef.current && toast?.message) {
+    toastRef.current = toast;
     startAnimation(toast.timer);
-  } else if (testRef.current && testRef.current !== toast && toast?.message) {
-    endAnimation();
-    testRef.current = toast;
+  } else if (toastRef.current && toastRef.current !== toast && toast?.message) {
+    toastRef.current = toast;
     startAnimation(toast.timer);
   }
 

--- a/packages/shared/src/components/notifications/Toast.tsx
+++ b/packages/shared/src/components/notifications/Toast.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import { useQuery, useQueryClient } from 'react-query';
-import classNames from 'classnames';
 import {
   ToastNotification,
   TOAST_NOTIF_KEY,
@@ -11,7 +10,12 @@ import { Button, ButtonSize } from '../buttons/Button';
 import styles from './Toast.module.css';
 import XIcon from '../icons/MiniClose';
 import { isTouchDevice } from '../../lib/tooltip';
-import { NotifContainer, NotifContent, NotifMessage, NotifProgress } from './utils';
+import {
+  NotifContainer,
+  NotifContent,
+  NotifMessage,
+  NotifProgress,
+} from './utils';
 import { useTimedAnimation } from '../../hooks/useTimedAnimation';
 import { nextTick } from '../../lib/func';
 
@@ -27,7 +31,7 @@ const Toast = ({
 }: ToastProps): ReactElement => {
   const router = useRouter();
   const client = useQueryClient();
-  const testRef = useRef(null)
+  const testRef = useRef(null);
   const { isAnimating, endAnimation, startAnimation } = useTimedAnimation({
     autoEndAnimation: autoDismissNotifications,
     onAnimationEnd: () => client.setQueryData(TOAST_NOTIF_KEY, null),

--- a/packages/shared/src/hooks/useTimedAnimation.ts
+++ b/packages/shared/src/hooks/useTimedAnimation.ts
@@ -15,7 +15,6 @@ interface UseTimedAnimationProps {
   onAnimationEnd?: () => void;
 }
 
-const PROGRESS_INTERVAL = 10;
 const OUT_ANIMATION_DURATION = 140;
 const MANUAL_DISMISS_ANIMATION_ID = 1;
 
@@ -54,18 +53,13 @@ export const useTimedAnimation = ({
       setTimer(duration);
       clearInterval();
 
+      setTimeout(() => {
+        setTimer(0);
+      }, duration);
+
       if (!autoEndAnimation) {
         interval.current = MANUAL_DISMISS_ANIMATION_ID;
-        return;
       }
-
-      interval.current = window.setInterval(
-        () =>
-          setTimer((current) =>
-            PROGRESS_INTERVAL >= current ? 0 : current - PROGRESS_INTERVAL,
-          ),
-        PROGRESS_INTERVAL,
-      );
     },
     [autoEndAnimation, timer],
   );
@@ -73,7 +67,7 @@ export const useTimedAnimation = ({
   useEffect(() => {
     // when the timer ends we need to do cleanups
     // we delay the callback execution so we can let the slide out animation finish
-    if (timer <= 0 && interval?.current) {
+    if (timer <= 0) {
       clearInterval();
       animationEnd();
     }

--- a/packages/shared/src/hooks/useTimedAnimation.ts
+++ b/packages/shared/src/hooks/useTimedAnimation.ts
@@ -47,7 +47,7 @@ export const useTimedAnimation = ({
 
   const startAnimation = useCallback(
     (duration: number) => {
-      if (isNullOrUndefined(duration) || duration <= 0) {
+      if (isNullOrUndefined(duration) || duration <= 0 || timer > 0) {
         return;
       }
 
@@ -67,7 +67,7 @@ export const useTimedAnimation = ({
         PROGRESS_INTERVAL,
       );
     },
-    [autoEndAnimation],
+    [autoEndAnimation, timer],
   );
 
   useEffect(() => {

--- a/packages/shared/src/hooks/useTimedAnimation.ts
+++ b/packages/shared/src/hooks/useTimedAnimation.ts
@@ -15,6 +15,7 @@ interface UseTimedAnimationProps {
   onAnimationEnd?: () => void;
 }
 
+const PROGRESS_INTERVAL = 10;
 const OUT_ANIMATION_DURATION = 140;
 const MANUAL_DISMISS_ANIMATION_ID = 1;
 
@@ -46,20 +47,24 @@ export const useTimedAnimation = ({
 
   const startAnimation = useCallback(
     (duration: number) => {
-      if (isNullOrUndefined(duration) || duration <= 0 || timer > 0) {
+      setTimer(duration);
+
+      if (isNullOrUndefined(duration) || duration <= 0) {
         return;
       }
 
-      setTimer(duration);
-      clearInterval();
-
-      setTimeout(() => {
-        setTimer(0);
-      }, duration);
 
       if (!autoEndAnimation) {
         interval.current = MANUAL_DISMISS_ANIMATION_ID;
       }
+
+      interval.current = window.setInterval(
+        () =>
+          setTimer((current) =>
+            PROGRESS_INTERVAL >= current ? 0 : current - PROGRESS_INTERVAL,
+          ),
+        PROGRESS_INTERVAL,
+      );
     },
     [autoEndAnimation, timer],
   );
@@ -82,6 +87,6 @@ export const useTimedAnimation = ({
       endAnimation,
       startAnimation,
     }),
-    [timer, endAnimation, startAnimation],
+    [endAnimation, startAnimation],
   );
 };

--- a/packages/shared/src/hooks/useTimedAnimation.ts
+++ b/packages/shared/src/hooks/useTimedAnimation.ts
@@ -53,7 +53,6 @@ export const useTimedAnimation = ({
         return;
       }
 
-
       if (!autoEndAnimation) {
         interval.current = MANUAL_DISMISS_ANIMATION_ID;
       }
@@ -66,7 +65,7 @@ export const useTimedAnimation = ({
         PROGRESS_INTERVAL,
       );
     },
-    [autoEndAnimation, timer],
+    [autoEndAnimation],
   );
 
   useEffect(() => {
@@ -87,6 +86,6 @@ export const useTimedAnimation = ({
       endAnimation,
       startAnimation,
     }),
-    [endAnimation, startAnimation],
+    [endAnimation, startAnimation, timer],
   );
 };

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -218,11 +218,11 @@ module.exports = {
         'logo-big': '2.0625rem',
       },
       transitionProperty: {
-        'width': 'width',
+        width: 'width',
       },
       transitionDuration: {
-        '5000': '5000ms',
-      }
+        5000: '5000ms',
+      },
     },
     lineClamp: {
       1: '1',

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -217,12 +217,6 @@ module.exports = {
         logo: '1.125rem',
         'logo-big': '2.0625rem',
       },
-      transitionProperty: {
-        width: 'width',
-      },
-      transitionDuration: {
-        5000: '5000ms',
-      },
     },
     lineClamp: {
       1: '1',

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -217,6 +217,12 @@ module.exports = {
         logo: '1.125rem',
         'logo-big': '2.0625rem',
       },
+      transitionProperty: {
+        'width': 'width',
+      },
+      transitionDuration: {
+        '5000': '5000ms',
+      }
     },
     lineClamp: {
       1: '1',


### PR DESCRIPTION
## Changes
This stops the toasts timer resetting when scrolling or changing page. However, it does seem to have a performance issue as you scroll it almost freezes the timer as you scroll then continues. I have tried adapting the setInterval, using a useEffect and setTimeout instead all none of them improve this. If anyone has an ideas please do say otherwise agreed with Chris this was okay to progress as is

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1521 #done
