### PR TITLE
fix: layout shift on pages because of different header height

### DIFF
--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -132,9 +132,8 @@ function MainLayoutHeader({
   return (
     <header
       className={classNames(
-        'sticky z-header flex h-14 flex-row items-center justify-between gap-3 border-b border-theme-divider-tertiary bg-theme-bg-primary px-4 py-3 tablet:px-8 laptop:left-0 laptop:w-full laptop:flex-row laptop:px-4',
+        'sticky z-header flex h-14 flex-row items-center justify-between gap-3 border-b border-theme-divider-tertiary bg-theme-bg-primary px-4 py-3 tablet:px-8 laptop:left-0 laptop:h-16 laptop:w-full laptop:flex-row laptop:px-4',
         hasBanner ? 'top-8' : 'top-0',
-        isSearchV1 && 'laptop:h-16',
         isSearchPage && 'mb-16 laptop:mb-0',
       )}
     >

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -60,11 +60,11 @@ const modalKindAndSizeToClassName: Partial<
   Record<ModalKind, Partial<Record<ModalSize, string>>>
 > = {
   [ModalKind.FlexibleTop]: {
-    [ModalSize.XSmall]: 'laptop:mt-14 laptop:mb-10',
+    [ModalSize.XSmall]: 'laptop:mt-16 laptop:mb-10',
     [ModalSize.Medium]:
       'h-full mobileL:h-auto min-h-[25rem] max-h-[calc(100vh-10rem)]',
-    [ModalSize.Large]: 'laptop:mt-14 laptop:mb-10',
-    [ModalSize.XLarge]: 'laptop:mt-14 laptop:mb-10',
+    [ModalSize.Large]: 'laptop:mt-16 laptop:mb-10',
+    [ModalSize.XLarge]: 'laptop:mt-16 laptop:mb-10',
   },
 };
 export const modalSizeToClassName: Record<ModalSize, string> = {

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -24,9 +24,6 @@ import {
   ManageSection,
 } from './index';
 import { getFeedName } from '../../lib/feed';
-import { useFeature } from '../GrowthBookProvider';
-import { feature } from '../../lib/featureManagement';
-import { SearchExperiment } from '../../lib/featureValues';
 
 const UserSettingsModal = dynamic(
   () =>
@@ -48,8 +45,6 @@ export default function Sidebar({
   setOpenMobileSidebar,
   onShowDndClick,
 }: SidebarProps): ReactElement {
-  const searchVersion = useFeature(feature.search);
-  const isSearchV1 = searchVersion === SearchExperiment.V1;
   const { user, isLoggedIn } = useContext(AuthContext);
   const { alerts } = useContext(AlertContext);
   const {
@@ -95,16 +90,9 @@ export default function Sidebar({
         className={classNames(
           sidebarExpanded ? 'laptop:w-60' : 'laptop:w-11',
           openMobileSidebar ? '-translate-x-0' : '-translate-x-70',
-          {
-            'laptop:top-24 laptop:h-[calc(100vh-theme(space.24))]':
-              promotionalBannerActive && isSearchV1,
-            'laptop:top-16 laptop:h-[calc(100vh-theme(space.16))]':
-              !promotionalBannerActive && isSearchV1,
-            'laptop:top-22 laptop:h-[calc(100vh-theme(space.22))]':
-              promotionalBannerActive && !isSearchV1,
-            'laptop:top-14 laptop:h-[calc(100vh-theme(space.14))]':
-              !promotionalBannerActive && !isSearchV1,
-          },
+          promotionalBannerActive
+            ? 'laptop:top-24 laptop:h-[calc(100vh-theme(space.24))]'
+            : 'laptop:top-16 laptop:h-[calc(100vh-theme(space.16))]',
         )}
       >
         {sidebarRendered && (

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -171,12 +171,12 @@ module.exports = {
         'img-desktop': '400px',
         'img-mobile': '280px',
         'rank-modal': 'calc(100vh - 5rem)',
-        page: 'calc(100vh - 3.5rem)',
+        page: 'calc(100vh - 4rem)',
         commentBox: '18.25rem',
         card: '24rem',
       },
       minHeight: {
-        page: 'calc(100vh - 3.5rem)',
+        page: 'calc(100vh - 4rem)',
         card: '24rem',
       },
       gap: {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Make laptop header 64px across control and experiments to fix layout shift due to vary size

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-110 #done
