### PR TITLE
fix: post options menu state

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -90,7 +90,7 @@ export default function PostOptionsMenu({
   const router = useRouter();
   const { user } = useContext(AuthContext);
   const { displayToast } = useToastNotification();
-  const { feedSettings, advancedSettings, checkEnabledSettings } =
+  const { feedSettings, advancedSettings, checkSettingsEnabledState } =
     useFeedSettings({ enabled: isOpen });
   const { onUpdateSettings } = useAdvancedSettings({ enabled: false });
   const { trackEvent } = useContext(AnalyticsContext);
@@ -242,7 +242,7 @@ export default function PostOptionsMenu({
   };
   const video = advancedSettings?.find(({ title }) => title === 'Videos');
   const onToggleVideo = async () => {
-    const isEnabled = checkEnabledSettings(video?.id);
+    const isEnabled = checkSettingsEnabledState(video?.id);
     const icon = isEnabled ? '⛔️' : '✅';
     const label = isEnabled ? 'blocked' : 'unblocked';
     await onUpdateSettings(video.id, !isEnabled);
@@ -320,7 +320,7 @@ export default function PostOptionsMenu({
   ];
 
   if (video && isVideoPost(post)) {
-    const isEnabled = checkEnabledSettings(video.id);
+    const isEnabled = checkSettingsEnabledState(video.id);
     const label = isEnabled ? `Don't show` : 'Show';
     postOptions.push({
       icon: <MenuIcon Icon={isEnabled ? BlockIcon : PlusIcon} />,

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -25,7 +25,7 @@ export interface FeedSettingsReturnType {
   isLoading: boolean;
   hasAnyFilter?: boolean;
   advancedSettings: AdvancedSettings[];
-  checkEnabledSettings(value: number): boolean;
+  checkSettingsEnabledState(value: number): boolean;
 }
 
 export const getHasAnyFilter = (feedSettings: FeedSettings): boolean =>
@@ -54,16 +54,18 @@ export default function useFeedSettings({
   );
 
   const { tagsCategories, feedSettings, advancedSettings } = feedQuery;
-  const checkEnabledSettings = useCallback(
-    (value: number) => {
-      const advancedSetting = advancedSettings?.find(({ id }) => id === value);
+  const checkSettingsEnabledState = useCallback(
+    (idParam: number) => {
+      const advancedSetting = advancedSettings?.find(
+        ({ id }) => id === idParam,
+      );
 
       if (!advancedSettings) {
         return false;
       }
 
       const setting = feedSettings?.advancedSettings?.find(
-        ({ id }) => id === value,
+        ({ id }) => id === idParam,
       );
 
       return setting?.enabled ?? advancedSetting.defaultEnabledState;
@@ -77,6 +79,6 @@ export default function useFeedSettings({
     isLoading,
     advancedSettings,
     hasAnyFilter: getHasAnyFilter(feedSettings),
-    checkEnabledSettings,
+    checkSettingsEnabledState,
   };
 }

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -56,11 +56,9 @@ export default function useFeedSettings({
   const { tagsCategories, feedSettings, advancedSettings } = feedQuery;
   const checkSettingsEnabledState = useCallback(
     (idParam: number) => {
-      const advancedSetting = advancedSettings?.find(
-        ({ id }) => id === idParam,
-      );
+      const advanced = advancedSettings?.find(({ id }) => id === idParam);
 
-      if (!advancedSetting) {
+      if (!advanced) {
         return false;
       }
 
@@ -68,7 +66,7 @@ export default function useFeedSettings({
         ({ id }) => id === idParam,
       );
 
-      return setting?.enabled ?? advancedSetting.defaultEnabledState;
+      return setting?.enabled ?? advanced.defaultEnabledState;
     },
     [advancedSettings, feedSettings],
   );

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -60,7 +60,7 @@ export default function useFeedSettings({
         ({ id }) => id === idParam,
       );
 
-      if (!advancedSettings) {
+      if (!advancedSetting) {
         return false;
       }
 


### PR DESCRIPTION
## Changes
- When viewing a post page, and you try to follow/unfollow certain tags/sources/settings, the values do not update when you do any action.
- In this PR, we now consider the current state of the user's preference to reflect better the actual status.
- Introduced a new settings function to update the value based on the desired state. This was due to a bug encountered were the value is not getting updated after clicking undo (because of the memoized function).

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-2057 #done
