### PR TITLE
hotfix: change maximum number of columns in feed layout to 6

### DIFF
--- a/packages/shared/src/components/FeedLayout.tsx
+++ b/packages/shared/src/components/FeedLayout.tsx
@@ -22,14 +22,7 @@ type DetermineFeedSettingsProps = {
   sidebarRendered: boolean;
 };
 
-export const feedBreakpoints = [
-  tablet,
-  laptop,
-  laptopL,
-  laptopXL,
-  desktop,
-  desktopXL,
-];
+export const feedBreakpoints = [tablet, laptop, laptopL, laptopXL, desktop];
 
 const baseFeedSettings: FeedContextData[] = [
   {
@@ -75,15 +68,6 @@ const baseFeedSettings: FeedContextData[] = [
       eco: 6,
       roomy: 5,
       cozy: 4,
-    },
-  },
-  {
-    pageSize: 29,
-    adSpot: 0,
-    numCards: {
-      eco: 7,
-      roomy: 6,
-      cozy: 5,
     },
   },
 ];

--- a/packages/shared/src/components/FeedLayout.tsx
+++ b/packages/shared/src/components/FeedLayout.tsx
@@ -1,12 +1,5 @@
 import React, { ReactElement, ReactNode, useContext } from 'react';
-import {
-  desktop,
-  desktopXL,
-  laptop,
-  laptopL,
-  laptopXL,
-  tablet,
-} from '../styles/media';
+import { desktop, laptop, laptopL, laptopXL, tablet } from '../styles/media';
 import FeedContext, {
   defaultFeedContextData,
   FeedContextData,

--- a/packages/shared/src/styles/media.ts
+++ b/packages/shared/src/styles/media.ts
@@ -6,4 +6,3 @@ export const laptopL = `@media (min-width: 1360px)`;
 export const laptopXL = `@media (min-width: 1668px)`;
 export const desktop = `@media (min-width: 1976px)`;
 export const desktopL = `@media (min-width: 2156px)`;
-export const desktopXL = `@media (min-width: 2294px)`;


### PR DESCRIPTION
## Changes

After [slack discussion](https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1704360982001079) and syncing with Tsahi, it seems the best way forward would be to limit the number of columns in feed layout to 6 at maximum. Showing 7 columns with sidebar open might skew our current metrics.

### Screenshot

After:
<img width="1192" alt="Screenshot 2024-01-04 at 11 39 42" src="https://github.com/dailydotdev/apps/assets/9974711/c0f3fe45-d9ba-462d-a92f-71b7d8b94e61">


## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
