### PR TITLE
fix: tag link size wasn't leverage `buttonSize`

### DIFF
--- a/packages/shared/src/components/TagLinks.tsx
+++ b/packages/shared/src/components/TagLinks.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import Link from 'next/link';
-import { Button } from './buttons/Button';
+import { Button, ButtonSize } from './buttons/Button';
 import { getTagPageLink } from '../lib/links';
 
 interface TagLinkProps {
@@ -14,7 +14,8 @@ export function TagLink({ tag, className }: TagLinkProps): ReactElement {
     <Link href={getTagPageLink(tag)} passHref key={tag} prefetch={false}>
       <Button
         tag="a"
-        className={classNames('btn-tertiaryFloat xsmall', className)}
+        buttonSize={ButtonSize.XSmall}
+        className={classNames('btn-tertiaryFloat', className)}
       >
         #{tag}
       </Button>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The tag links didn't leverage the `buttonSize` prop so they both got `medium` and `xsmall` as classes.

Before:
<img width="659" alt="Screenshot 2023-12-13 at 13 20 45" src="https://github.com/dailydotdev/apps/assets/554874/cb7f3f7f-abee-4662-a1de-3f207fcc8a97">

After:
<img width="664" alt="Screenshot 2023-12-13 at 13 20 51" src="https://github.com/dailydotdev/apps/assets/554874/8eef54be-ad08-40eb-8610-b05518e9d748">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
