### PR TITLE
fix(profile): take into account sidebar for responsiveness

### DIFF
--- a/packages/shared/src/components/CalendarHeatmap.tsx
+++ b/packages/shared/src/components/CalendarHeatmap.tsx
@@ -132,9 +132,7 @@ export function CalendarHeatmap<T extends { date: string }>({
         };
         return acc;
       }, {}),
-    // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [values, valueToCount, startDate, endDate, bins],
+    [values, startDateWithEmptyDays, valueToCount, bins],
   );
 
   const getMonthLabelCoordinates = (weekIndex: number): [number, number] => [

--- a/packages/shared/src/hooks/profile/useActivityTimeFilter.ts
+++ b/packages/shared/src/hooks/profile/useActivityTimeFilter.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useContext, useMemo, useState } from 'react';
 import {
   addDays,
   endOfYear,
@@ -8,6 +8,7 @@ import {
   subYears,
 } from 'date-fns';
 import { useViewSize, ViewSize } from '../useViewSize';
+import SettingsContext from '../../contexts/SettingsContext';
 
 const BASE_YEAR = 2018;
 const currentYear = new Date().getFullYear();
@@ -28,7 +29,10 @@ type UseActivityTimeFilterRet = {
 };
 
 export function useActivityTimeFilter(): UseActivityTimeFilterRet {
-  const fullHistory = useViewSize(ViewSize.Laptop);
+  const laptop = useViewSize(ViewSize.Laptop);
+  const laptopL = useViewSize(ViewSize.LaptopL);
+  const { sidebarExpanded } = useContext(SettingsContext);
+  const fullHistory = (laptop && !sidebarExpanded) || laptopL;
   const [selectedHistoryYear, setSelectedHistoryYear] = useState(0);
   const [before, after] = useMemo<[Date, Date]>(() => {
     if (!fullHistory) {

--- a/packages/webapp/__tests__/ProfileIndexPage.tsx
+++ b/packages/webapp/__tests__/ProfileIndexPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { render, RenderResult, screen } from '@testing-library/react';
-import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { PublicProfile } from '@dailydotdev/shared/src/lib/user';
 import nock from 'nock';
 import {
@@ -9,7 +8,7 @@ import {
   MostReadTag,
   ProfileReadingData,
 } from '@dailydotdev/shared/src/graphql/users';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
 import { RANKS } from '@dailydotdev/shared/src/lib/rank';
 import { startOfTomorrow, subDays, subMonths } from 'date-fns';
 import {
@@ -17,6 +16,7 @@ import {
   mockGraphQL,
 } from '@dailydotdev/shared/__tests__/helpers/graphql';
 import { waitForNock } from '@dailydotdev/shared/__tests__/helpers/utilities';
+import { TestBootProvider } from '@dailydotdev/shared/__tests__/helpers/boot';
 import ProfilePage from '../pages/[userId]/index';
 
 beforeEach(() => {
@@ -96,22 +96,9 @@ const renderComponent = (
 
   mocks.forEach(mockGraphQL);
   return render(
-    <QueryClientProvider client={client}>
-      <AuthContext.Provider
-        value={{
-          user: null,
-          shouldShowLogin: false,
-          showLogin: jest.fn(),
-          logout: jest.fn(),
-          updateUser: jest.fn(),
-          tokenRefreshed: true,
-          getRedirectUri: jest.fn(),
-          closeLogin: jest.fn(),
-        }}
-      >
-        <ProfilePage user={{ ...defaultProfile, ...profile }} />
-      </AuthContext.Provider>
-    </QueryClientProvider>,
+    <TestBootProvider client={client} auth={{ user: null }}>
+      <ProfilePage user={{ ...defaultProfile, ...profile }} />
+    </TestBootProvider>,
   );
 };
 

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -97,7 +97,9 @@ export const getLayout = (
   props: ProfileLayoutProps,
 ): ReactNode =>
   getFooterNavBarLayout(
-    getMainLayout(<ProfileLayout {...props}>{page}</ProfileLayout>, null),
+    getMainLayout(<ProfileLayout {...props}>{page}</ProfileLayout>, null, {
+      screenCentered: false,
+    }),
   );
 
 interface ProfileParams extends ParsedUrlQuery {


### PR DESCRIPTION
## Changes

### Describe what this PR does

I forgot to set `screenCentered` for the profile page which ignored the sidebar.

Moreover, I set the heatmap to be dynamically responsive. Up until now, it was responsive only on fresh load. Which means the opening and closing the sidebar broke the page even with screen centered.

<img src="https://github.com/dailydotdev/apps/assets/1993245/79b92459-378f-42b2-ab7b-3b1452c9161f" height=300/>
<img src="https://github.com/dailydotdev/apps/assets/1993245/17d974df-9595-4035-950c-f06b953cd0df" height=300/>


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
