### PR TITLE
refactor: search input as a standalone component

### DIFF
--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -111,7 +111,6 @@ export const FeedContainer = ({
       <ScrollToTopButton />
       <div className="flex flex-col pt-2 laptopL:mx-auto w-full" style={style}>
         {!inlineHeader && header}
-
         <div
           className={classNames(
             'relative mx-auto w-full',
@@ -123,15 +122,7 @@ export const FeedContainer = ({
           data-testid="posts-feed"
         >
           {inlineHeader && header}
-
-          {showSearch && (
-            <SearchBar
-              className={{ container: 'mb-8' }}
-              inputId="search"
-              completedTime="12:12"
-            />
-          )}
-
+          {showSearch && <SearchBar className={{ container: 'mb-8' }} />}
           <div
             className={classNames(
               'grid',

--- a/packages/shared/src/components/search/SearchBar.spec.tsx
+++ b/packages/shared/src/components/search/SearchBar.spec.tsx
@@ -56,7 +56,7 @@ describe('SearchBar', () => {
     renderComponent();
 
     expect(screen.getByTestId('searchBar')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Ask anything…')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Ask anything...')).toBeInTheDocument();
     expect(screen.getByText('Beta')).toBeInTheDocument();
   });
 
@@ -77,8 +77,10 @@ describe('SearchBar', () => {
       })),
     });
 
-    renderComponent(true, { value: 'search' });
+    renderComponent(true);
     const input = screen.queryByRole('textbox') as HTMLInputElement;
+    fireEvent.input(input, { target: { value: 'search' } });
+    input.value = 'search';
     const clear = screen.queryByTitle('Clear query');
 
     await waitFor(() => expect(clear).toBeInTheDocument());

--- a/packages/shared/src/components/search/SearchBar.spec.tsx
+++ b/packages/shared/src/components/search/SearchBar.spec.tsx
@@ -24,10 +24,6 @@ const renderComponent = (
   props: Partial<SearchBarProps> = {},
 ): RenderResult => {
   const client = new QueryClient();
-  const defaultProps: SearchBarProps = {
-    inputId: 'name',
-    name: 'name',
-  };
 
   return render(
     <QueryClientProvider client={client}>
@@ -40,7 +36,7 @@ const renderComponent = (
         loadedUserFromCache
         squads={squads}
       >
-        <SearchBar {...defaultProps} {...props} />
+        <SearchBar {...props} />
       </AuthContextProvider>
     </QueryClientProvider>,
   );

--- a/packages/shared/src/components/search/SearchBar.tsx
+++ b/packages/shared/src/components/search/SearchBar.tsx
@@ -8,9 +8,15 @@ import AuthContext from '../../contexts/AuthContext';
 import useSidebarRendered from '../../hooks/useSidebarRendered';
 import { SearchBarInput, SearchBarInputProps } from './SearchBarInput';
 
-export type SearchBarProps = Pick<SearchBarInputProps, 'className'>;
+export type SearchBarProps = Pick<
+  SearchBarInputProps,
+  'className' | 'valueChanged' | 'onSubmit'
+>;
 
-export function SearchBar({ className }: SearchBarProps): ReactElement {
+export function SearchBar({
+  className,
+  ...props
+}: SearchBarProps): ReactElement {
   const { user, showLogin } = useContext(AuthContext);
   const { sidebarRendered } = useSidebarRendered();
   const suggestions: SearchBarSuggestionProps[] = [];
@@ -26,6 +32,7 @@ export function SearchBar({ className }: SearchBarProps): ReactElement {
   return (
     <div className={classNames('w-full', className?.container)}>
       <SearchBarInput
+        {...props}
         inputProps={{ id: 'search' }}
         className={{ container: 'max-w-2xl', field: className?.field }}
         completedTime="12:12"

--- a/packages/shared/src/components/search/SearchBar.tsx
+++ b/packages/shared/src/components/search/SearchBar.tsx
@@ -16,22 +16,11 @@ export function SearchBar({ className }: SearchBarProps): ReactElement {
   const suggestions: SearchBarSuggestionProps[] = [];
 
   if (!user) {
-    suggestions.push(
-      {
-        suggestion:
-          'Sign up and read your first post to get search recommendations',
-        onClick: () => showLogin('search bar suggestion'),
-      },
-      {
-        suggestion: 'Sign up and read your ',
-        onClick: () => showLogin('search bar suggestion'),
-      },
-      {
-        suggestion:
-          'Sign up and read your first post to get search recommendations',
-        onClick: () => showLogin('search bar suggestion'),
-      },
-    );
+    suggestions.push({
+      suggestion:
+        'Sign up and read your first post to get search recommendations',
+      onClick: () => showLogin('search bar suggestion'),
+    });
   }
 
   return (

--- a/packages/shared/src/components/search/SearchBar.tsx
+++ b/packages/shared/src/components/search/SearchBar.tsx
@@ -10,7 +10,7 @@ import { SearchBarInput, SearchBarInputProps } from './SearchBarInput';
 
 export type SearchBarProps = Pick<
   SearchBarInputProps,
-  'className' | 'valueChanged' | 'onSubmit'
+  'className' | 'valueChanged' | 'onSubmit' | 'showProgress'
 >;
 
 export function SearchBar({

--- a/packages/shared/src/components/search/SearchBar.tsx
+++ b/packages/shared/src/components/search/SearchBar.tsx
@@ -1,264 +1,46 @@
-import React, {
-  ForwardedRef,
-  forwardRef,
-  InputHTMLAttributes,
-  MouseEvent,
-  ReactElement,
-  useContext,
-} from 'react';
+import React, { ReactElement, useContext } from 'react';
 import classNames from 'classnames';
-import { useInputField } from '../../hooks/useInputField';
-import { AiIcon, SendAirplaneIcon } from '../icons';
-import CloseIcon from '../icons/MiniClose';
-import { Button, ButtonProps, ButtonSize } from '../buttons/Button';
-import { BaseField, FieldInput } from '../fields/common';
-import { getFieldFontColor } from '../fields/BaseFieldContainer';
-import {
-  RaisedLabel,
-  RaisedLabelContainer,
-  RaisedLabelType,
-} from '../cards/RaisedLabel';
-import TimerIcon from '../icons/Timer';
-import { IconSize } from '../Icon';
-import { SearchProgressBar } from './SearchProgressBar';
 import {
   SearchBarSuggestion,
   SearchBarSuggestionProps,
 } from './SearchBarSuggestion';
 import AuthContext from '../../contexts/AuthContext';
-import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import useSidebarRendered from '../../hooks/useSidebarRendered';
+import { SearchBarInput, SearchBarInputProps } from './SearchBarInput';
 
-export interface SearchBarProps
-  extends Pick<
-    InputHTMLAttributes<HTMLInputElement>,
-    | 'placeholder'
-    | 'value'
-    | 'style'
-    | 'name'
-    | 'autoFocus'
-    | 'onBlur'
-    | 'onFocus'
-    | 'aria-haspopup'
-    | 'aria-expanded'
-    | 'onKeyDown'
-    | 'disabled'
-    | 'readOnly'
-    | 'aria-describedby'
-    | 'autoComplete'
-  > {
-  inputId: string;
-  valueChanged?: (value: string) => void;
-  showIcon?: boolean;
-  rightButtonProps?: ButtonProps<'button'> | false;
-  completedTime?: string;
-  showProgress?: boolean;
-  className?: {
-    container?: string;
-  };
-  onSubmit?: <T>(event: MouseEvent<T>) => void;
-}
+export type SearchBarProps = Pick<SearchBarInputProps, 'className'>;
 
-export interface SearchBarProgressBarProps {
-  progress: number;
-}
-
-export const SearchBar = forwardRef(function SearchBar(
-  {
-    inputId,
-    name,
-    value,
-    valueChanged,
-    placeholder = 'Ask anything…',
-    readOnly,
-    className,
-    autoFocus,
-    disabled,
-    rightButtonProps = { type: 'button' },
-    'aria-describedby': describedBy,
-    onBlur: externalOnBlur,
-    onFocus: externalOnFocus,
-    showProgress = true,
-    completedTime,
-    onSubmit: handleSubmit,
-    ...props
-  }: SearchBarProps,
-  ref: ForwardedRef<HTMLDivElement>,
-): ReactElement {
-  const {
-    inputRef,
-    focused,
-    hasInput,
-    onFocus,
-    onBlur,
-    onInput,
-    focusInput,
-    setInput,
-  } = useInputField(value, valueChanged);
+export function SearchBar({ className }: SearchBarProps): ReactElement {
   const { user, showLogin } = useContext(AuthContext);
-  const progress = 0;
-  const searchHistory = [];
   const { sidebarRendered } = useSidebarRendered();
   const suggestions: SearchBarSuggestionProps[] = [];
 
   if (!user) {
-    suggestions.push({
-      suggestion:
-        'Sign up and read your first post to get search recommendations',
-      onClick: () => showLogin('search bar suggestion'),
-    });
+    suggestions.push(
+      {
+        suggestion:
+          'Sign up and read your first post to get search recommendations',
+        onClick: () => showLogin('search bar suggestion'),
+      },
+      {
+        suggestion: 'Sign up and read your ',
+        onClick: () => showLogin('search bar suggestion'),
+      },
+      {
+        suggestion:
+          'Sign up and read your first post to get search recommendations',
+        onClick: () => showLogin('search bar suggestion'),
+      },
+    );
   }
 
-  const onClearClick = (event: MouseEvent): void => {
-    event.stopPropagation();
-    setInput('');
-  };
-
-  const onSubmit = (event: MouseEvent): void => {
-    event.stopPropagation();
-
-    if (handleSubmit) {
-      handleSubmit(event);
-    }
-
-    setInput(null);
-  };
-
-  const seeSearchHistory = (event: MouseEvent): void => {
-    event.stopPropagation();
-  };
-
   return (
-    <div className={classNames('w-full max-w-2xl', className?.container)}>
-      <RaisedLabelContainer>
-        <BaseField
-          {...props}
-          className={classNames(
-            'relative items-center px-3 h-16 rounded-14 border !border-theme-divider-tertiary !bg-theme-bg-primary',
-            className,
-            { focused },
-          )}
-          onClick={sidebarRendered ? focusInput : () => {}}
-          data-testid="searchBar"
-          ref={ref}
-        >
-          {sidebarRendered && (
-            <AiIcon
-              size={IconSize.Large}
-              className="mr-3 text-theme-label-tertiary"
-            />
-          )}
-
-          {!sidebarRendered && (
-            <div className="flex-1 text-theme-label-tertiary">
-              {placeholder}
-            </div>
-          )}
-
-          {sidebarRendered && (
-            <FieldInput
-              disabled={disabled}
-              placeholder={placeholder}
-              name={name}
-              id={inputId}
-              ref={inputRef}
-              onFocus={(event) => {
-                onFocus();
-                externalOnFocus?.(event);
-              }}
-              onBlur={(event) => {
-                onBlur();
-                externalOnBlur?.(event);
-              }}
-              onInput={onInput}
-              autoFocus={autoFocus}
-              type="primary"
-              aria-describedby={describedBy}
-              autoComplete="off"
-              className={classNames(
-                'flex-1 caret-theme-status-cabbage',
-                getFieldFontColor({ readOnly, disabled, hasInput, focused }),
-              )}
-              required
-            />
-          )}
-
-          <div className="flex gap-3 items-center">
-            {hasInput && (
-              <Button
-                {...rightButtonProps}
-                className="btn-tertiary"
-                buttonSize={ButtonSize.Small}
-                title="Clear query"
-                onClick={onClearClick}
-                icon={<CloseIcon />}
-                disabled={!hasInput}
-              />
-            )}
-
-            {sidebarRendered && (
-              <div className="h-8 border border-theme-divider-quaternary" />
-            )}
-
-            <SimpleTooltip
-              content={
-                searchHistory.length === 0
-                  ? 'Your search history is empty'
-                  : 'See search history'
-              }
-            >
-              <div>
-                <Button
-                  {...rightButtonProps}
-                  className="btn-tertiary"
-                  buttonSize={ButtonSize.Small}
-                  title="Search history"
-                  onClick={seeSearchHistory}
-                  icon={<TimerIcon />}
-                  disabled={searchHistory.length === 0}
-                />
-              </div>
-            </SimpleTooltip>
-            {sidebarRendered && (
-              <SimpleTooltip
-                content={!hasInput && 'Enter text to start searching'}
-              >
-                <div>
-                  <Button
-                    {...rightButtonProps}
-                    className="btn-primary"
-                    title="Submit"
-                    onClick={onSubmit}
-                    icon={<SendAirplaneIcon size={IconSize.Medium} />}
-                    disabled={!hasInput}
-                  />
-                </div>
-              </SimpleTooltip>
-            )}
-          </div>
-        </BaseField>
-
-        <RaisedLabel type={RaisedLabelType.Beta} />
-      </RaisedLabelContainer>
-
-      {sidebarRendered && showProgress && (
-        <div className="mt-6">
-          <SearchProgressBar progress={progress} />
-
-          {progress > 0 && progress < 100 && (
-            <div className="mt-2 typo-callout text-theme-label-tertiary">
-              🚀 Generating answer
-            </div>
-          )}
-
-          {completedTime && (
-            <div className="mt-2 typo-callout text-theme-label-tertiary">
-              Done! {completedTime} seconds.
-            </div>
-          )}
-        </div>
-      )}
-
+    <div className={classNames('w-full', className?.container)}>
+      <SearchBarInput
+        inputProps={{ id: 'search' }}
+        className={{ container: 'max-w-2xl', field: className?.field }}
+        completedTime="12:12"
+      />
       {sidebarRendered && suggestions && (
         <div className="flex flex-wrap gap-4 mt-6">
           {suggestions.map((suggestion) => (
@@ -272,4 +54,4 @@ export const SearchBar = forwardRef(function SearchBar(
       )}
     </div>
   );
-});
+}

--- a/packages/shared/src/components/search/SearchBarInput.tsx
+++ b/packages/shared/src/components/search/SearchBarInput.tsx
@@ -58,7 +58,7 @@ function SearchBarInputComponent(
     value,
     onFocus: externalOnFocus,
     onBlur: externalOnBlur,
-    placeholder,
+    placeholder = 'Ask anything...',
   } = inputProps;
   const {
     inputRef,

--- a/packages/shared/src/components/search/SearchBarInput.tsx
+++ b/packages/shared/src/components/search/SearchBarInput.tsx
@@ -118,6 +118,7 @@ function SearchBarInputComponent(
         {sidebarRendered && (
           <FieldInput
             {...inputProps}
+            placeholder={placeholder}
             ref={inputRef}
             onFocus={(event) => {
               onFocus();

--- a/packages/shared/src/components/search/SearchBarInput.tsx
+++ b/packages/shared/src/components/search/SearchBarInput.tsx
@@ -1,0 +1,214 @@
+import React, {
+  ForwardedRef,
+  forwardRef,
+  InputHTMLAttributes,
+  MouseEvent,
+  ReactElement,
+} from 'react';
+import classNames from 'classnames';
+import {
+  RaisedLabel,
+  RaisedLabelContainer,
+  RaisedLabelType,
+} from '../cards/RaisedLabel';
+import { BaseField, FieldInput } from '../fields/common';
+import { AiIcon, SendAirplaneIcon } from '../icons';
+import { IconSize } from '../Icon';
+import { getFieldFontColor } from '../fields/BaseFieldContainer';
+import { Button, ButtonProps, ButtonSize } from '../buttons/Button';
+import CloseIcon from '../icons/MiniClose';
+import TimerIcon from '../icons/Timer';
+import useSidebarRendered from '../../hooks/useSidebarRendered';
+import { useInputField } from '../../hooks/useInputField';
+import { SimpleTooltip } from '../tooltips/SimpleTooltip';
+import { SearchProgressBar } from './SearchProgressBar';
+
+interface SearchBarClassName {
+  container?: string;
+  field?: string;
+}
+
+export interface SearchBarInputProps {
+  valueChanged?: (value: string) => void;
+  showIcon?: boolean;
+  rightButtonProps?: ButtonProps<'button'> | false;
+  completedTime?: string;
+  showProgress?: boolean;
+  className?: SearchBarClassName;
+  onSubmit?: <T>(event: MouseEvent<T>) => void;
+  inputProps?: InputHTMLAttributes<HTMLInputElement>;
+}
+
+function SearchBarInputComponent(
+  {
+    inputProps = {},
+    valueChanged,
+    className,
+    rightButtonProps = { type: 'button' },
+    showProgress = true,
+    completedTime,
+    onSubmit: handleSubmit,
+    ...props
+  }: SearchBarInputProps,
+  ref: ForwardedRef<HTMLDivElement>,
+): ReactElement {
+  const {
+    readOnly,
+    disabled,
+    value,
+    onFocus: externalOnFocus,
+    onBlur: externalOnBlur,
+    placeholder,
+  } = inputProps;
+  const {
+    inputRef,
+    focused,
+    hasInput,
+    onFocus,
+    onBlur,
+    onInput,
+    focusInput,
+    setInput,
+  } = useInputField(value, valueChanged);
+  const { sidebarRendered } = useSidebarRendered();
+  const searchHistory = [];
+  const progress = 0;
+
+  const onClearClick = (event: MouseEvent): void => {
+    event.stopPropagation();
+    setInput('');
+  };
+
+  const onSubmit = (event: MouseEvent): void => {
+    event.stopPropagation();
+
+    if (handleSubmit) {
+      handleSubmit(event);
+    }
+
+    setInput(null);
+  };
+
+  const seeSearchHistory = (event: MouseEvent): void => {
+    event.stopPropagation();
+  };
+
+  return (
+    <RaisedLabelContainer className={className?.container}>
+      <BaseField
+        {...props}
+        className={classNames(
+          'relative items-center px-3 h-16 rounded-14 border !border-theme-divider-tertiary !bg-theme-bg-primary',
+          className?.field,
+          { focused },
+        )}
+        onClick={sidebarRendered ? focusInput : () => {}}
+        data-testid="searchBar"
+        ref={ref}
+      >
+        {sidebarRendered && (
+          <AiIcon
+            size={IconSize.Large}
+            className="mr-3 text-theme-label-tertiary"
+          />
+        )}
+        {!sidebarRendered && (
+          <div className="flex-1 text-theme-label-tertiary">{placeholder}</div>
+        )}
+        {sidebarRendered && (
+          <FieldInput
+            {...inputProps}
+            ref={inputRef}
+            onFocus={(event) => {
+              onFocus();
+              externalOnFocus?.(event);
+            }}
+            onBlur={(event) => {
+              onBlur();
+              externalOnBlur?.(event);
+            }}
+            onInput={onInput}
+            type="primary"
+            autoComplete="off"
+            className={classNames(
+              'flex-1 caret-theme-status-cabbage',
+              getFieldFontColor({ readOnly, disabled, hasInput, focused }),
+            )}
+          />
+        )}
+
+        <div className="flex gap-3 items-center">
+          {hasInput && (
+            <Button
+              {...rightButtonProps}
+              className="btn-tertiary"
+              buttonSize={ButtonSize.Small}
+              title="Clear query"
+              onClick={onClearClick}
+              icon={<CloseIcon />}
+              disabled={!hasInput}
+            />
+          )}
+          {sidebarRendered && (
+            <div className="h-8 border border-theme-divider-quaternary" />
+          )}
+          <SimpleTooltip
+            content={
+              searchHistory.length === 0
+                ? 'Your search history is empty'
+                : 'See search history'
+            }
+          >
+            <div>
+              <Button
+                {...rightButtonProps}
+                className="btn-tertiary"
+                buttonSize={ButtonSize.Small}
+                title="Search history"
+                onClick={seeSearchHistory}
+                icon={<TimerIcon />}
+                disabled={searchHistory.length === 0}
+              />
+            </div>
+          </SimpleTooltip>
+          {sidebarRendered && (
+            <SimpleTooltip
+              content={!hasInput && 'Enter text to start searching'}
+            >
+              <div>
+                <Button
+                  {...rightButtonProps}
+                  className="btn-primary"
+                  title="Submit"
+                  onClick={onSubmit}
+                  icon={<SendAirplaneIcon size={IconSize.Medium} />}
+                  disabled={!hasInput}
+                />
+              </div>
+            </SimpleTooltip>
+          )}
+        </div>
+      </BaseField>
+      <RaisedLabel type={RaisedLabelType.Beta} />
+      {sidebarRendered && showProgress && (
+        <div className="mt-6">
+          <SearchProgressBar progress={progress} />
+
+          {progress > 0 && progress < 100 && (
+            <div className="mt-2 typo-callout text-theme-label-tertiary">
+              🚀 Generating answer
+            </div>
+          )}
+
+          {completedTime && (
+            <div className="mt-2 typo-callout text-theme-label-tertiary">
+              Done! {completedTime} seconds.
+            </div>
+          )}
+        </div>
+      )}
+    </RaisedLabelContainer>
+  );
+}
+
+export const SearchBarInput = forwardRef(SearchBarInputComponent);

--- a/packages/webapp/__tests__/SearchPage.tsx
+++ b/packages/webapp/__tests__/SearchPage.tsx
@@ -18,6 +18,6 @@ const renderComponent = (): RenderResult => {
 
 it('should render the search page', async () => {
   renderComponent();
-  const text = screen.queryByText('Search component area');
+  const text = screen.queryByTestId('searchBar');
   expect(text).toBeInTheDocument();
 });

--- a/packages/webapp/pages/search/index.tsx
+++ b/packages/webapp/pages/search/index.tsx
@@ -18,11 +18,7 @@ const SearchPage = (): ReactElement => {
       <NextSeo nofollow noindex />
       <div className="grid grid-cols-1 laptop:grid-cols-3 gap-y-6 pt-8 m-auto max-w-screen-laptop">
         <main className="flex flex-col flex-1 col-span-2 px-4 laptop:px-8">
-          <SearchBar
-            inputId="search"
-            valueChanged={setInput}
-            onSubmit={handleSubmit}
-          />
+          <SearchBar valueChanged={setInput} onSubmit={handleSubmit} />
         </main>
         <SearchFeedback />
         {!!content && (


### PR DESCRIPTION
Note: The component in itself was written amazingly, **this is purely a refactor** to break down the components and to ease the review down the line.

## Changes
- To revamp the Feed Header, there are certain differences between the placements of the elements from the Search page but using the same `SearchInputBar`.
- Broke down the component to allow other implementations to have freedom of what to include.
- @TomDowling would love to hear your thoughts and if I missed anything as you are very familiar with the component 🙏 

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1639
