### PR TITLE
fix: initial error not showing due to wrong queryKey

### DIFF
--- a/packages/shared/src/hooks/chat/useChatStream.ts
+++ b/packages/shared/src/hooks/chat/useChatStream.ts
@@ -45,9 +45,10 @@ export const useChatStream = (): UseChatStream => {
       let queryKey: ReturnType<typeof generateQueryKey> = generateQueryKey(
         RequestKey.Search,
         user,
-        Date.now().toString(),
+        null,
       );
       let streamId: string = null;
+      client.removeQueries(queryKey);
 
       const initSession = (payload: Pick<CreatePayload, 'id'>) => {
         queryKey = generateQueryKey(RequestKey.Search, user, payload.id);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- initial error (like rate limit) did not show because I introduced the new query key based on current timestamp for each new query https://github.com/dailydotdev/apps/pull/2142#discussion_r1311516282
- this however made `useChatSession` to not know about it 🤦 
- in this PR I fallback to empty query key with `null` and clean it before each new query
  - also makes less mess inside our react query devtools

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
