### PR TITLE
fix: recovery flow

### DIFF
--- a/packages/shared/src/components/auth/CodeVerificationForm.tsx
+++ b/packages/shared/src/components/auth/CodeVerificationForm.tsx
@@ -11,7 +11,6 @@ import { AuthEventNames } from '../../lib/auth';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 import AuthForm from './AuthForm';
 import { KeyIcon } from '../icons';
-import { AnalyticsEvent, TargetType } from '../../lib/analytics';
 
 interface CodeVerificationFormProps extends AuthFormProps {
   initialEmail: string;

--- a/packages/shared/src/components/auth/CodeVerificationForm.tsx
+++ b/packages/shared/src/components/auth/CodeVerificationForm.tsx
@@ -32,7 +32,7 @@ function CodeVerificationForm({
   const [emailSent, setEmailSent] = useState(false);
   const { sendEmail, verifyCode, resendTimer, isLoading } = useAccountEmailFlow(
     {
-      flow: AuthFlow.Verification,
+      flow: AuthFlow.Recovery,
       flowId: initialFlow,
       onTimerFinished: () => setEmailSent(false),
       onError: setHint,
@@ -40,9 +40,6 @@ function CodeVerificationForm({
         setEmailSent(true);
       },
       onVerifyCodeSuccess: () => {
-        trackEvent({
-          event_name: AuthEventNames.VerifiedSuccessfully,
-        });
         onSubmit();
       },
     },
@@ -51,8 +48,7 @@ function CodeVerificationForm({
   const onCodeVerification = async (e) => {
     e.preventDefault();
     trackEvent({
-      event_name: AnalyticsEvent.Click,
-      target_type: TargetType.VerifyEmail,
+      event_name: AuthEventNames.SubmitForgotPassword,
     });
     setHint('');
     const { code } = formToJson<{ code: string }>(e.currentTarget);
@@ -61,8 +57,7 @@ function CodeVerificationForm({
 
   const onSendEmail = async () => {
     trackEvent({
-      event_name: AnalyticsEvent.Click,
-      target_type: TargetType.ResendVerificationCode,
+      event_name: AuthEventNames.SubmitForgotPassword,
     });
     await sendEmail(initialEmail);
   };

--- a/packages/shared/src/hooks/useAccountEmailFlow.ts
+++ b/packages/shared/src/hooks/useAccountEmailFlow.ts
@@ -44,6 +44,11 @@ interface UseAccountEmailProps {
 
 type EmailFlow = AuthFlow.Recovery | AuthFlow.Verification;
 
+const FlowActionURLs: Record<EmailFlow, string> = {
+  [AuthFlow.Recovery]: `${authUrl}/self-service/recovery?flow=`,
+  [AuthFlow.Verification]: `${authUrl}/self-service/verification?flow=`,
+};
+
 function useAccountEmailFlow({
   flow,
   flowId,
@@ -129,12 +134,13 @@ function useAccountEmailFlow({
   const { mutateAsync: verifyCode } = useMutation(
     ({ code, altFlowId }: { code: string; altFlowId?: string }) =>
       submitKratosFlow({
-        action: `${authUrl}/self-service/verification?flow=${
-          altFlowId ?? activeFlow
-        }`,
+        action: FlowActionURLs[flow] + (altFlowId ?? activeFlow),
         params: {
           code,
           method: 'code',
+          ...(flow === AuthFlow.Recovery && {
+            csrf_token: getNodeValue('csrf_token', emailFlow.ui.nodes),
+          }),
         },
       } as VerifyEmail),
     {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- With introducing the one-stop code flows we overwritten some of the recovery flow logic.
- This reintroduces/cleans this logic
- Verified locally all code flows work + all signups work

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
