### PR TITLE
feat: tree shaking barrel files webapp

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -130,5 +130,5 @@
     "web-vitals": "^3.5.0",
     "webextension-polyfill-ts": "^0.22.0"
   },
-  "sideEffects": false
+  "sideEffects": ["./src/lib/lazysizesImport.ts"]
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -130,5 +130,5 @@
     "web-vitals": "^3.5.0",
     "webextension-polyfill-ts": "^0.22.0"
   },
-  "sideEffects": ["./src/lib/lazysizesImport.ts"]
+  "sideEffects": ["./src/lib/lazysizesImport.ts", "*.css"]
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -129,5 +129,6 @@
     "uuid": "^8.3.2",
     "web-vitals": "^3.5.0",
     "webextension-polyfill-ts": "^0.22.0"
-  }
+  },
+  "sideEffects": false
 }

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -103,5 +103,5 @@
     "typescript": "^4.6.4",
     "vercel": "^21.3.3"
   },
-  "sideEffects": false
+  "sideEffects": ["*.css"]
 }

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -102,5 +102,6 @@
     "ts-jest": "^26.5.4",
     "typescript": "^4.6.4",
     "vercel": "^21.3.3"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
## Changes

### Describe what this PR does

In last few weeks/moths (since react migration) I noticed our bundle size was rising incrementally with each PR. In partial this might be for not using lazy loading for some components and probably due to barrel files usage in project. But while looking at it I noticed we might be able to save on those KBs with enabling tree shaking of all unused code. 

Read more at: https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

Basically by declaring no side effects all unused code is remove from final bundle. I don't think we have any side effects because at the end our shared is bundled during webapp build so actually all the code needed is pulled there. 

Only side effect I could find was `lazysizes` import which at this point is legacy and we already mentioned we should remove it in favor of native lazy loading. 🤞 

I also added `.css` to side effects for now since we use global stylesheet.

Available on [preview](https://preview3.app.daily.dev/) if anyone wants take a look.

Difference (shared js bundle, affects all pages):
Current main: 
<img width="731" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/5967a805-4183-4a32-b556-9fa157cb2d62">

This PR:
<img width="728" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/c058a03a-b730-4e7b-86cb-66a6701d3f72">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
