### PR TITLE
fix: unnecessary video overlay

### DIFF
--- a/packages/shared/src/components/image/VideoImage.tsx
+++ b/packages/shared/src/components/image/VideoImage.tsx
@@ -18,7 +18,7 @@ const VideoImage = ({
     <div
       className={classNames(
         wrapperClassName,
-        'pointer-events-none relative flex h-auto w-full items-center justify-center rounded-12',
+        'pointer-events-none relative flex h-fit w-full items-center justify-center rounded-12',
       )}
     >
       <span className="absolute h-full w-full rounded-12 bg-overlay-tertiary-black" />


### PR DESCRIPTION
## Changes
- The `h-auto` is consuming more height than intended.
- Applying the `h-fit` makes the container fit to the actual content.
- The control value uses the same component. Hence, should fix both ends.

I have thought of removing the floating `span` overlay at first, but it is probably needed in some cases. ~~Though not sure now whether that background overlay will ever be seen.~~

@dailydotdev/web-team does anyone know why we need that overlay? The color has a bit of opacity, which is why it is turning out to be **not** pitch-black.

Edit: is it probably for the actual overlay that makes the thumbnail a bit dark?

Before:

![Screenshot 2024-01-22 at 3 21 02 PM](https://github.com/dailydotdev/apps/assets/13744167/15b4e989-8a9b-46ae-858c-5094e2374ae2)

After:

![Screenshot 2024-01-22 at 3 24 35 PM](https://github.com/dailydotdev/apps/assets/13744167/f6d8715f-6ef2-4f3e-b065-311a9f67c014)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-93 #done
