### PR TITLE
feat: create video component wrapper

### DIFF
--- a/packages/shared/src/components/video/YoutubeVideo.spec.tsx
+++ b/packages/shared/src/components/video/YoutubeVideo.spec.tsx
@@ -1,0 +1,36 @@
+import { render, RenderResult, screen } from '@testing-library/react';
+
+import React from 'react';
+import YoutubeVideo from './YoutubeVideo';
+
+const renderComponent = (): RenderResult => {
+  return render(
+    <YoutubeVideo
+      title="test title"
+      videoId="igZCEr3HwCg"
+      data-testid="iframeId"
+    />,
+  );
+};
+
+describe('YoutubeVideo', () => {
+  it('should render successfully', () => {
+    const { baseElement } = renderComponent();
+    expect(baseElement).toBeTruthy();
+  });
+  it('should add the right title attribute', () => {
+    renderComponent();
+
+    const iframe = screen.getByTestId('iframeId');
+    expect(iframe).toHaveAttribute('title', 'test title');
+  });
+  it('should add the right src attribute', () => {
+    renderComponent();
+
+    const iframe = screen.getByTestId('iframeId');
+    expect(iframe).toHaveAttribute(
+      'src',
+      'https://www.youtube-nocookie.com/embed/igZCEr3HwCg',
+    );
+  });
+});

--- a/packages/shared/src/components/video/YoutubeVideo.tsx
+++ b/packages/shared/src/components/video/YoutubeVideo.tsx
@@ -24,7 +24,7 @@ const YoutubeVideo = ({
       src={`https://www.youtube-nocookie.com/embed/${videoId}`}
       allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
       allowFullScreen
-      className="absolute inset-0 w-full h-full border-0 aspect-video"
+      className="absolute inset-0 w-full border-0 aspect-video"
       {...props}
     />
   </div>

--- a/packages/shared/src/components/video/YoutubeVideo.tsx
+++ b/packages/shared/src/components/video/YoutubeVideo.tsx
@@ -1,0 +1,33 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+
+interface YoutubeVideoProps {
+  videoId: string;
+  className?: string;
+  title: string;
+}
+
+const YoutubeVideo = ({
+  videoId,
+  className,
+  title,
+  ...props
+}: YoutubeVideoProps): ReactElement => (
+  <div
+    className={classNames(
+      'overflow-hidden relative pt-[56.25%] w-full',
+      className,
+    )}
+  >
+    <iframe
+      title={title}
+      src={`https://www.youtube-nocookie.com/embed/${videoId}`}
+      allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
+      allowFullScreen
+      className="absolute inset-0 w-full h-full border-0 aspect-video"
+      {...props}
+    />
+  </div>
+);
+
+export default YoutubeVideo;

--- a/packages/storybook/stories/video.stories.tsx
+++ b/packages/storybook/stories/video.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import YoutubeVideo from '@dailydotdev/shared/src/components/video/YoutubeVideo';
+
+const meta: Meta<typeof YoutubeVideo> = {
+  component: YoutubeVideo,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof YoutubeVideo>;
+
+export const Primary: Story = {
+  render: (props) => (
+      <YoutubeVideo {...props} />
+  ),
+  name: "YoutubeVideo",
+  args: {
+    videoId: "igZCEr3HwCg",
+    title: "Daily dev introduction video",
+    className: ''
+  },
+};


### PR DESCRIPTION
## Changes
- added new youtube video component that renders a div with iframe (the div is added to make sure about the aspect ratio mentioned in the DR)
-- the title is added and set as required as it helps with accessibility
- added storybook story about component
- added component test

### Describe what this PR does
Adds a component wrapper for the iframe youtube video content, that makes sure that the component is responsive in the 16:9 ratio

<img width="1473" alt="Screenshot 2023-12-01 at 1 19 45 PM" src="https://github.com/dailydotdev/apps/assets/36197304/8eef6412-7a4f-48e3-805b-e2bac365f2e1">
<img width="1461" alt="Screenshot 2023-12-01 at 1 19 54 PM" src="https://github.com/dailydotdev/apps/assets/36197304/abc144f3-71f1-4103-9439-ca779b376778">
<img width="1470" alt="Screenshot 2023-12-01 at 1 20 21 PM" src="https://github.com/dailydotdev/apps/assets/36197304/325e3ff9-5186-449a-94a2-515da29ec473">

## Events

Did you introduce any new tracking events? No


### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion? No

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices? No
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1987 #done
