### PR TITLE
fix: vertical align of tags + border width of profile image

### DIFF
--- a/packages/shared/src/components/profile/devcard/DevCard.tsx
+++ b/packages/shared/src/components/profile/devcard/DevCard.tsx
@@ -85,7 +85,7 @@ export function DevCard({
               alt={`avatar of ${user.name}`}
               className={classNames(
                 '-rotate-3 border-white object-cover',
-                showBorder && (isHorizontal ? 'border-8' : 'border-4'),
+                showBorder && 'border-8',
                 {
                   'size-40 rounded-48': isVertical,
                   'size-24 rounded-32': isHorizontal,

--- a/packages/shared/src/components/profile/devcard/DevCardFooter.tsx
+++ b/packages/shared/src/components/profile/devcard/DevCardFooter.tsx
@@ -37,7 +37,7 @@ export function DevCardFooter({
               ? 'border-white text-white'
               : 'border-pepper-90 text-pepper-90',
             type === DevCardType.Vertical &&
-              '!block !leading-[1.375rem] max-w-[5rem] overflow-hidden text-ellipsis',
+              '!block max-w-[5rem] overflow-hidden text-ellipsis !leading-[1.375rem]',
           ),
         }}
         tags={tags}

--- a/packages/shared/src/components/profile/devcard/DevCardFooter.tsx
+++ b/packages/shared/src/components/profile/devcard/DevCardFooter.tsx
@@ -32,12 +32,12 @@ export function DevCardFooter({
             !shouldShowLogo && 'justify-center px-2',
           ),
           tag: classNames(
-            'pt-0.5 !typo-caption1',
+            'typo-caption1',
             theme === DevCardTheme.Iron
               ? 'border-white text-white'
               : 'border-pepper-90 text-pepper-90',
             type === DevCardType.Vertical &&
-              '!block max-w-[5rem] overflow-hidden text-ellipsis',
+              '!block !leading-[1.375rem] max-w-[5rem] overflow-hidden text-ellipsis',
           ),
         }}
         tags={tags}


### PR DESCRIPTION
The tags are now vertically aligned
Profile picture border is set to 8px in all cases, not just for horizontally laid out card

<img width="353" alt="Screenshot 2024-02-12 at 15 50 59" src="https://github.com/dailydotdev/apps/assets/9974711/97532d13-c912-4a5c-8750-1521287e854e">
