### PR TITLE
fix: missing analytics

### DIFF
--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -42,6 +42,7 @@ function SharePostContent({
           <div className="flex flex-1 flex-col">
             <SharedPostLink
               post={post}
+              onGoToLinkProps={combinedClicks(openArticle)}
               className="mb-4 mt-4 flex flex-wrap font-bold typo-body laptop:mt-0"
             >
               {post.sharedPost.title}

--- a/packages/shared/src/components/post/ShareYouTubeContent.tsx
+++ b/packages/shared/src/components/post/ShareYouTubeContent.tsx
@@ -6,13 +6,17 @@ import { SharedLinkContainer } from './common/SharedLinkContainer';
 import { SharedPostLink } from './common/SharedPostLink';
 import YoutubeVideo from '../video/YoutubeVideo';
 import { formatReadTime } from '../utilities';
+import { combinedClicks } from '../../lib/click';
 
 interface ShareYouTubeContentProps {
   post: Post;
   onReadArticle: () => Promise<void>;
 }
 
-function ShareYouTubeContent({ post }: ShareYouTubeContentProps): ReactElement {
+function ShareYouTubeContent({
+  post,
+  onReadArticle,
+}: ShareYouTubeContentProps): ReactElement {
   return (
     <>
       <SharePostTitle post={post} />
@@ -23,6 +27,7 @@ function ShareYouTubeContent({ post }: ShareYouTubeContentProps): ReactElement {
         />
         <SharedPostLink
           post={post}
+          onGoToLinkProps={combinedClicks(onReadArticle)}
           className="m-4 flex flex-wrap font-bold typo-body"
         >
           {post.sharedPost.title}


### PR DESCRIPTION
## Changes
- While working on the YT section being clickable as a section and redirect, I noticed there are still missing analytics.

[Discussion](https://dailydotdev.slack.com/archives/C015T1Y237Z/p1702292038866539) in the past.

One of the recent PRs fixed the click on image analytics, but the title itself was not fixed.

![image](https://github.com/dailydotdev/apps/assets/13744167/22149ee8-aed5-47d8-b26f-7f75c21e028d)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
