### PR TITLE
refactor: use ButtonV2 in all of the prompts

### DIFF
--- a/packages/shared/src/components/modals/OnboardingModal.tsx
+++ b/packages/shared/src/components/modals/OnboardingModal.tsx
@@ -20,6 +20,7 @@ import { AuthEventNames, AuthTriggers } from '../../lib/auth';
 import CloseButton from '../CloseButton';
 import { ExperimentWinner } from '../../lib/featureValues';
 import { PromptOptions, usePrompt } from '../../hooks/usePrompt';
+import { ButtonColor, ButtonVariant } from '../buttons/ButtonV2';
 
 interface OnboardingModalProps extends ModalProps {
   mode?: OnboardingMode;
@@ -37,13 +38,12 @@ const promptOptions: PromptOptions = {
     'You will lose any personalization preferences you have chosen if you quit. Continue to personalize your feed?',
   okButton: {
     title: 'Quit',
+    variant: ButtonVariant.Primary,
+    color: ButtonColor.Ketchup,
   },
   cancelButton: {
     title: 'Continue',
-  },
-  className: {
-    cancel: 'btn-secondary',
-    ok: 'btn-primary-ketchup',
+    variant: ButtonVariant.Secondary,
   },
 };
 

--- a/packages/shared/src/components/modals/Prompt.tsx
+++ b/packages/shared/src/components/modals/Prompt.tsx
@@ -1,7 +1,6 @@
-import classNames from 'classnames';
 import React, { ReactElement } from 'react';
 import { usePrompt } from '../../hooks/usePrompt';
-import { Button } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import classed from '../../lib/classed';
 import { Modal, ModalProps } from './common/Modal';
 
@@ -25,8 +24,8 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement {
       description,
       content,
       promptSize = Modal.Size.XSmall,
-      cancelButton = {},
-      okButton = {},
+      cancelButton,
+      okButton,
       className = {},
     },
   } = prompt;
@@ -49,18 +48,24 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement {
         )}
         {content}
         <Buttons className={className.buttons}>
-          {cancelButton !== null && (
+          {cancelButton && (
             <Button
-              className={classNames('btn-secondary', className.cancel)}
+              variant={cancelButton.variant ?? ButtonVariant.Secondary}
+              color={cancelButton.color}
+              icon={cancelButton.icon}
+              iconPosition={cancelButton.iconPosition}
               onClick={onFail}
               {...cancelButton}
             >
               {cancelButton?.title ?? 'Cancel'}
             </Button>
           )}
-          {okButton !== null && (
+          {okButton && (
             <Button
-              className={classNames('btn-primary', className.ok)}
+              variant={okButton.variant ?? ButtonVariant.Primary}
+              color={okButton.color}
+              icon={okButton.icon}
+              iconPosition={okButton.iconPosition}
               onClick={onSuccess}
               {...okButton}
             >

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -27,6 +27,7 @@ import { postAnalyticsEvent } from '../../lib/feed';
 import { removePostComments } from '../../hooks/usePostById';
 import { CommentClassName } from '../fields/MarkdownInput/CommentMarkdownInput';
 import { generateQueryKey, RequestKey } from '../../lib/query';
+import { ButtonColor, ButtonVariant } from '../buttons/ButtonV2';
 
 interface PostCommentsProps {
   post: Post;
@@ -89,7 +90,8 @@ export function PostComments({
         'Are you sure you want to delete your comment? This action cannot be undone.',
       okButton: {
         title: 'Delete',
-        className: 'btn-primary-cabbage',
+        variant: ButtonVariant.Primary,
+        color: ButtonColor.Cabbage,
       },
     };
     if (!(await showPrompt(options))) {

--- a/packages/shared/src/components/post/PostHeaderActions.tsx
+++ b/packages/shared/src/components/post/PostHeaderActions.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../graphql/posts';
 import classed from '../../lib/classed';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
-import { Button } from '../buttons/Button';
+import { Button, ButtonColor, ButtonVariant } from '../buttons/ButtonV2';
 import PostOptionsMenu, { PostOptionsMenuProps } from '../PostOptionsMenu';
 import { ShareBookmarkProps } from './PostActions';
 import { PromptOptions, usePrompt } from '../../hooks/usePrompt';
@@ -68,7 +68,8 @@ export function PostHeaderActions({
       description: 'Are you sure you want to ban this post?',
       okButton: {
         title: 'Ban',
-        className: 'btn-primary-ketchup',
+        variant: ButtonVariant.Primary,
+        color: ButtonColor.Ketchup,
       },
     };
     if (await showPrompt(options)) {
@@ -106,7 +107,9 @@ export function PostHeaderActions({
           disabled={!inlineActions}
         >
           <Button
-            className={inlineActions ? 'btn-tertiary' : 'btn-secondary'}
+            variant={
+              inlineActions ? ButtonVariant.Tertiary : ButtonVariant.Secondary
+            }
             tag="a"
             href={post.sharedPost?.permalink ?? post.permalink}
             target={openNewTab ? '_blank' : '_self'}
@@ -128,7 +131,7 @@ export function PostHeaderActions({
       {onClose && (
         <SimpleTooltip placement="bottom" content="Close">
           <Button
-            className="btn-tertiary"
+            variant={ButtonVariant.Tertiary}
             icon={<CloseIcon />}
             onClick={(e) => onClose(e)}
           />

--- a/packages/shared/src/components/squads/SquadMemberItemAdditionalContent.tsx
+++ b/packages/shared/src/components/squads/SquadMemberItemAdditionalContent.tsx
@@ -1,6 +1,11 @@
 import React, { ReactElement } from 'react';
 import { SourceMember, SourceMemberRole } from '../../graphql/sources';
-import { Button, ButtonSize } from '../buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonSize,
+  ButtonVariant,
+} from '../buttons/ButtonV2';
 import BlockIcon from '../icons/Block';
 import MenuIcon from '../icons/Menu';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
@@ -33,7 +38,11 @@ function SquadMemberItemAdditionalContent({
     const options: PromptOptions = {
       title: 'Unblock member?',
       description: `${user.name} will now have access to join your Squad and can then post, upvote and comment`,
-      okButton: { title: 'Unblock', className: 'btn-primary-cabbage' },
+      okButton: {
+        title: 'Unblock',
+        variant: ButtonVariant.Primary,
+        color: ButtonColor.Cabbage,
+      },
       content: (
         <UserShortInfo
           disableTooltip
@@ -69,9 +78,9 @@ function SquadMemberItemAdditionalContent({
   const option = (
     <SimpleTooltip content="Member options">
       <Button
-        buttonSize={ButtonSize.Small}
-        className="m-auto mr-0 btn-tertiary"
-        iconOnly
+        size={ButtonSize.Small}
+        variant={ButtonVariant.Tertiary}
+        className="m-auto mr-0"
         onClick={onOptionsClick}
         icon={<MenuIcon />}
       />

--- a/packages/shared/src/hooks/useAuthForms.ts
+++ b/packages/shared/src/hooks/useAuthForms.ts
@@ -1,5 +1,6 @@
 import React, { MutableRefObject, useMemo, useRef, useState } from 'react';
 import { PromptOptions, usePrompt } from './usePrompt';
+import { ButtonColor, ButtonVariant } from '../components/buttons/ButtonV2';
 
 export type CloseAuthModalFunc = (
   e: React.MouseEvent | React.KeyboardEvent | React.FormEvent,
@@ -22,11 +23,12 @@ const promptOptions: PromptOptions = {
   description: 'If you leave your changes will not be saved',
   okButton: {
     title: 'Leave',
-    className: 'btn-secondary',
+    variant: ButtonVariant.Secondary,
   },
   cancelButton: {
     title: 'Stay',
-    className: 'btn-primary-cabbage',
+    variant: ButtonVariant.Primary,
+    color: ButtonColor.Cabbage,
   },
   className: {
     buttons: 'flex-row-reverse',

--- a/packages/shared/src/hooks/useDeleteSquad.ts
+++ b/packages/shared/src/hooks/useDeleteSquad.ts
@@ -5,6 +5,7 @@ import { PromptOptions, usePrompt } from './usePrompt';
 import { useBoot } from './useBoot';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../lib/analytics';
+import { ButtonColor, ButtonVariant } from '../components/buttons/ButtonV2';
 
 interface UseDeleteSquadModal {
   onDeleteSquad: () => void;
@@ -33,11 +34,12 @@ export const useDeleteSquad = ({
         : `Deleting your Squad will free up your handle and members you invited will not be able to join`,
       okButton: {
         title: 'Delete',
-        className: 'btn-secondary',
+        variant: ButtonVariant.Secondary,
       },
       cancelButton: {
         title: 'No, keep it',
-        className: 'btn-primary-cabbage',
+        variant: ButtonVariant.Primary,
+        color: ButtonColor.Cabbage,
       },
       className: {
         buttons: 'flex-row-reverse',

--- a/packages/shared/src/hooks/useLeaveSquad.ts
+++ b/packages/shared/src/hooks/useLeaveSquad.ts
@@ -5,6 +5,7 @@ import { PromptOptions, usePrompt } from './usePrompt';
 import { useBoot } from './useBoot';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../lib/analytics';
+import { ButtonColor, ButtonVariant } from '../components/buttons/ButtonV2';
 
 type UseLeaveSquad = () => Promise<boolean>;
 
@@ -24,11 +25,12 @@ export const useLeaveSquad = ({ squad }: UseLeaveSquadProps): UseLeaveSquad => {
       description: `Leaving ${squad.name} means that you will lose your access to all posts that were shared in the Squad`,
       okButton: {
         title: 'Leave',
-        className: 'btn-secondary',
+        variant: ButtonVariant.Secondary,
       },
       cancelButton: {
         title: 'Stay',
-        className: 'btn-primary-cabbage',
+        variant: ButtonVariant.Primary,
+        color: ButtonColor.Cabbage,
         type: 'button',
       },
       className: {

--- a/packages/shared/src/hooks/usePostMenuActions.ts
+++ b/packages/shared/src/hooks/usePostMenuActions.ts
@@ -14,6 +14,7 @@ import { useAuthContext } from '../contexts/AuthContext';
 import { useVotePost } from './vote/useVotePost';
 import { Origin } from '../lib/analytics';
 import { useBlockPostPanel } from './post/useBlockPostPanel';
+import { ButtonColor, ButtonVariant } from '../components/buttons/ButtonV2';
 
 interface UsePostMenuActions {
   onConfirmDeletePost: () => Promise<void>;
@@ -45,7 +46,8 @@ const deletePromptOptions: PromptOptions = {
     'Are you sure you want to delete this post? This action cannot be undone.',
   okButton: {
     title: 'Delete',
-    className: 'btn-primary-cabbage',
+    variant: ButtonVariant.Primary,
+    color: ButtonColor.Cabbage,
   },
 };
 

--- a/packages/shared/src/hooks/usePrompt.ts
+++ b/packages/shared/src/hooks/usePrompt.ts
@@ -1,15 +1,14 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { ReactNode, useCallback } from 'react';
-import { ButtonProps, StyledButtonProps } from '../components/buttons/Button';
+import { ButtonProps } from '../components/buttons/ButtonV2';
 import { ModalSize } from '../components/modals/common/types';
 import { generateQueryKey, RequestKey } from '../lib/query';
 
 export const PROMPT_KEY = generateQueryKey(RequestKey.Prompt, null);
 
-export type PromptButtonProps = StyledButtonProps &
-  Omit<ButtonProps<'button'>, 'onClick'> & {
-    title?: string;
-  };
+export type PromptButtonProps = Omit<ButtonProps<'button'>, 'onClick'> & {
+  title?: string;
+};
 
 export type PromptOptions = {
   title: string;
@@ -23,8 +22,6 @@ export type PromptOptions = {
     title?: string;
     description?: string;
     buttons?: string;
-    ok?: string;
-    cancel?: string;
   };
 };
 


### PR DESCRIPTION
## Changes

### Describe what this PR does

Use ButtonV2 in all of the prompts. Also refactored the interface of the `usePrompt` hook to make it less ambiguous -> removed the `ok` and `cancel` fields from the `className` field. These were redundant, since we already had `okButton` and `cancelButton` fields on the options object itself, which allow to set the className and other button fields as well.

### Screenshots

<img width="355" alt="Screenshot 2023-12-19 at 09 03 40" src="https://github.com/dailydotdev/apps/assets/9974711/e8e1b71c-34dd-4312-b92a-c74e76e9eaac">
<img width="352" alt="Screenshot 2023-12-19 at 09 54 06" src="https://github.com/dailydotdev/apps/assets/9974711/1296eba9-9990-4c65-8baf-9373ab24642e">
<img width="357" alt="Screenshot 2023-12-19 at 09 30 06" src="https://github.com/dailydotdev/apps/assets/9974711/29d3f90d-5aa3-4a25-ac8a-9b7a4d88ca98">
<img width="354" alt="Screenshot 2023-12-19 at 09 29 09" src="https://github.com/dailydotdev/apps/assets/9974711/22f9bfa0-0701-42db-95a5-ba945e27fe58">
<img width="351" alt="Screenshot 2023-12-19 at 09 28 05" src="https://github.com/dailydotdev/apps/assets/9974711/de1fa6ee-6459-4299-bc49-d5b9e0c688b6">
<img width="438" alt="Screenshot 2023-12-19 at 09 18 26" src="https://github.com/dailydotdev/apps/assets/9974711/e5a002d4-4913-4fe3-a33b-fb573222087f">
<img width="353" alt="Screenshot 2023-12-19 at 09 16 11" src="https://github.com/dailydotdev/apps/assets/9974711/8a8d3b7f-0922-4098-a250-62f3ad13fad4">
<img width="353" alt="Screenshot 2023-12-19 at 09 15 56" src="https://github.com/dailydotdev/apps/assets/9974711/38b3fe15-0f84-4f89-9ef6-374f3253c0d1">
<img width="358" alt="Screenshot 2023-12-19 at 09 14 58" src="https://github.com/dailydotdev/apps/assets/9974711/b963d8a6-648b-43d4-97c3-415d3f79947b">


## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
