### PR TITLE
fix: card height

### DIFF
--- a/packages/shared/src/components/cards/Card.tsx
+++ b/packages/shared/src/components/cards/Card.tsx
@@ -35,10 +35,10 @@ const Title = ({
 
 export const FreeformCardTitle = classed(
   'h3',
-  'my-2 break-words multi-truncate font-bold typo-title3',
+  'break-words multi-truncate font-bold typo-title3',
 );
 
-export const CardTitle = classed(Title, 'my-2 break-words');
+export const CardTitle = classed(Title, 'break-words');
 
 export const ListCardTitle = classed(Title, 'mr-2');
 

--- a/packages/shared/src/components/cards/Card.tsx
+++ b/packages/shared/src/components/cards/Card.tsx
@@ -61,7 +61,7 @@ export const CardLink = classed('a', clickableCardClasses);
 export const Card = classed(
   'article',
   styles.card,
-  'relative h-full flex flex-col p-2 rounded-2xl bg-theme-bg-secondary border border-theme-divider-tertiary hover:border-theme-divider-secondary shadow-2',
+  'relative max-h-card h-full flex flex-col p-2 rounded-2xl bg-theme-bg-secondary border border-theme-divider-tertiary hover:border-theme-divider-secondary shadow-2',
 );
 
 export const CardHeader = classed(

--- a/packages/shared/src/components/cards/Card.tsx
+++ b/packages/shared/src/components/cards/Card.tsx
@@ -35,10 +35,10 @@ const Title = ({
 
 export const FreeformCardTitle = classed(
   'h3',
-  'break-words multi-truncate font-bold typo-title3',
+  'mt-2 break-words multi-truncate font-bold typo-title3',
 );
 
-export const CardTitle = classed(Title, 'break-words');
+export const CardTitle = classed(Title, 'mt-2 break-words');
 
 export const ListCardTitle = classed(Title, 'mr-2');
 

--- a/packages/shared/src/components/cards/CollectionCard/CollectionCardHeader.tsx
+++ b/packages/shared/src/components/cards/CollectionCard/CollectionCardHeader.tsx
@@ -17,7 +17,7 @@ export const CollectionCardHeader = ({
   return (
     <>
       <CollectionPillSources
-        className="m-2 mb-3"
+        className="m-2"
         sources={sources}
         totalSources={totalSources}
       />

--- a/packages/shared/src/components/cards/SharedPostCardHeader.tsx
+++ b/packages/shared/src/components/cards/SharedPostCardHeader.tsx
@@ -16,7 +16,7 @@ export const SharedPostCardHeader = ({
   enableSourceHeader = false,
 }: SharedPostCardHeaderProps): ReactElement => {
   return (
-    <div className="flex relative flex-row gap-2 m-2 mb-4">
+    <div className="flex relative flex-row gap-2 m-2">
       <div className="relative">
         <ProfilePicture
           user={author}

--- a/packages/shared/src/components/cards/SharedPostCardHeader.tsx
+++ b/packages/shared/src/components/cards/SharedPostCardHeader.tsx
@@ -16,7 +16,7 @@ export const SharedPostCardHeader = ({
   enableSourceHeader = false,
 }: SharedPostCardHeaderProps): ReactElement => {
   return (
-    <div className="flex relative flex-row gap-2 m-2 mb-3">
+    <div className="flex relative flex-row gap-2 m-2 mb-4">
       <div className="relative">
         <ProfilePicture
           user={author}

--- a/packages/shared/src/components/cards/SharedPostText.tsx
+++ b/packages/shared/src/components/cards/SharedPostText.tsx
@@ -20,7 +20,7 @@ export const SharedPostText = ({
   }, [sharedPostTitleRef.current?.offsetHeight]);
 
   return (
-    <div className="px-2 pt-2 pb-3" ref={sharedPostTitleRef}>
+    <div className="p-2" ref={sharedPostTitleRef}>
       <p className="line-clamp-6 typo-callout">{title}</p>
     </div>
   );

--- a/packages/shared/src/components/cards/WelcomePostCardHeader.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCardHeader.tsx
@@ -16,7 +16,7 @@ export const WelcomePostCardHeader = ({
   enableSourceHeader = false,
 }: WelcomePostCardHeaderProps): ReactElement => {
   return (
-    <div className="flex relative flex-row gap-2 m-2 mb-3">
+    <div className="flex relative flex-row gap-2 m-2">
       <div className="relative">
         <ProfilePicture
           user={author}

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -170,11 +170,11 @@ module.exports = {
         'rank-modal': 'calc(100vh - 5rem)',
         page: 'calc(100vh - 3.5rem)',
         commentBox: '18.25rem',
-        card: '23.75rem',
+        card: '24rem',
       },
       minHeight: {
         page: 'calc(100vh - 3.5rem)',
-        card: '23.75rem',
+        card: '24rem',
       },
       gap: {
         unset: 'unset',


### PR DESCRIPTION
## Changes
- After further investigation, there seem to be quite a few inaccuracies in the implementation of spacings around the card.
  - Spacing between the user info and the post's title/description.
  - Spacing between the title/description and the post's image.
- Even though the max height from the design is `364px`, it doesn't seem to fit the content even though all the other parts are accurate, such as the margins, paddings, image size, etc. - probably due to some line height or something else. Though this is a known issue that sometimes design are not 100% translatable in terms of the sizing. With that, the current card max height is `380px` and after fixing the spacings, it seems what we actually need is `388px`.
- Currently deployed at preview3. Screenshots below but feel free to check the differences yourself. 
- AI Squad has quite some dynamic content, probably a good one to do the testing.

Preview of the issues mentioned in bullet item number 1:

![Screenshot 2023-12-26 at 5 09 18 PM](https://github.com/dailydotdev/apps/assets/13744167/7b15b51e-b7a0-4cf1-a568-918aedde886d)
![Screenshot 2023-12-26 at 5 08 49 PM](https://github.com/dailydotdev/apps/assets/13744167/b54b98fa-a81b-4147-83f3-a1fd67795144)

https://preview2.app.daily.dev/squads/ai

Preview before:

![Screenshot 2023-12-26 at 5 17 56 PM](https://github.com/dailydotdev/apps/assets/13744167/653e2817-2720-4ed6-b4de-0976ca47a265)

Preview after:
![Screenshot 2023-12-26 at 5 17 46 PM](https://github.com/dailydotdev/apps/assets/13744167/5b85e429-a677-4729-90c0-feada17746d0)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2071 #done
