### PR TITLE
fix: media hooks evals

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -272,14 +272,14 @@ export default function MainFeedLayout({
   }, [sortingEnabled, selectedAlgo, loadedSettings, loadedAlgo]);
 
   const isMobile = useViewSize(ViewSize.MobileL);
-  const isTablet = useViewSize(ViewSize.Tablet);
+  const isLaptop = useViewSize(ViewSize.Laptop);
 
   const getImage = () => {
     if (isMobile) {
       return cloudinary.feed.bg.mobile;
     }
 
-    return isTablet ? cloudinary.feed.bg.tablet : cloudinary.feed.bg.laptop;
+    return isLaptop ? cloudinary.feed.bg.laptop : cloudinary.feed.bg.tablet;
   };
 
   return (

--- a/packages/shared/src/components/onboarding/OnboardingHeader.tsx
+++ b/packages/shared/src/components/onboarding/OnboardingHeader.tsx
@@ -26,14 +26,14 @@ export const OnboardingHeader = ({
 }: OnboardingHeaderProps): ReactElement => {
   const onboardingV4 = useFeature(feature.onboardingV4);
   const isMobile = useViewSize(ViewSize.MobileL);
-  const isTablet = useViewSize(ViewSize.Tablet);
+  const isLaptop = useViewSize(ViewSize.Laptop);
 
   const getImage = () => {
     if (isMobile) {
       return cloudinary.feed.bg.mobile;
     }
 
-    return isTablet ? cloudinary.feed.bg.tablet : cloudinary.feed.bg.laptop;
+    return isLaptop ? cloudinary.feed.bg.laptop : cloudinary.feed.bg.tablet;
   };
 
   if (isFiltering && onboardingV4 === OnboardingV4.V4) {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Old implementations where other way around, so decided to fix it as they showed wrong.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
