### PR TITLE
feat: adjust search page and empty state

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -176,7 +176,11 @@ export default function MainFeedLayout({
   );
 
   const feedProps = useMemo<FeedProps<unknown>>(() => {
-    if (isSearchOn && searchQuery) {
+    if (isSearchOn) {
+      if (!searchQuery) {
+        return null;
+      }
+
       return {
         feedName: SharedFeedPage.Search,
         feedQueryKey: generateQueryKey(

--- a/packages/shared/src/components/SearchEmptyScreen.tsx
+++ b/packages/shared/src/components/SearchEmptyScreen.tsx
@@ -6,7 +6,7 @@ export default function SearchEmptyScreen(): ReactElement {
   return (
     <div className="flex w-full max-w-[32rem] flex-col items-center gap-4 self-center px-6">
       <MagnifyingIcon
-        className="text-overlay-tertiary-salt"
+        className="text-theme-label-disabled"
         size={IconSize.XXXLarge}
       />
       <h2 className="text-center typo-title2">No results found</h2>

--- a/packages/shared/src/components/SearchEmptyScreen.tsx
+++ b/packages/shared/src/components/SearchEmptyScreen.tsx
@@ -1,19 +1,16 @@
 import React, { ReactElement } from 'react';
 import { SearchIcon as MagnifyingIcon } from './icons';
-import { EmptyScreenIcon } from './EmptyScreen';
+import { IconSize } from './Icon';
 
 export default function SearchEmptyScreen(): ReactElement {
   return (
-    <div
-      className="flex w-full flex-col self-center px-6"
-      style={{ maxWidth: '32.5rem' }}
-    >
+    <div className="flex w-full max-w-[32rem] flex-col items-center gap-4 self-center px-6">
       <MagnifyingIcon
-        className="self-center text-theme-label-disabled"
-        style={EmptyScreenIcon.style}
+        className="text-overlay-tertiary-salt"
+        size={IconSize.XXXLarge}
       />
-      <h2 className="my-4 text-center typo-title1">No results found</h2>
-      <p className="m-0 p-0 text-center text-theme-label-secondary typo-callout">
+      <h2 className="text-center typo-title2">No results found</h2>
+      <p className="text-center text-theme-label-secondary typo-callout">
         We cannot find the posts you are searching for. 🤷‍♀️
       </p>
     </div>

--- a/packages/shared/src/graphql/search.ts
+++ b/packages/shared/src/graphql/search.ts
@@ -274,7 +274,11 @@ export const getSearchUrl = (params: SearchUrlParams): string => {
     searchParams.append('q', query);
   }
 
-  return `${searchPageUrl}?${searchParams}`;
+  const searchParamsString = searchParams.toString();
+
+  return `${searchPageUrl}${
+    searchParamsString ? `?${searchParamsString}` : ''
+  }`;
 };
 
 export const searchQueryUrl = `${apiUrl}/search/query`;

--- a/packages/webapp/components/search/SearchControlPage.tsx
+++ b/packages/webapp/components/search/SearchControlPage.tsx
@@ -7,11 +7,15 @@ import {
   providerToLabelTextMap,
 } from '@dailydotdev/shared/src/components';
 import { SearchProviderEnum } from '@dailydotdev/shared/src/graphql/search';
+import { MagicIcon } from '@dailydotdev/shared/src/components/icons';
+import { IconSize } from '@dailydotdev/shared/src/components/Icon';
+import classNames from 'classnames';
+import { useSettingsContext } from '@dailydotdev/shared/src/contexts/SettingsContext';
+import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 import {
   getMainFeedLayout,
   mainFeedLayoutProps,
 } from '../layouts/MainFeedPage';
-import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 
 const baseSeo: NextSeoProps = {
   openGraph: { ...defaultOpenGraph },
@@ -21,6 +25,8 @@ const baseSeo: NextSeoProps = {
 const Search = (): ReactElement => {
   const router = useRouter();
   const { query } = router;
+  const searchQuery = query?.q?.toString();
+  const { sidebarExpanded } = useSettingsContext();
 
   const seo = useMemo(() => {
     if ('q' in query) {
@@ -36,6 +42,26 @@ const Search = (): ReactElement => {
   return (
     <>
       <NextSeo {...seo} {...baseSeo} />
+      {!searchQuery && (
+        <div
+          className={classNames(
+            'flex w-full max-w-[32rem] flex-col items-center gap-4  self-center px-6',
+            sidebarExpanded ? '!-left-32' : '!-left-6',
+          )}
+        >
+          <MagicIcon
+            className="text-overlay-tertiary-salt"
+            secondary
+            size={IconSize.XXXLarge}
+          />
+          <h2 className="font-bold text-theme-label-primary typo-title2">
+            Ready to dive in?
+          </h2>
+          <p className="text-theme-label-tertiary typo-callout">
+            Start your search to explore a world of developer resources.
+          </p>
+        </div>
+      )}
     </>
   );
 };

--- a/packages/webapp/components/search/SearchControlPage.tsx
+++ b/packages/webapp/components/search/SearchControlPage.tsx
@@ -50,7 +50,7 @@ const Search = (): ReactElement => {
           )}
         >
           <MagicIcon
-            className="text-overlay-tertiary-salt"
+            className="text-theme-label-disabled"
             secondary
             size={IconSize.XXXLarge}
           />


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Adjustments to empty state of the new search page
- Now by default the `/search` page does not show anything until you search
- Also made adjustments to no results page from AS-40 since it was connected closely

TODO:
- [ ] just missing gradient at the bottom on mobile

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-69 #done
