### PR TITLE
fix: add downvote click handler to other card types

### DIFF
--- a/packages/shared/src/components/cards/v1/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/v1/CollectionCard.tsx
@@ -23,6 +23,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
     post,
     domProps = {},
     onUpvoteClick,
+    onDownvoteClick,
     onCommentClick,
     onMenuClick,
     onShareClick,
@@ -103,6 +104,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
           openNewTab={openNewTab}
           post={post}
           onUpvoteClick={onUpvoteClick}
+          onDownvoteClick={onDownvoteClick}
           onCommentClick={onCommentClick}
           onShareClick={onShareClick}
           onMenuClick={(event) => onMenuClick?.(event, post)}

--- a/packages/shared/src/components/cards/v1/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/SharePostCard.tsx
@@ -14,6 +14,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
     post,
     onPostClick,
     onUpvoteClick,
+    onDownvoteClick,
     onCommentClick,
     onMenuClick,
     onShareClick,
@@ -78,6 +79,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
           openNewTab={openNewTab}
           post={post}
           onUpvoteClick={onUpvoteClick}
+          onDownvoteClick={onDownvoteClick}
           onCommentClick={onCommentClick}
           onShareClick={onShareClick}
           onBookmarkClick={onBookmarkClick}

--- a/packages/shared/src/components/cards/v1/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/WelcomePostCard.tsx
@@ -20,6 +20,7 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
     post,
     onPostClick,
     onUpvoteClick,
+    onDownvoteClick,
     onCommentClick,
     onMenuClick,
     onShareClick,
@@ -137,6 +138,7 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
           openNewTab={openNewTab}
           post={post}
           onUpvoteClick={onUpvoteClick}
+          onDownvoteClick={onDownvoteClick}
           onCommentClick={onCommentClick}
           onShareClick={onShareClick}
           onBookmarkClick={onBookmarkClick}


### PR DESCRIPTION
## Changes

Fixes missing click handler, because prop was not drilled down.

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-115 #done
