### PR TITLE
fix: query invalidation of connected providers

### DIFF
--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -25,6 +25,7 @@ export const generateStorageKey = (
   (generateQueryKey(key, null, ...params) as Array<string>).join(':');
 
 export enum RequestKey {
+  Providers = 'providers',
   Bookmarks = 'bookmarks',
   PostComments = 'post_comments',
   PostCommentsMutations = 'post_comments_mutations',

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -44,8 +44,9 @@ const AccountSecurityPage = (): ReactElement => {
   const [activeDisplay, setActiveDisplay] = useState(Display.Default);
   const [hint, setHint] = useState<string>(null);
   const { onUpdateSignBack, signBack, provider } = useSignBack();
-  const { data: userProviders, refetch: refetchProviders } = useQuery(
-    'providers',
+  const providersKey = generateQueryKey(RequestKey.Providers, user);
+  const { data: userProviders } = useQuery(
+    providersKey,
     () => getKratosProviders(),
     { ...disabledRefetch },
   );
@@ -169,7 +170,7 @@ const AccountSecurityPage = (): ReactElement => {
 
         const { params } = vars;
         if ('link' in params || 'unlink' in params) {
-          refetchProviders();
+          client.invalidateQueries(providersKey);
 
           if ('unlink' in params && params.unlink === provider) {
             const validProvider = userProviders.result?.find(

--- a/packages/webapp/pages/account/security.tsx
+++ b/packages/webapp/pages/account/security.tsx
@@ -23,7 +23,6 @@ import {
   SignBackProvider,
   useSignBack,
 } from '@dailydotdev/shared/src/hooks/auth/useSignBack';
-import { disabledRefetch } from '@dailydotdev/shared/src/lib/func';
 import {
   generateQueryKey,
   RequestKey,
@@ -45,10 +44,8 @@ const AccountSecurityPage = (): ReactElement => {
   const [hint, setHint] = useState<string>(null);
   const { onUpdateSignBack, signBack, provider } = useSignBack();
   const providersKey = generateQueryKey(RequestKey.Providers, user);
-  const { data: userProviders } = useQuery(
-    providersKey,
-    () => getKratosProviders(),
-    { ...disabledRefetch },
+  const { data: userProviders } = useQuery(providersKey, () =>
+    getKratosProviders(),
   );
   const { data: settings } = useQuery(['settings'], () =>
     initializeKratosFlow(AuthFlow.Settings),


### PR DESCRIPTION
## Changes
- After the recent change, connecting providers work, but doesn't reflect the status update until you refresh.
- Probably due to the disabledRefetch (removed it now since even just invalidating doesn't work).
- Invalidate query instead to ensure refetch.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
