### PR TITLE
fix: tldr section to navigate to post

### DIFF
--- a/packages/shared/src/components/cards/ShowMoreContent.tsx
+++ b/packages/shared/src/components/cards/ShowMoreContent.tsx
@@ -37,7 +37,7 @@ export default function ShowMoreContent({
 
   return (
     <div className={className}>
-      <p className="break-words typo-body">
+      <p className="select-text break-words typo-body">
         {contentPrefix}
         {getContent()}{' '}
         {displayShowMoreLink() && (

--- a/packages/shared/src/components/post/ShareYouTubeContent.tsx
+++ b/packages/shared/src/components/post/ShareYouTubeContent.tsx
@@ -1,12 +1,11 @@
 import React, { ReactElement } from 'react';
-import Link from 'next/link';
 import PostSourceInfo from './PostSourceInfo';
 import { Post } from '../../graphql/posts';
 import { SharePostTitle } from './share';
 import { SharedLinkContainer } from './common/SharedLinkContainer';
 import { SharedPostLink } from './common/SharedPostLink';
 import YoutubeVideo from '../video/YoutubeVideo';
-import { formatReadTime } from '../utilities';
+import { formatReadTime, SelectableLink } from '../utilities';
 import { combinedClicks } from '../../lib/click';
 import ConditionalWrapper from '../ConditionalWrapper';
 
@@ -20,23 +19,6 @@ function ShareYouTubeContent({
   onReadArticle,
 }: ShareYouTubeContentProps): ReactElement {
   const isUnknownSource = post.sharedPost.source.id === 'unknown';
-  const onLinkClick = (e: React.MouseEvent) => {
-    const selection = globalThis?.window?.getSelection();
-    const hasSelection = selection?.anchorOffset !== selection?.focusOffset;
-
-    if (hasSelection) {
-      e.preventDefault();
-    }
-  };
-
-  const linkToPost = post.sharedPost.commentsPermalink;
-  const wrappedComponent = (wrapped) => (
-    <Link href={linkToPost}>
-      <a href={linkToPost} draggable="false" onClick={onLinkClick}>
-        {wrapped}
-      </a>
-    </Link>
-  );
 
   return (
     <>
@@ -47,7 +29,11 @@ function ShareYouTubeContent({
         wrapper={(node) => (
           <ConditionalWrapper
             condition={!isUnknownSource}
-            wrapper={wrappedComponent}
+            wrapper={(comp) => (
+              <SelectableLink href={post.sharedPost.commentsPermalink}>
+                {comp}
+              </SelectableLink>
+            )}
           >
             <SharedPostLink
               post={post}

--- a/packages/shared/src/components/post/ShareYouTubeContent.tsx
+++ b/packages/shared/src/components/post/ShareYouTubeContent.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import Link from 'next/link';
 import PostSourceInfo from './PostSourceInfo';
 import { Post } from '../../graphql/posts';
 import { SharePostTitle } from './share';
@@ -17,30 +18,53 @@ function ShareYouTubeContent({
   post,
   onReadArticle,
 }: ShareYouTubeContentProps): ReactElement {
+  const onLinkClick = (e: React.MouseEvent) => {
+    const selection = globalThis?.window?.getSelection();
+    const hasSelection = selection?.anchorOffset !== selection?.focusOffset;
+
+    if (hasSelection) {
+      e.preventDefault();
+    }
+  };
+
   return (
     <>
       <SharePostTitle post={post} />
-      <SharedLinkContainer className="my-5" summary={post?.sharedPost?.summary}>
+      <SharedLinkContainer
+        className="my-5"
+        summary={post?.sharedPost?.summary}
+        wrapper={(node) => (
+          <Link href={post.commentsPermalink}>
+            <a
+              href={post.commentsPermalink}
+              draggable="false"
+              onClick={onLinkClick}
+            >
+              <SharedPostLink
+                post={post}
+                onGoToLinkProps={combinedClicks(onReadArticle)}
+                className="m-4 flex flex-wrap font-bold typo-body"
+              >
+                {post.sharedPost.title}
+              </SharedPostLink>
+              <PostSourceInfo
+                date={
+                  post.sharedPost.readTime
+                    ? `${formatReadTime(post.sharedPost.readTime)} watch time`
+                    : undefined
+                }
+                source={post.sharedPost.source}
+                className="mx-4 mb-4"
+                size="small"
+              />
+              {node}
+            </a>
+          </Link>
+        )}
+      >
         <YoutubeVideo
           title={post?.sharedPost?.title}
           videoId={post?.sharedPost?.videoId}
-        />
-        <SharedPostLink
-          post={post}
-          onGoToLinkProps={combinedClicks(onReadArticle)}
-          className="m-4 flex flex-wrap font-bold typo-body"
-        >
-          {post.sharedPost.title}
-        </SharedPostLink>
-        <PostSourceInfo
-          date={
-            post.sharedPost.readTime
-              ? `${formatReadTime(post.sharedPost.readTime)} watch time`
-              : undefined
-          }
-          source={post.sharedPost.source}
-          className="mx-4 mb-4"
-          size="small"
         />
       </SharedLinkContainer>
     </>

--- a/packages/shared/src/components/post/ShareYouTubeContent.tsx
+++ b/packages/shared/src/components/post/ShareYouTubeContent.tsx
@@ -8,6 +8,7 @@ import { SharedPostLink } from './common/SharedPostLink';
 import YoutubeVideo from '../video/YoutubeVideo';
 import { formatReadTime } from '../utilities';
 import { combinedClicks } from '../../lib/click';
+import ConditionalWrapper from '../ConditionalWrapper';
 
 interface ShareYouTubeContentProps {
   post: Post;
@@ -18,6 +19,7 @@ function ShareYouTubeContent({
   post,
   onReadArticle,
 }: ShareYouTubeContentProps): ReactElement {
+  const isUnknownSource = post.sharedPost.source.id === 'unknown';
   const onLinkClick = (e: React.MouseEvent) => {
     const selection = globalThis?.window?.getSelection();
     const hasSelection = selection?.anchorOffset !== selection?.focusOffset;
@@ -27,6 +29,15 @@ function ShareYouTubeContent({
     }
   };
 
+  const linkToPost = post.sharedPost.commentsPermalink;
+  const wrappedComponent = (wrapped) => (
+    <Link href={linkToPost}>
+      <a href={linkToPost} draggable="false" onClick={onLinkClick}>
+        {wrapped}
+      </a>
+    </Link>
+  );
+
   return (
     <>
       <SharePostTitle post={post} />
@@ -34,32 +45,29 @@ function ShareYouTubeContent({
         className="my-5"
         summary={post?.sharedPost?.summary}
         wrapper={(node) => (
-          <Link href={post.commentsPermalink}>
-            <a
-              href={post.commentsPermalink}
-              draggable="false"
-              onClick={onLinkClick}
+          <ConditionalWrapper
+            condition={!isUnknownSource}
+            wrapper={wrappedComponent}
+          >
+            <SharedPostLink
+              post={post}
+              onGoToLinkProps={combinedClicks(onReadArticle)}
+              className="m-4 flex flex-wrap font-bold typo-body"
             >
-              <SharedPostLink
-                post={post}
-                onGoToLinkProps={combinedClicks(onReadArticle)}
-                className="m-4 flex flex-wrap font-bold typo-body"
-              >
-                {post.sharedPost.title}
-              </SharedPostLink>
-              <PostSourceInfo
-                date={
-                  post.sharedPost.readTime
-                    ? `${formatReadTime(post.sharedPost.readTime)} watch time`
-                    : undefined
-                }
-                source={post.sharedPost.source}
-                className="mx-4 mb-4"
-                size="small"
-              />
-              {node}
-            </a>
-          </Link>
+              {post.sharedPost.title}
+            </SharedPostLink>
+            <PostSourceInfo
+              date={
+                post.sharedPost.readTime
+                  ? `${formatReadTime(post.sharedPost.readTime)} watch time`
+                  : undefined
+              }
+              source={post.sharedPost.source}
+              className="mx-4 mb-4"
+              size="small"
+            />
+            {node}
+          </ConditionalWrapper>
         )}
       >
         <YoutubeVideo

--- a/packages/shared/src/components/post/ShareYouTubeContent.tsx
+++ b/packages/shared/src/components/post/ShareYouTubeContent.tsx
@@ -26,7 +26,7 @@ function ShareYouTubeContent({
       <SharedLinkContainer
         className="my-5"
         summary={post?.sharedPost?.summary}
-        Wrapper={(node) => (
+        Wrapper={({ children }) => (
           <ConditionalWrapper
             condition={!isUnknownSource}
             wrapper={(comp) => (
@@ -52,7 +52,7 @@ function ShareYouTubeContent({
               className="mx-4 mb-4"
               size="small"
             />
-            {node}
+            {children}
           </ConditionalWrapper>
         )}
       >

--- a/packages/shared/src/components/post/ShareYouTubeContent.tsx
+++ b/packages/shared/src/components/post/ShareYouTubeContent.tsx
@@ -26,7 +26,7 @@ function ShareYouTubeContent({
       <SharedLinkContainer
         className="my-5"
         summary={post?.sharedPost?.summary}
-        wrapper={(node) => (
+        Wrapper={(node) => (
           <ConditionalWrapper
             condition={!isUnknownSource}
             wrapper={(comp) => (

--- a/packages/shared/src/components/post/common/SharedLinkContainer.tsx
+++ b/packages/shared/src/components/post/common/SharedLinkContainer.tsx
@@ -7,12 +7,14 @@ interface SharedLinkContainerProps {
   children: ReactNode;
   summary?: string;
   className?: string;
+  wrapper?: (node: ReactNode) => ReactNode;
 }
 
 export function SharedLinkContainer({
   children,
   summary,
   className,
+  wrapper,
 }: SharedLinkContainerProps): ReactElement {
   const [height, setHeight] = useState<number>(null);
   const [shouldShowSummary, setShouldShowSummary] = useState(true);
@@ -24,6 +26,24 @@ export function SharedLinkContainer({
     return shouldShowSummary ? height : 0;
   }, [shouldShowSummary, height]);
 
+  const postSummary = (
+    <PostSummary
+      ref={(el) => {
+        if (!el?.offsetHeight || height !== null) {
+          return;
+        }
+
+        setHeight(el.offsetHeight);
+      }}
+      style={{ height: tldrHeight }}
+      className={classNames(
+        'mx-4 transition-all duration-300 ease-in-out',
+        shouldShowSummary && 'mb-4',
+      )}
+      summary={summary}
+    />
+  );
+
   return (
     <div
       className={classNames(
@@ -34,21 +54,7 @@ export function SharedLinkContainer({
       {children}
       {summary && (
         <>
-          <PostSummary
-            ref={(el) => {
-              if (!el?.offsetHeight || height !== null) {
-                return;
-              }
-
-              setHeight(el.offsetHeight);
-            }}
-            style={{ height: tldrHeight }}
-            className={classNames(
-              'mx-4 transition-all duration-300 ease-in-out',
-              shouldShowSummary && 'mb-4',
-            )}
-            summary={summary}
-          />
+          {wrapper ? wrapper(postSummary) : postSummary}
           <button
             type="button"
             className="flex w-full flex-row justify-center border-t border-theme-divider-tertiary py-2 font-bold typo-callout hover:underline"

--- a/packages/shared/src/components/post/common/SharedLinkContainer.tsx
+++ b/packages/shared/src/components/post/common/SharedLinkContainer.tsx
@@ -7,7 +7,7 @@ interface SharedLinkContainerProps {
   children: ReactNode;
   summary?: string;
   className?: string;
-  Wrapper?: (node: ReactNode) => ReactNode;
+  Wrapper?: React.ComponentType<{ children: ReactNode }>;
 }
 
 export function SharedLinkContainer({
@@ -54,7 +54,7 @@ export function SharedLinkContainer({
       {children}
       {summary && (
         <>
-          {Wrapper ? Wrapper(postSummary) : postSummary}
+          {Wrapper ? <Wrapper>{postSummary}</Wrapper> : postSummary}
           <button
             type="button"
             className="flex w-full flex-row justify-center border-t border-theme-divider-tertiary py-2 font-bold typo-callout hover:underline"

--- a/packages/shared/src/components/post/common/SharedLinkContainer.tsx
+++ b/packages/shared/src/components/post/common/SharedLinkContainer.tsx
@@ -7,14 +7,14 @@ interface SharedLinkContainerProps {
   children: ReactNode;
   summary?: string;
   className?: string;
-  wrapper?: (node: ReactNode) => ReactNode;
+  Wrapper?: (node: ReactNode) => ReactNode;
 }
 
 export function SharedLinkContainer({
   children,
   summary,
   className,
-  wrapper,
+  Wrapper,
 }: SharedLinkContainerProps): ReactElement {
   const [height, setHeight] = useState<number>(null);
   const [shouldShowSummary, setShouldShowSummary] = useState(true);
@@ -54,7 +54,7 @@ export function SharedLinkContainer({
       {children}
       {summary && (
         <>
-          {wrapper ? wrapper(postSummary) : postSummary}
+          {Wrapper ? Wrapper(postSummary) : postSummary}
           <button
             type="button"
             className="flex w-full flex-row justify-center border-t border-theme-divider-tertiary py-2 font-bold typo-callout hover:underline"

--- a/packages/shared/src/components/utilities/SelectableLink.tsx
+++ b/packages/shared/src/components/utilities/SelectableLink.tsx
@@ -1,0 +1,33 @@
+import React, { ReactElement, AnchorHTMLAttributes, ReactNode } from 'react';
+import Link, { LinkProps } from 'next/link';
+
+interface SelectableLinkProps {
+  href: string;
+  linkProps?: Omit<LinkProps, 'href'>;
+  anchorProps?: Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>;
+  children: ReactNode;
+}
+
+export function SelectableLink({
+  href,
+  linkProps,
+  anchorProps,
+  children,
+}: SelectableLinkProps): ReactElement {
+  const onLinkClick = (e: React.MouseEvent) => {
+    const selection = globalThis?.window?.getSelection();
+    const hasSelection = selection?.anchorOffset !== selection?.focusOffset;
+
+    if (hasSelection) {
+      e.preventDefault();
+    }
+  };
+
+  return (
+    <Link href={href} {...linkProps}>
+      <a href={href} draggable="false" onClick={onLinkClick} {...anchorProps}>
+        {children}
+      </a>
+    </Link>
+  );
+}

--- a/packages/shared/src/components/utilities/index.ts
+++ b/packages/shared/src/components/utilities/index.ts
@@ -1,2 +1,3 @@
 export * from './common';
 export * from './Divider';
+export * from './SelectableLink';


### PR DESCRIPTION
## Changes
- When clicking the whole section below of a YT content, it should redirect the user when it is a post found inside dailydev.
- When it is a shared external video, the user should do nothing.
- An edge case we were asked to cover: prevent default on click when the user is highlighting the content/selecting texts.

Currently deployed at preview2.

https://preview2.app.daily.dev/squads/youtubecontent

See the difference between the first and second post.

Preview:

https://github.com/dailydotdev/apps/assets/13744167/6f353d4b-6cd0-4715-a28f-6867337bbe3c


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-81 #done
