### PR TITLE
feat: support video in feed and private squads feed

### DIFF
--- a/packages/shared/src/graphql/feed.ts
+++ b/packages/shared/src/graphql/feed.ts
@@ -21,6 +21,7 @@ export const baseFeedSupportedTypes = [
   PostType.Article,
   PostType.Share,
   PostType.Freeform,
+  PostType.VideoYouTube,
 ];
 
 const joinedTypes = baseFeedSupportedTypes.join('","');

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -38,6 +38,7 @@ export const supportedTypesForPrivateSources = [
   PostType.Share,
   PostType.Welcome,
   PostType.Freeform,
+  PostType.VideoYouTube,
 ];
 
 type PostFlags = {


### PR DESCRIPTION
## Changes
- Updated the base types for which types to display in our regular feed.
- Though I have also updated the types required on private Squads feed, let me know if we proceed with that.

Also, there are other places where we generate feed data and supply it with supported types not based from the `baseSupportedFeedTypes`, such as:
- Bookmark (uses `supportedTypesForPrivateSources`).
- FurtherReading
- FeedPreview
- Sources
- Tags

Let me know if the list above needs to be updated as well. I feel like we should somehow unify this.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1986 #done
