### PR TITLE
feat: update input prompt for session when new chunk loads

### DIFF
--- a/packages/shared/src/components/search/SearchBarInput.tsx
+++ b/packages/shared/src/components/search/SearchBarInput.tsx
@@ -6,6 +6,8 @@ import React, {
   MouseEvent,
   ReactElement,
   useContext,
+  useEffect,
+  useRef,
   useState,
 } from 'react';
 import classNames from 'classnames';
@@ -84,6 +86,21 @@ function SearchBarInputComponent(
     [true],
     false,
   );
+
+  const lastChunkIdRef = useRef(chunk?.id);
+
+  useEffect(() => {
+    if (!chunk?.prompt) {
+      return;
+    }
+
+    if (chunk.id === lastChunkIdRef.current) {
+      return;
+    }
+
+    lastChunkIdRef.current = chunk.id;
+    setInput(chunk.prompt);
+  }, [chunk?.prompt, chunk?.id, setInput]);
 
   const onClearClick = (event: MouseEvent): void => {
     event.stopPropagation();


### PR DESCRIPTION
## Changes

### Describe what this PR does
- when we move to other search result we load its prompt to search input
- if we land on search input from history it loads the prompt for that search to search input
- if we query from feed page it loads the prompt to search input

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
