### PR TITLE
fix: set card image to object-cover and keep max 1:1 aspect ratio

### DIFF
--- a/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
@@ -127,7 +127,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
                 src={post.image}
                 fallbackSrc={cloudinary.post.imageCoverPlaceholder}
                 className={classNames(
-                  'object-cover mobileXXL:self-start mobileXXL:object-fill',
+                  'object-cover mobileXXL:self-start',
                   !isVideoType && 'mt-4',
                 )}
                 loading="lazy"

--- a/packages/shared/src/components/cards/v1/Card.tsx
+++ b/packages/shared/src/components/cards/v1/Card.tsx
@@ -45,11 +45,11 @@ export const CardContent = classed('div', 'flex flex-col mobileXL:flex-row');
 
 export const CardImage = classed(
   Image,
-  'rounded-12 h-50 mobileXL:h-28 mobileXL:w-40 mobileXXL:h-auto mobileXXL:w-56',
+  'rounded-12 max-h-[calc(100vw-34px)] mobileXL:aspect-auto mobileXL:max-h-40 mobileXL:w-40 mobileXXL:max-h-56 mobileXXL:w-56',
 );
 export const CardVideoImage = classed(
   VideoImage,
-  'rounded-12 h-50 mobileXL:h-28 mobileXL:w-40 mobileXXL:h-auto mobileXXL:w-56',
+  'rounded-12 max-h-[calc(100vw-34px)] mobileXL:max-h-40 mobileXL:w-40 mobileXXL:max-h-56 mobileXXL:w-56',
 );
 
 export const CardSpace = classed('div', 'flex-1');

--- a/packages/shared/src/components/cards/v1/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/v1/CollectionCard.tsx
@@ -91,7 +91,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
               alt="Post Cover image"
               src={image}
               fallbackSrc={cloudinary.post.imageCoverPlaceholder}
-              className="my-2 object-cover mobileXXL:self-start mobileXXL:object-fill"
+              className="my-2 object-cover mobileXXL:self-start"
               loading="lazy"
             />
           )}

--- a/packages/shared/src/components/cards/v1/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/WelcomePostCard.tsx
@@ -126,7 +126,7 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
               alt="Post Cover image"
               src={image}
               fallbackSrc={cloudinary.post.imageCoverPlaceholder}
-              className="my-2 object-cover mobileXXL:self-start mobileXXL:object-fill"
+              className="my-2 object-cover mobileXXL:self-start"
               loading="lazy"
             />
           )}


### PR DESCRIPTION
## Changes

### Describe what this PR does

Sets card image as always `object-cover` and keeps aspect ratio to 1:1 at most. Wider images keep being wider.

#### Loom video

https://www.loom.com/share/32069f44198343a6ace989791a9c5793?sid=09b36bc9-919b-47f3-b32d-ee0dad2358f1

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-95 #done
