### PR TITLE
:lipstick: fix copy icon bg color

### DIFF
--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -106,13 +106,9 @@ export const SocialShare = ({
       <SocialShareContainer title="Share externally">
         <SocialShareIcon
           onClick={trackAndCopyLink}
-          pressed={copying}
           icon={
             <CopyIcon
-              className={classNames(
-                'text-theme-label-invert',
-                copying && 'text-theme-color-avocado',
-              )}
+              className={classNames('text-theme-label-invert')}
               secondary={copying}
             />
           }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- the Copy Button displays a dark background when pressed and on blur.
- removing the "pressed" property resolves the issue.

#### Before 
<img width="416" alt="Screenshot 2023-10-24 at 22 35 05" src="https://github.com/dailydotdev/apps/assets/1566127/4a94f31d-f401-4ae1-b471-6ef3c40748d2">

#### After 
<img width="413" alt="Screenshot 2023-10-24 at 22 35 25" src="https://github.com/dailydotdev/apps/assets/1566127/5a72ff62-900b-4661-b533-542351191d5e">

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
