### PR TITLE
feat: add pixel & gtm scripts

### DIFF
--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -314,6 +314,73 @@ export function OnboardPage(): ReactElement {
     return <ProgressBar percentage={isAuthenticating ? percentage : 0} />;
   };
 
+  const getPixelTracking = () => {
+    return (
+      <>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+            !function(f,b,e,v,n,t,s)
+            {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+              n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+              if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+              n.queue=[];t=b.createElement(e);t.async=!0;
+              t.src=v;s=b.getElementsByTagName(e)[0];
+              s.parentNode.insertBefore(t,s)}(window, document,'script',
+            'https://connect.facebook.net/en_US/fbevents.js');
+            fbq('init', '519268979315924');
+            fbq('track', 'PageView');
+          `,
+          }}
+        />
+
+        <noscript>
+          <img
+            alt="Facebook Pixel"
+            height="1"
+            width="1"
+            style={{ display: 'none' }}
+            src="https://www.facebook.com/tr?id=519268979315924&ev=PageView&noscript=1"
+          />
+        </noscript>
+      </>
+    );
+  };
+
+  const getGtagTracking = () => {
+    return (
+      <>
+        <script
+          async
+          src="https://www.googletagmanager.com/gtag/js?id=G-88PBR8PHX0"
+        />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('set', 'developer_id.dZGVlNj', true);
+              gtag('config', 'G-88PBR8PHX0');
+            `,
+          }}
+        />
+      </>
+    );
+  };
+
+  const trackAnalyticsSignUp = () => {
+    if (typeof gtag === 'function') {
+      gtag('event', 'signup', {
+        send_to: 'AW-619408403/8JaXCNWU7voBEJPYracC',
+      });
+    }
+
+    if (typeof fbq === 'function') {
+      fbq('track', 'signup');
+    }
+  };
+
   const showOnboardingPage = !isAuthenticating && !isFiltering;
 
   if (!isPageReady) {
@@ -333,6 +400,8 @@ export function OnboardPage(): ReactElement {
     // eslint-disable-next-line @dailydotdev/daily-dev-eslint-rules/no-custom-color
     <Container className="bg-[#0e1019]">
       <NextSeo {...seo} titleTemplate="%s | daily.dev" />
+      {getPixelTracking()}
+      {getGtagTracking()}
       {getProgressBar()}
       <OnboardingHeader
         showOnboardingPage={showOnboardingPage}


### PR DESCRIPTION
- possible naive approach, there may be cleaner ways to do this
- I did not want to install third-party libraries for these, although there are some out there if that would be the easier route

TODO:
- [ ] trigger the signup events when the sign up button is clicked
- [ ] check if there is a possibly cleaner way of adding these (without requiring too much work)

## Changes

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
