### PR TITLE
fix: prevent empty source list render

### DIFF
--- a/packages/shared/src/components/search/SearchSourceList.tsx
+++ b/packages/shared/src/components/search/SearchSourceList.tsx
@@ -29,6 +29,10 @@ export const SearchSourceList = ({
     limit: 3,
   });
 
+  if (!isLoading && !sources) {
+    return null;
+  }
+
   const handleSourceClick = (): void =>
     !sidebarRendered && setIsSourcesOpen((prev) => !prev);
 

--- a/packages/shared/src/components/search/SearchSourceList.tsx
+++ b/packages/shared/src/components/search/SearchSourceList.tsx
@@ -29,7 +29,7 @@ export const SearchSourceList = ({
     limit: 3,
   });
 
-  if (!isLoading && !sources) {
+  if (!isLoading && sources?.length === 0) {
     return null;
   }
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Prevent empty source render when done loading but sources still empty

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
