### PR TITLE
fix: header button back to plain element

### DIFF
--- a/packages/shared/src/components/referral/SearchReferralButton.tsx
+++ b/packages/shared/src/components/referral/SearchReferralButton.tsx
@@ -9,7 +9,6 @@ import { KeyReferralIcon } from '../icons';
 import { IconSize } from '../Icon';
 import { useAnalyticsContext } from '../../contexts/AnalyticsContext';
 import { AnalyticsEvent, TargetId, TargetType } from '../../lib/analytics';
-import { Button, ButtonVariant } from '../buttons/ButtonV2';
 
 interface SearchReferralButtonProps {
   className?: string;
@@ -40,14 +39,16 @@ export function SearchReferralButton({
   }
 
   return (
-    <Button
+    <button
       type="button"
-      variant={ButtonVariant.Float}
-      className={classNames('bg-theme-overlay-from', className)}
+      className={classNames(
+        'flex h-10 flex-row items-center rounded-12 bg-theme-overlay-from px-3 font-bold text-theme-label-tertiary typo-callout hover:text-theme-label-primary',
+        className,
+      )}
       onClick={handleClick}
     >
       {availableCount}
       <KeyReferralIcon size={IconSize.Medium} className="-mr-1 ml-1 mt-1" />
-    </Button>
+    </button>
   );
 }


### PR DESCRIPTION
## Changes
- As mentioned in the Slack, we are moving back to using a plain `button` element rather than our `Button` element. However, it can be argued that can probably just override the x-padding.

Preview:
![Screenshot 2024-01-12 at 12 55 12 PM](https://github.com/dailydotdev/apps/assets/13744167/46d52c4b-236d-439f-930d-1b211e3caacd)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-1 #done
