### PR TITLE
fix: update TLDR treshold

### DIFF
--- a/packages/shared/src/components/cards/PostSummary.tsx
+++ b/packages/shared/src/components/cards/PostSummary.tsx
@@ -19,7 +19,7 @@ function PostSummary(
     <SummaryContainer ref={ref} {...props}>
       <ShowMoreContent
         content={summary}
-        charactersLimit={300}
+        charactersLimit={330}
         threshold={50}
         contentPrefix={<TLDRText>TLDR</TLDRText>}
       />

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -616,7 +616,7 @@ it('should toggle TLDR on click', async () => {
   renderPost({}, [
     createPostMock({
       summary:
-        "Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book type specimen book type specimen book type specimen book type.Ipsum is simply dummy text of the printing and typesetting industry.",
+        "Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book type specimen book type specimen book type specimen book type.Ipsum is simply dummy text of the printing and typesetting industry. book type.Ipsum is simply dummy text of the printing and typesetting industry.",
     }),
   ]);
   const el = await screen.findByText('TLDR');


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Update TLDR limit to 330.
- Discussion [here](https://dailydotdev.slack.com/archives/C01473UNK9C/p1698149739497239?thread_ts=1698131764.163069&cid=C01473UNK9C).

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
