### PR TITLE
fix: truncate usernames in comment boxes

### DIFF
--- a/packages/shared/src/components/cards/PostMetadata.tsx
+++ b/packages/shared/src/components/cards/PostMetadata.tsx
@@ -48,7 +48,9 @@ export default function PostMetadata({
           className="my-auto mr-1 text-theme-label-primary"
         />
       )}
-      {!!description && <TruncateText>{description}</TruncateText>}
+      {!!description && (
+        <TruncateText title={description}>{description}</TruncateText>
+      )}
       {!!createdAt && !!description && <Separator />}
       {!!createdAt && <time dateTime={createdAt}>{date}</time>}
       {!!createdAt && showReadTime && <Separator />}

--- a/packages/shared/src/components/cards/PostMetadata.tsx
+++ b/packages/shared/src/components/cards/PostMetadata.tsx
@@ -5,7 +5,7 @@ import { Separator } from './common';
 import { Post } from '../../graphql/posts';
 import { PlayIcon } from '../icons';
 import { IconSize } from '../Icon';
-import { formatReadTime } from '../utilities';
+import { TruncateText, formatReadTime } from '../utilities';
 
 interface PostMetadataProps
   extends Pick<Post, 'createdAt' | 'readTime' | 'numUpvotes'> {
@@ -48,7 +48,7 @@ export default function PostMetadata({
           className="my-auto mr-1 text-theme-label-primary"
         />
       )}
-      {!!description && <span>{description}</span>}
+      {!!description && <TruncateText>{description}</TruncateText>}
       {!!createdAt && !!description && <Separator />}
       {!!createdAt && <time dateTime={createdAt}>{date}</time>}
       {!!createdAt && showReadTime && <Separator />}

--- a/packages/shared/src/components/cards/common/SquadPostCardHeader.tsx
+++ b/packages/shared/src/components/cards/common/SquadPostCardHeader.tsx
@@ -32,7 +32,7 @@ export const SquadPostCardHeader = ({
   };
 
   return (
-    <div className="relative m-2 flex flex-row gap-2">
+    <div className="relative m-2 flex gap-2">
       <div className="relative">
         {author && (
           <ProfilePicture
@@ -48,8 +48,10 @@ export const SquadPostCardHeader = ({
           size={enableSourceHeader ? 'large' : 'xsmall'}
         />
       </div>
-      <div className="ml-2 mr-6 flex flex-1 flex-grow flex-col typo-footnote">
-        <span className="line-clamp-2 font-bold">{getHeaderName()}</span>
+      <div className="ml-2 mr-6 flex flex-1 flex-col overflow-auto typo-footnote">
+        <span className="line-clamp-2 break-words font-bold">
+          {getHeaderName()}
+        </span>
         <PostMetadata
           className="line-clamp-1 break-words"
           createdAt={createdAt}

--- a/packages/shared/src/components/cards/common/SquadPostCardHeader.tsx
+++ b/packages/shared/src/components/cards/common/SquadPostCardHeader.tsx
@@ -49,7 +49,10 @@ export const SquadPostCardHeader = ({
         />
       </div>
       <div className="ml-2 mr-6 flex flex-1 flex-col overflow-auto typo-footnote">
-        <span className="line-clamp-2 break-words font-bold">
+        <span
+          className="line-clamp-2 break-words font-bold"
+          title={getHeaderName()}
+        >
           {getHeaderName()}
         </span>
         <PostMetadata

--- a/packages/shared/src/components/comments/CommentAuthor.tsx
+++ b/packages/shared/src/components/comments/CommentAuthor.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { Author } from '../../graphql/comments';
 import { ProfileLink } from '../profile/ProfileLink';
 import { ProfileTooltip } from '../profile/ProfileTooltip';
+import { TruncateText } from '../utilities';
 
 export interface CommentAuthorProps {
   author: Author;
@@ -24,7 +25,7 @@ export default function CommentAuthor({
           className,
         )}
       >
-        <span className="max-w-full truncate">{author.name}</span>
+        <TruncateText>{author.name}</TruncateText>
       </ProfileLink>
     </ProfileTooltip>
   );

--- a/packages/shared/src/components/comments/CommentAuthor.tsx
+++ b/packages/shared/src/components/comments/CommentAuthor.tsx
@@ -8,26 +8,23 @@ export interface CommentAuthorProps {
   author: Author;
   className?: string;
   appendTooltipTo?: () => HTMLElement;
-  badges?: ReactElement[];
 }
 
 export default function CommentAuthor({
   author,
   className,
   appendTooltipTo,
-  badges,
 }: CommentAuthorProps): ReactElement {
   return (
     <ProfileTooltip user={author} tooltip={{ appendTo: appendTooltipTo }}>
       <ProfileLink
         href={author.permalink}
         className={classNames(
-          'commentAuthor w-fit overflow-hidden whitespace-nowrap font-bold text-theme-label-primary typo-callout',
+          'commentAuthor w-fit font-bold text-theme-label-primary typo-callout',
           className,
         )}
       >
-        {author.name}
-        {badges}
+        <span className="max-w-full truncate">{author.name}</span>
       </ProfileLink>
     </ProfileTooltip>
   );

--- a/packages/shared/src/components/comments/CommentAuthor.tsx
+++ b/packages/shared/src/components/comments/CommentAuthor.tsx
@@ -24,6 +24,7 @@ export default function CommentAuthor({
           'commentAuthor w-fit font-bold text-theme-label-primary typo-callout',
           className,
         )}
+        title={author.name}
       >
         <TruncateText>{author.name}</TruncateText>
       </ProfileLink>

--- a/packages/shared/src/components/comments/CommentBox.tsx
+++ b/packages/shared/src/components/comments/CommentBox.tsx
@@ -128,7 +128,9 @@ function CommentBox({
           </FlexRow>
           <FlexRow className="items-center text-theme-label-quaternary">
             <ProfileLink href={comment.author.permalink}>
-              <TruncateText>@{comment.author.username}</TruncateText>
+              <TruncateText title={`@${comment.author.username}`}>
+                @{comment.author.username}
+              </TruncateText>
             </ProfileLink>
             <div className="mx-2 h-0.5 w-0.5 bg-theme-label-quaternary" />
             <CommentPublishDate comment={comment} />

--- a/packages/shared/src/components/comments/CommentBox.tsx
+++ b/packages/shared/src/components/comments/CommentBox.tsx
@@ -11,7 +11,7 @@ import { ProfileLink } from '../profile/ProfileLink';
 import { ProfileTooltip } from '../profile/ProfileTooltip';
 import SquadMemberBadge from '../squads/SquadMemberBadge';
 import UserBadge from '../UserBadge';
-import { FlexRow } from '../utilities';
+import { FlexRow, TruncateText } from '../utilities';
 import CommentActionButtons, {
   CommentActionProps,
 } from './CommentActionButtons';
@@ -128,9 +128,7 @@ function CommentBox({
           </FlexRow>
           <FlexRow className="items-center text-theme-label-quaternary">
             <ProfileLink href={comment.author.permalink}>
-              <span className="max-w-full truncate">
-                @{comment.author.username}
-              </span>
+              <TruncateText>@{comment.author.username}</TruncateText>
             </ProfileLink>
             <div className="mx-2 h-0.5 w-0.5 bg-theme-label-quaternary" />
             <CommentPublishDate comment={comment} />

--- a/packages/shared/src/components/comments/CommentBox.tsx
+++ b/packages/shared/src/components/comments/CommentBox.tsx
@@ -84,53 +84,53 @@ function CommentBox({
         </Link>
       )}
       {children}
-      <header className="z-1 flex flex-row self-start">
+      <header className="z-1 flex w-full flex-row self-start">
         <ProfileTooltip
           user={comment.author}
           tooltip={{ appendTo: appendTooltipTo }}
         >
           <ProfileImageLink user={comment.author} />
         </ProfileTooltip>
-        <div className="ml-3 flex flex-col typo-callout">
+        <div className="ml-3 flex min-w-0 flex-1 flex-col typo-callout">
           <FlexRow>
             <CommentAuthor
               author={comment.author}
               appendTooltipTo={appendTooltipTo}
-              badges={[
-                <ReputationUserBadge
-                  key="reputation"
-                  className="ml-1"
-                  user={comment.author}
-                />,
-                <SquadMemberBadge key="squadMemberRole" role={role} />,
-                comment.author.id === postAuthorId && (
-                  <UserBadge
-                    key="author"
-                    className="text-theme-status-help"
-                    content="Author"
-                    Icon={FeatherIcon}
-                    iconProps={{
-                      secondary: true,
-                    }}
-                  />
-                ),
-                comment.author.id === postScoutId && (
-                  <UserBadge
-                    key="scout"
-                    className="text-theme-color-bun"
-                    content="Scout"
-                    Icon={ScoutIcon}
-                    iconProps={{
-                      secondary: true,
-                    }}
-                  />
-                ),
-              ]}
             />
+            <ReputationUserBadge
+              key="reputation"
+              className="ml-1"
+              user={comment.author}
+            />
+            <SquadMemberBadge key="squadMemberRole" role={role} />
+            {comment.author.id === postAuthorId && (
+              <UserBadge
+                key="author"
+                className="text-theme-status-help"
+                content="Author"
+                Icon={FeatherIcon}
+                iconProps={{
+                  secondary: true,
+                }}
+              />
+            )}
+            {comment.author.id === postScoutId && (
+              <UserBadge
+                key="scout"
+                className="text-theme-color-bun"
+                content="Scout"
+                Icon={ScoutIcon}
+                iconProps={{
+                  secondary: true,
+                }}
+              />
+            )}
           </FlexRow>
           <FlexRow className="items-center text-theme-label-quaternary">
             <ProfileLink href={comment.author.permalink}>
-              @{comment.author.username}
+              <span className="max-w-full truncate">
+                @{comment.author.username}
+              </span>
             </ProfileLink>
             <div className="mx-2 h-0.5 w-0.5 bg-theme-label-quaternary" />
             <CommentPublishDate comment={comment} />

--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -45,7 +45,10 @@ function SquadPostAuthor({
           )}
         >
           <div className="flex w-full">
-            <TruncateText className={classNames('font-bold', className?.name)}>
+            <TruncateText
+              className={classNames('font-bold', className?.name)}
+              title={author.name}
+            >
               {author.name}
             </TruncateText>
             <div className="flex gap-1">
@@ -65,7 +68,9 @@ function SquadPostAuthor({
               className?.handle,
             )}
           >
-            <TruncateText>@{author.username}</TruncateText>
+            <TruncateText title={`@${author.username}`}>
+              @{author.username}
+            </TruncateText>
             {!!date && <Separator />}
             {!!date && <time dateTime={date}>{date}</time>}
           </div>

--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -7,6 +7,7 @@ import { Author } from '../../graphql/comments';
 import { SourceMemberRole } from '../../graphql/sources';
 import { Separator } from '../cards/common';
 import { ReputationUserBadge } from '../ReputationUserBadge';
+import { TruncateText } from '../utilities';
 
 interface SquadPostAuthorProps {
   className?: Partial<{
@@ -44,14 +45,9 @@ function SquadPostAuthor({
           )}
         >
           <div className="flex w-full">
-            <span
-              className={classNames(
-                'max-w-full shrink truncate font-bold',
-                className?.name,
-              )}
-            >
+            <TruncateText className={classNames('font-bold', className?.name)}>
               {author.name}
-            </span>
+            </TruncateText>
             <div className="flex gap-1">
               <ReputationUserBadge user={author} />
               {!!role && (
@@ -69,9 +65,7 @@ function SquadPostAuthor({
               className?.handle,
             )}
           >
-            <span className="max-w-full shrink truncate">
-              @{author.username}
-            </span>
+            <TruncateText>@{author.username}</TruncateText>
             {!!date && <Separator />}
             {!!date && <time dateTime={date}>{date}</time>}
           </div>

--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -21,8 +21,6 @@ interface SquadPostAuthorProps {
   date?: string;
 }
 
-const lineClamp = 'block text-ellipsis whitespace-nowrap overflow-hidden';
-
 function SquadPostAuthor({
   className,
   author,
@@ -41,12 +39,17 @@ function SquadPostAuthor({
         <a
           href={author.permalink}
           className={classNames(
-            'ml-4 flex flex-col overflow-hidden',
+            'ml-4 flex flex-1 flex-col overflow-hidden',
             className?.details,
           )}
         >
-          <div className={lineClamp}>
-            <span className={classNames('font-bold', className?.name)}>
+          <div className="flex w-full">
+            <span
+              className={classNames(
+                'max-w-full shrink truncate font-bold',
+                className?.name,
+              )}
+            >
               {author.name}
             </span>
             <div className="flex gap-1">
@@ -62,12 +65,13 @@ function SquadPostAuthor({
           </div>
           <div
             className={classNames(
-              'text-theme-label-tertiary',
+              'flex text-theme-label-tertiary',
               className?.handle,
-              lineClamp,
             )}
           >
-            @{author.username}
+            <span className="max-w-full shrink truncate">
+              @{author.username}
+            </span>
             {!!date && <Separator />}
             {!!date && <time dateTime={date}>{date}</time>}
           </div>

--- a/packages/shared/src/components/profile/ProfileLink.tsx
+++ b/packages/shared/src/components/profile/ProfileLink.tsx
@@ -21,7 +21,10 @@ function ProfileLinkComponent(
       <a
         {...props}
         ref={ref}
-        className={classNames(className, 'flex items-center no-underline')}
+        className={classNames(
+          className,
+          'flex min-w-0 shrink items-center no-underline',
+        )}
       >
         {children}
       </a>

--- a/packages/shared/src/components/profile/UserMetadata.tsx
+++ b/packages/shared/src/components/profile/UserMetadata.tsx
@@ -5,6 +5,7 @@ import JoinedDate from './JoinedDate';
 import { Separator } from '../cards/common';
 import { ReputationUserBadge } from '../ReputationUserBadge';
 import { IconSize } from '../Icon';
+import { TruncateText, truncateTextClassNames } from '../utilities';
 
 export type UserMetadataProps = Pick<
   PublicProfile,
@@ -29,7 +30,12 @@ export function UserMetadata({
       )}
     >
       <div className="flex items-center">
-        <h2 className="overflow-hidden text-ellipsis whitespace-nowrap font-bold text-theme-label-primary typo-title3">
+        <h2
+          className={classNames(
+            truncateTextClassNames,
+            'font-bold text-theme-label-primary typo-title3',
+          )}
+        >
           {name}
         </h2>
         {reputation && (
@@ -42,9 +48,9 @@ export function UserMetadata({
         )}
       </div>
       <div className="flex items-center">
-        <span className="overflow-hidden text-ellipsis whitespace-nowrap text-theme-label-secondary typo-footnote">
+        <TruncateText className="text-theme-label-secondary typo-footnote">
           @{username}
-        </span>
+        </TruncateText>
         <Separator />
         <JoinedDate
           className="text-theme-label-quaternary typo-caption2"

--- a/packages/shared/src/components/profile/UserShortInfo.tsx
+++ b/packages/shared/src/components/profile/UserShortInfo.tsx
@@ -89,10 +89,15 @@ const UserShortInfoComponent = <Tag extends React.ElementType>(
           )}
         >
           <div className="flex">
-            <TruncateText className="font-bold">{name}</TruncateText>
+            <TruncateText className="font-bold" title={name}>
+              {name}
+            </TruncateText>
             <ReputationUserBadge user={user} />
           </div>
-          <TruncateText className="text-theme-label-secondary">
+          <TruncateText
+            className="text-theme-label-secondary"
+            title={`@${username}`}
+          >
             {transformUsername ? transformUsername(user) : `@${username}`}
           </TruncateText>
           {bio && showDescription && (

--- a/packages/shared/src/components/profile/UserShortInfo.tsx
+++ b/packages/shared/src/components/profile/UserShortInfo.tsx
@@ -84,7 +84,7 @@ const UserShortInfoComponent = <Tag extends React.ElementType>(
       >
         <div
           className={classNames(
-            'ml-4 flex flex-col overflow-hidden typo-callout',
+            'ml-4 flex max-w-full flex-col typo-callout',
             className.textWrapper ?? defaultClassName.textWrapper,
           )}
         >

--- a/packages/shared/src/components/profile/UserShortInfo.tsx
+++ b/packages/shared/src/components/profile/UserShortInfo.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React, { forwardRef, ReactElement, ReactNode, Ref } from 'react';
 import { ProfileImageSize, ProfilePicture } from '../ProfilePicture';
 import { TooltipProps } from '../tooltips/BaseTooltip';
-import { getTextEllipsis } from '../utilities';
+import { TruncateText } from '../utilities';
 import { ProfileTooltip } from './ProfileTooltip';
 import { UserShortProfile } from '../../lib/user';
 import { ReputationUserBadge } from '../ReputationUserBadge';
@@ -32,8 +32,6 @@ export interface UserShortInfoProps<
   showDescription?: boolean;
   transformUsername?(user: UserShortProfile): ReactNode;
 }
-
-const TextEllipsis = getTextEllipsis();
 
 const defaultClassName = {
   container: 'py-3 px-6 hover:bg-theme-hover',
@@ -91,12 +89,12 @@ const UserShortInfoComponent = <Tag extends React.ElementType>(
           )}
         >
           <div className="flex">
-            <TextEllipsis className="min-w-0 font-bold">{name}</TextEllipsis>
+            <TruncateText className="font-bold">{name}</TruncateText>
             <ReputationUserBadge user={user} />
           </div>
-          <TextEllipsis className="text-theme-label-secondary">
+          <TruncateText className="text-theme-label-secondary">
             {transformUsername ? transformUsername(user) : `@${username}`}
-          </TextEllipsis>
+          </TruncateText>
           {bio && showDescription && (
             <span className="mt-1 text-theme-label-tertiary">{bio}</span>
           )}

--- a/packages/shared/src/components/utilities/common.tsx
+++ b/packages/shared/src/components/utilities/common.tsx
@@ -63,7 +63,8 @@ export const PageContainer = classed(
   pageContainerClassNames,
 );
 
-export const TruncateText = classed('span', 'max-w-full shrink truncate');
+export const truncateTextClassNames = 'max-w-full shrink truncate';
+export const TruncateText = classed('span', truncateTextClassNames);
 
 const RawPageWidgets = classed(
   'aside',

--- a/packages/shared/src/components/utilities/common.tsx
+++ b/packages/shared/src/components/utilities/common.tsx
@@ -63,6 +63,8 @@ export const PageContainer = classed(
   pageContainerClassNames,
 );
 
+export const TruncateText = classed('span', 'max-w-full shrink truncate');
+
 const RawPageWidgets = classed(
   'aside',
   'flex flex-col gap-6 px-4 w-full max-w-full',

--- a/packages/shared/src/components/utilities/common.tsx
+++ b/packages/shared/src/components/utilities/common.tsx
@@ -161,14 +161,6 @@ export const HotLabel = (): ReactElement => (
   </div>
 );
 
-export const getTextEllipsis = <
-  P extends HTMLAttributes<T>,
-  T extends HTMLElement,
->(
-  type: keyof ReactHTML = 'span',
-): ClassedHTML<P, T> =>
-  classed<P, T>(type, 'overflow-hidden whitespace-nowrap text-ellipsis');
-
 export const SecondaryCenteredBodyText = classed(
   'p',
   'typo-body text-theme-label-secondary text-center',

--- a/packages/shared/src/components/utilities/common.tsx
+++ b/packages/shared/src/components/utilities/common.tsx
@@ -1,11 +1,6 @@
-import React, {
-  HTMLAttributes,
-  ReactElement,
-  ReactHTML,
-  ReactNode,
-} from 'react';
+import React, { HTMLAttributes, ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
-import classed, { ClassedHTML } from '../../lib/classed';
+import classed from '../../lib/classed';
 import styles from './utilities.module.css';
 import { ArrowIcon } from '../icons';
 import { Post, PostType, isSharedPostSquadPost } from '../../graphql/posts';

--- a/packages/webapp/pages/account/invite.tsx
+++ b/packages/webapp/pages/account/invite.tsx
@@ -31,6 +31,7 @@ import {
 import { ShareProvider } from '@dailydotdev/shared/src/lib/share';
 import { useShareOrCopyLink } from '@dailydotdev/shared/src/hooks/useShareOrCopyLink';
 import { InviteLinkInput } from '@dailydotdev/shared/src/components/referral/InviteLinkInput';
+import { TruncateText } from '@dailydotdev/shared/src/components/utilities';
 import AccountContentSection from '../../components/layouts/AccountLayout/AccountContentSection';
 import { AccountPageContainer } from '../../components/layouts/AccountLayout/AccountPageContainer';
 import { getAccountLayout } from '../../components/layouts/AccountLayout';
@@ -131,8 +132,8 @@ const AccountInvitePage = (): ReactElement => {
               createdAt,
             }: UserShortProfile): React.ReactNode {
               return (
-                <span className="mt-2 text-theme-label-secondary typo-callout">
-                  @{username}
+                <span className="flex text-theme-label-secondary typo-callout">
+                  <TruncateText>@{username}</TruncateText>
                   <Separator />
                   <time dateTime={createdAt}>
                     {format(new Date(createdAt), 'dd MMM yyyy')}


### PR DESCRIPTION
## Changes

Truncates the really long user names and handles wherever I found them. There might still be places where I have not encountered them.

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td>
	<img src="https://github.com/dailydotdev/apps/assets/1681525/7df83a82-b84a-44ae-a50b-42d891e17db4">
	<img src="https://github.com/dailydotdev/apps/assets/1681525/77dd5676-046d-485f-8abd-896725cbe4c3">
	<img src="https://github.com/dailydotdev/apps/assets/1681525/a49a315f-34f5-4d7a-9a05-eef9efde65c0">
	<img src="https://github.com/dailydotdev/apps/assets/1681525/b7ae9905-b24b-4e9f-a4b7-dac6246ba7bf">
	<img src="https://github.com/dailydotdev/apps/assets/1681525/5db162de-f9dc-4442-b45a-7bb09e6d3e6c">
 <td>
	<img src="https://github.com/dailydotdev/apps/assets/1681525/a7e0b215-b809-4d39-9fd0-f2c09c6ba03c">
	<img src=https://github.com/dailydotdev/apps/assets/1681525/65ed4df6-3ece-48cf-b7c3-46d6c1dcb4e9>
	<img src="https://github.com/dailydotdev/apps/assets/1681525/cf70c146-231d-4c43-926b-4dbe3356910c">
	<img src="https://github.com/dailydotdev/apps/assets/1681525/f6eced13-b1ed-4dec-ab60-55acea27cceb">
	<img src="https://github.com/dailydotdev/apps/assets/1681525/c88ffcc7-df39-440f-8c3c-9c60d9086024">
</table>

AS-151
