### PR TITLE
fix: clear query cache before each test run

### DIFF
--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -1,7 +1,6 @@
 import nock from 'nock';
 import React from 'react';
 import {
-  findAllByRole,
   findByRole,
   findByText,
   fireEvent,
@@ -258,12 +257,16 @@ describe('Feed', () => {
     await waitForNock();
     const elements = await screen.findAllByTestId('postItem');
     expect(elements.length).toBeGreaterThan(0);
-    await Promise.all(
-      elements.map(async (el) =>
-        // eslint-disable-next-line testing-library/prefer-screen-queries
-        expect((await findAllByRole(el, 'link'))[0]).toHaveAttribute('href'),
-      ),
-    );
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const el of elements) {
+      // eslint-disable-next-line no-await-in-loop,@typescript-eslint/no-loop-func
+      await waitFor(async () => {
+        const links = await within(el).findAllByRole('link');
+        expect(links[0]).toHaveAttribute('href');
+      });
+    }
+
     await waitFor(async () => {
       const el = await screen.findByTestId('adItem');
       // eslint-disable-next-line testing-library/prefer-screen-queries

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -82,10 +82,13 @@ const defaultVariables = {
   loggedIn: true,
 };
 
+const queryClient = new QueryClient();
+
 beforeEach(() => {
   jest.restoreAllMocks();
   jest.clearAllMocks();
   nock.cleanAll();
+  queryClient.clear();
   variables = defaultVariables;
 });
 
@@ -132,14 +135,10 @@ const createFeedMock = (
   },
 });
 
-let queryClient: QueryClient;
-
 const renderComponent = (
   mocks: MockedGraphQLResponse[] = [createFeedMock()],
   user: LoggedUser = defaultUser,
 ): RenderResult => {
-  queryClient = new QueryClient();
-
   mocks.forEach(mockGraphQL);
   nock('http://localhost:3000').get('/v1/a?active=false').reply(200, [ad]);
   const settingsContext: SettingsContextData = {

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -84,24 +84,7 @@ const defaultVariables = {
 
 const queryClient = new QueryClient();
 
-beforeEach(() => {
-  jest.restoreAllMocks();
-  jest.clearAllMocks();
-  nock.cleanAll();
-  queryClient.clear();
-  variables = defaultVariables;
-});
-
 const originalScrollTo = window.scrollTo;
-
-beforeAll(() => {
-  window.scrollTo = jest.fn();
-  feature.search.defaultValue = SearchExperiment.Control;
-});
-
-afterAll(() => {
-  window.scrollTo = originalScrollTo;
-});
 
 const createTagsSettingsMock = (
   feedSettings: FeedSettings = {
@@ -203,649 +186,6 @@ const renderComponent = (
   );
 };
 
-it('should add one placeholder when loading', async () => {
-  renderComponent();
-  expect(await screen.findByRole('article')).toHaveAttribute('aria-busy');
-});
-
-it('should replace placeholders with posts and ad', async () => {
-  renderComponent();
-  await waitForNock();
-  const elements = await screen.findAllByTestId('postItem');
-  expect(elements.length).toBeGreaterThan(0);
-  await Promise.all(
-    elements.map(async (el) =>
-      // eslint-disable-next-line testing-library/prefer-screen-queries
-      expect((await findAllByRole(el, 'link'))[0]).toHaveAttribute('href'),
-    ),
-  );
-  await waitFor(async () => {
-    const el = await screen.findByTestId('adItem');
-    // eslint-disable-next-line testing-library/prefer-screen-queries
-    expect(await findByRole(el, 'link')).toHaveAttribute('href', ad.link);
-  });
-});
-
-it('should render feed with sorting ranking by date', async () => {
-  variables = { ...defaultVariables, ranking: 'TIME' };
-  renderComponent(
-    [createFeedMock(defaultFeedPage, ANONYMOUS_FEED_QUERY)],
-    defaultUser,
-  );
-  await waitForNock();
-  const elements = await screen.findAllByTestId('postItem');
-  expect(elements.length).toBeGreaterThan(0);
-  const [latest, old] = elements;
-  // eslint-disable-next-line testing-library/no-node-access
-  const latestTitle = latest.querySelector('button').getAttribute('title');
-  const latestPost = defaultFeedPage.edges.find(
-    (edge) => edge.node.title === latestTitle,
-  ).node;
-  // eslint-disable-next-line testing-library/no-node-access
-  const oldTitle = old.querySelector('button').getAttribute('title');
-  const oldPost = defaultFeedPage.edges.find(
-    (edge) => edge.node.title === oldTitle,
-  ).node;
-  expect(new Date(latestPost.createdAt).getTime()).toBeGreaterThan(
-    new Date(oldPost.createdAt).getTime(),
-  );
-});
-
-it('should send upvote mutation', async () => {
-  let mutationCalled = false;
-  renderComponent([
-    createFeedMock({
-      pageInfo: defaultFeedPage.pageInfo,
-      edges: [defaultFeedPage.edges[0]],
-    }),
-    {
-      request: {
-        query: UPVOTE_MUTATION,
-        variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
-      },
-      result: () => {
-        mutationCalled = true;
-        return { data: { _: true } };
-      },
-    },
-  ]);
-  const [el] = await screen.findAllByLabelText('Upvote');
-  el.click();
-  await waitFor(() => expect(mutationCalled).toBeTruthy());
-});
-
-it('should send cancel upvote mutation', async () => {
-  let mutationCalled = false;
-  renderComponent([
-    createFeedMock({
-      pageInfo: defaultFeedPage.pageInfo,
-      edges: [
-        {
-          ...defaultFeedPage.edges[0],
-          node: { ...defaultFeedPage.edges[0].node, upvoted: true },
-        },
-      ],
-    }),
-    {
-      request: {
-        query: CANCEL_UPVOTE_MUTATION,
-        variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
-      },
-      result: () => {
-        mutationCalled = true;
-        return { data: { _: true } };
-      },
-    },
-  ]);
-  const [el] = await screen.findAllByLabelText('Remove upvote');
-  el.click();
-  await waitFor(() => expect(mutationCalled).toBeTruthy());
-});
-
-it('should open login modal on anonymous upvote', async () => {
-  renderComponent(
-    [
-      createFeedMock(
-        {
-          pageInfo: defaultFeedPage.pageInfo,
-          edges: [defaultFeedPage.edges[0]],
-        },
-        ANONYMOUS_FEED_QUERY,
-        {
-          first: 7,
-          loggedIn: false,
-        },
-      ),
-    ],
-    null,
-  );
-  const [el] = await screen.findAllByLabelText('Upvote');
-  el.click();
-  expect(showLogin).toBeCalledWith('upvote');
-});
-
-it('should send add bookmark mutation', async () => {
-  let mutationCalled = false;
-  renderComponent([
-    createFeedMock({
-      pageInfo: defaultFeedPage.pageInfo,
-      edges: [
-        {
-          ...defaultFeedPage.edges[0],
-          node: { ...defaultFeedPage.edges[0].node, bookmarked: false },
-        },
-      ],
-    }),
-    {
-      request: {
-        query: ADD_BOOKMARKS_MUTATION,
-        variables: { data: { postIds: ['4f354bb73009e4adfa5dbcbf9b3c4ebf'] } },
-      },
-      result: () => {
-        mutationCalled = true;
-        return { data: { _: true } };
-      },
-    },
-  ]);
-  const [menuBtn] = await screen.findAllByLabelText('Options');
-  menuBtn.click();
-  const el = await screen.findByText('Save to bookmarks');
-  el.click();
-  await waitFor(() => expect(mutationCalled).toBeTruthy());
-});
-
-it('should send remove bookmark mutation', async () => {
-  let mutationCalled = false;
-  renderComponent([
-    createFeedMock({
-      pageInfo: defaultFeedPage.pageInfo,
-      edges: [
-        {
-          ...defaultFeedPage.edges[0],
-          node: { ...defaultFeedPage.edges[0].node, bookmarked: true },
-        },
-      ],
-    }),
-    {
-      request: {
-        query: REMOVE_BOOKMARK_MUTATION,
-        variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
-      },
-      result: () => {
-        mutationCalled = true;
-        return { data: { _: true } };
-      },
-    },
-  ]);
-  const [menuBtn] = await screen.findAllByLabelText('Options');
-  menuBtn.click();
-  const el = await screen.findByText('Remove from bookmarks');
-  el.click();
-  await waitFor(() => expect(mutationCalled).toBeTruthy());
-});
-
-it('should open login modal on anonymous bookmark', async () => {
-  renderComponent(
-    [
-      createFeedMock(
-        {
-          pageInfo: defaultFeedPage.pageInfo,
-          edges: [defaultFeedPage.edges[0]],
-        },
-        ANONYMOUS_FEED_QUERY,
-        {
-          first: 7,
-          loggedIn: false,
-        },
-      ),
-    ],
-    null,
-  );
-  const [menuBtn] = await screen.findAllByLabelText('Options');
-  menuBtn.click();
-  const el = await screen.findByText('Save to bookmarks');
-  el.click();
-  await waitFor(() => expect(showLogin).toBeCalledWith('bookmark'));
-});
-
-it('should increase reading rank progress', async () => {
-  renderComponent([
-    createFeedMock({
-      pageInfo: defaultFeedPage.pageInfo,
-      edges: [
-        {
-          ...defaultFeedPage.edges[0],
-          node: {
-            ...defaultFeedPage.edges[0].node,
-            read: false,
-          },
-        },
-      ],
-    }),
-  ]);
-  const queryKey = getRankQueryKey(defaultUser);
-  queryClient.setQueryData<MyRankData>(queryKey, {
-    rank: { readToday: false, currentRank: 0, progressThisWeek: 0 },
-  });
-  const main = await screen.findByTitle(
-    'Eminem Quotes Generator - Simple PHP RESTful API',
-  );
-  // eslint-disable-next-line testing-library/no-node-access
-  const el = await within(main.parentElement).findByText('Read post');
-  el.click();
-  await waitFor(async () => {
-    const data = await queryClient.getQueryData<MyRankData>(queryKey);
-    expect(data).toEqual({
-      rank: {
-        readToday: true,
-        currentRank: 1,
-        progressThisWeek: 1,
-        lastReadTime: expect.anything(),
-        rankLastWeek: undefined,
-      },
-    });
-    const state = queryClient.getQueryState(queryKey);
-    expect(state.isInvalidated).toEqual(true);
-  });
-});
-
-it('should not increase reading rank progress when read today', async () => {
-  renderComponent();
-  const queryKey = getRankQueryKey(defaultUser);
-  queryClient.setQueryData<MyRankData>(queryKey, {
-    rank: { readToday: true, currentRank: 0, progressThisWeek: 0 },
-  });
-  const el = await screen.findByTitle(
-    'One Word Domains — Database of all available one-word domains',
-  );
-  el.click();
-  await waitFor(async () => {
-    const data = await queryClient.getQueryData<MyRankData>(queryKey);
-    expect(data).toEqual({
-      rank: { readToday: true, currentRank: 0, progressThisWeek: 0 },
-    });
-  });
-});
-
-it('should increase reading rank progress and rank', async () => {
-  renderComponent([
-    createFeedMock({
-      pageInfo: defaultFeedPage.pageInfo,
-      edges: [
-        {
-          ...defaultFeedPage.edges[0],
-          node: { ...defaultFeedPage.edges[0].node, read: false },
-        },
-      ],
-    }),
-  ]);
-  const queryKey = getRankQueryKey(defaultUser);
-  queryClient.setQueryData<MyRankData>(queryKey, {
-    rank: { readToday: false, currentRank: 0, progressThisWeek: 2 },
-  });
-  const main = await screen.findByTitle(
-    'Eminem Quotes Generator - Simple PHP RESTful API',
-  );
-  // eslint-disable-next-line testing-library/no-node-access
-  const el = await within(main.parentElement).findByText('Read post');
-  el.click();
-  await waitFor(async () => {
-    const data = await queryClient.getQueryData<MyRankData>(queryKey);
-    expect(data).toEqual({
-      rank: {
-        readToday: true,
-        currentRank: 1,
-        progressThisWeek: 3,
-        lastReadTime: expect.anything(),
-      },
-    });
-  });
-});
-
-it('should not increase reading rank progress when reached final rank', async () => {
-  renderComponent();
-  const queryKey = getRankQueryKey(defaultUser);
-  queryClient.setQueryData<MyRankData>(queryKey, {
-    rank: { readToday: false, currentRank: 5, progressThisWeek: 7 },
-  });
-  const el = await screen.findByTitle(
-    'One Word Domains — Database of all available one-word domains',
-  );
-  el.click();
-  await waitFor(async () => {
-    const data = await queryClient.getQueryData<MyRankData>(queryKey);
-    expect(data).toEqual({
-      rank: { readToday: false, currentRank: 5, progressThisWeek: 7 },
-    });
-  });
-});
-
-it('should increase reading rank progress for anonymous users', async () => {
-  renderComponent(
-    [
-      createFeedMock(
-        {
-          pageInfo: defaultFeedPage.pageInfo,
-          edges: [
-            {
-              ...defaultFeedPage.edges[0],
-              node: { ...defaultFeedPage.edges[0].node, read: false },
-            },
-          ],
-        },
-        ANONYMOUS_FEED_QUERY,
-        {
-          first: 7,
-          loggedIn: false,
-        },
-      ),
-    ],
-    null,
-  );
-  const queryKey = getRankQueryKey(null);
-  queryClient.setQueryData<MyRankData>(queryKey, {
-    rank: { readToday: false, currentRank: 0, progressThisWeek: 0 },
-  });
-  const main = await screen.findByTitle(
-    'Eminem Quotes Generator - Simple PHP RESTful API',
-  );
-  // eslint-disable-next-line testing-library/no-node-access
-  const el = await within(main.parentElement).findByText('Read post');
-  el.click();
-  await waitFor(async () => {
-    const data = await queryClient.getQueryData<MyRankData>(queryKey);
-    expect(data).toEqual({
-      rank: {
-        readToday: true,
-        currentRank: 1,
-        progressThisWeek: 1,
-        lastReadTime: expect.anything(),
-      },
-    });
-  });
-});
-
-it('should update feed item on subscription message', async () => {
-  renderComponent([
-    createFeedMock({
-      pageInfo: defaultFeedPage.pageInfo,
-      edges: [defaultFeedPage.edges[0]],
-    }),
-  ]);
-  await screen.findByTestId('adItem');
-  await waitFor(async () => {
-    const [el] = await screen.findAllByLabelText('Upvote');
-    // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
-    expect(await findByText(el.parentElement, '5')).toBeInTheDocument();
-  });
-  nextCallback({
-    postsEngaged: {
-      id: defaultFeedPage.edges[0].node.id,
-      numUpvotes: 6,
-      numComments: 7,
-    },
-  });
-  await waitFor(async () => {
-    const [el] = await screen.findAllByLabelText('Upvote');
-    // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
-    expect(await findByText(el.parentElement, '6')).toBeInTheDocument();
-  });
-});
-
-it('should report broken link', async () => {
-  let mutationCalled = false;
-  renderComponent([
-    createFeedMock({
-      pageInfo: defaultFeedPage.pageInfo,
-      edges: [defaultFeedPage.edges[0]],
-    }),
-    {
-      request: {
-        query: REPORT_POST_MUTATION,
-        variables: {
-          id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
-          reason: 'BROKEN',
-          tags: [],
-        },
-      },
-      result: () => {
-        mutationCalled = true;
-        return { data: { _: true } };
-      },
-    },
-  ]);
-  const [menuBtn] = await screen.findAllByLabelText('Options');
-  menuBtn.click();
-  const contextBtn = await screen.findByText('Report');
-  contextBtn.click();
-  const brokenLinkBtn = await screen.findByText('Broken link');
-  brokenLinkBtn.click();
-  const submitBtn = await screen.findByText('Submit report');
-  submitBtn.click();
-  await waitFor(() => expect(mutationCalled).toBeTruthy());
-  await waitFor(() =>
-    expect(
-      screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
-    ).not.toBeInTheDocument(),
-  );
-
-  await waitFor(async () => {
-    await screen.findByRole('alert');
-    const feed = await screen.findByTestId('posts-feed');
-
-    return expect(feed).toHaveAttribute('aria-live', 'assertive');
-  });
-});
-
-it('should report broken link with comment', async () => {
-  let mutationCalled = false;
-  renderComponent([
-    createFeedMock({
-      pageInfo: defaultFeedPage.pageInfo,
-      edges: [defaultFeedPage.edges[0]],
-    }),
-    {
-      request: {
-        query: REPORT_POST_MUTATION,
-        variables: {
-          id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
-          reason: 'BROKEN',
-          comment: 'comment',
-          tags: [],
-        },
-      },
-      result: () => {
-        mutationCalled = true;
-        return { data: { _: true } };
-      },
-    },
-  ]);
-  const [menuBtn] = await screen.findAllByLabelText('Options');
-  menuBtn.click();
-  const contextBtn = await screen.findByText('Report');
-  contextBtn.click();
-  const brokenLinkBtn = await screen.findByText('Broken link');
-  brokenLinkBtn.click();
-  const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
-  fireEvent.change(input, { target: { value: 'comment' } });
-  input.dispatchEvent(new Event('input', { bubbles: true }));
-  const submitBtn = await screen.findByText('Submit report');
-  submitBtn.click();
-  await waitFor(() => expect(mutationCalled).toBeTruthy());
-  await waitFor(() =>
-    expect(
-      screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
-    ).not.toBeInTheDocument(),
-  );
-  await waitFor(async () => {
-    await screen.findByRole('alert');
-    const feed = await screen.findByTestId('posts-feed');
-
-    return expect(feed).toHaveAttribute('aria-live', 'assertive');
-  });
-});
-
-it('should report nsfw', async () => {
-  let mutationCalled = false;
-  renderComponent([
-    createFeedMock({
-      pageInfo: defaultFeedPage.pageInfo,
-      edges: [defaultFeedPage.edges[0]],
-    }),
-    {
-      request: {
-        query: REPORT_POST_MUTATION,
-        variables: {
-          id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
-          reason: 'NSFW',
-          tags: [],
-        },
-      },
-      result: () => {
-        mutationCalled = true;
-        return { data: { _: true } };
-      },
-    },
-  ]);
-  const [menuBtn] = await screen.findAllByLabelText('Options');
-  menuBtn.click();
-  const contextBtn = await screen.findByText('Report');
-  contextBtn.click();
-  const brokenLinkBtn = await screen.findByText('NSFW');
-  brokenLinkBtn.click();
-  const submitBtn = await screen.findByText('Submit report');
-  submitBtn.click();
-  await waitFor(() => expect(mutationCalled).toBeTruthy());
-  await waitFor(() =>
-    expect(
-      screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
-    ).not.toBeInTheDocument(),
-  );
-
-  await waitFor(async () => {
-    await screen.findByRole('alert');
-    const feed = await screen.findByTestId('posts-feed');
-
-    return expect(feed).toHaveAttribute('aria-live', 'assertive');
-  });
-});
-
-it('should hide post', async () => {
-  let mutationCalled = false;
-  renderComponent([
-    createFeedMock({
-      pageInfo: defaultFeedPage.pageInfo,
-      edges: [defaultFeedPage.edges[0]],
-    }),
-    {
-      request: {
-        query: HIDE_POST_MUTATION,
-        variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
-      },
-      result: () => {
-        mutationCalled = true;
-        return { data: { _: true } };
-      },
-    },
-  ]);
-  const [menuBtn] = await screen.findAllByLabelText('Options');
-  menuBtn.click();
-  const contextBtn = await screen.findByText('Hide');
-  contextBtn.click();
-  await waitFor(() => expect(mutationCalled).toBeTruthy());
-  await waitFor(() =>
-    expect(
-      screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
-    ).not.toBeInTheDocument(),
-  );
-});
-
-it('should block a source', async () => {
-  let mutationCalled = false;
-  renderComponent([
-    createFeedMock({
-      pageInfo: defaultFeedPage.pageInfo,
-      edges: [defaultFeedPage.edges[0]],
-    }),
-    createTagsSettingsMock(),
-    {
-      request: {
-        query: ADD_FILTERS_TO_FEED_MUTATION,
-        variables: { filters: { excludeSources: ['echojs'] } },
-      },
-      result: () => {
-        mutationCalled = true;
-        return { data: { _: true } };
-      },
-    },
-  ]);
-  await waitFor(async () => {
-    const data = await queryClient.getQueryData(
-      getFeedSettingsQueryKey(defaultUser),
-    );
-    expect(data).toBeTruthy();
-  });
-  const [menuBtn] = await screen.findAllByLabelText('Options');
-  menuBtn.click();
-  const contextBtn = await screen.findByText("Don't show posts from Echo JS");
-  contextBtn.click();
-  await waitFor(() => expect(mutationCalled).toBeTruthy());
-
-  // await waitFor(async () => {
-  await screen.findByRole('alert');
-  const feed = await screen.findByTestId('posts-feed');
-
-  expect(feed).toHaveAttribute('aria-live', 'assertive');
-  // });
-});
-
-it('should block a tag', async () => {
-  let mutationCalled = false;
-  renderComponent([
-    createFeedMock({
-      pageInfo: defaultFeedPage.pageInfo,
-      edges: [defaultFeedPage.edges[0]],
-    }),
-    createTagsSettingsMock(),
-    {
-      request: {
-        query: ADD_FILTERS_TO_FEED_MUTATION,
-        variables: { filters: { blockedTags: ['javascript'] } },
-      },
-      result: () => {
-        mutationCalled = true;
-        return { data: { _: true } };
-      },
-    },
-  ]);
-  await waitFor(async () => {
-    const data = await queryClient.getQueryData(
-      getFeedSettingsQueryKey(defaultUser),
-    );
-    expect(data).toBeTruthy();
-  });
-  const [menuBtn] = await screen.findAllByLabelText('Options');
-  menuBtn.click();
-  const contextBtn = await screen.findByText('Not interested in #javascript');
-  contextBtn.click();
-  await waitFor(() => expect(mutationCalled).toBeTruthy());
-
-  await waitFor(async () => {
-    await screen.findByRole('alert');
-    const feed = await screen.findByTestId('posts-feed');
-
-    return expect(feed).toHaveAttribute('aria-live', 'assertive');
-  });
-});
-
-it('should open a modal to view post details', async () => {
-  renderComponent();
-  await waitForNock();
-  const [first] = await screen.findAllByLabelText('Comments');
-  fireEvent.click(first);
-  await screen.findByRole('dialog');
-});
-
 const createPostMock = (
   data: Partial<Post> = {},
 ): MockedGraphQLResponse<PostData> => ({
@@ -890,78 +230,744 @@ const createPostMock = (
   },
 });
 
-it('should be able to navigate through posts', async () => {
-  const [firstPost, secondPost] = defaultFeedPage.edges;
-  renderComponent();
-  await waitForNock();
+describe('Feed', () => {
+  beforeAll(() => {
+    window.scrollTo = jest.fn();
+    feature.search.defaultValue = SearchExperiment.Control;
+  });
 
-  mockGraphQL(createPostMock({ id: firstPost.node.id }));
-  const [first] = await screen.findAllByLabelText('Comments');
-  fireEvent.click(first);
+  afterAll(() => {
+    window.scrollTo = originalScrollTo;
+  });
 
-  await screen.findByRole('dialog');
-  const title = await screen.findByTestId('post-modal-title');
-  expect(title).toHaveTextContent(firstPost.node.title);
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    nock.cleanAll();
+    queryClient.clear();
+    variables = defaultVariables;
+  });
 
-  await screen.findByRole('navigation');
-  const next = await screen.findByLabelText('Next');
-  const params = { id: secondPost.node.id, title: secondPost.node.title };
-  mockGraphQL(createPostMock(params));
-  fireEvent.click(next);
-  const secondTitle = await screen.findByTestId('post-modal-title');
-  expect(secondTitle).toHaveTextContent(secondPost.node.title);
+  it('should add one placeholder when loading', async () => {
+    renderComponent();
+    expect(await screen.findByRole('article')).toHaveAttribute('aria-busy');
+  });
 
-  await screen.findByRole('navigation');
-  const previous = await screen.findByLabelText('Previous');
-  mockGraphQL(createPostMock({ id: firstPost.node.id }));
-  fireEvent.click(previous);
-  const firstTitle = await screen.findByTestId('post-modal-title');
-  expect(firstTitle).toHaveTextContent(firstPost.node.title);
-});
+  it('should replace placeholders with posts and ad', async () => {
+    renderComponent();
+    await waitForNock();
+    const elements = await screen.findAllByTestId('postItem');
+    expect(elements.length).toBeGreaterThan(0);
+    await Promise.all(
+      elements.map(async (el) =>
+        // eslint-disable-next-line testing-library/prefer-screen-queries
+        expect((await findAllByRole(el, 'link'))[0]).toHaveAttribute('href'),
+      ),
+    );
+    await waitFor(async () => {
+      const el = await screen.findByTestId('adItem');
+      // eslint-disable-next-line testing-library/prefer-screen-queries
+      expect(await findByRole(el, 'link')).toHaveAttribute('href', ad.link);
+    });
+  });
 
-it('should report irrelevant tags', async () => {
-  let mutationCalled = false;
-  renderComponent([
-    createFeedMock({
-      pageInfo: defaultFeedPage.pageInfo,
-      edges: [defaultFeedPage.edges[0]],
-    }),
-    {
-      request: {
-        query: REPORT_POST_MUTATION,
-        variables: {
-          id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
-          reason: 'IRRELEVANT',
-          tags: ['javascript'],
+  it('should render feed with sorting ranking by date', async () => {
+    variables = { ...defaultVariables, ranking: 'TIME' };
+    renderComponent(
+      [createFeedMock(defaultFeedPage, ANONYMOUS_FEED_QUERY)],
+      defaultUser,
+    );
+    await waitForNock();
+    const elements = await screen.findAllByTestId('postItem');
+    expect(elements.length).toBeGreaterThan(0);
+    const [latest, old] = elements;
+    // eslint-disable-next-line testing-library/no-node-access
+    const latestTitle = latest.querySelector('button').getAttribute('title');
+    const latestPost = defaultFeedPage.edges.find(
+      (edge) => edge.node.title === latestTitle,
+    ).node;
+    // eslint-disable-next-line testing-library/no-node-access
+    const oldTitle = old.querySelector('button').getAttribute('title');
+    const oldPost = defaultFeedPage.edges.find(
+      (edge) => edge.node.title === oldTitle,
+    ).node;
+    expect(new Date(latestPost.createdAt).getTime()).toBeGreaterThan(
+      new Date(oldPost.createdAt).getTime(),
+    );
+  });
+
+  it('should send upvote mutation', async () => {
+    let mutationCalled = false;
+    renderComponent([
+      createFeedMock({
+        pageInfo: defaultFeedPage.pageInfo,
+        edges: [defaultFeedPage.edges[0]],
+      }),
+      {
+        request: {
+          query: UPVOTE_MUTATION,
+          variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
+        },
+        result: () => {
+          mutationCalled = true;
+          return { data: { _: true } };
         },
       },
-      result: () => {
-        mutationCalled = true;
-        return { data: { _: true } };
+    ]);
+    const [el] = await screen.findAllByLabelText('Upvote');
+    fireEvent.click(el);
+    await waitFor(() => expect(mutationCalled).toBeTruthy());
+  });
+
+  it('should send cancel upvote mutation', async () => {
+    let mutationCalled = false;
+    renderComponent([
+      createFeedMock({
+        pageInfo: defaultFeedPage.pageInfo,
+        edges: [
+          {
+            ...defaultFeedPage.edges[0],
+            node: { ...defaultFeedPage.edges[0].node, upvoted: true },
+          },
+        ],
+      }),
+      {
+        request: {
+          query: CANCEL_UPVOTE_MUTATION,
+          variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
+        },
+        result: () => {
+          mutationCalled = true;
+          return { data: { _: true } };
+        },
       },
-    },
-  ]);
-  const [menuBtn] = await screen.findAllByLabelText('Options');
-  fireEvent.click(menuBtn);
-  const contextBtn = await screen.findByText('Report');
-  fireEvent.click(contextBtn);
-  const irrelevantTagsBtn = await screen.findByText('The post is not about...');
-  fireEvent.click(irrelevantTagsBtn);
-  const javascriptBtn = await screen.findByText('#javascript');
-  fireEvent.click(javascriptBtn);
-  const submitBtn = await screen.findByText('Submit report');
-  fireEvent.click(submitBtn);
-  await waitFor(() => expect(mutationCalled).toBeTruthy());
-  await waitFor(() =>
-    expect(
-      screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
-    ).not.toBeInTheDocument(),
-  );
+    ]);
+    const [el] = await screen.findAllByLabelText('Remove upvote');
+    fireEvent.click(el);
+    await waitFor(() => expect(mutationCalled).toBeTruthy());
+  });
 
-  await waitFor(async () => {
-    await screen.findByRole('alert');
-    const feed = await screen.findByTestId('posts-feed');
+  it('should open login modal on anonymous upvote', async () => {
+    renderComponent(
+      [
+        createFeedMock(
+          {
+            pageInfo: defaultFeedPage.pageInfo,
+            edges: [defaultFeedPage.edges[0]],
+          },
+          ANONYMOUS_FEED_QUERY,
+          {
+            first: 7,
+            loggedIn: false,
+          },
+        ),
+      ],
+      null,
+    );
+    const [el] = await screen.findAllByLabelText('Upvote');
+    fireEvent.click(el);
+    expect(showLogin).toBeCalledWith('upvote');
+  });
 
-    return expect(feed).toHaveAttribute('aria-live', 'assertive');
+  it('should send add bookmark mutation', async () => {
+    let mutationCalled = false;
+    renderComponent([
+      createFeedMock({
+        pageInfo: defaultFeedPage.pageInfo,
+        edges: [
+          {
+            ...defaultFeedPage.edges[0],
+            node: { ...defaultFeedPage.edges[0].node, bookmarked: false },
+          },
+        ],
+      }),
+      {
+        request: {
+          query: ADD_BOOKMARKS_MUTATION,
+          variables: {
+            data: { postIds: ['4f354bb73009e4adfa5dbcbf9b3c4ebf'] },
+          },
+        },
+        result: () => {
+          mutationCalled = true;
+          return { data: { _: true } };
+        },
+      },
+    ]);
+    const [menuBtn] = await screen.findAllByLabelText('Options');
+    fireEvent.click(menuBtn);
+    const el = await screen.findByText('Save to bookmarks');
+    fireEvent.click(el);
+    await waitFor(() => expect(mutationCalled).toBeTruthy());
+  });
+
+  it('should send remove bookmark mutation', async () => {
+    let mutationCalled = false;
+    renderComponent([
+      createFeedMock({
+        pageInfo: defaultFeedPage.pageInfo,
+        edges: [
+          {
+            ...defaultFeedPage.edges[0],
+            node: { ...defaultFeedPage.edges[0].node, bookmarked: true },
+          },
+        ],
+      }),
+      {
+        request: {
+          query: REMOVE_BOOKMARK_MUTATION,
+          variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
+        },
+        result: () => {
+          mutationCalled = true;
+          return { data: { _: true } };
+        },
+      },
+    ]);
+    const [menuBtn] = await screen.findAllByLabelText('Options');
+    fireEvent.click(menuBtn);
+    const el = await screen.findByText('Remove from bookmarks');
+    fireEvent.click(el);
+    await waitFor(() => expect(mutationCalled).toBeTruthy());
+  });
+
+  it('should open login modal on anonymous bookmark', async () => {
+    renderComponent(
+      [
+        createFeedMock(
+          {
+            pageInfo: defaultFeedPage.pageInfo,
+            edges: [defaultFeedPage.edges[0]],
+          },
+          ANONYMOUS_FEED_QUERY,
+          {
+            first: 7,
+            loggedIn: false,
+          },
+        ),
+      ],
+      null,
+    );
+    const [menuBtn] = await screen.findAllByLabelText('Options');
+    fireEvent.click(menuBtn);
+    const el = await screen.findByText('Save to bookmarks');
+    fireEvent.click(el);
+    await waitFor(() => expect(showLogin).toBeCalledWith('bookmark'));
+  });
+
+  it('should increase reading rank progress', async () => {
+    renderComponent([
+      createFeedMock({
+        pageInfo: defaultFeedPage.pageInfo,
+        edges: [
+          {
+            ...defaultFeedPage.edges[0],
+            node: {
+              ...defaultFeedPage.edges[0].node,
+              read: false,
+            },
+          },
+        ],
+      }),
+    ]);
+    const queryKey = getRankQueryKey(defaultUser);
+    queryClient.setQueryData<MyRankData>(queryKey, {
+      rank: { readToday: false, currentRank: 0, progressThisWeek: 0 },
+    });
+    const main = await screen.findByTitle(
+      'Eminem Quotes Generator - Simple PHP RESTful API',
+    );
+    // eslint-disable-next-line testing-library/no-node-access
+    const el = await within(main.parentElement).findByText('Read post');
+    fireEvent.click(el);
+    await waitFor(async () => {
+      const data = await queryClient.getQueryData<MyRankData>(queryKey);
+      expect(data).toEqual({
+        rank: {
+          readToday: true,
+          currentRank: 1,
+          progressThisWeek: 1,
+          lastReadTime: expect.anything(),
+          rankLastWeek: undefined,
+        },
+      });
+      const state = queryClient.getQueryState(queryKey);
+      expect(state.isInvalidated).toEqual(true);
+    });
+  });
+
+  it('should not increase reading rank progress when read today', async () => {
+    renderComponent();
+    const queryKey = getRankQueryKey(defaultUser);
+    queryClient.setQueryData<MyRankData>(queryKey, {
+      rank: { readToday: true, currentRank: 0, progressThisWeek: 0 },
+    });
+    const el = await screen.findByTitle(
+      'One Word Domains — Database of all available one-word domains',
+    );
+    fireEvent.click(el);
+    await waitFor(async () => {
+      const data = await queryClient.getQueryData<MyRankData>(queryKey);
+      expect(data).toEqual({
+        rank: { readToday: true, currentRank: 0, progressThisWeek: 0 },
+      });
+    });
+  });
+
+  it('should increase reading rank progress and rank', async () => {
+    renderComponent([
+      createFeedMock({
+        pageInfo: defaultFeedPage.pageInfo,
+        edges: [
+          {
+            ...defaultFeedPage.edges[0],
+            node: { ...defaultFeedPage.edges[0].node, read: false },
+          },
+        ],
+      }),
+    ]);
+    const queryKey = getRankQueryKey(defaultUser);
+    queryClient.setQueryData<MyRankData>(queryKey, {
+      rank: { readToday: false, currentRank: 0, progressThisWeek: 2 },
+    });
+    const main = await screen.findByTitle(
+      'Eminem Quotes Generator - Simple PHP RESTful API',
+    );
+    // eslint-disable-next-line testing-library/no-node-access
+    const el = await within(main.parentElement).findByText('Read post');
+    fireEvent.click(el);
+    await waitFor(async () => {
+      const data = await queryClient.getQueryData<MyRankData>(queryKey);
+      expect(data).toEqual({
+        rank: {
+          readToday: true,
+          currentRank: 1,
+          progressThisWeek: 3,
+          lastReadTime: expect.anything(),
+        },
+      });
+    });
+  });
+
+  it('should not increase reading rank progress when reached final rank', async () => {
+    renderComponent();
+    const queryKey = getRankQueryKey(defaultUser);
+    queryClient.setQueryData<MyRankData>(queryKey, {
+      rank: { readToday: false, currentRank: 5, progressThisWeek: 7 },
+    });
+    const el = await screen.findByTitle(
+      'One Word Domains — Database of all available one-word domains',
+    );
+    fireEvent.click(el);
+    await waitFor(async () => {
+      const data = await queryClient.getQueryData<MyRankData>(queryKey);
+      expect(data).toEqual({
+        rank: { readToday: false, currentRank: 5, progressThisWeek: 7 },
+      });
+    });
+  });
+
+  it('should increase reading rank progress for anonymous users', async () => {
+    renderComponent(
+      [
+        createFeedMock(
+          {
+            pageInfo: defaultFeedPage.pageInfo,
+            edges: [
+              {
+                ...defaultFeedPage.edges[0],
+                node: { ...defaultFeedPage.edges[0].node, read: false },
+              },
+            ],
+          },
+          ANONYMOUS_FEED_QUERY,
+          {
+            first: 7,
+            loggedIn: false,
+          },
+        ),
+      ],
+      null,
+    );
+    const queryKey = getRankQueryKey(null);
+    queryClient.setQueryData<MyRankData>(queryKey, {
+      rank: { readToday: false, currentRank: 0, progressThisWeek: 0 },
+    });
+    const main = await screen.findByTitle(
+      'Eminem Quotes Generator - Simple PHP RESTful API',
+    );
+    // eslint-disable-next-line testing-library/no-node-access
+    const el = await within(main.parentElement).findByText('Read post');
+    fireEvent.click(el);
+    await waitFor(async () => {
+      const data = await queryClient.getQueryData<MyRankData>(queryKey);
+      expect(data).toEqual({
+        rank: {
+          readToday: true,
+          currentRank: 1,
+          progressThisWeek: 1,
+          lastReadTime: expect.anything(),
+        },
+      });
+    });
+  });
+
+  it('should update feed item on subscription message', async () => {
+    renderComponent([
+      createFeedMock({
+        pageInfo: defaultFeedPage.pageInfo,
+        edges: [defaultFeedPage.edges[0]],
+      }),
+    ]);
+    await screen.findByTestId('adItem');
+    await waitFor(async () => {
+      const [el] = await screen.findAllByLabelText('Upvote');
+      // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
+      expect(await findByText(el.parentElement, '5')).toBeInTheDocument();
+    });
+    nextCallback({
+      postsEngaged: {
+        id: defaultFeedPage.edges[0].node.id,
+        numUpvotes: 6,
+        numComments: 7,
+      },
+    });
+    await waitFor(async () => {
+      const [el] = await screen.findAllByLabelText('Upvote');
+      // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
+      expect(await findByText(el.parentElement, '6')).toBeInTheDocument();
+    });
+  });
+
+  it('should report broken link', async () => {
+    let mutationCalled = false;
+    renderComponent([
+      createFeedMock({
+        pageInfo: defaultFeedPage.pageInfo,
+        edges: [defaultFeedPage.edges[0]],
+      }),
+      {
+        request: {
+          query: REPORT_POST_MUTATION,
+          variables: {
+            id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
+            reason: 'BROKEN',
+            tags: [],
+          },
+        },
+        result: () => {
+          mutationCalled = true;
+          return { data: { _: true } };
+        },
+      },
+    ]);
+    const [menuBtn] = await screen.findAllByLabelText('Options');
+    fireEvent.click(menuBtn);
+    const contextBtn = await screen.findByText('Report');
+    fireEvent.click(contextBtn);
+    const brokenLinkBtn = await screen.findByText('Broken link');
+    fireEvent.click(brokenLinkBtn);
+    const submitBtn = await screen.findByText('Submit report');
+    fireEvent.click(submitBtn);
+    await waitFor(() => expect(mutationCalled).toBeTruthy());
+    await waitFor(() =>
+      expect(
+        screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
+      ).not.toBeInTheDocument(),
+    );
+
+    await waitFor(async () => {
+      await screen.findByRole('alert');
+      const feed = await screen.findByTestId('posts-feed');
+
+      return expect(feed).toHaveAttribute('aria-live', 'assertive');
+    });
+  });
+
+  it('should report broken link with comment', async () => {
+    let mutationCalled = false;
+    renderComponent([
+      createFeedMock({
+        pageInfo: defaultFeedPage.pageInfo,
+        edges: [defaultFeedPage.edges[0]],
+      }),
+      {
+        request: {
+          query: REPORT_POST_MUTATION,
+          variables: {
+            id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
+            reason: 'BROKEN',
+            comment: 'comment',
+            tags: [],
+          },
+        },
+        result: () => {
+          mutationCalled = true;
+          return { data: { _: true } };
+        },
+      },
+    ]);
+    const [menuBtn] = await screen.findAllByLabelText('Options');
+    fireEvent.click(menuBtn);
+    const contextBtn = await screen.findByText('Report');
+    fireEvent.click(contextBtn);
+    const brokenLinkBtn = await screen.findByText('Broken link');
+    fireEvent.click(brokenLinkBtn);
+    const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'comment' } });
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    const submitBtn = await screen.findByText('Submit report');
+    fireEvent.click(submitBtn);
+    await waitFor(() => expect(mutationCalled).toBeTruthy());
+    await waitFor(() =>
+      expect(
+        screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
+      ).not.toBeInTheDocument(),
+    );
+    await waitFor(async () => {
+      await screen.findByRole('alert');
+      const feed = await screen.findByTestId('posts-feed');
+
+      return expect(feed).toHaveAttribute('aria-live', 'assertive');
+    });
+  });
+
+  it('should report nsfw', async () => {
+    let mutationCalled = false;
+    renderComponent([
+      createFeedMock({
+        pageInfo: defaultFeedPage.pageInfo,
+        edges: [defaultFeedPage.edges[0]],
+      }),
+      {
+        request: {
+          query: REPORT_POST_MUTATION,
+          variables: {
+            id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
+            reason: 'NSFW',
+            tags: [],
+          },
+        },
+        result: () => {
+          mutationCalled = true;
+          return { data: { _: true } };
+        },
+      },
+    ]);
+    const [menuBtn] = await screen.findAllByLabelText('Options');
+    fireEvent.click(menuBtn);
+    const contextBtn = await screen.findByText('Report');
+    fireEvent.click(contextBtn);
+    const brokenLinkBtn = await screen.findByText('NSFW');
+    fireEvent.click(brokenLinkBtn);
+    const submitBtn = await screen.findByText('Submit report');
+    fireEvent.click(submitBtn);
+    await waitFor(() => expect(mutationCalled).toBeTruthy());
+    await waitFor(() =>
+      expect(
+        screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
+      ).not.toBeInTheDocument(),
+    );
+
+    await waitFor(async () => {
+      await screen.findByRole('alert');
+      const feed = await screen.findByTestId('posts-feed');
+
+      return expect(feed).toHaveAttribute('aria-live', 'assertive');
+    });
+  });
+
+  it('should hide post', async () => {
+    let mutationCalled = false;
+    renderComponent([
+      createFeedMock({
+        pageInfo: defaultFeedPage.pageInfo,
+        edges: [defaultFeedPage.edges[0]],
+      }),
+      {
+        request: {
+          query: HIDE_POST_MUTATION,
+          variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
+        },
+        result: () => {
+          mutationCalled = true;
+          return { data: { _: true } };
+        },
+      },
+    ]);
+    const [menuBtn] = await screen.findAllByLabelText('Options');
+    fireEvent.click(menuBtn);
+    const contextBtn = await screen.findByText('Hide');
+    fireEvent.click(contextBtn);
+    await waitFor(() => expect(mutationCalled).toBeTruthy());
+    await waitFor(() =>
+      expect(
+        screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
+      ).not.toBeInTheDocument(),
+    );
+  });
+
+  it('should block a source', async () => {
+    let mutationCalled = false;
+    renderComponent([
+      createFeedMock({
+        pageInfo: defaultFeedPage.pageInfo,
+        edges: [defaultFeedPage.edges[0]],
+      }),
+      createTagsSettingsMock(),
+      {
+        request: {
+          query: ADD_FILTERS_TO_FEED_MUTATION,
+          variables: { filters: { excludeSources: ['echojs'] } },
+        },
+        result: () => {
+          mutationCalled = true;
+          return { data: { _: true } };
+        },
+      },
+    ]);
+    await waitFor(async () => {
+      const data = await queryClient.getQueryData(
+        getFeedSettingsQueryKey(defaultUser),
+      );
+      expect(data).toBeTruthy();
+    });
+    const [menuBtn] = await screen.findAllByLabelText('Options');
+    fireEvent.click(menuBtn);
+    const contextBtn = await screen.findByText("Don't show posts from Echo JS");
+    fireEvent.click(contextBtn);
+    await waitFor(() => expect(mutationCalled).toBeTruthy());
+
+    await waitFor(async () => {
+      await screen.findByRole('alert');
+      const feed = await screen.findByTestId('posts-feed');
+
+      expect(feed).toHaveAttribute('aria-live', 'assertive');
+    });
+  });
+
+  it('should block a tag', async () => {
+    let mutationCalled = false;
+    renderComponent([
+      createFeedMock({
+        pageInfo: defaultFeedPage.pageInfo,
+        edges: [defaultFeedPage.edges[0]],
+      }),
+      createTagsSettingsMock(),
+      {
+        request: {
+          query: ADD_FILTERS_TO_FEED_MUTATION,
+          variables: { filters: { blockedTags: ['javascript'] } },
+        },
+        result: () => {
+          mutationCalled = true;
+          return { data: { _: true } };
+        },
+      },
+    ]);
+    await waitFor(async () => {
+      const data = await queryClient.getQueryData(
+        getFeedSettingsQueryKey(defaultUser),
+      );
+      expect(data).toBeTruthy();
+    });
+    const [menuBtn] = await screen.findAllByLabelText('Options');
+    fireEvent.click(menuBtn);
+    const contextBtn = await screen.findByText('Not interested in #javascript');
+    fireEvent.click(contextBtn);
+    await waitFor(() => expect(mutationCalled).toBeTruthy());
+
+    await waitFor(async () => {
+      await screen.findByRole('alert');
+      const feed = await screen.findByTestId('posts-feed');
+
+      return expect(feed).toHaveAttribute('aria-live', 'assertive');
+    });
+  });
+
+  it('should open a modal to view post details', async () => {
+    renderComponent();
+    await waitForNock();
+    const [first] = await screen.findAllByLabelText('Comments');
+    fireEvent.click(first);
+    await screen.findByRole('dialog');
+  });
+
+  it('should be able to navigate through posts', async () => {
+    const [firstPost, secondPost] = defaultFeedPage.edges;
+    renderComponent();
+    await waitForNock();
+
+    mockGraphQL(createPostMock({ id: firstPost.node.id }));
+    const [first] = await screen.findAllByLabelText('Comments');
+    fireEvent.click(first);
+
+    await screen.findByRole('dialog');
+    const title = await screen.findByTestId('post-modal-title');
+    expect(title).toHaveTextContent(firstPost.node.title);
+
+    await screen.findByRole('navigation');
+    const next = await screen.findByLabelText('Next');
+    const params = { id: secondPost.node.id, title: secondPost.node.title };
+    mockGraphQL(createPostMock(params));
+    fireEvent.click(next);
+    const secondTitle = await screen.findByTestId('post-modal-title');
+    expect(secondTitle).toHaveTextContent(secondPost.node.title);
+
+    await screen.findByRole('navigation');
+    const previous = await screen.findByLabelText('Previous');
+    mockGraphQL(createPostMock({ id: firstPost.node.id }));
+    fireEvent.click(previous);
+    const firstTitle = await screen.findByTestId('post-modal-title');
+    expect(firstTitle).toHaveTextContent(firstPost.node.title);
+  });
+
+  it('should report irrelevant tags', async () => {
+    let mutationCalled = false;
+    renderComponent([
+      createFeedMock({
+        pageInfo: defaultFeedPage.pageInfo,
+        edges: [defaultFeedPage.edges[0]],
+      }),
+      {
+        request: {
+          query: REPORT_POST_MUTATION,
+          variables: {
+            id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
+            reason: 'IRRELEVANT',
+            tags: ['javascript'],
+          },
+        },
+        result: () => {
+          mutationCalled = true;
+          return { data: { _: true } };
+        },
+      },
+    ]);
+    const [menuBtn] = await screen.findAllByLabelText('Options');
+    fireEvent.click(menuBtn);
+    const contextBtn = await screen.findByText('Report');
+    fireEvent.click(contextBtn);
+    const irrelevantTagsBtn = await screen.findByText(
+      'The post is not about...',
+    );
+    fireEvent.click(irrelevantTagsBtn);
+    const javascriptBtn = await screen.findByText('#javascript');
+    fireEvent.click(javascriptBtn);
+    const submitBtn = await screen.findByText('Submit report');
+    fireEvent.click(submitBtn);
+    await waitFor(() => expect(mutationCalled).toBeTruthy());
+    await waitFor(() =>
+      expect(
+        screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
+      ).not.toBeInTheDocument(),
+    );
+
+    await waitFor(async () => {
+      await screen.findByRole('alert');
+      const feed = await screen.findByTestId('posts-feed');
+
+      return expect(feed).toHaveAttribute('aria-live', 'assertive');
+    });
   });
 });

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -1,6 +1,7 @@
 import nock from 'nock';
 import React from 'react';
 import {
+  findAllByRole,
   findByRole,
   findByText,
   fireEvent,
@@ -83,7 +84,24 @@ const defaultVariables = {
 
 const queryClient = new QueryClient();
 
+beforeEach(() => {
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
+  nock.cleanAll();
+  queryClient.clear();
+  variables = defaultVariables;
+});
+
 const originalScrollTo = window.scrollTo;
+
+beforeAll(() => {
+  window.scrollTo = jest.fn();
+  feature.search.defaultValue = SearchExperiment.Control;
+});
+
+afterAll(() => {
+  window.scrollTo = originalScrollTo;
+});
 
 const createTagsSettingsMock = (
   feedSettings: FeedSettings = {
@@ -185,6 +203,654 @@ const renderComponent = (
   );
 };
 
+it('should add one placeholder when loading', async () => {
+  renderComponent();
+  expect(await screen.findByRole('article')).toHaveAttribute('aria-busy');
+});
+
+  it('should replace placeholders with posts and ad', async () => {
+    renderComponent();
+    await waitForNock();
+    const elements = await screen.findAllByTestId('postItem');
+    expect(elements.length).toBeGreaterThan(0);
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const el of elements) {
+      // eslint-disable-next-line no-await-in-loop,@typescript-eslint/no-loop-func
+      await waitFor(async () => {
+        const links = await within(el).findAllByRole('link');
+        expect(links[0]).toHaveAttribute('href');
+      });
+    }
+
+  await waitFor(async () => {
+    const el = await screen.findByTestId('adItem');
+    // eslint-disable-next-line testing-library/prefer-screen-queries
+    expect(await findByRole(el, 'link')).toHaveAttribute('href', ad.link);
+  });
+});
+
+it('should render feed with sorting ranking by date', async () => {
+  variables = { ...defaultVariables, ranking: 'TIME' };
+  renderComponent(
+    [createFeedMock(defaultFeedPage, ANONYMOUS_FEED_QUERY)],
+    defaultUser,
+  );
+  await waitForNock();
+  const elements = await screen.findAllByTestId('postItem');
+  expect(elements.length).toBeGreaterThan(0);
+  const [latest, old] = elements;
+  // eslint-disable-next-line testing-library/no-node-access
+  const latestTitle = latest.querySelector('button').getAttribute('title');
+  const latestPost = defaultFeedPage.edges.find(
+    (edge) => edge.node.title === latestTitle,
+  ).node;
+  // eslint-disable-next-line testing-library/no-node-access
+  const oldTitle = old.querySelector('button').getAttribute('title');
+  const oldPost = defaultFeedPage.edges.find(
+    (edge) => edge.node.title === oldTitle,
+  ).node;
+  expect(new Date(latestPost.createdAt).getTime()).toBeGreaterThan(
+    new Date(oldPost.createdAt).getTime(),
+  );
+});
+
+it('should send upvote mutation', async () => {
+  let mutationCalled = false;
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [defaultFeedPage.edges[0]],
+    }),
+    {
+      request: {
+        query: UPVOTE_MUTATION,
+        variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
+      },
+      result: () => {
+        mutationCalled = true;
+        return { data: { _: true } };
+      },
+    },
+  ]);
+  const [el] = await screen.findAllByLabelText('Upvote');
+  fireEvent.click(el);
+  await waitFor(() => expect(mutationCalled).toBeTruthy());
+});
+
+it('should send cancel upvote mutation', async () => {
+  let mutationCalled = false;
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [
+        {
+          ...defaultFeedPage.edges[0],
+          node: { ...defaultFeedPage.edges[0].node, upvoted: true },
+        },
+      ],
+    }),
+    {
+      request: {
+        query: CANCEL_UPVOTE_MUTATION,
+        variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
+      },
+      result: () => {
+        mutationCalled = true;
+        return { data: { _: true } };
+      },
+    },
+  ]);
+  const [el] = await screen.findAllByLabelText('Remove upvote');
+  fireEvent.click(el);
+  await waitFor(() => expect(mutationCalled).toBeTruthy());
+});
+
+it('should open login modal on anonymous upvote', async () => {
+  renderComponent(
+    [
+      createFeedMock(
+        {
+          pageInfo: defaultFeedPage.pageInfo,
+          edges: [defaultFeedPage.edges[0]],
+        },
+        ANONYMOUS_FEED_QUERY,
+        {
+          first: 7,
+          loggedIn: false,
+        },
+      ),
+    ],
+    null,
+  );
+  const [el] = await screen.findAllByLabelText('Upvote');
+  fireEvent.click(el);
+  expect(showLogin).toBeCalledWith('upvote');
+});
+
+it('should send add bookmark mutation', async () => {
+  let mutationCalled = false;
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [
+        {
+          ...defaultFeedPage.edges[0],
+          node: { ...defaultFeedPage.edges[0].node, bookmarked: false },
+        },
+      ],
+    }),
+    {
+      request: {
+        query: ADD_BOOKMARKS_MUTATION,
+        variables: { data: { postIds: ['4f354bb73009e4adfa5dbcbf9b3c4ebf'] } },
+      },
+      result: () => {
+        mutationCalled = true;
+        return { data: { _: true } };
+      },
+    },
+  ]);
+  const [menuBtn] = await screen.findAllByLabelText('Options');
+  fireEvent.click(menuBtn);
+  const el = await screen.findByText('Save to bookmarks');
+  fireEvent.click(el);
+  await waitFor(() => expect(mutationCalled).toBeTruthy());
+});
+
+it('should send remove bookmark mutation', async () => {
+  let mutationCalled = false;
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [
+        {
+          ...defaultFeedPage.edges[0],
+          node: { ...defaultFeedPage.edges[0].node, bookmarked: true },
+        },
+      ],
+    }),
+    {
+      request: {
+        query: REMOVE_BOOKMARK_MUTATION,
+        variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
+      },
+      result: () => {
+        mutationCalled = true;
+        return { data: { _: true } };
+      },
+    },
+  ]);
+  const [menuBtn] = await screen.findAllByLabelText('Options');
+  fireEvent.click(menuBtn);
+  const el = await screen.findByText('Remove from bookmarks');
+  fireEvent.click(el);
+  await waitFor(() => expect(mutationCalled).toBeTruthy());
+});
+
+it('should open login modal on anonymous bookmark', async () => {
+  renderComponent(
+    [
+      createFeedMock(
+        {
+          pageInfo: defaultFeedPage.pageInfo,
+          edges: [defaultFeedPage.edges[0]],
+        },
+        ANONYMOUS_FEED_QUERY,
+        {
+          first: 7,
+          loggedIn: false,
+        },
+      ),
+    ],
+    null,
+  );
+  const [menuBtn] = await screen.findAllByLabelText('Options');
+  fireEvent.click(menuBtn);
+  const el = await screen.findByText('Save to bookmarks');
+  fireEvent.click(el);
+  await waitFor(() => expect(showLogin).toBeCalledWith('bookmark'));
+});
+
+it('should increase reading rank progress', async () => {
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [
+        {
+          ...defaultFeedPage.edges[0],
+          node: {
+            ...defaultFeedPage.edges[0].node,
+            read: false,
+          },
+        },
+      ],
+    }),
+  ]);
+  const queryKey = getRankQueryKey(defaultUser);
+  queryClient.setQueryData<MyRankData>(queryKey, {
+    rank: { readToday: false, currentRank: 0, progressThisWeek: 0 },
+  });
+  const main = await screen.findByTitle(
+    'Eminem Quotes Generator - Simple PHP RESTful API',
+  );
+  // eslint-disable-next-line testing-library/no-node-access
+  const el = await within(main.parentElement).findByText('Read post');
+  el.click();
+  await waitFor(async () => {
+    const data = await queryClient.getQueryData<MyRankData>(queryKey);
+    expect(data).toEqual({
+      rank: {
+        readToday: true,
+        currentRank: 1,
+        progressThisWeek: 1,
+        lastReadTime: expect.anything(),
+        rankLastWeek: undefined,
+      },
+    });
+    const state = queryClient.getQueryState(queryKey);
+    expect(state.isInvalidated).toEqual(true);
+  });
+});
+
+it('should not increase reading rank progress when read today', async () => {
+  renderComponent();
+  const queryKey = getRankQueryKey(defaultUser);
+  queryClient.setQueryData<MyRankData>(queryKey, {
+    rank: { readToday: true, currentRank: 0, progressThisWeek: 0 },
+  });
+  const el = await screen.findByTitle(
+    'One Word Domains — Database of all available one-word domains',
+  );
+  fireEvent.click(el);
+  await waitFor(async () => {
+    const data = await queryClient.getQueryData<MyRankData>(queryKey);
+    expect(data).toEqual({
+      rank: { readToday: true, currentRank: 0, progressThisWeek: 0 },
+    });
+  });
+});
+
+it('should increase reading rank progress and rank', async () => {
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [
+        {
+          ...defaultFeedPage.edges[0],
+          node: { ...defaultFeedPage.edges[0].node, read: false },
+        },
+      ],
+    }),
+  ]);
+  const queryKey = getRankQueryKey(defaultUser);
+  queryClient.setQueryData<MyRankData>(queryKey, {
+    rank: { readToday: false, currentRank: 0, progressThisWeek: 2 },
+  });
+  const main = await screen.findByTitle(
+    'Eminem Quotes Generator - Simple PHP RESTful API',
+  );
+  // eslint-disable-next-line testing-library/no-node-access
+  const el = await within(main.parentElement).findByText('Read post');
+  fireEvent.click(el);
+  await waitFor(async () => {
+    const data = await queryClient.getQueryData<MyRankData>(queryKey);
+    expect(data).toEqual({
+      rank: {
+        readToday: true,
+        currentRank: 1,
+        progressThisWeek: 3,
+        lastReadTime: expect.anything(),
+      },
+    });
+  });
+});
+
+it('should not increase reading rank progress when reached final rank', async () => {
+  renderComponent();
+  const queryKey = getRankQueryKey(defaultUser);
+  queryClient.setQueryData<MyRankData>(queryKey, {
+    rank: { readToday: false, currentRank: 5, progressThisWeek: 7 },
+  });
+  const el = await screen.findByTitle(
+    'One Word Domains — Database of all available one-word domains',
+  );
+  fireEvent.click(el);
+  await waitFor(async () => {
+    const data = await queryClient.getQueryData<MyRankData>(queryKey);
+    expect(data).toEqual({
+      rank: { readToday: false, currentRank: 5, progressThisWeek: 7 },
+    });
+  });
+});
+
+it('should increase reading rank progress for anonymous users', async () => {
+  renderComponent(
+    [
+      createFeedMock(
+        {
+          pageInfo: defaultFeedPage.pageInfo,
+          edges: [
+            {
+              ...defaultFeedPage.edges[0],
+              node: { ...defaultFeedPage.edges[0].node, read: false },
+            },
+          ],
+        },
+        ANONYMOUS_FEED_QUERY,
+        {
+          first: 7,
+          loggedIn: false,
+        },
+      ),
+    ],
+    null,
+  );
+  const queryKey = getRankQueryKey(null);
+  queryClient.setQueryData<MyRankData>(queryKey, {
+    rank: { readToday: false, currentRank: 0, progressThisWeek: 0 },
+  });
+  const main = await screen.findByTitle(
+    'Eminem Quotes Generator - Simple PHP RESTful API',
+  );
+  // eslint-disable-next-line testing-library/no-node-access
+  const el = await within(main.parentElement).findByText('Read post');
+  el.click();
+  await waitFor(async () => {
+    const data = await queryClient.getQueryData<MyRankData>(queryKey);
+    expect(data).toEqual({
+      rank: {
+        readToday: true,
+        currentRank: 1,
+        progressThisWeek: 1,
+        lastReadTime: expect.anything(),
+      },
+    });
+  });
+});
+
+it('should update feed item on subscription message', async () => {
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [defaultFeedPage.edges[0]],
+    }),
+  ]);
+  await screen.findByTestId('adItem');
+  await waitFor(async () => {
+    const [el] = await screen.findAllByLabelText('Upvote');
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
+    expect(await findByText(el.parentElement, '5')).toBeInTheDocument();
+  });
+  nextCallback({
+    postsEngaged: {
+      id: defaultFeedPage.edges[0].node.id,
+      numUpvotes: 6,
+      numComments: 7,
+    },
+  });
+  await waitFor(async () => {
+    const [el] = await screen.findAllByLabelText('Upvote');
+    // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
+    expect(await findByText(el.parentElement, '6')).toBeInTheDocument();
+  });
+});
+
+it('should report broken link', async () => {
+  let mutationCalled = false;
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [defaultFeedPage.edges[0]],
+    }),
+    {
+      request: {
+        query: REPORT_POST_MUTATION,
+        variables: {
+          id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
+          reason: 'BROKEN',
+          tags: [],
+        },
+      },
+      result: () => {
+        mutationCalled = true;
+        return { data: { _: true } };
+      },
+    },
+  ]);
+  const [menuBtn] = await screen.findAllByLabelText('Options');
+  fireEvent.click(menuBtn);
+  const contextBtn = await screen.findByText('Report');
+  fireEvent.click(contextBtn);
+  const brokenLinkBtn = await screen.findByText('Broken link');
+  fireEvent.click(brokenLinkBtn);
+  const submitBtn = await screen.findByText('Submit report');
+  fireEvent.click(submitBtn);
+  await waitFor(() => expect(mutationCalled).toBeTruthy());
+  await waitFor(() =>
+    expect(
+      screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
+    ).not.toBeInTheDocument(),
+  );
+
+  await waitFor(async () => {
+    await screen.findByRole('alert');
+    const feed = await screen.findByTestId('posts-feed');
+
+    return expect(feed).toHaveAttribute('aria-live', 'assertive');
+  });
+});
+
+it('should report broken link with comment', async () => {
+  let mutationCalled = false;
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [defaultFeedPage.edges[0]],
+    }),
+    {
+      request: {
+        query: REPORT_POST_MUTATION,
+        variables: {
+          id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
+          reason: 'BROKEN',
+          comment: 'comment',
+          tags: [],
+        },
+      },
+      result: () => {
+        mutationCalled = true;
+        return { data: { _: true } };
+      },
+    },
+  ]);
+  const [menuBtn] = await screen.findAllByLabelText('Options');
+  fireEvent.click(menuBtn);
+  const contextBtn = await screen.findByText('Report');
+  fireEvent.click(contextBtn);
+  const brokenLinkBtn = await screen.findByText('Broken link');
+  fireEvent.click(brokenLinkBtn);
+  const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
+  fireEvent.change(input, { target: { value: 'comment' } });
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  const submitBtn = await screen.findByText('Submit report');
+  fireEvent.click(submitBtn);
+  await waitFor(() => expect(mutationCalled).toBeTruthy());
+  await waitFor(() =>
+    expect(
+      screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
+    ).not.toBeInTheDocument(),
+  );
+  await waitFor(async () => {
+    await screen.findByRole('alert');
+    const feed = await screen.findByTestId('posts-feed');
+
+    return expect(feed).toHaveAttribute('aria-live', 'assertive');
+  });
+});
+
+it('should report nsfw', async () => {
+  let mutationCalled = false;
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [defaultFeedPage.edges[0]],
+    }),
+    {
+      request: {
+        query: REPORT_POST_MUTATION,
+        variables: {
+          id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
+          reason: 'NSFW',
+          tags: [],
+        },
+      },
+      result: () => {
+        mutationCalled = true;
+        return { data: { _: true } };
+      },
+    },
+  ]);
+  const [menuBtn] = screen.getAllByLabelText('Options');
+  fireEvent.click(menuBtn);
+  const contextBtn = await screen.findByText('Report');
+  fireEvent.click(contextBtn);
+  const brokenLinkBtn = await screen.findByText('NSFW');
+  fireEvent.click(brokenLinkBtn);
+  const submitBtn = screen.getByText('Submit report');
+  fireEvent.click(submitBtn);
+  await waitFor(() => expect(mutationCalled).toBeTruthy());
+  await waitFor(() =>
+    expect(
+      screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
+    ).not.toBeInTheDocument(),
+  );
+
+  await waitFor(async () => {
+    await screen.findByRole('alert');
+    const feed = await screen.findByTestId('posts-feed');
+
+    return expect(feed).toHaveAttribute('aria-live', 'assertive');
+  });
+});
+
+it('should hide post', async () => {
+  let mutationCalled = false;
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [defaultFeedPage.edges[0]],
+    }),
+    {
+      request: {
+        query: HIDE_POST_MUTATION,
+        variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
+      },
+      result: () => {
+        mutationCalled = true;
+        return { data: { _: true } };
+      },
+    },
+  ]);
+  const [menuBtn] = await screen.findAllByLabelText('Options');
+  fireEvent.click(menuBtn);
+  const contextBtn = await screen.findByText('Hide');
+  fireEvent.click(contextBtn);
+  await waitFor(() => expect(mutationCalled).toBeTruthy());
+  await waitFor(() =>
+    expect(
+      screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
+    ).not.toBeInTheDocument(),
+  );
+});
+
+it('should block a source', async () => {
+  let mutationCalled = false;
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [defaultFeedPage.edges[0]],
+    }),
+    createTagsSettingsMock(),
+    {
+      request: {
+        query: ADD_FILTERS_TO_FEED_MUTATION,
+        variables: { filters: { excludeSources: ['echojs'] } },
+      },
+      result: () => {
+        mutationCalled = true;
+        return { data: { _: true } };
+      },
+    },
+  ]);
+  await waitFor(async () => {
+    const data = await queryClient.getQueryData(
+      getFeedSettingsQueryKey(defaultUser),
+    );
+    expect(data).toBeTruthy();
+  });
+  const [menuBtn] = screen.getAllByLabelText('Options');
+  fireEvent.click(menuBtn);
+
+  const contextBtn = await screen.findByText("Don't show posts from Echo JS");
+  fireEvent.click(contextBtn);
+  await waitFor(() => expect(mutationCalled).toBeTruthy());
+
+  await waitFor(async () => {
+    await screen.findByRole('alert');
+    const feed = await screen.findByTestId('posts-feed');
+
+    expect(feed).toHaveAttribute('aria-live', 'assertive');
+  });
+});
+
+it('should block a tag', async () => {
+  let mutationCalled = false;
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [defaultFeedPage.edges[0]],
+    }),
+    createTagsSettingsMock(),
+    {
+      request: {
+        query: ADD_FILTERS_TO_FEED_MUTATION,
+        variables: { filters: { blockedTags: ['javascript'] } },
+      },
+      result: () => {
+        mutationCalled = true;
+        return { data: { _: true } };
+      },
+    },
+  ]);
+  await waitFor(async () => {
+    const data = await queryClient.getQueryData(
+      getFeedSettingsQueryKey(defaultUser),
+    );
+    expect(data).toBeTruthy();
+  });
+  const [menuBtn] = await screen.findAllByLabelText('Options');
+  fireEvent.click(menuBtn);
+  const contextBtn = await screen.findByText('Not interested in #javascript');
+  fireEvent.click(contextBtn);
+  await waitFor(() => expect(mutationCalled).toBeTruthy());
+
+  await waitFor(async () => {
+    await screen.findByRole('alert');
+    const feed = await screen.findByTestId('posts-feed');
+
+    return expect(feed).toHaveAttribute('aria-live', 'assertive');
+  });
+});
+
+it('should open a modal to view post details', async () => {
+  renderComponent();
+  await waitForNock();
+  const [first] = await screen.findAllByLabelText('Comments');
+  fireEvent.click(first);
+  await screen.findByRole('dialog');
+});
+
 const createPostMock = (
   data: Partial<Post> = {},
 ): MockedGraphQLResponse<PostData> => ({
@@ -229,749 +895,78 @@ const createPostMock = (
   },
 });
 
-describe('Feed', () => {
-  beforeAll(() => {
-    window.scrollTo = jest.fn();
-    feature.search.defaultValue = SearchExperiment.Control;
-  });
+it('should be able to navigate through posts', async () => {
+  const [firstPost, secondPost] = defaultFeedPage.edges;
+  renderComponent();
+  await waitForNock();
 
-  afterAll(() => {
-    window.scrollTo = originalScrollTo;
-  });
+  mockGraphQL(createPostMock({ id: firstPost.node.id }));
+  const [first] = await screen.findAllByLabelText('Comments');
+  fireEvent.click(first);
 
-  beforeEach(() => {
-    jest.restoreAllMocks();
-    jest.clearAllMocks();
-    nock.cleanAll();
-    queryClient.clear();
-    variables = defaultVariables;
-  });
+  await screen.findByRole('dialog');
+  const title = await screen.findByTestId('post-modal-title');
+  expect(title).toHaveTextContent(firstPost.node.title);
 
-  it('should add one placeholder when loading', async () => {
-    renderComponent();
-    expect(await screen.findByRole('article')).toHaveAttribute('aria-busy');
-  });
+  await screen.findByRole('navigation');
+  const next = await screen.findByLabelText('Next');
+  const params = { id: secondPost.node.id, title: secondPost.node.title };
+  mockGraphQL(createPostMock(params));
+  fireEvent.click(next);
+  const secondTitle = await screen.findByTestId('post-modal-title');
+  expect(secondTitle).toHaveTextContent(secondPost.node.title);
 
-  it('should replace placeholders with posts and ad', async () => {
-    renderComponent();
-    await waitForNock();
-    const elements = await screen.findAllByTestId('postItem');
-    expect(elements.length).toBeGreaterThan(0);
+  await screen.findByRole('navigation');
+  const previous = await screen.findByLabelText('Previous');
+  mockGraphQL(createPostMock({ id: firstPost.node.id }));
+  fireEvent.click(previous);
+  const firstTitle = await screen.findByTestId('post-modal-title');
+  expect(firstTitle).toHaveTextContent(firstPost.node.title);
+});
 
-    // eslint-disable-next-line no-restricted-syntax
-    for (const el of elements) {
-      // eslint-disable-next-line no-await-in-loop,@typescript-eslint/no-loop-func
-      await waitFor(async () => {
-        const links = await within(el).findAllByRole('link');
-        expect(links[0]).toHaveAttribute('href');
-      });
-    }
-
-    await waitFor(async () => {
-      const el = await screen.findByTestId('adItem');
-      // eslint-disable-next-line testing-library/prefer-screen-queries
-      expect(await findByRole(el, 'link')).toHaveAttribute('href', ad.link);
-    });
-  });
-
-  it('should render feed with sorting ranking by date', async () => {
-    variables = { ...defaultVariables, ranking: 'TIME' };
-    renderComponent(
-      [createFeedMock(defaultFeedPage, ANONYMOUS_FEED_QUERY)],
-      defaultUser,
-    );
-    await waitForNock();
-    const elements = await screen.findAllByTestId('postItem');
-    expect(elements.length).toBeGreaterThan(0);
-    const [latest, old] = elements;
-    // eslint-disable-next-line testing-library/no-node-access
-    const latestTitle = latest.querySelector('button').getAttribute('title');
-    const latestPost = defaultFeedPage.edges.find(
-      (edge) => edge.node.title === latestTitle,
-    ).node;
-    // eslint-disable-next-line testing-library/no-node-access
-    const oldTitle = old.querySelector('button').getAttribute('title');
-    const oldPost = defaultFeedPage.edges.find(
-      (edge) => edge.node.title === oldTitle,
-    ).node;
-    expect(new Date(latestPost.createdAt).getTime()).toBeGreaterThan(
-      new Date(oldPost.createdAt).getTime(),
-    );
-  });
-
-  it('should send upvote mutation', async () => {
-    let mutationCalled = false;
-    renderComponent([
-      createFeedMock({
-        pageInfo: defaultFeedPage.pageInfo,
-        edges: [defaultFeedPage.edges[0]],
-      }),
-      {
-        request: {
-          query: UPVOTE_MUTATION,
-          variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
-        },
-        result: () => {
-          mutationCalled = true;
-          return { data: { _: true } };
+it('should report irrelevant tags', async () => {
+  let mutationCalled = false;
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [defaultFeedPage.edges[0]],
+    }),
+    {
+      request: {
+        query: REPORT_POST_MUTATION,
+        variables: {
+          id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
+          reason: 'IRRELEVANT',
+          tags: ['javascript'],
         },
       },
-    ]);
-    const [el] = await screen.findAllByLabelText('Upvote');
-    fireEvent.click(el);
-    await waitFor(() => expect(mutationCalled).toBeTruthy());
-  });
-
-  it('should send cancel upvote mutation', async () => {
-    let mutationCalled = false;
-    renderComponent([
-      createFeedMock({
-        pageInfo: defaultFeedPage.pageInfo,
-        edges: [
-          {
-            ...defaultFeedPage.edges[0],
-            node: { ...defaultFeedPage.edges[0].node, upvoted: true },
-          },
-        ],
-      }),
-      {
-        request: {
-          query: CANCEL_UPVOTE_MUTATION,
-          variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
-        },
-        result: () => {
-          mutationCalled = true;
-          return { data: { _: true } };
-        },
+      result: () => {
+        mutationCalled = true;
+        return { data: { _: true } };
       },
-    ]);
-    const [el] = await screen.findAllByLabelText('Remove upvote');
-    fireEvent.click(el);
-    await waitFor(() => expect(mutationCalled).toBeTruthy());
-  });
+    },
+  ]);
+  const [menuBtn] = screen.getAllByLabelText('Options');
+  fireEvent.click(menuBtn);
+  const contextBtn = await screen.findByText('Report');
+  fireEvent.click(contextBtn);
+  const irrelevantTagsBtn = await screen.findByText('The post is not about...');
+  fireEvent.click(irrelevantTagsBtn);
+  const javascriptBtn = await screen.findByText('#javascript');
+  fireEvent.click(javascriptBtn);
+  const submitBtn = screen.getByText('Submit report');
+  fireEvent.click(submitBtn);
+  await waitFor(() => expect(mutationCalled).toBeTruthy());
+  await waitFor(() =>
+    expect(
+      screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
+    ).not.toBeInTheDocument(),
+  );
 
-  it('should open login modal on anonymous upvote', async () => {
-    renderComponent(
-      [
-        createFeedMock(
-          {
-            pageInfo: defaultFeedPage.pageInfo,
-            edges: [defaultFeedPage.edges[0]],
-          },
-          ANONYMOUS_FEED_QUERY,
-          {
-            first: 7,
-            loggedIn: false,
-          },
-        ),
-      ],
-      null,
-    );
-    const [el] = await screen.findAllByLabelText('Upvote');
-    fireEvent.click(el);
-    expect(showLogin).toBeCalledWith('upvote');
-  });
+  await waitFor(async () => {
+    await screen.findByRole('alert');
+    const feed = await screen.findByTestId('posts-feed');
 
-  it('should send add bookmark mutation', async () => {
-    let mutationCalled = false;
-    renderComponent([
-      createFeedMock({
-        pageInfo: defaultFeedPage.pageInfo,
-        edges: [
-          {
-            ...defaultFeedPage.edges[0],
-            node: { ...defaultFeedPage.edges[0].node, bookmarked: false },
-          },
-        ],
-      }),
-      {
-        request: {
-          query: ADD_BOOKMARKS_MUTATION,
-          variables: {
-            data: { postIds: ['4f354bb73009e4adfa5dbcbf9b3c4ebf'] },
-          },
-        },
-        result: () => {
-          mutationCalled = true;
-          return { data: { _: true } };
-        },
-      },
-    ]);
-    const [menuBtn] = await screen.findAllByLabelText('Options');
-    fireEvent.click(menuBtn);
-    const el = await screen.findByText('Save to bookmarks');
-    fireEvent.click(el);
-    await waitFor(() => expect(mutationCalled).toBeTruthy());
-  });
-
-  it('should send remove bookmark mutation', async () => {
-    let mutationCalled = false;
-    renderComponent([
-      createFeedMock({
-        pageInfo: defaultFeedPage.pageInfo,
-        edges: [
-          {
-            ...defaultFeedPage.edges[0],
-            node: { ...defaultFeedPage.edges[0].node, bookmarked: true },
-          },
-        ],
-      }),
-      {
-        request: {
-          query: REMOVE_BOOKMARK_MUTATION,
-          variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
-        },
-        result: () => {
-          mutationCalled = true;
-          return { data: { _: true } };
-        },
-      },
-    ]);
-    const [menuBtn] = await screen.findAllByLabelText('Options');
-    fireEvent.click(menuBtn);
-    const el = await screen.findByText('Remove from bookmarks');
-    fireEvent.click(el);
-    await waitFor(() => expect(mutationCalled).toBeTruthy());
-  });
-
-  it('should open login modal on anonymous bookmark', async () => {
-    renderComponent(
-      [
-        createFeedMock(
-          {
-            pageInfo: defaultFeedPage.pageInfo,
-            edges: [defaultFeedPage.edges[0]],
-          },
-          ANONYMOUS_FEED_QUERY,
-          {
-            first: 7,
-            loggedIn: false,
-          },
-        ),
-      ],
-      null,
-    );
-    const [menuBtn] = await screen.findAllByLabelText('Options');
-    fireEvent.click(menuBtn);
-    const el = await screen.findByText('Save to bookmarks');
-    fireEvent.click(el);
-    await waitFor(() => expect(showLogin).toBeCalledWith('bookmark'));
-  });
-
-  it('should increase reading rank progress', async () => {
-    renderComponent([
-      createFeedMock({
-        pageInfo: defaultFeedPage.pageInfo,
-        edges: [
-          {
-            ...defaultFeedPage.edges[0],
-            node: {
-              ...defaultFeedPage.edges[0].node,
-              read: false,
-            },
-          },
-        ],
-      }),
-    ]);
-    const queryKey = getRankQueryKey(defaultUser);
-    queryClient.setQueryData<MyRankData>(queryKey, {
-      rank: { readToday: false, currentRank: 0, progressThisWeek: 0 },
-    });
-    const main = await screen.findByTitle(
-      'Eminem Quotes Generator - Simple PHP RESTful API',
-    );
-    // eslint-disable-next-line testing-library/no-node-access
-    const el = await within(main.parentElement).findByText('Read post');
-    fireEvent.click(el);
-    await waitFor(async () => {
-      const data = await queryClient.getQueryData<MyRankData>(queryKey);
-      expect(data).toEqual({
-        rank: {
-          readToday: true,
-          currentRank: 1,
-          progressThisWeek: 1,
-          lastReadTime: expect.anything(),
-          rankLastWeek: undefined,
-        },
-      });
-      const state = queryClient.getQueryState(queryKey);
-      expect(state.isInvalidated).toEqual(true);
-    });
-  });
-
-  it('should not increase reading rank progress when read today', async () => {
-    renderComponent();
-    const queryKey = getRankQueryKey(defaultUser);
-    queryClient.setQueryData<MyRankData>(queryKey, {
-      rank: { readToday: true, currentRank: 0, progressThisWeek: 0 },
-    });
-    const el = await screen.findByTitle(
-      'One Word Domains — Database of all available one-word domains',
-    );
-    fireEvent.click(el);
-    await waitFor(async () => {
-      const data = await queryClient.getQueryData<MyRankData>(queryKey);
-      expect(data).toEqual({
-        rank: { readToday: true, currentRank: 0, progressThisWeek: 0 },
-      });
-    });
-  });
-
-  it('should increase reading rank progress and rank', async () => {
-    renderComponent([
-      createFeedMock({
-        pageInfo: defaultFeedPage.pageInfo,
-        edges: [
-          {
-            ...defaultFeedPage.edges[0],
-            node: { ...defaultFeedPage.edges[0].node, read: false },
-          },
-        ],
-      }),
-    ]);
-    const queryKey = getRankQueryKey(defaultUser);
-    queryClient.setQueryData<MyRankData>(queryKey, {
-      rank: { readToday: false, currentRank: 0, progressThisWeek: 2 },
-    });
-    const main = await screen.findByTitle(
-      'Eminem Quotes Generator - Simple PHP RESTful API',
-    );
-    // eslint-disable-next-line testing-library/no-node-access
-    const el = await within(main.parentElement).findByText('Read post');
-    fireEvent.click(el);
-    await waitFor(async () => {
-      const data = await queryClient.getQueryData<MyRankData>(queryKey);
-      expect(data).toEqual({
-        rank: {
-          readToday: true,
-          currentRank: 1,
-          progressThisWeek: 3,
-          lastReadTime: expect.anything(),
-        },
-      });
-    });
-  });
-
-  it('should not increase reading rank progress when reached final rank', async () => {
-    renderComponent();
-    const queryKey = getRankQueryKey(defaultUser);
-    queryClient.setQueryData<MyRankData>(queryKey, {
-      rank: { readToday: false, currentRank: 5, progressThisWeek: 7 },
-    });
-    const el = await screen.findByTitle(
-      'One Word Domains — Database of all available one-word domains',
-    );
-    fireEvent.click(el);
-    await waitFor(async () => {
-      const data = await queryClient.getQueryData<MyRankData>(queryKey);
-      expect(data).toEqual({
-        rank: { readToday: false, currentRank: 5, progressThisWeek: 7 },
-      });
-    });
-  });
-
-  it('should increase reading rank progress for anonymous users', async () => {
-    renderComponent(
-      [
-        createFeedMock(
-          {
-            pageInfo: defaultFeedPage.pageInfo,
-            edges: [
-              {
-                ...defaultFeedPage.edges[0],
-                node: { ...defaultFeedPage.edges[0].node, read: false },
-              },
-            ],
-          },
-          ANONYMOUS_FEED_QUERY,
-          {
-            first: 7,
-            loggedIn: false,
-          },
-        ),
-      ],
-      null,
-    );
-    const queryKey = getRankQueryKey(null);
-    queryClient.setQueryData<MyRankData>(queryKey, {
-      rank: { readToday: false, currentRank: 0, progressThisWeek: 0 },
-    });
-    const main = await screen.findByTitle(
-      'Eminem Quotes Generator - Simple PHP RESTful API',
-    );
-    // eslint-disable-next-line testing-library/no-node-access
-    const el = await within(main.parentElement).findByText('Read post');
-    fireEvent.click(el);
-    await waitFor(async () => {
-      const data = await queryClient.getQueryData<MyRankData>(queryKey);
-      expect(data).toEqual({
-        rank: {
-          readToday: true,
-          currentRank: 1,
-          progressThisWeek: 1,
-          lastReadTime: expect.anything(),
-        },
-      });
-    });
-  });
-
-  it('should update feed item on subscription message', async () => {
-    renderComponent([
-      createFeedMock({
-        pageInfo: defaultFeedPage.pageInfo,
-        edges: [defaultFeedPage.edges[0]],
-      }),
-    ]);
-    await screen.findByTestId('adItem');
-    await waitFor(async () => {
-      const [el] = await screen.findAllByLabelText('Upvote');
-      // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
-      expect(await findByText(el.parentElement, '5')).toBeInTheDocument();
-    });
-    nextCallback({
-      postsEngaged: {
-        id: defaultFeedPage.edges[0].node.id,
-        numUpvotes: 6,
-        numComments: 7,
-      },
-    });
-    await waitFor(async () => {
-      const [el] = await screen.findAllByLabelText('Upvote');
-      // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
-      expect(await findByText(el.parentElement, '6')).toBeInTheDocument();
-    });
-  });
-
-  it('should report broken link', async () => {
-    let mutationCalled = false;
-    renderComponent([
-      createFeedMock({
-        pageInfo: defaultFeedPage.pageInfo,
-        edges: [defaultFeedPage.edges[0]],
-      }),
-      {
-        request: {
-          query: REPORT_POST_MUTATION,
-          variables: {
-            id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
-            reason: 'BROKEN',
-            tags: [],
-          },
-        },
-        result: () => {
-          mutationCalled = true;
-          return { data: { _: true } };
-        },
-      },
-    ]);
-    const [menuBtn] = await screen.findAllByLabelText('Options');
-    fireEvent.click(menuBtn);
-    const contextBtn = await screen.findByText('Report');
-    fireEvent.click(contextBtn);
-    const brokenLinkBtn = await screen.findByText('Broken link');
-    fireEvent.click(brokenLinkBtn);
-    const submitBtn = await screen.findByText('Submit report');
-    fireEvent.click(submitBtn);
-    await waitFor(() => expect(mutationCalled).toBeTruthy());
-    await waitFor(() =>
-      expect(
-        screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
-      ).not.toBeInTheDocument(),
-    );
-
-    await waitFor(async () => {
-      await screen.findByRole('alert');
-      const feed = await screen.findByTestId('posts-feed');
-
-      return expect(feed).toHaveAttribute('aria-live', 'assertive');
-    });
-  });
-
-  it('should report broken link with comment', async () => {
-    let mutationCalled = false;
-    renderComponent([
-      createFeedMock({
-        pageInfo: defaultFeedPage.pageInfo,
-        edges: [defaultFeedPage.edges[0]],
-      }),
-      {
-        request: {
-          query: REPORT_POST_MUTATION,
-          variables: {
-            id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
-            reason: 'BROKEN',
-            comment: 'comment',
-            tags: [],
-          },
-        },
-        result: () => {
-          mutationCalled = true;
-          return { data: { _: true } };
-        },
-      },
-    ]);
-    const [menuBtn] = await screen.findAllByLabelText('Options');
-    fireEvent.click(menuBtn);
-    const contextBtn = await screen.findByText('Report');
-    fireEvent.click(contextBtn);
-    const brokenLinkBtn = await screen.findByText('Broken link');
-    fireEvent.click(brokenLinkBtn);
-    const input = (await screen.findByRole('textbox')) as HTMLTextAreaElement;
-    fireEvent.change(input, { target: { value: 'comment' } });
-    input.dispatchEvent(new Event('input', { bubbles: true }));
-    const submitBtn = await screen.findByText('Submit report');
-    fireEvent.click(submitBtn);
-    await waitFor(() => expect(mutationCalled).toBeTruthy());
-    await waitFor(() =>
-      expect(
-        screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
-      ).not.toBeInTheDocument(),
-    );
-    await waitFor(async () => {
-      await screen.findByRole('alert');
-      const feed = await screen.findByTestId('posts-feed');
-
-      return expect(feed).toHaveAttribute('aria-live', 'assertive');
-    });
-  });
-
-  it('should report nsfw', async () => {
-    let mutationCalled = false;
-    renderComponent([
-      createFeedMock({
-        pageInfo: defaultFeedPage.pageInfo,
-        edges: [defaultFeedPage.edges[0]],
-      }),
-      {
-        request: {
-          query: REPORT_POST_MUTATION,
-          variables: {
-            id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
-            reason: 'NSFW',
-            tags: [],
-          },
-        },
-        result: () => {
-          mutationCalled = true;
-          return { data: { _: true } };
-        },
-      },
-    ]);
-    const [menuBtn] = screen.getAllByLabelText('Options');
-    fireEvent.click(menuBtn);
-    const contextBtn = await screen.findByText('Report');
-    fireEvent.click(contextBtn);
-    const brokenLinkBtn = await screen.findByText('NSFW');
-    fireEvent.click(brokenLinkBtn);
-    const submitBtn = screen.getByText('Submit report');
-    fireEvent.click(submitBtn);
-    await waitFor(() => expect(mutationCalled).toBeTruthy());
-    await waitFor(() =>
-      expect(
-        screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
-      ).not.toBeInTheDocument(),
-    );
-
-    await waitFor(async () => {
-      await screen.findByRole('alert');
-      const feed = await screen.findByTestId('posts-feed');
-
-      return expect(feed).toHaveAttribute('aria-live', 'assertive');
-    });
-  });
-
-  it('should hide post', async () => {
-    let mutationCalled = false;
-    renderComponent([
-      createFeedMock({
-        pageInfo: defaultFeedPage.pageInfo,
-        edges: [defaultFeedPage.edges[0]],
-      }),
-      {
-        request: {
-          query: HIDE_POST_MUTATION,
-          variables: { id: '4f354bb73009e4adfa5dbcbf9b3c4ebf' },
-        },
-        result: () => {
-          mutationCalled = true;
-          return { data: { _: true } };
-        },
-      },
-    ]);
-    const [menuBtn] = await screen.findAllByLabelText('Options');
-    fireEvent.click(menuBtn);
-    const contextBtn = await screen.findByText('Hide');
-    fireEvent.click(contextBtn);
-    await waitFor(() => expect(mutationCalled).toBeTruthy());
-    await waitFor(() =>
-      expect(
-        screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
-      ).not.toBeInTheDocument(),
-    );
-  });
-
-  it('should block a source', async () => {
-    let mutationCalled = false;
-    renderComponent([
-      createFeedMock({
-        pageInfo: defaultFeedPage.pageInfo,
-        edges: [defaultFeedPage.edges[0]],
-      }),
-      createTagsSettingsMock(),
-      {
-        request: {
-          query: ADD_FILTERS_TO_FEED_MUTATION,
-          variables: { filters: { excludeSources: ['echojs'] } },
-        },
-        result: () => {
-          mutationCalled = true;
-          return { data: { _: true } };
-        },
-      },
-    ]);
-    await waitFor(async () => {
-      const data = await queryClient.getQueryData(
-        getFeedSettingsQueryKey(defaultUser),
-      );
-      expect(data).toBeTruthy();
-    });
-    const [menuBtn] = screen.getAllByLabelText('Options');
-    fireEvent.click(menuBtn);
-
-    const contextBtn = await screen.findByText("Don't show posts from Echo JS");
-    fireEvent.click(contextBtn);
-    await waitFor(() => expect(mutationCalled).toBeTruthy());
-
-    await waitFor(async () => {
-      await screen.findByRole('alert');
-      const feed = await screen.findByTestId('posts-feed');
-
-      expect(feed).toHaveAttribute('aria-live', 'assertive');
-    });
-  });
-
-  it('should block a tag', async () => {
-    let mutationCalled = false;
-    renderComponent([
-      createFeedMock({
-        pageInfo: defaultFeedPage.pageInfo,
-        edges: [defaultFeedPage.edges[0]],
-      }),
-      createTagsSettingsMock(),
-      {
-        request: {
-          query: ADD_FILTERS_TO_FEED_MUTATION,
-          variables: { filters: { blockedTags: ['javascript'] } },
-        },
-        result: () => {
-          mutationCalled = true;
-          return { data: { _: true } };
-        },
-      },
-    ]);
-    await waitFor(async () => {
-      const data = await queryClient.getQueryData(
-        getFeedSettingsQueryKey(defaultUser),
-      );
-      expect(data).toBeTruthy();
-    });
-    const [menuBtn] = await screen.findAllByLabelText('Options');
-    fireEvent.click(menuBtn);
-    const contextBtn = await screen.findByText('Not interested in #javascript');
-    fireEvent.click(contextBtn);
-    await waitFor(() => expect(mutationCalled).toBeTruthy());
-
-    await waitFor(async () => {
-      await screen.findByRole('alert');
-      const feed = await screen.findByTestId('posts-feed');
-
-      return expect(feed).toHaveAttribute('aria-live', 'assertive');
-    });
-  });
-
-  it('should open a modal to view post details', async () => {
-    renderComponent();
-    await waitForNock();
-    const [first] = await screen.findAllByLabelText('Comments');
-    fireEvent.click(first);
-    await screen.findByRole('dialog');
-  });
-
-  it('should be able to navigate through posts', async () => {
-    const [firstPost, secondPost] = defaultFeedPage.edges;
-    renderComponent();
-    await waitForNock();
-
-    mockGraphQL(createPostMock({ id: firstPost.node.id }));
-    const [first] = await screen.findAllByLabelText('Comments');
-    fireEvent.click(first);
-
-    await screen.findByRole('dialog');
-    const title = await screen.findByTestId('post-modal-title');
-    expect(title).toHaveTextContent(firstPost.node.title);
-
-    await screen.findByRole('navigation');
-    const next = await screen.findByLabelText('Next');
-    const params = { id: secondPost.node.id, title: secondPost.node.title };
-    mockGraphQL(createPostMock(params));
-    fireEvent.click(next);
-    const secondTitle = await screen.findByTestId('post-modal-title');
-    expect(secondTitle).toHaveTextContent(secondPost.node.title);
-
-    await screen.findByRole('navigation');
-    const previous = await screen.findByLabelText('Previous');
-    mockGraphQL(createPostMock({ id: firstPost.node.id }));
-    fireEvent.click(previous);
-    const firstTitle = await screen.findByTestId('post-modal-title');
-    expect(firstTitle).toHaveTextContent(firstPost.node.title);
-  });
-
-  it('should report irrelevant tags', async () => {
-    let mutationCalled = false;
-    renderComponent([
-      createFeedMock({
-        pageInfo: defaultFeedPage.pageInfo,
-        edges: [defaultFeedPage.edges[0]],
-      }),
-      {
-        request: {
-          query: REPORT_POST_MUTATION,
-          variables: {
-            id: '4f354bb73009e4adfa5dbcbf9b3c4ebf',
-            reason: 'IRRELEVANT',
-            tags: ['javascript'],
-          },
-        },
-        result: () => {
-          mutationCalled = true;
-          return { data: { _: true } };
-        },
-      },
-    ]);
-    const [menuBtn] = screen.getAllByLabelText('Options');
-    fireEvent.click(menuBtn);
-    const contextBtn = await screen.findByText('Report');
-    fireEvent.click(contextBtn);
-    const irrelevantTagsBtn = await screen.findByText(
-      'The post is not about...',
-    );
-    fireEvent.click(irrelevantTagsBtn);
-    const javascriptBtn = await screen.findByText('#javascript');
-    fireEvent.click(javascriptBtn);
-    const submitBtn = screen.getByText('Submit report');
-    fireEvent.click(submitBtn);
-    await waitFor(() => expect(mutationCalled).toBeTruthy());
-    await waitFor(() =>
-      expect(
-        screen.queryByTitle('Eminem Quotes Generator - Simple PHP RESTful API'),
-      ).not.toBeInTheDocument(),
-    );
-
-    await waitFor(async () => {
-      await screen.findByRole('alert');
-      const feed = await screen.findByTestId('posts-feed');
-
-      return expect(feed).toHaveAttribute('aria-live', 'assertive');
-    });
+    return expect(feed).toHaveAttribute('aria-live', 'assertive');
   });
 });

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -791,12 +791,12 @@ it('should block a source', async () => {
   contextBtn.click();
   await waitFor(() => expect(mutationCalled).toBeTruthy());
 
-  await waitFor(async () => {
-    await screen.findByRole('alert');
-    const feed = await screen.findByTestId('posts-feed');
+  // await waitFor(async () => {
+  await screen.findByRole('alert');
+  const feed = await screen.findByTestId('posts-feed');
 
-    return expect(feed).toHaveAttribute('aria-live', 'assertive');
-  });
+  expect(feed).toHaveAttribute('aria-live', 'assertive');
+  // });
 });
 
 it('should block a tag', async () => {

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -754,13 +754,13 @@ describe('Feed', () => {
         },
       },
     ]);
-    const [menuBtn] = await screen.findAllByLabelText('Options');
+    const [menuBtn] = screen.getAllByLabelText('Options');
     fireEvent.click(menuBtn);
     const contextBtn = await screen.findByText('Report');
     fireEvent.click(contextBtn);
     const brokenLinkBtn = await screen.findByText('NSFW');
     fireEvent.click(brokenLinkBtn);
-    const submitBtn = await screen.findByText('Submit report');
+    const submitBtn = screen.getByText('Submit report');
     fireEvent.click(submitBtn);
     await waitFor(() => expect(mutationCalled).toBeTruthy());
     await waitFor(() =>
@@ -945,7 +945,7 @@ describe('Feed', () => {
         },
       },
     ]);
-    const [menuBtn] = await screen.findAllByLabelText('Options');
+    const [menuBtn] = screen.getAllByLabelText('Options');
     fireEvent.click(menuBtn);
     const contextBtn = await screen.findByText('Report');
     fireEvent.click(contextBtn);
@@ -955,7 +955,7 @@ describe('Feed', () => {
     fireEvent.click(irrelevantTagsBtn);
     const javascriptBtn = await screen.findByText('#javascript');
     fireEvent.click(javascriptBtn);
-    const submitBtn = await screen.findByText('Submit report');
+    const submitBtn = screen.getByText('Submit report');
     fireEvent.click(submitBtn);
     await waitFor(() => expect(mutationCalled).toBeTruthy());
     await waitFor(() =>

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -832,8 +832,9 @@ describe('Feed', () => {
       );
       expect(data).toBeTruthy();
     });
-    const [menuBtn] = await screen.findAllByLabelText('Options');
+    const [menuBtn] = screen.getAllByLabelText('Options');
     fireEvent.click(menuBtn);
+
     const contextBtn = await screen.findByText("Don't show posts from Echo JS");
     fireEvent.click(contextBtn);
     await waitFor(() => expect(mutationCalled).toBeTruthy());

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -1,7 +1,6 @@
 import nock from 'nock';
 import React from 'react';
 import {
-  findAllByRole,
   findByRole,
   findByText,
   fireEvent,
@@ -208,20 +207,20 @@ it('should add one placeholder when loading', async () => {
   expect(await screen.findByRole('article')).toHaveAttribute('aria-busy');
 });
 
-  it('should replace placeholders with posts and ad', async () => {
-    renderComponent();
-    await waitForNock();
-    const elements = await screen.findAllByTestId('postItem');
-    expect(elements.length).toBeGreaterThan(0);
+it('should replace placeholders with posts and ad', async () => {
+  renderComponent();
+  await waitForNock();
+  const elements = await screen.findAllByTestId('postItem');
+  expect(elements.length).toBeGreaterThan(0);
 
-    // eslint-disable-next-line no-restricted-syntax
-    for (const el of elements) {
-      // eslint-disable-next-line no-await-in-loop,@typescript-eslint/no-loop-func
-      await waitFor(async () => {
-        const links = await within(el).findAllByRole('link');
-        expect(links[0]).toHaveAttribute('href');
-      });
-    }
+  // eslint-disable-next-line no-restricted-syntax
+  for (const el of elements) {
+    // eslint-disable-next-line no-await-in-loop,@typescript-eslint/no-loop-func
+    await waitFor(async () => {
+      const links = await within(el).findAllByRole('link');
+      expect(links[0]).toHaveAttribute('href');
+    });
+  }
 
   await waitFor(async () => {
     const el = await screen.findByTestId('adItem');
@@ -711,13 +710,13 @@ it('should report nsfw', async () => {
       },
     },
   ]);
-  const [menuBtn] = screen.getAllByLabelText('Options');
+  const [menuBtn] = await screen.findAllByLabelText('Options');
   fireEvent.click(menuBtn);
   const contextBtn = await screen.findByText('Report');
   fireEvent.click(contextBtn);
   const brokenLinkBtn = await screen.findByText('NSFW');
   fireEvent.click(brokenLinkBtn);
-  const submitBtn = screen.getByText('Submit report');
+  const submitBtn = await screen.findByText('Submit report');
   fireEvent.click(submitBtn);
   await waitFor(() => expect(mutationCalled).toBeTruthy());
   await waitFor(() =>
@@ -946,7 +945,7 @@ it('should report irrelevant tags', async () => {
       },
     },
   ]);
-  const [menuBtn] = screen.getAllByLabelText('Options');
+  const [menuBtn] = await screen.findAllByLabelText('Options');
   fireEvent.click(menuBtn);
   const contextBtn = await screen.findByText('Report');
   fireEvent.click(contextBtn);
@@ -954,7 +953,7 @@ it('should report irrelevant tags', async () => {
   fireEvent.click(irrelevantTagsBtn);
   const javascriptBtn = await screen.findByText('#javascript');
   fireEvent.click(javascriptBtn);
-  const submitBtn = screen.getByText('Submit report');
+  const submitBtn = await screen.findByText('Submit report');
   fireEvent.click(submitBtn);
   await waitFor(() => expect(mutationCalled).toBeTruthy());
   await waitFor(() =>


### PR DESCRIPTION
## Changes

N / A

## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1834 #done
