### PR TITLE
fix: calculate the local timezone offset when generating the heatmap

### DIFF
--- a/packages/shared/src/components/CalendarHeatmap.tsx
+++ b/packages/shared/src/components/CalendarHeatmap.tsx
@@ -118,7 +118,10 @@ export function CalendarHeatmap<T extends { date: string }>({
   >(
     () =>
       values.reduce((acc, value) => {
-        const date = new Date(value.date);
+        const localDate = new Date(value.date);
+        const date = new Date(
+          localDate.valueOf() + localDate.getTimezoneOffset() * 60 * 1000,
+        );
         const index = differenceInDays(date, startDateWithEmptyDays);
         if (index < 0) {
           return acc;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Adds local timezone offset when generating heat map

The heatmap generator does not take into account the users timezone, so when they have read a post today, it looks like it was yesterday.

I set my local timezone to GMT-8 (Vancouver, Canada), and ran the following line, which assumes GMT+0 time, and then it outputs it as local time. 

```
> new Date("2024-02-22")
Wed Feb 21 2024 16:00:00 GMT-0800
```

<tr>
<td><img src="https://github.com/dailydotdev/apps/assets/1681525/be21bacb-161a-4610-b83e-500b44c20678">
<td><img src="https://github.com/dailydotdev/apps/assets/1681525/9d003f54-8d40-4efc-bdc2-6ab4d6aa49d0">


```json
{
  "data": {
    "userReadingRankHistory": [
      {
        "rank": 1,
        "count": 1
      }
    ],
    "userReadHistory": [
      {
        "date": "2024-02-22",
        "reads": 1
      }
    ],
    "userMostReadTags": []
  }
}
```