### PR TITLE
fix: height of checklist to be based on content

### DIFF
--- a/packages/shared/src/components/cards/Card.tsx
+++ b/packages/shared/src/components/cards/Card.tsx
@@ -64,6 +64,12 @@ export const Card = classed(
   'relative max-h-card h-full flex flex-col p-2 rounded-2xl bg-theme-bg-secondary border border-theme-divider-tertiary hover:border-theme-divider-secondary shadow-2',
 );
 
+export const ChecklistCardComponent = classed(
+  'article',
+  styles.card,
+  'max-w-[21.5rem] w-full relative max-h-fit h-full flex flex-col rounded-14 bg-theme-bg-secondary border border-theme-color-cabbage hover:border-theme-color-cabbage shadow-2',
+);
+
 export const CardHeader = classed(
   'div',
   styles.header,

--- a/packages/shared/src/components/checklist/ChecklistCard.tsx
+++ b/packages/shared/src/components/checklist/ChecklistCard.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
-import { Card } from '../cards/Card';
+import { ChecklistCardComponent } from '../cards/Card';
 import { ChecklistStep } from './ChecklistStep';
 import { ChecklistCardProps } from '../../lib/checklist';
 import { useChecklist } from '../../hooks/useChecklist';
@@ -21,7 +21,7 @@ const ChecklistCard = ({
 
   return (
     <div className={className}>
-      <Card className="w-[340px] rounded-14 !border-theme-color-cabbage !p-0 hover:!border-theme-color-cabbage">
+      <ChecklistCardComponent>
         <div className="relative overflow-hidden rounded-t-12 bg-gradient-to-t from-cabbage-90 to-cabbage-50 p-4">
           {isDone && (
             <RankConfetti className="absolute bottom-0 left-0 right-0 top-0 opacity-40" />
@@ -74,7 +74,7 @@ const ChecklistCard = ({
             );
           })}
         </div>
-      </Card>
+      </ChecklistCardComponent>
     </div>
   );
 };


### PR DESCRIPTION
## Changes
- created new styled component to remove the overrides on the Card component
- added max-w-fit

### Describe what this PR does
- fixes squad checklist not being able to show all content

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices? no
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-140 #done
