### PR TITLE
fix: allow ethical ads to render fully

### DIFF
--- a/packages/shared/src/components/cards/AdCard.tsx
+++ b/packages/shared/src/components/cards/AdCard.tsx
@@ -24,7 +24,7 @@ export const AdCard = forwardRef(function AdCard(
   { ad, onLinkClick, showImage = true, ...props }: AdCardProps,
   ref: Ref<HTMLElement>,
 ): ReactElement {
-  const showBlurredImage = ad.source === 'Carbon';
+  const showBlurredImage = ad.source === 'Carbon' || ad.source === 'EthicalAds';
 
   return (
     <Card {...props} ref={ref}>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Allow ethical ads to show fully.

Before:
![Screenshot 2023-09-26 at 13 28 34](https://github.com/dailydotdev/apps/assets/554874/aea8fc4a-5fcb-486b-bd39-84c665a40233)

After:
![Screenshot 2023-09-26 at 13 28 41](https://github.com/dailydotdev/apps/assets/554874/a1100454-5297-437d-8d8a-7c6c6f674256)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1864 #done
