### PR TITLE
fix: card on mobile layout

### DIFF
--- a/packages/shared/src/components/cards/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.tsx
@@ -110,7 +110,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
           </CardTitle>
         </CardTextContainer>
         {!showFeedback && (
-          <Container className="mb-8 tablet:mb-0">
+          <Container>
             <CardSpace />
             <PostMetadata
               createdAt={post.createdAt}

--- a/packages/shared/src/components/cards/common/SquadPostCardHeader.tsx
+++ b/packages/shared/src/components/cards/common/SquadPostCardHeader.tsx
@@ -32,7 +32,7 @@ export const SquadPostCardHeader = ({
   };
 
   return (
-    <div className="flex relative flex-row gap-2 m-2 mb-3">
+    <div className="flex relative flex-row gap-2 m-2">
       <div className="relative">
         {author && (
           <ProfilePicture


### PR DESCRIPTION
## Changes
- Fixed a merge issue.
- Fixed the card layout for mobile - there was a `mb-8` which is not really necessary due to the fact that we have an empty div with `flex-1` class.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
