### PR TITLE
feat: generic referral campaign analytics

### DIFF
--- a/packages/shared/src/components/modals/referral/GenericReferralModal.tsx
+++ b/packages/shared/src/components/modals/referral/GenericReferralModal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { Modal, ModalProps } from '../common/Modal';
 import { cloudinary } from '../../../lib/image';
 import CloseButton from '../../CloseButton';
@@ -17,8 +17,9 @@ import TwitterIcon from '../../icons/Twitter';
 import { useShareOrCopyLink } from '../../../hooks/useShareOrCopyLink';
 import { link } from '../../../lib/links';
 import { labels } from '../../../lib';
-import { AnalyticsEvent, TargetId } from '../../../lib/analytics';
+import { AnalyticsEvent, TargetId, TargetType } from '../../../lib/analytics';
 import { ReferralCampaignKey, useReferralCampaign } from '../../../hooks';
+import { useAnalyticsContext } from '../../../contexts/AnalyticsContext';
 
 function GenericReferralModal({
   onRequestClose,
@@ -37,10 +38,18 @@ function GenericReferralModal({
       target_id: TargetId.GenericReferralPopup,
     }),
   });
+  const { trackEvent } = useAnalyticsContext();
   const onShareClick = () => {
     onShareOrCopyLink();
     setShareState(true);
   };
+
+  useEffect(() => {
+    trackEvent({
+      event_name: AnalyticsEvent.Impression,
+      target_type: TargetType.ReferralPopup,
+    });
+  }, [trackEvent]);
 
   return (
     <Modal {...props} onRequestClose={onRequestClose} size={ModalSize.Small}>

--- a/packages/shared/src/components/modals/referral/GenericReferralModal.tsx
+++ b/packages/shared/src/components/modals/referral/GenericReferralModal.tsx
@@ -49,7 +49,10 @@ function GenericReferralModal({
       event_name: AnalyticsEvent.Impression,
       target_type: TargetType.ReferralPopup,
     });
-  }, [trackEvent]);
+
+    // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Modal {...props} onRequestClose={onRequestClose} size={ModalSize.Small}>

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -117,7 +117,7 @@ export enum AnalyticsEvent {
   CreateFeed = 'create feed',
   // Referral campaign
   CopyReferralLink = 'copy referral link',
-  ShareReferral = 'share referral',
+  InviteReferral = 'invite referral',
 }
 
 export enum FeedItemTitle {

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -107,6 +107,7 @@ export enum AnalyticsEvent {
   CloseInvitationPopup = 'close invitation popup',
   ErrorSearch = 'error search',
   AcceptInvitation = 'accept invitation',
+  DownloadExtension = 'download extension',
   SearchHighlightAnimation = 'highlight search',
   // search end
   RequestContentScripts = 'request content scripts',
@@ -116,6 +117,7 @@ export enum AnalyticsEvent {
   CreateFeed = 'create feed',
   // Referral campaign
   CopyReferralLink = 'copy referral link',
+  ShareReferral = 'share referral',
 }
 
 export enum FeedItemTitle {
@@ -135,6 +137,8 @@ export enum TargetType {
   SearchSource = 'search source',
   SearchInviteButton = 'search invite button',
   HideInviteCheckbox = 'hide invite mechanism',
+  ReferralPopup = 'referral popup',
+  InviteFriendsPage = 'invite friends page',
 }
 
 export enum TargetId {
@@ -143,6 +147,7 @@ export enum TargetId {
   InviteProfileMenu = 'invite in profile menu',
   // Referral campaign
   GenericReferralPopup = 'generic referral popup',
+  InviteFriendsPage = 'invite friends page',
 }
 
 export enum NotificationChannel {

--- a/packages/webapp/components/invite/Referral.tsx
+++ b/packages/webapp/components/invite/Referral.tsx
@@ -29,8 +29,6 @@ export function Referral({
   const { isLoggedIn } = useAuthContext();
 
   const handleAcceptClick = () => {
-    // since in the page view, query params are tracked automatically,
-    // we don't need to send the params here explicitly
     trackEvent({ event_name: AnalyticsEvent.DownloadExtension });
   };
 

--- a/packages/webapp/components/invite/Referral.tsx
+++ b/packages/webapp/components/invite/Referral.tsx
@@ -31,7 +31,7 @@ export function Referral({
   const handleAcceptClick = () => {
     // since in the page view, query params are tracked automatically,
     // we don't need to send the params here explicitly
-    trackEvent({ event_name: AnalyticsEvent.AcceptInvitation });
+    trackEvent({ event_name: AnalyticsEvent.DownloadExtension });
   };
 
   useEffect(() => {

--- a/packages/webapp/pages/account/invite.tsx
+++ b/packages/webapp/pages/account/invite.tsx
@@ -82,7 +82,7 @@ const AccountInvitePage = (): ReactElement => {
 
   const onTrackShare = (provider: ShareProvider) => {
     trackEvent({
-      event_name: AnalyticsEvent.ShareReferral,
+      event_name: AnalyticsEvent.InviteReferral,
       target_id: provider,
       target_type: TargetType.InviteFriendsPage,
     });

--- a/packages/webapp/pages/account/invite.tsx
+++ b/packages/webapp/pages/account/invite.tsx
@@ -23,11 +23,18 @@ import UserList from '@dailydotdev/shared/src/components/profile/UserList';
 import { checkFetchMore } from '@dailydotdev/shared/src/components/containers/InfiniteScrolling';
 import { ReferredUsersData } from '@dailydotdev/shared/src/graphql/common';
 import { SocialShareList } from '@dailydotdev/shared/src/components/widgets/SocialShareList';
-import { useCopyLink } from '@dailydotdev/shared/src/hooks/useCopy';
 import { Separator } from '@dailydotdev/shared/src/components/cards/common';
 import { UserShortProfile } from '@dailydotdev/shared/src/lib/user';
 import { format } from 'date-fns';
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
+import { useAnalyticsContext } from '@dailydotdev/shared/src/contexts/AnalyticsContext';
+import {
+  AnalyticsEvent,
+  TargetId,
+  TargetType,
+} from '@dailydotdev/shared/src/lib/analytics';
+import { ShareProvider } from '@dailydotdev/shared/src/lib/share';
+import { useShareOrCopyLink } from '@dailydotdev/shared/src/hooks/useShareOrCopyLink';
 import AccountContentSection from '../../components/layouts/AccountLayout/AccountContentSection';
 import { AccountPageContainer } from '../../components/layouts/AccountLayout/AccountPageContainer';
 import { getAccountLayout } from '../../components/layouts/AccountLayout';
@@ -40,8 +47,16 @@ const AccountInvitePage = (): ReactElement => {
   const { url, referredUsersCount } = useReferralCampaign({
     campaignKey: ReferralCampaignKey.Generic,
   });
+  const { trackEvent } = useAnalyticsContext();
   const inviteLink = url || link.referral.defaultUrl;
-  const [copyingLink, onCopyLink] = useCopyLink(() => inviteLink);
+  const [copyingLink, onShareOrCopyLink] = useShareOrCopyLink({
+    text: labels.referral.generic.inviteText,
+    link: inviteLink,
+    trackObject: () => ({
+      event_name: AnalyticsEvent.CopyReferralLink,
+      target_id: TargetId.InviteFriendsPage,
+    }),
+  });
   const usersResult = useInfiniteQuery<ReferredUsersData>(
     referredKey,
     ({ pageParam }) =>
@@ -65,15 +80,12 @@ const AccountInvitePage = (): ReactElement => {
     return list;
   }, [usersResult]);
 
-  const onNativeShare = async () => {
-    await navigator.share({
-      title: labels.referral.generic.inviteText,
-      url: inviteLink,
+  const onTrackShare = (provider: ShareProvider) => {
+    trackEvent({
+      event_name: AnalyticsEvent.ShareReferral,
+      target_id: provider,
+      target_type: TargetType.InviteFriendsPage,
     });
-  };
-
-  const onTrackShare = () => {
-    // add tracking here
   };
 
   return (
@@ -90,7 +102,7 @@ const AccountInvitePage = (): ReactElement => {
           <Button
             buttonSize={ButtonSize.Small}
             className="btn-primary"
-            onClick={() => onCopyLink()}
+            onClick={() => onShareOrCopyLink()}
           >
             {copyingLink ? 'Copying...' : 'Copy link'}
           </Button>
@@ -104,7 +116,7 @@ const AccountInvitePage = (): ReactElement => {
         <SocialShareList
           link={inviteLink}
           description={labels.referral.generic.inviteText}
-          onNativeShare={onNativeShare}
+          onNativeShare={onShareOrCopyLink}
           onClickSocial={onTrackShare}
         />
       </div>


### PR DESCRIPTION
~~Blocked: once the profile page changes is ready, I will update this PR for the relevant tracking events.~~
We will apply the proper analytics on the profile page widget on its own PR.

## Changes
- Impression when the Generic Referral Popup is seen by the user.
  - The copy link button has its built-in tracking and already added the required properties.
- Invite page
  - Same copy referral event like the popup but with a different value for the target id
  - On social share click, we send an event
- The Generic Referral Page should have an event of `download extension` instead of `accept invitation`.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1931 #done
