### PR TITLE
fix: name can be undefined for social provider

### DIFF
--- a/packages/shared/src/components/auth/SignBackButton.tsx
+++ b/packages/shared/src/components/auth/SignBackButton.tsx
@@ -24,9 +24,11 @@ export function SignBackButton({
     >
       <ProfilePicture user={signBack} size="large" />
       <div className="flex flex-col items-start ml-2 text-theme-label-invert">
-        <span className="font-bold typo-callout">
-          Continue as {signBack.name.split(' ')[0]}
-        </span>
+        {!!signBack.name && (
+          <span className="font-bold typo-callout">
+            Continue as {signBack.name.split(' ')[0]}
+          </span>
+        )}
         <span className="typo-footnote">{signBack.email}</span>
       </div>
       <span className="p-1 ml-auto rounded-8 border border-theme-divider-secondary">


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Not rendering `Continue as` block
- It will only render email 
- Fixes https://github.com/dailydotdev/daily/issues/977

<img width="278" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/fa2daeba-3602-4aec-bd9f-e65231b17c72">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
