### PR TITLE
fix: use the correct query key to update reading history cache

### DIFF
--- a/packages/shared/src/components/PostOptionsReadingHistoryMenu.tsx
+++ b/packages/shared/src/components/PostOptionsReadingHistoryMenu.tsx
@@ -16,7 +16,11 @@ import {
 import { MenuIcon } from './MenuIcon';
 import { QueryIndexes } from '../hooks/useReadingHistory';
 import { postAnalyticsEvent } from '../lib/feed';
-import { updateInfiniteCache } from '../lib/query';
+import {
+  generateQueryKey,
+  RequestKey,
+  updateInfiniteCache,
+} from '../lib/query';
 import { AnalyticsEvent } from '../lib/analytics';
 
 const PortalMenu = dynamic(
@@ -45,8 +49,8 @@ const updateReadingHistoryPost =
   ): ((args: { id: string }) => Promise<() => void>) =>
   async () => {
     const history = client.getQueryData<ReadHistoryInfiniteData>(queryKey);
-    const { node } = history.pages[page].readHistory.edges[edge];
-    const updated = { ...node, post: { ...node.post, ...post } };
+    const { node } = history?.pages[page].readHistory.edges[edge] || {};
+    const updated = { ...node, post: { ...node?.post, ...post } };
 
     updateInfiniteCache<ReadHistoryData>({
       client,
@@ -87,7 +91,7 @@ export default function PostOptionsReadingHistoryMenu({
 }: PostOptionsReadingHistoryMenuProps): ReactElement {
   const { user } = useContext(AuthContext);
   const queryClient = useQueryClient();
-  const historyQueryKey = ['readHistory', user?.id];
+  const historyQueryKey = generateQueryKey(RequestKey.ReadingHistory, user);
 
   const { bookmark, removeBookmark } = useBookmarkPost({
     onBookmarkMutate: updateReadingHistoryPost(


### PR DESCRIPTION
## Changes

_self explanatory_

## Events

_N / A_

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1841 #done
