### PR TITLE
fix: actions rendering in list mode

### DIFF
--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -164,17 +164,19 @@ export default function ActionButtons({
         </SimpleTooltip>
         {insaneMode && lastActions}
       </ConditionalWrapper>
-      {insaneMode && !isInternalReadType(post) ? (
+      {insaneMode ? (
         <div
           className={classNames('flex justify-between', visibleOnGroupHover)}
         >
-          <ReadArticleButton
-            content={getReadPostButtonText(post)}
-            className="mr-2 btn-primary"
-            href={getReadArticleLink(post)}
-            onClick={onReadArticleClick}
-            openNewTab={!isSharedPostSquadPost(post) && openNewTab}
-          />
+          {!isInternalReadType(post) && (
+            <ReadArticleButton
+              content={getReadPostButtonText(post)}
+              className="mr-2 btn-primary"
+              href={getReadArticleLink(post)}
+              onClick={onReadArticleClick}
+              openNewTab={!isSharedPostSquadPost(post) && openNewTab}
+            />
+          )}
           <OptionsButton
             className={visibleOnGroupHover}
             onClick={onMenuClick}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- no options for freeform (and other internal read types)
- additional bookmark/share when experiment is active

Before:
![image](https://github.com/dailydotdev/apps/assets/9803078/7149c9d8-7189-4ae2-8c61-1c9a7a297c9d)

After:
<img width="1203" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/dcf64b02-5c33-420b-89c9-21abf1c4d50d">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
