### PR TITLE
fix: placeholder roundness for post page

### DIFF
--- a/packages/shared/src/components/comments/PlaceholderComment.tsx
+++ b/packages/shared/src/components/comments/PlaceholderComment.tsx
@@ -11,7 +11,7 @@ export default function PlaceholderComment(): ReactElement {
           <ElementPlaceholder className="h-3 w-1/5 rounded-12" />
         </div>
       </div>
-      <ElementPlaceholder className="my-2 h-8 w-full rounded-full" />
+      <ElementPlaceholder className="my-2 h-8 w-full rounded-10" />
     </article>
   );
 }

--- a/packages/shared/src/components/post/PostLoadingPlaceholder.tsx
+++ b/packages/shared/src/components/post/PostLoadingPlaceholder.tsx
@@ -44,14 +44,14 @@ export const PostLoadingPlaceholder = ({
   return (
     <>
       <Container className={className}>
-        <ElementPlaceholder className="my-2 mb-8 h-8 w-3/5 rounded-full" />
+        <ElementPlaceholder className="my-2 mb-8 h-8 w-3/5 rounded-10" />
         <ListItemPlaceholder padding="p-0 gap-2" textClassName="h-4" />
         <div className="my-8 flex flex-row gap-2">
-          <ElementPlaceholder className="h-6 w-20 rounded-full" />
-          <ElementPlaceholder className="h-6 w-20 rounded-full" />
+          <ElementPlaceholder className="h-6 w-20 rounded-10" />
+          <ElementPlaceholder className="h-6 w-20 rounded-10" />
         </div>
         <ElementPlaceholder className="h-52 w-4/5 rounded-16" />
-        <ElementPlaceholder className="my-8 h-8 w-2/5 rounded-full" />
+        <ElementPlaceholder className="my-8 h-8 w-2/5 rounded-10" />
         <PlaceholderSeparator />
         <PlaceholderCommentList />
       </Container>


### PR DESCRIPTION
## Changes
- The `rounded-full` in the placeholder suddenly started working after the migration (was introduced way back) 🤔 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
