### PR TITLE
refactor: post options menu removing bookmark

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -17,7 +17,7 @@ import useTagAndSource from '../hooks/useTagAndSource';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { postAnalyticsEvent } from '../lib/feed';
 import { MenuIcon } from './MenuIcon';
-import { ToastSubject, useToastNotification } from '../hooks';
+import { ToastSubject, useFeedLayout, useToastNotification } from '../hooks';
 import {
   AllFeedPages,
   generateQueryKey,
@@ -289,6 +289,7 @@ export default function PostOptionsMenu({
     },
   ];
 
+  const { shouldUseFeedLayoutV1 } = useFeedLayout();
   const bookmarkOnCard = useFeature(feature.bookmarkOnCard);
 
   if (!bookmarkOnCard) {
@@ -305,8 +306,8 @@ export default function PostOptionsMenu({
     });
   }
 
-  postOptions.push(
-    {
+  if (shouldUseFeedLayoutV1) {
+    postOptions.push({
       icon: (
         <MenuIcon
           className={classNames(
@@ -319,15 +320,16 @@ export default function PostOptionsMenu({
       ),
       label: 'Downvote',
       action: onToggleDownvotePost,
-    },
-    {
-      icon: <MenuIcon Icon={BlockIcon} />,
-      label: isSourceBlocked
-        ? `Show posts from ${post?.source?.name}`
-        : `Don't show posts from ${post?.source?.name}`,
-      action: isSourceBlocked ? onUnblockSource : onBlockSource,
-    },
-  );
+    });
+  }
+
+  postOptions.push({
+    icon: <MenuIcon Icon={BlockIcon} />,
+    label: isSourceBlocked
+      ? `Show posts from ${post?.source?.name}`
+      : `Don't show posts from ${post?.source?.name}`,
+    action: isSourceBlocked ? onUnblockSource : onBlockSource,
+  });
 
   if (video && isVideoPost(post)) {
     const isEnabled = checkSettingsEnabledState(video.id);

--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -46,6 +46,8 @@ import {
 import { ActiveFeedContext } from '../contexts';
 import { useAdvancedSettings } from '../hooks/feed';
 import PlusIcon from './icons/Plus';
+import { useFeature } from './GrowthBookProvider';
+import { feature } from '../lib/featureManagement';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ './fields/PortalMenu'),
@@ -285,7 +287,12 @@ export default function PostOptionsMenu({
       label: 'Hide',
       action: onHidePost,
     },
-    {
+  ];
+
+  const bookmarkOnCard = useFeature(feature.bookmarkOnCard);
+
+  if (!bookmarkOnCard) {
+    postOptions.push({
       icon: (
         <MenuIcon
           secondary={post?.bookmarked}
@@ -295,7 +302,10 @@ export default function PostOptionsMenu({
       ),
       label: `${post?.bookmarked ? 'Remove from' : 'Save to'} bookmarks`,
       action: onToggleBookmark,
-    },
+    });
+  }
+
+  postOptions.push(
     {
       icon: (
         <MenuIcon
@@ -317,7 +327,7 @@ export default function PostOptionsMenu({
         : `Don't show posts from ${post?.source?.name}`,
       action: isSourceBlocked ? onUnblockSource : onBlockSource,
     },
-  ];
+  );
 
   if (video && isVideoPost(post)) {
     const isEnabled = checkSettingsEnabledState(video.id);

--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -292,7 +292,7 @@ export default function PostOptionsMenu({
   const { shouldUseFeedLayoutV1 } = useFeedLayout();
   const bookmarkOnCard = useFeature(feature.bookmarkOnCard);
 
-  if (!bookmarkOnCard) {
+  if (!bookmarkOnCard && !shouldUseFeedLayoutV1) {
     postOptions.push({
       icon: (
         <MenuIcon
@@ -306,7 +306,7 @@ export default function PostOptionsMenu({
     });
   }
 
-  if (shouldUseFeedLayoutV1) {
+  if (!shouldUseFeedLayoutV1) {
     postOptions.push({
       icon: (
         <MenuIcon

--- a/packages/shared/src/components/ShareOptionsMenu.tsx
+++ b/packages/shared/src/components/ShareOptionsMenu.tsx
@@ -12,6 +12,9 @@ import { Origin } from '../lib/analytics';
 import { ShareProvider } from '../lib/share';
 import { useCopyPostLink } from '../hooks/useCopyPostLink';
 import LinkIcon from './icons/Link';
+import { useFeature } from './GrowthBookProvider';
+import { feature } from '../lib/featureManagement';
+import { useFeedLayout } from '../hooks';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ './fields/PortalMenu'),
@@ -53,13 +56,20 @@ export default function ShareOptionsMenu({
     copyLink();
     onClick(ShareProvider.CopyLink);
   };
+
+  const bookmarkOnCard = useFeature(feature.bookmarkOnCard);
+  const { shouldUseFeedLayoutV1 } = useFeedLayout();
+
   const shareOptions: ShareOption[] = [
     {
       icon: <MenuIcon Icon={ShareIcon} />,
       text: 'Share post via...',
       action: () => onShare(post),
     },
-    {
+  ];
+
+  if (!bookmarkOnCard && !shouldUseFeedLayoutV1) {
+    shareOptions.push({
       icon: (
         <MenuIcon
           secondary={post?.bookmarked}
@@ -69,13 +79,14 @@ export default function ShareOptionsMenu({
       ),
       text: `${post?.bookmarked ? 'Remove from' : 'Save to'} bookmarks`,
       action: onBookmark,
-    },
-    {
-      icon: <MenuIcon Icon={LinkIcon} />,
-      text: 'Copy link to post',
-      action: trackAndCopyLink,
-    },
-  ];
+    });
+  }
+
+  shareOptions.push({
+    icon: <MenuIcon Icon={LinkIcon} />,
+    text: 'Copy link to post',
+    action: trackAndCopyLink,
+  });
 
   return (
     <PortalMenu

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -11,8 +11,6 @@ import { useFeedPreviewMode } from '../../../hooks';
 import BookmarkIcon from '../../icons/Bookmark';
 import DownvoteIcon from '../../icons/Downvote';
 import { ActionButtonsProps } from '../ActionButtons';
-import { useFeature } from '../../GrowthBookProvider';
-import { feature } from '../../../lib/featureManagement';
 
 const ShareIcon = dynamic(
   () => import(/* webpackChunkName: "shareIcon" */ '../../icons/Share'),
@@ -53,7 +51,6 @@ export default function ActionButtons({
   className,
 }: ActionButtonsPropsV1): ReactElement {
   const isFeedPreview = useFeedPreviewMode();
-  const bookmarkOnCard = useFeature(feature.bookmarkOnCard);
 
   if (isFeedPreview) {
     return null;
@@ -128,21 +125,17 @@ export default function ActionButtons({
           />
         </Button>
       </SimpleTooltip>
-      {bookmarkOnCard && (
-        <SimpleTooltip
-          content={post.bookmarked ? 'Remove bookmark' : 'Bookmark'}
-        >
-          <Button
-            id={`post-${post.id}-bookmark-btn`}
-            className="ml-2"
-            icon={<BookmarkIcon secondary={post.bookmarked} />}
-            onClick={() => onBookmarkClick(post)}
-            color={ButtonColor.Bun}
-            pressed={post.bookmarked}
-            variant={ButtonVariant.Float}
-          />
-        </SimpleTooltip>
-      )}
+      <SimpleTooltip content={post.bookmarked ? 'Remove bookmark' : 'Bookmark'}>
+        <Button
+          id={`post-${post.id}-bookmark-btn`}
+          className="ml-2"
+          icon={<BookmarkIcon secondary={post.bookmarked} />}
+          onClick={() => onBookmarkClick(post)}
+          color={ButtonColor.Bun}
+          pressed={post.bookmarked}
+          variant={ButtonVariant.Float}
+        />
+      </SimpleTooltip>
       {shareButton}
     </div>
   );

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -11,6 +11,8 @@ import { useFeedPreviewMode } from '../../../hooks';
 import BookmarkIcon from '../../icons/Bookmark';
 import DownvoteIcon from '../../icons/Downvote';
 import { ActionButtonsProps } from '../ActionButtons';
+import { useFeature } from '../../GrowthBookProvider';
+import { feature } from '../../../lib/featureManagement';
 
 const ShareIcon = dynamic(
   () => import(/* webpackChunkName: "shareIcon" */ '../../icons/Share'),
@@ -51,6 +53,7 @@ export default function ActionButtons({
   className,
 }: ActionButtonsPropsV1): ReactElement {
   const isFeedPreview = useFeedPreviewMode();
+  const bookmarkOnCard = useFeature(feature.bookmarkOnCard);
 
   if (isFeedPreview) {
     return null;
@@ -125,17 +128,21 @@ export default function ActionButtons({
           />
         </Button>
       </SimpleTooltip>
-      <SimpleTooltip content={post.bookmarked ? 'Remove bookmark' : 'Bookmark'}>
-        <Button
-          id={`post-${post.id}-bookmark-btn`}
-          className="ml-2"
-          icon={<BookmarkIcon secondary={post.bookmarked} />}
-          onClick={() => onBookmarkClick(post)}
-          color={ButtonColor.Bun}
-          pressed={post.bookmarked}
-          variant={ButtonVariant.Float}
-        />
-      </SimpleTooltip>
+      {bookmarkOnCard && (
+        <SimpleTooltip
+          content={post.bookmarked ? 'Remove bookmark' : 'Bookmark'}
+        >
+          <Button
+            id={`post-${post.id}-bookmark-btn`}
+            className="ml-2"
+            icon={<BookmarkIcon secondary={post.bookmarked} />}
+            onClick={() => onBookmarkClick(post)}
+            color={ButtonColor.Bun}
+            pressed={post.bookmarked}
+            variant={ButtonVariant.Float}
+          />
+        </SimpleTooltip>
+      )}
       {shareButton}
     </div>
   );


### PR DESCRIPTION
## Changes
- Bookmark on card should be based on the experiment not on the feed layout.
- For the post options menu, it should be the same.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-20 #done
