### PR TITLE
feat: new onboarding modal

### DIFF
--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -54,6 +54,7 @@ import { labels } from '../../lib';
 import OnboardingRegistrationForm from './OnboardingRegistrationForm';
 import { useEventListener } from '../../hooks';
 import { trackAnalyticsSignUp } from './OnboardingAnalytics';
+import { OnboardingRegistrationForm4d5 } from './OnboardingRegistrationForm4d5';
 
 export enum AuthDisplay {
   Default = 'default',
@@ -66,6 +67,7 @@ export enum AuthDisplay {
   EmailSent = 'email_sent',
   VerifiedEmail = 'VerifiedEmail',
   OnboardingSignup = 'onboarding_signup',
+  OnboardingSignupV4d5 = 'onboarding_signup_v4.5',
 }
 
 export interface AuthProps {
@@ -507,6 +509,34 @@ function AuthOptions({
               />
             )}
           </EmailVerified>
+        </Tab>
+        <Tab label={AuthDisplay.OnboardingSignupV4d5}>
+          <OnboardingRegistrationForm4d5
+            onSignup={(signupEmail) => {
+              onAuthStateUpdate({
+                isAuthenticating: true,
+                email: signupEmail,
+                defaultDisplay: AuthDisplay.Registration,
+              });
+            }}
+            onExistingEmail={(existingEmail) => {
+              onAuthStateUpdate({
+                isAuthenticating: true,
+                isLoginFlow: true,
+                email: existingEmail,
+              });
+            }}
+            onProviderClick={(provider, login) => {
+              onProviderClick(provider, login);
+              onAuthStateUpdate({ isAuthenticating: true });
+            }}
+            trigger={trigger}
+            isReady={isReady}
+            simplified={simplified}
+            targetId={targetId}
+            className={className?.onboardingSignup}
+            onClose={onClose}
+          />
         </Tab>
       </TabContainer>
     </div>

--- a/packages/shared/src/components/auth/OnboardingRegistrationForm4d5.tsx
+++ b/packages/shared/src/components/auth/OnboardingRegistrationForm4d5.tsx
@@ -1,0 +1,185 @@
+import React, { ReactElement, useContext, useEffect, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import classNames from 'classnames';
+import { checkKratosEmail } from '../../lib/kratos';
+import { AuthFormProps, getFormEmail, providerMap } from './common';
+import OrDivider from './OrDivider';
+import AnalyticsContext from '../../contexts/AnalyticsContext';
+import { AuthEventNames, AuthTriggersType } from '../../lib/auth';
+import { Button, ButtonVariant } from '../buttons/ButtonV2';
+import AuthForm from './AuthForm';
+import { TextField } from '../fields/TextField';
+import { MailIcon } from '../icons';
+import { IconSize } from '../Icon';
+import Alert, { AlertParagraph, AlertType } from '../widgets/Alert';
+import { OnboardingHeadline } from './OnboardingHeadline';
+import AuthModalFooter from './AuthModalFooter';
+import Logo, { LogoPosition } from '../Logo';
+import { ModalClose } from '../modals/common/ModalClose';
+import { CloseAuthModalFunc } from '../../hooks/useAuthForms';
+
+const signupProviders = [providerMap.google, providerMap.github];
+
+interface OnboardingRegistrationForm4d5Props extends AuthFormProps {
+  onExistingEmail?: (email: string) => unknown;
+  onSignup?: (email: string) => unknown;
+  onProviderClick?: (provider: string, login?: boolean) => unknown;
+  targetId?: string;
+  isLoginFlow?: boolean;
+  logInTitle?: string;
+  signUpTitle?: string;
+  trigger: AuthTriggersType;
+  isReady: boolean;
+  className?: string;
+  onClose?: CloseAuthModalFunc;
+}
+
+export const OnboardingRegistrationForm4d5 = ({
+  onSignup,
+  onExistingEmail,
+  onProviderClick,
+  targetId,
+  isReady,
+  trigger,
+  className,
+  onClose,
+}: OnboardingRegistrationForm4d5Props): ReactElement => {
+  const { trackEvent } = useContext(AnalyticsContext);
+  const [shouldLogin, setShouldLogin] = useState(false);
+  const [registerEmail, setRegisterEmail] = useState<string>(null);
+  const { mutateAsync: checkEmail, isLoading } = useMutation(
+    (emailParam: string) => checkKratosEmail(emailParam),
+  );
+
+  useEffect(() => {
+    trackEvent({
+      event_name: shouldLogin
+        ? AuthEventNames.OpenLogin
+        : AuthEventNames.OpenSignup,
+      extra: JSON.stringify({ trigger }),
+      target_id: targetId,
+    });
+    // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldLogin]);
+
+  const onEmailSignup = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isLoading) {
+      return null;
+    }
+
+    trackEvent({
+      event_name: 'click',
+      target_type: AuthEventNames.SignUpProvider,
+      target_id: 'email',
+      extra: JSON.stringify({ trigger }),
+    });
+
+    const email = getFormEmail(e);
+
+    if (!email) {
+      return null;
+    }
+    const res = await checkEmail(email);
+
+    if (res?.result) {
+      setRegisterEmail(email);
+      return setShouldLogin(true);
+    }
+
+    return onSignup(email);
+  };
+
+  const onSocialClick = (provider: string) => {
+    onProviderClick?.(provider, shouldLogin);
+  };
+
+  return (
+    <>
+      <div className={classNames(className, 'flex flex-1 flex-col p-6')}>
+        <div className="relative mb-auto flex items-center justify-between">
+          <Logo position={LogoPosition.Relative} logoClassName="h-6" />
+          <ModalClose right="0" onClick={onClose} />
+        </div>
+
+        <OnboardingHeadline
+          className={{
+            title: 'typo-large-title',
+            description: 'typo-body',
+          }}
+        />
+
+        <AuthForm className="mb-8 gap-8" onSubmit={onEmailSignup}>
+          <TextField
+            leftIcon={<MailIcon size={IconSize.Small} />}
+            required
+            inputId="email"
+            label="Email address"
+            type="email"
+            name="email"
+          />
+
+          {shouldLogin && (
+            <>
+              <Alert type={AlertType.Error} flexDirection="flex-row">
+                <AlertParagraph className="!mt-0 flex-1">
+                  Email is taken. Existing user?{' '}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onExistingEmail(registerEmail);
+                    }}
+                    className="font-bold underline"
+                  >
+                    Log in.
+                  </button>
+                </AlertParagraph>
+              </Alert>
+            </>
+          )}
+
+          <Button
+            className="w-full"
+            variant={ButtonVariant.Primary}
+            type="submit"
+            loading={!isReady || isLoading}
+          >
+            Sign up - it&rsquo;s free ➔
+          </Button>
+        </AuthForm>
+
+        <OrDivider className="mb-8" label="Or sign up with" />
+
+        <div className="flex gap-8">
+          {signupProviders.map((provider) => (
+            <Button
+              key={provider.value}
+              className="flex flex-1 bg-theme-active text-white"
+              icon={provider.icon}
+              loading={!isReady}
+              onClick={() => onSocialClick(provider.value)}
+            >
+              {provider.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <AuthModalFooter
+        text={{
+          body: shouldLogin
+            ? 'Not a member yet?'
+            : 'Already a daily.dev member?',
+          button: shouldLogin ? 'Sign up' : 'Log in',
+        }}
+        onClick={() => {
+          if (!shouldLogin) {
+            setRegisterEmail(null);
+          }
+          setShouldLogin(!shouldLogin);
+        }}
+      />
+    </>
+  );
+};


### PR DESCRIPTION
## Changes

### Describe what this PR does

Adding new onboarding modal needed to show on the flow:
- its a modification of original modal
- added back email field/signup
- moved to separate component so we can easily manipulate until feature is done
- only adding view in this PR so that it can be used where needed per new spec

Some changes from design:
- modal background in design is popover, all our auth modals are tertiary
- email field has placeholder vs everywhere else its with label animating to top (so left it as that)
- title gradient is a slightly different, left it as in app currently

<img width="561" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/0a749ffc-f669-402e-b907-8892fb345ccb">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-87 #done
