### PR TITLE
feat: align top border radius with latest design

### DIFF
--- a/packages/shared/src/components/cards/v1/Card.tsx
+++ b/packages/shared/src/components/cards/v1/Card.tsx
@@ -55,7 +55,7 @@ export const CardVideoImage = classed(
 export const CardSpace = classed('div', 'flex-1');
 
 const clickableCardClasses = classNames(
-  'focus-outline absolute inset-0 block h-full w-full',
+  'focus-outline absolute inset-0 block h-full w-full rounded-16',
 );
 
 export const CardButton = classed('button', clickableCardClasses);
@@ -64,7 +64,7 @@ export const CardLink = classed('a', clickableCardClasses);
 
 export const Card = classed(
   'article',
-  `group relative w-full flex flex-col py-6 px-4 border-t border-theme-divider-tertiary
+  `group relative w-full flex flex-col py-6 px-4 border-t border-theme-divider-tertiary rounded-16
    hover:bg-theme-float
   `,
 );

--- a/packages/shared/src/components/cards/v1/FeedItemContainer.tsx
+++ b/packages/shared/src/components/cards/v1/FeedItemContainer.tsx
@@ -65,7 +65,7 @@ function FeedItemContainer(
           <TypeLabel
             focus={focus}
             type={adAttribution ?? type}
-            className="absolute left-2"
+            className="absolute left-3"
           />
         )}
         {showFlag && (

--- a/packages/shared/src/components/cards/v1/RaisedLabel.tsx
+++ b/packages/shared/src/components/cards/v1/RaisedLabel.tsx
@@ -30,7 +30,7 @@ export function RaisedLabel({
   return (
     <div
       className={classNames(
-        'absolute right-2 flex flex-row px-2 group-hover:bg-theme-bg-secondary group-focus:-top-0.5 group-focus:bg-theme-bg-secondary',
+        'absolute right-3 flex flex-row group-hover:bg-theme-bg-secondary group-focus:-top-0.5 group-focus:bg-theme-bg-secondary',
         !focus && '-top-px bg-theme-bg-primary',
         focus && '-top-0.5 bg-theme-bg-secondary',
         className,


### PR DESCRIPTION
## Changes

- Added `border-radius: 16px` to the top border of a card.
- Changed positioning of the type label and flag so that they are `12px` from the side of the card.
- Removed padding from the flag label, so that it aligns with the design.

### Screenshots

<img width="667" alt="Screenshot 2024-01-22 at 10 50 22" src="https://github.com/dailydotdev/apps/assets/9974711/82a56121-d29b-4e79-908c-66416c9196e7">
<img width="663" alt="Screenshot 2024-01-22 at 10 50 02" src="https://github.com/dailydotdev/apps/assets/9974711/5a182b11-e113-46ad-8a15-1b7dce27a722">
<img width="669" alt="Screenshot 2024-01-22 at 10 47 10" src="https://github.com/dailydotdev/apps/assets/9974711/1b16df6d-3d00-4a33-b8ec-cc2b0b67b685">
<img width="654" alt="Screenshot 2024-01-22 at 10 45 32" src="https://github.com/dailydotdev/apps/assets/9974711/efb9f59c-6fda-4c42-8bbc-5446ca29d02b">
<img width="658" alt="Screenshot 2024-01-22 at 10 45 19" src="https://github.com/dailydotdev/apps/assets/9974711/b611a905-64cd-44ec-9c7f-48605eabef39">

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-110 #done
