### PR TITLE
fix: invalid DOM nesting of `AccountDangerZone`

### DIFF
--- a/packages/shared/src/components/profile/AccountDangerZone.tsx
+++ b/packages/shared/src/components/profile/AccountDangerZone.tsx
@@ -15,7 +15,7 @@ function AccountDangerZone({
 }: AccountDangerZoneProps): ReactElement {
   return (
     <section className={classNames('flex flex-col', className)}>
-      <p className="typo-callout text-theme-label-tertiary">
+      <div className="typo-callout text-theme-label-tertiary">
         Deleting your account will:
         <br />
         <br />
@@ -42,7 +42,7 @@ function AccountDangerZone({
           support@daily.dev
         </a>{' '}
         with any questions.
-      </p>
+      </div>
       {children}
       <Button
         onClick={onDelete}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- fix: invalid DOM nesting of `AccountDangerZone`
  Replace `p` with `div`

## Events

N/A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
