### PR TITLE
refactor: query for editing comments

### DIFF
--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -14,6 +14,7 @@ import { Squad } from '../../graphql/sources';
 import { Comment } from '../../graphql/comments';
 import usePersistentContext from '../../hooks/usePersistentContext';
 import { SQUAD_COMMENT_JOIN_BANNER_KEY } from '../../graphql/squads';
+import { useCommentEdit } from '../../hooks/post/useCommentEdit';
 
 export interface MainCommentProps
   extends Omit<CommentBoxProps, 'onEdit' | 'onComment'> {
@@ -55,30 +56,32 @@ export default function MainComment({
     !props.post.source?.currentMember &&
     !isJoinSquadBannerDismissed;
 
-  const { replyComment, inputProps, onReplyTo } = useComments(props.post);
-  const {
-    replyComment: editComment,
-    inputProps: editProps,
-    onReplyTo: onEdit,
-  } = useComments(props.post);
+  const { commentId, inputProps, onReplyTo } = useComments(props.post);
+  const { inputProps: editProps, onEdit } = useCommentEdit();
 
   return (
     <section
       className="flex flex-col items-stretch rounded-24 border border-theme-divider-tertiary scroll-mt-16"
       data-testid="comment"
     >
-      {!editComment && (
+      {!editProps && (
         <CommentBox
           {...props}
           comment={comment}
           parentId={comment.id}
           className={{ container: 'border-b' }}
           appendTooltipTo={appendTooltipTo}
-          onComment={(selected, parentId) => onReplyTo([selected, parentId])}
-          onEdit={(selected) => onEdit([selected, null, true])}
+          onComment={(selected, parentId) =>
+            onReplyTo({
+              username: selected.author.username,
+              parentCommentId: parentId,
+              commentId: selected.id,
+            })
+          }
+          onEdit={(selected) => onEdit({ commentId: selected.id })}
         />
       )}
-      {editComment && (
+      {editProps && (
         <CommentMarkdownInput
           {...editProps}
           post={props.post}
@@ -89,7 +92,7 @@ export default function MainComment({
           className={className}
         />
       )}
-      {replyComment?.id === comment.id && (
+      {commentId === comment.id && (
         <CommentMarkdownInput
           {...inputProps}
           post={props.post}

--- a/packages/shared/src/components/comments/SubComment.tsx
+++ b/packages/shared/src/components/comments/SubComment.tsx
@@ -6,6 +6,7 @@ import {
   CommentMarkdownInputProps,
 } from '../fields/MarkdownInput/CommentMarkdownInput';
 import { useComments } from '../../hooks/post';
+import { useCommentEdit } from '../../hooks/post/useCommentEdit';
 
 export interface SubCommentProps
   extends Omit<CommentBoxProps, 'onEdit' | 'onComment'> {
@@ -20,24 +21,31 @@ function SubComment({
   onCommented,
   ...props
 }: SubCommentProps): ReactElement {
-  const { replyComment, onReplyTo, inputProps } = useComments(props.post);
-  const {
-    replyComment: editComment,
-    inputProps: editProps,
-    onReplyTo: onEdit,
-  } = useComments(props.post);
+  const { inputProps, commentId, onReplyTo } = useComments(props.post);
+  const { inputProps: editProps, onEdit } = useCommentEdit();
 
   return (
     <>
-      {!editComment && (
+      {!editProps && (
         <CommentBox
           {...props}
           key={comment.id}
           parentId={parentComment.id}
           comment={comment}
-          onEdit={(selected) => onEdit([selected, parentComment.id, true])}
+          onEdit={(selected) =>
+            onEdit({
+              commentId: selected.id,
+              parentCommentId: parentComment.id,
+            })
+          }
           className={{ container: 'relative', content: 'ml-14' }}
-          onComment={(selected, parent) => onReplyTo([comment, parent])}
+          onComment={(selected, parent) =>
+            onReplyTo({
+              username: comment.author.username,
+              parentCommentId: parent,
+              commentId: selected.id,
+            })
+          }
         >
           <div
             className="absolute top-0 bottom-0 left-9 -ml-px w-0.5 bg-theme-float"
@@ -45,7 +53,7 @@ function SubComment({
           />
         </CommentBox>
       )}
-      {editComment && (
+      {editProps && (
         <CommentMarkdownInput
           {...editProps}
           post={props.post}
@@ -56,7 +64,7 @@ function SubComment({
           className={className}
         />
       )}
-      {replyComment?.id === comment.id && (
+      {commentId === comment.id && (
         <CommentMarkdownInput
           {...inputProps}
           className={className}

--- a/packages/shared/src/graphql/comments.ts
+++ b/packages/shared/src/graphql/comments.ts
@@ -27,7 +27,7 @@ export type Scout = Author;
 export interface Comment {
   __typename?: string;
   id: string;
-  content: string;
+  content?: string;
   contentHtml: string;
   createdAt: string;
   lastUpdatedAt?: string;
@@ -212,3 +212,12 @@ export const deleteComment = (
     id,
   });
 };
+
+export const COMMENT_BY_ID_QUERY = gql`
+  query Comment($id: ID!) {
+    comment(id: $id) {
+      id
+      content
+    }
+  }
+`;

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -113,7 +113,6 @@ export const SHARED_POST_INFO_FRAGMENT = gql`
 export const COMMENT_FRAGMENT = gql`
   fragment CommentFragment on Comment {
     id
-    content
     contentHtml
     createdAt
     lastUpdatedAt

--- a/packages/shared/src/hooks/post/common.ts
+++ b/packages/shared/src/hooks/post/common.ts
@@ -1,0 +1,10 @@
+import { CommentMarkdownInputProps } from '../../components/fields/MarkdownInput/CommentMarkdownInput';
+
+export interface CommentWriteProps {
+  commentId: string;
+  parentCommentId?: string;
+}
+
+export interface CommentWrite {
+  inputProps: Partial<CommentMarkdownInputProps>;
+}

--- a/packages/shared/src/hooks/post/useCommentEdit.ts
+++ b/packages/shared/src/hooks/post/useCommentEdit.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+import { Comment, COMMENT_BY_ID_QUERY } from '../../graphql/comments';
+import { generateQueryKey, RequestKey } from '../../lib/query';
+import { graphqlUrl } from '../../lib/config';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { useRequestProtocol } from '../useRequestProtocol';
+import { CommentWrite, CommentWriteProps } from './common';
+
+interface UseCommentEdit extends CommentWrite {
+  onEdit: (params: CommentWriteProps) => void;
+}
+
+export const useCommentEdit = (): UseCommentEdit => {
+  const [state, setState] = useState<CommentWriteProps>();
+  const { commentId: id } = state ?? {};
+  const { user } = useAuthContext();
+  const { requestMethod } = useRequestProtocol();
+  const { data } = useQuery<{ comment: Comment }>(
+    generateQueryKey(RequestKey.Comment, user, id),
+    () => requestMethod(graphqlUrl, COMMENT_BY_ID_QUERY, { id }),
+    { enabled: !!id },
+  );
+
+  const inputProps = useMemo(() => {
+    if (!state || !data) {
+      return null;
+    }
+
+    return {
+      editCommentId: state.commentId,
+      parentCommentId: state.parentCommentId,
+      initialContent: data?.comment?.content,
+    };
+  }, [data, state]);
+
+  return {
+    onEdit: setState,
+    inputProps,
+  };
+};

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -74,6 +74,7 @@ export enum RequestKey {
   ReferredUsers = 'referred',
   PostKey = 'post',
   Prompt = 'prompt',
+  Comment = 'comment',
   SquadTour = 'squad_tour',
 }
 


### PR DESCRIPTION
## Changes
- Simplified the `useComments` hook to just manage new comments.
- Introduced a new hook for editing comments to avoid all the ternary operators that are somewhat confusing when it becomes many.
- Used the new query to fetch the comment's id.
- Updated the fragment for post comments to not contain the markdown content.
- Thoroughly tested locally, but I am deploying this on preview so I can do tests there as well.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1919 #done
