### PR TITLE
fix: set correct min/max height on iOS devices

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -105,6 +105,7 @@
     "nock": "^13.2.4",
     "node-fetch": "^2.6.6",
     "postcss": "^8.4.12",
+    "postcss-100vh-fix": "^1.0.2",
     "postcss-custom-media": "^8.0.0",
     "postcss-focus-visible": "^6.0.4",
     "postcss-import": "^14.1.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -84,6 +84,7 @@
     "next": "^12.2.2",
     "nock": "^13.3.1",
     "postcss": "^8.4.12",
+    "postcss-100vh-fix": "^1.0.2",
     "postcss-custom-media": "^8.0.0",
     "postcss-focus-visible": "^6.0.4",
     "postcss-import": "^14.1.0",

--- a/packages/shared/postcss.config.js
+++ b/packages/shared/postcss.config.js
@@ -23,6 +23,7 @@ module.exports = {
     'postcss-focus-visible',
     'postcss-custom-media',
     'postcss-mixins',
+    'postcss-100vh-fix',
     process.env.TARGET_BROWSER
       ? require('postcss-rem-to-responsive-pixel')({
           rootValue: 16,

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -91,6 +91,7 @@
     "nock": "^13.2.4",
     "node-fetch": "^2.6.7",
     "postcss": "^8.4.12",
+    "postcss-100vh-fix": "^1.0.2",
     "postcss-custom-media": "^8.0.0",
     "postcss-focus-visible": "^5.0.0",
     "postcss-import": "^14.1.0",

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -318,7 +318,7 @@ export function OnboardPage(): ReactElement {
               className="grid-cols-2 tablet:grid-cols-4 laptop:grid-cols-6 mt-4"
               onSelectedTopics={hasSelectedTopics}
             />
-            <div className="flex sticky bottom-0 z-3 flex-col items-center pt-4 mt-4 w-full">
+            <div className="flex sticky bottom-0 z-3 flex-col items-center py-4 mt-4 w-full">
               <div className="flex absolute inset-0 -z-1 w-full h-1/2 bg-gradient-to-t to-transparent from-theme-bg-primary" />
               <div className="flex absolute inset-0 top-1/2 -z-1 w-full h-1/2 bg-theme-bg-primary" />
               <Button className="btn-primary w-[22.5rem]" onClick={onClickNext}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 3.9.4(eslint@7.32.0)
       eslint-plugin-testing-library:
         specifier: ^3.10.2
-        version: 3.10.2(typescript@4.6.4)
+        version: 3.10.2(eslint@7.32.0)(typescript@4.6.4)
     devDependencies:
       '@dailydotdev/eslint-plugin-daily-dev-eslint-rules':
         specifier: '*'
@@ -328,6 +328,9 @@ importers:
       postcss:
         specifier: ^8.4.12
         version: 8.4.12
+      postcss-100vh-fix:
+        specifier: ^1.0.2
+        version: 1.0.2(postcss@8.4.12)
       postcss-custom-media:
         specifier: ^8.0.0
         version: 8.0.0(postcss@8.4.12)
@@ -613,6 +616,9 @@ importers:
       postcss:
         specifier: ^8.4.12
         version: 8.4.12
+      postcss-100vh-fix:
+        specifier: ^1.0.2
+        version: 1.0.2(postcss@8.4.12)
       postcss-custom-media:
         specifier: ^8.0.0
         version: 8.0.0(postcss@8.4.12)
@@ -902,6 +908,9 @@ importers:
       postcss:
         specifier: ^8.4.12
         version: 8.4.12
+      postcss-100vh-fix:
+        specifier: ^1.0.2
+        version: 1.0.2(postcss@8.4.12)
       postcss-custom-media:
         specifier: ^8.0.0
         version: 8.0.0(postcss@8.4.12)
@@ -3467,7 +3476,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils@3.10.1(typescript@4.6.4):
+  /@typescript-eslint/experimental-utils@3.10.1(eslint@7.32.0)(typescript@4.6.4):
     resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -3476,6 +3485,7 @@ packages:
       '@types/json-schema': 7.0.12
       '@typescript-eslint/types': 3.10.1
       '@typescript-eslint/typescript-estree': 3.10.1(typescript@4.6.4)
+      eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 2.1.0
     transitivePeerDependencies:
@@ -4134,22 +4144,6 @@ packages:
       normalize-range: 0.1.2
       picocolors: 1.0.0
       postcss: 8.4.12
-      postcss-value-parser: 4.2.0
-    dev: true
-
-  /autoprefixer@10.4.5(postcss@8.4.24):
-    resolution: {integrity: sha512-Fvd8yCoA7lNX/OUllvS+aS1I7WRBclGXsepbvT8ZaPgrH24rgXpZzF0/6Hh3ZEkwg+0AES/Osd196VZmYoEFtw==}
-    engines: {node: ^10 || ^12 || >=14}
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.1.0
-    dependencies:
-      browserslist: 4.21.8
-      caniuse-lite: 1.0.30001502
-      fraction.js: 4.2.0
-      normalize-range: 0.1.2
-      picocolors: 1.0.0
-      postcss: 8.4.24
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -6178,13 +6172,14 @@ packages:
       - ts-node
     dev: true
 
-  /eslint-plugin-testing-library@3.10.2(typescript@4.6.4):
+  /eslint-plugin-testing-library@3.10.2(eslint@7.32.0)(typescript@4.6.4):
     resolution: {integrity: sha512-WAmOCt7EbF1XM8XfbCKAEzAPnShkNSwcIsAD2jHdsMUT9mZJPjLCG7pMzbcC8kK366NOuGip8HKLDC+Xk4yIdA==}
     engines: {node: ^10.12.0 || >=12.0.0, npm: '>=6'}
     peerDependencies:
       eslint: ^5 || ^6 || ^7
     dependencies:
-      '@typescript-eslint/experimental-utils': 3.10.1(typescript@4.6.4)
+      '@typescript-eslint/experimental-utils': 3.10.1(eslint@7.32.0)(typescript@4.6.4)
+      eslint: 7.32.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -7025,6 +7020,7 @@ packages:
 
   /growly@1.3.0:
     resolution: {integrity: sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -7554,6 +7550,7 @@ packages:
     resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
     engines: {node: '>=8'}
     hasBin: true
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -7767,6 +7764,7 @@ packages:
   /is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
+    requiresBuild: true
     dependencies:
       is-docker: 2.2.1
     dev: true
@@ -10176,6 +10174,15 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /postcss-100vh-fix@1.0.2(postcss@8.4.12):
+    resolution: {integrity: sha512-t7vqk9AfjI4fXmWlQCEiMZFFhi1hro4WlECINI1TV6Qh1XapUJE++gCmNr95F5Hen/+bz1OmO+SiSB9TZmFmSg==}
+    engines: {node: '>=10.0'}
+    peerDependencies:
+      postcss: ^8.1.0
+    dependencies:
+      postcss: 8.4.12
+    dev: true
+
   /postcss-calc@8.2.4(postcss@8.4.24):
     resolution: {integrity: sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==}
     peerDependencies:
@@ -11842,6 +11849,7 @@ packages:
 
   /shellwords@0.1.1:
     resolution: {integrity: sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -12456,7 +12464,7 @@ packages:
       postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
-      autoprefixer: 10.4.5(postcss@8.4.24)
+      autoprefixer: 10.4.5(postcss@8.4.12)
       bytes: 3.1.2
       chalk: 4.1.2
       chokidar: 3.5.3
@@ -13945,7 +13953,7 @@ packages:
     dev: false
 
   '@gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?a0d1a3add257acdbf5353dfd690547feebbada92':
-    resolution: {tarball: https://gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?a0d1a3add257acdbf5353dfd690547feebbada92}
+    resolution: {registry: https://registry.npmjs.org/, tarball: https://gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?a0d1a3add257acdbf5353dfd690547feebbada92}
     name: '@growthbook/growthbook'
     version: 0.27.0
     engines: {node: '>=10'}


### PR DESCRIPTION
## Changes

<table>
<tr>
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/4278e793-b272-4b49-ba2f-0c5ea8487c03" />
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/ec443932-c654-4192-b7e8-b7a11630237b" />
</table>



### Describe what this PR does
- Adds a postcss plugin to automagically supplement `100vh` with a `-webkit-fill-available`
- Fixes position of Next button during filtering

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
