### PR TITLE
fix: ensure footer renders on brave browser

### DIFF
--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -122,7 +122,7 @@ export default function FooterNavBar({
   };
 
   return (
-    <div className="fixed bottom-0 left-0 z-2 w-full">
+    <div className="fixed !bottom-0 left-0 z-2 w-full">
       <ScrollToTopButton />
       <Flipper
         flipKey={selectedTab}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Not the biggest fan of the fix, but apparently brave injects this user agent styling:
![Screenshot 2024-02-28 at 11 10 04](https://github.com/dailydotdev/apps/assets/554874/b0d87cc9-35b7-42d6-b5c0-eb5149a9da6c)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
