### PR TITLE
fix: hard set extension font size for markdown posts

### DIFF
--- a/packages/shared/src/components/markdown.module.css
+++ b/packages/shared/src/components/markdown.module.css
@@ -21,13 +21,13 @@
     @apply text-theme-label-tertiary font-bold mt-4 mb-3;
   }
   & :where(p) {
-    @apply my-7 relative;
+    @apply typo-body my-7 relative;
   }
   & :where(blockquote) {
     @apply typo-body italic pl-7 my-7 border-l border-theme-divider-secondary;
   }
   & :where(pre) {
-    @apply relative bg-theme-float py-7 px-6 my-7 rounded-12 border border-theme-divider-quaternary;
+    @apply typo-body relative bg-theme-float py-7 px-6 my-7 rounded-12 border border-theme-divider-quaternary;
   }
   & :where(pre) > code {
     @apply whitespace-pre-wrap;
@@ -49,10 +49,10 @@
     @apply text-theme-label-secondary;
   }
   & :where(ul ul, ul ol, ol ul, ol ol) {
-    @apply my-2;
+    @apply typo-body my-2;
   }
   & :where(a) {
-    @apply text-theme-label-link hover:underline;
+    @apply typo-body text-theme-label-link hover:underline;
   }
   & :where(a[data-mention-username]) {
     @apply relative text-theme-label-primary hover:underline bg-theme-bg-mention-primary font-bold px-1 rounded-6;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Extension injects a `font-size: 75%` on chrome
- In order to obtain stability we need to set our default typos on markdown content

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
