### PR TITLE
fix: make url input always controlled on share post bar

### DIFF
--- a/packages/shared/src/components/squads/SharePostBar.tsx
+++ b/packages/shared/src/components/squads/SharePostBar.tsx
@@ -31,7 +31,7 @@ function SharePostBar({
   const inputRef = useRef<HTMLInputElement>();
   const { user } = useAuthContext();
   const { openModal } = useLazyModal();
-  const [url, setUrl] = useState<string>(undefined);
+  const [url, setUrl] = useState<string>('');
   const isMobile = !useMedia([mobileL.replace('@media ', '')], [true], false);
   const onSharedSuccessfully = () => {
     inputRef.current.value = '';
@@ -108,7 +108,7 @@ function SharePostBar({
           )}
           onInput={(e) => setUrl(e.currentTarget.value)}
           value={url}
-          onBlur={() => !url?.length && setUrl(undefined)}
+          onBlur={() => !url?.length && setUrl('')}
           onFocus={() => !url?.length && setUrl('')}
         />
         {url === undefined && (

--- a/packages/shared/src/components/squads/SharePostBar.tsx
+++ b/packages/shared/src/components/squads/SharePostBar.tsx
@@ -33,10 +33,13 @@ function SharePostBar({
   const { openModal } = useLazyModal();
   const [url, setUrl] = useState<string>('');
   const isMobile = !useMedia([mobileL.replace('@media ', '')], [true], false);
+  const [urlFocused, toggleUrlFocus] = useState(false);
   const onSharedSuccessfully = () => {
     inputRef.current.value = '';
-    setUrl(undefined);
+    setUrl('');
   };
+
+  const shouldRenderReadingHistory = !urlFocused && url.length === 0;
 
   const onOpenCreatePost = (preview: ExternalLinkPreview, link?: string) =>
     openModal({
@@ -104,14 +107,14 @@ function SharePostBar({
           placeholder={`Enter URL${isMobile ? '' : ' / Choose from'}`}
           className={classNames(
             'pl-1 tablet:min-w-[11rem] w-auto outline-none bg-theme-bg-transparent text-theme-label-primary focus:placeholder-theme-label-quaternary hover:placeholder-theme-label-primary typo-body flex-1 w-full tablet:flex-none tablet:w-auto',
-            url !== undefined && 'flex-1 pr-2',
+            !shouldRenderReadingHistory && 'flex-1 pr-2',
           )}
           onInput={(e) => setUrl(e.currentTarget.value)}
           value={url}
-          onBlur={() => !url?.length && setUrl('')}
-          onFocus={() => !url?.length && setUrl('')}
+          onBlur={() => toggleUrlFocus(false)}
+          onFocus={() => toggleUrlFocus(true)}
         />
-        {url === undefined && (
+        {shouldRenderReadingHistory && (
           <ClickableText
             className="hidden tablet:flex ml-1 font-bold reading-history hover:text-theme-label-primary"
             inverseUnderline


### PR DESCRIPTION
## Changes

- sets the default value of the URL input to an empty string

## Events

**N / A**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1846 #done
