### PR TITLE
fix overflowing action buttons on feed cards

### DIFF
--- a/packages/shared/src/components/FeedLayout.tsx
+++ b/packages/shared/src/components/FeedLayout.tsx
@@ -99,7 +99,7 @@ const replaceDigitsWithIncrement = (str: string, increment: number): string => {
   if (!match) {
     return str;
   }
-  return str.replace(match[0], `${parseInt(match[0]) + increment}`);
+  return str.replace(match[0], `${parseInt(match[0], 10) + increment}`);
 };
 
 const sidebarRenderedWidth = 44;
@@ -118,11 +118,12 @@ const determineBreakPoints = ({
   sidebarExpanded,
   sidebarRendered,
 }: DetermineFeedSettingsProps): string[] => {
-  return sidebarRendered
-    ? sidebarExpanded
+  if (sidebarRendered) {
+    return sidebarExpanded
       ? reversedBreakpointsSidebarOpen
-      : reversedBreakpointsSidebarRendered
-    : reversedBreakpoints;
+      : reversedBreakpointsSidebarRendered;
+  }
+  return reversedBreakpoints;
 };
 
 export default function FeedLayout({

--- a/packages/shared/src/components/FeedLayout.tsx
+++ b/packages/shared/src/components/FeedLayout.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, ReactNode, useContext } from 'react';
 import {
   desktop,
-  desktopL,
+  desktopXL,
   laptop,
   laptopL,
   laptopXL,
@@ -28,7 +28,7 @@ export const feedBreakpoints = [
   laptopL,
   laptopXL,
   desktop,
-  desktopL,
+  desktopXL,
 ];
 
 const baseFeedSettings: FeedContextData[] = [
@@ -88,77 +88,41 @@ const baseFeedSettings: FeedContextData[] = [
   },
 ];
 
-const sidebarOpenFeedSettings: FeedContextData[] = [
-  {
-    pageSize: 7,
-    adSpot: 2,
-    numCards: {
-      cozy: 1,
-      eco: 1,
-      roomy: 1,
-    },
-  },
-  {
-    pageSize: 9,
-    adSpot: 0,
-    numCards: {
-      eco: 2,
-      roomy: 2,
-      cozy: 1,
-    },
-  },
-  {
-    pageSize: 13,
-    adSpot: 0,
-    numCards: {
-      eco: 3,
-      roomy: 2,
-      cozy: 2,
-    },
-  },
-  {
-    pageSize: 17,
-    adSpot: 0,
-    numCards: {
-      eco: 4,
-      roomy: 3,
-      cozy: 3,
-    },
-  },
-  {
-    pageSize: 21,
-    adSpot: 0,
-    numCards: {
-      eco: 5,
-      roomy: 4,
-      cozy: 3,
-    },
-  },
-  {
-    pageSize: 25,
-    adSpot: 0,
-    numCards: {
-      eco: 6,
-      roomy: 5,
-      cozy: 4,
-    },
-  },
-];
-
 const reversedBreakpoints = feedBreakpoints
   .map((media) => media.replace('@media ', ''))
   .reverse();
 
-const reversedSettings = baseFeedSettings.reverse();
-const reversedSettingsSidebar = sidebarOpenFeedSettings.reverse();
+const digitsRegex = /\d+/;
 
-const determineFeedSettings = ({
+const replaceDigitsWithIncrement = (str: string, increment: number): string => {
+  const match = str.match(digitsRegex);
+  if (!match) {
+    return str;
+  }
+  return str.replace(match[0], `${parseInt(match[0]) + increment}`);
+};
+
+const sidebarRenderedWidth = 44;
+const reversedBreakpointsSidebarRendered = reversedBreakpoints.map(
+  (breakpoint) => replaceDigitsWithIncrement(breakpoint, sidebarRenderedWidth),
+);
+
+const sidebarOpenWidth = 240;
+const reversedBreakpointsSidebarOpen = reversedBreakpoints.map((breakpoint) =>
+  replaceDigitsWithIncrement(breakpoint, sidebarOpenWidth),
+);
+
+const reversedSettings = baseFeedSettings.reverse();
+
+const determineBreakPoints = ({
   sidebarExpanded,
   sidebarRendered,
-}: DetermineFeedSettingsProps): FeedContextData[] => {
-  return sidebarExpanded && sidebarRendered
-    ? reversedSettingsSidebar
-    : reversedSettings;
+}: DetermineFeedSettingsProps): string[] => {
+  return sidebarRendered
+    ? sidebarExpanded
+      ? reversedBreakpointsSidebarOpen
+      : reversedBreakpointsSidebarRendered
+    : reversedBreakpoints;
 };
 
 export default function FeedLayout({
@@ -166,9 +130,10 @@ export default function FeedLayout({
 }: FeedLayoutProps): ReactElement {
   const { sidebarExpanded } = useContext(SettingsContext);
   const { sidebarRendered } = useSidebarRendered();
+
   const currentSettings = useMedia(
-    reversedBreakpoints,
-    determineFeedSettings({ sidebarExpanded, sidebarRendered }),
+    determineBreakPoints({ sidebarExpanded, sidebarRendered }),
+    reversedSettings,
     defaultFeedContextData,
   );
 

--- a/packages/shared/src/hooks/useMedia.ts
+++ b/packages/shared/src/hooks/useMedia.ts
@@ -40,7 +40,7 @@ export default function useMedia<T>(
       });
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [values]);
+  }, [values, queries]);
 
   return value;
 }

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -16,7 +16,7 @@ const feature = {
   feedVersion: new Feature('feed_version', 15),
   search: new Feature('search', SearchExperiment.Control),
   lowImps: new Feature('feed_low_imps'),
-  bookmarkOnCard: new Feature('bookmark_on_card', false),
+  bookmarkOnCard: new Feature('bookmark_on_card', true),
   onboardingCopy: new Feature('onboarding_copy', {
     title: 'Where developers grow together',
     description: 'Get one personalized feed for all the knowledge you need.',

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -16,7 +16,7 @@ const feature = {
   feedVersion: new Feature('feed_version', 15),
   search: new Feature('search', SearchExperiment.Control),
   lowImps: new Feature('feed_low_imps'),
-  bookmarkOnCard: new Feature('bookmark_on_card', true),
+  bookmarkOnCard: new Feature('bookmark_on_card', false),
   onboardingCopy: new Feature('onboarding_copy', {
     title: 'Where developers grow together',
     description: 'Get one personalized feed for all the knowledge you need.',

--- a/packages/shared/src/styles/media.ts
+++ b/packages/shared/src/styles/media.ts
@@ -6,3 +6,4 @@ export const laptopL = `@media (min-width: 1360px)`;
 export const laptopXL = `@media (min-width: 1668px)`;
 export const desktop = `@media (min-width: 1976px)`;
 export const desktopL = `@media (min-width: 2156px)`;
+export const desktopXL = `@media (min-width: 2294px)`;


### PR DESCRIPTION
3rd try - this time we are using different media queries depending on if the sidebar is rendered closed, rendered open or not rendered at all.

We do not need different configurations this way and align to the minimal size of 272px for the single card, as defined in Figma.

## Screenshot

Before:
![image](https://github.com/dailydotdev/apps/assets/9974711/adf76850-fade-42e7-80cf-fd033a3c0f36)

After:
<img width="1722" alt="Screenshot 2024-01-03 at 10 45 23" src="https://github.com/dailydotdev/apps/assets/9974711/2a5a3480-a08d-49ab-9efc-66486ef8af81">

## Manual Testing

Manually checked all the combinations of sidebar closed, open and not rendered at all and settings eco, cozy and roomy as well.

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)
- [X] Laptop XL (2156px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2079 #done
