### PR TITLE
fix: force the streaks tooltip to be displayed on mobile resolutions

### DIFF
--- a/packages/shared/src/components/streak/ReadingStreakButton.tsx
+++ b/packages/shared/src/components/streak/ReadingStreakButton.tsx
@@ -5,6 +5,7 @@ import { ReadingStreakIcon } from '../icons';
 import { SimpleTooltip } from '../tooltips';
 import { UserStreak } from '../../graphql/users';
 import { useViewSize, ViewSize } from '../../hooks';
+import { isTesting } from '../../lib/constants';
 
 interface ReadingStreakButtonProps {
   streak: UserStreak;
@@ -28,6 +29,7 @@ function CustomStreaksTooltip({
       interactive
       showArrow={false}
       visible={shouldShowStreaks}
+      forceLoad={!isTesting}
       container={{
         paddingClassName: 'p-4',
         bgClassName: 'bg-theme-bg-tertiary',


### PR DESCRIPTION
## Changes

- by default tooltips are disabled on mobile

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android


