### PR TITLE
fix: modal header

### DIFF
--- a/packages/shared/src/components/post/FixedPostNavigation.tsx
+++ b/packages/shared/src/components/post/FixedPostNavigation.tsx
@@ -24,7 +24,7 @@ function FixedPostNavigation({
       post={post}
       className={{
         container: classNames(
-          'fixed z-3 w-full bg-theme-bg-secondary border border-theme-divider-tertiary py-4 px-6 top-0 ml-0',
+          'fixed z-3 bg-theme-bg-secondary border border-theme-divider-tertiary py-4 px-6 top-0 ml-0',
           'laptop:left-[unset] max-w-full',
           className?.container,
         ),


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Issue aired with latest tailwind upgrade
- Basically the w-full before would get overwritten *(which is correct)
- Meaning we didn't even need it 😅

Before:
![Screenshot 2023-08-23 at 14 30 13](https://github.com/dailydotdev/apps/assets/554874/047cdab0-1f83-4a30-aafd-e209972a2462)

After:
![Screenshot 2023-08-23 at 14 31 20](https://github.com/dailydotdev/apps/assets/554874/dda1cd4b-73f1-4da5-81dd-438f007234cd)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1687 #done
