### PR TITLE
fix: clashing labels

### DIFF
--- a/packages/shared/src/components/widgets/SocialShareButton.tsx
+++ b/packages/shared/src/components/widgets/SocialShareButton.tsx
@@ -47,7 +47,7 @@ export const SocialShareButton = ({
       />
       <ShareText
         className={classNames(
-          'mt-1.5 overflow-hidden overflow-ellipsis text-center',
+          'mt-1.5 max-w-16 overflow-hidden overflow-ellipsis text-center',
           sizeToText[size],
         )}
         onClick={() => button?.current?.click()}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We removed the max width on the label in this [PR](https://github.com/dailydotdev/apps/commit/cc0fc7fddf42f8906ddde9ec9416dd8fb400edb8#diff-c51536179cd65e101734e0bc1ef33c9d3eea7d8b5e31b853212daacd43410a3bR50).
- @kopancek not sure this was intended, maybe it had a reason.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2076 #done
