### PR TITLE
fix: centered profile and profile 404 page

### DIFF
--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -279,7 +279,9 @@ export const getLayout = (
   page: ReactNode,
   props: ProfileLayoutProps,
 ): ReactNode =>
-  getMainLayout(<ProfileLayout {...props}>{page}</ProfileLayout>, null);
+  getMainLayout(<ProfileLayout {...props}>{page}</ProfileLayout>, null, {
+    screenCentered: false,
+  });
 
 interface ProfileParams extends ParsedUrlQuery {
   userId: string;


### PR DESCRIPTION
## Changes

Centers the profile page (and the new 404 page) by setting `screenCentered=false` on `MainLayout`

<table>
<tr>
 <td>Before</td>
 <td>After</td>
<tr>
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/ba788984-9c7e-4ed9-97fb-401aa2bf41d9"></td>
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/762686a9-716f-4d6a-ba9d-1ef3d93582ae"></td>
<tr>
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/018ca00a-e096-455b-84f0-458fba068df8">
<td><img src="https://github.com/dailydotdev/apps/assets/1681525/6fddeab3-1410-4c20-8f2a-2ee48ef78b25">
</table>