### PR TITLE
fix: recommendations alignment

### DIFF
--- a/packages/shared/src/components/search/SearchBarSuggestionList.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestionList.tsx
@@ -15,8 +15,8 @@ export interface SearchBarSuggestionListProps {
 }
 
 const lengthToClass = {
-  '1': 'tablet:grid-cols-1',
-  '2': 'tablet:grid-cols-2',
+  '1': 'max-w-full',
+  '2': 'max-w-[50%]',
 };
 
 export function SearchBarSuggestionList({
@@ -57,20 +57,24 @@ export function SearchBarSuggestionList({
   }
 
   const gridClass =
-    lengthToClass[suggestions.length.toString()] ?? 'tablet:grid-cols-3';
+    lengthToClass[suggestions.length.toString()] ?? 'max-w-[33%]';
 
   return (
     <div
       className={classNames(
-        'flex tablet:grid max-w-full w-full gap-4',
+        'flex flex-row w-full shrink gap-4',
         gridClass,
         className,
       )}
     >
-      {suggestions.map((suggestion) => (
+      {suggestions.map((suggestion, i) => (
         <SearchBarSuggestion
           tag="a"
           origin={origin}
+          className={classNames(
+            i >= 2 && 'tablet:hidden laptop:flex',
+            lengthToClass,
+          )}
           suggestion={suggestion}
           key={suggestion.prompt}
           href={getSearchUrl({


### PR DESCRIPTION
## Changes
- Usage of flex row over grid to fill the gaps.
- max-w doesn't support `1/2` or `1/3`.
## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1754 #done
