### PR TITLE
fix: history popup link

### DIFF
--- a/packages/shared/src/components/search/SearchHistoryButton.tsx
+++ b/packages/shared/src/components/search/SearchHistoryButton.tsx
@@ -44,7 +44,10 @@ export function SearchHistoryButton(): ReactElement {
     result.push({
       icon: null,
       label: 'Show all',
-      action: () => router.push(searchPageUrl),
+      action: () =>
+        router.push(
+          `${process.env.NEXT_PUBLIC_WEBAPP_URL}history?t=Search%20history`,
+        ),
     });
 
     return result;
@@ -67,7 +70,7 @@ export function SearchHistoryButton(): ReactElement {
             title="Search history"
             onClick={onMenuOpen}
             icon={<TimerIcon />}
-            disabled={nodes.length === 0 || isLoading}
+            disabled={options.length === 0 || isLoading}
           />
         </div>
       </SimpleTooltip>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Link to reading history with the search tab active

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1709 #done
