### PR TITLE
fix: ensure recommendation impression events are triggered on update

### DIFF
--- a/packages/shared/src/components/search/SearchBarSuggestion.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestion.tsx
@@ -39,7 +39,7 @@ export const SearchBarSuggestion = ({
 
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [props.suggestion?.id]);
 
   const handleSuggestionsClick = useCallback(() => {
     if (props.suggestion?.id) {

--- a/packages/shared/src/components/search/SearchBarSuggestionList.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestionList.tsx
@@ -65,7 +65,6 @@ export function SearchBarSuggestionList({
           suggestion={suggestion}
           key={suggestion.prompt}
           href={getSearchUrl({
-            id: suggestion.id,
             question: suggestion.prompt,
           })}
         >

--- a/packages/shared/src/components/search/SearchHistory.tsx
+++ b/packages/shared/src/components/search/SearchHistory.tsx
@@ -43,7 +43,6 @@ export function SearchHistory({
           suggestion={suggestion}
           href={getSearchUrl({
             id: suggestion.id,
-            question: suggestion.prompt,
           })}
         >
           {suggestion.prompt}

--- a/packages/shared/src/graphql/search.ts
+++ b/packages/shared/src/graphql/search.ts
@@ -72,6 +72,7 @@ export const SEARCH_POST_SUGGESTIONS = gql`
 export const SEARCH_POST_RECOMMENDATION = gql`
   query SearchQuestionRecommendations {
     searchQuestionRecommendations {
+      id
       question
     }
   }


### PR DESCRIPTION
## Events
_No events changes_

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1779 #done
