### PR TITLE
fix: vscode eslint argument

### DIFF
--- a/.vscode/apps.code-workspace
+++ b/.vscode/apps.code-workspace
@@ -27,7 +27,7 @@
       "**/.next": true,
     },
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     },
     "tailwindCSS.classAttributes": [
       "class",


### PR DESCRIPTION
Keep getting this change whenever I open apps in VSCode, so I presume it means that the extension has changed the default value from `true` to `explicit`.