### PR TITLE
fix: use loading state instead of fetched to handle error state

### DIFF
--- a/packages/shared/src/hooks/useActions.ts
+++ b/packages/shared/src/hooks/useActions.ts
@@ -21,7 +21,7 @@ export const useActions = (): UseActions => {
   const client = useQueryClient();
   const { user } = useAuthContext();
   const actionsKey = generateQueryKey(RequestKey.Actions, user);
-  const { data: actions, isFetched: isActionsFetched } = useQuery(
+  const { data: actions, isLoading } = useQuery(
     actionsKey,
     async () => {
       const data = await getUserActions();
@@ -39,6 +39,8 @@ export const useActions = (): UseActions => {
     },
     { enabled: !!user, ...disabledRefetch },
   );
+  const isActionsFetched = !isLoading;
+
   const { mutateAsync: completeAction } = useMutation(completeUserAction, {
     onMutate: (type) => {
       client.setQueryData<Action[]>(actionsKey, (data) => {


### PR DESCRIPTION
## Changes

### Describe what this PR does

On logout (or if actions failed to fetch for any reason) the `isFetched` would be `true`. Which would mean logic that relies on actions being fetched so it can use `checkHasCompleted` would get falsy value which would then trigger any kind of logic as if action was not completed.

Example on reputation popup:
- user gets logged out
- after logout redirect actions still get to be fetched once (they fail because user is no longer authenticated)
- query is in error state but isFetched is true (because query did fetch once, no matter if it failed or not)
- logic checks `ack_rep_250` was completed, gets falsy and shows the modal

Fix uses `isLoading` instead of `isFetched` because `state.loading` for `useQuery` makes sure that query was once fetched succesfully or has cached data. 
<img width="701" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/679b8ad7-5411-429d-bda7-267279dc9c62">

I think generally in 99% of the cases for `useQuery` we want to use `isLoading` instead of `isFetched`. So might be something to consider when adding new stuff. 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
