### PR TITLE
fix: pushing button

### DIFF
--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -163,7 +163,7 @@ export const FeedContainer = ({
             <span className="flex flex-row flex-1 mt-4">
               <SearchBarSuggestionList
                 {...suggestionsProps}
-                className="hidden tablet:flex overflow-hidden flex-1 tablet:flex-none mr-3"
+                className="hidden tablet:flex mr-3"
               />
               {actionButtons && (
                 <span className="flex flex-row gap-3 pl-3 ml-auto border-l border-theme-divider-tertiary">


### PR DESCRIPTION
## Changes
- The `flex-1` from the inside should have fixed the issue. But then the outside is setting the `flex-none` to disable it from the earlier versions.
- Also removed classes that exist from the inside already.

![Screenshot 2023-08-31 at 8 51 34 PM](https://github.com/dailydotdev/apps/assets/13744167/29f71024-6e99-4fa5-bfdc-9307ffa687d1)
![Screenshot 2023-08-31 at 8 51 18 PM](https://github.com/dailydotdev/apps/assets/13744167/93deded4-3341-41bc-b864-d056d71b1970)
![Screenshot 2023-08-31 at 8 51 10 PM](https://github.com/dailydotdev/apps/assets/13744167/67e69d1d-bd01-4ef1-81b1-0dae149de539)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet]

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1762 #done
