### PR TITLE
fix: cleanup the search as winning experiment

### DIFF
--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -9,10 +9,7 @@ import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import AlertContext from '@dailydotdev/shared/src/contexts/AlertContext';
 import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
 import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
-import {
-  FeedLayout as FeedLayoutEnum,
-  SearchExperiment,
-} from '@dailydotdev/shared/src/lib/featureValues';
+import { FeedLayout as FeedLayoutEnum } from '@dailydotdev/shared/src/lib/featureValues';
 import { getFeedName } from '@dailydotdev/shared/src/lib/feed';
 import {
   SearchProviderEnum,
@@ -45,7 +42,6 @@ export type MainFeedPageProps = {
 export default function MainFeedPage({
   onPageChanged,
 }: MainFeedPageProps): ReactElement {
-  const searchVersion = useFeature(feature.search);
   const { alerts } = useContext(AlertContext);
   const { trackEvent } = useAnalyticsContext();
   const [isSearchOn, setIsSearchOn] = useState(false);
@@ -57,16 +53,9 @@ export default function MainFeedPage({
   useCompanionSettings();
   const { isActive: isDndActive } = useContext(DndContext);
   const enableSearch = () => {
-    if (searchVersion !== SearchExperiment.Control) {
-      window.location.assign(
-        getSearchUrl({ provider: SearchProviderEnum.Posts }),
-      );
-      return;
-    }
-
-    setIsSearchOn(true);
-    setSearchQuery(null);
-    onPageChanged('/search');
+    window.location.assign(
+      getSearchUrl({ provider: SearchProviderEnum.Posts }),
+    );
   };
 
   const onNavTabClick = (tab: string): void => {
@@ -111,7 +100,6 @@ export default function MainFeedPage({
         <ScrollToTopButton />
       </div>
       <MainLayout
-        greeting
         mainPage
         isNavItemsButton
         activePage={activePage}
@@ -130,7 +118,6 @@ export default function MainFeedPage({
             feedName={feedName}
             isSearchOn={isSearchOn}
             searchQuery={searchQuery}
-            onFeedPageChanged={onNavTabClick}
             searchChildren={
               <PostsSearch
                 onSubmitQuery={async (query) => {

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -57,8 +57,6 @@ import { getFeedSettingsQueryKey } from '../hooks/useFeedSettings';
 import Toast from './notifications/Toast';
 import OnboardingContext from '../contexts/OnboardingContext';
 import { LazyModalElement } from './modals/LazyModalElement';
-import { feature } from '../lib/featureManagement';
-import { SearchExperiment } from '../lib/featureValues';
 import { AuthTriggers } from '../lib/auth';
 import { SourceType } from '../graphql/sources';
 
@@ -96,7 +94,6 @@ const originalScrollTo = window.scrollTo;
 
 beforeAll(() => {
   window.scrollTo = jest.fn();
-  feature.search.defaultValue = SearchExperiment.Control;
 });
 
 afterAll(() => {

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -54,7 +54,6 @@ const feeds = Object.values(SharedFeedPage);
 
 function MainLayoutComponent({
   children,
-  greeting,
   activePage,
   isNavItemsButton,
   showDnd,
@@ -179,7 +178,6 @@ function MainLayoutComponent({
       <PromptElement />
       <Toast autoDismissNotifications={autoDismissNotifications} />
       <MainLayoutHeader
-        greeting={greeting}
         hasBanner={isBannerAvailable}
         sidebarRendered={sidebarRendered}
         optOutWeeklyGoal={optOutWeeklyGoal}

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -12,7 +12,7 @@ import FeedContext from '../../contexts/FeedContext';
 import styles from '../Feed.module.css';
 import { useFeature } from '../GrowthBookProvider';
 import { feature } from '../../lib/featureManagement';
-import { OnboardingV4dot5, SearchExperiment } from '../../lib/featureValues';
+import { OnboardingV4dot5 } from '../../lib/featureValues';
 import { FeedReadyMessage } from '../onboarding';
 import { useFeedLayout, ToastSubject, useToastNotification } from '../../hooks';
 import ConditionalWrapper from '../ConditionalWrapper';
@@ -110,7 +110,6 @@ export const FeedContainer = ({
   const { shouldUseFeedLayoutV1 } = useFeedLayout();
   const { feedName } = useActiveFeedNameContext();
   const router = useRouter();
-  const searchValue = useFeature(feature.search);
   const onboardingV4dot5 = useFeature(feature.onboardingV4dot5);
   const isOnboardingV4dot5 = onboardingV4dot5 === OnboardingV4dot5.V4dot5;
   const numCards = currentSettings.numCards[spaciness ?? 'eco'];
@@ -124,8 +123,7 @@ export const FeedContainer = ({
   } as CSSProperties;
   const cardContainerStyle = { ...getStyle(isList, spaciness) };
   const isFinder = router.pathname === '/search/posts';
-  const isV1Search =
-    searchValue === SearchExperiment.V1 && showSearch && !isFinder;
+  const isV1Search = showSearch && !isFinder;
 
   if (!loadedSettings) {
     return <></>;

--- a/packages/shared/src/components/filters/MyFeedHeading.tsx
+++ b/packages/shared/src/components/filters/MyFeedHeading.tsx
@@ -16,9 +16,6 @@ import AlertPointer, {
 import { Alerts } from '../../graphql/alerts';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../../lib/analytics';
-import { useFeature } from '../GrowthBookProvider';
-import { feature } from '../../lib/featureManagement';
-import { SearchExperiment } from '../../lib/featureValues';
 import { useFeedLayout } from '../../hooks';
 
 export const filterAlertMessage = 'Edit your personal feed preferences here';
@@ -38,10 +35,8 @@ function MyFeedHeading({
 }: MyFeedHeadingProps): ReactElement {
   const router = useRouter();
   const { trackEvent } = useContext(AnalyticsContext);
-  const searchVersion = useFeature(feature.search);
   const shouldHighlightFeedSettings = router.query?.hset === 'true';
   const { shouldUseFeedLayoutV1 } = useFeedLayout();
-  const isV1Search = searchVersion === SearchExperiment.V1;
 
   const onClick = () => {
     trackEvent({ event_name: AnalyticsEvent.ManageTags });
@@ -56,16 +51,7 @@ function MyFeedHeading({
     }
   };
 
-  const isControlSearch = searchVersion === SearchExperiment.Control;
   const getPlacement = () => {
-    if (shouldUseFeedLayoutV1) {
-      return AlertPlacement.Bottom;
-    }
-
-    if (sidebarRendered && isControlSearch) {
-      return AlertPlacement.Right;
-    }
-
     return AlertPlacement.Bottom;
   };
 
@@ -74,11 +60,7 @@ function MyFeedHeading({
       return [0, 8];
     }
 
-    if (isV1Search) {
-      return [0, 0];
-    }
-
-    return sidebarRendered ? [4, 0] : [-32, 4];
+    return [0, 0];
   };
 
   const alertProps: Omit<AlertPointerProps, 'children'> = {
@@ -103,11 +85,7 @@ function MyFeedHeading({
     <AlertPointer {...alertProps}>
       <Button
         size={shouldUseFeedLayoutV1 ? ButtonSize.Small : ButtonSize.Medium}
-        variant={
-          isV1Search || shouldUseFeedLayoutV1
-            ? ButtonVariant.Float
-            : ButtonVariant.Tertiary
-        }
+        variant={ButtonVariant.Float}
         className={classNames(
           'mr-auto',
           shouldHighlightFeedSettings && 'highlight-pulse',

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -23,12 +23,8 @@ import { CreatePostButton } from '../post/write';
 import { useViewSize, ViewSize } from '../../hooks';
 import { ReadingStreakButton } from '../streak/ReadingStreakButton';
 import { useReadingStreak } from '../../hooks/streaks';
-import { useFeature } from '../GrowthBookProvider';
-import { feature } from '../../lib/featureManagement';
-import { SearchExperiment } from '../../lib/featureValues';
 
 export interface MainLayoutHeaderProps {
-  greeting?: boolean;
   hasBanner?: boolean;
   sidebarRendered?: boolean;
   optOutWeeklyGoal?: boolean;
@@ -45,7 +41,6 @@ const SearchPanel = dynamic(
 );
 
 function MainLayoutHeader({
-  greeting,
   hasBanner,
   sidebarRendered,
   optOutWeeklyGoal,
@@ -53,8 +48,6 @@ function MainLayoutHeader({
   onLogoClick,
   onMobileSidebarToggle,
 }: MainLayoutHeaderProps): ReactElement {
-  const searchVersion = useFeature(feature.search);
-  const isSearchV1 = searchVersion === SearchExperiment.V1;
   const { trackEvent } = useAnalyticsContext();
   const { unreadCount } = useNotificationContext();
   const { user, loadingUser } = useContext(AuthContext);
@@ -153,11 +146,10 @@ function MainLayoutHeader({
             <HeaderLogo
               user={user}
               onLogoClick={onLogoClick}
-              // currently isSearchV1 we do not show greeting
-              greeting={isSearchV1 ? false : greeting}
+              greeting={false}
             />
           </div>
-          {isSearchV1 && !!user && (
+          {!!user && (
             <SearchPanel
               className={{
                 container: classNames(

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -1,17 +1,13 @@
 import React, {
   Dispatch,
   ReactElement,
-  ReactNode,
   SetStateAction,
   useContext,
 } from 'react';
-import classNames from 'classnames';
 import classed from '../../lib/classed';
-import { FeedHeading, SharedFeedPage } from '../utilities';
+import { SharedFeedPage } from '../utilities';
 import MyFeedHeading from '../filters/MyFeedHeading';
 import AlertContext from '../../contexts/AlertContext';
-import CreateMyFeedButton from '../CreateMyFeedButton';
-import OnboardingContext from '../../contexts/OnboardingContext';
 import useSidebarRendered from '../../hooks/useSidebarRendered';
 import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
@@ -21,9 +17,6 @@ import { CalendarIcon, SortIcon } from '../icons';
 import { IconSize } from '../Icon';
 import { RankingAlgorithm } from '../../graphql/feed';
 import SettingsContext from '../../contexts/SettingsContext';
-import { useFeature } from '../GrowthBookProvider';
-import { feature } from '../../lib/featureManagement';
-import { OnboardingV4dot5, SearchExperiment } from '../../lib/featureValues';
 import { useFeedName } from '../../hooks/feed/useFeedName';
 import { useFeedLayout } from '../../hooks';
 
@@ -31,9 +24,6 @@ type State<T> = [T, Dispatch<SetStateAction<T>>];
 
 export interface SearchControlHeaderProps {
   feedName: SharedFeedPage;
-  navChildren?: ReactNode;
-  isSearchOn?: boolean;
-  onFeedPageChanged: (value: SharedFeedPage) => void;
   algoState: State<number>;
   periodState: State<number>;
 }
@@ -57,136 +47,57 @@ const periodTexts = periods.map((period) => period.text);
 
 export const SearchControlHeader = ({
   feedName,
-  navChildren,
-  isSearchOn,
-  onFeedPageChanged,
   algoState: [selectedAlgo, setSelectedAlgo],
   periodState: [selectedPeriod, setSelectedPeriod],
 }: SearchControlHeaderProps): ReactElement => {
-  const searchVersion = useFeature(feature.search);
-  const onboardingV4dot5 = useFeature(feature.onboardingV4dot5);
-  const isOnboardingV4dot5 = onboardingV4dot5 === OnboardingV4dot5.V4dot5;
   const { alerts, updateAlerts } = useContext(AlertContext);
   const { sidebarRendered } = useSidebarRendered();
-  const hasMyFeedAlert = alerts.myFeed;
-  const { onInitializeOnboarding } = useContext(OnboardingContext);
   const { openModal } = useLazyModal();
   const { sortingEnabled } = useContext(SettingsContext);
-  const { isUpvoted, isSortableFeed } = useFeedName({ feedName, isSearchOn });
+  const { isUpvoted, isSortableFeed } = useFeedName({ feedName });
   const { shouldUseFeedLayoutV1 } = useFeedLayout();
   const openFeedFilters = () =>
     openModal({ type: LazyModal.FeedFilters, persistOnRouteChange: true });
 
-  /* eslint-disable react/no-children-prop */
-  const feedHeading = {
-    [SharedFeedPage.MyFeed]: (
+  const dropdownProps: Partial<DropdownProps> = {
+    className: { label: 'hidden', chevron: 'hidden', button: '!px-1' },
+    dynamicMenuWidth: true,
+    shouldIndicateSelected: true,
+    buttonSize: shouldUseFeedLayoutV1 ? ButtonSize.Small : ButtonSize.Medium,
+    iconOnly: true,
+  };
+  const actionButtons = [
+    feedName === SharedFeedPage.MyFeed ? (
       <MyFeedHeading
-        isAlertDisabled={!hasMyFeedAlert}
+        key="my-feed"
+        isAlertDisabled={!alerts.myFeed}
         sidebarRendered={sidebarRendered}
         onOpenFeedFilters={openFeedFilters}
         onUpdateAlerts={() => updateAlerts({ myFeed: null })}
       />
-    ),
-    [SharedFeedPage.Popular]: <FeedHeading children="Popular" />,
-    [SharedFeedPage.Upvoted]: <FeedHeading children="Most upvoted" />,
-    [SharedFeedPage.Discussed]: <FeedHeading children="Best discussions" />,
-  };
+    ) : null,
+    isUpvoted ? (
+      <Dropdown
+        {...dropdownProps}
+        key="algorithm"
+        icon={<CalendarIcon size={IconSize.Medium} />}
+        selectedIndex={selectedPeriod}
+        options={periodTexts}
+        onChange={(_, index) => setSelectedPeriod(index)}
+      />
+    ) : null,
+    sortingEnabled && isSortableFeed ? (
+      <Dropdown
+        {...dropdownProps}
+        key="sorting"
+        icon={<SortIcon size={IconSize.Medium} />}
+        selectedIndex={selectedAlgo}
+        options={algorithmsList}
+        onChange={(_, index) => setSelectedAlgo(index)}
+      />
+    ) : null,
+  ];
+  const actions = actionButtons.filter((button) => !!button);
 
-  if (searchVersion === SearchExperiment.V1 || shouldUseFeedLayoutV1) {
-    const dropdownProps: Partial<DropdownProps> = {
-      className: { label: 'hidden', chevron: 'hidden', button: '!px-1' },
-      dynamicMenuWidth: true,
-      shouldIndicateSelected: true,
-      buttonSize: shouldUseFeedLayoutV1 ? ButtonSize.Small : ButtonSize.Medium,
-      iconOnly: true,
-    };
-    const actionButtons = [
-      feedName === SharedFeedPage.MyFeed ? (
-        <MyFeedHeading
-          key="my-feed"
-          isAlertDisabled={!alerts.myFeed}
-          sidebarRendered={sidebarRendered}
-          onOpenFeedFilters={openFeedFilters}
-          onUpdateAlerts={() => updateAlerts({ myFeed: null })}
-        />
-      ) : null,
-      isUpvoted ? (
-        <Dropdown
-          {...dropdownProps}
-          key="algorithm"
-          icon={<CalendarIcon size={IconSize.Medium} />}
-          selectedIndex={selectedPeriod}
-          options={periodTexts}
-          onChange={(_, index) => setSelectedPeriod(index)}
-        />
-      ) : null,
-      sortingEnabled && isSortableFeed ? (
-        <Dropdown
-          {...dropdownProps}
-          key="sorting"
-          icon={<SortIcon size={IconSize.Medium} />}
-          selectedIndex={selectedAlgo}
-          options={algorithmsList}
-          onChange={(_, index) => setSelectedAlgo(index)}
-        />
-      ) : null,
-    ];
-    const actions = actionButtons.filter((button) => !!button);
-
-    return actions?.length ? <>{actions}</> : null;
-  }
-
-  return (
-    <LayoutHeader className="flex-col overflow-x-visible">
-      {alerts?.filter && !isOnboardingV4dot5 && (
-        <CreateMyFeedButton
-          action={() =>
-            onInitializeOnboarding(() =>
-              onFeedPageChanged(SharedFeedPage.MyFeed),
-            )
-          }
-        />
-      )}
-      <div
-        className={classNames(
-          'mr-px flex w-full flex-row flex-wrap items-center gap-4',
-          alerts.filter || !hasMyFeedAlert ? 'h-14' : 'h-32 laptop:h-16',
-          !sidebarRendered && hasMyFeedAlert && 'content-start',
-        )}
-      >
-        {feedHeading[feedName]}
-        {navChildren}
-        {isUpvoted && (
-          <Dropdown
-            className={{ container: 'w-44' }}
-            buttonSize={ButtonSize.Large}
-            icon={<CalendarIcon className="mr-2" />}
-            selectedIndex={selectedPeriod}
-            options={periodTexts}
-            onChange={(_, index) => setSelectedPeriod(index)}
-          />
-        )}
-        {sortingEnabled && isSortableFeed && (
-          <Dropdown
-            className={{
-              container: 'w-12 tablet:w-44',
-              indicator: 'flex tablet:hidden',
-              chevron: 'hidden tablet:flex',
-              label: 'hidden tablet:flex',
-              menu: 'w-44',
-            }}
-            dynamicMenuWidth
-            shouldIndicateSelected
-            buttonSize={ButtonSize.Large}
-            selectedIndex={selectedAlgo}
-            options={algorithmsList}
-            icon={
-              <SortIcon size={IconSize.Small} className="flex tablet:hidden" />
-            }
-            onChange={(_, index) => setSelectedAlgo(index)}
-          />
-        )}
-      </div>
-    </LayoutHeader>
-  );
+  return actions?.length ? <>{actions}</> : null;
 };

--- a/packages/shared/src/components/sidebar/ManageSection.tsx
+++ b/packages/shared/src/components/sidebar/ManageSection.tsx
@@ -8,9 +8,6 @@ import {
 } from '../icons';
 import { ListIcon, SidebarMenuItem } from './common';
 import { Section, SectionCommonProps } from './Section';
-import { useFeature } from '../GrowthBookProvider';
-import { feature } from '../../lib/featureManagement';
-import { SearchExperiment } from '../../lib/featureValues';
 
 interface ManageSectionProps extends SectionCommonProps {
   isDndActive?: boolean;
@@ -28,7 +25,6 @@ export function ManageSection({
   onShowSettings,
   ...props
 }: ManageSectionProps): ReactElement {
-  const searchValue = useFeature(feature.search);
   const shouldShowDnD = !!process.env.TARGET_BROWSER;
   const manageMenuItems: SidebarMenuItem[] = [
     {
@@ -44,10 +40,7 @@ export function ManageSection({
       icon: (active: boolean) => (
         <ListIcon Icon={() => <EyeIcon secondary={active} />} />
       ),
-      title:
-        searchValue === SearchExperiment.Control
-          ? 'Reading history'
-          : 'History',
+      title: 'History',
       path: `${process.env.NEXT_PUBLIC_WEBAPP_URL}history`,
       requiresLogin: true,
     },

--- a/packages/shared/src/components/sidebar/Sidebar.spec.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.spec.tsx
@@ -151,7 +151,7 @@ const sidebarItems = [
   ['Best discussions', '/discussed'],
   ['Search', '/search'],
   ['Bookmarks', '/bookmarks'],
-  ['Reading history', '/history'],
+  ['History', '/history'],
 ];
 
 describe('sidebar items', () => {

--- a/packages/shared/src/components/sidebar/Sidebar.spec.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.spec.tsx
@@ -19,8 +19,6 @@ import { AlertContextProvider } from '../../contexts/AlertContext';
 import { waitForNock } from '../../../__tests__/helpers/utilities';
 import ProgressiveEnhancementContext from '../../contexts/ProgressiveEnhancementContext';
 import { Alerts } from '../../graphql/alerts';
-import { SearchExperiment } from '../../lib/featureValues';
-import { feature } from '../../lib/featureManagement';
 
 let client: QueryClient;
 const updateAlerts = jest.fn();
@@ -157,8 +155,6 @@ const sidebarItems = [
 ];
 
 describe('sidebar items', () => {
-  feature.search.defaultValue = SearchExperiment.Control;
-
   it.each(sidebarItems.map((item) => [item[0], item[1]]))(
     'it should expect %s to exist',
     async (name, href) => {

--- a/packages/shared/src/hooks/feed/useFeedName.ts
+++ b/packages/shared/src/hooks/feed/useFeedName.ts
@@ -1,10 +1,6 @@
 import { SharedFeedPage } from '../../components/utilities';
-import { useFeature } from '../../components/GrowthBookProvider';
-import { feature } from '../../lib/featureManagement';
-import { SearchExperiment } from '../../lib/featureValues';
 
 interface UseFeedNameProps {
-  isSearchOn: boolean;
   feedName: SharedFeedPage;
 }
 
@@ -15,20 +11,9 @@ interface UseFeedName {
 
 const sortableFeeds = [SharedFeedPage.Popular, SharedFeedPage.MyFeed];
 
-export const useFeedName = ({
-  feedName,
-  isSearchOn,
-}: UseFeedNameProps): UseFeedName => {
-  const searchVersion = useFeature(feature.search);
-
+export const useFeedName = ({ feedName }: UseFeedNameProps): UseFeedName => {
   return {
-    isUpvoted:
-      searchVersion === SearchExperiment.Control
-        ? !isSearchOn && feedName === 'upvoted'
-        : feedName === 'upvoted',
-    isSortableFeed:
-      searchVersion === SearchExperiment.Control
-        ? !isSearchOn && sortableFeeds.includes(feedName)
-        : sortableFeeds.includes(feedName),
+    isUpvoted: feedName === 'upvoted',
+    isSortableFeed: sortableFeeds.includes(feedName),
   };
 };

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -2,7 +2,6 @@ import { JSONValue } from '@growthbook/growthbook';
 import {
   FeedLayout,
   ReadingStreaksExperiment,
-  SearchExperiment,
   OnboardingV4dot5,
 } from './featureValues';
 import { cloudinary } from './image';
@@ -21,7 +20,6 @@ export class Feature<T extends JSONValue> {
 const feature = {
   feedVersion: new Feature('feed_version', 15),
   onboardingV4dot5: new Feature('onboarding_v4dot5', OnboardingV4dot5.Control),
-  search: new Feature('search', SearchExperiment.Control),
   lowImps: new Feature('feed_low_imps'),
   bookmarkOnCard: new Feature('bookmark_on_card', false),
   feedLayout: new Feature('feed_layout', FeedLayout.Control),

--- a/packages/shared/src/lib/featureValues.ts
+++ b/packages/shared/src/lib/featureValues.ts
@@ -6,11 +6,6 @@ export enum ExperimentWinner {
   OnboardingV4 = 'v4',
 }
 
-export enum SearchExperiment {
-  Control = 'control',
-  V1 = 'v1',
-}
-
 export enum FeedLayout {
   Control = 'control',
   V1 = 'v1',

--- a/packages/webapp/__tests__/BookmarksPage.tsx
+++ b/packages/webapp/__tests__/BookmarksPage.tsx
@@ -126,7 +126,9 @@ it('should show the search bar', async () => {
 it('should update query param on enter', async (done) => {
   renderComponent();
   await waitForNock();
-  const input = (await screen.findByRole('textbox')) as HTMLInputElement;
+  const input = (await screen.findByPlaceholderText(
+    'Search bookmarks',
+  )) as HTMLInputElement;
   input.value = 'daily';
   input.dispatchEvent(new Event('input', { bubbles: true }));
   setTimeout(async () => {

--- a/packages/webapp/__tests__/SearchPage.tsx
+++ b/packages/webapp/__tests__/SearchPage.tsx
@@ -2,15 +2,11 @@ import React from 'react';
 import { render, RenderResult, screen } from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
 import defaultUser from '@dailydotdev/shared/__tests__/fixture/loggedUser';
-import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
-import { SearchExperiment } from '@dailydotdev/shared/src/lib/featureValues';
 import { mocked } from 'ts-jest/utils';
 import { NextRouter, useRouter } from 'next/router';
 import { TestBootProvider } from '../../shared/__tests__/helpers/boot';
-import SearchPage from '../pages/search/posts';
 import SearchPageV1 from '../pages/search/chat';
 import { getLayout } from '../components/layouts/MainLayout';
-import { getMainFeedLayout } from '../components/layouts/MainFeedPage';
 
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
@@ -28,32 +24,19 @@ beforeEach(() => {
   );
 });
 
-const renderComponent = (
-  layout = getLayout,
-  searchExperiment: SearchExperiment,
-): RenderResult => {
+const renderComponent = (layout = getLayout): RenderResult => {
   const client = new QueryClient();
   const user = defaultUser;
-  const PageComponent =
-    searchExperiment === SearchExperiment.V1 ? SearchPageV1 : SearchPage;
 
   return render(
     <TestBootProvider client={client} auth={{ user }}>
-      {layout(<PageComponent />, {}, {})}
+      {layout(<SearchPageV1 />, {}, {})}
     </TestBootProvider>,
   );
 };
 
-it('should render the search page control', async () => {
-  feature.search.defaultValue = SearchExperiment.Control;
-  renderComponent(getMainFeedLayout, SearchExperiment.Control);
-  const text = screen.queryByTestId('search-panel');
-  expect(text).not.toBeInTheDocument();
-});
-
 it('should render the search page v1', async () => {
-  feature.search.defaultValue = SearchExperiment.V1;
-  renderComponent(undefined, SearchExperiment.V1);
+  renderComponent(undefined);
   const text = screen.queryByTestId('search-panel');
   expect(text).toBeInTheDocument();
 });

--- a/packages/webapp/components/invite/AISearchInvite.tsx
+++ b/packages/webapp/components/invite/AISearchInvite.tsx
@@ -10,9 +10,6 @@ import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
 import { useMutation } from '@tanstack/react-query';
 import { acceptFeatureInvitation } from '@dailydotdev/shared/src/graphql/features';
 import { useRouter } from 'next/router';
-import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
-import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
-import { SearchExperiment } from '@dailydotdev/shared/src/lib/featureValues';
 import { useActions } from '@dailydotdev/shared/src/hooks/useActions';
 import { ActionType } from '@dailydotdev/shared/src/graphql/actions';
 import { cloudinary } from '@dailydotdev/shared/src/lib/image';
@@ -32,7 +29,6 @@ export function AISearchInvite({
   token,
 }: JoinPageProps): ReactElement {
   const router = useRouter();
-  const search = useFeature(feature.search);
   const { completeAction } = useActions();
   const { trackEvent } = useAnalyticsContext();
   const { displayToast } = useToastNotification();
@@ -81,14 +77,10 @@ export function AISearchInvite({
   };
 
   useEffect(() => {
-    if (search === SearchExperiment.Control) {
-      return;
-    }
-
     router.push(redirectTo);
     // router is an unstable dependency
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [redirectTo, search]);
+  }, [redirectTo]);
 
   return (
     <div className="relative flex h-full min-h-page flex-1 flex-col items-center justify-center overflow-hidden p-6 laptop:items-start">

--- a/packages/webapp/components/layouts/BookmarkFeedPage.tsx
+++ b/packages/webapp/components/layouts/BookmarkFeedPage.tsx
@@ -60,7 +60,6 @@ export function getBookmarkFeedLayout(
 }
 
 export const bookmarkFeedLayoutProps: MainLayoutProps = {
-  greeting: true,
   mainPage: true,
   screenCentered: false,
 };

--- a/packages/webapp/components/layouts/MainFeedPage.tsx
+++ b/packages/webapp/components/layouts/MainFeedPage.tsx
@@ -94,7 +94,6 @@ export function getMainFeedLayout(
 }
 
 export const mainFeedLayoutProps: MainLayoutProps = {
-  greeting: true,
   mainPage: true,
   screenCentered: false,
 };

--- a/packages/webapp/components/layouts/MainFeedPage.tsx
+++ b/packages/webapp/components/layouts/MainFeedPage.tsx
@@ -71,7 +71,6 @@ export default function MainFeedPage({
     <MainFeedLayout
       feedName={feedName}
       isSearchOn={isSearchOn}
-      onFeedPageChanged={(page) => router.replace(`/${page}`)}
       searchQuery={router.query?.q?.toString()}
       isFinder={isFinder}
       searchChildren={searchChildren}

--- a/packages/webapp/components/layouts/MainFooterLayout.tsx
+++ b/packages/webapp/components/layouts/MainFooterLayout.tsx
@@ -21,6 +21,5 @@ export const getLayout = (
 };
 
 export const mainFooterLayoutProps: MainLayoutProps = {
-  greeting: true,
   mainPage: true,
 };

--- a/packages/webapp/components/layouts/SearchLayout.tsx
+++ b/packages/webapp/components/layouts/SearchLayout.tsx
@@ -1,28 +1,14 @@
 import { ReactNode } from 'react';
 import { MainLayoutProps } from '@dailydotdev/shared/src/components/MainLayout';
-import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
-import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
-import { SearchExperiment } from '@dailydotdev/shared/src/lib/featureValues';
 import { getLayout as getMainLayout } from './MainLayout';
-import { getMainFeedLayout, mainFeedLayoutProps } from './MainFeedPage';
 import { getLayout as getFooterNavBarLayout } from './FooterNavBarLayout';
-
-const props: Record<SearchExperiment, Record<string, unknown>> = {
-  control: { ...mainFeedLayoutProps },
-  v1: { screenCentered: false },
-};
 
 export const GetSearchLayout = (
   page: ReactNode,
   pageProps?: Record<string, unknown>,
   layoutProps: MainLayoutProps = {},
 ): ReactNode => {
-  const searchVersion = useFeature(feature.search);
-  const finalProps = { ...props[searchVersion], ...layoutProps };
+  const finalProps = { screenCentered: false, ...layoutProps };
 
-  if (searchVersion === SearchExperiment.V1) {
-    return getFooterNavBarLayout(getMainLayout(page, pageProps, finalProps));
-  }
-
-  return getMainFeedLayout(page, pageProps, finalProps);
+  return getFooterNavBarLayout(getMainLayout(page, pageProps, finalProps));
 };

--- a/packages/webapp/components/search/SearchControlPage.tsx
+++ b/packages/webapp/components/search/SearchControlPage.tsx
@@ -17,10 +17,6 @@ import SettingsContext, {
 } from '@dailydotdev/shared/src/contexts/SettingsContext';
 import styles from '@dailydotdev/shared/src/components/Feed.module.css';
 import FeedContext from '@dailydotdev/shared/src/contexts/FeedContext';
-import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
-import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
-import { SearchExperiment } from '@dailydotdev/shared/src/lib/featureValues';
-import dynamic from 'next/dynamic';
 import { useAnalyticsContext } from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 import { AnalyticsEvent } from '@dailydotdev/shared/src/lib/analytics';
 import {
@@ -34,19 +30,11 @@ const baseSeo: NextSeoProps = {
   ...defaultSeo,
 };
 
-const PostsSearch = dynamic(
-  () =>
-    import(/* webpackChunkName: "routerPostsSearch" */ '../RouterPostsSearch'),
-  { ssr: false },
-);
-
 const Search = (): ReactElement => {
   const router = useRouter();
   const { query } = router;
   const searchQuery = query?.q?.toString();
   const { sidebarExpanded } = useSettingsContext();
-  const searchVersion = useFeature(feature.search);
-  const isV1Search = searchVersion === SearchExperiment.V1;
 
   const seo = useMemo(() => {
     if ('q' in query) {
@@ -62,7 +50,7 @@ const Search = (): ReactElement => {
   return (
     <>
       <NextSeo {...seo} {...baseSeo} />
-      {isV1Search && !searchQuery && (
+      {!searchQuery && (
         <div
           className={classNames(
             'flex w-full max-w-[32rem] flex-col items-center gap-4  self-center px-6',
@@ -87,7 +75,6 @@ const Search = (): ReactElement => {
 };
 
 const AiSearchProviderButton = () => {
-  const searchVersion = useFeature(feature.search);
   const router = useRouter();
   const { trackEvent } = useAnalyticsContext();
   const searchQuery = router.query?.q?.toString();
@@ -100,10 +87,6 @@ const AiSearchProviderButton = () => {
     '--num-cards': !isList ? numCards : undefined,
     '--feed-gap': `${feedGapPx / 16}rem`,
   } as CSSProperties;
-
-  if (searchVersion === SearchExperiment.Control) {
-    return <PostsSearch />;
-  }
 
   if (!searchQuery) {
     return null;

--- a/packages/webapp/pages/history.tsx
+++ b/packages/webapp/pages/history.tsx
@@ -14,9 +14,6 @@ import {
 } from '@dailydotdev/shared/src/components/tabs/TabContainer';
 import { SearchHistory } from '@dailydotdev/shared/src/components';
 import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
-import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
-import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
-import { SearchExperiment } from '@dailydotdev/shared/src/lib/featureValues';
 import { AnalyticsEvent, Origin } from '@dailydotdev/shared/src/lib/analytics';
 import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 import { getLayout } from '../components/layouts/MainLayout';
@@ -25,17 +22,8 @@ import { HistoryType, ReadingHistory } from '../components/history';
 
 const History = (): ReactElement => {
   const { trackEvent } = useContext(AnalyticsContext);
-  const searchValue = useFeature(feature.search);
   const isLaptop = useViewSize(ViewSize.Laptop);
-  const seo = (
-    <NextSeo
-      title={
-        searchValue === SearchExperiment.Control ? 'Reading history' : 'History'
-      }
-      nofollow
-      noindex
-    />
-  );
+  const seo = <NextSeo title="History" nofollow noindex />;
   const router = useRouter();
   const tabQuery = router.query?.t?.toString() as HistoryType;
   const [page, setPage] = useState(HistoryType.Reading);
@@ -68,22 +56,18 @@ const History = (): ReactElement => {
     <ProtectedPage seo={seo}>
       <div className="absolute left-0 top-[6.75rem] flex h-px w-full bg-theme-divider-tertiary laptop:hidden" />
       <ResponsivePageContainer className="relative !p-0" role="main">
-        {searchValue === SearchExperiment.Control ? (
-          <ReadingHistory />
-        ) : (
-          <TabContainer<HistoryType>
-            controlledActive={page}
-            onActiveChange={handleSetPage}
-            showBorder={isLaptop}
-          >
-            <Tab label={HistoryType.Reading}>
-              <ReadingHistory />
-            </Tab>
-            <Tab label={HistoryType.Search}>
-              <SearchHistory origin={Origin.HistoryPage} />
-            </Tab>
-          </TabContainer>
-        )}
+        <TabContainer<HistoryType>
+          controlledActive={page}
+          onActiveChange={handleSetPage}
+          showBorder={isLaptop}
+        >
+          <Tab label={HistoryType.Reading}>
+            <ReadingHistory />
+          </Tab>
+          <Tab label={HistoryType.Search}>
+            <SearchHistory origin={Origin.HistoryPage} />
+          </Tab>
+        </TabContainer>
       </ResponsivePageContainer>
     </ProtectedPage>
   );

--- a/packages/webapp/pages/search/chat/index.tsx
+++ b/packages/webapp/pages/search/chat/index.tsx
@@ -1,32 +1,11 @@
-import React, { ReactElement, useEffect } from 'react';
-import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
-import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
-import { SearchExperiment } from '@dailydotdev/shared/src/lib/featureValues';
-import { useRouter } from 'next/router';
+import React, { ReactElement } from 'react';
 import { withFeaturesBoundary } from '@dailydotdev/shared/src/components';
 import { MainLayoutProps } from '@dailydotdev/shared/src/components/MainLayout';
 import SearchV1Page from '../../../components/search/SearchV1Page';
 import { GetSearchLayout } from '../../../components/layouts/SearchLayout';
 
 const SearchChatPage = (): ReactElement => {
-  const searchVersion = useFeature(feature.search);
-  const router = useRouter();
-
-  useEffect(() => {
-    if (searchVersion === SearchExperiment.Control) {
-      const url = new URL(window.location.href);
-      url.pathname = '/search';
-      url.searchParams.set('provider', 'posts');
-
-      router.replace(url);
-    }
-  }, [searchVersion, router]);
-
-  if (searchVersion === SearchExperiment.V1) {
-    return <SearchV1Page />;
-  }
-
-  return null;
+  return <SearchV1Page />;
 };
 
 SearchChatPage.getLayout = GetSearchLayout;

--- a/packages/webapp/pages/search/posts/index.tsx
+++ b/packages/webapp/pages/search/posts/index.tsx
@@ -4,22 +4,14 @@ import {
   SearchProviderEnum,
   getSearchUrl,
 } from '@dailydotdev/shared/src/graphql/search';
-import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
-import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
-import { SearchExperiment } from '@dailydotdev/shared/src/lib/featureValues';
 import { withFeaturesBoundary } from '@dailydotdev/shared/src/components';
 import SearchControlPage from '../../../components/search/SearchControlPage';
 
 const SearchPostsPage = (): ReactElement => {
-  const searchVersion = useFeature(feature.search);
   const router = useRouter();
   const { id, provider } = router.query;
 
   useEffect(() => {
-    if (searchVersion === SearchExperiment.Control) {
-      return;
-    }
-
     if (id && provider !== SearchProviderEnum.Chat) {
       router.replace(
         getSearchUrl({
@@ -28,7 +20,7 @@ const SearchPostsPage = (): ReactElement => {
         }),
       );
     }
-  }, [id, provider, router, searchVersion]);
+  }, [id, provider, router]);
 
   return <SearchControlPage />;
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Cleanup winnig search experiment.
- @capJavert Greeting not really used now, but left the actual component as it's lazy loaded

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-141 #done
