### PR TITLE
fix: adjust mobile layout as per design when streaks are enabled

### DIFF
--- a/packages/shared/src/components/layout/HeaderLogo.tsx
+++ b/packages/shared/src/components/layout/HeaderLogo.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { LoggedUser } from '../../lib/user';
-import Logo from '../Logo';
+import Logo, { LogoPosition } from '../Logo';
 
 const Greeting = dynamic(
   () => import(/* webpackChunkName: "greeting" */ '../Greeting'),
@@ -11,18 +11,24 @@ interface HeaderLogoProps {
   user?: LoggedUser;
   greeting?: boolean;
   onLogoClick?: (e: React.MouseEvent) => unknown;
+  position?: LogoPosition;
 }
 
 function HeaderLogo({
   user,
   greeting,
   onLogoClick,
+  position,
 }: HeaderLogoProps): ReactElement {
   const [showGreeting, setShowGreeting] = useState(false);
 
   return (
     <>
-      <Logo onLogoClick={onLogoClick} showGreeting={showGreeting} />
+      <Logo
+        position={position}
+        onLogoClick={onLogoClick}
+        showGreeting={showGreeting}
+      />
       {greeting && (
         <Greeting
           user={user}

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -23,6 +23,7 @@ import { CreatePostButton } from '../post/write';
 import { useViewSize, ViewSize } from '../../hooks';
 import { ReadingStreakButton } from '../streak/ReadingStreakButton';
 import { useReadingStreak } from '../../hooks/streaks';
+import { LogoPosition } from '../Logo';
 
 export interface MainLayoutHeaderProps {
   hasBanner?: boolean;
@@ -51,9 +52,10 @@ function MainLayoutHeader({
   const { trackEvent } = useAnalyticsContext();
   const { unreadCount } = useNotificationContext();
   const { user, loadingUser } = useContext(AuthContext);
-  const { streak, isEnabled, isLoading } = useReadingStreak();
-  const hideButton = loadingUser || (isEnabled && isLoading);
+  const { streak, isEnabled: isStreaksEnabled, isLoading } = useReadingStreak();
+  const hideButton = loadingUser || (isStreaksEnabled && isLoading);
   const isMobile = useViewSize(ViewSize.MobileL);
+  const isStreakLarge = streak?.current > 99; // if we exceed 100, we need to display it differently in the UI
   const router = useRouter();
   const isSearchPage = !!router.pathname?.startsWith('/search');
 
@@ -86,8 +88,8 @@ function MainLayoutHeader({
   const RenderButtons = () => {
     return (
       <div className="flex gap-3">
-        <CreatePostButton />
         {streak && <ReadingStreakButton streak={streak} />}
+        <CreatePostButton compact={isStreaksEnabled} />
         {!hideButton && user && (
           <>
             <LinkWithTooltip
@@ -119,9 +121,10 @@ function MainLayoutHeader({
         )}
         {additionalButtons}
         {headerButton}
-        {!sidebarRendered && !optOutWeeklyGoal && !isMobile && (
-          <MobileHeaderRankProgress />
-        )}
+        {!isStreaksEnabled &&
+          !sidebarRendered &&
+          !optOutWeeklyGoal &&
+          !isMobile && <MobileHeaderRankProgress />}
       </div>
     );
   };
@@ -129,7 +132,8 @@ function MainLayoutHeader({
   return (
     <header
       className={classNames(
-        'sticky top-0 z-header flex h-14 flex-row items-center justify-between gap-3 border-b border-theme-divider-tertiary bg-theme-bg-primary px-4 py-3 tablet:px-8 laptop:left-0 laptop:h-16 laptop:w-full laptop:flex-row laptop:px-4',
+        'sticky top-0 z-header flex h-14 flex-row items-center gap-3 border-b border-theme-divider-tertiary bg-theme-bg-primary px-4 py-3 tablet:px-8 laptop:left-0 laptop:h-16 laptop:w-full laptop:flex-row laptop:px-4',
+        isStreakLarge ? 'justify-start' : 'justify-between',
         hasBanner && 'laptop:top-8',
         isSearchPage && 'mb-16 laptop:mb-0',
       )}
@@ -142,8 +146,18 @@ function MainLayoutHeader({
             onClick={() => onMobileSidebarToggle(true)}
             icon={<HamburgerIcon secondary />}
           />
-          <div className="flex flex-1 justify-center laptop:flex-none laptop:justify-start">
+          <div
+            className={classNames(
+              'flex flex-1  laptop:flex-none laptop:justify-start',
+              isStreakLarge ? 'justify-start' : 'justify-center',
+            )}
+          >
             <HeaderLogo
+              position={
+                isStreaksEnabled && isStreakLarge
+                  ? LogoPosition.Relative
+                  : LogoPosition.Absolute
+              }
               user={user}
               onLogoClick={onLogoClick}
               greeting={false}

--- a/packages/shared/src/components/post/write/CreatePostButton.tsx
+++ b/packages/shared/src/components/post/write/CreatePostButton.tsx
@@ -6,13 +6,16 @@ import { useSquad, useViewSize, ViewSize } from '../../../hooks';
 import { verifyPermission } from '../../../graphql/squads';
 import { SourcePermissions } from '../../../graphql/sources';
 import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
+import { PlusIcon } from '../../icons';
 
 interface CreatePostButtonProps {
   className?: string;
+  compact?: boolean;
 }
 
 export function CreatePostButton({
   className,
+  compact,
 }: CreatePostButtonProps): ReactElement {
   const { user, isAuthReady, squads } = useAuthContext();
   const { route, query } = useRouter();
@@ -45,6 +48,7 @@ export function CreatePostButton({
       variant={ButtonVariant.Secondary}
       className={className}
       disabled={getIsDisabled()}
+      icon={compact && !isLaptop && <PlusIcon />}
       tag="a"
       href={
         link.post.create +
@@ -52,7 +56,7 @@ export function CreatePostButton({
       }
       size={isLaptop ? ButtonSize.Medium : ButtonSize.Small}
     >
-      New post
+      {!compact || isLaptop ? 'New post' : null}
     </Button>
   );
 }

--- a/packages/shared/src/components/streak/ReadingStreakButton.tsx
+++ b/packages/shared/src/components/streak/ReadingStreakButton.tsx
@@ -1,9 +1,10 @@
 import React, { ReactElement, useState } from 'react';
 import { ReadingStreakPopup } from './popup';
-import { Button, ButtonVariant } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { ReadingStreakIcon } from '../icons';
 import { SimpleTooltip } from '../tooltips';
 import { UserStreak } from '../../graphql/users';
+import { useViewSize, ViewSize } from '../../hooks';
 
 interface ReadingStreakButtonProps {
   streak: UserStreak;
@@ -12,6 +13,7 @@ interface ReadingStreakButtonProps {
 export function ReadingStreakButton({
   streak,
 }: ReadingStreakButtonProps): ReactElement {
+  const isLaptop = useViewSize(ViewSize.Laptop);
   const [shouldShowStreaks, setShouldShowStreaks] = useState(false);
   const hasReadToday =
     new Date(streak.lastViewAt).getDate() === new Date().getDate();
@@ -36,6 +38,7 @@ export function ReadingStreakButton({
         variant={ButtonVariant.Float}
         onClick={() => setShouldShowStreaks((state) => !state)}
         className="gap-1 text-theme-color-bacon"
+        size={isLaptop ? ButtonSize.Medium : ButtonSize.Small}
       >
         {streak?.current}
       </Button>


### PR DESCRIPTION
## Changes

| small streak | large streak |
| ------------ | ------------ |
| <img width="392" alt="Screenshot 2024-03-03 at 14 07 55" src="https://github.com/dailydotdev/apps/assets/1225100/64f78124-e3a1-4b72-98e4-706c1566401f"> |  <img width="392" alt="Screenshot 2024-03-03 at 14 08 38" src="https://github.com/dailydotdev/apps/assets/1225100/98c4bc9b-8f29-4107-93c8-b777925182c9">
 |

## Events

N / A

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-198 #done
