### PR TITLE
fix: conditional hotfix middle click issue

### DIFF
--- a/packages/shared/src/components/cards/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.tsx
@@ -17,7 +17,6 @@ import { useBlockPostPanel } from '../../hooks/post/useBlockPostPanel';
 import { PostTagsPanel } from '../post/block/PostTagsPanel';
 import { usePostFeedback } from '../../hooks';
 import styles from './Card.module.css';
-import ConditionalWrapper from '../ConditionalWrapper';
 import { FeedbackCard } from './FeedbackCard';
 
 export const ArticlePostCard = forwardRef(function PostCard(
@@ -74,30 +73,24 @@ export const ArticlePostCard = forwardRef(function PostCard(
 
       {showFeedback && <FeedbackCard post={post} />}
 
-      <ConditionalWrapper
-        condition={showFeedback}
-        wrapper={(wrapperChildren) => (
-          <div
-            className={classNames(
-              'p-2 border !border-theme-divider-tertiary rounded-2xl overflow-hidden',
-              styles.post,
-              styles.read,
-            )}
-          >
-            {wrapperChildren}
-          </div>
+      <div
+        className={classNames(
+          showFeedback
+            ? 'p-2 border !border-theme-divider-tertiary rounded-2xl overflow-hidden'
+            : 'flex flex-col flex-1',
+          showFeedback && styles.post,
+          showFeedback && styles.read,
         )}
       >
         <CardTextContainer>
-          {!showFeedback && (
-            <PostCardHeader
-              openNewTab={openNewTab}
-              source={post.source}
-              postLink={post.permalink}
-              onMenuClick={(event) => onMenuClick?.(event, post)}
-              onReadArticleClick={onReadArticleClick}
-            />
-          )}
+          <PostCardHeader
+            className={showFeedback ? 'hidden' : 'flex'}
+            openNewTab={openNewTab}
+            source={post.source}
+            postLink={post.permalink}
+            onMenuClick={(event) => onMenuClick?.(event, post)}
+            onReadArticleClick={onReadArticleClick}
+          />
           <CardTitle lineClamp={showFeedback ? 'line-clamp-2' : undefined}>
             {post.title}
           </CardTitle>
@@ -118,7 +111,6 @@ export const ArticlePostCard = forwardRef(function PostCard(
             openNewTab={openNewTab}
             post={post}
             showImage={showImage}
-            onReadArticleClick={onReadArticleClick}
             className={{
               image: classNames(showFeedback && 'mb-0'),
             }}
@@ -142,7 +134,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
             />
           )}
         </Container>
-      </ConditionalWrapper>
+      </div>
       {children}
     </FeedItemContainer>
   );

--- a/packages/shared/src/components/cards/PostCardFooter.tsx
+++ b/packages/shared/src/components/cards/PostCardFooter.tsx
@@ -17,7 +17,6 @@ type PostCardFooterProps = {
   openNewTab: boolean;
   showImage: boolean;
   post: Post;
-  onReadArticleClick?: (e: React.MouseEvent) => unknown;
   className: PostCardFooterClassName;
 };
 

--- a/packages/shared/src/components/cards/PostCardHeader.tsx
+++ b/packages/shared/src/components/cards/PostCardHeader.tsx
@@ -7,6 +7,7 @@ import { ReadArticleButton } from './ReadArticleButton';
 import { getGroupedHoverContainer } from './common';
 
 interface CardHeaderProps {
+  className?: string;
   children?: ReactNode;
   source: Source;
   onMenuClick?: (e: React.MouseEvent) => void;
@@ -18,6 +19,7 @@ interface CardHeaderProps {
 const Container = getGroupedHoverContainer('span');
 
 export const PostCardHeader = ({
+  className,
   onMenuClick,
   onReadArticleClick,
   children,
@@ -26,7 +28,7 @@ export const PostCardHeader = ({
   openNewTab,
 }: CardHeaderProps): ReactElement => {
   return (
-    <CardHeader>
+    <CardHeader className={className}>
       <SourceButton source={source} />
       {children}
       <Container


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We had a issue where the conditional wrapper re-render would actually remove the element it had before, and make the click disappear (our internal mouseUp would fire first)

- **Web**: Good to keep in mind when using conditional wrapper in the future.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
