### PR TITLE
fix: make `getRank` resilient to undefined arguments being passed in

### DIFF
--- a/packages/shared/src/components/modals/SharedBookmarksModal.tsx
+++ b/packages/shared/src/components/modals/SharedBookmarksModal.tsx
@@ -113,7 +113,7 @@ export default function SharedBookmarksModal({
             </Button>
             <div className="flex gap-2 items-center h-8 text-2xl">
               <DiscordIcon size={IconSize.Medium} />
-              <TwitterIcon size={IconSize.Medium} secondary />
+              <TwitterIcon size={IconSize.Medium} />
               <SlackIcon size={IconSize.Medium} />
               <GithubIcon size={IconSize.Medium} />
             </div>

--- a/packages/shared/src/lib/rank.ts
+++ b/packages/shared/src/lib/rank.ts
@@ -103,7 +103,7 @@ interface GetNextRankTextProps {
   showNextLevel?: boolean;
 }
 
-export const getRank = (rank: number | undefined): number => {
+export const getRank = (rank = 0): number => {
   const computedRank = rank ? Math.max(0, rank - 1) : 0;
 
   if (computedRank >= RANKS.length) {

--- a/packages/shared/src/lib/rank.ts
+++ b/packages/shared/src/lib/rank.ts
@@ -103,8 +103,8 @@ interface GetNextRankTextProps {
   showNextLevel?: boolean;
 }
 
-export const getRank = (rank: number): number => {
-  const computedRank = Math.max(0, rank - 1);
+export const getRank = (rank: number | undefined): number => {
+  const computedRank = rank ? Math.max(0, rank - 1) : 0;
 
   if (computedRank >= RANKS.length) {
     return RANKS.length - 1;


### PR DESCRIPTION
- why the `rank` may be coming back as undefined is to be determined separately

## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2036 #done
