### PR TITLE
fix: increase min height on share post, freeform and placeholder card

### DIFF
--- a/packages/shared/src/components/cards/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.tsx
@@ -63,7 +63,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
         className: getPostClassNames(
           post,
           classNames(className, showFeedback && '!p-0'),
-          'min-h-[23.75rem]',
+          'min-h-card',
         ),
       }}
       ref={ref}

--- a/packages/shared/src/components/cards/PlaceholderCard.tsx
+++ b/packages/shared/src/components/cards/PlaceholderCard.tsx
@@ -20,6 +20,7 @@ export const PlaceholderCard = forwardRef(function PlaceholderCard(
       className={classNames(
         className,
         'flex flex-col rounded-2xl p-2 bg-theme-post-disabled',
+        'min-h-[23.75rem]',
       )}
       {...props}
       ref={ref}

--- a/packages/shared/src/components/cards/PlaceholderCard.tsx
+++ b/packages/shared/src/components/cards/PlaceholderCard.tsx
@@ -20,7 +20,7 @@ export const PlaceholderCard = forwardRef(function PlaceholderCard(
       className={classNames(
         className,
         'flex flex-col rounded-2xl p-2 bg-theme-post-disabled',
-        'min-h-[23.75rem]',
+        'min-h-card',
       )}
       {...props}
       ref={ref}

--- a/packages/shared/src/components/cards/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.tsx
@@ -44,7 +44,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
         className: getPostClassNames(
           post,
           domProps.className,
-          'min-h-[22.5rem]',
+          'min-h-[23.75rem]',
         ),
       }}
       ref={ref}

--- a/packages/shared/src/components/cards/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.tsx
@@ -44,7 +44,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
         className: getPostClassNames(
           post,
           domProps.className,
-          'min-h-[23.75rem]',
+          'min-h-card',
         ),
       }}
       ref={ref}

--- a/packages/shared/src/components/cards/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.tsx
@@ -41,11 +41,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
     <FeedItemContainer
       domProps={{
         ...domProps,
-        className: getPostClassNames(
-          post,
-          domProps.className,
-          'min-h-card',
-        ),
+        className: getPostClassNames(post, domProps.className, 'min-h-card'),
       }}
       ref={ref}
       flagProps={{ pinnedAt, trending }}

--- a/packages/shared/src/components/cards/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCard.tsx
@@ -60,7 +60,7 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
         className: getPostClassNames(
           post,
           domProps.className,
-          'min-h-[23.75rem]',
+          'min-h-card',
           shouldShowHighlightPulse && 'highlight-pulse',
         ),
       }}

--- a/packages/shared/src/components/cards/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCard.tsx
@@ -60,7 +60,7 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
         className: getPostClassNames(
           post,
           domProps.className,
-          'min-h-[22.5rem]',
+          'min-h-[23.75rem]',
           shouldShowHighlightPulse && 'highlight-pulse',
         ),
       }}

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -216,6 +216,9 @@ module.exports = {
         logo: '1.125rem',
         'logo-big': '2.0625rem',
       },
+      minHeight: {
+        card: '23.75rem',
+      },
     },
     lineClamp: {
       1: '1',


### PR DESCRIPTION
## Changes

Forgot to adjust min-height on the other card types 😬 

### Describe what this PR does
- increases min-height on share post and freeform card
- set min-height on placeholder card

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1873 #done
