### PR TITLE
fix: unnecessary spacing on registration form

### DIFF
--- a/packages/shared/src/components/auth/AuthForm.tsx
+++ b/packages/shared/src/components/auth/AuthForm.tsx
@@ -14,7 +14,7 @@ function AuthForm(
     <form
       {...props}
       ref={ref}
-      className={classNames('grid grid-cols-1', className)}
+      className={classNames('flex flex-col', className)}
     >
       {children}
     </form>


### PR DESCRIPTION
## Changes
- Consuming the whole height opens up gaps in-between the elements.

Before the fix:
![Screenshot 2023-09-04 at 3 02 17 PM](https://github.com/dailydotdev/apps/assets/13744167/30205b22-5fb6-4014-a139-3d7957164f55)

After the fix:
![Screenshot 2023-09-04 at 3 02 25 PM](https://github.com/dailydotdev/apps/assets/13744167/06bbeffd-41a8-4c8b-887a-ff14241c889b)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1743 #done
