### PR TITLE
chore: remove tailwind base classes for border radius

### DIFF
--- a/packages/extension/src/newtab/CustomLinks.tsx
+++ b/packages/extension/src/newtab/CustomLinks.tsx
@@ -44,7 +44,7 @@ export function CustomLinks({
           href={url}
           rel="noopener noreferrer"
           className={classNames(
-            'focus-outline h-8 w-8 overflow-hidden rounded-lg bg-white',
+            'focus-outline h-8 w-8 overflow-hidden rounded-8 bg-white',
             i >= 4 && 'hidden laptopL:block',
           )}
           key={url}

--- a/packages/extension/src/newtab/MostVisitedSitesModal.tsx
+++ b/packages/extension/src/newtab/MostVisitedSitesModal.tsx
@@ -35,7 +35,7 @@ export default function MostVisitedSitesModal({
               : '/mvs_google.jpg'
           }
           imgAlt="Image of the browser's default home screen"
-          className="mx-auto my-8 w-full max-w-[22rem] rounded-2xl"
+          className="mx-auto my-8 w-full max-w-[22rem] rounded-16"
           ratio="45.8%"
           eager
         />

--- a/packages/shared/src/components/ShareNewCommentPopup.tsx
+++ b/packages/shared/src/components/ShareNewCommentPopup.tsx
@@ -45,7 +45,7 @@ export default function ShareNewCommentPopup({
 
   return (
     <div
-      className="fixed bottom-6 right-6 z-3 hidden flex-col rounded-2xl border border-theme-divider-secondary bg-theme-bg-tertiary px-6 pb-6 pt-10 shadow-2 laptop:flex"
+      className="fixed bottom-6 right-6 z-3 hidden flex-col rounded-16 border border-theme-divider-secondary bg-theme-bg-tertiary px-6 pb-6 pt-10 shadow-2 laptop:flex"
       style={{ width: '20.625rem' }}
     >
       <ModalClose onClick={onRequestClose} top="2" />

--- a/packages/shared/src/components/cards/AdCard.tsx
+++ b/packages/shared/src/components/cards/AdCard.tsx
@@ -37,7 +37,7 @@ export const AdCard = forwardRef(function AdCard(
       </CardTextContainer>
       <CardSpace />
       {showImage && (
-        <div className="relative overflow-hidden rounded-xl">
+        <div className="relative overflow-hidden rounded-12">
           <CardImage
             alt="Ad image"
             src={ad.image}

--- a/packages/shared/src/components/cards/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.tsx
@@ -113,7 +113,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
       <div
         className={classNames(
           showFeedback
-            ? 'overflow-hidden rounded-2xl border !border-theme-divider-tertiary p-2'
+            ? 'overflow-hidden rounded-16 border !border-theme-divider-tertiary p-2'
             : 'flex flex-1 flex-col',
           showFeedback && styles.post,
           showFeedback && styles.read,

--- a/packages/shared/src/components/cards/Card.tsx
+++ b/packages/shared/src/components/cards/Card.tsx
@@ -61,7 +61,7 @@ export const CardLink = classed('a', clickableCardClasses);
 export const Card = classed(
   'article',
   styles.card,
-  'relative max-h-card h-full flex flex-col p-2 rounded-2xl bg-theme-bg-secondary border border-theme-divider-tertiary hover:border-theme-divider-secondary shadow-2',
+  'relative max-h-card h-full flex flex-col p-2 rounded-16 bg-theme-bg-secondary border border-theme-divider-tertiary hover:border-theme-divider-secondary shadow-2',
 );
 
 export const ChecklistCardComponent = classed(
@@ -79,7 +79,7 @@ export const CardHeader = classed(
 export const ListCard = classed(
   'article',
   styles.card,
-  'relative flex items-stretch pt-4 pb-3 pr-4 rounded-2xl bg-theme-bg-secondary border border-theme-divider-tertiary hover:border-theme-divider-secondary shadow-2',
+  'relative flex items-stretch pt-4 pb-3 pr-4 rounded-16 bg-theme-bg-secondary border border-theme-divider-tertiary hover:border-theme-divider-secondary shadow-2',
 );
 
 export const ListCardMain = classed(

--- a/packages/shared/src/components/cards/CommentPopup.tsx
+++ b/packages/shared/src/components/cards/CommentPopup.tsx
@@ -57,7 +57,7 @@ export default function CommentPopup({
   return (
     <div
       className={classNames(
-        'absolute left-0 top-0 z-2 flex h-full w-full flex-col justify-end overflow-hidden rounded-2xl bg-theme-post-disabled',
+        'absolute left-0 top-0 z-2 flex h-full w-full flex-col justify-end overflow-hidden rounded-16 bg-theme-post-disabled',
         !show && 'opacity-0',
       )}
       ref={containerRef}
@@ -69,7 +69,7 @@ export default function CommentPopup({
     >
       <div
         className={classNames(
-          'invert relative flex flex-col rounded-2xl bg-theme-bg-primary p-4',
+          'invert relative flex flex-col rounded-16 bg-theme-bg-primary p-4',
           layoutModeClass,
         )}
       >

--- a/packages/shared/src/components/cards/PlaceholderCard.tsx
+++ b/packages/shared/src/components/cards/PlaceholderCard.tsx
@@ -4,7 +4,7 @@ import { CardSpace, CardTextContainer } from './Card';
 import { ElementPlaceholder } from '../ElementPlaceholder';
 import classed from '../../lib/classed';
 
-const Text = classed(ElementPlaceholder, 'h-3 rounded-xl my-2');
+const Text = classed(ElementPlaceholder, 'h-3 rounded-12 my-2');
 
 export type PlaceholderCardProps = {
   showImage?: boolean;
@@ -19,7 +19,7 @@ export const PlaceholderCard = forwardRef(function PlaceholderCard(
       aria-busy
       className={classNames(
         className,
-        'flex flex-col rounded-2xl bg-theme-post-disabled p-2',
+        'flex flex-col rounded-16 bg-theme-post-disabled p-2',
         'min-h-card',
       )}
       {...props}
@@ -32,7 +32,7 @@ export const PlaceholderCard = forwardRef(function PlaceholderCard(
         <Text style={{ width: '80%' }} />
       </CardTextContainer>
       <CardSpace className={showImage ? 'my-2' : 'my-6'} />
-      {showImage && <ElementPlaceholder className="my-2 h-40 rounded-xl" />}
+      {showImage && <ElementPlaceholder className="my-2 h-40 rounded-12" />}
       <CardTextContainer>
         <Text style={{ width: '32%' }} />
       </CardTextContainer>

--- a/packages/shared/src/components/cards/PlaceholderList.tsx
+++ b/packages/shared/src/components/cards/PlaceholderList.tsx
@@ -5,7 +5,7 @@ import { ElementPlaceholder } from '../ElementPlaceholder';
 import classed from '../../lib/classed';
 import { PlaceholderCardProps } from './PlaceholderCard';
 
-const Text = classed(ElementPlaceholder, 'h-3 rounded-xl');
+const Text = classed(ElementPlaceholder, 'h-3 rounded-12');
 
 export const PlaceholderList = forwardRef(function PlaceholderList(
   { className, showImage, ...props }: PlaceholderCardProps,
@@ -16,7 +16,7 @@ export const PlaceholderList = forwardRef(function PlaceholderList(
       aria-busy
       className={classNames(
         className,
-        'flex items-start rounded-2xl bg-theme-post-disabled py-4 pl-4 pr-10',
+        'flex items-start rounded-16 bg-theme-post-disabled py-4 pl-4 pr-10',
       )}
       {...props}
       ref={ref}

--- a/packages/shared/src/components/cards/PostCardFooter.tsx
+++ b/packages/shared/src/components/cards/PostCardFooter.tsx
@@ -56,7 +56,7 @@ export const PostCardFooter = ({
       {showImage && post.author && (
         <div
           className={classNames(
-            'absolute z-1 mt-2 flex w-full items-center rounded-t-xl bg-theme-bg-primary px-3 py-2 font-bold text-theme-label-secondary typo-callout',
+            'absolute z-1 mt-2 flex w-full items-center rounded-t-12 bg-theme-bg-primary px-3 py-2 font-bold text-theme-label-secondary typo-callout',
             visibleOnGroupHover,
           )}
         >

--- a/packages/shared/src/components/cards/RaisedLabel.tsx
+++ b/packages/shared/src/components/cards/RaisedLabel.tsx
@@ -50,8 +50,8 @@ export function RaisedLabel({
             styles.flag,
             typeToClassName[type],
             listMode
-              ? 'h-5 w-full justify-center rounded-l mouse:translate-x-9'
-              : 'h-full flex-col rounded-t mouse:translate-y-4',
+              ? 'h-5 w-full justify-center rounded-l-4 mouse:translate-x-9'
+              : 'h-full flex-col rounded-t-4 mouse:translate-y-4',
           )}
         >
           <span className="font-bold uppercase text-white typo-caption2">

--- a/packages/shared/src/components/cards/v1/RaisedLabel.tsx
+++ b/packages/shared/src/components/cards/v1/RaisedLabel.tsx
@@ -39,7 +39,7 @@ export function RaisedLabel({
       <SimpleTooltip content={description}>
         <div
           className={classNames(
-            'relative -top-2 h-4 rounded px-2 font-bold uppercase text-white typo-caption2',
+            'relative -top-2 h-4 rounded-4 px-2 font-bold uppercase text-white typo-caption2',
             typeToClassName[type],
           )}
         >

--- a/packages/shared/src/components/cards/v1/TypeLabel.tsx
+++ b/packages/shared/src/components/cards/v1/TypeLabel.tsx
@@ -42,7 +42,7 @@ export function TypeLabel({
   return (
     <legend
       className={classNames(
-        'rounded bg-theme-bg-primary font-bold capitalize typo-caption1',
+        'rounded-4 bg-theme-bg-primary font-bold capitalize typo-caption1',
         typeToClassName[type as PostType] ?? 'text-theme-label-tertiary',
         !focus && '-top-[9px]', // taking the border width into account
         focus && '-top-2.5',
@@ -51,7 +51,7 @@ export function TypeLabel({
     >
       <div
         className={classNames(
-          'rounded px-2 group-hover:bg-theme-float group-focus:bg-theme-float',
+          'rounded-4 px-2 group-hover:bg-theme-float group-focus:bg-theme-float',
           focus && 'bg-theme-float',
         )}
       >

--- a/packages/shared/src/components/comments/PlaceholderComment.tsx
+++ b/packages/shared/src/components/comments/PlaceholderComment.tsx
@@ -7,8 +7,8 @@ export default function PlaceholderComment(): ReactElement {
       <div className="mb-2 flex items-center">
         <ElementPlaceholder className="h-10 w-10 rounded-10" />
         <div className="ml-2 flex h-8 flex-1 flex-col justify-between">
-          <ElementPlaceholder className="h-3 w-2/5 rounded-xl" />
-          <ElementPlaceholder className="h-3 w-1/5 rounded-xl" />
+          <ElementPlaceholder className="h-3 w-2/5 rounded-12" />
+          <ElementPlaceholder className="h-3 w-1/5 rounded-12" />
         </div>
       </div>
       <ElementPlaceholder className="my-2 h-8 w-full rounded-full" />

--- a/packages/shared/src/components/fields/Checkbox.tsx
+++ b/packages/shared/src/components/fields/Checkbox.tsx
@@ -69,7 +69,7 @@ export const Checkbox = forwardRef(function Checkbox(
       />
       <div
         className={classNames(
-          'relative z-1 mr-3 flex h-5 w-5 items-center justify-center rounded-md border-2 border-theme-divider-primary',
+          'relative z-1 mr-3 flex h-5 w-5 items-center justify-center rounded-6 border-2 border-theme-divider-primary',
           styles.checkmark,
         )}
       >

--- a/packages/shared/src/components/fields/CustomSwitch.tsx
+++ b/packages/shared/src/components/fields/CustomSwitch.tsx
@@ -112,7 +112,7 @@ export function CustomSwitch({
       <span className="absolute inset-0 my-auto h-7 rounded-10 bg-cabbage-50 opacity-24 group-hover:opacity-32" />
       <span
         className={classNames(
-          'absolute  top-0 z-1 h-full rounded-xl',
+          'absolute  top-0 z-1 h-full rounded-12',
           styles.knob,
         )}
         style={{

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -47,7 +47,7 @@ const getButtonSizeClass = (buttonSize: string): string => {
     return 'h-9 rounded-10 text-theme-label-primary typo-body';
   }
   if (buttonSize === 'medium') {
-    return 'h-10 rounded-xl min-w-[2.5rem]';
+    return 'h-10 rounded-12 min-w-[2.5rem]';
   }
   if (buttonSize === 'small') {
     return 'h-8 rounded-10';

--- a/packages/shared/src/components/fields/Switch.tsx
+++ b/packages/shared/src/components/fields/Switch.tsx
@@ -63,7 +63,7 @@ export function Switch({
         <span
           className={classNames(
             'absolute left-0 top-0 bg-theme-label-tertiary',
-            compact ? 'h-4 w-4 rounded-3' : 'h-5 w-5 rounded-md',
+            compact ? 'h-4 w-4 rounded-3' : 'h-5 w-5 rounded-6',
             styles.knob,
           )}
         />

--- a/packages/shared/src/components/fields/Switch.tsx
+++ b/packages/shared/src/components/fields/Switch.tsx
@@ -56,7 +56,7 @@ export function Switch({
         <span
           className={classNames(
             'absolute bottom-0 left-0 top-0 my-auto w-full bg-theme-overlay-quaternary',
-            compact ? 'h-2.5 rounded-3' : 'h-3 rounded',
+            compact ? 'h-2.5 rounded-3' : 'h-3 rounded-4',
             styles.track,
           )}
         />

--- a/packages/shared/src/components/filters/SourceItemRow.tsx
+++ b/packages/shared/src/components/filters/SourceItemRow.tsx
@@ -17,11 +17,11 @@ export default function SourceItemRow({
 }): ReactElement {
   return (
     <FilterItem className="relative">
-      <a className="flex h-12 flex-1 cursor-default items-center rounded-md py-2 pl-6 pr-14">
+      <a className="flex h-12 flex-1 cursor-default items-center rounded-6 py-2 pl-6 pr-14">
         <LazyImage
           imgSrc={source.image}
           imgAlt={`${source.name} logo`}
-          className="h-8 w-8 rounded-md"
+          className="h-8 w-8 rounded-6"
         />
         <span className="ml-3 flex-1 truncate text-left text-theme-label-tertiary typo-callout">
           {source.name}

--- a/packages/shared/src/components/post/AuthorOnboarding.tsx
+++ b/packages/shared/src/components/post/AuthorOnboarding.tsx
@@ -14,7 +14,7 @@ function AuthorOnboarding({ onSignUp }: AuthorOnboardingProps): ReactElement {
   return (
     <section
       className={classNames(
-        'mb-6 rounded-2xl bg-theme-bg-secondary p-6',
+        'mb-6 rounded-16 bg-theme-bg-secondary p-6',
         styles.authorOnboarding,
       )}
     >

--- a/packages/shared/src/components/post/MarkdownPostContent.tsx
+++ b/packages/shared/src/components/post/MarkdownPostContent.tsx
@@ -22,7 +22,7 @@ function MarkdownPostContent({ post }: MarkdownPostContentProps): ReactElement {
             <Image
               src={post.image}
               alt="Post cover image"
-              className="mb-10 h-auto max-h-[62.5rem] w-full rounded-xl object-cover"
+              className="mb-10 h-auto max-h-[62.5rem] w-full rounded-12 object-cover"
               fallbackSrc={cloudinary.post.imageCoverPlaceholder}
             />
           </a>
@@ -33,7 +33,7 @@ function MarkdownPostContent({ post }: MarkdownPostContentProps): ReactElement {
         className={post.type !== PostType.Welcome && 'mb-5'}
       />
       {post.type === PostType.Welcome && post.image && (
-        <div className="mb-5 mt-8 block h-fit max-w-sm cursor-pointer overflow-hidden rounded-2xl">
+        <div className="mb-5 mt-8 block h-fit max-w-sm cursor-pointer overflow-hidden rounded-16">
           <LazyImage
             imgSrc={post.image}
             imgAlt="Post cover image"

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -172,7 +172,7 @@ export function PostContent({
               target="_blank"
               rel="noopener"
               {...combinedClicks(onReadArticle)}
-              className="mb-10 block cursor-pointer overflow-hidden rounded-2xl"
+              className="mb-10 block cursor-pointer overflow-hidden rounded-16"
               style={{ maxWidth: '25.625rem' }}
             >
               <LazyImage

--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -75,7 +75,7 @@ function SharePostContent({
           <SharedPostLink
             post={post}
             onGoToLinkProps={combinedClicks(openArticle)}
-            className="ml-2 block h-fit w-70 cursor-pointer overflow-hidden rounded-2xl"
+            className="ml-2 block h-fit w-70 cursor-pointer overflow-hidden rounded-16"
           >
             <LazyImage
               imgSrc={post.sharedPost.image}

--- a/packages/shared/src/components/post/collection/CollectionPostContent.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPostContent.tsx
@@ -155,7 +155,7 @@ export const CollectionPostContent = ({
               </div>
             )}
             {image && (
-              <div className="block h-auto w-full cursor-pointer overflow-hidden rounded-xl">
+              <div className="block h-auto w-full cursor-pointer overflow-hidden rounded-12">
                 <LazyImage
                   imgSrc={image}
                   imgAlt="Post cover image"

--- a/packages/shared/src/components/search/PlaceholderSearchSource.tsx
+++ b/packages/shared/src/components/search/PlaceholderSearchSource.tsx
@@ -9,7 +9,7 @@ export const PlaceholderSearchSource = (): ReactElement => {
     >
       <div className="mb-2 flex items-center">
         <ElementPlaceholder className="mr-2 h-6 w-6 rounded-6" />
-        <ElementPlaceholder className="h-4 flex-1 rounded-xl" />
+        <ElementPlaceholder className="h-4 flex-1 rounded-12" />
       </div>
       <ElementPlaceholder className="my-2 h-4 w-4/5 rounded-full" />
       <ElementPlaceholder className="my-2 h-4 w-3/5 rounded-full" />

--- a/packages/shared/src/components/search/SearchPanel/SearchPanelInputCursor.tsx
+++ b/packages/shared/src/components/search/SearchPanel/SearchPanelInputCursor.tsx
@@ -36,7 +36,7 @@ export const SearchPanelInputCursor = ({
         {searchPanel.query}
       </span>
       {!!purifySanitize && (
-        <div className="ml-0.5 flex items-center rounded bg-overlay-quaternary-cabbage px-1">
+        <div className="ml-0.5 flex items-center rounded-4 bg-overlay-quaternary-cabbage px-1">
           <span
             className="text-theme-label-tertiary typo-footnote"
             dangerouslySetInnerHTML={{

--- a/packages/shared/src/components/sources/SourceCard.tsx
+++ b/packages/shared/src/components/sources/SourceCard.tsx
@@ -82,7 +82,7 @@ export const SourceCard = ({
         borderColorToClassName[source?.borderColor || borderColor],
       )}
     >
-      <div className="h-24 rounded-t-2xl bg-theme-bg-onion">
+      <div className="h-24 rounded-t-16 bg-theme-bg-onion">
         <Image
           className="h-full w-full object-cover"
           src={
@@ -93,7 +93,7 @@ export const SourceCard = ({
           alt="Banner image for source"
         />
       </div>
-      <div className="-mt-12 flex flex-1 flex-col rounded-t-2xl bg-theme-bg-secondary p-4">
+      <div className="-mt-12 flex flex-1 flex-col rounded-t-16 bg-theme-bg-secondary p-4">
         <div className="mb-3 flex items-end justify-between">
           <a href={source?.permalink}>
             {source?.image ? (

--- a/packages/shared/src/components/tabs/TabList.tsx
+++ b/packages/shared/src/components/tabs/TabList.tsx
@@ -61,7 +61,7 @@ function TabList({
       {offset !== undefined && (
         <div
           className={classNames(
-            'absolute bottom-0 mx-auto h-0.5 w-12 -translate-x-1/2 rounded bg-theme-label-primary transition-[left] ease-linear',
+            'absolute bottom-0 mx-auto h-0.5 w-12 -translate-x-1/2 rounded-4 bg-theme-label-primary transition-[left] ease-linear',
             className?.indicator,
           )}
           style={{ left: offset }}

--- a/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
@@ -98,7 +98,7 @@ function ChangelogTooltip(): ReactElement {
         </header>
         <section className="flex h-full max-h-full flex-1 shrink flex-col p-5">
           <Image
-            className="h-[108px] w-[207px] rounded-lg object-cover"
+            className="h-[108px] w-[207px] rounded-8 object-cover"
             alt="Post cover image"
             src={post.image}
             fallbackSrc={cloudinary.post.imageCoverPlaceholder}

--- a/packages/shared/src/components/utilities/common.tsx
+++ b/packages/shared/src/components/utilities/common.tsx
@@ -153,7 +153,7 @@ export const TLDRText = classed(
 );
 
 export const HotLabel = (): ReactElement => (
-  <div className="rounded bg-theme-status-error px-2 py-px font-bold uppercase text-white typo-caption2">
+  <div className="rounded-4 bg-theme-status-error px-2 py-px font-bold uppercase text-white typo-caption2">
     Hot
   </div>
 );

--- a/packages/shared/src/components/widgets/BestDiscussions.tsx
+++ b/packages/shared/src/components/widgets/BestDiscussions.tsx
@@ -58,7 +58,7 @@ const ListItem = ({ post, onLinkClick }: PostProps): ReactElement => (
   </article>
 );
 
-const TextPlaceholder = classed(ElementPlaceholder, 'h-3 rounded-xl my-0.5');
+const TextPlaceholder = classed(ElementPlaceholder, 'h-3 rounded-12 my-0.5');
 
 const ListItemPlaceholder = (): ReactElement => (
   <article aria-busy className="relative flex flex-col items-start px-4 py-3">

--- a/packages/shared/src/components/widgets/PostToc.tsx
+++ b/packages/shared/src/components/widgets/PostToc.tsx
@@ -58,7 +58,7 @@ export default function PostToc({
     return (
       <details
         className={classNames(
-          'select-none flex-col overflow-hidden rounded-2xl',
+          'select-none flex-col overflow-hidden rounded-16',
           styles.details,
           className,
         )}
@@ -78,7 +78,7 @@ export default function PostToc({
   return (
     <WidgetContainer
       className={classNames(
-        'flex-col overflow-hidden rounded-2xl border border-theme-divider-quaternary pb-3',
+        'flex-col overflow-hidden rounded-16 border border-theme-divider-quaternary pb-3',
         className,
       )}
     >

--- a/packages/shared/src/components/widgets/SimilarPosts.tsx
+++ b/packages/shared/src/components/widgets/SimilarPosts.tsx
@@ -109,7 +109,7 @@ const DefaultListItem = ({
   </article>
 );
 
-const TextPlaceholder = classed(ElementPlaceholder, 'h-3 rounded-xl my-0.5');
+const TextPlaceholder = classed(ElementPlaceholder, 'h-3 rounded-12 my-0.5');
 
 const DefaultListItemPlaceholder = (): ReactElement => (
   <article aria-busy className="relative flex items-start py-2 pl-4 pr-2">
@@ -148,7 +148,7 @@ export default function SimilarPosts({
   return (
     <section
       className={classNames(
-        'flex flex-col rounded-2xl border border-theme-divider-tertiary',
+        'flex flex-col rounded-16 border border-theme-divider-tertiary',
         className,
       )}
     >

--- a/packages/shared/src/components/widgets/common.ts
+++ b/packages/shared/src/components/widgets/common.ts
@@ -7,7 +7,7 @@ export const WidgetContainer = classed('div', widgetClasses);
 
 export const TextPlaceholder = classed(
   ElementPlaceholder,
-  'h-3 rounded-xl my-0.5',
+  'h-3 rounded-12 my-0.5',
 );
 
 export const PlaceholderSeparator = classed(

--- a/packages/shared/src/styles/components/menu.css
+++ b/packages/shared/src/styles/components/menu.css
@@ -3,7 +3,7 @@
   opacity: 0;
   user-select: none;
   z-index: 1000;
-  @apply py-1 px-0 m-0 bg-theme-bg-secondary rounded-xl border border-theme-divider-secondary shadow-2 -translate-x-full;
+  @apply py-1 px-0 m-0 bg-theme-bg-secondary rounded-12 border border-theme-divider-secondary shadow-2 -translate-x-full;
 
   &.scrollable {
     height: 15rem;

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -1,25 +1,10 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-// eslint-disable-next-line import/no-extraneous-dependencies
-const defaultTheme = require('tailwindcss/defaultTheme');
 const colors = require('./tailwind/colors');
 const overlay = require('./tailwind/overlay');
 const boxShadow = require('./tailwind/boxShadow');
 const caret = require('./tailwind/caret');
 const typography = require('./tailwind/typography');
 const buttons = require('./tailwind/buttons');
-
-// by setting a key to undefined, it gets removed in tailwind
-const removeDefaults = (obj, excluded, overwrites) => {
-  const removed = Object.keys(obj).reduce((acc, key) => {
-    if (excluded.includes(key)) {
-      return acc;
-    }
-
-    return { ...acc, [key]: undefined };
-  }, {});
-
-  return { ...removed, ...overwrites };
-};
 
 module.exports = {
   theme: {
@@ -185,6 +170,28 @@ module.exports = {
       mouse: { raw: '(pointer: fine)' },
       responsiveModalBreakpoint: '420px',
     },
+    borderRadius: {
+      none: '0',
+      full: '100%',
+      '1/2': '50%',
+      2: '0.125rem',
+      3: '0.1875rem',
+      4: '0.25rem',
+      6: '0.375rem',
+      8: '0.5rem',
+      10: '0.625rem',
+      12: '0.75rem',
+      14: '0.875rem',
+      16: '1rem',
+      18: '1.125rem',
+      22: '1.375rem',
+      24: '1.5rem',
+      26: '1.625rem',
+      32: '2rem',
+      40: '2.5rem',
+      48: '3rem',
+      50: '3.125rem',
+    },
     extend: {
       maxHeight: {
         'img-desktop': '400px',
@@ -201,30 +208,6 @@ module.exports = {
       gap: {
         unset: 'unset',
       },
-      borderRadius: removeDefaults(
-        defaultTheme.borderRadius,
-        ['full', 'none'],
-        {
-          half: '50%',
-          2: '0.125rem',
-          3: '0.1875rem',
-          4: '0.25rem',
-          6: '0.375rem',
-          8: '0.5rem',
-          10: '0.625rem',
-          12: '0.75rem',
-          14: '0.875rem',
-          16: '1rem',
-          18: '1.125rem',
-          22: '1.375rem',
-          24: '1.5rem',
-          26: '1.625rem',
-          32: '2rem',
-          40: '2.5rem',
-          48: '3rem',
-          50: '3.125rem',
-        },
-      ),
       opacity: {
         24: '0.24',
         32: '0.32',

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -7,36 +7,17 @@ const caret = require('./tailwind/caret');
 const typography = require('./tailwind/typography');
 const buttons = require('./tailwind/buttons');
 
-const getBorderRadius = () => {
-  const { full, none, ...rest } = defaultTheme.borderRadius;
-  const removed = Object.keys(rest).reduce(
-    (acc, key) => ({ ...acc, [key]: undefined }),
-    {},
-  );
+// by setting a key to undefined, it gets removed in tailwind
+const removeDefaults = (obj, excluded, overwrites) => {
+  const removed = Object.keys(obj).reduce((acc, key) => {
+    if (excluded.includes(key)) {
+      return acc;
+    }
 
-  return {
-    ...removed,
-    full,
-    none,
-    half: '50%',
-    2: '0.125rem',
-    3: '0.1875rem',
-    4: '0.25rem',
-    6: '0.375rem',
-    8: '0.5rem',
-    10: '0.625rem',
-    12: '0.75rem',
-    14: '0.875rem',
-    16: '1rem',
-    18: '1.125rem',
-    22: '1.375rem',
-    24: '1.5rem',
-    26: '1.625rem',
-    32: '2rem',
-    40: '2.5rem',
-    48: '3rem',
-    50: '3.125rem',
-  };
+    return { ...acc, [key]: undefined };
+  }, {});
+
+  return { ...removed, ...overwrites };
 };
 
 module.exports = {
@@ -219,7 +200,30 @@ module.exports = {
       gap: {
         unset: 'unset',
       },
-      borderRadius: getBorderRadius(),
+      borderRadius: removeDefaults(
+        defaultTheme.borderRadius,
+        ['full', 'none'],
+        {
+          half: '50%',
+          2: '0.125rem',
+          3: '0.1875rem',
+          4: '0.25rem',
+          6: '0.375rem',
+          8: '0.5rem',
+          10: '0.625rem',
+          12: '0.75rem',
+          14: '0.875rem',
+          16: '1rem',
+          18: '1.125rem',
+          22: '1.375rem',
+          24: '1.5rem',
+          26: '1.625rem',
+          32: '2rem',
+          40: '2.5rem',
+          48: '3rem',
+          50: '3.125rem',
+        },
+      ),
       opacity: {
         24: '0.24',
         32: '0.32',

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -1,10 +1,43 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+const defaultTheme = require('tailwindcss/defaultTheme');
 const colors = require('./tailwind/colors');
 const overlay = require('./tailwind/overlay');
 const boxShadow = require('./tailwind/boxShadow');
 const caret = require('./tailwind/caret');
 const typography = require('./tailwind/typography');
 const buttons = require('./tailwind/buttons');
+
+const getBorderRadius = () => {
+  const { full, none, ...rest } = defaultTheme.borderRadius;
+  const removed = Object.keys(rest).reduce(
+    (acc, key) => ({ ...acc, [key]: undefined }),
+    {},
+  );
+
+  return {
+    ...removed,
+    full,
+    none,
+    half: '50%',
+    2: '0.125rem',
+    3: '0.1875rem',
+    4: '0.25rem',
+    6: '0.375rem',
+    8: '0.5rem',
+    10: '0.625rem',
+    12: '0.75rem',
+    14: '0.875rem',
+    16: '1rem',
+    18: '1.125rem',
+    22: '1.375rem',
+    24: '1.5rem',
+    26: '1.625rem',
+    32: '2rem',
+    40: '2.5rem',
+    48: '3rem',
+    50: '3.125rem',
+  };
+};
 
 module.exports = {
   theme: {
@@ -186,24 +219,7 @@ module.exports = {
       gap: {
         unset: 'unset',
       },
-      borderRadius: {
-        2: '0.125rem',
-        3: '0.1875rem',
-        6: '0.375rem',
-        8: '0.5rem',
-        10: '0.625rem',
-        12: '0.75rem',
-        14: '0.875rem',
-        16: '1rem',
-        18: '1.125rem',
-        22: '1.375rem',
-        24: '1.5rem',
-        26: '1.625rem',
-        32: '2rem',
-        40: '2.5rem',
-        48: '3rem',
-        50: '3.125rem',
-      },
+      borderRadius: getBorderRadius(),
       opacity: {
         24: '0.24',
         32: '0.32',

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+// eslint-disable-next-line import/no-extraneous-dependencies
 const defaultTheme = require('tailwindcss/defaultTheme');
 const colors = require('./tailwind/colors');
 const overlay = require('./tailwind/overlay');

--- a/packages/webapp/components/CookieBanner.tsx
+++ b/packages/webapp/components/CookieBanner.tsx
@@ -21,7 +21,7 @@ export default function CookieBanner({
   };
 
   return (
-    <div className="fixed bottom-0 left-0 z-max flex w-full flex-col border-t border-theme-divider-secondary bg-theme-bg-tertiary py-4 pl-4 pr-14 text-theme-label-secondary typo-footnote laptop:bottom-6 laptop:left-[unset] laptop:right-6 laptop:w-48 laptop:items-center laptop:rounded-2xl laptop:border laptop:p-6 laptop:text-center">
+    <div className="fixed bottom-0 left-0 z-max flex w-full flex-col border-t border-theme-divider-secondary bg-theme-bg-tertiary py-4 pl-4 pr-14 text-theme-label-secondary typo-footnote laptop:bottom-6 laptop:left-[unset] laptop:right-6 laptop:w-48 laptop:items-center laptop:rounded-16 laptop:border laptop:p-6 laptop:text-center">
       <ModalClose onClick={close} top="2" />
       <CookieIcon
         size={IconSize.XXLarge}

--- a/packages/webapp/components/KeywordManagement.tsx
+++ b/packages/webapp/components/KeywordManagement.tsx
@@ -135,7 +135,7 @@ export default function KeywordManagement({
               <LazyImage
                 imgSrc={smallPostImage(post.image)}
                 imgAlt="Post cover image"
-                className="h-16 w-16 rounded-2xl"
+                className="h-16 w-16 rounded-16"
               />
               <p
                 className="break-words-overflow multi-truncate ml-4 flex-1 self-center whitespace-pre-wrap p-0 text-theme-label-primary typo-callout tablet:mr-6"


### PR DESCRIPTION
## Changes
- Set the defaults to undefined. Once undefined, it becomes excluded from the classes list. Proven by the first commit which had a failing build for using `@apply` on an unknown class.
- Create a reusable function to remove a whole object.
- Start removing undefined from rounded.
- This also removed `rounded` as it apparently has a value of `4px` which is not intuitive with our current setup. With that, I introduced a rounded-4

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-80 #done
