### PR TITLE
fix: prompts not showing cancel button in some cases

### DIFF
--- a/packages/shared/src/components/modals/Prompt.tsx
+++ b/packages/shared/src/components/modals/Prompt.tsx
@@ -24,8 +24,8 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement {
       description,
       content,
       promptSize = Modal.Size.XSmall,
-      cancelButton,
-      okButton,
+      cancelButton = {},
+      okButton = {},
       className = {},
     },
   } = prompt;
@@ -48,7 +48,7 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement {
         )}
         {content}
         <Buttons className={className.buttons}>
-          {cancelButton && (
+          {cancelButton !== null && (
             <Button
               variant={cancelButton.variant ?? ButtonVariant.Secondary}
               color={cancelButton.color}
@@ -60,7 +60,7 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement {
               {cancelButton?.title ?? 'Cancel'}
             </Button>
           )}
-          {okButton && (
+          {okButton !== null && (
             <Button
               variant={okButton.variant ?? ButtonVariant.Primary}
               color={okButton.color}


### PR DESCRIPTION
## Changes

### Describe what this PR does

Reverts prompt conditions to the state prior to 
- #2437 

### Screenshot

After fix:
<img width="354" alt="Screenshot 2023-12-20 at 08 33 04" src="https://github.com/dailydotdev/apps/assets/9974711/ccf728b8-1b43-43f4-81c1-b756ae665692">


## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
