### PR TITLE
fix: acquisition form card on mobile layout

### DIFF
--- a/packages/shared/src/components/cards/AcquisitionFormCard.tsx
+++ b/packages/shared/src/components/cards/AcquisitionFormCard.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useContext, useEffect, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
+import classNames from 'classnames';
 import { Card } from './Card';
 import { Radio } from '../fields/Radio';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
@@ -10,6 +11,7 @@ import { OnboardingTitleGradient } from '../onboarding/common';
 import { removeQueryParam } from '../../lib/links';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 import { AnalyticsEvent, UserAcquisitionEvent } from '../../lib/analytics';
+import { useFeedLayout } from '../../hooks';
 
 const options = [
   {
@@ -36,6 +38,7 @@ export function AcquisitionFormCard(): ReactElement {
   const { trackEvent } = useContext(AnalyticsContext);
   const [isDismissed, setIsDismissed] = useState(false);
   const [value, setValue] = useState<AcquisitionChannel>();
+  const { shouldUseMobileFeedLayout } = useFeedLayout();
   const router = useRouter();
   const onRemoveQueryParams = () => {
     const updatedUrl = removeQueryParam(window.location.href, acquisitionKey);
@@ -77,7 +80,13 @@ export function AcquisitionFormCard(): ReactElement {
   }
 
   return (
-    <Card data-testid="acquisitionFormCard" className="p-4">
+    <Card
+      data-testid="acquisitionFormCard"
+      className={classNames(
+        'p-4',
+        shouldUseMobileFeedLayout && '!bg-theme-bg-primary',
+      )}
+    >
       <OnboardingTitleGradient className="flex w-full flex-row items-center whitespace-nowrap pb-1 typo-body">
         How did you hear about us?
         <Button
@@ -96,7 +105,10 @@ export function AcquisitionFormCard(): ReactElement {
         value={value}
       />
       <Button
-        className="mt-auto w-full"
+        className={classNames(
+          'w-full',
+          shouldUseMobileFeedLayout ? 'mt-4' : 'mt-auto',
+        )}
         variant={ButtonVariant.Primary}
         size={ButtonSize.Small}
         loading={isLoading}


### PR DESCRIPTION
## Changes
- Apply the correct background color and top margin when on mobile. Discussion: https://dailydotdev.slack.com/archives/C06CLJV4NFL/p1709641497119569
![Screenshot 2024-03-05 at 9 20 56 PM](https://github.com/dailydotdev/apps/assets/13744167/93ae518c-19a3-4d9d-881f-310ceb4a0135)

Preview:


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
