### PR TITLE
fix: share post bar spacing

### DIFF
--- a/packages/shared/src/components/squads/SharePostBar.tsx
+++ b/packages/shared/src/components/squads/SharePostBar.tsx
@@ -106,8 +106,8 @@ function SharePostBar({
           name="share-post-bar"
           placeholder={`Enter URL${isMobile ? '' : ' / Choose from'}`}
           className={classNames(
-            'pl-1 tablet:min-w-[11rem] w-auto outline-none bg-theme-bg-transparent text-theme-label-primary focus:placeholder-theme-label-quaternary hover:placeholder-theme-label-primary typo-body flex-1 w-full tablet:flex-none tablet:w-auto',
-            !shouldRenderReadingHistory && 'flex-1 pr-2',
+            'pl-1 tablet:min-w-[11rem] outline-none bg-theme-bg-transparent text-theme-label-primary focus:placeholder-theme-label-quaternary hover:placeholder-theme-label-primary typo-body flex-1 w-full tablet:flex-none tablet:w-auto',
+            !shouldRenderReadingHistory && '!flex-1 pr-2',
           )}
           onInput={(e) => setUrl(e.currentTarget.value)}
           value={url}
@@ -116,7 +116,7 @@ function SharePostBar({
         />
         {shouldRenderReadingHistory && (
           <ClickableText
-            className="hidden tablet:flex ml-1 font-bold reading-history hover:text-theme-label-primary"
+            className="hidden tablet:flex ml-1.5 font-bold reading-history hover:text-theme-label-primary"
             inverseUnderline
             onClick={onOpenHistory}
             type="button"


### PR DESCRIPTION
## Changes
- Fix the overlapping width classes.
- Fix the empty space when typing a link. Due to `tablet:flex-none` - in this case, we apply `!` on `flex-1` as it is conditionally being applied.
- Fix the spacing in-between the texts by adding a `.5` on the margin.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1876 #done
