### PR TITLE
fix: default to code when language missing

### DIFF
--- a/packages/shared/src/components/RenderMarkdown.tsx
+++ b/packages/shared/src/components/RenderMarkdown.tsx
@@ -146,7 +146,7 @@ const RenderMarkdown = ({
               {!inline && (
                 <div className="flex justify-between items-center py-2 px-5 bg-theme-float">
                   <span className="inline leading-8 text-theme-label-tertiary">
-                    {language}
+                    {language || 'code'}
                   </span>
 
                   <Button


### PR DESCRIPTION
## Events

_no events changes_

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1744 #done
