### PR TITLE
fix: only append q if id is not existing

### DIFF
--- a/packages/shared/src/graphql/search.ts
+++ b/packages/shared/src/graphql/search.ts
@@ -229,8 +229,7 @@ export const getSearchUrl = (params: SearchUrlParams): string => {
   if (!id && !question) throw new Error('Must have at least one parameter');
 
   if (id) searchParams.append('id', id);
-
-  if (question) searchParams.append('q', question);
+  else if (question) searchParams.append('q', question);
 
   return `${searchPageUrl}?${searchParams}`;
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Only append the q param if id is not existing
- Otherwise we always know what the ID is

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1756 #done
