### PR TITLE
fix: regex handle uniformity

### DIFF
--- a/packages/shared/src/components/auth/RegistrationForm.tsx
+++ b/packages/shared/src/components/auth/RegistrationForm.tsx
@@ -33,6 +33,7 @@ import { useGenerateUsername } from '../../hooks';
 import { AuthFormProps } from './common';
 import ConditionalWrapper from '../ConditionalWrapper';
 import AuthContainer from './AuthContainer';
+import { onValidateHandles } from '../../hooks/useProfileForm';
 
 export interface RegistrationFormProps extends AuthFormProps {
   email: string;
@@ -110,6 +111,29 @@ export const RegistrationForm = ({
       }
 
       onUpdateHints(setHints);
+      return;
+    }
+
+    const error = onValidateHandles(
+      {},
+      {
+        username: values['traits.username'],
+        twitter: values['traits.twitter'],
+      },
+    );
+
+    if (error.username || error.twitter) {
+      const updatedHints = { ...hints };
+
+      if (error.username) {
+        updatedHints['traits.username'] = error.username;
+      }
+
+      if (error.twitter) {
+        updatedHints['traits.twitter'] = error.twitter;
+      }
+
+      onUpdateHints(updatedHints);
       return;
     }
 

--- a/packages/shared/src/graphql/common.ts
+++ b/packages/shared/src/graphql/common.ts
@@ -111,3 +111,10 @@ interface ApiResponse {
 export interface ApiErrorResult {
   response: ApiResponse;
 }
+
+export const errorMessage = {
+  profile: {
+    invalidUsername: 'Invalid characters found in username!',
+    invalidHandle: 'Invalid character(s) found in social handle',
+  },
+};

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -263,7 +263,10 @@ export const GET_USERNAME_SUGGESTION = gql`
   }
 `;
 
-export const handleRegex = new RegExp(/^@?([\w-]){1,39}$/i);
+// Regex taken from https://github.com/dailydotdev/daily-api/blob/234b0be53fea85954403cef5a2326fc50ce498fd/src/common/object.ts#L41
+export const handleRegex = new RegExp(/^@?[a-z0-9](\w){2,38}$/i);
+// Regex taken from https://github.com/dailydotdev/daily-api/blob/234b0be53fea85954403cef5a2326fc50ce498fd/src/common/object.ts#L40
+export const socialHandleRegex = new RegExp(/^@?([\w-]){1,39}$/i);
 
 export const REFERRAL_CAMPAIGN_QUERY = gql`
   query ReferralCampaign($referralOrigin: String!) {

--- a/packages/shared/src/hooks/useProfileForm.ts
+++ b/packages/shared/src/hooks/useProfileForm.ts
@@ -12,6 +12,7 @@ import {
 import { graphqlUrl } from '../lib/config';
 import { LoggedUser, UserProfile } from '../lib/user';
 import { useToastNotification } from './useToastNotification';
+import { errorMessage } from '../graphql/common';
 
 export interface ProfileFormHint {
   portfolio?: string;
@@ -64,7 +65,7 @@ export const onValidateHandles = (
     const isValid = handleRegex.test(after.username);
 
     if (!isValid) {
-      return { username: 'Invalid characters found in username!' };
+      return { username: errorMessage.profile.invalidUsername };
     }
   }
 
@@ -81,7 +82,7 @@ export const onValidateHandles = (
 
     return {
       ...obj,
-      [social]: 'Invalid character(s) found in social handle',
+      [social]: errorMessage.profile.invalidHandle,
     };
   }, {});
 };

--- a/packages/shared/src/hooks/useProfileForm.ts
+++ b/packages/shared/src/hooks/useProfileForm.ts
@@ -1,12 +1,17 @@
 import { GraphQLError } from 'graphql-request/dist/types';
 import request from 'graphql-request';
-import { useContext, useMemo, useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
 import { useMutation } from 'react-query';
 import { UseMutateFunction } from 'react-query/types/react/types';
 import AuthContext from '../contexts/AuthContext';
-import { UPDATE_USER_PROFILE_MUTATION } from '../graphql/users';
+import {
+  handleRegex,
+  socialHandleRegex,
+  UPDATE_USER_PROFILE_MUTATION,
+} from '../graphql/users';
 import { graphqlUrl } from '../lib/config';
 import { LoggedUser, UserProfile } from '../lib/user';
+import { useToastNotification } from './useToastNotification';
 
 export interface ProfileFormHint {
   portfolio?: string;
@@ -45,10 +50,47 @@ interface UseProfileFormProps {
   onSuccess?: () => void;
 }
 
+type Handles = Pick<
+  UserProfile,
+  'github' | 'hashnode' | 'twitter' | 'username'
+>;
+const socials: Array<keyof Handles> = ['github', 'hashnode', 'twitter'];
+
+export const onValidateHandles = (
+  before: Partial<Handles>,
+  after: Partial<Handles>,
+): Partial<Record<keyof Handles, string>> => {
+  if (after.username && after.username !== before.username) {
+    const isValid = handleRegex.test(after.username);
+
+    if (!isValid) {
+      return { username: 'Invalid characters found in username!' };
+    }
+  }
+
+  return socials.reduce((obj, social) => {
+    if (after[social] && after[social] === before[social]) {
+      return obj;
+    }
+
+    const isValid = socialHandleRegex.test(after[social]);
+
+    if (isValid) {
+      return obj;
+    }
+
+    return {
+      ...obj,
+      [social]: 'Invalid character(s) found in social handle',
+    };
+  }, {});
+};
+
 const useProfileForm = ({
   onSuccess,
 }: UseProfileFormProps = {}): UseProfileForm => {
   const { user, updateUser } = useContext(AuthContext);
+  const { displayToast } = useToastNotification();
   const [hint, setHint] = useState<ProfileFormHint>({});
   const { isLoading, mutate: updateUserProfile } = useMutation<
     LoggedUser,
@@ -76,12 +118,26 @@ const useProfileForm = ({
     },
   );
 
-  return useMemo(
-    () => ({ hint, isLoading, onUpdateHint: setHint, updateUserProfile }),
-    // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [user, hint, isLoading],
+  const handleUpdate: typeof updateUserProfile = useCallback(
+    (values) => {
+      const error = onValidateHandles(user, values);
+      const message = Object.values(error)[0];
+
+      if (message) {
+        return displayToast(message);
+      }
+
+      return updateUserProfile(values);
+    },
+    [displayToast, user, updateUserProfile],
   );
+
+  return {
+    hint,
+    isLoading,
+    onUpdateHint: setHint,
+    updateUserProfile: handleUpdate,
+  };
 };
 
 export default useProfileForm;

--- a/packages/webapp/pages/account/profile.tsx
+++ b/packages/webapp/pages/account/profile.tsx
@@ -16,20 +16,12 @@ import CameraIcon from '@dailydotdev/shared/src/components/icons/Camera';
 import Textarea from '@dailydotdev/shared/src/components/fields/Textarea';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
-import {
-  handleRegex,
-  socialHandleRegex,
-} from '@dailydotdev/shared/src/graphql/users';
-import { UserProfile } from '@dailydotdev/shared/src/lib/user';
 import { getAccountLayout } from '../../components/layouts/AccountLayout';
 import AccountContentSection from '../../components/layouts/AccountLayout/AccountContentSection';
 import { AccountPageContainer } from '../../components/layouts/AccountLayout/AccountPageContainer';
 import { AccountTextField } from '../../components/layouts/AccountLayout/common';
 
 const id = 'avatar_file';
-
-type Socials = Pick<UserProfile, 'github' | 'hashnode' | 'twitter'>;
-const socials: Array<keyof Socials> = ['github', 'hashnode', 'twitter'];
 
 const AccountProfilePage = (): ReactElement => {
   const formRef = useRef<HTMLFormElement>();
@@ -41,29 +33,6 @@ const AccountProfilePage = (): ReactElement => {
   const onSubmit = (e: React.MouseEvent) => {
     e.preventDefault();
     const values = formToJson<UpdateProfileParameters>(formRef.current);
-
-    if (values.username !== user.username) {
-      const isValid = handleRegex.test(values.username);
-
-      if (!isValid) {
-        displayToast('Invalid characters found in username!');
-        return;
-      }
-    }
-
-    const areHandlesValid = socials.every((social) => {
-      if (values[social] === user[social]) {
-        return true;
-      }
-
-      return socialHandleRegex.test(values[social]);
-    });
-
-    if (!areHandlesValid) {
-      displayToast(`Invalid character(s) found in social handle`);
-      return;
-    }
-
     const params = {
       name: values.name,
       username: values.username,

--- a/packages/webapp/pages/account/profile.tsx
+++ b/packages/webapp/pages/account/profile.tsx
@@ -16,12 +16,20 @@ import CameraIcon from '@dailydotdev/shared/src/components/icons/Camera';
 import Textarea from '@dailydotdev/shared/src/components/fields/Textarea';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
+import {
+  handleRegex,
+  socialHandleRegex,
+} from '@dailydotdev/shared/src/graphql/users';
+import { UserProfile } from '@dailydotdev/shared/src/lib/user';
 import { getAccountLayout } from '../../components/layouts/AccountLayout';
 import AccountContentSection from '../../components/layouts/AccountLayout/AccountContentSection';
 import { AccountPageContainer } from '../../components/layouts/AccountLayout/AccountPageContainer';
 import { AccountTextField } from '../../components/layouts/AccountLayout/common';
 
 const id = 'avatar_file';
+
+type Socials = Pick<UserProfile, 'github' | 'hashnode' | 'twitter'>;
+const socials: Array<keyof Socials> = ['github', 'hashnode', 'twitter'];
 
 const AccountProfilePage = (): ReactElement => {
   const formRef = useRef<HTMLFormElement>();
@@ -33,6 +41,28 @@ const AccountProfilePage = (): ReactElement => {
   const onSubmit = (e: React.MouseEvent) => {
     e.preventDefault();
     const values = formToJson<UpdateProfileParameters>(formRef.current);
+
+    if (values.username !== user.username) {
+      const isValid = handleRegex.test(values.username);
+
+      if (!isValid) {
+        displayToast('Invalid characters found in username!');
+        return;
+      }
+    }
+
+    const areHandlesValid = socials.every((social) => {
+      if (values[social] === user[social]) {
+        return true;
+      }
+
+      return socialHandleRegex.test(values[social]);
+    });
+
+    if (!areHandlesValid) {
+      displayToast(`Invalid character(s) found in social handle`);
+      return;
+    }
 
     const params = {
       name: values.name,


### PR DESCRIPTION
## Changes
- Make the APIs recent changes be the basis of the regex for handles and socials.

Note: since this regex won't allow the character dash `-`, it would affect the comment box as this is also the basis of the mentions triggers. Do we maybe want to allow it in the mention in the meantime?

![Screenshot 2023-10-19 at 11 02 22 AM](https://github.com/dailydotdev/apps/assets/13744167/7ad55b98-409c-436c-a273-bafcbfce7bba)

![Screenshot 2023-10-19 at 11 02 31 AM](https://github.com/dailydotdev/apps/assets/13744167/f038272b-b65f-4ed2-8cca-8c3ef07cb0ca)



## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1897 #done
