### PR TITLE
fix: mobile source limit removal

### DIFF
--- a/packages/shared/src/components/search/SearchSourceList.tsx
+++ b/packages/shared/src/components/search/SearchSourceList.tsx
@@ -9,6 +9,7 @@ import { SearchSourceItem } from './SearchSourceItem';
 import { SearchChunkSource } from '../../graphql/search';
 import { PaginationActions } from '../pagination';
 import { usePagination } from '../../hooks/utils';
+import useSidebarRendered from '../../hooks/useSidebarRendered';
 
 interface SearchSourceListProps {
   sources: SearchChunkSource[];
@@ -20,6 +21,7 @@ export const SearchSourceList = ({
   isLoading,
 }: SearchSourceListProps): ReactElement => {
   const [isSourcesOpen, setIsSourcesOpen] = useState(false);
+  const { sidebarRendered } = useSidebarRendered();
   const { paginated, ...pagination } = usePagination({
     items: sources,
     limit: 3,
@@ -62,7 +64,7 @@ export const SearchSourceList = ({
           {isLoading && !sources?.length ? (
             <PlaceholderSearchSource />
           ) : (
-            paginated.map((source) => (
+            (sidebarRendered ? paginated : sources).map((source) => (
               <SearchSourceItem key={source.id} item={source} />
             ))
           )}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Remove source limit on mobile as we directly show all results

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1706 #done
