### PR TITLE
fix: remove background color on `post-content` class

### DIFF
--- a/packages/shared/src/components/modals/ArticlePostModal.tsx
+++ b/packages/shared/src/components/modals/ArticlePostModal.tsx
@@ -40,7 +40,7 @@ export default function ArticlePostModal({
       onRequestClose={onRequestClose}
       postType={PostType.Article}
       source={post.source}
-      loadingClassName="post-content"
+      loadingClassName="!pb-2 tablet:pb-0"
     >
       <PostContent
         position={position}

--- a/packages/shared/src/components/modals/BasePostModal.module.css
+++ b/packages/shared/src/components/modals/BasePostModal.module.css
@@ -10,21 +10,4 @@
     overflow-y: scroll;
     z-index: 10;
   }
-
-  & :global(.post-content) {
-    display: flex;
-    border: none;
-    border-radius: 0;
-    max-width: 100%;
-    padding-bottom: 4rem;
-
-    @screen tablet {
-      padding-bottom: 0;
-    }
-
-    @screen laptop {
-      height: unset;
-      border-radius: 1rem;
-    }
-  }
 }

--- a/packages/shared/src/components/modals/BasePostModal.module.css
+++ b/packages/shared/src/components/modals/BasePostModal.module.css
@@ -12,8 +12,6 @@
   }
 
   & :global(.post-content) {
-    @apply bg-theme-bg-primary;
-
     display: flex;
     border: none;
     border-radius: 0;

--- a/packages/shared/src/components/modals/BasePostModal.tsx
+++ b/packages/shared/src/components/modals/BasePostModal.tsx
@@ -32,7 +32,7 @@ function BasePostModal({
       overlayClassName="post-modal-overlay bg-overlay-quaternary-onion"
       className={classNames(
         className,
-        'mx-auto focus:outline-none bg-theme-bg-primary',
+        'mx-auto focus:outline-none !bg-theme-bg-primary',
       )}
     >
       {isLoading ? (

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -33,7 +33,6 @@ export default function PostModal({
     isDisplayed: props.isOpen,
     offset: showArticleOnboarding ? ONBOARDING_OFFSET : 0,
   });
-  const containerClass = 'post-content';
   const isPublicSquad = isSourcePublicSquad(post.source);
 
   return (
@@ -43,7 +42,7 @@ export default function PostModal({
       onRequestClose={onRequestClose}
       postType={PostType.Share}
       source={post.source}
-      loadingClassName={containerClass}
+      loadingClassName="!pb-2 tablet:pb-0"
     >
       <EnableNotification
         source={NotificationPromptSource.SquadPostModal}
@@ -60,7 +59,6 @@ export default function PostModal({
         origin={Origin.ArticleModal}
         onRemovePost={onRemovePost}
         className={{
-          container: containerClass,
           fixedNavigation: { container: '!w-[inherit]', actions: 'ml-auto' },
           navigation: { actions: 'tablet:hidden ml-auto' },
           onboarding: 'mt-8 mb-0',

--- a/packages/shared/src/components/post/PostLoadingSkeleton.tsx
+++ b/packages/shared/src/components/post/PostLoadingSkeleton.tsx
@@ -29,7 +29,7 @@ function PostLoadingSkeleton({
       <PostContentContainer
         className={classNames(className, {
           'm-auto': !publicSquadPost,
-          'tablet:pb-0 tablet:flex-row bg-theme-bg-primary': publicSquadPost,
+          'tablet:pb-0 tablet:flex-row': publicSquadPost,
         })}
         hasNavigation={hasNavigation}
       >
@@ -47,10 +47,7 @@ function PostLoadingSkeleton({
   return (
     <PostContentContainer
       hasNavigation={hasNavigation}
-      className={classNames(
-        className,
-        'tablet:pb-0 tablet:flex-row bg-theme-bg-primary',
-      )}
+      className={classNames(className, 'tablet:pb-0 tablet:flex-row')}
     >
       <PostLoadingPlaceholder className="tablet:border-r tablet:border-theme-divider-tertiary" />
     </PostContentContainer>

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -84,7 +84,7 @@ function SquadPostContent({
       )}
       <PostContentContainer
         className={classNames(
-          'relative post-content',
+          'relative tablet:pb-0 !pb-2',
           className?.container,
           isPublicSquad && 'flex-1 flex-col tablet:flex-row',
         )}


### PR DESCRIPTION
## Changes

<table>
<tr>
  <td>Before
  <td>After
<tr>
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/1b500a06-fc07-4d52-9805-68772e70a516">
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/fc7d800d-2367-4394-818b-ffc1dc7a4be0">
</table>

### Describe what this PR does
- removes the background colour from the `post-content` class
 
## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1867 #done
