### PR TITLE
fix: alignment and render of shortcuts

### DIFF
--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -167,23 +167,14 @@ export const FeedContainer = ({
             />
           )}
           {inlineHeader && header}
-          {isV1Search && (
-            <ConditionalWrapper
-              condition={!shouldUseFeedLayoutV1}
-              wrapper={(child) => (
-                <span className="flex flex-row gap-3">{child}</span>
-              )}
-            >
-              {!!shortcuts && shortcuts}
-            </ConditionalWrapper>
-          )}
-          {isV1Search && (
-            <span className="flex flex-1 flex-row">
-              {actionButtons && !shouldUseFeedLayoutV1 && (
+          {isV1Search && !shouldUseFeedLayoutV1 && (
+            <span className="flex flex-1 flex-row items-center">
+              {!!actionButtons && (
                 <span className="mr-auto flex flex-row gap-3 border-theme-divider-tertiary pr-3">
                   {actionButtons}
                 </span>
               )}
+              {shortcuts}
             </span>
           )}
           {shouldUseFeedLayoutV1 && shortcuts}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixes alignment and render of shortcuts in different feed layouts and experiments

Control:
<img width="1489" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/4a692f27-429e-4e16-9359-d4d7bd2b0e42">

Search V1:
<img width="1493" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/f6e93946-be75-4cda-ac11-388cb6e9f3ed">

Layout V1:
<img width="1492" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/246a037a-9069-404a-b729-e918bfa1930e">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-108 #done
