### PR TITLE
fix: background of label to be same as card

### DIFF
--- a/packages/shared/src/components/cards/v1/FeedItemContainer.tsx
+++ b/packages/shared/src/components/cards/v1/FeedItemContainer.tsx
@@ -63,12 +63,9 @@ function FeedItemContainer(
       <fieldset>
         {showTypeLabel && (
           <TypeLabel
+            focus={focus}
             type={adAttribution ?? type}
-            className={classNames(
-              'absolute left-2',
-              !focus && '-top-[9px]', // taking the border width into account
-              focus && '-top-2.5 bg-theme-bg-secondary',
-            )}
+            className="absolute left-2"
           />
         )}
         {showFlag && (

--- a/packages/shared/src/components/cards/v1/TypeLabel.tsx
+++ b/packages/shared/src/components/cards/v1/TypeLabel.tsx
@@ -26,11 +26,13 @@ const excludedTypes = new Set<PostType>([
 export interface TypeLabelProps {
   type: TypeLabelType;
   className?: string | undefined;
+  focus?: boolean;
 }
 
 export function TypeLabel({
   type = PostType.Article,
   className,
+  focus,
 }: TypeLabelProps): ReactElement {
   // do not show tag label for excluded types
   if (excludedTypes.has(type as PostType)) {
@@ -40,12 +42,21 @@ export function TypeLabel({
   return (
     <legend
       className={classNames(
-        'rounded bg-theme-bg-primary px-2 font-bold capitalize typo-caption1 group-hover:bg-theme-bg-secondary group-focus:bg-theme-bg-secondary',
+        'rounded bg-theme-bg-primary font-bold capitalize typo-caption1',
         typeToClassName[type as PostType] ?? 'text-theme-label-tertiary',
+        !focus && '-top-[9px]', // taking the border width into account
+        focus && '-top-2.5',
         className,
       )}
     >
-      {typeToLabel[type as PostType] ?? type}
+      <div
+        className={classNames(
+          'rounded px-2 group-hover:bg-theme-float group-focus:bg-theme-float',
+          focus && 'bg-theme-float',
+        )}
+      >
+        {typeToLabel[type as PostType] ?? type}
+      </div>
     </legend>
   );
 }


### PR DESCRIPTION
### Describe what this PR does
- As the color of card hover/focus state is with opacity based on the current card color, an extra div is needed to help the label achieve the same color without needing to add another color to our base css themes
- Added another div to surround the label and added appropriate theme-float color
- moved focus prop inside TypeLabel since it was needed to determine the inner div's classname

P.s difference in color is quite small so it's a bit hard to notice (more noticeable on light mode)

Before:
<img width="1477" alt="Screenshot 2024-01-22 at 6 21 34 AM" src="https://github.com/dailydotdev/apps/assets/36197304/7ea98492-e5cf-4acd-802e-01d6fc295bd3">
<img width="1388" alt="Screenshot 2024-01-22 at 6 21 48 AM" src="https://github.com/dailydotdev/apps/assets/36197304/e1bae3b3-32bc-4c7a-bff3-626e79d25a1b">


After:
<img width="1479" alt="Screenshot 2024-01-22 at 6 20 22 AM" src="https://github.com/dailydotdev/apps/assets/36197304/a99d2b5b-63d8-43f4-859b-d5c5e186b5a4">
<img width="1491" alt="Screenshot 2024-01-22 at 6 20 36 AM" src="https://github.com/dailydotdev/apps/assets/36197304/51099c2c-5eeb-4922-9753-0478f6fc2967">


## Events - No

## Manual Testing

### On those affected packages:
- [ x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion? No

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices? No
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-111 #done
