### PR TITLE
fix: onboarding tags not showing dots for similar tags

### DIFF
--- a/packages/shared/src/components/onboarding/FilterOnboardingV4.tsx
+++ b/packages/shared/src/components/onboarding/FilterOnboardingV4.tsx
@@ -174,9 +174,12 @@ export function FilterOnboardingV4({
             return (
               <Button
                 key={tag.name}
-                className={classNames({
-                  'btn-tag': !isSelected,
-                })}
+                className={classNames(
+                  {
+                    'btn-tag': !isSelected,
+                  },
+                  'relative',
+                )}
                 variant={
                   isSelected ? ButtonVariant.Primary : ButtonVariant.Float
                 }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- missing relative positioning on new button because dots are absolute position

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-81 #done
