### PR TITLE
fix: edge-case clean main key as well

### DIFF
--- a/packages/shared/src/hooks/input/useDiscardPost.ts
+++ b/packages/shared/src/hooks/input/useDiscardPost.ts
@@ -51,6 +51,7 @@ export const useDiscardPost = ({
   const clearDraft = useCallback(async () => {
     await updateDraft({});
     await deleteCache(draftKey);
+    await deleteCache(generateWritePostKey());
   }, [updateDraft, draftKey]);
 
   return {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Edge-case where you opened the create page without squad -> post in squad -> main key still set in IDB only
- This ensures we always clear the main key as well as the squad one

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1885 #done
