### PR TITLE
fix: revert flag animation to css

### DIFF
--- a/packages/shared/src/components/cards/Card.module.css
+++ b/packages/shared/src/components/cards/Card.module.css
@@ -41,6 +41,19 @@
   }
 }
 
+.flag {
+  will-change: transform;
+  z-index: -1;
+  transition: transform 0.1s linear;
+}
+
+.cardContainer:hover .flag,
+.flag:hover {
+  transform: none;
+  z-index: 1;
+  transition: transform 0.1s linear, z-index 0.1s step-end;
+}
+
 .header > a,
 .header > button {
   margin: 0 0.375rem;

--- a/packages/shared/src/components/cards/RaisedLabel.tsx
+++ b/packages/shared/src/components/cards/RaisedLabel.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import classed from '../../lib/classed';
+import styles from './Card.module.css';
 
 export enum RaisedLabelType {
   Hot = 'Hot',
@@ -24,7 +25,8 @@ export interface RaisedLabelProps {
 
 export const RaisedLabelContainer = classed(
   'div',
-  'relative group group-hover:transform-none group-hover:z-10 group-hover:transition-transform group-hover:ease-linear group-hover:transition-z-index group-hover:duration-100 group-hover:step-end',
+  `relative`,
+  styles.cardContainer,
 );
 
 export function RaisedLabel({
@@ -45,7 +47,7 @@ export function RaisedLabel({
         <div
           className={classNames(
             'flex items-center px-1',
-            'will-change-auto -z-1 transition-transform duration-100 ease-linear group-hover:transform-none group-hover:z-10 group-hover:transition-transform group-hover:ease-linear group-hover:transition-z-index group-hover:duration-100 group-hover:step-end',
+            styles.flag,
             typeToClassName[type],
             listMode
               ? 'h-5 w-full justify-center mouse:translate-x-9 rounded-l'


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We tried to convert existing animation to tailwind
- It kind of worked, but the z-index was not working, and unfortunately Tailwind won't allow for delayed animation on specific sub types, so had to revert back to CSS for complex animation timings.

See it work:
![Screenshot 2023-09-13 at 09 41 24](https://github.com/dailydotdev/apps/assets/554874/3546b13c-bcbc-427d-9f79-16bd378254f8)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1785 #done
