### PR TITLE
fix: remove max height from changelog popup

### DIFF
--- a/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
@@ -99,7 +99,7 @@ function ChangelogTooltip({
       <InteractivePopup
         {...props}
         position={InteractivePopupPosition.MainFeedLeftEnd}
-        className="ml-6 border shadow-2 focus:outline-none w-[24rem] max-w-[360px] max-h-[466px] bg-theme-bg-tertiary border-theme-color-cabbage"
+        className="ml-6 border shadow-2 focus:outline-none w-[24rem] max-w-[360px] bg-theme-bg-tertiary border-theme-color-cabbage"
         data-testid="changelog"
       >
         <header className="flex flex-1 items-center py-3 px-4 border-b border-theme-divider-tertiary">


### PR DESCRIPTION
## Changes

- remove max height from ChangelogTooltip component

### Describe what this PR does
- Fixes broken render of the ChangelogTooltip component that cuts off elements in the card if the text is long. 

Before:
![image](https://github.com/dailydotdev/apps/assets/36197304/292e9cbd-c310-48c7-a487-a25e8502f343)

After:
<img width="1549" alt="Screenshot 2023-10-27 at 5 00 12 PM" src="https://github.com/dailydotdev/apps/assets/36197304/c0d49082-c6a7-430a-815d-de6fb9adfb90">


## Events

Did you introduce any new tracking events? No

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

