### PR TITLE
refactor: post notification type

### DIFF
--- a/packages/shared/src/components/notifications/NotificationItem.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.tsx
@@ -120,11 +120,11 @@ function NotificationItem({
             }}
           />
         )}
-        {attachments?.map(({ image, title: attachment }) => (
+        {attachments?.map(({ title: attachment, ...props }) => (
           <NotificationItemAttachment
             key={attachment}
-            image={image}
             title={attachment}
+            {...props}
           />
         ))}
       </div>

--- a/packages/shared/src/components/notifications/NotificationItemAttachment.tsx
+++ b/packages/shared/src/components/notifications/NotificationItemAttachment.tsx
@@ -1,15 +1,23 @@
 import React, { ReactElement } from 'react';
-import { NotificationAttachment } from '../../graphql/notifications';
+import {
+  NotificationAttachment,
+  NotificationAttachmentType,
+} from '../../graphql/notifications';
 import { cloudinary } from '../../lib/image';
 import { Image } from '../image/Image';
+import VideoImage from '../image/VideoImage';
 
 function NotificationItemAttachment({
   image,
   title,
+  type,
 }: NotificationAttachment): ReactElement {
+  const ImageComponent =
+    type === NotificationAttachmentType.Video ? VideoImage : Image;
+
   return (
     <div className="flex flex-row items-center p-4 mt-2 rounded-16 border border-theme-divider-tertiary">
-      <Image
+      <ImageComponent
         src={image}
         alt={`Cover preview of: ${title}`}
         className="object-cover w-24 h-16 rounded-16"

--- a/packages/shared/src/graphql/notifications.ts
+++ b/packages/shared/src/graphql/notifications.ts
@@ -21,9 +21,15 @@ export interface NotificationAvatar extends WithClassNameProps {
   referenceId: string;
 }
 
+export enum NotificationAttachmentType {
+  Post = 'post',
+  Video = 'video',
+}
+
 export interface NotificationAttachment {
   image: string;
   title: string;
+  type: NotificationAttachmentType;
 }
 
 export interface Notification {


### PR DESCRIPTION
## Changes
- Adjust the `NotificationAttachment` component to identify whether to use the image component for video or not.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2055 #done
