### PR TITLE
fix: align squad colors with theme colors

### DIFF
--- a/packages/shared/src/components/sources/SourceCard.spec.tsx
+++ b/packages/shared/src/components/sources/SourceCard.spec.tsx
@@ -128,7 +128,7 @@ it('should render the component with basic props', async () => {
 
   expect(screen.getByText('title')).toBeInTheDocument();
   expect(screen.getByText('icon')).toBeInTheDocument();
-  expect(element).toHaveClass('border-theme-color-avocado');
+  expect(element).toHaveClass('!border-theme-color-avocado');
   expect(img).toHaveAttribute(
     'src',
     cloudinary.squads.directory.cardBannerDefault,
@@ -142,7 +142,7 @@ it('should render the component with basic props and custom border and banner', 
 
   expect(screen.getByText('title')).toBeInTheDocument();
   expect(screen.getByText('icon')).toBeInTheDocument();
-  expect(element).toHaveClass('border-theme-color-onion');
+  expect(element).toHaveClass('!border-theme-color-onion');
   expect(img).toHaveAttribute('src', 'banner-image.jpg');
 });
 

--- a/packages/shared/src/components/sources/SourceCard.spec.tsx
+++ b/packages/shared/src/components/sources/SourceCard.spec.tsx
@@ -128,7 +128,7 @@ it('should render the component with basic props', async () => {
 
   expect(screen.getByText('title')).toBeInTheDocument();
   expect(screen.getByText('icon')).toBeInTheDocument();
-  expect(element).toHaveClass('border-theme-squads-avocado');
+  expect(element).toHaveClass('border-theme-color-avocado');
   expect(img).toHaveAttribute(
     'src',
     cloudinary.squads.directory.cardBannerDefault,
@@ -142,7 +142,7 @@ it('should render the component with basic props and custom border and banner', 
 
   expect(screen.getByText('title')).toBeInTheDocument();
   expect(screen.getByText('icon')).toBeInTheDocument();
-  expect(element).toHaveClass('border-theme-squads-onion');
+  expect(element).toHaveClass('border-theme-color-onion');
   expect(img).toHaveAttribute('src', 'banner-image.jpg');
 });
 

--- a/packages/shared/src/components/sources/SourceCard.tsx
+++ b/packages/shared/src/components/sources/SourceCard.tsx
@@ -33,23 +33,34 @@ interface SourceCardProps {
 
 export enum SourceCardBorderColor {
   Avocado = 'avocado',
+  Burger = 'burger',
+  BlueCheese = 'blueCheese',
+  Lettuce = 'lettuce',
+  Cheese = 'cheese',
+  Bun = 'bun',
+  Ketchup = 'ketchup',
   Bacon = 'bacon',
   Cabbage = 'cabbage',
   Onion = 'onion',
+  Water = 'water',
+  Salt = 'salt',
   Pepper = 'pepper',
 }
 
 const borderColorToClassName: Record<SourceCardBorderColor, string> = {
-  [SourceCardBorderColor.Avocado]:
-    'border-theme-squads-avocado hover:border-theme-squads-avocado',
-  [SourceCardBorderColor.Bacon]:
-    'border-theme-squads-bacon hover:border-theme-squads-bacon',
-  [SourceCardBorderColor.Cabbage]:
-    'border-theme-squads-cabbage hover:border-theme-squads-cabbage',
-  [SourceCardBorderColor.Onion]:
-    'border-theme-squads-onion hover:border-theme-squads-onion',
-  [SourceCardBorderColor.Pepper]:
-    'border-theme-squads-pepper hover:border-theme-squads-pepper',
+  [SourceCardBorderColor.Avocado]: '!border-theme-color-avocado',
+  [SourceCardBorderColor.Burger]: '!border-theme-color-burger',
+  [SourceCardBorderColor.BlueCheese]: '!border-theme-color-blueCheese',
+  [SourceCardBorderColor.Lettuce]: '!border-theme-color-lettuce',
+  [SourceCardBorderColor.Cheese]: '!border-theme-color-cheese',
+  [SourceCardBorderColor.Bun]: '!border-theme-color-bun',
+  [SourceCardBorderColor.Ketchup]: '!border-theme-color-ketchup',
+  [SourceCardBorderColor.Bacon]: '!border-theme-color-bacon',
+  [SourceCardBorderColor.Cabbage]: '!border-theme-color-cabbage',
+  [SourceCardBorderColor.Onion]: '!border-theme-color-onion',
+  [SourceCardBorderColor.Water]: '!border-theme-color-water',
+  [SourceCardBorderColor.Salt]: '!border-theme-color-salt',
+  [SourceCardBorderColor.Pepper]: '!border-theme-color-pepper',
 };
 
 export const SourceCard = ({

--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -155,13 +155,8 @@ body {
   --theme-color-onion: theme('colors.onion.40');
   --theme-color-water: theme('colors.water.40');
   --theme-color-salt: theme('colors.salt.40');
+  --theme-color-pepper: theme('colors.pepper.40');
   --theme-color-email: theme('colors.pepper.10');
-
-  --theme-squads-avocado: theme('colors.avocado.10');
-  --theme-squads-bacon: theme('colors.bacon.60');
-  --theme-squads-cabbage: theme('colors.cabbage.20');
-  --theme-squads-onion: theme('colors.onion.90');
-  --theme-squads-pepper: theme('colors.pepper.10');
 }
 
 @define-mixin light-mode {
@@ -285,6 +280,7 @@ body {
   --theme-color-onion: theme('colors.onion.60');
   --theme-color-water: theme('colors.water.60');
   --theme-color-salt: theme('colors.pepper.40');
+  --theme-color-pepper: theme('colors.pepper.60');
   --theme-color-email: theme('colors.pepper.10');
 }
 

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -101,6 +101,7 @@ module.exports = {
           onion: 'var(--theme-color-onion)',
           water: 'var(--theme-color-water)',
           salt: 'var(--theme-color-salt)',
+          pepper: 'var(--theme-color-pepper)',
         },
         'post-disabled': 'var(--theme-post-disabled)',
         highlight: {
@@ -113,13 +114,6 @@ module.exports = {
           blue: 'var(--theme-highlight-blue)',
           purple: 'var(--theme-highlight-purple)',
           label: 'var(--theme-highlight-label)',
-        },
-        squads: {
-          avocado: 'var(--theme-squads-avocado)',
-          bacon: 'var(--theme-squads-bacon)',
-          cabbage: 'var(--theme-squads-cabbage)',
-          onion: 'var(--theme-squads-onion)',
-          pepper: 'var(--theme-squads-pepper)',
         },
       },
       white: '#ffffff',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Re-align squad colors with theme colors for future options

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
