### PR TITLE
fix: remove padding on main, and adjust banner padding

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -222,7 +222,7 @@ function MainLayout({
           'flex flex-row',
           className,
           !showOnlyLogo && !screenCentered && mainLayoutClass(sidebarExpanded),
-          isBannerAvailable ? 'laptop:pt-8' : '',
+          isBannerAvailable && 'laptop:pt-8',
         )}
       >
         {renderSidebar()}

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -222,7 +222,7 @@ function MainLayout({
           'flex flex-row',
           className,
           !showOnlyLogo && !screenCentered && mainLayoutClass(sidebarExpanded),
-          isBannerAvailable ? 'laptop:pt-22' : 'laptop:pt-14',
+          isBannerAvailable ? 'laptop:pt-8' : '',
         )}
       >
         {renderSidebar()}


### PR DESCRIPTION

## Changes
- fix padding on main since header is now set to sticky

Before:
<img width="1458" alt="Screenshot 2023-10-27 at 1 55 21 PM" src="https://github.com/dailydotdev/apps/assets/36197304/a20298f5-455d-4687-981e-0b8028a8eb47">

After
<img width="1460" alt="Screenshot 2023-10-27 at 1 54 52 PM" src="https://github.com/dailydotdev/apps/assets/36197304/ef433cc8-319a-4a6b-b375-89f5ab91b4b2">

### Describe what this PR does
- remove padding on main

## Events

Did you introduce any new tracking events? No

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-901 #done
