### PR TITLE
feat: search squad members

### DIFF
--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -14,7 +14,7 @@ import Feed, { FeedProps } from './Feed';
 import BookmarkEmptyScreen from './BookmarkEmptyScreen';
 import { Button } from './buttons/Button';
 import ShareIcon from './icons/Share';
-import { generateQueryKey, RequestKey } from '../lib/query';
+import { generateQueryKey, OtherFeedPage, RequestKey } from '../lib/query';
 import { supportedTypesForPrivateSources } from '../graphql/posts';
 
 export type BookmarkFeedLayoutProps = {
@@ -43,7 +43,7 @@ export default function BookmarkFeedLayout({
   const feedProps = useMemo<FeedProps<unknown>>(() => {
     if (searchQuery) {
       return {
-        feedName: 'search-bookmarks',
+        feedName: OtherFeedPage.SearchBookmarks,
         feedQueryKey: defaultKey.concat(searchQuery),
         query: SEARCH_BOOKMARKS_QUERY,
         variables: {
@@ -54,7 +54,7 @@ export default function BookmarkFeedLayout({
       };
     }
     return {
-      feedName: 'bookmarks',
+      feedName: OtherFeedPage.Bookmarks,
       feedQueryKey: defaultKey,
       query: BOOKMARKS_FEED_QUERY,
       variables: {

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -43,10 +43,11 @@ import { ActiveFeedContext } from '../contexts';
 import { useFeedVotePost } from '../hooks';
 import { useFeature } from './GrowthBookProvider';
 import { feature } from '../lib/featureManagement';
+import { AllFeedPages } from '../lib/query';
 
 export interface FeedProps<T>
   extends Pick<UseFeedOptionalParams<T>, 'options'> {
-  feedName: string;
+  feedName: AllFeedPages;
   feedQueryKey: unknown[];
   query?: string;
   variables?: T;

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -36,7 +36,7 @@ import { ExperimentWinner, OnboardingV2 } from '../lib/featureValues';
 import useSidebarRendered from '../hooks/useSidebarRendered';
 import OnboardingContext from '../contexts/OnboardingContext';
 import AlertContext from '../contexts/AlertContext';
-import { MainFeedPage } from './utilities';
+import { SharedFeedPage } from './utilities';
 import { FeedContainer } from './feeds';
 import useCompanionTrigger from '../hooks/useCompanionTrigger';
 import { ActiveFeedContext } from '../contexts';
@@ -177,7 +177,7 @@ export default function Feed<T>({
 
   const showScrollOnboardingVersion =
     sidebarRendered &&
-    feedName === MainFeedPage.Popular &&
+    feedName === SharedFeedPage.Popular &&
     !isLoading &&
     alerts?.filter &&
     !user?.id &&
@@ -379,8 +379,8 @@ export default function Feed<T>({
     return <>{emptyScreen}</>;
   }
 
-  const isValidFeed = Object.values(MainFeedPage).includes(
-    feedName as MainFeedPage,
+  const isValidFeed = Object.values(SharedFeedPage).includes(
+    feedName as SharedFeedPage,
   );
 
   return (

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -198,7 +198,11 @@ export default function MainFeedLayout({
     if (isSearchOn && searchQuery) {
       return {
         feedName: SharedFeedPage.Search,
-        feedQueryKey: generateQueryKey(SharedFeedPage.Search, user, searchQuery),
+        feedQueryKey: generateQueryKey(
+          SharedFeedPage.Search,
+          user,
+          searchQuery,
+        ),
         query: SEARCH_POSTS_QUERY,
         variables: { query: searchQuery },
         emptyScreen: <SearchEmptyScreen />,

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -197,7 +197,7 @@ export default function MainFeedLayout({
   const feedProps = useMemo<FeedProps<unknown>>(() => {
     if (isSearchOn && searchQuery) {
       return {
-        feedName: 'search',
+        feedName: MainFeedPage.Search,
         feedQueryKey: generateQueryKey(RequestKey.Search, user, searchQuery),
         query: SEARCH_POSTS_QUERY,
         variables: { query: searchQuery },

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -18,7 +18,7 @@ import {
   MOST_UPVOTED_FEED_QUERY,
   SEARCH_POSTS_QUERY,
 } from '../graphql/feed';
-import { generateQueryKey } from '../lib/query';
+import { generateQueryKey, RequestKey } from '../lib/query';
 import SettingsContext from '../contexts/SettingsContext';
 import usePersistentContext from '../hooks/usePersistentContext';
 import AlertContext from '../contexts/AlertContext';
@@ -198,7 +198,7 @@ export default function MainFeedLayout({
     if (isSearchOn && searchQuery) {
       return {
         feedName: 'search',
-        feedQueryKey: generateQueryKey('search', user, searchQuery),
+        feedQueryKey: generateQueryKey(RequestKey.Search, user, searchQuery),
         query: SEARCH_POSTS_QUERY,
         variables: { query: searchQuery },
         emptyScreen: <SearchEmptyScreen />,

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -18,7 +18,7 @@ import {
   MOST_UPVOTED_FEED_QUERY,
   SEARCH_POSTS_QUERY,
 } from '../graphql/feed';
-import { generateQueryKey, RequestKey } from '../lib/query';
+import { generateQueryKey } from '../lib/query';
 import SettingsContext from '../contexts/SettingsContext';
 import usePersistentContext from '../hooks/usePersistentContext';
 import AlertContext from '../contexts/AlertContext';

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -198,7 +198,7 @@ export default function MainFeedLayout({
     if (isSearchOn && searchQuery) {
       return {
         feedName: MainFeedPage.Search,
-        feedQueryKey: generateQueryKey(RequestKey.Search, user, searchQuery),
+        feedQueryKey: generateQueryKey(MainFeedPage.Search, user, searchQuery),
         query: SEARCH_POSTS_QUERY,
         variables: { query: searchQuery },
         emptyScreen: <SearchEmptyScreen />,

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -10,7 +10,7 @@ import dynamic from 'next/dynamic';
 import Feed, { FeedProps } from './Feed';
 import AuthContext from '../contexts/AuthContext';
 import { LoggedUser } from '../lib/user';
-import { FeedPage, MainFeedPage } from './utilities';
+import { FeedPage, SharedFeedPage } from './utilities';
 import {
   ANONYMOUS_FEED_QUERY,
   FEED_QUERY,
@@ -53,7 +53,7 @@ type FeedQueryProps = {
   variables?: Record<string, unknown>;
 };
 
-const propsByFeed: Record<MainFeedPage, FeedQueryProps> = {
+const propsByFeed: Record<SharedFeedPage, FeedQueryProps> = {
   'my-feed': {
     query: ANONYMOUS_FEED_QUERY,
     queryIfLogged: FEED_QUERY,
@@ -81,7 +81,7 @@ export type MainFeedLayoutProps = {
   searchChildren: ReactNode;
   besideSearch?: ReactNode;
   navChildren?: ReactNode;
-  onFeedPageChanged: (page: MainFeedPage) => void;
+  onFeedPageChanged: (page: SharedFeedPage) => void;
   isFinder?: boolean;
 };
 
@@ -107,12 +107,12 @@ interface GetDefaultFeedProps {
   hasUser?: boolean;
 }
 
-const getDefaultFeed = ({ hasUser }: GetDefaultFeedProps): MainFeedPage => {
+const getDefaultFeed = ({ hasUser }: GetDefaultFeedProps): SharedFeedPage => {
   if (!hasUser) {
-    return MainFeedPage.Popular;
+    return SharedFeedPage.Popular;
   }
 
-  return MainFeedPage.MyFeed;
+  return SharedFeedPage.MyFeed;
 };
 
 const defaultFeedConditions = [null, 'default', '/', ''];
@@ -120,7 +120,7 @@ const defaultFeedConditions = [null, 'default', '/', ''];
 export const getFeedName = (
   path: string,
   options: GetDefaultFeedProps = {},
-): MainFeedPage => {
+): SharedFeedPage => {
   const feed = path?.replaceAll?.('/', '') || '';
 
   if (defaultFeedConditions.some((condition) => condition === feed)) {
@@ -129,7 +129,7 @@ export const getFeedName = (
 
   const [page] = feed.split('?');
 
-  return page.replace(/^\/+/, '') as MainFeedPage;
+  return page.replace(/^\/+/, '') as SharedFeedPage;
 };
 
 export default function MainFeedLayout({
@@ -197,8 +197,8 @@ export default function MainFeedLayout({
   const feedProps = useMemo<FeedProps<unknown>>(() => {
     if (isSearchOn && searchQuery) {
       return {
-        feedName: MainFeedPage.Search,
-        feedQueryKey: generateQueryKey(MainFeedPage.Search, user, searchQuery),
+        feedName: SharedFeedPage.Search,
+        feedQueryKey: generateQueryKey(SharedFeedPage.Search, user, searchQuery),
         query: SEARCH_POSTS_QUERY,
         variables: { query: searchQuery },
         emptyScreen: <SearchEmptyScreen />,

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -28,7 +28,7 @@ import { PromptElement } from './modals/Prompt';
 import { useNotificationParams } from '../hooks/useNotificationParams';
 import { daysLeft, OnboardingV2 } from '../lib/featureValues';
 import { useAuthContext } from '../contexts/AuthContext';
-import { MainFeedPage } from './utilities';
+import { SharedFeedPage } from './utilities';
 import { isTesting, onboardingUrl } from '../lib/constants';
 import { useBanner } from '../hooks/useBanner';
 import { useFeature, useGrowthBookContext } from './GrowthBookProvider';
@@ -56,7 +56,7 @@ export interface MainLayoutProps
 const mainLayoutClass = (sidebarExpanded: boolean) =>
   sidebarExpanded ? 'laptop:pl-60' : 'laptop:pl-11';
 
-const feeds = Object.values(MainFeedPage);
+const feeds = Object.values(SharedFeedPage);
 
 function MainLayout({
   children,
@@ -151,7 +151,7 @@ function MainLayout({
   };
 
   const router = useRouter();
-  const page = router?.route?.substring(1).trim() as MainFeedPage;
+  const page = router?.route?.substring(1).trim() as SharedFeedPage;
   const isPageReady =
     (growthbook?.ready && router?.isReady && isAuthReady) || isTesting;
   const isPageApplicableForOnboarding = !page || feeds.includes(page);

--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -21,7 +21,7 @@ import {
   ToastSubject,
   useToastNotification,
 } from '../hooks/useToastNotification';
-import { generateQueryKey } from '../lib/query';
+import { AllFeedPages, generateQueryKey } from '../lib/query';
 import AuthContext from '../contexts/AuthContext';
 import { ShareBookmarkProps } from './post/PostActions';
 import BookmarkIcon from './icons/Bookmark';
@@ -47,7 +47,7 @@ const PortalMenu = dynamic(
 export interface PostOptionsMenuProps extends ShareBookmarkProps {
   postIndex?: number;
   post: Post;
-  feedName?: string;
+  feedName?: AllFeedPages;
   onHidden?: () => unknown;
   feedQueryKey?: QueryKey;
   onRemovePost?: (postIndex: number) => Promise<unknown>;

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 import classed from '../../lib/classed';
-import { FeedHeading, MainFeedPage } from '../utilities';
+import { FeedHeading, SharedFeedPage } from '../utilities';
 import MyFeedHeading from '../filters/MyFeedHeading';
 import AlertContext from '../../contexts/AlertContext';
 import CreateMyFeedButton from '../CreateMyFeedButton';
@@ -30,10 +30,10 @@ import { useFeedName } from '../../hooks/feed/useFeedName';
 type State<T> = [T, Dispatch<SetStateAction<T>>];
 
 export interface SearchControlHeaderProps {
-  feedName: MainFeedPage;
+  feedName: SharedFeedPage;
   navChildren?: ReactNode;
   isSearchOn?: boolean;
-  onFeedPageChanged: (value: MainFeedPage) => void;
+  onFeedPageChanged: (value: SharedFeedPage) => void;
   algoState: State<number>;
   periodState: State<number>;
 }
@@ -75,7 +75,7 @@ export const SearchControlHeader = ({
 
   /* eslint-disable react/no-children-prop */
   const feedHeading = {
-    [MainFeedPage.MyFeed]: (
+    [SharedFeedPage.MyFeed]: (
       <MyFeedHeading
         isAlertDisabled={!hasMyFeedAlert}
         sidebarRendered={sidebarRendered}
@@ -83,9 +83,9 @@ export const SearchControlHeader = ({
         onUpdateAlerts={() => updateAlerts({ myFeed: null })}
       />
     ),
-    [MainFeedPage.Popular]: <FeedHeading children="Popular" />,
-    [MainFeedPage.Upvoted]: <FeedHeading children="Most upvoted" />,
-    [MainFeedPage.Discussed]: <FeedHeading children="Best discussions" />,
+    [SharedFeedPage.Popular]: <FeedHeading children="Popular" />,
+    [SharedFeedPage.Upvoted]: <FeedHeading children="Most upvoted" />,
+    [SharedFeedPage.Discussed]: <FeedHeading children="Best discussions" />,
   };
 
   if (searchVersion === SearchExperiment.V1) {
@@ -97,7 +97,7 @@ export const SearchControlHeader = ({
       iconOnly: true,
     };
     const actionButtons = [
-      feedName === MainFeedPage.MyFeed ? (
+      feedName === SharedFeedPage.MyFeed ? (
         <MyFeedHeading
           key="my-feed"
           isAlertDisabled={!alerts.myFeed}
@@ -137,7 +137,7 @@ export const SearchControlHeader = ({
       {alerts?.filter && (
         <CreateMyFeedButton
           action={() =>
-            onInitializeOnboarding(() => onFeedPageChanged(MainFeedPage.MyFeed))
+            onInitializeOnboarding(() => onFeedPageChanged(SharedFeedPage.MyFeed))
           }
         />
       )}

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -137,7 +137,9 @@ export const SearchControlHeader = ({
       {alerts?.filter && (
         <CreateMyFeedButton
           action={() =>
-            onInitializeOnboarding(() => onFeedPageChanged(SharedFeedPage.MyFeed))
+            onInitializeOnboarding(() =>
+              onFeedPageChanged(SharedFeedPage.MyFeed),
+            )
           }
         />
       )}

--- a/packages/shared/src/components/modals/SquadMemberModal.tsx
+++ b/packages/shared/src/components/modals/SquadMemberModal.tsx
@@ -127,7 +127,9 @@ export function SquadMemberModal({
             />
           ),
           emptyPlaceholder: query ? (
-            <FlexCentered className="p-10">No user found</FlexCentered>
+            <FlexCentered className="p-10 typo-callout text-theme-label-tertiary">
+              No user found
+            </FlexCentered>
           ) : (
             <BlockedMembersPlaceholder />
           ),

--- a/packages/shared/src/components/modals/SquadMemberModal.tsx
+++ b/packages/shared/src/components/modals/SquadMemberModal.tsx
@@ -15,10 +15,12 @@ import { IconSize } from '../Icon';
 import LinkIcon from '../icons/Link';
 import { useSquadInvitation } from '../../hooks/useSquadInvitation';
 import { FlexCentered } from '../utilities';
-import { useSquadActions } from '../../hooks/squads/useSquadActions';
+import { useSquadActions } from '../../hooks';
 import SquadMemberItemAdditionalContent from '../squads/SquadMemberItemAdditionalContent';
-import BlockIcon from '../icons/Block';
 import { verifyPermission } from '../../graphql/squads';
+import useDebounce from '../../hooks/useDebounce';
+import { defaultSearchDebounceMs } from '../../lib/func';
+import { BlockedMembersPlaceholder } from '../squads/Members';
 
 enum SquadMemberTab {
   AllMembers = 'Squad members',
@@ -66,6 +68,11 @@ export function SquadMemberModal({
   const { onMenuClick, onHide: hideMenu } = useContextMenu({
     id: 'squad-member-menu-context',
   });
+  const [query, setQuery] = useState('');
+  const [handleSearchDebounce] = useDebounce(
+    (value: string) => setQuery(value),
+    defaultSearchDebounceMs,
+  );
   const {
     members,
     membersQueryResult: queryResult,
@@ -73,6 +80,7 @@ export function SquadMemberModal({
     onUpdateRole,
   } = useSquadActions({
     squad,
+    query: query?.trim?.(),
     membersQueryParams: { role: roleFilter },
     membersQueryEnabled: true,
   });
@@ -118,13 +126,10 @@ export function SquadMemberModal({
               onOptionsClick={(e) => onOptionsClick(e, members[index])}
             />
           ),
-          emptyPlaceholder: (
-            <FlexCentered className="flex-col h-full">
-              <BlockIcon secondary size={IconSize.XXXLarge} />
-              <p className="text-theme-label-secondary typo-body">
-                No blocked members found
-              </p>
-            </FlexCentered>
+          emptyPlaceholder: query ? (
+            <FlexCentered className="p-10">No user found</FlexCentered>
+          ) : (
+            <BlockedMembersPlaceholder />
           ),
           isLoading: queryResult.isLoading,
           initialItem:
@@ -133,6 +138,7 @@ export function SquadMemberModal({
             ),
         }}
         users={members?.map(({ user }) => user)}
+        onSearch={handleSearchDebounce}
       />
       <SquadMemberMenu
         squad={squad}

--- a/packages/shared/src/components/modals/SquadMemberModal.tsx
+++ b/packages/shared/src/components/modals/SquadMemberModal.tsx
@@ -80,7 +80,7 @@ export function SquadMemberModal({
     onUpdateRole,
   } = useSquadActions({
     squad,
-    query: query?.trim?.(),
+    query: query?.trim?.()?.length ? query : undefined,
     membersQueryParams: { role: roleFilter },
     membersQueryEnabled: true,
   });

--- a/packages/shared/src/components/modals/UserListModal.tsx
+++ b/packages/shared/src/components/modals/UserListModal.tsx
@@ -3,6 +3,7 @@ import { Modal, ModalProps } from './common/Modal';
 import UserList, { UserListProps } from '../profile/UserList';
 import { InfiniteScrollingProps } from '../containers/InfiniteScrolling';
 import { UserShortProfile } from '../../lib/user';
+import { SearchField } from '../fields/SearchField';
 
 export interface UserListModalProps extends Omit<ModalProps, 'children'> {
   users: UserShortProfile[];
@@ -14,6 +15,7 @@ export interface UserListModalProps extends Omit<ModalProps, 'children'> {
     UserListProps,
     'additionalContent' | 'initialItem' | 'isLoading' | 'emptyPlaceholder'
   >;
+  onSearch?(query: string): void;
 }
 
 function UserListModal({
@@ -24,6 +26,7 @@ function UserListModal({
   placeholderAmount,
   size = Modal.Size.Medium,
   userListProps,
+  onSearch,
   ...props
 }: UserListModalProps): ReactElement {
   const container = useRef<HTMLElement>();
@@ -40,6 +43,13 @@ function UserListModal({
     >
       {header ?? <Modal.Header title={title} />}
       <Modal.Body className="py-2 px-0" onScroll={onScroll} ref={container}>
+        {onSearch && (
+          <SearchField
+            className="mx-6"
+            inputId="members-search"
+            valueChanged={onSearch}
+          />
+        )}
         <UserList
           {...userListProps}
           users={users}

--- a/packages/shared/src/components/squads/Members/BlockedMembersPlaceholder.tsx
+++ b/packages/shared/src/components/squads/Members/BlockedMembersPlaceholder.tsx
@@ -1,0 +1,14 @@
+import React, { ReactElement } from 'react';
+import BlockIcon from '../../icons/Block';
+import { IconSize } from '../../Icon';
+
+export function BlockedMembersPlaceholder(): ReactElement {
+  return (
+    <div className="flex flex-col flex-1 justify-center items-center">
+      <BlockIcon secondary size={IconSize.XXXLarge} />
+      <p className="text-theme-label-secondary typo-body">
+        No blocked members found
+      </p>
+    </div>
+  );
+}

--- a/packages/shared/src/components/squads/Members/index.ts
+++ b/packages/shared/src/components/squads/Members/index.ts
@@ -1,0 +1,1 @@
+export * from './BlockedMembersPlaceholder';

--- a/packages/shared/src/components/utilities/common.tsx
+++ b/packages/shared/src/components/utilities/common.tsx
@@ -166,7 +166,7 @@ export const SecondaryCenteredBodyText = classed(
 
 export type HTMLElementComponent<T = HTMLElement> = React.FC<HTMLAttributes<T>>;
 
-export enum MainFeedPage {
+export enum SharedFeedPage {
   MyFeed = 'my-feed',
   Popular = 'popular',
   Search = 'search',

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -10,7 +10,7 @@ import { BootApp, BootCacheData, getBootData } from '../lib/boot';
 import { AuthContextProvider } from './AuthContext';
 import { AnonymousUser, LoggedUser } from '../lib/user';
 import { AlertContextProvider } from './AlertContext';
-import { generateQueryKey } from '../lib/query';
+import { generateQueryKey, RequestKey } from '../lib/query';
 import {
   applyTheme,
   SettingsContextProvider,
@@ -157,7 +157,9 @@ export const BootDataProvider = ({
     async (newUser: LoggedUser | AnonymousUser) => {
       const updated = updateLocalBootData(cachedBootData, { user: newUser });
       setCachedBootData(updated);
-      await queryClient.invalidateQueries(generateQueryKey('profile', newUser));
+      await queryClient.invalidateQueries(
+        generateQueryKey(RequestKey.Profile, newUser),
+      );
     },
     [queryClient, cachedBootData],
   );

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -223,8 +223,20 @@ export const SQUAD_HANDE_AVAILABILITY_QUERY = gql`
 `;
 
 export const SQUAD_MEMBERS_QUERY = gql`
-  query SourceMembers($id: ID!, $after: String, $first: Int, $role: String) {
-    sourceMembers(sourceId: $id, after: $after, first: $first, role: $role) {
+  query SourceMembers(
+    $id: ID!
+    $after: String
+    $first: Int
+    $role: String
+    $query: String
+  ) {
+    sourceMembers(
+      sourceId: $id
+      after: $after
+      first: $first
+      role: $role
+      query: $query
+    ) {
       pageInfo {
         endCursor
         hasNextPage

--- a/packages/shared/src/hooks/feed/useFeedName.ts
+++ b/packages/shared/src/hooks/feed/useFeedName.ts
@@ -1,11 +1,11 @@
-import { MainFeedPage } from '../../components/utilities';
+import { SharedFeedPage } from '../../components/utilities';
 import { useFeature } from '../../components/GrowthBookProvider';
 import { feature } from '../../lib/featureManagement';
 import { SearchExperiment } from '../../lib/featureValues';
 
 interface UseFeedNameProps {
   isSearchOn: boolean;
-  feedName: MainFeedPage;
+  feedName: SharedFeedPage;
 }
 
 interface UseFeedName {
@@ -13,7 +13,7 @@ interface UseFeedName {
   isSortableFeed: boolean;
 }
 
-const sortableFeeds = [MainFeedPage.Popular, MainFeedPage.MyFeed];
+const sortableFeeds = [SharedFeedPage.Popular, SharedFeedPage.MyFeed];
 
 export const useFeedName = ({
   feedName,

--- a/packages/shared/src/hooks/squads/useSquadActions.ts
+++ b/packages/shared/src/hooks/squads/useSquadActions.ts
@@ -60,7 +60,7 @@ export const useSquadActions = ({
     ({ pageParam }) =>
       request(graphqlUrl, SQUAD_MEMBERS_QUERY, {
         id: squad?.id,
-        after: pageParam,
+        after: typeof pageParam === pageParam ? pageParam : null,
         query,
         ...membersQueryParams,
       }),

--- a/packages/shared/src/hooks/squads/useSquadActions.ts
+++ b/packages/shared/src/hooks/squads/useSquadActions.ts
@@ -60,7 +60,7 @@ export const useSquadActions = ({
     ({ pageParam }) =>
       request(graphqlUrl, SQUAD_MEMBERS_QUERY, {
         id: squad?.id,
-        after: typeof pageParam === pageParam ? pageParam : null,
+        after: typeof pageParam === 'string' ? pageParam : null,
         query,
         ...membersQueryParams,
       }),

--- a/packages/shared/src/hooks/squads/useSquadActions.ts
+++ b/packages/shared/src/hooks/squads/useSquadActions.ts
@@ -60,7 +60,7 @@ export const useSquadActions = ({
     ({ pageParam }) =>
       request(graphqlUrl, SQUAD_MEMBERS_QUERY, {
         id: squad?.id,
-        after: typeof pageParam === 'string' ? pageParam : null,
+        after: typeof pageParam === 'string' ? pageParam : undefined,
         query,
         ...membersQueryParams,
       }),

--- a/packages/shared/src/hooks/squads/useSquadActions.ts
+++ b/packages/shared/src/hooks/squads/useSquadActions.ts
@@ -14,6 +14,7 @@ import {
 } from '../../graphql/squads';
 import { graphqlUrl } from '../../lib/config';
 import { SourceMember, SourceMemberRole, Squad } from '../../graphql/sources';
+import { generateQueryKey, RequestKey } from '../../lib/query';
 
 export interface UseSquadActions {
   onUnblock?: typeof unblockSquadMember;
@@ -28,17 +29,25 @@ interface MembersQueryParams {
 
 interface UseSquadActionsProps {
   squad: Squad;
+  query?: string;
   membersQueryParams?: MembersQueryParams;
   membersQueryEnabled?: boolean;
 }
 
 export const useSquadActions = ({
   squad,
+  query,
   membersQueryParams = {},
   membersQueryEnabled,
 }: UseSquadActionsProps): UseSquadActions => {
   const client = useQueryClient();
-  const membersQueryKey = ['squadMembers', squad?.id, membersQueryParams];
+  const membersQueryKey = generateQueryKey(
+    RequestKey.SquadMembers,
+    null,
+    membersQueryParams,
+    squad?.id,
+    query,
+  );
   const { mutateAsync: onUpdateRole } = useMutation(updateSquadMemberRole, {
     onSuccess: () => client.invalidateQueries(membersQueryKey),
   });
@@ -52,6 +61,7 @@ export const useSquadActions = ({
       request(graphqlUrl, SQUAD_MEMBERS_QUERY, {
         id: squad?.id,
         after: pageParam,
+        query,
         ...membersQueryParams,
       }),
     {

--- a/packages/shared/src/hooks/usePostFeedback.ts
+++ b/packages/shared/src/hooks/usePostFeedback.ts
@@ -6,7 +6,7 @@ import { optimisticPostUpdateInFeed } from '../lib/feed';
 import { updatePostCache } from './usePostById';
 import { updateCachedPagePost } from '../lib/query';
 import { ActiveFeedContext } from '../contexts';
-import { MainFeedPage } from '../components/utilities';
+import { SharedFeedPage } from '../components/utilities';
 import { EmptyResponse } from '../graphql/emptyResponse';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../lib/analytics';
@@ -33,7 +33,7 @@ export const usePostFeedback = ({
     feature.engagementLoopJuly2023Upvote.id,
   );
   const isMyFeed = useMemo(() => {
-    return feedQueryKey?.some((item) => item === MainFeedPage.MyFeed);
+    return feedQueryKey?.some((item) => item === SharedFeedPage.MyFeed);
   }, [feedQueryKey]);
 
   const dismissFeedbackMutation = useMutation(

--- a/packages/shared/src/hooks/useTagAndSource.ts
+++ b/packages/shared/src/hooks/useTagAndSource.ts
@@ -6,7 +6,7 @@ import useMutateFilters from './useMutateFilters';
 import { Source } from '../graphql/sources';
 import AlertContext from '../contexts/AlertContext';
 import { BooleanPromise } from '../components/filters/common';
-import { generateQueryKey } from '../lib/query';
+import { generateQueryKey, RequestKey } from '../lib/query';
 import useDebounce from './useDebounce';
 
 export interface TagActionArguments {
@@ -63,7 +63,7 @@ export default function useTagAndSource({
       return;
     }
 
-    queryClient.invalidateQueries(generateQueryKey('my-feed', user));
+    queryClient.invalidateQueries(generateQueryKey(RequestKey.MyFeed, user));
   }, 100);
 
   const onFollowTags = useCallback(

--- a/packages/shared/src/hooks/useTagAndSource.ts
+++ b/packages/shared/src/hooks/useTagAndSource.ts
@@ -6,8 +6,9 @@ import useMutateFilters from './useMutateFilters';
 import { Source } from '../graphql/sources';
 import AlertContext from '../contexts/AlertContext';
 import { BooleanPromise } from '../components/filters/common';
-import { generateQueryKey, RequestKey } from '../lib/query';
+import { generateQueryKey } from '../lib/query';
 import useDebounce from './useDebounce';
+import { MainFeedPage } from '../components/utilities';
 
 export interface TagActionArguments {
   tags: Array<string>;
@@ -63,7 +64,7 @@ export default function useTagAndSource({
       return;
     }
 
-    queryClient.invalidateQueries(generateQueryKey(RequestKey.MyFeed, user));
+    queryClient.invalidateQueries(generateQueryKey(MainFeedPage.MyFeed, user));
   }, 100);
 
   const onFollowTags = useCallback(

--- a/packages/shared/src/hooks/useTagAndSource.ts
+++ b/packages/shared/src/hooks/useTagAndSource.ts
@@ -8,7 +8,7 @@ import AlertContext from '../contexts/AlertContext';
 import { BooleanPromise } from '../components/filters/common';
 import { generateQueryKey } from '../lib/query';
 import useDebounce from './useDebounce';
-import { MainFeedPage } from '../components/utilities';
+import { SharedFeedPage } from '../components/utilities';
 
 export interface TagActionArguments {
   tags: Array<string>;
@@ -64,7 +64,7 @@ export default function useTagAndSource({
       return;
     }
 
-    queryClient.invalidateQueries(generateQueryKey(MainFeedPage.MyFeed, user));
+    queryClient.invalidateQueries(generateQueryKey(SharedFeedPage.MyFeed, user));
   }, 100);
 
   const onFollowTags = useCallback(

--- a/packages/shared/src/hooks/useTagAndSource.ts
+++ b/packages/shared/src/hooks/useTagAndSource.ts
@@ -64,7 +64,9 @@ export default function useTagAndSource({
       return;
     }
 
-    queryClient.invalidateQueries(generateQueryKey(SharedFeedPage.MyFeed, user));
+    queryClient.invalidateQueries(
+      generateQueryKey(SharedFeedPage.MyFeed, user),
+    );
   }, 100);
 
   const onFollowTags = useCallback(

--- a/packages/shared/src/lib/func.ts
+++ b/packages/shared/src/lib/func.ts
@@ -30,3 +30,5 @@ export const postWindowMessage = (
 ): void => window.opener?.postMessage?.({ ...params, eventKey }, attributes);
 
 export const checkIsExtension = (): boolean => !!process.env.TARGET_BROWSER;
+
+export const defaultSearchDebounceMs = 200;

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -10,11 +10,18 @@ import { EmptyObjectLiteral } from './kratos';
 import { LoggedUser } from './user';
 import { FeedData, Post, ReadHistoryPost } from '../graphql/posts';
 import { ReadHistoryInfiniteData } from '../hooks/useInfiniteReadingHistory';
+import { MainFeedPage } from '../components/utilities';
+
+export enum OtherFeedPage {
+  Squad = 'squad',
+}
+
+export type AllFeedPages = MainFeedPage | OtherFeedPage;
 
 export type MutateFunc<T> = (variables: T) => Promise<(() => void) | undefined>;
 
 export const generateQueryKey = (
-  name: RequestKey,
+  name: RequestKey | AllFeedPages,
   user: Pick<LoggedUser, 'id'> | null,
   ...additional: unknown[]
 ): unknown[] => {
@@ -47,7 +54,6 @@ export enum RequestKey {
   CurrentSession = 'current_session',
   PersonalizedDigest = 'personalizedDigest',
   Changelog = 'changelog',
-  MyFeed = 'my-feed',
 }
 
 export type HasConnection<

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -10,7 +10,7 @@ import { EmptyObjectLiteral } from './kratos';
 import { LoggedUser } from './user';
 import { FeedData, Post, ReadHistoryPost } from '../graphql/posts';
 import { ReadHistoryInfiniteData } from '../hooks/useInfiniteReadingHistory';
-import { MainFeedPage } from '../components/utilities';
+import { SharedFeedPage } from '../components/utilities';
 
 export enum OtherFeedPage {
   Tag = 'tag',
@@ -20,7 +20,7 @@ export enum OtherFeedPage {
   SearchBookmarks = 'search-bookmarks',
 }
 
-export type AllFeedPages = MainFeedPage | OtherFeedPage;
+export type AllFeedPages = SharedFeedPage | OtherFeedPage;
 
 export type MutateFunc<T> = (variables: T) => Promise<(() => void) | undefined>;
 

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -43,9 +43,11 @@ export enum RequestKey {
   NotificationPreference = 'notification_preference',
   Banner = 'latest_banner',
   Auth = 'auth',
+  Profile = 'profile',
   CurrentSession = 'current_session',
   PersonalizedDigest = 'personalizedDigest',
   Changelog = 'changelog',
+  MyFeed = 'my-feed',
 }
 
 export type HasConnection<

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -14,6 +14,8 @@ import { MainFeedPage } from '../components/utilities';
 
 export enum OtherFeedPage {
   Squad = 'squad',
+  Bookmarks = 'bookmarks',
+  SearchBookmarks = 'search-bookmarks',
 }
 
 export type AllFeedPages = MainFeedPage | OtherFeedPage;

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -14,6 +14,7 @@ import { MainFeedPage } from '../components/utilities';
 
 export enum OtherFeedPage {
   Squad = 'squad',
+  Source = 'source',
   Bookmarks = 'bookmarks',
   SearchBookmarks = 'search-bookmarks',
 }

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -13,6 +13,7 @@ import { ReadHistoryInfiniteData } from '../hooks/useInfiniteReadingHistory';
 import { MainFeedPage } from '../components/utilities';
 
 export enum OtherFeedPage {
+  Tag = 'tag',
   Squad = 'squad',
   Source = 'source',
   Bookmarks = 'bookmarks',

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -14,7 +14,7 @@ import { ReadHistoryInfiniteData } from '../hooks/useInfiniteReadingHistory';
 export type MutateFunc<T> = (variables: T) => Promise<(() => void) | undefined>;
 
 export const generateQueryKey = (
-  name: string | RequestKey,
+  name: RequestKey,
   user: Pick<LoggedUser, 'id'> | null,
   ...additional: unknown[]
 ): unknown[] => {
@@ -34,6 +34,7 @@ export enum RequestKey {
   PostCommentsMutations = 'post_comments_mutations',
   Actions = 'actions',
   Squad = 'squad',
+  SquadMembers = 'squad_members',
   Search = 'search',
   SearchHistory = 'searchHistory',
   ReadingHistory = 'readingHistory',

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -33,6 +33,7 @@ import useFeedSettings from '@dailydotdev/shared/src/hooks/useFeedSettings';
 import useTagAndSource from '@dailydotdev/shared/src/hooks/useTagAndSource';
 import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
 import { ApiError } from '@dailydotdev/shared/src/graphql/common';
+import { OtherFeedPage } from '@dailydotdev/shared/src/lib/query';
 import Custom404 from '../404';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
@@ -115,7 +116,7 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
         </Button>
       </CustomFeedHeader>
       <Feed
-        feedName="source"
+        feedName={OtherFeedPage.Squad}
         feedQueryKey={[
           'sourceFeed',
           user?.id ?? 'anonymous',

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -14,8 +14,8 @@ import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { SquadPageHeader } from '@dailydotdev/shared/src/components/squads/SquadPageHeader';
 import { BaseFeedPage } from '@dailydotdev/shared/src/components/utilities';
 import {
-  SQUAD_STATIC_FIELDS_QUERY,
   getSquadMembers,
+  SQUAD_STATIC_FIELDS_QUERY,
 } from '@dailydotdev/shared/src/graphql/squads';
 import { SourceMember, Squad } from '@dailydotdev/shared/src/graphql/sources';
 import Unauthorized from '@dailydotdev/shared/src/components/errors/Unauthorized';
@@ -34,6 +34,7 @@ import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
 import { ApiError } from '@dailydotdev/shared/src/graphql/common';
 import { PublicProfile } from '@dailydotdev/shared/src/lib/user';
 import { GET_REFERRING_USER_QUERY } from '@dailydotdev/shared/src/graphql/users';
+import { OtherFeedPage } from '@dailydotdev/shared/src/lib/query';
 import { mainFeedLayoutProps } from '../../../components/layouts/MainFeedPage';
 import { getLayout } from '../../../components/layouts/FeedLayout';
 import ProtectedPage, {
@@ -193,7 +194,7 @@ const SquadPage = ({
         <SquadChecklistCard squad={squad} />
         <Feed
           className="px-6 pt-14 laptop:pt-10"
-          feedName="squad"
+          feedName={OtherFeedPage.Squad}
           feedQueryKey={[
             'sourceFeed',
             user?.id ?? 'anonymous',

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -29,6 +29,7 @@ import classNames from 'classnames';
 import useTagAndSource from '@dailydotdev/shared/src/hooks/useTagAndSource';
 import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
 import XIcon from '@dailydotdev/shared/src/components/icons/MiniClose';
+import { OtherFeedPage } from '@dailydotdev/shared/src/lib/query';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
 import { getLayout } from '../../components/layouts/FeedLayout';
@@ -150,7 +151,7 @@ const TagPage = ({ tag }: TagPageProps): ReactElement => {
         )}
       </CustomFeedHeader>
       <Feed
-        feedName="tag"
+        feedName={OtherFeedPage.Tag}
         feedQueryKey={[
           'tagFeed',
           user?.id ?? 'anonymous',


### PR DESCRIPTION
## Changes
- In the Squad members modal, we should allow search.
- Fixed the generate query key function to not accept any kind of string but a rather more strict typing.

Preview:
![Screenshot 2023-10-23 at 6 52 50 PM](https://github.com/dailydotdev/apps/assets/13744167/5e45515a-1cf2-4078-8658-21e9e69bfb37)
![Screenshot 2023-10-23 at 6 36 22 PM](https://github.com/dailydotdev/apps/assets/13744167/75d38325-f42e-40c5-8234-aa51d12a79de)
![Screenshot 2023-10-23 at 6 36 05 PM](https://github.com/dailydotdev/apps/assets/13744167/318400d5-e59f-44d3-ad99-d9fc4c045c9a)
![Screenshot 2023-10-23 at 6 53 25 PM](https://github.com/dailydotdev/apps/assets/13744167/1a06a501-717b-42f6-a305-6a54bc5716c4)



## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1815 #done
