### PR TITLE
fix: check if shared post and use sharedPost permalink in insane mode

### DIFF
--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
-import { Post, UserPostVote } from '../../graphql/posts';
+import { Post, PostType, UserPostVote } from '../../graphql/posts';
 import InteractionCounter from '../InteractionCounter';
 import { QuaternaryButton } from '../buttons/QuaternaryButton';
 import UpvoteIcon from '../icons/Upvote';
@@ -163,7 +163,11 @@ export default function ActionButtons({
         >
           <ReadArticleButton
             className="mr-2 btn-primary"
-            href={post.permalink}
+            href={
+              post.type === PostType.Share
+                ? post.sharedPost.permalink
+                : post.permalink
+            }
             onClick={onReadArticleClick}
             openNewTab={openNewTab}
           />


### PR DESCRIPTION
## Changes

### Describe what this PR does
- When in insane mode, it checks if the post is of type `shared`, and then gets the permalink from the sharedPost