### PR TITLE
fix: change condition to show streak record modal

### DIFF
--- a/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
+++ b/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
@@ -12,11 +12,12 @@ const Paragraph = classed('p', 'text-center text-theme-label-tertiary');
 
 export default function NewStreakModal({
   currentStreak,
+  maxStreak,
   onRequestClose,
   ...props
 }: StreakModalProps): ReactElement {
   const { toggleOptOutWeeklyGoal, optOutWeeklyGoal } = useSettingsContext();
-  const shouldShowSplash = currentStreak > 20;
+  const shouldShowSplash = currentStreak >= maxStreak;
 
   return (
     <Modal

--- a/packages/shared/src/components/modals/streaks/common.ts
+++ b/packages/shared/src/components/modals/streaks/common.ts
@@ -1,5 +1,7 @@
+import { UserStreak } from '../../../graphql/users';
 import { LazyModalCommonProps } from '../common/Modal';
 
 export interface StreakModalProps extends LazyModalCommonProps {
-  currentStreak: number;
+  currentStreak: UserStreak['current'];
+  maxStreak: UserStreak['max'];
 }

--- a/packages/shared/src/hooks/streaks/useStreakMilestone.ts
+++ b/packages/shared/src/hooks/streaks/useStreakMilestone.ts
@@ -36,6 +36,7 @@ export const useStreakMilestone = (): void => {
       type: modalType,
       props: {
         currentStreak: streak?.current,
+        maxStreak: streak?.max,
         onAfterClose: () => {
           updateAlerts({ showStreakMilestone: false });
         },


### PR DESCRIPTION
## Changes

<img width="435" alt="Screenshot 2024-02-29 at 13 15 26" src="https://github.com/dailydotdev/apps/assets/9974711/b3be55ef-3670-49bb-bbd0-4f5a96c506b6">

New streak record modal is shown whenever the currentStreak >= maxStreak

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-192 #done
