### PR TITLE
fix: freeform card

### DIFF
--- a/packages/shared/src/components/cards/AdCard.tsx
+++ b/packages/shared/src/components/cards/AdCard.tsx
@@ -31,9 +31,7 @@ export const AdCard = forwardRef(function AdCard(
     <Card {...domProps} data-testid="adItem" ref={ref}>
       <AdLink ad={ad} onLinkClick={onLinkClick} />
       <CardTextContainer>
-        <CardTitle
-          className={classNames('my-4 line-clamp-4 font-bold typo-title3')}
-        >
+        <CardTitle className="my-4 font-bold line-clamp-4 typo-title3">
           {ad.description}
         </CardTitle>
       </CardTextContainer>

--- a/packages/shared/src/components/cards/AdCard.tsx
+++ b/packages/shared/src/components/cards/AdCard.tsx
@@ -31,7 +31,7 @@ export const AdCard = forwardRef(function AdCard(
     <Card {...domProps} data-testid="adItem" ref={ref}>
       <AdLink ad={ad} onLinkClick={onLinkClick} />
       <CardTextContainer>
-        <CardTitle className="my-4 font-bold line-clamp-4 typo-title3">
+        <CardTitle className="my-4 line-clamp-4 font-bold typo-title3">
           {ad.description}
         </CardTitle>
       </CardTextContainer>

--- a/packages/shared/src/components/cards/AdList.tsx
+++ b/packages/shared/src/components/cards/AdList.tsx
@@ -12,7 +12,7 @@ export const AdList = forwardRef(function AdList(
     <ListCard {...domProps} data-testid="adItem" ref={ref}>
       <AdLink ad={ad} onLinkClick={onLinkClick} />
       <ListCardMain>
-        <ListCardTitle className="font-bold line-clamp-4 typo-title3">
+        <ListCardTitle className="line-clamp-4 font-bold typo-title3">
           {ad.description}
         </ListCardTitle>
         <AdAttribution ad={ad} className="mt-2" />

--- a/packages/shared/src/components/cards/AdList.tsx
+++ b/packages/shared/src/components/cards/AdList.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, ReactElement, Ref } from 'react';
-import classNames from 'classnames';
 import { AdCardProps } from './AdCard';
 import { ListCard, ListCardMain, ListCardTitle } from './Card';
 import AdLink from './AdLink';
@@ -13,9 +12,7 @@ export const AdList = forwardRef(function AdList(
     <ListCard {...domProps} data-testid="adItem" ref={ref}>
       <AdLink ad={ad} onLinkClick={onLinkClick} />
       <ListCardMain>
-        <ListCardTitle
-          className={classNames('line-clamp-4 font-bold typo-title3')}
-        >
+        <ListCardTitle className="font-bold line-clamp-4 typo-title3">
           {ad.description}
         </ListCardTitle>
         <AdAttribution ad={ad} className="mt-2" />

--- a/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
@@ -12,6 +12,7 @@ import {
 import { WelcomePostCardFooter } from '../WelcomePostCardFooter';
 import ActionButtons from '../ActionButtons';
 import PostMetadata from '../PostMetadata';
+import { usePostImage } from '../../../hooks/post/usePostImage';
 
 export const CollectionCard = forwardRef(function CollectionCard(
   {
@@ -29,12 +30,13 @@ export const CollectionCard = forwardRef(function CollectionCard(
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ) {
+  const image = usePostImage(post);
   const clamp = (() => {
     if (post.image) {
       return 'line-clamp-3';
     }
 
-    return post.contentHtml ? 'line-clamp-3' : 'line-clamp-9';
+    return post.contentHtml ? 'line-clamp-4' : 'line-clamp-9';
   })();
 
   return (
@@ -70,7 +72,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
       />
 
       <Container>
-        <WelcomePostCardFooter post={post} />
+        <WelcomePostCardFooter image={image} contentHtml={post.contentHtml} />
         <ActionButtons
           openNewTab={openNewTab}
           post={post}

--- a/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
@@ -34,7 +34,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
       return 'line-clamp-3';
     }
 
-    return post.contentHtml ? 'line-clamp-4' : 'line-clamp-9';
+    return post.contentHtml ? 'line-clamp-3' : 'line-clamp-9';
   })();
 
   return (

--- a/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, Ref } from 'react';
 import classNames from 'classnames';
-import { Container, PostCardProps } from '../common';
+import { Container, generateTitleClamp, PostCardProps } from '../common';
 import FeedItemContainer from '../FeedItemContainer';
 import { CollectionCardHeader } from './CollectionCardHeader';
 import {
@@ -31,13 +31,6 @@ export const CollectionCard = forwardRef(function CollectionCard(
   ref: Ref<HTMLElement>,
 ) {
   const image = usePostImage(post);
-  const clamp = (() => {
-    if (post.image) {
-      return 'line-clamp-3';
-    }
-
-    return post.contentHtml ? 'line-clamp-4' : 'line-clamp-9';
-  })();
 
   return (
     <FeedItemContainer
@@ -57,7 +50,10 @@ export const CollectionCard = forwardRef(function CollectionCard(
       />
       <FreeformCardTitle
         className={classNames(
-          clamp,
+          generateTitleClamp({
+            hasImage: !!image,
+            hasHtmlContent: !!post.contentHtml,
+          }),
           'px-2 font-bold text-theme-label-primary typo-title3',
         )}
       >

--- a/packages/shared/src/components/cards/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCard.tsx
@@ -12,6 +12,7 @@ import FeedItemContainer from './FeedItemContainer';
 import { PostType } from '../../graphql/posts';
 import { useFeedPreviewMode } from '../../hooks';
 import { SquadPostCardHeader } from './common/SquadPostCardHeader';
+import { usePostImage } from '../../hooks/post/usePostImage';
 
 export const WelcomePostCard = forwardRef(function SharePostCard(
   {
@@ -35,7 +36,7 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
   const onPostCardClick = () => onPostClick(post);
   const containerRef = useRef<HTMLDivElement>();
   const isFeedPreview = useFeedPreviewMode();
-
+  const image = usePostImage(post);
   const { openStep, isChecklistVisible } = useSquadChecklist({
     squad: post.source as Squad,
   });
@@ -48,11 +49,11 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
     );
 
   const clamp = (() => {
-    if (post.image) {
+    if (image) {
       return 'line-clamp-3';
     }
 
-    return post.contentHtml ? 'line-clamp-3' : 'line-clamp-9';
+    return post.contentHtml ? 'line-clamp-4' : 'line-clamp-9';
   })();
 
   return (
@@ -93,7 +94,7 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
         {post.title}
       </FreeformCardTitle>
       <Container ref={containerRef}>
-        <WelcomePostCardFooter post={post} />
+        <WelcomePostCardFooter image={image} contentHtml={post.contentHtml} />
         <ActionButtons
           openNewTab={openNewTab}
           post={post}

--- a/packages/shared/src/components/cards/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCard.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, ReactElement, Ref, useRef } from 'react';
 import classNames from 'classnames';
 import { CardButton, FreeformCardTitle, getPostClassNames } from './Card';
 import ActionButtons from './ActionButtons';
-import { Container, PostCardProps } from './common';
+import { Container, generateTitleClamp, PostCardProps } from './common';
 import OptionsButton from '../buttons/OptionsButton';
 import { WelcomePostCardFooter } from './WelcomePostCardFooter';
 import { useSquadChecklist } from '../../hooks/useSquadChecklist';
@@ -48,14 +48,6 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
       openStep,
     );
 
-  const clamp = (() => {
-    if (image) {
-      return 'line-clamp-3';
-    }
-
-    return post.contentHtml ? 'line-clamp-4' : 'line-clamp-9';
-  })();
-
   return (
     <FeedItemContainer
       domProps={{
@@ -87,7 +79,10 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
       />
       <FreeformCardTitle
         className={classNames(
-          clamp,
+          generateTitleClamp({
+            hasImage: !!image,
+            hasHtmlContent: !!post.contentHtml,
+          }),
           'px-2 font-bold !text-theme-label-primary typo-title3',
         )}
       >

--- a/packages/shared/src/components/cards/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCard.tsx
@@ -52,7 +52,7 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
       return 'line-clamp-3';
     }
 
-    return post.contentHtml ? 'line-clamp-4' : 'line-clamp-9';
+    return post.contentHtml ? 'line-clamp-3' : 'line-clamp-9';
   })();
 
   return (

--- a/packages/shared/src/components/cards/WelcomePostCardFooter.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCardFooter.tsx
@@ -1,37 +1,21 @@
 import React, { ReactElement, useMemo } from 'react';
 import { sanitize } from 'dompurify';
 import { CardImage, CardSpace } from './Card';
-import { Post } from '../../graphql/posts';
 import { cloudinary } from '../../lib/image';
 
-type WelcomePostCardFooterProps = {
-  post: Post;
-};
+interface WelcomePostCardFooterProps {
+  image?: string;
+  contentHtml?: string;
+}
 
 export const WelcomePostCardFooter = ({
-  post,
+  image,
+  contentHtml,
 }: WelcomePostCardFooterProps): ReactElement => {
   const content = useMemo(
-    () =>
-      post?.contentHtml ? sanitize(post.contentHtml, { ALLOWED_TAGS: [] }) : '',
-    [post?.contentHtml],
+    () => (contentHtml ? sanitize(contentHtml, { ALLOWED_TAGS: [] }) : ''),
+    [contentHtml],
   );
-
-  const image = useMemo(() => {
-    if (post?.image) {
-      return post?.image;
-    }
-
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(post?.contentHtml, 'text/html');
-    const imgTag = doc.querySelector('img');
-    if (imgTag) {
-      return imgTag.getAttribute('src');
-    }
-
-    return undefined;
-  }, [post?.contentHtml, post?.image]);
-
   const decodedText = useMemo(() => {
     const span = document.createElement('div');
     span.innerHTML = content || '';

--- a/packages/shared/src/components/cards/WelcomePostCardFooter.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCardFooter.tsx
@@ -39,7 +39,7 @@ export const WelcomePostCardFooter = ({
 
   if (content) {
     return (
-      <p className="line-clamp-6 break-words px-2 mt-1 typo-callout">
+      <p className="mt-1 line-clamp-6 break-words px-2 typo-callout">
         {decodedText}
       </p>
     );

--- a/packages/shared/src/components/cards/WelcomePostCardFooter.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCardFooter.tsx
@@ -36,9 +36,10 @@ export const WelcomePostCardFooter = ({
       </>
     );
   }
+
   if (content) {
     return (
-      <p className="px-2 break-words line-clamp-6 typo-callout">
+      <p className="px-2 mt-1 break-words line-clamp-6 typo-callout">
         {decodedText}
       </p>
     );

--- a/packages/shared/src/components/cards/common.tsx
+++ b/packages/shared/src/components/cards/common.tsx
@@ -46,3 +46,19 @@ export interface PostCardProps {
   children?: ReactNode;
   domProps?: HTMLAttributes<HTMLDivElement>;
 }
+
+interface GenerateTitleClampProps {
+  hasImage?: boolean;
+  hasHtmlContent?: boolean;
+}
+
+export const generateTitleClamp = ({
+  hasImage,
+  hasHtmlContent,
+}: GenerateTitleClampProps = {}): string => {
+  if (hasImage) {
+    return 'line-clamp-3';
+  }
+
+  return hasHtmlContent ? 'line-clamp-4' : 'line-clamp-9';
+};

--- a/packages/shared/src/hooks/post/usePostImage.ts
+++ b/packages/shared/src/hooks/post/usePostImage.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+import { Post } from '../../graphql/posts';
+
+export const usePostImage = (post: Post): string =>
+  useMemo(() => {
+    if (post?.image) {
+      return post?.image;
+    }
+
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(post?.contentHtml, 'text/html');
+    const imgTag = doc.querySelector('img');
+    if (imgTag) {
+      return imgTag.getAttribute('src');
+    }
+
+    return undefined;
+  }, [post?.contentHtml, post?.image]);


### PR DESCRIPTION
## Changes
- Fixed the freeform card's max clamp. From the design it should have been 3 lines only, similar to article post card.

From Sketch:
![image](https://github.com/dailydotdev/apps/assets/13744167/21d324b9-6b4d-48b0-ad8c-3341286cd048)

Before fix:
![Screenshot 2024-01-02 at 11 17 19 AM](https://github.com/dailydotdev/apps/assets/13744167/636ebcd5-acdc-447b-9c1f-b5397da7f227)

After the fix:
![Screenshot 2024-01-02 at 11 20 25 AM](https://github.com/dailydotdev/apps/assets/13744167/f03b9b56-2716-461c-b01c-beaaf30ef901)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
