### PR TITLE
feat: add feedback CTA loop from post page for feed layout v1

### DIFF
--- a/packages/shared/src/hooks/useFeatureFeedLayoutV1.ts
+++ b/packages/shared/src/hooks/useFeatureFeedLayoutV1.ts
@@ -1,0 +1,8 @@
+import { useFeature } from '../components/GrowthBookProvider';
+import { feature } from '../lib/featureManagement';
+import { FeedLayout } from '../lib/featureValues';
+
+export const useFeatureFeedLayoutV1 = (): boolean => {
+  const feedLayoutVersion = useFeature(feature.feedLayout);
+  return feedLayoutVersion === FeedLayout.V1;
+};

--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -1,10 +1,8 @@
 import { useMemo } from 'react';
-import { useFeature } from '../components/GrowthBookProvider';
-import { feature } from '../lib/featureManagement';
-import { FeedLayout } from '../lib/featureValues';
 import { SharedFeedPage } from '../components/utilities';
 import { AllFeedPages } from '../lib/query';
 import { useActiveFeedNameContext } from '../contexts';
+import { useFeatureFeedLayoutV1 } from './useFeatureFeedLayoutV1';
 
 interface UseFeedLayoutProps {
   feedName?: AllFeedPages;
@@ -28,8 +26,7 @@ export const useFeedLayout = ({
 }: UseFeedLayoutProps = {}): UseFeedLayout => {
   const { feedName } = useActiveFeedNameContext();
   const name = (feedNameProp ?? feedName) as SharedFeedPage;
-  const feedLayoutVersion = useFeature(feature.feedLayout);
-  const isV1 = feedLayoutVersion === FeedLayout.V1;
+  const isV1 = useFeatureFeedLayoutV1();
   const isIncludedFeed = useMemo(
     () => checkShouldUseFeedLayoutV1(name),
     [name],

--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -14,10 +14,14 @@ interface UseFeedLayout {
   shouldUseFeedLayoutV1: boolean;
 }
 
+export const FeedLayoutV1FeedPages = new Set(
+  Object.values(SharedFeedPage).filter(
+    (feedPage) => feedPage !== SharedFeedPage.Search,
+  ),
+);
+
 const checkShouldUseFeedLayoutV1 = (feedName: SharedFeedPage): boolean =>
-  Object.values(SharedFeedPage)
-    .filter((feedPage) => feedPage !== SharedFeedPage.Search)
-    .includes(feedName) && feedName !== SharedFeedPage.Search;
+  FeedLayoutV1FeedPages.has(feedName) && feedName !== SharedFeedPage.Search;
 
 export const useFeedLayout = ({
   feedName: feedNameProp,

--- a/packages/shared/src/hooks/useOnPostClick.ts
+++ b/packages/shared/src/hooks/useOnPostClick.ts
@@ -15,11 +15,11 @@ import {
 import { Post, PostType } from '../graphql/posts';
 import { Origin } from '../lib/analytics';
 import { ActiveFeedContext } from '../contexts';
-import { AllFeedPages, updateCachedPagePost } from '../lib/query';
+import { updateCachedPagePost } from '../lib/query';
 import { usePostFeedback } from './usePostFeedback';
-import { FeedLayoutV1FeedPages, useFeedLayout } from './useFeedLayout';
-import { SharedFeedPage } from '../components/utilities';
+import { FeedLayoutV1FeedPages } from './useFeedLayout';
 import { FeedData } from '../graphql/feed';
+import { useFeatureFeedLayoutV1 } from './useFeatureFeedLayoutV1';
 
 interface PostClickOptionalProps {
   skipPostUpdate?: boolean;
@@ -99,10 +99,7 @@ export default function useOnPostClick({
   const { trackEvent } = useContext(AnalyticsContext);
   const { incrementReadingRank } = useIncrementReadingRank();
   const { queryKey: feedQueryKey, items } = useContext(ActiveFeedContext);
-  const { shouldUseFeedLayoutV1 } = useFeedLayout({
-    // need to provide something, in case feedName is undefined (such as on post page)
-    feedName: (feedName as AllFeedPages) || SharedFeedPage.MyFeed,
-  });
+  const isFeedLayoutV1 = useFeatureFeedLayoutV1();
 
   const { isLowImpsEnabled } = usePostFeedback();
 
@@ -160,7 +157,7 @@ export default function useOnPostClick({
             }
 
             updateFeedPostCache({ index: postIndex });
-          } else if (!feedName && shouldUseFeedLayoutV1) {
+          } else if (!feedName && isFeedLayoutV1) {
             const trySetPostRead = (queryKey: QueryKey, id: string) => {
               const updateFeedPost = updateCachedPagePost(
                 queryKey as unknown[],
@@ -186,8 +183,19 @@ export default function useOnPostClick({
           }
         }
       },
-    // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [columns, feedName, feedQueryKey, ranking, origin, shouldUseFeedLayoutV1],
+    [
+      client,
+      columns,
+      eventName,
+      feedName,
+      feedQueryKey,
+      incrementReadingRank,
+      isFeedLayoutV1,
+      isLowImpsEnabled,
+      items,
+      ranking,
+      origin,
+      trackEvent,
+    ],
   );
 }

--- a/packages/shared/src/hooks/useOnPostClick.ts
+++ b/packages/shared/src/hooks/useOnPostClick.ts
@@ -167,7 +167,7 @@ export default function useOnPostClick({
                 queryKey,
               ) as InfiniteData<FeedData>;
 
-              const { post: foundPost, page, index } = findPost(data, post.id);
+              const { post: foundPost, page, index } = findPost(data, id);
               if (foundPost) {
                 updateFeedPost(page, index, {
                   ...foundPost,
@@ -176,9 +176,9 @@ export default function useOnPostClick({
               }
             };
 
-            for (const key of getFeedQueryKeys(client)) {
+            getFeedQueryKeys(client).forEach((key) => {
               trySetPostRead(key, post.id);
-            }
+            });
           }
         }
       },

--- a/packages/shared/src/hooks/useOnPostClick.ts
+++ b/packages/shared/src/hooks/useOnPostClick.ts
@@ -1,5 +1,10 @@
 import { useContext, useMemo } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
+import {
+  InfiniteData,
+  QueryClient,
+  QueryKey,
+  useQueryClient,
+} from '@tanstack/react-query';
 import useIncrementReadingRank from './useIncrementReadingRank';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import {
@@ -12,6 +17,9 @@ import { Origin } from '../lib/analytics';
 import { ActiveFeedContext } from '../contexts';
 import { updateCachedPagePost } from '../lib/query';
 import { usePostFeedback } from './usePostFeedback';
+import { FeedLayoutV1FeedPages, useFeedLayout } from './useFeedLayout';
+import { SharedFeedPage } from '../components/utilities';
+import { FeedData } from '../graphql/feed';
 
 interface PostClickOptionalProps {
   skipPostUpdate?: boolean;
@@ -30,6 +38,44 @@ export type FeedPostClick = ({
   optional?: PostClickOptionalProps;
 }) => Promise<void>;
 
+const getFeedQueryKeys = (client: QueryClient): QueryKey[] => {
+  const queryKeys = client
+    .getQueryCache()
+    .findAll()
+    .map((query) => query.queryKey);
+
+  // filter only query keys for supported feed layout v1 feeds
+  const keys = queryKeys.filter(
+    (key) =>
+      Array.isArray(key) && key.length > 0 && FeedLayoutV1FeedPages.has(key[0]),
+  );
+  return keys;
+};
+
+interface PostItem {
+  post: Post;
+  page: number;
+  index: number;
+}
+
+const findPost = (data: InfiniteData<FeedData>, id: string): PostItem => {
+  let index = -1;
+  const pageIndex = data.pages.findIndex(({ page }) => {
+    index = page.edges.findIndex(({ node }) => node.id === id);
+    return index > -1;
+  });
+
+  const post =
+    pageIndex > -1 && index > -1
+      ? data.pages[pageIndex].page.edges[index].node
+      : undefined;
+
+  return {
+    post,
+    page: pageIndex,
+    index,
+  };
+};
 interface UseOnPostClickProps {
   eventName?: string;
   columns?: number;
@@ -37,6 +83,7 @@ interface UseOnPostClickProps {
   ranking?: string;
   origin?: Origin;
 }
+
 export default function useOnPostClick({
   eventName = 'go to link',
   columns,
@@ -48,6 +95,11 @@ export default function useOnPostClick({
   const { trackEvent } = useContext(AnalyticsContext);
   const { incrementReadingRank } = useIncrementReadingRank();
   const { queryKey: feedQueryKey, items } = useContext(ActiveFeedContext);
+  const { shouldUseFeedLayoutV1 } = useFeedLayout({
+    // need to provide something, otherwise it's always false
+    feedName: SharedFeedPage.MyFeed,
+  });
+
   const { isLowImpsEnabled } = usePostFeedback();
 
   return useMemo(
@@ -81,27 +133,53 @@ export default function useOnPostClick({
           await incrementReadingRank();
         }
 
-        if (eventName === 'go to link' && feedQueryKey) {
+        if (eventName === 'go to link') {
           const mutationHandler = () => {
             return {
               read: true,
             };
           };
-          const updateFeedPost = updateCachedPagePost(feedQueryKey, client);
-          const updateFeedPostCache = optimisticPostUpdateInFeed(
-            items,
-            updateFeedPost,
-            mutationHandler,
-          );
-          const postIndex = items.findIndex(
-            (item) => item.type === 'post' && item.post.id === post.id,
-          );
 
-          if (postIndex === -1) {
-            return;
+          if (feedQueryKey) {
+            const updateFeedPost = updateCachedPagePost(feedQueryKey, client);
+            const updateFeedPostCache = optimisticPostUpdateInFeed(
+              items,
+              updateFeedPost,
+              mutationHandler,
+            );
+            const postIndex = items.findIndex(
+              (item) => item.type === 'post' && item.post.id === post.id,
+            );
+
+            if (postIndex === -1) {
+              return;
+            }
+
+            updateFeedPostCache({ index: postIndex });
+          } else if (shouldUseFeedLayoutV1) {
+            const trySetPostRead = (queryKey: QueryKey, id: string) => {
+              const updateFeedPost = updateCachedPagePost(
+                queryKey as unknown[],
+                client,
+              );
+
+              const data = client.getQueryData(
+                queryKey,
+              ) as InfiniteData<FeedData>;
+
+              const { post: foundPost, page, index } = findPost(data, post.id);
+              if (foundPost) {
+                updateFeedPost(page, index, {
+                  ...foundPost,
+                  ...mutationHandler(),
+                });
+              }
+            };
+
+            for (const key of getFeedQueryKeys(client)) {
+              trySetPostRead(key, post.id);
+            }
           }
-
-          updateFeedPostCache({ index: postIndex });
         }
       },
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM


### PR DESCRIPTION
## Changes

### Describe what this PR does

Change the `useOnPostClick` hook implementation.
The flow is as following:
- If `ActiveFeedContext` provides `feedQueryKey`, behavior is the same as before
- If `shouldUseFeedLayoutV1` is `false`, behavior is the same as before
- If `shouldUseFeedLayoutV1` is `true` and `feedQueryKey` is undefined, we do the following:
  1. Get all feed query keys from react query cache
  2. For each feed query key:
    1. Find the correct `page`, `index` and `post` item based on the `post.id`
    2. Call the `updatePost` function with the `page`, `index`, `post`, and apply `read: true` 
  3. Use the go back button on the post page
  4. Profit from the updated cache 💪 

### Loom video
https://www.loom.com/share/461dd564a737480daca28722be801be1?sid=222b6c95-43fa-442c-a221-81bb4115007f 

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-32 #done
