### PR TITLE
fix: remove the `'` from version parameter

### DIFF
--- a/packages/webapp/next.config.js
+++ b/packages/webapp/next.config.js
@@ -63,7 +63,7 @@ module.exports = withTM(
           return config;
         },
         env: {
-          CURRENT_VERSION: `'${version}'`,
+          CURRENT_VERSION: version,
         },
         rewrites: () => [
           {


### PR DESCRIPTION
## Changes

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/a112491b-e6b9-4c57-beab-dd1dd357e38d" />
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/52d924a5-4131-486a-8ab9-b4f88ad27c3a" />
</table>

### Describe what this PR does
- Removes the extra `'` that is wrapping around the version parameter in webapp
  This was only needed in extension when defining a plugin

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
