### PR TITLE
fix: referral join page copy

### DIFF
--- a/packages/webapp/components/invite/Referral.tsx
+++ b/packages/webapp/components/invite/Referral.tsx
@@ -70,8 +70,8 @@ export function Referral({
         <p className="mx-auto laptop:mx-0 mt-7 tablet:mt-8 max-w-sm laptopL:max-w-xl text-center laptop:text-left typo-title3 text-theme-label-tertiary">
           We know how hard it is to be a developer. It doesn’t have to be.
           Personalized news feed, dev communities and search, much better than
-          what’s out there. Maybe 😉
-          <span className="tablet:block laptopL:inline">Stay up to date.</span>
+          what’s out there. Maybe 😉.
+          <span className="tablet:block laptopL:inline"> Stay up to date.</span>
         </p>
         <Button
           buttonSize={ButtonSize.Large}


### PR DESCRIPTION
## Changes
- Add a dot and a space in between the message.

Preview:

![Screenshot 2023-11-15 at 6 52 57 PM](https://github.com/dailydotdev/apps/assets/13744167/a4f31848-65d4-4e20-b921-013b75898fa0)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
