### PR TITLE
fix: set 16px font size for article summary

### DIFF
--- a/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
@@ -116,7 +116,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
                 </CardTitle>
 
                 {post.summary && (
-                  <CardTextContainer className="mt-4 text-theme-label-secondary text-base">
+                  <CardTextContainer className="mt-4 text-theme-label-secondary typo-body">
                     {summary}
                   </CardTextContainer>
                 )}

--- a/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
@@ -116,7 +116,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
                 </CardTitle>
 
                 {post.summary && (
-                  <CardTextContainer className="mt-4 text-theme-label-secondary">
+                  <CardTextContainer className="mt-4 text-theme-label-secondary text-base">
                     {summary}
                   </CardTextContainer>
                 )}

--- a/packages/shared/src/components/cards/v1/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/v1/CollectionCard.tsx
@@ -79,7 +79,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
             </CardTitle>
 
             {post.summary && (
-              <CardTextContainer className="mt-4 text-theme-label-secondary">
+              <CardTextContainer className="mt-4 text-theme-label-secondary text-base">
                 {summary}
               </CardTextContainer>
             )}

--- a/packages/shared/src/components/cards/v1/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/v1/CollectionCard.tsx
@@ -79,7 +79,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
             </CardTitle>
 
             {post.summary && (
-              <CardTextContainer className="mt-4 text-theme-label-secondary text-base">
+              <CardTextContainer className="mt-4 text-theme-label-secondary typo-body">
                 {summary}
               </CardTextContainer>
             )}


### PR DESCRIPTION
## Changes

Changes font size for summary to be consistent on extension as well.

### Screenshots

Before
![Screenshot 2024-01-22 at 11 33 08](https://github.com/dailydotdev/apps/assets/9974711/09f488f0-8f24-44b2-8197-f91b593de80d)

After
<img width="654" alt="Screenshot 2024-01-22 at 12 24 58" src="https://github.com/dailydotdev/apps/assets/9974711/58836dc7-e46a-4561-a641-a78bf10a182a">

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-114 #done
