### PR TITLE
fix(profile): apply ellipsis on long social link

### DIFF
--- a/packages/shared/src/components/profile/SocialChips.tsx
+++ b/packages/shared/src/components/profile/SocialChips.tsx
@@ -44,11 +44,11 @@ export function SocialChips({ links }: SocialChipsProps): ReactElement {
     .filter((key) => !!links[key])
     .map((key) => (
       <Button
-        spanClassName="w-fit my-2 font-normal"
+        spanClassName="my-2 font-normal text-ellipsis whitespace-nowrap overflow-hidden flex-1"
         textPosition="justify-start"
         icon={handlers[key].icon}
         buttonSize={ButtonSize.Small}
-        className="btn-secondary w-fit border-theme-divider-tertiary text-theme-label-tertiary typo-subhead first:ml-4 tablet:first:ml-0"
+        className="btn-secondary w-fit max-w-full border-theme-divider-tertiary text-theme-label-tertiary typo-subhead first:ml-4 tablet:first:ml-0"
         tag="a"
         target="_blank"
         rel="noopener"


### PR DESCRIPTION
## Changes

### Describe what this PR does

Long portfolio links broke the design of the page

Fixed version:
<img width="328" alt="image" src="https://github.com/dailydotdev/apps/assets/1993245/e5c215b3-d198-462d-abc8-80bbf4da131c">


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
