### PR TITLE
fix: disabled post button

### DIFF
--- a/packages/shared/src/components/post/write/CreatePostButton.tsx
+++ b/packages/shared/src/components/post/write/CreatePostButton.tsx
@@ -20,18 +20,33 @@ export function CreatePostButton({
   const { user, isAuthReady, squads } = useAuthContext();
   const { route, query } = useRouter();
   const isTablet = !useMedia([laptop.replace('@media ', '')], [true], false);
-
   const handle = route === '/squads/[handle]' ? (query.handle as string) : '';
   const { squad } = useSquad({ handle });
   const allowedToPost = verifyPermission(squad, SourcePermissions.Post);
+  const hasAccess = squads?.some((item) =>
+    verifyPermission(item, SourcePermissions.Post),
+  );
 
   if (!user || !isAuthReady || !squads?.length) {
     return null;
   }
 
+  const getIsDisabled = () => {
+    if (!hasAccess) {
+      return true;
+    }
+
+    if (!handle) {
+      return false;
+    }
+
+    return !allowedToPost;
+  };
+
   return (
     <Button
       className={classNames('btn-secondary', className)}
+      disabled={getIsDisabled()}
       tag="a"
       href={
         link.post.create +


### PR DESCRIPTION
## Changes
- The New post button should be disabled when you have no access to post on any Squad.

My feed with Squads you can both post and not post
![Screenshot 2023-10-19 at 9 54 55 AM](https://github.com/dailydotdev/apps/assets/13744167/491a28a8-b853-4431-86b1-0e169706f459)

Squad feed with Squads you can both post and not post
![Screenshot 2023-10-19 at 9 54 45 AM](https://github.com/dailydotdev/apps/assets/13744167/f2cfda20-949a-4973-8907-1a7a2f2e2021)

Squad feed you can't post with Squads you can both post and not post
![Screenshot 2023-10-19 at 9 54 33 AM](https://github.com/dailydotdev/apps/assets/13744167/42ff7ba5-ff33-41c7-9f80-66f4b32f0922)

My feed with Squads only you can't post
![Screenshot 2023-10-19 at 9 52 01 AM](https://github.com/dailydotdev/apps/assets/13744167/e09445cf-66e6-4b6d-885d-619f3cf1cc1d)



## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1811 #done
