### PR TITLE
fix: CollectionPillSources className prop treated as an object

### DIFF
--- a/packages/shared/src/components/post/collection/CollectionPillSources.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPillSources.tsx
@@ -22,7 +22,7 @@ export const CollectionPillSources = ({
   const hasSources = !!sources?.length;
 
   return (
-    <div className={classNames(className, 'relative flex flex-row')}>
+    <div className={classNames(className?.main, 'relative flex flex-row')}>
       {hasSources && (
         <ProfilePictureGroup
           className={classNames({
@@ -35,7 +35,7 @@ export const CollectionPillSources = ({
             <SourceAvatar
               className={classNames(
                 '-my-0.5 !mr-0 box-content border-2 border-theme-bg-primary',
-                className.avatar,
+                className?.avatar,
               )}
               key={source.handle}
               source={source}


### PR DESCRIPTION
## Changes

Fixes bad implementation from before, where `className` prop was changed from a string to an object, but not all usages of the prop where refactored.

Also fixes an edge case when accessing fields of the `className` object, which could be potentially `undefined`.

This broke the visuals, because margins were not applied properly.

### Screenshot

Before fix:
<img width="305" alt="Screenshot 2024-01-16 at 13 29 29" src="https://github.com/dailydotdev/apps/assets/9974711/5e5fd166-ed9c-4fef-94dc-e41dda657f5e">
<img width="311" alt="Screenshot 2024-01-16 at 13 29 18" src="https://github.com/dailydotdev/apps/assets/9974711/f6159953-db16-4fef-bdeb-40c37926008d">


After fix:
<img width="326" alt="Screenshot 2024-01-16 at 13 19 38" src="https://github.com/dailydotdev/apps/assets/9974711/05121292-8009-4a0e-97d2-812d7a740d2e">
<img width="312" alt="Screenshot 2024-01-16 at 13 19 54" src="https://github.com/dailydotdev/apps/assets/9974711/71317ccb-a913-4b24-9d92-88d072b6b1fc">


### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-84 #done
