### PR TITLE
fix: post modal

### DIFF
--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -53,7 +53,7 @@ const modalKindToClassName: Record<ModalKind, string> = {
     'h-full max-h-[calc(100vh-2.5rem)] mobileL:h-[40rem] mobileL:max-h-[calc(100vh-5rem)]',
   [ModalKind.FlexibleCenter]:
     'mx-4 max-w-[calc(100vw-2rem)] max-h-[min(calc(100vh),40rem)] mobileL:max-h-[min(calc(100vh-5rem),40rem)]',
-  [ModalKind.FlexibleTop]: 'max-h-full h-auto',
+  [ModalKind.FlexibleTop]: 'h-auto',
   [ModalKind.FixedBottom]: 'rounded-b-none max-h-[34.75rem]',
 };
 const modalKindAndSizeToClassName: Partial<


### PR DESCRIPTION
## Changes

### Describe what this PR does
- With now tailwind defaults we need to remove the `max-h-full` on the modal (post modal)

Before:
<img width="1624" alt="Screenshot 2023-12-12 at 17 29 51" src="https://github.com/dailydotdev/apps/assets/554874/51884226-80e7-4a62-abaf-e66904eda6ba">

After:
<img width="1624" alt="Screenshot 2023-12-12 at 17 29 38" src="https://github.com/dailydotdev/apps/assets/554874/42d14605-fc22-430e-b85d-29c98558ac02">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
