### PR TITLE
fix: editing comments cache update

### DIFF
--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -78,7 +78,9 @@ export default function MainComment({
               commentId: selected.id,
             })
           }
-          onEdit={(selected) => onEdit({ commentId: selected.id })}
+          onEdit={({ id, lastUpdatedAt }) =>
+            onEdit({ commentId: id, lastUpdatedAt })
+          }
         />
       )}
       {editProps && (

--- a/packages/shared/src/components/comments/SubComment.tsx
+++ b/packages/shared/src/components/comments/SubComment.tsx
@@ -32,9 +32,10 @@ function SubComment({
           key={comment.id}
           parentId={parentComment.id}
           comment={comment}
-          onEdit={(selected) =>
+          onEdit={({ id, lastUpdatedAt }) =>
             onEdit({
-              commentId: selected.id,
+              commentId: id,
+              lastUpdatedAt,
               parentCommentId: parentComment.id,
             })
           }

--- a/packages/shared/src/components/fields/MarkdownInput/CommentMarkdownInput.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/CommentMarkdownInput.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import classNames from 'classnames';
+import cloneDeep from 'lodash.clonedeep';
 import { defaultMarkdownCommands } from '../../../hooks/input';
 import MarkdownInput, { MarkdownRef } from './index';
 import {
@@ -91,7 +92,7 @@ export function CommentMarkdownInput({
 
     const comments = generateQueryKey(RequestKey.PostComments, null, postId);
     client.setQueryData<PostCommentsData>(comments, (data) => {
-      const copy = { ...data };
+      const copy = cloneDeep(data);
 
       if (!editCommentId) {
         const edge = generateCommentEdge(comment);

--- a/packages/shared/src/hooks/post/common.ts
+++ b/packages/shared/src/hooks/post/common.ts
@@ -3,6 +3,7 @@ import { CommentMarkdownInputProps } from '../../components/fields/MarkdownInput
 export interface CommentWriteProps {
   commentId: string;
   parentCommentId?: string;
+  lastUpdatedAt?: string;
 }
 
 export interface CommentWrite {

--- a/packages/shared/src/hooks/post/useCommentEdit.ts
+++ b/packages/shared/src/hooks/post/useCommentEdit.ts
@@ -13,11 +13,11 @@ interface UseCommentEdit extends CommentWrite {
 
 export const useCommentEdit = (): UseCommentEdit => {
   const [state, setState] = useState<CommentWriteProps>();
-  const { commentId: id } = state ?? {};
+  const { commentId: id, lastUpdatedAt } = state ?? {};
   const { user } = useAuthContext();
   const { requestMethod } = useRequestProtocol();
   const { data } = useQuery<{ comment: Comment }>(
-    generateQueryKey(RequestKey.Comment, user, id),
+    generateQueryKey(RequestKey.Comment, user, id, lastUpdatedAt),
     () => requestMethod(graphqlUrl, COMMENT_BY_ID_QUERY, { id }),
     { enabled: !!id },
   );


### PR DESCRIPTION
## Changes
- The reason why the cache is not updating, we should now deep-clone the data we are trying to update. Else, if it is considered to be the same, no re-render is triggered.
- Another issue shows, that when editing the same comment for the second time in one session, the latest value is not displayed, so in order to always base from the query, we need to add another parameter to ensure the value and date match.

Seems like after the react-query upgrade we now need to deep clone objects.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2022 #done
