### PR TITLE
fix: add missing tooltip for weekend days

### DIFF
--- a/packages/shared/src/components/streak/popup/DayStreak.tsx
+++ b/packages/shared/src/components/streak/popup/DayStreak.tsx
@@ -4,6 +4,7 @@ import { ReadingStreakIcon, TriangleArrowIcon } from '../../icons';
 import classed from '../../../lib/classed';
 import { IconSize, iconSizeToClassName } from '../../Icon';
 import { isNullOrUndefined } from '../../../lib/func';
+import { WithSimpleTooltip } from '../../tooltips';
 
 export enum Streak {
   Completed = 'completed',
@@ -58,15 +59,25 @@ export function DayStreak({
   const finalDay = day < 7 ? day : day % 7;
 
   return (
-    <div className="relative flex flex-col items-center gap-1">
-      {shouldShowArrow && (
-        <TriangleArrowIcon
-          className="absolute -top-4 text-theme-color-bacon"
-          size={IconSize.XXSmall}
-        />
-      )}
-      {renderIcon()}
-      {!isNullOrUndefined(day) ? dayInitial[finalDay] : null}
-    </div>
+    <WithSimpleTooltip
+      show={streak === Streak.Freeze}
+      content="We auto-freeze streaks during the weekend, but you can still keep going if you want to"
+      placement="bottom"
+      container={{
+        className: 'max-w-44 text-center',
+        paddingClassName: 'p-2',
+      }}
+    >
+      <div className="relative flex flex-col items-center gap-1">
+        {shouldShowArrow && (
+          <TriangleArrowIcon
+            className="absolute -top-4 text-theme-color-bacon"
+            size={IconSize.XXSmall}
+          />
+        )}
+        {renderIcon()}
+        {!isNullOrUndefined(day) ? dayInitial[finalDay] : null}
+      </div>
+    </WithSimpleTooltip>
   );
 }

--- a/packages/shared/src/components/streak/popup/DayStreak.tsx
+++ b/packages/shared/src/components/streak/popup/DayStreak.tsx
@@ -4,7 +4,7 @@ import { ReadingStreakIcon, TriangleArrowIcon } from '../../icons';
 import classed from '../../../lib/classed';
 import { IconSize, iconSizeToClassName } from '../../Icon';
 import { isNullOrUndefined } from '../../../lib/func';
-import { WithSimpleTooltip } from '../../tooltips';
+import { SimpleTooltip } from '../../tooltips';
 
 export enum Streak {
   Completed = 'completed',
@@ -59,7 +59,7 @@ export function DayStreak({
   const finalDay = day < 7 ? day : day % 7;
 
   return (
-    <WithSimpleTooltip
+    <SimpleTooltip
       show={streak === Streak.Freeze}
       content="We auto-freeze streaks during the weekend, but you can still keep going if you want to"
       placement="bottom"
@@ -78,6 +78,6 @@ export function DayStreak({
         {renderIcon()}
         {!isNullOrUndefined(day) ? dayInitial[finalDay] : null}
       </div>
-    </WithSimpleTooltip>
+    </SimpleTooltip>
   );
 }

--- a/packages/shared/src/components/tooltips/SimpleTooltip.tsx
+++ b/packages/shared/src/components/tooltips/SimpleTooltip.tsx
@@ -13,13 +13,14 @@ const TippyTooltip = dynamicParent<TooltipProps>(
 );
 
 export function SimpleTooltip({
+  show = true,
   children,
   content,
   onTrigger,
   onShow,
   forceLoad,
   ...props
-}: TooltipProps): ReactElement {
+}: TooltipProps & { show?: boolean }): ReactElement {
   /**
    * We introduced the `shouldShow` variable to manage a re-focus issue
    * The old implementation would re-focus the tooltip whenever a modal would close
@@ -64,6 +65,10 @@ export function SimpleTooltip({
     return false;
   };
 
+  if (!show) {
+    return component;
+  }
+
   return (
     <TippyTooltip
       {...props}
@@ -77,14 +82,5 @@ export function SimpleTooltip({
     </TippyTooltip>
   );
 }
-
-export const WithSimpleTooltip = ({
-  show,
-  children,
-  ...props
-}: TooltipProps & {
-  show: boolean;
-}): JSX.Element =>
-  show ? <SimpleTooltip {...props}>{children}</SimpleTooltip> : children;
 
 export default SimpleTooltip;

--- a/packages/shared/src/components/tooltips/SimpleTooltip.tsx
+++ b/packages/shared/src/components/tooltips/SimpleTooltip.tsx
@@ -78,4 +78,13 @@ export function SimpleTooltip({
   );
 }
 
+export const WithSimpleTooltip = ({
+  show,
+  children,
+  ...props
+}: TooltipProps & {
+  show: boolean;
+}): JSX.Element =>
+  show ? <SimpleTooltip {...props}>{children}</SimpleTooltip> : children;
+
 export default SimpleTooltip;


### PR DESCRIPTION
## Changes

![image](https://github.com/dailydotdev/apps/assets/1681525/5fa5a67c-11bf-4383-ab35-f968037d34f2)


### Describe what this PR does
- Added tooltips for weekend days

MI-194
