### PR TITLE
fix: add margin on top of squad source

### DIFF
--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -119,7 +119,10 @@ function SquadPostContent({
             origin={origin}
             post={post}
           >
-            <PostSourceInfo source={post.source} className="!typo-body" />
+            <PostSourceInfo
+              source={post.source}
+              className={classNames('!typo-body', customNavigation && 'mt-6')}
+            />
             {post.author && (
               <SquadPostAuthor
                 author={post.author}


### PR DESCRIPTION
### Describe what this PR does
- add margin on top of squad source to gain space with back button

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-117 #done
