### PR TITLE
fix: pluralisation of `day`

### DIFF
--- a/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
+++ b/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
@@ -19,6 +19,8 @@ export default function NewStreakModal({
   const { toggleOptOutWeeklyGoal, optOutWeeklyGoal } = useSettingsContext();
   const shouldShowSplash = currentStreak >= maxStreak;
 
+  const daysPlural = currentStreak === 1 ? 'days' : 'day';
+
   return (
     <Modal
       {...props}
@@ -58,7 +60,7 @@ export default function NewStreakModal({
         >
           {shouldShowSplash
             ? 'New streak record!'
-            : `${currentStreak} days streak`}
+            : `${currentStreak} ${daysPlural} streak`}
         </strong>
         <Paragraph
           className={classNames(

--- a/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
+++ b/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
@@ -19,7 +19,7 @@ export default function NewStreakModal({
   const { toggleOptOutWeeklyGoal, optOutWeeklyGoal } = useSettingsContext();
   const shouldShowSplash = currentStreak >= maxStreak;
 
-  const daysPlural = currentStreak === 1 ? 'days' : 'day';
+  const daysPlural = currentStreak === 1 ? 'day' : 'days';
 
   return (
     <Modal

--- a/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
+++ b/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
@@ -69,7 +69,7 @@ export default function NewStreakModal({
           )}
         >
           {shouldShowSplash
-            ? 'Epic win! You are on a league of your own'
+            ? 'Epic win! You are in a league of your own'
             : `New milestone reached! You are unstoppable.`}
         </Paragraph>
         <Checkbox


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixed pluralisation of `days`
- Fixed typo in `in a league`

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td>
	<img src=https://github.com/dailydotdev/apps/assets/1681525/4ff22c50-f617-4a7b-b1fb-9e3adcd92185>
	<img src=https://github.com/dailydotdev/apps/assets/1681525/af7c0027-1335-403f-8e53-0265dd11cd98>

 <td>
	<img src=https://github.com/dailydotdev/apps/assets/1681525/17b6d6fc-dc8f-4b0c-9fda-f2bfc78e0d5a>
	<img src=https://github.com/dailydotdev/apps/assets/1681525/37b5121e-14e3-44fd-aeb5-76ee1de969c2>
</table>

MI-199