### PR TITLE
feat: collect restoration only on enabled pages

### DIFF
--- a/packages/shared/src/hooks/useScrollRestoration.ts
+++ b/packages/shared/src/hooks/useScrollRestoration.ts
@@ -8,20 +8,6 @@ export const useScrollRestoration = (): void => {
   const { pathname } = useRouter();
 
   useEffect(() => {
-    const scrollPosition = scrollPositions[pathname] || 0;
-
-    window.scrollTo(0, scrollPosition);
-  }, [pathname]);
-};
-
-export const useScrollRestorationCollection = (): void => {
-  const { pathname } = useRouter();
-
-  useEffect(() => {
-    if (typeof window.history?.scrollRestoration !== 'undefined') {
-      window.history.scrollRestoration = 'manual';
-    }
-
     const handleScroll = () => {
       scrollPositions[pathname] = window.scrollY;
     };
@@ -29,11 +15,27 @@ export const useScrollRestorationCollection = (): void => {
     window.addEventListener('scroll', handleScroll);
 
     return () => {
-      if (typeof window.history?.scrollRestoration !== 'undefined') {
-        window.history.scrollRestoration = 'auto';
-      }
-
       window.removeEventListener('scroll', handleScroll);
     };
   }, [pathname]);
+
+  useEffect(() => {
+    const scrollPosition = scrollPositions[pathname] || 0;
+
+    window.scrollTo(0, scrollPosition);
+  }, [pathname]);
+};
+
+export const useManualScrollRestoration = (): void => {
+  useEffect(() => {
+    if (typeof window.history?.scrollRestoration !== 'undefined') {
+      window.history.scrollRestoration = 'manual';
+    }
+
+    return () => {
+      if (typeof window.history?.scrollRestoration !== 'undefined') {
+        window.history.scrollRestoration = 'auto';
+      }
+    };
+  }, []);
 };

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -35,7 +35,7 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { defaultQueryClientConfig } from '@dailydotdev/shared/src/lib/query';
 import { useWebVitals } from '@dailydotdev/shared/src/hooks/useWebVitals';
 import { LazyModalElement } from '@dailydotdev/shared/src/components/modals/LazyModalElement';
-import { useScrollRestorationCollection } from '@dailydotdev/shared/src/hooks';
+import { useManualScrollRestoration } from '@dailydotdev/shared/src/hooks';
 import Seo from '../next-seo';
 import useWebappVersion from '../hooks/useWebappVersion';
 
@@ -182,7 +182,7 @@ export default function App(props: AppProps): ReactElement {
   const version = useWebappVersion();
   const deviceId = useDeviceId();
   useError();
-  useScrollRestorationCollection();
+  useManualScrollRestoration();
 
   return (
     <ProgressiveEnhancementContextProvider>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
