### PR TITLE
fix: reposition copy link

### DIFF
--- a/packages/shared/src/components/checklist/InviteMemberChecklistStep.tsx
+++ b/packages/shared/src/components/checklist/InviteMemberChecklistStep.tsx
@@ -35,7 +35,7 @@ const InviteMemberChecklistStep = ({
           trackAndCopyLink();
         }}
       >
-        Copy invitation link
+        Invitation link
       </Button>
     </ChecklistStep>
   );

--- a/packages/shared/src/components/squads/SquadHeaderBar.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderBar.tsx
@@ -51,22 +51,22 @@ export function SquadHeaderBar({
   const completedStepsCount = completedSteps.length;
   const totalStepsCount = steps.length;
   const checklistTooltipText = `${completedStepsCount}/${totalStepsCount}`;
+  const showJoinButton = squad.public && !squad.currentMember;
 
   return (
     <div
       {...props}
       className={classNames(
-        'flex flex-row gap-4 h-fit w-full tablet:w-auto',
+        'flex flex-row gap-4 h-fit w-full tablet:w-auto justify-center',
         className,
       )}
     >
       <div className="relative">
-        {verifyPermission(squad, SourcePermissions.Invite) && (
+        {verifyPermission(squad, SourcePermissions.Invite) && !showJoinButton && (
           <Button
             className={classNames(
               'btn-secondary',
               tourIndex === TourScreenIndex.CopyInvitation && 'highlight-pulse',
-              squad.public && 'hidden tablet:flex',
             )}
             onClick={() => {
               trackAndCopyLink();
@@ -74,11 +74,11 @@ export function SquadHeaderBar({
             icon={<AddUserIcon />}
             disabled={copying}
           >
-            Copy invitation link
+            Invitation link
           </Button>
         )}
       </div>
-      {squad.public && (
+      {showJoinButton && (
         <SquadJoinButton
           className="flex flex-1 tablet:flex-initial tablet:ml-auto w-full tablet:w-auto"
           squad={squad}

--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -66,24 +66,32 @@ export default function SquadHeaderMenu({
     const canEditSquad = verifyPermission(squad, SourcePermissions.Edit);
     const canDeleteSquad = verifyPermission(squad, SourcePermissions.Delete);
 
-    const list: MenuItemProps[] = [
-      {
-        icon: <ContextMenuIcon Icon={TourIcon} />,
-        action: () =>
-          openModal({
-            type: LazyModal.SquadTour,
-          }),
-        label: 'Learn how Squads work',
-      },
-    ];
+    const list: MenuItemProps[] = [];
+
+    if (canEditSquad) {
+      list.push({
+        icon: <ContextMenuIcon Icon={SettingsIcon} />,
+        action: () => editSquad({ handle: squad.handle }),
+        label: 'Squad settings',
+      });
+    }
 
     if (!squad.currentMember && squad.public) {
-      list.unshift({
+      list.push({
         icon: <ContextMenuIcon Icon={LinkIcon} />,
         action: () => trackAndCopyLink(),
         label: 'Invitation link',
       });
     }
+
+    list.push({
+      icon: <ContextMenuIcon Icon={TourIcon} />,
+      action: () =>
+        openModal({
+          type: LazyModal.SquadTour,
+        }),
+      label: 'Learn how Squads work',
+    });
 
     if (squad.currentMember) {
       list.push({
@@ -114,14 +122,6 @@ export default function SquadHeaderMenu({
           onLeaveSquad();
         },
         label: 'Leave Squad',
-      });
-    }
-
-    if (canEditSquad) {
-      list.unshift({
-        icon: <ContextMenuIcon Icon={SettingsIcon} />,
-        action: () => editSquad({ handle: squad.handle }),
-        label: 'Squad settings',
       });
     }
 

--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -126,7 +126,14 @@ export default function SquadHeaderMenu({
     }
 
     return list;
-  }, [editSquad, onDeleteSquad, onLeaveSquad, openModal, squad]);
+  }, [
+    editSquad,
+    onDeleteSquad,
+    trackAndCopyLink,
+    onLeaveSquad,
+    openModal,
+    squad,
+  ]);
 
   return (
     <PortalMenu

--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -21,6 +21,9 @@ import FeedbackIcon from '../icons/Feedback';
 import TourIcon from '../icons/Tour';
 import { useSquadNavigation } from '../../hooks';
 import { MenuItemProps } from '../fields/PortalMenu';
+import { useSquadInvitation } from '../../hooks/useSquadInvitation';
+import { Origin } from '../../lib/analytics';
+import LinkIcon from '../icons/Link';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ '../fields/PortalMenu'),
@@ -36,6 +39,10 @@ interface SquadHeaderMenuProps {
 export default function SquadHeaderMenu({
   squad,
 }: SquadHeaderMenuProps): ReactElement {
+  const { trackAndCopyLink } = useSquadInvitation({
+    squad,
+    origin: Origin.SquadPage,
+  });
   const router = useRouter();
   const { openModal } = useLazyModal();
   const { editSquad } = useSquadNavigation();
@@ -69,6 +76,14 @@ export default function SquadHeaderMenu({
         label: 'Learn how Squads work',
       },
     ];
+
+    if (!squad.currentMember && squad.public) {
+      list.unshift({
+        icon: <ContextMenuIcon Icon={LinkIcon} />,
+        action: () => trackAndCopyLink(),
+        label: 'Invitation link',
+      });
+    }
 
     if (squad.currentMember) {
       list.push({

--- a/packages/webapp/__tests__/SquadFeedPage.tsx
+++ b/packages/webapp/__tests__/SquadFeedPage.tsx
@@ -299,7 +299,7 @@ describe('squad header bar', () => {
       permissions: [SourcePermissions.Invite],
     };
     renderComponent();
-    const invite = await screen.findByText('Copy invitation link');
+    const invite = await screen.findByText('Invitation link');
 
     mockGraphQL({
       request: {
@@ -324,7 +324,7 @@ describe('squad header bar', () => {
       permissions: [SourcePermissions.Invite],
     };
     renderComponent();
-    const invite = await screen.findByText('Copy invitation link');
+    const invite = await screen.findByText('Invitation link');
 
     mockGraphQL({
       request: {
@@ -360,13 +360,6 @@ describe('squad header bar', () => {
     renderComponent(undefined, undefined, undefined, []);
 
     expect(await screen.findByText('Join Squad')).toBeInTheDocument();
-  });
-
-  it('should show leave squad button for open squad when already member', async () => {
-    requestedSquad.public = true;
-    renderComponent();
-
-    expect(await screen.findByText('Leave Squad')).toBeInTheDocument();
   });
 
   it('should not show join squad button for private squad', async () => {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Reposition of the invite link and minor alignment issues

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1800 #done
