### PR TITLE
fix: cover edge cases where the user has not loaded yet when determining feed name

### DIFF
--- a/packages/shared/src/contexts/ActiveFeedNameContext.tsx
+++ b/packages/shared/src/contexts/ActiveFeedNameContext.tsx
@@ -32,12 +32,13 @@ export const ActiveFeedNameContextProvider = ({
   const { pathname } = router || {};
   const { user } = useAuthContext();
   const previousPathname = usePrevious(pathname);
+  const previousUserId = usePrevious(user?.id);
   const [feedName, setFeedName] = useState<AllFeedPages>(
     getFeedName(pathname, { hasUser: !!user }),
   );
 
   useEffect(() => {
-    if (pathname !== previousPathname) {
+    if (pathname !== previousPathname || user?.id !== previousUserId) {
       const newFeedName = getFeedName(pathname, {
         hasUser: !!user,
       });
@@ -45,7 +46,7 @@ export const ActiveFeedNameContextProvider = ({
         setFeedName(newFeedName);
       }
     }
-  }, [pathname, previousPathname, feedName, user]);
+  }, [pathname, previousPathname, feedName, user, previousUserId]);
 
   const activeFeedNameContextValue = useMemo(() => ({ feedName }), [feedName]);
   return (


### PR DESCRIPTION
## Changes

- self explanatory

## Events

n / a

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-33 #done
