### PR TITLE
fix: copy link buttons to just copy the link

### DIFF
--- a/packages/shared/src/components/modals/referral/GenericReferralModal.tsx
+++ b/packages/shared/src/components/modals/referral/GenericReferralModal.tsx
@@ -3,15 +3,13 @@ import { Modal, ModalProps } from '../common/Modal';
 import { cloudinary } from '../../../lib/image';
 import CloseButton from '../../CloseButton';
 import { ModalSize } from '../common/types';
-import { Button, ButtonSize } from '../../buttons/Button';
-import { TextField } from '../../fields/TextField';
-import { useShareOrCopyLink } from '../../../hooks/useShareOrCopyLink';
+import { ButtonSize } from '../../buttons/Button';
 import { link } from '../../../lib/links';
-import { labels } from '../../../lib';
 import { AnalyticsEvent, TargetId, TargetType } from '../../../lib/analytics';
 import { ReferralCampaignKey, useReferralCampaign } from '../../../hooks';
 import ReferralSocialShareButtons from '../../widgets/ReferralSocialShareButtons';
 import { useAnalyticsContext } from '../../../contexts/AnalyticsContext';
+import { InviteLinkInput } from '../../referral/InviteLinkInput';
 
 function GenericReferralModal({
   onRequestClose,
@@ -22,19 +20,7 @@ function GenericReferralModal({
     campaignKey: ReferralCampaignKey.Generic,
   });
   const inviteLink = url || link.referral.defaultUrl;
-  const [copyingLink, onShareOrCopyLink] = useShareOrCopyLink({
-    text: labels.referral.generic.inviteText,
-    link: inviteLink,
-    trackObject: () => ({
-      event_name: AnalyticsEvent.CopyReferralLink,
-      target_id: TargetId.GenericReferralPopup,
-    }),
-  });
   const { trackEvent } = useAnalyticsContext();
-  const onShareClick = () => {
-    onShareOrCopyLink();
-    setShareState(true);
-  };
 
   useEffect(() => {
     trackEvent({
@@ -68,24 +54,10 @@ function GenericReferralModal({
           alt={!shareState ? 'CTO Ido looking sad' : 'CTO Ido looking happy'}
           className="object-cover absolute top-0 left-0 z-0 w-full aspect-square"
         />
-        <TextField
-          name="inviteURL"
-          inputId="inviteURL"
-          label="Your unique invite URL"
-          type="url"
-          autoComplete="off"
-          value={inviteLink}
-          fieldType="tertiary"
-          actionButton={
-            <Button
-              buttonSize={ButtonSize.Small}
-              className="btn-primary"
-              onClick={onShareClick}
-            >
-              Copy link {!copyingLink ? '😀' : '😉'}
-            </Button>
-          }
-          readOnly
+        <InviteLinkInput
+          targetId={TargetId.GenericReferralPopup}
+          link={inviteLink}
+          onCopy={() => setShareState(true)}
         />
         <div className="flex gap-3 justify-center items-center mt-7">
           <p className="mr-1 typo-callout text-theme-label-tertiary">

--- a/packages/shared/src/components/referral/InviteLinkInput.tsx
+++ b/packages/shared/src/components/referral/InviteLinkInput.tsx
@@ -1,0 +1,70 @@
+import React, { ReactElement } from 'react';
+import { Button, ButtonSize } from '../buttons/Button';
+import { TextField } from '../fields/TextField';
+import { AnalyticsEvent, TargetId } from '../../lib/analytics';
+import { useCopyLink } from '../../hooks/useCopy';
+import { useAnalyticsContext } from '../../contexts/AnalyticsContext';
+import { FieldClassName } from '../fields/BaseFieldContainer';
+
+interface InviteLinkInputProps {
+  targetId: TargetId;
+  link: string;
+  copyingText?: string;
+  onCopy?: () => void;
+  className?: FieldClassName;
+}
+
+export function InviteLinkInput({
+  link,
+  targetId,
+  copyingText,
+  onCopy,
+  className,
+}: InviteLinkInputProps): ReactElement {
+  const [copying, onCopyLink] = useCopyLink(() => link);
+  const { trackEvent } = useAnalyticsContext();
+  const onCopyClick = () => {
+    onCopyLink();
+    trackEvent({
+      event_name: AnalyticsEvent.CopyReferralLink,
+      target_id: targetId,
+    });
+
+    if (onCopy) {
+      onCopy();
+    }
+  };
+
+  const renderText = () => {
+    const copy = 'Copy link';
+
+    if (copyingText) {
+      return copying ? copyingText : copy;
+    }
+
+    return `${copy} ${copying ? '😀' : '😉'}`;
+  };
+
+  return (
+    <TextField
+      className={className}
+      name="inviteURL"
+      inputId="inviteURL"
+      label="Your unique invite URL"
+      type="url"
+      autoComplete="off"
+      value={link}
+      fieldType="tertiary"
+      actionButton={
+        <Button
+          buttonSize={ButtonSize.Small}
+          className="btn-primary"
+          onClick={onCopyClick}
+        >
+          {renderText()}
+        </Button>
+      }
+      readOnly
+    />
+  );
+}

--- a/packages/shared/src/components/widgets/ReferralWidget.tsx
+++ b/packages/shared/src/components/widgets/ReferralWidget.tsx
@@ -1,22 +1,11 @@
 import React, { ReactElement } from 'react';
-import { Button, ButtonSize } from '../buttons/Button';
-import { TextField } from '../fields/TextField';
 import { link } from '../../lib/links';
-import { useShareOrCopyLink } from '../../hooks/useShareOrCopyLink';
-import { labels } from '../../lib';
-import { AnalyticsEvent, TargetId, TargetType } from '../../lib/analytics';
+import { TargetId, TargetType } from '../../lib/analytics';
 import ReferralSocialShareButtons from './ReferralSocialShareButtons';
+import { InviteLinkInput } from '../referral/InviteLinkInput';
 
 const ReferralWidget = ({ url }: { url: string }): ReactElement => {
   const inviteLink = url || link.referral.defaultUrl;
-  const [, onShareOrCopyLink] = useShareOrCopyLink({
-    text: labels.referral.generic.inviteText,
-    link: inviteLink,
-    trackObject: () => ({
-      event_name: AnalyticsEvent.CopyReferralLink,
-      target_id: TargetId.ProfilePage,
-    }),
-  });
 
   return (
     <div
@@ -28,28 +17,14 @@ const ReferralWidget = ({ url }: { url: string }): ReactElement => {
         Tell your dev friends how easy is it to learn, collaborate, and grow
         together
       </p>
-      <TextField
-        name="inviteURL"
-        inputId="inviteURL"
-        label="Your unique invite URL"
-        autoComplete="off"
-        type="url"
-        value={inviteLink}
-        fieldType="tertiary"
+      <InviteLinkInput
+        targetId={TargetId.ProfilePage}
+        link={inviteLink}
+        copyingText="Copying..."
         className={{
           input: 'typo-footnote',
           container: 'flex flex-col my-5 w-auto tablet:w-70',
         }}
-        actionButton={
-          <Button
-            buttonSize={ButtonSize.XSmall}
-            className="btn-primary"
-            onClick={() => onShareOrCopyLink()}
-          >
-            Copy link
-          </Button>
-        }
-        readOnly
       />
       <div className="flex justify-between items-center">
         <p className="mr-3 typo-callout text-theme-label-tertiary">

--- a/packages/webapp/pages/account/invite.tsx
+++ b/packages/webapp/pages/account/invite.tsx
@@ -1,14 +1,9 @@
 import React, { ReactElement, useMemo, useRef } from 'react';
-import { TextField } from '@dailydotdev/shared/src/components/fields/TextField';
 import {
   ReferralCampaignKey,
   useReferralCampaign,
 } from '@dailydotdev/shared/src/hooks';
 import { link } from '@dailydotdev/shared/src/lib/links';
-import {
-  Button,
-  ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
 import { labels } from '@dailydotdev/shared/src/lib';
 import {
   generateQueryKey,
@@ -35,6 +30,7 @@ import {
 } from '@dailydotdev/shared/src/lib/analytics';
 import { ShareProvider } from '@dailydotdev/shared/src/lib/share';
 import { useShareOrCopyLink } from '@dailydotdev/shared/src/hooks/useShareOrCopyLink';
+import { InviteLinkInput } from '@dailydotdev/shared/src/components/referral/InviteLinkInput';
 import AccountContentSection from '../../components/layouts/AccountLayout/AccountContentSection';
 import { AccountPageContainer } from '../../components/layouts/AccountLayout/AccountPageContainer';
 import { getAccountLayout } from '../../components/layouts/AccountLayout';
@@ -49,7 +45,7 @@ const AccountInvitePage = (): ReactElement => {
   });
   const { trackEvent } = useAnalyticsContext();
   const inviteLink = url || link.referral.defaultUrl;
-  const [copyingLink, onShareOrCopyLink] = useShareOrCopyLink({
+  const [, onShareOrCopyLink] = useShareOrCopyLink({
     text: labels.referral.generic.inviteText,
     link: inviteLink,
     trackObject: () => ({
@@ -90,24 +86,10 @@ const AccountInvitePage = (): ReactElement => {
 
   return (
     <AccountPageContainer title="Invite friends">
-      <TextField
-        name="inviteURL"
-        inputId="inviteURL"
-        label="Your unique invite URL"
-        type="url"
-        autoComplete="off"
-        value={inviteLink}
-        fieldType="tertiary"
-        actionButton={
-          <Button
-            buttonSize={ButtonSize.Small}
-            className="btn-primary"
-            onClick={() => onShareOrCopyLink()}
-          >
-            {copyingLink ? 'Copying...' : 'Copy link'}
-          </Button>
-        }
-        readOnly
+      <InviteLinkInput
+        targetId={TargetId.InviteFriendsPage}
+        link={inviteLink}
+        copyingText="Copying..."
       />
       <span className="p-0.5 my-4 font-bold typo-callout text-theme-label-tertiary">
         or invite with


### PR DESCRIPTION
## Changes
- Create a common component for copying link with input.
- The button should only copy link, nothing else, regardless of platform, OS, browser.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1959 #done
