### PR TITLE
fix: prevent redirect on history article remove

### DIFF
--- a/packages/shared/src/components/post/PostItemCard.tsx
+++ b/packages/shared/src/components/post/PostItemCard.tsx
@@ -38,6 +38,7 @@ export default function PostItemCard({
   const { timestampDb, post } = postItem;
   const onHideClick = (e: MouseEvent) => {
     e.stopPropagation();
+    e.preventDefault(); // to prevent redirection.
     onHide({ postId: post.id, timestamp: timestampDb });
   };
   const article = post?.sharedPost ?? post;


### PR DESCRIPTION
## Changes
Added  `e.preventDefault()` to prevent the anchor tag from redirecting when the close button is clicked.
To reproduce the bug, refer to this issue below.
Fixes dailydotdev/daily#975

### Describe what this PR does
- Adds a line `e.preventDefault()` below: `e.stopPropagation()`
- because the stoppropagation doesn't stop the default browser behavior of the anchor tags href redirect.