### PR TITLE
fix: mobile search evaluation for InteractivePopup

### DIFF
--- a/packages/shared/src/components/search/MobileSearch.tsx
+++ b/packages/shared/src/components/search/MobileSearch.tsx
@@ -64,7 +64,7 @@ export function MobileSearch({
         alt="Gradient background"
       />
       <form className="flex flex-col" onSubmit={onSubmitForm}>
-        <span className="flex z-1 flex-row gap-4 px-2">
+        <span className="flex z-1 flex-row gap-4 px-2 mr-2">
           <CloseButton
             type="button"
             onClick={(event) => onClose(event, input)}

--- a/packages/shared/src/components/tooltips/InteractivePopup.tsx
+++ b/packages/shared/src/components/tooltips/InteractivePopup.tsx
@@ -72,8 +72,10 @@ function InteractivePopup({
   const container = useRef<HTMLDivElement>();
   const onCloseRef = useRef(onClose);
   const { sidebarRendered } = useSidebarRendered();
+  const validateSidebar =
+    sidebarRendered || position === InteractivePopupPosition.Screen;
   const { sidebarExpanded } = useSettingsContext();
-  const finalPosition = sidebarRendered
+  const finalPosition = validateSidebar
     ? position
     : InteractivePopupPosition.Center;
   const classes = positionClass[finalPosition];
@@ -90,13 +92,13 @@ function InteractivePopup({
         onCloseRef.current(e);
       }
     },
-    { enabled: closeOutsideClick || !sidebarRendered, validateKey: false },
+    { enabled: closeOutsideClick || !validateSidebar, validateKey: false },
   );
 
   return (
     <Portal>
       <ConditionalWrapper
-        condition={!sidebarRendered}
+        condition={!validateSidebar}
         wrapper={(child) => (
           <div className="flex fixed inset-0 z-modal flex-col items-center bg-overlay-quaternary-onion">
             {child}
@@ -109,7 +111,7 @@ function InteractivePopup({
             'fixed z-popup bg-theme-bg-primary rounded-16 overflow-hidden shadow-2',
             className,
             classes,
-            !sidebarRendered && 'shadow-2',
+            !validateSidebar && 'shadow-2',
             leftPositions.includes(finalPosition) &&
               !sidebarExpanded &&
               'laptop:left-16',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fix for the interactive popup to not show the wrapper if position is screen (meaning full size already)

![Screenshot 2023-11-20 at 09 20 27](https://github.com/dailydotdev/apps/assets/554874/fbe82367-5490-47f5-8ec1-a7d8adf6a2c8)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1955 #done
