### PR TITLE
fix: convert header position from fixed to sticky on laptop

### DIFF
--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -146,7 +146,7 @@ function MainLayoutHeader({
   return (
     <header
       className={classNames(
-        'flex relative laptop:fixed laptop:left-0 z-header flex-row laptop:flex-row justify-between items-center py-3 px-4 tablet:px-8 laptop:px-4 laptop:w-full h-14 border-b bg-theme-bg-primary border-theme-divider-tertiary',
+        'flex relative laptop:sticky laptop:left-0 z-header flex-row laptop:flex-row justify-between items-center py-3 px-4 tablet:px-8 laptop:px-4 laptop:w-full h-14 border-b bg-theme-bg-primary border-theme-divider-tertiary',
         hasBanner ? 'laptop:top-8' : 'laptop:top-0',
       )}
     >


### PR DESCRIPTION
## Changes
- changes header position from fixed to sticky

### Describe what this PR does
- Fixes bug that makes the header buttons move when overflow changes.
- Changing header from fixed to sticky fixes the issue because in sticky position of header is defined from parent. 

## Events

Did you introduce any new tracking events? No

### **Please make sure existing components are not breaking/affected by this PR**

Working solution video:

https://github.com/dailydotdev/apps/assets/36197304/e6ae9914-2de9-4211-b7c7-e2f9c98a5996

Video with issue present: 

https://github.com/dailydotdev/apps/assets/36197304/2bae2d1e-a192-432f-97d7-2ccd1652a349

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-901 #done
