### PR TITLE
fix: check if next page exists and disable pagination

### DIFF
--- a/packages/shared/src/components/post/RelatedPostsWidget.tsx
+++ b/packages/shared/src/components/post/RelatedPostsWidget.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { widgetClasses } from '../widgets/common';
 import { InfinitePaginationActions } from '../pagination';
@@ -40,6 +40,13 @@ export const RelatedPostsWidget = ({
   const [page, setPage] = useState(0);
   const relatedPostPage = relatedPosts?.pages[page];
   const hasRelatedPosts = isLoading || !!relatedPostPage?.edges.length;
+  const hasNextPageData = !!relatedPosts?.pages[page + 1];
+
+  useEffect(() => {
+    if (hasNextPage && !hasNextPageData) {
+      fetchNextPage();
+    }
+  }, [hasNextPage, hasNextPageData, fetchNextPage]);
 
   if (!hasRelatedPosts) {
     return null;
@@ -103,7 +110,7 @@ export const RelatedPostsWidget = ({
       </div>
 
       <InfinitePaginationActions
-        hasNext={relatedPostPage?.pageInfo?.hasNextPage}
+        hasNext={hasNextPageData}
         hasPrevious={page > 0}
         onPrevious={() => {
           setPage((currentPage) => (currentPage ? currentPage - 1 : 0));
@@ -112,8 +119,6 @@ export const RelatedPostsWidget = ({
           if (isFetchingNextPage) {
             return;
           }
-
-          const hasNextPageData = !!relatedPosts.pages[page + 1];
 
           if (hasNextPage && !hasNextPageData) {
             await fetchNextPage();


### PR DESCRIPTION
## Changes

### Describe what this PR does
- currently the next arrow in related posts widget will always be active until user clicks on it and request checks if there is data
- this is due to using cursor pagination which does not include total
- with this we always prefetch next page so we can preemptively disable the button if there is no next page

<img width="342" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/46c700b0-25e4-482e-96c8-76140cd5b7b0">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
