### PR TITLE
chore: refactor profile page and account settings to ButtonV2

### DIFF
--- a/packages/shared/src/components/buttons/ButtonV2.tsx
+++ b/packages/shared/src/components/buttons/ButtonV2.tsx
@@ -54,7 +54,7 @@ export type ButtonElementType<Tag extends AllowedTags> = Tag extends 'a'
   : HTMLButtonElement;
 
 export type ButtonProps<T extends AllowedTags> = BaseButtonProps &
-  HTMLAttributes<T> &
+  HTMLAttributes<AllowedElements> &
   JSX.IntrinsicElements[T] & {
     ref?: Ref<ButtonElementType<T>>;
   };

--- a/packages/shared/src/components/profile/AccountDangerZone.tsx
+++ b/packages/shared/src/components/profile/AccountDangerZone.tsx
@@ -1,6 +1,11 @@
 import classNames from 'classnames';
 import React, { ReactElement, ReactNode } from 'react';
-import { Button, ButtonSize } from '../buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonSize,
+  ButtonVariant,
+} from '../buttons/ButtonV2';
 
 interface AccountDangerZoneProps {
   onDelete: () => void;
@@ -46,8 +51,10 @@ function AccountDangerZone({
       {children}
       <Button
         onClick={onDelete}
-        buttonSize={ButtonSize.Small}
-        className="self-start mt-6 btn-primary-ketchup text-theme-label-primary"
+        size={ButtonSize.Small}
+        variant={ButtonVariant.Primary}
+        color={ButtonColor.Ketchup}
+        className="self-start mt-6 text-theme-label-primary"
       >
         Delete account
       </Button>

--- a/packages/shared/src/components/profile/AccountDangerZone.tsx
+++ b/packages/shared/src/components/profile/AccountDangerZone.tsx
@@ -54,7 +54,7 @@ function AccountDangerZone({
         size={ButtonSize.Small}
         variant={ButtonVariant.Primary}
         color={ButtonColor.Ketchup}
-        className="self-start mt-6 text-theme-label-primary"
+        className="self-start mt-6"
       >
         Delete account
       </Button>

--- a/packages/shared/src/components/profile/PostsSection.tsx
+++ b/packages/shared/src/components/profile/PostsSection.tsx
@@ -16,7 +16,7 @@ import {
   EmptyMessage,
 } from './common';
 import { ownershipGuide } from '../../lib/constants';
-import { Button } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import ActivitySection from './ActivitySection';
 import { smallPostImage } from '../../lib/image';
 import EyeIcon from '../icons/Eye';
@@ -182,7 +182,8 @@ export default function PostsSection({
             value={user.twitter}
           />
           <Button
-            className="mt-4 w-28 btn-primary"
+            className="mt-4 w-28"
+            variant={ButtonVariant.Primary}
             type="submit"
             disabled={isLoading}
           >

--- a/packages/shared/src/components/profile/ProfileButton.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.tsx
@@ -5,7 +5,7 @@ import AuthContext from '../../contexts/AuthContext';
 import { ProfilePicture } from '../ProfilePicture';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import SettingsIcon from '../icons/Settings';
-import { Button } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
 import { useInteractivePopup } from '../../hooks/utils/useInteractivePopup';
 
 const ProfileMenu = dynamic(
@@ -14,40 +14,38 @@ const ProfileMenu = dynamic(
 
 interface ProfileButtonProps {
   className?: string;
-  atMobileSidebar?: boolean;
+  settingsIconOnly?: boolean;
 }
 
 export default function ProfileButton({
   className,
-  atMobileSidebar,
+  settingsIconOnly,
 }: ProfileButtonProps): ReactElement {
   const { isOpen, onUpdate, wrapHandler } = useInteractivePopup();
   const { user } = useContext(AuthContext);
 
   return (
     <>
-      {atMobileSidebar ? (
+      {settingsIconOnly ? (
         <Button
-          iconOnly
-          className="btn btn-tertiary"
+          variant={ButtonVariant.Tertiary}
           onClick={wrapHandler(() => onUpdate(!isOpen))}
           icon={<SettingsIcon />}
         />
       ) : (
         <SimpleTooltip placement="left" content="Profile settings">
-          <button
-            type="button"
+          <Button
+            variant={ButtonVariant.Float}
+            size={ButtonSize.Small}
             className={classNames(
-              'items-center p-0 ml-0.5 font-bold no-underline rounded-lg border-none cursor-pointer text-theme-label-primary bg-theme-bg-secondary typo-callout focus-outline',
-              className ?? 'flex',
+              'items-center !p-0 ml-0.5 text-theme-label-primary gap-2',
+              className,
             )}
             onClick={wrapHandler(() => onUpdate(!isOpen))}
           >
-            <span className="hidden laptop:block mr-2 ml-3">
-              {user.reputation ?? 0}
-            </span>
+            <span className="block ml-3">{user.reputation ?? 0}</span>
             <ProfilePicture user={user} size="medium" />
-          </button>
+          </Button>
         </SimpleTooltip>
       )}
       {isOpen && <ProfileMenu onClose={() => onUpdate(false)} />}

--- a/packages/shared/src/components/profile/ProfileButton.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.tsx
@@ -34,18 +34,16 @@ export default function ProfileButton({
         />
       ) : (
         <SimpleTooltip placement="left" content="Profile settings">
-          <Button
-            variant={ButtonVariant.Float}
-            size={ButtonSize.Small}
+          <button
             className={classNames(
-              'items-center !p-0 ml-0.5 text-theme-label-primary gap-2',
+              'items-center p-0 ml-0.5 font-bold no-underline rounded-lg border-none cursor-pointer text-theme-label-primary bg-theme-bg-secondary typo-callout focus-outline gap-2',
               className,
             )}
             onClick={wrapHandler(() => onUpdate(!isOpen))}
           >
             <span className="block ml-3">{user.reputation ?? 0}</span>
             <ProfilePicture user={user} size="medium" />
-          </Button>
+          </button>
         </SimpleTooltip>
       )}
       {isOpen && <ProfileMenu onClose={() => onUpdate(false)} />}

--- a/packages/shared/src/components/profile/ProfileButton.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.tsx
@@ -5,7 +5,7 @@ import AuthContext from '../../contexts/AuthContext';
 import { ProfilePicture } from '../ProfilePicture';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import SettingsIcon from '../icons/Settings';
-import { Button, ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import { useInteractivePopup } from '../../hooks/utils/useInteractivePopup';
 
 const ProfileMenu = dynamic(
@@ -35,9 +35,10 @@ export default function ProfileButton({
       ) : (
         <SimpleTooltip placement="left" content="Profile settings">
           <button
+            type="button"
             className={classNames(
               'items-center p-0 ml-0.5 font-bold no-underline rounded-lg border-none cursor-pointer text-theme-label-primary bg-theme-bg-secondary typo-callout focus-outline gap-2',
-              className,
+              className ?? 'flex',
             )}
             onClick={wrapHandler(() => onUpdate(!isOpen))}
           >

--- a/packages/shared/src/components/sidebar/SidebarUserButton.tsx
+++ b/packages/shared/src/components/sidebar/SidebarUserButton.tsx
@@ -28,7 +28,7 @@ export function SidebarUserButton({
                 </ProfileLink>
                 <SearchReferralButton className="ml-3" />
                 <div className="flex-1" />
-                <ProfileButton atMobileSidebar />
+                <ProfileButton settingsIconOnly />
               </div>
               <strong className="mb-0.5 typo-callout">{user.name}</strong>
               <p className="typo-footnote text-theme-label-secondary">

--- a/packages/webapp/components/layouts/AccountLayout/EmailForm.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/EmailForm.tsx
@@ -60,7 +60,7 @@ function EmailForm({
         />
       )}
       <Button
-        className="mt-6 ml-auto w-fit text-theme-label-primary"
+        className="mt-6 ml-auto w-fit"
         variant={ButtonVariant.Primary}
         color={ButtonColor.Cabbage}
       >

--- a/packages/webapp/components/layouts/AccountLayout/EmailForm.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/EmailForm.tsx
@@ -1,4 +1,8 @@
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import {
   PasswordField,
   PasswordFieldProps,
@@ -55,7 +59,11 @@ function EmailForm({
           label={passwordProps?.label || 'Password'}
         />
       )}
-      <Button className="mt-6 ml-auto w-fit bg-theme-color-cabbage btn-quaternary">
+      <Button
+        className="mt-6 ml-auto w-fit text-theme-label-primary"
+        variant={ButtonVariant.Primary}
+        color={ButtonColor.Cabbage}
+      >
         Save changes
       </Button>
     </form>

--- a/packages/webapp/components/layouts/AccountLayout/Security/AccountLoginSection.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/AccountLoginSection.tsx
@@ -24,7 +24,7 @@ interface AccountLoginSectionProps {
   providerAction: (props: ManageSocialProvidersProps) => void;
   children?: ReactNode;
   className?: ClassName;
-  variant: ButtonVariant;
+  buttonVariant: ButtonVariant;
 }
 
 const providerLabel = {
@@ -40,7 +40,7 @@ function AccountLoginSection({
   providerAction,
   children,
   className,
-  variant = ButtonVariant.Primary,
+  buttonVariant = ButtonVariant.Primary,
 }: AccountLoginSectionProps): ReactElement {
   if (!providers?.length) {
     return null;
@@ -59,7 +59,7 @@ function AccountLoginSection({
             key={value}
             icon={icon}
             className={className?.button}
-            variant={variant}
+            variant={buttonVariant}
             onClick={() =>
               providerAction({
                 type: providerActionType,

--- a/packages/webapp/components/layouts/AccountLayout/Security/AccountLoginSection.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/AccountLoginSection.tsx
@@ -1,5 +1,8 @@
 import { Provider } from '@dailydotdev/shared/src/components/auth/common';
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import React, { ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
 import AccountContentSection from '../AccountContentSection';
@@ -21,6 +24,7 @@ interface AccountLoginSectionProps {
   providerAction: (props: ManageSocialProvidersProps) => void;
   children?: ReactNode;
   className?: ClassName;
+  variant: ButtonVariant;
 }
 
 const providerLabel = {
@@ -36,6 +40,7 @@ function AccountLoginSection({
   providerAction,
   children,
   className,
+  variant = ButtonVariant.Primary,
 }: AccountLoginSectionProps): ReactElement {
   if (!providers?.length) {
     return null;
@@ -54,6 +59,7 @@ function AccountLoginSection({
             key={value}
             icon={icon}
             className={className?.button}
+            variant={variant}
             onClick={() =>
               providerAction({
                 type: providerActionType,

--- a/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
@@ -220,7 +220,7 @@ function AccountSecurityDefault({
         )}
       </AccountContentSection>
       <AccountLoginSection
-        variant={ButtonVariant.Primary}
+        buttonVariant={ButtonVariant.Primary}
         title="Add login account"
         description="Add more accounts to ensure you never lose access to your daily.dev
         profile and to make login quick and easy cross device"
@@ -236,7 +236,7 @@ function AccountSecurityDefault({
         providerAction={({ provider }) => unlinkProvider(provider)}
         providerActionType="unlink"
         className={{ button: 'hover:bg-theme-color-ketchup' }}
-        variant={ButtonVariant.Secondary}
+        buttonVariant={ButtonVariant.Secondary}
         providers={removeProviderList.filter(({ value }) =>
           userProviders?.result.includes(value),
         )}

--- a/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
@@ -2,7 +2,8 @@ import { getProviderMapClone } from '@dailydotdev/shared/src/components/auth/com
 import {
   Button,
   ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import LockIcon from '@dailydotdev/shared/src/components/icons/Lock';
 import MailIcon from '@dailydotdev/shared/src/components/icons/Mail';
 import AccountDangerZone from '@dailydotdev/shared/src/components/profile/AccountDangerZone';
@@ -209,8 +210,9 @@ function AccountSecurityDefault({
         )}
         {hasPassword && (
           <Button
-            buttonSize={ButtonSize.Small}
-            className="mt-6 w-fit btn-secondary"
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Secondary}
+            className="mt-6 w-fit"
             onClick={() => onSwitchDisplay(Display.ChangeEmail)}
           >
             Change email
@@ -218,7 +220,7 @@ function AccountSecurityDefault({
         )}
       </AccountContentSection>
       <AccountLoginSection
-        className={{ button: 'btn-primary' }}
+        variant={ButtonVariant.Primary}
         title="Add login account"
         description="Add more accounts to ensure you never lose access to your daily.dev
         profile and to make login quick and easy cross device"
@@ -233,7 +235,8 @@ function AccountSecurityDefault({
         description="Remove the connection between daily.dev and authorized login providers."
         providerAction={({ provider }) => unlinkProvider(provider)}
         providerActionType="unlink"
-        className={{ button: 'btn-secondary hover:bg-theme-color-ketchup' }}
+        className={{ button: 'hover:bg-theme-color-ketchup' }}
+        variant={ButtonVariant.Secondary}
         providers={removeProviderList.filter(({ value }) =>
           userProviders?.result.includes(value),
         )}
@@ -257,8 +260,9 @@ function AccountSecurityDefault({
           />
           <Button
             type="submit"
-            buttonSize={ButtonSize.Small}
-            className="mt-6 w-fit btn-secondary"
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Secondary}
+            className="mt-6 w-fit"
           >
             Set password
           </Button>

--- a/packages/webapp/components/layouts/ProfileLayout/NavBar.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/NavBar.tsx
@@ -10,7 +10,8 @@ import { ActiveTabIndicator } from '@dailydotdev/shared/src/components/utilities
 import {
   Button,
   ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import classNames from 'classnames';
 import styles from './NavBar.module.css';
 
@@ -66,9 +67,9 @@ export default function NavBar({
           <Link href={getTabHref(tab)} passHref>
             <Button
               tag="a"
-              buttonSize={ButtonSize.Large}
+              size={ButtonSize.Large}
               pressed={selectedTab === index}
-              className="btn-tertiary"
+              variant={ButtonVariant.Tertiary}
             >
               {tab.title}
             </Button>

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -30,9 +30,8 @@ import {
   USER_READING_RANK_QUERY,
   UserReadingRankData,
 } from '@dailydotdev/shared/src/graphql/users';
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
 import {
-  Button as ButtonV2,
+  Button,
   ButtonVariant,
 } from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import { QuaternaryButton } from '@dailydotdev/shared/src/components/buttons/QuaternaryButton';
@@ -209,7 +208,7 @@ export default function ProfileLayout({
                     target="_blank"
                     rel="noopener"
                     icon={<TwitterIcon />}
-                    className="btn-tertiary"
+                    variant={ButtonVariant.Tertiary}
                   />
                 </SimpleTooltip>
               )}
@@ -221,7 +220,7 @@ export default function ProfileLayout({
                     target="_blank"
                     rel="noopener"
                     icon={<GitHubIcon secondary />}
-                    className="btn-tertiary"
+                    variant={ButtonVariant.Tertiary}
                   />
                 </SimpleTooltip>
               )}
@@ -233,7 +232,7 @@ export default function ProfileLayout({
                     target="_blank"
                     rel="noopener"
                     icon={<HashnodeIcon secondary />}
-                    className="btn-tertiary"
+                    variant={ButtonVariant.Tertiary}
                   />
                 </SimpleTooltip>
               )}
@@ -257,14 +256,14 @@ export default function ProfileLayout({
               )}
             </div>
             {isCurrentUserProfile && (
-              <ButtonV2
+              <Button
                 className="self-start mt-6 mb-0.5"
                 variant={ButtonVariant.Secondary}
                 tag="a"
                 href={`${process.env.NEXT_PUBLIC_WEBAPP_URL}account/profile`}
               >
                 Account details
-              </ButtonV2>
+              </Button>
             )}
           </div>
         </section>


### PR DESCRIPTION

## Changes

### Describe what this PR does

First iteration of moving to ButtonV2 in our components, more to come...

This one tackles ProfileButton, Profile Page and Account Settings pages.

Related: https://dailydotdev.atlassian.net/browse/WT-2017 

### Screenshots

<img width="151" alt="Screenshot 2023-12-13 at 10 36 38" src="https://github.com/dailydotdev/apps/assets/9974711/b823188c-1049-4692-8a59-91efe3a71bc7">
<br/>
<img width="292" alt="Screenshot 2023-12-13 at 11 42 40" src="https://github.com/dailydotdev/apps/assets/9974711/bd722ceb-376e-4ca9-9781-6ea18f9d21af">

<img width="658" alt="Screenshot 2023-12-13 at 10 28 26" src="https://github.com/dailydotdev/apps/assets/9974711/a451cec6-836c-49dc-ab33-236a267410ec">


<img width="603" alt="Screenshot 2023-12-13 at 11 35 59" src="https://github.com/dailydotdev/apps/assets/9974711/1bfb616e-0289-46e0-a8ec-ab44571c5054">


<img width="612" alt="Screenshot 2023-12-13 at 11 34 58" src="https://github.com/dailydotdev/apps/assets/9974711/ffdfee81-5391-44a4-80e6-0a10a52e8eab">
<img width="351" alt="Screenshot 2023-12-13 at 14 53 18" src="https://github.com/dailydotdev/apps/assets/9974711/86accde9-dee1-4098-9b18-cf4bd244ac8b">


### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [x] Android