### PR TITLE
fix: don't pass unused props down to `WelcomePostCard`

### DIFF
--- a/packages/shared/src/components/cards/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCard.tsx
@@ -28,6 +28,10 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
     style,
     onReadArticleClick,
     enableSourceHeader = false,
+    enableMenu: _e,
+    showImage: _s,
+    insaneMode: _i,
+    menuOpened: _m,
     ...props
   }: PostCardProps,
   ref: Ref<HTMLElement>,


### PR DESCRIPTION
## Changes

N / A

## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1845 #done
