### PR TITLE
fix: set max-height of freeform post cover to 1000px

### DIFF
--- a/packages/shared/src/components/post/MarkdownPostContent.tsx
+++ b/packages/shared/src/components/post/MarkdownPostContent.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import Link from 'next/link';
 import { Post, PostType } from '../../graphql/posts';
 import Markdown from '../Markdown';
 import { LazyImage } from '../LazyImage';
@@ -16,12 +17,16 @@ function WelcomePostContent({ post }: WelcomePostContentProps): ReactElement {
         {post.title}
       </h1>
       {post.type === PostType.Freeform && post.image && (
-        <Image
-          src={post.image}
-          alt="Post cover image"
-          className="object-cover mb-10 w-full h-auto rounded-xl max-h-[62.5rem]"
-          fallbackSrc={cloudinary.post.imageCoverPlaceholder}
-        />
+        <Link href={post.image}>
+          <a target="_blank">
+            <Image
+              src={post.image}
+              alt="Post cover image"
+              className="object-cover mb-10 w-full h-auto rounded-xl max-h-[62.5rem]"
+              fallbackSrc={cloudinary.post.imageCoverPlaceholder}
+            />
+          </a>
+        </Link>
       )}
       <Markdown content={post.contentHtml} />
       {post.type === PostType.Welcome && post.image && (

--- a/packages/shared/src/components/post/MarkdownPostContent.tsx
+++ b/packages/shared/src/components/post/MarkdownPostContent.tsx
@@ -6,11 +6,11 @@ import { LazyImage } from '../LazyImage';
 import { cloudinary } from '../../lib/image';
 import { Image } from '../image/Image';
 
-interface WelcomePostContentProps {
+interface MarkdownPostContentProps {
   post: Post;
 }
 
-function WelcomePostContent({ post }: WelcomePostContentProps): ReactElement {
+function MarkdownPostContent({ post }: MarkdownPostContentProps): ReactElement {
   return (
     <>
       <h1 className="my-6 font-bold whitespace-pre-line typo-title2">
@@ -44,4 +44,4 @@ function WelcomePostContent({ post }: WelcomePostContentProps): ReactElement {
   );
 }
 
-export default WelcomePostContent;
+export default MarkdownPostContent;

--- a/packages/shared/src/components/post/MarkdownPostContent.tsx
+++ b/packages/shared/src/components/post/MarkdownPostContent.tsx
@@ -19,7 +19,7 @@ function WelcomePostContent({ post }: WelcomePostContentProps): ReactElement {
         <Image
           src={post.image}
           alt="Post cover image"
-          className="object-cover mb-10 w-full h-auto rounded-xl max-h-[18rem]"
+          className="object-cover mb-10 w-full h-auto rounded-xl max-h-[62.5rem]"
           fallbackSrc={cloudinary.post.imageCoverPlaceholder}
         />
       )}

--- a/packages/shared/src/components/post/MarkdownPostContent.tsx
+++ b/packages/shared/src/components/post/MarkdownPostContent.tsx
@@ -18,7 +18,7 @@ function MarkdownPostContent({ post }: MarkdownPostContentProps): ReactElement {
       </h1>
       {post.type === PostType.Freeform && post.image && (
         <Link href={post.image}>
-          <a target="_blank" rel="noopener">
+          <a target="_blank" rel="noopener noreferrer">
             <Image
               src={post.image}
               alt="Post cover image"

--- a/packages/shared/src/components/post/MarkdownPostContent.tsx
+++ b/packages/shared/src/components/post/MarkdownPostContent.tsx
@@ -18,7 +18,7 @@ function WelcomePostContent({ post }: WelcomePostContentProps): ReactElement {
       </h1>
       {post.type === PostType.Freeform && post.image && (
         <Link href={post.image}>
-          <a target="_blank">
+          <a target="_blank" rel="noopener">
             <Image
               src={post.image}
               alt="Post cover image"


### PR DESCRIPTION
## Changes

<table>
<tr>
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/551c1fd9-0983-4d68-be41-35414c9c7027" />
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/6d3b322c-3c00-4a63-b1da-9befe4130abc" />
</table>

### Describe what this PR does
- gives freeform post cover image a max height of 1000px
- when clicking the cover image it opens in a new tab

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1804 #done
