### PR TITLE
fix: buttonsize to be large

### DIFF
--- a/packages/shared/src/components/search/SearchBarSuggestion.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestion.tsx
@@ -76,7 +76,7 @@ export const SearchBarSuggestion = ({
       spanClassName="w-fit my-2 flex-shrink tablet:line-clamp-1"
       textPosition="justify-start"
       icon={<AiIcon />}
-      buttonSize={ButtonSize.Large}
+      buttonSize={ButtonSize.Medium}
       className={classNames(
         'btn-secondary border-theme-divider-tertiary typo-subhead text-theme-label-tertiary w-fit !h-auto min-h-[2.5rem]',
         className,

--- a/packages/shared/src/components/search/SearchBarSuggestion.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestion.tsx
@@ -76,7 +76,7 @@ export const SearchBarSuggestion = ({
       spanClassName="w-fit my-2 flex-shrink tablet:line-clamp-1"
       textPosition="justify-start"
       icon={<AiIcon />}
-      buttonSize={ButtonSize.XLarge}
+      buttonSize={ButtonSize.Large}
       className={classNames(
         'btn-secondary border-theme-divider-tertiary typo-subhead text-theme-label-tertiary w-fit !h-auto min-h-[2.5rem]',
         className,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- As we removed the default border radius the suggestion is actually better as medium to be more inline. (this was rendered before)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
