### PR TITLE
feat: handle zeros and colors for card action buttons in feed layout v1

### DIFF
--- a/packages/shared/src/components/InteractionCounter.module.css
+++ b/packages/shared/src/components/InteractionCounter.module.css
@@ -1,9 +1,0 @@
-.interactionCounter {
-  min-width: 1ch;
-
-  & > * {
-    display: inline-block;
-    transition: opacity 0.3s ease-in-out, transform 0.3s ease-in-out;
-    will-change: opacity, transform;
-  }
-}

--- a/packages/shared/src/components/InteractionCounter.tsx
+++ b/packages/shared/src/components/InteractionCounter.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { requestIdleCallback } from 'next/dist/client/request-idle-callback';
 import classNames from 'classnames';
-import styles from './InteractionCounter.module.css';
 
 export type InteractionCounterProps = {
   className?: string;
@@ -15,7 +14,6 @@ export default function InteractionCounter({
 }: InteractionCounterProps): ReactElement {
   const [shownValue, setShownValue] = useState(value);
   const [animate, setAnimate] = useState(false);
-
   useEffect(() => {
     if (value !== shownValue) {
       if (value < shownValue) {
@@ -29,9 +27,14 @@ export default function InteractionCounter({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
 
+  const elementClassName = classNames(
+    'flex h-5 min-w-[1ch] flex-col items-center overflow-hidden',
+    className,
+  );
+
   if (shownValue === value) {
     return (
-      <span className={className} {...props}>
+      <span className={elementClassName} {...props}>
         {shownValue}
       </span>
     );
@@ -42,26 +45,24 @@ export default function InteractionCounter({
     setShownValue(value);
   };
 
+  const childClassName =
+    'h-5 inline-block transition-[opacity,transform] ease-in-out duration-300 will-change-[opacity,transform]';
+
   return (
-    <span
-      className={classNames(
-        'relative overflow-hidden',
-        styles.interactionCounter,
-        className,
-      )}
-      {...props}
-    >
+    <span className={elementClassName} {...props}>
       <span
-        className={
-          animate ? '-translate-y-full opacity-0' : 'translate-y-0 opacity-100'
-        }
+        className={classNames(
+          childClassName,
+          animate ? '-translate-y-full opacity-0' : 'translate-y-0 opacity-100',
+        )}
       >
         {shownValue}
       </span>
       <span
-        className={`absolute left-0 top-0 ${
-          animate ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0'
-        }`}
+        className={classNames(
+          childClassName,
+          animate ? '-translate-y-full opacity-100' : 'translate-y-0 opacity-0',
+        )}
         onTransitionEnd={updateShownValue}
       >
         {value}

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -84,10 +84,19 @@ export default function ActionButtons({
             variant={ButtonVariant.Tertiary}
           />
         </SimpleTooltip>
-        <InteractionCounter
-          className="font-bold text-theme-label-tertiary typo-callout"
-          value={post.numUpvotes}
-        />
+        {post?.numUpvotes > 0 && (
+          <InteractionCounter
+            className={classNames(
+              '!min-w-[2ch] font-bold tabular-nums typo-callout',
+              post?.userState?.vote === UserPostVote.Up &&
+                'text-theme-color-avocado',
+              post?.userState?.vote === UserPostVote.Down &&
+                'text-theme-color-ketchup',
+              !post?.userState?.vote && 'text-theme-label-tertiary',
+            )}
+            value={post?.numUpvotes}
+          />
+        )}
         <SimpleTooltip
           content={
             post?.userState?.vote === UserPostVote.Down
@@ -119,10 +128,17 @@ export default function ActionButtons({
           onClick={() => onCommentClick?.(post)}
           variant={ButtonVariant.Float}
         >
-          <InteractionCounter
-            className="text-theme-label-tertiary"
-            value={post.numComments}
-          />
+          {post?.numComments > 0 ? (
+            <InteractionCounter
+              className={classNames(
+                'tabular-nums',
+                post.commented
+                  ? 'text-theme-color-blueCheese'
+                  : 'text-theme-label-tertiary',
+              )}
+              value={post.numComments}
+            />
+          ) : null}
         </Button>
       </SimpleTooltip>
       <SimpleTooltip content={post.bookmarked ? 'Remove bookmark' : 'Bookmark'}>


### PR DESCRIPTION
## Changes

### Screenshots && video

Classic cards not affected
<img width="307" alt="Screenshot 2024-01-17 at 15 30 46" src="https://github.com/dailydotdev/apps/assets/9974711/18f15c91-d260-40cd-9c7c-2d80edefe8c3">

Feed layout v1 cards now behave well
<img width="651" alt="Screenshot 2024-01-17 at 15 32 22" src="https://github.com/dailydotdev/apps/assets/9974711/99d7370e-d2e4-4be9-ad0a-aed3c0d87856">

<img width="650" alt="Screenshot 2024-01-17 at 15 27 46" src="https://github.com/dailydotdev/apps/assets/9974711/76a0516f-6242-4446-97af-49b233240309">

https://www.loom.com/share/c92e27d866ef47e18c54989ce0e7d33f

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-20 #done
