### PR TITLE
fix: cleanup hide modal class on hook unmount

### DIFF
--- a/packages/shared/src/hooks/useHideOnModal.ts
+++ b/packages/shared/src/hooks/useHideOnModal.ts
@@ -4,12 +4,16 @@ export function useHideOnModal(predicate: boolean): void {
   useEffect(() => {
     const root = document.querySelector('#__next');
     if (!root) {
-      return;
+      return undefined;
     }
     if (predicate) {
       root.classList.add('hide-on-modal');
     } else {
       root.classList.remove('hide-on-modal');
     }
+
+    return () => {
+      root.classList.remove('hide-on-modal');
+    };
   }, [predicate]);
 }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Original [issue](https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1701346072422259) 
- Basically the issue was that we add `hide-on-modal` class on next root when modal is active, it is controlled in `useHideOnModal` hook
- This class (after opening post modal once) would not be cleaned, which then would hide the feed when any other modal like share is active
- This was due to modal which called the hook `useHideOnModal` being unmounted because it was closed
- Here I add the cleanup to remove the class on unmount which fixes the issue

Before:
<img width="392" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/3d31aaae-2744-494f-9c52-364c7605092d">

After:
<img width="391" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/af852f5c-8973-46e9-b291-84a0653deebe">


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2034 #done
