### PR TITLE
fix: share post history duplicate key

### DIFF
--- a/packages/shared/src/components/post/infinite/InfiniteReadingHistory.tsx
+++ b/packages/shared/src/components/post/infinite/InfiniteReadingHistory.tsx
@@ -28,7 +28,7 @@ export function InfiniteReadingHistory({
     >
       {data?.map((item) => (
         <button
-          key={item.post.id}
+          key={`${item.post.id}-${item.timestamp}`}
           type="button"
           className="group relative -mx-6 hover:bg-theme-hover cursor-pointer"
           onClick={(e) => onArticleClick(e, item)}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- duplicate key issue due to same post being read on different days
- added timestamp to make key unique

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1847 #done
