### PR TITLE
feat: search page crash mobile

### DIFF
--- a/packages/shared/src/components/search/SearchSourceList.tsx
+++ b/packages/shared/src/components/search/SearchSourceList.tsx
@@ -64,7 +64,7 @@ export const SearchSourceList = ({
           {isLoading && !sources?.length ? (
             <PlaceholderSearchSource />
           ) : (
-            (sidebarRendered ? paginated : sources).map((source) => (
+            (sidebarRendered ? paginated : sources)?.map((source) => (
               <SearchSourceItem key={source.id} item={source} />
             ))
           )}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- `sources` can be undefined if query returns the error
- happend only on mobile because on desktop we use paginated which always wraps in array
    - example where strict typechecking would caught this
 - fixed with optional chaining but also notified Ido in original thread to check why the query `The best cam software is?` fails because it looks like it should return result

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
