### PR TITLE
fix: error serialization

### DIFF
--- a/packages/shared/src/hooks/useRegistration.ts
+++ b/packages/shared/src/hooks/useRegistration.ts
@@ -65,10 +65,14 @@ const useRegistration = ({
 
   useEffect(() => {
     if (registrationError) {
+      const serializedError = JSON.stringify(
+        registrationError,
+        Object.getOwnPropertyNames(registrationError),
+      );
       trackEvent({
         event_name: AuthEventNames.RegistrationInitializationError,
         extra: JSON.stringify({
-          error: registrationError,
+          error: serializedError,
           origin: Origin.InitializeRegistrationFlow,
         }),
       });


### PR DESCRIPTION
## Changes

### Describe what this PR does
- JS Error object doesn't have a `toJSON` method so we need to manually serialize it first.

@idoshamun sample of what it would look like, does this align with your expectations?

```
[
    {
        "app_platform": "webapp",
        "app_theme": "dark",
        "feed_density": "eco",
        "feed_layout": "cards",
        "session_id": "npmXoijMzTzlIJDJfnUHL",
        "user_first_visit": "2023-10-05T08:07:45.337Z",
        "user_id": "lCLdgrrElIoTRLqmtDhNR",
        "visit_id": "5JmZ3xm7ZiXa7TwTScUon",
        "device_id": "46603749-9958-4796-a734-d1df79ac458c",
        "screen_height": 1440,
        "screen_width": 3440,
        "page_referrer": "",
        "window_height": 1240,
        "window_width": 1039,
        "page_state": "active",
        "event_timestamp": "2023-10-05T09:12:46.343Z",
        "event_id": "1696497166mkz6",
        "event_page": "/onboarding",
        "event_name": "registration initialization error",
        "extra": "{\"error\":\"{\\\"stack\\\":\\\"TypeError: Failed to fetch\\\\n    at _callee$ (webpack-internal:///../shared/src/lib/kratos.ts:50:28)\\\\n    at tryCatch (webpack-internal:///../../node_modules/.pnpm/next@12.2.2_@babel+core@7.17.9_react-dom@17.0.2_react@17.0.2_sass@1.53.0/node_modules/next/dist/compiled/regenerator-runtime/runtime.js:45:40)\\\\n    at Generator.invoke [as _invoke] (webpack-internal:///../../node_modules/.pnpm/next@12.2.2_@babel+core@7.17.9_react-dom@17.0.2_react@17.0.2_sass@1.53.0/node_modules/next/dist/compiled/regenerator-runtime/runtime.js:274:22)\\\\n    at prototype.<computed> [as next] (webpack-internal:///../../node_modules/.pnpm/next@12.2.2_@babel+core@7.17.9_react-dom@17.0.2_react@17.0.2_sass@1.53.0/node_modules/next/dist/compiled/regenerator-runtime/runtime.js:97:21)\\\\n    at asyncGeneratorStep (webpack-internal:///../../node_modules/.pnpm/@swc+helpers@0.4.2/node_modules/@swc/helpers/src/_async_to_generator.mjs:7:24)\\\\n    at _next (webpack-internal:///../../node_modules/.pnpm/@swc+helpers@0.4.2/node_modules/@swc/helpers/src/_async_to_generator.mjs:29:9)\\\\n    at eval (webpack-internal:///../../node_modules/.pnpm/@swc+helpers@0.4.2/node_modules/@swc/helpers/src/_async_to_generator.mjs:36:7)\\\\n    at new Promise (<anonymous>)\\\\n    at eval (webpack-internal:///../../node_modules/.pnpm/@swc+helpers@0.4.2/node_modules/@swc/helpers/src/_async_to_generator.mjs:25:12)\\\\n    at initializeKratosFlow (webpack-internal:///../shared/src/lib/kratos.ts:66:21)\\\\n    at ref1.refetchOnWindowFocus [as queryFn] (webpack-internal:///../shared/src/hooks/useRegistration.ts:38:81)\\\\n    at Object.fetchFn [as fn] (webpack-internal:///../../node_modules/.pnpm/react-query@3.39.1_react-dom@17.0.2_react@17.0.2/node_modules/react-query/es/core/query.js:307:29)\\\\n    at run (webpack-internal:///../../node_modules/.pnpm/react-query@3.39.1_react-dom@17.0.2_react@17.0.2/node_modules/react-query/es/core/retryer.js:105:31)\\\\n    at eval (webpack-internal:///../../node_modules/.pnpm/react-query@3.39.1_react-dom@17.0.2_react@17.0.2/node_modules/react-query/es/core/retryer.js:159:11)\\\",\\\"message\\\":\\\"Failed to fetch\\\"}\",\"origin\":\"initialize registration flow\"}"
    }
]
```

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1878 #done
