### PR TITLE
fix: changelog button and close on update click

### DIFF
--- a/packages/shared/src/components/tooltips/ChangelogTooltip.spec.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.spec.tsx
@@ -89,6 +89,17 @@ describe('ChangelogTooltip component', () => {
     );
   };
 
+  const mockGraphQLUpdateAlerts = () =>
+    mockGraphQL({
+      request: {
+        query: UPDATE_ALERTS,
+        variables: { data: { lastChangelog: /.*/ } },
+      },
+      result: () => ({
+        data: { data: { lastChangelog: new Date().toISOString() } },
+      }),
+    });
+
   it('should render', async () => {
     const client = new QueryClient();
     client.setQueryData(['changelog', 'anonymous', 'latest-post'], defaultPost);
@@ -181,15 +192,7 @@ describe('ChangelogTooltip component', () => {
 
     process.env.TARGET_BROWSER = 'chrome';
 
-    mockGraphQL({
-      request: {
-        query: UPDATE_ALERTS,
-        variables: { data: { lastChangelog: /.*/ } },
-      },
-      result: () => ({
-        data: { data: { lastChangelog: new Date().toISOString() } },
-      }),
-    });
+    mockGraphQLUpdateAlerts();
 
     renderComponent({ client });
     await screen.findByTestId('changelog');
@@ -219,15 +222,7 @@ describe('ChangelogTooltip component', () => {
     const client = new QueryClient();
     client.setQueryData(['changelog', 'anonymous', 'latest-post'], defaultPost);
 
-    mockGraphQL({
-      request: {
-        query: UPDATE_ALERTS,
-        variables: { data: { lastChangelog: /.*/ } },
-      },
-      result: () => ({
-        data: { data: { lastChangelog: new Date().toISOString() } },
-      }),
-    });
+    mockGraphQLUpdateAlerts();
 
     renderComponent({ client });
     await screen.findByTestId('changelog');
@@ -247,15 +242,7 @@ describe('ChangelogTooltip component', () => {
     const client = new QueryClient();
     client.setQueryData(['changelog', 'anonymous', 'latest-post'], defaultPost);
 
-    mockGraphQL({
-      request: {
-        query: UPDATE_ALERTS,
-        variables: { data: { lastChangelog: /.*/ } },
-      },
-      result: () => ({
-        data: { data: { lastChangelog: new Date().toISOString() } },
-      }),
-    });
+    mockGraphQLUpdateAlerts();
 
     renderComponent({ client });
     await screen.findByTestId('changelog');
@@ -274,15 +261,7 @@ describe('ChangelogTooltip component', () => {
   it('should link to blog post on firefox', async () => {
     const client = new QueryClient();
     client.setQueryData(['changelog', 'anonymous', 'latest-post'], defaultPost);
-    mockGraphQL({
-      request: {
-        query: UPDATE_ALERTS,
-        variables: { data: { lastChangelog: /.*/ } },
-      },
-      result: () => ({
-        data: { data: { lastChangelog: new Date().toISOString() } },
-      }),
-    });
+    mockGraphQLUpdateAlerts();
 
     process.env.TARGET_BROWSER = 'firefox';
 
@@ -312,15 +291,7 @@ describe('ChangelogTooltip component', () => {
 
     process.env.TARGET_BROWSER = 'chrome';
 
-    mockGraphQL({
-      request: {
-        query: UPDATE_ALERTS,
-        variables: { data: { lastChangelog: /.*/ } },
-      },
-      result: () => ({
-        data: { data: { lastChangelog: new Date().toISOString() } },
-      }),
-    });
+    mockGraphQLUpdateAlerts();
 
     renderComponent({ client });
     await screen.findByTestId('changelog');
@@ -348,15 +319,7 @@ describe('ChangelogTooltip component', () => {
     const client = new QueryClient();
     client.setQueryData(['changelog', 'anonymous', 'latest-post'], defaultPost);
 
-    mockGraphQL({
-      request: {
-        query: UPDATE_ALERTS,
-        variables: { data: { lastChangelog: /.*/ } },
-      },
-      result: () => ({
-        data: { data: { lastChangelog: new Date().toISOString() } },
-      }),
-    });
+    mockGraphQLUpdateAlerts();
     process.env.TARGET_BROWSER = 'chrome';
 
     renderComponent({ client });
@@ -385,15 +348,7 @@ describe('ChangelogTooltip component', () => {
     const client = new QueryClient();
     client.setQueryData(['changelog', 'anonymous', 'latest-post'], defaultPost);
 
-    mockGraphQL({
-      request: {
-        query: UPDATE_ALERTS,
-        variables: { data: { lastChangelog: /.*/ } },
-      },
-      result: () => ({
-        data: { data: { lastChangelog: new Date().toISOString() } },
-      }),
-    });
+    mockGraphQLUpdateAlerts();
 
     renderComponent({ client });
     await screen.findByTestId('changelog');

--- a/packages/shared/src/components/tooltips/ChangelogTooltip.spec.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.spec.tsx
@@ -101,7 +101,7 @@ describe('ChangelogTooltip component', () => {
     expect(changelogNewReleaseTag).toBeInTheDocument();
 
     const changelogModalClose = await screen.findByTestId(
-      'changelogModalClose',
+      'close-interactive-popup',
     );
     expect(changelogModalClose).toBeInTheDocument();
 
@@ -181,6 +181,16 @@ describe('ChangelogTooltip component', () => {
 
     process.env.TARGET_BROWSER = 'chrome';
 
+    mockGraphQL({
+      request: {
+        query: UPDATE_ALERTS,
+        variables: { data: { lastChangelog: /.*/ } },
+      },
+      result: () => ({
+        data: { data: { lastChangelog: new Date().toISOString() } },
+      }),
+    });
+
     renderComponent({ client });
     await screen.findByTestId('changelog');
 
@@ -190,6 +200,7 @@ describe('ChangelogTooltip component', () => {
       );
       fireEvent.click(changelogExtensionBtn);
       await new Promise(process.nextTick);
+      await waitForNock();
     });
 
     expect(
@@ -199,6 +210,7 @@ describe('ChangelogTooltip component', () => {
     expect(mockSendMessageFn).toHaveBeenCalledWith({
       type: ExtensionMessageType.RequestUpdate,
     });
+    expect(updateAlerts).toHaveBeenCalled();
 
     delete process.env.TARGET_BROWSER;
   });
@@ -250,7 +262,7 @@ describe('ChangelogTooltip component', () => {
 
     await act(async () => {
       const changelogModalClose = await screen.findByTestId(
-        'changelogModalClose',
+        'close-interactive-popup',
       );
       fireEvent.click(changelogModalClose);
       await waitForNock();
@@ -262,6 +274,15 @@ describe('ChangelogTooltip component', () => {
   it('should link to blog post on firefox', async () => {
     const client = new QueryClient();
     client.setQueryData(['changelog', 'anonymous', 'latest-post'], defaultPost);
+    mockGraphQL({
+      request: {
+        query: UPDATE_ALERTS,
+        variables: { data: { lastChangelog: /.*/ } },
+      },
+      result: () => ({
+        data: { data: { lastChangelog: new Date().toISOString() } },
+      }),
+    });
 
     process.env.TARGET_BROWSER = 'firefox';
 
@@ -275,6 +296,7 @@ describe('ChangelogTooltip component', () => {
     await act(async () => {
       fireEvent.click(changelogExtensionBtn);
       await new Promise(process.nextTick);
+      await waitForNock();
     });
 
     expect(mockSendMessageFn).not.toHaveBeenCalled();
@@ -290,6 +312,16 @@ describe('ChangelogTooltip component', () => {
 
     process.env.TARGET_BROWSER = 'chrome';
 
+    mockGraphQL({
+      request: {
+        query: UPDATE_ALERTS,
+        variables: { data: { lastChangelog: /.*/ } },
+      },
+      result: () => ({
+        data: { data: { lastChangelog: new Date().toISOString() } },
+      }),
+    });
+
     renderComponent({ client });
     await screen.findByTestId('changelog');
 
@@ -302,6 +334,7 @@ describe('ChangelogTooltip component', () => {
     await act(async () => {
       fireEvent.click(changelogExtensionBtn);
       await new Promise(process.nextTick);
+      await waitForNock();
     });
 
     expect(
@@ -315,6 +348,15 @@ describe('ChangelogTooltip component', () => {
     const client = new QueryClient();
     client.setQueryData(['changelog', 'anonymous', 'latest-post'], defaultPost);
 
+    mockGraphQL({
+      request: {
+        query: UPDATE_ALERTS,
+        variables: { data: { lastChangelog: /.*/ } },
+      },
+      result: () => ({
+        data: { data: { lastChangelog: new Date().toISOString() } },
+      }),
+    });
     process.env.TARGET_BROWSER = 'chrome';
 
     renderComponent({ client });
@@ -329,6 +371,7 @@ describe('ChangelogTooltip component', () => {
     await act(async () => {
       fireEvent.click(changelogExtensionBtn);
       await new Promise(process.nextTick);
+      await waitForNock();
     });
 
     expect(

--- a/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement } from 'react';
 import { useMutation } from 'react-query';
 import { Button, ButtonSize } from '../buttons/Button';
-import { ModalClose } from '../modals/common/ModalClose';
 import { cloudinary } from '../../lib/image';
 import { postDateFormat } from '../../lib/dateFormat';
 import { Image } from '../image/Image';
@@ -18,10 +17,6 @@ import InteractivePopup, { InteractivePopupPosition } from './InteractivePopup';
 import { Origin } from '../../lib/analytics';
 import { QuaternaryButton } from '../buttons/QuaternaryButton';
 
-interface ChangelogTooltipProps {
-  onRequestClose?: (e?: React.MouseEvent | React.KeyboardEvent) => void;
-}
-
 const toastMessageMap = {
   error: 'Something went wrong, try again later',
   throttled: 'There is no extension update available, try again later',
@@ -30,10 +25,7 @@ const toastMessageMap = {
   update_available: 'Browser extension updated 🎉',
 };
 
-function ChangelogTooltip({
-  onRequestClose,
-  ...props
-}: ChangelogTooltipProps): ReactElement {
+function ChangelogTooltip(): ReactElement {
   const isExtension = checkIsExtension();
   const isFirefoxExtension = process.env.TARGET_BROWSER === 'firefox';
   const {
@@ -78,16 +70,9 @@ function ChangelogTooltip({
       },
     );
 
-  const onModalCloseClick = async (event) => {
-    if (typeof onRequestClose === 'function') {
-      onRequestClose(event);
-    }
-
-    await dismissChangelog();
-  };
-
   const onExtensionUpdateClick = async () => {
     await updateExtension();
+    await dismissChangelog();
   };
 
   const onToggleUpvote = async () => {
@@ -97,10 +82,11 @@ function ChangelogTooltip({
   return (
     !!post && (
       <InteractivePopup
-        {...props}
         position={InteractivePopupPosition.LeftEnd}
         className="ml-6 border shadow-2 focus:outline-none w-[24rem] max-w-[360px] bg-theme-bg-tertiary border-theme-color-cabbage"
         data-testid="changelog"
+        onClose={dismissChangelog}
+        closeButtonTypeClassname="btn-tertiary"
       >
         <header className="flex flex-1 items-center py-3 px-4 border-b border-theme-divider-tertiary">
           <h3
@@ -109,12 +95,6 @@ function ChangelogTooltip({
           >
             New release
           </h3>
-          <ModalClose
-            className="right-4"
-            onClick={onModalCloseClick}
-            data-testid="changelogModalClose"
-            buttonSize={ButtonSize.XSmall}
-          />
         </header>
         <section className="flex flex-col flex-1 p-5 h-full shrink max-h-full">
           <Image
@@ -183,7 +163,7 @@ function ChangelogTooltip({
             </QuaternaryButton>
           </div>
         </section>
-        <footer className="flex gap-3 justify-between items-center py-3 px-4 w-full h-16 border-t border-theme-divider-tertiary">
+        <footer className="flex justify-between items-center p-3 w-full h-16 border-t border-theme-divider-tertiary">
           <Button
             className="btn-tertiary"
             onClick={dismissChangelog}

--- a/packages/shared/src/components/tooltips/InteractivePopup.tsx
+++ b/packages/shared/src/components/tooltips/InteractivePopup.tsx
@@ -29,6 +29,7 @@ interface InteractivePopupProps {
   position?: InteractivePopupPosition;
   closeOutsideClick?: boolean;
   onClose?: (e: MouseEvent | KeyboardEvent | MessageEvent) => void;
+  closeButtonTypeClassname?: 'btn-secondary' | 'btn-tertiary';
 }
 
 const centerClassX = 'left-1/2 -translate-x-1/2';
@@ -65,6 +66,7 @@ function InteractivePopup({
   position = InteractivePopupPosition.Center,
   closeOutsideClick,
   onClose,
+  closeButtonTypeClassname = 'btn-secondary',
   ...props
 }: InteractivePopupProps): ReactElement {
   const container = useRef<HTMLDivElement>();
@@ -118,10 +120,14 @@ function InteractivePopup({
             onClose && (
               <Button
                 buttonSize={ButtonSize.Small}
-                className="top-2 right-2 z-1 btn-secondary"
+                className={classNames(
+                  'top-2 right-2 z-1',
+                  closeButtonTypeClassname,
+                )}
                 position="absolute"
                 icon={<CloseIcon />}
                 onClick={(e: React.MouseEvent) => onClose(e.nativeEvent)}
+                data-testid="close-interactive-popup"
               />
             )}
           {children}


### PR DESCRIPTION
## Changes
- removed modal close an duse instead the close of interactive popup
- updated interactive popup close button to accept different button types
- removed all unused props fro changelog component
- Fixed spaces in update extension button

### Describe what this PR does
This PR fixes issues reported at: https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1700121692463069

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

Video from extension:

https://github.com/dailydotdev/apps/assets/36197304/f9fd6d39-6991-49ce-a47d-e07b8086a7b7

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices? No
- [ ] iOS (Chrome and Safari)
- [ ] Android

