### PR TITLE
feat: feed layout v1 card layout implementation

### DIFF
--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -172,16 +172,6 @@ export default function FeedItemComponent({
     (item as PostItem).post?.type,
   );
 
-  let postTypeToTag = PostTypeToTag;
-  let articlePostCard = ArticlePostCard;
-  let EffectiveAdTag = AdTag;
-
-  if (shouldUseFeedLayoutV1) {
-    postTypeToTag = PostTypeToTagV1;
-    articlePostCard = ArticlePostCardV1;
-    EffectiveAdTag = AdCardV1;
-  }
-
   switch (item.type) {
     case 'post': {
       if (
@@ -256,7 +246,7 @@ export default function FeedItemComponent({
     }
     case 'ad':
       return (
-        <EffectiveAdTag
+        <AdTag
           ref={inViewRef}
           ad={item.ad}
           onLinkClick={(ad) => onAdClick(ad, row, column)}

--- a/packages/shared/src/components/InteractionCounter.tsx
+++ b/packages/shared/src/components/InteractionCounter.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { requestIdleCallback } from 'next/dist/client/request-idle-callback';
-import styles from './InteractionCounter.module.css';
 import classNames from 'classnames';
+import styles from './InteractionCounter.module.css';
 
 export type InteractionCounterProps = {
   className?: string;

--- a/packages/shared/src/components/InteractionCounter.tsx
+++ b/packages/shared/src/components/InteractionCounter.tsx
@@ -2,9 +2,13 @@ import React, { ReactElement, useEffect, useState } from 'react';
 import { requestIdleCallback } from 'next/dist/client/request-idle-callback';
 import styles from './InteractionCounter.module.css';
 
-export type InteractionCounterProps = { value: number | null };
+export type InteractionCounterProps = {
+  className?: string;
+  value: number | null;
+};
 
 export default function InteractionCounter({
+  className,
   value,
   ...props
 }: InteractionCounterProps): ReactElement {
@@ -25,7 +29,11 @@ export default function InteractionCounter({
   }, [value]);
 
   if (shownValue === value) {
-    return <span {...props}>{shownValue}</span>;
+    return (
+      <span className={className} {...props}>
+        {shownValue}
+      </span>
+    );
   }
 
   const updateShownValue = () => {
@@ -35,7 +43,7 @@ export default function InteractionCounter({
 
   return (
     <span
-      className={`relative overflow-hidden ${styles.interactionCounter}`}
+      className={`relative overflow-hidden ${styles.interactionCounter} ${className}`}
       {...props}
     >
       <span

--- a/packages/shared/src/components/InteractionCounter.tsx
+++ b/packages/shared/src/components/InteractionCounter.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { requestIdleCallback } from 'next/dist/client/request-idle-callback';
 import styles from './InteractionCounter.module.css';
+import classNames from 'classnames';
 
 export type InteractionCounterProps = {
   className?: string;
@@ -43,7 +44,11 @@ export default function InteractionCounter({
 
   return (
     <span
-      className={`relative overflow-hidden ${styles.interactionCounter} ${className}`}
+      className={classNames(
+        'relative overflow-hidden',
+        styles.interactionCounter,
+        className,
+      )}
       {...props}
     >
       <span

--- a/packages/shared/src/components/auth/SignBackButton.tsx
+++ b/packages/shared/src/components/auth/SignBackButton.tsx
@@ -2,6 +2,7 @@ import React, { MouseEventHandler, ReactElement } from 'react';
 import { ProfilePicture } from '../ProfilePicture';
 import { SignBackProvider, SignedInUser } from '../../hooks/auth/useSignBack';
 import { providerMap } from './common';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
 
 interface SignBackButtonProps {
   signBack: SignedInUser;
@@ -17,13 +18,14 @@ export function SignBackButton({
   const item = providerMap[provider.toLowerCase()];
 
   return (
-    <button
-      className="btn-signback btn-primary"
-      type="button"
+    <Button
+      className="btn-signback"
+      variant={ButtonVariant.Primary}
+      size={ButtonSize.Large}
       onClick={onClick}
     >
       <ProfilePicture user={signBack} size="large" />
-      <div className="ml-2 flex flex-col items-start text-theme-label-invert">
+      <div className="ml-2 flex flex-col items-start">
         {!!signBack.name && (
           <span className="font-bold typo-callout">
             Continue as {signBack.name.split(' ')[0]}
@@ -34,6 +36,6 @@ export function SignBackButton({
       <span className="ml-auto rounded-8 border border-theme-divider-secondary p-1 text-theme-label-invert">
         {item.icon}
       </span>
-    </button>
+    </Button>
   );
 }

--- a/packages/shared/src/components/auth/SignBackButton.tsx
+++ b/packages/shared/src/components/auth/SignBackButton.tsx
@@ -2,7 +2,6 @@ import React, { MouseEventHandler, ReactElement } from 'react';
 import { ProfilePicture } from '../ProfilePicture';
 import { SignBackProvider, SignedInUser } from '../../hooks/auth/useSignBack';
 import { providerMap } from './common';
-import { Button, ButtonSize, ButtonVariant } from '../buttons/ButtonV2';
 
 interface SignBackButtonProps {
   signBack: SignedInUser;
@@ -18,14 +17,13 @@ export function SignBackButton({
   const item = providerMap[provider.toLowerCase()];
 
   return (
-    <Button
-      className="btn-signback"
-      variant={ButtonVariant.Primary}
-      size={ButtonSize.Large}
+    <button
+      className="btn-signback btn-primary"
+      type="button"
       onClick={onClick}
     >
       <ProfilePicture user={signBack} size="large" />
-      <div className="ml-2 flex flex-col items-start">
+      <div className="ml-2 flex flex-col items-start text-theme-label-invert">
         {!!signBack.name && (
           <span className="font-bold typo-callout">
             Continue as {signBack.name.split(' ')[0]}
@@ -36,6 +34,6 @@ export function SignBackButton({
       <span className="ml-auto rounded-8 border border-theme-divider-secondary p-1 text-theme-label-invert">
         {item.icon}
       </span>
-    </Button>
+    </button>
   );
 }

--- a/packages/shared/src/components/buttons/OptionsButton.tsx
+++ b/packages/shared/src/components/buttons/OptionsButton.tsx
@@ -19,6 +19,7 @@ const OptionsButton = ({
   className,
   tooltipPlacement = 'left',
   size = ButtonSize.Small,
+  icon = <MenuIcon />,
   ...props
 }: OptionsButtonProps): ReactElement => (
   <SimpleTooltip placement={tooltipPlacement} content="Options">
@@ -26,7 +27,7 @@ const OptionsButton = ({
       {...props}
       className={classNames('my-auto', className)}
       variant={ButtonVariant.Tertiary}
-      icon={<MenuIcon />}
+      icon={icon}
       size={size}
     />
   </SimpleTooltip>

--- a/packages/shared/src/components/cards/AdAttribution.tsx
+++ b/packages/shared/src/components/cards/AdAttribution.tsx
@@ -2,11 +2,16 @@ import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import { Ad } from '../../graphql/posts';
 
-export type AdAttributionProps = {
+interface AdClassName {
+  main?: string;
+  typo?: string;
+}
+
+export interface AdAttributionProps {
   ad: Ad;
-  className?: string;
+  className?: AdClassName;
   typoClassName?: string;
-};
+}
 
 export default function AdAttribution({
   ad,
@@ -15,8 +20,8 @@ export default function AdAttribution({
 }: AdAttributionProps): ReactElement {
   const elementClass = classNames(
     'text-theme-label-quaternary no-underline',
-    typoClassName ?? 'typo-footnote',
-    className,
+    className.typo ?? 'typo-footnote',
+    className.main,
   );
   if (ad.referralLink) {
     return (

--- a/packages/shared/src/components/cards/AdAttribution.tsx
+++ b/packages/shared/src/components/cards/AdAttribution.tsx
@@ -10,13 +10,11 @@ interface AdClassName {
 export interface AdAttributionProps {
   ad: Ad;
   className?: AdClassName;
-  typoClassName?: string;
 }
 
 export default function AdAttribution({
   ad,
   className,
-  typoClassName,
 }: AdAttributionProps): ReactElement {
   const elementClass = classNames(
     'text-theme-label-quaternary no-underline',

--- a/packages/shared/src/components/cards/AdAttribution.tsx
+++ b/packages/shared/src/components/cards/AdAttribution.tsx
@@ -5,14 +5,17 @@ import { Ad } from '../../graphql/posts';
 export type AdAttributionProps = {
   ad: Ad;
   className?: string;
+  typoClassName?: string;
 };
 
 export default function AdAttribution({
   ad,
   className,
+  typoClassName,
 }: AdAttributionProps): ReactElement {
   const elementClass = classNames(
-    'text-theme-label-quaternary no-underline typo-footnote',
+    'text-theme-label-quaternary no-underline',
+    typoClassName ?? 'typo-footnote',
     className,
   );
   if (ad.referralLink) {

--- a/packages/shared/src/components/cards/AdCard.tsx
+++ b/packages/shared/src/components/cards/AdCard.tsx
@@ -57,7 +57,7 @@ export const AdCard = forwardRef(function AdCard(
         </div>
       )}
       <CardTextContainer>
-        <AdAttribution ad={ad} className="mb-2 mt-4" />
+        <AdAttribution ad={ad} className={{ main: 'mb-2 mt-4' }} />
       </CardTextContainer>
       {ad.pixel?.map((pixel) => (
         <img

--- a/packages/shared/src/components/cards/AdList.tsx
+++ b/packages/shared/src/components/cards/AdList.tsx
@@ -15,7 +15,7 @@ export const AdList = forwardRef(function AdList(
         <ListCardTitle className="line-clamp-4 font-bold typo-title3">
           {ad.description}
         </ListCardTitle>
-        <AdAttribution ad={ad} className="mt-2" />
+        <AdAttribution ad={ad} className={{ main: 'mt-2' }} />
       </ListCardMain>
     </ListCard>
   );

--- a/packages/shared/src/components/cards/PlaceholderCard.tsx
+++ b/packages/shared/src/components/cards/PlaceholderCard.tsx
@@ -26,7 +26,7 @@ export const PlaceholderCard = forwardRef(function PlaceholderCard(
       ref={ref}
     >
       <CardTextContainer>
-        <ElementPlaceholder className="my-2 h-6 w-6 rounded-full" />
+        <ElementPlaceholder className="my-2 size-6 rounded-full" />
         <Text style={{ width: '100%' }} />
         <Text style={{ width: '100%' }} />
         <Text style={{ width: '80%' }} />

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -10,29 +10,17 @@ import { SimpleTooltip } from '../../tooltips/SimpleTooltip';
 import { useFeedPreviewMode } from '../../../hooks';
 import BookmarkIcon from '../../icons/Bookmark';
 import DownvoteIcon from '../../icons/Downvote';
+import { ActionButtonsProps } from '../ActionButtons';
 
 const ShareIcon = dynamic(
   () => import(/* webpackChunkName: "shareIcon" */ '../../icons/Share'),
 );
 
-export interface ActionButtonsProps {
-  post: Post;
-  onMenuClick?: (e: React.MouseEvent) => unknown;
-  onUpvoteClick?: (post: Post) => unknown;
-  onDownvoteClick?: (post: Post) => unknown;
-  onCommentClick?: (post: Post) => unknown;
-  onBookmarkClick?: (post: Post) => unknown;
+interface ShareButtonProps {
   onShareClick?: (event: React.MouseEvent, post: Post) => unknown;
-  onReadArticleClick?: (e: React.MouseEvent) => unknown;
-  className?: string;
-  insaneMode?: boolean;
-  openNewTab?: boolean;
+  post: Post;
 }
 
-type ShareButtonProps = {
-  onShareClick?: (event: React.MouseEvent, post: Post) => unknown;
-  post: Post;
-};
 function ShareButton(props: ShareButtonProps) {
   const { onShareClick, post } = props;
   const onClickShare = (event) => onShareClick?.(event, post);
@@ -49,6 +37,10 @@ function ShareButton(props: ShareButtonProps) {
   );
 }
 
+interface ActionButtonsPropsV1 extends ActionButtonsProps {
+  onDownvoteClick?: (post: Post) => unknown;
+}
+
 export default function ActionButtons({
   post,
   onUpvoteClick,
@@ -57,7 +49,7 @@ export default function ActionButtons({
   onBookmarkClick,
   onShareClick,
   className,
-}: ActionButtonsProps): ReactElement {
+}: ActionButtonsPropsV1): ReactElement {
   const isFeedPreview = useFeedPreviewMode();
 
   if (isFeedPreview) {

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -1,0 +1,150 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import dynamic from 'next/dynamic';
+import { Post, UserPostVote } from '../../../graphql/posts';
+import InteractionCounter from '../../InteractionCounter';
+import UpvoteIcon from '../../icons/Upvote';
+import CommentIcon from '../../icons/Discuss';
+import { Button, ButtonColor, ButtonVariant } from '../../buttons/ButtonV2';
+import { SimpleTooltip } from '../../tooltips/SimpleTooltip';
+import { useFeedPreviewMode } from '../../../hooks';
+import BookmarkIcon from '../../icons/Bookmark';
+import DownvoteIcon from '../../icons/Downvote';
+
+const ShareIcon = dynamic(
+  () => import(/* webpackChunkName: "share" */ '../../icons/Share'),
+);
+
+export interface ActionButtonsProps {
+  post: Post;
+  onMenuClick?: (e: React.MouseEvent) => unknown;
+  onUpvoteClick?: (post: Post) => unknown;
+  onDownvoteClick?: (post: Post) => unknown;
+  onCommentClick?: (post: Post) => unknown;
+  onBookmarkClick?: (post: Post) => unknown;
+  onShareClick?: (event: React.MouseEvent, post: Post) => unknown;
+  onReadArticleClick?: (e: React.MouseEvent) => unknown;
+  className?: string;
+  insaneMode?: boolean;
+  openNewTab?: boolean;
+}
+
+type ShareButtonProps = {
+  onShareClick?: (event: React.MouseEvent, post: Post) => unknown;
+  post: Post;
+};
+function ShareButton(props: ShareButtonProps) {
+  const { onShareClick, post } = props;
+  const onClickShare = (event) => onShareClick?.(event, post);
+  return (
+    <SimpleTooltip content="Share post">
+      <Button
+        className="ml-2"
+        icon={<ShareIcon />}
+        onClick={onClickShare}
+        color={ButtonColor.Cabbage}
+        variant={ButtonVariant.Float}
+      />
+    </SimpleTooltip>
+  );
+}
+
+export default function ActionButtons({
+  post,
+  onUpvoteClick,
+  onDownvoteClick,
+  onCommentClick,
+  onBookmarkClick,
+  onShareClick,
+  className,
+}: ActionButtonsProps): ReactElement {
+  const isFeedPreview = useFeedPreviewMode();
+
+  if (isFeedPreview) {
+    return null;
+  }
+
+  const shareButton = ShareButton({
+    post,
+    onShareClick,
+  });
+
+  return (
+    <div className={classNames('flex flex-row items-center', className)}>
+      <div className="flex flex-row items-center rounded-12 bg-theme-float">
+        <SimpleTooltip
+          content={
+            post?.userState?.vote === UserPostVote.Up
+              ? 'Remove upvote'
+              : 'Upvote'
+          }
+        >
+          <Button
+            id={`post-${post.id}-upvote-btn`}
+            color={ButtonColor.Avocado}
+            icon={
+              <UpvoteIcon
+                secondary={post?.userState?.vote === UserPostVote.Up}
+              />
+            }
+            pressed={post?.userState?.vote === UserPostVote.Up}
+            onClick={() => onUpvoteClick?.(post)}
+            variant={ButtonVariant.Tertiary}
+          />
+        </SimpleTooltip>
+        <InteractionCounter
+          className="font-bold text-theme-label-tertiary typo-callout"
+          value={post.numUpvotes}
+        />
+        <SimpleTooltip
+          content={
+            post?.userState?.vote === UserPostVote.Down
+              ? 'Remove downvote'
+              : 'Downvote'
+          }
+        >
+          <Button
+            id={`post-${post.id}-downvote-btn`}
+            color={ButtonColor.Ketchup}
+            icon={
+              <DownvoteIcon
+                secondary={post?.userState?.vote === UserPostVote.Down}
+              />
+            }
+            pressed={post?.userState?.vote === UserPostVote.Down}
+            onClick={() => onDownvoteClick?.(post)}
+            variant={ButtonVariant.Tertiary}
+          />
+        </SimpleTooltip>
+      </div>
+      <SimpleTooltip content="Comments">
+        <Button
+          id={`post-${post.id}-comment-btn`}
+          className="ml-2"
+          color={ButtonColor.BlueCheese}
+          icon={<CommentIcon secondary={post.commented} />}
+          pressed={post.commented}
+          onClick={() => onCommentClick?.(post)}
+          variant={ButtonVariant.Float}
+        >
+          <InteractionCounter
+            className="text-theme-label-tertiary"
+            value={post.numComments}
+          />
+        </Button>
+      </SimpleTooltip>
+      <SimpleTooltip content={post.bookmarked ? 'Remove bookmark' : 'Bookmark'}>
+        <Button
+          id={`post-${post.id}-bookmark-btn`}
+          className="ml-2"
+          icon={<BookmarkIcon secondary={post.bookmarked} />}
+          onClick={() => onBookmarkClick(post)}
+          color={ButtonColor.Bun}
+          pressed={post.bookmarked}
+          variant={ButtonVariant.Float}
+        />
+      </SimpleTooltip>
+      {shareButton}
+    </div>
+  );
+}

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -12,7 +12,7 @@ import BookmarkIcon from '../../icons/Bookmark';
 import DownvoteIcon from '../../icons/Downvote';
 
 const ShareIcon = dynamic(
-  () => import(/* webpackChunkName: "share" */ '../../icons/Share'),
+  () => import(/* webpackChunkName: "shareIcon" */ '../../icons/Share'),
 );
 
 export interface ActionButtonsProps {

--- a/packages/shared/src/components/cards/v1/AdCard.tsx
+++ b/packages/shared/src/components/cards/v1/AdCard.tsx
@@ -41,7 +41,7 @@ export const AdCard = forwardRef(function AdCard(
       </CardTextContainer>
       <CardSpace />
       {showImage && (
-        <div className="relative overflow-hidden rounded-xl">
+        <div className="relative overflow-hidden rounded-12">
           <CardImage
             alt="Ad image"
             src={ad.image}

--- a/packages/shared/src/components/cards/v1/AdCard.tsx
+++ b/packages/shared/src/components/cards/v1/AdCard.tsx
@@ -1,0 +1,72 @@
+import React, { forwardRef, HTMLAttributes, ReactElement, Ref } from 'react';
+import classNames from 'classnames';
+import { CardImage, CardSpace, CardTextContainer, CardTitle } from './Card';
+import { Ad } from '../../../graphql/posts';
+import AdLink from '../AdLink';
+import AdAttribution from '../AdAttribution';
+import FeedItemContainer from './FeedItemContainer';
+
+type Callback = (ad: Ad) => unknown;
+
+export interface AdCardProps {
+  ad: Ad;
+  onLinkClick?: Callback;
+  showImage?: boolean;
+  domProps?: HTMLAttributes<HTMLDivElement>;
+}
+
+export const AdCard = forwardRef(function AdCard(
+  { ad, onLinkClick, showImage = true, domProps }: AdCardProps,
+  ref: Ref<HTMLElement>,
+): ReactElement {
+  const showBlurredImage = ad.source === 'Carbon' || ad.source === 'EthicalAds';
+
+  return (
+    <FeedItemContainer
+      domProps={domProps}
+      ref={ref}
+      flagProps={{
+        adAttribution: <AdAttribution ad={ad} typoClassName="typo-caption1" />,
+        type: undefined,
+      }}
+      data-testid="adItem"
+    >
+      <AdLink ad={ad} onLinkClick={onLinkClick} />
+      <CardTextContainer>
+        <CardTitle className="my-4 line-clamp-4 font-bold typo-title3">
+          {ad.description}
+        </CardTitle>
+      </CardTextContainer>
+      <CardSpace />
+      {showImage && (
+        <div className="relative overflow-hidden rounded-xl">
+          <CardImage
+            alt="Ad image"
+            src={ad.image}
+            className={classNames(
+              'z-1 w-full',
+              showBlurredImage && 'absolute inset-0 m-auto',
+            )}
+            style={{ objectFit: showBlurredImage ? 'contain' : 'cover' }}
+          />
+          {showBlurredImage && (
+            <CardImage
+              alt="Ad image background"
+              src={ad.image}
+              className={classNames('-z-1 w-full')}
+            />
+          )}
+        </div>
+      )}
+      {ad.pixel?.map((pixel) => (
+        <img
+          src={pixel}
+          key={pixel}
+          data-testid="pixel"
+          className="hidden h-0 w-0"
+          alt="Pixel"
+        />
+      ))}
+    </FeedItemContainer>
+  );
+});

--- a/packages/shared/src/components/cards/v1/AdCard.tsx
+++ b/packages/shared/src/components/cards/v1/AdCard.tsx
@@ -2,9 +2,9 @@ import React, { forwardRef, HTMLAttributes, ReactElement, Ref } from 'react';
 import classNames from 'classnames';
 import { CardImage, CardSpace, CardTextContainer, CardTitle } from './Card';
 import { Ad } from '../../../graphql/posts';
-import AdLink from '../AdLink';
 import AdAttribution from '../AdAttribution';
 import FeedItemContainer from './FeedItemContainer';
+import getLinkProps from './AdLink';
 
 type Callback = (ad: Ad) => unknown;
 
@@ -32,8 +32,8 @@ export const AdCard = forwardRef(function AdCard(
         type: undefined,
       }}
       data-testid="adItem"
+      linkProps={getLinkProps(ad, onLinkClick)}
     >
-      <AdLink ad={ad} onLinkClick={onLinkClick} />
       <CardTextContainer>
         <CardTitle className="line-clamp-4 font-bold typo-title3">
           {ad.description}

--- a/packages/shared/src/components/cards/v1/AdCard.tsx
+++ b/packages/shared/src/components/cards/v1/AdCard.tsx
@@ -26,14 +26,16 @@ export const AdCard = forwardRef(function AdCard(
       domProps={domProps}
       ref={ref}
       flagProps={{
-        adAttribution: <AdAttribution ad={ad} typoClassName="typo-caption1" />,
+        adAttribution: (
+          <AdAttribution ad={ad} className={{ typo: 'typo-caption1' }} />
+        ),
         type: undefined,
       }}
       data-testid="adItem"
     >
       <AdLink ad={ad} onLinkClick={onLinkClick} />
       <CardTextContainer>
-        <CardTitle className="my-4 line-clamp-4 font-bold typo-title3">
+        <CardTitle className="line-clamp-4 font-bold typo-title3">
           {ad.description}
         </CardTitle>
       </CardTextContainer>

--- a/packages/shared/src/components/cards/v1/AdCard.tsx
+++ b/packages/shared/src/components/cards/v1/AdCard.tsx
@@ -55,7 +55,7 @@ export const AdCard = forwardRef(function AdCard(
             <CardImage
               alt="Ad image background"
               src={ad.image}
-              className={classNames('-z-1 w-full')}
+              className="-z-1 w-full blur-20"
             />
           )}
         </div>

--- a/packages/shared/src/components/cards/v1/AdLink.ts
+++ b/packages/shared/src/components/cards/v1/AdLink.ts
@@ -1,0 +1,16 @@
+import { AnchorHTMLAttributes } from 'react';
+import { Ad } from '../../../graphql/posts';
+import { combinedClicks } from '../../../lib/click';
+
+export default function getLinkProps(
+  ad: Ad,
+  onLinkClick: (ad: Ad) => unknown,
+): AnchorHTMLAttributes<HTMLAnchorElement> {
+  return {
+    href: ad.link,
+    target: '_blank',
+    rel: 'noopener',
+    title: ad.description,
+    ...combinedClicks(() => onLinkClick?.(ad)),
+  };
+}

--- a/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
@@ -80,7 +80,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
           <CardTextContainer>
             <PostCardHeader
               post={post}
-              className={showFeedback ? 'hidden' : 'flex'}
+              className={'flex'}
               openNewTab={openNewTab}
               source={post.source}
               postLink={post.permalink}
@@ -88,7 +88,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
               onReadArticleClick={onReadArticleClick}
             />
             <CardTitle
-              lineClamp={showFeedback ? 'line-clamp-2' : undefined}
+              lineClamp={undefined}
               className={!!post.read && 'text-theme-label-tertiary'}
             >
               {post.title}
@@ -105,9 +105,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
               openNewTab={openNewTab}
               post={post}
               showImage={showImage}
-              className={{
-                image: classNames(showFeedback && 'mb-0'),
-              }}
+              className={{}}
             />
             <ActionButtons
               className="mt-4"

--- a/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
@@ -1,7 +1,5 @@
 import React, { forwardRef, ReactElement, Ref } from 'react';
-import classNames from 'classnames';
-import Link from 'next/link';
-import { CardLink, CardTextContainer, CardTitle } from './Card';
+import { CardTextContainer, CardTitle } from './Card';
 import ActionButtons from './ActionButtons';
 import { PostCardHeader } from './PostCardHeader';
 import { PostCardFooter } from './PostCardFooter';
@@ -57,16 +55,12 @@ export const ArticlePostCard = forwardRef(function PostCard(
       }}
       ref={ref}
       flagProps={{ pinnedAt, trending, type }}
-      link={
-        !isFeedPreview && (
-          <Link href={post.commentsPermalink}>
-            <CardLink
-              title={post.title}
-              onClick={onPostCardClick}
-              href={post.commentsPermalink}
-            />
-          </Link>
-        )
+      linkProps={
+        !isFeedPreview && {
+          title: post.title,
+          onClick: onPostCardClick,
+          href: post.commentsPermalink,
+        }
       }
     >
       {showFeedback ? (
@@ -81,7 +75,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
           <CardTextContainer>
             <PostCardHeader
               post={post}
-              className={'flex'}
+              className="flex"
               openNewTab={openNewTab}
               source={post.source}
               postLink={post.permalink}

--- a/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
@@ -57,17 +57,18 @@ export const ArticlePostCard = forwardRef(function PostCard(
       }}
       ref={ref}
       flagProps={{ pinnedAt, trending, type }}
+      link={
+        !isFeedPreview && (
+          <Link href={post.commentsPermalink}>
+            <CardLink
+              title={post.title}
+              onClick={onPostCardClick}
+              href={post.commentsPermalink}
+            />
+          </Link>
+        )
+      }
     >
-      {!isFeedPreview && (
-        <Link href={post.commentsPermalink}>
-          <CardLink
-            title={post.title}
-            onClick={onPostCardClick}
-            href={post.commentsPermalink}
-          />
-        </Link>
-      )}
-
       {showFeedback ? (
         <FeedbackCard
           post={post}

--- a/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
@@ -77,53 +77,51 @@ export const ArticlePostCard = forwardRef(function PostCard(
         />
       ) : (
         <>
-          <div>
-            <CardTextContainer>
-              <PostCardHeader
-                post={post}
-                className={showFeedback ? 'hidden' : 'flex'}
-                openNewTab={openNewTab}
-                source={post.source}
-                postLink={post.permalink}
-                onMenuClick={(event) => onMenuClick?.(event, post)}
-                onReadArticleClick={onReadArticleClick}
-              />
-              <CardTitle
-                lineClamp={showFeedback ? 'line-clamp-2' : undefined}
-                className={!!post.read && 'text-theme-label-tertiary'}
-              >
-                {post.title}
-              </CardTitle>
+          <CardTextContainer>
+            <PostCardHeader
+              post={post}
+              className={showFeedback ? 'hidden' : 'flex'}
+              openNewTab={openNewTab}
+              source={post.source}
+              postLink={post.permalink}
+              onMenuClick={(event) => onMenuClick?.(event, post)}
+              onReadArticleClick={onReadArticleClick}
+            />
+            <CardTitle
+              lineClamp={showFeedback ? 'line-clamp-2' : undefined}
+              className={!!post.read && 'text-theme-label-tertiary'}
+            >
+              {post.title}
+            </CardTitle>
+          </CardTextContainer>
+          {post.summary && (
+            <CardTextContainer className="mt-4 text-theme-label-secondary">
+              {post.summary}
             </CardTextContainer>
-            {post.summary && (
-              <CardTextContainer className="mt-4 text-theme-label-secondary">
-                {post.summary}
-              </CardTextContainer>
-            )}
-            <Container>
-              <PostCardFooter
-                insaneMode={insaneMode}
-                openNewTab={openNewTab}
-                post={post}
-                showImage={showImage}
-                className={{
-                  image: classNames(showFeedback && 'mb-0'),
-                }}
-              />
-              <ActionButtons
-                className="mt-4"
-                openNewTab={openNewTab}
-                post={post}
-                onUpvoteClick={onUpvoteClick}
-                onDownvoteClick={onDownvoteClick}
-                onCommentClick={onCommentClick}
-                onShareClick={onShareClick}
-                onBookmarkClick={onBookmarkClick}
-                onMenuClick={(event) => onMenuClick?.(event, post)}
-                onReadArticleClick={onReadArticleClick}
-              />
-            </Container>
-          </div>
+          )}
+          <Container>
+            <PostCardFooter
+              insaneMode={insaneMode}
+              openNewTab={openNewTab}
+              post={post}
+              showImage={showImage}
+              className={{
+                image: classNames(showFeedback && 'mb-0'),
+              }}
+            />
+            <ActionButtons
+              className="mt-4"
+              openNewTab={openNewTab}
+              post={post}
+              onUpvoteClick={onUpvoteClick}
+              onDownvoteClick={onDownvoteClick}
+              onCommentClick={onCommentClick}
+              onShareClick={onShareClick}
+              onBookmarkClick={onBookmarkClick}
+              onMenuClick={(event) => onMenuClick?.(event, post)}
+              onReadArticleClick={onReadArticleClick}
+            />
+          </Container>
           {children}
         </>
       )}

--- a/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
@@ -1,0 +1,132 @@
+import React, { forwardRef, ReactElement, Ref } from 'react';
+import classNames from 'classnames';
+import Link from 'next/link';
+import { CardLink, CardTextContainer, CardTitle } from './Card';
+import ActionButtons from './ActionButtons';
+import { PostCardHeader } from './PostCardHeader';
+import { PostCardFooter } from './PostCardFooter';
+import { Container, PostCardProps } from '../common';
+import FeedItemContainer from './FeedItemContainer';
+import { useBlockPostPanel } from '../../../hooks/post/useBlockPostPanel';
+import { PostTagsPanel } from '../../post/block/PostTagsPanel';
+import { useFeedPreviewMode, usePostFeedback } from '../../../hooks';
+import { FeedbackCard } from './FeedbackCard';
+import { Origin } from '../../../lib/analytics';
+
+export const ArticlePostCard = forwardRef(function PostCard(
+  {
+    post,
+    onPostClick,
+    onUpvoteClick,
+    onDownvoteClick,
+    onCommentClick,
+    onMenuClick,
+    onBookmarkClick,
+    onShareClick,
+    openNewTab,
+    children,
+    showImage = true,
+    insaneMode,
+    onReadArticleClick,
+    domProps = {},
+  }: PostCardProps,
+  ref: Ref<HTMLElement>,
+): ReactElement {
+  const { className, style } = domProps;
+  const { data } = useBlockPostPanel(post);
+  const { type, pinnedAt, trending } = post;
+
+  const onPostCardClick = () => onPostClick?.(post);
+
+  const customStyle = !showImage ? { minHeight: '15.125rem' } : {};
+  const { showFeedback } = usePostFeedback({ post });
+  const isFeedPreview = useFeedPreviewMode();
+
+  if (data?.showTagsPanel && post.tags.length > 0) {
+    return (
+      <PostTagsPanel className="overflow-hidden" post={post} toastOnSuccess />
+    );
+  }
+
+  return (
+    <FeedItemContainer
+      domProps={{
+        ...domProps,
+        style: { ...style, ...customStyle },
+        className,
+      }}
+      ref={ref}
+      flagProps={{ pinnedAt, trending, type }}
+    >
+      {!isFeedPreview && (
+        <Link href={post.commentsPermalink}>
+          <CardLink
+            title={post.title}
+            onClick={onPostCardClick}
+            href={post.commentsPermalink}
+          />
+        </Link>
+      )}
+
+      {showFeedback ? (
+        <FeedbackCard
+          post={post}
+          onUpvoteClick={() => onUpvoteClick(post, Origin.FeedbackCard)}
+          onDownvoteClick={() => onDownvoteClick(post, Origin.FeedbackCard)}
+          showImage={showImage}
+        />
+      ) : (
+        <>
+          <div>
+            <CardTextContainer>
+              <PostCardHeader
+                post={post}
+                className={showFeedback ? 'hidden' : 'flex'}
+                openNewTab={openNewTab}
+                source={post.source}
+                postLink={post.permalink}
+                onMenuClick={(event) => onMenuClick?.(event, post)}
+                onReadArticleClick={onReadArticleClick}
+              />
+              <CardTitle
+                lineClamp={showFeedback ? 'line-clamp-2' : undefined}
+                className={!!post.read && 'text-theme-label-tertiary'}
+              >
+                {post.title}
+              </CardTitle>
+            </CardTextContainer>
+            {post.summary && (
+              <CardTextContainer className="mt-4 text-theme-label-secondary">
+                {post.summary}
+              </CardTextContainer>
+            )}
+            <Container>
+              <PostCardFooter
+                insaneMode={insaneMode}
+                openNewTab={openNewTab}
+                post={post}
+                showImage={showImage}
+                className={{
+                  image: classNames(showFeedback && 'mb-0'),
+                }}
+              />
+              <ActionButtons
+                className="mt-4"
+                openNewTab={openNewTab}
+                post={post}
+                onUpvoteClick={onUpvoteClick}
+                onDownvoteClick={onDownvoteClick}
+                onCommentClick={onCommentClick}
+                onShareClick={onShareClick}
+                onBookmarkClick={onBookmarkClick}
+                onMenuClick={(event) => onMenuClick?.(event, post)}
+                onReadArticleClick={onReadArticleClick}
+              />
+            </Container>
+          </div>
+          {children}
+        </>
+      )}
+    </FeedItemContainer>
+  );
+});

--- a/packages/shared/src/components/cards/v1/Card.tsx
+++ b/packages/shared/src/components/cards/v1/Card.tsx
@@ -58,7 +58,6 @@ export const Card = classed(
   'article',
   `group relative w-full flex flex-col py-6 px-4 border-t border-theme-divider-tertiary
    hover:bg-theme-float
-   focus:bg-theme-float focus:border-2 focus:border-theme-focus
   `,
 );
 

--- a/packages/shared/src/components/cards/v1/Card.tsx
+++ b/packages/shared/src/components/cards/v1/Card.tsx
@@ -1,0 +1,68 @@
+import React, { HTMLAttributes, ReactNode } from 'react';
+import classNames from 'classnames';
+import { ReactElement } from 'react-markdown/lib/react-markdown';
+import classed from '../../../lib/classed';
+import { Image } from '../../image/Image';
+import VideoImage from '../../image/VideoImage';
+
+type TitleProps = HTMLAttributes<HTMLHeadingElement> & {
+  lineClamp?: `line-clamp-${number}`;
+  children: ReactNode;
+};
+
+const Title = ({
+  className,
+  lineClamp = 'line-clamp-3',
+  children,
+  ...rest
+}: TitleProps): ReactElement => {
+  return (
+    <h3
+      {...rest}
+      className={classNames(
+        'multi-truncate font-bold text-theme-label-primary typo-title3',
+        lineClamp,
+        className,
+      )}
+    >
+      {children}
+    </h3>
+  );
+};
+
+export const FreeformCardTitle = classed(
+  'h3',
+  'mt-2 break-words multi-truncate font-bold typo-title3',
+);
+
+export const CardTitle = classed(Title, 'mt-4 break-words');
+
+export const ListCardTitle = classed(Title, 'mr-2');
+
+export const CardTextContainer = classed('div', 'flex flex-col');
+
+export const CardImage = classed(Image, 'rounded-12 h-50');
+export const CardVideoImage = classed(VideoImage, 'rounded-12 h-50');
+
+export const CardSpace = classed('div', 'flex-1');
+
+const clickableCardClasses = classNames(
+  'focus-outline absolute inset-0 block h-full w-full',
+);
+
+export const CardButton = classed('button', clickableCardClasses);
+
+export const CardLink = classed('a', clickableCardClasses);
+
+export const Card = classed(
+  'article',
+  `group relative w-full flex flex-col py-6 px-4 border-t border-theme-divider-tertiary
+   hover:bg-theme-float
+   focus:bg-theme-float focus:border-2 focus:border-theme-focus
+  `,
+);
+
+export const CardHeader = classed(
+  'div',
+  'flex items-center h-8 items-center my-1',
+);

--- a/packages/shared/src/components/cards/v1/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/v1/CollectionCard.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { Container, generateTitleClamp, PostCardProps } from '../common';
 import FeedItemContainer from './FeedItemContainer';
 import { CollectionCardHeader } from '../CollectionCard/CollectionCardHeader';
-import { FreeformCardTitle, CardSpace, CardButton } from './Card';
+import { FreeformCardTitle, CardSpace } from './Card';
 import { WelcomePostCardFooter } from '../WelcomePostCardFooter';
 import ActionButtons from './ActionButtons';
 import PostMetadata from './PostMetadata';
@@ -34,7 +34,11 @@ export const CollectionCard = forwardRef(function CollectionCard(
       }}
       ref={ref}
       flagProps={{ pinnedAt: post.pinnedAt, type: post.type }}
-      link={<CardButton title={post.title} onClick={() => onPostClick(post)} />}
+      linkProps={{
+        title: post.title,
+        onClick: () => onPostClick(post),
+        href: post.commentsPermalink,
+      }}
     >
       <CollectionCardHeader
         sources={post.collectionSources}

--- a/packages/shared/src/components/cards/v1/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/v1/CollectionCard.tsx
@@ -1,0 +1,84 @@
+import React, { forwardRef, Ref } from 'react';
+import classNames from 'classnames';
+import { Container, generateTitleClamp, PostCardProps } from '../common';
+import FeedItemContainer from './FeedItemContainer';
+import { CollectionCardHeader } from '../CollectionCard/CollectionCardHeader';
+import {
+  getPostClassNames,
+  FreeformCardTitle,
+  CardSpace,
+  CardButton,
+} from '../Card';
+import { WelcomePostCardFooter } from '../WelcomePostCardFooter';
+import ActionButtons from './ActionButtons';
+import PostMetadata from './PostMetadata';
+import { usePostImage } from '../../../hooks/post/usePostImage';
+
+export const CollectionCard = forwardRef(function CollectionCard(
+  {
+    children,
+    post,
+    domProps = {},
+    onUpvoteClick,
+    onCommentClick,
+    onMenuClick,
+    onShareClick,
+    openNewTab,
+    onReadArticleClick,
+    onPostClick,
+  }: PostCardProps,
+  ref: Ref<HTMLElement>,
+) {
+  const image = usePostImage(post);
+
+  return (
+    <FeedItemContainer
+      domProps={{
+        ...domProps,
+        className: getPostClassNames(post, domProps.className, 'min-h-card'),
+      }}
+      ref={ref}
+      flagProps={{ pinnedAt: post.pinnedAt, type: post.type }}
+    >
+      <CardButton title={post.title} onClick={() => onPostClick(post)} />
+
+      <CollectionCardHeader
+        sources={post.collectionSources}
+        totalSources={post.numCollectionSources}
+        onMenuClick={(event) => onMenuClick?.(event, post)}
+      />
+      <FreeformCardTitle
+        className={classNames(
+          generateTitleClamp({
+            hasImage: !!image,
+            hasHtmlContent: !!post.contentHtml,
+          }),
+          'px-2 font-bold text-theme-label-primary typo-title3',
+        )}
+      >
+        {post.title}
+      </FreeformCardTitle>
+
+      {!!post.image && <CardSpace />}
+      <PostMetadata
+        createdAt={post.createdAt}
+        readTime={post.readTime}
+        className={classNames('m-2', post.image ? 'mb-0' : 'mb-4')}
+      />
+
+      <Container>
+        <WelcomePostCardFooter image={image} contentHtml={post.contentHtml} />
+        <ActionButtons
+          openNewTab={openNewTab}
+          post={post}
+          onUpvoteClick={onUpvoteClick}
+          onCommentClick={onCommentClick}
+          onShareClick={onShareClick}
+          onMenuClick={(event) => onMenuClick?.(event, post)}
+          onReadArticleClick={onReadArticleClick}
+        />
+      </Container>
+      {children}
+    </FeedItemContainer>
+  );
+});

--- a/packages/shared/src/components/cards/v1/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/v1/CollectionCard.tsx
@@ -3,12 +3,7 @@ import classNames from 'classnames';
 import { Container, generateTitleClamp, PostCardProps } from '../common';
 import FeedItemContainer from './FeedItemContainer';
 import { CollectionCardHeader } from '../CollectionCard/CollectionCardHeader';
-import {
-  getPostClassNames,
-  FreeformCardTitle,
-  CardSpace,
-  CardButton,
-} from '../Card';
+import { FreeformCardTitle, CardSpace, CardButton } from './Card';
 import { WelcomePostCardFooter } from '../WelcomePostCardFooter';
 import ActionButtons from './ActionButtons';
 import PostMetadata from './PostMetadata';
@@ -35,13 +30,12 @@ export const CollectionCard = forwardRef(function CollectionCard(
     <FeedItemContainer
       domProps={{
         ...domProps,
-        className: getPostClassNames(post, domProps.className, 'min-h-card'),
+        className: domProps.className,
       }}
       ref={ref}
       flagProps={{ pinnedAt: post.pinnedAt, type: post.type }}
+      link={<CardButton title={post.title} onClick={() => onPostClick(post)} />}
     >
-      <CardButton title={post.title} onClick={() => onPostClick(post)} />
-
       <CollectionCardHeader
         sources={post.collectionSources}
         totalSources={post.numCollectionSources}

--- a/packages/shared/src/components/cards/v1/FeedItemContainer.tsx
+++ b/packages/shared/src/components/cards/v1/FeedItemContainer.tsx
@@ -1,0 +1,64 @@
+import React, {
+  forwardRef,
+  HTMLAttributes,
+  ReactElement,
+  ReactNode,
+  Ref,
+} from 'react';
+import { Post } from '../../../graphql/posts';
+import { Card } from './Card';
+import { RaisedLabel, RaisedLabelType } from './RaisedLabel';
+import { useFeedPreviewMode } from '../../../hooks';
+import { TypeLabel } from './TypeLabel';
+
+interface FeedItemContainerProps {
+  flagProps?: FlagProps;
+  children: ReactNode;
+  domProps: HTMLAttributes<HTMLDivElement>;
+}
+
+interface FlagProps extends Pick<Post, 'pinnedAt' | 'trending' | 'type'> {
+  adAttribution?: ReactElement | string;
+}
+
+function FeedItemContainer(
+  { flagProps, children, domProps }: FeedItemContainerProps,
+  ref?: Ref<HTMLElement>,
+): ReactElement {
+  const { adAttribution, pinnedAt, trending, type } = flagProps;
+
+  const raisedLabelType = pinnedAt
+    ? RaisedLabelType.Pinned
+    : RaisedLabelType.Hot;
+  const description =
+    raisedLabelType === RaisedLabelType.Hot && trending > 0
+      ? `${trending} devs read it last hour`
+      : undefined;
+  const isFeedPreview = useFeedPreviewMode();
+  const showFlag = (!!pinnedAt || !!trending) && !isFeedPreview && description;
+  const showTypeLabel = !!adAttribution || !!type;
+
+  return (
+    <Card
+      {...domProps}
+      data-testid="postItem"
+      ref={ref}
+      className={domProps?.className}
+    >
+      <fieldset>
+        {showTypeLabel && (
+          <TypeLabel
+            type={adAttribution ?? type}
+            className="absolute -top-2 left-2"
+          />
+        )}
+        {showFlag && (
+          <RaisedLabel type={raisedLabelType} description={description} />
+        )}
+      </fieldset>
+      {children}
+    </Card>
+  );
+}
+
+export default forwardRef(FeedItemContainer);

--- a/packages/shared/src/components/cards/v1/FeedItemContainer.tsx
+++ b/packages/shared/src/components/cards/v1/FeedItemContainer.tsx
@@ -65,7 +65,7 @@ function FeedItemContainer(
           <TypeLabel
             type={adAttribution ?? type}
             className={classNames(
-              'absolute -top-[9px] left-2',
+              'absolute left-2',
               !focus && '-top-[9px]', // taking the border width into account
               focus && '-top-2.5 bg-theme-bg-secondary',
             )}

--- a/packages/shared/src/components/cards/v1/FeedItemContainer.tsx
+++ b/packages/shared/src/components/cards/v1/FeedItemContainer.tsx
@@ -1,21 +1,26 @@
 import React, {
+  AnchorHTMLAttributes,
   forwardRef,
   HTMLAttributes,
   ReactElement,
   ReactNode,
   Ref,
+  useState,
 } from 'react';
+import Link from 'next/link';
+import classNames from 'classnames';
 import { Post } from '../../../graphql/posts';
-import { Card } from './Card';
+import { Card, CardLink } from './Card';
 import { RaisedLabel, RaisedLabelType } from './RaisedLabel';
 import { useFeedPreviewMode } from '../../../hooks';
 import { TypeLabel } from './TypeLabel';
+import ConditionalWrapper from '../../ConditionalWrapper';
 
 interface FeedItemContainerProps {
   flagProps?: FlagProps;
   children: ReactNode;
   domProps: HTMLAttributes<HTMLDivElement>;
-  link?: ReactElement;
+  linkProps?: AnchorHTMLAttributes<HTMLAnchorElement>;
 }
 
 interface FlagProps extends Pick<Post, 'pinnedAt' | 'trending' | 'type'> {
@@ -23,7 +28,7 @@ interface FlagProps extends Pick<Post, 'pinnedAt' | 'trending' | 'type'> {
 }
 
 function FeedItemContainer(
-  { flagProps, children, domProps, link }: FeedItemContainerProps,
+  { flagProps, children, domProps, linkProps }: FeedItemContainerProps,
   ref?: Ref<HTMLElement>,
 ): ReactElement {
   const { adAttribution, pinnedAt, trending, type } = flagProps;
@@ -38,24 +43,43 @@ function FeedItemContainer(
   const isFeedPreview = useFeedPreviewMode();
   const showFlag = (!!pinnedAt || !!trending) && !isFeedPreview && description;
   const showTypeLabel = !!adAttribution || !!type;
+  const [focus, setFocus] = useState(false);
 
   return (
     <Card
       {...domProps}
       data-testid="postItem"
       ref={ref}
-      className={domProps?.className}
+      className={classNames(domProps?.className, focus && 'bg-theme-float')}
     >
-      {link}
+      {linkProps && (
+        <ConditionalWrapper
+          condition={!linkProps.href.startsWith('https://')}
+          wrapper={(child) => <Link href={linkProps.href}>{child}</Link>}
+        >
+          <CardLink
+            {...linkProps}
+            onFocus={() => setFocus(true)}
+            onBlur={() => setFocus(false)}
+          />
+        </ConditionalWrapper>
+      )}
       <fieldset>
         {showTypeLabel && (
           <TypeLabel
             type={adAttribution ?? type}
-            className="absolute -top-2 left-2"
+            className={classNames(
+              'absolute -top-2 left-2',
+              focus && 'bg-theme-bg-secondary',
+            )}
           />
         )}
         {showFlag && (
-          <RaisedLabel type={raisedLabelType} description={description} />
+          <RaisedLabel
+            type={raisedLabelType}
+            description={description}
+            focus={focus}
+          />
         )}
       </fieldset>
       {children}

--- a/packages/shared/src/components/cards/v1/FeedItemContainer.tsx
+++ b/packages/shared/src/components/cards/v1/FeedItemContainer.tsx
@@ -14,7 +14,6 @@ import { Card, CardLink } from './Card';
 import { RaisedLabel, RaisedLabelType } from './RaisedLabel';
 import { useFeedPreviewMode } from '../../../hooks';
 import { TypeLabel } from './TypeLabel';
-import ConditionalWrapper from '../../ConditionalWrapper';
 
 interface FeedItemContainerProps {
   flagProps?: FlagProps;
@@ -53,24 +52,22 @@ function FeedItemContainer(
       className={classNames(domProps?.className, focus && 'bg-theme-float')}
     >
       {linkProps && (
-        <ConditionalWrapper
-          condition={!linkProps.href.startsWith('https://')}
-          wrapper={(child) => <Link href={linkProps.href}>{child}</Link>}
-        >
+        <Link href={linkProps.href}>
           <CardLink
             {...linkProps}
             onFocus={() => setFocus(true)}
             onBlur={() => setFocus(false)}
           />
-        </ConditionalWrapper>
+        </Link>
       )}
       <fieldset>
         {showTypeLabel && (
           <TypeLabel
             type={adAttribution ?? type}
             className={classNames(
-              'absolute -top-2 left-2',
-              focus && 'bg-theme-bg-secondary',
+              'absolute -top-[9px] left-2',
+              !focus && '-top-[9px]', // taking the border width into account
+              focus && '-top-2.5 bg-theme-bg-secondary',
             )}
           />
         )}

--- a/packages/shared/src/components/cards/v1/FeedItemContainer.tsx
+++ b/packages/shared/src/components/cards/v1/FeedItemContainer.tsx
@@ -15,6 +15,7 @@ interface FeedItemContainerProps {
   flagProps?: FlagProps;
   children: ReactNode;
   domProps: HTMLAttributes<HTMLDivElement>;
+  link?: ReactElement;
 }
 
 interface FlagProps extends Pick<Post, 'pinnedAt' | 'trending' | 'type'> {
@@ -22,7 +23,7 @@ interface FlagProps extends Pick<Post, 'pinnedAt' | 'trending' | 'type'> {
 }
 
 function FeedItemContainer(
-  { flagProps, children, domProps }: FeedItemContainerProps,
+  { flagProps, children, domProps, link }: FeedItemContainerProps,
   ref?: Ref<HTMLElement>,
 ): ReactElement {
   const { adAttribution, pinnedAt, trending, type } = flagProps;
@@ -45,6 +46,7 @@ function FeedItemContainer(
       ref={ref}
       className={domProps?.className}
     >
+      {link}
       <fieldset>
         {showTypeLabel && (
           <TypeLabel

--- a/packages/shared/src/components/cards/v1/FeedbackCard.tsx
+++ b/packages/shared/src/components/cards/v1/FeedbackCard.tsx
@@ -1,0 +1,89 @@
+import React, { MouseEventHandler, ReactElement } from 'react';
+import {
+  Button,
+  ButtonColor,
+  ButtonSize,
+  ButtonVariant,
+} from '../../buttons/ButtonV2';
+import DownvoteIcon from '../../icons/Downvote';
+import UpvoteIcon from '../../icons/Upvote';
+import { Post, UserPostVote } from '../../../graphql/posts';
+import { usePostFeedback } from '../../../hooks';
+import { useFeature } from '../../GrowthBookProvider';
+import { feature } from '../../../lib/featureManagement';
+import CloseButton from '../../CloseButton';
+import { PostCardFooter } from './PostCardFooter';
+
+interface FeedbackCardProps {
+  post: Post;
+  onUpvoteClick: MouseEventHandler;
+  onDownvoteClick: MouseEventHandler;
+  showImage?: boolean;
+}
+
+export const FeedbackCard = ({
+  post,
+  onUpvoteClick,
+  onDownvoteClick,
+  showImage = true,
+}: FeedbackCardProps): ReactElement => {
+  const { dismissFeedback } = usePostFeedback({ post });
+  const feedbackCopy = useFeature(feature.cardFeedbackCopy);
+
+  return (
+    <div className="flex-1 space-y-4">
+      <div className="relative flex justify-between">
+        <p className="font-bold typo-callout">{feedbackCopy}</p>
+        <CloseButton
+          id="close-engagement-loop-btn"
+          className="absolute -right-2.5 -top-2.5"
+          size={ButtonSize.XSmall}
+          onClick={dismissFeedback}
+        />
+      </div>
+      <div className="flex items-center gap-3">
+        <Button
+          id="upvote-post-btn"
+          pressed={post?.userState?.vote === UserPostVote.Up}
+          onClick={onUpvoteClick}
+          icon={
+            <UpvoteIcon secondary={post?.userState?.vote === UserPostVote.Up} />
+          }
+          variant={ButtonVariant.Secondary}
+          color={ButtonColor.Avocado}
+          aria-label="Upvote"
+        />
+        <Button
+          id="downvote-post-btn"
+          pressed={post?.userState?.vote === UserPostVote.Down}
+          onClick={onDownvoteClick}
+          icon={
+            <DownvoteIcon
+              secondary={post?.userState?.vote === UserPostVote.Down}
+            />
+          }
+          variant={ButtonVariant.Secondary}
+          color={ButtonColor.Ketchup}
+          aria-label="Downvote"
+        />
+      </div>
+      <div className="rounded-14 border border-theme-divider-tertiary p-4">
+        <h2 className="line-clamp-1 typo-body">{post.title}</h2>
+        {post.summary && (
+          <p className="mt-2 line-clamp-2 text-theme-label-quaternary typo-callout">
+            {post.summary}
+          </p>
+        )}
+        <PostCardFooter
+          className={{
+            image: 'mb-0',
+          }}
+          post={post}
+          showImage={showImage}
+          insaneMode={false}
+          openNewTab
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/shared/src/components/cards/v1/FeedbackCard.tsx
+++ b/packages/shared/src/components/cards/v1/FeedbackCard.tsx
@@ -41,7 +41,7 @@ export const FeedbackCard = ({
           onClick={dismissFeedback}
         />
       </div>
-      <div className="flex items-center gap-3">
+      <div className="relative flex items-center gap-3">
         <Button
           id="upvote-post-btn"
           pressed={post?.userState?.vote === UserPostVote.Up}

--- a/packages/shared/src/components/cards/v1/FeedbackCard.tsx
+++ b/packages/shared/src/components/cards/v1/FeedbackCard.tsx
@@ -9,8 +9,6 @@ import DownvoteIcon from '../../icons/Downvote';
 import UpvoteIcon from '../../icons/Upvote';
 import { Post, UserPostVote } from '../../../graphql/posts';
 import { usePostFeedback } from '../../../hooks';
-import { useFeature } from '../../GrowthBookProvider';
-import { feature } from '../../../lib/featureManagement';
 import CloseButton from '../../CloseButton';
 import { PostCardFooter } from './PostCardFooter';
 
@@ -28,12 +26,13 @@ export const FeedbackCard = ({
   showImage = true,
 }: FeedbackCardProps): ReactElement => {
   const { dismissFeedback } = usePostFeedback({ post });
-  const feedbackCopy = useFeature(feature.cardFeedbackCopy);
 
   return (
     <div className="flex-1 space-y-4">
       <div className="relative flex justify-between">
-        <p className="font-bold typo-callout">{feedbackCopy}</p>
+        <p className="font-bold typo-callout">
+          Want to see more posts like this?
+        </p>
         <CloseButton
           id="close-engagement-loop-btn"
           className="absolute -right-2.5 -top-2.5"

--- a/packages/shared/src/components/cards/v1/PlaceholderCard.tsx
+++ b/packages/shared/src/components/cards/v1/PlaceholderCard.tsx
@@ -18,7 +18,7 @@ export const PlaceholderCard = forwardRef(function PlaceholderCard(
     <Card aria-busy className={classNames(className)} {...props} ref={ref}>
       <CardTextContainer>
         <CardSpace className="mb-2 flex flex-row">
-          <ElementPlaceholder className="h-10 w-10 rounded-full" />
+          <ElementPlaceholder className="size-10 rounded-full" />
           <CardSpace className="ml-4 grid content-center gap-2">
             <Text className="h-2 w-20" />
             <Text className="h-2 w-40" />

--- a/packages/shared/src/components/cards/v1/PlaceholderCard.tsx
+++ b/packages/shared/src/components/cards/v1/PlaceholderCard.tsx
@@ -1,0 +1,35 @@
+import React, { forwardRef, HTMLAttributes, ReactElement, Ref } from 'react';
+import classNames from 'classnames';
+import { Card, CardSpace, CardTextContainer } from './Card';
+import { ElementPlaceholder } from '../../ElementPlaceholder';
+import classed from '../../../lib/classed';
+
+const Text = classed(ElementPlaceholder, 'rounded-xl');
+
+export type PlaceholderCardProps = {
+  showImage?: boolean;
+} & HTMLAttributes<HTMLDivElement>;
+
+export const PlaceholderCard = forwardRef(function PlaceholderCard(
+  { className, showImage, ...props }: PlaceholderCardProps,
+  ref: Ref<HTMLElement>,
+): ReactElement {
+  return (
+    <Card aria-busy className={classNames(className)} {...props} ref={ref}>
+      <CardTextContainer>
+        <CardSpace className="mb-2 flex flex-row">
+          <ElementPlaceholder className="h-10 w-10 rounded-full" />
+          <CardSpace className="ml-4 grid content-center gap-2">
+            <Text className="h-2 w-20" />
+            <Text className="h-2 w-40" />
+          </CardSpace>
+        </CardSpace>
+      </CardTextContainer>
+      <CardSpace className="my-4">
+        <Text className="h-4 w-3/4" />
+        <Text className="mt-2 h-4 w-1/2" />
+      </CardSpace>
+      <ElementPlaceholder className="h-50 rounded-16" />
+    </Card>
+  );
+});

--- a/packages/shared/src/components/cards/v1/PlaceholderCard.tsx
+++ b/packages/shared/src/components/cards/v1/PlaceholderCard.tsx
@@ -4,7 +4,7 @@ import { Card, CardSpace, CardTextContainer } from './Card';
 import { ElementPlaceholder } from '../../ElementPlaceholder';
 import classed from '../../../lib/classed';
 
-const Text = classed(ElementPlaceholder, 'rounded-xl');
+const Text = classed(ElementPlaceholder, 'rounded-12');
 
 export type PlaceholderCardProps = {
   showImage?: boolean;

--- a/packages/shared/src/components/cards/v1/PostCardFooter.tsx
+++ b/packages/shared/src/components/cards/v1/PostCardFooter.tsx
@@ -29,7 +29,8 @@ export const PostCardFooter = ({
   }
   return (
     <>
-      {/* {!showImage && post.author && (
+      {/* TODO: WT-2007 leaving this here in case it's needed to implement the footers properly
+      {!showImage && post.author && (
         <PostAuthor
           author={post.author}
           className={classNames(
@@ -51,7 +52,8 @@ export const PostCardFooter = ({
         data-testid="postImage"
         {...(isVideoType && { wrapperClassName: 'mt-4' })}
       />
-      {/* {showImage && post.author && (
+      {/* TODO: WT-2007 leaving this here in case it's needed to implement the footers properly
+      {showImage && post.author && (
         <div
           className={classNames(
             'absolute z-1 mt-2 flex w-full items-center rounded-t-xl bg-theme-bg-primary px-3 py-2 font-bold text-theme-label-secondary typo-callout',

--- a/packages/shared/src/components/cards/v1/PostCardFooter.tsx
+++ b/packages/shared/src/components/cards/v1/PostCardFooter.tsx
@@ -1,0 +1,68 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import { CardImage, CardVideoImage } from './Card';
+import { Post, isVideoPost } from '../../../graphql/posts';
+import { cloudinary } from '../../../lib/image';
+
+interface PostCardFooterClassName {
+  image?: string;
+}
+
+type PostCardFooterProps = {
+  insaneMode: boolean;
+  openNewTab: boolean;
+  showImage: boolean;
+  post: Post;
+  className: PostCardFooterClassName;
+};
+
+export const PostCardFooter = ({
+  post,
+  showImage,
+  className,
+}: PostCardFooterProps): ReactElement => {
+  const isVideoType = isVideoPost(post);
+  const ImageComponent = isVideoType ? CardVideoImage : CardImage;
+
+  if (!showImage) {
+    return null;
+  }
+  return (
+    <>
+      {/* {!showImage && post.author && (
+        <PostAuthor
+          author={post.author}
+          className={classNames(
+            'mx-4 mt-2 hidden tablet:flex laptop:hidden',
+            visibleOnGroupHover,
+          )}
+        />
+      )} */}
+      <ImageComponent
+        alt="Post Cover image"
+        src={post.image}
+        fallbackSrc={cloudinary.post.imageCoverPlaceholder}
+        className={classNames(
+          'w-full object-cover',
+          className.image,
+          !isVideoType && 'mt-4',
+        )}
+        loading="lazy"
+        data-testid="postImage"
+        {...(isVideoType && { wrapperClassName: 'mt-4' })}
+      />
+      {/* {showImage && post.author && (
+        <div
+          className={classNames(
+            'absolute z-1 mt-2 flex w-full items-center rounded-t-xl bg-theme-bg-primary px-3 py-2 font-bold text-theme-label-secondary typo-callout',
+            visibleOnGroupHover,
+          )}
+        >
+          <ProfilePicture size="small" user={post.author} />
+          <span className="mx-3 flex-1 truncate">{post.author.name}</span>
+          <FeatherIcon secondary className="text-2xl text-theme-status-help" />
+        </div>
+      )} */}
+    </>
+  );
+};

--- a/packages/shared/src/components/cards/v1/PostCardFooter.tsx
+++ b/packages/shared/src/components/cards/v1/PostCardFooter.tsx
@@ -8,13 +8,13 @@ interface PostCardFooterClassName {
   image?: string;
 }
 
-type PostCardFooterProps = {
+interface PostCardFooterProps {
   insaneMode: boolean;
   openNewTab: boolean;
   showImage: boolean;
   post: Post;
   className: PostCardFooterClassName;
-};
+}
 
 export const PostCardFooter = ({
   post,

--- a/packages/shared/src/components/cards/v1/PostCardHeader.tsx
+++ b/packages/shared/src/components/cards/v1/PostCardHeader.tsx
@@ -1,0 +1,80 @@
+import React, { ReactElement, ReactNode } from 'react';
+import OptionsButton from '../../buttons/OptionsButton';
+import { CardHeader } from './Card';
+import SourceButton from '../SourceButton';
+import { Source } from '../../../graphql/sources';
+import { ReadArticleButton } from '../ReadArticleButton';
+import { getGroupedHoverContainer } from '../common';
+import { useFeedPreviewMode } from '../../../hooks';
+import {
+  Post,
+  getReadPostButtonText,
+  isVideoPost,
+} from '../../../graphql/posts';
+import { ButtonVariant } from '../../buttons/ButtonV2';
+import PostMetadata from './PostMetadata';
+import MenuIcon from '../../icons/Menu';
+
+interface CardHeaderProps {
+  post: Post;
+  className?: string;
+  children?: ReactNode;
+  source: Source;
+  onMenuClick?: (e: React.MouseEvent) => void;
+  onReadArticleClick?: (e: React.MouseEvent) => unknown;
+  postLink: string;
+  openNewTab?: boolean;
+}
+
+const Container = getGroupedHoverContainer('span');
+
+export const PostCardHeader = ({
+  post,
+  className,
+  onMenuClick,
+  onReadArticleClick,
+  children,
+  source,
+  postLink,
+  openNewTab,
+}: CardHeaderProps): ReactElement => {
+  const isFeedPreview = useFeedPreviewMode();
+  const isVideoType = isVideoPost(post);
+
+  return (
+    <CardHeader className={className}>
+      <SourceButton size="large" source={source} />
+      <PostMetadata
+        className="ml-4"
+        createdAt={post.createdAt}
+        readTime={post.readTime}
+        author={post.author}
+        source={post.source}
+        isVideoType={isVideoType}
+      />
+      {children}
+      <Container
+        className="relative ml-auto flex flex-row"
+        data-testid="cardHeaderActions"
+      >
+        {!isFeedPreview && (
+          <>
+            <ReadArticleButton
+              content={getReadPostButtonText(post)}
+              className="mr-2"
+              variant={ButtonVariant.Primary}
+              href={postLink}
+              onClick={onReadArticleClick}
+              openNewTab={openNewTab}
+            />
+            <OptionsButton
+              icon={<MenuIcon className="rotate-90" />}
+              onClick={onMenuClick}
+              tooltipPlacement="top"
+            />
+          </>
+        )}
+      </Container>
+    </CardHeader>
+  );
+};

--- a/packages/shared/src/components/cards/v1/PostMetadata.tsx
+++ b/packages/shared/src/components/cards/v1/PostMetadata.tsx
@@ -55,7 +55,8 @@ export default function PostMetadata({
         )}
         {!!createdAt && showReadTime && <Separator />}
         {!!createdAt && <time dateTime={createdAt}>{date}</time>}
-        {/* {(!!createdAt || showReadTime) && !!numUpvotes && <Separator />}
+        {/* TODO: WT-2005 leaving this here in case it's needed to implement the footers properly
+        {(!!createdAt || showReadTime) && !!numUpvotes && <Separator />}
       {!!numUpvotes && (
         <span data-testid="numUpvotes">
           {numUpvotes} upvote{numUpvotes > 1 ? 's' : ''}

--- a/packages/shared/src/components/cards/v1/PostMetadata.tsx
+++ b/packages/shared/src/components/cards/v1/PostMetadata.tsx
@@ -1,0 +1,68 @@
+import React, { ReactElement, ReactNode, useMemo } from 'react';
+import classNames from 'classnames';
+import { postDateFormat } from '../../../lib/dateFormat';
+import { Separator } from '../common';
+import { Post } from '../../../graphql/posts';
+import { formatReadTime } from '../../utilities';
+
+interface PostMetadataProps
+  extends Pick<
+    Post,
+    'createdAt' | 'readTime' | 'numUpvotes' | 'author' | 'source'
+  > {
+  className?: string;
+  description?: string;
+  children?: ReactNode;
+  isVideoType?: boolean;
+  insaneMode?: boolean;
+}
+
+const getAuthor = (author?: Post['author'], source?: Post['source']) => {
+  if (!author) {
+    return source?.name;
+  }
+  return author.name;
+};
+
+export default function PostMetadata({
+  createdAt,
+  author,
+  source,
+  readTime,
+  className,
+  children,
+  isVideoType,
+}: PostMetadataProps): ReactElement {
+  const date = useMemo(
+    () => createdAt && postDateFormat(createdAt),
+    [createdAt],
+  );
+
+  const timeActionContent = isVideoType ? 'watch' : 'read';
+  const showReadTime = isVideoType ? Number.isInteger(readTime) : !!readTime;
+  const authorLabel = getAuthor(author, source);
+
+  return (
+    <div className={classNames('grid items-center gap-1', className)}>
+      {authorLabel && (
+        <div className="font-bold typo-footnote">{authorLabel}</div>
+      )}
+      <div className="flex items-center text-theme-label-tertiary typo-footnote">
+        {showReadTime && (
+          <span data-testid="readTime">
+            {formatReadTime(readTime)} {timeActionContent} time
+          </span>
+        )}
+        {!!createdAt && showReadTime && <Separator />}
+        {!!createdAt && <time dateTime={createdAt}>{date}</time>}
+        {/* {(!!createdAt || showReadTime) && !!numUpvotes && <Separator />}
+      {!!numUpvotes && (
+        <span data-testid="numUpvotes">
+          {numUpvotes} upvote{numUpvotes > 1 ? 's' : ''}
+        </span>
+      )} */}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/shared/src/components/cards/v1/RaisedLabel.tsx
+++ b/packages/shared/src/components/cards/v1/RaisedLabel.tsx
@@ -1,0 +1,55 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import { SimpleTooltip } from '../../tooltips/SimpleTooltip';
+import classed from '../../../lib/classed';
+
+export enum RaisedLabelType {
+  Hot = 'Hot',
+  Pinned = 'Pinned',
+  Beta = 'Beta',
+}
+
+const typeToClassName: Record<RaisedLabelType, string> = {
+  [RaisedLabelType.Hot]: 'bg-theme-status-error',
+  [RaisedLabelType.Pinned]: 'bg-theme-bg-bun',
+  [RaisedLabelType.Beta]: 'bg-cabbage-40',
+};
+
+export interface RaisedLabelProps {
+  type: RaisedLabelType;
+  description?: string;
+  className?: string | undefined;
+}
+
+const Spacer = classed(
+  'div',
+  'mt-[7px] w-2 h-1 bg-theme-bg-primary  group-hover:bg-theme-bg-secondary group-focus:bg-theme-bg-secondary group-focus:mt-1.5',
+);
+
+export function RaisedLabel({
+  type = RaisedLabelType.Hot,
+  description,
+  className,
+}: RaisedLabelProps): ReactElement {
+  return (
+    <div
+      className={classNames(
+        'absolute -top-2 right-2 flex flex-row px-2',
+        className,
+      )}
+    >
+      <Spacer />
+      <SimpleTooltip content={description}>
+        <div
+          className={classNames(
+            'h-4 rounded-sm px-2 font-bold uppercase text-white typo-caption2',
+            typeToClassName[type],
+          )}
+        >
+          {type}
+        </div>
+      </SimpleTooltip>
+      <Spacer />
+    </div>
+  );
+}

--- a/packages/shared/src/components/cards/v1/RaisedLabel.tsx
+++ b/packages/shared/src/components/cards/v1/RaisedLabel.tsx
@@ -31,7 +31,7 @@ export function RaisedLabel({
     <div
       className={classNames(
         'absolute right-2 flex flex-row px-2 group-hover:bg-theme-bg-secondary group-focus:-top-0.5 group-focus:bg-theme-bg-secondary',
-        !focus && '-top-[1px] bg-theme-bg-primary',
+        !focus && '-top-px bg-theme-bg-primary',
         focus && '-top-0.5 bg-theme-bg-secondary',
         className,
       )}
@@ -39,7 +39,7 @@ export function RaisedLabel({
       <SimpleTooltip content={description}>
         <div
           className={classNames(
-            'relative -top-2 h-4 rounded-sm px-2 font-bold uppercase text-white typo-caption2',
+            'relative -top-2 h-4 rounded px-2 font-bold uppercase text-white typo-caption2',
             typeToClassName[type],
           )}
         >

--- a/packages/shared/src/components/cards/v1/RaisedLabel.tsx
+++ b/packages/shared/src/components/cards/v1/RaisedLabel.tsx
@@ -12,7 +12,7 @@ export enum RaisedLabelType {
 const typeToClassName: Record<RaisedLabelType, string> = {
   [RaisedLabelType.Hot]: 'bg-theme-status-error',
   [RaisedLabelType.Pinned]: 'bg-theme-bg-bun',
-  [RaisedLabelType.Beta]: 'bg-cabbage-40',
+  [RaisedLabelType.Beta]: 'bg-theme-bg-cabbage',
 };
 
 export interface RaisedLabelProps {

--- a/packages/shared/src/components/cards/v1/RaisedLabel.tsx
+++ b/packages/shared/src/components/cards/v1/RaisedLabel.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import { SimpleTooltip } from '../../tooltips/SimpleTooltip';
-import classed from '../../../lib/classed';
 
 export enum RaisedLabelType {
   Hot = 'Hot',
@@ -19,17 +18,21 @@ export interface RaisedLabelProps {
   type: RaisedLabelType;
   description?: string;
   className?: string | undefined;
+  focus?: boolean;
 }
 
 export function RaisedLabel({
   type = RaisedLabelType.Hot,
   description,
   className,
+  focus = false,
 }: RaisedLabelProps): ReactElement {
   return (
     <div
       className={classNames(
-        'absolute -top-[1px] right-2 flex flex-row px-2 bg-theme-bg-primary group-hover:bg-theme-bg-secondary group-focus:bg-theme-bg-secondary group-focus:-top-0.5',
+        'absolute right-2 flex flex-row px-2 group-hover:bg-theme-bg-secondary group-focus:-top-0.5 group-focus:bg-theme-bg-secondary',
+        !focus && '-top-[1px] bg-theme-bg-primary',
+        focus && '-top-0.5 bg-theme-bg-secondary',
         className,
       )}
     >

--- a/packages/shared/src/components/cards/v1/RaisedLabel.tsx
+++ b/packages/shared/src/components/cards/v1/RaisedLabel.tsx
@@ -21,11 +21,6 @@ export interface RaisedLabelProps {
   className?: string | undefined;
 }
 
-const Spacer = classed(
-  'div',
-  'mt-[7px] w-2 h-1 bg-theme-bg-primary  group-hover:bg-theme-bg-secondary group-focus:bg-theme-bg-secondary group-focus:mt-1.5',
-);
-
 export function RaisedLabel({
   type = RaisedLabelType.Hot,
   description,
@@ -34,22 +29,20 @@ export function RaisedLabel({
   return (
     <div
       className={classNames(
-        'absolute -top-2 right-2 flex flex-row px-2',
+        'absolute -top-[1px] right-2 flex flex-row px-2 bg-theme-bg-primary group-hover:bg-theme-bg-secondary group-focus:bg-theme-bg-secondary group-focus:-top-0.5',
         className,
       )}
     >
-      <Spacer />
       <SimpleTooltip content={description}>
         <div
           className={classNames(
-            'h-4 rounded-sm px-2 font-bold uppercase text-white typo-caption2',
+            'relative -top-2 h-4 rounded-sm px-2 font-bold uppercase text-white typo-caption2',
             typeToClassName[type],
           )}
         >
           {type}
         </div>
       </SimpleTooltip>
-      <Spacer />
     </div>
   );
 }

--- a/packages/shared/src/components/cards/v1/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/SharePostCard.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, ReactElement, Ref, useRef, useState } from 'react';
-import { CardButton, getPostClassNames } from '../Card';
+import { CardButton } from './Card';
 import ActionButtons from './ActionButtons';
 import { SharedPostText } from '../SharedPostText';
 import { SharedPostCardFooter } from '../SharedPostCardFooter';
@@ -44,19 +44,16 @@ export const SharePostCard = forwardRef(function SharePostCard(
     <FeedItemContainer
       domProps={{
         ...domProps,
-        className: getPostClassNames(
-          post,
-          domProps.className,
-          'min-h-card max-h-card',
-        ),
+        className: domProps.className,
       }}
       ref={ref}
       flagProps={{ pinnedAt, trending, type }}
+      link={
+        !isFeedPreview && (
+          <CardButton title={post.title} onClick={onPostCardClick} />
+        )
+      }
     >
-      {!isFeedPreview && (
-        <CardButton title={post.title} onClick={onPostCardClick} />
-      )}
-
       <OptionsButton
         className="absolute right-2 top-2 group-hover:flex laptop:hidden"
         onClick={(event) => onMenuClick?.(event, post)}

--- a/packages/shared/src/components/cards/v1/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/SharePostCard.tsx
@@ -1,5 +1,4 @@
 import React, { forwardRef, ReactElement, Ref, useRef, useState } from 'react';
-import { CardButton } from './Card';
 import ActionButtons from './ActionButtons';
 import { SharedPostText } from '../SharedPostText';
 import { SharedPostCardFooter } from '../SharedPostCardFooter';
@@ -48,10 +47,12 @@ export const SharePostCard = forwardRef(function SharePostCard(
       }}
       ref={ref}
       flagProps={{ pinnedAt, trending, type }}
-      link={
-        !isFeedPreview && (
-          <CardButton title={post.title} onClick={onPostCardClick} />
-        )
+      linkProps={
+        !isFeedPreview && {
+          title: post.title,
+          onClick: onPostCardClick,
+          href: post.commentsPermalink,
+        }
       }
     >
       <OptionsButton

--- a/packages/shared/src/components/cards/v1/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/SharePostCard.tsx
@@ -1,0 +1,95 @@
+import React, { forwardRef, ReactElement, Ref, useRef, useState } from 'react';
+import { CardButton, getPostClassNames } from '../Card';
+import ActionButtons from './ActionButtons';
+import { SharedPostText } from '../SharedPostText';
+import { SharedPostCardFooter } from '../SharedPostCardFooter';
+import { Container, PostCardProps } from '../common';
+import OptionsButton from '../../buttons/OptionsButton';
+import FeedItemContainer from './FeedItemContainer';
+import { useFeedPreviewMode } from '../../../hooks';
+import { isVideoPost } from '../../../graphql/posts';
+import { SquadPostCardHeader } from '../common/SquadPostCardHeader';
+
+export const SharePostCard = forwardRef(function SharePostCard(
+  {
+    post,
+    onPostClick,
+    onUpvoteClick,
+    onCommentClick,
+    onMenuClick,
+    onShareClick,
+    onBookmarkClick,
+    openNewTab,
+    children,
+    onReadArticleClick,
+    enableSourceHeader = false,
+    domProps = {},
+  }: PostCardProps,
+  ref: Ref<HTMLElement>,
+): ReactElement {
+  const { pinnedAt, trending, type } = post;
+  const onPostCardClick = () => onPostClick(post);
+  const [isSharedPostShort, setSharedPostShort] = useState(true);
+  const containerRef = useRef<HTMLDivElement>();
+  const onSharedPostTextHeightChange = (height: number) => {
+    if (!containerRef.current) {
+      return;
+    }
+    setSharedPostShort(containerRef.current.offsetHeight - height < 40);
+  };
+  const isFeedPreview = useFeedPreviewMode();
+  const isVideoType = isVideoPost(post);
+
+  return (
+    <FeedItemContainer
+      domProps={{
+        ...domProps,
+        className: getPostClassNames(
+          post,
+          domProps.className,
+          'min-h-card max-h-card',
+        ),
+      }}
+      ref={ref}
+      flagProps={{ pinnedAt, trending, type }}
+    >
+      {!isFeedPreview && (
+        <CardButton title={post.title} onClick={onPostCardClick} />
+      )}
+
+      <OptionsButton
+        className="absolute right-2 top-2 group-hover:flex laptop:hidden"
+        onClick={(event) => onMenuClick?.(event, post)}
+        tooltipPlacement="top"
+      />
+      <SquadPostCardHeader
+        author={post.author}
+        source={post.source}
+        createdAt={post.createdAt}
+        enableSourceHeader={enableSourceHeader}
+      />
+      <SharedPostText
+        title={post.title}
+        onHeightChange={onSharedPostTextHeightChange}
+      />
+      <Container ref={containerRef} className="min-h-0 justify-end">
+        <SharedPostCardFooter
+          sharedPost={post.sharedPost}
+          isShort={isSharedPostShort}
+          isVideoType={isVideoType}
+        />
+        <ActionButtons
+          openNewTab={openNewTab}
+          post={post}
+          onUpvoteClick={onUpvoteClick}
+          onCommentClick={onCommentClick}
+          onShareClick={onShareClick}
+          onBookmarkClick={onBookmarkClick}
+          onMenuClick={(event) => onMenuClick?.(event, post)}
+          onReadArticleClick={onReadArticleClick}
+        />
+      </Container>
+      {children}
+    </FeedItemContainer>
+  );
+});

--- a/packages/shared/src/components/cards/v1/TypeLabel.tsx
+++ b/packages/shared/src/components/cards/v1/TypeLabel.tsx
@@ -1,0 +1,50 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import { PostType } from '../../../graphql/posts';
+
+type TypeLabelType = PostType | ReactElement | string;
+
+const typeToClassName: Record<PostType, string> = {
+  [PostType.Article]: 'text-theme-label-tertiary',
+  [PostType.Collection]: 'text-theme-color-cabbage',
+  [PostType.Freeform]: 'text-theme-label-tertiary',
+  [PostType.Share]: 'text-theme-label-tertiary',
+  [PostType.VideoYouTube]: 'text-theme-color-blueCheese',
+  [PostType.Welcome]: 'text-theme-label-tertiary',
+};
+
+const typeToLabel = {
+  [PostType.VideoYouTube]: 'Video',
+};
+
+export interface TypeLabelProps {
+  type: TypeLabelType;
+  className?: string | undefined;
+}
+
+export function TypeLabel({
+  type = PostType.Article,
+  className,
+}: TypeLabelProps): ReactElement {
+  // do not show tag label for these types
+  if (
+    type === PostType.Article ||
+    type === PostType.Freeform ||
+    type === PostType.Share ||
+    type === PostType.Welcome
+  ) {
+    return null;
+  }
+
+  return (
+    <legend
+      className={classNames(
+        'rounded bg-theme-bg-primary px-2 font-bold capitalize typo-caption1 group-hover:bg-theme-bg-secondary group-focus:bg-theme-bg-secondary',
+        typeToClassName[type as PostType] ?? 'text-theme-label-tertiary',
+        className,
+      )}
+    >
+      {typeToLabel[type as PostType] ?? type}
+    </legend>
+  );
+}

--- a/packages/shared/src/components/cards/v1/TypeLabel.tsx
+++ b/packages/shared/src/components/cards/v1/TypeLabel.tsx
@@ -4,18 +4,24 @@ import { PostType } from '../../../graphql/posts';
 
 type TypeLabelType = PostType | ReactElement | string;
 
-const typeToClassName: Record<PostType, string> = {
-  [PostType.Article]: 'text-theme-label-tertiary',
+const typeToClassName: Record<
+  PostType.Collection | PostType.VideoYouTube,
+  string
+> = {
   [PostType.Collection]: 'text-theme-color-cabbage',
-  [PostType.Freeform]: 'text-theme-label-tertiary',
-  [PostType.Share]: 'text-theme-label-tertiary',
   [PostType.VideoYouTube]: 'text-theme-color-blueCheese',
-  [PostType.Welcome]: 'text-theme-label-tertiary',
 };
 
 const typeToLabel = {
   [PostType.VideoYouTube]: 'Video',
 };
+
+const excludedTypes = new Set<PostType>([
+  PostType.Article,
+  PostType.Freeform,
+  PostType.Share,
+  PostType.Welcome,
+]);
 
 export interface TypeLabelProps {
   type: TypeLabelType;
@@ -26,13 +32,8 @@ export function TypeLabel({
   type = PostType.Article,
   className,
 }: TypeLabelProps): ReactElement {
-  // do not show tag label for these types
-  if (
-    type === PostType.Article ||
-    type === PostType.Freeform ||
-    type === PostType.Share ||
-    type === PostType.Welcome
-  ) {
+  // do not show tag label for excluded types
+  if (excludedTypes.has(type as PostType)) {
     return null;
   }
 

--- a/packages/shared/src/components/cards/v1/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/WelcomePostCard.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, ReactElement, Ref, useRef } from 'react';
 import classNames from 'classnames';
-import { CardButton, FreeformCardTitle, getPostClassNames } from '../Card';
+import { CardButton, FreeformCardTitle } from './Card';
 import ActionButtons from './ActionButtons';
 import { Container, generateTitleClamp, PostCardProps } from '../common';
 import OptionsButton from '../../buttons/OptionsButton';
@@ -51,20 +51,19 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
     <FeedItemContainer
       domProps={{
         ...domProps,
-        className: getPostClassNames(
-          post,
+        className: classNames(
           domProps.className,
-          'min-h-card',
           shouldShowHighlightPulse && 'highlight-pulse',
         ),
       }}
       ref={ref}
       flagProps={{ pinnedAt, type: postType }}
+      link={
+        !isFeedPreview && (
+          <CardButton title={post.title} onClick={onPostCardClick} />
+        )
+      }
     >
-      {!isFeedPreview && (
-        <CardButton title={post.title} onClick={onPostCardClick} />
-      )}
-
       <OptionsButton
         className="absolute right-2 top-2 group-hover:flex laptop:hidden"
         onClick={(event) => onMenuClick?.(event, post)}

--- a/packages/shared/src/components/cards/v1/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/WelcomePostCard.tsx
@@ -1,0 +1,107 @@
+import React, { forwardRef, ReactElement, Ref, useRef } from 'react';
+import classNames from 'classnames';
+import { CardButton, FreeformCardTitle, getPostClassNames } from '../Card';
+import ActionButtons from './ActionButtons';
+import { Container, generateTitleClamp, PostCardProps } from '../common';
+import OptionsButton from '../../buttons/OptionsButton';
+import { WelcomePostCardFooter } from '../WelcomePostCardFooter';
+import { useSquadChecklist } from '../../../hooks/useSquadChecklist';
+import { Squad } from '../../../graphql/sources';
+import { ActionType } from '../../../graphql/actions';
+import FeedItemContainer from './FeedItemContainer';
+import { PostType } from '../../../graphql/posts';
+import { useFeedPreviewMode } from '../../../hooks';
+import { SquadPostCardHeader } from '../common/SquadPostCardHeader';
+import { usePostImage } from '../../../hooks/post/usePostImage';
+
+export const WelcomePostCard = forwardRef(function SharePostCard(
+  {
+    post,
+    onPostClick,
+    onUpvoteClick,
+    onCommentClick,
+    onMenuClick,
+    onShareClick,
+    onBookmarkClick,
+    openNewTab,
+    children,
+    onReadArticleClick,
+    enableSourceHeader = false,
+    domProps = {},
+  }: PostCardProps,
+  ref: Ref<HTMLElement>,
+): ReactElement {
+  const { pinnedAt, type: postType } = post;
+  const onPostCardClick = () => onPostClick(post);
+  const containerRef = useRef<HTMLDivElement>();
+  const isFeedPreview = useFeedPreviewMode();
+  const image = usePostImage(post);
+  const { openStep, isChecklistVisible } = useSquadChecklist({
+    squad: post.source as Squad,
+  });
+
+  const shouldShowHighlightPulse =
+    postType === PostType.Welcome &&
+    isChecklistVisible &&
+    [ActionType.SquadFirstComment, ActionType.EditWelcomePost].includes(
+      openStep,
+    );
+
+  return (
+    <FeedItemContainer
+      domProps={{
+        ...domProps,
+        className: getPostClassNames(
+          post,
+          domProps.className,
+          'min-h-card',
+          shouldShowHighlightPulse && 'highlight-pulse',
+        ),
+      }}
+      ref={ref}
+      flagProps={{ pinnedAt, type: postType }}
+    >
+      {!isFeedPreview && (
+        <CardButton title={post.title} onClick={onPostCardClick} />
+      )}
+
+      <OptionsButton
+        className="absolute right-2 top-2 group-hover:flex laptop:hidden"
+        onClick={(event) => onMenuClick?.(event, post)}
+        tooltipPlacement="top"
+      />
+      <SquadPostCardHeader
+        author={post.author}
+        source={post.source}
+        createdAt={post.createdAt}
+        enableSourceHeader={enableSourceHeader}
+      />
+      <FreeformCardTitle
+        className={classNames(
+          generateTitleClamp({
+            hasImage: !!image,
+            hasHtmlContent: !!post.contentHtml,
+          }),
+          'px-2 font-bold !text-theme-label-primary typo-title3',
+        )}
+      >
+        {post.title}
+      </FreeformCardTitle>
+      <Container ref={containerRef}>
+        <WelcomePostCardFooter image={image} contentHtml={post.contentHtml} />
+        <ActionButtons
+          openNewTab={openNewTab}
+          post={post}
+          onUpvoteClick={onUpvoteClick}
+          onCommentClick={onCommentClick}
+          onShareClick={onShareClick}
+          onBookmarkClick={onBookmarkClick}
+          onMenuClick={(event) => onMenuClick?.(event, post)}
+          onReadArticleClick={onReadArticleClick}
+          className="mt-auto"
+        />
+      </Container>
+      {children}
+    </FeedItemContainer>
+  );
+});

--- a/packages/shared/src/components/cards/v1/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/WelcomePostCard.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, ReactElement, Ref, useRef } from 'react';
 import classNames from 'classnames';
-import { CardButton, FreeformCardTitle } from './Card';
+import { FreeformCardTitle } from './Card';
 import ActionButtons from './ActionButtons';
 import { Container, generateTitleClamp, PostCardProps } from '../common';
 import OptionsButton from '../../buttons/OptionsButton';
@@ -58,10 +58,12 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
       }}
       ref={ref}
       flagProps={{ pinnedAt, type: postType }}
-      link={
-        !isFeedPreview && (
-          <CardButton title={post.title} onClick={onPostCardClick} />
-        )
+      linkProps={
+        !isFeedPreview && {
+          title: post.title,
+          onClick: onPostCardClick,
+          href: post.commentsPermalink,
+        }
       }
     >
       <OptionsButton

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -75,8 +75,16 @@ const getFeedGapPx = {
   'gap-14': 56,
 };
 
-const gapClass = (isList: boolean, space: Spaciness) =>
-  isList ? listGaps[space] ?? 'gap-2' : gridGaps[space] ?? 'gap-8';
+const gapClass = (
+  isList: boolean,
+  isFeedLayoutV1: boolean,
+  space: Spaciness,
+) => {
+  if (isFeedLayoutV1) {
+    return '';
+  }
+  return isList ? listGaps[space] ?? 'gap-2' : gridGaps[space] ?? 'gap-8';
+};
 
 const cardClass = (isList: boolean, numberOfCards: number): string =>
   isList ? 'grid-cols-1' : cardListClass[numberOfCards];
@@ -124,7 +132,8 @@ export const FeedContainer = ({
   const numCards = currentSettings.numCards[spaciness ?? 'eco'];
   const insaneMode = !forceCardMode && listMode;
   const isList = (insaneMode && numCards > 1) || shouldUseFeedLayoutV1;
-  const feedGapPx = getFeedGapPx[gapClass(isList, spaciness)];
+  const feedGapPx =
+    getFeedGapPx[gapClass(isList, shouldUseFeedLayoutV1, spaciness)];
   const style = {
     '--num-cards': numCards,
     '--feed-gap': `${feedGapPx / 16}rem`,
@@ -266,7 +275,7 @@ export const FeedContainer = ({
               className={classNames(
                 'grid',
                 isV1Search && !shouldUseFeedLayoutV1 && 'mt-8',
-                gapClass(isList, spaciness),
+                gapClass(isList, shouldUseFeedLayoutV1, spaciness),
                 cardClass(isList, numCards),
               )}
             >

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -217,6 +217,7 @@ module.exports = {
       height: {
         logo: '1.125rem',
         'logo-big': '2.0625rem',
+        50: '12.5rem',
       },
     },
     lineClamp: {

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -219,6 +219,9 @@ module.exports = {
         'logo-big': '2.0625rem',
         50: '12.5rem',
       },
+      blur: {
+        20: '1.25rem',
+      }
     },
     lineClamp: {
       1: '1',

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -221,7 +221,7 @@ module.exports = {
       },
       blur: {
         20: '1.25rem',
-      }
+      },
     },
     lineClamp: {
       1: '1',


### PR DESCRIPTION
## Changes

- Added copies of cards and other needed components into `/v1` folder
- Using the copied v1 cards based on type and feed v1 being on in `FeedItemComponent.tsx`
- Added proper borders and spacing around cards
- Changed the header of the card to show the type (for video and collection cards)
- Changed the display of the hot/pinned flag, based on figma designs

### Out of scope

- Please do not focus your review on inner card details. I did some work already (mistakenly), but we do have subtasks to tackle the card contents, the card header and card footer (action buttons).
- The decision to make card copies in another directory was made in the DR.

### Screenshots

<img width="618" alt="Screenshot 2024-01-08 at 14 55 32" src="https://github.com/dailydotdev/apps/assets/9974711/9bc58072-2574-4270-a442-93350e122d3f">
<img width="621" alt="Screenshot 2024-01-08 at 14 52 09" src="https://github.com/dailydotdev/apps/assets/9974711/975cedc1-31d0-4ff1-8a17-e02f348bab48">
<img width="620" alt="Screenshot 2024-01-08 at 14 49 58" src="https://github.com/dailydotdev/apps/assets/9974711/6c51b8bb-b459-4ce1-b697-927ba60b9938">
<img width="615" alt="Screenshot 2024-01-08 at 14 49 28" src="https://github.com/dailydotdev/apps/assets/9974711/ef1481bb-ea3b-4b59-9afe-1d3ca758399f">
<img width="608" alt="Screenshot 2024-01-08 at 14 48 56" src="https://github.com/dailydotdev/apps/assets/9974711/dfd9b260-abaf-495d-8fcb-43f550ca6b0c">
<img width="632" alt="Screenshot 2024-01-08 at 14 43 56" src="https://github.com/dailydotdev/apps/assets/9974711/76a7bbfe-dc9b-429b-aff8-c3950343fb6e">
<img width="615" alt="Screenshot 2024-01-08 at 14 43 43" src="https://github.com/dailydotdev/apps/assets/9974711/adba7837-6a4d-4013-b146-d6aed2579bd3">
<img width="617" alt="Screenshot 2024-01-08 at 14 43 08" src="https://github.com/dailydotdev/apps/assets/9974711/ca207875-9b3d-4e44-ba4a-ffff26795916">

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2004 #done
