### PR TITLE
refactor: use ButtonV2 in webapp components and onboarding

### DIFF
--- a/packages/shared/src/components/onboarding/CreateFeedButton.tsx
+++ b/packages/shared/src/components/onboarding/CreateFeedButton.tsx
@@ -1,7 +1,6 @@
 import React, { HTMLAttributes, ReactElement } from 'react';
-import classNames from 'classnames';
 import useFeedSettings from '../../hooks/useFeedSettings';
-import { Button, ButtonElementType } from '../buttons/Button';
+import { Button, ButtonElementType, ButtonVariant } from '../buttons/ButtonV2';
 import { SimpleTooltip } from '../tooltips';
 import { isTesting } from '../../lib/constants';
 import useSidebarRendered from '../../hooks/useSidebarRendered';
@@ -29,7 +28,8 @@ export const CreateFeedButton = ({
     >
       <div>
         <Button
-          className={classNames('btn btn-primary', className)}
+          className={className}
+          variant={ButtonVariant.Primary}
           disabled={!canCreateFeed}
           onClick={onClick}
         >

--- a/packages/shared/src/components/onboarding/FilterOnboardingStep.tsx
+++ b/packages/shared/src/components/onboarding/FilterOnboardingStep.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useContext } from 'react';
 import Container from './OnboardingStep';
 import { Modal } from '../modals/common/Modal';
 import { Justify } from '../utilities';
-import { Button } from '../buttons/Button';
+import { Button, ButtonColor, ButtonVariant } from '../buttons/ButtonV2';
 import { OnboardingStep } from './common';
 import { ModalPropsContext } from '../modals/common/types';
 import { FilterOnboarding } from './FilterOnboarding';
@@ -27,12 +27,16 @@ export function FilterOnboardingStep(): ReactElement {
           </Container>
           <Modal.Footer justify={Justify.Between}>
             <Button
-              className="btn-tertiary"
+              variant={ButtonVariant.Tertiary}
               onClick={activeStepIndex === 0 ? onRequestClose : previousStep}
             >
               {activeStepIndex === 0 ? 'Close' : 'Back'}
             </Button>
-            <Button className="bg-theme-color-cabbage" onClick={nextStep}>
+            <Button
+              color={ButtonColor.Cabbage}
+              variant={ButtonVariant.Primary}
+              onClick={nextStep}
+            >
               Next
             </Button>
           </Modal.Footer>

--- a/packages/shared/src/components/onboarding/FilterOnboardingV4.tsx
+++ b/packages/shared/src/components/onboarding/FilterOnboardingV4.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../graphql/feedSettings';
 import { graphqlUrl } from '../../lib/config';
 import { disabledRefetch, getRandomNumber } from '../../lib/func';
-import { Button } from '../buttons/Button';
+import { Button, ButtonColor, ButtonVariant } from '../buttons/ButtonV2';
 import { AlertColor, AlertDot } from '../AlertDot';
 import { SearchField } from '../fields/SearchField';
 import useDebounce from '../../hooks/useDebounce';
@@ -169,26 +169,32 @@ export function FilterOnboardingV4({
             </ElementPlaceholder>
           ))}
         {!isLoading &&
-          tags?.map((tag) => (
-            <Button
-              key={tag.name}
-              className={classNames(
-                'btn',
-                selectedTags.has(tag.name) ? 'btn-primary-cabbage' : 'btn-tag',
-              )}
-              onClick={() => {
-                onClickTag({ tag });
-              }}
-            >
-              {tag.name}
-              {!searchQuery && !!recommendedTags?.has(tag.name) && (
-                <AlertDot
-                  className="absolute top-1 right-1"
-                  color={AlertColor.Cabbage}
-                />
-              )}
-            </Button>
-          ))}
+          tags?.map((tag) => {
+            const isSelected = selectedTags.has(tag.name);
+            return (
+              <Button
+                key={tag.name}
+                className={classNames({
+                  'btn-tag': !isSelected,
+                })}
+                variant={
+                  isSelected ? ButtonVariant.Primary : ButtonVariant.Float
+                }
+                color={isSelected ? ButtonColor.Cabbage : undefined}
+                onClick={() => {
+                  onClickTag({ tag });
+                }}
+              >
+                {tag.name}
+                {!searchQuery && !!recommendedTags?.has(tag.name) && (
+                  <AlertDot
+                    className="absolute top-1 right-1"
+                    color={AlertColor.Cabbage}
+                  />
+                )}
+              </Button>
+            );
+          })}
       </div>
     </div>
   );

--- a/packages/shared/src/components/onboarding/IntroductionOnboarding.tsx
+++ b/packages/shared/src/components/onboarding/IntroductionOnboarding.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Button } from '../buttons/Button';
+import { Button, ButtonColor, ButtonVariant } from '../buttons/ButtonV2';
 import { Modal } from '../modals/common/Modal';
 import { StepComponentProps } from '../modals/common/ModalStepsWrapper';
 import { Justify } from '../utilities';
@@ -61,10 +61,14 @@ function IntroductionOnboarding({
             )}
           </Container>
           <Modal.Footer justify={Justify.Between}>
-            <Button className="btn-tertiary" onClick={onClose}>
+            <Button variant={ButtonVariant.Tertiary} onClick={onClose}>
               Skip
             </Button>
-            <Button className="bg-theme-color-cabbage" onClick={nextStep}>
+            <Button
+              color={ButtonColor.Cabbage}
+              variant={ButtonVariant.Primary}
+              onClick={nextStep}
+            >
               Continue
             </Button>
           </Modal.Footer>

--- a/packages/shared/src/components/onboarding/OnboardingHeader.tsx
+++ b/packages/shared/src/components/onboarding/OnboardingHeader.tsx
@@ -4,7 +4,7 @@ import { useViewSize, ViewSize } from '../../hooks';
 import { cloudinary } from '../../lib/image';
 import Logo, { LogoPosition } from '../Logo';
 import { AuthProps, AuthDisplay } from '../auth/AuthOptions';
-import { Button } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import { CreateFeedButton } from './CreateFeedButton';
 import { wrapperMaxWidth } from './common';
 
@@ -78,7 +78,8 @@ export const OnboardingHeader = ({
       >
         <span className="hidden tablet:block">Already a daily.dev member?</span>
         <Button
-          className="ml-3 btn-secondary"
+          className="ml-3"
+          variant={ButtonVariant.Secondary}
           onClick={() => {
             setAuth({
               isAuthenticating: true,

--- a/packages/webapp/components/CookieBanner.tsx
+++ b/packages/webapp/components/CookieBanner.tsx
@@ -4,7 +4,8 @@ import CookieIcon from '@dailydotdev/shared/src/components/icons/Cookie';
 import {
   Button,
   ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import { ModalCloseButton } from '@dailydotdev/shared/src/components/modals/ModalCloseButton';
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 
@@ -41,8 +42,9 @@ export default function CookieBanner({
       </div>
       <Button
         onClick={close}
-        className="self-start laptop:self-stretch mt-4 btn-primary"
-        buttonSize={ButtonSize.Small}
+        className="self-start laptop:self-stretch mt-4"
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Small}
       >
         I like cookies
       </Button>

--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, ReactElement, useContext } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import { Flipped, Flipper } from 'react-flip-toolkit';
 import HomeIcon from '@dailydotdev/shared/src/components/icons/Home';
 import BookmarkIcon from '@dailydotdev/shared/src/components/icons/Bookmark';

--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -12,8 +12,10 @@ import { LinkWithTooltip } from '@dailydotdev/shared/src/components/tooltips/Lin
 import { ActiveTabIndicator } from '@dailydotdev/shared/src/components/utilities';
 import {
   Button,
+  ButtonProps,
   ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import classNames from 'classnames';
 import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
 import { Bubble } from '@dailydotdev/shared/src/components/tooltips/utils';
@@ -92,12 +94,10 @@ export default function FooterNavBar(): ReactElement {
   const router = useRouter();
   const selectedTab = tabs.findIndex((tab) => tab.path === router?.pathname);
 
-  const buttonProps: HTMLAttributes<HTMLButtonElement> & {
-    buttonSize: ButtonSize;
-  } = {
-    className: 'btn-tertiary',
+  const buttonProps: ButtonProps<'a' | 'button'> = {
+    variant: ButtonVariant.Tertiary,
     style: { width: '100%' },
-    buttonSize: ButtonSize.Large,
+    size: ButtonSize.Large,
   };
 
   const onNavigateNotifications = () => {

--- a/packages/webapp/components/KeywordManagement.tsx
+++ b/packages/webapp/components/KeywordManagement.tsx
@@ -15,7 +15,11 @@ import { NextSeo } from 'next-seo';
 import ActivitySection from '@dailydotdev/shared/src/components/profile/ActivitySection';
 import Link from 'next/link';
 import { smallPostImage } from '@dailydotdev/shared/src/lib/image';
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import { LazyImage } from '@dailydotdev/shared/src/components/LazyImage';
 import { ResponsivePageContainer } from '@dailydotdev/shared/src/components/utilities';
 import dynamic from 'next/dynamic';
@@ -157,14 +161,14 @@ export default function KeywordManagement({
           loading={currentAction === 'allow'}
           onClick={onAllow}
           disabled={disableActions}
-          className="btn-primary"
+          variant={ButtonVariant.Primary}
         >
           Allow
         </Button>
         <Button
           disabled={disableActions}
           onClick={onSynonym}
-          className="btn-secondary"
+          variant={ButtonVariant.Secondary}
         >
           Synonym
         </Button>
@@ -172,7 +176,8 @@ export default function KeywordManagement({
           loading={currentAction === 'deny'}
           onClick={onDeny}
           disabled={disableActions}
-          className="btn-primary-ketchup"
+          variant={ButtonVariant.Primary}
+          color={ButtonColor.Ketchup}
         >
           Deny
         </Button>

--- a/packages/webapp/components/invite/AISearchInvite.tsx
+++ b/packages/webapp/components/invite/AISearchInvite.tsx
@@ -1,5 +1,8 @@
 import React, { ReactElement, useEffect } from 'react';
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Button,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import { ProfileImageLink } from '@dailydotdev/shared/src/components/profile/ProfileImageLink';
 import KeyIcon from '@dailydotdev/shared/src/components/icons/Key';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
@@ -110,9 +113,9 @@ export function AISearchInvite({
         </p>
         <Button
           icon={<KeyIcon secondary />}
-          className="mt-12 btn-primary"
+          className="mt-12"
+          variant={ButtonVariant.Primary}
           onClick={handleAcceptClick}
-          type="button"
           loading={isLoading}
           disabled={isLoading || isSuccess}
         >

--- a/packages/webapp/components/invite/Referral.tsx
+++ b/packages/webapp/components/invite/Referral.tsx
@@ -2,7 +2,8 @@ import React, { ReactElement, useEffect } from 'react';
 import {
   Button,
   ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import { ProfileImageLink } from '@dailydotdev/shared/src/components/profile/ProfileImageLink';
 import { cloudinary } from '@dailydotdev/shared/src/lib/image';
 import { useAnalyticsContext } from '@dailydotdev/shared/src/contexts/AnalyticsContext';
@@ -72,9 +73,10 @@ export function Referral({
           what’s out there. Maybe 😉
         </p>
         <Button
-          buttonSize={ButtonSize.Large}
+          size={ButtonSize.Large}
+          variant={ButtonVariant.Primary}
           // important has been used is some classnames to override the default styles as agreed on [thread](https://dailydotdev.slack.com/archives/C05P9ET7S9K/p1699023366663489?thread_ts=1699011522.350609&cid=C05P9ET7S9K)
-          className="p-4 mx-auto laptop:mx-0 mt-6 tablet:mt-12 max-w-[17.5rem] tablet:max-w-fit btn-primary tablet:!h-16 tablet:!p-0 tablet:!px-6"
+          className="p-4 mx-auto laptop:mx-0 mt-6 tablet:mt-12 max-w-[17.5rem] tablet:max-w-fit tablet:!h-16 tablet:!p-0 tablet:!px-6"
           tag="a"
           href={downloadBrowserExtension}
           onClick={() => {

--- a/packages/webapp/components/layouts/AccountLayout/AccountPageContainer.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/AccountPageContainer.tsx
@@ -4,7 +4,8 @@ import classNames from 'classnames';
 import {
   Button,
   ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import ArrowIcon from '@dailydotdev/shared/src/components/icons/Arrow';
 import {
   AccountPageContent,
@@ -43,16 +44,18 @@ export const AccountPageContainer = ({
     <AccountPageContent className={classNames('relative', className.container)}>
       <AccountPageHeading className={classNames('sticky', className.heading)}>
         <Button
-          className="flex tablet:hidden mr-2 btn-tertiary"
+          className={classNames('flex tablet:hidden mr-2', { hidden: onBack })}
           icon={<ArrowIcon className="-rotate-90" />}
-          buttonSize={ButtonSize.XSmall}
+          variant={ButtonVariant.Tertiary}
+          size={ButtonSize.XSmall}
           onClick={openSideNav}
         />
         {onBack && (
           <Button
-            className="mr-2 btn-tertiary"
+            className="mr-2"
             icon={<ArrowIcon className="-rotate-90" />}
-            buttonSize={ButtonSize.XSmall}
+            variant={ButtonVariant.Tertiary}
+            size={ButtonSize.XSmall}
             onClick={onBack}
           />
         )}

--- a/packages/webapp/components/layouts/AccountLayout/EmailSentSection.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/EmailSentSection.tsx
@@ -2,7 +2,8 @@ import AlertBanner from '@dailydotdev/shared/src/components/alert/AlertBanner';
 import {
   Button,
   ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import useAccountEmailFlow from '@dailydotdev/shared/src/hooks/useAccountEmailFlow';
@@ -37,8 +38,9 @@ function EmailSentSection({
       <span className="flex flex-row gap-4 mt-4">
         <Button
           onClick={() => sendEmail(email)}
-          buttonSize={ButtonSize.XSmall}
-          className="w-fit btn-primary"
+          size={ButtonSize.XSmall}
+          variant={ButtonVariant.Primary}
+          className="w-fit"
           disabled={isLoading || resendTimer > 0}
         >
           {resendTimer === 0 ? 'Resend' : `${resendTimer}s`}
@@ -46,8 +48,9 @@ function EmailSentSection({
         {onCancel && (
           <Button
             onClick={onCancel}
-            buttonSize={ButtonSize.XSmall}
-            className="w-fit btn-secondary"
+            size={ButtonSize.XSmall}
+            variant={ButtonVariant.Secondary}
+            className="w-fit"
           >
             Cancel Request
           </Button>

--- a/packages/webapp/pages/account/profile.tsx
+++ b/packages/webapp/pages/account/profile.tsx
@@ -7,7 +7,11 @@ import TwitterIcon from '@dailydotdev/shared/src/components/icons/Twitter';
 import { UserIcon } from '@dailydotdev/shared/src/components/icons';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { formToJson } from '@dailydotdev/shared/src/lib/form';
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import React, { ReactElement, useContext, useRef } from 'react';
 import useProfileForm, {
   UpdateProfileParameters,
@@ -52,7 +56,9 @@ const AccountProfilePage = (): ReactElement => {
       title="Profile"
       footer={
         <Button
-          className="ml-auto btn-primary-cabbage"
+          className="ml-auto"
+          variant={ButtonVariant.Primary}
+          color={ButtonColor.Cabbage}
           onClick={onSubmit}
           disabled={isLoading}
         >

--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -11,7 +11,8 @@ import { RadioItem } from '@dailydotdev/shared/src/components/fields/RadioItem';
 import {
   Button,
   ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import { LoaderOverlay } from '@dailydotdev/shared/src/components/LoaderOverlay';
 import { ClickableText } from '@dailydotdev/shared/src/components/buttons/ClickableText';
 import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
@@ -74,8 +75,8 @@ const Step1 = ({
         {!loadingUser &&
           (user ? (
             <Button
-              className="btn-primary"
-              buttonSize={ButtonSize.Large}
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Large}
               onClick={() => onGenerateImage()}
               loading={isLoadingImage}
             >
@@ -83,8 +84,8 @@ const Step1 = ({
             </Button>
           ) : (
             <Button
-              className="btn-secondary"
-              buttonSize={ButtonSize.Large}
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Large}
               onClick={() => showLogin({ trigger: AuthTriggers.DevCard })}
             >
               Login to generate
@@ -186,16 +187,16 @@ const Step2 = ({
           </Tilt>
           <div className="grid grid-cols-2 gap-4 mx-2 mt-8">
             <Button
-              className="btn-primary"
-              buttonSize={ButtonSize.Large}
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Large}
               onClick={downloadImage}
               loading={downloading}
             >
               Download
             </Button>
             <Button
-              className="btn-secondary"
-              buttonSize={ButtonSize.Large}
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Large}
               onClick={() => copyLink()}
             >
               {!copyingLink ? 'Copy link' : 'Copied!'}
@@ -271,8 +272,9 @@ const Step2 = ({
               {embedCode}
             </textarea>
             <Button
-              className="mt-4 btn-secondary"
-              buttonSize={ButtonSize.Small}
+              className="mt-4"
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Small}
               onClick={() => copyEmbed()}
             >
               {!copyingEmbed ? 'Copy code' : 'Copied!'}

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -12,7 +12,11 @@ import {
   FilterOnboardingV4,
   OnboardingHeader,
 } from '@dailydotdev/shared/src/components/onboarding';
-import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Button,
+  ButtonIconPosition,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import { ExperimentWinner } from '@dailydotdev/shared/src/lib/featureValues';
 import { storageWrapper as storage } from '@dailydotdev/shared/src/lib/storageWrapper';
 import classed from '@dailydotdev/shared/src/lib/classed';
@@ -220,16 +224,19 @@ export function OnboardPage(): ReactElement {
             </Title>
             <FilterOnboardingV4 className="mt-10 max-w-4xl" />
             <Button
-              className={classNames(
-                'mt-10 btn',
-                isPreviewVisible ? 'btn-primary' : 'btn-secondary',
-              )}
+              className="mt-10"
+              variant={
+                isPreviewVisible
+                  ? ButtonVariant.Primary
+                  : ButtonVariant.Secondary
+              }
               disabled={!isPreviewEnabled}
-              rightIcon={
+              icon={
                 <ArrowIcon
                   className={classNames(!isPreviewVisible && 'rotate-180')}
                 />
               }
+              iconPosition={ButtonIconPosition.Right}
               onClick={() => {
                 setPreviewVisible((current) => {
                   const newValue = !current;

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -22,7 +22,8 @@ import {
   Button,
   ButtonProps,
   ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import {
   CustomFeedHeader,
   FeedPage,
@@ -82,7 +83,7 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
   };
 
   const buttonProps: ButtonProps<'button'> = {
-    buttonSize: ButtonSize.Small,
+    size: ButtonSize.Small,
     icon: unfollowingSource ? <PlusIcon /> : <BlockIcon />,
     onClick: async (): Promise<void> => {
       if (user) {
@@ -108,11 +109,16 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
         />
         <span className="mr-auto">{source.name}</span>
         <Button
-          className="laptop:hidden btn-secondary"
+          className="laptop:hidden"
+          variant={ButtonVariant.Secondary}
           {...buttonProps}
           aria-label={unfollowingSource ? 'Follow' : 'Block'}
         />
-        <Button className="hidden laptop:flex btn-secondary" {...buttonProps}>
+        <Button
+          className="hidden laptop:flex"
+          variant={ButtonVariant.Secondary}
+          {...buttonProps}
+        >
           {unfollowingSource ? 'Follow' : 'Block'}
         </Button>
       </CustomFeedHeader>

--- a/packages/webapp/pages/squads/[handle]/edit.tsx
+++ b/packages/webapp/pages/squads/[handle]/edit.tsx
@@ -24,7 +24,8 @@ import { ParsedUrlQuery } from 'querystring';
 import {
   Button,
   ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import ArrowIcon from '@dailydotdev/shared/src/components/icons/Arrow';
 import {
   generateQueryKey,
@@ -99,9 +100,10 @@ const EditSquad = ({ handle }: EditSquadPageProps): ReactElement => {
       <ManageSquadPageMain>
         <ManageSquadPageHeader>
           <Button
-            className="mr-2 btn-tertiary"
+            className="mr-2"
+            variant={ButtonVariant.Tertiary}
             icon={<ArrowIcon className="-rotate-90" />}
-            buttonSize={ButtonSize.XSmall}
+            size={ButtonSize.XSmall}
             onClick={() => {
               router.push(`/squads/${squad.handle}`);
             }}

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -19,7 +19,8 @@ import {
   Button,
   ButtonProps,
   ButtonSize,
-} from '@dailydotdev/shared/src/components/buttons/Button';
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
 import {
   CustomFeedHeader,
   customFeedIcon,
@@ -77,7 +78,7 @@ const TagPage = ({ tag }: TagPageProps): ReactElement => {
   };
 
   const followButtonProps: ButtonProps<'button'> = {
-    buttonSize: ButtonSize.Small,
+    size: ButtonSize.Small,
     icon: tagStatus === 'followed' ? <XIcon /> : <PlusIcon />,
     onClick: async (): Promise<void> => {
       if (user) {
@@ -93,7 +94,7 @@ const TagPage = ({ tag }: TagPageProps): ReactElement => {
   };
 
   const blockButtonProps: ButtonProps<'button'> = {
-    buttonSize: ButtonSize.Small,
+    size: ButtonSize.Small,
     icon: tagStatus === 'blocked' ? <XIcon /> : <BlockIcon />,
     onClick: async (): Promise<void> => {
       if (user) {
@@ -117,12 +118,14 @@ const TagPage = ({ tag }: TagPageProps): ReactElement => {
         {tagStatus !== 'followed' && (
           <>
             <Button
-              className="laptop:hidden btn-secondary"
+              className="laptop:hidden"
+              variant={ButtonVariant.Secondary}
               {...blockButtonProps}
               aria-label={tagStatus === 'blocked' ? 'Unblock' : 'Block'}
             />
             <Button
-              className="hidden laptop:flex btn-secondary"
+              className="hidden laptop:flex"
+              variant={ButtonVariant.Secondary}
               {...blockButtonProps}
             >
               {tagStatus === 'blocked' ? 'Unblock' : 'Block'}
@@ -133,17 +136,19 @@ const TagPage = ({ tag }: TagPageProps): ReactElement => {
           <>
             <Button
               className={classNames(
-                'btn-secondary laptop:hidden',
+                'laptop:hidden',
                 tagStatus !== 'followed' && 'ml-4',
               )}
+              variant={ButtonVariant.Secondary}
               {...followButtonProps}
               aria-label={tagStatus === 'followed' ? 'Unfollow' : 'Follow'}
             />
             <Button
               className={classNames(
-                'btn-secondary hidden laptop:flex',
+                'hidden laptop:flex',
                 tagStatus !== 'followed' && 'ml-4',
               )}
+              variant={ButtonVariant.Secondary}
               {...followButtonProps}
             >
               {tagStatus === 'followed' ? 'Unfollow' : 'Follow'}


### PR DESCRIPTION
## Changes

refactor to use ButtonV2 in `packages/webapp` and onboarding components

Fixed 1 bug with email form displaying two arrows on mobile:

Before:

<img width="416" alt="Screenshot 2023-12-14 at 12 53 14" src="https://github.com/dailydotdev/apps/assets/9974711/a62e9be4-4dfe-410e-85e9-852f2695bb1d">

After:
<img width="421" alt="Screenshot 2023-12-14 at 13 02 08" src="https://github.com/dailydotdev/apps/assets/9974711/694e582c-df90-463e-aa40-e1445da5c44a">

### Screenshots
<img width="204" alt="Screenshot 2023-12-14 at 10 37 51" src="https://github.com/dailydotdev/apps/assets/9974711/beb84a8f-cc6a-4980-b929-dbdf316c0f16">
<img width="951" alt="Screenshot 2023-12-14 at 10 40 27" src="https://github.com/dailydotdev/apps/assets/9974711/9c3ae33e-56a4-45a1-83ee-200b66d879f2">
<img width="420" alt="Screenshot 2023-12-14 at 10 41 10" src="https://github.com/dailydotdev/apps/assets/9974711/c1204325-976f-415e-ab0f-3dbd99db9c34">
<img width="470" alt="Screenshot 2023-12-14 at 11 11 50" src="https://github.com/dailydotdev/apps/assets/9974711/cbaeb955-5697-43ee-9728-a18a6a34d1da">
<img width="600" alt="Screenshot 2023-12-14 at 11 15 24" src="https://github.com/dailydotdev/apps/assets/9974711/80c97a97-4f39-48aa-a61d-2c9399ebb248">
<img width="421" alt="Screenshot 2023-12-14 at 13 00 58" src="https://github.com/dailydotdev/apps/assets/9974711/e1762d99-b1ff-4bb7-a862-dc1b3d6c2eb5">
<img width="405" alt="Screenshot 2023-12-14 at 13 03 58" src="https://github.com/dailydotdev/apps/assets/9974711/781a9704-82ca-4dd1-a5b0-5c52d4db2f7b">
<img width="400" alt="Screenshot 2023-12-14 at 13 04 20" src="https://github.com/dailydotdev/apps/assets/9974711/b846d83f-4f7f-4936-b5f5-28162b94d59a">
<img width="554" alt="Screenshot 2023-12-14 at 13 07 19" src="https://github.com/dailydotdev/apps/assets/9974711/1b542d25-ea2b-40fc-b6cc-6b98592324b6">
<img width="699" alt="Screenshot 2023-12-14 at 16 19 22" src="https://github.com/dailydotdev/apps/assets/9974711/2ca8ec37-1c85-4ee0-b79d-fd2fd775addb">
<img width="915" alt="Screenshot 2023-12-14 at 15 01 03" src="https://github.com/dailydotdev/apps/assets/9974711/b63b4e05-94bb-4ade-8d40-48d57e41384c">
<img width="777" alt="Screenshot 2023-12-14 at 16 36 21" src="https://github.com/dailydotdev/apps/assets/9974711/73633dac-ab5a-4de6-82d4-981e5d9bbad8">
<img width="899" alt="Screenshot 2023-12-14 at 15 09 55" src="https://github.com/dailydotdev/apps/assets/9974711/49720879-8a00-4d8d-a61d-32fe160d905b">
<img width="640" alt="Screenshot 2023-12-14 at 15 11 35" src="https://github.com/dailydotdev/apps/assets/9974711/6178c8f7-05d5-4a8e-bac3-211529465655">
<img width="697" alt="Screenshot 2023-12-14 at 16 40 44" src="https://github.com/dailydotdev/apps/assets/9974711/1e396e50-fe64-4533-91d1-1bc7ea35ec98">
<img width="695" alt="Screenshot 2023-12-14 at 16 43 09" src="https://github.com/dailydotdev/apps/assets/9974711/52631267-c5a6-4be5-9ca0-fddd5cf52245">

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
