### PR TITLE
fix: prevent search bar hijacking on new tab

### DIFF
--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -59,10 +59,6 @@ export default function MainFeedPage({
     }
   };
 
-  const onExtensionOnboarding = (): void => {
-    onPageChanged('/hijacking');
-  };
-
   const activePage = useMemo(() => {
     if (isSearchOn) {
       return '/search';
@@ -99,7 +95,6 @@ export default function MainFeedPage({
       onShowDndClick={() => setShowDnd(true)}
       enableSearch={enableSearch}
       onNavTabClick={onNavTabClick}
-      onExtensionOnboarding={onExtensionOnboarding}
       screenCentered={false}
       customBanner={isDndActive && <DndBanner />}
       additionalButtons={!loadingUser && <CompanionPopupButton />}

--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -59,6 +59,10 @@ export default function MainFeedPage({
     }
   };
 
+  const onExtensionOnboarding = (): void => {
+    onPageChanged('/hijacking');
+  };
+
   const activePage = useMemo(() => {
     if (isSearchOn) {
       return '/search';
@@ -95,6 +99,7 @@ export default function MainFeedPage({
       onShowDndClick={() => setShowDnd(true)}
       enableSearch={enableSearch}
       onNavTabClick={onNavTabClick}
+      onExtensionOnboarding={onExtensionOnboarding}
       screenCentered={false}
       customBanner={isDndActive && <DndBanner />}
       additionalButtons={!loadingUser && <CompanionPopupButton />}

--- a/packages/shared/src/components/ExtensionOnboarding.tsx
+++ b/packages/shared/src/components/ExtensionOnboarding.tsx
@@ -22,8 +22,9 @@ const ExtensionOnboarding = (): ReactElement => {
         The magic awaits inside! ✨
       </p>
 
-      <Link href={onboardingUrl}>
+      <Link href={onboardingUrl} passHref>
         <Button
+          tag="a"
           className="w-full btn-primary max-w-[18.75rem]"
           buttonSize={ButtonSize.Large}
         >

--- a/packages/shared/src/components/ExtensionOnboarding.tsx
+++ b/packages/shared/src/components/ExtensionOnboarding.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import Link from 'next/link';
 import Logo, { LogoPosition } from './Logo';
 import { OnboardingTitleGradient } from './onboarding/common';
-import { webappUrl } from '../lib/constants';
+import { onboardingUrl } from '../lib/constants';
 import { Button, ButtonSize } from './buttons/Button';
 import { cloudinary } from '../lib/image';
 
@@ -22,7 +22,7 @@ const ExtensionOnboarding = (): ReactElement => {
         The magic awaits inside! ✨
       </p>
 
-      <Link href={webappUrl}>
+      <Link href={onboardingUrl}>
         <Button
           className="w-full btn-primary max-w-[18.75rem]"
           buttonSize={ButtonSize.Large}

--- a/packages/shared/src/components/ExtensionOnboarding.tsx
+++ b/packages/shared/src/components/ExtensionOnboarding.tsx
@@ -1,0 +1,43 @@
+import React, { ReactElement } from 'react';
+import Link from 'next/link';
+import Logo, { LogoPosition } from './Logo';
+import { OnboardingTitleGradient } from './onboarding/common';
+import { webappUrl } from '../lib/constants';
+import { Button, ButtonSize } from './buttons/Button';
+import { cloudinary } from '../lib/image';
+
+const ExtensionOnboarding = (): ReactElement => {
+  return (
+    <div className="flex overflow-hidden flex-col justify-center items-center px-7 antialiased text-center min-h-[100vh] max-h-[100vh]">
+      <Logo position={LogoPosition.Relative} logoClassName="h-logo-big" />
+
+      <OnboardingTitleGradient className="my-6 typo-mega2 tablet:typo-mega1">
+        Let&apos;s jump back&nbsp;in!
+      </OnboardingTitleGradient>
+
+      <p className="mb-9 tablet:mb-16 max-w-[25rem] typo-title3 tablet:typo-title2">
+        Please resume onboarding to unlock the entire feature suite of
+        daily.dev.
+        <br />
+        The magic awaits inside! ✨
+      </p>
+
+      <Link href={webappUrl}>
+        <Button
+          className="w-full btn-primary max-w-[18.75rem]"
+          buttonSize={ButtonSize.Large}
+        >
+          Continue ➔
+        </Button>
+      </Link>
+
+      <img
+        className="absolute bottom-0 w-[33rem]"
+        src={cloudinary.onboarding.glow}
+        alt="Gradient background"
+      />
+    </div>
+  );
+};
+
+export default ExtensionOnboarding;

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -29,7 +29,7 @@ import { useNotificationParams } from '../hooks/useNotificationParams';
 import { OnboardingV2 } from '../lib/featureValues';
 import { useAuthContext } from '../contexts/AuthContext';
 import { MainFeedPage } from './utilities';
-import { isTesting, webappUrl } from '../lib/constants';
+import { isTesting, onboardingUrl } from '../lib/constants';
 import { useBanner } from '../hooks/useBanner';
 import { useFeature, useGrowthBookContext } from './GrowthBookProvider';
 import { feature } from '../lib/featureManagement';
@@ -166,11 +166,10 @@ export default function MainLayout({
       return;
     }
 
-    const onboarding = `${webappUrl}onboarding`;
     const entries = Object.entries(router.query);
 
     if (entries.length === 0) {
-      router.push(onboarding);
+      router.push(onboardingUrl);
       return;
     }
 
@@ -180,7 +179,7 @@ export default function MainLayout({
       params.append(key, value as string);
     });
 
-    router.push(`${onboarding}?${params.toString()}`);
+    router.push(`${onboardingUrl}?${params.toString()}`);
   }, [shouldRedirectOnboarding, router, isExtension]);
 
   useEffect(() => {

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -33,6 +33,8 @@ import { isTesting, webappUrl } from '../lib/constants';
 import { useBanner } from '../hooks/useBanner';
 import { useFeature, useGrowthBookContext } from './GrowthBookProvider';
 import { feature } from '../lib/featureManagement';
+import ExtensionOnboarding from './ExtensionOnboarding';
+import { checkIsExtension } from '../lib/func';
 
 export interface MainLayoutProps
   extends Omit<MainLayoutHeaderProps, 'onMobileSidebarToggle'>,
@@ -47,6 +49,7 @@ export interface MainLayoutProps
   showSidebar?: boolean;
   enableSearch?: () => void;
   onNavTabClick?: (tab: string) => void;
+  onExtensionOnboarding?: () => void;
   onShowDndClick?: () => unknown;
 }
 
@@ -71,6 +74,7 @@ export default function MainLayout({
   className,
   onLogoClick,
   onNavTabClick,
+  onExtensionOnboarding,
   enableSearch,
   onShowDndClick,
   showPostButton,
@@ -147,6 +151,7 @@ export default function MainLayout({
   const page = router?.route?.substring(1).trim() as MainFeedPage;
   const isPageReady =
     (growthbook?.ready && router?.isReady && isAuthReady) || isTesting;
+  const isExtension = checkIsExtension();
 
   const isPageApplicableForOnboarding = !page || feeds.includes(page);
   const shouldRedirectOnboarding =
@@ -157,7 +162,7 @@ export default function MainLayout({
     !isTesting;
 
   useEffect(() => {
-    if (!shouldRedirectOnboarding) {
+    if (!shouldRedirectOnboarding || isExtension) {
       return;
     }
 
@@ -176,13 +181,15 @@ export default function MainLayout({
     });
 
     router.push(`${onboarding}?${params.toString()}`);
-  }, [shouldRedirectOnboarding, router]);
+  }, [shouldRedirectOnboarding, router, isExtension]);
 
-  if (
-    (!isPageReady && isPageApplicableForOnboarding) ||
-    shouldRedirectOnboarding
-  ) {
+  if (!isPageReady && isPageApplicableForOnboarding) {
     return null;
+  }
+
+  if (isExtension && shouldRedirectOnboarding) {
+    onExtensionOnboarding();
+    return <ExtensionOnboarding />;
   }
 
   return (

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -183,12 +183,17 @@ export default function MainLayout({
     router.push(`${onboarding}?${params.toString()}`);
   }, [shouldRedirectOnboarding, router, isExtension]);
 
+  useEffect(() => {
+    if (shouldRedirectOnboarding && isExtension) {
+      onExtensionOnboarding();
+    }
+  }, [isExtension, onExtensionOnboarding, shouldRedirectOnboarding]);
+
   if (!isPageReady && isPageApplicableForOnboarding) {
     return null;
   }
 
   if (isExtension && shouldRedirectOnboarding) {
-    onExtensionOnboarding();
     return <ExtensionOnboarding />;
   }
 

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -33,8 +33,6 @@ import { isTesting, onboardingUrl } from '../lib/constants';
 import { useBanner } from '../hooks/useBanner';
 import { useFeature, useGrowthBookContext } from './GrowthBookProvider';
 import { feature } from '../lib/featureManagement';
-import ExtensionOnboarding from './ExtensionOnboarding';
-import { checkIsExtension } from '../lib/func';
 
 export interface MainLayoutProps
   extends Omit<MainLayoutHeaderProps, 'onMobileSidebarToggle'>,
@@ -49,7 +47,6 @@ export interface MainLayoutProps
   showSidebar?: boolean;
   enableSearch?: () => void;
   onNavTabClick?: (tab: string) => void;
-  onExtensionOnboarding?: () => void;
   onShowDndClick?: () => unknown;
 }
 
@@ -74,7 +71,6 @@ export default function MainLayout({
   className,
   onLogoClick,
   onNavTabClick,
-  onExtensionOnboarding,
   enableSearch,
   onShowDndClick,
   showPostButton,
@@ -151,7 +147,6 @@ export default function MainLayout({
   const page = router?.route?.substring(1).trim() as MainFeedPage;
   const isPageReady =
     (growthbook?.ready && router?.isReady && isAuthReady) || isTesting;
-  const isExtension = checkIsExtension();
 
   const isPageApplicableForOnboarding = !page || feeds.includes(page);
   const shouldRedirectOnboarding =
@@ -162,7 +157,7 @@ export default function MainLayout({
     !isTesting;
 
   useEffect(() => {
-    if (!shouldRedirectOnboarding || isExtension) {
+    if (!shouldRedirectOnboarding) {
       return;
     }
 
@@ -180,20 +175,13 @@ export default function MainLayout({
     });
 
     router.push(`${onboardingUrl}?${params.toString()}`);
-  }, [shouldRedirectOnboarding, router, isExtension]);
+  }, [shouldRedirectOnboarding, router]);
 
-  useEffect(() => {
-    if (shouldRedirectOnboarding && isExtension) {
-      onExtensionOnboarding();
-    }
-  }, [isExtension, onExtensionOnboarding, shouldRedirectOnboarding]);
-
-  if (!isPageReady && isPageApplicableForOnboarding) {
+  if (
+    (!isPageReady && isPageApplicableForOnboarding) ||
+    shouldRedirectOnboarding
+  ) {
     return null;
-  }
-
-  if (isExtension && shouldRedirectOnboarding) {
-    return <ExtensionOnboarding />;
   }
 
   return (

--- a/packages/shared/src/components/Settings.tsx
+++ b/packages/shared/src/components/Settings.tsx
@@ -18,6 +18,7 @@ import LineIcon from './icons/Line';
 import { CustomSwitch } from './fields/CustomSwitch';
 import AuthContext from '../contexts/AuthContext';
 import { AuthTriggers } from '../lib/auth';
+import { checkIsExtension } from '../lib/func';
 
 const densities = [
   { label: 'Eco', value: 'eco' },
@@ -59,7 +60,7 @@ export default function Settings({
   className,
   ...props
 }: HTMLAttributes<HTMLDivElement>): ReactElement {
-  const isExtension = process.env.TARGET_BROWSER;
+  const isExtension = checkIsExtension();
   const { user, showLogin } = useContext(AuthContext);
   const {
     spaciness,

--- a/packages/shared/src/components/onboarding/common.ts
+++ b/packages/shared/src/components/onboarding/common.ts
@@ -13,6 +13,11 @@ export const OnboardingTitle = classed(
   'text-center typo-title2 font-bold px-4',
 );
 
+export const OnboardingTitleGradient = classed(
+  'h1',
+  'font-bold text-transparent bg-clip-text bg-gradient-to-r from-theme-color-bacon to-theme-color-cabbage',
+);
+
 export interface OnboardingStepProps {
   onClose?: (e: React.MouseEvent | React.KeyboardEvent) => void;
   isModal?: boolean;

--- a/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
@@ -22,6 +22,7 @@ import CommentIcon from '../icons/Discuss';
 import InteractionCounter from '../InteractionCounter';
 import SettingsContext from '../../contexts/SettingsContext';
 import { AlertColor, AlertDot } from '../AlertDot';
+import { checkIsExtension } from '../../lib/func';
 
 interface ChangelogTooltipProps<TRef> extends BaseTooltipProps {
   elementRef: MutableRefObject<TRef>;
@@ -41,7 +42,7 @@ function ChangelogTooltip<TRef extends HTMLElement>({
   onRequestClose,
   ...props
 }: ChangelogTooltipProps<TRef>): ReactElement {
-  const isExtension = !!process.env.TARGET_BROWSER;
+  const isExtension = checkIsExtension();
   const isFirefoxExtension = process.env.TARGET_BROWSER === 'firefox';
   const { latestPost: post, dismiss: dismissChangelog } = useChangelog();
   const toast = useToastNotification();

--- a/packages/shared/src/contexts/AuthContext.tsx
+++ b/packages/shared/src/contexts/AuthContext.tsx
@@ -16,7 +16,7 @@ import { AccessToken, Boot, Visit } from '../lib/boot';
 import { isCompanionActivated } from '../lib/element';
 import { AuthTriggers, AuthTriggersOrString } from '../lib/auth';
 import { Squad } from '../graphql/sources';
-import { isNullOrUndefined } from '../lib/func';
+import { checkIsExtension, isNullOrUndefined } from '../lib/func';
 
 export interface LoginState {
   trigger: AuthTriggersOrString;
@@ -55,7 +55,7 @@ export interface AuthContextData {
   squads?: Squad[];
   isAuthReady?: boolean;
 }
-const isExtension = process.env.TARGET_BROWSER;
+const isExtension = checkIsExtension();
 const AuthContext = React.createContext<AuthContextData>(null);
 export const useAuthContext = (): AuthContextData => useContext(AuthContext);
 export default AuthContext;

--- a/packages/shared/src/hooks/useCompanionTrigger.tsx
+++ b/packages/shared/src/hooks/useCompanionTrigger.tsx
@@ -11,6 +11,7 @@ import { useActions } from './useActions';
 import { ActionType } from '../graphql/actions';
 import { AnalyticsEvent, Origin } from '../lib/analytics';
 import { useContentScriptStatus } from './useContentScriptStatus';
+import { checkIsExtension } from '../lib/func';
 
 type CompanionTriggerProps = {
   post: Post;
@@ -36,7 +37,7 @@ export default function useCompanionTrigger(
     column?: number,
   ) => Promise<void>,
 ): CompanionTrigger {
-  const isExtension = process.env.TARGET_BROWSER;
+  const isExtension = checkIsExtension();
   const { trackEvent } = useAnalyticsContext();
   const { closeModal: closeLazyModal, openModal: openLazyModal } =
     useLazyModal();

--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -6,6 +6,7 @@ import { postAnalyticsEvent } from '../lib/feed';
 import { FeedItem, PostItem, UpdateFeedPost } from './useFeed';
 import { useKeyboardNavigation } from './useKeyboardNavigation';
 import { Origin } from '../lib/analytics';
+import { checkIsExtension } from '../lib/func';
 
 export enum PostPosition {
   First = 'first',
@@ -32,7 +33,7 @@ export const usePostModalNavigation = (
   canFetchMore: boolean,
 ): UsePostModalNavigation => {
   const [currentPage, setCurrentPage] = useState<string>();
-  const isExtension = !!process.env.TARGET_BROWSER;
+  const isExtension = checkIsExtension();
   const [openedPostIndex, setOpenedPostIndex] = useState<number>(null);
   const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
   const { trackEvent } = useContext(AnalyticsContext);

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -51,6 +51,7 @@ export const isBrave = (): boolean => {
 };
 
 export const webappUrl = process.env.NEXT_PUBLIC_WEBAPP_URL;
+export const onboardingUrl = `${webappUrl}onboarding`;
 
 export const authUrl =
   process.env.NEXT_PUBLIC_AUTH_URL || 'http://127.0.0.1:4433';

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -33,7 +33,10 @@ import {
   AnalyticsEvent,
   TargetType,
 } from '@dailydotdev/shared/src/lib/analytics';
-import { OnboardingStep } from '@dailydotdev/shared/src/components/onboarding/common';
+import {
+  OnboardingStep,
+  OnboardingTitleGradient,
+} from '@dailydotdev/shared/src/components/onboarding/common';
 import { OnboardingMode } from '@dailydotdev/shared/src/graphql/feed';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import { Loader } from '@dailydotdev/shared/src/components/Loader';
@@ -69,11 +72,6 @@ const wrapperMaxWidth = 'max-w-[75rem] laptopXL:max-w-[90rem]';
 const Container = classed(
   'div',
   'flex flex-col overflow-x-hidden items-center min-h-[100vh] w-full h-full max-h-[100vh] flex-1 z-max',
-);
-
-const OnboardingTitle = classed(
-  'h1',
-  'mb-4 font-bold text-transparent bg-clip-text bg-gradient-to-r from-theme-color-bacon to-theme-color-cabbage',
 );
 
 const seo: NextSeoProps = {
@@ -463,9 +461,9 @@ export function OnboardPage(): ReactElement {
               'flex flex-1 flex-col laptop:max-w-[27.5rem] laptop:mr-8',
             )}
           >
-            <OnboardingTitle className="typo-large-title tablet:typo-mega1">
+            <OnboardingTitleGradient className="mb-4 typo-large-title tablet:typo-mega1">
               Where developers grow together
-            </OnboardingTitle>
+            </OnboardingTitleGradient>
 
             <h2 className="mb-8 typo-body tablet:typo-title2">
               Get one personalized feed for all the knowledge you need.


### PR DESCRIPTION
## Changes

### Describe what this PR does
- refactors onboarding title to a shared component
- creates onboarding component for extension
- prevents search bar hijacking on new tab

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1865 #done
