### PR TITLE
fix: padding consistency of squad sidebar widgets

### DIFF
--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -141,7 +141,7 @@ function SquadPostContent({
             onShare={onSharePost}
             onReadArticle={onReadArticle}
             post={post}
-            className="mb-6 border-l border-theme-divider-tertiary px-8 tablet:mb-0 tablet:pl-4"
+            className="mb-6 border-l border-theme-divider-tertiary tablet:mb-0"
             onClose={onClose}
             origin={origin}
           />


### PR DESCRIPTION
## Changes

Discovered while fixing some other overflow issues that the padding of the widgets for public squad posts didn't match the normal posts. [Conferred with design that it should be 16px](https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1709715348049359?thread_ts=1709659937.401039&cid=C01L0QXQJNB)

### Describe what this PR does
- fixed sidebar widgets for squad posts to be more consistent

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/e22333a4-a520-42bf-80f2-a76b444f998d">

 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/cdc53db0-aa77-4f8b-a1a0-fd72d2a77e17">
</table>
