### PR TITLE
fix: encode the email passed in query params

### DIFF
--- a/packages/shared/src/lib/kratos.ts
+++ b/packages/shared/src/lib/kratos.ts
@@ -246,8 +246,9 @@ export const getKratosError = async (id: string): Promise<ErrorData> => {
 export const checkKratosEmail = async (
   email: string,
 ): Promise<KratosEmailData> => {
-  const params = new URLSearchParams({ email_address: email });
-  const res = await fetch(`${heimdallUrl}/api/check_email?${params}`, {
+  const url = new URL(`${heimdallUrl}/api/check_email`);
+  url.searchParams.append('email_address', email);
+  const res = await fetch(url.toString(), {
     method: 'POST',
   });
   return res.json();

--- a/packages/shared/src/lib/kratos.ts
+++ b/packages/shared/src/lib/kratos.ts
@@ -246,12 +246,10 @@ export const getKratosError = async (id: string): Promise<ErrorData> => {
 export const checkKratosEmail = async (
   email: string,
 ): Promise<KratosEmailData> => {
-  const res = await fetch(
-    `${heimdallUrl}/api/check_email?email_address=${email}`,
-    {
-      method: 'POST',
-    },
-  );
+  const params = new URLSearchParams({ email_address: email });
+  const res = await fetch(`${heimdallUrl}/api/check_email?${params}`, {
+    method: 'POST',
+  });
   return res.json();
 };
 


### PR DESCRIPTION
- covers more complex addresses such as alias email addresses

## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
