### PR TITLE
feat: render watch time as 1h 23m

### DIFF
--- a/packages/shared/src/components/cards/PostMetadata.tsx
+++ b/packages/shared/src/components/cards/PostMetadata.tsx
@@ -5,6 +5,7 @@ import { Separator } from './common';
 import { Post } from '../../graphql/posts';
 import PlayIcon from '../icons/Play';
 import { IconSize } from '../Icon';
+import { formatReadTime } from '../utilities';
 
 interface PostMetadataProps
   extends Pick<Post, 'createdAt' | 'readTime' | 'numUpvotes'> {
@@ -52,7 +53,7 @@ export default function PostMetadata({
       {!!createdAt && !!readTime && <Separator />}
       {!!readTime && (
         <span data-testid="readTime">
-          {readTime}m {timeActionContent} time
+          {formatReadTime(readTime)} {timeActionContent} time
         </span>
       )}
       {(!!createdAt || !!readTime) && !!numUpvotes && <Separator />}

--- a/packages/shared/src/components/post/ShareYouTubeContent.tsx
+++ b/packages/shared/src/components/post/ShareYouTubeContent.tsx
@@ -5,6 +5,7 @@ import { SharePostTitle } from './share';
 import { SharedLinkContainer } from './common/SharedLinkContainer';
 import { SharedPostLink } from './common/SharedPostLink';
 import YoutubeVideo from '../video/YoutubeVideo';
+import { formatReadTime } from '../utilities';
 
 interface ShareYouTubeContentProps {
   post: Post;
@@ -29,7 +30,7 @@ function ShareYouTubeContent({ post }: ShareYouTubeContentProps): ReactElement {
         <PostSourceInfo
           date={
             post.sharedPost.readTime
-              ? `${post.sharedPost.readTime}m watch time`
+              ? `${formatReadTime(post.sharedPost.readTime)} watch time`
               : undefined
           }
           source={post.sharedPost.source}

--- a/packages/shared/src/components/utilities/common.spec.tsx
+++ b/packages/shared/src/components/utilities/common.spec.tsx
@@ -1,0 +1,24 @@
+import { formatReadTime } from './common';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('function formatReadTime', () => {
+  it('should return 1h 30m when passed 90', () => {
+    expect(formatReadTime(90)).toEqual('1h 30m');
+  });
+  it('should return 2h 3m when passed 123', () => {
+    expect(formatReadTime(123)).toEqual('2h 3m');
+  });
+  it('should return 1h 0m when passed 60', () => {
+    expect(formatReadTime(60)).toEqual('1h 0m');
+  });
+  it('should return 30m when passed 30', () => {
+    expect(formatReadTime(30)).toEqual('30m');
+  });
+  it('should not return 0h 30m when passed 30', () => {
+    expect(formatReadTime(30)).not.toContain('0h ');
+    expect(formatReadTime(30)).toEqual('30m');
+  });
+});

--- a/packages/shared/src/components/utilities/common.tsx
+++ b/packages/shared/src/components/utilities/common.tsx
@@ -214,3 +214,11 @@ export const getContextBottomPosition = (
 export interface WithClassNameProps {
   className?: string;
 }
+
+export const formatReadTime = (minutes: number): string => {
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return hours > 0
+    ? `${hours.toString()}h ${remainingMinutes.toString()}m`
+    : `${remainingMinutes.toString()}m`;
+};


### PR DESCRIPTION
## Changes

Creates a new function that formats the readTime as [discussed here](https://dailydotdev.slack.com/archives/C059GQ5RFP0/p1702562731056579).

I decided to also do it for read time, in the extreme cases the read time is over 60 minutes