### PR TITLE
fix: always pass a string to `className` prop

### DIFF
--- a/packages/shared/src/components/modals/SubmitArticleModal.tsx
+++ b/packages/shared/src/components/modals/SubmitArticleModal.tsx
@@ -286,7 +286,9 @@ export default function SubmitArticleModal({
             loading={isValidating}
             form="submit-article"
           >
-            <span className={isValidating && 'invisible'}>Submit article</span>
+            <span className={isValidating ? 'invisible' : ''}>
+              Submit article
+            </span>
           </Button>
         )}
         {isSubmitted && (


### PR DESCRIPTION
## Changes

_self explanatory_

## Events

_N / A_

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1840 #done
