### PR TITLE
fix: missing close button on profile menu mobile

### DIFF
--- a/packages/shared/src/components/tooltips/InteractivePopup.tsx
+++ b/packages/shared/src/components/tooltips/InteractivePopup.tsx
@@ -5,6 +5,8 @@ import { useSettingsContext } from '../../contexts/SettingsContext';
 import useSidebarRendered from '../../hooks/useSidebarRendered';
 import ConditionalWrapper from '../ConditionalWrapper';
 import useWindowEvents from '../../hooks/useWindowEvents';
+import { Button, ButtonSize } from '../buttons/Button';
+import CloseIcon from '../icons/MiniClose';
 
 export enum InteractivePopupPosition {
   Center = 'center',
@@ -25,6 +27,7 @@ interface InteractivePopupProps {
   className?: string;
   position?: InteractivePopupPosition;
   closeOutsideClick?: boolean;
+  alwaysShowClose?: boolean;
   onClose?: (e: MouseEvent | KeyboardEvent | MessageEvent) => void;
 }
 
@@ -61,6 +64,7 @@ function InteractivePopup({
   className,
   position = InteractivePopupPosition.Center,
   closeOutsideClick,
+  alwaysShowClose,
   onClose,
   ...props
 }: InteractivePopupProps): ReactElement {
@@ -107,6 +111,15 @@ function InteractivePopup({
           )}
           {...props}
         >
+          {(!sidebarRendered || alwaysShowClose) && (
+            <Button
+              buttonSize={ButtonSize.Small}
+              className="top-2 right-2 z-1 btn-secondary"
+              position="absolute"
+              icon={<CloseIcon />}
+              onClick={(e: React.MouseEvent) => onClose(e.nativeEvent)}
+            />
+          )}
           {children}
         </div>
       </ConditionalWrapper>

--- a/packages/shared/src/components/tooltips/InteractivePopup.tsx
+++ b/packages/shared/src/components/tooltips/InteractivePopup.tsx
@@ -7,6 +7,7 @@ import ConditionalWrapper from '../ConditionalWrapper';
 import useWindowEvents from '../../hooks/useWindowEvents';
 import { Button, ButtonSize } from '../buttons/Button';
 import CloseIcon from '../icons/MiniClose';
+import { isNullOrUndefined } from '../../lib/func';
 
 export enum InteractivePopupPosition {
   Center = 'center',
@@ -27,7 +28,6 @@ interface InteractivePopupProps {
   className?: string;
   position?: InteractivePopupPosition;
   closeOutsideClick?: boolean;
-  alwaysShowClose?: boolean;
   onClose?: (e: MouseEvent | KeyboardEvent | MessageEvent) => void;
 }
 
@@ -64,7 +64,6 @@ function InteractivePopup({
   className,
   position = InteractivePopupPosition.Center,
   closeOutsideClick,
-  alwaysShowClose,
   onClose,
   ...props
 }: InteractivePopupProps): ReactElement {
@@ -81,7 +80,10 @@ function InteractivePopup({
     'click',
     'click',
     (e: MessageEvent) => {
-      if (!container.current.contains(e.target as Node)) {
+      if (
+        !isNullOrUndefined(container.current) &&
+        !container.current.contains(e.target as Node)
+      ) {
         onCloseRef.current(e);
       }
     },
@@ -111,7 +113,7 @@ function InteractivePopup({
           )}
           {...props}
         >
-          {(!sidebarRendered || alwaysShowClose) && (
+          {finalPosition !== InteractivePopupPosition.ProfileMenu && (
             <Button
               buttonSize={ButtonSize.Small}
               className="top-2 right-2 z-1 btn-secondary"


### PR DESCRIPTION
## Changes
- Interactive popup should show the close button on mobile or when the user decides to always show it, similar to Squad Checklist.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1958 #done
