### PR TITLE
refactor: feed settings button alert pointer

### DIFF
--- a/packages/shared/src/components/alert/AlertPointer.tsx
+++ b/packages/shared/src/components/alert/AlertPointer.tsx
@@ -18,7 +18,7 @@ interface ClassName {
   label?: string;
 }
 
-type OffsetXY = [number?, number?];
+export type OffsetXY = [number?, number?];
 
 export enum AlertPlacement {
   Top = 'top',


### PR DESCRIPTION
## Changes
- Placement of the alert pointer should depend on the layout/search experiment.

Previews of all the variations:

![Screenshot 2024-01-09 at 7 10 47 PM](https://github.com/dailydotdev/apps/assets/13744167/faa6d0ef-0ab6-4d79-be9d-23ad1ab36061)
![Screenshot 2024-01-09 at 7 10 40 PM](https://github.com/dailydotdev/apps/assets/13744167/fa64d6d7-c1e7-4224-a27f-d2e062fd3111)
![Screenshot 2024-01-09 at 7 10 32 PM](https://github.com/dailydotdev/apps/assets/13744167/38d1b04b-69a9-4614-a432-39f064e14a69)
![Screenshot 2024-01-09 at 7 08 11 PM](https://github.com/dailydotdev/apps/assets/13744167/07ec03bb-d2b1-4173-8cc7-adfae9871de5)
![Screenshot 2024-01-09 at 7 08 04 PM](https://github.com/dailydotdev/apps/assets/13744167/c7e77579-7ffe-47da-9a4e-de75eb894b1f)
![Screenshot 2024-01-09 at 7 07 57 PM](https://github.com/dailydotdev/apps/assets/13744167/4927c752-f2f4-40cc-a79b-25f692cc71d8)
![Screenshot 2024-01-09 at 7 07 41 PM](https://github.com/dailydotdev/apps/assets/13744167/99d91bff-cf81-429c-b515-5758fb994b88)
![Screenshot 2024-01-09 at 7 07 31 PM](https://github.com/dailydotdev/apps/assets/13744167/e0a75fe1-275a-4ac7-833f-977e305c32fa)
![Screenshot 2024-01-09 at 7 07 24 PM](https://github.com/dailydotdev/apps/assets/13744167/9083352f-c7ec-4d52-95c5-44010565f1b0)
![Screenshot 2024-01-09 at 7 06 48 PM](https://github.com/dailydotdev/apps/assets/13744167/42d8dddf-85d0-423f-af3c-5f9ab6d8ea68)
![Screenshot 2024-01-09 at 7 06 37 PM](https://github.com/dailydotdev/apps/assets/13744167/4e16c00b-a58e-4b48-a2b1-ec0f6b090464)
![Screenshot 2024-01-09 at 7 06 25 PM](https://github.com/dailydotdev/apps/assets/13744167/d6c7ec85-177a-4e79-bc2c-e514bc3b682e)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2011 #done
