### PR TITLE
feat: add post finder page as old search

### DIFF
--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -8,6 +8,10 @@ import FeedLayout from '@dailydotdev/shared/src/components/FeedLayout';
 import dynamic from 'next/dynamic';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import AlertContext from '@dailydotdev/shared/src/contexts/AlertContext';
+import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
+import { SearchExperiment } from '@dailydotdev/shared/src/lib/featureValues';
+import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import ShortcutLinks from './ShortcutLinks';
 import DndBanner from './DndBanner';
 import DndContext from './DndContext';
@@ -32,6 +36,7 @@ export type MainFeedPageProps = {
 export default function MainFeedPage({
   onPageChanged,
 }: MainFeedPageProps): ReactElement {
+  const searchVersion = useFeature(feature.search);
   const { alerts } = useContext(AlertContext);
   const [isSearchOn, setIsSearchOn] = useState(false);
   const { user, loadingUser } = useContext(AuthContext);
@@ -41,6 +46,11 @@ export default function MainFeedPage({
   useCompanionSettings();
   const { isActive: isDndActive } = useContext(DndContext);
   const enableSearch = () => {
+    if (searchVersion !== SearchExperiment.Control) {
+      window.location.assign(`${webappUrl}posts/finder`);
+      return;
+    }
+
     setIsSearchOn(true);
     setSearchQuery(null);
     onPageChanged('/search');

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -82,6 +82,7 @@ export type MainFeedLayoutProps = {
   besideSearch?: ReactNode;
   navChildren?: ReactNode;
   onFeedPageChanged: (page: MainFeedPage) => void;
+  isFinder?: boolean;
 };
 
 const getQueryBasedOnLogin = (
@@ -140,6 +141,7 @@ export default function MainFeedLayout({
   besideSearch,
   onFeedPageChanged,
   navChildren,
+  isFinder,
 }: MainFeedLayoutProps): ReactElement {
   const { sortingEnabled, loadedSettings } = useContext(SettingsContext);
   const { user, tokenRefreshed } = useContext(AuthContext);
@@ -279,7 +281,7 @@ export default function MainFeedLayout({
 
   return (
     <FeedPage className="relative">
-      {searchVersion === SearchExperiment.V1 && (
+      {searchVersion === SearchExperiment.V1 && !isFinder && (
         <img
           className="absolute top-0 left-0 w-full max-w-[58.75rem]"
           src={getImage()}

--- a/packages/shared/src/components/PostsSearch.tsx
+++ b/packages/shared/src/components/PostsSearch.tsx
@@ -137,7 +137,7 @@ export default function PostsSearch({
         className={classNames('flex-1 compact', className)}
         inputId="posts-search"
         fieldSize="medium"
-        placeholder={placeholder}
+        placeholder={placeholder ?? 'Find posts'}
         ref={searchBoxRef}
         value={initialQuery}
         valueChanged={onValueChanged}

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -115,7 +115,9 @@ export const FeedContainer = ({
     return <></>;
   }
 
-  const isV1Search = searchValue === SearchExperiment.V1 && showSearch;
+  const isFinder = router.pathname === '/posts/finder';
+  const isV1Search =
+    searchValue === SearchExperiment.V1 && showSearch && !isFinder;
   const onSearch = (event: FormEvent, input: string) => {
     event.preventDefault();
     router.push(`${webappUrl}search?q=${encodeURIComponent(input)}`);

--- a/packages/shared/src/components/sidebar/DiscoverSection.tsx
+++ b/packages/shared/src/components/sidebar/DiscoverSection.tsx
@@ -67,7 +67,7 @@ export function DiscoverSection({
         <ListIcon Icon={() => <SearchIcon secondary={active} />} />
       ),
       title: isControlSearch ? 'Search' : 'Post finder',
-      hideOnMobile: true,
+      hideOnMobile: isControlSearch,
       path: isControlSearch ? '/search' : '/posts/finder',
       action: enableSearch,
     },

--- a/packages/shared/src/components/sidebar/DiscoverSection.tsx
+++ b/packages/shared/src/components/sidebar/DiscoverSection.tsx
@@ -23,6 +23,7 @@ export function DiscoverSection({
   ...defaultRenderSectionProps
 }: DiscoverSectionProps): ReactElement {
   const searchValue = useFeature(feature.search);
+  const isControlSearch = searchValue === SearchExperiment.Control;
   const discoverMenuItems: SidebarMenuItem[] = [
     {
       icon: (active: boolean) => (
@@ -61,19 +62,16 @@ export function DiscoverSection({
         </span>
       ),
     },
-  ];
-
-  if (searchValue === SearchExperiment.Control) {
-    discoverMenuItems.push({
+    {
       icon: (active: boolean) => (
         <ListIcon Icon={() => <SearchIcon secondary={active} />} />
       ),
-      title: 'Search',
+      title: isControlSearch ? 'Search' : 'Post finder',
       hideOnMobile: true,
-      path: '/search',
+      path: isControlSearch ? '/search' : '/posts/finder',
       action: enableSearch,
-    });
-  }
+    },
+  ];
 
   return (
     <Section

--- a/packages/webapp/components/layouts/MainFeedPage.tsx
+++ b/packages/webapp/components/layouts/MainFeedPage.tsx
@@ -28,6 +28,11 @@ const getFeedName = (path: string): string => {
   if (path === '/') {
     return 'default';
   }
+
+  if (path === '/posts/finder') {
+    return 'search';
+  }
+
   return path.replace(/^\/+/, '');
 };
 
@@ -38,9 +43,7 @@ export default function MainFeedPage({
   const router = useRouter();
   const { user } = useContext(AuthContext);
   const isFinderPage = router?.pathname === '/search' || isFinder;
-  const [feedName, setFeedName] = useState(
-    getFeedName(isFinder ? '/search' : router?.pathname),
-  );
+  const [feedName, setFeedName] = useState(getFeedName(router?.pathname));
   const [isSearchOn, setIsSearchOn] = useState(isFinderPage);
   useEffect(() => {
     const isMyFeed = router?.pathname === '/my-feed';

--- a/packages/webapp/components/layouts/MainFeedPage.tsx
+++ b/packages/webapp/components/layouts/MainFeedPage.tsx
@@ -21,6 +21,7 @@ const PostsSearch = dynamic(
 
 export type MainFeedPageProps = {
   children?: ReactNode;
+  isFinder?: boolean;
 };
 
 const getFeedName = (path: string): string => {
@@ -32,17 +33,20 @@ const getFeedName = (path: string): string => {
 
 export default function MainFeedPage({
   children,
+  isFinder,
 }: MainFeedPageProps): ReactElement {
   const router = useRouter();
   const { user } = useContext(AuthContext);
-  const [feedName, setFeedName] = useState(getFeedName(router?.pathname));
-  const [isSearchOn, setIsSearchOn] = useState(router?.pathname === '/search');
-
+  const isFinderPage = router?.pathname === '/search' || isFinder;
+  const [feedName, setFeedName] = useState(
+    getFeedName(isFinder ? '/search' : router?.pathname),
+  );
+  const [isSearchOn, setIsSearchOn] = useState(isFinderPage);
   useEffect(() => {
     const isMyFeed = router?.pathname === '/my-feed';
     if (getShouldRedirect(isMyFeed, !!user)) {
       router.replace('/');
-    } else if (router?.pathname === '/search') {
+    } else if (isFinderPage) {
       setIsSearchOn(true);
       if (!feedName) {
         setFeedName('popular');

--- a/packages/webapp/components/layouts/MainFeedPage.tsx
+++ b/packages/webapp/components/layouts/MainFeedPage.tsx
@@ -79,7 +79,7 @@ export default function MainFeedPage({
       isSearchOn={isSearchOn}
       onFeedPageChanged={(page) => router.replace(`/${page}`)}
       searchQuery={router.query?.q?.toString()}
-      searchChildren={<PostsSearch placeholder="Search posts" />}
+      searchChildren={<PostsSearch />}
     >
       {children}
     </MainFeedLayout>

--- a/packages/webapp/components/layouts/MainFeedPage.tsx
+++ b/packages/webapp/components/layouts/MainFeedPage.tsx
@@ -80,6 +80,7 @@ export default function MainFeedPage({
       onFeedPageChanged={(page) => router.replace(`/${page}`)}
       searchQuery={router.query?.q?.toString()}
       searchChildren={<PostsSearch />}
+      isFinder={isFinder}
     >
       {children}
     </MainFeedLayout>

--- a/packages/webapp/components/search/SearchControlPage.tsx
+++ b/packages/webapp/components/search/SearchControlPage.tsx
@@ -20,7 +20,7 @@ const Search = (): ReactElement => {
   const seo = useMemo(() => {
     if ('q' in query) {
       return {
-        title: `${query.q} - daily.dev search`,
+        title: `${query.q} - daily.dev post finder`,
       };
     }
     return {
@@ -36,6 +36,10 @@ const Search = (): ReactElement => {
 };
 
 Search.getLayout = getMainFeedLayout;
-Search.layoutProps = { ...mainFeedLayoutProps, mobileTitle: 'Search' };
+Search.layoutProps = {
+  ...mainFeedLayoutProps,
+  mobileTitle: 'Post finder',
+  isFinder: true,
+};
 
 export default Search;

--- a/packages/webapp/pages/posts/finder.tsx
+++ b/packages/webapp/pages/posts/finder.tsx
@@ -1,7 +1,3 @@
-import SearchControlPage from '../../../components/search/SearchControlPage';
+import SearchControlPage from '../../components/search/SearchControlPage';
 
-const PostFinder = () => {
-  return <h1>Post Finder</h1>;
-};
-
-export default PostFinder;
+export default SearchControlPage;

--- a/packages/webapp/pages/posts/finder.tsx
+++ b/packages/webapp/pages/posts/finder.tsx
@@ -1,0 +1,7 @@
+import SearchControlPage from '../../../components/search/SearchControlPage';
+
+const PostFinder = () => {
+  return <h1>Post Finder</h1>;
+};
+
+export default PostFinder;


### PR DESCRIPTION
## Changes
- We have now a dedicated page for the old search which can be found at `/posts/finder`.
- As mentioned in Slack, we will now keep the item in the sidebar originally intended for search but the name will vary based on which version you are at.
- For extension users with AI search, we will redirect to the new page when the sidebar item is clicked.
- Since we still have the legacy Search, we will reuse the same component but refactor all the words from "Search" to "Post finder" as per Slack message.
- Have also tested on extension with legacy Search to not redirect and work as it currently is instead.

This is deployed in [preview2](https://preview2.app.daily.dev/posts/finder).

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1871 #done
