### PR TITLE
feat: lazy load related posts

### DIFF
--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -204,7 +204,6 @@ export const POST_BY_ID_QUERY = gql`
     }
   }
   ${SHARED_POST_INFO_FRAGMENT}
-  ${RELATED_POST_FRAGMENT}
 `;
 
 export const POST_UPVOTES_BY_ID_QUERY = gql`

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -202,21 +202,6 @@ export const POST_BY_ID_QUERY = gql`
       updatedAt
       numCollectionSources
     }
-    relatedCollectionPosts: relatedPosts(
-      id: $id
-      relationType: COLLECTION
-      first: ${RELATED_POSTS_PER_PAGE_DEFAULT}
-    ) {
-      edges {
-        node {
-          ...RelatedPost
-        }
-      }
-      pageInfo {
-        endCursor
-        hasNextPage
-      }
-    }
   }
   ${SHARED_POST_INFO_FRAGMENT}
   ${RELATED_POST_FRAGMENT}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- as alternative we don't really need to load related posts in initial request for all posts, we can do it only in collections when `useRelatedPosts` is mounted
- `useRelatedPosts` will just fetch it when it mounts now when its no longer available from single post query
- from [thread](https://dailydotdev.slack.com/archives/C0601MRBJJU/p1703171288640749?thread_ts=1703084846.243609&cid=C0601MRBJJU) here

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
