### PR TITLE
fix: add feedback colors

### DIFF
--- a/packages/shared/src/components/search/SearchResult.tsx
+++ b/packages/shared/src/components/search/SearchResult.tsx
@@ -59,16 +59,18 @@ export function SearchResult({
           <SearchMessage {...searchMessageProps} content={chunk.response} />
           <div className="flex pt-4">
             <Button
-              className="btn-tertiary"
+              className="btn-tertiary-avocado"
               iconOnly
+              pressed={chunk.feedback === 1}
               icon={<UpvoteIcon secondary={chunk.feedback === 1} />}
               buttonSize={ButtonSize.Small}
               onClick={() => sendFeedback(chunk.feedback === 1 ? 0 : 1)}
               disabled={isInProgress}
             />
             <Button
-              className="btn-tertiary"
+              className="btn-tertiary-ketchup"
               iconOnly
+              pressed={chunk.feedback === -1}
               icon={<DownvoteIcon secondary={chunk.feedback === -1} />}
               buttonSize={ButtonSize.Small}
               onClick={() => sendFeedback(chunk.feedback === -1 ? 0 : -1)}

--- a/packages/shared/src/styles/utilities.css
+++ b/packages/shared/src/styles/utilities.css
@@ -4,7 +4,6 @@
 
     &:focus-visible {
       box-shadow: 0 0 0 0.125rem var(--theme-focus);
-      border-radius: 1rem;
     }
   }
 }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Add feedback colors

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1711 #done
