### PR TITLE
feat: restore search join page for links that are already in the wild

### DIFF
--- a/packages/shared/src/hooks/referral/useReferralCampaign.ts
+++ b/packages/shared/src/hooks/referral/useReferralCampaign.ts
@@ -25,6 +25,7 @@ export interface UseReferralCampaign extends ReferralCampaign {
 
 export enum ReferralCampaignKey {
   Generic = 'generic',
+  Search = 'search',
 }
 
 export type UseReferralCampaignProps = {

--- a/packages/webapp/components/invite/AISearchInvite.tsx
+++ b/packages/webapp/components/invite/AISearchInvite.tsx
@@ -1,0 +1,142 @@
+import React, { ReactElement, useEffect } from 'react';
+import {
+  Button,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/ButtonV2';
+import { ProfileImageLink } from '@dailydotdev/shared/src/components/profile/ProfileImageLink';
+import { KeyIcon } from '@dailydotdev/shared/src/components/icons';
+import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
+import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
+import { useMutation } from '@tanstack/react-query';
+import { acceptFeatureInvitation } from '@dailydotdev/shared/src/graphql/features';
+import { useRouter } from 'next/router';
+import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
+import { SearchExperiment } from '@dailydotdev/shared/src/lib/featureValues';
+import { useActions } from '@dailydotdev/shared/src/hooks/useActions';
+import { ActionType } from '@dailydotdev/shared/src/graphql/actions';
+import { cloudinary } from '@dailydotdev/shared/src/lib/image';
+import {
+  ApiErrorResult,
+  DEFAULT_ERROR,
+} from '@dailydotdev/shared/src/graphql/common';
+import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
+import { useAnalyticsContext } from '@dailydotdev/shared/src/contexts/AnalyticsContext';
+import { AnalyticsEvent } from '@dailydotdev/shared/src/lib/analytics';
+import { ReferralCampaignKey } from '@dailydotdev/shared/src/hooks';
+import { DailyDevLogo, JoinPageProps } from './common';
+
+export function AISearchInvite({
+  referringUser,
+  redirectTo,
+  token,
+}: JoinPageProps): ReactElement {
+  const router = useRouter();
+  const search = useFeature(feature.search);
+  const { completeAction } = useActions();
+  const { trackEvent } = useAnalyticsContext();
+  const { displayToast } = useToastNotification();
+  const { user, refetchBoot, showLogin } = useAuthContext();
+  const {
+    mutateAsync: onAcceptMutation,
+    isLoading,
+    isSuccess,
+  } = useMutation(acceptFeatureInvitation, {
+    onSuccess: async () => {
+      await Promise.all([
+        completeAction(ActionType.AcceptedSearch),
+        refetchBoot(),
+      ]);
+      router.push(redirectTo);
+    },
+    onError: (err: ApiErrorResult) => {
+      const message = err?.response?.errors?.[0]?.message;
+      displayToast(message ?? DEFAULT_ERROR);
+    },
+  });
+
+  const handleAcceptClick = () => {
+    const handleAccept = () =>
+      onAcceptMutation({
+        token,
+        referrerId: referringUser.id,
+        feature: ReferralCampaignKey.Search,
+      });
+
+    if (!user) {
+      return showLogin({
+        trigger: AuthTriggers.SearchReferral,
+        options: {
+          onLoginSuccess: handleAccept,
+          onRegistrationSuccess: handleAccept,
+        },
+      });
+    }
+
+    // since in the page view, query params are tracked automatically,
+    // we don't need to send the params here explicitly
+    trackEvent({ event_name: AnalyticsEvent.AcceptInvitation });
+
+    return handleAccept();
+  };
+
+  useEffect(() => {
+    if (search === SearchExperiment.Control) {
+      return;
+    }
+
+    router.push(redirectTo);
+    // router is an unstable dependency
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [redirectTo, search]);
+
+  return (
+    <div className="relative flex h-full min-h-page flex-1 flex-col items-center justify-center overflow-hidden p-6 laptop:items-start">
+      <DailyDevLogo />
+      <div className="relative z-1 flex w-full flex-col tablet:max-w-[27.5rem] laptop:ml-3 laptopL:ml-[9.75rem]">
+        <span className="mb-6 flex flex-col items-center gap-3 tablet:mb-10 tablet:gap-4 laptop:mb-8 laptop:flex-row laptop:items-start laptop:gap-2">
+          <ProfileImageLink user={referringUser} />
+          <p className="text-center text-theme-label-tertiary typo-callout laptop:text-left">
+            {referringUser.name}
+            <br />
+            invites you to try daily.dev search
+          </p>
+        </span>
+        <h1 className="break-words-overflow w-full text-center font-bold typo-large-title tablet:typo-mega3 laptop:text-left">
+          {referringUser.name.split(' ')[0]} gave you early access to daily.dev
+          search!
+        </h1>
+        <p className="mt-6 text-center text-theme-label-secondary laptop:text-left">
+          This isn’t just another search engine; it’s a search engine that’s
+          both fine-tuned for developers and fully integrated into the daily.dev
+          ecosystem.
+        </p>
+        <Button
+          icon={<KeyIcon secondary />}
+          className="mt-12"
+          variant={ButtonVariant.Primary}
+          onClick={handleAcceptClick}
+          loading={isLoading}
+          disabled={isLoading || isSuccess}
+        >
+          Accept invitation ➔
+        </Button>
+      </div>
+      <img
+        src={cloudinary.referralCampaign.search.bg}
+        alt="search input depicting our new AI search feature"
+        className="absolute right-0 z-0 hidden tablet:w-1/2 laptop:block"
+      />
+      <img
+        src={cloudinary.referralCampaign.search.bgPopupMobile}
+        alt="search input depicting our new AI search feature"
+        className="hidden max-w-[27.5rem] tablet:block laptop:hidden"
+      />
+      <img
+        src={cloudinary.referralCampaign.search.bgMobile}
+        alt="search input depicting our new AI search feature"
+        className="absolute inset-0 top-[unset] z-0 block w-full translate-y-1/2 tablet:hidden"
+      />
+    </div>
+  );
+}

--- a/packages/webapp/pages/join.tsx
+++ b/packages/webapp/pages/join.tsx
@@ -11,12 +11,14 @@ import { oneYear } from '@dailydotdev/shared/src/lib/dateFormat';
 import { useReferralConfig } from '@dailydotdev/shared/src/hooks/referral/useReferralConfig';
 import { defaultOpenGraph } from '../next-seo';
 import { JoinPageProps } from '../components/invite/common';
+import { AISearchInvite } from '../components/invite/AISearchInvite';
 import Custom404Seo from './404';
 import { Referral } from '../components/invite/Referral';
 
 type ReferralRecord<T> = Record<ReferralCampaignKey, T>;
 
 const componentsMap: ReferralRecord<FunctionComponent<JoinPageProps>> = {
+  search: AISearchInvite,
   generic: Referral,
 };
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Discussion [here](https://dailydotdev.slack.com/archives/C063RS0QZTM/p1708271776431239) 
- I think it won't interfere with anything but people that got invites recently will be able to join 🙏 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
