### PR TITLE
fix: workaround to avoid eslint-disable

### DIFF
--- a/packages/shared/src/components/notifications/NotificationItem.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.tsx
@@ -9,6 +9,7 @@ import NotificationItemAttachment from './NotificationItemAttachment';
 import NotificationItemAvatar from './NotificationItemAvatar';
 import { notificationTypeTheme } from './utils';
 import OptionsButton from '../buttons/OptionsButton';
+import { KeyboardCommand } from '../../lib/element';
 
 export interface NotificationItemProps
   extends Pick<
@@ -78,7 +79,7 @@ function NotificationItem({
             data-testid="openNotification"
             tabIndex={0}
             onKeyDown={(e) => {
-              if (e.code === 'Space') {
+              if (e.code === KeyboardCommand.Space) {
                 onClick(e);
                 router.push(targetUrl);
               }

--- a/packages/shared/src/components/notifications/NotificationItem.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.tsx
@@ -1,6 +1,7 @@
-import React, { MouseEventHandler, ReactElement } from 'react';
+import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { Notification } from '../../graphql/notifications';
 import { useObjectPurify } from '../../hooks/useDomPurify';
 import NotificationItemIcon from './NotificationIcon';
@@ -16,7 +17,11 @@ export interface NotificationItemProps
   > {
   isUnread?: boolean;
   targetUrl: string;
-  onClick?: MouseEventHandler;
+  onClick?: (
+    e:
+      | React.MouseEvent<HTMLAnchorElement>
+      | React.KeyboardEvent<HTMLAnchorElement>,
+  ) => void;
   onOptionsClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
@@ -37,6 +42,7 @@ function NotificationItem({
     title: memoizedTitle,
     description: memoizedDescription,
   } = useObjectPurify({ title, description });
+  const router = useRouter();
 
   if (!isReady) {
     return null;
@@ -63,14 +69,24 @@ function NotificationItem({
     >
       {onClick && (
         <Link href={targetUrl} passHref>
-          {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/anchor-has-content, jsx-a11y/no-static-element-interactions */}
           <a
+            role="link"
             aria-label="Open notification"
             className="absolute inset-0 z-0"
             onClick={onClick}
             title="Open notification"
             data-testid="openNotification"
-          />
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.code === 'Space') {
+                onClick(e);
+                router.push(targetUrl);
+              }
+              return true;
+            }}
+          >
+            <span />
+          </a>
         </Link>
       )}
       {onOptionsClick && (

--- a/packages/shared/src/lib/element.ts
+++ b/packages/shared/src/lib/element.ts
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 
 export enum KeyboardCommand {
   Enter = 'Enter',
+  Space = 'Space',
 }
 
 export enum ArrowKey {


### PR DESCRIPTION
## Changes
- added tabIndex={0} and role="link" in order to avoid disabling eslint for `jsx-a11y/no-static-element-interactions`
- added empty <span/> tag in order to avoid disabling eslint for `jsx-a11y/anchor-has-content`
- added onKeyDown event to make the link be clicked and work with Spacebar as well (as it was working as a button) in order to avoid disabling eslint for `jsx-a11y/click-events-have-key-events`

### Describe what this PR does
- Cleans up code from eslint-disbales

## Events

Did you introduce any new tracking events? No

### **Please make sure existing components are not breaking/affected by this PR** ✅ 

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension? No
- [ ] Does this not break anything in companion? No

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices? No
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1891 #done
