### PR TITLE
fix: set default feed as 15

### DIFF
--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -18,7 +18,7 @@ export class Feature<T extends JSONValue> {
 }
 
 const feature = {
-  feedVersion: new Feature('feed_version', 1),
+  feedVersion: new Feature('feed_version', 15),
   onboardingV2: new Feature('onboarding_v2', OnboardingV2.Control),
   onboardingV3: new Feature('onboarding_v3', OnboardingV3.Control),
   search: new Feature('search', SearchExperiment.Control),

--- a/packages/webapp/__tests__/MostDiscussedPage.tsx
+++ b/packages/webapp/__tests__/MostDiscussedPage.tsx
@@ -71,7 +71,7 @@ it('should request most discussed feed when logged-in', async () => {
     createFeedMock(defaultFeedPage, MOST_DISCUSSED_FEED_QUERY, {
       first: 7,
       loggedIn: true,
-      version: 1,
+      version: 15,
     }),
   ]);
   await waitFor(async () => {
@@ -80,13 +80,13 @@ it('should request most discussed feed when logged-in', async () => {
   });
 });
 
-it('should request most discussed feed when not', async () => {
+it('should request most discussed feed when not logged-in', async () => {
   renderComponent(
     [
       createFeedMock(defaultFeedPage, MOST_DISCUSSED_FEED_QUERY, {
         first: 7,
         loggedIn: false,
-        version: 1,
+        version: 15,
       }),
     ],
     null,

--- a/packages/webapp/__tests__/MostUpvotedPage.tsx
+++ b/packages/webapp/__tests__/MostUpvotedPage.tsx
@@ -73,7 +73,7 @@ it('should request most upvoted feed when logged-in', async () => {
       first: 7,
       loggedIn: true,
       period: 7,
-      version: 1,
+      version: 15,
     }),
   ]);
   await waitFor(async () => {
@@ -89,7 +89,7 @@ it('should request most upvoted feed when not', async () => {
         first: 7,
         loggedIn: false,
         period: 7,
-        version: 1,
+        version: 15,
       }),
     ],
     null,

--- a/packages/webapp/__tests__/MyFeedPage.tsx
+++ b/packages/webapp/__tests__/MyFeedPage.tsx
@@ -90,7 +90,7 @@ it('should request user feed', async () => {
     createFeedMock(defaultFeedPage, FEED_QUERY, {
       first: 7,
       loggedIn: true,
-      version: 1,
+      version: 15,
       ranking: RankingAlgorithm.Popularity,
     }),
   ]);
@@ -106,7 +106,7 @@ it('should request anonymous feed', async () => {
       createFeedMock(defaultFeedPage, ANONYMOUS_FEED_QUERY, {
         first: 7,
         loggedIn: false,
-        version: 1,
+        version: 15,
         ranking: RankingAlgorithm.Popularity,
       }),
     ],

--- a/packages/webapp/__tests__/PopularPage.tsx
+++ b/packages/webapp/__tests__/PopularPage.tsx
@@ -76,7 +76,7 @@ it('should request anonymous feed', async () => {
       createFeedMock(defaultFeedPage, ANONYMOUS_FEED_QUERY, {
         first: 7,
         loggedIn: false,
-        version: 1,
+        version: 15,
         ranking: RankingAlgorithm.Popularity,
       }),
     ],


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Set the default as 15 for feed version

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
