### PR TITLE
feat: authentication banner

### DIFF
--- a/packages/shared/src/components/LoginButton.tsx
+++ b/packages/shared/src/components/LoginButton.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { HTMLAttributes, ReactElement, useContext } from 'react';
+import classNames from 'classnames';
 import { Button, ButtonVariant } from './buttons/ButtonV2';
 import AuthContext from '../contexts/AuthContext';
 import AnalyticsContext from '../contexts/AnalyticsContext';
@@ -6,8 +7,14 @@ import { AnalyticsEvent } from '../hooks/analytics/useAnalyticsQueue';
 import { AuthTriggers } from '../lib/auth';
 import { TargetType } from '../lib/analytics';
 
-interface LoginButtonProps {
-  className?: string;
+interface ClassName {
+  container?: string;
+  button?: string;
+}
+
+interface LoginButtonProps
+  extends Omit<HTMLAttributes<HTMLSpanElement>, 'className'> {
+  className?: ClassName;
 }
 
 enum ButtonCopy {
@@ -24,7 +31,8 @@ const getAnalyticsEvent = (copy: ButtonCopy): AnalyticsEvent => ({
 });
 
 export default function LoginButton({
-  className,
+  className = {},
+  ...props
 }: LoginButtonProps): ReactElement {
   const { showLogin } = useContext(AuthContext);
   const { trackEvent } = useContext(AnalyticsContext);
@@ -38,18 +46,21 @@ export default function LoginButton({
   };
 
   return (
-    <span className="flex flex-row gap-4">
+    <span
+      {...props}
+      className={classNames('flex flex-row', className?.container)}
+    >
       <Button
         onClick={() => onClick(ButtonCopy.Login)}
         variant={ButtonVariant.Secondary}
-        className={className}
+        className={className?.button}
       >
         {ButtonCopy.Login}
       </Button>
       <Button
         onClick={() => onClick(ButtonCopy.Signup)}
         variant={ButtonVariant.Primary}
-        className={className}
+        className={className?.button}
       >
         {ButtonCopy.Signup}
       </Button>

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -32,6 +32,7 @@ import { useGrowthBookContext } from './GrowthBookProvider';
 import { useReferralReminder } from '../hooks/referral/useReferralReminder';
 import { ActiveFeedNameContextProvider } from '../contexts';
 import { useFeedLayout, useViewSize, ViewSize } from '../hooks';
+import { AuthenticationBanner } from './auth';
 
 export interface MainLayoutProps
   extends Omit<MainLayoutHeaderProps, 'onMobileSidebarToggle'>,
@@ -197,6 +198,7 @@ function MainLayoutComponent({
       >
         {renderSidebar()}
         {children}
+        {isAuthReady && !user && <AuthenticationBanner />}
       </main>
       <PromptElement />
     </div>

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -32,7 +32,6 @@ import { useGrowthBookContext } from './GrowthBookProvider';
 import { useReferralReminder } from '../hooks/referral/useReferralReminder';
 import { ActiveFeedNameContextProvider } from '../contexts';
 import { useFeedLayout, useViewSize, ViewSize } from '../hooks';
-import { AuthenticationBanner } from './auth';
 
 export interface MainLayoutProps
   extends Omit<MainLayoutHeaderProps, 'onMobileSidebarToggle'>,
@@ -198,7 +197,6 @@ function MainLayoutComponent({
       >
         {renderSidebar()}
         {children}
-        {isAuthReady && !user && <AuthenticationBanner />}
       </main>
       <PromptElement />
     </div>

--- a/packages/shared/src/components/auth/AuthModal.tsx
+++ b/packages/shared/src/components/auth/AuthModal.tsx
@@ -54,7 +54,7 @@ export default function AuthModal({
       className={classNames(className, 'auth')}
     >
       <AuthOptions
-        className="h-full"
+        className={{ container: 'h-full' }}
         onClose={onClose}
         formRef={formRef}
         onSuccessfulLogin={onSuccessfulLogin}

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -75,6 +75,11 @@ export interface AuthProps {
   defaultDisplay?: AuthDisplay;
 }
 
+interface ClassName {
+  container?: string;
+  onboardingSignup?: string;
+}
+
 export interface AuthOptionsProps {
   onClose?: CloseAuthModalFunc;
   onAuthStateUpdate?: (props: Partial<AuthProps>) => void;
@@ -84,7 +89,7 @@ export interface AuthOptionsProps {
   trigger: AuthTriggersType;
   defaultDisplay?: AuthDisplay;
   forceDefaultDisplay?: boolean;
-  className?: string;
+  className?: ClassName;
   simplified?: boolean;
   isLoginFlow?: boolean;
   onDisplayChange?: (value: string) => void;
@@ -97,7 +102,7 @@ function AuthOptions({
   onAuthStateUpdate,
   onSuccessfulLogin,
   onSuccessfulRegistration,
-  className,
+  className = {},
   formRef,
   trigger,
   defaultDisplay = AuthDisplay.Default,
@@ -344,12 +349,12 @@ function AuthOptions({
       className={classNames(
         'z-1 flex w-full max-w-[26.25rem] flex-col overflow-y-auto rounded-16',
         !simplified && 'bg-theme-bg-tertiary',
-        className,
+        className?.container,
       )}
     >
       <TabContainer<AuthDisplay>
         onActiveChange={(active) => onSetActiveDisplay(active)}
-        controlledActive={activeDisplay}
+        controlledActive={forceDefaultDisplay ? defaultDisplay : activeDisplay}
         showHeader={false}
       >
         <Tab label={AuthDisplay.Default}>
@@ -419,6 +424,7 @@ function AuthOptions({
             isReady={isReady}
             simplified={simplified}
             targetId={targetId}
+            className={className?.onboardingSignup}
           />
         </Tab>
         <Tab label={AuthDisplay.SignBack}>

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -95,6 +95,7 @@ export interface AuthOptionsProps {
   onDisplayChange?: (value: string) => void;
   initialEmail?: string;
   targetId?: string;
+  ignoreMessages?: boolean;
 }
 
 function AuthOptions({
@@ -112,6 +113,7 @@ function AuthOptions({
   targetId,
   simplified = false,
   initialEmail = '',
+  ignoreMessages = false,
 }: AuthOptionsProps): ReactElement {
   const { displayToast } = useToastNotification();
   const { syncSettings } = useContext(SettingsContext);
@@ -247,7 +249,7 @@ function AuthOptions({
   };
 
   useEventListener(globalThis, 'message', async (e) => {
-    if (e.data?.eventKey !== AuthEvent.SocialRegistration) {
+    if (e.data?.eventKey !== AuthEvent.SocialRegistration || ignoreMessages) {
       return undefined;
     }
 

--- a/packages/shared/src/components/auth/AuthenticationBanner.tsx
+++ b/packages/shared/src/components/auth/AuthenticationBanner.tsx
@@ -1,0 +1,54 @@
+import React, { ReactElement } from 'react';
+import classed from '../../lib/classed';
+import { OnboardingHeadline } from './OnboardingHeadline';
+import AuthOptions, { AuthDisplay } from './AuthOptions';
+import { AuthTriggers } from '../../lib/auth';
+import { MemberAlready } from '../onboarding/MemberAlready';
+import { useAuthContext } from '../../contexts/AuthContext';
+
+const Container = classed('div', 'flex flex-col w-[23.25rem]');
+
+export function AuthenticationBanner(): ReactElement {
+  const { showLogin } = useAuthContext();
+
+  return (
+    <div
+      className="fixed bottom-0 left-0 z-modal flex w-full flex-row justify-center gap-6 py-10"
+      style={{
+        background: `linear-gradient(270deg, rgba(206, 61, 243, 0.16) 0%, rgba(113, 71, 237, 0.16) 100%), var(--Colors-Background-default, #0E1217)`,
+      }}
+    >
+      <Container>
+        <OnboardingHeadline
+          className={{ title: '!typo-mega3', description: '!typo-title3' }}
+        />
+      </Container>
+      <Container className="pt-2">
+        <AuthOptions
+          ignoreMessages
+          formRef={null}
+          trigger={AuthTriggers.Onboarding}
+          simplified
+          defaultDisplay={AuthDisplay.OnboardingSignup}
+          forceDefaultDisplay
+          className={{ onboardingSignup: '!gap-4' }}
+          onAuthStateUpdate={() =>
+            showLogin({ trigger: AuthTriggers.Onboarding })
+          }
+        />
+        <MemberAlready
+          onLogin={() =>
+            showLogin({
+              trigger: AuthTriggers.Onboarding,
+              options: { isLogin: true },
+            })
+          }
+          className={{
+            container: 'justify-center text-theme-label-secondary typo-callout',
+            login: 'font-bold',
+          }}
+        />
+      </Container>
+    </div>
+  );
+}

--- a/packages/shared/src/components/auth/AuthenticationBanner.tsx
+++ b/packages/shared/src/components/auth/AuthenticationBanner.tsx
@@ -15,7 +15,7 @@ export function AuthenticationBanner(): ReactElement {
     <div
       className="fixed bottom-0 left-0 z-modal flex w-full flex-row justify-center gap-6 py-10"
       style={{
-        background: `linear-gradient(270deg, rgba(206, 61, 243, 0.16) 0%, rgba(113, 71, 237, 0.16) 100%), var(--theme-background-primary)`,
+        background: `linear-gradient(270deg, var(--theme-overlay-active-cabbage) 0%, var(--theme-overlay-active-onion) 100%), var(--theme-background-primary)`,
       }}
     >
       <Container>

--- a/packages/shared/src/components/auth/AuthenticationBanner.tsx
+++ b/packages/shared/src/components/auth/AuthenticationBanner.tsx
@@ -20,7 +20,7 @@ export function AuthenticationBanner(): ReactElement {
     >
       <Container>
         <OnboardingHeadline
-          className={{ title: '!typo-mega3', description: '!typo-title3' }}
+          className={{ title: 'typo-mega3', description: 'typo-title3' }}
         />
       </Container>
       <Container className="pt-2">

--- a/packages/shared/src/components/auth/AuthenticationBanner.tsx
+++ b/packages/shared/src/components/auth/AuthenticationBanner.tsx
@@ -1,29 +1,44 @@
-import React, { ReactElement } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
+import classNames from 'classnames';
 import classed from '../../lib/classed';
 import { OnboardingHeadline } from './OnboardingHeadline';
 import AuthOptions, { AuthDisplay } from './AuthOptions';
 import { AuthTriggers } from '../../lib/auth';
 import { MemberAlready } from '../onboarding/MemberAlready';
 import { useAuthContext } from '../../contexts/AuthContext';
+import { useViewSize, ViewSize } from '../../hooks';
+import LoginButton from '../LoginButton';
+import { bottomBannerBaseClasses, BottomBannerContainer } from '../banners';
 
-const Container = classed('div', 'flex flex-col w-[23.25rem]');
+const Section = classed('div', 'flex flex-col w-[23.25rem]');
+const style: CSSProperties = {
+  background: `linear-gradient(270deg, var(--theme-overlay-active-cabbage) 0%, var(--theme-overlay-active-onion) 100%), var(--theme-background-primary)`,
+};
 
 export function AuthenticationBanner(): ReactElement {
   const { showLogin } = useAuthContext();
+  const isLaptop = useViewSize(ViewSize.Laptop);
+
+  if (!isLaptop) {
+    return (
+      <LoginButton
+        style={style}
+        className={{
+          container: classNames(bottomBannerBaseClasses, 'gap-2 px-4 py-2'),
+          button: 'flex-1 tablet:max-w-[9rem]',
+        }}
+      />
+    );
+  }
 
   return (
-    <div
-      className="fixed bottom-0 left-0 z-modal flex w-full flex-row justify-center gap-6 py-10"
-      style={{
-        background: `linear-gradient(270deg, var(--theme-overlay-active-cabbage) 0%, var(--theme-overlay-active-onion) 100%), var(--theme-background-primary)`,
-      }}
-    >
-      <Container>
+    <BottomBannerContainer className="gap-6 py-10" style={style}>
+      <Section>
         <OnboardingHeadline
           className={{ title: 'typo-mega3', description: 'typo-title3' }}
         />
-      </Container>
-      <Container className="pt-2">
+      </Section>
+      <Section className="pt-2">
         <AuthOptions
           ignoreMessages
           formRef={null}
@@ -48,7 +63,7 @@ export function AuthenticationBanner(): ReactElement {
             login: 'font-bold',
           }}
         />
-      </Container>
-    </div>
+      </Section>
+    </BottomBannerContainer>
   );
 }

--- a/packages/shared/src/components/auth/AuthenticationBanner.tsx
+++ b/packages/shared/src/components/auth/AuthenticationBanner.tsx
@@ -15,7 +15,7 @@ export function AuthenticationBanner(): ReactElement {
     <div
       className="fixed bottom-0 left-0 z-modal flex w-full flex-row justify-center gap-6 py-10"
       style={{
-        background: `linear-gradient(270deg, rgba(206, 61, 243, 0.16) 0%, rgba(113, 71, 237, 0.16) 100%), var(--Colors-Background-default, #0E1217)`,
+        background: `linear-gradient(270deg, rgba(206, 61, 243, 0.16) 0%, rgba(113, 71, 237, 0.16) 100%), var(--theme-background-primary)`,
       }}
     >
       <Container>

--- a/packages/shared/src/components/auth/OnboardingHeadline.tsx
+++ b/packages/shared/src/components/auth/OnboardingHeadline.tsx
@@ -1,0 +1,40 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import { OnboardingTitleGradient } from '../onboarding/common';
+
+interface ClassName {
+  title?: string;
+  description?: string;
+}
+
+interface OnboardingHeadlineProps {
+  className?: ClassName;
+}
+
+export function OnboardingHeadline({
+  className = {},
+}: OnboardingHeadlineProps): ReactElement {
+  return (
+    <>
+      <OnboardingTitleGradient
+        className={classNames(
+          'mb-4 typo-large-title tablet:typo-mega1',
+          className?.title,
+        )}
+      >
+        Where developers suffer together
+      </OnboardingTitleGradient>
+
+      <h2
+        className={classNames(
+          'mb-8 typo-body tablet:typo-title2',
+          className?.description,
+        )}
+      >
+        We know how hard it is to be a developer. It doesn&apos;t have to be.
+        Personalized news feed, dev community and search, much better than
+        what&apos;s out there. Maybe ;)
+      </h2>
+    </>
+  );
+}

--- a/packages/shared/src/components/auth/OnboardingHeadline.tsx
+++ b/packages/shared/src/components/auth/OnboardingHeadline.tsx
@@ -16,21 +16,11 @@ export function OnboardingHeadline({
 }: OnboardingHeadlineProps): ReactElement {
   return (
     <>
-      <OnboardingTitleGradient
-        className={classNames(
-          'mb-4 typo-large-title tablet:typo-mega1',
-          className?.title,
-        )}
-      >
+      <OnboardingTitleGradient className={classNames('mb-4', className?.title)}>
         Where developers suffer together
       </OnboardingTitleGradient>
 
-      <h2
-        className={classNames(
-          'mb-8 typo-body tablet:typo-title2',
-          className?.description,
-        )}
-      >
+      <h2 className={classNames('mb-8', className?.description)}>
         We know how hard it is to be a developer. It doesn&apos;t have to be.
         Personalized news feed, dev community and search, much better than
         what&apos;s out there. Maybe ;)

--- a/packages/shared/src/components/auth/OnboardingRegistrationForm.tsx
+++ b/packages/shared/src/components/auth/OnboardingRegistrationForm.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useContext, useEffect, useState } from 'react';
+import classNames from 'classnames';
 import { AuthFormProps, providerMap } from './common';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 import { AuthEventNames, AuthTriggersType } from '../../lib/auth';
@@ -16,6 +17,7 @@ interface OnboardingRegistrationFormProps extends AuthFormProps {
   signUpTitle?: string;
   trigger: AuthTriggersType;
   isReady: boolean;
+  className?: string;
 }
 
 const OnboardingRegistrationForm = ({
@@ -23,6 +25,7 @@ const OnboardingRegistrationForm = ({
   targetId,
   isReady,
   trigger,
+  className,
 }: OnboardingRegistrationFormProps): ReactElement => {
   const { trackEvent } = useContext(AnalyticsContext);
   const [shouldLogin] = useState(false);
@@ -44,22 +47,20 @@ const OnboardingRegistrationForm = ({
   };
 
   return (
-    <>
-      <div className="flex flex-col gap-8 pb-8">
-        {signupProviders.map((provider) => (
-          <Button
-            key={provider.value}
-            icon={provider.icon}
-            loading={!isReady}
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Large}
-            onClick={() => onSocialClick(provider.value)}
-          >
-            {provider.label}
-          </Button>
-        ))}
-      </div>
-    </>
+    <div className={classNames('flex flex-col gap-8 pb-8', className)}>
+      {signupProviders.map((provider) => (
+        <Button
+          key={provider.value}
+          icon={provider.icon}
+          loading={!isReady}
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Large}
+          onClick={() => onSocialClick(provider.value)}
+        >
+          {provider.label}
+        </Button>
+      ))}
+    </div>
   );
 };
 

--- a/packages/shared/src/components/auth/index.ts
+++ b/packages/shared/src/components/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './OnboardingHeadline';

--- a/packages/shared/src/components/auth/index.ts
+++ b/packages/shared/src/components/auth/index.ts
@@ -1,1 +1,2 @@
+export * from './AuthenticationBanner';
 export * from './OnboardingHeadline';

--- a/packages/shared/src/components/banners/common.ts
+++ b/packages/shared/src/components/banners/common.ts
@@ -1,0 +1,6 @@
+import classed from '../../lib/classed';
+
+export const bottomBannerBaseClasses =
+  'fixed bottom-0 left-0 z-modal flex w-full flex-row justify-center';
+
+export const BottomBannerContainer = classed('div', bottomBannerBaseClasses);

--- a/packages/shared/src/components/banners/index.ts
+++ b/packages/shared/src/components/banners/index.ts
@@ -1,0 +1,1 @@
+export * from './common';

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -73,7 +73,11 @@ function MainLayoutHeader({
       return <ProfileButton className="hidden laptop:flex" />;
     }
 
-    return <LoginButton className="hidden laptop:block" />;
+    return (
+      <LoginButton
+        className={{ container: 'gap-4', button: 'hidden laptop:block' }}
+      />
+    );
   })();
 
   const hasNotification = !!unreadCount;

--- a/packages/shared/src/components/modals/NewRankModal.tsx
+++ b/packages/shared/src/components/modals/NewRankModal.tsx
@@ -190,7 +190,7 @@ export default function NewRankModal({
             </Button>
           </div>
         ) : (
-          <LoginButton className="mx-auto" />
+          <LoginButton className={{ container: 'gap-4', button: 'mx-auto' }} />
         )}
         <Checkbox ref={inputRef} name="neverShow" className="mt-4 self-center">
           Never show this popup again

--- a/packages/shared/src/components/modals/OnboardingModal.tsx
+++ b/packages/shared/src/components/modals/OnboardingModal.tsx
@@ -140,7 +140,7 @@ function OnboardingModal({
     if (isAuthenticating) {
       return (
         <AuthOptions
-          className="h-full"
+          className={{ container: 'h-full' }}
           onClose={onClose}
           formRef={formRef}
           onSuccessfulLogin={onRegistrationSuccess}

--- a/packages/shared/src/components/post/BasePostContent.tsx
+++ b/packages/shared/src/components/post/BasePostContent.tsx
@@ -5,6 +5,7 @@ import { PostFeedFiltersOnboarding } from './PostFeedFiltersOnboarding';
 import PostEngagements from './PostEngagements';
 import OnboardingContext from '../../contexts/OnboardingContext';
 import { BasePostContentProps } from './common';
+import { useOnboarding } from '../../hooks/auth';
 
 const ShareModal = dynamic(
   () => import(/* webpackChunkName: "shareModal" */ '../modals/ShareModal'),
@@ -29,20 +30,18 @@ export function BasePostContent({
   customNavigation,
 }: BasePostContentProps): ReactElement {
   const { id } = post ?? {};
+  const { onCloseShare, sharePost, onSharePost } = engagementProps;
+  const { onStartArticleOnboarding, showArticleOnboarding } =
+    useContext(OnboardingContext);
+  const { shouldShowBottomBanner } = useOnboarding();
 
   if (!id && !isFallback) {
     return <Custom404 />;
   }
 
-  const { onCloseShare, sharePost, onSharePost } = engagementProps;
-  const { onStartArticleOnboarding, showArticleOnboarding } =
-    // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    useContext(OnboardingContext);
-
   return (
     <>
-      {showArticleOnboarding && (
+      {showArticleOnboarding && !shouldShowBottomBanner && (
         <PostFeedFiltersOnboarding
           className={className?.onboarding}
           onInitializeOnboarding={onStartArticleOnboarding}

--- a/packages/shared/src/components/sidebar/SidebarUserButton.tsx
+++ b/packages/shared/src/components/sidebar/SidebarUserButton.tsx
@@ -34,7 +34,7 @@ export function SidebarUserButton({
               </p>
             </>
           ) : (
-            <LoginButton />
+            <LoginButton className={{ container: 'gap-4' }} />
           )}
         </li>
       )}

--- a/packages/shared/src/hooks/auth/index.ts
+++ b/packages/shared/src/hooks/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './useOnboarding';

--- a/packages/shared/src/hooks/auth/useOnboarding.tsx
+++ b/packages/shared/src/hooks/auth/useOnboarding.tsx
@@ -1,7 +1,6 @@
 import { useFeature } from '../../components/GrowthBookProvider';
 import { feature } from '../../lib/featureManagement';
 import { PostPageOnboarding } from '../../lib/featureValues';
-import { useViewSize, ViewSize } from '../useViewSize';
 import { useAuthContext } from '../../contexts/AuthContext';
 
 interface UseOnboarding {
@@ -9,14 +8,10 @@ interface UseOnboarding {
 }
 
 export const useOnboarding = (): UseOnboarding => {
-  const isLaptop = useViewSize(ViewSize.Laptop);
   const { isAuthReady, user } = useAuthContext();
   const postPageOnboarding = useFeature(feature.postPageOnboarding);
   const shouldShowBottomBanner =
-    postPageOnboarding === PostPageOnboarding.V1 &&
-    isLaptop &&
-    isAuthReady &&
-    !user;
+    postPageOnboarding === PostPageOnboarding.V1 && isAuthReady && !user;
 
   return { shouldShowBottomBanner };
 };

--- a/packages/shared/src/hooks/auth/useOnboarding.tsx
+++ b/packages/shared/src/hooks/auth/useOnboarding.tsx
@@ -1,0 +1,22 @@
+import { useFeature } from '../../components/GrowthBookProvider';
+import { feature } from '../../lib/featureManagement';
+import { PostPageOnboarding } from '../../lib/featureValues';
+import { useViewSize, ViewSize } from '../useViewSize';
+import { useAuthContext } from '../../contexts/AuthContext';
+
+interface UseOnboarding {
+  shouldShowBottomBanner: boolean;
+}
+
+export const useOnboarding = (): UseOnboarding => {
+  const isLaptop = useViewSize(ViewSize.Laptop);
+  const { isAuthReady, user } = useAuthContext();
+  const postPageOnboarding = useFeature(feature.postPageOnboarding);
+  const shouldShowBottomBanner =
+    postPageOnboarding === PostPageOnboarding.V1 &&
+    isLaptop &&
+    isAuthReady &&
+    !user;
+
+  return { shouldShowBottomBanner };
+};

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -33,6 +33,7 @@ const feature = {
     webm: cloudinary.onboarding.video.webm,
     mp4: cloudinary.onboarding.video.mp4,
   }),
+  showPostAuthBanner: new Feature('show_post_auth_banner', false),
 };
 
 export { feature };

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -1,6 +1,7 @@
 import { JSONValue } from '@growthbook/growthbook';
 import {
   FeedLayout,
+  PostPageOnboarding,
   ReadingStreaksExperiment,
   SearchExperiment,
 } from './featureValues';
@@ -33,7 +34,10 @@ const feature = {
     webm: cloudinary.onboarding.video.webm,
     mp4: cloudinary.onboarding.video.mp4,
   }),
-  showPostAuthBanner: new Feature('show_post_auth_banner', false),
+  postPageOnboarding: new Feature(
+    'post_page_onboarding',
+    PostPageOnboarding.Control,
+  ),
 };
 
 export { feature };

--- a/packages/shared/src/lib/featureValues.ts
+++ b/packages/shared/src/lib/featureValues.ts
@@ -20,3 +20,8 @@ export enum ReadingStreaksExperiment {
   Control = 'control',
   V1 = 'v1',
 }
+
+export enum PostPageOnboarding {
+  Control = 'control',
+  V1 = 'v1',
+}

--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -97,6 +97,9 @@ body {
   --theme-overlay-float-avocado: theme('colors.overlay.float.avocado');
   --theme-overlay-float-ketchup: theme('colors.overlay.float.ketchup');
 
+  --theme-overlay-active-cabbage: theme('colors.overlay.active.cabbage');
+  --theme-overlay-active-onion: theme('colors.overlay.active.onion');
+
   --theme-gradient-cabbage: theme('colors.cabbage.10')66;
   --theme-gradient-onion: theme('colors.onion.10')66;
 
@@ -221,6 +224,9 @@ body {
   --theme-overlay-float-cabbage: theme('colors.overlay.float.cabbage');
   --theme-overlay-float-avocado: theme('colors.overlay.float.avocado');
   --theme-overlay-float-ketchup: theme('colors.overlay.float.ketchup');
+
+  --theme-overlay-active-cabbage: theme('colors.overlay.active.cabbage');
+  --theme-overlay-active-onion: theme('colors.overlay.active.onion');
 
   --theme-gradient-cabbage: theme('colors.cabbage.10')66;
   --theme-gradient-onion: theme('colors.onion.10')66;
@@ -490,6 +496,6 @@ details.right-icon {
 
 input {
   @apply bg-clip-text;
-  
+
   -webkit-text-fill-color: var(--theme-label-primary);
 }

--- a/packages/shared/tailwind/overlay.js
+++ b/packages/shared/tailwind/overlay.js
@@ -28,6 +28,7 @@ const overlay = {
   secondary: '66',
   tertiary: '52',
   quaternary: '3D',
+  active: '29',
   float: '14',
 };
 

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -29,7 +29,6 @@ import {
 } from '@dailydotdev/shared/src/lib/analytics';
 import {
   OnboardingStep,
-  OnboardingTitleGradient,
   REQUIRED_TAGS_THRESHOLD,
   wrapperMaxWidth,
 } from '@dailydotdev/shared/src/components/onboarding/common';

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -60,6 +60,7 @@ import {
   PixelTracking,
 } from '@dailydotdev/shared/src/components/auth/OnboardingAnalytics';
 import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
+import { OnboardingHeadline } from '@dailydotdev/shared/src/components/auth';
 import { defaultOpenGraph, defaultSeo } from '../next-seo';
 import styles from '../components/layouts/Onboarding/index.module.css';
 
@@ -189,12 +190,14 @@ export function OnboardPage(): ReactElement {
     return (
       <AuthOptions
         simplified
-        className={classNames(
-          'w-full rounded-none',
-          maxAuthWidth,
-          isAuthenticating && 'h-full',
-          !isAuthenticating && 'max-w-full',
-        )}
+        className={{
+          container: classNames(
+            'w-full rounded-none',
+            maxAuthWidth,
+            isAuthenticating && 'h-full',
+            !isAuthenticating && 'max-w-full',
+          ),
+        }}
         trigger={AuthTriggers.Onboarding}
         formRef={formRef}
         defaultDisplay={defaultDisplay}
@@ -375,16 +378,7 @@ export function OnboardPage(): ReactElement {
               'flex flex-1 flex-col laptop:mr-8 laptop:max-w-[27.5rem]',
             )}
           >
-            <OnboardingTitleGradient className="mb-4 typo-large-title tablet:typo-mega1">
-              Where developers suffer together
-            </OnboardingTitleGradient>
-
-            <h2 className="mb-8 typo-body tablet:typo-title2">
-              We know how hard it is to be a developer. It doesn&apos;t have to
-              be. Personalized news feed, dev community and search, much better
-              than what&apos;s out there. Maybe ;)
-            </h2>
-
+            <OnboardingHeadline />
             {getAuthOptions()}
           </div>
         )}

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -378,7 +378,12 @@ export function OnboardPage(): ReactElement {
               'flex flex-1 flex-col laptop:mr-8 laptop:max-w-[27.5rem]',
             )}
           >
-            <OnboardingHeadline />
+            <OnboardingHeadline
+              className={{
+                title: 'typo-large-title tablet:typo-mega1',
+                description: 'typo-body tablet:typo-title2',
+              }}
+            />
             {getAuthOptions()}
           </div>
         )}

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -50,8 +50,7 @@ import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { FeedLayout } from '@dailydotdev/shared/src/lib/featureValues';
 import { PostBackButton } from '@dailydotdev/shared/src/components/post/common/PostBackButton';
 import { AuthenticationBanner } from '@dailydotdev/shared/src/components/auth';
-import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
-import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
+import { useOnboarding } from '@dailydotdev/shared/src/hooks/auth/useOnboarding';
 import { getTemplatedTitle } from '../../../components/layouts/utils';
 import { getLayout as getMainLayout } from '../../../components/layouts/MainLayout';
 
@@ -87,7 +86,6 @@ interface PostParams extends ParsedUrlQuery {
 }
 
 const PostPage = ({ id, initialData }: Props): ReactElement => {
-  const { isAuthReady, user } = useAuthContext();
   const { showArticleOnboarding } = useContext(OnboardingContext);
   const [position, setPosition] =
     useState<CSSProperties['position']>('relative');
@@ -95,9 +93,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
   const layout = useFeature(feature.feedLayout);
   const { sidebarRendered } = useSidebarRendered();
   const { isFallback } = router;
-  const showPostAuthBanner = useFeature(feature.showPostAuthBanner);
-  const isLaptop = useViewSize(ViewSize.Laptop);
-  const showBanner = showPostAuthBanner && isLaptop && isAuthReady && !user;
+  const { shouldShowBottomBanner } = useOnboarding();
   const { post, isError, isFetched, isPostLoadingOrFetching } = usePostById({
     id,
     options: { initialData, retry: false },
@@ -214,7 +210,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
           content: 'pt-8',
         }}
       />
-      {showBanner && <AuthenticationBanner />}
+      {shouldShowBottomBanner && <AuthenticationBanner />}
     </>
   );
 };

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -49,6 +49,9 @@ import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvide
 import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { FeedLayout } from '@dailydotdev/shared/src/lib/featureValues';
 import { PostBackButton } from '@dailydotdev/shared/src/components/post/common/PostBackButton';
+import { AuthenticationBanner } from '@dailydotdev/shared/src/components/auth';
+import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
+import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
 import { getTemplatedTitle } from '../../../components/layouts/utils';
 import { getLayout as getMainLayout } from '../../../components/layouts/MainLayout';
 
@@ -84,6 +87,7 @@ interface PostParams extends ParsedUrlQuery {
 }
 
 const PostPage = ({ id, initialData }: Props): ReactElement => {
+  const { isAuthReady, user } = useAuthContext();
   const { showArticleOnboarding } = useContext(OnboardingContext);
   const [position, setPosition] =
     useState<CSSProperties['position']>('relative');
@@ -91,7 +95,9 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
   const layout = useFeature(feature.feedLayout);
   const { sidebarRendered } = useSidebarRendered();
   const { isFallback } = router;
-
+  const showPostAuthBanner = useFeature(feature.showPostAuthBanner);
+  const isLaptop = useViewSize(ViewSize.Laptop);
+  const showBanner = showPostAuthBanner && isLaptop && isAuthReady && !user;
   const { post, isError, isFetched, isPostLoadingOrFetching } = usePostById({
     id,
     options: { initialData, retry: false },
@@ -208,6 +214,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
           content: 'pt-8',
         }}
       />
+      {showBanner && <AuthenticationBanner />}
     </>
   );
 };

--- a/packages/webapp/pages/signup.tsx
+++ b/packages/webapp/pages/signup.tsx
@@ -29,7 +29,7 @@ function Signup(): ReactElement {
       <main className="mx-0 flex h-full flex-1 flex-col items-center justify-center tablet:mx-8 tablet:flex-row tablet:justify-start laptop:items-center laptopL:mx-32">
         <div className=" flex max-w-full flex-col-reverse laptop:flex-row">
           <AuthOptions
-            className="h-full max-h-[40rem] min-h-[40rem]"
+            className={{ container: 'h-full max-h-[40rem] min-h-[40rem]' }}
             formRef={formRef}
             trigger={AuthTriggers.LoginPage}
             onClose={onClose}


### PR DESCRIPTION
## Changes
- Made the `AuthOptions` accept a `className` object to be applied on certain elements.
- Introduced `ignoreMessages` prop. This is because we will now be rendering two `AuthOptions` component. One for the banner, and one for the modal. We want the banner to only be utilized when clicking the provider buttons. The other (modal) auth options will be listening to the messages which will continue the process.
- Tracking events are intact since we just reused the same component.

Preview in action:
https://dailydotdev.slack.com/archives/C06K1LYU716/p1707947399158029?thread_ts=1707940049.888179&cid=C06K1LYU716

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-169 #done
