### PR TITLE
fix: ensure the beta tag is hidden properly

### DIFF
--- a/packages/shared/src/components/cards/RaisedLabel.tsx
+++ b/packages/shared/src/components/cards/RaisedLabel.tsx
@@ -38,7 +38,7 @@ export function RaisedLabel({
   return (
     <div
       className={classNames(
-        'absolute flex items-start',
+        'absolute flex items-start overflow-hidden',
         listMode ? 'right-full top-0 mt-5' : 'bottom-full left-0 ml-5 h-5',
         className,
       )}


### PR DESCRIPTION
## Changes

![image](https://github.com/dailydotdev/apps/assets/1225100/d928e2f5-bdaf-4d64-8af8-05a63240c274)
![image](https://github.com/dailydotdev/apps/assets/1225100/7b9b0fbc-10b9-40fd-a892-57f15d534ece)

## Events

n / a

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-89 #done
