### PR TITLE
feat: video advanced settings

### DIFF
--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -6,7 +6,11 @@ import React, {
   useState,
 } from 'react';
 import dynamic from 'next/dynamic';
-import { BOOKMARKS_FEED_QUERY, SEARCH_BOOKMARKS_QUERY } from '../graphql/feed';
+import {
+  BOOKMARKS_FEED_QUERY,
+  SEARCH_BOOKMARKS_QUERY,
+  supportedTypesForPrivateSources,
+} from '../graphql/feed';
 import AuthContext from '../contexts/AuthContext';
 import { CustomFeedHeader, FeedPage, FeedPageHeader } from './utilities';
 import SearchEmptyScreen from './SearchEmptyScreen';
@@ -15,7 +19,6 @@ import BookmarkEmptyScreen from './BookmarkEmptyScreen';
 import { Button } from './buttons/Button';
 import ShareIcon from './icons/Share';
 import { generateQueryKey, OtherFeedPage, RequestKey } from '../lib/query';
-import { supportedTypesForPrivateSources } from '../graphql/posts';
 
 export type BookmarkFeedLayoutProps = {
   searchQuery?: string;

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -90,6 +90,8 @@ const PostModalMap: Record<PostType, typeof ArticlePostModal> = {
   [PostType.Share]: SharePostModal,
   [PostType.Welcome]: SharePostModal,
   [PostType.Freeform]: SharePostModal,
+  // TODO: remove this once we have a modal for youtube videos
+  [PostType.VideoYouTube]: null,
 };
 
 export default function Feed<T>({

--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -86,6 +86,8 @@ const PostTypeToTag: Record<PostType, FunctionComponent> = {
   [PostType.Share]: SharePostCard,
   [PostType.Welcome]: WelcomePostCard,
   [PostType.Freeform]: WelcomePostCard,
+  // TODO: remove this once we have a proper video feed card
+  [PostType.VideoYouTube]: null,
 };
 
 export default function FeedItemComponent({

--- a/packages/shared/src/components/fields/FilterCheckbox.tsx
+++ b/packages/shared/src/components/fields/FilterCheckbox.tsx
@@ -1,0 +1,23 @@
+import React, { ReactElement } from 'react';
+import { Checkbox, CheckboxProps } from './Checkbox';
+
+interface FilterCheckboxProps extends CheckboxProps {
+  description: string;
+}
+
+export function FilterCheckbox({
+  description,
+  children,
+  ...props
+}: FilterCheckboxProps): ReactElement {
+  return (
+    <Checkbox {...props} className="!items-start !typo-callout">
+      <div className="flex flex-col">
+        <span className="mb-2">{children}</span>
+        <span className="font-normal text-theme-label-secondary">
+          {description}
+        </span>
+      </div>
+    </Checkbox>
+  );
+}

--- a/packages/shared/src/components/filters/AdvancedSettings.spec.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.spec.tsx
@@ -1,11 +1,11 @@
 import nock from 'nock';
 import React from 'react';
 import {
+  fireEvent,
   render,
   RenderResult,
   screen,
   waitFor,
-  fireEvent,
 } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import defaultUser from '../../../__tests__/fixture/loggedUser';
@@ -16,18 +16,19 @@ import {
 } from '../../../__tests__/helpers/graphql';
 import { LoggedUser } from '../../lib/user';
 import {
+  AdvancedSettings,
+  AdvancedSettingsGroup,
+  AllTagCategoriesData,
   FEED_SETTINGS_QUERY,
   FeedSettings,
-  AllTagCategoriesData,
-  AdvancedSettings,
   UPDATE_ADVANCED_SETTINGS_FILTERS_MUTATION,
 } from '../../graphql/feedSettings';
 import AdvancedSettingsPage from './AdvancedSettings';
 import { getFeedSettingsQueryKey } from '../../hooks/useFeedSettings';
 import { waitForNock } from '../../../__tests__/helpers/utilities';
 import AlertContext, {
-  AlertContextData,
   ALERT_DEFAULTS,
+  AlertContextData,
 } from '../../contexts/AlertContext';
 
 const showLogin = jest.fn();
@@ -51,12 +52,14 @@ const createAdvancedSettingsAndFiltersMock = (
       title: 'Tech magazines',
       description: 'Description for Tech magazines',
       defaultEnabledState: true,
+      group: AdvancedSettingsGroup.Advanced,
     },
     {
       id: 2,
       title: 'Newsletters',
       description: 'Description for Newsletters',
       defaultEnabledState: true,
+      group: AdvancedSettingsGroup.Advanced,
     },
   ],
 ): MockedGraphQLResponse<AllTagCategoriesData> => ({

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -5,6 +5,7 @@ import AuthContext from '../../contexts/AuthContext';
 import useFeedSettings from '../../hooks/useFeedSettings';
 import useMutateFilters from '../../hooks/useMutateFilters';
 import { FilterSwitch } from './FilterSwitch';
+import { AdvancedSettingsGroup } from '../../graphql/feedSettings';
 
 const ADVANCED_SETTINGS_KEY = 'advancedSettings';
 
@@ -43,21 +44,27 @@ function AdvancedSettingsFilter(): ReactElement {
     });
   };
 
+  const settingsList = useMemo(
+    () =>
+      advancedSettings.filter(
+        ({ group }) => group === AdvancedSettingsGroup.Advanced,
+      ),
+    [advancedSettings],
+  );
+
   return (
     <section className="flex flex-col px-6" aria-busy={isLoading}>
-      {advancedSettings?.map(
-        ({ id, title, description, defaultEnabledState }) => (
-          <FilterSwitch
-            key={id}
-            label={title}
-            checked={settings[id] ?? defaultEnabledState}
-            name={`${ADVANCED_SETTINGS_KEY}-${id}`}
-            description={description}
-            onToggle={() => onToggle(id, defaultEnabledState)}
-            inputId={`${ADVANCED_SETTINGS_KEY}-${id}`}
-          />
-        ),
-      )}
+      {settingsList?.map(({ id, title, description, defaultEnabledState }) => (
+        <FilterSwitch
+          key={id}
+          label={title}
+          checked={settings[id] ?? defaultEnabledState}
+          name={`${ADVANCED_SETTINGS_KEY}-${id}`}
+          description={description}
+          onToggle={() => onToggle(id, defaultEnabledState)}
+          inputId={`${ADVANCED_SETTINGS_KEY}-${id}`}
+        />
+      ))}
     </section>
   );
 }

--- a/packages/shared/src/components/filters/AdvancedSettings.tsx
+++ b/packages/shared/src/components/filters/AdvancedSettings.tsx
@@ -11,9 +11,9 @@ function AdvancedSettingsFilter(): ReactElement {
   const { selectedSettings, onToggleSettings } = useAdvancedSettings();
   const settingsList = useMemo(
     () =>
-      advancedSettings.filter(
+      advancedSettings?.filter(
         ({ group }) => group === AdvancedSettingsGroup.Advanced,
-      ),
+      ) ?? [],
     [advancedSettings],
   );
 

--- a/packages/shared/src/components/filters/ContentTypes.tsx
+++ b/packages/shared/src/components/filters/ContentTypes.tsx
@@ -3,7 +3,7 @@ import { FilterSwitch } from './FilterSwitch';
 import { useAdvancedSettings } from '../../hooks/feed';
 import useFeedSettings from '../../hooks/useFeedSettings';
 
-function ContentTypes(): ReactElement {
+export function ContentTypesFilter(): ReactElement {
   const { advancedSettings, isLoading } = useFeedSettings();
   const { selectedSettings, onToggleSettings } = useAdvancedSettings();
   const videos = advancedSettings.find(({ title }) => title === 'Videos');
@@ -29,5 +29,3 @@ function ContentTypes(): ReactElement {
     </section>
   );
 }
-
-export default ContentTypes;

--- a/packages/shared/src/components/filters/ContentTypes.tsx
+++ b/packages/shared/src/components/filters/ContentTypes.tsx
@@ -1,0 +1,33 @@
+import React, { ReactElement } from 'react';
+import { FilterSwitch } from './FilterSwitch';
+import { useAdvancedSettings } from '../../hooks/feed';
+import useFeedSettings from '../../hooks/useFeedSettings';
+
+function ContentTypes(): ReactElement {
+  const { advancedSettings, isLoading } = useFeedSettings();
+  const { selectedSettings, onToggleSettings } = useAdvancedSettings();
+  const videos = advancedSettings.find(({ title }) => title === 'Videos');
+
+  return (
+    <section className="flex flex-col px-6" aria-busy={isLoading}>
+      <FilterSwitch
+        name={videos.title}
+        label={videos.title}
+        inputId={videos.title}
+        description={videos.description}
+        checked={selectedSettings[videos.id] ?? videos.defaultEnabledState}
+        onToggle={() => onToggleSettings(videos.id, videos.defaultEnabledState)}
+      />
+      <FilterSwitch
+        name="Articles"
+        label="Articles"
+        inputId="Articles"
+        description="Show article posts on my feed"
+        disabled
+        checked
+      />
+    </section>
+  );
+}
+
+export default ContentTypes;

--- a/packages/shared/src/components/filters/ContentTypesFilter.tsx
+++ b/packages/shared/src/components/filters/ContentTypesFilter.tsx
@@ -6,6 +6,11 @@ import useFeedSettings from '../../hooks/useFeedSettings';
 export function ContentTypesFilter(): ReactElement {
   const { advancedSettings, isLoading } = useFeedSettings();
   const { selectedSettings, onToggleSettings } = useAdvancedSettings();
+  /*
+   * At the moment, we are only referencing the Video entity, but it should be based from the group that it is in.
+   * Point being, we have to send multiple mutation requests at the same time if the user toggles the switch.
+   * We should instead introduce a new mutation to handle an array of settings to toggle.
+   * */
   const videos = advancedSettings.find(({ title }) => title === 'Videos');
 
   return (

--- a/packages/shared/src/components/filters/ContentTypesFilter.tsx
+++ b/packages/shared/src/components/filters/ContentTypesFilter.tsx
@@ -10,14 +10,18 @@ export function ContentTypesFilter(): ReactElement {
 
   return (
     <section className="flex flex-col px-6" aria-busy={isLoading}>
-      <FilterSwitch
-        name={videos.title}
-        label={videos.title}
-        inputId={videos.title}
-        description={videos.description}
-        checked={selectedSettings[videos.id] ?? videos.defaultEnabledState}
-        onToggle={() => onToggleSettings(videos.id, videos.defaultEnabledState)}
-      />
+      {videos && (
+        <FilterSwitch
+          name={videos.title}
+          label={videos.title}
+          inputId={videos.title}
+          description={videos.description}
+          checked={selectedSettings[videos.id] ?? videos.defaultEnabledState}
+          onToggle={() =>
+            onToggleSettings(videos.id, videos.defaultEnabledState)
+          }
+        />
+      )}
       <FilterSwitch
         name="Articles"
         label="Articles"

--- a/packages/shared/src/components/filters/ContentTypesFilter.tsx
+++ b/packages/shared/src/components/filters/ContentTypesFilter.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { FilterSwitch } from './FilterSwitch';
+import { FilterCheckbox } from '../fields/FilterCheckbox';
 import { useAdvancedSettings } from '../../hooks/feed';
 import useFeedSettings from '../../hooks/useFeedSettings';
 
@@ -14,27 +14,27 @@ export function ContentTypesFilter(): ReactElement {
   const videos = advancedSettings.find(({ title }) => title === 'Videos');
 
   return (
-    <section className="flex flex-col px-6" aria-busy={isLoading}>
+    <section className="flex flex-col gap-6 px-6" aria-busy={isLoading}>
       {videos && (
-        <FilterSwitch
+        <FilterCheckbox
           name={videos.title}
-          label={videos.title}
-          inputId={videos.title}
           description={videos.description}
           checked={selectedSettings[videos.id] ?? videos.defaultEnabledState}
           onToggle={() =>
             onToggleSettings(videos.id, videos.defaultEnabledState)
           }
-        />
+        >
+          {videos.title}
+        </FilterCheckbox>
       )}
-      <FilterSwitch
+      <FilterCheckbox
         name="Articles"
-        label="Articles"
-        inputId="Articles"
         description="Show article posts on my feed"
         disabled
         checked
-      />
+      >
+        Articles
+      </FilterCheckbox>
     </section>
   );
 }

--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -13,6 +13,7 @@ import { Modal, ModalProps } from '../modals/common/Modal';
 import { usePrompt } from '../../hooks/usePrompt';
 import { UnblockSourceCopy, UnblockTagCopy } from './UnblockCopy';
 import { ContentTypesFilter } from './ContentTypes';
+import AppIcon from '../icons/App';
 
 enum FilterMenuTitle {
   Tags = 'Manage tags',
@@ -46,6 +47,10 @@ export default function FeedFilters(props: FeedFiltersProps): ReactElement {
     {
       title: FilterMenuTitle.Advanced,
       options: { icon: <FilterIcon /> },
+    },
+    {
+      title: FilterMenuTitle.ContentTypes,
+      options: { icon: <AppIcon /> },
     },
     {
       title: FilterMenuTitle.Blocked,

--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -12,7 +12,7 @@ import { UnblockItem, unBlockPromptOptions } from './FilterMenu';
 import { Modal, ModalProps } from '../modals/common/Modal';
 import { usePrompt } from '../../hooks/usePrompt';
 import { UnblockSourceCopy, UnblockTagCopy } from './UnblockCopy';
-import { ContentTypesFilter } from './ContentTypes';
+import { ContentTypesFilter } from './ContentTypesFilter';
 import AppIcon from '../icons/App';
 
 enum FilterMenuTitle {

--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -12,10 +12,12 @@ import { UnblockItem, unBlockPromptOptions } from './FilterMenu';
 import { Modal, ModalProps } from '../modals/common/Modal';
 import { usePrompt } from '../../hooks/usePrompt';
 import { UnblockSourceCopy, UnblockTagCopy } from './UnblockCopy';
+import { ContentTypesFilter } from './ContentTypes';
 
 enum FilterMenuTitle {
   Tags = 'Manage tags',
   Advanced = 'Advanced',
+  ContentTypes = 'Content types',
   Blocked = 'Blocked items',
 }
 
@@ -80,6 +82,9 @@ export default function FeedFilters(props: FeedFiltersProps): ReactElement {
           </Modal.Body>
           <Modal.Body view={FilterMenuTitle.Advanced}>
             <AdvancedSettingsFilter />
+          </Modal.Body>
+          <Modal.Body view={FilterMenuTitle.ContentTypes}>
+            <ContentTypesFilter />
           </Modal.Body>
           <Modal.Body view={FilterMenuTitle.Blocked}>
             <BlockedFilter onUnblockItem={unBlockPrompt} />

--- a/packages/shared/src/components/filters/FilterMenu.tsx
+++ b/packages/shared/src/components/filters/FilterMenu.tsx
@@ -12,6 +12,7 @@ import AdvancedSettingsFilter from './AdvancedSettings';
 import { Source } from '../../graphql/sources';
 import { PromptOptions, usePrompt } from '../../hooks/usePrompt';
 import { UnblockSourceCopy, UnblockTagCopy } from './UnblockCopy';
+import { ContentTypesFilter } from './ContentTypes';
 
 const NewSourceModal = dynamic(
   () =>
@@ -61,6 +62,11 @@ export default function FilterMenu({
       icon: <FilterIcon className="mr-3 text-xl" />,
       title: 'Advanced',
       component: <AdvancedSettingsFilter />,
+    },
+    {
+      icon: <BlockIcon className="mr-3 text-xl" />,
+      title: 'Content Types',
+      component: <ContentTypesFilter />,
     },
     {
       icon: <BlockIcon className="mr-3 text-xl" />,

--- a/packages/shared/src/components/filters/FilterMenu.tsx
+++ b/packages/shared/src/components/filters/FilterMenu.tsx
@@ -12,7 +12,7 @@ import AdvancedSettingsFilter from './AdvancedSettings';
 import { Source } from '../../graphql/sources';
 import { PromptOptions, usePrompt } from '../../hooks/usePrompt';
 import { UnblockSourceCopy, UnblockTagCopy } from './UnblockCopy';
-import { ContentTypesFilter } from './ContentTypes';
+import { ContentTypesFilter } from './ContentTypesFilter';
 
 const NewSourceModal = dynamic(
   () =>

--- a/packages/shared/src/contexts/AlertContext.tsx
+++ b/packages/shared/src/contexts/AlertContext.tsx
@@ -1,5 +1,5 @@
 import request from 'graphql-request';
-import React, { ReactNode, ReactElement, useMemo } from 'react';
+import React, { ReactNode, ReactElement, useMemo, useContext } from 'react';
 import { UseMutateAsyncFunction, useMutation } from '@tanstack/react-query';
 import {
   Alerts,
@@ -117,3 +117,6 @@ export const AlertContextProvider = ({
 };
 
 export default AlertContext;
+
+export const useAlertsContext = (): AlertContextData =>
+  useContext(AlertContext);

--- a/packages/shared/src/graphql/feed.ts
+++ b/packages/shared/src/graphql/feed.ts
@@ -21,6 +21,12 @@ export const baseFeedSupportedTypes = [
   PostType.Article,
   PostType.Share,
   PostType.Freeform,
+  PostType.VideoYouTube,
+];
+
+export const supportedTypesForPrivateSources = [
+  ...baseFeedSupportedTypes,
+  PostType.Welcome,
 ];
 
 const joinedTypes = baseFeedSupportedTypes.join('","');

--- a/packages/shared/src/graphql/feedSettings.ts
+++ b/packages/shared/src/graphql/feedSettings.ts
@@ -1,17 +1,23 @@
 import { gql } from 'graphql-request';
 import { Source } from './sources';
 
+export enum AdvancedSettingsGroup {
+  Advanced = 'advanced',
+  ContentTypes = 'content_types',
+}
+
 export interface AdvancedSettings {
   id: number;
   title: string;
   description: string;
   defaultEnabledState: boolean;
+  group: AdvancedSettingsGroup;
 }
 
-export interface FeedAdvancedSettings
-  extends Partial<Omit<AdvancedSettings, 'defaultEnabledState'>> {
+export interface FeedAdvancedSettings {
   id: number;
   enabled: boolean;
+  advancedSettings?: AdvancedSettings;
 }
 
 export interface Tag {
@@ -90,6 +96,7 @@ export const FEED_SETTINGS_QUERY = gql`
       title
       description
       defaultEnabledState
+      group
     }
   }
 `;

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -28,16 +28,10 @@ export enum PostType {
   Share = 'share',
   Welcome = 'welcome',
   Freeform = 'freeform',
+  VideoYouTube = 'video:youtube',
 }
 
 export const internalReadTypes: PostType[] = [PostType.Welcome];
-
-export const supportedTypesForPrivateSources = [
-  PostType.Article,
-  PostType.Share,
-  PostType.Welcome,
-  PostType.Freeform,
-];
 
 type PostFlags = {
   sentAnalyticsReport: boolean;

--- a/packages/shared/src/hooks/feed/index.ts
+++ b/packages/shared/src/hooks/feed/index.ts
@@ -1,0 +1,1 @@
+export * from './useAdvancedSettings';

--- a/packages/shared/src/hooks/feed/useAdvancedSettings.ts
+++ b/packages/shared/src/hooks/feed/useAdvancedSettings.ts
@@ -1,0 +1,60 @@
+import { useCallback, useMemo } from 'react';
+import useFeedSettings from '../useFeedSettings';
+import { useAlertsContext } from '../../contexts/AlertContext';
+import { useAnalyticsContext } from '../../contexts/AnalyticsContext';
+import { useAuthContext } from '../../contexts/AuthContext';
+import useMutateFilters from '../useMutateFilters';
+
+interface UseAdvancedSettings {
+  selectedSettings: Record<string, boolean>;
+  onToggleSettings(id: number, state: boolean): void;
+}
+
+export const useAdvancedSettings = (): UseAdvancedSettings => {
+  const { user } = useAuthContext();
+  const { feedSettings } = useFeedSettings();
+  const { trackEvent } = useAnalyticsContext();
+  const { updateAdvancedSettings } = useMutateFilters(user);
+  const { alerts, updateAlerts } = useAlertsContext();
+
+  const selectedSettings = useMemo(
+    () =>
+      feedSettings?.advancedSettings?.reduce((settingsMap, currentSettings) => {
+        const map = { ...settingsMap };
+        map[currentSettings.id] = currentSettings.enabled;
+        return map;
+      }, {}) || {},
+    [feedSettings?.advancedSettings],
+  );
+
+  const onToggleSettings = useCallback(
+    (id: number, defaultEnabledState: boolean) => {
+      if (alerts?.filter && user) {
+        updateAlerts({ filter: false });
+      }
+
+      const enabled = !(selectedSettings[id] ?? defaultEnabledState);
+
+      trackEvent({
+        event_name: `toggle ${enabled ? 'on' : 'off'}`,
+        target_type: 'advanced setting',
+        target_id: id.toString(),
+        extra: JSON.stringify({ origin: 'advanced settings filter' }),
+      });
+
+      updateAdvancedSettings({
+        advancedSettings: [{ id, enabled }],
+      });
+    },
+    [
+      alerts?.filter,
+      selectedSettings,
+      trackEvent,
+      updateAdvancedSettings,
+      updateAlerts,
+      user,
+    ],
+  );
+
+  return { selectedSettings, onToggleSettings };
+};

--- a/packages/shared/src/hooks/feed/useAdvancedSettings.ts
+++ b/packages/shared/src/hooks/feed/useAdvancedSettings.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from 'react';
-import useFeedSettings from '../useFeedSettings';
+import useFeedSettings, { UseFeedSettingsProps } from '../useFeedSettings';
 import { useAlertsContext } from '../../contexts/AlertContext';
 import { useAnalyticsContext } from '../../contexts/AnalyticsContext';
 import { useAuthContext } from '../../contexts/AuthContext';
@@ -10,9 +10,11 @@ interface UseAdvancedSettings {
   onToggleSettings(id: number, state: boolean): void;
 }
 
-export const useAdvancedSettings = (): UseAdvancedSettings => {
+export const useAdvancedSettings = (
+  props?: UseFeedSettingsProps,
+): UseAdvancedSettings => {
   const { user } = useAuthContext();
-  const { feedSettings } = useFeedSettings();
+  const { feedSettings } = useFeedSettings(props);
   const { trackEvent } = useAnalyticsContext();
   const { updateAdvancedSettings } = useMutateFilters(user);
   const { alerts, updateAlerts } = useAlertsContext();

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -33,7 +33,7 @@ export const getHasAnyFilter = (feedSettings: FeedSettings): boolean =>
   feedSettings?.excludeSources?.length > 0 ||
   feedSettings?.advancedSettings?.length > 0;
 
-interface UseFeedSettingsProps {
+export interface UseFeedSettingsProps {
   enabled?: boolean;
 }
 

--- a/packages/shared/src/hooks/useFindSquadWelcomePost.ts
+++ b/packages/shared/src/hooks/useFindSquadWelcomePost.ts
@@ -1,13 +1,9 @@
 import { useContext, useMemo } from 'react';
 import { InfiniteData, useQueryClient } from '@tanstack/react-query';
-import {
-  FeedData,
-  Post,
-  PostType,
-  supportedTypesForPrivateSources,
-} from '../graphql/posts';
+import { FeedData, Post, PostType } from '../graphql/posts';
 import { Squad } from '../graphql/sources';
 import AuthContext from '../contexts/AuthContext';
+import { supportedTypesForPrivateSources } from '../graphql/feed';
 
 const useFindSquadWelcomePost = ({
   id: squadId,

--- a/packages/webapp/__tests__/BookmarksPage.tsx
+++ b/packages/webapp/__tests__/BookmarksPage.tsx
@@ -1,8 +1,8 @@
+import { FeedData } from '@dailydotdev/shared/src/graphql/posts';
 import {
-  FeedData,
+  BOOKMARKS_FEED_QUERY,
   supportedTypesForPrivateSources,
-} from '@dailydotdev/shared/src/graphql/posts';
-import { BOOKMARKS_FEED_QUERY } from '@dailydotdev/shared/src/graphql/feed';
+} from '@dailydotdev/shared/src/graphql/feed';
 import nock from 'nock';
 import React from 'react';
 import { render, RenderResult, screen, waitFor } from '@testing-library/react';

--- a/packages/webapp/__tests__/SquadFeedPage.tsx
+++ b/packages/webapp/__tests__/SquadFeedPage.tsx
@@ -1,8 +1,8 @@
+import { FeedData } from '@dailydotdev/shared/src/graphql/posts';
 import {
-  FeedData,
+  SOURCE_FEED_QUERY,
   supportedTypesForPrivateSources,
-} from '@dailydotdev/shared/src/graphql/posts';
-import { SOURCE_FEED_QUERY } from '@dailydotdev/shared/src/graphql/feed';
+} from '@dailydotdev/shared/src/graphql/feed';
 import nock from 'nock';
 import React from 'react';
 import {

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -72,6 +72,8 @@ const CONTENT_MAP: Record<PostType, typeof PostContent> = {
   share: SquadPostContent,
   welcome: SquadPostContent,
   freeform: SquadPostContent,
+  // TODO: remove this once we know what content to use
+  [PostType.VideoYouTube]: null,
 };
 
 interface PostParams extends ParsedUrlQuery {
@@ -163,6 +165,8 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     share: shareNavigation,
     welcome: shareNavigation,
     freeform: shareNavigation,
+    // TODO: remove this once we know what navigation to use
+    [PostType.VideoYouTube]: null,
   };
   const customNavigation = navigation[post?.type] ?? navigation.article;
 

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -9,7 +9,10 @@ import React, {
 } from 'react';
 import { NextSeo } from 'next-seo';
 import Feed from '@dailydotdev/shared/src/components/Feed';
-import { SOURCE_FEED_QUERY } from '@dailydotdev/shared/src/graphql/feed';
+import {
+  SOURCE_FEED_QUERY,
+  supportedTypesForPrivateSources,
+} from '@dailydotdev/shared/src/graphql/feed';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { SquadPageHeader } from '@dailydotdev/shared/src/components/squads/SquadPageHeader';
 import SquadFeedHeading from '@dailydotdev/shared/src/components/squads/SquadFeedHeading';
@@ -27,7 +30,6 @@ import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext'
 import dynamic from 'next/dynamic';
 import useSidebarRendered from '@dailydotdev/shared/src/hooks/useSidebarRendered';
 import classNames from 'classnames';
-import { supportedTypesForPrivateSources } from '@dailydotdev/shared/src/graphql/posts';
 import { useJoinReferral, useSquad } from '@dailydotdev/shared/src/hooks';
 import { oneHour } from '@dailydotdev/shared/src/lib/dateFormat';
 import request, { ClientError } from 'graphql-request';


### PR DESCRIPTION
## Changes
- Introduced use advanced settings to manage users advanced settings.
- Refactor the Settings page for filters to use the said hook.
- Introduce a new tab for content_types.
  - The selection contains just the video only, but once our advanced settings with `group` grows, this should trigger multiple mutations to update each item. Otherwise we must introduce a new mutation to update all at once.

Note: do we already have an intermediate branch to point this to?

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1985 #done
