### PR TITLE
fix: overlapping bg overspilling on borders

### DIFF
--- a/packages/shared/src/components/markdown.module.css
+++ b/packages/shared/src/components/markdown.module.css
@@ -2,6 +2,10 @@
   position: relative;
   word-break: break-word;
 
+  & > pre {
+    @apply overflow-hidden;
+  }
+
   & :where(h1) {
     @apply font-bold typo-title2 mt-10 mb-7;
   }


### PR DESCRIPTION
## Changes
- The overflow hidden is only applied to every `pre` child of the root element.

![Screenshot 2023-08-30 at 1 39 11 PM](https://github.com/dailydotdev/apps/assets/13744167/45d27f93-64e5-4231-b946-df263abf8c3d)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1745 #done
