### PR TITLE
fix: position of search gradient background

### DIFF
--- a/packages/shared/src/components/feeds/FeedGradientBg.tsx
+++ b/packages/shared/src/components/feeds/FeedGradientBg.tsx
@@ -10,7 +10,7 @@ export function FeedGradientBg(): ReactElement {
   return (
     <div
       className={classNames(
-        'absolute -top-24 flex flex-row-reverse justify-center',
+        'absolute -top-40 flex flex-row-reverse justify-center',
         centered,
         !shouldUseFeedLayoutV1 && 'laptop:left-0 laptop:translate-x-0',
       )}


### PR DESCRIPTION
## Changes

Based on [figma spec](https://www.figma.com/file/nmfWPS7x3kzLUvYMkBx2kW/daily.dev---Dev-Mode?node-id=1882%3A12132&mode=dev), the position of the gradient div should be right above the search container. 

### Screenshots

#### Current implementation
<img width="1214" alt="Screenshot 2024-01-24 at 15 35 37" src="https://github.com/dailydotdev/apps/assets/9974711/7408f314-6cfa-4405-917d-5bf7369da0c2">
<img width="558" alt="Screenshot 2024-01-24 at 15 35 52" src="https://github.com/dailydotdev/apps/assets/9974711/1bab7c70-1fcc-414e-b9c5-10d5743db23b">

#### With the fix
<img width="550" alt="Screenshot 2024-01-24 at 15 36 22" src="https://github.com/dailydotdev/apps/assets/9974711/d3913b03-162f-453b-94f1-0d56ac5e2569">
<img width="1121" alt="Screenshot 2024-01-24 at 15 36 11" src="https://github.com/dailydotdev/apps/assets/9974711/9b18d741-8878-4be1-969d-0b6b4c86bfe0">

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
