### PR TITLE
fix: article card height on feedback

### DIFF
--- a/packages/shared/src/components/cards/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.tsx
@@ -91,7 +91,10 @@ export const ArticlePostCard = forwardRef(function PostCard(
             onMenuClick={(event) => onMenuClick?.(event, post)}
             onReadArticleClick={onReadArticleClick}
           />
-          <CardTitle lineClamp={showFeedback ? 'line-clamp-2' : undefined}>
+          <CardTitle
+            lineClamp={showFeedback ? 'line-clamp-2' : undefined}
+            className={!showFeedback && 'min-h-[4.875rem]'}
+          >
             {post.title}
           </CardTitle>
         </CardTextContainer>

--- a/packages/shared/src/components/cards/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.tsx
@@ -63,7 +63,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
         className: getPostClassNames(
           post,
           classNames(className, showFeedback && '!p-0'),
-          'min-h-[22.5rem]',
+          'min-h-[23.75rem]',
         ),
       }}
       ref={ref}
@@ -91,10 +91,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
             onMenuClick={(event) => onMenuClick?.(event, post)}
             onReadArticleClick={onReadArticleClick}
           />
-          <CardTitle
-            lineClamp={showFeedback ? 'line-clamp-2' : undefined}
-            className={!showFeedback && 'min-h-[4.875rem]'}
-          >
+          <CardTitle lineClamp={showFeedback ? 'line-clamp-2' : undefined}>
             {post.title}
           </CardTitle>
         </CardTextContainer>

--- a/packages/shared/src/components/cards/FeedbackCard.tsx
+++ b/packages/shared/src/components/cards/FeedbackCard.tsx
@@ -18,11 +18,12 @@ export const FeedbackCard = ({ post }: FeedbackCardProps): ReactElement => {
 
   return (
     <div className="flex-1 p-6 space-y-4">
-      <div className="flex justify-between">
+      <div className="flex relative justify-between">
         <p className="font-bold typo-callout">Did you like the post?</p>
         <Button
           id="close-engagement-loop-btn"
-          className="relative -top-2.5 -right-2.5 btn-tertiary"
+          className="-top-2.5 -right-2.5 btn-tertiary"
+          position="absolute"
           buttonSize={ButtonSize.XSmall}
           icon={<MiniCloseIcon />}
           onClick={dismissFeedback}

--- a/packages/shared/src/components/cards/FeedbackCard.tsx
+++ b/packages/shared/src/components/cards/FeedbackCard.tsx
@@ -17,7 +17,7 @@ export const FeedbackCard = ({ post }: FeedbackCardProps): ReactElement => {
   const { toggleUpvote, toggleDownvote } = useVotePost();
 
   return (
-    <div className="flex-1 p-6 space-y-4">
+    <div className="flex-1 p-6 pb-5 space-y-4">
       <div className="flex relative justify-between">
         <p className="font-bold typo-callout">Did you like the post?</p>
         <Button


### PR DESCRIPTION
## Changes

### Describe what this PR does
- fixes the card height change when feedback is shown

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1873 #done
