### PR TITLE
fix: collection pills break layout when collection button is hovered

### DIFF
--- a/packages/shared/src/components/post/collection/CollectionPillSources.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPillSources.tsx
@@ -34,7 +34,7 @@ export const CollectionPillSources = ({
           {sources.map((source) => (
             <SourceAvatar
               className={classNames(
-                '!mr-0 box-content border-2 border-theme-bg-primary',
+                '!mr-0 -my-0.5 box-content border-2 border-theme-bg-primary',
                 className.avatar,
               )}
               key={source.handle}

--- a/packages/shared/src/components/post/collection/CollectionPillSources.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPillSources.tsx
@@ -34,7 +34,7 @@ export const CollectionPillSources = ({
           {sources.map((source) => (
             <SourceAvatar
               className={classNames(
-                '!mr-0 -my-0.5 box-content border-2 border-theme-bg-primary',
+                '-my-0.5 !mr-0 box-content border-2 border-theme-bg-primary',
                 className.avatar,
               )}
               key={source.handle}


### PR DESCRIPTION
## Changes

Added negative margin to collection pills to make sure the container stays at 32px size

### Screenshot

<img width="310" alt="Screenshot 2024-01-15 at 17 34 40" src="https://github.com/dailydotdev/apps/assets/9974711/c54eb2b5-6247-4d8b-82c7-5d0dfccb9c21">

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-83 #done
