### PR TITLE
feat: ab test onboarding title and subtitle

### DIFF
--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -16,14 +16,10 @@ const feature = {
   feedVersion: new Feature('feed_version', 15),
   search: new Feature('search', SearchExperiment.Control),
   lowImps: new Feature('feed_low_imps'),
-  onboardingTitle: new Feature(
-    'onboarding_title',
-    'Where developers grow together',
-  ),
-  onboardingSubTitle: new Feature(
-    'onboarding_sub_title',
-    'Get one personalized feed for all the knowledge you need.',
-  ),
+  onboardingCopy: new Feature('onboarding_copy', {
+    title: 'Where developers grow together',
+    description: 'Get one personalized feed for all the knowledge you need.',
+  }),
 };
 
 export { feature };

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -16,6 +16,11 @@ const feature = {
   feedVersion: new Feature('feed_version', 15),
   search: new Feature('search', SearchExperiment.Control),
   lowImps: new Feature('feed_low_imps'),
+  onboardingTitle: new Feature('onboarding_title', 'grow'),
+  onboardingSubTitle: new Feature(
+    'onboarding_sub_title',
+    'Get one personalized feed for all the knowledge you need.',
+  ),
 };
 
 export { feature };

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -16,7 +16,10 @@ const feature = {
   feedVersion: new Feature('feed_version', 15),
   search: new Feature('search', SearchExperiment.Control),
   lowImps: new Feature('feed_low_imps'),
-  onboardingTitle: new Feature('onboarding_title', 'grow'),
+  onboardingTitle: new Feature(
+    'onboarding_title',
+    'Where developers grow together',
+  ),
   onboardingSubTitle: new Feature(
     'onboarding_sub_title',
     'Get one personalized feed for all the knowledge you need.',

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -353,7 +353,7 @@ export function OnboardPage(): ReactElement {
             )}
           >
             <OnboardingTitleGradient className="mb-4 typo-large-title tablet:typo-mega1">
-              Where developers {onboardingTitle} together
+              {onboardingTitle}
             </OnboardingTitleGradient>
 
             <h2 className="mb-8 typo-body tablet:typo-title2">

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -37,7 +37,10 @@ import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import { Loader } from '@dailydotdev/shared/src/components/Loader';
 import { NextSeo, NextSeoProps } from 'next-seo';
 import { SIGNIN_METHOD_KEY } from '@dailydotdev/shared/src/hooks/auth/useSignBack';
-import { useGrowthBookContext } from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import {
+  useFeature,
+  useGrowthBookContext,
+} from '@dailydotdev/shared/src/components/GrowthBookProvider';
 import TrustedCompanies from '@dailydotdev/shared/src/components/TrustedCompanies';
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import { cloudinary } from '@dailydotdev/shared/src/lib/image';
@@ -48,6 +51,7 @@ import { OtherFeedPage, RequestKey } from '@dailydotdev/shared/src/lib/query';
 import FeedLayout from '@dailydotdev/shared/src/components/FeedLayout';
 import useFeedSettings from '@dailydotdev/shared/src/hooks/useFeedSettings';
 import ArrowIcon from '@dailydotdev/shared/src/components/icons/Arrow';
+import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { defaultOpenGraph, defaultSeo } from '../next-seo';
 import styles from '../components/layouts/Onboarding/index.module.css';
 
@@ -86,6 +90,8 @@ export function OnboardPage(): ReactElement {
   const { feedSettings } = useFeedSettings();
   const targetId = ExperimentWinner.OnboardingV4;
   const formRef = useRef<HTMLFormElement>();
+  const onboardingTitle = useFeature(feature.onboardingTitle);
+  const onboardingSubTitle = useFeature(feature.onboardingSubTitle);
 
   const onClickNext = () => {
     let screen = OnboardingStep.Intro;
@@ -347,11 +353,11 @@ export function OnboardPage(): ReactElement {
             )}
           >
             <OnboardingTitleGradient className="mb-4 typo-large-title tablet:typo-mega1">
-              Where developers grow together
+              Where developers {onboardingTitle} together
             </OnboardingTitleGradient>
 
             <h2 className="mb-8 typo-body tablet:typo-title2">
-              Get one personalized feed for all the knowledge you need.
+              {onboardingSubTitle}
             </h2>
 
             {getAuthOptions()}

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -90,8 +90,7 @@ export function OnboardPage(): ReactElement {
   const { feedSettings } = useFeedSettings();
   const targetId = ExperimentWinner.OnboardingV4;
   const formRef = useRef<HTMLFormElement>();
-  const onboardingTitle = useFeature(feature.onboardingTitle);
-  const onboardingSubTitle = useFeature(feature.onboardingSubTitle);
+  const { title, description } = useFeature(feature.onboardingCopy);
 
   const onClickNext = () => {
     let screen = OnboardingStep.Intro;
@@ -353,12 +352,10 @@ export function OnboardPage(): ReactElement {
             )}
           >
             <OnboardingTitleGradient className="mb-4 typo-large-title tablet:typo-mega1">
-              {onboardingTitle}
+              {title}
             </OnboardingTitleGradient>
 
-            <h2 className="mb-8 typo-body tablet:typo-title2">
-              {onboardingSubTitle}
-            </h2>
+            <h2 className="mb-8 typo-body tablet:typo-title2">{description}</h2>
 
             {getAuthOptions()}
           </div>


### PR DESCRIPTION
## Changes
- AB test the onboarding's both title and subtitle.
- As discussed during the meeting, the feature value should be what is expected as opposed to the usual values of v1, v2, etc.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2018 #done
