### PR TITLE
fix: image overlay on both control and v1

### DIFF
--- a/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
@@ -139,7 +139,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
                 loading="lazy"
                 data-testid="postImage"
                 {...(isVideoType && {
-                  wrapperClassName: 'mt-4 mobileXL:w-40 mobileXXL:w-56',
+                  wrapperClassName: 'mt-4 mobileXL:w-40 mobileXXL:w-56 !h-fit',
                 })}
               />
             </CardContent>

--- a/packages/shared/src/components/cards/v1/SharedPostCardFooter.tsx
+++ b/packages/shared/src/components/cards/v1/SharedPostCardFooter.tsx
@@ -37,7 +37,7 @@ export const SharedPostCardFooter = ({
             'h-auto min-h-0 w-full object-cover mobileL:w-56 mobileXL:h-auto mobileXL:w-40 mobileXXL:w-56',
           )}
           {...(isVideoType && {
-            wrapperClassName: 'mobileXL:w-40 mobileXXL:w-56',
+            wrapperClassName: 'mobileXL:w-40 mobileXXL:w-56 !h-fit',
           })}
           loading="lazy"
           data-testid="sharedPostImage"

--- a/packages/shared/src/components/image/VideoImage.tsx
+++ b/packages/shared/src/components/image/VideoImage.tsx
@@ -18,7 +18,7 @@ const VideoImage = ({
     <div
       className={classNames(
         wrapperClassName,
-        'pointer-events-none relative flex h-fit w-full items-center justify-center rounded-12',
+        'pointer-events-none relative flex h-auto max-h-fit w-full items-center justify-center rounded-12',
       )}
     >
       <span className="absolute h-full w-full rounded-12 bg-overlay-tertiary-black" />


### PR DESCRIPTION
## Changes
Reverted back to h-auto as default then override on v1. To fix the control, we set the `max-height: fit-content`. 
Tested 3 cases:
- Feed control
- Feed control shared video post
- Feed v1

Fixes the issue here: https://github.com/dailydotdev/apps/pull/2530#issuecomment-1903415156

![Screenshot 2024-01-22 at 3 51 05 PM](https://github.com/dailydotdev/apps/assets/13744167/d38313fa-e994-4dcb-a82c-c40dd54f41a4)
![Screenshot 2024-01-22 at 3 50 55 PM](https://github.com/dailydotdev/apps/assets/13744167/d1c18054-5c00-4e0d-9437-b042494e4b75)
![Screenshot 2024-01-22 at 3 50 48 PM](https://github.com/dailydotdev/apps/assets/13744167/4a1fd63a-78d5-476e-9da2-634ac4bb9015)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
