### PR TITLE
fix: button when value is 0

### DIFF
--- a/packages/shared/src/components/buttons/ButtonV2.tsx
+++ b/packages/shared/src/components/buttons/ButtonV2.tsx
@@ -21,6 +21,7 @@ import {
   VariantColorToClassName,
   VariantToClassName,
 } from './common';
+import { isNullOrUndefined } from '../../lib/func';
 
 export type IconType = React.ReactElement<IconProps>;
 
@@ -76,7 +77,7 @@ function ButtonComponent<TagName extends AllowedTags>(
   }: ButtonProps<TagName>,
   ref?: Ref<ButtonElementType<TagName>>,
 ): ReactElement {
-  const iconOnly = icon && !children;
+  const iconOnly = icon && isNullOrUndefined(children);
   const getIconWithSize = useGetIconWithSize(size, iconOnly, iconPosition);
   const isAnchor = Tag === 'a';
 


### PR DESCRIPTION
## Changes
- When the value is 0, it is considered falsy, the button thinks it should be an icon-only render.

Before:
![Screenshot 2024-01-12 at 9 01 58 PM](https://github.com/dailydotdev/apps/assets/13744167/59473387-ae00-45d3-8f62-10af8aaac44f)

After:
![Screenshot 2024-01-12 at 9 05 46 PM](https://github.com/dailydotdev/apps/assets/13744167/b9f48eb8-8382-4767-affc-05db9f0e075f)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
