### PR TITLE
fix: ensure post navigation sit on top of header

### DIFF
--- a/packages/shared/src/components/post/FixedPostNavigation.tsx
+++ b/packages/shared/src/components/post/FixedPostNavigation.tsx
@@ -25,7 +25,7 @@ function FixedPostNavigation({
       post={post}
       className={{
         container: classNames(
-          'fixed top-0 z-3 ml-0 w-full border border-theme-divider-tertiary bg-theme-bg-secondary px-6 py-4',
+          'fixed top-0 z-postNavigation ml-0 w-full border border-theme-divider-tertiary bg-theme-bg-secondary px-6 py-4',
           'max-w-full laptop:left-[unset]',
           className?.container,
         ),

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -129,6 +129,7 @@ module.exports = {
       3: '3',
       rank: '3',
       header: '4',
+      postNavigation: '5',
       sidebar: '7',
       tooltip: '8',
       popup: '9',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Ensure the post navigation lays on top of the now sticky top header.
- Not perfect, but since mobile-UX will come this is the best solution for now (to avoid eating too much space there)

![Screenshot 2024-02-12 at 09 34 32](https://github.com/dailydotdev/apps/assets/554874/72edd7c7-ce0c-451a-8e4d-14a762f13e5f)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-109 #done
