### PR TITLE
fix: replace useRef with state

### DIFF
--- a/packages/extension/src/contexts/ExtensionContext.tsx
+++ b/packages/extension/src/contexts/ExtensionContext.tsx
@@ -1,10 +1,4 @@
-import React, {
-  ReactElement,
-  ReactNode,
-  useContext,
-  useMemo,
-  useState,
-} from 'react';
+import React, { ReactElement, ReactNode, useContext, useMemo } from 'react';
 
 import browser from 'webextension-polyfill';
 import { useQueryClient } from '@tanstack/react-query';

--- a/packages/extension/src/contexts/ExtensionContext.tsx
+++ b/packages/extension/src/contexts/ExtensionContext.tsx
@@ -12,11 +12,13 @@ import {
 } from '../lib/extensionScripts';
 
 export type ExtensionContextProviderProps = {
+  currentPage: string;
   setCurrentPage: React.Dispatch<React.SetStateAction<string>>;
   children?: ReactNode;
 };
 
 export const ExtensionContextProvider = ({
+  currentPage,
   setCurrentPage,
   children,
 }: ExtensionContextProviderProps): ReactElement => {
@@ -30,9 +32,10 @@ export const ExtensionContextProvider = ({
       getHostPermission,
       requestHostPermissions: browser.permissions.request,
       origins: HOST_PERMISSIONS,
+      currentPage,
       setCurrentPage,
     }),
-    [client, setCurrentPage, trackEvent],
+    [client, currentPage, setCurrentPage, trackEvent],
   );
 
   return (

--- a/packages/extension/src/contexts/ExtensionContext.tsx
+++ b/packages/extension/src/contexts/ExtensionContext.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, ReactNode, useContext, useMemo } from 'react';
+import React, {
+  ReactElement,
+  ReactNode,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 
 import browser from 'webextension-polyfill';
 import { useQueryClient } from '@tanstack/react-query';
@@ -12,10 +18,12 @@ import {
 } from '../lib/extensionScripts';
 
 export type ExtensionContextProviderProps = {
+  setCurrentPage: React.Dispatch<React.SetStateAction<string>>;
   children?: ReactNode;
 };
 
 export const ExtensionContextProvider = ({
+  setCurrentPage,
   children,
 }: ExtensionContextProviderProps): ReactElement => {
   const client = useQueryClient();
@@ -28,8 +36,9 @@ export const ExtensionContextProvider = ({
       getHostPermission,
       requestHostPermissions: browser.permissions.request,
       origins: HOST_PERMISSIONS,
+      setCurrentPage,
     }),
-    [client, trackEvent],
+    [client, setCurrentPage, trackEvent],
   );
 
   return (

--- a/packages/extension/src/newtab/App.tsx
+++ b/packages/extension/src/newtab/App.tsx
@@ -138,7 +138,10 @@ export default function App({
     <RouterContext.Provider value={router}>
       <ProgressiveEnhancementContextProvider>
         <QueryClientProvider client={queryClient}>
-          <ExtensionContextProvider setCurrentPage={setCurrentPage}>
+          <ExtensionContextProvider
+            currentPage={currentPage}
+            setCurrentPage={setCurrentPage}
+          >
             <BootDataProvider
               app={BootApp.Extension}
               getRedirectUri={getRedirectUri}

--- a/packages/extension/src/newtab/App.tsx
+++ b/packages/extension/src/newtab/App.tsx
@@ -1,10 +1,4 @@
-import React, {
-  MutableRefObject,
-  ReactElement,
-  useContext,
-  useEffect,
-  useRef,
-} from 'react';
+import React, { ReactElement, useContext, useEffect, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
 import Modal from 'react-modal';
@@ -37,6 +31,7 @@ import { withFeaturesBoundary } from '@dailydotdev/shared/src/components/withFea
 import { LazyModalElement } from '@dailydotdev/shared/src/components/modals/LazyModalElement';
 import { useHostStatus } from '@dailydotdev/shared/src/hooks/useHostPermissionStatus';
 import ExtensionPermissionsPrompt from '@dailydotdev/shared/src/components/ExtensionPermissionsPrompt';
+import { useExtensionContext } from '@dailydotdev/shared/src/contexts/ExtensionContext';
 import { ExtensionContextProvider } from '../contexts/ExtensionContext';
 import CustomRouter from '../lib/CustomRouter';
 import { version } from '../../package.json';
@@ -60,16 +55,13 @@ Modal.setAppElement('#__next');
 Modal.defaultStyles = {};
 
 const getRedirectUri = () => browser.runtime.getURL('index.html');
-function InternalApp({
-  pageRef,
-}: {
-  pageRef: MutableRefObject<string>;
-}): ReactElement {
+function InternalApp(): ReactElement {
   useError();
   useInAppNotification();
   useLazyModal();
   usePrompt();
   useWebVitals();
+  const { setCurrentPage } = useExtensionContext();
   const { unreadCount } = useNotificationContext();
   const { closeLogin, shouldShowLogin, loginState } = useContext(AuthContext);
   const { contentScriptGranted } = useContentScriptStatus();
@@ -91,8 +83,7 @@ function InternalApp({
   const { dismissToast } = useToastNotification();
 
   const onPageChanged = (page: string): void => {
-    // eslint-disable-next-line no-param-reassign
-    pageRef.current = page;
+    setCurrentPage(page);
     routeChangedCallbackRef.current();
     dismissToast();
   };
@@ -110,12 +101,10 @@ function InternalApp({
   }, [unreadCount]);
 
   if (!hostGranted) {
-    return <ExtensionPermissionsPrompt pageRef={pageRef} />;
+    return <ExtensionPermissionsPrompt />;
   }
 
   if (shouldRedirectOnboarding) {
-    // eslint-disable-next-line no-param-reassign
-    pageRef.current = '/hijacking';
     return <ExtensionOnboarding />;
   }
 
@@ -141,25 +130,25 @@ const InternalAppWithFeaturesBoundary = withFeaturesBoundary(InternalApp, {
 export default function App({
   localBootData,
 }: Pick<BootDataProviderProps, 'localBootData'>): ReactElement {
-  const pageRef = useRef('/');
+  const [currentPage, setCurrentPage] = useState<string>('/');
   const deviceId = useDeviceId();
 
   return (
     <RouterContext.Provider value={router}>
       <ProgressiveEnhancementContextProvider>
         <QueryClientProvider client={queryClient}>
-          <ExtensionContextProvider>
+          <ExtensionContextProvider setCurrentPage={setCurrentPage}>
             <BootDataProvider
               app={BootApp.Extension}
               getRedirectUri={getRedirectUri}
               localBootData={localBootData}
               version={version}
-              getPage={() => pageRef.current}
+              getPage={() => currentPage}
               deviceId={deviceId}
             >
               <SubscriptionContextProvider>
                 <OnboardingContextProvider>
-                  <InternalAppWithFeaturesBoundary pageRef={pageRef} />
+                  <InternalAppWithFeaturesBoundary />
                 </OnboardingContextProvider>
               </SubscriptionContextProvider>
             </BootDataProvider>

--- a/packages/extension/src/newtab/App.tsx
+++ b/packages/extension/src/newtab/App.tsx
@@ -65,7 +65,8 @@ function InternalApp(): ReactElement {
   const { unreadCount } = useNotificationContext();
   const { closeLogin, shouldShowLogin, loginState } = useContext(AuthContext);
   const { contentScriptGranted } = useContentScriptStatus();
-  const { hostGranted } = useHostStatus();
+  const { hostGranted, isFetching: isCheckingHostPermissions } =
+    useHostStatus();
   const routeChangedCallbackRef = useTrackPageView();
 
   const { user, isAuthReady } = useAuthContext();
@@ -101,7 +102,7 @@ function InternalApp(): ReactElement {
   }, [unreadCount]);
 
   if (!hostGranted) {
-    return <ExtensionPermissionsPrompt />;
+    return isCheckingHostPermissions ? null : <ExtensionPermissionsPrompt />;
   }
 
   if (shouldRedirectOnboarding) {

--- a/packages/shared/src/components/ExtensionOnboarding.tsx
+++ b/packages/shared/src/components/ExtensionOnboarding.tsx
@@ -1,12 +1,22 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useEffect } from 'react';
 import Link from 'next/link';
 import Logo, { LogoPosition } from './Logo';
 import { OnboardingTitleGradient } from './onboarding/common';
 import { onboardingUrl } from '../lib/constants';
 import { Button, ButtonSize } from './buttons/Button';
 import { cloudinary } from '../lib/image';
+import { useExtensionContext } from '../contexts/ExtensionContext';
 
 const ExtensionOnboarding = (): ReactElement => {
+  const { setCurrentPage } = useExtensionContext();
+
+  useEffect(() => {
+    setCurrentPage('/hijacking');
+    return () => {
+      setCurrentPage('/');
+    };
+  });
+
   return (
     <div className="flex overflow-hidden flex-col justify-center items-center px-7 antialiased text-center min-h-[100vh] max-h-[100vh]">
       <Logo position={LogoPosition.Relative} logoClassName="h-logo-big" />

--- a/packages/shared/src/components/ExtensionOnboarding.tsx
+++ b/packages/shared/src/components/ExtensionOnboarding.tsx
@@ -15,7 +15,7 @@ const ExtensionOnboarding = (): ReactElement => {
     return () => {
       setCurrentPage('/');
     };
-  });
+  }, [setCurrentPage]);
 
   return (
     <div className="flex overflow-hidden flex-col justify-center items-center px-7 antialiased text-center min-h-[100vh] max-h-[100vh]">

--- a/packages/shared/src/components/ExtensionPermissionsPrompt.tsx
+++ b/packages/shared/src/components/ExtensionPermissionsPrompt.tsx
@@ -1,4 +1,4 @@
-import React, { MutableRefObject, ReactElement } from 'react';
+import React, { ReactElement, useEffect } from 'react';
 import Logo, { LogoPosition } from './Logo';
 import { OnboardingTitleGradient } from './onboarding/common';
 import { Button, ButtonSize } from './buttons/Button';
@@ -6,15 +6,18 @@ import { cloudinary } from '../lib/image';
 import { useExtensionContext } from '../contexts/ExtensionContext';
 import { useHostStatus } from '../hooks/useHostPermissionStatus';
 
-const ExtensionPermissionsPrompt = ({
-  pageRef,
-}: {
-  pageRef: MutableRefObject<string>;
-}): ReactElement => {
-  // eslint-disable-next-line no-param-reassign
-  pageRef.current = '/permissions';
-  const { requestHostPermissions, origins } = useExtensionContext();
+const ExtensionPermissionsPrompt = (): ReactElement => {
+  const { requestHostPermissions, origins, setCurrentPage } =
+    useExtensionContext();
   const { refetch: refetchHostPermissions } = useHostStatus();
+
+  useEffect(() => {
+    setCurrentPage('/permissions');
+
+    return () => {
+      setCurrentPage('/');
+    };
+  });
 
   const handleRequestHostPermissions = async () => {
     const success = await requestHostPermissions({ origins });

--- a/packages/shared/src/components/ExtensionPermissionsPrompt.tsx
+++ b/packages/shared/src/components/ExtensionPermissionsPrompt.tsx
@@ -17,7 +17,7 @@ const ExtensionPermissionsPrompt = (): ReactElement => {
     return () => {
       setCurrentPage('/');
     };
-  });
+  }, [setCurrentPage]);
 
   const handleRequestHostPermissions = async () => {
     const success = await requestHostPermissions({ origins });

--- a/packages/shared/src/contexts/ExtensionContext.tsx
+++ b/packages/shared/src/contexts/ExtensionContext.tsx
@@ -13,6 +13,7 @@ export interface ExtensionContextData {
   getHostPermission?: () => Promise<boolean>;
   requestHostPermissions?: Permissions.Static['request'];
   origins?: string[];
+  currentPage?: string;
   setCurrentPage?: React.Dispatch<React.SetStateAction<string>>;
 }
 

--- a/packages/shared/src/contexts/ExtensionContext.tsx
+++ b/packages/shared/src/contexts/ExtensionContext.tsx
@@ -13,6 +13,7 @@ export interface ExtensionContextData {
   getHostPermission?: () => Promise<boolean>;
   requestHostPermissions?: Permissions.Static['request'];
   origins?: string[];
+  setCurrentPage?: React.Dispatch<React.SetStateAction<string>>;
 }
 
 // This is an empty context when used outside the extension

--- a/packages/shared/src/hooks/useHostPermissionStatus.ts
+++ b/packages/shared/src/hooks/useHostPermissionStatus.ts
@@ -7,6 +7,7 @@ export const hostKey = ['host_key'];
 export type UseHostStatus = {
   hostGranted: boolean;
   isFetched: boolean;
+  isFetching: boolean;
   refetch: () => void;
 };
 
@@ -17,6 +18,7 @@ export const useHostStatus = (): UseHostStatus => {
     data: hostGranted,
     isFetched,
     refetch,
+    isFetching,
   } = useQuery(
     hostKey,
     () => {
@@ -29,5 +31,5 @@ export const useHostStatus = (): UseHostStatus => {
     { ...disabledRefetch },
   );
 
-  return { hostGranted, isFetched, refetch };
+  return { hostGranted, isFetched, isFetching, refetch };
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Replaces useRef with useState and adds it to `ExtensionContextProvider` to prevent prop drilling
- Render nothing while checking for host permissions

WT-2021 #done
