### PR TITLE
fix: squad description text

### DIFF
--- a/packages/shared/src/components/squads/SquadsDirectoryHeader.tsx
+++ b/packages/shared/src/components/squads/SquadsDirectoryHeader.tsx
@@ -53,8 +53,10 @@ export const SquadsDirectoryHeader = (): ReactElement => {
           {isOwner ? 'Join waitlist' : 'Create new squad'}
         </Button>
       </div>
-      <div className="text-right typo-footnote text-theme-label-quaternary">
-        Squads are just getting started. More awesomeness coming soon.
+      <div className="text-center tablet:text-right typo-footnote text-theme-label-quaternary">
+        Squads are just getting started.
+        <br className="inline-block tablet:hidden" /> More awesomeness coming
+        soon.
       </div>
     </div>
   );


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Squad description text was not rendering neat on mobile.

New mobile:
<img width="417" alt="Screenshot 2023-08-18 at 13 26 42" src="https://github.com/dailydotdev/apps/assets/554874/258916ed-10ab-4014-95fb-7d66741c1868">

New tablet + sizes:
<img width="778" alt="Screenshot 2023-08-18 at 13 26 48" src="https://github.com/dailydotdev/apps/assets/554874/228ee279-d822-41a4-843c-f5570ccd1561">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1633 #done
