### PR TITLE
fix: improve upvote/downvote design

### DIFF
--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -113,19 +113,21 @@ export default function ActionButtons({
               pressed={post?.userState?.vote === UserPostVote.Up}
               onClick={() => onUpvoteClick?.(post)}
               variant={ButtonVariant.Tertiary}
-            />
+            >
+              {post?.numUpvotes > 0 ? (
+                <InteractionCounter
+                  className={classNames(
+                    '!min-w-[2ch] font-bold tabular-nums typo-callout',
+                    post?.userState?.vote === UserPostVote.Up
+                      ? 'text-theme-color-avocado'
+                      : 'text-theme-label-tertiary',
+                  )}
+                  value={post?.numUpvotes}
+                />
+              ) : null}
+            </Button>
           </SimpleTooltip>
-          {post?.numUpvotes > 0 && (
-            <InteractionCounter
-              className={classNames(
-                '!min-w-[2ch] font-bold tabular-nums typo-callout',
-                post?.userState?.vote === UserPostVote.Up
-                  ? 'text-theme-color-avocado'
-                  : 'text-theme-label-tertiary',
-              )}
-              value={post?.numUpvotes}
-            />
-          )}
+          <div className="box-border border border-theme-float py-2.5" />
           <SimpleTooltip
             content={
               post?.userState?.vote === UserPostVote.Down


### PR DESCRIPTION
### Describe what this PR does
- Moved number of upvotes inside upvotes button
- Added a separator div between downvote and upvote

<img width="100" alt="Screenshot 2024-01-23 at 12 40 24 AM" src="https://github.com/dailydotdev/apps/assets/36197304/229811a3-0164-43ba-b222-9aadaa94670f">
<img width="100" alt="Screenshot 2024-01-23 at 12 40 16 AM" src="https://github.com/dailydotdev/apps/assets/36197304/59c6493e-672e-4fe4-8b8b-9b2486bf9f91">
<img width="100" alt="Screenshot 2024-01-23 at 12 40 11 AM" src="https://github.com/dailydotdev/apps/assets/36197304/48ee0e1f-af81-4382-b728-1dfbc2c60ca7">
<img width="100" alt="Screenshot 2024-01-23 at 12 40 02 AM" src="https://github.com/dailydotdev/apps/assets/36197304/0ef4a7f3-6ac5-4b22-8905-2f9b6f4f03be">
<img width="100" alt="Screenshot 2024-01-23 at 12 39 43 AM" src="https://github.com/dailydotdev/apps/assets/36197304/c6a9678e-4dd0-4ec8-b5a9-50c605d1acc3">
<img width="100" alt="Screenshot 2024-01-23 at 12 39 28 AM" src="https://github.com/dailydotdev/apps/assets/36197304/ad52b93d-ca68-467d-96b9-56d082321ae8">
<img width="100" alt="Screenshot 2024-01-23 at 12 39 17 AM" src="https://github.com/dailydotdev/apps/assets/36197304/afda1b1f-18df-435c-852b-3e66acd65519">
<img width="100" alt="Screenshot 2024-01-23 at 12 39 24 AM" src="https://github.com/dailydotdev/apps/assets/36197304/52b7706e-6df2-41ce-a5e2-7e5d7bbc02aa">


## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-99 #done
