### PR TITLE
fix: introduce dirty flag to prevent initial content after initial value

### DIFF
--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -8,6 +8,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { useQuery } from 'react-query';
@@ -97,6 +98,7 @@ export const useMarkdownInput = ({
   initialContent = '',
   enabledCommand = {},
 }: UseMarkdownInputProps): UseMarkdownInput => {
+  const dirtyRef = useRef(false);
   const textarea = textareaRef?.current;
   const isLinkEnabled = enabledCommand[MarkdownCommand.Link];
   const isUploadEnabled = enabledCommand[MarkdownCommand.Upload];
@@ -112,12 +114,20 @@ export const useMarkdownInput = ({
   const { displayToast } = useToastNotification();
 
   useEffect(() => {
+    if (dirtyRef.current) {
+      return;
+    }
+
     if (input?.length === 0 && initialContent?.length > 0) {
       setInput(initialContent);
     }
   }, [input, initialContent]);
 
   const onUpdate = (value: string) => {
+    if (!dirtyRef.current) {
+      dirtyRef.current = true;
+    }
+
     setInput(value);
     if (onValueUpdate) {
       onValueUpdate(value);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Initial content was again set when input was cleared because of the useEffect check
- added dirty flag to only do it once and allow user to clear the draft input

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1937 #done
