### PR TITLE
fix: onboarding visuals

### DIFF
--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -176,6 +176,7 @@ export const FeedContainer = ({
 
     completeAction(ActionType.UsedSearch);
   };
+  const showFeedReadyMessage = router.query?.welcome === 'true';
 
   return (
     <div
@@ -199,8 +200,22 @@ export const FeedContainer = ({
           aria-live={subject === ToastSubject.Feed ? 'assertive' : 'off'}
           data-testid="posts-feed"
         >
-          {router.query?.welcome === 'true' && (
-            <FeedReadyMessage className="mb-10" />
+          {showFeedReadyMessage && (
+            <FeedReadyMessage
+              className={{
+                main: classNames(
+                  shouldUseFeedLayoutV1
+                    ? 'mt-8 mb-8 w-full laptop:gap-4 [@media(width<=680px)]:px-6'
+                    : 'mb-10 max-w-xl laptop:gap-6',
+                ),
+                textContainer: classNames(
+                  shouldUseFeedLayoutV1 ? 'laptop:flex-1' : 'flex flex-col',
+                ),
+                header: classNames(
+                  shouldUseFeedLayoutV1 ? 'mb-0.5' : 'mb-2 laptop:mb-1',
+                ),
+              }}
+            />
           )}
           {inlineHeader && header}
           {isV1Search && (

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -203,17 +203,13 @@ export const FeedContainer = ({
           {showFeedReadyMessage && (
             <FeedReadyMessage
               className={{
-                main: classNames(
-                  shouldUseFeedLayoutV1
-                    ? 'mt-8 mb-8 w-full laptop:gap-4 [@media(width<=680px)]:px-6'
-                    : 'mb-10 max-w-xl laptop:gap-6',
-                ),
-                textContainer: classNames(
-                  shouldUseFeedLayoutV1 ? 'laptop:flex-1' : 'flex flex-col',
-                ),
-                header: classNames(
-                  shouldUseFeedLayoutV1 ? 'mb-0.5' : 'mb-2 laptop:mb-1',
-                ),
+                main: shouldUseFeedLayoutV1
+                  ? 'mb-8 mt-8 w-full laptop:gap-4 [@media(width<=680px)]:px-6'
+                  : 'mb-10 max-w-xl laptop:gap-6',
+                textContainer: shouldUseFeedLayoutV1
+                  ? 'laptop:flex-1'
+                  : 'flex flex-col',
+                header: shouldUseFeedLayoutV1 ? 'mb-0.5' : 'mb-2 laptop:mb-1',
               }}
             />
           )}

--- a/packages/shared/src/components/onboarding/FeedReadyMessage.tsx
+++ b/packages/shared/src/components/onboarding/FeedReadyMessage.tsx
@@ -19,7 +19,7 @@ export const FeedReadyMessage = ({
   return (
     <div
       className={classNames(
-        'mx-auto flex w-full flex-col items-center text-center laptop:mx-0 laptop:flex-row laptop:text-left gap-5',
+        'mx-auto flex w-full flex-col items-center gap-5 text-center laptop:mx-0 laptop:flex-row laptop:text-left',
         className.main,
       )}
     >

--- a/packages/shared/src/components/onboarding/FeedReadyMessage.tsx
+++ b/packages/shared/src/components/onboarding/FeedReadyMessage.tsx
@@ -4,7 +4,11 @@ import { ProfilePicture } from '../ProfilePicture';
 import AuthContext from '../../contexts/AuthContext';
 
 export type FeedReadyMessageProps = {
-  className?: string;
+  className?: {
+    main?: string;
+    textContainer?: string;
+    header?: string;
+  };
 };
 
 export const FeedReadyMessage = ({
@@ -15,17 +19,15 @@ export const FeedReadyMessage = ({
   return (
     <div
       className={classNames(
-        'mx-auto flex w-full max-w-xl flex-col items-center text-center laptop:mx-0 laptop:flex-row laptop:text-left',
-        className,
+        'mx-auto flex w-full flex-col items-center text-center laptop:mx-0 laptop:flex-row laptop:text-left gap-5',
+        className.main,
       )}
     >
-      <ProfilePicture
-        className="mb-5 laptop:mb-0 laptop:mr-6"
-        user={user}
-        size="xxxlarge"
-      />
-      <div className="flex w-full flex-col">
-        <p className="mb-2 font-bold typo-large-title laptop:mb-1">
+      <ProfilePicture user={user} size="xxxlarge" />
+      <div className={classNames('w-full', className.textContainer)}>
+        <p
+          className={classNames('font-bold typo-large-title', className.header)}
+        >
           Your feed is ready
         </p>
         <p className="flex text-theme-label-tertiary typo-callout">


### PR DESCRIPTION
## Changes

Fixes the onboarding `FeedReadyMessage` styling for feed layout v1.

### Screenshots

Old feed
<img width="502" alt="Screenshot 2024-01-19 at 15 07 20" src="https://github.com/dailydotdev/apps/assets/9974711/d3208334-93b6-417d-b6df-a1ec8a522577">
<img width="660" alt="Screenshot 2024-01-19 at 15 07 09" src="https://github.com/dailydotdev/apps/assets/9974711/fa5f9839-5efa-4d7c-92ea-fc4c8a1e071f">
<img width="1004" alt="Screenshot 2024-01-19 at 15 06 57" src="https://github.com/dailydotdev/apps/assets/9974711/601cfbe3-995e-4e2f-85b1-01fdf87e96b3">

Feed Layout V1
<img width="422" alt="Screenshot 2024-01-19 at 14 55 51" src="https://github.com/dailydotdev/apps/assets/9974711/28ba51b5-ad5d-4529-933e-47cf742a77fa">
<img width="658" alt="Screenshot 2024-01-19 at 14 55 11" src="https://github.com/dailydotdev/apps/assets/9974711/31a7bff6-d4dd-4e01-848a-2523e667f559">
<img width="769" alt="Screenshot 2024-01-19 at 14 54 19" src="https://github.com/dailydotdev/apps/assets/9974711/44f28a92-1c0e-4a2c-b241-089916a78ddb">


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-102 #done
