### PR TITLE
fix: wrong analytics format in companion

### DIFF
--- a/packages/shared/src/hooks/analytics/useAnalyticsQueue.ts
+++ b/packages/shared/src/hooks/analytics/useAnalyticsQueue.ts
@@ -84,7 +84,7 @@ export default function useAnalyticsQueue({
               url: ANALYTICS_ENDPOINT,
               type: ExtensionMessageType.FetchRequest,
               args: {
-                body: JSON.stringify(events),
+                body: JSON.stringify({ events }),
                 credentials: 'include',
                 method: 'POST',
                 headers: {


### PR DESCRIPTION


## Changes

When sending analytics events from the companion, some of them were sent in the wrong format. This caused the api to ignore these events

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
