### PR TITLE
fix: move list styling to new format

### DIFF
--- a/packages/shared/src/components/cards/AdList.tsx
+++ b/packages/shared/src/components/cards/AdList.tsx
@@ -1,13 +1,7 @@
 import React, { forwardRef, ReactElement, Ref } from 'react';
 import classNames from 'classnames';
 import { AdCardProps } from './AdCard';
-import {
-  ListCard,
-  ListCardAside,
-  ListCardDivider,
-  ListCardMain,
-  ListCardTitle,
-} from './Card';
+import { ListCard, ListCardMain, ListCardTitle } from './Card';
 import AdLink from './AdLink';
 import AdAttribution from './AdAttribution';
 
@@ -18,8 +12,6 @@ export const AdList = forwardRef(function AdList(
   return (
     <ListCard {...domProps} data-testid="adItem" ref={ref}>
       <AdLink ad={ad} onLinkClick={onLinkClick} />
-      <ListCardAside />
-      <ListCardDivider />
       <ListCardMain>
         <ListCardTitle
           className={classNames('line-clamp-4 font-bold typo-title3')}

--- a/packages/shared/src/components/cards/Card.tsx
+++ b/packages/shared/src/components/cards/Card.tsx
@@ -79,8 +79,6 @@ export const ListCardMain = classed(
   'flex-1 flex flex-col items-start ml-4',
 );
 
-export const ListCardAside = classed('div', 'flex flex-col items-center');
-
 export const ListCardDivider = classed(
   'div',
   'w-px h-full bg-theme-divider-tertiary',

--- a/packages/shared/src/components/cards/PostList.tsx
+++ b/packages/shared/src/components/cards/PostList.tsx
@@ -3,8 +3,6 @@ import { PostCardProps } from './common';
 import {
   getPostClassNames,
   ListCardTitle,
-  ListCardDivider,
-  ListCardAside,
   ListCardMain,
   CardButton,
 } from './Card';
@@ -56,15 +54,12 @@ export const PostList = forwardRef(function PostList(
       flagProps={{ listMode: true, pinnedAt, trending }}
     >
       <CardButton title={post.title} onClick={onPostCardClick} />
-      <ListCardAside className="w-14">
+      <ListCardMain>
         <SourceButton
           source={post?.source}
-          className="pb-2"
+          className="mb-2.5"
           tooltipPosition="top"
         />
-      </ListCardAside>
-      <ListCardDivider className="mb-1" />
-      <ListCardMain>
         <ListCardTitle>{post.title}</ListCardTitle>
         <PostMetadata
           createdAt={post.createdAt}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- New list styling -> Removes the left source and places it on top.

Before:
<img width="1165" alt="Screenshot 2023-12-06 at 09 46 01" src="https://github.com/dailydotdev/apps/assets/554874/630c80e0-3bca-42c2-beb0-5f5962708900">

After:
<img width="1180" alt="Screenshot 2023-12-06 at 09 56 58" src="https://github.com/dailydotdev/apps/assets/554874/8651c8c5-4ab3-47bb-b1ba-61dbd5b9a54c">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2039 #done
