### PR TITLE
fix: usage of layout type

### DIFF
--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -72,7 +72,9 @@ function SquadPostContent({
     onSendViewPost(post.id);
   }, [post.id, onSendViewPost, user?.id]);
 
-  const Content = ContentMap[post?.type];
+  const isVideoShared = post?.sharedPost?.type === PostType.VideoYouTube;
+  const finalType = isVideoShared ? PostType.VideoYouTube : post?.type;
+  const Content = ContentMap[finalType];
 
   return (
     <>


### PR DESCRIPTION
## Changes
- Decide whether to use the shared post's type to use for the layout.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
