### PR TITLE
fix: mobile suggestion wrap

### DIFF
--- a/packages/shared/src/components/search/MobileSearch.tsx
+++ b/packages/shared/src/components/search/MobileSearch.tsx
@@ -47,8 +47,8 @@ export function MobileSearch({
 
   return (
     <InteractivePopup
-      position={InteractivePopupPosition.Center}
-      className="flex flex-col py-2 w-screen h-screen"
+      position={InteractivePopupPosition.Screen}
+      className="flex flex-col py-2"
     >
       <img
         className="absolute top-0 left-0 -z-1 w-full"

--- a/packages/shared/src/components/search/SearchBarSuggestionList.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestionList.tsx
@@ -37,12 +37,12 @@ export function SearchBarSuggestionList({
     return (
       <span
         className={classNames(
-          'flex overflow-hidden flex-row items-center whitespace-nowrap text-theme-label-quaternary text-ellipsis',
+          'flex flex-row items-center text-theme-label-quaternary',
           className,
         )}
       >
         <FeedbackIcon />
-        <span className="ml-2 typo-footnote">
+        <span className="flex flex-1 ml-2 typo-footnote">
           Start getting search recommendations by upvoting several posts
         </span>
       </span>

--- a/packages/shared/src/components/tooltips/InteractivePopup.tsx
+++ b/packages/shared/src/components/tooltips/InteractivePopup.tsx
@@ -12,6 +12,7 @@ export enum InteractivePopupPosition {
   LeftStart = 'leftStart',
   LeftCenter = 'leftCenter',
   LeftEnd = 'leftEnd',
+  Screen = 'screen',
 }
 
 interface InteractivePopupProps {
@@ -37,6 +38,7 @@ const positionClass: Record<InteractivePopupPosition, string> = {
   leftStart: classNames(leftClass, startClass),
   leftCenter: classNames(leftClass, centerClassY),
   leftEnd: classNames(leftClass, endClass),
+  screen: 'inset-0 w-screen h-screen',
 };
 
 function InteractivePopup({


### PR DESCRIPTION
## Changes
- Fix the wrapping of recommendation.

Preview:
![image](https://github.com/dailydotdev/apps/assets/13744167/595e4c0b-c0e5-467e-9d4a-8f4308b1da46)
![Screenshot 2023-08-29 at 6 31 26 PM](https://github.com/dailydotdev/apps/assets/13744167/7c41b423-a0b0-4989-bab5-79b08bcc1c51)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1708 #done
