### PR TITLE
fix: padding around interaction counters on card ActionButtons

### DIFF
--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -117,7 +117,7 @@ export default function ActionButtons({
               {post?.numUpvotes > 0 ? (
                 <InteractionCounter
                   className={classNames(
-                    '!min-w-[2ch] font-bold tabular-nums typo-callout ml-1 -mr-2',
+                    '-mr-2 ml-1 !min-w-[2ch] font-bold tabular-nums typo-callout',
                     post?.userState?.vote === UserPostVote.Up
                       ? 'text-theme-color-avocado'
                       : 'text-theme-label-tertiary',
@@ -166,7 +166,7 @@ export default function ActionButtons({
               {post?.numComments > 0 ? (
                 <InteractionCounter
                   className={classNames(
-                    'tabular-nums ml-1 -mr-2',
+                    '-mr-2 ml-1 tabular-nums',
                     post.commented
                       ? 'text-theme-color-blueCheese'
                       : 'text-theme-label-tertiary',

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -117,7 +117,7 @@ export default function ActionButtons({
               {post?.numUpvotes > 0 ? (
                 <InteractionCounter
                   className={classNames(
-                    '!min-w-[2ch] font-bold tabular-nums typo-callout',
+                    '!min-w-[2ch] font-bold tabular-nums typo-callout ml-1 -mr-2',
                     post?.userState?.vote === UserPostVote.Up
                       ? 'text-theme-color-avocado'
                       : 'text-theme-label-tertiary',
@@ -166,7 +166,7 @@ export default function ActionButtons({
               {post?.numComments > 0 ? (
                 <InteractionCounter
                   className={classNames(
-                    'tabular-nums',
+                    'tabular-nums ml-1 -mr-2',
                     post.commented
                       ? 'text-theme-color-blueCheese'
                       : 'text-theme-label-tertiary',

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -166,7 +166,7 @@ export default function ActionButtons({
               <CommentIcon secondary={post.commented} size={IconSize.Medium} />
               {post?.numComments > 0 ? (
                 <InteractionCounter
-                  className="ml-1.5 -mr-0.5 tabular-nums"
+                  className="-mr-0.5 ml-1.5 tabular-nums"
                   value={post.numComments}
                 />
               ) : null}

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -16,6 +16,7 @@ import { combinedClicks } from '../../../lib/click';
 import { useBlockPostPanel } from '../../../hooks/post/useBlockPostPanel';
 import ConditionalWrapper from '../../ConditionalWrapper';
 import { PostTagsPanel } from '../../post/block/PostTagsPanel';
+import { IconSize } from '../../Icon';
 
 const ShareIcon = dynamic(
   () => import(/* webpackChunkName: "shareIcon" */ '../../icons/Share'),
@@ -102,26 +103,23 @@ export default function ActionButtons({
             }
           >
             <Button
-              className="pointer-events-auto"
+              className={classNames(
+                'pointer-events-auto',
+                post?.numUpvotes > 0 ? '!pl-1 !pr-3' : '!px-1',
+              )}
               id={`post-${post.id}-upvote-btn`}
               color={ButtonColor.Avocado}
-              icon={
-                <UpvoteIcon
-                  secondary={post?.userState?.vote === UserPostVote.Up}
-                />
-              }
               pressed={post?.userState?.vote === UserPostVote.Up}
               onClick={() => onUpvoteClick?.(post)}
               variant={ButtonVariant.Tertiary}
             >
+              <UpvoteIcon
+                secondary={post?.userState?.vote === UserPostVote.Up}
+                size={IconSize.Medium}
+              />
               {post?.numUpvotes > 0 ? (
                 <InteractionCounter
-                  className={classNames(
-                    '-mr-2 ml-1 !min-w-[2ch] font-bold tabular-nums typo-callout',
-                    post?.userState?.vote === UserPostVote.Up
-                      ? 'text-theme-color-avocado'
-                      : 'text-theme-label-tertiary',
-                  )}
+                  className="ml-1.5 !min-w-[2ch] tabular-nums"
                   value={post?.numUpvotes}
                 />
               ) : null}
@@ -154,23 +152,21 @@ export default function ActionButtons({
           <Link href={post.commentsPermalink}>
             <Button
               id={`post-${post.id}-comment-btn`}
-              className="pointer-events-auto ml-2 hover:text-theme-color-blueCheese"
+              className={classNames(
+                'pointer-events-auto ml-2',
+                post?.numUpvotes > 0 ? '!pl-3' : '!px-1',
+              )}
               color={ButtonColor.BlueCheese}
-              icon={<CommentIcon secondary={post.commented} />}
               tag="a"
               href={post.commentsPermalink}
               pressed={post.commented}
               variant={ButtonVariant.Float}
               {...combinedClicks(() => onCommentClick?.(post))}
             >
+              <CommentIcon secondary={post.commented} size={IconSize.Medium} />
               {post?.numComments > 0 ? (
                 <InteractionCounter
-                  className={classNames(
-                    '-mr-2 ml-1 tabular-nums',
-                    post.commented
-                      ? 'text-theme-color-blueCheese'
-                      : 'text-theme-label-tertiary',
-                  )}
+                  className="ml-1.5 -mr-0.5 tabular-nums"
                   value={post.numComments}
                 />
               ) : null}


### PR DESCRIPTION
## Changes

Adds  `ml-1` left  margin and `-mr-2` negative margin to the interaction counter.
That way, we align with figma - `12px` padding on the button and the number looks centered.

### Screenshots

#### Before
<img width="324" alt="Screenshot 2024-01-23 at 09 09 46" src="https://github.com/dailydotdev/apps/assets/9974711/a904fd21-85ca-4798-bd14-85d282fe57a6">

#### After

<img width="324" alt="Screenshot 2024-01-23 at 10 29 21" src="https://github.com/dailydotdev/apps/assets/9974711/7e38b2e2-3850-45b6-b8a5-e92053e4ddce">
<br/>
<img width="323" alt="Screenshot 2024-01-23 at 10 29 16" src="https://github.com/dailydotdev/apps/assets/9974711/789b774f-4075-4399-9a42-c7113aa4386c">
<br/>
<img width="253" alt="Screenshot 2024-01-23 at 10 29 26" src="https://github.com/dailydotdev/apps/assets/9974711/9aacbec3-bd64-467d-96ec-1a3dfa7410e4">


## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-118 #done
