### PR TITLE
fix: size of filtering boxes

### DIFF
--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -307,17 +307,13 @@ export function OnboardPage(): ReactElement {
             : 'ml-auto laptop:max-w-[37.5rem]',
         )}
       >
-        {isFiltering && (
+        {isFiltering ? (
           <>
             <Title className="text-center typo-title1">{title}</Title>
             <p className="mt-3 mb-10 text-center text-theme-label-secondary typo-title3">
               Pick a few subjects that interest you. <br />
               You can always change theselater.
             </p>
-          </>
-        )}
-        {isFiltering ? (
-          <>
             <FilterOnboarding
               className="grid-cols-2 tablet:grid-cols-4 laptop:grid-cols-6 mt-4"
               onSelectedTopics={hasSelectedTopics}

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -301,9 +301,10 @@ export function OnboardPage(): ReactElement {
     return (
       <div
         className={classNames(
-          'tablet:flex-1 laptop:max-w-[37.5rem]',
-          !isFiltering && 'flex',
-          isAuthenticating || isFiltering ? 'ml-0' : 'ml-auto',
+          'flex tablet:flex-1 laptop:max-w-[37.5rem]',
+          isFiltering
+            ? 'flex-col items-center ml-0 tablet:max-w-[32rem] laptop:max-w-[48.75rem]'
+            : 'ml-auto laptop:max-w-[37.5rem]',
         )}
       >
         {isFiltering && (

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -304,7 +304,7 @@ export function OnboardPage(): ReactElement {
           'flex tablet:flex-1 laptop:max-w-[37.5rem]',
           isFiltering
             ? 'flex-col items-center ml-0 tablet:max-w-[32rem] laptop:max-w-[48.75rem]'
-            : 'ml-auto laptop:max-w-[37.5rem]',
+            : 'ml-auto',
         )}
       >
         {isFiltering ? (


### PR DESCRIPTION
## Changes

![image](https://github.com/dailydotdev/apps/assets/1681525/0332564b-5014-47aa-9907-caafabf773e0)


### Describe what this PR does
- size of the topics filtering in onboarding

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
