### PR TITLE
fix: comment box input focus on the end

### DIFF
--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -6,6 +6,7 @@ import React, {
   ReactElement,
   ReactNode,
   TextareaHTMLAttributes,
+  useEffect,
   useImperativeHandle,
   useRef,
   useState,
@@ -35,6 +36,7 @@ import { useAuthContext } from '../../../contexts/AuthContext';
 import { Loader } from '../../Loader';
 import { Divider } from '../../utilities';
 import { usePopupSelector } from '../../../hooks/usePopupSelector';
+import { focusInput } from '../../../lib/textarea';
 
 interface ClassName {
   container?: string;
@@ -149,6 +151,16 @@ function MarkdownInput(
       checkMention();
     }
   };
+
+  useEffect(() => {
+    const content = textareaRef?.current?.value;
+
+    if (!content) {
+      return;
+    }
+
+    focusInput(textareaRef.current, [content.length, content.length]);
+  }, []);
 
   return (
     <div

--- a/packages/shared/src/lib/textarea.ts
+++ b/packages/shared/src/lib/textarea.ts
@@ -32,10 +32,10 @@ const concatReplacement = (
 };
 
 /* eslint-disable no-param-reassign */
-const focusInput = async (
+export const focusInput = async (
   textarea: HTMLTextAreaElement,
   [start, end]: number[],
-) => {
+): Promise<void> => {
   textarea.focus();
   await nextTick(); // for the selection to work, we need to wait for the input to get updated
   textarea.selectionStart = start;


### PR DESCRIPTION
## Changes
- This fixes the issue when replying to someone and mention is included, focus will be at the end of the content.
- This also fixes the issue when you edit a comment, the focus would automatically be then at the end.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1896 #done
