### PR TITLE
fix: add tracking event for 404 page

### DIFF
--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -132,6 +132,8 @@ export enum AnalyticsEvent {
   GenerateDevcard = 'generate devcard',
   DownloadDevcard = 'download devcard',
   CopyDevcardCode = 'copy devcard code',
+  // 404 page
+  View404Page = '404 page',
 }
 
 export enum FeedItemTitle {

--- a/packages/webapp/pages/404.tsx
+++ b/packages/webapp/pages/404.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext, useEffect, useState } from 'react';
+import React, { ReactElement, useContext, useEffect, useRef } from 'react';
 import Custom404 from '@dailydotdev/shared/src/components/Custom404';
 import { NextSeo } from 'next-seo';
 import { AnalyticsEvent } from '@dailydotdev/shared/src/lib/analytics';
@@ -6,17 +6,17 @@ import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext'
 
 export default function Custom404Seo(): ReactElement {
   const { trackEvent } = useContext(AnalyticsContext);
-  const [trackedImpression, setTrackedImpression] = useState(false);
+  const trackedImpression = useRef(false);
 
   useEffect(() => {
-    if (trackedImpression) {
+    if (trackedImpression.current) {
       return;
     }
 
     trackEvent({
       event_name: AnalyticsEvent.View404Page,
     });
-    setTrackedImpression(true);
+    trackedImpression.current = true;
   }, [trackEvent, trackedImpression]);
 
   return (

--- a/packages/webapp/pages/404.tsx
+++ b/packages/webapp/pages/404.tsx
@@ -1,8 +1,24 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useContext, useEffect, useState } from 'react';
 import Custom404 from '@dailydotdev/shared/src/components/Custom404';
 import { NextSeo } from 'next-seo';
+import { AnalyticsEvent } from '@dailydotdev/shared/src/lib/analytics';
+import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 
 export default function Custom404Seo(): ReactElement {
+  const { trackEvent } = useContext(AnalyticsContext);
+  const [trackedImpression, setTrackedImpression] = useState(false);
+
+  useEffect(() => {
+    if (trackedImpression) {
+      return;
+    }
+
+    trackEvent({
+      event_name: AnalyticsEvent.View404Page,
+    });
+    setTrackedImpression(true);
+  }, [trackEvent, trackedImpression]);
+
   return (
     <Custom404>
       <NextSeo title="Page not found" nofollow noindex />


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Requested by Dave

![Screenshot 2024-03-06 at 10 55 30](https://github.com/dailydotdev/apps/assets/554874/b1d778cd-4086-47fe-9fa5-c30be64d4aca)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
|New | 404 page  |  |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
