### PR TITLE
fix: modal overwrite values

### DIFF
--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -61,7 +61,7 @@ export default function PostModal({
         onRemovePost={onRemovePost}
         className={{
           container: containerClass,
-          fixedNavigation: { container: 'w-[inherit]', actions: 'ml-auto' },
+          fixedNavigation: { container: '!w-[inherit]', actions: 'ml-auto' },
           navigation: { actions: 'tablet:hidden ml-auto' },
           onboarding: 'mt-8 mb-0',
         }}

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -67,11 +67,11 @@ const modalKindAndSizeToClassName: Partial<
   },
 };
 export const modalSizeToClassName: Record<ModalSize, string> = {
-  [ModalSize.XSmall]: 'w-[21.25rem]',
-  [ModalSize.Small]: 'w-[26.25rem]',
-  [ModalSize.Medium]: 'w-[35rem]',
+  [ModalSize.XSmall]: '!w-[21.25rem]',
+  [ModalSize.Small]: '!w-[26.25rem]',
+  [ModalSize.Medium]: '!w-[35rem]',
   [ModalSize.Large]: '!w-[42.5rem]',
-  [ModalSize.XLarge]: 'w-[63.75rem]',
+  [ModalSize.XLarge]: '!w-[63.75rem]',
 };
 
 export function Modal({

--- a/packages/shared/src/components/post/FixedPostNavigation.tsx
+++ b/packages/shared/src/components/post/FixedPostNavigation.tsx
@@ -24,7 +24,7 @@ function FixedPostNavigation({
       post={post}
       className={{
         container: classNames(
-          'fixed z-3 bg-theme-bg-secondary border border-theme-divider-tertiary py-4 px-6 top-0 ml-0',
+          'fixed z-3 bg-theme-bg-secondary border border-theme-divider-tertiary py-4 px-6 top-0 ml-0 w-full',
           'laptop:left-[unset] max-w-full',
           className?.container,
         ),


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Yesterday I introduced a different approach of unsetting the width.
- But decided to go the safer route which we proposed before on certain widths, to simply add important notices to always have the right order where applicable.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
