### PR TITLE
fix: replace onChange with onBlur to set squad handle when focusing on next field

### DIFF
--- a/packages/shared/src/components/squads/Details.tsx
+++ b/packages/shared/src/components/squads/Details.tsx
@@ -142,7 +142,7 @@ export function SquadDetails({
         <form
           className="flex flex-col gap-4 items-center -mb-2"
           onSubmit={handleSubmit}
-          onChange={handleChange}
+          onBlur={handleChange}
           id="squad-form"
         >
           {!createMode && (


### PR DESCRIPTION
## Changes

### Describe what this PR does
- fix: replace onChange with onBlur to set squad handle when focusing on next field

## Events

N/A

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1861 #done
