### PR TITLE
fix: add stale time to avoid retriggers

### DIFF
--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -10,7 +10,7 @@ import { BootApp, BootCacheData, getBootData } from '../lib/boot';
 import { AuthContextProvider } from './AuthContext';
 import { AnonymousUser, LoggedUser } from '../lib/user';
 import { AlertContextProvider } from './AlertContext';
-import { generateQueryKey, RequestKey } from '../lib/query';
+import { generateQueryKey, RequestKey, STALE_TIME } from '../lib/query';
 import {
   applyTheme,
   SettingsContextProvider,
@@ -22,8 +22,6 @@ import { NotificationsContextProvider } from './NotificationsContext';
 import { BOOT_LOCAL_KEY, BOOT_QUERY_KEY } from './common';
 import { AnalyticsContextProvider } from './AnalyticsContext';
 import { GrowthBookProvider } from '../components/GrowthBookProvider';
-
-const STALE_TIME = 30 * 1000;
 
 function filteredProps<T extends Record<string, unknown>>(
   obj: T,

--- a/packages/shared/src/hooks/referral/useReferralCampaign.ts
+++ b/packages/shared/src/hooks/referral/useReferralCampaign.ts
@@ -3,7 +3,7 @@ import { useContext } from 'react';
 import { useRequestProtocol } from '../useRequestProtocol';
 import { REFERRAL_CAMPAIGN_QUERY } from '../../graphql/users';
 import { graphqlUrl } from '../../lib/config';
-import { RequestKey, generateQueryKey } from '../../lib/query';
+import { RequestKey, generateQueryKey, STALE_TIME } from '../../lib/query';
 import AuthContext from '../../contexts/AuthContext';
 import { feature, Feature } from '../../lib/featureManagement';
 import { useFeatureIsOn } from '../../components/GrowthBookProvider';
@@ -64,6 +64,7 @@ const useReferralCampaign = ({
     },
     {
       enabled: !!user?.id && !!isCampaignEnabled,
+      staleTime: STALE_TIME,
     },
   );
   const {

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -20,6 +20,8 @@ export enum OtherFeedPage {
   SearchBookmarks = 'search-bookmarks',
 }
 
+export const STALE_TIME = 30 * 1000;
+
 export type AllFeedPages = SharedFeedPage | OtherFeedPage;
 
 export type MutateFunc<T> = (variables: T) => Promise<(() => void) | undefined>;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since this hook has multiple trigger points it would execute multiple times and query multiple times
- I added our default short stale time to ensure this doesn't happen on the same render basically
- Since it's not a super urgent visual interface this should be more then enough

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
