### PR TITLE
fix: feedback close icon and image max height

### DIFF
--- a/packages/shared/src/components/cards/v1/FeedbackCard.tsx
+++ b/packages/shared/src/components/cards/v1/FeedbackCard.tsx
@@ -1,4 +1,5 @@
 import React, { MouseEventHandler, ReactElement } from 'react';
+import classNames from 'classnames';
 import {
   Button,
   ButtonColor,
@@ -84,7 +85,7 @@ export const FeedbackCard = ({
           alt="Post Cover image"
           src={post.image}
           fallbackSrc={cloudinary.post.imageCoverPlaceholder}
-          className="object-cover"
+          className="!h-full max-h-[5rem] object-cover"
           loading="lazy"
           data-testid="postImage"
           {...(isVideoType && {

--- a/packages/shared/src/components/cards/v1/FeedbackCard.tsx
+++ b/packages/shared/src/components/cards/v1/FeedbackCard.tsx
@@ -1,5 +1,4 @@
 import React, { MouseEventHandler, ReactElement } from 'react';
-import classNames from 'classnames';
 import {
   Button,
   ButtonColor,

--- a/packages/shared/src/components/cards/v1/FeedbackCard.tsx
+++ b/packages/shared/src/components/cards/v1/FeedbackCard.tsx
@@ -38,8 +38,8 @@ export const FeedbackCard = ({
         </p>
         <CloseButton
           id="close-engagement-loop-btn"
-          className="absolute -right-2.5 -top-2.5"
-          size={ButtonSize.XSmall}
+          className="absolute -right-2 -top-4"
+          size={ButtonSize.Small}
           onClick={dismissFeedback}
         />
       </div>


### PR DESCRIPTION
## Changes
- Moved the close icon button a size larger.
- Also fixed the placement since the existing values are from the control layout.
- Set max height if 80px for image on feedback UI.

Preview:

![Screenshot 2024-01-22 at 8 10 08 PM](https://github.com/dailydotdev/apps/assets/13744167/3315039e-5bc0-4615-a176-405925b489f0)

![Screenshot 2024-01-22 at 8 20 14 PM](https://github.com/dailydotdev/apps/assets/13744167/6a11f618-4802-4118-8d7e-226448146ffc)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-96 #done
MI-97 #done
