### PR TITLE
fix: hide old rank progress if we show reading streak

### DIFF
--- a/packages/shared/src/components/sidebar/SidebarBottomSection.tsx
+++ b/packages/shared/src/components/sidebar/SidebarBottomSection.tsx
@@ -7,6 +7,7 @@ import { Section, SectionCommonProps } from './Section';
 import { docs, feedback } from '../../lib/constants';
 import { useChangelog } from '../../hooks/useChangelog';
 import { AlertColor, AlertDot } from '../AlertDot';
+import { useReadingStreak, useStreakExperiment } from '../../hooks/streaks';
 
 const ChangelogTooltip = dynamic(
   () =>
@@ -26,6 +27,7 @@ export function SidebarBottomSection({
   ...props
 }: SidebarBottomSectionProps): ReactElement {
   const changelog = useChangelog();
+  const { shouldShowStreak } = useStreakExperiment();
 
   const bottomMenuItems: SidebarMenuItem[] = [
     {
@@ -54,7 +56,7 @@ export function SidebarBottomSection({
   return (
     <Nav>
       <Section {...props} items={bottomMenuItems} isItemsButton={false} />
-      {props.sidebarExpanded && !optOutWeeklyGoal && (
+      {!shouldShowStreak && props.sidebarExpanded && !optOutWeeklyGoal && (
         <SidebarRankProgress {...props} disableNewRankPopup={showSettings} />
       )}
       {changelog.isAvailable && <ChangelogTooltip />}

--- a/packages/shared/src/components/sidebar/SidebarBottomSection.tsx
+++ b/packages/shared/src/components/sidebar/SidebarBottomSection.tsx
@@ -7,7 +7,7 @@ import { Section, SectionCommonProps } from './Section';
 import { docs, feedback } from '../../lib/constants';
 import { useChangelog } from '../../hooks/useChangelog';
 import { AlertColor, AlertDot } from '../AlertDot';
-import { useReadingStreak, useStreakExperiment } from '../../hooks/streaks';
+import { useStreakExperiment } from '../../hooks/streaks';
 
 const ChangelogTooltip = dynamic(
   () =>

--- a/packages/webapp/pages/[userId]/index.tsx
+++ b/packages/webapp/pages/[userId]/index.tsx
@@ -17,6 +17,7 @@ import {
 } from '@dailydotdev/shared/src/lib/query';
 import { Readme } from '@dailydotdev/shared/src/components/profile/Readme';
 import { useProfile } from '@dailydotdev/shared/src/hooks/profile/useProfile';
+import { useStreakExperiment } from '@dailydotdev/shared/src/hooks/streaks';
 import {
   getLayout as getProfileLayout,
   getStaticPaths as getProfileStaticPaths,
@@ -29,6 +30,7 @@ const ProfilePage = ({
   user: initialUser,
 }: ProfileLayoutProps): ReactElement => {
   const { tokenRefreshed } = useContext(AuthContext);
+  const { shouldShowStreak } = useStreakExperiment();
 
   const {
     selectedHistoryYear,
@@ -64,12 +66,14 @@ const ProfilePage = ({
       <Readme user={user} />
       {readingHistory?.userReadingRankHistory && (
         <>
-          <RanksWidget
-            rankHistory={readingHistory?.userReadingRankHistory}
-            yearOptions={yearOptions}
-            selectedHistoryYear={selectedHistoryYear}
-            setSelectedHistoryYear={setSelectedHistoryYear}
-          />
+          {!shouldShowStreak && (
+            <RanksWidget
+              rankHistory={readingHistory?.userReadingRankHistory}
+              yearOptions={yearOptions}
+              selectedHistoryYear={selectedHistoryYear}
+              setSelectedHistoryYear={setSelectedHistoryYear}
+            />
+          )}
           <ReadingTagsWidget mostReadTags={readingHistory?.userMostReadTags} />
           <ReadingHeatmapWidget
             fullHistory={fullHistory}


### PR DESCRIPTION
## Changes

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/c61b2f5e-9cfa-46be-b8a4-92a39367494f">
 <td><img src=https://github.com/dailydotdev/apps/assets/1681525/b4024b9e-99c2-4fb3-b7e6-0abcdb2faf70>

</table>

### Describe what this PR does
- Hides the old rank progress from sidebar if part of streaks experiment
- Hides the old rank progress from profile page if part of streaks experiment

MI-196
