### PR TITLE
fix: don't nest button inside button

### DIFF
--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -324,7 +324,7 @@ function MarkdownInput(
             <Button
               className="ml-auto btn-primary-cabbage"
               type="submit"
-              disabled={isLoading || disabledSubmit}
+              disabled={isLoading || disabledSubmit || input === ''}
               loading={isLoading}
             >
               {submitCopy}

--- a/packages/shared/src/components/post/NewComment.tsx
+++ b/packages/shared/src/components/post/NewComment.tsx
@@ -132,6 +132,7 @@ function NewCommentComponent(
         buttonSize={buttonSize[size]}
         className="ml-auto btn-secondary"
         readOnly
+        tag="span"
       >
         Post
       </Button>


### PR DESCRIPTION
## Changes

N / A

## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1850 #done
