### PR TITLE
refactor: unused prompt for analytics

### DIFF
--- a/packages/extension/src/newtab/App.tsx
+++ b/packages/extension/src/newtab/App.tsx
@@ -15,7 +15,6 @@ import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { SubscriptionContextProvider } from '@dailydotdev/shared/src/contexts/SubscriptionContext';
 import { browser } from 'webextension-polyfill-ts';
 import { useInAppNotification } from '@dailydotdev/shared/src/hooks/useInAppNotification';
-import usePersistentState from '@dailydotdev/shared/src/hooks/usePersistentState';
 import { BootDataProviderProps } from '@dailydotdev/shared/src/contexts/BootProvider';
 import { RouterContext } from 'next/dist/shared/lib/router-context';
 import useTrackPageView from '@dailydotdev/shared/src/hooks/analytics/useTrackPageView';
@@ -25,10 +24,7 @@ import { useError } from '@dailydotdev/shared/src/hooks/useError';
 import { BootApp } from '@dailydotdev/shared/src/lib/boot';
 import { useNotificationContext } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import { useLazyModal } from '@dailydotdev/shared/src/hooks/useLazyModal';
-import {
-  PromptOptions,
-  usePrompt,
-} from '@dailydotdev/shared/src/hooks/usePrompt';
+import { usePrompt } from '@dailydotdev/shared/src/hooks/usePrompt';
 import { defaultQueryClientConfig } from '@dailydotdev/shared/src/lib/query';
 import CustomRouter from '../lib/CustomRouter';
 import { version } from '../../package.json';

--- a/packages/extension/src/newtab/App.tsx
+++ b/packages/extension/src/newtab/App.tsx
@@ -56,31 +56,7 @@ const AuthModal = dynamic(
 Modal.setAppElement('#__next');
 Modal.defaultStyles = {};
 
-const shouldShowConsent = process.env.TARGET_BROWSER === 'firefox';
-
 const getRedirectUri = () => browser.runtime.getURL('index.html');
-
-const analyticsConsentPromptOptions: PromptOptions = {
-  title: 'Your privacy stays yours',
-  description: (
-    <p>
-      We use 3rd party analytics platforms to improve daily.dev. Instead of just
-      using it, we would like to ask for your approval. We promise to never
-      misuse it. 🙏
-      <br />
-      <br />
-      Do you agree to opt-in?
-    </p>
-  ),
-  okButton: {
-    title: "Yes, I'd love to",
-    className: 'btn-primary-water',
-  },
-  cancelButton: {
-    title: 'No',
-  },
-};
-
 function InternalApp({
   pageRef,
 }: {
@@ -90,34 +66,16 @@ function InternalApp({
   useInAppNotification();
   useLazyModal();
   usePrompt();
-  const { showPrompt } = usePrompt();
   const { unreadCount } = useNotificationContext();
   const { closeLogin, shouldShowLogin, loginState } = useContext(AuthContext);
   const { contentScriptGranted } = useContentScriptStatus();
-
-  const [analyticsConsent, setAnalyticsConsent] = usePersistentState(
-    'consent',
-    false,
-    shouldShowConsent ? null : true,
-  );
   const routeChangedCallbackRef = useTrackPageView();
-  const analyticsConsentPrompt = async () => {
-    setAnalyticsConsent(await showPrompt(analyticsConsentPromptOptions));
-  };
 
   useQuery(EXTENSION_PERMISSION_KEY, () => ({
     requestContentScripts,
     registerBrowserContentScripts,
     useContentScriptStatus,
   }));
-
-  useEffect(() => {
-    if (analyticsConsent === null) {
-      analyticsConsentPrompt();
-    }
-    // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [analyticsConsent]);
 
   useEffect(() => {
     if (routeChangedCallbackRef.current) {


### PR DESCRIPTION
## Changes
- Cleanup unused prompt for analytics as we don't use 3rd party tracking anymore.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1722 #done
