### PR TITLE
fix: replace headline with body + bold

### DIFF
--- a/packages/shared/src/components/filters/BlockedFilter.tsx
+++ b/packages/shared/src/components/filters/BlockedFilter.tsx
@@ -37,7 +37,7 @@ export default function BlockedFilter({
         (⋮) and choose “Not interested in…“.
       </p>
 
-      <h3 className="my-3 mx-6 typo-headline">Blocked tags</h3>
+      <h3 className="my-3 mx-6 font-bold typo-body">Blocked tags</h3>
 
       <TagItemList
         tags={feedSettings?.blockedTags}
@@ -47,7 +47,7 @@ export default function BlockedFilter({
         rowIcon={<BlockIcon />}
       />
 
-      <h3 className="mx-6 mt-10 mb-3 typo-headline">Blocked sources</h3>
+      <h3 className="mx-6 mt-10 mb-3 font-bold typo-body">Blocked sources</h3>
 
       <SourceItemList
         excludeSources={feedSettings?.excludeSources}

--- a/packages/shared/src/components/filters/TagsFilter.tsx
+++ b/packages/shared/src/components/filters/TagsFilter.tsx
@@ -94,7 +94,7 @@ export default function TagsFilter({
           ref={searchRef}
           valueChanged={onSearch}
         />
-        <h3 className="mb-3 typo-headline">Choose tags to follow</h3>
+        <h3 className="mb-3 font-bold typo-body">Choose tags to follow</h3>
         <p className="mb-2 typo-callout text-theme-label-tertiary">
           Let’s super-charge your feed with relevant content! Start by choosing
           tags you want to follow, and we will curate your feed accordingly.

--- a/packages/shared/src/components/markdown.module.css
+++ b/packages/shared/src/components/markdown.module.css
@@ -13,10 +13,10 @@
     @apply font-bold typo-title3 mt-8 mb-6;
   }
   & :where(h3) {
-    @apply font-bold typo-headline mt-7 mb-5;
+    @apply font-bold typo-body mt-7 mb-5;
   }
   & :where(h4) {
-    @apply typo-headline mt-6 mb-4;
+    @apply typo-body font-bold mt-6 mb-4;
   }
   & :where(h5) {
     @apply text-theme-label-tertiary font-bold typo-markdown mt-5 mb-4;

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -146,7 +146,7 @@ export const ModalTitle = classed(
   'h1',
   'typo-title1 font-bold text-center mb-4',
 );
-export const ModalSubtitle = classed('strong', 'typo-headline mb-2');
+export const ModalSubtitle = classed('strong', 'typo-body font-bold mb-2');
 export const ModalText = classed('p', 'typo-callout text-theme-label-tertiary');
 
 Modal.Size = ModalSize;

--- a/packages/shared/src/components/modals/referral/SearchReferralModal.tsx
+++ b/packages/shared/src/components/modals/referral/SearchReferralModal.tsx
@@ -81,7 +81,7 @@ function SearchReferralModal({
               ? `Need more keys?`
               : `Give your friends early access to daily.dev's search!`}
           </h1>
-          <p className="mt-6 text-center laptop:text-left !font-normal typo-body tablet:typo-headline laptop:typo-title3 text-theme-label-secondary">
+          <p className="mt-6 font-bold text-center laptop:text-left !font-normal typo-body tablet:typo-body laptop:typo-title3 text-theme-label-secondary">
             {noKeysAvailable
               ? `You've already used all your invitation keys, but you can always ask for more...`
               : `Be that cool friend who got access to yet another AI feature! You

--- a/packages/shared/src/components/multiLevelMenu/MultiLevelMenuMaster.tsx
+++ b/packages/shared/src/components/multiLevelMenu/MultiLevelMenuMaster.tsx
@@ -29,7 +29,7 @@ export default function MultiLevelMenuMaster({
             }
           >
             {item.icon}
-            <a className="flex-1 text-left typo-headline">{item.title}</a>
+            <a className="flex-1 font-bold text-left typo-body">{item.title}</a>
             <ArrowIcon className="text-xl rotate-90" />
           </MenuButton>
         </li>

--- a/packages/shared/src/components/post/FixedPostNavigation.tsx
+++ b/packages/shared/src/components/post/FixedPostNavigation.tsx
@@ -43,7 +43,7 @@ function FixedPostNavigation({
         <span className="overflow-hidden whitespace-nowrap typo-footnote text-ellipsis text-theme-label-tertiary">
           {content.subtitle}
         </span>
-        <h3 className="overflow-hidden font-bold whitespace-nowrap text-ellipsis typo-headline">
+        <h3 className="overflow-hidden font-bold whitespace-nowrap text-ellipsis typo-body">
           {content.title}
         </h3>
       </div>

--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -114,7 +114,7 @@ export function WriteFreeformContent({
         offset={[0, -12]}
         message={
           <div className="flex flex-col w-64">
-            <h3 className="font-bold typo-headline">First time? 👋</h3>
+            <h3 className="font-bold typo-body">First time? 👋</h3>
             <p className="mt-1 typo-subhead">
               It looks like this is your first time sharing a post with the
               Squad! This is a community we build together. Please be welcoming

--- a/packages/shared/src/components/squads/SquadEmptyScreen.tsx
+++ b/packages/shared/src/components/squads/SquadEmptyScreen.tsx
@@ -21,7 +21,7 @@ function SquadEmptyScreen(): ReactElement {
             : cloudinary.squads.emptySquad
         }
       />
-      <span className="max-w-lg text-theme-label-primary tablet:typo-title1 typo-headline">
+      <span className="max-w-lg text-theme-label-primary tablet:typo-title1 typo-body">
         Get started by sharing your first post and inviting other developers you
         know and appreciate.
       </span>

--- a/packages/shared/src/components/utilities/common.tsx
+++ b/packages/shared/src/components/utilities/common.tsx
@@ -176,7 +176,7 @@ export enum SharedFeedPage {
 
 export const FeedHeading = classed(
   'h3',
-  'flex flex-row flex-1 items-center typo-headline',
+  'flex flex-row flex-1 items-center typo-body font-bold',
 );
 
 export const getShouldRedirect = (

--- a/packages/shared/src/styles/typography.ts
+++ b/packages/shared/src/styles/typography.ts
@@ -48,12 +48,6 @@ export const typoTitle3 = `
   line-height: 1.625rem;
 `;
 
-export const typoHeadline = `
-  font-size: 1.0625rem;
-  line-height: 1.5rem;
-  font-weight: bold;
-`;
-
 export const typoBody = `
   font-size: 1.0625rem;
   line-height: 1.375rem;

--- a/packages/shared/tailwind/typography.js
+++ b/packages/shared/tailwind/typography.js
@@ -52,12 +52,6 @@ module.exports = plugin(({ addUtilities }) => {
       'line-height': '1.625rem',
     },
 
-    '.typo-headline': {
-      'font-size': '1.0625rem',
-      'line-height': '1.5rem',
-      'font-weight': 'bold',
-    },
-
     '.typo-markdown': {
       'font-size': '1.0625rem',
       'line-height': '1.75rem',

--- a/packages/webapp/components/invite/Referral.tsx
+++ b/packages/webapp/components/invite/Referral.tsx
@@ -54,7 +54,7 @@ export function Referral({
             user={referringUser}
             picture={{ size: isLaptopL ? 'xxxlarge' : 'xlarge' }}
           />
-          <p className="my-auto text-center laptop:text-left typo-headline laptop:typo-title3 laptopL:typo-title2">
+          <p className="my-auto text-center laptop:text-left typo-body laptop:typo-title3 laptopL:typo-title2">
             <span className="block laptop:inline">{referringUser.name}</span>
             <span className="font-normal"> invited you to daily.dev</span>
           </p>

--- a/packages/webapp/components/layouts/AccountLayout/AccountContentSection.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/AccountContentSection.tsx
@@ -13,7 +13,7 @@ interface AccountContentSectionProps {
   className?: ClassName;
 }
 
-const ContentHeading = classed('h2', 'font-bold typo-headline');
+const ContentHeading = classed('h2', 'font-bold typo-body');
 const ContentText = classed('p', 'mt-1 typo-callout text-theme-label-tertiary');
 
 function AccountContentSection({

--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -212,7 +212,7 @@ const Step2 = ({
           />
         </section>
         <section className="flex flex-col self-stretch text-theme-label-tertiary">
-          <h2 className="typo-headline">Customize Style</h2>
+          <h2 className="font-bold typo-body">Customize Style</h2>
           <div className={classNames('flex flex-col -my-0.5 items-start mt-8')}>
             <RadioItem
               disabled={isLoadingImage}

--- a/packages/webapp/pages/notifications.tsx
+++ b/packages/webapp/pages/notifications.tsx
@@ -128,7 +128,7 @@ const Notifications = (): ReactElement => {
       >
         <EnableNotification />
         <h2
-          className="p-6 font-bold typo-headline"
+          className="p-6 font-bold typo-body"
           data-testid="notification_page-title"
         >
           Notifications

--- a/packages/webapp/pages/squads/[handle]/[token].tsx
+++ b/packages/webapp/pages/squads/[handle]/[token].tsx
@@ -226,7 +226,9 @@ const SquadReferral = ({
           <div className="flex flex-row flex-1 items-start">
             <SourceButton source={source} size="xxlarge" />
             <div className="flex flex-col flex-1 mr-0 tablet:mr-4 ml-4">
-              <h2 className="flex flex-col typo-headline">{source.name}</h2>
+              <h2 className="flex flex-col font-bold typo-body">
+                {source.name}
+              </h2>
               <BodyParagraph className="mt-2">@{source.handle}</BodyParagraph>
               {source.description && (
                 <BodyParagraph className="mt-4 break-words">


### PR DESCRIPTION
## Changes

### Describe what this PR does
- [Design](https://dailydotdev.slack.com/archives/C0381BQUEN9/p1701255543561259) removed the typo-headline in favor of using typo-body + font-bold

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
