### PR TITLE
fix: feed card feedback actions

### DIFF
--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -150,10 +150,10 @@ export default function FeedItemComponent({
             ...item.post,
           }}
           data-testid="postItem"
-          onUpvoteClick={(post) => {
+          onUpvoteClick={(post, origin = Origin.Feed) => {
             toggleUpvote({
               post,
-              origin: Origin.Feed,
+              origin,
               opts: {
                 columns,
                 column,
@@ -161,10 +161,10 @@ export default function FeedItemComponent({
               },
             });
           }}
-          onDownvoteClick={(post) => {
+          onDownvoteClick={(post, origin = Origin.Feed) => {
             toggleDownvote({
               post,
-              origin: Origin.Feed,
+              origin,
               opts: {
                 columns,
                 column,

--- a/packages/shared/src/components/cards/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.tsx
@@ -18,12 +18,14 @@ import { PostTagsPanel } from '../post/block/PostTagsPanel';
 import { useFeedPreviewMode, usePostFeedback } from '../../hooks';
 import styles from './Card.module.css';
 import { FeedbackCard } from './FeedbackCard';
+import { Origin } from '../../lib/analytics';
 
 export const ArticlePostCard = forwardRef(function PostCard(
   {
     post,
     onPostClick,
     onUpvoteClick,
+    onDownvoteClick,
     onCommentClick,
     onMenuClick,
     onShare,
@@ -73,7 +75,13 @@ export const ArticlePostCard = forwardRef(function PostCard(
         <CardButton title={post.title} onClick={onPostCardClick} />
       )}
 
-      {showFeedback && <FeedbackCard post={post} />}
+      {showFeedback && (
+        <FeedbackCard
+          post={post}
+          onUpvoteClick={() => onUpvoteClick(post, Origin.FeedbackCard)}
+          onDownvoteClick={() => onDownvoteClick(post, Origin.FeedbackCard)}
+        />
+      )}
 
       <div
         className={classNames(

--- a/packages/shared/src/components/cards/FeedbackCard.tsx
+++ b/packages/shared/src/components/cards/FeedbackCard.tsx
@@ -1,20 +1,23 @@
-import React, { ReactElement } from 'react';
+import React, { MouseEventHandler, ReactElement } from 'react';
 import { Button, ButtonSize } from '../buttons/Button';
 import DownvoteIcon from '../icons/Downvote';
 import MiniCloseIcon from '../icons/MiniClose';
 import UpvoteIcon from '../icons/Upvote';
 import { Post, UserPostVote } from '../../graphql/posts';
-import { usePostFeedback, useVotePost } from '../../hooks';
-import { Origin } from '../../lib/analytics';
+import { usePostFeedback } from '../../hooks';
 
 interface FeedbackCardProps {
   post: Post;
+  onUpvoteClick: MouseEventHandler;
+  onDownvoteClick: MouseEventHandler;
 }
 
-export const FeedbackCard = ({ post }: FeedbackCardProps): ReactElement => {
+export const FeedbackCard = ({
+  post,
+  onUpvoteClick,
+  onDownvoteClick,
+}: FeedbackCardProps): ReactElement => {
   const { dismissFeedback } = usePostFeedback({ post });
-
-  const { toggleUpvote, toggleDownvote } = useVotePost();
 
   return (
     <div className="flex-1 p-6 pb-5 space-y-4">
@@ -33,7 +36,7 @@ export const FeedbackCard = ({ post }: FeedbackCardProps): ReactElement => {
         <Button
           id="upvote-post-btn"
           pressed={post?.userState?.vote === UserPostVote.Up}
-          onClick={() => toggleUpvote({ post, origin: Origin.FeedbackCard })}
+          onClick={onUpvoteClick}
           icon={
             <UpvoteIcon secondary={post?.userState?.vote === UserPostVote.Up} />
           }
@@ -43,7 +46,7 @@ export const FeedbackCard = ({ post }: FeedbackCardProps): ReactElement => {
         <Button
           id="downvote-post-btn"
           pressed={post?.userState?.vote === UserPostVote.Down}
-          onClick={() => toggleDownvote({ post, origin: Origin.FeedbackCard })}
+          onClick={onDownvoteClick}
           icon={
             <DownvoteIcon
               secondary={post?.userState?.vote === UserPostVote.Down}

--- a/packages/shared/src/components/cards/common.tsx
+++ b/packages/shared/src/components/cards/common.tsx
@@ -6,6 +6,7 @@ import React, {
 } from 'react';
 import { Post } from '../../graphql/posts';
 import classed, { ClassedHTML } from '../../lib/classed';
+import { Origin } from '../../lib/analytics';
 
 export const Separator = (): ReactElement => (
   <span className="mx-1">&#x2022;</span>
@@ -28,8 +29,8 @@ export const Container = classed('div', 'relative flex flex-1 flex-col');
 export interface PostCardProps {
   post: Post;
   onPostClick?: Callback;
-  onUpvoteClick?: (post: Post) => unknown;
-  onDownvoteClick?: (post: Post, downvoted: boolean | number) => unknown;
+  onUpvoteClick?: (post: Post, origin?: Origin) => unknown;
+  onDownvoteClick?: (post: Post, origin?: Origin) => unknown;
   onCommentClick?: Callback;
   onMenuClick?: (event: React.MouseEvent, post: Post) => unknown;
   onReadArticleClick?: (e: React.MouseEvent) => unknown;


### PR DESCRIPTION
## Changes
- The reason there is no change with the UI is, that the `useVotePost` updates the local cache for specific post query, not the feed query.
- The upvote and downvote are inherently available from the cards so utilizing that instead as it follows the correct update of cache.

Deployed at https://preview3.app.daily.dev/

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
