### PR TITLE
fix: action button sizes

### DIFF
--- a/packages/shared/src/components/buttons/QuaternaryButton.tsx
+++ b/packages/shared/src/components/buttons/QuaternaryButton.tsx
@@ -7,7 +7,12 @@ import React, {
   useState,
 } from 'react';
 import classNames from 'classnames';
-import { Button, AllowedTags, ButtonProps, ButtonElementType } from './Button';
+import {
+  AllowedTags,
+  Button,
+  ButtonElementType,
+  ButtonProps,
+} from './ButtonV2';
 
 type QuandaryButtonProps = {
   id: string;
@@ -44,13 +49,12 @@ function QuaternaryButtonComponent<TagName extends AllowedTags>(
         }
       : {};
   const labelDisplay = responsiveLabelClass ?? 'flex';
-
   return (
     <div
       style={style}
       className={classNames(
         { reverse },
-        props.buttonSize,
+        props.size,
         'btn-quaternary',
         'flex',
         'flex-row',
@@ -73,7 +77,7 @@ function QuaternaryButtonComponent<TagName extends AllowedTags>(
           className={classNames(
             'items-center font-bold cursor-pointer typo-callout',
             labelDisplay,
-            { readOnly: props.readOnly },
+            { readOnly: props.disabled },
           )}
         >
           {children}

--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -59,6 +59,7 @@ function LastActionButton(props: LastActionButtonProps) {
   return (
     <SimpleTooltip content="Share post">
       <Button
+        size={ButtonSize.Small}
         icon={<ShareIcon />}
         onClick={onClickShare}
         variant={ButtonVariant.Tertiary}

--- a/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
@@ -137,7 +137,7 @@ function ChangelogTooltip(): ReactElement {
               }
               pressed={post?.userState?.vote === UserPostVote.Up}
               onClick={onToggleUpvote}
-              buttonSize={ButtonSize.Small}
+              size={ButtonSize.Small}
               className="btn-tertiary-avocado"
               data-testid="changelogUpvotesButton"
             >
@@ -153,7 +153,7 @@ function ChangelogTooltip(): ReactElement {
               tag="a"
               href={post.commentsPermalink}
               onClick={dismissChangelog}
-              buttonSize={ButtonSize.Small}
+              size={ButtonSize.Small}
               className="btn-tertiary-blueCheese"
               data-testid="changelogCommentsButton"
             >


### PR DESCRIPTION
## Changes

### Describe what this PR does
- With button v2 props, but rendering v1 it would not take size into account.
- This fixes the usecase of button v2 for action buttons

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
