### PR TITLE
fix: removing share section from devcard

### DIFF
--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -10,7 +10,6 @@ import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import {
   GitHubIcon,
   OpenLinkIcon,
-  ShareIcon,
   TwitterIcon,
 } from '@dailydotdev/shared/src/components/icons';
 import { RadioItem } from '@dailydotdev/shared/src/components/fields/RadioItem';
@@ -52,13 +51,9 @@ import {
 import { SimpleTooltip } from '@dailydotdev/shared/src/components/tooltips';
 import request from 'graphql-request';
 import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
-import { SocialShareList } from '@dailydotdev/shared/src/components/widgets/SocialShareList';
 import { ClickableText } from '@dailydotdev/shared/src/components/buttons/ClickableText';
-import { useShareOrCopyLink } from '@dailydotdev/shared/src/hooks/useShareOrCopyLink';
 import { AnalyticsEvent } from '@dailydotdev/shared/src/lib/analytics';
-import { ShareProvider } from '@dailydotdev/shared/src/lib/share';
 import { useAnalyticsContext } from '@dailydotdev/shared/src/contexts/AnalyticsContext';
-import { labels } from '@dailydotdev/shared/src/lib';
 import { isNullOrUndefined } from '@dailydotdev/shared/src/lib/func';
 import { downloadUrl } from '@dailydotdev/shared/src/lib/blob';
 import { checkLowercaseEquality } from '@dailydotdev/shared/src/lib/strings';
@@ -161,17 +156,6 @@ const Step2 = ({ initialDevCardSrc }: Step2Props): ReactElement => {
     [user?.name, user?.username, devCardSrc, type],
   );
   const [copyingEmbed, copyEmbed] = useCopyLink(() => embedCode);
-  const [copyingLink, copyLink] = useCopyLink(() => devCardSrc);
-  const [, onShareOrCopyLink] = useShareOrCopyLink({
-    text: labels.devcard.generic.shareText,
-    link: devCardSrc,
-    trackObject: (provider) => ({
-      event_name: AnalyticsEvent.ShareDevcard,
-      extra: JSON.stringify({
-        provider,
-      }),
-    }),
-  });
   const [selectedTab, setSelectedTab] = useState(0);
   const { mutateAsync: onDownloadUrl, isLoading: downloading } =
     useMutation(downloadUrl);
@@ -199,15 +183,6 @@ const Step2 = ({ initialDevCardSrc }: Step2Props): ReactElement => {
       },
     },
   );
-
-  const onTrackShare = (provider: ShareProvider) => {
-    trackEvent({
-      event_name: AnalyticsEvent.ShareDevcard,
-      extra: JSON.stringify({
-        provider,
-      }),
-    });
-  };
 
   const onUpdatePreference = useCallback(
     (props: Partial<Omit<GenerateDevCardParams, 'type'>>) => {
@@ -417,24 +392,6 @@ const Step2 = ({ initialDevCardSrc }: Step2Props): ReactElement => {
                   >
                     Download X cover image
                   </Button>
-                </div>
-
-                <div>
-                  <h3 className="typo-title4 flex font-bold">
-                    <ShareIcon size={IconSize.Small} className="mr-1.5" />
-                    Share
-                  </h3>
-                  <div className="mt-3 flex flex-row flex-wrap gap-3 gap-y-3">
-                    <SocialShareList
-                      link={devCardSrc}
-                      description={labels.devcard.generic.shareText}
-                      isCopying={copyingLink}
-                      onCopy={copyLink}
-                      onNativeShare={onShareOrCopyLink}
-                      onClickSocial={onTrackShare}
-                      emailTitle={labels.devcard.generic.emailTitle}
-                    />
-                  </div>
                 </div>
               </>
             )}


### PR DESCRIPTION
### Describe what this PR does
- removes sharing section from devcard
- decision coming from [slack](https://dailydotdev.slack.com/archives/C06FDFQC6QZ/p1708328543387319?thread_ts=1708002083.892319&cid=C06FDFQC6QZ)

## Events

I removed event: share devcard

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)
