### PR TITLE
fix: added fixed header styling

### DIFF
--- a/packages/eslint-rules/lib/rules/no-custom-color.js
+++ b/packages/eslint-rules/lib/rules/no-custom-color.js
@@ -15,6 +15,7 @@ const alwaysValidClasses = [
   'bg-gradient-to-l',
   'bg-gradient-to-t',
   'bg-theme-bg-inherit',
+  'bg-gradient-to-b',
   'bg-gradient-to-br',
   'bg-cover',
   'bg-no-repeat',

--- a/packages/shared/src/components/onboarding/OnboardingFeedHeader.tsx
+++ b/packages/shared/src/components/onboarding/OnboardingFeedHeader.tsx
@@ -96,7 +96,7 @@ export const OnboardingFeedHeader = ({
 
   return (
     <LayoutHeader className="flex-col overflow-x-visible">
-      <div className="fixed z-1 flex w-full justify-center bg-gradient-to-b from-theme-surface-invert via-80% tablet:px-4 tablet:py-10">
+      <div className="fixed z-1 flex w-full justify-center bg-gradient-to-b from-theme-surface-invert via-theme-surface-invert-opacity-80 via-90% tablet:px-4 tablet:py-10">
         <div className="flex h-44 w-full max-w-[40rem] flex-col items-center border-l-2 border-theme-color-cabbage bg-theme-bg-popover  p-6 tablet:h-auto tablet:flex-row tablet:rounded-16">
           <div className="text-center tablet:text-left">
             <p className="font-bold typo-title3">

--- a/packages/shared/src/components/onboarding/OnboardingFeedHeader.tsx
+++ b/packages/shared/src/components/onboarding/OnboardingFeedHeader.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   ButtonColor,
   ButtonIconPosition,
+  ButtonSize,
   ButtonVariant,
 } from '../buttons/ButtonV2';
 import { REQUIRED_TAGS_THRESHOLD } from './common';
@@ -95,9 +96,9 @@ export const OnboardingFeedHeader = ({
 
   return (
     <LayoutHeader className="flex-col overflow-x-visible">
-      <div className="fixed z-1 flex w-full justify-center bg-gradient-to-b from-overlay-primary-pepper from-90% to-transparent py-10">
-        <div className="flex w-[40rem] rounded-16 border-l-2 border-l-cabbage-10 bg-theme-bg-notification p-6">
-          <div className="mr-auto">
+      <div className="fixed z-1 flex w-full justify-center bg-gradient-to-b from-theme-surface-invert via-80% tablet:px-4 tablet:py-10">
+        <div className="flex h-44 w-full max-w-[40rem] flex-col items-center border-l-2 border-theme-color-cabbage bg-theme-bg-popover  p-6 tablet:h-auto tablet:flex-row tablet:rounded-16">
+          <div className="text-center tablet:text-left">
             <p className="font-bold typo-title3">
               Pick tags that are relevant to you
             </p>
@@ -105,11 +106,11 @@ export const OnboardingFeedHeader = ({
               You can always modify your tags later
             </p>
           </div>
-
+          <div className="flex flex-1" />
           <Button
+            size={ButtonSize.Large}
             variant={ButtonVariant.Primary}
             disabled={!isFeedPreviewEnabled}
-            className="self-center"
             onClick={completeOnboarding}
           >
             Create my feed
@@ -118,7 +119,7 @@ export const OnboardingFeedHeader = ({
       </div>
 
       <div className="flex max-w-full flex-col">
-        <FilterOnboardingV4 className="mt-[11rem]" />
+        <FilterOnboardingV4 className="mt-44 pt-6 tablet:pt-0" />
         <div className="mt-10 flex items-center justify-center gap-10 text-theme-label-quaternary typo-callout">
           <div className="h-px flex-1 bg-theme-divider-tertiary" />
           <Button

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -21,7 +21,7 @@ export class Feature<T extends JSONValue> {
 
 const feature = {
   feedVersion: new Feature('feed_version', 15),
-  onboardingV4dot5: new Feature('onboarding_v4dot5', OnboardingV4dot5.Control),
+  onboardingV4dot5: new Feature('onboarding_v4dot5', OnboardingV4dot5.V4dot5),
   search: new Feature('search', SearchExperiment.Control),
   lowImps: new Feature('feed_low_imps'),
   bookmarkOnCard: new Feature('bookmark_on_card', false),

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -21,7 +21,7 @@ export class Feature<T extends JSONValue> {
 
 const feature = {
   feedVersion: new Feature('feed_version', 15),
-  onboardingV4dot5: new Feature('onboarding_v4dot5', OnboardingV4dot5.V4dot5),
+  onboardingV4dot5: new Feature('onboarding_v4dot5', OnboardingV4dot5.Control),
   search: new Feature('search', SearchExperiment.Control),
   lowImps: new Feature('feed_low_imps'),
   bookmarkOnCard: new Feature('bookmark_on_card', false),

--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -58,6 +58,8 @@ body {
   --theme-background-popover: theme('colors.pepper.70');
 
   --theme-surface-invert: theme('colors.pepper.90');
+  /* stylelint-disable-next-line unit-no-unknown */
+  --theme-surface-invert-opacity-80: theme('colors.pepper.90')CC;
 
   --theme-label-primary: #ffffff;
   --theme-label-secondary: theme('colors.salt.50');
@@ -189,6 +191,8 @@ body {
   --theme-background-popover: theme('colors.salt.0');
 
   --theme-surface-invert: theme('colors.salt.0');
+  /* stylelint-disable-next-line unit-no-unknown */
+  --theme-surface-invert-opacity-80: theme('colors.salt.0')CC;
 
   --theme-label-primary: theme('colors.pepper.90');
   --theme-label-secondary: theme('colors.pepper.50');

--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -55,6 +55,9 @@ body {
   --theme-background-pepper-40: theme('colors.pepper.40');
   /* stylelint-disable-next-line unit-no-unknown */
   --theme-background-cabbage-opacity-24: theme('colors.cabbage.40')3D;
+  --theme-background-popover: theme('colors.pepper.70');
+
+  --theme-surface-invert: theme('colors.pepper.90');
 
   --theme-label-primary: #ffffff;
   --theme-label-secondary: theme('colors.salt.50');
@@ -183,6 +186,9 @@ body {
   --theme-background-pepper-40: theme('colors.salt.40');
   /* stylelint-disable-next-line unit-no-unknown */
   --theme-background-cabbage-opacity-24: theme('colors.cabbage.40')3D;
+  --theme-background-popover: theme('colors.salt.0');
+
+  --theme-surface-invert: theme('colors.salt.0');
 
   --theme-label-primary: theme('colors.pepper.90');
   --theme-label-secondary: theme('colors.pepper.50');

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -38,6 +38,10 @@ module.exports = {
           'cabbage-opacity-24': 'var(--theme-background-cabbage-opacity-24)',
           'overlay-cabbage-opacity': 'var(--theme-overlay-cabbage-opacity)',
           'overlay-onion-opacity': 'var(--theme-overlay-onion-opacity)',
+          popover: 'var(--theme-background-popover)',
+        },
+        surface: {
+          invert: 'var(--theme-surface-invert)',
         },
         label: {
           primary: 'var(--theme-label-primary)',

--- a/packages/shared/tailwind.config.js
+++ b/packages/shared/tailwind.config.js
@@ -42,6 +42,7 @@ module.exports = {
         },
         surface: {
           invert: 'var(--theme-surface-invert)',
+          'invert-opacity-80': 'var(--theme-surface-invert-opacity-80)',
         },
         label: {
           primary: 'var(--theme-label-primary)',

--- a/packages/shared/tailwind/colors.js
+++ b/packages/shared/tailwind/colors.js
@@ -127,6 +127,7 @@ const colors = {
     90: '#0D31D9',
   },
   salt: {
+    0: '#FFFFFF',
     10: '#F5F8FC',
     20: '#EDF0F7',
     30: '#E4E9F2',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Styling issues for the header part.
- One [open](https://dailydotdev.slack.com/archives/C068F77M8Q7/p1708439180773429) question as the color for lightmode seems wrongly defined in Figma

Screens:
![Screenshot 2024-02-20 at 16 37 11](https://github.com/dailydotdev/apps/assets/554874/231f1b41-422e-4e29-8423-b33749e08422)
![Screenshot 2024-02-20 at 16 36 59](https://github.com/dailydotdev/apps/assets/554874/06fb5576-8873-4132-ae78-de7d6af7df27)
![Screenshot 2024-02-20 at 16 36 52](https://github.com/dailydotdev/apps/assets/554874/d0c27e99-922a-4f94-b8db-b3ac95db7912)
![Screenshot 2024-02-20 at 16 36 42](https://github.com/dailydotdev/apps/assets/554874/073986ad-f0fa-4589-a61f-a540cbc7c6be)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
