### PR TITLE
fix: horizontal scroll caused by bg

### DIFF
--- a/packages/shared/src/components/feeds/FeedGradientBg.tsx
+++ b/packages/shared/src/components/feeds/FeedGradientBg.tsx
@@ -10,7 +10,7 @@ export function FeedGradientBg(): ReactElement {
   return (
     <div
       className={classNames(
-        'absolute -top-40 flex flex-row-reverse justify-center',
+        'absolute -top-40 flex max-w-full flex-row-reverse justify-center',
         centered,
         !shouldUseFeedLayoutV1 && 'laptop:left-0 laptop:translate-x-0',
       )}


### PR DESCRIPTION
## Changes
- The size of the gradient bg is what causes it to overflow. Have set a max-width to prevent the scroll to show.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
