### PR TITLE
fix: right blue color for link

### DIFF
--- a/packages/shared/src/components/cards/ShowMoreContent.tsx
+++ b/packages/shared/src/components/cards/ShowMoreContent.tsx
@@ -42,7 +42,7 @@ export default function ShowMoreContent({
         {getContent()}{' '}
         {displayShowMoreLink() && (
           <ClickableText
-            className="inline-flex text-theme-label-link"
+            className="inline-flex !text-theme-label-link"
             onClick={toggleTextExpanded}
           >
             {linkName}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We need to overwrite to link color as there's a default color
- We already check manually if tag == A, but in this case it's not.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
