### PR TITLE
fix: alignment of extension buttons

### DIFF
--- a/packages/extension/src/newtab/CustomLinks.tsx
+++ b/packages/extension/src/newtab/CustomLinks.tsx
@@ -6,8 +6,9 @@ import SimpleTooltip from '@dailydotdev/shared/src/components/tooltips/SimpleToo
 import MenuIcon from '@dailydotdev/shared/src/components/icons/Menu';
 import classNames from 'classnames';
 import React, { ReactElement } from 'react';
+import { WithClassNameProps } from '@dailydotdev/shared/src/components/utilities';
 
-interface CustomLinksProps {
+interface CustomLinksProps extends WithClassNameProps {
   links: string[];
   onOptions?: () => unknown;
 }
@@ -15,9 +16,15 @@ interface CustomLinksProps {
 export function CustomLinks({
   links,
   onOptions,
+  className,
 }: CustomLinksProps): ReactElement {
   return (
-    <div className="hidden laptop:flex flex-row gap-2 p-2 ml-auto rounded-14 border border-theme-divider-secondary h-fit">
+    <div
+      className={classNames(
+        'hidden laptop:flex flex-row gap-2 p-2 ml-auto rounded-14 border border-theme-divider-secondary h-fit',
+        className,
+      )}
+    >
       {links.map((url, i) => (
         <a
           href={url}

--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -111,7 +111,7 @@ export default function MainFeedPage({
             />
           }
           navChildren={!isSearchOn && <ShortcutLinks />}
-          besideSearch={<ShortcutLinks />}
+          besideSearch={<ShortcutLinks className="ml-auto" />}
         />
       </FeedLayout>
       <DndModal isOpen={showDnd} onRequestClose={() => setShowDnd(false)} />

--- a/packages/extension/src/newtab/ShortcutLinks.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.tsx
@@ -2,12 +2,16 @@ import React, { FormEvent, ReactElement, useContext, useState } from 'react';
 import PlusIcon from '@dailydotdev/shared/src/components/icons/Plus';
 import SettingsContext from '@dailydotdev/shared/src/contexts/SettingsContext';
 import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import { WithClassNameProps } from '@dailydotdev/shared/src/components/utilities';
+import classNames from 'classnames';
 import CustomLinksModal from './ShortcutLinksModal';
 import MostVisitedSitesModal from './MostVisitedSitesModal';
 import { CustomLinks } from './CustomLinks';
 import useShortcutLinks from './useShortcutLinks';
 
-export default function ShortcutLinks(): ReactElement {
+export default function ShortcutLinks({
+  className,
+}: WithClassNameProps): ReactElement {
   const { showTopSites } = useContext(SettingsContext);
   const [showModal, setShowModal] = useState(false);
   const [showOptions, setShowOptions] = useState(false);
@@ -52,11 +56,12 @@ export default function ShortcutLinks(): ReactElement {
       {shortcutLinks?.length ? (
         <CustomLinks
           links={shortcutLinks}
+          className={className}
           onOptions={() => setShowOptions(true)}
         />
       ) : (
         <Button
-          className="btn-tertiary"
+          className={classNames('btn-tertiary', className)}
           rightIcon={<PlusIcon />}
           onClick={() => setShowOptions(true)}
         >


### PR DESCRIPTION
## Changes
- Missing left margin on V1. The control should still be as it is.

![Screenshot 2023-08-30 at 7 45 06 PM](https://github.com/dailydotdev/apps/assets/13744167/e41a0dee-ce8c-43a1-851e-d998c361c95e)

![Screenshot 2023-08-30 at 7 44 48 PM](https://github.com/dailydotdev/apps/assets/13744167/f2a5a706-8b31-4bff-b44f-5555cf3a44b0)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1751 #done
