### PR TITLE
fix: unwanted right border on safari

### DIFF
--- a/packages/shared/src/components/post/PostContentContainer.tsx
+++ b/packages/shared/src/components/post/PostContentContainer.tsx
@@ -11,7 +11,7 @@ const BodyContainer = classed('div', 'flex flex-col w-full pb-6');
 
 const PageBodyContainer = classed(
   BodyContainer,
-  'm-auto w-full laptop:border-l laptop:border-theme-divider-tertiary',
+  'm-auto w-full laptop:border-l laptop:border-r laptop:border-theme-divider-tertiary',
 );
 
 function PostContentContainer({

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -109,7 +109,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     options: { initialData, retry: false },
   });
   const containerClass = classNames(
-    'max-w-screen-laptop border-r pb-20 laptop:min-h-page laptop:pb-6 laptopL:pb-0',
+    'max-w-screen-laptop pb-20 laptop:min-h-page laptop:pb-6 laptopL:pb-0',
     [PostType.Share, PostType.Welcome, PostType.Freeform].includes(
       post?.type,
     ) &&


### PR DESCRIPTION
## Changes
- The border seems to be intended for laptop, but since the laptop pseudo was applied on the color instead of the border width, there is a primary border but only on safari.
- Moved the borders classes in a single place to avoid confusion on where things are coming from.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-64 #done
