### PR TITLE
fix: checkbox font weight

### DIFF
--- a/packages/shared/src/components/fields/Checkbox.tsx
+++ b/packages/shared/src/components/fields/Checkbox.tsx
@@ -48,7 +48,7 @@ export const Checkbox = forwardRef(function Checkbox(
   return (
     <label
       className={classNames(
-        'relative z-1 inline-flex cursor-pointer select-none items-center p-1 pr-3 font-bold text-theme-label-tertiary typo-footnote',
+        'relative z-1 inline-flex cursor-pointer select-none items-center p-1 pr-3 text-theme-label-tertiary typo-footnote',
         styles.label,
         className,
         { checked: actualChecked, disabled },


### PR DESCRIPTION
## Changes
- From the discussion, Checkboxes should now have a normal font-weight.

Reference: https://dailydotdev.slack.com/archives/C05TQL6HWTH/p1705395060244609

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
