### PR TITLE
fix: evaluate edges length for comments count

### DIFF
--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -107,7 +107,7 @@ export function PostComments({
     }
   }, [commentsCount, scrollToComment]);
 
-  if (post.numComments === 0) {
+  if (commentsCount === 0) {
     return (
       <div className="mt-8 mb-12 text-center text-theme-label-quaternary typo-subhead">
         Be the first to comment.


### PR DESCRIPTION
## Changes

### Describe what this PR does
As noted in https://github.com/dailydotdev/apps/pull/2101#issuecomment-1695410789 feed post cache is not updated correctly so numComments stays 0 even though user commented.

This created an edge case where if post had no comments it would always show "be first to comment" placeholder in modal since numComments would stay the same until post is refetched.

This fix evaluates postComments edges to get the real count which is updated since it is a separate cache item.

This is a temp fix until post feed cache is updated correctly for comments.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1728 #done
