### PR TITLE
refactor: use ButtonV2 in extension directories

### DIFF
--- a/packages/extension/src/companion/CompanionContent.tsx
+++ b/packages/extension/src/companion/CompanionContent.tsx
@@ -8,9 +8,12 @@ import {
 import '@dailydotdev/shared/src/styles/globals.css';
 import SimpleTooltip from '@dailydotdev/shared/src/components/tooltips/SimpleTooltip';
 import { PostBootData } from '@dailydotdev/shared/src/lib/boot';
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import { useCopyLink } from '@dailydotdev/shared/src/hooks/useCopy';
-import classNames from 'classnames';
 import { useUpvoteQuery } from '@dailydotdev/shared/src/hooks/useUpvoteQuery';
 import { postAnalyticsEvent } from '@dailydotdev/shared/src/lib/feed';
 import { ShareProvider } from '@dailydotdev/shared/src/lib/share';
@@ -57,9 +60,7 @@ export default function CompanionContent({
   return (
     <div
       ref={onContainerChange}
-      className={classNames(
-        'flex relative flex-col p-6 h-auto rounded-tl-16 border border-r-0 w-[22.5rem] border-theme-divider-quaternary bg-theme-bg-primary',
-      )}
+      className="flex relative flex-col p-6 h-auto rounded-tl-16 border border-r-0 w-[22.5rem] border-theme-divider-quaternary bg-theme-bg-primary"
     >
       <div className="flex flex-row gap-3 items-center">
         <a href={process.env.NEXT_PUBLIC_WEBAPP_URL} target="_parent">
@@ -74,10 +75,9 @@ export default function CompanionContent({
         >
           <Button
             icon={<CopyIcon />}
-            className={classNames(
-              'ml-auto',
-              copying ? 'btn-tertiary-avocado' : ' btn-tertiary',
-            )}
+            variant={ButtonVariant.Tertiary}
+            color={copying ? ButtonColor.Avocado : undefined}
+            className="ml-auto"
             onClick={trackAndCopyLink}
           />
         </SimpleTooltip>

--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -1,5 +1,9 @@
 import React, { ReactElement, useContext, useEffect } from 'react';
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import UpvoteIcon from '@dailydotdev/shared/src/components/icons/Upvote';
 import CommentIcon from '@dailydotdev/shared/src/components/icons/Discuss';
 import MenuIcon from '@dailydotdev/shared/src/components/icons/Menu';
@@ -222,7 +226,8 @@ export default function CompanionMenu({
           }
           pressed={post?.userState?.vote === UserPostVote.Up}
           onClick={onToggleUpvote}
-          className="btn-tertiary-avocado"
+          variant={ButtonVariant.Tertiary}
+          color={ButtonColor.Avocado}
         />
       </SimpleTooltip>
       <SimpleTooltip
@@ -232,7 +237,8 @@ export default function CompanionMenu({
         container={tooltipContainerProps}
       >
         <Button
-          className="btn-tertiary-blueCheese"
+          variant={ButtonVariant.Tertiary}
+          color={ButtonColor.BlueCheese}
           pressed={post?.commented}
           icon={<CommentIcon />}
           onClick={() => {
@@ -259,7 +265,8 @@ export default function CompanionMenu({
           icon={<BookmarkIcon secondary={post?.bookmarked} />}
           pressed={post?.bookmarked}
           onClick={toggleBookmark}
-          className="btn-tertiary-bun"
+          variant={ButtonVariant.Tertiary}
+          color={ButtonColor.Bun}
         />
       </SimpleTooltip>
       <SimpleTooltip
@@ -269,7 +276,8 @@ export default function CompanionMenu({
         container={tooltipContainerProps}
       >
         <Button
-          className="btn-tertiary-cabbage"
+          variant={ButtonVariant.Tertiary}
+          color={ButtonColor.Cabbage}
           onClick={onShare}
           icon={<ShareIcon />}
         />
@@ -281,7 +289,7 @@ export default function CompanionMenu({
         container={tooltipContainerProps}
       >
         <Button
-          className="btn-tertiary"
+          variant={ButtonVariant.Tertiary}
           icon={<MenuIcon />}
           onClick={onContextOptions}
         />

--- a/packages/extension/src/companion/CompanionPermission.tsx
+++ b/packages/extension/src/companion/CompanionPermission.tsx
@@ -1,7 +1,8 @@
 import {
   Button,
   ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import classed from '@dailydotdev/shared/src/lib/classed';
 import { companionExplainerVideo } from '@dailydotdev/shared/src/lib/constants';
 import React, { ReactElement, Ref, forwardRef } from 'react';
@@ -35,13 +36,14 @@ const CompanionPermissionComponent = (
           {description}
         </p>
         <Button
-          className="mt-1 w-[12.5rem] btn btn-primary"
+          className="mt-1 w-[12.5rem]"
           onClick={() =>
             requestContentScripts({
               origin: 'companion permission popup',
             })
           }
-          buttonSize={ButtonSize.Small}
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Primary}
         >
           {button}
         </Button>

--- a/packages/extension/src/companion/CompanionPopupButton.tsx
+++ b/packages/extension/src/companion/CompanionPopupButton.tsx
@@ -1,6 +1,9 @@
 import React, { useState, ReactElement, useContext, useEffect } from 'react';
-import classNames from 'classnames';
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import SimpleTooltip from '@dailydotdev/shared/src/components/tooltips/SimpleTooltip';
 import CompanionIcon from '@dailydotdev/shared/src/components/icons/App';
 import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext';
@@ -61,12 +64,13 @@ export const CompanionPopupButton = (): ReactElement => {
     >
       <Button
         onClick={onButtonClick}
-        className={classNames(
-          'mr-4 border-theme-status-cabbage hidden laptop:flex',
+        variant={
           showCompanionPermission
-            ? 'btn-primary-cabbage'
-            : 'btn-secondary-cabbage',
-        )}
+            ? ButtonVariant.Primary
+            : ButtonVariant.Secondary
+        }
+        color={ButtonColor.Cabbage}
+        className="mr-4 border-theme-status-cabbage hidden laptop:flex"
         icon={
           <CompanionIcon
             secondary={showCompanionPermission}

--- a/packages/extension/src/companion/CompanionPopupButton.tsx
+++ b/packages/extension/src/companion/CompanionPopupButton.tsx
@@ -70,7 +70,7 @@ export const CompanionPopupButton = (): ReactElement => {
             : ButtonVariant.Secondary
         }
         color={ButtonColor.Cabbage}
-        className="mr-4 border-theme-status-cabbage hidden laptop:flex"
+        className="hidden laptop:flex mr-4 border-theme-status-cabbage"
         icon={
           <CompanionIcon
             secondary={showCompanionPermission}

--- a/packages/extension/src/companion/CompanionToggle.tsx
+++ b/packages/extension/src/companion/CompanionToggle.tsx
@@ -1,5 +1,8 @@
 import React, { ReactElement } from 'react';
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import ArrowIcon from '@dailydotdev/shared/src/components/icons/Arrow';
 import { SimpleTooltip } from '@dailydotdev/shared/src/components/tooltips/SimpleTooltip';
 import LogoIcon from '@dailydotdev/shared/src/svg/LogoIcon';
@@ -41,11 +44,12 @@ function CompanionToggle({
         container={tooltipContainerProps}
       >
         <Button
-          className={classNames(
-            companionState
-              ? 'btn-secondary'
-              : 'btn-tertiary group-hover:btn-secondary',
-          )}
+          variant={
+            companionState ? ButtonVariant.Secondary : ButtonVariant.Tertiary
+          }
+          className={classNames({
+            'group-hover:btn-secondary': !companionState,
+          })}
           icon={
             <>
               <LogoIcon

--- a/packages/extension/src/newtab/CustomLinks.tsx
+++ b/packages/extension/src/newtab/CustomLinks.tsx
@@ -1,7 +1,8 @@
 import {
   Button,
   ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import SimpleTooltip from '@dailydotdev/shared/src/components/tooltips/SimpleTooltip';
 import MenuIcon from '@dailydotdev/shared/src/components/icons/Menu';
 import classNames from 'classnames';
@@ -52,10 +53,10 @@ export function CustomLinks({
       ))}
       <SimpleTooltip placement="left" content="Edit shortcuts">
         <Button
-          className="btn-tertiary"
+          variant={ButtonVariant.Tertiary}
           icon={<MenuIcon />}
           onClick={onOptions}
-          buttonSize={ButtonSize.Small}
+          size={ButtonSize.Small}
         />
       </SimpleTooltip>
     </div>

--- a/packages/extension/src/newtab/DndBanner.tsx
+++ b/packages/extension/src/newtab/DndBanner.tsx
@@ -2,7 +2,8 @@ import React, { ReactElement, useContext } from 'react';
 import {
   Button,
   ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import XIcon from '@dailydotdev/shared/src/components/icons/MiniClose';
 import DndContext from './DndContext';
 
@@ -15,16 +16,17 @@ export default function DndBanner(): ReactElement {
     <div className="flex relative laptop:fixed z-3 flex-col laptop:flex-row laptop:justify-center items-start laptop:items-center laptop:p-0 py-3 pr-12 pl-3 w-full laptop:h-8 typo-footnote bg-theme-bg-onion">
       <strong>daily.dev in a new tab is paused</strong>
       <Button
-        buttonSize={ButtonSize.XSmall}
-        className="mt-2 laptop:mt-0 laptop:ml-4 btn-primary"
+        size={ButtonSize.XSmall}
+        variant={ButtonVariant.Primary}
+        className="mt-2 laptop:mt-0 laptop:ml-4"
         onClick={turnOff}
       >
         Unpause
       </Button>
       <Button
-        buttonSize={ButtonSize.XSmall}
-        className="laptop:inset-y-0 top-2 right-2 laptop:my-auto btn-tertiary"
-        style={{ position: 'absolute' }}
+        size={ButtonSize.XSmall}
+        variant={ButtonVariant.Tertiary}
+        className="laptop:inset-y-0 top-2 right-2 laptop:my-auto absolute"
         icon={<XIcon />}
         onClick={turnOff}
       />

--- a/packages/extension/src/newtab/DndBanner.tsx
+++ b/packages/extension/src/newtab/DndBanner.tsx
@@ -26,7 +26,7 @@ export default function DndBanner(): ReactElement {
       <Button
         size={ButtonSize.XSmall}
         variant={ButtonVariant.Tertiary}
-        className="laptop:inset-y-0 top-2 right-2 laptop:my-auto absolute"
+        className="absolute laptop:inset-y-0 top-2 right-2 laptop:my-auto"
         icon={<XIcon />}
         onClick={turnOff}
       />

--- a/packages/extension/src/newtab/DndModal.tsx
+++ b/packages/extension/src/newtab/DndModal.tsx
@@ -1,7 +1,10 @@
 import React, { ReactElement, useState, useContext } from 'react';
 import { format } from 'date-fns';
 import { Radio } from '@dailydotdev/shared/src/components/fields/Radio';
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import { Dropdown } from '@dailydotdev/shared/src/components/fields/Dropdown';
 import { TextField } from '@dailydotdev/shared/src/components/fields/TextField';
 import {
@@ -100,15 +103,18 @@ export default function DndModal({
       <Modal.Footer justify={!isActive ? Justify.End : Justify.Between}>
         {isActive ? (
           <>
-            <Button className="btn-secondary" onClick={onRequestClose}>
+            <Button variant={ButtonVariant.Secondary} onClick={onRequestClose}>
               Keep paused
             </Button>
-            <Button className="btn-primary" onClick={() => onDndSettings(null)}>
+            <Button
+              variant={ButtonVariant.Primary}
+              onClick={() => onDndSettings(null)}
+            >
               Unpause now
             </Button>
           </>
         ) : (
-          <Button className=" btn-primary" onClick={handleSubmit}>
+          <Button variant={ButtonVariant.Primary} onClick={handleSubmit}>
             Done
           </Button>
         )}

--- a/packages/extension/src/newtab/MostVisitedSitesModal.tsx
+++ b/packages/extension/src/newtab/MostVisitedSitesModal.tsx
@@ -1,6 +1,9 @@
 import React, { ReactElement } from 'react';
 import { LazyImage } from '@dailydotdev/shared/src/components/LazyImage';
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import {
   Modal,
   ModalProps,
@@ -41,7 +44,7 @@ export default function MostVisitedSitesModal({
         </Modal.Text>
       </Modal.Body>
       <Modal.Footer justify={Justify.Center}>
-        <Button onClick={onApprove} className="btn-primary">
+        <Button onClick={onApprove} variant={ButtonVariant.Primary}>
           Add the shortcuts
         </Button>
       </Modal.Footer>

--- a/packages/extension/src/newtab/ShortcutLinks.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.tsx
@@ -8,7 +8,11 @@ import React, {
 } from 'react';
 import PlusIcon from '@dailydotdev/shared/src/components/icons/Plus';
 import SettingsContext from '@dailydotdev/shared/src/contexts/SettingsContext';
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Button,
+  ButtonIconPosition,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import { WithClassNameProps } from '@dailydotdev/shared/src/components/utilities';
 import classNames from 'classnames';
 import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext';
@@ -115,8 +119,10 @@ export default function ShortcutLinks({
         />
       ) : (
         <Button
-          className={classNames('btn-tertiary', className)}
-          rightIcon={<PlusIcon />}
+          className={className}
+          variant={ButtonVariant.Tertiary}
+          icon={<PlusIcon />}
+          iconPosition={ButtonIconPosition.Right}
           onClick={onOptionsOpen}
         >
           Add shortcuts

--- a/packages/extension/src/newtab/ShortcutLinks.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.tsx
@@ -14,7 +14,6 @@ import {
   ButtonVariant,
 } from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import { WithClassNameProps } from '@dailydotdev/shared/src/components/utilities';
-import classNames from 'classnames';
 import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 import {
   AnalyticsEvent,

--- a/packages/extension/src/newtab/ShortcutLinksModal.tsx
+++ b/packages/extension/src/newtab/ShortcutLinksModal.tsx
@@ -1,5 +1,9 @@
 import React, { FormEventHandler, MutableRefObject, ReactElement } from 'react';
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import { UserIcon } from '@dailydotdev/shared/src/components/icons';
 import SitesIcon from '@dailydotdev/shared/src/components/icons/Sites';
 import {
@@ -83,13 +87,18 @@ export default function CustomLinksModal({
           <Button
             onClick={onRevokePermission}
             form="shortcuts-modal"
-            className="btn-primary-ketchup text-theme-label-primary"
+            variant={ButtonVariant.Primary}
+            color={ButtonColor.Ketchup}
             type="button"
           >
             Revoke access
           </Button>
         )}
-        <Button className="btn-primary" form="shortcuts-modal" type="submit">
+        <Button
+          variant={ButtonVariant.Primary}
+          form="shortcuts-modal"
+          type="submit"
+        >
           Save changes
         </Button>
       </Modal.Footer>


### PR DESCRIPTION
## Changes

### Describe what this PR does

refactored to use ButtonV2 in all of the files inside `packages/extension` directory

Related: https://dailydotdev.atlassian.net/browse/WT-2017

### Screenshots

<img width="84" alt="Screenshot 2023-12-13 at 17 32 25" src="https://github.com/dailydotdev/apps/assets/9974711/880aafb5-8028-4ffc-9d8a-2b68f7e454a2">
<img width="200" alt="Screenshot 2023-12-13 at 17 32 34" src="https://github.com/dailydotdev/apps/assets/9974711/2919da1f-1840-4bf0-8a7e-09154bfb9d51">
<img width="190" alt="Screenshot 2023-12-13 at 17 32 42" src="https://github.com/dailydotdev/apps/assets/9974711/38efccde-8f7d-42cf-b3b1-99c6518f91e9">
<img width="421" alt="Screenshot 2023-12-13 at 17 34 09" src="https://github.com/dailydotdev/apps/assets/9974711/9cbb6637-2469-407d-bdac-eb4b09189523">
<img width="163" alt="Screenshot 2023-12-13 at 17 34 26" src="https://github.com/dailydotdev/apps/assets/9974711/606faf10-ec69-4db5-8c26-172560ec96b6">


### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
