### PR TITLE
chore: add missing tooltip for devcard theme buttons

### DIFF
--- a/packages/webapp/pages/devcard.tsx
+++ b/packages/webapp/pages/devcard.tsx
@@ -408,18 +408,20 @@ const Step2 = ({ initialDevCardSrc }: Step2Props): ReactElement => {
                         <SimpleTooltip
                           key={value}
                           content={
-                            isLocked
-                              ? `Earn ${requiredPoints[value]} reputation points to unlock this theme`
-                              : null
+                            isLocked ? (
+                              `Earn ${requiredPoints[value]} reputation points to unlock ${value} theme`
+                            ) : (
+                              <span className="capitalize">{value}</span>
+                            )
                           }
                         >
-                          <span>
+                          <span className="mb-3 mr-3">
                             <button
                               disabled={isLocked || isLoading}
                               type="button"
                               aria-label={`Select ${value} theme`}
                               className={classNames(
-                                'mb-3 mr-3 h-10 w-10 rounded-full',
+                                'h-10 w-10 rounded-full',
                                 isLocked && 'opacity-32',
                                 checkLowercaseEquality(theme, value) &&
                                   'border-4 border-theme-color-cabbage',


### PR DESCRIPTION
## Changes

- add missing tooltip for devcard theme buttons
- centered the tooltip, since it was off center before

### Before
<img width="517" alt="Screenshot 2024-02-26 at 16 53 07" src="https://github.com/dailydotdev/apps/assets/9974711/129f899c-7ca7-4ffe-8194-48ad0f5d1151">


### After
<img width="559" alt="Screenshot 2024-02-26 at 16 53 21" src="https://github.com/dailydotdev/apps/assets/9974711/b6e61b96-a001-4f95-b9f3-cf1cecc9a1f6">
<img width="436" alt="Screenshot 2024-02-26 at 16 53 31" src="https://github.com/dailydotdev/apps/assets/9974711/19a548bc-64f7-4ff3-b928-bd89a4d5a085">


## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
