### PR TITLE
fix: notification card z-index

### DIFF
--- a/packages/shared/src/components/notifications/NotificationItem.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.tsx
@@ -59,8 +59,7 @@ function NotificationItem({
         <button
           type="button"
           aria-label="Open notification"
-          className="absolute inset-0"
-          title={title}
+          className="absolute inset-0 z-0"
           onClick={onClick}
         />
       )}
@@ -78,7 +77,9 @@ function NotificationItem({
       />
       <div className="flex flex-col flex-1 ml-4 w-full text-left typo-callout">
         {hasAvatar && (
-          <span className="flex flex-row gap-2 mb-4">{avatarComponents}</span>
+          <span className="flex z-1 flex-row gap-2 mb-4">
+            {avatarComponents}
+          </span>
         )}
         <span
           className="break-words"

--- a/packages/shared/src/components/notifications/NotificationItem.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.tsx
@@ -43,7 +43,11 @@ function NotificationItem({
   const avatarComponents =
     avatars
       ?.map?.((avatar) => (
-        <NotificationItemAvatar key={avatar.referenceId} {...avatar} />
+        <NotificationItemAvatar
+          key={avatar.referenceId}
+          className="z-1"
+          {...avatar}
+        />
       ))
       .filter((avatar) => avatar) ?? [];
   const hasAvatar = avatarComponents.length > 0;
@@ -77,9 +81,7 @@ function NotificationItem({
       />
       <div className="flex flex-col flex-1 ml-4 w-full text-left typo-callout">
         {hasAvatar && (
-          <span className="flex z-1 flex-row gap-2 mb-4">
-            {avatarComponents}
-          </span>
+          <span className="flex flex-row gap-2 mb-4">{avatarComponents}</span>
         )}
         <span
           className="break-words"

--- a/packages/shared/src/components/notifications/NotificationItemAvatar.tsx
+++ b/packages/shared/src/components/notifications/NotificationItemAvatar.tsx
@@ -38,7 +38,8 @@ function NotificationItemAvatar({
           picture={{ size: 'medium' }}
           user={{
             id: referenceId,
-            username: name,
+            username: referenceId,
+            name,
             image,
             permalink: targetUrl,
           }}

--- a/packages/shared/src/components/notifications/NotificationItemAvatar.tsx
+++ b/packages/shared/src/components/notifications/NotificationItemAvatar.tsx
@@ -5,7 +5,7 @@ import {
 } from '../../graphql/notifications';
 import SourceButton from '../cards/SourceButton';
 import { ProfileTooltip } from '../profile/ProfileTooltip';
-import { ProfilePicture } from '../ProfilePicture';
+import { ProfileImageLink } from '../profile/ProfileImageLink';
 
 function NotificationItemAvatar({
   type,
@@ -13,10 +13,12 @@ function NotificationItemAvatar({
   name,
   targetUrl,
   referenceId,
+  className,
 }: NotificationAvatar): ReactElement {
   if (type === NotificationAvatarType.Source) {
     return (
       <SourceButton
+        className={className}
         source={{
           id: referenceId,
           handle: referenceId,
@@ -31,10 +33,15 @@ function NotificationItemAvatar({
   if (type === NotificationAvatarType.User) {
     return (
       <ProfileTooltip link={{ href: targetUrl }} user={{ id: referenceId }}>
-        <ProfilePicture
-          user={{ image, id: referenceId }}
-          nativeLazyLoading
-          size="medium"
+        <ProfileImageLink
+          className={className}
+          picture={{ size: 'medium' }}
+          user={{
+            id: referenceId,
+            username: name,
+            image,
+            permalink: targetUrl,
+          }}
         />
       </ProfileTooltip>
     );

--- a/packages/shared/src/components/profile/ProfileImageLink.tsx
+++ b/packages/shared/src/components/profile/ProfileImageLink.tsx
@@ -6,7 +6,7 @@ import { Author } from '../../graphql/comments';
 interface ProfileImageLinkProps extends ProfileLinkProps {
   picture?: Omit<ProfilePictureProps, 'user'>;
   ref?: Ref<HTMLAnchorElement>;
-  user: Pick<Author, 'id' | 'username' | 'permalink' | 'image'>;
+  user: Pick<Author, 'id' | 'name' | 'username' | 'permalink' | 'image'>;
 }
 
 function ProfileImageLinkComponent(

--- a/packages/shared/src/components/profile/ProfileImageLink.tsx
+++ b/packages/shared/src/components/profile/ProfileImageLink.tsx
@@ -6,7 +6,7 @@ import { Author } from '../../graphql/comments';
 interface ProfileImageLinkProps extends ProfileLinkProps {
   picture?: Omit<ProfilePictureProps, 'user'>;
   ref?: Ref<HTMLAnchorElement>;
-  user: Author;
+  user: Pick<Author, 'id' | 'username' | 'permalink' | 'image'>;
 }
 
 function ProfileImageLinkComponent(

--- a/packages/shared/src/graphql/notifications.ts
+++ b/packages/shared/src/graphql/notifications.ts
@@ -6,13 +6,14 @@ import {
 import { Connection } from './common';
 import { graphqlUrl } from '../lib/config';
 import { EmptyResponse } from './emptyResponse';
+import { WithClassNameProps } from '../components/utilities';
 
 export enum NotificationAvatarType {
   User = 'user',
   Source = 'source',
 }
 
-export interface NotificationAvatar {
+export interface NotificationAvatar extends WithClassNameProps {
   type: NotificationAvatarType;
   image: string;
   name: string;


### PR DESCRIPTION
## Changes
- The tooltip wasn't working anymore due to the overlay button.
- Title doesn't seem to be needed since we already have the aria-label.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
