### PR TITLE
fix: missing placeholder that causes layout shifts

### DIFF
--- a/packages/shared/src/components/search/SearchBarSuggestionList.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestionList.tsx
@@ -24,7 +24,7 @@ export function SearchBarSuggestionList({
   const { user, showLogin } = useContext(AuthContext);
 
   if (isLoading) {
-    return <Pill className={className} />;
+    return <Pill className={classNames('!h-10 w-1/2', className)} />;
   }
 
   if (!user) {
@@ -42,7 +42,7 @@ export function SearchBarSuggestionList({
     return (
       <span
         className={classNames(
-          'flex flex-row items-center text-theme-label-quaternary',
+          'flex h-10 flex-row items-center text-theme-label-quaternary',
           className,
         )}
       >


### PR DESCRIPTION
## Changes
- The reason for the layout shift was that the pill's width was not set. Hence, it was not working and taking the supposed space.
- Fixed the consistency of the elements to avoid layout shifts by making them have the same height.

Preview but on Control since I can't test on Search locally.


https://github.com/dailydotdev/apps/assets/13744167/5026603b-9a51-4f92-a193-9b98dd15224d



## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-104 #done
