### PR TITLE
fix: small modal related fixes

### DIFF
--- a/packages/shared/src/components/markdown.module.css
+++ b/packages/shared/src/components/markdown.module.css
@@ -1,6 +1,7 @@
 .markdown {
   position: relative;
   word-break: break-word;
+  white-space: pre-line;
 
   & > pre {
     @apply overflow-hidden;

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -107,7 +107,7 @@ export function Modal({
     overlayClassName,
   );
   const modalClassName = classNames(
-    'modal flex flex-col relative focus:outline-none max-w-full items-center bg-theme-bg-tertiary shadow-2 border border-theme-divider-secondary rounded-16',
+    'antialiased modal flex flex-col relative focus:outline-none max-w-full items-center bg-theme-bg-tertiary shadow-2 border border-theme-divider-secondary rounded-16',
     modalKindToClassName[kind],
     modalSizeToClassName[size],
     modalKindAndSizeToClassName[kind]?.[size],

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -69,6 +69,7 @@ export const SHARED_POST_INFO_FRAGMENT = gql`
   fragment SharedPostInfo on Post {
     id
     title
+    titleHtml
     image
     readTime
     permalink

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -160,7 +160,6 @@ export const POST_BY_ID_QUERY = gql`
       ...SharedPostInfo
       trending
       views
-      titleHtml
       content
       contentHtml
       sharedPost {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Couple of modal related fixes
- We recently set everything to antialiased, but forgot to expand to modal as it's outside the doc basically.
- We had a evaluation for `titleHtml` but it was missing from the basic post query (feed)
- Our markdown was missing pre space for paragraph enters

![Screenshot 2023-09-13 at 14 42 00](https://github.com/dailydotdev/apps/assets/554874/33e4cce9-57c1-4314-b544-a44b1d8c3ec3)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1817 #done
