### PR TITLE
fix: properly display code even when the language is unknown

### DIFF
--- a/packages/shared/src/components/RenderMarkdown.tsx
+++ b/packages/shared/src/components/RenderMarkdown.tsx
@@ -163,7 +163,7 @@ const RenderMarkdown = ({
                 </div>
               )}
 
-              {!inline && language ? (
+              {!inline ? (
                 <div className="py-3 px-5">
                   <SyntaxHighlighterAsync
                     {...props}


### PR DESCRIPTION
## Changes

- remove language requirement when displaying code blocks

## Events

_no events changed_

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1738 #done
