### PR TITLE
fix: disable search suggestions query when search is not enabled

### DIFF
--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -116,7 +116,14 @@ export const FeedContainer = ({
     '--feed-gap': `${feedGapPx / 16}rem`,
   } as CSSProperties;
   const cardContainerStyle = { ...getStyle(isList, spaciness) };
-  const suggestionsProps = useSearchSuggestions({ origin: Origin.HomePage });
+  const isFinder = router.pathname === '/posts/finder';
+  const isV1Search =
+    searchValue === SearchExperiment.V1 && showSearch && !isFinder;
+
+  const suggestionsProps = useSearchSuggestions({
+    origin: Origin.HomePage,
+    disabled: !isV1Search,
+  });
   const isTracked = useRef(false);
   const shouldShowPulse =
     checkHasCompleted(ActionType.AcceptedSearch) &&
@@ -135,9 +142,6 @@ export const FeedContainer = ({
     return <></>;
   }
 
-  const isFinder = router.pathname === '/posts/finder';
-  const isV1Search =
-    searchValue === SearchExperiment.V1 && showSearch && !isFinder;
   const onSearch = (event: FormEvent, input: string) => {
     event.preventDefault();
     router.push(`${webappUrl}search?q=${encodeURIComponent(input)}`);

--- a/packages/shared/src/hooks/search/useSearchSuggestions.ts
+++ b/packages/shared/src/hooks/search/useSearchSuggestions.ts
@@ -8,17 +8,21 @@ import { disabledRefetch } from '../../lib/func';
 
 type UseSearchSuggestions = (data: {
   origin: SearchBarSuggestionListProps['origin'];
+  disabled?: boolean;
 }) => Pick<
   SearchBarSuggestionListProps,
   'origin' | 'suggestions' | 'isLoading'
 >;
 
-export const useSearchSuggestions: UseSearchSuggestions = (args) => {
+export const useSearchSuggestions: UseSearchSuggestions = ({
+  disabled,
+  ...args
+}) => {
   const { user } = useAuthContext();
   const { data, isLoading } = useQuery(
     generateQueryKey(RequestKey.SearchHistory, user),
     getSearchSuggestions,
-    { ...disabledRefetch, enabled: !!user },
+    { ...disabledRefetch, enabled: !disabled && !!user },
   );
 
   const suggestions = useMemo(


### PR DESCRIPTION
## Changes

- due to the usage of `useSearchSuggestions` in the main `FeedContainer`, this query was triggered regardless of wether the feature was enabled or not.
- adding a `disabled` argument which disables the query if `true`

## Events

N / A

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1786 #done
