### PR TITLE
hotfix: add z-index to button to be on top of the glow

### DIFF
--- a/packages/shared/src/components/ExtensionOnboarding.tsx
+++ b/packages/shared/src/components/ExtensionOnboarding.tsx
@@ -25,7 +25,7 @@ const ExtensionOnboarding = (): ReactElement => {
       <Link href={onboardingUrl} passHref>
         <Button
           tag="a"
-          className="w-full max-w-[18.75rem]"
+          className="z-1 w-full max-w-[18.75rem]"
           variant={ButtonVariant.Primary}
           size={ButtonSize.Large}
         >


### PR DESCRIPTION
## Changes
- add z-index to button to be on top of the glow

### Describe what this PR does
- issue in slack https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1707294893902169

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

