### PR TITLE
fix: local clearing and initial set of content

### DIFF
--- a/packages/shared/src/hooks/input/useDiscardPost.ts
+++ b/packages/shared/src/hooks/input/useDiscardPost.ts
@@ -49,8 +49,9 @@ export const useDiscardPost = ({
   const { onAskConfirmation } = useExitConfirmation({ onValidateAction });
 
   const clearDraft = useCallback(async () => {
+    await updateDraft({});
     await deleteCache(draftKey);
-  }, [draftKey]);
+  }, [updateDraft, draftKey]);
 
   return {
     onAskConfirmation,

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -111,6 +111,12 @@ export const useMarkdownInput = ({
   const { user } = useAuthContext();
   const { displayToast } = useToastNotification();
 
+  useEffect(() => {
+    if (input.length === 0 && initialContent.length > 0) {
+      setInput(initialContent);
+    }
+  }, [input, initialContent]);
+
   const onUpdate = (value: string) => {
     setInput(value);
     if (onValueUpdate) {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixed actual clearing of the freeform after posting
- Issue lied in only clearing the IDB value, not the react query cache so unsetting that manually to reset both ends
- Also noticed the content part was not setting, update issue

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1885 #done
