### PR TITLE
fix: do not render PostUpvotesCommentsCount if there are no comments or upvotes

### DIFF
--- a/packages/shared/src/components/post/PostUpvotesCommentsCount.tsx
+++ b/packages/shared/src/components/post/PostUpvotesCommentsCount.tsx
@@ -13,9 +13,10 @@ export function PostUpvotesCommentsCount({
 }: PostUpvotesCommentsCountProps): ReactElement {
   const upvotes = post.numUpvotes || 0;
   const comments = post.numComments || 0;
-  const hasUpvotesOrComments = upvotes > 0 || comments > 0;
+  const hasUpvotesOrCommentsOrViews =
+    upvotes > 0 || comments > 0 || post.views > 0;
 
-  return !hasUpvotesOrComments ? (
+  return !hasUpvotesOrCommentsOrViews ? (
     <></>
   ) : (
     <div

--- a/packages/shared/src/components/post/PostUpvotesCommentsCount.tsx
+++ b/packages/shared/src/components/post/PostUpvotesCommentsCount.tsx
@@ -13,8 +13,11 @@ export function PostUpvotesCommentsCount({
 }: PostUpvotesCommentsCountProps): ReactElement {
   const upvotes = post.numUpvotes || 0;
   const comments = post.numComments || 0;
+  const hasUpvotesOrComments = upvotes > 0 || comments > 0;
 
-  return (
+  return !hasUpvotesOrComments ? (
+    <></>
+  ) : (
     <div
       className="flex gap-x-4 items-center my-5 text-theme-label-tertiary typo-callout"
       data-testid="statsBar"

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -429,8 +429,8 @@ it('should open new comment modal and set the correct props', async () => {
 
 it('should not show stats when they are zero', async () => {
   renderPost();
-  const el = await screen.findByTestId('statsBar');
-  expect(el).toHaveTextContent('');
+  const el = screen.queryByTestId('statsBar');
+  expect(el).not.toBeInTheDocument();
 });
 
 it('should show num upvotes when it is greater than zero', async () => {
@@ -538,8 +538,8 @@ it('should not update post on subscription message when id is not the same', asy
       numComments: 0,
     },
   });
-  const el = await screen.findByTestId('statsBar');
-  expect(el).not.toHaveTextContent('15 Upvotes');
+  const el = screen.queryByTestId('statsBar');
+  expect(el).not.toBeInTheDocument();
 });
 
 it('should send bookmark mutation', async () => {


### PR DESCRIPTION
## Changes

Stops rendering an empty div if there are no comments or upvotes, reducing the black gap

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/a198f060-9444-494e-8bf5-24c570bac440">

 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/79ae7d87-3358-48c3-8859-758c05547cd5">
</table>
