### PR TITLE
fix: border bottom on history page

### DIFF
--- a/packages/shared/src/components/tabs/TabContainer.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.tsx
@@ -44,6 +44,7 @@ export interface TabContainerProps<T extends string> {
   showHeader?: boolean;
   controlledActive?: string;
   tabListProps?: Pick<TabListProps, 'className'>;
+  showBorder?: boolean;
 }
 
 export function TabContainer<T extends string = string>({
@@ -53,6 +54,7 @@ export function TabContainer<T extends string = string>({
   className = {},
   style,
   showHeader = true,
+  showBorder = true,
   controlledActive,
   tabListProps = {},
 }: TabContainerProps<T>): ReactElement {
@@ -99,8 +101,9 @@ export function TabContainer<T extends string = string>({
     >
       <header
         className={classNames(
-          'flex flex-row border-b border-theme-divider-tertiary',
+          'flex flex-row',
           className?.header,
+          showBorder && 'border-b border-theme-divider-tertiary',
         )}
       >
         <TabList

--- a/packages/webapp/pages/history.tsx
+++ b/packages/webapp/pages/history.tsx
@@ -6,6 +6,8 @@ import {
   Tab,
   TabContainer,
 } from '@dailydotdev/shared/src/components/tabs/TabContainer';
+import useMedia from '@dailydotdev/shared/src/hooks/useMedia';
+import { laptop } from '@dailydotdev/shared/src/styles/media';
 import { getLayout } from '../components/layouts/MainLayout';
 import ProtectedPage from '../components/ProtectedPage';
 import {
@@ -15,6 +17,7 @@ import {
 } from '../components/history';
 
 const History = (): ReactElement => {
+  const isLaptop = useMedia([laptop.replace('@media ', '')], [true], false);
   const seo = <NextSeo title="Reading History" nofollow noindex />;
   const router = useRouter();
   const tabQuery = router.query?.t?.toString() as HistoryType;
@@ -32,11 +35,13 @@ const History = (): ReactElement => {
 
   return (
     <ProtectedPage seo={seo}>
-      <ResponsivePageContainer className="!p-0" role="main">
+      <div className="flex laptop:hidden absolute left-0 w-full h-px top-[6.75rem] bg-theme-divider-tertiary" />
+      <ResponsivePageContainer className="relative !p-0" role="main">
         <TabContainer<HistoryType>
           controlledActive={page}
           onActiveChange={setPage}
           className={{ container: 'max-h-page h-full' }}
+          showBorder={isLaptop}
         >
           <Tab label={HistoryType.Reading}>
             <ReadingHistory />


### PR DESCRIPTION
## Changes
- It won't be possible to have the border from the inside out to the main layout.
- Feels like a hack though to stamp a div on top of everything.
- If you have any suggestions, feel free to shoot.

Previews:

![Screenshot 2023-08-25 at 2 10 39 PM](https://github.com/dailydotdev/apps/assets/13744167/289f3a2e-de73-40ac-8060-3e2cceed1832)
![Screenshot 2023-08-25 at 2 10 30 PM](https://github.com/dailydotdev/apps/assets/13744167/231052e2-5425-4b59-8324-69b6e470b02c)
![Screenshot 2023-08-25 at 2 10 21 PM](https://github.com/dailydotdev/apps/assets/13744167/28b622e0-e563-4749-aa8b-3fa744ee7167)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1696 #done
