### PR TITLE
fix: profile button flicker

### DIFF
--- a/packages/shared/src/components/profile/ProfileButton.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.tsx
@@ -52,7 +52,7 @@ export default function ProfileButton({
               }}
               disableTooltip
             />
-            <ProfilePicture user={user} size="large" />
+            <ProfilePicture user={user} size="large" nativeLazyLoading />
           </button>
         </SimpleTooltip>
       )}

--- a/packages/webapp/__tests__/MainLayout.tsx
+++ b/packages/webapp/__tests__/MainLayout.tsx
@@ -43,7 +43,7 @@ describe('MainLayout', () => {
       infoConfirmed: true,
     });
     const [el] = await screen.findAllByAltText(`idoshamun's profile`);
-    expect(el).toHaveAttribute('data-src', 'https://daily.dev/ido.png');
+    expect(el).toHaveAttribute('src', 'https://daily.dev/ido.png');
     expect(await screen.findAllByText('5')).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Changes
- Sorry I can't take it anymore, I am being bothered by the flickering profile button on the header 😅 
- There seems to be an issue with our legacy lazy loading component.
- For context: we are moving away from it, and trying to utilize the native lazy loading feature.

Deployed at preview: https://preview.app.daily.dev/

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
