### PR TITLE
feat: reading streak button and popup integration

### DIFF
--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -27,7 +27,7 @@ import {
 } from '../../hooks';
 import { SearchReferralButton } from '../referral/SearchReferralButton';
 import { ReadingStreakButton } from '../streak/ReadingStreakButton';
-import { useStreakExperiment } from '../../hooks/streaks';
+import { useReadingStreak } from '../../hooks/streaks';
 
 export interface MainLayoutHeaderProps {
   greeting?: boolean;
@@ -51,8 +51,8 @@ function MainLayoutHeader({
   const { trackEvent } = useAnalyticsContext();
   const { unreadCount } = useNotificationContext();
   const { user, loadingUser } = useContext(AuthContext);
-  const { shouldShowStreak } = useStreakExperiment();
-  const hideButton = loadingUser;
+  const { streak, isEnabled, isLoading } = useReadingStreak();
+  const hideButton = loadingUser || (isEnabled && isLoading);
   const isMobile = useViewSize(ViewSize.MobileL);
 
   const headerButton = (() => {
@@ -83,10 +83,10 @@ function MainLayoutHeader({
   const renderButtons = () => {
     return (
       <>
-        <CreatePostButton />
-        {user && shouldShowStreak && <ReadingStreakButton />}
         {!hideButton && user && (
           <>
+            <CreatePostButton />
+            {streak && <ReadingStreakButton streak={streak} />}
             {sidebarRendered && <SearchReferralButton />}
             <LinkWithTooltip
               tooltip={{ placement: 'bottom', content: 'Notifications' }}

--- a/packages/shared/src/components/streak/ReadingStreakButton.tsx
+++ b/packages/shared/src/components/streak/ReadingStreakButton.tsx
@@ -7,7 +7,7 @@ import { useReadingStreak } from '../../hooks/streaks';
 
 export function ReadingStreakButton(): ReactElement {
   const [shouldShowStreaks, setShouldShowStreaks] = useState(false);
-  const { currentStreak } = useReadingStreak();
+  const { streak } = useReadingStreak();
 
   return (
     <SimpleTooltip
@@ -20,7 +20,8 @@ export function ReadingStreakButton(): ReactElement {
         textClassName: 'text-theme-label-primary typo-callout',
         className: 'border border-theme-divider-tertiary',
       }}
-      content={<ReadingStreakPopup />}
+      content={<ReadingStreakPopup streak={streak} />}
+      onClickOutside={() => setShouldShowStreaks(false)}
     >
       <Button
         type="button"
@@ -29,7 +30,7 @@ export function ReadingStreakButton(): ReactElement {
         onClick={() => setShouldShowStreaks((state) => !state)}
         className="gap-1 text-theme-color-bacon"
       >
-        {currentStreak}
+        {streak?.current}
       </Button>
     </SimpleTooltip>
   );

--- a/packages/shared/src/components/streak/ReadingStreakButton.tsx
+++ b/packages/shared/src/components/streak/ReadingStreakButton.tsx
@@ -3,11 +3,16 @@ import { ReadingStreakPopup } from './popup';
 import { Button, ButtonVariant } from '../buttons/ButtonV2';
 import ReadingStreakIcon from '../icons/ReadingStreak';
 import { SimpleTooltip } from '../tooltips';
-import { useReadingStreak } from '../../hooks/streaks';
+import { UserStreak } from '../../graphql/users';
 
-export function ReadingStreakButton(): ReactElement {
+interface ReadingStreakButtonProps {
+  streak: UserStreak;
+}
+
+export function ReadingStreakButton({
+  streak,
+}: ReadingStreakButtonProps): ReactElement {
   const [shouldShowStreaks, setShouldShowStreaks] = useState(false);
-  const { streak } = useReadingStreak();
 
   return (
     <SimpleTooltip

--- a/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
+++ b/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
@@ -1,9 +1,13 @@
-import React, { ReactElement } from 'react';
-import { addDays, subDays } from 'date-fns';
+import React, { ReactElement, useMemo } from 'react';
+import { addDays, isSameDay, subDays } from 'date-fns';
+import { useQuery } from '@tanstack/react-query';
 import { Button, ButtonVariant } from '../../buttons/ButtonV2';
 import { StreakSection } from './StreakSection';
 import { DayStreak, Streak } from './DayStreak';
 import { ButtonSize } from '../../buttons/Button';
+import { generateQueryKey, RequestKey } from '../../../lib/query';
+import { getReadingStreak30Days, UserStreak } from '../../../graphql/users';
+import { useAuthContext } from '../../../contexts/AuthContext';
 
 const today = new Date();
 const dateToday = today.getDate();
@@ -19,52 +23,71 @@ const streakDays = [
   addDays(today, 4),
 ]; // these dates will then be compared to the user's post views
 
-export function ReadingStreakPopup(): ReactElement {
+interface ReadingStreakPopupProps {
+  streak: UserStreak;
+}
+
+export function ReadingStreakPopup({
+  streak,
+}: ReadingStreakPopupProps): ReactElement {
+  const { user } = useAuthContext();
+  const { data: history } = useQuery(
+    generateQueryKey(RequestKey.ReadingStreak30Days, user),
+    () => getReadingStreak30Days(user.id),
+  );
+
+  const streaks = useMemo(() => {
+    return streakDays.map((value) => {
+      const day = value.getDay();
+      const date = value.getDate();
+      const isCompleted = history?.some(({ date: historyDate, reads }) => {
+        const dateToCompare = new Date(historyDate);
+        const sameDate = isSameDay(dateToCompare, value);
+
+        return sameDate && reads > 0;
+      });
+
+      const getStreak = () => {
+        if (isCompleted) {
+          return Streak.Completed;
+        }
+
+        if (day === 0 || day === 6) {
+          return Streak.Freeze;
+        }
+
+        if (date === dateToday) {
+          return Streak.Pending;
+        }
+
+        return Streak.Upcoming;
+      };
+
+      return (
+        <DayStreak
+          key={value.getTime()}
+          streak={getStreak()}
+          day={day}
+          shouldShowArrow={date === dateToday}
+        />
+      );
+    });
+  }, [history]);
+
   return (
     <div className="flex flex-col">
       <div className="flex flex-row">
-        <StreakSection streak={44} label="Current streak" />
-        <StreakSection streak={100} label="Longest streak 🏆" />
+        <StreakSection streak={streak.current} label="Current streak" />
+        <StreakSection streak={streak.max} label="Longest streak 🏆" />
       </div>
-      <div className="mt-6 flex flex-row gap-2">
-        {streakDays.map((value) => {
-          const day = value.getDay();
-          const date = value.getDate();
-
-          // this is just a dummy logic to simulate the popup with different values
-          const getStreak = () => {
-            if (date === dateToday) {
-              return Streak.Pending;
-            }
-
-            if (day === 0 || day === 6) {
-              return Streak.Freeze;
-            }
-
-            if (dateToday > date) {
-              return Streak.Completed;
-            }
-
-            return Streak.Upcoming;
-          };
-
-          return (
-            <DayStreak
-              key={value.getTime()}
-              streak={getStreak()}
-              day={day}
-              shouldShowArrow={date === dateToday}
-            />
-          );
-        })}
-      </div>
+      <div className="mt-6 flex flex-row gap-2">{streaks}</div>
       <Button
         type="button"
         variant={ButtonVariant.Float}
         size={ButtonSize.Small}
         className="mt-4"
       >
-        Total reading days: 44
+        Total reading days: {streak.total}
       </Button>
     </div>
   );

--- a/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
+++ b/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
@@ -8,6 +8,7 @@ import { ButtonSize } from '../../buttons/Button';
 import { generateQueryKey, RequestKey } from '../../../lib/query';
 import { getReadingStreak30Days, UserStreak } from '../../../graphql/users';
 import { useAuthContext } from '../../../contexts/AuthContext';
+import { Weekends } from '../../../lib/dateFormat';
 
 const today = new Date();
 const dateToday = today.getDate();
@@ -55,7 +56,7 @@ export function ReadingStreakPopup({
           return Streak.Completed;
         }
 
-        if (day === 0 || day === 6) {
+        if (Weekends.includes(day)) {
           return Streak.Freeze;
         }
 

--- a/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
+++ b/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
@@ -40,12 +40,15 @@ export function ReadingStreakPopup({
     return streakDays.map((value) => {
       const day = value.getDay();
       const date = value.getDate();
-      const isCompleted = history?.some(({ date: historyDate, reads }) => {
-        const dateToCompare = new Date(historyDate);
-        const sameDate = isSameDay(dateToCompare, value);
+      const isFuture = value > today;
+      const isCompleted =
+        !isFuture &&
+        history?.some(({ date: historyDate, reads }) => {
+          const dateToCompare = new Date(historyDate);
+          const sameDate = isSameDay(dateToCompare, value);
 
-        return sameDate && reads > 0;
-      });
+          return sameDate && reads > 0;
+        });
 
       const getStreak = () => {
         if (isCompleted) {

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -1,4 +1,5 @@
-import { gql } from 'graphql-request';
+import request, { gql } from 'graphql-request';
+import { subDays } from 'date-fns';
 import {
   SHARED_POST_INFO_FRAGMENT,
   USER_SHORT_INFO_FRAGMENT,
@@ -6,6 +7,7 @@ import {
 import type { PublicProfile } from '../lib/user';
 import { Connection } from './common';
 import { SourceMember } from './sources';
+import { graphqlUrl } from '../lib/config';
 
 type PostStats = {
   numPosts: number;
@@ -230,6 +232,15 @@ export const USER_READING_HISTORY_QUERY = gql`
   }
 `;
 
+export const USER_STREAK_HISTORY = gql`
+  query UserStreakHistory($id: ID!, $after: String!, $before: String!) {
+    userReadHistory(id: $id, after: $after, before: $before) {
+      date
+      reads
+    }
+  }
+`;
+
 const READING_HISTORY_FRAGMENT = gql`
   fragment ReadingHistoryFragment on ReadingHistory {
     timestamp
@@ -423,3 +434,46 @@ export const UNSUBSCRIBE_PERSONALIZED_DIGEST_MUTATION = gql`
     }
   }
 `;
+
+interface ReadingDay {
+  date: string;
+  reads: number;
+}
+
+export const getReadingStreak30Days = async (
+  id: string,
+): Promise<ReadingDay[]> => {
+  const today = new Date();
+  const last30Days = subDays(today, 30);
+  const res = await request(graphqlUrl, USER_STREAK_HISTORY, {
+    after: last30Days.toISOString(),
+    before: today,
+    id,
+  });
+
+  return res.userReadHistory;
+};
+
+export const USER_STREAK_QUERY = gql`
+  query UserStreak {
+    userStreak {
+      max
+      total
+      current
+      lastViewAt
+    }
+  }
+`;
+
+export interface UserStreak {
+  max: number;
+  total: number;
+  current: number;
+  lastViewAt: Date;
+}
+
+export const getReadingStreak = async (): Promise<UserStreak> => {
+  const res = await request(graphqlUrl, USER_STREAK_QUERY);
+
+  return res.userStreak;
+};

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -442,11 +442,11 @@ interface ReadingDay {
 
 export const getReadingStreak30Days = async (
   id: string,
+  start: Date = subDays(new Date(), 30),
 ): Promise<ReadingDay[]> => {
   const today = new Date();
-  const last30Days = subDays(today, 30);
   const res = await request(graphqlUrl, USER_STREAK_HISTORY, {
-    after: last30Days.toISOString(),
+    after: start.toISOString(),
     before: today.toISOString(),
     id,
   });

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -447,7 +447,7 @@ export const getReadingStreak30Days = async (
   const last30Days = subDays(today, 30);
   const res = await request(graphqlUrl, USER_STREAK_HISTORY, {
     after: last30Days.toISOString(),
-    before: today,
+    before: today.toISOString(),
     id,
   });
 

--- a/packages/shared/src/hooks/streaks/useReadingStreak.ts
+++ b/packages/shared/src/hooks/streaks/useReadingStreak.ts
@@ -1,15 +1,22 @@
-interface UseReadingStreak {
-  maxStreak: number;
-  currentStreak: number;
+import { useQuery } from '@tanstack/react-query';
+import { generateQueryKey, RequestKey } from '../../lib/query';
+import { getReadingStreak, UserStreak } from '../../graphql/users';
+import { useAuthContext } from '../../contexts/AuthContext';
+
+interface UserReadingStreak {
+  streak: UserStreak;
   loading: boolean;
 }
 
-export const useReadingStreak = (): UseReadingStreak => {
-  const streak = 0; // TODO: make this a query in a separate ticket
+export const useReadingStreak = (): UserReadingStreak => {
+  const { user } = useAuthContext();
+  const { data: streak } = useQuery(
+    generateQueryKey(RequestKey.UserStreak, user),
+    getReadingStreak,
+  );
 
   return {
-    maxStreak: 44,
-    currentStreak: streak,
+    streak,
     loading: false,
   };
 };

--- a/packages/shared/src/hooks/streaks/useReadingStreak.ts
+++ b/packages/shared/src/hooks/streaks/useReadingStreak.ts
@@ -2,21 +2,26 @@ import { useQuery } from '@tanstack/react-query';
 import { generateQueryKey, RequestKey } from '../../lib/query';
 import { getReadingStreak, UserStreak } from '../../graphql/users';
 import { useAuthContext } from '../../contexts/AuthContext';
+import { useStreakExperiment } from './useStreakExperiment';
 
 interface UserReadingStreak {
   streak: UserStreak;
-  loading: boolean;
+  isLoading: boolean;
+  isEnabled: boolean;
 }
 
 export const useReadingStreak = (): UserReadingStreak => {
   const { user } = useAuthContext();
-  const { data: streak } = useQuery(
+  const { shouldShowStreak } = useStreakExperiment();
+  const { data: streak, isLoading } = useQuery(
     generateQueryKey(RequestKey.UserStreak, user),
     getReadingStreak,
+    { enabled: shouldShowStreak },
   );
 
   return {
     streak,
-    loading: false,
+    isLoading,
+    isEnabled: shouldShowStreak,
   };
 };

--- a/packages/shared/src/lib/dateFormat.ts
+++ b/packages/shared/src/lib/dateFormat.ts
@@ -112,3 +112,15 @@ export const getReadHistoryDateFormat = (currentDate: Date): string => {
 
   return `${dayOfTheWeek}, ${dayOfTheMonth} ${month}${year}`;
 };
+
+export enum Day {
+  Sunday,
+  Monday,
+  Tuesday,
+  Wednesday,
+  Thursday,
+  Friday,
+  Saturday,
+}
+
+export const Weekends = [Day.Saturday, Day.Sunday];

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -72,6 +72,8 @@ export enum RequestKey {
   Auth = 'auth',
   Profile = 'profile',
   CurrentSession = 'current_session',
+  ReadingStreak30Days = 'reading_streak_30_days',
+  UserStreak = 'user_streak',
   PersonalizedDigest = 'personalizedDigest',
   Changelog = 'changelog',
   Tags = 'tags',


### PR DESCRIPTION
## Changes
- Utilized an existing query used in the heatmap to check whether the user has read from previous days but limited the amount.
- Fixed the issue when the popup is opened, it should close when the user clicks anywhere outside.
- Integrates the popup content with the live data.

The complete days indicated in the image below is true from the live data.

![Screenshot 2024-01-29 at 4 40 20 AM](https://github.com/dailydotdev/apps/assets/13744167/553b7da5-e727-4f6d-9c2d-c5f888cae70b)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-78 #done
