### PR TITLE
fix: add views to shared object so it's uniform

### DIFF
--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -80,6 +80,7 @@ export const SHARED_POST_INFO_FRAGMENT = gql`
     upvoted
     commented
     bookmarked
+    views
     numUpvotes
     numComments
     scout {

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -157,7 +157,6 @@ export const POST_BY_ID_QUERY = gql`
     post(id: $id) {
       ...SharedPostInfo
       trending
-      views
       content
       contentHtml
       sharedPost {
@@ -481,7 +480,6 @@ export const EDIT_POST_MUTATION = gql`
     editPost(id: $id, title: $title, content: $content, image: $image) {
       ...SharedPostInfo
       trending
-      views
       content
       contentHtml
       source {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Mentioned by Nimrod he couldn't see views on his own post.
- After checking it turns out it doesn't show views inside a modal, but it does on the article page.
- This is due to different queries having/not having the data requested.
- I decided to uniform views in our post shared object so it will be always available

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1877 #done
