### PR TITLE
fix: don't crash when trying to truncate a null title

### DIFF
--- a/packages/shared/src/hooks/useTruncatedSummary.ts
+++ b/packages/shared/src/hooks/useTruncatedSummary.ts
@@ -5,8 +5,8 @@ export const useTruncatedSummary = (
   sanitizedSummary?: string,
 ): { summary?: string; title: string } => {
   const title =
-    post.title.length > 300 ? `${post.title.slice(0, 300)}...` : post.title;
-  const maxSummaryLength = Math.max(0, 300 - post.title.length);
+    post.title?.length > 300 ? `${post.title.slice(0, 300)}...` : post.title;
+  const maxSummaryLength = Math.max(0, 300 - post.title?.length || 0);
   const summary = sanitizedSummary || post.summary;
   const truncatedSummary =
     summary && summary.length > maxSummaryLength


### PR DESCRIPTION
## Changes

Root cause of the error:

![image](https://github.com/dailydotdev/apps/assets/1225100/d7b25b3a-fe96-4f94-ab9b-b8337efe3753)
<img width="1438" alt="Screenshot 2024-01-18 at 12 17 25" src="https://github.com/dailydotdev/apps/assets/1225100/d4050ee0-79a6-4f5b-bf5d-d0b5203b4956">


## Events

n / a

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-87 #done
