### PR TITLE
fix: notification bell spacing

### DIFF
--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -116,7 +116,10 @@ function MainLayoutHeader({
           </div>
           {showPostButton && (
             <CreatePostButton
-              className={!optOutWeeklyGoal && 'mr-0 tablet:mr-2'}
+              className={classNames(
+                'mr-0 laptop:mr-4',
+                !optOutWeeklyGoal ? 'tablet:mr-4' : 'tablet:mr-0',
+              )}
             />
           )}
           {!hideButton && user && (

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -118,7 +118,7 @@ function MainLayoutHeader({
             <CreatePostButton
               className={classNames(
                 'mr-0 laptop:mr-4',
-                !optOutWeeklyGoal ? 'tablet:mr-4' : 'tablet:mr-0',
+                optOutWeeklyGoal ? 'tablet:mr-0' : 'tablet:mr-4',
               )}
             />
           )}


### PR DESCRIPTION
## Changes
- I am really bothered by the lack of spacing between the elements (new post and notification bell).

<img width="241" alt="Screenshot 2023-09-21 at 10 53 06 AM" src="https://github.com/dailydotdev/apps/assets/13744167/855e3d38-2251-4e90-950b-ba7ceb6d0c23">


I can't stand it anymore, I have to raise this PR. Preview after the fix:

<img width="634" alt="Screenshot 2023-09-21 at 11 03 16 AM" src="https://github.com/dailydotdev/apps/assets/13744167/9c3c3f33-d881-4303-a8a3-bad0a467152b">


<img width="302" alt="Screenshot 2023-09-21 at 11 02 51 AM" src="https://github.com/dailydotdev/apps/assets/13744167/7d8bcb46-a8be-4291-aeae-83820e2da9db">


<img width="343" alt="Screenshot 2023-09-21 at 11 02 32 AM" src="https://github.com/dailydotdev/apps/assets/13744167/fcd936dd-8789-414b-ba64-463a752c01e4">


<img width="303" alt="Screenshot 2023-09-21 at 11 02 04 AM" src="https://github.com/dailydotdev/apps/assets/13744167/8af766a4-db21-4907-be77-0efcd9cc2cf3">


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
