### PR TITLE
fix: squad widgets content overflow

### DIFF
--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -12,7 +12,7 @@ interface SquadPostAuthorProps {
     container: string;
     name: string;
     handle: string;
-    details?: string;
+    details: string;
   }>;
   author: Author;
   role?: SourceMemberRole;
@@ -31,10 +31,7 @@ function SquadPostAuthor({
 }: SquadPostAuthorProps): ReactElement {
   return (
     <span
-      className={classNames(
-        'mt-3 flex flex-row items-center',
-        className?.container,
-      )}
+      className={classNames('flex flex-row items-center', className?.container)}
     >
       <ProfileTooltip user={author} link={{ href: author.permalink }}>
         <ProfilePicture user={author} size={size} nativeLazyLoading />

--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -19,6 +19,8 @@ interface SquadPostAuthorProps {
   date?: string;
 }
 
+const lineClamp = 'block text-ellipsis whitespace-nowrap';
+
 function SquadPostAuthor({
   className,
   author,
@@ -36,9 +38,9 @@ function SquadPostAuthor({
       <ProfileTooltip user={author} link={{ href: author.permalink }}>
         <ProfilePicture user={author} size={size} nativeLazyLoading />
       </ProfileTooltip>
-      <div className="ml-4 flex flex-1 flex-col">
+      <div className="ml-4 flex flex-1 flex-col overflow-hidden">
         <ProfileTooltip user={author} link={{ href: author.permalink }}>
-          <a href={author.permalink} className="line-clamp-1 flex flex-row">
+          <a href={author.permalink} className={lineClamp}>
             <span className={classNames('font-bold', className?.name)}>
               {author.name}
             </span>
@@ -49,8 +51,9 @@ function SquadPostAuthor({
           <a
             href={author.permalink}
             className={classNames(
-              'line-clamp-1 flex flex-row text-theme-label-tertiary',
+              'text-theme-label-tertiary',
               className?.handle,
+              lineClamp,
             )}
           >
             @{author.username}

--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -12,6 +12,7 @@ interface SquadPostAuthorProps {
     container: string;
     name: string;
     handle: string;
+    details?: string;
   }>;
   author: Author;
   role?: SourceMemberRole;
@@ -41,7 +42,10 @@ function SquadPostAuthor({
       <ProfileTooltip user={author} link={{ href: author.permalink }}>
         <a
           href={author.permalink}
-          className={classNames('ml-4 flex flex-1 flex-col overflow-hidden')}
+          className={classNames(
+            'ml-4 flex flex-col overflow-hidden',
+            className?.details,
+          )}
         >
           <div className={lineClamp}>
             <span className={classNames('font-bold', className?.name)}>

--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -19,7 +19,7 @@ interface SquadPostAuthorProps {
   date?: string;
 }
 
-const lineClamp = 'block text-ellipsis whitespace-nowrap';
+const lineClamp = 'block text-ellipsis whitespace-nowrap overflow-hidden';
 
 function SquadPostAuthor({
   className,
@@ -38,18 +38,18 @@ function SquadPostAuthor({
       <ProfileTooltip user={author} link={{ href: author.permalink }}>
         <ProfilePicture user={author} size={size} nativeLazyLoading />
       </ProfileTooltip>
-      <div className="ml-4 flex flex-1 flex-col overflow-hidden">
-        <ProfileTooltip user={author} link={{ href: author.permalink }}>
-          <a href={author.permalink} className={lineClamp}>
+      <ProfileTooltip user={author} link={{ href: author.permalink }}>
+        <a
+          href={author.permalink}
+          className={classNames('ml-4 flex flex-1 flex-col overflow-hidden')}
+        >
+          <div className={lineClamp}>
             <span className={classNames('font-bold', className?.name)}>
               {author.name}
             </span>
             {!!role && <SquadMemberBadge key="squadMemberRole" role={role} />}
-          </a>
-        </ProfileTooltip>
-        <ProfileTooltip user={author} link={{ href: author.permalink }}>
-          <a
-            href={author.permalink}
+          </div>
+          <div
             className={classNames(
               'text-theme-label-tertiary',
               className?.handle,
@@ -59,9 +59,9 @@ function SquadPostAuthor({
             @{author.username}
             {!!date && <Separator />}
             {!!date && <time dateTime={date}>{date}</time>}
-          </a>
-        </ProfileTooltip>
-      </div>
+          </div>
+        </a>
+      </ProfileTooltip>
     </span>
   );
 }

--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -36,30 +36,29 @@ function SquadPostAuthor({
       <ProfileTooltip user={author} link={{ href: author.permalink }}>
         <ProfilePicture user={author} size={size} nativeLazyLoading />
       </ProfileTooltip>
-      <ProfileTooltip user={author} link={{ href: author.permalink }}>
-        <a href={author.permalink} className="ml-4 flex flex-col">
-          <div className="flex items-center">
+      <div className="ml-4 flex flex-1 flex-col">
+        <ProfileTooltip user={author} link={{ href: author.permalink }}>
+          <a href={author.permalink} className="line-clamp-1 flex flex-row">
             <span className={classNames('font-bold', className?.name)}>
               {author.name}
             </span>
             {!!role && <SquadMemberBadge key="squadMemberRole" role={role} />}
-          </div>
-          <span
+          </a>
+        </ProfileTooltip>
+        <ProfileTooltip user={author} link={{ href: author.permalink }}>
+          <a
+            href={author.permalink}
             className={classNames(
-              'text-theme-label-tertiary',
+              'line-clamp-1 flex flex-row text-theme-label-tertiary',
               className?.handle,
             )}
           >
             @{author.username}
-            {!!date && (
-              <>
-                <Separator />
-                <time dateTime={date}>{date}</time>
-              </>
-            )}
-          </span>
-        </a>
-      </ProfileTooltip>
+            {!!date && <Separator />}
+            {!!date && <time dateTime={date}>{date}</time>}
+          </a>
+        </ProfileTooltip>
+      </div>
     </span>
   );
 }

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -130,6 +130,7 @@ function SquadPostContent({
                 author={post.author}
                 role={role}
                 date={postDateFormat(post.createdAt)}
+                className={{ container: 'mt-3' }}
               />
             )}
             <Content post={post} onReadArticle={onReadArticle} />

--- a/packages/shared/src/components/squads/SquadPostListItem.tsx
+++ b/packages/shared/src/components/squads/SquadPostListItem.tsx
@@ -44,9 +44,10 @@ export const SquadPostListItem = ({
         {post?.author && (
           <SquadPostAuthor
             className={{
-              container: 'mt-0',
+              container: '!mt-0',
               name: 'text-theme-label-primary typo-callout',
               handle: 'text-theme-label-quaternary typo-callout',
+              details: 'flex-1 pr-8',
             }}
             author={post.author}
             size="large"
@@ -59,7 +60,7 @@ export const SquadPostListItem = ({
       </div>
       <SimpleTooltip content={post.bookmarked ? 'Remove bookmark' : 'Bookmark'}>
         <Button
-          className="mt-1 group-hover:visible mouse:invisible"
+          className="absolute right-3 group-hover:visible mouse:invisible"
           variant={ButtonVariant.Tertiary}
           color={ButtonColor.Bun}
           pressed={post.bookmarked}

--- a/packages/shared/src/components/squads/SquadPostListItem.tsx
+++ b/packages/shared/src/components/squads/SquadPostListItem.tsx
@@ -45,8 +45,8 @@ export const SquadPostListItem = ({
           <SquadPostAuthor
             className={{
               container: 'mt-0',
-              name: 'line-clamp-1 text-theme-label-primary typo-callout',
-              handle: 'line-clamp-1 text-theme-label-quaternary typo-callout',
+              name: 'text-theme-label-primary typo-callout',
+              handle: 'text-theme-label-quaternary typo-callout',
             }}
             author={post.author}
             size="large"

--- a/packages/shared/src/components/squads/SquadPostListItem.tsx
+++ b/packages/shared/src/components/squads/SquadPostListItem.tsx
@@ -45,8 +45,8 @@ export const SquadPostListItem = ({
           <SquadPostAuthor
             className={{
               container: 'mt-0',
-              name: 'text-theme-label-primary typo-callout',
-              handle: 'text-theme-label-quaternary typo-callout',
+              name: 'line-clamp-1 text-theme-label-primary typo-callout',
+              handle: 'line-clamp-1 text-theme-label-quaternary typo-callout',
             }}
             author={post.author}
             size="large"

--- a/packages/shared/src/components/squads/SquadPostListItem.tsx
+++ b/packages/shared/src/components/squads/SquadPostListItem.tsx
@@ -31,7 +31,7 @@ export const SquadPostListItem = ({
   return (
     <article
       className={classNames(
-        'group relative flex items-start py-2 pl-4 pr-2 hover:bg-theme-hover',
+        'group relative flex items-start px-4 py-2 hover:bg-theme-hover',
         styles.card,
       )}
     >
@@ -40,11 +40,10 @@ export const SquadPostListItem = ({
         title={post.title}
         {...combinedClicks(() => onLinkClick(post))}
       />
-      <div className="flex flex-1 flex-col">
+      <div className="flex w-full flex-col">
         {post?.author && (
           <SquadPostAuthor
             className={{
-              container: '!mt-0',
               name: 'text-theme-label-primary typo-callout',
               handle: 'text-theme-label-quaternary typo-callout',
               details: 'flex-1 pr-8',


### PR DESCRIPTION
## Changes
- Fixed the widget's content overflow - line clamp 1 was not working, so I manually added the common classes for ellipsis.
- Fixed some minor spacing issues.

![Screenshot 2024-02-16 at 4 35 17 AM](https://github.com/dailydotdev/apps/assets/13744167/6f370718-e82d-4a96-9ac3-0e025a12619a)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
