### PR TITLE
feat: only restore on feed pages

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -36,7 +36,7 @@ import { ExperimentWinner } from '../lib/featureValues';
 import { SharedFeedPage } from './utilities';
 import { FeedContainer, FeedContainerProps } from './feeds';
 import { ActiveFeedContext } from '../contexts';
-import { useFeedLayout, useFeedVotePost } from '../hooks';
+import { useFeedLayout, useFeedVotePost, useScrollRestoration } from '../hooks';
 import { AllFeedPages, RequestKey, updateCachedPagePost } from '../lib/query';
 import {
   mutateBookmarkFeedPost,
@@ -119,6 +119,7 @@ export default function Feed<T>({
   actionButtons,
   disableAds,
 }: FeedProps<T>): ReactElement {
+  useScrollRestoration();
   const origin = Origin.Feed;
   const { trackEvent } = useContext(AnalyticsContext);
   const currentSettings = useContext(FeedContext);

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -36,7 +36,7 @@ import { ExperimentWinner } from '../lib/featureValues';
 import { SharedFeedPage } from './utilities';
 import { FeedContainer, FeedContainerProps } from './feeds';
 import { ActiveFeedContext } from '../contexts';
-import { useFeedLayout, useFeedVotePost, useScrollRestoration } from '../hooks';
+import { useFeedLayout, useFeedVotePost } from '../hooks';
 import { AllFeedPages, RequestKey, updateCachedPagePost } from '../lib/query';
 import {
   mutateBookmarkFeedPost,
@@ -119,7 +119,6 @@ export default function Feed<T>({
   actionButtons,
   disableAds,
 }: FeedProps<T>): ReactElement {
-  useScrollRestoration();
   const origin = Origin.Feed;
   const { trackEvent } = useContext(AnalyticsContext);
   const currentSettings = useContext(FeedContext);

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -36,7 +36,7 @@ import {
   SearchControlHeaderProps,
 } from './layout/common';
 import { useFeedName } from '../hooks/feed/useFeedName';
-import { useFeedLayout } from '../hooks';
+import { useFeedLayout, useScrollRestoration } from '../hooks';
 import { feature } from '../lib/featureManagement';
 import { isDevelopment } from '../lib/constants';
 import { FeedContainerProps } from './feeds';
@@ -120,6 +120,7 @@ export default function MainFeedLayout({
   navChildren,
   isFinder,
 }: MainFeedLayoutProps): ReactElement {
+  useScrollRestoration();
   const { sortingEnabled, loadedSettings } = useContext(SettingsContext);
   const { user, tokenRefreshed } = useContext(AuthContext);
   const { alerts } = useContext(AlertContext);

--- a/packages/shared/src/hooks/useScrollRestoration.ts
+++ b/packages/shared/src/hooks/useScrollRestoration.ts
@@ -4,18 +4,17 @@ import { useRouter } from 'next/router';
 
 const scrollPositions: Record<string, number> = {};
 
-const restorablePaths = [
-  '/',
-  '/my-feed',
-  '/popular',
-  '/search',
-  '/upvoted',
-  '/discussed',
-  '/squads',
-  '/sources',
-];
-
 export const useScrollRestoration = (): void => {
+  const { pathname } = useRouter();
+
+  useEffect(() => {
+    const scrollPosition = scrollPositions[pathname] || 0;
+
+    window.scrollTo(0, scrollPosition);
+  }, [pathname]);
+};
+
+export const useScrollRestorationCollection = (): void => {
   const { pathname } = useRouter();
 
   useEffect(() => {
@@ -36,17 +35,5 @@ export const useScrollRestoration = (): void => {
 
       window.removeEventListener('scroll', handleScroll);
     };
-  }, [pathname]);
-
-  useEffect(() => {
-    if (!restorablePaths.some((path) => pathname.startsWith(path))) {
-      window.scrollTo(0, 0);
-
-      return;
-    }
-
-    const scrollPosition = scrollPositions[pathname] || 0;
-
-    window.scrollTo(0, scrollPosition);
   }, [pathname]);
 };

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -35,7 +35,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { defaultQueryClientConfig } from '@dailydotdev/shared/src/lib/query';
 import { useWebVitals } from '@dailydotdev/shared/src/hooks/useWebVitals';
 import { LazyModalElement } from '@dailydotdev/shared/src/components/modals/LazyModalElement';
-import { useScrollRestoration } from '@dailydotdev/shared/src/hooks';
+import { useScrollRestorationCollection } from '@dailydotdev/shared/src/hooks';
 import Seo from '../next-seo';
 import useWebappVersion from '../hooks/useWebappVersion';
 
@@ -182,7 +182,7 @@ export default function App(props: AppProps): ReactElement {
   const version = useWebappVersion();
   const deviceId = useDeviceId();
   useError();
-  useScrollRestoration();
+  useScrollRestorationCollection();
 
   return (
     <ProgressiveEnhancementContextProvider>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
