### PR TITLE
fix: feed layout comment tooltip and source link

### DIFF
--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -17,6 +17,7 @@ import { useBlockPostPanel } from '../../../hooks/post/useBlockPostPanel';
 import ConditionalWrapper from '../../ConditionalWrapper';
 import { PostTagsPanel } from '../../post/block/PostTagsPanel';
 import { IconSize } from '../../Icon';
+import { LinkWithTooltip } from '../../tooltips/LinkWithTooltip';
 
 const ShareIcon = dynamic(
   () => import(/* webpackChunkName: "shareIcon" */ '../../icons/Share'),
@@ -144,31 +145,32 @@ export default function ActionButtons({
             />
           </SimpleTooltip>
         </div>
-        <SimpleTooltip content="Comments">
-          <Link href={post.commentsPermalink}>
-            <Button
-              id={`post-${post.id}-comment-btn`}
-              className={classNames(
-                'pointer-events-auto ml-2',
-                post?.numComments > 0 ? '!pl-3' : '!px-1',
-              )}
-              color={ButtonColor.BlueCheese}
-              tag="a"
-              href={post.commentsPermalink}
-              pressed={post.commented}
-              variant={ButtonVariant.Float}
-              {...combinedClicks(() => onCommentClick?.(post))}
-            >
-              <CommentIcon secondary={post.commented} size={IconSize.Medium} />
-              {post?.numComments > 0 ? (
-                <InteractionCounter
-                  className="-mr-0.5 ml-1.5 tabular-nums"
-                  value={post.numComments}
-                />
-              ) : null}
-            </Button>
-          </Link>
-        </SimpleTooltip>
+        <LinkWithTooltip
+          tooltip={{ content: 'Comment' }}
+          href={post.commentsPermalink}
+        >
+          <Button
+            id={`post-${post.id}-comment-btn`}
+            className={classNames(
+              'pointer-events-auto ml-2',
+              post?.numComments > 0 ? '!pl-3' : '!px-1',
+            )}
+            color={ButtonColor.BlueCheese}
+            tag="a"
+            href={post.commentsPermalink}
+            pressed={post.commented}
+            variant={ButtonVariant.Float}
+            {...combinedClicks(() => onCommentClick?.(post))}
+          >
+            <CommentIcon secondary={post.commented} size={IconSize.Medium} />
+            {post?.numComments > 0 ? (
+              <InteractionCounter
+                className="-mr-0.5 ml-1.5 tabular-nums"
+                value={post.numComments}
+              />
+            ) : null}
+          </Button>
+        </LinkWithTooltip>
         <SimpleTooltip
           content={post.bookmarked ? 'Remove bookmark' : 'Bookmark'}
         >

--- a/packages/shared/src/components/cards/v1/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/v1/ActionButtons.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
-import Link from 'next/link';
 import { Post, UserPostVote } from '../../../graphql/posts';
 import InteractionCounter from '../../InteractionCounter';
 import UpvoteIcon from '../../icons/Upvote';

--- a/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef, ReactElement, Ref } from 'react';
 import classNames from 'classnames';
+import Link from 'next/link';
 import {
   CardContainer,
   CardContent,
@@ -90,7 +91,13 @@ export const ArticlePostCard = forwardRef(function PostCard(
               onMenuClick={(event) => onMenuClick?.(event, post)}
               onReadArticleClick={onReadArticleClick}
               metadata={{
-                topLabel: post.source.name,
+                topLabel: (
+                  <Link href={post.source.permalink}>
+                    <a href={post.source.permalink} className="relative z-1">
+                      {post.source.name}
+                    </a>
+                  </Link>
+                ),
                 bottomLabel: (
                   <PostReadTime
                     readTime={post.readTime}

--- a/packages/shared/src/components/cards/v1/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/SharePostCard.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, ReactElement, Ref, useRef } from 'react';
+import Link from 'next/link';
 import ActionButtons from './ActionButtons';
 import { SharedPostText } from '../SharedPostText';
 import { SharedPostCardFooter } from './SharedPostCardFooter';
@@ -54,7 +55,15 @@ export const SharePostCard = forwardRef(function SharePostCard(
         post={post}
         onMenuClick={(event) => onMenuClick?.(event, post)}
         metadata={{
-          topLabel: enableSourceHeader ? post.source.name : post.author.name,
+          topLabel: enableSourceHeader ? (
+            <Link href={post.source.permalink}>
+              <a href={post.source.permalink} className="relative z-1">
+                {post.source.name}
+              </a>
+            </Link>
+          ) : (
+            post.author.name
+          ),
           bottomLabel: enableSourceHeader
             ? post.author.name
             : `@${post.sharedPost?.source.handle}`,


### PR DESCRIPTION
## Changes
- Fixes the tooltip for the comment button which has now become a link.
- Fixes the card's header to make the source name a link.
- Bookmark missing undo button seems to be the case since then, no changes needed, I think.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
