### PR TITLE
fix: use webapp url so that links open there in extension

### DIFF
--- a/packages/shared/src/components/search/SearchPanel/SearchPanelPostSuggestions.tsx
+++ b/packages/shared/src/components/search/SearchPanel/SearchPanelPostSuggestions.tsx
@@ -15,6 +15,7 @@ import {
 import { SearchPanelContext } from './SearchPanelContext';
 import { useDomPurify } from '../../../hooks/useDomPurify';
 import { useSearchPanelAction } from './useSearchPanelAction';
+import { webappUrl } from '../../../lib/constants';
 
 export type SearchPanelPostSuggestionsProps = {
   className?: string;
@@ -61,7 +62,7 @@ export const SearchPanelPostSuggestions = ({
 
   const onSuggestionClick = (suggestion: SearchSuggestion) => {
     if (suggestion.id) {
-      router.push(`/posts/${suggestion.id}`);
+      router.push(`${webappUrl}posts/${suggestion.id}`);
 
       return;
     }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- search panel suggestion post links in extension were broken
- this opens them in webapp

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
