### PR TITLE
fix: enable search footerbar

### DIFF
--- a/packages/webapp/components/layouts/SearchLayout.tsx
+++ b/packages/webapp/components/layouts/SearchLayout.tsx
@@ -3,8 +3,9 @@ import { MainLayoutProps } from '@dailydotdev/shared/src/components/MainLayout';
 import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
 import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { SearchExperiment } from '@dailydotdev/shared/src/lib/featureValues';
-import { getLayout } from './MainLayout';
+import { getLayout as getMainLayout } from './MainLayout';
 import { getMainFeedLayout, mainFeedLayoutProps } from './MainFeedPage';
+import { getLayout as getFooterNavBarLayout } from './FooterNavBarLayout';
 
 const props: Record<SearchExperiment, Record<string, unknown>> = {
   control: { ...mainFeedLayoutProps },
@@ -20,7 +21,7 @@ export const GetSearchLayout = (
   const finalProps = { ...props[searchVersion], ...layoutProps };
 
   if (searchVersion === SearchExperiment.V1) {
-    return getLayout(page, pageProps, finalProps);
+    return getFooterNavBarLayout(getMainLayout(page, pageProps, finalProps));
   }
 
   return getMainFeedLayout(page, pageProps, finalProps);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Enable search footer bar for the AI search page

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
