### PR TITLE
fix: tag navigation is breaking

### DIFF
--- a/packages/shared/src/components/TagLinks.tsx
+++ b/packages/shared/src/components/TagLinks.tsx
@@ -11,7 +11,7 @@ interface TagLinkProps {
 
 export function TagLink({ tag, className }: TagLinkProps): ReactElement {
   return (
-    <Link href={getTagPageLink(tag)} passHref key={tag}>
+    <Link href={getTagPageLink(tag)} passHref key={tag} prefetch={false}>
       <Button
         tag="a"
         className={classNames('btn-tertiaryFloat xsmall', className)}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We had a small issue where the modal would be active.
- Basically we use prefetch false everywhere for these pages, it was just missing in this spot

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1681 #done
