### PR TITLE
fix: squad post options verification

### DIFF
--- a/packages/shared/src/components/post/write/SquadsDropdown.tsx
+++ b/packages/shared/src/components/post/write/SquadsDropdown.tsx
@@ -4,6 +4,8 @@ import SquadIcon from '../../icons/Squad';
 import { ButtonSize } from '../../buttons/Button';
 import { Dropdown } from '../../fields/Dropdown';
 import { useAuthContext } from '../../../contexts/AuthContext';
+import { verifyPermission } from '../../../graphql/squads';
+import { SourcePermissions } from '../../../graphql/sources';
 
 interface SquadsDropdownProps {
   onSelect: (index: number) => void;
@@ -15,7 +17,12 @@ export function SquadsDropdown({
   selected,
 }: SquadsDropdownProps): ReactElement {
   const { squads } = useAuthContext();
-  const squadsList = squads?.map(({ name }) => name) ?? [];
+  const squadsList = squads?.reduce((acc, squad) => {
+    if (squad?.active && verifyPermission(squad, SourcePermissions.Post)) {
+      acc.push(squad.name);
+    }
+    return acc;
+  }, []);
 
   const renderDropdownItem = (value: string, index: number) => {
     const source = squads[index];


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Ensure new post page only shows active squads and squads you can actually post in

![Screenshot 2023-08-17 at 14 41 49](https://github.com/dailydotdev/apps/assets/554874/f8bd1c21-6707-4c12-971f-1ad1283db125)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
