### PR TITLE
fix: refactor ad placement for squads

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -129,6 +129,7 @@ export default function Feed<T>({
   } = useContext(SettingsContext);
   const insaneMode = !forceCardMode && listMode;
   const numCards = currentSettings.numCards[spaciness ?? 'eco'];
+  const isSquadFeed = feedName === 'squad';
   const {
     items,
     updatePost,
@@ -140,9 +141,14 @@ export default function Feed<T>({
   } = useFeed(
     feedQueryKey,
     currentSettings.pageSize,
-    currentSettings.adSpot,
+    isSquadFeed ? 3 : currentSettings.adSpot,
     numCards,
-    { query, variables, options },
+    {
+      query,
+      variables,
+      options,
+      ...(isSquadFeed && { settings: { adPostLength: 2 } }),
+    },
   );
   const feedContextValue = useMemo(() => {
     return {

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -56,10 +56,15 @@ const findIndexOfPostInData = (
   return { pageIndex: -1, index: -1 };
 };
 
+type UseFeedSettingParams = {
+  adPostLength?: number;
+};
+
 export interface UseFeedOptionalParams<T> {
   query?: string;
   variables?: T;
   options?: UseInfiniteQueryOptions<FeedData>;
+  settings?: UseFeedSettingParams;
 }
 
 export default function useFeed<T>(
@@ -69,7 +74,7 @@ export default function useFeed<T>(
   placeholdersPerPage: number,
   params: UseFeedOptionalParams<T> = {},
 ): FeedReturnType {
-  const { query, variables, options = {} } = params;
+  const { query, variables, options = {}, settings } = params;
   const { user, tokenRefreshed } = useContext(AuthContext);
   const queryClient = useQueryClient();
 
@@ -131,15 +136,21 @@ export default function useFeed<T>(
             page: pageIndex,
             index,
           }));
-          if (adsQuery.data?.pages[pageIndex]) {
-            posts.splice(adSpot, 0, {
-              type: 'ad',
-              ad: adsQuery.data?.pages[pageIndex],
-            });
-          } else {
-            posts.splice(adSpot, 0, {
-              type: 'placeholder',
-            });
+
+          if (
+            !settings?.adPostLength ||
+            posts.length > settings?.adPostLength
+          ) {
+            if (adsQuery.data?.pages[pageIndex]) {
+              posts.splice(adSpot, 0, {
+                type: 'ad',
+                ad: adsQuery.data?.pages[pageIndex],
+              });
+            } else {
+              posts.splice(adSpot, 0, {
+                type: 'placeholder',
+              });
+            }
           }
           return posts;
         },

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -98,6 +98,11 @@ export default function useFeed<T>(
     },
   );
 
+  const isAdsQueryEnabled =
+    query &&
+    tokenRefreshed &&
+    (!settings?.adPostLength ||
+      feedQuery.data?.pages[0]?.page.edges.length > settings?.adPostLength);
   const adsQuery = useInfiniteQuery<Ad>(
     ['ads', ...feedQueryKey],
     async ({ pageParam }) => {
@@ -107,7 +112,7 @@ export default function useFeed<T>(
     },
     {
       getNextPageParam: () => Date.now(),
-      enabled: query && tokenRefreshed,
+      enabled: isAdsQueryEnabled,
       refetchOnMount: false,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
@@ -137,10 +142,7 @@ export default function useFeed<T>(
             index,
           }));
 
-          if (
-            !settings?.adPostLength ||
-            posts.length > settings?.adPostLength
-          ) {
+          if (isAdsQueryEnabled) {
             if (adsQuery.data?.pages[pageIndex]) {
               posts.splice(adSpot, 0, {
                 type: 'ad',
@@ -152,6 +154,7 @@ export default function useFeed<T>(
               });
             }
           }
+
           return posts;
         },
       );


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The request was to put ads not in the first place for squads.
- I added a extra criteria to only add a ad if there are at least 2 posts (so it doesn't show after welcome post)
- And added the option to add the ad preferably in 3th spot

I tried to make it as dynamic as possible, unfurtionally we don't really support great feed config per feed, something I think we should invest in down the line (talked about this before) 
For now this felt least intrusive and lean.

@idoshamun From your perspective would love to hear if it harms metrics that we perform the query for ads, but optionally don't render them? 
I thought about not querying at all, but it would delay the page

My feed: (unchanged)
![Screenshot 2023-10-12 at 10 37 09](https://github.com/dailydotdev/apps/assets/554874/ee027442-6afa-46fe-9bcb-4a141ecc1147)

Empty squad (only welcome)
![Screenshot 2023-10-12 at 10 37 16](https://github.com/dailydotdev/apps/assets/554874/ade80311-9a95-44a8-9baa-a4a2e3e4c22a)

Filled squad (after 3th position)
![Screenshot 2023-10-12 at 10 37 23](https://github.com/dailydotdev/apps/assets/554874/e1f9da2a-5135-4f5c-bd65-675820597929)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
