### PR TITLE
fix: should not show close button

### DIFF
--- a/packages/shared/src/components/tooltips/InteractivePopup.tsx
+++ b/packages/shared/src/components/tooltips/InteractivePopup.tsx
@@ -82,7 +82,8 @@ function InteractivePopup({
     (e: MessageEvent) => {
       if (
         !isNullOrUndefined(container.current) &&
-        !container.current.contains(e.target as Node)
+        !container.current.contains(e.target as Node) &&
+        onCloseRef.current
       ) {
         onCloseRef.current(e);
       }
@@ -113,15 +114,16 @@ function InteractivePopup({
           )}
           {...props}
         >
-          {finalPosition !== InteractivePopupPosition.ProfileMenu && (
-            <Button
-              buttonSize={ButtonSize.Small}
-              className="top-2 right-2 z-1 btn-secondary"
-              position="absolute"
-              icon={<CloseIcon />}
-              onClick={(e: React.MouseEvent) => onClose(e.nativeEvent)}
-            />
-          )}
+          {finalPosition !== InteractivePopupPosition.ProfileMenu &&
+            onClose && (
+              <Button
+                buttonSize={ButtonSize.Small}
+                className="top-2 right-2 z-1 btn-secondary"
+                position="absolute"
+                icon={<CloseIcon />}
+                onClick={(e: React.MouseEvent) => onClose(e.nativeEvent)}
+              />
+            )}
           {children}
         </div>
       </ConditionalWrapper>


### PR DESCRIPTION
## Changes
- When the onClose property is null or undefined we should not show the close button as it would not do anything.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
