### PR TITLE
fix: comments button opens post page

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -317,16 +317,17 @@ export default function Feed<T>({
     row: number,
     column: number,
   ): void => {
-    onPostModalOpen(index, () =>
-      trackEvent(
-        postAnalyticsEvent('comments click', post, {
-          columns: virtualizedNumCards,
-          column,
-          row,
-          ...feedAnalyticsExtra(feedName, ranking),
-        }),
-      ),
+    trackEvent(
+      postAnalyticsEvent('comments click', post, {
+        columns: virtualizedNumCards,
+        column,
+        row,
+        ...feedAnalyticsExtra(feedName, ranking),
+      }),
     );
+    if (!shouldUseFeedLayoutV1) {
+      onPostModalOpen(index);
+    }
   };
 
   const onAdClick = (ad: Ad, row: number, column: number) => {

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -11,6 +11,7 @@ import { useFeedPreviewMode } from '../../../hooks';
 import BookmarkIcon from '../../icons/Bookmark';
 import DownvoteIcon from '../../icons/Downvote';
 import { ActionButtonsProps } from '../ActionButtons';
+import { combinedClicks } from '../../../lib/click';
 
 const ShareIcon = dynamic(
   () => import(/* webpackChunkName: "shareIcon" */ '../../icons/Share'),
@@ -115,9 +116,11 @@ export default function ActionButtons({
           className="ml-2"
           color={ButtonColor.BlueCheese}
           icon={<CommentIcon secondary={post.commented} />}
+          tag="a"
+          href={post.commentsPermalink}
           pressed={post.commented}
-          onClick={() => onCommentClick?.(post)}
           variant={ButtonVariant.Float}
+          {...combinedClicks(() => onCommentClick?.(post))}
         >
           <InteractionCounter
             className="text-theme-label-tertiary"

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
+import Link from 'next/link';
 import { Post, UserPostVote } from '../../../graphql/posts';
 import InteractionCounter from '../../InteractionCounter';
 import UpvoteIcon from '../../icons/Upvote';
@@ -12,7 +13,6 @@ import BookmarkIcon from '../../icons/Bookmark';
 import DownvoteIcon from '../../icons/Downvote';
 import { ActionButtonsProps } from '../ActionButtons';
 import { combinedClicks } from '../../../lib/click';
-import Link from 'next/link';
 
 const ShareIcon = dynamic(
   () => import(/* webpackChunkName: "shareIcon" */ '../../icons/Share'),

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -12,6 +12,7 @@ import BookmarkIcon from '../../icons/Bookmark';
 import DownvoteIcon from '../../icons/Downvote';
 import { ActionButtonsProps } from '../ActionButtons';
 import { combinedClicks } from '../../../lib/click';
+import Link from 'next/link';
 
 const ShareIcon = dynamic(
   () => import(/* webpackChunkName: "shareIcon" */ '../../icons/Share'),
@@ -111,22 +112,24 @@ export default function ActionButtons({
         </SimpleTooltip>
       </div>
       <SimpleTooltip content="Comments">
-        <Button
-          id={`post-${post.id}-comment-btn`}
-          className="ml-2"
-          color={ButtonColor.BlueCheese}
-          icon={<CommentIcon secondary={post.commented} />}
-          tag="a"
-          href={post.commentsPermalink}
-          pressed={post.commented}
-          variant={ButtonVariant.Float}
-          {...combinedClicks(() => onCommentClick?.(post))}
-        >
-          <InteractionCounter
-            className="text-theme-label-tertiary"
-            value={post.numComments}
-          />
-        </Button>
+        <Link href={post.commentsPermalink}>
+          <Button
+            id={`post-${post.id}-comment-btn`}
+            className="ml-2"
+            color={ButtonColor.BlueCheese}
+            icon={<CommentIcon secondary={post.commented} />}
+            tag="a"
+            href={post.commentsPermalink}
+            pressed={post.commented}
+            variant={ButtonVariant.Float}
+            {...combinedClicks(() => onCommentClick?.(post))}
+          >
+            <InteractionCounter
+              className="text-theme-label-tertiary"
+              value={post.numComments}
+            />
+          </Button>
+        </Link>
       </SimpleTooltip>
       <SimpleTooltip content={post.bookmarked ? 'Remove bookmark' : 'Bookmark'}>
         <Button


### PR DESCRIPTION
## Changes

### Describe what this PR does

Changes `onCommentClick` handler to not open the post modal on feed layout v1.
Changes comments action `<button>` to an `<a>` HTML element and adds `href` to point to the post page.

## Events

All tracking events should be fired the same way as they did previously. We also track the comment click the same way as we did previously for the feed layout version.

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
MI-92 #done
