### PR TITLE
fix: consistent border-radius and button sizes in main layout header and sidebar

### DIFF
--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -5,7 +5,7 @@ import AuthContext from '../../contexts/AuthContext';
 import { useNotificationContext } from '../../contexts/NotificationsContext';
 import { AnalyticsEvent, NotificationTarget } from '../../lib/analytics';
 import { webappUrl } from '../../lib/constants';
-import { Button, ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import BellIcon from '../icons/Bell';
 import HamburgerIcon from '../icons/Hamburger';
 import LoginButton from '../LoginButton';
@@ -82,8 +82,8 @@ function MainLayoutHeader({
       <>
         <CreatePostButton
           className={classNames(
-            'mr-0 laptop:mr-4',
-            optOutWeeklyGoal ? 'tablet:mr-0' : 'tablet:mr-4',
+            'mr-0 laptop:mr-3',
+            optOutWeeklyGoal ? 'tablet:mr-0' : 'tablet:mr-3',
           )}
         />
         {!hideButton && user && (
@@ -93,10 +93,9 @@ function MainLayoutHeader({
               tooltip={{ placement: 'bottom', content: 'Notifications' }}
               href={`${webappUrl}notifications`}
             >
-              <div className="relative mr-4 hidden laptop:flex">
+              <div className="relative mr-3 hidden laptop:flex">
                 <Button
                   variant={ButtonVariant.Float}
-                  size={ButtonSize.Small}
                   onClick={onNavigateNotifications}
                   icon={
                     <BellIcon
@@ -109,7 +108,7 @@ function MainLayoutHeader({
                   }
                 />
                 {hasNotification && (
-                  <Bubble className="right-0 top-0 -translate-y-1/2 translate-x-1/2 cursor-pointer px-1 shadow-bubble-cabbage">
+                  <Bubble className="-right-1.5 -top-1.5 cursor-pointer px-1">
                     {getUnreadText(unreadCount)}
                   </Bubble>
                 )}

--- a/packages/shared/src/components/post/write/CreatePostButton.tsx
+++ b/packages/shared/src/components/post/write/CreatePostButton.tsx
@@ -16,7 +16,7 @@ export function CreatePostButton({
 }: CreatePostButtonProps): ReactElement {
   const { user, isAuthReady, squads } = useAuthContext();
   const { route, query } = useRouter();
-  const isTablet = useViewSize(ViewSize.Tablet);
+  const isMediumSize = useViewSize(ViewSize.Laptop);
   const handle = route === '/squads/[handle]' ? (query.handle as string) : '';
   const { squad } = useSquad({ handle });
   const allowedToPost = verifyPermission(squad, SourcePermissions.Post);
@@ -50,7 +50,7 @@ export function CreatePostButton({
         link.post.create +
         (squad && allowedToPost ? `?sid=${squad.handle}` : '')
       }
-      size={isTablet ? ButtonSize.Small : ButtonSize.Medium}
+      size={isMediumSize ? ButtonSize.Medium : ButtonSize.Small}
     >
       New post
     </Button>

--- a/packages/shared/src/components/post/write/CreatePostButton.tsx
+++ b/packages/shared/src/components/post/write/CreatePostButton.tsx
@@ -16,7 +16,7 @@ export function CreatePostButton({
 }: CreatePostButtonProps): ReactElement {
   const { user, isAuthReady, squads } = useAuthContext();
   const { route, query } = useRouter();
-  const isMediumSize = useViewSize(ViewSize.Laptop);
+  const isLaptop = useViewSize(ViewSize.Laptop);
   const handle = route === '/squads/[handle]' ? (query.handle as string) : '';
   const { squad } = useSquad({ handle });
   const allowedToPost = verifyPermission(squad, SourcePermissions.Post);
@@ -50,7 +50,7 @@ export function CreatePostButton({
         link.post.create +
         (squad && allowedToPost ? `?sid=${squad.handle}` : '')
       }
-      size={isMediumSize ? ButtonSize.Medium : ButtonSize.Small}
+      size={isLaptop ? ButtonSize.Medium : ButtonSize.Small}
     >
       New post
     </Button>

--- a/packages/shared/src/components/profile/ProfileButton.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.tsx
@@ -37,13 +37,13 @@ export default function ProfileButton({
           <button
             type="button"
             className={classNames(
-              'focus-outline ml-0.5 cursor-pointer items-center gap-2 rounded-10 border-none bg-theme-bg-secondary p-0 font-bold text-theme-label-primary no-underline typo-callout',
+              'focus-outline h-10 cursor-pointer items-center gap-2 rounded-12 border-none bg-theme-bg-secondary p-0 font-bold text-theme-label-primary no-underline typo-callout',
               className ?? 'flex',
             )}
             onClick={wrapHandler(() => onUpdate(!isOpen))}
           >
             <span className="ml-3 block">{user.reputation ?? 0}</span>
-            <ProfilePicture user={user} size="medium" />
+            <ProfilePicture user={user} size="large" />
           </button>
         </SimpleTooltip>
       )}

--- a/packages/shared/src/components/profile/ProfileButton.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.tsx
@@ -37,7 +37,7 @@ export default function ProfileButton({
           <button
             type="button"
             className={classNames(
-              'focus-outline ml-0.5 cursor-pointer items-center gap-2 rounded-lg border-none bg-theme-bg-secondary p-0 font-bold text-theme-label-primary no-underline typo-callout',
+              'focus-outline ml-0.5 cursor-pointer items-center gap-2 rounded-10 border-none bg-theme-bg-secondary p-0 font-bold text-theme-label-primary no-underline typo-callout',
               className ?? 'flex',
             )}
             onClick={wrapHandler(() => onUpdate(!isOpen))}

--- a/packages/shared/src/components/referral/SearchReferralButton.tsx
+++ b/packages/shared/src/components/referral/SearchReferralButton.tsx
@@ -9,6 +9,7 @@ import { KeyReferralIcon } from '../icons';
 import { IconSize } from '../Icon';
 import { useAnalyticsContext } from '../../contexts/AnalyticsContext';
 import { AnalyticsEvent, TargetId, TargetType } from '../../lib/analytics';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
 
 interface SearchReferralButtonProps {
   className?: string;
@@ -39,16 +40,15 @@ export function SearchReferralButton({
   }
 
   return (
-    <button
+    <Button
       type="button"
-      className={classNames(
-        'flex flex-row items-center justify-center rounded-12 bg-theme-overlay-from px-3 py-1 font-bold text-theme-label-tertiary typo-callout',
-        className,
-      )}
+      variant={ButtonVariant.Float}
+      size={ButtonSize.Small}
+      className={classNames('bg-theme-overlay-from', className)}
       onClick={handleClick}
     >
       {availableCount}
-      <KeyReferralIcon size={IconSize.Medium} className="ml-1 mt-1" />
-    </button>
+      <KeyReferralIcon size={IconSize.Medium} className="ml-1 mt-1 -mr-1" />
+    </Button>
   );
 }

--- a/packages/shared/src/components/referral/SearchReferralButton.tsx
+++ b/packages/shared/src/components/referral/SearchReferralButton.tsx
@@ -9,7 +9,7 @@ import { KeyReferralIcon } from '../icons';
 import { IconSize } from '../Icon';
 import { useAnalyticsContext } from '../../contexts/AnalyticsContext';
 import { AnalyticsEvent, TargetId, TargetType } from '../../lib/analytics';
-import { Button, ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
 
 interface SearchReferralButtonProps {
   className?: string;
@@ -43,7 +43,6 @@ export function SearchReferralButton({
     <Button
       type="button"
       variant={ButtonVariant.Float}
-      size={ButtonSize.Small}
       className={classNames('bg-theme-overlay-from', className)}
       onClick={handleClick}
     >

--- a/packages/shared/src/components/referral/SearchReferralButton.tsx
+++ b/packages/shared/src/components/referral/SearchReferralButton.tsx
@@ -48,7 +48,7 @@ export function SearchReferralButton({
       onClick={handleClick}
     >
       {availableCount}
-      <KeyReferralIcon size={IconSize.Medium} className="ml-1 mt-1 -mr-1" />
+      <KeyReferralIcon size={IconSize.Medium} className="-mr-1 ml-1 mt-1" />
     </Button>
   );
 }

--- a/packages/shared/src/components/sidebar/SidebarUserButton.tsx
+++ b/packages/shared/src/components/sidebar/SidebarUserButton.tsx
@@ -21,7 +21,7 @@ export function SidebarUserButton({
               <div className="mb-4 flex items-center">
                 <ProfileLink
                   href={user.permalink}
-                  className="focus-outline ml-0.5 flex cursor-pointer items-center rounded-lg border-none bg-theme-bg-secondary p-0 font-bold text-theme-label-primary no-underline typo-callout"
+                  className="focus-outline ml-0.5 flex cursor-pointer items-center rounded-10 border-none bg-theme-bg-secondary p-0 font-bold text-theme-label-primary no-underline typo-callout"
                 >
                   <ProfilePicture user={user} size="medium" />
                   <span className="ml-2 mr-3">{user.reputation ?? 0}</span>

--- a/packages/shared/src/components/sidebar/SidebarUserButton.tsx
+++ b/packages/shared/src/components/sidebar/SidebarUserButton.tsx
@@ -21,9 +21,9 @@ export function SidebarUserButton({
               <div className="mb-4 flex items-center">
                 <ProfileLink
                   href={user.permalink}
-                  className="focus-outline ml-0.5 flex cursor-pointer items-center rounded-10 border-none bg-theme-bg-secondary p-0 font-bold text-theme-label-primary no-underline typo-callout"
+                  className="focus-outline flex h-10 cursor-pointer items-center rounded-12 border-none bg-theme-bg-secondary p-0 font-bold text-theme-label-primary no-underline typo-callout"
                 >
-                  <ProfilePicture user={user} size="medium" />
+                  <ProfilePicture user={user} size="large" />
                   <span className="ml-2 mr-3">{user.reputation ?? 0}</span>
                 </ProfileLink>
                 <SearchReferralButton className="ml-3" />


### PR DESCRIPTION
## Changes

Changes the border radius of buttons and button sizes in the main layout header, so that we are consistent across the board.

The figma design is here: https://www.figma.com/file/C7n8EiXBwV1sYIEHkQHS8R/daily.dev---Design-System?node-id=1886%3A8672&mode=dev

### Screenshots

Before:
<img width="251" alt="Screenshot 2024-01-04 at 09 21 19" src="https://github.com/dailydotdev/apps/assets/9974711/b8558482-f5fb-454f-b604-098096764969">
<img width="337" alt="Screenshot 2024-01-04 at 09 21 12" src="https://github.com/dailydotdev/apps/assets/9974711/eb15e67c-bb16-4f68-a64c-b77b17c71e8c">


After:
<img width="279" alt="Screenshot 2024-01-04 at 15 37 01" src="https://github.com/dailydotdev/apps/assets/9974711/d6b00b08-7d36-4af2-aa4a-4b5d2b6192a4">
<img width="389" alt="Screenshot 2024-01-04 at 15 37 11" src="https://github.com/dailydotdev/apps/assets/9974711/1c9e6bd8-a3dc-437a-9112-0edc8631b517">
<img width="1003" alt="Screenshot 2024-01-04 at 15 47 20" src="https://github.com/dailydotdev/apps/assets/9974711/68e42943-8a33-460f-b6ad-2c851ed1ca97">



## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
