### PR TITLE
chore: bump target to es6

### DIFF
--- a/packages/extension/tsconfig.jest.json
+++ b/packages/extension/tsconfig.jest.json
@@ -6,6 +6,6 @@
     "esModuleInterop": true,
     "noImplicitAny": true,
     "sourceMap": true,
-    "target": "es5"
+    "target": "es6"
   }
 }

--- a/packages/extension/tsconfig.json
+++ b/packages/extension/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": [
       "dom",
       "dom.iterable",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": [
       "dom",
       "dom.iterable",

--- a/packages/webapp/tsconfig.jest.json
+++ b/packages/webapp/tsconfig.jest.json
@@ -6,6 +6,6 @@
     "esModuleInterop": true,
     "noImplicitAny": true,
     "sourceMap": true,
-    "target": "es5"
+    "target": "es6"
   }
 }

--- a/packages/webapp/tsconfig.json
+++ b/packages/webapp/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
## Changes

### Describe what this PR does
- According to TS `es6` is a [good choice](https://www.typescriptlang.org/tsconfig#target) currently so let's pick this to have modern options, but not break to many things.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
