### PR TITLE
fix: typo size on search referral button

### DIFF
--- a/packages/shared/src/components/referral/SearchReferralButton.tsx
+++ b/packages/shared/src/components/referral/SearchReferralButton.tsx
@@ -42,7 +42,7 @@ export function SearchReferralButton({
     <button
       type="button"
       className={classNames(
-        'flex flex-row items-center justify-center rounded-12 py-1 px-3 font-bold text-theme-label-tertiary bg-theme-overlay-from',
+        'flex flex-row items-center justify-center typo-callout rounded-12 py-1 px-3 font-bold text-theme-label-tertiary bg-theme-overlay-from',
         className,
       )}
       onClick={handleClick}


### PR DESCRIPTION
## Changes
- The right value should be typo-callout

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
