### PR TITLE
fix: top position hack

### DIFF
--- a/packages/shared/src/components/PostsSearch.tsx
+++ b/packages/shared/src/components/PostsSearch.tsx
@@ -151,15 +151,13 @@ export default function PostsSearch({
         aria-haspopup="true"
         aria-expanded={isOpen}
       />
-      {isOpen && (
-        <AutoCompleteMenu
-          placement={menuPosition}
-          items={items}
-          focusedItemIndex={selectedItemIndex}
-          onItemClick={submitQuery}
-          isOpen
-        />
-      )}
+      <AutoCompleteMenu
+        placement={menuPosition}
+        items={items}
+        focusedItemIndex={selectedItemIndex}
+        onItemClick={submitQuery}
+        isOpen={isOpen}
+      />
     </>
   );
 }

--- a/packages/shared/src/components/fields/AutoCompleteMenu.tsx
+++ b/packages/shared/src/components/fields/AutoCompleteMenu.tsx
@@ -36,7 +36,10 @@ export default function AutoCompleteMenu({
   return createPortal(
     <div
       role="menu"
-      className="top-full mt-1 react-contexify menu-secondary"
+      className={classNames(
+        'mt-1 react-contexify menu-secondary',
+        isOpen ? 'flex flex-col' : 'hidden',
+      )}
       style={{
         position: 'absolute',
         top: placement?.y,


### PR DESCRIPTION
## Changes
- The motivation behind wrapping the component with `isOpen` was to avoid the unnecessary scroll that happens when it is always rendered.
- We reverted it back, but we now removed the hack of hiding it from the screen from doing a `top-full` that places it to the bottom-most part which results in scrollbar showing even when not needed.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1773 #done
