### PR TITLE
fix: leverage memo to avoid re-renders

### DIFF
--- a/packages/shared/src/components/image/LabeledImage.tsx
+++ b/packages/shared/src/components/image/LabeledImage.tsx
@@ -27,7 +27,7 @@ export function LabeledImage({
     <Container className={classNames(className?.container, 'relative')}>
       <img
         className={classNames(
-          'w-full bg-cover opacity-64 aspect-square',
+          'w-full bg-cover opacity-64 aspect-square object-cover',
           className?.image,
         )}
         src={src}

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -86,7 +86,7 @@ export default function ProfileLayout({
   const profile = fetchedProfile ?? initialProfile;
   const { twitterHandle, githubHandle, hashnodeHandle, portfolioLink } =
     useMemo(() => {
-      if (typeof window === 'undefined') {
+      if (typeof window === 'undefined' || !profile) {
         return {};
       }
       const purify = DOMPurify(globalThis.window);

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -1,10 +1,4 @@
-import React, {
-  ReactElement,
-  ReactNode,
-  useContext,
-  useEffect,
-  useState,
-} from 'react';
+import React, { ReactElement, ReactNode, useContext, useMemo } from 'react';
 import {
   getProfile,
   getProfileSSR,
@@ -78,10 +72,7 @@ export default function ProfileLayout({
     campaignKey: ReferralCampaignKey.Generic,
     enabled: initialProfile?.id === user?.id,
   });
-  const [twitterHandle, setTwitterHandle] = useState<string>();
-  const [githubHandle, setGithubHandle] = useState<string>();
-  const [hashnodeHandle, setHashnodeHandle] = useState<string>();
-  const [portfolioLink, setPortfolioLink] = useState<string>();
+
   const queryKey = ['profile', initialProfile?.id];
   const { data: fetchedProfile } = useQuery<PublicProfile>(
     queryKey,
@@ -93,15 +84,19 @@ export default function ProfileLayout({
   );
   // Needed because sometimes initialProfile is defined and fetchedProfile is not
   const profile = fetchedProfile ?? initialProfile;
-  useEffect(() => {
-    if (profile) {
-      const purify = DOMPurify(window);
-      setTwitterHandle(sanitizeOrNull(purify, profile.twitter));
-      setGithubHandle(sanitizeOrNull(purify, profile.github));
-      setHashnodeHandle(sanitizeOrNull(purify, profile.hashnode));
-      setPortfolioLink(sanitizeOrNull(purify, profile.portfolio));
-    }
-  }, [profile]);
+  const { twitterHandle, githubHandle, hashnodeHandle, portfolioLink } =
+    useMemo(() => {
+      if (typeof window === 'undefined') {
+        return {};
+      }
+      const purify = DOMPurify(globalThis.window);
+      return {
+        twitterHandle: sanitizeOrNull(purify, profile?.twitter),
+        githubHandle: sanitizeOrNull(purify, profile?.github),
+        hashnodeHandle: sanitizeOrNull(purify, profile?.hashnode),
+        portfolioLink: sanitizeOrNull(purify, profile?.portfolio),
+      };
+    }, [profile]);
   const userRankQueryKey = ['userRank', initialProfile?.id];
   const { data: userRank } = useQuery<UserReadingRankData>(
     userRankQueryKey,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Remove effect/state in favor of memo.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2056 #done
