### PR TITLE
feat: invalidate search suggestions on query change

### DIFF
--- a/packages/shared/src/hooks/search/useSearchProviderSuggestions.ts
+++ b/packages/shared/src/hooks/search/useSearchProviderSuggestions.ts
@@ -37,7 +37,6 @@ export const useSearchProviderSuggestions = ({
     {
       enabled: query?.length >= minSearchQueryLength,
       staleTime: StaleTime.Default,
-      keepPreviousData: true,
       select: useCallback(
         (currentData) => {
           if (!currentData) {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Just remove suggestions when query changes to avoid focus lose if you focused one of the old suggestions when new ones display

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
