### PR TITLE
fix: insane mode read post button

### DIFF
--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -166,7 +166,7 @@ export default function ActionButtons({
             className="mr-2 btn-primary"
             href={getReadArticleLink(post)}
             onClick={onReadArticleClick}
-            openNewTab={isSharedPostSquadPost(post) ? false : openNewTab}
+            openNewTab={!isSharedPostSquadPost(post) && openNewTab}
           />
           <OptionsButton
             className={visibleOnGroupHover}

--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -1,12 +1,7 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
-import {
-  Post,
-  PostType,
-  UserPostVote,
-  isInternalReadType,
-} from '../../graphql/posts';
+import { Post, UserPostVote, isInternalReadType } from '../../graphql/posts';
 import InteractionCounter from '../InteractionCounter';
 import { QuaternaryButton } from '../buttons/QuaternaryButton';
 import UpvoteIcon from '../icons/Upvote';
@@ -21,7 +16,7 @@ import { useFeedPreviewMode } from '../../hooks';
 import { useFeature } from '../GrowthBookProvider';
 import { feature } from '../../lib/featureManagement';
 import BookmarkIcon from '../icons/Bookmark';
-import { SourceType } from '../../graphql/sources';
+import { getReadArticleLink, isSharedPostSquadPost } from '../utilities';
 
 const ShareIcon = dynamic(
   () => import(/* webpackChunkName: "share" */ '../icons/Share'),
@@ -109,18 +104,6 @@ export default function ActionButtons({
     </>
   );
 
-  const isSharedPostSquadPost =
-    post.sharedPost?.source.type === SourceType.Squad;
-
-  const insaneReadArticleLink = () => {
-    if (post.type === PostType.Share) {
-      return isSharedPostSquadPost
-        ? post.sharedPost.commentsPermalink
-        : post.sharedPost.permalink;
-    }
-    return post.permalink;
-  };
-
   return (
     <div
       className={classNames(
@@ -181,9 +164,9 @@ export default function ActionButtons({
         >
           <ReadArticleButton
             className="mr-2 btn-primary"
-            href={insaneReadArticleLink()}
+            href={getReadArticleLink(post)}
             onClick={onReadArticleClick}
-            openNewTab={isSharedPostSquadPost ? false : openNewTab}
+            openNewTab={isSharedPostSquadPost(post) ? false : openNewTab}
           />
           <OptionsButton
             className={visibleOnGroupHover}

--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -16,6 +16,7 @@ import { useFeedPreviewMode } from '../../hooks';
 import { useFeature } from '../GrowthBookProvider';
 import { feature } from '../../lib/featureManagement';
 import BookmarkIcon from '../icons/Bookmark';
+import { SourceType } from '../../graphql/sources';
 
 const ShareIcon = dynamic(
   () => import(/* webpackChunkName: "share" */ '../icons/Share'),
@@ -103,6 +104,18 @@ export default function ActionButtons({
     </>
   );
 
+  const isSharedPostSquadPost =
+    post.sharedPost?.source.type === SourceType.Squad;
+
+  const insaneReadArticleLink = () => {
+    if (post.type === PostType.Share) {
+      return isSharedPostSquadPost
+        ? post.sharedPost.commentsPermalink
+        : post.sharedPost.permalink;
+    }
+    return post.permalink;
+  };
+
   return (
     <div
       className={classNames(
@@ -157,19 +170,15 @@ export default function ActionButtons({
         </SimpleTooltip>
         {insaneMode && lastActions}
       </ConditionalWrapper>
-      {insaneMode ? (
+      {insaneMode && post.type !== PostType.Freeform ? (
         <div
           className={classNames('flex justify-between', visibleOnGroupHover)}
         >
           <ReadArticleButton
             className="mr-2 btn-primary"
-            href={
-              post.type === PostType.Share
-                ? post.sharedPost.permalink
-                : post.permalink
-            }
+            href={insaneReadArticleLink()}
             onClick={onReadArticleClick}
-            openNewTab={openNewTab}
+            openNewTab={isSharedPostSquadPost ? false : openNewTab}
           />
           <OptionsButton
             className={visibleOnGroupHover}

--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -1,7 +1,12 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
-import { Post, PostType, UserPostVote } from '../../graphql/posts';
+import {
+  Post,
+  PostType,
+  UserPostVote,
+  isInternalReadType,
+} from '../../graphql/posts';
 import InteractionCounter from '../InteractionCounter';
 import { QuaternaryButton } from '../buttons/QuaternaryButton';
 import UpvoteIcon from '../icons/Upvote';
@@ -170,7 +175,7 @@ export default function ActionButtons({
         </SimpleTooltip>
         {insaneMode && lastActions}
       </ConditionalWrapper>
-      {insaneMode && post.type !== PostType.Freeform ? (
+      {insaneMode && !isInternalReadType(post) ? (
         <div
           className={classNames('flex justify-between', visibleOnGroupHover)}
         >

--- a/packages/shared/src/components/post/PostHeaderActions.tsx
+++ b/packages/shared/src/components/post/PostHeaderActions.tsx
@@ -14,7 +14,7 @@ import AuthContext from '../../contexts/AuthContext';
 import {
   banPost,
   demotePost,
-  internalReadTypes,
+  isInternalReadType,
   Post,
   promotePost,
 } from '../../graphql/posts';
@@ -59,7 +59,6 @@ export function PostHeaderActions({
   const { showPrompt } = usePrompt();
   const { onMenuClick, isOpen } = useContextMenu({ id: contextMenuId });
 
-  const isInternalReadType = internalReadTypes.includes(post?.type);
   const isModerator = user?.roles?.includes(Roles.Moderator);
 
   const banPostPrompt = async () => {
@@ -99,7 +98,7 @@ export function PostHeaderActions({
 
   return (
     <Container {...props} className={classNames('gap-2', className)}>
-      {!isInternalReadType && onReadArticle && (
+      {!isInternalReadType(post) && onReadArticle && (
         <SimpleTooltip
           placement="bottom"
           content="Read post"

--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -12,6 +12,7 @@ import { SharePostTitle } from './share';
 import { combinedClicks } from '../../lib/click';
 import { SourceType } from '../../graphql/sources';
 import { SharedPostLink } from './common/SharedPostLink';
+import { isSharedPostSquadPost } from '../utilities';
 
 interface SharePostContentProps {
   post: Post;
@@ -39,9 +40,6 @@ function SharePostContent({
     onReadArticle();
   };
 
-  const isSharedPostSquadPost =
-    post.sharedPost.source.type === SourceType.Squad;
-
   return (
     <>
       <SharePostTitle post={post} />
@@ -67,11 +65,11 @@ function SharePostContent({
             <ReadArticleButton
               className="mt-5 btn-secondary w-fit"
               href={
-                isSharedPostSquadPost
+                isSharedPostSquadPost(post)
                   ? post.sharedPost.commentsPermalink
                   : post.sharedPost.permalink
               }
-              openNewTab={isSharedPostSquadPost ? false : openNewTab}
+              openNewTab={isSharedPostSquadPost(post) ? false : openNewTab}
               title="Go to post"
               rel="noopener"
               {...combinedClicks(openArticle)}

--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -10,7 +10,6 @@ import { Post } from '../../graphql/posts';
 import SettingsContext from '../../contexts/SettingsContext';
 import { SharePostTitle } from './share';
 import { combinedClicks } from '../../lib/click';
-import { SourceType } from '../../graphql/sources';
 import { SharedPostLink } from './common/SharedPostLink';
 import { isSharedPostSquadPost } from '../utilities';
 

--- a/packages/shared/src/components/utilities/common.tsx
+++ b/packages/shared/src/components/utilities/common.tsx
@@ -8,6 +8,8 @@ import classNames from 'classnames';
 import classed, { ClassedHTML } from '../../lib/classed';
 import styles from './utilities.module.css';
 import ArrowIcon from '../icons/Arrow';
+import { Post, PostType } from '../../graphql/posts';
+import { SourceType } from '../../graphql/sources';
 
 export enum Theme {
   Avocado = 'avocado',
@@ -214,3 +216,15 @@ export const getContextBottomPosition = (
 export interface WithClassNameProps {
   className?: string;
 }
+
+export const isSharedPostSquadPost = (post: Post): boolean =>
+  post.sharedPost?.source.type === SourceType.Squad;
+
+export const getReadArticleLink = (post: Post): string => {
+  if (post.type === PostType.Share) {
+    return isSharedPostSquadPost(post)
+      ? post.sharedPost.commentsPermalink
+      : post.sharedPost.permalink;
+  }
+  return post.permalink;
+};

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -30,7 +30,13 @@ export enum PostType {
   Freeform = 'freeform',
 }
 
-export const internalReadTypes: PostType[] = [PostType.Welcome];
+export const internalReadTypes: PostType[] = [
+  PostType.Welcome,
+  PostType.Freeform,
+];
+
+export const isInternalReadType = (post: Post): boolean =>
+  internalReadTypes.includes(post?.type);
 
 export const supportedTypesForPrivateSources = [
   PostType.Article,


### PR DESCRIPTION
## Changes

It just hides the read post button if the post is a freeform, as clicking on the card opens it. I was thinking about mimicking that on the button, but thought removing it made more sense. Let me know if I should re-introduce it.

Also updated the target link of the button if the article is a shared post that points to another squad.