### PR TITLE
fix: generic error search fix

### DIFF
--- a/packages/shared/src/components/search/SearchBar.tsx
+++ b/packages/shared/src/components/search/SearchBar.tsx
@@ -9,11 +9,14 @@ import { labels } from '../../lib';
 export type SearchBarProps = Pick<
   SearchBarInputProps,
   'className' | 'valueChanged' | 'onSubmit' | 'showProgress' | 'chunk'
->;
+> & {
+  isLoading?: boolean;
+};
 
 export function SearchBar({
   className,
   chunk,
+  isLoading,
   ...props
 }: SearchBarProps): ReactElement {
   const suggestionsProps = useSearchSuggestions();
@@ -31,7 +34,7 @@ export function SearchBar({
         }}
         suggestionsProps={suggestionsProps}
       />
-      {chunk?.error?.code !== null && (
+      {!isLoading && chunk?.error?.code !== null && (
         <Alert
           className="my-4"
           type={AlertType.Error}

--- a/packages/shared/src/components/search/SearchContainer.tsx
+++ b/packages/shared/src/components/search/SearchContainer.tsx
@@ -30,6 +30,7 @@ export function SearchContainer({
               onSubmit={onSubmit}
               chunk={chunk}
               showProgress={!!chunk}
+              isLoading={isLoading}
             />
           )}
         </main>


### PR DESCRIPTION
## Changes

- While loading search results, don't display the error block

## Events

_no event changes_

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1749 #done
