### PR TITLE
fix: email title for sharing invite

### DIFF
--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -91,6 +91,7 @@ export const SocialShare = ({
           onCopy={trackAndCopyLink}
           onNativeShare={() => openNativeSharePost(post)}
           onClickSocial={trackClick}
+          emailTitle="I found this amazing post"
         />
       </SocialShareContainer>
     </>

--- a/packages/shared/src/components/widgets/SocialShareList.tsx
+++ b/packages/shared/src/components/widgets/SocialShareList.tsx
@@ -25,6 +25,7 @@ import { IconSize } from '../Icon';
 interface SocialShareListProps {
   link: string;
   description: string;
+  emailTitle?: string;
   isCopying?: boolean;
   onCopy?(): void;
   onNativeShare(): void;
@@ -33,6 +34,7 @@ interface SocialShareListProps {
 
 export function SocialShareList({
   link,
+  emailTitle,
   description,
   isCopying,
   onCopy,
@@ -97,7 +99,7 @@ export function SocialShareList({
         label="Telegram"
       />
       <SocialShareIcon
-        href={getEmailShareLink(link, 'I found this amazing post')}
+        href={getEmailShareLink(link, emailTitle ?? description)}
         icon={<MailIcon />}
         className="bg-theme-bg-email"
         onClick={() => onClickSocial(ShareProvider.Email)}


### PR DESCRIPTION
## Changes
- Fix the title when sharing through email.
- The title for invite will utilize the same description we added.
- Fixed the email title to be passed from props. Hence, updated the implementation of sharing post.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
