### PR TITLE
fix: pre-select squad on new post button

### DIFF
--- a/packages/shared/src/components/post/write/CreatePostButton.tsx
+++ b/packages/shared/src/components/post/write/CreatePostButton.tsx
@@ -1,10 +1,14 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
+import { useRouter } from 'next/router';
 import { Button, ButtonSize } from '../../buttons/Button';
 import { link } from '../../../lib/links';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import useMedia from '../../../hooks/useMedia';
 import { laptop } from '../../../styles/media';
+import { useSquad } from '../../../hooks';
+import { verifyPermission } from '../../../graphql/squads';
+import { SourcePermissions } from '../../../graphql/sources';
 
 interface CreatePostButtonProps {
   className?: string;
@@ -14,7 +18,12 @@ export function CreatePostButton({
   className,
 }: CreatePostButtonProps): ReactElement {
   const { user, isAuthReady, squads } = useAuthContext();
+  const { route, query } = useRouter();
   const isTablet = !useMedia([laptop.replace('@media ', '')], [true], false);
+
+  const handle = route === '/squads/[handle]' ? (query.handle as string) : '';
+  const { squad } = useSquad({ handle });
+  const allowedToPost = verifyPermission(squad, SourcePermissions.Post);
 
   if (!user || !isAuthReady || !squads?.length) {
     return null;
@@ -24,7 +33,10 @@ export function CreatePostButton({
     <Button
       className={classNames('btn-secondary', className)}
       tag="a"
-      href={link.post.create}
+      href={
+        link.post.create +
+        (squad && allowedToPost ? `?sid=${squad.handle}` : '')
+      }
       buttonSize={isTablet ? ButtonSize.Small : ButtonSize.Medium}
     >
       New post

--- a/packages/webapp/pages/squads/create.tsx
+++ b/packages/webapp/pages/squads/create.tsx
@@ -43,7 +43,7 @@ function CreatePost(): ReactElement {
     (squad) => squad?.active && verifyPermission(squad, SourcePermissions.Post),
   );
   const squad = activeSquads?.[selected];
-  const [display, setDisplay] = useState(WriteFormTab.Share);
+  const [display, setDisplay] = useState(WriteFormTab.NewPost);
   const { displayToast } = useToastNotification();
   const {
     onAskConfirmation,
@@ -128,6 +128,10 @@ function CreatePost(): ReactElement {
           shouldMountInactive
           className={{ header: 'px-1' }}
         >
+          <Tab label={WriteFormTab.NewPost} className="px-5">
+            <SquadsDropdown onSelect={setSelected} selected={selected} />
+            <WriteFreeformContent className="mt-6" />
+          </Tab>
           <Tab label={WriteFormTab.Share} className="px-5">
             <SquadsDropdown onSelect={setSelected} selected={selected} />
             <ShareLink
@@ -138,10 +142,6 @@ function CreatePost(): ReactElement {
                 push(squad.permalink);
               }}
             />
-          </Tab>
-          <Tab label={WriteFormTab.NewPost} className="px-5">
-            <SquadsDropdown onSelect={setSelected} selected={selected} />
-            <WriteFreeformContent className="mt-6" />
           </Tab>
         </TabContainer>
       </WritePageContainer>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- when clicking the `New post` in the header while on a squad page, pre-select the squad when creating a new post.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1803 #done
