### PR TITLE
fix: code block paddings

### DIFF
--- a/packages/shared/src/components/markdown.module.css
+++ b/packages/shared/src/components/markdown.module.css
@@ -31,7 +31,7 @@
     @apply typo-markdown italic pl-7 my-5 border-l border-theme-divider-secondary;
   }
   & :where(pre) {
-    @apply typo-markdown relative bg-theme-float py-0 px-0 my-5 rounded-12 border border-theme-divider-quaternary;
+    @apply typo-markdown relative bg-theme-float py-7 px-6 my-5 rounded-12 border border-theme-divider-quaternary;
   }
 
   & :where(pre) > code {

--- a/packages/shared/src/components/markdown.module.css
+++ b/packages/shared/src/components/markdown.module.css
@@ -39,7 +39,7 @@
     color: var(--theme-highlight-label);
   }
   & :not(pre) > code {
-    @apply bg-theme-float typo-footnote border border-theme-divider-quaternary px-1 rounded-6;
+    @apply bg-theme-float typo-footnote border border-theme-divider-quaternary px-1 rounded-6 box-decoration-clone;
   }
   & :where(ul) {
     @apply list-disc my-5 pl-7;


### PR DESCRIPTION
## Changes
- The fix on the multi-line code block padding should now be applied.
- Though on the inline ones, I can't seem to find the right pseudo-class to apply the proper paddings.

Fix:
![image](https://github.com/dailydotdev/apps/assets/13744167/ccb1df41-0b63-494a-97cb-c9cef43c5193)

Sketch:
![Screenshot 2024-01-05 at 8 11 24 PM](https://github.com/dailydotdev/apps/assets/13744167/88910711-a7b8-4b00-967a-2af0bebc2a7f)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-1975 #done
