### PR TITLE
refactor: rename `id` to `sessionId` on search history query results

### DIFF
--- a/packages/shared/src/components/search/MobileSearch.tsx
+++ b/packages/shared/src/components/search/MobileSearch.tsx
@@ -103,6 +103,7 @@ export function MobileSearch({
           className="!p-4"
           showEmptyState={false}
           title="Search history"
+          origin={suggestionsProps.origin}
         />
       </div>
     </InteractivePopup>

--- a/packages/shared/src/components/search/PlaceholderSearchSuggestion.tsx
+++ b/packages/shared/src/components/search/PlaceholderSearchSuggestion.tsx
@@ -1,0 +1,28 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import {
+  AllowedTags,
+  Button,
+  ButtonProps,
+  ButtonSize,
+} from '../buttons/Button';
+import { AiIcon } from '../icons';
+
+export const PlaceholderSearchSuggestion = ({
+  className,
+  ...props
+}: ButtonProps<AllowedTags>): ReactElement => {
+  return (
+    <Button
+      spanClassName="w-fit my-2 flex-shrink tablet:line-clamp-1"
+      textPosition="justify-start"
+      icon={<AiIcon />}
+      buttonSize={ButtonSize.XLarge}
+      className={classNames(
+        'btn-secondary border-theme-divider-tertiary typo-subhead text-theme-label-tertiary w-fit !h-auto min-h-[2.5rem]',
+        className,
+      )}
+      {...props}
+    />
+  );
+};

--- a/packages/shared/src/components/search/SearchBarSuggestion.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestion.tsx
@@ -40,7 +40,7 @@ export const SearchBarSuggestion = ({
 
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.suggestion?.id]);
+  }, [props.id]);
 
   const handleSuggestionsClick = useCallback(() => {
     if (props?.id) {

--- a/packages/shared/src/components/search/SearchBarSuggestion.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestion.tsx
@@ -55,7 +55,7 @@ export const SearchBarSuggestion = ({
 
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [suggestionId, isHistory, impressionEmitted]);
+  }, [suggestionId, isHistory]);
 
   const handleSuggestionsClick = useCallback(() => {
     if (suggestionId) {

--- a/packages/shared/src/components/search/SearchBarSuggestion.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestion.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, useCallback, useContext, useEffect } from 'react';
+import React, {
+  ReactElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 import classNames from 'classnames';
 import {
   AllowedTags,
@@ -23,38 +29,44 @@ type SearchBarSuggestionProps = ButtonProps<AllowedTags> & {
 export const SearchBarSuggestion = ({
   className,
   origin,
+  id: suggestionId,
+  isHistory,
+  prompt,
   ...props
 }: SearchBarSuggestionProps): ReactElement => {
   const { trackEvent } = useContext(AnalyticsContext);
+  const [impressionEmitted, toggleImpressionEmitted] = useState(false);
 
   useEffect(() => {
-    if (!props.isHistory && props?.id) {
+    if (!isHistory && suggestionId && !impressionEmitted) {
       trackEvent({
         event_name: AnalyticsEvent.Impression,
         target_type: TargetType.SearchRecommendation,
-        target_id: props.id,
-        feed_item_title: props.prompt,
+        target_id: suggestionId,
+        feed_item_title: prompt,
         extra: JSON.stringify({ origin }),
       });
+
+      toggleImpressionEmitted(true);
     }
 
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.id]);
+  }, [suggestionId, isHistory, impressionEmitted]);
 
   const handleSuggestionsClick = useCallback(() => {
-    if (props?.id) {
+    if (suggestionId) {
       trackEvent({
         event_name: AnalyticsEvent.Click,
-        target_type: props.isHistory
+        target_type: isHistory
           ? TargetType.SearchHistory
           : TargetType.SearchRecommendation,
-        target_id: props.id,
-        feed_item_title: props.prompt,
+        target_id: suggestionId,
+        feed_item_title: prompt,
         extra: JSON.stringify({ origin }),
       });
     }
-  }, [origin, props.id, props.prompt, trackEvent, props.isHistory]);
+  }, [origin, suggestionId, prompt, trackEvent, isHistory]);
 
   return (
     <Button

--- a/packages/shared/src/components/search/SearchBarSuggestion.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestion.tsx
@@ -3,7 +3,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
-  useState,
+  useRef,
 } from 'react';
 import classNames from 'classnames';
 import {
@@ -35,10 +35,10 @@ export const SearchBarSuggestion = ({
   ...props
 }: SearchBarSuggestionProps): ReactElement => {
   const { trackEvent } = useContext(AnalyticsContext);
-  const [impressionEmitted, toggleImpressionEmitted] = useState(false);
+  const impressionEmitted = useRef(false);
 
   useEffect(() => {
-    if (!isHistory && suggestionId && !impressionEmitted) {
+    if (!isHistory && suggestionId && !impressionEmitted.current) {
       trackEvent({
         event_name: AnalyticsEvent.Impression,
         target_type: TargetType.SearchRecommendation,
@@ -47,7 +47,7 @@ export const SearchBarSuggestion = ({
         extra: JSON.stringify({ origin }),
       });
 
-      toggleImpressionEmitted(true);
+      impressionEmitted.current = true;
     }
 
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM

--- a/packages/shared/src/components/search/SearchBarSuggestion.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestion.tsx
@@ -17,12 +17,15 @@ import { AnalyticsEvent, Origin, TargetType } from '../../lib/analytics';
 import { SearchQuestion } from '../../graphql/search';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 
-export type SuggestionOrigin = Origin.HomePage | Origin.SearchPage;
+export type SuggestionOrigin =
+  | Origin.HomePage
+  | Origin.SearchPage
+  | Origin.HistoryPage;
 
 type SearchBarSuggestionProps = ButtonProps<AllowedTags> & {
-  id?: SearchQuestion['id'];
-  prompt?: SearchQuestion['question'];
-  origin?: SuggestionOrigin;
+  id: SearchQuestion['id'];
+  prompt: SearchQuestion['question'];
+  origin: SuggestionOrigin;
   isHistory?: boolean;
 };
 

--- a/packages/shared/src/components/search/SearchBarSuggestion.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestion.tsx
@@ -8,13 +8,14 @@ import {
 } from '../buttons/Button';
 import { AiIcon } from '../icons';
 import { AnalyticsEvent, Origin, TargetType } from '../../lib/analytics';
-import { SearchQuestion, SearchSession } from '../../graphql/search';
+import { SearchQuestion } from '../../graphql/search';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 
 export type SuggestionOrigin = Origin.HomePage | Origin.SearchPage;
 
 type SearchBarSuggestionProps = ButtonProps<AllowedTags> & {
-  suggestion?: Partial<SearchQuestion | SearchSession>;
+  id?: SearchQuestion['id'];
+  prompt?: SearchQuestion['question'];
   origin?: SuggestionOrigin;
   isHistory?: boolean;
 };
@@ -27,14 +28,12 @@ export const SearchBarSuggestion = ({
   const { trackEvent } = useContext(AnalyticsContext);
 
   useEffect(() => {
-    const suggestion = props.suggestion as SearchQuestion;
-
-    if (!props.isHistory && suggestion?.id) {
+    if (!props.isHistory && props?.id) {
       trackEvent({
         event_name: AnalyticsEvent.Impression,
         target_type: TargetType.SearchRecommendation,
-        target_id: suggestion.id,
-        feed_item_title: suggestion.question,
+        target_id: props.id,
+        feed_item_title: props.prompt,
         extra: JSON.stringify({ origin }),
       });
     }
@@ -44,21 +43,18 @@ export const SearchBarSuggestion = ({
   }, []);
 
   const handleSuggestionsClick = useCallback(() => {
-    const session = props.suggestion as SearchSession;
-    const suggestion = props.suggestion as SearchQuestion;
-
-    if (suggestion?.id || session?.sessionId) {
+    if (props?.id) {
       trackEvent({
         event_name: AnalyticsEvent.Click,
         target_type: props.isHistory
           ? TargetType.SearchHistory
           : TargetType.SearchRecommendation,
-        target_id: props.isHistory ? session.sessionId : suggestion.id,
-        feed_item_title: props.isHistory ? session.prompt : suggestion.question,
+        target_id: props.id,
+        feed_item_title: props.prompt,
         extra: JSON.stringify({ origin }),
       });
     }
-  }, [origin, props.suggestion, trackEvent, props.isHistory]);
+  }, [origin, props.id, props.prompt, trackEvent, props.isHistory]);
 
   return (
     <Button

--- a/packages/shared/src/components/search/SearchBarSuggestionList.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestionList.tsx
@@ -62,8 +62,9 @@ export function SearchBarSuggestionList({
         <SearchBarSuggestion
           tag="a"
           origin={origin}
-          suggestion={suggestion}
-          key={suggestion.question}
+          id={suggestion.id}
+          prompt={suggestion.question}
+          key={suggestion.id}
           href={getSearchUrl({
             id: suggestion.id,
             question: suggestion.question,

--- a/packages/shared/src/components/search/SearchBarSuggestionList.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestionList.tsx
@@ -3,14 +3,14 @@ import classNames from 'classnames';
 import { SearchBarSuggestion, SuggestionOrigin } from './SearchBarSuggestion';
 import AuthContext from '../../contexts/AuthContext';
 import FeedbackIcon from '../icons/Feedback';
-import { getSearchUrl, SearchSession } from '../../graphql/search';
+import { getSearchUrl, SearchQuestion } from '../../graphql/search';
 import { Pill } from '../utilities/loaders';
 import { LoginTrigger } from '../../lib/analytics';
 
 export interface SearchBarSuggestionListProps {
   className?: string;
   isLoading?: boolean;
-  suggestions?: Partial<SearchSession>[];
+  suggestions?: Partial<SearchQuestion>[];
   origin: SuggestionOrigin;
 }
 
@@ -63,13 +63,13 @@ export function SearchBarSuggestionList({
           tag="a"
           origin={origin}
           suggestion={suggestion}
-          key={suggestion.prompt}
+          key={suggestion.question}
           href={getSearchUrl({
             id: suggestion.id,
-            question: suggestion.prompt,
+            question: suggestion.question,
           })}
         >
-          {suggestion.prompt}
+          {suggestion.question}
         </SearchBarSuggestion>
       ))}
     </div>

--- a/packages/shared/src/components/search/SearchBarSuggestionList.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestionList.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import classNames from 'classnames';
 import { SearchBarSuggestion, SuggestionOrigin } from './SearchBarSuggestion';
+import { PlaceholderSearchSuggestion } from './PlaceholderSearchSuggestion';
 import AuthContext from '../../contexts/AuthContext';
 import FeedbackIcon from '../icons/Feedback';
 import { getSearchUrl, SearchQuestion } from '../../graphql/search';
@@ -28,12 +29,12 @@ export function SearchBarSuggestionList({
 
   if (!user) {
     return (
-      <SearchBarSuggestion
+      <PlaceholderSearchSuggestion
         className={className}
         onClick={() => showLogin(LoginTrigger.SearchSuggestion)}
       >
         Sign up and read your first post to get search recommendations
-      </SearchBarSuggestion>
+      </PlaceholderSearchSuggestion>
     );
   }
 

--- a/packages/shared/src/components/search/SearchHistory.tsx
+++ b/packages/shared/src/components/search/SearchHistory.tsx
@@ -38,9 +38,10 @@ export function SearchHistory({
         <SearchBarSuggestion
           isHistory
           key={suggestion.sessionId}
+          id={suggestion.sessionId}
+          prompt={suggestion.prompt}
           tag="a"
           icon={<TimerIcon />}
-          suggestion={suggestion}
           href={getSearchUrl({
             id: suggestion.sessionId,
           })}

--- a/packages/shared/src/components/search/SearchHistory.tsx
+++ b/packages/shared/src/components/search/SearchHistory.tsx
@@ -3,7 +3,7 @@ import { getSearchUrl } from '../../graphql/search';
 import { InfiniteScrollScreenOffset } from '../../hooks/feed/useFeedInfiniteScroll';
 import { SearchEmpty } from './SearchEmpty';
 import { SearchHistoryContainer } from './common';
-import { SearchBarSuggestion } from './SearchBarSuggestion';
+import { SearchBarSuggestion, SuggestionOrigin } from './SearchBarSuggestion';
 import { SearchSkeleton } from './SearchSkeleton';
 import TimerIcon from '../icons/Timer';
 import { useSearchHistory } from '../../hooks/search';
@@ -12,12 +12,14 @@ interface SearchHistoryProps {
   showEmptyState?: boolean;
   className?: string;
   title?: string;
+  origin: SuggestionOrigin;
 }
 
 export function SearchHistory({
   showEmptyState = true,
   className,
   title,
+  origin,
 }: SearchHistoryProps): ReactElement {
   const {
     result: { isLoading },
@@ -40,6 +42,7 @@ export function SearchHistory({
       </span>
       {nodes?.map(({ node: suggestion }) => (
         <SearchBarSuggestion
+          origin={origin}
           isHistory
           key={suggestion.sessionId}
           id={suggestion.sessionId}

--- a/packages/shared/src/components/search/SearchHistory.tsx
+++ b/packages/shared/src/components/search/SearchHistory.tsx
@@ -37,13 +37,12 @@ export function SearchHistory({
       {nodes?.map(({ node: suggestion }) => (
         <SearchBarSuggestion
           isHistory
-          key={suggestion.id}
+          key={suggestion.sessionId}
           tag="a"
           icon={<TimerIcon />}
           suggestion={suggestion}
           href={getSearchUrl({
-            id: suggestion.id,
-            question: suggestion.prompt,
+            id: suggestion.sessionId,
           })}
         >
           {suggestion.prompt}

--- a/packages/shared/src/components/search/SearchHistoryButton.tsx
+++ b/packages/shared/src/components/search/SearchHistoryButton.tsx
@@ -13,7 +13,7 @@ import { useSearchHistory } from '../../hooks/search';
 import { ContextMenu, MenuItemProps } from '../fields/PortalMenu';
 import useContextMenu from '../../hooks/useContextMenu';
 import { getSearchUrl } from '../../graphql/search';
-import { AnalyticsEvent } from '../../lib/analytics';
+import { AnalyticsEvent, Origin, TargetType } from '../../lib/analytics';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 
 const contextMenuId = 'search-history-input';
@@ -47,7 +47,17 @@ export function SearchHistoryButton(): ReactElement {
       id: node.sessionId,
       icon: <TimerIcon />,
       label: node.prompt,
-      action: () => router.push(getSearchUrl({ id: node.sessionId })),
+      action: () => {
+        trackEvent({
+          event_name: AnalyticsEvent.Click,
+          target_type: TargetType.SearchHistory,
+          target_id: node.sessionId,
+          feed_item_title: node.prompt,
+          extra: JSON.stringify({ origin: Origin.HistoryTooltip }),
+        });
+
+        return router.push(getSearchUrl({ id: node.sessionId }));
+      },
     }));
 
     result.push({
@@ -91,6 +101,9 @@ export function SearchHistoryButton(): ReactElement {
         id={contextMenuId}
         options={options}
         onHidden={() => setIsMenuOpen(false)}
+        onShown={() => {
+          trackEvent({ event_name: AnalyticsEvent.OpenSearchHistoryTooltip });
+        }}
       />
     </>
   );

--- a/packages/shared/src/components/search/SearchHistoryButton.tsx
+++ b/packages/shared/src/components/search/SearchHistoryButton.tsx
@@ -101,9 +101,6 @@ export function SearchHistoryButton(): ReactElement {
         id={contextMenuId}
         options={options}
         onHidden={() => setIsMenuOpen(false)}
-        onShown={() => {
-          trackEvent({ event_name: AnalyticsEvent.OpenSearchHistoryTooltip });
-        }}
       />
     </>
   );

--- a/packages/shared/src/components/search/SearchHistoryButton.tsx
+++ b/packages/shared/src/components/search/SearchHistoryButton.tsx
@@ -40,10 +40,10 @@ export function SearchHistoryButton(): ReactElement {
     if (!nodes.length) return [];
 
     const result = nodes.map(({ node }) => ({
-      id: node.id,
+      id: node.sessionId,
       icon: <TimerIcon />,
       label: node.prompt,
-      action: () => router.push(getSearchUrl({ id: node.id })),
+      action: () => router.push(getSearchUrl({ id: node.sessionId })),
     }));
 
     result.push({

--- a/packages/shared/src/graphql/search.ts
+++ b/packages/shared/src/graphql/search.ts
@@ -48,7 +48,7 @@ export interface Search {
 }
 
 export interface SearchSession {
-  id: string;
+  sessionId: string;
   prompt: string;
   createdAt: Date;
 }
@@ -114,7 +114,7 @@ export const SEARCH_HISTORY_QUERY = gql`
       }
       edges {
         node {
-          id
+          id: sessionId
           prompt
           createdAt
         }
@@ -131,7 +131,7 @@ export const SEARCH_FEEDBACK_MUTATION = gql`
   }
 `;
 
-interface SearchQuestion {
+export interface SearchQuestion {
   id: string;
   question: string;
   post: Post;

--- a/packages/shared/src/hooks/search/useSearchSuggestions.ts
+++ b/packages/shared/src/hooks/search/useSearchSuggestions.ts
@@ -25,7 +25,7 @@ export const useSearchSuggestions: UseSearchSuggestions = (args) => {
     () =>
       data?.map(({ id, question }) => ({
         id,
-        prompt: question,
+        question,
       })),
     [data],
   );

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -94,7 +94,6 @@ export enum AnalyticsEvent {
   FocusSearch = 'focus search',
   SubmitSearch = 'submit search',
   OpenSearchHistory = 'open search history',
-  OpenSearchHistoryTooltip = 'open search history tooltip',
   UpvoteSearch = 'upvote search',
   DownvoteSearch = 'downvote search',
   CopySearch = 'copy search',

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -29,6 +29,8 @@ export enum Origin {
   // search - start
   HomePage = 'home page',
   SearchPage = 'search page',
+  HistoryPage = 'history page',
+  HistoryTooltip = 'history tooltip',
   // search - end
 }
 
@@ -92,6 +94,7 @@ export enum AnalyticsEvent {
   FocusSearch = 'focus search',
   SubmitSearch = 'submit search',
   OpenSearchHistory = 'open search history',
+  OpenSearchHistoryTooltip = 'open search history tooltip',
   UpvoteSearch = 'upvote search',
   DownvoteSearch = 'downvote search',
   CopySearch = 'copy search',

--- a/packages/webapp/pages/history.tsx
+++ b/packages/webapp/pages/history.tsx
@@ -18,7 +18,7 @@ import { laptop } from '@dailydotdev/shared/src/styles/media';
 import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
 import { Features } from '@dailydotdev/shared/src/lib/featureManagement';
 import { SearchExperiment } from '@dailydotdev/shared/src/lib/featureValues';
-import { AnalyticsEvent } from '@dailydotdev/shared/src/lib/analytics';
+import { AnalyticsEvent, Origin } from '@dailydotdev/shared/src/lib/analytics';
 import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 import { getLayout } from '../components/layouts/MainLayout';
 import ProtectedPage from '../components/ProtectedPage';
@@ -81,7 +81,7 @@ const History = (): ReactElement => {
               <ReadingHistory />
             </Tab>
             <Tab label={HistoryType.Search}>
-              <SearchHistory />
+              <SearchHistory origin={Origin.HistoryPage} />
             </Tab>
           </TabContainer>
         )}


### PR DESCRIPTION
## Changes

To ensure the distinction between `SearchSession` and `SearchQuestion` objects is clear, we are renaming the `SearchSession.id` attribute to `SearcSession.sessionId` -- discussion started here: https://github.com/dailydotdev/apps/pull/2157#discussion_r1314869136

## Events

_no event changes_

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
