### PR TITLE
fix: profile menu user image aspect ratio

### DIFF
--- a/packages/shared/src/components/image/LabeledImage.tsx
+++ b/packages/shared/src/components/image/LabeledImage.tsx
@@ -27,7 +27,7 @@ export function LabeledImage({
     <Container className={classNames(className?.container, 'relative')}>
       <img
         className={classNames(
-          'w-full bg-cover opacity-64 aspect-square',
+          'w-full bg-cover opacity-64 aspect-square object-cover',
           className?.image,
         )}
         src={src}


### PR DESCRIPTION
## Changes

### Describe what this PR does

Fixes part of the bug in https://dailydotdev.atlassian.net/browse/WT-2053

The profile menu was showing the profile picture in the dropdown with square aspect ratio. This however mangled the profile picture unless the source picture was also in a square aspect ratio, which might not be the case.

Fixed by [adding `object-fit: cover` style](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) to the `<img` element with [tailwind `object-cover` className](https://tailwindcss.com/docs/object-fit).

#### Before
<img width="243" alt="Screenshot 2023-12-12 at 11 10 39" src="https://github.com/dailydotdev/apps/assets/9974711/920cf1d9-ec06-4e95-a37c-6ea983f66986">

#### After
<img width="234" alt="Screenshot 2023-12-12 at 11 11 03" src="https://github.com/dailydotdev/apps/assets/9974711/16de0f53-f0e6-45b5-8cc8-7dc7da4c8096">

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [x] Android

WT-2053 #done
