### PR TITLE
fix: top video margin in shared post content

### DIFF
--- a/packages/shared/src/components/post/ShareYouTubeContent.tsx
+++ b/packages/shared/src/components/post/ShareYouTubeContent.tsx
@@ -15,7 +15,7 @@ function ShareYouTubeContent({ post }: ShareYouTubeContentProps): ReactElement {
   return (
     <>
       <SharePostTitle post={post} />
-      <SharedLinkContainer summary={post?.sharedPost?.summary}>
+      <SharedLinkContainer className="mt-6" summary={post?.sharedPost?.summary}>
         <YoutubeVideo
           title={post?.sharedPost?.title}
           videoId={post?.sharedPost?.videoId}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2061 #done
