### PR TITLE
fix: use the correct icon if the user has read an article today

### DIFF
--- a/packages/shared/src/components/streak/ReadingStreakButton.tsx
+++ b/packages/shared/src/components/streak/ReadingStreakButton.tsx
@@ -13,6 +13,8 @@ export function ReadingStreakButton({
   streak,
 }: ReadingStreakButtonProps): ReactElement {
   const [shouldShowStreaks, setShouldShowStreaks] = useState(false);
+  const hasReadToday =
+    new Date(streak.lastViewAt).getDate() === new Date().getDate();
 
   return (
     <SimpleTooltip
@@ -30,7 +32,7 @@ export function ReadingStreakButton({
     >
       <Button
         type="button"
-        icon={<ReadingStreakIcon />}
+        icon={<ReadingStreakIcon secondary={hasReadToday} />}
         variant={ButtonVariant.Float}
         onClick={() => setShouldShowStreaks((state) => !state)}
         className="gap-1 text-theme-color-bacon"


### PR DESCRIPTION
- in other words, if their streak is active

<img width="547" alt="Screenshot 2024-03-01 at 10 37 48" src="https://github.com/dailydotdev/apps/assets/1225100/4badba69-49bf-4771-a5ea-f12c8a832264">

## Events

n / a

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-193 #done
