### PR TITLE
fix: welcome back view and default auth display on onboarding v3

### DIFF
--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -82,6 +82,7 @@ export interface AuthOptionsProps {
   formRef: MutableRefObject<HTMLFormElement>;
   trigger: AuthTriggersOrString;
   defaultDisplay?: AuthDisplay;
+  forceDefaultDisplay?: boolean;
   className?: string;
   simplified?: boolean;
   isLoginFlow?: boolean;
@@ -99,6 +100,7 @@ function AuthOptions({
   formRef,
   trigger,
   defaultDisplay = AuthDisplay.Default,
+  forceDefaultDisplay,
   onDisplayChange,
   isLoginFlow,
   targetId,
@@ -116,7 +118,9 @@ function AuthOptions({
   const [email, setEmail] = useState(initialEmail);
   const [flow, setFlow] = useState('');
   const [activeDisplay, setActiveDisplay] = useState(() =>
-    storage.getItem(SIGNIN_METHOD_KEY) ? AuthDisplay.SignBack : defaultDisplay,
+    storage.getItem(SIGNIN_METHOD_KEY) && !forceDefaultDisplay
+      ? AuthDisplay.SignBack
+      : defaultDisplay,
   );
 
   const onSetActiveDisplay = (display: AuthDisplay) => {

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -152,11 +152,10 @@ export function OnboardPage(): ReactElement {
   const [auth, setAuth] = useState<AuthProps>({
     isAuthenticating: isOnboardingV3 && !!storage.getItem(SIGNIN_METHOD_KEY),
     isLoginFlow: false,
-    defaultDisplay: isOnboardingV3
-      ? AuthDisplay.OnboardingSignup
-      : AuthDisplay.Default,
+    defaultDisplay: AuthDisplay.OnboardingSignup,
   });
   const { isAuthenticating, isLoginFlow, email, defaultDisplay } = auth;
+  const isPageReady = growthbook?.ready && isAuthReady;
 
   const formRef = useRef<HTMLFormElement>();
   const title = versionToTitle[filteringTitle];
@@ -166,7 +165,6 @@ export function OnboardPage(): ReactElement {
       setAuth((currentAuth) => ({
         ...currentAuth,
         isAuthenticating: !!storage.getItem(SIGNIN_METHOD_KEY),
-        defaultDisplay: AuthDisplay.OnboardingSignup,
       }));
     }
   }, [isOnboardingV3]);
@@ -225,8 +223,6 @@ export function OnboardPage(): ReactElement {
     }
   }, [alerts, hasSelectTopics, isOnboardingV3, router]);
 
-  const isPageReady = growthbook?.ready && isAuthReady;
-
   useEffect(() => {
     if (!isPageReady || isTracked.current) {
       return;
@@ -275,8 +271,8 @@ export function OnboardPage(): ReactElement {
         )}
         trigger={AuthTriggers.Onboarding}
         formRef={formRef}
-        defaultDisplay={defaultDisplay}
-        forceDefaultDisplay={!isAuthenticating}
+        defaultDisplay={isOnboardingV3 ? defaultDisplay : AuthDisplay.Default}
+        forceDefaultDisplay={isOnboardingV3 && !isAuthenticating}
         initialEmail={email}
         isLoginFlow={isLoginFlow}
         targetId={isOnboardingV3 ? onboardingV3 : onboardingV2}

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -275,6 +275,7 @@ export function OnboardPage(): ReactElement {
         trigger={AuthTriggers.Onboarding}
         formRef={formRef}
         defaultDisplay={defaultDisplay}
+        forceDefaultDisplay={!isAuthenticating}
         initialEmail={email}
         isLoginFlow={isLoginFlow}
         targetId={isOnboardingV3 ? onboardingV3 : onboardingV2}

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -165,6 +165,7 @@ export function OnboardPage(): ReactElement {
     if (isOnboardingV3) {
       setAuth((currentAuth) => ({
         ...currentAuth,
+        isAuthenticating: !!storage.getItem(SIGNIN_METHOD_KEY),
         defaultDisplay: AuthDisplay.OnboardingSignup,
       }));
     }


### PR DESCRIPTION
## Changes

<table>
<tr>
  <td>Before
  <td>After
<tr>
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/d1e6f196-3ccd-4a6c-ba96-77e36f3481dd" />
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/2a40dab6-186b-4ff9-ad21-f46b2031e10b"/>
<tr>
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/1e38e43c-563c-455d-8538-e36095341a93" />
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/081831a6-53fd-43f9-bd32-f9ca9d47e9c8" />
</table>

### Describe what this PR does
- don't show onboarding view if it is welcome back
- don't show signup display on onboarding v3

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
