### PR TITLE
fix: missing analytics for go to link action

### DIFF
--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement, useContext, useMemo, useState } from 'react';
 import classNames from 'classnames';
-import Link from 'next/link';
 import PostSourceInfo from './PostSourceInfo';
 import { ReadArticleButton } from '../cards/ReadArticleButton';
 import { LazyImage } from '../LazyImage';
@@ -12,23 +11,7 @@ import SettingsContext from '../../contexts/SettingsContext';
 import { SharePostTitle } from './share';
 import { combinedClicks } from '../../lib/click';
 import { SourceType } from '../../graphql/sources';
-
-interface PostLinkProps {
-  href: string;
-  as?: string;
-  target?: string;
-  rel?: string;
-  className?: string;
-  children: React.ReactNode;
-}
-
-const PostLink = ({ href, as, children, ...props }: PostLinkProps) => {
-  return (
-    <Link href={href} as={as}>
-      <a {...props}>{children}</a>
-    </Link>
-  );
-};
+import { SharedPostLink } from './common/SharedPostLink';
 
 interface SharePostContentProps {
   post: Post;
@@ -51,18 +34,6 @@ function SharePostContent({
     return shouldShowSummary ? height : 0;
   }, [shouldShowSummary, height]);
 
-  const isUnknownSource = post.sharedPost.source.id === 'unknown';
-  const postLink = isUnknownSource
-    ? {
-        href: post.sharedPost.permalink,
-        target: '_blank',
-        rel: 'noopener',
-      }
-    : {
-        href: `${post.sharedPost.commentsPermalink}?squad=${post.source.handle}&n=${post.source.name}`,
-        as: post.sharedPost.commentsPermalink,
-      };
-
   const openArticle = (e: React.MouseEvent) => {
     e.stopPropagation();
     onReadArticle();
@@ -77,12 +48,13 @@ function SharePostContent({
       <div className="flex flex-col mt-8 rounded-16 border border-theme-divider-tertiary hover:border-theme-divider-secondary">
         <div className="flex flex-col-reverse laptop:flex-row p-4 max-w-full">
           <div className="flex flex-col flex-1">
-            <PostLink
-              {...postLink}
+            <SharedPostLink
+              post={post}
+              onGoToLinkProps={combinedClicks(openArticle)}
               className="flex flex-wrap mt-4 laptop:mt-0 mb-4 font-bold typo-body"
             >
               {post.sharedPost.title}
-            </PostLink>
+            </SharedPostLink>
             <PostSourceInfo
               date={
                 post.sharedPost.readTime
@@ -106,8 +78,9 @@ function SharePostContent({
             />
           </div>
 
-          <PostLink
-            {...postLink}
+          <SharedPostLink
+            post={post}
+            onGoToLinkProps={combinedClicks(openArticle)}
             className="block overflow-hidden ml-2 w-70 rounded-2xl cursor-pointer h-fit"
           >
             <LazyImage
@@ -117,7 +90,7 @@ function SharePostContent({
               eager
               fallbackSrc={cloudinary.post.imageCoverPlaceholder}
             />
-          </PostLink>
+          </SharedPostLink>
         </div>
         {post.sharedPost.summary && (
           <>

--- a/packages/shared/src/components/post/common/SharedPostLink.tsx
+++ b/packages/shared/src/components/post/common/SharedPostLink.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+import React, { ReactElement, ReactNode } from 'react';
+import { Post } from '../../../graphql/posts';
+import { CombinedClicks } from '../../../lib/click';
+
+interface SharedPostTitleProps {
+  post: Post;
+  children: ReactNode;
+  className?: string;
+  onGoToLinkProps?: CombinedClicks;
+}
+
+export const SharedPostLink = ({
+  post,
+  className,
+  children,
+  onGoToLinkProps,
+}: SharedPostTitleProps): ReactElement => {
+  const isUnknownSource = post.sharedPost.source.id === 'unknown';
+  const { href, as, ...props } = isUnknownSource
+    ? {
+        href: post.sharedPost.permalink,
+        target: '_blank',
+        rel: 'noopener',
+        as: undefined,
+        ...onGoToLinkProps,
+      }
+    : {
+        href: `${post.sharedPost.commentsPermalink}?squad=${post.source.handle}&n=${post.source.name}`,
+        as: post.sharedPost.commentsPermalink,
+      };
+
+  return (
+    <Link href={href} as={as}>
+      <a {...props} className={className}>
+        {children}
+      </a>
+    </Link>
+  );
+};

--- a/packages/shared/src/lib/click.ts
+++ b/packages/shared/src/lib/click.ts
@@ -1,9 +1,10 @@
 import React from 'react';
 
-type CombinedClicks = {
+export interface CombinedClicks {
   onAuxClick: React.MouseEventHandler<HTMLAnchorElement>;
   onClick: React.MouseEventHandler<HTMLAnchorElement>;
-};
+}
+
 export const combinedClicks = (
   func: React.MouseEventHandler,
 ): CombinedClicks => {


### PR DESCRIPTION
## Changes
- Introduced the [same component](https://github.com/dailydotdev/apps/blob/f8e5b0aea4564937115b9c41399782b4579657dc/packages/shared/src/components/post/common/SharedPostLink.tsx) found in the YT intermediate branch.
- Fix the missing analytics for go to link actions.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2054 #done
