### PR TITLE
fix: add text truncating to sidebar items

### DIFF
--- a/packages/shared/src/components/sidebar/ClickableNavItem.tsx
+++ b/packages/shared/src/components/sidebar/ClickableNavItem.tsx
@@ -1,5 +1,6 @@
 import React, { HTMLAttributes, ReactElement, ReactNode } from 'react';
 import Link from 'next/link';
+import classNames from 'classnames';
 import { navBtnClass, SidebarMenuItem } from './common';
 
 interface ClickableNavItemProps
@@ -22,7 +23,7 @@ export function ClickableNavItem({
       <button
         {...props}
         type="button"
-        className={navBtnClass}
+        className={classNames(navBtnClass, props.className)}
         onClick={showLogin}
       >
         {children}
@@ -37,7 +38,7 @@ export function ClickableNavItem({
           {...(item.action && { onClick: item.action })}
           {...props}
           target={item?.target}
-          className={navBtnClass}
+          className={classNames(navBtnClass, props.className)}
           rel="noopener noreferrer"
         >
           {children}

--- a/packages/shared/src/components/sidebar/Section.tsx
+++ b/packages/shared/src/components/sidebar/Section.tsx
@@ -67,6 +67,7 @@ export function Section({
                 : null
             }
             isButton={isItemsButton && !item?.isForcedLink}
+            className="truncate"
           >
             <ItemInner
               item={item}

--- a/packages/shared/src/components/sidebar/SquadSection.tsx
+++ b/packages/shared/src/components/sidebar/SquadSection.tsx
@@ -45,9 +45,6 @@ export function SquadSection(props: SectionCommonProps): ReactElement {
         ),
       title: name,
       path: permalink,
-      className: {
-        text: '!block',
-      },
     });
   });
 

--- a/packages/shared/src/components/sidebar/SquadSection.tsx
+++ b/packages/shared/src/components/sidebar/SquadSection.tsx
@@ -45,6 +45,9 @@ export function SquadSection(props: SectionCommonProps): ReactElement {
         ),
       title: name,
       path: permalink,
+      className: {
+        text: '!block',
+      },
     });
   });
 

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -142,7 +142,7 @@ export const ItemInner = ({
       <Icon {...item} active={active} />
       <span
         className={classNames(
-          'truncate text-left transition-opacity',
+          'flex-1 truncate text-left transition-opacity',
           shouldShowLabel ? 'opacity-100 delay-150' : 'opacity-0',
           item?.className?.text,
         )}

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -146,6 +146,7 @@ export const ItemInner = ({
           shouldShowLabel ? 'opacity-100 delay-150' : 'opacity-0',
           item?.className?.text,
         )}
+        title={item.title}
       >
         {item.title}
       </span>

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -142,7 +142,7 @@ export const ItemInner = ({
       <Icon {...item} active={active} />
       <span
         className={classNames(
-          'flex flex-1 flex-row items-center truncate text-left transition-opacity',
+          'flex-1 truncate text-left transition-opacity',
           shouldShowLabel ? 'opacity-100 delay-150' : 'opacity-0',
           item?.className?.text,
         )}

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -142,7 +142,7 @@ export const ItemInner = ({
       <Icon {...item} active={active} />
       <span
         className={classNames(
-          'flex-1 truncate text-left transition-opacity',
+          'truncate text-left transition-opacity',
           shouldShowLabel ? 'opacity-100 delay-150' : 'opacity-0',
           item?.className?.text,
         )}


### PR DESCRIPTION
## Changes

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/0f1ec724-84be-4c53-8b26-1956c48c07d8">
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/95056299-f664-4517-b214-70a7ce7d4f37">
<tr>
  <td colspan="2">Bonus, added popover to truncated items<br><img src="https://github.com/dailydotdev/apps/assets/1681525/96fc10d7-7bd8-4014-8200-f3847a51dc9c"></td>
</table>



### Describe what this PR does
- Fixed truncating on sidebar items
- Added title to sidebar items to show popover on hover