### PR TITLE
fix: adding a redirect from source changelog to squad changelog as th…

### DIFF
--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -91,6 +91,7 @@ export const SOURCE_QUERY = gql`
       id
       image
       name
+      type
     }
   }
 `;

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -212,6 +212,7 @@ export const SQUAD_STATIC_FIELDS_QUERY = gql`
       public
       description
       image
+      type
     }
   }
 `;

--- a/packages/webapp/next.config.js
+++ b/packages/webapp/next.config.js
@@ -65,15 +65,6 @@ module.exports = withTM(
         env: {
           CURRENT_VERSION: version,
         },
-        redirects: async () => {
-          return [
-            {
-              source: '/sources/daily_updates',
-              destination: '/squads/daily_updates',
-              permanent: false,
-            }
-          ]
-        },
         rewrites: () => [
           {
             source: '/api/:path*',

--- a/packages/webapp/next.config.js
+++ b/packages/webapp/next.config.js
@@ -65,6 +65,14 @@ module.exports = withTM(
         env: {
           CURRENT_VERSION: version,
         },
+        redirects: async () => {
+          return [
+            {
+              source: '/sources/daily_updates',
+              destination: '/squads/daily_updates',
+            }
+          ]
+        },
         rewrites: () => [
           {
             source: '/api/:path*',

--- a/packages/webapp/next.config.js
+++ b/packages/webapp/next.config.js
@@ -70,6 +70,7 @@ module.exports = withTM(
             {
               source: '/sources/daily_updates',
               destination: '/squads/daily_updates',
+              permanent: false,
             }
           ]
         },

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -184,7 +184,6 @@ export async function getStaticProps({
       revalidate: 60,
     };
   } catch (err) {
-    console.log('some err');
     if (err?.response?.errors?.[0].extensions.code === ApiError.NotFound) {
       return {
         props: {

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -168,6 +168,15 @@ export async function getStaticProps({
       id: params.source,
     });
 
+    if (res.source?.type === 'squad') {
+      return {
+        redirect: {
+          destination: `/squads/${params.source}`,
+          permanent: false,
+        },
+      };
+    }
+
     return {
       props: {
         source: res.source,
@@ -175,6 +184,7 @@ export async function getStaticProps({
       revalidate: 60,
     };
   } catch (err) {
+    console.log('some err');
     if (err?.response?.errors?.[0].extensions.code === ApiError.NotFound) {
       return {
         props: {

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -269,6 +269,15 @@ export async function getServerSideProps({
 
     const [{ source: squad }, referringUser] = await Promise.all(promises);
 
+    if (squad?.type === 'machine') {
+      return {
+        redirect: {
+          destination: `/sources/${handle}`,
+          permanent: false,
+        },
+      };
+    }
+
     setCacheHeader();
 
     return {


### PR DESCRIPTION
To test visit this link:
```
https://daily-webapp-on5rccuj1-dailydotdev.vercel.app/sources/daily_updates
```

## Changes

### Describe what this PR does
- Added a redirect route to go from `source` to `squad` for the changelog as both technically are valid and we have links in places already.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
