### PR TITLE
fix: add margin to post page collection pill

### DIFF
--- a/packages/shared/src/components/post/collection/CollectionPostContent.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPostContent.tsx
@@ -131,7 +131,7 @@ export const CollectionPostContent = ({
           <div
             className={classNames(
               'mb-6 flex flex-col gap-6',
-              hasNavigation ? 'mt-6' : 'mt-6 tablet:mt-0',
+              hasNavigation || customNavigation ? 'mt-6' : 'mt-6 tablet:mt-0',
             )}
           >
             <CollectionsIntro className="tablet:hidden" />


### PR DESCRIPTION
## Changes

Added a margin in case there is customNavigation present

### Screenshots

Before

<img width="692" alt="Screenshot 2024-01-19 at 17 09 17" src="https://github.com/dailydotdev/apps/assets/9974711/dc5effa0-f642-4d5c-9554-a7480d511f75">
<img width="695" alt="Screenshot 2024-01-19 at 17 09 27" src="https://github.com/dailydotdev/apps/assets/9974711/06144e6b-fa2f-495f-aeb8-f11bb0976495">

After
<img width="683" alt="Screenshot 2024-01-19 at 17 08 01" src="https://github.com/dailydotdev/apps/assets/9974711/ce21edb3-3324-4340-aefa-367601445f4c">

Feed Layout Control unaffected
<img width="1029" alt="Screenshot 2024-01-19 at 17 08 43" src="https://github.com/dailydotdev/apps/assets/9974711/9091bcdc-5445-4018-8235-5b7ab6a65b25">

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-105 #done
