### PR TITLE
fix: remove user attribute from source link

### DIFF
--- a/packages/shared/src/components/profile/ProfileImageLink.tsx
+++ b/packages/shared/src/components/profile/ProfileImageLink.tsx
@@ -10,17 +10,12 @@ interface ProfileImageLinkProps extends ProfileLinkProps {
 }
 
 function ProfileImageLinkComponent(
-  { picture = { size: 'large' }, ...props }: ProfileImageLinkProps,
+  { picture = { size: 'large' }, user, ...props }: ProfileImageLinkProps,
   ref?: Ref<HTMLAnchorElement>,
 ): ReactElement {
   return (
-    <ProfileLink {...props} href={props.user.permalink} ref={ref}>
-      <ProfilePicture
-        {...picture}
-        ref={null}
-        user={props.user}
-        nativeLazyLoading
-      />
+    <ProfileLink {...props} href={user.permalink} ref={ref}>
+      <ProfilePicture {...picture} ref={null} user={user} nativeLazyLoading />
     </ProfileLink>
   );
 }


### PR DESCRIPTION
## Changes

removes the `user` attribute that was unintentionally passed through to the HTML `<a>` element.

See slack discussion:
https://dailydotdev.slack.com/archives/C06FDFQC6QZ/p1708673722619149
