### PR TITLE
fix: bookmark not working for collection cards

### DIFF
--- a/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
@@ -27,6 +27,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
     openNewTab,
     onReadArticleClick,
     onPostClick,
+    onBookmarkClick,
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ) {
@@ -79,6 +80,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
           onMenuClick={(event) => onMenuClick?.(event, post)}
           onReadArticleClick={onReadArticleClick}
           className={classNames('mx-4 mt-auto justify-between')}
+          onBookmarkClick={onBookmarkClick}
         />
       </Container>
       {children}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Not sure how we missed it, the bookmark action on cart did not work because of missing handler prop
- Noticed it when preparing collections demo

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
