### PR TITLE
fix: add image thumbnail back to the feedback card

### DIFF
--- a/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
@@ -87,6 +87,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
           onUpvoteClick={() => onUpvoteClick(post, Origin.FeedbackCard)}
           onDownvoteClick={() => onDownvoteClick(post, Origin.FeedbackCard)}
           showImage={showImage}
+          isVideoType={isVideoType}
         />
       ) : (
         <>

--- a/packages/shared/src/components/cards/v1/FeedbackCard.tsx
+++ b/packages/shared/src/components/cards/v1/FeedbackCard.tsx
@@ -10,20 +10,25 @@ import UpvoteIcon from '../../icons/Upvote';
 import { Post, UserPostVote } from '../../../graphql/posts';
 import { usePostFeedback } from '../../../hooks';
 import CloseButton from '../../CloseButton';
+import { cloudinary } from '../../../lib/image';
+import { CardContent, CardImage, CardVideoImage } from './Card';
 
 interface FeedbackCardProps {
   post: Post;
   onUpvoteClick: MouseEventHandler;
   onDownvoteClick: MouseEventHandler;
   showImage?: boolean;
+  isVideoType?: boolean;
 }
 
 export const FeedbackCard = ({
   post,
   onUpvoteClick,
   onDownvoteClick,
+  isVideoType,
 }: FeedbackCardProps): ReactElement => {
   const { dismissFeedback } = usePostFeedback({ post });
+  const ImageComponent = isVideoType ? CardVideoImage : CardImage;
 
   return (
     <div className="flex-1 space-y-4">
@@ -64,14 +69,29 @@ export const FeedbackCard = ({
           aria-label="Downvote"
         />
       </div>
-      <div className="rounded-14 border border-theme-divider-tertiary p-4">
-        <h2 className="line-clamp-1 typo-body">{post.title}</h2>
-        {post.summary && (
-          <p className="mt-2 line-clamp-2 text-theme-label-quaternary typo-callout">
-            {post.summary}
-          </p>
-        )}
-      </div>
+
+      <CardContent className="rounded-14 border border-theme-divider-tertiary p-4">
+        <div className="mr-2 flex-1">
+          <h2 className="mb-2 line-clamp-1 typo-body">{post.title}</h2>
+          {post.summary && (
+            <p className=" line-clamp-2 text-theme-label-quaternary typo-callout">
+              {post.summary}
+            </p>
+          )}
+        </div>
+
+        <ImageComponent
+          alt="Post Cover image"
+          src={post.image}
+          fallbackSrc={cloudinary.post.imageCoverPlaceholder}
+          className="object-cover"
+          loading="lazy"
+          data-testid="postImage"
+          {...(isVideoType && {
+            wrapperClassName: 'mobileXL:w-40 mobileXXL:w-56',
+          })}
+        />
+      </CardContent>
     </div>
   );
 };


### PR DESCRIPTION
## Changes

- added the image component back to the feedback card (was removed as a part of the footer component)

## Preview

<img width="845" alt="Screenshot 2024-01-17 at 10 11 17" src="https://github.com/dailydotdev/apps/assets/1225100/87d082c8-13c8-4cbe-b4ff-9fed9dccb16f">

<img width="399" alt="Screenshot 2024-01-17 at 10 14 41" src="https://github.com/dailydotdev/apps/assets/1225100/03beb565-d156-4ca2-b713-adab25fc35f6">
## Events


n / a

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-16 #done
