### PR TITLE
fix: mobile search scrolling list

### DIFF
--- a/packages/shared/src/components/search/MobileSearch.tsx
+++ b/packages/shared/src/components/search/MobileSearch.tsx
@@ -93,16 +93,18 @@ export function MobileSearch({
           onInput={(e) => setInput(e.currentTarget.value)}
         />
       </form>
-      {suggestionsProps && (
-        <div className="flex flex-col p-4">
-          <SearchBarSuggestionList {...suggestionsProps} />
-        </div>
-      )}
-      <SearchHistory
-        className="!p-4"
-        showEmptyState={false}
-        title="Search history"
-      />
+      <div className="flex overflow-auto flex-col flex-1">
+        {suggestionsProps && (
+          <div className="flex flex-col p-4">
+            <SearchBarSuggestionList {...suggestionsProps} />
+          </div>
+        )}
+        <SearchHistory
+          className="!p-4"
+          showEmptyState={false}
+          title="Search history"
+        />
+      </div>
     </InteractivePopup>
   );
 }


### PR DESCRIPTION
## Changes
- Contain the list with a scrollable element. This ensures the search input would be on top of the screen all the time.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1774 #done
