### PR TITLE
fix: wait for boot to be completed before we set features

### DIFF
--- a/packages/shared/src/components/GrowthBookProvider.tsx
+++ b/packages/shared/src/components/GrowthBookProvider.tsx
@@ -32,6 +32,7 @@ export type GrowthBookProviderProps = {
   experimentation?: BootCacheData['exp'];
   updateExperimentation?: (exp: BootCacheData['exp']) => unknown;
   children?: ReactNode;
+  isFetched?: boolean;
 };
 
 export const GrowthBookProvider = ({
@@ -42,6 +43,7 @@ export const GrowthBookProvider = ({
   experimentation,
   updateExperimentation,
   children,
+  isFetched,
 }: GrowthBookProviderProps): ReactElement => {
   const { fetchMethod } = useRequestProtocol();
   const { mutateAsync: sendAllocation } = useMutation(
@@ -77,7 +79,7 @@ export const GrowthBookProvider = ({
   );
 
   useEffect(() => {
-    if (gb && experimentation?.f) {
+    if (gb && experimentation?.f && isFetched) {
       const currentFeats = gb.getFeatures();
       // Do not update when the features are already set
       if (!currentFeats || !Object.keys(currentFeats).length) {
@@ -91,7 +93,7 @@ export const GrowthBookProvider = ({
         });
       }
     }
-  }, [gb, experimentation?.f]);
+  }, [gb, experimentation?.f, isFetched]);
 
   useEffect(() => {
     callback.current = async (experiment, result) => {

--- a/packages/shared/src/components/GrowthBookProvider.tsx
+++ b/packages/shared/src/components/GrowthBookProvider.tsx
@@ -32,7 +32,7 @@ export type GrowthBookProviderProps = {
   experimentation?: BootCacheData['exp'];
   updateExperimentation?: (exp: BootCacheData['exp']) => unknown;
   children?: ReactNode;
-  isFetched?: boolean;
+  firstLoad?: boolean;
 };
 
 export const GrowthBookProvider = ({
@@ -43,7 +43,7 @@ export const GrowthBookProvider = ({
   experimentation,
   updateExperimentation,
   children,
-  isFetched,
+  firstLoad,
 }: GrowthBookProviderProps): ReactElement => {
   const { fetchMethod } = useRequestProtocol();
   const { mutateAsync: sendAllocation } = useMutation(
@@ -79,7 +79,7 @@ export const GrowthBookProvider = ({
   );
 
   useEffect(() => {
-    if (gb && experimentation?.f && isFetched) {
+    if (gb && experimentation?.f && firstLoad) {
       const currentFeats = gb.getFeatures();
       // Do not update when the features are already set
       if (!currentFeats || !Object.keys(currentFeats).length) {
@@ -93,7 +93,7 @@ export const GrowthBookProvider = ({
         });
       }
     }
-  }, [gb, experimentation?.f, isFetched]);
+  }, [gb, experimentation?.f, firstLoad]);
 
   useEffect(() => {
     callback.current = async (experiment, result) => {

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -181,6 +181,7 @@ export const BootDataProvider = ({
       deviceId={deviceId}
       experimentation={cachedBootData?.exp}
       updateExperimentation={updateExperimentation}
+      isFetched={isFetched}
     >
       <AuthContextProvider
         user={user}

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -181,7 +181,7 @@ export const BootDataProvider = ({
       deviceId={deviceId}
       experimentation={cachedBootData?.exp}
       updateExperimentation={updateExperimentation}
-      isFetched={isFetched}
+      firstLoad={initialLoad}
     >
       <AuthContextProvider
         user={user}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- wait for boot to be completed before we set features

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
