### PR TITLE
fix: move max and min height to extend rather then override

### DIFF
--- a/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
@@ -96,7 +96,7 @@ function ChangelogTooltip(): ReactElement {
             New release
           </h3>
         </header>
-        <section className="flex flex-col flex-1 p-5 h-full shrink max-h-full">
+        <section className="flex flex-col flex-1 p-5 h-full max-h-full shrink">
           <Image
             className="object-cover rounded-lg w-[207px] h-[108px]"
             alt="Post cover image"

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -141,16 +141,6 @@ module.exports = {
       max: '100',
       '-1': '-1',
     },
-    maxHeight: {
-      'img-desktop': '400px',
-      'img-mobile': '280px',
-      'rank-modal': 'calc(100vh - 5rem)',
-      page: 'calc(100vh - 3.5rem)',
-      commentBox: '18.25rem',
-    },
-    minHeight: {
-      page: 'calc(100vh - 3.5rem)',
-    },
     fontFamily: {
       sans: [
         'system-ui',
@@ -179,6 +169,18 @@ module.exports = {
       responsiveModalBreakpoint: '420px',
     },
     extend: {
+      maxHeight: {
+        'img-desktop': '400px',
+        'img-mobile': '280px',
+        'rank-modal': 'calc(100vh - 5rem)',
+        page: 'calc(100vh - 3.5rem)',
+        commentBox: '18.25rem',
+        card: '23.75rem',
+      },
+      minHeight: {
+        page: 'calc(100vh - 3.5rem)',
+        card: '23.75rem',
+      },
       gap: {
         unset: 'unset',
       },
@@ -218,9 +220,6 @@ module.exports = {
       height: {
         logo: '1.125rem',
         'logo-big': '2.0625rem',
-      },
-      minHeight: {
-        card: '23.75rem',
       },
     },
     lineClamp: {


### PR DESCRIPTION
### Describe what this PR does
move max and min height to extend rather then override

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
