### PR TITLE
fix: comment mention on multiple lines

### DIFF
--- a/packages/shared/src/lib/textarea.ts
+++ b/packages/shared/src/lib/textarea.ts
@@ -51,7 +51,7 @@ export const getCloseWord = (
   const lines = textarea.value.split('\n');
   const line = lines[index];
   const preLines = lines.slice(0, index).join('\n');
-  const offset = lines.length === 1 ? 0 : 1;
+  const offset = index === 0 ? 0 : 1;
   const base = end - preLines.length - offset;
   let lastIndex = 0;
   let startIndex = 0;
@@ -157,6 +157,7 @@ export class TextareaCommand {
       this.textarea.selectionEnd,
     ];
     const [word, start] = getCloseWord(this.textarea, selection);
+    console.log(word, start, selection);
     const position = [start, start + word.length];
     const { replacement, offset } = getReplacement(CursorType.Adjacent, {
       word,

--- a/packages/shared/src/lib/textarea.ts
+++ b/packages/shared/src/lib/textarea.ts
@@ -157,7 +157,6 @@ export class TextareaCommand {
       this.textarea.selectionEnd,
     ];
     const [word, start] = getCloseWord(this.textarea, selection);
-    console.log(word, start, selection);
     const position = [start, start + word.length];
     const { replacement, offset } = getReplacement(CursorType.Adjacent, {
       word,


### PR DESCRIPTION
## Changes
- The offset should be based on where the current line is at not the number of lines since it is only needed on lines after the first one.

This was reproducible locally and has been verified to work after the fix.

To reproduce, write multi-lined comments, for example:
```
Sample

Test
```

Then focus your cursor on the first line having it adjacent to the word `Sample`.

Should show the issue. After the code change, this doesn't happen anymore, and have verified commands on lines 2 onwards still work.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1734 #done
