### PR TITLE
fix: tooltip request overload

### DIFF
--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -12,7 +12,7 @@ import AuthContext from '../contexts/AuthContext';
 import { graphqlUrl } from '../lib/config';
 import { LoggedUser } from '../lib/user';
 import { disabledRefetch } from '../lib/func';
-import { FEED_SETTINGS_STALE_TIME } from '../lib/query';
+import { StaleTime } from '../lib/query';
 
 export const getFeedSettingsQueryKey = (user?: LoggedUser): string[] => [
   user?.id,
@@ -48,7 +48,7 @@ export default function useFeedSettings({
     {
       ...disabledRefetch,
       enabled: enabled && !!user,
-      staleTime: FEED_SETTINGS_STALE_TIME,
+      staleTime: StaleTime.FeedSettings,
     },
   );
 

--- a/packages/shared/src/hooks/useProfileTooltip.ts
+++ b/packages/shared/src/hooks/useProfileTooltip.ts
@@ -8,7 +8,7 @@ import {
 } from '../graphql/users';
 import { graphqlUrl } from '../lib/config';
 import { useRequestProtocol } from './useRequestProtocol';
-import { STALE_TIME } from '../lib/query';
+import { StaleTime } from '../lib/query';
 
 export type UserTooltipContentData = {
   rank: UserReadingRank;
@@ -48,7 +48,7 @@ export const useProfileTooltip = ({
         { requestKey: JSON.stringify(key) },
       ),
     {
-      staleTime: STALE_TIME,
+      staleTime: StaleTime.Tooltip,
       refetchOnWindowFocus: false,
       enabled: shouldFetch && !!userId,
       onSettled: () => setShouldFetch(false),

--- a/packages/shared/src/hooks/useProfileTooltip.ts
+++ b/packages/shared/src/hooks/useProfileTooltip.ts
@@ -8,6 +8,7 @@ import {
 } from '../graphql/users';
 import { graphqlUrl } from '../lib/config';
 import { useRequestProtocol } from './useRequestProtocol';
+import { STALE_TIME } from '../lib/query';
 
 export type UserTooltipContentData = {
   rank: UserReadingRank;
@@ -47,6 +48,7 @@ export const useProfileTooltip = ({
         { requestKey: JSON.stringify(key) },
       ),
     {
+      staleTime: STALE_TIME,
       refetchOnWindowFocus: false,
       enabled: shouldFetch && !!userId,
       onSettled: () => setShouldFetch(false),

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -22,8 +22,14 @@ export enum OtherFeedPage {
 }
 
 const ONE_MINUTE = 60 * 1000;
+const THIRTY_MINUTES = ONE_MINUTE * 30;
 export const STALE_TIME = 30 * 1000;
-export const FEED_SETTINGS_STALE_TIME = ONE_MINUTE;
+
+export enum StaleTime {
+  FeedSettings = ONE_MINUTE,
+  Tooltip = THIRTY_MINUTES,
+  Base = STALE_TIME,
+}
 
 export type AllFeedPages = SharedFeedPage | OtherFeedPage;
 


### PR DESCRIPTION
## Changes
We have a feature that when you hovers on a user profile image/name/handle, it would send a request to our server to fetch the user information. While doing so, every in and out of the cursor triggers the process, which means it would trigger the fetch again as well. By setting a stale time, we can avoid sending the request which data does not change very often. Users hardly update their user information once set, so setting a stale time of 30 minutes should be reasonable. Watch the network requests before and after on the section below: https://dailydotdev.atlassian.net/wiki/spaces/HAN/pages/691339518/Managing+GraphQL+loads#Profile-tooltip-sending-requests-on-every-hover

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
