### PR TITLE
feat: search history page

### DIFF
--- a/packages/shared/src/components/search/SearchBarSuggestion.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestion.tsx
@@ -1,24 +1,26 @@
 import React, { ReactElement } from 'react';
-import { Button, ButtonSize } from '../buttons/Button';
+import classNames from 'classnames';
+import {
+  AllowedTags,
+  Button,
+  ButtonProps,
+  ButtonSize,
+} from '../buttons/Button';
 import { AiIcon } from '../icons';
 
-export interface SearchBarSuggestionProps {
-  suggestion: string;
-  onClick: () => void;
-}
-
-export const SearchBarSuggestion = ({
-  suggestion,
-  onClick,
-}: SearchBarSuggestionProps): ReactElement => {
+export const SearchBarSuggestion = <TagName extends AllowedTags>({
+  className,
+  ...props
+}: ButtonProps<TagName>): ReactElement => {
   return (
     <Button
-      className="btn-secondary border-theme-divider-tertiary typo-subhead text-theme-label-tertiary"
-      onClick={onClick}
-      buttonSize={ButtonSize.XLarge}
       icon={<AiIcon />}
-    >
-      {suggestion}
-    </Button>
+      buttonSize={ButtonSize.XLarge}
+      className={classNames(
+        'btn-secondary border-theme-divider-tertiary typo-subhead text-theme-label-tertiary w-fit',
+        className,
+      )}
+      {...props}
+    />
   );
 };

--- a/packages/shared/src/components/search/SearchBarSuggestionList.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestionList.tsx
@@ -1,34 +1,35 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
-import {
-  SearchBarSuggestion,
-  SearchBarSuggestionProps,
-} from './SearchBarSuggestion';
+import { SearchBarSuggestion } from './SearchBarSuggestion';
 import AuthContext from '../../contexts/AuthContext';
 import FeedbackIcon from '../icons/Feedback';
+import { getSearchIdUrl, SearchSession } from '../../graphql/search';
 
 interface SearchBarSuggestionListProps {
   className?: string;
+  suggestions?: SearchSession[];
 }
 
 export function SearchBarSuggestionList({
   className,
+  suggestions,
 }: SearchBarSuggestionListProps): React.ReactElement {
   const { user, showLogin } = useContext(AuthContext);
-  const suggestions: SearchBarSuggestionProps[] = [];
 
   if (!user) {
-    suggestions.push({
-      suggestion:
-        'Sign up and read your first post to get search recommendations',
-      onClick: () => showLogin('search bar suggestion'),
-    });
-  } else if (suggestions?.length === 0) {
+    return (
+      <SearchBarSuggestion onClick={() => showLogin('search bar suggestion')}>
+        Sign up and read your first post to get search recommendations
+      </SearchBarSuggestion>
+    );
+  }
+
+  if (suggestions?.length === 0) {
     return (
       <span className="flex flex-row items-center text-theme-label-quaternary">
         <FeedbackIcon />
         <span className="ml-2 typo-footnote">
-          Read and upvote your first post to get search recommendations
+          Start getting search recommendations by upvoting several posts
         </span>
       </span>
     );
@@ -36,12 +37,10 @@ export function SearchBarSuggestionList({
 
   return (
     <div className={classNames('flex flex-wrap gap-4', className)}>
-      {suggestions.map((suggestion) => (
-        <SearchBarSuggestion
-          key={suggestion.suggestion}
-          suggestion={suggestion.suggestion}
-          onClick={suggestion.onClick}
-        />
+      {suggestions.map(({ id, prompt }) => (
+        <SearchBarSuggestion key={prompt} tag="a" href={getSearchIdUrl(id)}>
+          {prompt}
+        </SearchBarSuggestion>
       ))}
     </div>
   );

--- a/packages/shared/src/components/search/SearchBarSuggestionList.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestionList.tsx
@@ -24,7 +24,7 @@ export function SearchBarSuggestionList({
     );
   }
 
-  if (suggestions?.length === 0) {
+  if (!suggestions?.length) {
     return (
       <span className="flex flex-row items-center text-theme-label-quaternary">
         <FeedbackIcon />

--- a/packages/shared/src/components/sidebar/Sidebar.spec.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.spec.tsx
@@ -21,6 +21,8 @@ import { waitForNock } from '../../../__tests__/helpers/utilities';
 import ProgressiveEnhancementContext from '../../contexts/ProgressiveEnhancementContext';
 import { Alerts } from '../../graphql/alerts';
 import { FeaturesContextProvider } from '../../contexts/FeaturesContext';
+import { Features } from '../../lib/featureManagement';
+import { SearchExperiment } from '../../lib/featureValues';
 
 let features: IFlags;
 let client: QueryClient;
@@ -163,14 +165,18 @@ const sidebarItems = [
   ['Reading history', '/history'],
 ];
 
-it.each(sidebarItems.map((item) => [item[0], item[1]]))(
-  'it should expect %s to exist',
-  async (name, href) => {
-    renderComponent();
-    waitForNock();
-    const el = await screen.findByText(name);
-    expect(el).toBeInTheDocument();
-    // eslint-disable-next-line testing-library/no-node-access
-    expect(el.closest('a')).toHaveAttribute('href', href);
-  },
-);
+describe('sidebar items', () => {
+  Features.Search.defaultValue = SearchExperiment.Control;
+
+  it.each(sidebarItems.map((item) => [item[0], item[1]]))(
+    'it should expect %s to exist',
+    async (name, href) => {
+      renderComponent();
+      waitForNock();
+      const el = await screen.findByText(name);
+      expect(el).toBeInTheDocument();
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(el.closest('a')).toHaveAttribute('href', href);
+    },
+  );
+});

--- a/packages/shared/src/components/tabs/TabContainer.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.tsx
@@ -57,13 +57,14 @@ export function TabContainer<T extends string = string>({
   tabListProps = {},
 }: TabContainerProps<T>): ReactElement {
   const [active, setActive] = useState(children[0].props.label);
+  const currentActive = controlledActive ?? active;
   const onClick = (label: T) => {
     setActive(label);
     onActiveChange?.(label);
   };
 
   const isTabActive = (child: ReactElement<TabProps<T>>) =>
-    child.props.label === (controlledActive ?? active);
+    child.props.label === currentActive;
 
   const renderSingleComponent = () => {
     if (!shouldMountInactive) {
@@ -105,7 +106,7 @@ export function TabContainer<T extends string = string>({
         <TabList
           items={children.map((child) => child.props.label)}
           onClick={onClick}
-          active={active}
+          active={currentActive}
           className={tabListProps?.className}
         />
       </header>

--- a/packages/shared/src/graphql/search.ts
+++ b/packages/shared/src/graphql/search.ts
@@ -1,6 +1,10 @@
 import request, { gql } from 'graphql-request';
 import { graphqlUrl } from '../lib/config';
 import { isNullOrUndefined } from '../lib/func';
+import { Connection, RequestQueryParams } from './common';
+import { webappUrl } from '../lib/constants';
+
+export const searchPageUrl = `${webappUrl}search`;
 
 export interface SearchChunkError {
   message: string;
@@ -31,6 +35,16 @@ export interface Search {
   id: string;
   createdAt: Date;
   chunks: SearchChunk[];
+}
+
+export interface SearchSession {
+  id: string;
+  prompt: string;
+  createdAt: Date;
+}
+
+export interface SearchHistoryData {
+  history: Connection<SearchSession>;
 }
 
 export const SEARCH_POST_SUGGESTIONS = gql`
@@ -70,11 +84,35 @@ export const SEARCH_SESSION_QUERY = gql`
   }
 `;
 
+export const SEARCH_HISTORY_QUERY = gql`
+  query SearchSessionHistory($after: String, $first: Int) {
+    history: searchSessionHistory(after: $after, first: $first) {
+      pageInfo {
+        endCursor
+        hasNextPage
+        hasPreviousPage
+      }
+      edges {
+        node {
+          id
+          prompt
+          createdAt
+        }
+      }
+    }
+  }
+`;
+
 export const getSearchSession = async (id: string): Promise<Search> => {
   const res = await request(graphqlUrl, SEARCH_SESSION_QUERY, { id });
 
   return res.searchSession;
 };
+
+export const getSearchHistory = async (
+  params: RequestQueryParams,
+): Promise<SearchHistoryData> =>
+  request(graphqlUrl, SEARCH_HISTORY_QUERY, params);
 
 type DeepPartial<T> = T extends unknown
   ? {
@@ -127,3 +165,6 @@ export const updateSearchData = (
 
   return updated;
 };
+
+export const getSearchIdUrl = (id: string): string =>
+  `${searchPageUrl}?id=${id}`;

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -25,6 +25,7 @@ export enum RequestKey {
   Actions = 'actions',
   Squad = 'squad',
   Search = 'search',
+  SearchHistory = 'searchHistory',
   ReadingHistory = 'readingHistory',
   ReferralCampaigns = 'referral_campaigns',
   NotificationPreference = 'notification_preference',

--- a/packages/webapp/__tests__/HistoryPage.spec.tsx
+++ b/packages/webapp/__tests__/HistoryPage.spec.tsx
@@ -27,6 +27,7 @@ beforeEach(() => {
         query: {},
         replace: routerReplace,
         push: jest.fn(),
+        isReady: true,
       } as unknown as NextRouter),
   );
 });
@@ -89,57 +90,59 @@ const renderComponent = (
   );
 };
 
-it('should show appropriate loading attributes', async () => {
-  renderComponent();
-  const initialBusyState = (
-    await screen.findByTestId('reading-history-container')
-  ).getAttribute('aria-busy');
-  expect(JSON.parse(initialBusyState)).toEqual(true);
+describe('user reading history page', () => {
+  it('should show appropriate loading attributes', async () => {
+    renderComponent();
+    const initialBusyState = (
+      await screen.findByTestId('reading-history-container')
+    ).getAttribute('aria-busy');
+    expect(JSON.parse(initialBusyState)).toEqual(true);
 
-  await waitForNock();
+    await waitForNock();
 
-  const afterFetchingBusyState = (
-    await screen.findByTestId('reading-history-container')
-  ).getAttribute('aria-busy');
-  expect(JSON.parse(afterFetchingBusyState)).toEqual(false);
-});
+    const afterFetchingBusyState = (
+      await screen.findByTestId('reading-history-container')
+    ).getAttribute('aria-busy');
+    expect(JSON.parse(afterFetchingBusyState)).toEqual(false);
+  });
 
-it('should show display empty screen when no view history is found', async () => {
-  const emptyHistory = getDefaultHistory([]);
-  const mock = createReadingHistoryMock(emptyHistory);
-  renderComponent([mock]);
-  await waitForNock();
-  await screen.findByText('Your reading history is empty.');
-});
+  it('should show display empty screen when no view history is found', async () => {
+    const emptyHistory = getDefaultHistory([]);
+    const mock = createReadingHistoryMock(emptyHistory);
+    renderComponent([mock]);
+    await waitForNock();
+    await screen.findByText('Your reading history is empty.');
+  });
 
-it('should show display the list of viewing history', async () => {
-  renderComponent();
-  await waitForNock();
-  await screen.findByText('Most Recent Post');
-});
+  it('should show display the list of viewing history', async () => {
+    renderComponent();
+    await waitForNock();
+    await screen.findByText('Most Recent Post');
+  });
 
-it('should show the search bar', async () => {
-  renderComponent();
-  await waitForNock();
-  expect(await screen.findByTestId('searchField')).toBeInTheDocument();
-});
+  it('should show the search bar', async () => {
+    renderComponent();
+    await waitForNock();
+    expect(await screen.findByTestId('searchField')).toBeInTheDocument();
+  });
 
-it('should update query param on enter', async (done) => {
-  renderComponent();
-  await waitForNock();
-  const input = (await screen.findByRole('textbox')) as HTMLInputElement;
-  input.value = 'daily';
-  input.dispatchEvent(new Event('input', { bubbles: true }));
-  setTimeout(async () => {
-    input.dispatchEvent(
-      new KeyboardEvent('keydown', { bubbles: true, keyCode: 13 }),
-    );
-    await waitFor(() =>
-      expect(routerReplace).toBeCalledWith({
-        pathname: '/history',
-        query: { q: 'daily' },
-      }),
-    );
-    done();
-  }, 150);
+  it('should update query param on enter', async (done) => {
+    renderComponent();
+    await waitForNock();
+    const input = (await screen.findByRole('textbox')) as HTMLInputElement;
+    input.value = 'daily';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    setTimeout(async () => {
+      input.dispatchEvent(
+        new KeyboardEvent('keydown', { bubbles: true, keyCode: 13 }),
+      );
+      await waitFor(() =>
+        expect(routerReplace).toBeCalledWith({
+          pathname: '/history',
+          query: { q: 'daily' },
+        }),
+      );
+      done();
+    }, 150);
+  });
 });

--- a/packages/webapp/components/history/SearchEmpty.tsx
+++ b/packages/webapp/components/history/SearchEmpty.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { AiIcon } from '@dailydotdev/shared/src/components/icons';
+import { IconSize } from '@dailydotdev/shared/src/components/Icon';
+import { SearchHistoryContainer } from './common';
+
+export function SearchEmpty(): React.ReactElement {
+  return (
+    <SearchHistoryContainer className="items-center pt-24">
+      <AiIcon className="text-theme-label-tertiary" size={IconSize.XXXLarge} />
+      <h1 className="text-center typo-title1">Your search history is empty.</h1>
+      <p className="text-center typo-body text-theme-label-secondary">
+        Go back to your feed, begin exploring with your queries. Each search
+        query will be listed here.
+      </p>
+    </SearchHistoryContainer>
+  );
+}

--- a/packages/webapp/components/history/SearchEmpty.tsx
+++ b/packages/webapp/components/history/SearchEmpty.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { ReactElement } from 'react';
 import { AiIcon } from '@dailydotdev/shared/src/components/icons';
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import { SearchHistoryContainer } from './common';
 
-export function SearchEmpty(): React.ReactElement {
+export function SearchEmpty(): ReactElement {
   return (
     <SearchHistoryContainer className="items-center pt-24">
       <AiIcon className="text-theme-label-tertiary" size={IconSize.XXXLarge} />

--- a/packages/webapp/components/history/SearchSkeleton.tsx
+++ b/packages/webapp/components/history/SearchSkeleton.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement } from 'react';
+import classed from '@dailydotdev/shared/src/lib/classed';
+import { ElementPlaceholder } from '@dailydotdev/shared/src/components/ElementPlaceholder';
+import { SearchHistoryContainer } from './common';
+
+const Pill = classed(ElementPlaceholder, 'h-8 rounded-12');
+const ShortPill = classed(Pill, 'w-1/2');
+const LongPill = classed(Pill, 'w-4/5');
+
+export function SearchSkeleton(): ReactElement {
+  return (
+    <SearchHistoryContainer aria-busy="true">
+      <LongPill />
+      <ShortPill />
+      <LongPill />
+      <ShortPill />
+      <LongPill />
+      <ShortPill />
+    </SearchHistoryContainer>
+  );
+}

--- a/packages/webapp/components/history/common.ts
+++ b/packages/webapp/components/history/common.ts
@@ -1,4 +1,8 @@
+import classed from '@dailydotdev/shared/src/lib/classed';
+
 export enum HistoryType {
   Reading = 'Reading history',
   Search = 'Search history',
 }
+
+export const SearchHistoryContainer = classed('div', 'flex flex-col gap-3 p-6');

--- a/packages/webapp/components/history/index.ts
+++ b/packages/webapp/components/history/index.ts
@@ -1,3 +1,5 @@
 export * from './search';
 export * from './reading';
 export * from './common';
+export * from './SearchEmpty';
+export * from './SearchSkeleton';

--- a/packages/webapp/components/history/search.tsx
+++ b/packages/webapp/components/history/search.tsx
@@ -1,5 +1,47 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useMemo } from 'react';
+import { useInfiniteQuery } from 'react-query';
+import {
+  getSearchHistory,
+  getSearchIdUrl,
+  SearchHistoryData,
+} from '@dailydotdev/shared/src/graphql/search';
+import {
+  generateQueryKey,
+  RequestKey,
+} from '@dailydotdev/shared/src/lib/query';
+import user from '@dailydotdev/shared/__tests__/fixture/loggedUser';
+import { SearchBarSuggestion } from '@dailydotdev/shared/src/components';
+import { SearchSkeleton } from './SearchSkeleton';
+import { SearchEmpty } from './SearchEmpty';
+import { SearchHistoryContainer } from './common';
 
 export function SearchHistory(): ReactElement {
-  return <div className="flex flex-col gap-3">SearchHistoryList</div>;
+  const { data, isLoading } = useInfiniteQuery<SearchHistoryData>(
+    generateQueryKey(RequestKey.SearchHistory, user),
+    ({ pageParam }) => getSearchHistory({ after: pageParam, first: 30 }),
+    {
+      getNextPageParam: (lastPage) =>
+        lastPage?.history?.pageInfo.hasNextPage &&
+        lastPage?.history?.pageInfo.endCursor,
+    },
+  );
+
+  const nodes = useMemo(
+    () => data?.pages?.map(({ history }) => history.edges).flat(),
+    [data],
+  );
+
+  if (isLoading) return <SearchSkeleton />;
+
+  if (!nodes?.length) return <SearchEmpty />;
+
+  return (
+    <SearchHistoryContainer>
+      {nodes?.map(({ node: { id, prompt } }) => (
+        <SearchBarSuggestion key={id} tag="a" href={getSearchIdUrl(id)}>
+          {prompt}
+        </SearchBarSuggestion>
+      ))}
+    </SearchHistoryContainer>
+  );
 }

--- a/packages/webapp/pages/history.tsx
+++ b/packages/webapp/pages/history.tsx
@@ -28,6 +28,8 @@ const History = (): ReactElement => {
     setPage(tabQuery);
   }, [tabQuery]);
 
+  if (!router.isReady) return seo;
+
   return (
     <ProtectedPage seo={seo}>
       <ResponsivePageContainer className="!p-0" role="main">


### PR DESCRIPTION
**Note:** Don't update the branch yet.

## Changes
- Fixed a bug in the tabbed container for using a controlled state.
- Search history loading state.
- Search history empty state.
- Rendering Search history list (infinite scroll).

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1645 #done
