### PR TITLE
fix: sending search feedback

### DIFF
--- a/packages/shared/src/components/search/SearchResult.tsx
+++ b/packages/shared/src/components/search/SearchResult.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import { QueryKey, useMutation, useQueryClient } from 'react-query';
 import { WidgetContainer } from '../widgets/common';
 import { Button, ButtonSize } from '../buttons/Button';
 import LogoIcon from '../../svg/LogoIcon';
@@ -6,45 +7,83 @@ import UpvoteIcon from '../icons/Upvote';
 import DownvoteIcon from '../icons/Downvote';
 import CopyIcon from '../icons/Copy';
 import { SearchMessage, SearchMessageProps } from './SearchMessage';
-import { SearchChunk } from '../../graphql/search';
+import {
+  Search,
+  SearchChunk,
+  sendSearchFeedback,
+  updateSearchData,
+} from '../../graphql/search';
+import { useCopyLink } from '../../hooks/useCopyLink';
 
 export interface SearchResultProps {
   chunk: SearchChunk;
+  queryKey: QueryKey;
+  isInProgress: boolean;
   searchMessageProps?: Omit<SearchMessageProps, 'content'>;
 }
 
-export const SearchResult = ({
+export function SearchResult({
   chunk,
+  queryKey,
+  isInProgress,
   searchMessageProps,
-}: SearchResultProps): ReactElement => (
-  <main className="order-3 laptop:order-3 col-span-2 px-4 laptop:px-8 mb-5">
-    <WidgetContainer className="flex p-4">
-      <div className="flex p-2 mr-4 w-10 h-10 rounded-10 bg-theme-color-cabbage">
-        <LogoIcon className="max-w-full" />
-      </div>
-      <div className="flex-1">
-        <SearchMessage {...searchMessageProps} content={chunk?.response} />
-        <div className="flex pt-4">
-          <Button
-            className="btn-tertiary"
-            iconOnly
-            icon={<UpvoteIcon />}
-            buttonSize={ButtonSize.Small}
-          />
-          <Button
-            className="btn-tertiary"
-            iconOnly
-            icon={<DownvoteIcon />}
-            buttonSize={ButtonSize.Small}
-          />
-          <Button
-            className="btn-tertiary"
-            iconOnly
-            icon={<CopyIcon />}
-            buttonSize={ButtonSize.Small}
-          />
+}: SearchResultProps): ReactElement {
+  const client = useQueryClient();
+  const [isCopying, copyContent] = useCopyLink(() => chunk.response);
+  const { mutateAsync: sendFeedback } = useMutation(
+    (value: number) => sendSearchFeedback({ chunkId: chunk.id, value }),
+    {
+      onMutate: (value) => {
+        const previousValue = chunk.feedback;
+
+        client.setQueryData<Search>(queryKey, (search) =>
+          updateSearchData(search, { feedback: value }),
+        );
+
+        return () =>
+          client.setQueryData<Search>(queryKey, (search) =>
+            updateSearchData(search, { feedback: previousValue }),
+          );
+      },
+      onError: (_, __, rollback: () => void) => rollback?.(),
+    },
+  );
+
+  return (
+    <main className="order-3 laptop:order-3 col-span-2 px-4 laptop:px-8 mb-5">
+      <WidgetContainer className="flex p-4">
+        <div className="flex p-2 mr-4 w-10 h-10 rounded-10 bg-theme-color-cabbage">
+          <LogoIcon className="max-w-full" />
         </div>
-      </div>
-    </WidgetContainer>
-  </main>
-);
+        <div className="flex-1">
+          <SearchMessage {...searchMessageProps} content={chunk.response} />
+          <div className="flex pt-4">
+            <Button
+              className="btn-tertiary"
+              iconOnly
+              icon={<UpvoteIcon secondary={chunk.feedback === 1} />}
+              buttonSize={ButtonSize.Small}
+              onClick={() => sendFeedback(chunk.feedback === 1 ? 0 : 1)}
+              disabled={isInProgress}
+            />
+            <Button
+              className="btn-tertiary"
+              iconOnly
+              icon={<DownvoteIcon secondary={chunk.feedback === -1} />}
+              buttonSize={ButtonSize.Small}
+              onClick={() => sendFeedback(chunk.feedback === -1 ? 0 : -1)}
+              disabled={isInProgress}
+            />
+            <Button
+              className="btn-tertiary"
+              iconOnly
+              icon={<CopyIcon secondary={isCopying} />}
+              buttonSize={ButtonSize.Small}
+              onClick={() => copyContent()}
+            />
+          </div>
+        </div>
+      </WidgetContainer>
+    </main>
+  );
+}

--- a/packages/shared/src/graphql/search.ts
+++ b/packages/shared/src/graphql/search.ts
@@ -103,6 +103,23 @@ export const SEARCH_HISTORY_QUERY = gql`
   }
 `;
 
+export const SEARCH_FEEDBACK_MUTATION = gql`
+  mutation SearchResultFeedback($chunkId: String!, $value: Int!) {
+    searchResultFeedback(chunkId: $chunkId, value: $value) {
+      _
+    }
+  }
+`;
+
+interface SearchFeedbackProps {
+  chunkId: string;
+  value: number;
+}
+
+export const sendSearchFeedback = (
+  params: SearchFeedbackProps,
+): Promise<void> => request(graphqlUrl, SEARCH_FEEDBACK_MUTATION, params);
+
 export const getSearchSession = async (id: string): Promise<Search> => {
   const res = await request(graphqlUrl, SEARCH_SESSION_QUERY, { id });
 

--- a/packages/shared/src/hooks/useChat.ts
+++ b/packages/shared/src/hooks/useChat.ts
@@ -1,5 +1,5 @@
 import { MouseEvent, useCallback, useEffect, useRef, useState } from 'react';
-import { useQuery, useQueryClient } from 'react-query';
+import { QueryKey, useQuery, useQueryClient } from 'react-query';
 import {
   getSearchSession,
   initializeSearchSession,
@@ -40,6 +40,7 @@ interface UseChatMessage<Payload = unknown> {
 }
 
 interface UseChat {
+  queryKey: QueryKey;
   data: Search;
   isLoading: boolean;
   handleSubmit(event: MouseEvent, value: string): void;
@@ -160,6 +161,7 @@ export const useChat = ({ id: idFromProps }: UseChatProps): UseChat => {
   }, []);
 
   return {
+    queryKey: idQueryKey,
     isLoading:
       isLoadingSession ||
       (search?.chunks?.[0]?.createdAt && !search?.chunks?.[0]?.completedAt),

--- a/packages/webapp/components/search/SearchV1Page.tsx
+++ b/packages/webapp/components/search/SearchV1Page.tsx
@@ -11,7 +11,7 @@ import { getLayout as getMainLayout } from '../layouts/MainLayout';
 
 const SearchPage = (): ReactElement => {
   const router = useRouter();
-  const { data, handleSubmit, isLoading } = useChat({
+  const { data, queryKey, handleSubmit, isLoading } = useChat({
     id: router?.query?.id?.toString(),
   });
   const content = data?.chunks?.[0]?.response || '';
@@ -22,6 +22,8 @@ const SearchPage = (): ReactElement => {
       {(!!content || !!data) && (
         <>
           <SearchResult
+            queryKey={queryKey}
+            isInProgress={isLoading}
             chunk={data?.chunks?.[0]}
             searchMessageProps={{ isLoading }}
           />


### PR DESCRIPTION
## Changes
- Mutation to send search feedback.
- Pass down query key to easily update the chunk data.
- In progress state to identify whether to disable the feedback buttons.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1685 #done
