### PR TITLE
fix: feed layout v1 ad and video image are not clickable

### DIFF
--- a/packages/shared/src/components/cards/v1/AdCard.tsx
+++ b/packages/shared/src/components/cards/v1/AdCard.tsx
@@ -40,7 +40,7 @@ export const AdCard = forwardRef(function AdCard(
         </CardTitle>
 
         {showImage && (
-          <div className="relative mt-4 overflow-hidden rounded-12">
+          <div className="pointer-events-none relative mt-4 overflow-hidden rounded-12">
             <CardImage
               alt="Ad image"
               src={ad.image}

--- a/packages/shared/src/components/image/VideoImage.tsx
+++ b/packages/shared/src/components/image/VideoImage.tsx
@@ -18,7 +18,7 @@ const VideoImage = ({
     <div
       className={classNames(
         wrapperClassName,
-        'relative flex h-auto w-full items-center justify-center rounded-12',
+        'pointer-events-none relative flex h-auto w-full items-center justify-center rounded-12',
       )}
     >
       <span className="absolute h-full w-full rounded-12 bg-overlay-tertiary-black" />


### PR DESCRIPTION
## Changes

Adds `pointer-events-none` to Ad image and VideoImage. That way, clickling on the images the container click event is used -> opens the post.

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-85 #done
