### PR TITLE
feat: add option to subscribe to collection post

### DIFF
--- a/packages/shared/src/graphql/notifications.ts
+++ b/packages/shared/src/graphql/notifications.ts
@@ -157,8 +157,17 @@ export const SHOW_SOURCE_ON_FEED_MUTATION = gql`
   }
 `;
 
+export const SUBSCRIBE_NOTIFICATION_MUTATION = gql`
+  mutation SubscribeNotificationPreference($referenceId: ID!, $type: String!) {
+    subscribeNotificationPreference(referenceId: $referenceId, type: $type) {
+      _
+    }
+  }
+`;
+
 export enum NotificationPreferenceStatus {
   Muted = 'muted',
+  Subscribed = 'subscribed',
 }
 
 enum NotificationPreferenceType {
@@ -175,7 +184,7 @@ export interface NotificationPreference {
   type: NotificationPreferenceType;
 }
 
-interface NotificationPreferenceParams
+export interface NotificationPreferenceParams
   extends Pick<NotificationPreference, 'referenceId'> {
   type: NotificationType;
 }
@@ -244,4 +253,16 @@ export const showSourceFeedPosts = async (
   });
 
   return res.showSourceFeedPosts;
+};
+
+export const subscribeNotification = async (
+  params: NotificationPreferenceParams,
+): Promise<EmptyResponse> => {
+  const res = await request(
+    graphqlUrl,
+    SUBSCRIBE_NOTIFICATION_MUTATION,
+    params,
+  );
+
+  return res.subscribeNotificationPreference;
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Implementing WT-2025
- Connecting subscribe button on collection post/modal
- API PR https://github.com/dailydotdev/daily-api/pull/1561

TODO:
- [ ] implement mobile subscribe button

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
