### PR TITLE
fix: add embedURL to youtube videos

### DIFF
--- a/packages/webapp/components/PostSEOSchema.tsx
+++ b/packages/webapp/components/PostSEOSchema.tsx
@@ -63,6 +63,7 @@ export const getSEOJsonLd = (post: Post): string => {
         uploadDate: post.createdAt,
         duration: `PT${post.readTime}M`,
         url: post.permalink,
+        embedUrl: `https://www.youtube.com/embed/${post.videoId}`,
       },
     }),
   });


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since we only have youtubevideos we can simply use the pattern youtube embed URLs

Validated:
![Screenshot 2024-03-06 at 11 06 14](https://github.com/dailydotdev/apps/assets/554874/55167dcf-3a04-416a-94b4-8a5b4bfe3bfc)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-207 #done
