### PR TITLE
fix: format k number with fraction

### DIFF
--- a/packages/shared/src/components/squads/SquadMemberShortList.tsx
+++ b/packages/shared/src/components/squads/SquadMemberShortList.tsx
@@ -13,6 +13,10 @@ export interface SquadMemberShortListProps {
   className?: string;
 }
 
+function kFormatter(num: number): string | number {
+  return Math.abs(num) > 999 ? `${(num / 1000).toFixed(1)}K` : num;
+}
+
 function SquadMemberShortList({
   squad,
   members,
@@ -43,9 +47,7 @@ function SquadMemberShortList({
           className="mr-1 ml-2 min-w-[1rem]"
           aria-label="squad-members-count"
         >
-          {squad.membersCount >= 1000
-            ? `${Math.floor(squad.membersCount / 1000)}K`
-            : squad.membersCount}
+          {kFormatter(squad.membersCount)}
         </span>
         {members?.slice(0, sidebarRendered ? 5 : 3).map(({ user }) => (
           <ProfilePicture


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Nimrod requested we show the squad numbers with 1 fraction as we never imagined to go over these thousand numbers before.

Example:
![Screenshot 2023-11-15 at 14 54 00](https://github.com/dailydotdev/apps/assets/554874/3cfab963-e18d-4d0a-817b-9e0a2cfc1ddb)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
