### PR TITLE
fix: console warning when using wrapperClassName prop on plain image

### DIFF
--- a/packages/shared/src/components/cards/PostCardFooter.tsx
+++ b/packages/shared/src/components/cards/PostCardFooter.tsx
@@ -27,11 +27,6 @@ export const PostCardFooter = ({
 }: PostCardFooterProps): ReactElement => {
   const isVideoType = isVideoPost(post);
   const ImageComponent = isVideoType ? CardVideoImage : CardImage;
-  const videoImageProps: { wrapperClassName?: string } = {};
-  if (isVideoType) {
-    videoImageProps.wrapperClassName = 'my-2';
-  }
-
   return (
     <>
       {!showImage && post.author && (
@@ -55,7 +50,7 @@ export const PostCardFooter = ({
           )}
           loading="lazy"
           data-testid="postImage"
-          {...videoImageProps}
+          {...(isVideoType && { wrapperClassName: 'overflow-hidden' })}
         />
       )}
       {showImage && post.author && (

--- a/packages/shared/src/components/cards/PostCardFooter.tsx
+++ b/packages/shared/src/components/cards/PostCardFooter.tsx
@@ -27,6 +27,11 @@ export const PostCardFooter = ({
 }: PostCardFooterProps): ReactElement => {
   const isVideoType = isVideoPost(post);
   const ImageComponent = isVideoType ? CardVideoImage : CardImage;
+  const videoImageProps: { wrapperClassName?: string } = {};
+  if (isVideoType) {
+    videoImageProps.wrapperClassName = 'my-2';
+  }
+
   return (
     <>
       {!showImage && post.author && (
@@ -50,7 +55,7 @@ export const PostCardFooter = ({
           )}
           loading="lazy"
           data-testid="postImage"
-          wrapperClassName="my-2"
+          {...videoImageProps}
         />
       )}
       {showImage && post.author && (

--- a/packages/shared/src/components/cards/SharedPostCardFooter.tsx
+++ b/packages/shared/src/components/cards/SharedPostCardFooter.tsx
@@ -16,11 +16,6 @@ export const SharedPostCardFooter = ({
   isVideoType,
 }: SharedPostCardFooterProps): ReactElement => {
   const ImageComponent = isVideoType ? CardVideoImage : CardImage;
-  const videoImageProps: { wrapperClassName?: string } = {};
-  if (isVideoType) {
-    videoImageProps.wrapperClassName = 'overflow-hidden';
-  }
-
   return (
     <div
       className={classNames(
@@ -47,9 +42,9 @@ export const SharedPostCardFooter = ({
             'object-cover h-auto min-h-0',
             isShort ? 'aspect-square' : 'w-full',
           )}
+          {...(isVideoType && { wrapperClassName: 'overflow-hidden' })}
           loading="lazy"
           data-testid="sharedPostImage"
-          {...videoImageProps}
         />
       </div>
     </div>

--- a/packages/shared/src/components/cards/SharedPostCardFooter.tsx
+++ b/packages/shared/src/components/cards/SharedPostCardFooter.tsx
@@ -16,6 +16,11 @@ export const SharedPostCardFooter = ({
   isVideoType,
 }: SharedPostCardFooterProps): ReactElement => {
   const ImageComponent = isVideoType ? CardVideoImage : CardImage;
+  const videoImageProps: { wrapperClassName?: string } = {};
+  if (isVideoType) {
+    videoImageProps.wrapperClassName = 'overflow-hidden';
+  }
+
   return (
     <div
       className={classNames(
@@ -42,9 +47,9 @@ export const SharedPostCardFooter = ({
             'object-cover h-auto min-h-0',
             isShort ? 'aspect-square' : 'w-full',
           )}
-          wrapperClassName="overflow-hidden"
           loading="lazy"
           data-testid="sharedPostImage"
+          {...videoImageProps}
         />
       </div>
     </div>


### PR DESCRIPTION
## Changes

### Describe what this PR does

Get's rid of the following react warning in dev tools console:
```
Warning: React does not recognize the `wrapperClassName` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `wrapperclassname` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
