### PR TITLE
fix: collection pills not clickable

### DIFF
--- a/packages/shared/src/components/cards/common/SquadHeaderPicture.tsx
+++ b/packages/shared/src/components/cards/common/SquadHeaderPicture.tsx
@@ -17,18 +17,18 @@ export default function SquadHeaderPicture({
 }: SquadHeaderPictureProps): ReactElement {
   if (reverse) {
     return (
-      <>
+      <div className="relative">
         {!!author && <ProfilePicture user={author} size="large" />}
         <SourceButton
           size="xsmall"
           source={source}
           className="absolute -bottom-2.5 -right-2.5"
         />
-      </>
+      </div>
     );
   }
   return (
-    <>
+    <div className="relative">
       <SourceButton size="large" source={source} />
       {!!author && (
         <ProfilePicture
@@ -38,6 +38,6 @@ export default function SquadHeaderPicture({
           absolute
         />
       )}
-    </>
+    </div>
   );
 }

--- a/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
@@ -108,7 +108,11 @@ export const ArticlePostCard = forwardRef(function PostCard(
                 ),
               }}
             >
-              <SourceButton size="large" source={post.source} />
+              <SourceButton
+                size="large"
+                source={post.source}
+                className="relative"
+              />
             </PostCardHeader>
 
             <CardContent>

--- a/packages/shared/src/components/cards/v1/PostCardHeader.tsx
+++ b/packages/shared/src/components/cards/v1/PostCardHeader.tsx
@@ -47,7 +47,7 @@ export const PostCardHeader = ({
 
   return (
     <CardHeader className={className}>
-      <div className="relative">{children}</div>
+      {children}
       <PostMetadata
         className={classNames(
           'mr-2 flex-1',

--- a/packages/shared/src/components/post/collection/CollectionPillSources.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPillSources.tsx
@@ -22,7 +22,12 @@ export const CollectionPillSources = ({
   const hasSources = !!sources?.length;
 
   return (
-    <div className={classNames(className?.main, 'relative flex flex-row')}>
+    <div
+      className={classNames(
+        className?.main,
+        'relative flex flex-row pointer-events-none',
+      )}
+    >
       {hasSources && (
         <ProfilePictureGroup
           className={classNames({


### PR DESCRIPTION
## Changes

Removes pointer events from collection pill sources on CollectionCard in feed layout v1. This replicates the same behavior as we had with the existing layout.

Removes relative div from PostCardHeader
Adds relative positioning to the SourceButton and Squad source picture in the PostCardHeader, so that you can still get to the source when you click on the image.

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-90 #done
