### PR TITLE
fix: GitHub and Apple icon to black on sign back in buttons

### DIFF
--- a/packages/shared/src/components/auth/AuthSignBack.tsx
+++ b/packages/shared/src/components/auth/AuthSignBack.tsx
@@ -75,7 +75,7 @@ export const AuthSignBack = ({
           wrapper={(component) => (
             <div className="relative">
               {component}
-              <span className="absolute right-0 bottom-0 p-1 bg-white rounded-8">
+              <span className="absolute right-0 bottom-0 p-1 bg-white rounded-8 text-theme-label-invert">
                 {providerItem.icon}
               </span>
             </div>

--- a/packages/shared/src/components/auth/SignBackButton.tsx
+++ b/packages/shared/src/components/auth/SignBackButton.tsx
@@ -31,7 +31,7 @@ export function SignBackButton({
         )}
         <span className="typo-footnote">{signBack.email}</span>
       </div>
-      <span className="p-1 ml-auto rounded-8 border border-theme-divider-secondary">
+      <span className="p-1 ml-auto rounded-8 border border-theme-divider-secondary text-theme-label-invert">
         {item.icon}
       </span>
     </button>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixes the Apple and GitHub icon to not be white on white background.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
