### PR TITLE
fix: transition to auth display

### DIFF
--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -55,6 +55,7 @@ import OnboardingRegistrationForm from './OnboardingRegistrationForm';
 import { useEventListener } from '../../hooks';
 import { trackAnalyticsSignUp } from './OnboardingAnalytics';
 import { ButtonSize } from '../buttons/Button';
+import { nextTick } from '../../lib/func';
 
 export enum AuthDisplay {
   Default = 'default',
@@ -421,8 +422,9 @@ function AuthOptions({
                 email: existingEmail,
               });
             }}
-            onProviderClick={(provider, login) => {
+            onProviderClick={async (provider, login) => {
               onProviderClick(provider, login);
+              await nextTick();
               onAuthStateUpdate({ isAuthenticating: true });
             }}
             trigger={trigger}


### PR DESCRIPTION
## Changes
- Fix the transition issue by waiting for the next tick before displaying the new UI.
- This ensures the window is opened.
- I also tried making the `onProviderClick` an async function that does the next tick but it might impact other areas, with that, I only kept the changes within the primary area of concern.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-175 #done
