### PR TITLE
fix: convert webapp requests to api directly

### DIFF
--- a/packages/shared/src/lib/config.ts
+++ b/packages/shared/src/lib/config.ts
@@ -1,9 +1,4 @@
-export const apiUrl =
-  typeof window === 'undefined' ||
-  process.env.NODE_ENV === 'test' ||
-  process.env.TARGET_BROWSER
-    ? process.env.NEXT_PUBLIC_API_URL
-    : '/api';
+export const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
 export const graphqlUrl = `${apiUrl}/graphql`;
 

--- a/packages/webapp/next.config.js
+++ b/packages/webapp/next.config.js
@@ -65,12 +65,6 @@ module.exports = withTM(
         env: {
           CURRENT_VERSION: `'${version}'`,
         },
-        rewrites: () => [
-          {
-            source: '/api/:path*',
-            destination: `${process.env.NEXT_PUBLIC_API_URL}/:path*`,
-          },
-        ],
         headers: async () => {
           return [
               {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We had some legacy code that for the webapp routed traffic internally first
- We now remove this to directly call API and avoid re-routing latency (potentially, probably low impact)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1886 #done
