### PR TITLE
refactor: chat logic to support navigation and different sessions

### DIFF
--- a/packages/shared/src/hooks/chat/index.ts
+++ b/packages/shared/src/hooks/chat/index.ts
@@ -1,0 +1,2 @@
+export * from './useChat';
+export * from './types';

--- a/packages/shared/src/hooks/chat/types.ts
+++ b/packages/shared/src/hooks/chat/types.ts
@@ -1,0 +1,54 @@
+import { QueryKey } from 'react-query';
+import { MouseEvent } from 'react';
+import { Search, SearchChunkSource } from '../../graphql/search';
+
+export interface UseChatProps {
+  id?: string;
+}
+
+export enum UseChatMessageType {
+  SessionCreated = 'session_created',
+  WebSearchFinished = 'web_search_finished',
+  WebResultsFiltered = 'web_results_filtered',
+  StatusUpdated = 'status_updated',
+  NewTokenReceived = 'new_token_received',
+  Completed = 'completed',
+  Error = 'error',
+  SessionFound = 'session_found',
+}
+
+export interface SourcesMessage {
+  sources: SearchChunkSource[];
+}
+
+export interface UseChatMessage<Payload = unknown> {
+  type: UseChatMessageType;
+  status?: string;
+  timestamp: number;
+  payload: Payload;
+}
+
+export interface UseChat {
+  queryKey: QueryKey;
+  data: Search;
+  isLoading: boolean;
+  handleSubmit(event: MouseEvent, value: string): void;
+}
+
+export interface CreatePayload {
+  id: string;
+  steps: number;
+  chunk_id: string;
+}
+
+export interface TokenPayload {
+  token: string;
+}
+
+export type UseChatSessionProps = Pick<UseChatProps, 'id'> & {
+  streamId?: string;
+};
+
+export type UseChatSession = Pick<UseChat, 'queryKey' | 'isLoading' | 'data'>;
+
+export type UseChatStream = Pick<UseChat, 'handleSubmit'> & { id?: string };

--- a/packages/shared/src/hooks/chat/useChat.ts
+++ b/packages/shared/src/hooks/chat/useChat.ts
@@ -1,0 +1,24 @@
+import { UseChat, UseChatProps } from './types';
+import { useChatSession } from './useChatSession';
+import { useChatStream } from './useChatStream';
+
+export const useChat = ({ id: idFromProps }: UseChatProps): UseChat => {
+  const stream = useChatStream();
+  const id = idFromProps || stream.id;
+  const session = useChatSession({
+    id,
+    streamId: stream.id,
+  });
+
+  const isStreaming = !!(
+    session?.data?.chunks?.[0]?.createdAt &&
+    !session?.data?.chunks?.[0]?.completedAt
+  );
+
+  return {
+    queryKey: session.queryKey,
+    isLoading: isStreaming || session.isLoading,
+    data: session.data,
+    handleSubmit: stream.handleSubmit,
+  };
+};

--- a/packages/shared/src/hooks/chat/useChatSession.ts
+++ b/packages/shared/src/hooks/chat/useChatSession.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import { useQueryClient, useQuery } from 'react-query';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { Search, getSearchSession } from '../../graphql/search';
+import { generateQueryKey, RequestKey } from '../../lib/query';
+import { UseChatSessionProps, UseChatSession } from './types';
+
+export const useChatSession = ({
+  id,
+  streamId,
+}: UseChatSessionProps): UseChatSession => {
+  const { user } = useAuthContext();
+  const client = useQueryClient();
+  const queryKey = useMemo(
+    () => generateQueryKey(RequestKey.Search, user, id),
+    [user, id],
+  );
+  const { data, isLoading } = useQuery(
+    queryKey,
+    () => {
+      if (streamId && streamId === id) {
+        return client.getQueryData<Search>(queryKey);
+      }
+
+      return getSearchSession(id);
+    },
+    { enabled: !!id },
+  );
+
+  return {
+    queryKey,
+    isLoading,
+    data,
+  };
+};

--- a/packages/shared/src/hooks/chat/useChatStream.ts
+++ b/packages/shared/src/hooks/chat/useChatStream.ts
@@ -140,12 +140,12 @@ export const useChatStream = (): UseChatStream => {
         trackErrorEvent();
       };
 
-      const source = await sendSearchQuery(value, accessToken.token);
+      const source = await sendSearchQuery(value, accessToken?.token);
       source.addEventListener('message', onMessage);
       source.addEventListener('error', onError);
       sourceRef.current = source;
     },
-    [accessToken.token, client, user, trackEvent],
+    [accessToken?.token, client, user, trackEvent],
   );
 
   useEffect(() => {

--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -6,5 +6,5 @@ export * from './useSquadNavigation';
 export * from './useLeaveSquad';
 export * from './useJoinSquad';
 export * from './useJoinReferral';
-export * from './useChat';
+export * from './chat';
 export * from './useExtensionPermission';

--- a/packages/webapp/components/search/SearchV1Page.tsx
+++ b/packages/webapp/components/search/SearchV1Page.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useEffect } from 'react';
 import { NextSeo } from 'next-seo';
 import {
   SearchResult,
@@ -7,19 +7,53 @@ import {
 import { useChat } from '@dailydotdev/shared/src/hooks';
 import { SearchContainer } from '@dailydotdev/shared/src/components/search/SearchContainer';
 import { useRouter } from 'next/router';
+import { searchPageUrl } from '@dailydotdev/shared/src/graphql/search';
 import { getLayout as getMainLayout } from '../layouts/MainLayout';
 
 const SearchPage = (): ReactElement => {
   const router = useRouter();
-  const { data, queryKey, handleSubmit, isLoading } = useChat({
-    id: router?.query?.id as string,
-    query: router?.query?.q as string,
+  const query = router?.query?.q as string;
+  const sessionId = router?.query?.id as string;
+  const { data, isLoading, queryKey, handleSubmit } = useChat({
+    id: sessionId,
   });
-  const content = data?.chunks?.[0]?.response || '';
+  const searchId = data?.id;
+  const chunk = data?.chunks?.[0];
+  const content = chunk?.response || '';
+
+  useEffect(() => {
+    if (!searchId) {
+      return;
+    }
+
+    const newRoute = `${searchPageUrl}?id=${searchId}`;
+
+    router.replace(newRoute, undefined, {
+      shallow: true,
+    });
+    // router reference is not stable https://github.com/vercel/next.js/issues/18127
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchId]);
+
+  useEffect(() => {
+    const shouldApplySearchQuery = !!(query && !searchId);
+
+    if (!shouldApplySearchQuery) {
+      return;
+    }
+
+    handleSubmit(undefined, query);
+  }, [searchId, query, handleSubmit]);
 
   return (
     <SearchContainer
-      onSubmit={handleSubmit}
+      onSubmit={(event, value) => {
+        router.push(searchPageUrl, undefined, {
+          shallow: true,
+        });
+
+        handleSubmit(event, value);
+      }}
       chunk={data?.chunks?.[0]}
       isLoading={!router?.isReady}
     >


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixing issues related to search navigation and mixup of streaming and existing session results 
- More info here https://dailydotdev.slack.com/archives/C05EM7ZFQMQ/p1693402562918429
- split up useChat hook internally into two parts
- refactor query keys to avoid wildcard `new` and always load correct ID from `session_created` message.
- move all router logic to `SearchPage` since it is specific to that page

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
