### PR TITLE
fix: settings modal based on feed experiment

### DIFF
--- a/packages/shared/src/components/Settings.tsx
+++ b/packages/shared/src/components/Settings.tsx
@@ -19,6 +19,9 @@ import { CustomSwitch } from './fields/CustomSwitch';
 import AuthContext from '../contexts/AuthContext';
 import { AuthTriggers } from '../lib/auth';
 import { checkIsExtension } from '../lib/func';
+import { FeedLayout } from '../lib/featureValues';
+import { useFeature } from './GrowthBookProvider';
+import { feature } from '../lib/featureManagement';
 
 const densities = [
   { label: 'Eco', value: 'eco' },
@@ -61,6 +64,7 @@ export default function Settings({
   ...props
 }: HTMLAttributes<HTMLDivElement>): ReactElement {
   const isExtension = checkIsExtension();
+  const isFeedV1 = useFeature(feature.feedLayout) === FeedLayout.V1;
   const { user, showLogin } = useContext(AuthContext);
   const {
     spaciness,
@@ -107,19 +111,21 @@ export default function Settings({
 
   return (
     <div className={classNames('flex', 'flex-col', className)} {...props}>
-      <Section className="!mt-0">
-        <SectionTitle>Layout</SectionTitle>
-        <CustomSwitch
-          inputId="layout-switch"
-          name="insaneMode"
-          leftContent={<CardIcon secondary={!insaneMode} />}
-          rightContent={<LineIcon secondary={insaneMode} />}
-          checked={insaneMode}
-          className="mx-1.5"
-          onToggle={toggleInsaneMode}
-        />
-      </Section>
-      <Section>
+      {!isFeedV1 && (
+        <Section className="!mt-0">
+          <SectionTitle>Layout</SectionTitle>
+          <CustomSwitch
+            inputId="layout-switch"
+            name="insaneMode"
+            leftContent={<CardIcon secondary={!insaneMode} />}
+            rightContent={<LineIcon secondary={insaneMode} />}
+            checked={insaneMode}
+            className="mx-1.5"
+            onToggle={toggleInsaneMode}
+          />
+        </Section>
+      )}
+      <Section className={isFeedV1 && '!mt-0'}>
         <SectionTitle>Theme</SectionTitle>
         <Radio
           name="theme"
@@ -128,15 +134,17 @@ export default function Settings({
           onChange={setTheme}
         />
       </Section>
-      <Section>
-        <SectionTitle>Density</SectionTitle>
-        <Radio
-          name="density"
-          options={densities}
-          value={spaciness}
-          onChange={setSpaciness}
-        />
-      </Section>
+      {!isFeedV1 && (
+        <Section>
+          <SectionTitle>Density</SectionTitle>
+          <Radio
+            name="density"
+            options={densities}
+            value={spaciness}
+            onChange={setSpaciness}
+          />
+        </Section>
+      )}
       <Section>
         <SectionTitle>Preferences</SectionTitle>
         <SectionContent>


### PR DESCRIPTION
## Changes
- Unable to use `useFeedLayout` since it requires Feed context which is not available in this Modal.
- Don't show the density and layout when the user is under the experiment for feed layout.

Preview:
![Screenshot 2023-12-13 at 1 38 43 PM](https://github.com/dailydotdev/apps/assets/13744167/e0818f52-7240-4756-9750-2b59c4e02ff1)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2002 #done
