### PR TITLE
fix: overflow on public squad post page and upvote modal

### DIFF
--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -95,7 +95,7 @@ function SquadPostContent({
       >
         <div
           className={classNames(
-            'relative max-w-[42.5rem] px-4 tablet:px-8',
+            'relative min-w-0 px-4 tablet:px-8',
             className?.content,
             isPublicSquad && 'flex flex-1 flex-col',
           )}

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -95,7 +95,7 @@ function SquadPostContent({
       >
         <div
           className={classNames(
-            'relative px-4 tablet:px-8',
+            'relative max-w-[42.5rem] px-4 tablet:px-8',
             className?.content,
             isPublicSquad && 'flex flex-1 flex-col',
           )}

--- a/packages/shared/src/components/profile/UserShortInfo.tsx
+++ b/packages/shared/src/components/profile/UserShortInfo.tsx
@@ -84,7 +84,7 @@ const UserShortInfoComponent = <Tag extends React.ElementType>(
       >
         <div
           className={classNames(
-            'ml-4 flex max-w-full flex-col typo-callout',
+            'ml-4 flex max-w-full flex-col overflow-auto typo-callout',
             className.textWrapper ?? defaultClassName.textWrapper,
           )}
         >


### PR DESCRIPTION
## Changes

### Describe what this PR does
- fix overflow issue in upvoted modal
- fix overflow issue on public squad post page and modal

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td>
  <img src="https://github.com/dailydotdev/apps/assets/1681525/f1c7e153-3a44-49b1-b9bd-5f585170afdc">
  <img src="https://github.com/dailydotdev/apps/assets/1681525/0937294b-57e3-41c4-a824-5c5cb7057481">
  <img src="https://github.com/dailydotdev/apps/assets/1681525/198a5358-2e7b-4292-90bf-d94a1eec77a6">
  <img src="https://github.com/dailydotdev/apps/assets/1681525/75982837-86cd-47fa-92b5-3cff9e135ba0">
 <td>
  <img src="https://github.com/dailydotdev/apps/assets/1681525/8a1095de-7727-42e4-ab05-a9a7f2ee41cd">
  <img src="https://github.com/dailydotdev/apps/assets/1681525/5b3c9fcb-19f8-4f0a-8816-5fc29f752fa0">
  <img src="https://github.com/dailydotdev/apps/assets/1681525/ca73a86c-c0d0-4172-a1ff-57984dc711a2">
  <img src="https://github.com/dailydotdev/apps/assets/1681525/64e1c53f-0a54-4402-895d-4c90db19128f">
</table>