### PR TITLE
fix: build by checking whether portals would work

### DIFF
--- a/packages/shared/src/components/tooltips/Portal.tsx
+++ b/packages/shared/src/components/tooltips/Portal.tsx
@@ -6,6 +6,10 @@ interface PortalProps {
 }
 
 function Portal({ children }: PortalProps): ReturnType<typeof createPortal> {
+  if (typeof globalThis?.document === 'undefined') {
+    return null;
+  }
+
   return createPortal(children, globalThis?.document?.body);
 }
 

--- a/packages/webapp/pages/notifications.tsx
+++ b/packages/webapp/pages/notifications.tsx
@@ -40,16 +40,16 @@ const hasUnread = (data: InfiniteData<NotificationsData>) =>
   );
 
 const contextId = 'notifications-context-menu';
+const seo = (
+  <NextSeo
+    title="Notifications"
+    nofollow
+    noindex
+    titleTemplate="%s | daily.dev"
+  />
+);
 
 const Notifications = (): ReactElement => {
-  const seo = (
-    <NextSeo
-      title="Notifications"
-      nofollow
-      noindex
-      titleTemplate="%s | daily.dev"
-    />
-  );
   const { trackEvent } = useAnalyticsContext();
   const { clearUnreadCount, isSubscribed } = useNotificationContext();
   const { mutateAsync: readNotifications } = useMutation(

--- a/packages/webapp/pages/notifications.tsx
+++ b/packages/webapp/pages/notifications.tsx
@@ -181,8 +181,4 @@ const getNotificationsLayout: typeof getLayout = (...props) =>
 
 Notifications.getLayout = getNotificationsLayout;
 
-// TODO WT-1778-move-to-react this is to make build pass
-// revert to Notifications export and fix the react render error
-export default process.env.NODE_ENV === 'test'
-  ? Notifications
-  : (): ReactElement => null;
+export default Notifications;


### PR DESCRIPTION
## Changes
- On the notifications page, we render the `Portal` as part of the whole UI, but then in the build time there is no context of the browser, hence, the `document` is not defined.
- This should prevent the build from failing.

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1778 #done
