### PR TITLE
fix: do not set cache if post was not fetched

### DIFF
--- a/packages/shared/src/hooks/usePostById.ts
+++ b/packages/shared/src/hooks/usePostById.ts
@@ -31,13 +31,20 @@ export const updatePostCache = (
   client: QueryClient,
   id: string,
   { id: _, ...postUpdate }: Partial<Post>,
-): PostData =>
-  client.setQueryData<PostData>(getPostByIdKey(id), (node) => ({
+): PostData => {
+  const currentPost = client.getQueryData<PostData>(getPostByIdKey(id));
+
+  if (!currentPost) {
+    return currentPost;
+  }
+
+  return client.setQueryData<PostData>(getPostByIdKey(id), (node) => ({
     post: {
       ...node.post,
       ...postUpdate,
     },
   }));
+};
 
 export const removePostComments = (
   client: QueryClient,


### PR DESCRIPTION
## Changes

### Describe what this PR does

Issue was that when commenting from modal we were trying to update single post cache. Since that one does not exist there was a runtime error in comment `onSuccess`. Comment would get posted but from UI it would look like it did not. User would then click comment again thus adding more then one comment.

We now skip cache update if there is not current single post cache.

This prevents cache update error when commenting from modal and also prevents filling partial post data to cache.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1728 #done
