### PR TITLE
refactor: share modal ui to open separate form for squad

### DIFF
--- a/packages/shared/src/components/modals/ShareModal.tsx
+++ b/packages/shared/src/components/modals/ShareModal.tsx
@@ -1,10 +1,4 @@
-import React, {
-  ReactElement,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { ReactElement, useContext, useEffect, useRef } from 'react';
 import { useSwipeable } from 'react-swipeable';
 import { Post } from '../../graphql/posts';
 import { SocialShare } from '../widgets/SocialShare';
@@ -41,7 +35,6 @@ export default function ShareModal({
     ? `${post?.commentsPermalink}${getCommentHash(comment.id)}`
     : post?.commentsPermalink;
   const { trackEvent } = useContext(AnalyticsContext);
-  const [commentary, setCommentary] = useState('');
   const isMobile = !useMedia([tablet.replace('@media ', '')], [true], false);
   const markdownRef = useRef<MarkdownRef>();
 
@@ -88,24 +81,25 @@ export default function ShareModal({
     >
       <Modal.Header title={isComment ? 'Share comment' : 'Share post'} />
       <Modal.Body {...handlers}>
-        <MarkdownInput
-          className={{ container: 'mb-4' }}
-          ref={markdownRef}
-          showUserAvatar
-          textareaProps={{ rows: 4, name: 'commentary' }}
-          allowPreview={false}
-          enabledCommand={{ mention: true }}
-          onValueUpdate={(value) => setCommentary(value)}
-          footer={
-            <WriteLinkPreview
-              className="flex-col-reverse m-3 !w-auto"
-              preview={post}
-              link={link}
-              showPreviewLink={false}
-              isMinimized
-            />
-          }
-        />
+        {isComment ? (
+          <MarkdownInput
+            className={{ container: 'mb-4' }}
+            ref={markdownRef}
+            showUserAvatar
+            textareaProps={{ rows: 4, name: 'commentary' }}
+            allowPreview={false}
+            enabledCommand={{ mention: true }}
+            footer={
+              <WriteLinkPreview
+                className="flex-col-reverse m-3 !w-auto"
+                preview={post}
+                link={link}
+                showPreviewLink={false}
+                isMinimized
+              />
+            }
+          />
+        ) : null}
         <SocialShare
           post={post}
           comment={comment}
@@ -114,7 +108,6 @@ export default function ShareModal({
           column={column}
           row={row}
           onSquadShare={() => onRequestClose(null)}
-          commentary={commentary}
         />
       </Modal.Body>
     </Modal>

--- a/packages/shared/src/components/modals/ShareModal.tsx
+++ b/packages/shared/src/components/modals/ShareModal.tsx
@@ -1,17 +1,15 @@
-import React, { ReactElement, useContext, useEffect, useRef } from 'react';
+import React, { ReactElement, useContext, useEffect } from 'react';
 import { useSwipeable } from 'react-swipeable';
 import { Post } from '../../graphql/posts';
 import { SocialShare } from '../widgets/SocialShare';
 import { Origin } from '../../lib/analytics';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 import { FeedItemPosition, postAnalyticsEvent } from '../../lib/feed';
-import { Comment, getCommentHash } from '../../graphql/comments';
+import { Comment } from '../../graphql/comments';
 import { Modal, ModalProps } from './common/Modal';
 import { ExperimentWinner } from '../../lib/featureValues';
 import useMedia from '../../hooks/useMedia';
 import { tablet } from '../../styles/media';
-import MarkdownInput, { MarkdownRef } from '../fields/MarkdownInput';
-import { WriteLinkPreview } from '../post/write';
 
 type ShareModalProps = {
   post: Post;
@@ -31,12 +29,8 @@ export default function ShareModal({
   ...props
 }: ShareModalProps): ReactElement {
   const isComment = !!comment;
-  const link = isComment
-    ? `${post?.commentsPermalink}${getCommentHash(comment.id)}`
-    : post?.commentsPermalink;
   const { trackEvent } = useContext(AnalyticsContext);
   const isMobile = !useMedia([tablet.replace('@media ', '')], [true], false);
-  const markdownRef = useRef<MarkdownRef>();
 
   const baseTrackingEvent = (
     eventName: string,
@@ -81,25 +75,6 @@ export default function ShareModal({
     >
       <Modal.Header title={isComment ? 'Share comment' : 'Share post'} />
       <Modal.Body {...handlers}>
-        {isComment ? (
-          <MarkdownInput
-            className={{ container: 'mb-4' }}
-            ref={markdownRef}
-            showUserAvatar
-            textareaProps={{ rows: 4, name: 'commentary' }}
-            allowPreview={false}
-            enabledCommand={{ mention: true }}
-            footer={
-              <WriteLinkPreview
-                className="flex-col-reverse m-3 !w-auto"
-                preview={post}
-                link={link}
-                showPreviewLink={false}
-                isMinimized
-              />
-            }
-          />
-        ) : null}
         <SocialShare
           post={post}
           comment={comment}

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -27,16 +27,18 @@ import { IconSize } from '../Icon';
 import { useSharePost } from '../../hooks/useSharePost';
 import MenuIcon from '../icons/Menu';
 import CopyIcon from '../icons/Copy';
-import { usePostToSquad } from '../../hooks';
 import { SocialShareContainer } from './SocialShareContainer';
 import { useCopyLink } from '../../hooks/useCopy';
 import { SquadsToShare } from '../squads/SquadsToShare';
+import { useLazyModal } from '../../hooks/useLazyModal';
+import { LazyModal } from '../modals/common/types';
+import { Squad } from '../../graphql/sources';
 
 interface SocialShareProps {
   origin: Origin;
   post: Post;
   comment?: Comment;
-  onSquadShare?: (post: Post) => void;
+  onSquadShare?: () => void;
   commentary?: string;
 }
 
@@ -48,7 +50,6 @@ export const SocialShare = ({
   column,
   row,
   onSquadShare,
-  commentary,
 }: SocialShareProps & FeedItemPosition): ReactElement => {
   const isComment = !!comment;
   const href = isComment
@@ -58,6 +59,7 @@ export const SocialShare = ({
   const link = isComment
     ? `${post?.commentsPermalink}${getCommentHash(comment.id)}`
     : post?.commentsPermalink;
+  const { openModal } = useLazyModal();
   const { trackEvent } = useContext(AnalyticsContext);
   const { openNativeSharePost } = useSharePost(Origin.Share);
   const trackClick = (provider: ShareProvider) =>
@@ -70,27 +72,35 @@ export const SocialShare = ({
       }),
     );
 
-  const { onSubmitPost, isPosting } = usePostToSquad({
-    initialPreview: post,
-    onPostSuccess: () => {
-      trackEvent(postAnalyticsEvent(AnalyticsEvent.ShareToSquad, post));
-      onSquadShare(null);
-    },
-  });
-
   const trackAndCopyLink = () => {
     copyLink();
     trackClick(ShareProvider.CopyLink);
+  };
+
+  const onSharedSuccessfully = () => {
+    trackEvent(postAnalyticsEvent(AnalyticsEvent.ShareToSquad, post));
+
+    if (onSquadShare) {
+      onSquadShare();
+    }
+  };
+
+  const onSquadsShare = (squad: Squad) => {
+    openModal({
+      type: LazyModal.CreateSharedPost,
+      props: {
+        squad,
+        preview: post,
+        onSharedSuccessfully,
+      },
+    });
   };
 
   return (
     <>
       {!isComment && !post.private && (
         <SocialShareContainer title="Share with your squad">
-          <SquadsToShare
-            onClick={(e, squad) => onSubmitPost(e, squad.id, commentary)}
-            isLoading={isPosting}
-          />
+          <SquadsToShare onClick={(_, squad) => onSquadsShare(squad)} />
         </SocialShareContainer>
       )}
       <SocialShareContainer title="Share externally" className="mt-4">

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -99,11 +99,11 @@ export const SocialShare = ({
   return (
     <>
       {!isComment && !post.private && (
-        <SocialShareContainer title="Share with your squad">
+        <SocialShareContainer title="Share with your squad" className="mb-4">
           <SquadsToShare onClick={(_, squad) => onSquadsShare(squad)} />
         </SocialShareContainer>
       )}
-      <SocialShareContainer title="Share externally" className="mt-4">
+      <SocialShareContainer title="Share externally">
         <SocialShareIcon
           onClick={trackAndCopyLink}
           pressed={copying}


### PR DESCRIPTION
## Changes
- Remove the Markdown input from the ShareModal.
- When clicking a Squad icon, we will then open the modal to share a post to Squad.
- Since the ShareModal was not used in the LazyModal enum, we won't have to make any changes with the LazyModal itself since only one instance is opened.

Preview:

https://github.com/dailydotdev/apps/assets/13744167/0b2bc640-3775-489b-8203-01e12181df82


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1794 #done
