### PR TITLE
fix: query param undefined

### DIFF
--- a/packages/webapp/components/search/SearchV1Page.tsx
+++ b/packages/webapp/components/search/SearchV1Page.tsx
@@ -12,8 +12,8 @@ import { getLayout as getMainLayout } from '../layouts/MainLayout';
 const SearchPage = (): ReactElement => {
   const router = useRouter();
   const { data, queryKey, handleSubmit, isLoading } = useChat({
-    id: router?.query?.id?.toString(),
-    query: router?.query?.q?.toString(),
+    id: router?.query?.id as string,
+    query: router?.query?.q as string,
   });
   const content = data?.chunks?.[0]?.response || '';
 


### PR DESCRIPTION
## Changes
- Query parameters are always string.
- Due to the `toString` function, the undefined was turned into an actual string.
- This should prevent the re-trigger of prompt.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
