### PR TITLE
fix: control page layout

### DIFF
--- a/packages/webapp/__tests__/SearchPage.tsx
+++ b/packages/webapp/__tests__/SearchPage.tsx
@@ -8,6 +8,8 @@ import { mocked } from 'ts-jest/utils';
 import { NextRouter, useRouter } from 'next/router';
 import { TestBootProvider } from '../../shared/__tests__/helpers/boot';
 import SearchPage from '../pages/search';
+import { getLayout } from '../components/layouts/MainLayout';
+import { getMainFeedLayout } from '../components/layouts/MainFeedPage';
 
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
@@ -17,7 +19,7 @@ beforeEach(() => {
   mocked(useRouter).mockImplementation(
     () =>
       ({
-        pathname: '/bookmarks',
+        pathname: '/search',
         query: {},
         push: jest.fn(),
         isReady: true,
@@ -25,18 +27,25 @@ beforeEach(() => {
   );
 });
 
-const renderComponent = (): RenderResult => {
+const renderComponent = (layout = getLayout): RenderResult => {
   const client = new QueryClient();
   const user = defaultUser;
 
   return render(
     <TestBootProvider client={client} auth={{ user }}>
-      {SearchPage.getLayout(<SearchPage />, {}, SearchPage.layoutProps)}
+      {layout(<SearchPage />, {}, {})}
     </TestBootProvider>,
   );
 };
 
-it('should render the search page', async () => {
+it('should render the search page control', async () => {
+  Features.Search.defaultValue = SearchExperiment.Control;
+  renderComponent(getMainFeedLayout);
+  const text = screen.queryByTestId('searchBar');
+  expect(text).not.toBeInTheDocument();
+});
+
+it('should render the search page v1', async () => {
   Features.Search.defaultValue = SearchExperiment.V1;
   renderComponent();
   const text = screen.queryByTestId('searchBar');

--- a/packages/webapp/components/layouts/SearchLayout.tsx
+++ b/packages/webapp/components/layouts/SearchLayout.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+import { MainLayoutProps } from '@dailydotdev/shared/src/components/MainLayout';
+import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import { Features } from '@dailydotdev/shared/src/lib/featureManagement';
+import { SearchExperiment } from '@dailydotdev/shared/src/lib/featureValues';
+import { getLayout } from './MainLayout';
+import { getMainFeedLayout, mainFeedLayoutProps } from './MainFeedPage';
+
+const props: Record<SearchExperiment, Record<string, unknown>> = {
+  control: { ...mainFeedLayoutProps, mobileTitle: 'Search' },
+  v1: { screenCentered: false },
+};
+
+export const GetSearchLayout = (
+  page: ReactNode,
+  pageProps?: Record<string, unknown>,
+  layoutProps: MainLayoutProps = {},
+): ReactNode => {
+  const searchVersion = useFeature(Features.Search);
+  const finalProps = { ...props[searchVersion], ...layoutProps };
+
+  if (searchVersion === SearchExperiment.V1) {
+    return getLayout(page, pageProps, finalProps);
+  }
+
+  return getMainFeedLayout(page, pageProps, finalProps);
+};

--- a/packages/webapp/pages/search/index.tsx
+++ b/packages/webapp/pages/search/index.tsx
@@ -2,9 +2,9 @@ import React, { ReactElement } from 'react';
 import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
 import { Features } from '@dailydotdev/shared/src/lib/featureManagement';
 import { SearchExperiment } from '@dailydotdev/shared/src/lib/featureValues';
-import { getLayout as getMainLayout } from '../../components/layouts/MainLayout';
 import SearchV1Page from '../../components/search/SearchV1Page';
 import SearchControlPage from '../../components/search/SearchControlPage';
+import { GetSearchLayout } from '../../components/layouts/SearchLayout';
 
 const SearchPage = (): ReactElement => {
   const searchVersion = useFeature(Features.Search);
@@ -16,7 +16,6 @@ const SearchPage = (): ReactElement => {
   return <SearchControlPage />;
 };
 
-SearchPage.getLayout = getMainLayout;
-SearchPage.layoutProps = { screenCentered: false };
+SearchPage.getLayout = GetSearchLayout;
 
 export default SearchPage;


### PR DESCRIPTION
## Changes
- Introduce a layout to make search page work on both versions.
- Have verified locally to work on both ends.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1763 #done
