### PR TITLE
fix: search input padding

### DIFF
--- a/packages/shared/src/components/search/SearchBarInput.tsx
+++ b/packages/shared/src/components/search/SearchBarInput.tsx
@@ -164,7 +164,7 @@ function SearchBarInputComponent(
             type="primary"
             autoComplete="off"
             className={classNames(
-              'flex-1 caret-theme-status-cabbage',
+              'flex-1 caret-theme-status-cabbage h-full',
               getFieldFontColor({ readOnly, disabled, hasInput, focused }),
             )}
           />

--- a/packages/shared/src/components/search/SearchSourceList.tsx
+++ b/packages/shared/src/components/search/SearchSourceList.tsx
@@ -33,7 +33,7 @@ export const SearchSourceList = ({
       <div className={classNames('flex flex-col', widgetClasses)}>
         <div
           className={classNames(
-            'flex justify-between items-center py-1.5 laptop:py-4 px-4 pb-0 laptop:bg-transparent rounded-t-16 bg-theme-bg-secondary',
+            'flex justify-between items-center py-1.5 laptop:py-4 px-4 !pb-0 laptop:bg-transparent rounded-t-16 bg-theme-bg-secondary',
             isSourcesOpen ? 'rounded-t-16' : 'rounded-16',
           )}
         >

--- a/packages/shared/src/components/search/SearchSourceList.tsx
+++ b/packages/shared/src/components/search/SearchSourceList.tsx
@@ -33,7 +33,7 @@ export const SearchSourceList = ({
       <div className={classNames('flex flex-col', widgetClasses)}>
         <div
           className={classNames(
-            'flex justify-between items-center py-1.5 laptop:py-4 px-4 !pb-0 laptop:bg-transparent rounded-t-16 bg-theme-bg-secondary',
+            'flex justify-between items-center py-1.5 laptop:py-4 px-4 laptop:!pb-0 laptop:bg-transparent rounded-t-16 bg-theme-bg-secondary',
             isSourcesOpen ? 'rounded-t-16' : 'rounded-16',
           )}
         >


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Made the input 100% height so the top/bottom padding are atleast sorted
- @capJavert You think that' sufficient enough? (For me the left/right are real edge-cases and have other buttons as well.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1717 #done
