### PR TITLE
fix: disallow non-existing rank indexes to be returned by `getRank`

### DIFF
--- a/packages/shared/src/lib/rank.ts
+++ b/packages/shared/src/lib/rank.ts
@@ -104,15 +104,13 @@ interface GetNextRankTextProps {
 }
 
 export const getRank = (rank: number): number => {
-  if (rank < 0) {
-    return 0;
-  }
+  const computedRank = Math.max(0, rank - 1);
 
-  if (rank >= RANKS.length) {
+  if (computedRank >= RANKS.length) {
     return RANKS.length - 1;
   }
 
-  return rank;
+  return computedRank;
 };
 
 export const getNextRankText = ({

--- a/packages/shared/src/lib/rank.ts
+++ b/packages/shared/src/lib/rank.ts
@@ -104,7 +104,15 @@ interface GetNextRankTextProps {
 }
 
 export const getRank = (rank: number): number => {
-  return rank === 0 ? rank : rank - 1;
+  if (rank < 0) {
+    return 0;
+  }
+
+  if (rank >= RANKS.length) {
+    return RANKS.length - 1;
+  }
+
+  return rank;
 };
 
 export const getNextRankText = ({


### PR DESCRIPTION
- may be part of the issues causing some users to experience authentication issues - as per slack thread: https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1700645470832879

## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
