### PR TITLE
fix(tools): exclude searching in dist and node_modules in the VS Code workspace

### DIFF
--- a/.vscode/apps.code-workspace
+++ b/.vscode/apps.code-workspace
@@ -18,6 +18,11 @@
     "editor.quickSuggestions": {
       "strings": true
     },
+    "search.exclude": {
+      "**/node_modules": true,
+      "**/dist": true,
+      "**/.next": true,
+    },
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": true
     },


### PR DESCRIPTION
## Changes

Excludes searching from the dist or node_modules directories.

Always annoyed me when I tried to search for something, and VS Code would also show me lots of results from the compiled code from the `dist` directory for extension or `.next` for webapp.

This just sets the setting for the workspace to exclude searching in those directories.
