### PR TITLE
fix: allow string attributes

### DIFF
--- a/packages/shared/src/components/cards/WelcomePostCardFooter.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCardFooter.tsx
@@ -32,6 +32,12 @@ export const WelcomePostCardFooter = ({
     return undefined;
   }, [post?.contentHtml, post?.image]);
 
+  const decodedText = useMemo(() => {
+    const span = document.createElement('div');
+    span.innerHTML = content || '';
+    return span.innerText || content;
+  }, [content]);
+
   if (image) {
     return (
       <>
@@ -48,7 +54,9 @@ export const WelcomePostCardFooter = ({
   }
   if (content) {
     return (
-      <p className="px-2 break-words line-clamp-6 typo-callout">{content}</p>
+      <p className="px-2 break-words line-clamp-6 typo-callout">
+        {decodedText}
+      </p>
     );
   }
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We only want to allow text based HTML entities (*eg not images/headers/list etc)
- Decided to use a custom html parsing method to only allow text entities

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1879 #done
