### PR TITLE
feat: existing anonymous user onboarding footer

### DIFF
--- a/packages/shared/src/components/LoginButton.tsx
+++ b/packages/shared/src/components/LoginButton.tsx
@@ -7,8 +7,15 @@ import { AnalyticsEvent } from '../hooks/analytics/useAnalyticsQueue';
 import { AuthTriggers } from '../lib/auth';
 import { TargetType } from '../lib/analytics';
 
+interface Copy {
+  login?: string;
+  signup?: string;
+}
+
 interface LoginButtonProps {
   className?: string;
+  showLoginButton?: boolean;
+  copy?: Copy;
 }
 
 enum ButtonCopy {
@@ -27,28 +34,34 @@ const getAnalyticsEvent = (copy: ButtonCopy): AnalyticsEvent => ({
 
 export default function LoginButton({
   className,
+  showLoginButton = true,
+  copy = {},
 }: LoginButtonProps): ReactElement {
   const { showLogin } = useContext(AuthContext);
   const { trackEvent } = useContext(AnalyticsContext);
 
-  const onClick = (copy: ButtonCopy) => {
-    trackEvent(getAnalyticsEvent(copy));
-    showLogin(AuthTriggers.MainButton, { isLogin: copy === ButtonCopy.Login });
+  const onClick = (trackingCopy: ButtonCopy) => {
+    trackEvent(getAnalyticsEvent(trackingCopy));
+    showLogin(AuthTriggers.MainButton, {
+      isLogin: trackingCopy === ButtonCopy.Login,
+    });
   };
 
   return (
     <span className="flex flex-row gap-4">
-      <Button
-        onClick={() => onClick(ButtonCopy.Login)}
-        className={classNames(className, 'btn-secondary')}
-      >
-        {ButtonCopy.Login}
-      </Button>
+      {showLoginButton && (
+        <Button
+          onClick={() => onClick(ButtonCopy.Login)}
+          className={classNames(className, 'btn-secondary')}
+        >
+          {copy?.login ?? ButtonCopy.Login}
+        </Button>
+      )}
       <Button
         onClick={() => onClick(ButtonCopy.Signup)}
         className={classNames(className, 'btn-primary')}
       >
-        {ButtonCopy.Signup}
+        {copy?.signup ?? ButtonCopy.Signup}
       </Button>
     </span>
   );

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -29,10 +29,13 @@ import { useNotificationParams } from '../hooks/useNotificationParams';
 import { OnboardingV2 } from '../lib/featureValues';
 import { useAuthContext } from '../contexts/AuthContext';
 import { MainFeedPage } from './utilities';
-import { isTesting, onboardingUrl } from '../lib/constants';
+import { isTesting, onboardingUrl, tellMeWhy } from '../lib/constants';
 import { useBanner } from '../hooks/useBanner';
 import { useFeature, useGrowthBookContext } from './GrowthBookProvider';
 import { feature } from '../lib/featureManagement';
+import CloseButton from './CloseButton';
+import { Button } from './buttons/Button';
+import LoginButton from './LoginButton';
 
 export interface MainLayoutProps
   extends Omit<MainLayoutHeaderProps, 'onMobileSidebarToggle'>,
@@ -216,6 +219,30 @@ export default function MainLayout({
         {children}
       </main>
       <PromptElement />
+      <div className="flex fixed inset-0 z-max justify-center items-center p-6 w-full bg-gradient-to-l top-[unset] from-[#EF43FD] to-[#6451F3]">
+        <CloseButton className="top-4 right-4" position="absolute" />
+        <div className="flex flex-col laptop:flex-row gap-4 justify-center laptop:items-center w-full laptop:max-w-[52.25rem]">
+          <div className="flex flex-col flex-1 gap-2 w-full">
+            <h1 className="font-bold typo-large-title">
+              Registration is going to be required in 30 days
+            </h1>
+            <p className="flex flex-1 w-full typo-title3">
+              We’d love to see you join our community ❤︎. Signing up gets you
+              free access to the personalized feed, discussions, squads, AI
+              search, and more!
+            </p>
+          </div>
+          <div className="flex flex-row laptop:flex-col gap-2">
+            <LoginButton
+              showLoginButton={false}
+              copy={{ signup: 'Sign up now' }}
+            />
+            <Button tag="a" href={tellMeWhy} className="btn-secondary">
+              Tell me why
+            </Button>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -29,13 +29,11 @@ import { useNotificationParams } from '../hooks/useNotificationParams';
 import { OnboardingV2 } from '../lib/featureValues';
 import { useAuthContext } from '../contexts/AuthContext';
 import { MainFeedPage } from './utilities';
-import { isTesting, onboardingUrl, tellMeWhy } from '../lib/constants';
+import { isTesting, onboardingUrl } from '../lib/constants';
 import { useBanner } from '../hooks/useBanner';
 import { useFeature, useGrowthBookContext } from './GrowthBookProvider';
 import { feature } from '../lib/featureManagement';
-import CloseButton from './CloseButton';
-import { Button } from './buttons/Button';
-import LoginButton from './LoginButton';
+import { FixedBottomBanner } from './banners/FixedBottomBanner';
 
 export interface MainLayoutProps
   extends Omit<MainLayoutHeaderProps, 'onMobileSidebarToggle'>,
@@ -219,30 +217,7 @@ export default function MainLayout({
         {children}
       </main>
       <PromptElement />
-      <div className="flex fixed inset-0 z-max justify-center items-center p-6 w-full bg-gradient-to-l top-[unset] from-[#EF43FD] to-[#6451F3]">
-        <CloseButton className="top-4 right-4" position="absolute" />
-        <div className="flex flex-col laptop:flex-row gap-4 justify-center laptop:items-center w-full laptop:max-w-[52.25rem]">
-          <div className="flex flex-col flex-1 gap-2 w-full">
-            <h1 className="font-bold typo-large-title">
-              Registration is going to be required in 30 days
-            </h1>
-            <p className="flex flex-1 w-full typo-title3">
-              We’d love to see you join our community ❤︎. Signing up gets you
-              free access to the personalized feed, discussions, squads, AI
-              search, and more!
-            </p>
-          </div>
-          <div className="flex flex-row laptop:flex-col gap-2">
-            <LoginButton
-              showLoginButton={false}
-              copy={{ signup: 'Sign up now' }}
-            />
-            <Button tag="a" href={tellMeWhy} className="btn-secondary">
-              Tell me why
-            </Button>
-          </div>
-        </div>
-      </div>
+      <FixedBottomBanner />
     </div>
   );
 }

--- a/packages/shared/src/components/banners/FixedBottomBanner.tsx
+++ b/packages/shared/src/components/banners/FixedBottomBanner.tsx
@@ -1,5 +1,6 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { differenceInDays } from 'date-fns';
 import CloseButton from '../CloseButton';
 import LoginButton from '../LoginButton';
 import { Button } from '../buttons/Button';
@@ -11,6 +12,10 @@ import { useAuthContext } from '../../contexts/AuthContext';
 import usePersistentContext from '../../hooks/usePersistentContext';
 import { generateStorageKey, StorageTopic } from '../../lib/storage';
 
+const anonymousMigrationDate = new Date(2023, 10, 4);
+const now = new Date();
+const daysLeft = differenceInDays(anonymousMigrationDate, now);
+
 export function FixedBottomBanner(): ReactElement {
   const { user } = useAuthContext();
   const router = useRouter();
@@ -19,6 +24,15 @@ export function FixedBottomBanner(): ReactElement {
     generateStorageKey(StorageTopic.Onboarding, 'wall_dismissed'),
     false,
   );
+
+  useEffect(() => {
+    if (
+      router.pathname !== '/onboarding' &&
+      anonymousMigrationDate < new Date()
+    ) {
+      router.push('/onboarding');
+    }
+  }, [router]);
 
   if (
     user ||
@@ -40,7 +54,8 @@ export function FixedBottomBanner(): ReactElement {
       <div className="flex flex-col laptop:flex-row gap-4 justify-center laptop:items-center w-full laptop:max-w-[52.25rem]">
         <div className="flex flex-col flex-1 gap-2 w-full">
           <h1 className="font-bold typo-large-title">
-            Registration is going to be required in 30 days
+            Registration is going to be required in {daysLeft} day
+            {daysLeft > 1 ? 's' : ''}
           </h1>
           <p className="flex flex-1 w-full typo-title3">
             We’d love to see you join our community ❤︎. Signing up gets you free

--- a/packages/shared/src/components/banners/FixedBottomBanner.tsx
+++ b/packages/shared/src/components/banners/FixedBottomBanner.tsx
@@ -1,0 +1,59 @@
+import React, { ReactElement } from 'react';
+import { useRouter } from 'next/router';
+import CloseButton from '../CloseButton';
+import LoginButton from '../LoginButton';
+import { Button } from '../buttons/Button';
+import { tellMeWhy } from '../../lib/constants';
+import { useActions } from '../../hooks/useActions';
+import { ActionType } from '../../graphql/actions';
+import { useFeature } from '../GrowthBookProvider';
+import { feature } from '../../lib/featureManagement';
+import { OnboardingV2 } from '../../lib/featureValues';
+import { useAuthContext } from '../../contexts/AuthContext';
+
+export function FixedBottomBanner(): ReactElement {
+  const { user } = useAuthContext();
+  const router = useRouter();
+  const onboarding = useFeature(feature.onboardingV2);
+  const { checkHasCompleted, completeAction } = useActions();
+
+  if (
+    user ||
+    router.pathname === '/onboarding' ||
+    onboarding !== OnboardingV2.Control ||
+    checkHasCompleted(ActionType.ExistingAnonymousBanner)
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="flex fixed inset-0 z-max justify-center items-center p-6 w-full bg-gradient-to-l top-[unset] from-[#EF43FD] to-[#6451F3]">
+      <CloseButton
+        className="top-4 right-4"
+        position="absolute"
+        onClick={() => completeAction(ActionType.ExistingAnonymousBanner)}
+      />
+      <div className="flex flex-col laptop:flex-row gap-4 justify-center laptop:items-center w-full laptop:max-w-[52.25rem]">
+        <div className="flex flex-col flex-1 gap-2 w-full">
+          <h1 className="font-bold typo-large-title">
+            Registration is going to be required in 30 days
+          </h1>
+          <p className="flex flex-1 w-full typo-title3">
+            We’d love to see you join our community ❤︎. Signing up gets you free
+            access to the personalized feed, discussions, squads, AI search, and
+            more!
+          </p>
+        </div>
+        <div className="flex flex-row laptop:flex-col gap-2">
+          <LoginButton
+            showLoginButton={false}
+            copy={{ signup: 'Sign up now' }}
+          />
+          <Button tag="a" href={tellMeWhy} className="btn-secondary">
+            Tell me why
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/shared/src/components/banners/FixedBottomBanner.tsx
+++ b/packages/shared/src/components/banners/FixedBottomBanner.tsx
@@ -49,7 +49,12 @@ export function FixedBottomBanner(): ReactElement {
             showLoginButton={false}
             copy={{ signup: 'Sign up now' }}
           />
-          <Button tag="a" href={tellMeWhy} className="btn-secondary">
+          <Button
+            tag="a"
+            target="_blank"
+            href={tellMeWhy}
+            className="btn-secondary"
+          >
             Tell me why
           </Button>
         </div>

--- a/packages/shared/src/components/banners/FixedBottomBanner.tsx
+++ b/packages/shared/src/components/banners/FixedBottomBanner.tsx
@@ -4,24 +4,28 @@ import CloseButton from '../CloseButton';
 import LoginButton from '../LoginButton';
 import { Button } from '../buttons/Button';
 import { tellMeWhy } from '../../lib/constants';
-import { useActions } from '../../hooks/useActions';
-import { ActionType } from '../../graphql/actions';
 import { useFeature } from '../GrowthBookProvider';
 import { feature } from '../../lib/featureManagement';
 import { OnboardingV2 } from '../../lib/featureValues';
 import { useAuthContext } from '../../contexts/AuthContext';
+import usePersistentContext from '../../hooks/usePersistentContext';
+import { generateStorageKey, StorageTopic } from '../../lib/storage';
 
 export function FixedBottomBanner(): ReactElement {
   const { user } = useAuthContext();
   const router = useRouter();
   const onboarding = useFeature(feature.onboardingV2);
-  const { checkHasCompleted, completeAction } = useActions();
+  const [isDismissed, setIsDismissed, isFetched] = usePersistentContext(
+    generateStorageKey(StorageTopic.Onboarding, 'wall_dismissed'),
+    false,
+  );
 
   if (
     user ||
     router.pathname === '/onboarding' ||
     onboarding !== OnboardingV2.Control ||
-    checkHasCompleted(ActionType.ExistingAnonymousBanner)
+    !isFetched ||
+    isDismissed
   ) {
     return null;
   }
@@ -31,7 +35,7 @@ export function FixedBottomBanner(): ReactElement {
       <CloseButton
         className="top-4 right-4"
         position="absolute"
-        onClick={() => completeAction(ActionType.ExistingAnonymousBanner)}
+        onClick={() => setIsDismissed(true)}
       />
       <div className="flex flex-col laptop:flex-row gap-4 justify-center laptop:items-center w-full laptop:max-w-[52.25rem]">
         <div className="flex flex-col flex-1 gap-2 w-full">

--- a/packages/shared/src/components/banners/FixedBottomBanner.tsx
+++ b/packages/shared/src/components/banners/FixedBottomBanner.tsx
@@ -1,55 +1,24 @@
-import React, { ReactElement, useEffect } from 'react';
-import { useRouter } from 'next/router';
-import { differenceInDays } from 'date-fns';
+import React, { ReactElement } from 'react';
 import CloseButton from '../CloseButton';
 import LoginButton from '../LoginButton';
 import { Button } from '../buttons/Button';
 import { tellMeWhy } from '../../lib/constants';
-import { useFeature } from '../GrowthBookProvider';
-import { feature } from '../../lib/featureManagement';
-import { OnboardingV2 } from '../../lib/featureValues';
-import { useAuthContext } from '../../contexts/AuthContext';
-import usePersistentContext from '../../hooks/usePersistentContext';
-import { generateStorageKey, StorageTopic } from '../../lib/storage';
 
-const anonymousMigrationDate = new Date(2023, 10, 4);
-const now = new Date();
-const daysLeft = differenceInDays(anonymousMigrationDate, now);
+interface FixedBottomBannerProps {
+  onDismiss(): void;
+  daysLeft: number;
+}
 
-export function FixedBottomBanner(): ReactElement {
-  const { user } = useAuthContext();
-  const router = useRouter();
-  const onboarding = useFeature(feature.onboardingV2);
-  const [isDismissed, setIsDismissed, isFetched] = usePersistentContext(
-    generateStorageKey(StorageTopic.Onboarding, 'wall_dismissed'),
-    false,
-  );
-
-  useEffect(() => {
-    if (
-      router.pathname !== '/onboarding' &&
-      anonymousMigrationDate < new Date()
-    ) {
-      router.push('/onboarding');
-    }
-  }, [router]);
-
-  if (
-    user ||
-    router.pathname === '/onboarding' ||
-    onboarding !== OnboardingV2.Control ||
-    !isFetched ||
-    isDismissed
-  ) {
-    return null;
-  }
-
+export function FixedBottomBanner({
+  onDismiss,
+  daysLeft,
+}: FixedBottomBannerProps): ReactElement {
   return (
     <div className="flex fixed inset-0 z-max justify-center items-center p-6 w-full bg-gradient-to-l top-[unset] from-[#EF43FD] to-[#6451F3]">
       <CloseButton
         className="top-4 right-4"
         position="absolute"
-        onClick={() => setIsDismissed(true)}
+        onClick={onDismiss}
       />
       <div className="flex flex-col laptop:flex-row gap-4 justify-center laptop:items-center w-full laptop:max-w-[52.25rem]">
         <div className="flex flex-col flex-1 gap-2 w-full">

--- a/packages/shared/src/graphql/actions.ts
+++ b/packages/shared/src/graphql/actions.ts
@@ -14,6 +14,7 @@ export enum ActionType {
   WritePost = 'write_post',
   HideBlockPanel = 'hide_block_panel',
   EngagementLoopJuly2023CompanionModal = 'exp_july23_companion',
+  ExistingAnonymousBanner = 'existingAnonymousBanner',
 }
 
 export interface Action {

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -12,6 +12,7 @@ export const reputationGuide = 'https://r.daily.dev/reputation-guide';
 export const ownershipGuide = 'https://r.daily.dev/claim';
 export const contentGuidelines = 'https://r.daily.dev/content-guidelines';
 export const communityLinksGuidelines = 'https://r.daily.dev/community-links';
+export const tellMeWhy = 'https://r.daily.dev/tellmewhy';
 export const companionExplainerVideo = 'https://r.daily.dev/companion-overview';
 export const companionPermissionGrantedLink =
   'https://r.daily.dev/try-the-companion';

--- a/packages/shared/src/lib/storage.ts
+++ b/packages/shared/src/lib/storage.ts
@@ -3,6 +3,7 @@ export enum StorageTopic {
   ReferralCampaign = 'referralCampaign',
   Popup = 'popup',
   Post = 'post',
+  Onboarding = 'onboarding',
 }
 
 export const APP_KEY_PREFIX = 'dailydev';

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -228,7 +228,7 @@ export function OnboardPage(): ReactElement {
       return;
     }
 
-    if (user || (onboardingV2 === OnboardingV2.Control && !isOnboardingV3)) {
+    if (user) {
       router.replace('/');
       return;
     }

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -22,7 +22,6 @@ import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
 import { MemberAlready } from '@dailydotdev/shared/src/components/onboarding/MemberAlready';
 import {
   OnboardingFilteringTitle,
-  OnboardingV2,
   OnboardingV3,
 } from '@dailydotdev/shared/src/lib/featureValues';
 import { storageWrapper as storage } from '@dailydotdev/shared/src/lib/storageWrapper';


### PR DESCRIPTION
## Changes
- Modified the login button component to allow the display of just one button.
- Added props to. the login button to allow different labels on the button itself.
- Introduce a banner in the footer for existing anonymous users only that is still under OnboardingV2.
- Rather than include changes in the API and increase the footprint of the changes, we have decided to put the config on whether to redirect to onboarding existing anonymous users, and be handled in the FE.
- Removed the condition to redirect users in the onboarding page to the main page if they are in control value for OnboardingV2.

Previews:
![Screenshot 2023-10-04 at 8 42 37 PM](https://github.com/dailydotdev/apps/assets/13744167/78f8d5b6-57f1-44f9-9dae-e12b93a40188)
![Screenshot 2023-10-04 at 8 42 29 PM](https://github.com/dailydotdev/apps/assets/13744167/df04a5fe-397b-4a7e-817d-fe37b5c21cc3)
![Screenshot 2023-10-04 at 8 24 46 PM](https://github.com/dailydotdev/apps/assets/13744167/c4026681-7c3c-43e6-8317-fc5fc2ca1cee)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
