### PR TITLE
refactor: use ButtonV2 in `src/components/[a-o]`

### DIFF
--- a/packages/shared/src/components/ShareMobile.tsx
+++ b/packages/shared/src/components/ShareMobile.tsx
@@ -2,7 +2,12 @@ import React, { ReactElement } from 'react';
 import CopyIcon from './icons/Copy';
 import ShareIcon from './icons/Share';
 import { useCopyPostLink } from '../hooks/useCopyPostLink';
-import { Button, ButtonSize } from './buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonSize,
+  ButtonVariant,
+} from './buttons/ButtonV2';
 import { WidgetContainer } from './widgets/common';
 import { postAnalyticsEvent } from '../lib/feed';
 import { AnalyticsEvent } from '../lib/analytics';
@@ -27,19 +32,21 @@ export function ShareMobile({ post, share, link }: Props): ReactElement {
   return (
     <WidgetContainer className="flex laptop:hidden flex-col gap-2 items-start p-3">
       <Button
-        buttonSize={ButtonSize.Small}
+        size={ButtonSize.Small}
         onClick={() => copyLink()}
         pressed={copying}
         icon={<CopyIcon />}
-        className="btn-tertiary-avocado"
+        variant={ButtonVariant.Tertiary}
+        color={ButtonColor.Avocado}
       >
         {copying ? 'Copied!' : 'Copy link'}
       </Button>
       <Button
-        buttonSize={ButtonSize.Small}
+        size={ButtonSize.Small}
         onClick={onShare}
         icon={<ShareIcon />}
-        className="btn-tertiary-cabbage"
+        variant={ButtonVariant.Tertiary}
+        color={ButtonColor.Cabbage}
       >
         Share with your friends
       </Button>

--- a/packages/shared/src/components/TagLinks.tsx
+++ b/packages/shared/src/components/TagLinks.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import Link from 'next/link';
-import { Button, ButtonSize } from './buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from './buttons/ButtonV2';
 import { getTagPageLink } from '../lib/links';
 
 interface TagLinkProps {
@@ -14,8 +14,9 @@ export function TagLink({ tag, className }: TagLinkProps): ReactElement {
     <Link href={getTagPageLink(tag)} passHref key={tag} prefetch={false}>
       <Button
         tag="a"
-        buttonSize={ButtonSize.XSmall}
-        className={classNames('btn-tertiaryFloat', className)}
+        size={ButtonSize.XSmall}
+        variant={ButtonVariant.Float}
+        className={className}
       >
         #{tag}
       </Button>

--- a/packages/shared/src/components/alert/AlertPointer.tsx
+++ b/packages/shared/src/components/alert/AlertPointer.tsx
@@ -1,7 +1,6 @@
 import React, { CSSProperties, ReactElement, ReactNode, useRef } from 'react';
 import classNames from 'classnames';
-import XIcon from '../icons/MiniClose';
-import { Button, ButtonSize } from '../buttons/Button';
+import { ButtonSize } from '../buttons/ButtonV2';
 import {
   AlertPointerMessage,
   AlertPointerCopy,
@@ -9,6 +8,7 @@ import {
   AlertPointerContainer,
 } from './common';
 import Pointer, { PointerColor } from './Pointer';
+import CloseButton from '../CloseButton';
 
 interface ClassName {
   container?: string;
@@ -124,14 +124,11 @@ export default function AlertPointer({
           ) : (
             message
           )}
-          <Button
+          <CloseButton
             data-testid="alert-close"
             onClick={onClose}
-            icon={<XIcon />}
-            buttonSize={ButtonSize.XSmall}
-            iconOnly
-            style={{ position: 'absolute' }}
-            className="top-2 right-2 btn-tertiary"
+            size={ButtonSize.XSmall}
+            className="absolute top-2 right-2"
           />
         </AlertPointerMessage>
       </AlertPointerContainer>

--- a/packages/shared/src/components/buttons/ButtonV2.tsx
+++ b/packages/shared/src/components/buttons/ButtonV2.tsx
@@ -33,7 +33,6 @@ interface CommonButtonProps {
   disabled?: boolean;
   children?: ReactNode;
   tag?: React.ElementType & AllowedTags;
-  iconOnly?: boolean;
 }
 
 // when color is present, variant is required
@@ -70,7 +69,6 @@ function ButtonComponent<TagName extends AllowedTags>(
     iconPosition = ButtonIconPosition.Left,
     loading,
     pressed,
-    iconOnly: forceIconOnly = false,
     children,
     onClick,
     tag: Tag = 'button',
@@ -78,7 +76,7 @@ function ButtonComponent<TagName extends AllowedTags>(
   }: ButtonProps<TagName>,
   ref?: Ref<ButtonElementType<TagName>>,
 ): ReactElement {
-  const iconOnly = forceIconOnly || (icon && !children);
+  const iconOnly = icon && !children;
   const getIconWithSize = useGetIconWithSize(size, iconOnly, iconPosition);
   const isAnchor = Tag === 'a';
 

--- a/packages/shared/src/components/buttons/ButtonV2.tsx
+++ b/packages/shared/src/components/buttons/ButtonV2.tsx
@@ -33,6 +33,7 @@ interface CommonButtonProps {
   disabled?: boolean;
   children?: ReactNode;
   tag?: React.ElementType & AllowedTags;
+  iconOnly?: boolean;
 }
 
 // when color is present, variant is required
@@ -69,6 +70,7 @@ function ButtonComponent<TagName extends AllowedTags>(
     iconPosition = ButtonIconPosition.Left,
     loading,
     pressed,
+    iconOnly: forceIconOnly = false,
     children,
     onClick,
     tag: Tag = 'button',
@@ -76,7 +78,7 @@ function ButtonComponent<TagName extends AllowedTags>(
   }: ButtonProps<TagName>,
   ref?: Ref<ButtonElementType<TagName>>,
 ): ReactElement {
-  const iconOnly = icon && !children;
+  const iconOnly = forceIconOnly || (icon && !children);
   const getIconWithSize = useGetIconWithSize(size, iconOnly, iconPosition);
   const isAnchor = Tag === 'a';
 

--- a/packages/shared/src/components/buttons/OptionsButton.tsx
+++ b/packages/shared/src/components/buttons/OptionsButton.tsx
@@ -1,6 +1,12 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
-import { AllowedTags, Button, ButtonProps, ButtonSize } from './Button';
+import {
+  AllowedTags,
+  Button,
+  ButtonProps,
+  ButtonSize,
+  ButtonVariant,
+} from './ButtonV2';
 import MenuIcon from '../icons/Menu';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import { TooltipPosition } from '../tooltips/BaseTooltipContainer';
@@ -12,15 +18,16 @@ type OptionsButtonProps = ButtonProps<AllowedTags> & {
 const OptionsButton = ({
   className,
   tooltipPlacement = 'left',
-  buttonSize = ButtonSize.Small,
+  size = ButtonSize.Small,
   ...props
 }: OptionsButtonProps): ReactElement => (
   <SimpleTooltip placement={tooltipPlacement} content="Options">
     <Button
       {...props}
-      className={classNames('my-auto btn-tertiary', className)}
+      className={classNames('my-auto', className)}
+      variant={ButtonVariant.Tertiary}
       icon={<MenuIcon />}
-      buttonSize={buttonSize}
+      size={size}
     />
   </SimpleTooltip>
 );

--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -12,7 +12,13 @@ import InteractionCounter from '../InteractionCounter';
 import { QuaternaryButton } from '../buttons/QuaternaryButton';
 import UpvoteIcon from '../icons/Upvote';
 import CommentIcon from '../icons/Discuss';
-import { Button, ButtonProps, ButtonSize } from '../buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonProps,
+  ButtonSize,
+  ButtonVariant,
+} from '../buttons/ButtonV2';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import OptionsButton from '../buttons/OptionsButton';
 import { ReadArticleButton } from './ReadArticleButton';
@@ -54,9 +60,10 @@ function LastActionButton(props: LastActionButtonProps) {
     <SimpleTooltip content="Share post">
       <Button
         icon={<ShareIcon />}
-        buttonSize={ButtonSize.Small}
+        size={ButtonSize.Small}
         onClick={onClickShare}
-        className="btn-tertiary-cabbage"
+        variant={ButtonVariant.Tertiary}
+        color={ButtonColor.Cabbage}
       />
     </SimpleTooltip>
   );
@@ -77,7 +84,7 @@ export default function ActionButtons({
 }: ActionButtonsProps): ReactElement {
   const bookmarkOnCard = useFeature(feature.bookmarkOnCard);
   const upvoteCommentProps: ButtonProps<'button'> = {
-    buttonSize: ButtonSize.Small,
+    size: ButtonSize.Small,
   };
   const isFeedPreview = useFeedPreviewMode();
 
@@ -171,7 +178,8 @@ export default function ActionButtons({
           {!isInternalReadType(post) && (
             <ReadArticleButton
               content={getReadPostButtonText(post)}
-              className="mr-2 btn-primary"
+              className="mr-2"
+              variant={ButtonVariant.Primary}
               href={getReadArticleLink(post)}
               onClick={onReadArticleClick}
               openNewTab={!isSharedPostSquadPost(post) && openNewTab}

--- a/packages/shared/src/components/cards/CollectionCard/CollectionCard.spec.tsx
+++ b/packages/shared/src/components/cards/CollectionCard/CollectionCard.spec.tsx
@@ -86,6 +86,6 @@ it('should display the `collection` pill in the header', async () => {
 it('should show options button on hover when in laptop size', async () => {
   renderComponent();
   const header = await screen.findByLabelText('Options');
-  expect(header).toHaveClass('flex');
+  expect(header).toHaveClass('inline-flex');
   expect(header).toHaveClass('group-hover:flex laptop:hidden');
 });

--- a/packages/shared/src/components/cards/CollectionCard/CollectionCardHeader.tsx
+++ b/packages/shared/src/components/cards/CollectionCard/CollectionCardHeader.tsx
@@ -22,7 +22,7 @@ export const CollectionCardHeader = ({
         totalSources={totalSources}
       />
       <OptionsButton
-        className="marker:group-hover:flex laptop:hidden absolute top-3 right-3"
+        className="group-hover:flex laptop:hidden absolute top-3 right-3"
         onClick={onMenuClick}
         tooltipPlacement="top"
       />

--- a/packages/shared/src/components/cards/CollectionCard/CollectionCardHeader.tsx
+++ b/packages/shared/src/components/cards/CollectionCard/CollectionCardHeader.tsx
@@ -22,7 +22,7 @@ export const CollectionCardHeader = ({
         totalSources={totalSources}
       />
       <OptionsButton
-        className="absolute marker:group-hover:flex laptop:hidden top-3 right-3"
+        className="marker:group-hover:flex laptop:hidden absolute top-3 right-3"
         onClick={onMenuClick}
         tooltipPlacement="top"
       />

--- a/packages/shared/src/components/cards/CollectionCard/CollectionCardHeader.tsx
+++ b/packages/shared/src/components/cards/CollectionCard/CollectionCardHeader.tsx
@@ -22,10 +22,9 @@ export const CollectionCardHeader = ({
         totalSources={totalSources}
       />
       <OptionsButton
-        className="group-hover:flex laptop:hidden top-3 right-3"
+        className="absolute marker:group-hover:flex laptop:hidden top-3 right-3"
         onClick={onMenuClick}
         tooltipPlacement="top"
-        position="absolute"
       />
     </>
   );

--- a/packages/shared/src/components/cards/FeedbackCard.tsx
+++ b/packages/shared/src/components/cards/FeedbackCard.tsx
@@ -6,7 +6,6 @@ import {
   ButtonVariant,
 } from '../buttons/ButtonV2';
 import DownvoteIcon from '../icons/Downvote';
-import MiniCloseIcon from '../icons/MiniClose';
 import UpvoteIcon from '../icons/Upvote';
 import { Post, UserPostVote } from '../../graphql/posts';
 import { usePostFeedback } from '../../hooks';

--- a/packages/shared/src/components/cards/FeedbackCard.tsx
+++ b/packages/shared/src/components/cards/FeedbackCard.tsx
@@ -1,5 +1,10 @@
 import React, { MouseEventHandler, ReactElement } from 'react';
-import { Button, ButtonSize } from '../buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonSize,
+  ButtonVariant,
+} from '../buttons/ButtonV2';
 import DownvoteIcon from '../icons/Downvote';
 import MiniCloseIcon from '../icons/MiniClose';
 import UpvoteIcon from '../icons/Upvote';
@@ -7,6 +12,7 @@ import { Post, UserPostVote } from '../../graphql/posts';
 import { usePostFeedback } from '../../hooks';
 import { useFeature } from '../GrowthBookProvider';
 import { feature } from '../../lib/featureManagement';
+import CloseButton from '../CloseButton';
 
 interface FeedbackCardProps {
   post: Post;
@@ -26,12 +32,10 @@ export const FeedbackCard = ({
     <div className="flex-1 p-6 pb-5 space-y-4">
       <div className="flex relative justify-between">
         <p className="font-bold typo-callout">{feedbackCopy}</p>
-        <Button
+        <CloseButton
           id="close-engagement-loop-btn"
-          className="-top-2.5 -right-2.5 btn-tertiary"
-          position="absolute"
-          buttonSize={ButtonSize.XSmall}
-          icon={<MiniCloseIcon />}
+          className="absolute -top-2.5 -right-2.5"
+          size={ButtonSize.XSmall}
           onClick={dismissFeedback}
         />
       </div>
@@ -43,8 +47,9 @@ export const FeedbackCard = ({
           icon={
             <UpvoteIcon secondary={post?.userState?.vote === UserPostVote.Up} />
           }
+          variant={ButtonVariant.Secondary}
+          color={ButtonColor.Avocado}
           aria-label="Upvote"
-          className="btn-secondary-avocado"
         />
         <Button
           id="downvote-post-btn"
@@ -55,8 +60,9 @@ export const FeedbackCard = ({
               secondary={post?.userState?.vote === UserPostVote.Down}
             />
           }
+          variant={ButtonVariant.Secondary}
+          color={ButtonColor.Ketchup}
           aria-label="Downvote"
-          className="btn-secondary-ketchup"
         />
       </div>
     </div>

--- a/packages/shared/src/components/cards/PostCardHeader.tsx
+++ b/packages/shared/src/components/cards/PostCardHeader.tsx
@@ -7,6 +7,7 @@ import { ReadArticleButton } from './ReadArticleButton';
 import { getGroupedHoverContainer } from './common';
 import { useFeedPreviewMode } from '../../hooks';
 import { Post, getReadPostButtonText } from '../../graphql/posts';
+import { ButtonVariant } from '../buttons/ButtonV2';
 
 interface CardHeaderProps {
   post: Post;
@@ -45,7 +46,8 @@ export const PostCardHeader = ({
           <>
             <ReadArticleButton
               content={getReadPostButtonText(post)}
-              className="mr-2 btn-primary"
+              className="mr-2"
+              variant={ButtonVariant.Primary}
               href={postLink}
               onClick={onReadArticleClick}
               openNewTab={openNewTab}

--- a/packages/shared/src/components/cards/ReadArticleButton.tsx
+++ b/packages/shared/src/components/cards/ReadArticleButton.tsx
@@ -1,29 +1,30 @@
 import React, { ReactElement } from 'react';
-import { Button, ButtonSize } from '../buttons/Button';
+import {
+  Button,
+  ButtonIconPosition,
+  ButtonProps,
+  ButtonSize,
+} from '../buttons/ButtonV2';
 import OpenLinkIcon from '../icons/OpenLink';
 
-interface ReadArticleButtonProps {
+type ReadArticleButtonProps = ButtonProps<'a'> & {
   content: string;
   href: string;
-  className?: string;
   openNewTab?: boolean;
-  buttonSize?: ButtonSize;
-  onClick?: (e: React.MouseEvent) => unknown;
-  title?: string;
-  rel?: string;
-}
+};
 
 export const ReadArticleButton = ({
   content,
   openNewTab,
-  buttonSize = ButtonSize.Small,
+  size = ButtonSize.Small,
   ...props
 }: ReadArticleButtonProps): ReactElement => (
   <Button
-    tag="a"
     {...props}
-    buttonSize={buttonSize}
-    rightIcon={<OpenLinkIcon className="ml-2" secondary />}
+    tag="a"
+    size={size}
+    icon={<OpenLinkIcon className="ml-2" secondary />}
+    iconPosition={ButtonIconPosition.Right}
     target={openNewTab ? '_blank' : '_self'}
   >
     {content}

--- a/packages/shared/src/components/cards/SharePostCard.spec.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.spec.tsx
@@ -105,7 +105,7 @@ it('should show author name and author handle when enableSourceHeader is false',
 it('should show options button on hover when in laptop size', async () => {
   renderComponent();
   const header = await screen.findByLabelText('Options');
-  expect(header).toHaveClass('flex');
+  expect(header).toHaveClass('inline-flex');
   expect(header).toHaveClass('group-hover:flex laptop:hidden');
 });
 

--- a/packages/shared/src/components/cards/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.tsx
@@ -59,10 +59,9 @@ export const SharePostCard = forwardRef(function SharePostCard(
       )}
 
       <OptionsButton
-        className="group-hover:flex laptop:hidden top-2 right-2"
+        className="absolute group-hover:flex laptop:hidden top-2 right-2"
         onClick={(event) => onMenuClick?.(event, post)}
         tooltipPlacement="top"
-        position="absolute"
       />
       <SharedPostCardHeader
         author={post.author}

--- a/packages/shared/src/components/cards/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.tsx
@@ -59,7 +59,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
       )}
 
       <OptionsButton
-        className="absolute group-hover:flex laptop:hidden top-2 right-2"
+        className="group-hover:flex laptop:hidden absolute top-2 right-2"
         onClick={(event) => onMenuClick?.(event, post)}
         tooltipPlacement="top"
       />

--- a/packages/shared/src/components/cards/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCard.tsx
@@ -74,7 +74,7 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
       )}
 
       <OptionsButton
-        className="absolute group-hover:flex laptop:hidden top-2 right-2"
+        className="group-hover:flex laptop:hidden absolute top-2 right-2"
         onClick={(event) => onMenuClick?.(event, post)}
         tooltipPlacement="top"
       />

--- a/packages/shared/src/components/cards/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCard.tsx
@@ -74,10 +74,9 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
       )}
 
       <OptionsButton
-        className="group-hover:flex laptop:hidden top-2 right-2"
+        className="absolute group-hover:flex laptop:hidden top-2 right-2"
         onClick={(event) => onMenuClick?.(event, post)}
         tooltipPlacement="top"
-        position="absolute"
       />
       <WelcomePostCardHeader
         author={post.author}

--- a/packages/shared/src/components/checklist/ChecklistCard.tsx
+++ b/packages/shared/src/components/checklist/ChecklistCard.tsx
@@ -4,9 +4,8 @@ import { Card } from '../cards/Card';
 import { ChecklistStep } from './ChecklistStep';
 import { ChecklistCardProps } from '../../lib/checklist';
 import { useChecklist } from '../../hooks/useChecklist';
-import { ButtonSize } from '../buttons/Button';
 import { RankConfetti } from '../../svg/RankConfetti';
-import { ButtonVariant } from '../buttons/ButtonV2';
+import { ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
 import { ModalClose } from '../modals/common/ModalClose';
 
 const ChecklistCard = ({

--- a/packages/shared/src/components/checklist/InstallExtensionChecklistStep.tsx
+++ b/packages/shared/src/components/checklist/InstallExtensionChecklistStep.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { ChecklistStepProps } from '../../lib/checklist';
 import { ChecklistStep } from './ChecklistStep';
-import { Button } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import BrowsersIcon from '../../../icons/browsers.svg';
 import { FlexCentered } from '../utilities';
 import { useActions } from '../../hooks/useActions';
@@ -16,7 +16,7 @@ const InstallExtensionChecklistStep = (
   return (
     <ChecklistStep {...props}>
       <Button
-        className="btn-primary"
+        variant={ButtonVariant.Primary}
         tag="a"
         href={downloadBrowserExtension}
         onClick={() => {

--- a/packages/shared/src/components/checklist/InviteMemberChecklistStep.tsx
+++ b/packages/shared/src/components/checklist/InviteMemberChecklistStep.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { ChecklistStepProps } from '../../lib/checklist';
 import { ChecklistStep } from './ChecklistStep';
-import { Button } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import LinkIcon from '../icons/Link';
 import { useSquadInvitation } from '../../hooks/useSquadInvitation';
 import { Squad } from '../../graphql/sources';
@@ -30,7 +30,7 @@ const InviteMemberChecklistStep = ({
       />
       <Button
         icon={<LinkIcon />}
-        className="btn-primary"
+        variant={ButtonVariant.Primary}
         onClick={() => {
           trackAndCopyLink();
         }}

--- a/packages/shared/src/components/checklist/NotificationChecklistStep.tsx
+++ b/packages/shared/src/components/checklist/NotificationChecklistStep.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { ChecklistStepProps } from '../../lib/checklist';
-import { Button } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import { ChecklistStep } from './ChecklistStep';
 import BellIcon from '../icons/Bell';
 import { NotificationPromptSource } from '../../lib/analytics';
@@ -13,7 +13,11 @@ const NotificationChecklistStep = (props: ChecklistStepProps): ReactElement => {
 
   return (
     <ChecklistStep {...props}>
-      <Button icon={<BellIcon />} className="btn-primary" onClick={onEnable}>
+      <Button
+        icon={<BellIcon />}
+        variant={ButtonVariant.Primary}
+        onClick={onEnable}
+      >
         Subscribe
       </Button>
     </ChecklistStep>

--- a/packages/shared/src/components/checklist/SharePostChecklistStep.tsx
+++ b/packages/shared/src/components/checklist/SharePostChecklistStep.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useContext } from 'react';
 import { ChecklistStepProps } from '../../lib/checklist';
-import { Button } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import { ChecklistStep } from './ChecklistStep';
 import { FlexRow } from '../utilities';
 import { useLazyModal } from '../../hooks/useLazyModal';
@@ -20,7 +20,11 @@ const SharePostChecklistStep = ({
     <ChecklistStep {...props}>
       <FlexRow className="gap-4">
         <Button
-          className={showArticleOnboarding ? 'btn-secondary' : 'btn-primary'}
+          variant={
+            showArticleOnboarding
+              ? ButtonVariant.Secondary
+              : ButtonVariant.Primary
+          }
           onClick={() => {
             openModal({
               type: LazyModal.CreateSharedPost,
@@ -35,7 +39,7 @@ const SharePostChecklistStep = ({
         </Button>
         {showArticleOnboarding && (
           <Button
-            className="btn-primary"
+            variant={ButtonVariant.Primary}
             onClick={() => {
               onInitializeOnboarding();
             }}

--- a/packages/shared/src/components/checklist/SquadEditWelcomePostChecklistStep.tsx
+++ b/packages/shared/src/components/checklist/SquadEditWelcomePostChecklistStep.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { ChecklistStepProps } from '../../lib/checklist';
-import { Button } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import { ChecklistStep } from './ChecklistStep';
 import EditIcon from '../icons/Edit';
 import { useFindSquadWelcomePost } from '../../hooks/useFindSquadWelcomePost';
@@ -21,7 +21,7 @@ const SquadEditWelcomePostChecklistStep = ({
       <div className="flex">
         <Button
           tag="a"
-          className="btn-primary"
+          variant={ButtonVariant.Primary}
           disabled={!welcomePost}
           icon={<EditIcon />}
           href={`/posts/${welcomePost?.id}/edit`}

--- a/packages/shared/src/components/checklist/SquadFirstCommentChecklistStep.tsx
+++ b/packages/shared/src/components/checklist/SquadFirstCommentChecklistStep.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { useRouter } from 'next/router';
 import { ChecklistStepProps } from '../../lib/checklist';
-import { Button } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import { ChecklistStep } from './ChecklistStep';
 import { Squad } from '../../graphql/sources';
 import { useFindSquadWelcomePost } from '../../hooks/useFindSquadWelcomePost';
@@ -18,7 +18,7 @@ const SquadFirstCommentChecklistStep = ({
   return (
     <ChecklistStep {...props}>
       <Button
-        className="btn-primary"
+        variant={ButtonVariant.Primary}
         disabled={!welcomePost}
         onClick={() => {
           router.push(

--- a/packages/shared/src/components/comments/CommentActionButtons.tsx
+++ b/packages/shared/src/components/comments/CommentActionButtons.tsx
@@ -14,7 +14,12 @@ import {
 } from '../../graphql/comments';
 import { Roles } from '../../lib/user';
 import { graphqlUrl } from '../../lib/config';
-import { Button, ButtonSize } from '../buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonSize,
+  ButtonVariant,
+} from '../buttons/ButtonV2';
 import { ClickableText } from '../buttons/ClickableText';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import { useRequestProtocol } from '../../hooks/useRequestProtocol';
@@ -197,27 +202,33 @@ export default function CommentActionButtons({
       <SimpleTooltip content="Upvote">
         <Button
           id={`comment-${comment.id}-upvote-btn`}
-          buttonSize={ButtonSize.Small}
+          size={ButtonSize.Small}
           pressed={upvoted}
           onClick={toggleUpvote}
           icon={<UpvoteIcon secondary={upvoted} />}
-          className="mr-3 btn-tertiary-avocado"
+          className="mr-3"
+          variant={ButtonVariant.Tertiary}
+          color={ButtonColor.Avocado}
         />
       </SimpleTooltip>
       <SimpleTooltip content="Reply">
         <Button
-          buttonSize={ButtonSize.Small}
+          size={ButtonSize.Small}
           onClick={() => onComment(comment, parentId)}
           icon={<CommentIcon />}
-          className="mr-3 btn-tertiary-blueCheese"
+          className="mr-3"
+          variant={ButtonVariant.Tertiary}
+          color={ButtonColor.BlueCheese}
         />
       </SimpleTooltip>
       <SimpleTooltip content="Share comment">
         <Button
-          buttonSize={ButtonSize.Small}
+          size={ButtonSize.Small}
           onClick={() => onShare(comment)}
           icon={<ShareIcon />}
-          className="mr-3 btn-tertiary-cabbage"
+          className="mr-3"
+          variant={ButtonVariant.Tertiary}
+          color={ButtonColor.Cabbage}
         />
       </SimpleTooltip>
       {!!commentOptions && (

--- a/packages/shared/src/components/errors/Unauthorized.tsx
+++ b/packages/shared/src/components/errors/Unauthorized.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, ReactNode } from 'react';
-import { Button, ButtonSize } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
 import LockIcon from '../icons/Lock';
 import { PageContainerCentered } from '../utilities';
 import { IconSize } from '../Icon';
@@ -32,7 +32,11 @@ function Unauthorized({
         {description}
       </p>
       {children}
-      <Button className="mt-6 btn-primary w-fit" buttonSize={ButtonSize.Large}>
+      <Button
+        className="mt-6 w-fit"
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Large}
+      >
         Back home
       </Button>
     </PageContainerCentered>

--- a/packages/shared/src/components/fields/ImageInput.tsx
+++ b/packages/shared/src/components/fields/ImageInput.tsx
@@ -11,8 +11,8 @@ import { fallbackImages } from '../../lib/config';
 import EditIcon from '../icons/Edit';
 import { IconSize } from '../Icon';
 import { useToastNotification } from '../../hooks/useToastNotification';
-import { Button, ButtonSize } from '../buttons/Button';
-import MiniCloseIcon from '../icons/MiniClose';
+import { ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
+import CloseButton from '../CloseButton';
 
 type Size = 'medium' | 'large';
 
@@ -157,13 +157,11 @@ function ImageInput({
         )}
       </button>
       {image && closeable && (
-        <Button
-          type="button"
-          buttonSize={ButtonSize.Small}
-          position="absolute"
-          className="absolute -top-2 -right-2 !shadow-2 btn-primary"
+        <CloseButton
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Primary}
+          className="absolute -top-2 -right-2 !shadow-2"
           onClick={onClose}
-          icon={<MiniCloseIcon />}
         />
       )}
     </div>

--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -13,7 +13,12 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 import { ImageIcon, MarkdownIcon } from '../../icons';
-import { Button, ButtonSize } from '../../buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonSize,
+  ButtonVariant,
+} from '../../buttons/ButtonV2';
 import LinkIcon from '../../icons/Link';
 import AtIcon from '../../icons/At';
 import { RecommendedMentionTooltip } from '../../tooltips/RecommendedMentionTooltip';
@@ -262,17 +267,17 @@ function MarkdownInput(
         <span className="flex flex-row gap-3 justify-end items-center p-3 px-4 border-t border-theme-divider-tertiary text-theme-label-tertiary">
           {!!onUploadCommand && (
             <Button
-              type="button"
-              buttonSize={actionButtonSizes}
+              size={actionButtonSizes}
+              variant={ButtonVariant.Tertiary}
+              color={uploadingCount ? ButtonColor.Cabbage : undefined}
               className={classNames(
-                'btn-tertiary font-normal',
+                'font-normal',
                 uploadingCount && 'mr-auto text-theme-color-cabbage',
               )}
               icon={icon}
-              iconOnly={!sidebarRendered}
               onClick={() => uploadRef?.current?.click()}
             >
-              {shouldShowSubmit ? null : (
+              {!sidebarRendered || shouldShowSubmit ? null : (
                 <MarkdownUploadLabel
                   uploadingCount={uploadingCount}
                   uploadedCount={uploadedCount}
@@ -303,27 +308,24 @@ function MarkdownInput(
           >
             {!!onLinkCommand && (
               <Button
-                className="btn-tertiary"
-                type="button"
-                buttonSize={actionButtonSizes}
+                variant={ButtonVariant.Tertiary}
+                size={actionButtonSizes}
                 icon={<LinkIcon secondary />}
                 onClick={onLinkCommand}
               />
             )}
             {!!onMentionCommand && (
               <Button
-                className="btn-tertiary"
-                type="button"
-                buttonSize={actionButtonSizes}
+                variant={ButtonVariant.Tertiary}
+                size={actionButtonSizes}
                 icon={<AtIcon />}
                 onClick={onMentionCommand}
               />
             )}
             {showMarkdownGuide && (
               <Button
-                className="btn-tertiary"
-                type="button"
-                buttonSize={actionButtonSizes}
+                variant={ButtonVariant.Tertiary}
+                size={actionButtonSizes}
                 icon={<MarkdownIcon />}
                 tag="a"
                 target="_blank"
@@ -334,7 +336,9 @@ function MarkdownInput(
           </ConditionalWrapper>
           {shouldShowSubmit && (
             <Button
-              className="ml-auto btn-primary-cabbage"
+              className="ml-auto"
+              variant={ButtonVariant.Primary}
+              color={ButtonColor.Cabbage}
               type="submit"
               disabled={isLoading || disabledSubmit || input === ''}
               loading={isLoading}

--- a/packages/shared/src/components/fields/SearchField.tsx
+++ b/packages/shared/src/components/fields/SearchField.tsx
@@ -11,7 +11,12 @@ import { BaseField, FieldInput } from './common';
 import SearchIcon from '../icons/Search';
 import CloseIcon from '../icons/MiniClose';
 import ArrowIcon from '../icons/Arrow';
-import { Button, ButtonProps, ButtonSize } from '../buttons/Button';
+import {
+  Button,
+  ButtonProps,
+  ButtonSize,
+  ButtonVariant,
+} from '../buttons/ButtonV2';
 import { getFieldFontColor } from './BaseFieldContainer';
 
 export interface SearchFieldProps
@@ -100,9 +105,9 @@ export const SearchField = forwardRef(function SearchField(
       {!!showIcon &&
         (isSecondary && hasInput ? (
           <Button
-            type="button"
-            className="mr-2 btn-tertiary"
-            buttonSize={ButtonSize.XSmall}
+            className="mr-2"
+            size={ButtonSize.XSmall}
+            variant={ButtonVariant.Tertiary}
             title="Clear query"
             onClick={onClearClick}
             icon={
@@ -151,8 +156,8 @@ export const SearchField = forwardRef(function SearchField(
       {((hasInput && isPrimary) || isSecondary) && !!rightButtonProps && (
         <Button
           {...rightButtonProps}
-          className={isSecondary ? 'btn-primary' : 'btn-tertiary'}
-          buttonSize={rightButtonProps.buttonSize || ButtonSize.XSmall}
+          variant={isSecondary ? ButtonVariant.Primary : ButtonVariant.Tertiary}
+          size={rightButtonProps.size || ButtonSize.XSmall}
           title={rightButtonProps.title || 'Clear query'}
           onClick={
             rightButtonProps.type !== 'submit'

--- a/packages/shared/src/components/fields/TextField.tsx
+++ b/packages/shared/src/components/fields/TextField.tsx
@@ -15,7 +15,7 @@ import BaseFieldContainer, {
   getFieldLabelColor,
   getFieldPlaceholder,
 } from './BaseFieldContainer';
-import { ButtonProps } from '../buttons/Button';
+import { ButtonProps } from '../buttons/ButtonV2';
 import useInputFieldFunctions from '../../hooks/useInputFieldFunctions';
 
 export interface TextFieldProps extends BaseFieldProps<HTMLInputElement> {

--- a/packages/shared/src/components/filters/CategoryButton.tsx
+++ b/packages/shared/src/components/filters/CategoryButton.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Button } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
 import { TagCategory } from '../../graphql/feedSettings';
 import { TagActionArguments } from '../../hooks/useTagAndSource';
 
@@ -10,13 +10,23 @@ const ClearCategoryButton = ({
   matches: number;
   action: () => unknown;
 }) => (
-  <Button onClick={action} className="px-4 btn-secondary small">
+  <Button
+    onClick={action}
+    className="px-4"
+    variant={ButtonVariant.Secondary}
+    size={ButtonSize.Small}
+  >
     Clear ({matches})
   </Button>
 );
 
 const FollowCategoryButton = ({ action }: { action: () => unknown }) => (
-  <Button onClick={action} className="px-4 btn-primary small">
+  <Button
+    onClick={action}
+    className="px-4"
+    variant={ButtonVariant.Primary}
+    size={ButtonSize.Small}
+  >
     Follow all
   </Button>
 );

--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -7,7 +7,7 @@ import { TagCategoryLayout } from './TagCategoryDropdown';
 import AdvancedSettingsFilter from './AdvancedSettings';
 import BlockedFilter from './BlockedFilter';
 import ArrowIcon from '../icons/Arrow';
-import { Button, ButtonSize } from '../buttons/Button';
+import { Button, ButtonSize } from '../buttons/ButtonV2';
 import { UnblockItem, unBlockPromptOptions } from './FilterMenu';
 import { Modal, ModalProps } from '../modals/common/Modal';
 import { usePrompt } from '../../hooks/usePrompt';
@@ -76,7 +76,7 @@ export default function FeedFilters(props: FeedFiltersProps): ReactElement {
         <Modal.Sidebar.Inner>
           <Modal.Header>
             <Button
-              buttonSize={ButtonSize.Small}
+              size={ButtonSize.Small}
               className="flex tablet:hidden mr-2 -rotate-90"
               icon={<ArrowIcon />}
               onClick={() => setIsNavOpen(true)}

--- a/packages/shared/src/components/filters/MyFeedHeading.tsx
+++ b/packages/shared/src/components/filters/MyFeedHeading.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useContext } from 'react';
 import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import FilterIcon from '../icons/Filter';
-import { Button } from '../buttons/Button';
+import { Button, ButtonIconPosition, ButtonVariant } from '../buttons/ButtonV2';
 import AlertPointer, {
   AlertPlacement,
   AlertPointerProps,
@@ -71,8 +71,9 @@ function MyFeedHeading({
     return (
       <AlertPointer {...alertProps} offset={[0, 0]}>
         <Button
+          variant={ButtonVariant.Float}
           className={classNames(
-            'mr-auto btn-tertiaryFloat',
+            'mr-auto',
             shouldShowHighlightPulse && 'highlight-pulse',
           )}
           onClick={onClick}
@@ -87,12 +88,14 @@ function MyFeedHeading({
   return (
     <AlertPointer {...alertProps}>
       <Button
+        variant={ButtonVariant.Tertiary}
         className={classNames(
-          'mr-auto btn-tertiary',
+          'mr-auto',
           shouldShowHighlightPulse && 'highlight-pulse',
         )}
         onClick={onClick}
-        rightIcon={<FilterIcon />}
+        icon={<FilterIcon />}
+        iconPosition={ButtonIconPosition.Right}
       >
         Feed settings
       </Button>

--- a/packages/shared/src/components/filters/SourceItemRow.tsx
+++ b/packages/shared/src/components/filters/SourceItemRow.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import { FilterItem } from './common';
 import { Source } from '../../graphql/sources';
 import { LazyImage } from '../LazyImage';
-import { Button } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import BlockIcon from '../icons/Block';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 
@@ -32,8 +32,8 @@ export default function SourceItemRow({
         content={blocked ? 'Unblock source' : 'Block source'}
       >
         <Button
-          className="right-4 my-auto btn-tertiary"
-          style={{ position: 'absolute' }}
+          className="absolute right-4 my-auto"
+          variant={ButtonVariant.Tertiary}
           onClick={() => onSourceClick?.(source)}
           icon={<BlockIcon />}
         />

--- a/packages/shared/src/components/filters/TagButton.tsx
+++ b/packages/shared/src/components/filters/TagButton.tsx
@@ -5,20 +5,24 @@ import BlockIcon from '../icons/Block';
 import {
   AllowedTags,
   Button,
+  ButtonIconPosition,
   ButtonProps,
   ButtonSize,
-} from '../buttons/Button';
+  ButtonVariant,
+} from '../buttons/ButtonV2';
 import { TagActionArguments } from '../../hooks/useTagAndSource';
 
-interface GenericTagButtonProps extends HTMLAttributes<HTMLButtonElement> {
-  tag: string;
+interface GenericTagButtonProps
+  extends Omit<HTMLAttributes<HTMLButtonElement>, 'color'> {
+  tagItem: string;
   className?: string;
   icon?: ReactElement;
   action: () => unknown;
+  variant?: ButtonVariant;
 }
 
 export const GenericTagButton = ({
-  tag,
+  tagItem,
   className,
   icon,
   action,
@@ -26,17 +30,18 @@ export const GenericTagButton = ({
 }: GenericTagButtonProps): ReactElement => (
   <Button
     {...props}
-    buttonSize={ButtonSize.Small}
+    size={ButtonSize.Small}
     className={classNames('font-bold typo-callout', className)}
     onClick={action}
-    rightIcon={action ? icon : null}
+    icon={action ? icon : undefined}
+    iconPosition={action ? ButtonIconPosition.Right : undefined}
   >
-    {`#${tag}`}
+    {`#${tagItem}`}
   </Button>
 );
 
 const UnblockTagButton = ({
-  tag,
+  tagItem,
   className,
   action,
   ...props
@@ -46,27 +51,28 @@ const UnblockTagButton = ({
     className={classNames('btn-tagBlocked', className)}
     icon={<BlockIcon className="ml-2 text-xl transition-transform" />}
     action={action}
-    tag={tag}
+    tagItem={tagItem}
   />
 );
 
 const UnfollowTagButton = ({
-  tag,
+  tagItem,
   className,
   action,
   ...props
 }: GenericTagButtonProps) => (
   <GenericTagButton
     {...props}
-    className={classNames('btn-primary', className)}
+    className={className}
+    variant={ButtonVariant.Primary}
     icon={<PlusIcon className="ml-2 transition-transform rotate-45" />}
     action={action}
-    tag={tag}
+    tagItem={tagItem}
   />
 );
 
 const FollowTagButton = ({
-  tag,
+  tagItem,
   className,
   action,
   ...props
@@ -76,7 +82,7 @@ const FollowTagButton = ({
     className={classNames('btn-tag', className)}
     icon={<PlusIcon className="ml-2 transition-transform rotate-0" />}
     action={action}
-    tag={tag}
+    tagItem={tagItem}
   />
 );
 
@@ -102,7 +108,7 @@ export default function TagButton<Tag extends AllowedTags>({
     return (
       <UnfollowTagButton
         {...props}
-        tag={tagItem}
+        tagItem={tagItem}
         action={
           onUnfollowTags ? () => onUnfollowTags({ tags: [tagItem] }) : null
         }
@@ -114,7 +120,7 @@ export default function TagButton<Tag extends AllowedTags>({
     return (
       <UnblockTagButton
         {...props}
-        tag={tagItem}
+        tagItem={tagItem}
         action={() => onUnblockTags({ tags: [tagItem] })}
       />
     );
@@ -131,7 +137,7 @@ export default function TagButton<Tag extends AllowedTags>({
   return (
     <FollowTagButton
       {...props}
-      tag={tagItem}
+      tagItem={tagItem}
       action={onFollowTags ? () => onFollowTags({ tags: [tagItem] }) : null}
     />
   );

--- a/packages/shared/src/components/filters/TagCategoryDropdown.tsx
+++ b/packages/shared/src/components/filters/TagCategoryDropdown.tsx
@@ -77,7 +77,7 @@ export default function TagCategoryDropdown({
       <TagCategoryDetailsContent data-testid="tagCategoryTags">
         {tagCategory.tags.map((tag) => (
           <TagButton
-            className="mr-3 mb-3"
+            className="mr-3 mb-3 tag-button"
             tagItem={tag}
             followedTags={followedTags}
             blockedTags={blockedTags}

--- a/packages/shared/src/components/filters/TagCategoryDropdown.tsx
+++ b/packages/shared/src/components/filters/TagCategoryDropdown.tsx
@@ -77,7 +77,7 @@ export default function TagCategoryDropdown({
       <TagCategoryDetailsContent data-testid="tagCategoryTags">
         {tagCategory.tags.map((tag) => (
           <TagButton
-            className="mr-3 mb-3 tag-button"
+            className="mr-3 mb-3"
             tagItem={tag}
             followedTags={followedTags}
             blockedTags={blockedTags}

--- a/packages/shared/src/components/filters/TagItemRow.tsx
+++ b/packages/shared/src/components/filters/TagItemRow.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes, ReactElement } from 'react';
 import { FilterItem } from './common';
-import { Button, ButtonSize } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
 import TagButton from './TagButton';
 import { TagActionArguments } from '../../hooks/useTagAndSource';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
@@ -33,7 +33,7 @@ export default function TagItemRow({
     <FilterItem className="relative pl-6 my-2">
       <TagButton
         className={!onFollowTags ? 'cursor-default' : ''}
-        buttonSize={ButtonSize.Small}
+        size={ButtonSize.Small}
         followedTags={followedTags}
         blockedTags={blockedTags}
         tagItem={tag}
@@ -43,8 +43,8 @@ export default function TagItemRow({
       />
       <SimpleTooltip placement="left" content={tooltip}>
         <Button
-          className="right-4 my-auto btn-tertiary"
-          style={{ position: 'absolute' }}
+          className="absolute right-4 my-auto"
+          variant={ButtonVariant.Tertiary}
           onClick={(event) => onClick?.(event, tag)}
           icon={rowIcon}
         />

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -93,28 +93,28 @@ function MainLayoutHeader({
               tooltip={{ placement: 'bottom', content: 'Notifications' }}
               href={`${webappUrl}notifications`}
             >
-              <Button
-                className="hidden laptop:flex relative mr-4"
-                variant={ButtonVariant.Float}
-                size={ButtonSize.Small}
-                onClick={onNavigateNotifications}
-                icon={
-                  <BellIcon
-                    className={classNames(
-                      'hover:text-theme-label-primary',
-                      atNotificationsPage && 'text-theme-label-primary',
-                    )}
-                    secondary={atNotificationsPage}
-                  />
-                }
-                iconOnly
-              >
+              <div className="relative mr-4">
+                <Button
+                  className="hidden laptop:flex"
+                  variant={ButtonVariant.Float}
+                  size={ButtonSize.Small}
+                  onClick={onNavigateNotifications}
+                  icon={
+                    <BellIcon
+                      className={classNames(
+                        'hover:text-theme-label-primary',
+                        atNotificationsPage && 'text-theme-label-primary',
+                      )}
+                      secondary={atNotificationsPage}
+                    />
+                  }
+                />
                 {hasNotification && (
-                  <Bubble className="top-0 right-0 px-1 shadow-bubble-cabbage translate-x-1/2 -translate-y-1/2">
+                  <Bubble className="top-0 right-0 px-1 shadow-bubble-cabbage translate-x-1/2 -translate-y-1/2 cursor-pointer">
                     {getUnreadText(unreadCount)}
                   </Bubble>
                 )}
-              </Button>
+              </div>
             </LinkWithTooltip>
           </>
         )}

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -5,7 +5,7 @@ import AuthContext from '../../contexts/AuthContext';
 import { useNotificationContext } from '../../contexts/NotificationsContext';
 import { AnalyticsEvent, NotificationTarget } from '../../lib/analytics';
 import { webappUrl } from '../../lib/constants';
-import { Button, ButtonSize } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
 import BellIcon from '../icons/Bell';
 import HamburgerIcon from '../icons/Hamburger';
 import LoginButton from '../LoginButton';
@@ -94,9 +94,9 @@ function MainLayoutHeader({
               href={`${webappUrl}notifications`}
             >
               <Button
-                className="hidden laptop:flex mr-4 btn-tertiary bg-theme-bg-secondary"
-                buttonSize={ButtonSize.Small}
-                iconOnly
+                className="relative hidden laptop:flex mr-4"
+                variant={ButtonVariant.Float}
+                size={ButtonSize.Small}
                 onClick={onNavigateNotifications}
                 icon={
                   <BellIcon
@@ -107,6 +107,7 @@ function MainLayoutHeader({
                     secondary={atNotificationsPage}
                   />
                 }
+                iconOnly
               >
                 {hasNotification && (
                   <Bubble className="top-0 right-0 px-1 shadow-bubble-cabbage translate-x-1/2 -translate-y-1/2">

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -137,8 +137,8 @@ function MainLayoutHeader({
       {sidebarRendered !== undefined && (
         <>
           <Button
-            className="block laptop:hidden btn-tertiary"
-            iconOnly
+            className="block laptop:hidden"
+            variant={ButtonVariant.Tertiary}
             onClick={() => onMobileSidebarToggle(true)}
             icon={<HamburgerIcon secondary />}
           />

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -94,7 +94,7 @@ function MainLayoutHeader({
               href={`${webappUrl}notifications`}
             >
               <Button
-                className="relative hidden laptop:flex mr-4"
+                className="hidden laptop:flex relative mr-4"
                 variant={ButtonVariant.Float}
                 size={ButtonSize.Small}
                 onClick={onNavigateNotifications}

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -16,7 +16,7 @@ import useSidebarRendered from '../../hooks/useSidebarRendered';
 import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
 import { Dropdown, DropdownProps } from '../fields/Dropdown';
-import { ButtonSize } from '../buttons/Button';
+import { ButtonSize } from '../buttons/ButtonV2';
 import CalendarIcon from '../icons/Calendar';
 import SortIcon from '../icons/Sort';
 import { IconSize } from '../Icon';

--- a/packages/shared/src/components/modals/KeywordSynonymModal.tsx
+++ b/packages/shared/src/components/modals/KeywordSynonymModal.tsx
@@ -8,7 +8,7 @@ import {
   SET_KEYWORD_AS_SYNONYM_MUTATION,
 } from '../../graphql/keywords';
 import { graphqlUrl } from '../../lib/config';
-import { Button } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import { Modal, ModalProps } from './common/Modal';
 
 export type KeywordSynonymModalProps = { selectedKeyword: string } & ModalProps;
@@ -63,7 +63,7 @@ export default function KeywordSynonymModal({
               <li className="p-0 m-0" key={keyword.value}>
                 <Button
                   onClick={() => setSynonym(keyword.value)}
-                  className="btn-tertiary"
+                  variant={ButtonVariant.Tertiary}
                 >
                   {keyword.value}
                 </Button>

--- a/packages/shared/src/components/modals/NewSourceModal.tsx
+++ b/packages/shared/src/components/modals/NewSourceModal.tsx
@@ -8,7 +8,7 @@ import React, {
 import { useMutation } from '@tanstack/react-query';
 import classNames from 'classnames';
 import request from 'graphql-request';
-import { Button } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
 import { SearchField } from '../fields/SearchField';
 import { Radio } from '../fields/Radio';
 import { formToJson } from '../../lib/form';
@@ -63,7 +63,7 @@ const getFeedLabel = (label: string, link: string) => (
   <span className="flex flex-1 justify-between items-center w-full">
     {label}
     <Button
-      className="btn-tertiary"
+      variant={ButtonVariant.Tertiary}
       tag="a"
       target="_blank"
       href={link}
@@ -308,7 +308,9 @@ export default function NewSourceModal(props: ModalProps): ReactElement {
             {showContact && (
               <Button
                 tag="a"
-                className="self-start mt-3 mb-6 btn-secondary small"
+                className="self-start mt-3 mb-6"
+                variant={ButtonVariant.Secondary}
+                size={ButtonSize.Small}
                 href="mailto:hi@daily.dev?subject=Failed to add new source"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -323,7 +325,7 @@ export default function NewSourceModal(props: ModalProps): ReactElement {
         {!feeds?.length && (
           <Button
             form="submit-source"
-            className="btn-primary"
+            variant={ButtonVariant.Primary}
             type="submit"
             disabled={isScraping || !enableSubmission}
             loading={isScraping}
@@ -344,7 +346,7 @@ export default function NewSourceModal(props: ModalProps): ReactElement {
             </Button>
             <Button
               form="select-feed"
-              className="btn-primary"
+              variant={ButtonVariant.Primary}
               type="submit"
               disabled={!selectedFeed || !!existingSource}
               loading={checkingIfExists || requestingSource}

--- a/packages/shared/src/components/modals/PushNotificationModal.tsx
+++ b/packages/shared/src/components/modals/PushNotificationModal.tsx
@@ -5,7 +5,7 @@ import {
 } from '../../hooks/useNotificationPermissionPopup';
 import useWindowEvents from '../../hooks/useWindowEvents';
 import { cloudinary } from '../../lib/image';
-import { Button } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import { Justify } from '../utilities';
 import { Modal, ModalProps } from './common/Modal';
 import { useNotificationContext } from '../../contexts/NotificationsContext';
@@ -58,7 +58,7 @@ function PushNotificationModal(modalProps: ModalProps): ReactElement {
         />
       </Modal.Body>
       <Modal.Footer justify={Justify.Center}>
-        <Button className="btn-primary" onClick={enableNotifications}>
+        <Button variant={ButtonVariant.Primary} onClick={enableNotifications}>
           Enable notifications
         </Button>
       </Modal.Footer>

--- a/packages/shared/src/components/modals/RanksModal/index.tsx
+++ b/packages/shared/src/components/modals/RanksModal/index.tsx
@@ -6,7 +6,7 @@ import RanksTags from './RanksTags';
 import DevCardFooter from './DevCardFooter';
 import { RanksModalProps } from './common';
 import AuthContext from '../../../contexts/AuthContext';
-import { Button } from '../../buttons/Button';
+import { Button, ButtonVariant } from '../../buttons/ButtonV2';
 import { RANKS } from '../../../lib/rank';
 import { AuthTriggers } from '../../../lib/auth';
 import { Modal } from '../common/Modal';
@@ -50,9 +50,10 @@ export default function RanksModal({
             </span>
             <Button
               className={classNames(
-                'mt-3 w-40 btn-primary',
+                'mt-3 w-40',
                 rank && RANKS[rank].background,
               )}
+              variant={ButtonVariant.Primary}
               onClick={() => showLogin({ trigger: AuthTriggers.RanksModal })}
             >
               Sign up

--- a/packages/shared/src/components/modals/SharedBookmarksModal.tsx
+++ b/packages/shared/src/components/modals/SharedBookmarksModal.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import request from 'graphql-request';
 import CopyIcon from '../icons/Copy';
-import { Button, ButtonSize } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
 import { Switch } from '../fields/Switch';
 import {
   BookmarksSharingData,
@@ -84,8 +84,8 @@ export default function SharedBookmarksModal({
               fieldType="tertiary"
               actionButton={
                 <Button
-                  buttonSize={ButtonSize.Small}
-                  className="btn-tertiary"
+                  size={ButtonSize.Small}
+                  variant={ButtonVariant.Tertiary}
                   icon={<CopyIcon />}
                   onClick={() => copyRssUrl()}
                 />

--- a/packages/shared/src/components/modals/SharedBookmarksModal.tsx
+++ b/packages/shared/src/components/modals/SharedBookmarksModal.tsx
@@ -103,8 +103,8 @@ export default function SharedBookmarksModal({
           <div className="flex justify-between mt-4">
             <Button
               rel="noopener noreferrer"
-              className="btn-secondary"
-              buttonSize={ButtonSize.Small}
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Small}
               href={sharingBookmarks}
               tag="a"
               target="_blank"

--- a/packages/shared/src/components/modals/SubmitArticleModal.tsx
+++ b/packages/shared/src/components/modals/SubmitArticleModal.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import request from 'graphql-request';
-import { Button } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import { formToJson } from '../../lib/form';
 import { graphqlUrl } from '../../lib/config';
 import {
@@ -279,7 +279,7 @@ export default function SubmitArticleModal({
       <Modal.Footer justify={isSubmitted ? Justify.Center : Justify.End}>
         {(!isSubmitted || !!existingArticle) && (
           <Button
-            className="btn-primary"
+            variant={ButtonVariant.Primary}
             type="submit"
             aria-label="Submit article"
             disabled={!enableSubmission || !isEnabled || !!existingArticle}
@@ -293,7 +293,8 @@ export default function SubmitArticleModal({
         )}
         {isSubmitted && (
           <Button
-            className="flex-1 btn-primary max-w-[22.5rem]"
+            className="flex-1 max-w-[22.5rem]"
+            variant={ButtonVariant.Primary}
             aria-label="Close submit article modal"
             onClick={onRequestClose}
           >

--- a/packages/shared/src/components/modals/common/ModalHeader.tsx
+++ b/packages/shared/src/components/modals/common/ModalHeader.tsx
@@ -4,7 +4,7 @@ import classed from '../../../lib/classed';
 import { ModalTabs, ModalTabsProps } from './ModalTabs';
 import { ModalClose } from './ModalClose';
 import { ModalHeaderKind, ModalPropsContext } from './types';
-import { Button, ButtonProps } from '../../buttons/Button';
+import { Button, ButtonProps, ButtonVariant } from '../../buttons/ButtonV2';
 import ArrowIcon from '../../icons/Arrow';
 import { ModalStepsWrapper } from './ModalStepsWrapper';
 import { ProgressBar } from '../../fields/ProgressBar';
@@ -73,7 +73,8 @@ export function ModalHeaderTabs(props: ModalTabsProps): ReactElement {
 const ModalHeaderStepsButton = (props: ButtonProps<'button'>) => (
   <Button
     icon={<ArrowIcon className="-rotate-90" />}
-    className="flex justify-center items-center mr-2 -ml-2 btn btn-tertiary iconOnly"
+    className="mr-2 -ml-2"
+    variant={ButtonVariant.Tertiary}
     {...props}
   />
 );

--- a/packages/shared/src/components/modals/report/ReportModal.tsx
+++ b/packages/shared/src/components/modals/report/ReportModal.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, ReactNode, useState } from 'react';
 import { Radio, RadioOption } from '../../fields/Radio';
-import { Button } from '../../buttons/Button';
+import { Button, ButtonVariant } from '../../buttons/ButtonV2';
 import { Modal, ModalProps } from '../common/Modal';
 import { Justify } from '../../utilities';
 import { ReportReason } from '../../../graphql/posts';
@@ -59,7 +59,7 @@ export function ReportModal({
       <Modal.Footer justify={footer ? Justify.Between : Justify.End}>
         {footer}
         <Button
-          className="btn-primary"
+          variant={ButtonVariant.Primary}
           disabled={!reason || (reason === OTHER_KEY && !note) || disabled}
           onClick={(e) => onReport(e, reason, note)}
         >

--- a/packages/shared/src/components/modals/report/ReportPostModal.tsx
+++ b/packages/shared/src/components/modals/report/ReportPostModal.tsx
@@ -10,7 +10,7 @@ import React, {
 import { RadioOption } from '../../fields/Radio';
 import { Post, ReadHistoryPost, ReportReason } from '../../../graphql/posts';
 import { Checkbox } from '../../fields/Checkbox';
-import { Button, ButtonSize } from '../../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../../buttons/ButtonV2';
 import { PostBootData } from '../../../lib/boot';
 import { ModalProps } from '../common/Modal';
 import { FlexRow } from '../../utilities';
@@ -69,8 +69,8 @@ const reportReasonsMap: Partial<
           return (
             <Button
               key={tag}
-              className={isSelected ? 'btn-primary' : 'btn-tertiaryFloat'}
-              buttonSize={ButtonSize.Small}
+              variant={isSelected ? ButtonVariant.Primary : ButtonVariant.Float}
+              size={ButtonSize.Small}
               onClick={() => {
                 if (isSelected) {
                   setSelectedTags(selectedTags.filter((t) => t !== tag));

--- a/packages/shared/src/components/multiLevelMenu/MultiLevelMenuDetail.tsx
+++ b/packages/shared/src/components/multiLevelMenu/MultiLevelMenuDetail.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, ReactNode } from 'react';
-import { Button } from '../buttons/Button';
+import { Button } from '../buttons/ButtonV2';
 import ArrowIcon from '../icons/Arrow';
 import { MenuItem } from '../filters/common';
 

--- a/packages/shared/src/components/notifications/NotificationItem.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.tsx
@@ -118,8 +118,7 @@ function NotificationItem({
       )}
       {onOptionsClick && (
         <OptionsButton
-          className="hidden group-hover:flex top-3 right-2"
-          position="absolute"
+          className="absolute hidden group-hover:flex top-3 right-2"
           type="button"
           onClick={onOptionsClick}
         />

--- a/packages/shared/src/components/notifications/NotificationItem.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.tsx
@@ -118,7 +118,7 @@ function NotificationItem({
       )}
       {onOptionsClick && (
         <OptionsButton
-          className="absolute hidden group-hover:flex top-3 right-2"
+          className="hidden group-hover:flex absolute top-3 right-2"
           type="button"
           onClick={onOptionsClick}
         />

--- a/packages/shared/src/components/notifications/Toast.tsx
+++ b/packages/shared/src/components/notifications/Toast.tsx
@@ -6,7 +6,7 @@ import {
   TOAST_NOTIF_KEY,
 } from '../../hooks/useToastNotification';
 import classed from '../../lib/classed';
-import { Button, ButtonSize } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
 import styles from './Toast.module.css';
 import XIcon from '../icons/MiniClose';
 import { isTouchDevice } from '../../lib/tooltip';
@@ -100,8 +100,9 @@ const Toast = ({
         <NotifMessage>{toast.message}</NotifMessage>
         {toast?.onUndo && (
           <Button
-            className="ml-2 btn-primary"
-            buttonSize={ButtonSize.XSmall}
+            className="ml-2"
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.XSmall}
             onClick={undoAction}
             aria-label="Undo action"
           >
@@ -109,8 +110,9 @@ const Toast = ({
           </Button>
         )}
         <Button
-          className="ml-2 btn-primary"
-          buttonSize={ButtonSize.Small}
+          className="ml-2"
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Small}
           icon={<XIcon />}
           onClick={dismissToast}
           aria-label="Dismiss toast notification"

--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -14,6 +14,7 @@ import { SharePostTitle } from './share';
 import { combinedClicks } from '../../lib/click';
 import { SharedLinkContainer } from './common/SharedLinkContainer';
 import { SharedPostLink } from './common/SharedPostLink';
+import { ButtonVariant } from '../buttons/ButtonV2';
 
 interface SharePostContentProps {
   post: Post;
@@ -56,7 +57,8 @@ function SharePostContent({
             />
             <ReadArticleButton
               content={getReadPostButtonText(post)}
-              className="mt-5 btn-secondary w-fit"
+              className="mt-5 w-fit"
+              variant={ButtonVariant.Secondary}
               href={
                 shouldUseInternalLink
                   ? post.sharedPost.commentsPermalink

--- a/packages/shared/src/components/post/block/PostTagsPanel.tsx
+++ b/packages/shared/src/components/post/block/PostTagsPanel.tsx
@@ -109,9 +109,9 @@ export function PostTagsPanel({
           <GenericTagButton
             key={tag}
             role="listitem"
-            className={tags[tag] ? 'btn-primary' : 'btn-tertiaryFloat'}
+            variant={tags[tag] ? ButtonVariant.Primary : ButtonVariant.Float}
             action={() => setTags({ ...tags, [tag]: !tags[tag] })}
-            tag={tag}
+            tagItem={tag}
           />
         ))}
       </span>


### PR DESCRIPTION
## Changes

### Describe what this PR does

- Refactored to use ButtonV2 in `src/components/[a-o]`
- Needed to reintroduce `iconOnly` prop to ButtonV2, because the notification button was not playing ball without defining it. Maybe there's a better way though? 🤔 

### Screenshots

<img width="391" alt="Screenshot 2023-12-22 at 11 03 38" src="https://github.com/dailydotdev/apps/assets/9974711/aadeb23b-2732-4a11-8088-7d90f425cc08">
<img width="191" alt="Screenshot 2023-12-22 at 11 05 51" src="https://github.com/dailydotdev/apps/assets/9974711/54ce68f4-0f4b-4982-94d3-9b0413cc9c2b">
<img width="172" alt="Screenshot 2023-12-22 at 11 12 11" src="https://github.com/dailydotdev/apps/assets/9974711/8e8ef787-d060-4ef4-8d2c-6bb5616dda6a">
<img width="188" alt="Screenshot 2023-12-22 at 11 12 27" src="https://github.com/dailydotdev/apps/assets/9974711/24237e54-c77e-4c9f-a726-69c79eef4de8">
<img width="326" alt="Screenshot 2023-12-22 at 11 17 36" src="https://github.com/dailydotdev/apps/assets/9974711/9f911a60-bcd9-430a-acd5-178ab8cf3947">
<img width="319" alt="Screenshot 2023-12-22 at 11 20 21" src="https://github.com/dailydotdev/apps/assets/9974711/ea84e8f2-bd73-431b-b32a-0ebf2fbd2163">
<img width="342" alt="Screenshot 2023-12-22 at 11 32 28" src="https://github.com/dailydotdev/apps/assets/9974711/f3dfcd8c-5952-45b2-85ce-d2d104130b37">
<img width="326" alt="Screenshot 2023-12-22 at 11 35 52" src="https://github.com/dailydotdev/apps/assets/9974711/98173800-9d9c-479b-aabf-29c3651a0e95">
<img width="326" alt="Screenshot 2023-12-22 at 11 38 18" src="https://github.com/dailydotdev/apps/assets/9974711/a92c43b4-d9b0-469c-b713-d108e35100fe">
<img width="326" alt="Screenshot 2023-12-22 at 11 39 05" src="https://github.com/dailydotdev/apps/assets/9974711/aeb914c9-c674-4fbc-864c-80f69b723882">
<img width="325" alt="Screenshot 2023-12-22 at 11 39 59" src="https://github.com/dailydotdev/apps/assets/9974711/a577008f-7632-48f3-bc88-bcb03aebb570">
<img width="324" alt="Screenshot 2023-12-22 at 11 40 35" src="https://github.com/dailydotdev/apps/assets/9974711/4303aa6a-0474-4a5e-8d26-44ea29e2aa89">
<img width="324" alt="Screenshot 2023-12-22 at 11 43 12" src="https://github.com/dailydotdev/apps/assets/9974711/3adf2ee0-db31-42ad-9780-f43f6e158e70">
<img width="324" alt="Screenshot 2023-12-22 at 11 49 29" src="https://github.com/dailydotdev/apps/assets/9974711/5748d162-9a29-4232-b414-e05abdf614fd">
<img width="584" alt="Screenshot 2023-12-22 at 11 59 14" src="https://github.com/dailydotdev/apps/assets/9974711/a2f40bb4-1faa-4304-b4ac-75193b87d272">
<img width="329" alt="Screenshot 2023-12-22 at 12 12 11" src="https://github.com/dailydotdev/apps/assets/9974711/eb0c99e0-05b0-4a4e-93e5-f303335e2099">
<img width="166" alt="Screenshot 2023-12-22 at 12 24 58" src="https://github.com/dailydotdev/apps/assets/9974711/340fd7f8-4daa-499a-820a-005e72dc099d">
<img width="658" alt="Screenshot 2023-12-22 at 13 14 48" src="https://github.com/dailydotdev/apps/assets/9974711/4176153f-4692-415b-ac84-be7761f8527a">
<img width="662" alt="Screenshot 2023-12-22 at 13 15 12" src="https://github.com/dailydotdev/apps/assets/9974711/739c4983-f04d-4117-a24e-9083b210582f">
<img width="678" alt="Screenshot 2023-12-22 at 13 53 34" src="https://github.com/dailydotdev/apps/assets/9974711/0ed2a02c-0dc4-4bce-bc40-ad959639e13d">
<img width="674" alt="Screenshot 2023-12-22 at 14 16 58" src="https://github.com/dailydotdev/apps/assets/9974711/6873807c-e6ab-430b-a298-ae3cf7b53548">
<img width="670" alt="Screenshot 2023-12-22 at 14 20 58" src="https://github.com/dailydotdev/apps/assets/9974711/12a12d59-e931-4717-adfb-32b61ff32588">
<img width="300" alt="Screenshot 2023-12-22 at 14 38 40" src="https://github.com/dailydotdev/apps/assets/9974711/b1c5e1f2-32dc-45e8-991b-d018404185b7">
<img width="272" alt="Screenshot 2023-12-22 at 14 38 48" src="https://github.com/dailydotdev/apps/assets/9974711/072fd2fc-ecc7-4af7-9e89-f38d4ed4833e">
<img width="280" alt="Screenshot 2023-12-22 at 14 39 04" src="https://github.com/dailydotdev/apps/assets/9974711/3761ace4-4142-45d3-a7d8-302fd73e27cb">
<img width="584" alt="Screenshot 2023-12-22 at 14 46 20" src="https://github.com/dailydotdev/apps/assets/9974711/4de99638-1e01-4c80-9b10-f17cb3e942e9">
<img width="574" alt="Screenshot 2023-12-22 at 14 48 57" src="https://github.com/dailydotdev/apps/assets/9974711/f2cdb490-0d04-4757-81c1-a7a7b9a60454">
<img width="573" alt="Screenshot 2023-12-22 at 14 54 38" src="https://github.com/dailydotdev/apps/assets/9974711/4f7207d4-5356-45e4-ac89-2ce6e3f37d17">
<img width="528" alt="Screenshot 2023-12-22 at 15 03 55" src="https://github.com/dailydotdev/apps/assets/9974711/271481d5-1362-44d7-be0e-37d704b4b39c">
<img width="576" alt="Screenshot 2023-12-22 at 15 05 44" src="https://github.com/dailydotdev/apps/assets/9974711/9700eb64-f6f3-4ed6-8b1b-b341eb1f43ec">
<img width="575" alt="Screenshot 2023-12-22 at 15 07 50" src="https://github.com/dailydotdev/apps/assets/9974711/624a0246-240e-4d38-9b59-697ab0268a60">
<img width="327" alt="Screenshot 2023-12-22 at 15 14 44" src="https://github.com/dailydotdev/apps/assets/9974711/c0ba4ef4-109f-45d1-a228-a7c7276c4e80">



## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [ ] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
