### PR TITLE
feat: search progress bar

### DIFF
--- a/packages/shared/src/components/search/SearchBarInput.tsx
+++ b/packages/shared/src/components/search/SearchBarInput.tsx
@@ -220,7 +220,7 @@ function SearchBarInputComponent(
       <RaisedLabel type={RaisedLabelType.Beta} />
       {showProgress && (
         <div className="mt-6">
-          <SearchProgressBar progress={progress} />
+          <SearchProgressBar max={chunk?.steps} progress={chunk?.progress} />
           {(chunk?.status || chunk?.error?.code) && (
             <div className="mt-2 typo-callout text-theme-label-tertiary">
               {chunk?.error?.code || chunk?.status}

--- a/packages/shared/src/components/search/SearchBarInput.tsx
+++ b/packages/shared/src/components/search/SearchBarInput.tsx
@@ -84,7 +84,6 @@ function SearchBarInputComponent(
     false,
   );
   const searchHistory = [];
-  const progress = 0;
 
   const onClearClick = (event: MouseEvent): void => {
     event.stopPropagation();

--- a/packages/shared/src/components/search/SearchBarInput.tsx
+++ b/packages/shared/src/components/search/SearchBarInput.tsx
@@ -24,7 +24,6 @@ import { useInputField } from '../../hooks/useInputField';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import { SearchProgressBar } from './SearchProgressBar';
 import { SearchChunk } from '../../graphql/search';
-import { getSecondsDifference } from '../../lib/dateFormat';
 import useMedia from '../../hooks/useMedia';
 import { tablet } from '../../styles/media';
 import { useAuthContext } from '../../contexts/AuthContext';
@@ -223,12 +222,6 @@ function SearchBarInputComponent(
           {(chunk?.status || chunk?.error?.code) && (
             <div className="mt-2 typo-callout text-theme-label-tertiary">
               {chunk?.error?.code || chunk?.status}
-            </div>
-          )}
-          {chunk?.completedAt && chunk?.createdAt && (
-            <div className="mt-2 typo-callout text-theme-label-tertiary">
-              Done! {getSecondsDifference(chunk.createdAt, chunk.completedAt)}{' '}
-              seconds.
             </div>
           )}
         </div>

--- a/packages/shared/src/components/search/SearchProgressBar.module.css
+++ b/packages/shared/src/components/search/SearchProgressBar.module.css
@@ -1,0 +1,13 @@
+.animatedBar {
+  background-image: linear-gradient(to right, rgba(113, 71, 237, 0), rgb(206, 61, 243));
+  animation: fadeLeftToRight 1.2s linear infinite;
+}
+
+@keyframes fadeLeftToRight {
+  0% {
+    left: -100%;
+  }
+  100% {
+    left: 120%;
+  }
+}

--- a/packages/shared/src/components/search/SearchProgressBar.tsx
+++ b/packages/shared/src/components/search/SearchProgressBar.tsx
@@ -1,46 +1,41 @@
 import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import styles from './SearchProgressBar.module.css';
 
 export interface SearchProgressBarProps {
   progress: number;
+  max: number;
 }
 
 export const SearchProgressBar = ({
-  progress,
+  progress = -1,
+  max = 3,
 }: SearchProgressBarProps): ReactElement => {
+  const isDone = progress >= max;
+
   return (
-    <div className="flex relative gap-6 h-2" data-testId="SearchProgressBar">
-      <div className="relative flex-1 h-full bg-theme-float rounded-full">
-        <div
-          className={`absolute left-0 h-full bg-theme-status-cabbage rounded-full ${
-            progress >= 33 ? 'w-full' : ''
-          }`}
-          style={progress < 33 ? { width: `${progress * 3}%` } : {}}
-        />
-      </div>
-      <div className="relative flex-1 h-full bg-theme-float rounded-full">
-        <div
-          className={`absolute left-0 h-full bg-theme-status-cabbage rounded-full ${
-            progress >= 66 ? 'w-full' : ''
-          }`}
-          style={
-            progress >= 33 && progress < 66
-              ? { width: `${(progress - 33) * 3}%` }
-              : {}
-          }
-        />
-      </div>
-      <div className="relative flex-1 h-full bg-theme-float rounded-full">
-        <div
-          className={`absolute left-0 h-full bg-theme-status-cabbage rounded-full ${
-            progress >= 100 ? 'w-full' : ''
-          }`}
-          style={
-            progress >= 66 && progress < 100
-              ? { width: `${(progress - 66) * 3}%` }
-              : {}
-          }
-        />
-      </div>
+    <div className="flex relative gap-3" data-testId="SearchProgressBar">
+      {Array.from({ length: max }).map((_, index) => (
+        <span
+          /* eslint-disable-next-line react/no-array-index-key */
+          key={index}
+          className={classNames(
+            'flex-1 h-2 rounded-10 relative overflow-hidden z-0',
+            index < progress || isDone
+              ? 'bg-theme-status-cabbage'
+              : 'bg-theme-float',
+          )}
+        >
+          {index === progress && !isDone && (
+            <span
+              className={classNames(
+                styles.animatedBar,
+                'rounded-10 h-2 w-3/5 absolute',
+              )}
+            />
+          )}
+        </span>
+      ))}
     </div>
   );
 };

--- a/packages/shared/src/graphql/search.ts
+++ b/packages/shared/src/graphql/search.ts
@@ -29,6 +29,7 @@ export interface SearchChunk {
   feedback: number;
   sources: SearchChunkSource[];
   steps?: number;
+  progress?: number;
   status?: string;
 }
 
@@ -183,6 +184,7 @@ export const initializeSearchSession = ({
         sources: [],
         status,
         steps,
+        progress: 0,
       },
     ],
   };
@@ -198,6 +200,14 @@ export const updateSearchData = (
     ...previous,
     chunks: [{ ...previous.chunks[0], ...chunk }],
   };
+
+  if (chunk.status) {
+    updated.chunks[0].progress += 1;
+  }
+
+  if (chunk.completedAt) {
+    updated.chunks[0].progress = updated.chunks[0].steps;
+  }
 
   if (isNullOrUndefined(chunk.response)) return updated;
 

--- a/packages/shared/src/hooks/useChat.ts
+++ b/packages/shared/src/hooks/useChat.ts
@@ -121,7 +121,7 @@ export const useChat = ({ id: idFromProps, query }: UseChatProps): UseChat => {
             setSearchQuery({ response: (data.payload as TokenPayload).token });
             break;
           case UseChatMessageType.Completed: {
-            setSearchQuery({ completedAt: new Date(), status: data.status });
+            setSearchQuery({ completedAt: new Date() });
             setPrompt(undefined);
             sourceRef.current?.close();
             break;

--- a/packages/shared/src/lib/dateFormat.ts
+++ b/packages/shared/src/lib/dateFormat.ts
@@ -104,6 +104,3 @@ export const getReadHistoryDateFormat = (currentDate: Date): string => {
 
   return `${dayOfTheWeek}, ${dayOfTheMonth} ${month}${year}`;
 };
-
-export const getSecondsDifference = (start: Date, end: Date): number =>
-  (end.getTime() - start.getTime()) / 1000;


### PR DESCRIPTION
## Changes
- Introduce keyframes for the search progress bar.
- Whenever the status gets updated, we increment.
- When the `completedAt` has value, the progress should equal to the number of steps.

Preview:


https://github.com/dailydotdev/apps/assets/13744167/644737f5-0cd7-4af3-8dfa-1c1dc386617e


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
