### PR TITLE
fix: feed bottom banner

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -191,7 +191,11 @@ export default function MainLayout({
   }
 
   const shouldShowBanner =
-    !user && onboardingV2 === OnboardingV2.Control && isFetched && !isDismissed;
+    !user &&
+    onboardingV2 === OnboardingV2.Control &&
+    isPageApplicableForOnboarding &&
+    isFetched &&
+    !isDismissed;
 
   return (
     <div {...handlers} className="antialiased">


### PR DESCRIPTION
## Changes
- The bottom banner should only be applicable to feed pages

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
