### PR TITLE
fix: image wrapper width in notifications

### DIFF
--- a/packages/shared/src/components/image/VideoImage.tsx
+++ b/packages/shared/src/components/image/VideoImage.tsx
@@ -7,21 +7,18 @@ import { ImageProps, Image } from './Image';
 export interface VideoImageProps extends ImageProps {
   size?: IconSize;
   wrapperClassName?: string;
-  wrapperWidth?: 'w-full' | 'w-fit';
 }
 
 const VideoImage = ({
   size = IconSize.XLarge,
   wrapperClassName,
-  wrapperWidth = 'w-full',
   ...props
 }: VideoImageProps): ReactElement => {
   return (
     <div
       className={classNames(
         wrapperClassName,
-        wrapperWidth,
-        'flex relative justify-center items-center h-auto rounded-12',
+        'flex relative justify-center items-center h-auto rounded-12 w-full',
       )}
     >
       <span className="absolute w-full h-full rounded-12 bg-overlay-tertiary-black" />

--- a/packages/shared/src/components/image/VideoImage.tsx
+++ b/packages/shared/src/components/image/VideoImage.tsx
@@ -7,18 +7,21 @@ import { ImageProps, Image } from './Image';
 export interface VideoImageProps extends ImageProps {
   size?: IconSize;
   wrapperClassName?: string;
+  wrapperWidth?: 'w-full' | 'w-fit';
 }
 
 const VideoImage = ({
-  size = IconSize.XXXLarge,
+  size = IconSize.XLarge,
   wrapperClassName,
+  wrapperWidth = 'w-full',
   ...props
 }: VideoImageProps): ReactElement => {
   return (
     <div
       className={classNames(
         wrapperClassName,
-        'flex relative justify-center items-center w-full h-auto rounded-12',
+        wrapperWidth,
+        'flex relative justify-center items-center h-auto rounded-12',
       )}
     >
       <span className="absolute w-full h-full rounded-12 bg-overlay-tertiary-black" />

--- a/packages/shared/src/components/image/VideoImage.tsx
+++ b/packages/shared/src/components/image/VideoImage.tsx
@@ -18,7 +18,7 @@ const VideoImage = ({
     <div
       className={classNames(
         wrapperClassName,
-        'flex relative justify-center items-center h-auto rounded-12 w-full',
+        'flex relative justify-center items-center w-full h-auto rounded-12',
       )}
     >
       <span className="absolute w-full h-full rounded-12 bg-overlay-tertiary-black" />

--- a/packages/shared/src/components/image/VideoImage.tsx
+++ b/packages/shared/src/components/image/VideoImage.tsx
@@ -10,7 +10,7 @@ export interface VideoImageProps extends ImageProps {
 }
 
 const VideoImage = ({
-  size = IconSize.XLarge,
+  size = IconSize.XXXLarge,
   wrapperClassName,
   ...props
 }: VideoImageProps): ReactElement => {

--- a/packages/shared/src/components/notifications/NotificationItemAttachment.tsx
+++ b/packages/shared/src/components/notifications/NotificationItemAttachment.tsx
@@ -18,17 +18,18 @@ function NotificationItemAttachment({
 
   return (
     <div className="flex flex-row items-center p-4 mt-2 rounded-16 border border-theme-divider-tertiary">
-      <ImageComponent
-        src={image}
-        alt={`Cover preview of: ${title}`}
-        className="object-cover w-24 h-16 rounded-16"
-        loading="lazy"
-        fallbackSrc={cloudinary.post.imageCoverPlaceholder}
-        {...(type === NotificationAttachmentType.Video && {
-          wrapperWidth: 'w-fit',
-          size: IconSize.XLarge,
-        })}
-      />
+      <div>
+        <ImageComponent
+          src={image}
+          alt={`Cover preview of: ${title}`}
+          className="object-cover w-24 h-16 rounded-16"
+          loading="lazy"
+          fallbackSrc={cloudinary.post.imageCoverPlaceholder}
+          {...(type === NotificationAttachmentType.Video && {
+            size: IconSize.XLarge,
+          })}
+        />
+      </div>
       <span className="flex-1 ml-4 break-words typo-callout">{title}</span>
     </div>
   );

--- a/packages/shared/src/components/notifications/NotificationItemAttachment.tsx
+++ b/packages/shared/src/components/notifications/NotificationItemAttachment.tsx
@@ -6,6 +6,7 @@ import {
 import { cloudinary } from '../../lib/image';
 import { Image } from '../image/Image';
 import VideoImage from '../image/VideoImage';
+import { IconSize } from '../Icon';
 
 function NotificationItemAttachment({
   image,
@@ -23,6 +24,10 @@ function NotificationItemAttachment({
         className="object-cover w-24 h-16 rounded-16"
         loading="lazy"
         fallbackSrc={cloudinary.post.imageCoverPlaceholder}
+        {...(type === NotificationAttachmentType.Video && {
+          wrapperWidth: 'w-fit',
+          size: IconSize.XLarge,
+        })}
       />
       <span className="flex-1 ml-4 break-words typo-callout">{title}</span>
     </div>


### PR DESCRIPTION
## Changes

### Describe what this PR does

Fixes the width of video image in notifications, and reduces the size of the play icon

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td>
<img width="383" alt="image" src="https://github.com/dailydotdev/apps/assets/1681525/b36d0860-a220-499c-b5de-b98ec22d09f5">
</td>
 <td><img width="383" alt="image" src="https://github.com/dailydotdev/apps/assets/1681525/982cf08f-2233-4766-906e-ead7471bdaee">
</table>
