### PR TITLE
feat: add mobile attribute to growthbook

### DIFF
--- a/packages/shared/src/components/GrowthBookProvider.tsx
+++ b/packages/shared/src/components/GrowthBookProvider.tsx
@@ -24,6 +24,7 @@ import { BootApp, BootCacheData } from '../lib/boot';
 import { apiUrl } from '../lib/config';
 import { useRequestProtocol } from '../hooks/useRequestProtocol';
 import { Feature } from '../lib/featureManagement';
+import { useViewSize, ViewSize } from '../hooks/useViewSize';
 
 export type FeaturesReadyContextValue = {
   ready: boolean;
@@ -77,6 +78,7 @@ export const GrowthBookProvider = ({
       retry: 3,
     },
   );
+  const isMobile = useViewSize(ViewSize.MobileL);
 
   const callback = useRef<Context['trackingCallback']>();
   const [gb] = useState<GrowthBook>(
@@ -133,6 +135,7 @@ export const GrowthBookProvider = ({
       deviceId,
       version,
       platform: app,
+      mobile: isMobile,
       ...experimentation?.a,
     };
 

--- a/packages/shared/src/components/GrowthBookProvider.tsx
+++ b/packages/shared/src/components/GrowthBookProvider.tsx
@@ -155,7 +155,7 @@ export const GrowthBookProvider = ({
       };
     }
     gb.setAttributes(atts);
-  }, [app, user, deviceId, gb, version, experimentation?.a]);
+  }, [app, user, deviceId, gb, version, experimentation?.a, isMobile]);
 
   const featuresReadyContextValue = useMemo<FeaturesReadyContextValue>(() => {
     return {


### PR DESCRIPTION
## Changes
- adding mobile attribute based on view size

### Describe what this PR does
- In order to run the feed layout experiment only on mobile we need a new attribute provided to growthbook

Based on the decision in slack [thread](https://dailydotdev.slack.com/archives/C061T644XV3/p1706629276404129?thread_ts=1706628190.527109&cid=C061T644XV3).

