### PR TITLE
fix: needed optional chaining for shared post edit

### DIFF
--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -24,6 +24,7 @@ import { base64ToFile } from '../../../../lib/base64';
 import { useWritePostContext, WriteForm } from '../../../../contexts';
 import { defaultMarkdownCommands } from '../../../../hooks/input';
 import { WriteFooter } from '../../write';
+import { isNullOrUndefined } from '../../../../lib/func';
 
 export const generateWritePostKey = (reference = 'create'): string =>
   `write:post:${reference}`;
@@ -146,7 +147,11 @@ export function WriteFreeformContent({
         className={{ container: 'mt-4' }}
         sourceId={squad?.id}
         onValueUpdate={onFormUpdate}
-        initialContent={draft?.content ?? post?.content}
+        initialContent={
+          draft?.content ?? isNullOrUndefined(post?.content)
+            ? ''
+            : post?.content
+        }
         textareaProps={{ name: 'content' }}
         enabledCommand={{ ...defaultMarkdownCommands, upload: true }}
         isUpdatingDraft={isUpdatingDraft}

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -112,7 +112,7 @@ export const useMarkdownInput = ({
   const { displayToast } = useToastNotification();
 
   useEffect(() => {
-    if (input.length === 0 && initialContent.length > 0) {
+    if (input?.length === 0 && initialContent?.length > 0) {
       setInput(initialContent);
     }
   }, [input, initialContent]);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Optional chaining issue when editing freeform content

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
