### PR TITLE
feat: clear interval when hook unmounts

### DIFF
--- a/packages/shared/src/hooks/useTimedAnimation.ts
+++ b/packages/shared/src/hooks/useTimedAnimation.ts
@@ -79,6 +79,13 @@ export const useTimedAnimation = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [timer]);
 
+  useEffect(() => {
+    return () => {
+      window.clearInterval(interval.current);
+      interval.current = null;
+    };
+  }, []);
+
   return useMemo(
     () => ({
       timer,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- leftover timer was causing set state when hook/component unmounts
- this makes sure timer is cleared when hook unmounts

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1851 #done
