### PR TITLE
fix: "already a member" element centered horizontally

### DIFF
--- a/packages/shared/src/components/onboarding/MemberAlready.tsx
+++ b/packages/shared/src/components/onboarding/MemberAlready.tsx
@@ -17,7 +17,7 @@ export function MemberAlready({
   onLogin,
 }: MemberAlreadyProps): ReactElement {
   return (
-    <span className={classNames('flex', className?.container)}>
+    <span className={classNames('flex items-center', className?.container)}>
       Already a member?
       <ClickableText
         className={classNames('ml-1', className?.login)}


### PR DESCRIPTION
## Changes
- Missing items-center to horizontally center the elements.
- Unable to reproduce, hence, no screenshot. However to ensure it won't happen on any other layouts, we apply the CSS.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1736 #done
