### PR TITLE
fix: spacing between social share buttons

### DIFF
--- a/packages/webapp/pages/account/invite.tsx
+++ b/packages/webapp/pages/account/invite.tsx
@@ -94,7 +94,7 @@ const AccountInvitePage = (): ReactElement => {
       <span className="p-0.5 my-4 font-bold typo-callout text-theme-label-tertiary">
         or invite with
       </span>
-      <div className="flex flex-row flex-wrap gap-4">
+      <div className="flex flex-row flex-wrap gap-2 gap-y-4">
         <SocialShareList
           link={inviteLink}
           description={labels.referral.generic.inviteText}


### PR DESCRIPTION
## Changes
- From the discussion in Slack, we will adjust the spacing between the buttons.
![Screenshot 2023-11-15 at 4 08 43 PM](https://github.com/dailydotdev/apps/assets/13744167/373ed617-6fa5-4257-a8c4-767a0af2cea0)

Preview:
![Screenshot 2023-11-15 at 4 09 27 PM](https://github.com/dailydotdev/apps/assets/13744167/5116ab20-2a26-4a52-b066-2d79317c8105)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1971 #done
