### PR TITLE
fix: single line recommendations

### DIFF
--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -162,7 +162,7 @@ export const FeedContainer = ({
             <span className="flex flex-row flex-1 mt-4">
               <SearchBarSuggestionList
                 {...suggestionsProps}
-                className="hidden tablet:flex overflow-hidden flex-1 mr-3"
+                className="hidden tablet:flex overflow-hidden flex-1 tablet:flex-none mr-3"
               />
               {actionButtons && (
                 <span className="flex flex-row gap-3 pl-3 ml-auto border-l border-theme-divider-tertiary">

--- a/packages/shared/src/components/search/SearchBarSuggestionList.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestionList.tsx
@@ -50,7 +50,12 @@ export function SearchBarSuggestionList({
   }
 
   return (
-    <div className={classNames('flex flex-wrap gap-4', className)}>
+    <div
+      className={classNames(
+        'flex max-w-full overflow-scroll gap-4 p-2 pl-0',
+        className,
+      )}
+    >
       {suggestions.map(({ id, prompt }) => (
         <SearchBarSuggestion
           tag="a"

--- a/packages/shared/src/hooks/search/useSearchHistory.ts
+++ b/packages/shared/src/hooks/search/useSearchHistory.ts
@@ -23,6 +23,7 @@ export const useSearchHistory = ({
     generateQueryKey(RequestKey.SearchHistory, user, `limit:${limit}`),
     ({ pageParam }) => getSearchHistory({ after: pageParam, first: limit }),
     {
+      enabled: !!user,
       getNextPageParam: (lastPage) =>
         lastPage?.history?.pageInfo.hasNextPage &&
         lastPage?.history?.pageInfo.endCursor,

--- a/packages/shared/src/hooks/search/useSearchSuggestions.ts
+++ b/packages/shared/src/hooks/search/useSearchSuggestions.ts
@@ -14,9 +14,7 @@ export const useSearchSuggestions = (): Pick<
   const { data, isLoading } = useQuery(
     generateQueryKey(RequestKey.SearchHistory, user),
     getSearchSuggestions,
-    {
-      ...disabledRefetch,
-    },
+    { ...disabledRefetch, enabled: !!user },
   );
 
   const suggestions = useMemo(


### PR DESCRIPTION
## Changes
- Make the search recommendation in a single scrollable line.
- Making it have ellipsis won't be possible due to the nature of the component.

![Screenshot 2023-08-30 at 8 31 50 PM](https://github.com/dailydotdev/apps/assets/13744167/3a9de387-ae88-4385-b827-8ca3e4b84773)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1701 #done
