### PR TITLE
fix: new post button should show everywhere

### DIFF
--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -96,7 +96,6 @@ export default function MainFeedPage({
     <MainLayout
       greeting
       mainPage
-      showPostButton
       isNavItemsButton
       activePage={activePage}
       onLogoClick={onLogoClick}

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -71,7 +71,6 @@ function MainLayout({
   onNavTabClick,
   enableSearch,
   onShowDndClick,
-  showPostButton,
 }: MainLayoutProps): ReactElement {
   const { trackEvent } = useContext(AnalyticsContext);
   const { user, isAuthReady } = useAuthContext();
@@ -194,7 +193,6 @@ function MainLayout({
         additionalButtons={additionalButtons}
         onLogoClick={onLogoClick}
         onMobileSidebarToggle={onMobileSidebarToggle}
-        showPostButton={showPostButton}
       />
       <main
         className={classNames(

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -38,7 +38,6 @@ export interface MainLayoutHeaderProps extends ShouldShowLogoProps {
   showOnlyLogo?: boolean;
   optOutWeeklyGoal?: boolean;
   additionalButtons?: ReactNode;
-  showPostButton?: boolean;
   onLogoClick?: (e: React.MouseEvent) => unknown;
   onMobileSidebarToggle: (state: boolean) => unknown;
 }
@@ -55,7 +54,6 @@ function MainLayoutHeader({
   hasBanner,
   mobileTitle,
   showOnlyLogo,
-  showPostButton,
   sidebarRendered,
   optOutWeeklyGoal,
   additionalButtons,
@@ -96,14 +94,12 @@ function MainLayoutHeader({
   const renderButtons = () => {
     return (
       <>
-        {showPostButton && (
-          <CreatePostButton
-            className={classNames(
-              'mr-0 laptop:mr-4',
-              optOutWeeklyGoal ? 'tablet:mr-0' : 'tablet:mr-4',
-            )}
-          />
-        )}
+        <CreatePostButton
+          className={classNames(
+            'mr-0 laptop:mr-4',
+            optOutWeeklyGoal ? 'tablet:mr-0' : 'tablet:mr-4',
+          )}
+        />
         {!hideButton && user && (
           <>
             {sidebarRendered && <SearchReferralButton className="mr-3" />}

--- a/packages/webapp/components/layouts/FeedLayout.tsx
+++ b/packages/webapp/components/layouts/FeedLayout.tsx
@@ -17,7 +17,7 @@ export const getLayout = (
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const router = useRouter();
   return getFooterNavBarLayout(
-    <MainLayout {...layoutProps} showPostButton activePage={router?.asPath}>
+    <MainLayout {...layoutProps} activePage={router?.asPath}>
       <FeedLayout>{page}</FeedLayout>
     </MainLayout>,
   );


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The new post should be stable in the header across the app.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1954 #done
