### PR TITLE
fix: public squad with articles didn't render

### DIFF
--- a/packages/shared/src/components/squads/SquadPostListItem.tsx
+++ b/packages/shared/src/components/squads/SquadPostListItem.tsx
@@ -41,16 +41,18 @@ export const SquadPostListItem = ({
         {...combinedClicks(() => onLinkClick(post))}
       />
       <div className="flex flex-1 flex-col">
-        <SquadPostAuthor
-          className={{
-            container: 'mt-0',
-            name: 'text-theme-label-primary typo-callout',
-            handle: 'text-theme-label-quaternary typo-callout',
-          }}
-          author={post.author}
-          size="large"
-          date={postDateFormat(post.createdAt)}
-        />
+        {post?.author && (
+          <SquadPostAuthor
+            className={{
+              container: 'mt-0',
+              name: 'text-theme-label-primary typo-callout',
+              handle: 'text-theme-label-quaternary typo-callout',
+            }}
+            author={post.author}
+            size="large"
+            date={postDateFormat(post.createdAt)}
+          />
+        )}
         <p className="mt-2 line-clamp-3 text-theme-label-primary typo-callout">
           {post.title}
         </p>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Small fix for squads that have articlePosts which don't have authors assigned. (Can happen in relatedArticles basically)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
