### PR TITLE
fix: feed layout margins, paddings and breakpoints

### DIFF
--- a/packages/extension/src/newtab/CustomLinks.tsx
+++ b/packages/extension/src/newtab/CustomLinks.tsx
@@ -9,6 +9,7 @@ import classNames from 'classnames';
 import React, { MouseEventHandler, ReactElement } from 'react';
 import { WithClassNameProps } from '@dailydotdev/shared/src/components/utilities';
 import { combinedClicks } from '@dailydotdev/shared/src/lib/click';
+import { useFeedLayout } from '@dailydotdev/shared/src/hooks';
 
 interface CustomLinksProps extends WithClassNameProps {
   links: string[];
@@ -24,10 +25,12 @@ export function CustomLinks({
   className,
   onLinkClick = noop,
 }: CustomLinksProps): ReactElement {
+  const { shouldUseFeedLayoutV1 } = useFeedLayout();
+
   return (
     <div
       className={classNames(
-        'hidden h-fit flex-row gap-2 rounded-14 border border-theme-divider-secondary p-2 laptop:flex',
+        'h-fit flex-row gap-2 rounded-14 border p-2',
         className,
       )}
     >
@@ -54,7 +57,7 @@ export function CustomLinks({
       <SimpleTooltip placement="left" content="Edit shortcuts">
         <Button
           variant={ButtonVariant.Tertiary}
-          icon={<MenuIcon />}
+          icon={<MenuIcon className={shouldUseFeedLayoutV1 && 'rotate-90'} />}
           onClick={onOptions}
           size={ButtonSize.Small}
         />

--- a/packages/extension/src/newtab/CustomLinks.tsx
+++ b/packages/extension/src/newtab/CustomLinks.tsx
@@ -30,7 +30,10 @@ export function CustomLinks({
   return (
     <div
       className={classNames(
-        'h-fit flex-row gap-2 rounded-14 border p-2',
+        'hidden h-fit flex-row gap-2 rounded-14 border p-2',
+        shouldUseFeedLayoutV1
+          ? 'border-theme-divider-tertiary tablet:flex'
+          : 'border-theme-divider-secondary laptop:flex',
         className,
       )}
     >

--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -127,10 +127,9 @@ export default function MainFeedPage({
           shortcuts={
             <ShortcutLinks
               className={classNames(
-                'hidden',
                 layout === FeedLayoutEnum.Control
-                  ? 'ml-auto border-theme-divider-secondary laptop:flex'
-                  : 'mx-6 mt-4 w-fit border-theme-divider-tertiary tablet:flex tabletL:mx-0',
+                  ? 'ml-auto'
+                  : 'mt-4 w-fit [@media(width<=680px)]:mx-6',
               )}
             />
           }

--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -14,6 +14,7 @@ import {
 } from '@dailydotdev/shared/src/lib/featureValues';
 import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import { getFeedName } from '@dailydotdev/shared/src/lib/feed';
+import classNames from 'classnames';
 import ShortcutLinks from './ShortcutLinks';
 import DndBanner from './DndBanner';
 import DndContext from './DndContext';
@@ -125,9 +126,12 @@ export default function MainFeedPage({
           navChildren={!isSearchOn && <ShortcutLinks />}
           shortcuts={
             <ShortcutLinks
-              className={
-                layout === FeedLayoutEnum.Control ? 'ml-auto' : 'mt-4 w-fit'
-              }
+              className={classNames(
+                'hidden',
+                layout === FeedLayoutEnum.Control
+                  ? 'ml-auto border-theme-divider-secondary laptop:flex'
+                  : 'mx-6 mt-4 w-fit border-theme-divider-tertiary tablet:flex tabletL:mx-0',
+              )}
             />
           }
         />

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -218,7 +218,7 @@ export const FeedContainer = ({
                   container: classNames(
                     'flex w-full flex-1',
                     shouldUseFeedLayoutV1
-                      ? 'mt-6 w-full [@media(width<=680px)]:px-6'
+                      ? 'mt-6 [@media(width<=680px)]:px-6'
                       : 'max-w-2xl',
                     shouldShowPulse && 'highlight-pulse',
                   ),

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -216,9 +216,10 @@ export const FeedContainer = ({
               <SearchBarInput
                 className={{
                   container: classNames(
-                    'flex w-full max-w-2xl flex-1',
-                    shouldUseFeedLayoutV1 &&
-                      'mt-6 px-6 pt-2 laptop:px-0 laptop:pt-0',
+                    'flex w-full flex-1',
+                    shouldUseFeedLayoutV1
+                      ? 'mt-6 w-full px-6 tabletL:px-0'
+                      : 'max-w-2xl',
                     shouldShowPulse && 'highlight-pulse',
                   ),
                   field: classNames(
@@ -236,12 +237,11 @@ export const FeedContainer = ({
             </ConditionalWrapper>
           )}
           {isV1Search && (
-            <span className="mt-4 flex flex-1 flex-row">
+            <span className="mt-4 hidden flex-1 flex-row tablet:flex">
               <SearchBarSuggestionList
                 {...suggestionsProps}
                 className={classNames(
-                  'hidden tablet:flex',
-                  shouldUseFeedLayoutV1 ? 'mx-6 laptop:mx-0' : 'mr-3',
+                  shouldUseFeedLayoutV1 ? 'mx-6 tabletL:mx-0' : 'mr-3',
                 )}
               />
               {actionButtons && !shouldUseFeedLayoutV1 && (

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -218,7 +218,7 @@ export const FeedContainer = ({
                   container: classNames(
                     'flex w-full flex-1',
                     shouldUseFeedLayoutV1
-                      ? 'mt-6 w-full px-6 tabletL:px-0'
+                      ? 'mt-6 w-full [@media(width<=680px)]:px-6'
                       : 'max-w-2xl',
                     shouldShowPulse && 'highlight-pulse',
                   ),
@@ -237,12 +237,15 @@ export const FeedContainer = ({
             </ConditionalWrapper>
           )}
           {isV1Search && (
-            <span className="mt-4 hidden flex-1 flex-row tablet:flex">
+            <span
+              className={classNames(
+                'mt-4 hidden flex-1 flex-row tablet:flex',
+                shouldUseFeedLayoutV1 && '[@media(width<=680px)]:mx-6',
+              )}
+            >
               <SearchBarSuggestionList
                 {...suggestionsProps}
-                className={classNames(
-                  shouldUseFeedLayoutV1 ? 'mx-6 tabletL:mx-0' : 'mr-3',
-                )}
+                className={classNames(!shouldUseFeedLayoutV1 && 'mr-3')}
               />
               {actionButtons && !shouldUseFeedLayoutV1 && (
                 <span className="ml-auto flex flex-row gap-3 border-l border-theme-divider-tertiary pl-3">
@@ -257,7 +260,7 @@ export const FeedContainer = ({
             wrapper={(child) => (
               <div
                 className={classNames(
-                  'flex flex-col rounded-16 border border-theme-divider-tertiary laptop:mx-0 laptop:mt-6',
+                  'flex flex-col rounded-16 border border-theme-divider-tertiary tablet:mt-6',
                   isV1Search && 'mt-6',
                 )}
               >

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -157,7 +157,6 @@ module.exports = {
       mobileXL: '500px',
       mobileXXL: '550px',
       tablet: '656px',
-      tabletL: '680px',
       laptop: '1020px',
       laptopL: '1360px',
       laptopXL: '1668px',

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -157,6 +157,7 @@ module.exports = {
       mobileXL: '500px',
       mobileXXL: '550px',
       tablet: '656px',
+      tabletL: '680px',
       laptop: '1020px',
       laptopL: '1360px',
       laptopXL: '1668px',


### PR DESCRIPTION
## Changes

Changed paddings, margins, border color, etc. to adhere to Figma designs.
Added new arbitrary breakpoint - `[@media(width<=680px)]`, which is the same size as feed width. That way, we set the margin/padding around search bar and shortcuts at the right spot.

### Screenshots

Before:
<img width="748" alt="Screenshot 2024-01-18 at 14 14 42" src="https://github.com/dailydotdev/apps/assets/9974711/f4d973c8-38cf-49dd-9582-eb20290b5a9f">


After:
<img width="641" alt="Screenshot 2024-01-18 at 14 07 18" src="https://github.com/dailydotdev/apps/assets/9974711/9f8d9a3e-71c4-4614-b38d-1b0d17bc2070">
<img width="670" alt="Screenshot 2024-01-18 at 14 06 59" src="https://github.com/dailydotdev/apps/assets/9974711/ba5ac94f-1987-4368-80d0-12d4336b6128">
<img width="668" alt="Screenshot 2024-01-18 at 14 06 41" src="https://github.com/dailydotdev/apps/assets/9974711/fdc73091-ef5e-4ded-872a-6eed56ec4655">

Loom:
https://www.loom.com/share/953538f05f714772bd6efb7ea6e8521c?sid=453e64b4-41fd-4afc-9785-682c6bd32f91

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-91 #done
