### PR TITLE
fix: reintroduce the screenCentered variable

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -59,6 +59,7 @@ function MainLayout({
   dndActive,
   customBanner,
   additionalButtons,
+  screenCentered = true,
   showSidebar = true,
   className,
   onLogoClick,
@@ -186,7 +187,7 @@ function MainLayout({
         className={classNames(
           'flex flex-row',
           className,
-          sidebarExpanded ? 'laptop:pl-60' : 'laptop:pl-11',
+          !screenCentered && sidebarExpanded ? 'laptop:pl-60' : 'laptop:pl-11',
           isBannerAvailable && 'laptop:pt-8',
         )}
       >


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We should respect the screenCentered variable that got removed initially.

Works on different screens now:
<img width="1624" alt="Screenshot 2023-12-05 at 09 59 01" src="https://github.com/dailydotdev/apps/assets/554874/25bbc678-4baf-4f21-8f60-ad7aba365dc4">
<img width="1624" alt="Screenshot 2023-12-05 at 09 59 07" src="https://github.com/dailydotdev/apps/assets/554874/d8c96a18-eb93-4105-af9f-55c37a3a2cfb">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2035 #done
