### PR TITLE
fix: comments button color and type

### DIFF
--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -152,9 +152,9 @@ export default function ActionButtons({
           <Link href={post.commentsPermalink}>
             <Button
               id={`post-${post.id}-comment-btn`}
-              className="pointer-events-auto ml-2"
+              className="pointer-events-auto ml-2 hover:text-theme-color-blueCheese"
               color={ButtonColor.BlueCheese}
-              icon={<CommentIcon secondary={post.commented} />}
+              icon={<CommentIcon />}
               tag="a"
               href={post.commentsPermalink}
               pressed={post.commented}
@@ -163,12 +163,7 @@ export default function ActionButtons({
             >
               {post?.numComments > 0 ? (
                 <InteractionCounter
-                  className={classNames(
-                    'tabular-nums',
-                    post.commented
-                      ? 'text-theme-color-blueCheese'
-                      : 'text-theme-label-tertiary',
-                  )}
+                  className="tabular-nums"
                   value={post.numComments}
                 />
               ) : null}

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -157,7 +157,6 @@ export default function ActionButtons({
               icon={<CommentIcon />}
               tag="a"
               href={post.commentsPermalink}
-              pressed={post.commented}
               variant={ButtonVariant.Float}
               {...combinedClicks(() => onCommentClick?.(post))}
             >

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -154,15 +154,21 @@ export default function ActionButtons({
               id={`post-${post.id}-comment-btn`}
               className="pointer-events-auto ml-2 hover:text-theme-color-blueCheese"
               color={ButtonColor.BlueCheese}
-              icon={<CommentIcon />}
+              icon={<CommentIcon secondary={post.commented} />}
               tag="a"
               href={post.commentsPermalink}
+              pressed={post.commented}
               variant={ButtonVariant.Float}
               {...combinedClicks(() => onCommentClick?.(post))}
             >
               {post?.numComments > 0 ? (
                 <InteractionCounter
-                  className="tabular-nums"
+                  className={classNames(
+                    'tabular-nums',
+                    post.commented
+                      ? 'text-theme-color-blueCheese'
+                      : 'text-theme-label-tertiary',
+                  )}
                   value={post.numComments}
                 />
               ) : null}


### PR DESCRIPTION
### Describe what this PR does
- removed secondary type from button to get the type based on figma
- on button hover the color of nr of comments should be same color as the highlighted comments button

<img width="744" alt="Screenshot 2024-01-22 at 11 23 18 PM" src="https://github.com/dailydotdev/apps/assets/36197304/ec84498f-63fb-4fb8-8dfe-571e7b71f120">
<img width="805" alt="Screenshot 2024-01-22 at 11 23 12 PM" src="https://github.com/dailydotdev/apps/assets/36197304/815b3807-dcdd-4018-b4f5-7c7b25c0b6e1">


## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices? No
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-116 #done
