### PR TITLE
fix: set title length and validation

### DIFF
--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -139,6 +139,7 @@ export function WriteFreeformContent({
           required
           defaultValue={draft?.title ?? post?.title}
           onInput={onFormUpdate}
+          maxLength={250}
         />
       </AlertPointer>
       <MarkdownInput

--- a/packages/shared/src/hooks/useInputFieldFunctions.ts
+++ b/packages/shared/src/hooks/useInputFieldFunctions.ts
@@ -43,6 +43,16 @@ function useInputFieldFunctions<
     setValidInput(inputRef.current.checkValidity());
   }, 1500);
 
+  useEffect(() => {
+    if (inputRef.current?.value) {
+      setInputLength(inputRef.current.value.length);
+      const inputValidity = inputRef.current.checkValidity();
+      if (inputValidity) {
+        setValidInput(true);
+      }
+    }
+  }, [inputRef]);
+
   const onInput = (event: SyntheticEvent<T, InputEvent>): void => {
     clearIdleTimeout();
     baseOnInput(event);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Set the max length frontend wise for freeform title
- I noticed we didn't have it working when accessing the edit page, so decided to set validity once it's known.

Related API:
https://github.com/dailydotdev/daily-api/pull/1465

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
