### PR TITLE
fix: recommendation pills single line styling

### DIFF
--- a/packages/shared/src/components/search/SearchBarSuggestion.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestion.tsx
@@ -57,7 +57,7 @@ export const SearchBarSuggestion = ({
 
   return (
     <Button
-      spanClassName="w-fit my-2 flex-shrink laptop:line-clamp-2"
+      spanClassName="w-fit my-2 flex-shrink tablet:line-clamp-1"
       textPosition="justify-start"
       icon={<AiIcon />}
       buttonSize={ButtonSize.XLarge}

--- a/packages/shared/src/components/search/SearchBarSuggestionList.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestionList.tsx
@@ -14,11 +14,6 @@ export interface SearchBarSuggestionListProps {
   origin: SuggestionOrigin;
 }
 
-const lengthToClass = {
-  '1': 'max-w-full',
-  '2': 'max-w-[50%]',
-};
-
 export function SearchBarSuggestionList({
   className,
   isLoading,
@@ -56,20 +51,17 @@ export function SearchBarSuggestionList({
     );
   }
 
-  const itemClass =
-    lengthToClass[suggestions.length.toString()] ?? 'max-w-[33%]';
-
   return (
-    <div className={classNames('flex flex-row flex-1 shrink gap-4', className)}>
-      {suggestions.map((suggestion, i) => (
+    <div
+      className={classNames(
+        'flex flex-wrap gap-4 w-full flex-1 tablet:h-10 overflow-hidden',
+        className,
+      )}
+    >
+      {suggestions.map((suggestion) => (
         <SearchBarSuggestion
           tag="a"
           origin={origin}
-          className={classNames(
-            i >= 2 && 'tablet:hidden laptop:flex',
-            itemClass,
-            'flex-1',
-          )}
           suggestion={suggestion}
           key={suggestion.prompt}
           href={getSearchUrl({


### PR DESCRIPTION
## Changes
- I have no words to say, but, finally 😂 

Single line for recommendations as per requirement. We overflow the excess and hide it as necessary.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1757 #done
