### PR TITLE
fix: gitpod env variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,4 +70,4 @@ services:
       - JWT_PUBLIC_KEY_PATH=/opt/app/.cert/public.pem
       - JWT_PRIVATE_KEY_PATH=/opt/app/.cert/key.pem
       - GROWTHBOOK_CLIENT_KEY='local'
-      - MOCK_USER_ID='testuser'
+      - MOCK_USER_ID=testuser


### PR DESCRIPTION
## Changes
- After verifying from GitPod's end, it seems the apostrophe is not needed.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
