### PR TITLE
fix: missed one attribute for social

### DIFF
--- a/packages/shared/src/components/auth/SocialRegistrationForm.tsx
+++ b/packages/shared/src/components/auth/SocialRegistrationForm.tsx
@@ -243,7 +243,9 @@ export const SocialRegistrationForm = ({
       </AuthForm>
       <ConditionalWrapper
         condition={simplified}
-        wrapper={(component) => <AuthContainer>{component}</AuthContainer>}
+        wrapper={(component) => (
+          <AuthContainer className="!mt-0">{component}</AuthContainer>
+        )}
       >
         <Modal.Footer>
           <Button


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Missed the bottom margin on the social form

![Screenshot 2023-09-26 at 14 03 44](https://github.com/dailydotdev/apps/assets/554874/7e7ad754-0bf7-4556-a3a9-b04ede2f4ac0)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
