### PR TITLE
chore: don't pass `sourceId` on update post

### DIFF
--- a/packages/shared/src/components/post/write/ShareLink.tsx
+++ b/packages/shared/src/components/post/write/ShareLink.tsx
@@ -43,7 +43,7 @@ export function ShareLink({
     }
 
     return post?.id
-      ? onUpdatePost(e, post.id, squad.id, commentary)
+      ? onUpdatePost(e, post.id, commentary)
       : onSubmitPost(e, squad.id, commentary);
   };
 

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -53,7 +53,7 @@ type EditSquadOutput = {
 
 type PostToSquadProps = {
   id: string;
-  sourceId: string;
+  sourceId?: string;
   commentary: string;
 };
 
@@ -188,8 +188,8 @@ export const ADD_POST_TO_SQUAD_MUTATION = gql`
 `;
 
 export const UPDATE_SQUAD_POST_MUTATION = gql`
-  mutation UpdateSquadPost($id: ID!, $sourceId: ID!, $commentary: String) {
-    editSharePost(id: $id, sourceId: $sourceId, commentary: $commentary) {
+  mutation UpdateSquadPost($id: ID!, $commentary: String) {
+    editSharePost(id: $id, commentary: $commentary) {
       id
     }
   }

--- a/packages/shared/src/hooks/squads/usePostToSquad.ts
+++ b/packages/shared/src/hooks/squads/usePostToSquad.ts
@@ -19,7 +19,6 @@ import { ActionType } from '../../graphql/actions';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useActions } from '../useActions';
 import { useRequestProtocol } from '../useRequestProtocol';
-import { Squad } from '../../graphql/sources';
 
 interface UsePostToSquad {
   preview: ExternalLinkPreview;
@@ -39,7 +38,6 @@ interface UsePostToSquad {
   onUpdatePost: (
     e: BaseSyntheticEvent,
     postId: Post['id'],
-    sourceId: Squad['id'],
     commentary: string,
   ) => Promise<unknown>;
 }
@@ -176,7 +174,7 @@ export const usePostToSquad = ({
   );
 
   const onUpdatePost = useCallback<UsePostToSquad['onUpdatePost']>(
-    (e, postId, sourceId, commentary) => {
+    (e, postId, commentary) => {
       e.preventDefault();
 
       if (isUpdating) {
@@ -185,7 +183,6 @@ export const usePostToSquad = ({
 
       return updatePost({
         id: postId,
-        sourceId,
         commentary,
       });
     },


### PR DESCRIPTION
## Changes

leftover item from the original PR for editing posts: https://github.com/dailydotdev/apps/pull/2259#discussion_r1360551010
API changes: https://github.com/dailydotdev/daily-api/pull/1487

## Events

n / a

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1801 #done
