### PR TITLE
feat: waiting to redirect from onboarding till feed is ready

### DIFF
--- a/packages/shared/src/components/onboarding/FilterOnboarding.tsx
+++ b/packages/shared/src/components/onboarding/FilterOnboarding.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 import classNames from 'classnames';
 import FeedTopicCard, { ButtonEvent } from '../containers/FeedTopicCard';
 import useTagAndSource from '../../hooks/useTagAndSource';
@@ -8,13 +8,11 @@ import { Origin } from '../../lib/analytics';
 interface FilterOnboardingProps {
   onSelectedTopics?(tags: Record<string, boolean>): void;
   className?: string;
-  setHasCategories?: (hasCategories: boolean) => void;
 }
 
 export function FilterOnboarding({
   onSelectedTopics,
   className,
-  setHasCategories,
 }: FilterOnboardingProps): ReactElement {
   const [invalidMessage, setInvalidMessage] = useState<string>(null);
   const [selectedTopics, setSelectedTopics] = useState({});
@@ -36,13 +34,6 @@ export function FilterOnboarding({
       setInvalidMessage(null);
     }
   };
-
-  useEffect(() => {
-    const hasSelectedTopics = Object.values(selectedTopics).some(
-      (value) => value === true,
-    );
-    if (setHasCategories) setHasCategories(hasSelectedTopics);
-  }, [selectedTopics, setHasCategories]);
 
   return (
     <div

--- a/packages/shared/src/components/onboarding/FilterOnboarding.tsx
+++ b/packages/shared/src/components/onboarding/FilterOnboarding.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import FeedTopicCard, { ButtonEvent } from '../containers/FeedTopicCard';
 import useTagAndSource from '../../hooks/useTagAndSource';
@@ -8,11 +8,13 @@ import { Origin } from '../../lib/analytics';
 interface FilterOnboardingProps {
   onSelectedTopics?(tags: Record<string, boolean>): void;
   className?: string;
+  setHasCategories?: (hasCategories: boolean) => void;
 }
 
 export function FilterOnboarding({
   onSelectedTopics,
   className,
+  setHasCategories,
 }: FilterOnboardingProps): ReactElement {
   const [invalidMessage, setInvalidMessage] = useState<string>(null);
   const [selectedTopics, setSelectedTopics] = useState({});
@@ -34,6 +36,13 @@ export function FilterOnboarding({
       setInvalidMessage(null);
     }
   };
+
+  useEffect(() => {
+    const hasSelectedTopics = Object.values(selectedTopics).some(
+      (value) => value === true,
+    );
+    if (setHasCategories) setHasCategories(hasSelectedTopics);
+  }, [selectedTopics, setHasCategories]);
 
   return (
     <div

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -85,6 +85,7 @@ export function OnboardPage(): ReactElement {
   const { onboardingIntroduction } = useThemedAsset();
   const { trackEvent } = useAnalyticsContext();
   const { alerts } = useContext(AlertContext);
+  const [hasSelectTopics, setHasSelectTopics] = useState(false);
 
   const onClickNext = () => {
     const screen = isFiltering ? OnboardingStep.Topics : OnboardingStep.Intro;
@@ -100,7 +101,6 @@ export function OnboardPage(): ReactElement {
   };
 
   const formRef = useRef<HTMLFormElement>();
-  const [onSelectTopic, setOnSelectTopic] = useState(false);
   const title = versionToTitle[onboardingFilteringTitle];
   const percentage = isAuthenticating ? 100 : 50;
   const content = isAuthenticating
@@ -110,7 +110,7 @@ export function OnboardPage(): ReactElement {
   const onSuccessfulTransaction = () => {
     onShouldUpdateFilters(true);
     setFinishedOnboarding(true);
-    if (onSelectTopic) {
+    if (hasSelectTopics) {
       return;
     }
 
@@ -118,12 +118,12 @@ export function OnboardPage(): ReactElement {
   };
 
   useEffect(() => {
-    if (!onSelectTopic || !alerts?.myFeed) return;
+    if (!hasSelectTopics || !alerts?.myFeed) return;
 
     if (alerts.myFeed === 'created') {
       router.push('/');
     }
-  }, [alerts, onSelectTopic, router]);
+  }, [alerts, hasSelectTopics, router]);
 
   const isPageReady = isFeaturesLoaded && isAuthReady;
 
@@ -154,7 +154,7 @@ export function OnboardPage(): ReactElement {
 
   const hasSelectedTopics = (tags: Record<string, boolean>) => {
     const hasTopics = Object.values(tags).some((value) => value === true);
-    if (setOnSelectTopic) setOnSelectTopic(hasTopics);
+    setHasSelectTopics(hasTopics);
   };
 
   const containerClass = isAuthenticating ? maxAuthWidth : 'max-w-[22.25rem]';

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -100,7 +100,7 @@ export function OnboardPage(): ReactElement {
   };
 
   const formRef = useRef<HTMLFormElement>();
-  const [hasCategories, setHasCategories] = useState(false);
+  const [onSelectTopic, setOnSelectTopic] = useState(false);
   const title = versionToTitle[onboardingFilteringTitle];
   const percentage = isAuthenticating ? 100 : 50;
   const content = isAuthenticating
@@ -110,7 +110,7 @@ export function OnboardPage(): ReactElement {
   const onSuccessfulTransaction = () => {
     onShouldUpdateFilters(true);
     setFinishedOnboarding(true);
-    if (hasCategories) {
+    if (onSelectTopic) {
       return;
     }
 
@@ -118,12 +118,12 @@ export function OnboardPage(): ReactElement {
   };
 
   useEffect(() => {
-    if (!hasCategories || !alerts?.myFeed) return;
+    if (!onSelectTopic || !alerts?.myFeed) return;
 
     if (alerts.myFeed === 'created') {
       router.push('/');
     }
-  }, [alerts, hasCategories, router]);
+  }, [alerts, onSelectTopic, router]);
 
   const isPageReady = isFeaturesLoaded && isAuthReady;
 
@@ -151,6 +151,13 @@ export function OnboardPage(): ReactElement {
   useEffect(() => {
     updateCookieBanner(user);
   }, [updateCookieBanner, user]);
+
+  const hasSelectedTopics = (tags: Record<string, boolean>) => {
+    const hasTopics = Object.values(tags).some(
+      (value) => value === true,
+    );
+    if (setOnSelectTopic) setOnSelectTopic(hasTopics);
+  }
 
   const containerClass = isAuthenticating ? maxAuthWidth : 'max-w-[22.25rem]';
 
@@ -210,7 +217,7 @@ export function OnboardPage(): ReactElement {
           {isFiltering ? (
             <FilterOnboarding
               className="grid-cols-2 tablet:grid-cols-4 laptop:grid-cols-6 mt-4"
-              setHasCategories={setHasCategories}
+              onSelectedTopics={hasSelectedTopics}
             />
           ) : (
             <img

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, useContext, useEffect, useRef, useState } from 'react';
+import React, {
+  ReactElement,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useOnboardingContext } from '@dailydotdev/shared/src/contexts/OnboardingContext';
 import { useFeaturesContext } from '@dailydotdev/shared/src/contexts/FeaturesContext';
 import { ProgressBar } from '@dailydotdev/shared/src/components/fields/ProgressBar';
@@ -29,9 +35,9 @@ import { Loader } from '@dailydotdev/shared/src/components/Loader';
 import { NextSeo, NextSeoProps } from 'next-seo';
 import { useThemedAsset } from '@dailydotdev/shared/src/hooks/utils';
 import { useCookieBanner } from '@dailydotdev/shared/src/hooks/useCookieBanner';
+import AlertContext from '@dailydotdev/shared/src/contexts/AlertContext';
 import { defaultOpenGraph, defaultSeo } from '../next-seo';
 import CookieBanner from '../components/CookieBanner';
-import AlertContext from '@dailydotdev/shared/src/contexts/AlertContext';
 
 const versionToTitle: Record<OnboardingFilteringTitle, string> = {
   [OnboardingFilteringTitle.Control]: 'Choose topics to follow',
@@ -105,7 +111,7 @@ export function OnboardPage(): ReactElement {
     onShouldUpdateFilters(true);
     setFinishedOnboarding(true);
     if (hasCategories) {
-      return
+      return;
     }
 
     router.push('/');
@@ -113,12 +119,11 @@ export function OnboardPage(): ReactElement {
 
   useEffect(() => {
     if (!hasCategories || !alerts?.myFeed) return;
-  
+
     if (alerts.myFeed === 'created') {
       router.push('/');
     }
   }, [alerts, hasCategories, router]);
-  
 
   const isPageReady = isFeaturesLoaded && isAuthReady;
 
@@ -203,7 +208,10 @@ export function OnboardPage(): ReactElement {
           )}
         >
           {isFiltering ? (
-            <FilterOnboarding className="grid-cols-2 tablet:grid-cols-4 laptop:grid-cols-6 mt-4" setHasCategories={setHasCategories} />
+            <FilterOnboarding
+              className="grid-cols-2 tablet:grid-cols-4 laptop:grid-cols-6 mt-4"
+              setHasCategories={setHasCategories}
+            />
           ) : (
             <img
               alt="Sample illustration of selecting topics"

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -153,11 +153,9 @@ export function OnboardPage(): ReactElement {
   }, [updateCookieBanner, user]);
 
   const hasSelectedTopics = (tags: Record<string, boolean>) => {
-    const hasTopics = Object.values(tags).some(
-      (value) => value === true,
-    );
+    const hasTopics = Object.values(tags).some((value) => value === true);
     if (setOnSelectTopic) setOnSelectTopic(hasTopics);
-  }
+  };
 
   const containerClass = isAuthenticating ? maxAuthWidth : 'max-w-[22.25rem]';
 


### PR DESCRIPTION
## Changes
Currently after onboarding the flicker happens as the homepage loads before the user my-feed is ready. after a few seconds it is created and the page re-renders taking the user from popular to my-feed. This fix leaves the flow the same if you haven't selected any topics in the onboarding but wait for your feed if you have selected some

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1546 #done
