### PR TITLE
hotfix: card padding squad directory

### DIFF
--- a/packages/shared/src/components/sources/SourceCard.tsx
+++ b/packages/shared/src/components/sources/SourceCard.tsx
@@ -67,7 +67,7 @@ export const SourceCard = ({
   return (
     <Card
       className={classNames(
-        'overflow-hidden p-0',
+        'overflow-hidden !p-0',
         borderColorToClassName[source?.borderColor || borderColor],
       )}
     >


### PR DESCRIPTION
## Changes

### Describe what this PR does
- with the recent tailwind upgrade order of classes needs important, else the lowest one will be set

Before:
![Screenshot 2023-08-14 at 12 55 32](https://github.com/dailydotdev/apps/assets/554874/92b2181d-6809-4126-892f-8c1648837075)

After:
![Screenshot 2023-08-14 at 12 55 40](https://github.com/dailydotdev/apps/assets/554874/d32f8fef-ab21-406c-8a6d-d60c6103da10)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
