### PR TITLE
fix: add noindex to private/unwanted pages

### DIFF
--- a/packages/webapp/components/layouts/AccountLayout/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/index.tsx
@@ -42,7 +42,7 @@ export default function AccountLayout({
       <Head>
         <link rel="preload" as="image" href={profile.image} />
       </Head>
-      <NextSeo {...Seo} />
+      <NextSeo {...Seo} noindex nofollow />
       <main className="relative mx-auto flex w-full flex-1 flex-row items-stretch pt-0 laptop:max-w-[calc(100vw-17.5rem)]">
         <SidebarNav
           className="absolute z-3 ml-auto h-full w-full border-l border-theme-divider-tertiary bg-theme-bg-primary tablet:relative tablet:w-[unset]"

--- a/packages/webapp/pages/bookmarks.tsx
+++ b/packages/webapp/pages/bookmarks.tsx
@@ -16,7 +16,7 @@ const seo: NextSeoProps = {
 const BookmarksPage = (): ReactElement => {
   return (
     <>
-      <NextSeo {...seo} />
+      <NextSeo {...seo} nofollow noindex />
     </>
   );
 };

--- a/packages/webapp/pages/filters.tsx
+++ b/packages/webapp/pages/filters.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import FilterMenu from '@dailydotdev/shared/src/components/filters/FilterMenu';
+import { NextSeo } from 'next-seo';
 import {
   getLayout,
   mainFooterLayoutProps,
@@ -7,6 +8,7 @@ import {
 
 const FiltersPage = (): ReactElement => (
   <main className="withNavBar w-full">
+    <NextSeo title="Filters" nofollow noindex />
     <FilterMenu />
   </main>
 );

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -99,7 +99,7 @@ function EditPost(): ReactElement {
         enableUpload: true,
       }}
     >
-      <NextSeo {...seo} />
+      <NextSeo {...seo} noindex nofollow />
       <WritePage
         isLoading={!isReady || !isFetched || !isDraftReady}
         isForbidden={!isVerified || !squad || !canEdit}

--- a/packages/webapp/pages/squads/[handle]/edit.tsx
+++ b/packages/webapp/pages/squads/[handle]/edit.tsx
@@ -96,7 +96,7 @@ const EditSquad = ({ handle }: EditSquadPageProps): ReactElement => {
 
   return (
     <ManageSquadPageContainer>
-      <NextSeo {...seo} titleTemplate="%s | daily.dev" />
+      <NextSeo {...seo} titleTemplate="%s | daily.dev" noindex nofollow />
       <ManageSquadPageMain>
         <ManageSquadPageHeader>
           <Button

--- a/packages/webapp/pages/squads/create.tsx
+++ b/packages/webapp/pages/squads/create.tsx
@@ -121,7 +121,7 @@ function CreatePost(): ReactElement {
       }}
     >
       <WritePageContainer>
-        <NextSeo {...seo} titleTemplate="%s | daily.dev" />
+        <NextSeo {...seo} titleTemplate="%s | daily.dev" noindex nofollow />
         <TabContainer<WriteFormTab>
           onActiveChange={(active) => setDisplay(active)}
           controlledActive={display}

--- a/packages/webapp/pages/squads/new.tsx
+++ b/packages/webapp/pages/squads/new.tsx
@@ -77,7 +77,7 @@ const NewSquad = (): ReactElement => {
 
   return (
     <ManageSquadPageContainer>
-      <NextSeo {...seo} titleTemplate="%s | daily.dev" />
+      <NextSeo {...seo} titleTemplate="%s | daily.dev" noindex nofollow />
       <ManageSquadPageMain>
         <div
           style={{

--- a/packages/webapp/public/robots.txt
+++ b/packages/webapp/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Disallow: /join
+Disallow: /error
+Disallow: /callback


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Add more noindex/nofollow for pages that are private/unwanted in search results

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
