### PR TITLE
fix: optimize boot calls

### DIFF
--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -23,6 +23,8 @@ import { BOOT_LOCAL_KEY, BOOT_QUERY_KEY } from './common';
 import { AnalyticsContextProvider } from './AnalyticsContext';
 import { GrowthBookProvider } from '../components/GrowthBookProvider';
 
+const STALE_TIME = 30 * 1000;
+
 function filteredProps<T extends Record<string, unknown>>(
   obj: T,
   filteredKeys: (keyof T)[],
@@ -89,12 +91,16 @@ export const BootDataProvider = ({
   const loadedFromCache = !!cachedBootData;
   const { user, settings, alerts, notifications, squads } =
     cachedBootData || {};
+  const loggedUser = !!(user && 'providers' in user && user?.id);
   const {
     data: bootRemoteData,
     refetch,
     isFetched,
     dataUpdatedAt,
-  } = useQuery(BOOT_QUERY_KEY, () => getBootData(app));
+  } = useQuery(BOOT_QUERY_KEY, () => getBootData(app), {
+    refetchOnWindowFocus: loggedUser,
+    staleTime: STALE_TIME,
+  });
 
   useEffect(() => {
     const boot = getLocalBootData();


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Disable refetch on mount for anonymous user as data could never change
- Add stale time of 30 seconds for boot
- We already manually invalidate on logging in/out 
- Idea is to reduce calls to boot that are unnecessary 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
