### PR TITLE
fix: set `#__next` `min-height` to be `100vh`/`-webkit-fill-available`

### DIFF
--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -337,6 +337,8 @@ html.light .invert .invert,
   position: relative;
   flex-direction: column;
   align-items: stretch;
+  min-height: -webkit-fill-available;
+  min-height: 100vh;
 }
 
 img.lazyload:not([src]) {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Set the min-height on the #__next element

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
