### PR TITLE
fix: broken layout when PostItemCard isn't clickable

### DIFF
--- a/packages/shared/src/components/post/PostItemCard.tsx
+++ b/packages/shared/src/components/post/PostItemCard.tsx
@@ -43,7 +43,14 @@ export default function PostItemCard({
   const article = post?.sharedPost ?? post;
 
   return (
-    <article>
+    <article
+      className={classNames(
+        !clickable && [
+          'flex relative flex-row items-center py-3 pr-5 pl-9',
+          className,
+        ],
+      )}
+    >
       <ConditionalWrapper
         condition={clickable}
         wrapper={(children) => (

--- a/packages/shared/src/components/post/PostItemCard.tsx
+++ b/packages/shared/src/components/post/PostItemCard.tsx
@@ -42,27 +42,19 @@ export default function PostItemCard({
   };
   const article = post?.sharedPost ?? post;
 
+  const classes = classNames(
+    'flex relative flex-row items-center py-3 pr-5 pl-9 w-full',
+    clickable && 'hover:bg-theme-hover hover:cursor-pointer',
+    className,
+  );
+
   return (
-    <article
-      className={classNames(
-        !clickable && [
-          'flex relative flex-row items-center py-3 pr-5 pl-9',
-          className,
-        ],
-      )}
-    >
+    <article className={classNames(!clickable && classes)}>
       <ConditionalWrapper
         condition={clickable}
         wrapper={(children) => (
           <Link href={post.commentsPermalink}>
-            <a
-              className={classNames(
-                'flex relative flex-row items-center py-3 pr-5 pl-9 w-full',
-                clickable && 'hover:bg-theme-hover hover:cursor-pointer',
-                className,
-              )}
-              title="Go to post"
-            >
+            <a className={classes} title="Go to post">
               {children}
             </a>
           </Link>


### PR DESCRIPTION
## Changes

The classes were not being applied to the container if the item wasn't clickable. I added it to the article as conditional to fix this situation

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1660 #done
