### PR TITLE
feat: add block state for post option

### DIFF
--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -50,6 +50,7 @@ import {
   AllTagCategoriesData,
   FEED_SETTINGS_QUERY,
   FeedSettings,
+  REMOVE_FILTERS_FROM_FEED_MUTATION,
 } from '../graphql/feedSettings';
 import { getFeedSettingsQueryKey } from '../hooks/useFeedSettings';
 import Toast from './notifications/Toast';
@@ -58,6 +59,7 @@ import { LazyModalElement } from './modals/LazyModalElement';
 import { feature } from '../lib/featureManagement';
 import { SearchExperiment } from '../lib/featureValues';
 import { AuthTriggers } from '../lib/auth';
+import { SourceType } from '../graphql/sources';
 
 const showLogin = jest.fn();
 let nextCallback: (value: PostsEngaged) => unknown = null;
@@ -812,6 +814,62 @@ it('should block a source', async () => {
     expect(data).toBeTruthy();
   });
   const contextBtn = await screen.findByText("Don't show posts from Echo JS");
+  contextBtn.click();
+
+  await waitFor(async () => {
+    await screen.findByRole('alert');
+    const feed = await screen.findByTestId('posts-feed');
+
+    return expect(feed).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  await waitFor(() => expect(mutationCalled).toBeTruthy());
+});
+
+it('should unblock a source', async () => {
+  let mutationCalled = false;
+  renderComponent([
+    createFeedMock({
+      pageInfo: defaultFeedPage.pageInfo,
+      edges: [defaultFeedPage.edges[0]],
+    }),
+    {
+      request: {
+        query: REMOVE_FILTERS_FROM_FEED_MUTATION,
+        variables: { filters: { excludeSources: ['echojs'] } },
+      },
+      result: () => {
+        mutationCalled = true;
+        return { data: { _: true } };
+      },
+    },
+  ]);
+  const [menuBtn] = await screen.findAllByLabelText('Options');
+  menuBtn.click();
+  mockGraphQL(
+    createTagsSettingsMock({
+      includeTags: [],
+      blockedTags: [],
+      excludeSources: [
+        {
+          id: 'echojs',
+          name: 'Echo JS',
+          handle: 'echojs',
+          image: 'https://s1.com/echojs.jpg',
+          permalink: 'https://s1.com/echojs',
+          type: SourceType.Machine,
+          public: true,
+        },
+      ],
+    }),
+  );
+  await waitFor(async () => {
+    const data = await queryClient.getQueryData(
+      getFeedSettingsQueryKey(defaultUser),
+    );
+    expect(data).toBeTruthy();
+  });
+  const contextBtn = await screen.findByText('Show posts from Echo JS');
   contextBtn.click();
 
   await waitFor(async () => {

--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement, useContext, useMemo } from 'react';
 import { Item } from '@dailydotdev/react-contexify';
 import dynamic from 'next/dynamic';
 import { useQueryClient } from '@tanstack/react-query';
@@ -208,6 +208,21 @@ export default function PostOptionsMenu({
     );
   };
 
+  const onUnblockSource = async (): Promise<void> => {
+    const { successful } = await onFollowSource({
+      source: post?.source,
+      requireLogin: true,
+    });
+
+    if (!successful) {
+      return;
+    }
+
+    displayToast(`${post?.source?.name} unblocked`, {
+      subject: ToastSubject.Feed,
+    });
+  };
+
   const onBlockTag = async (tag: string): Promise<void> => {
     const { successful } = await onBlockTags({
       tags: [tag],
@@ -245,6 +260,12 @@ export default function PostOptionsMenu({
     );
   };
 
+  const isSourceBlocked = useMemo(() => {
+    return !!feedSettings?.excludeSources?.some(
+      (excludedSource) => excludedSource.id === post?.source?.id,
+    );
+  }, [feedSettings?.excludeSources, post?.source?.id]);
+
   const postOptions: MenuItemProps[] = [
     {
       icon: <MenuIcon Icon={EyeIcon} />,
@@ -278,8 +299,10 @@ export default function PostOptionsMenu({
     },
     {
       icon: <MenuIcon Icon={BlockIcon} />,
-      label: `Don't show posts from ${post?.source?.name}`,
-      action: onBlockSource,
+      label: isSourceBlocked
+        ? `Show posts from ${post?.source?.name}`
+        : `Don't show posts from ${post?.source?.name}`,
+      action: isSourceBlocked ? onUnblockSource : onBlockSource,
     },
   ];
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We were missing actual block state when user clicks "Don't show posts from..:" 
- We use `feedSettings` to check the state and show it
- Added option to "Show posts from" when source is blocked which remove filter eg. follows source

<img width="501" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/a2b1e92d-2800-4a3f-bfba-36323431c643">
<img width="689" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/fca2ae4c-51cb-4657-92c8-2c6f0097a77e">


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2013 #done
