### PR TITLE
fix: notification image size override

### DIFF
--- a/packages/shared/src/components/notifications/NotificationItemAttachment.tsx
+++ b/packages/shared/src/components/notifications/NotificationItemAttachment.tsx
@@ -21,7 +21,7 @@ function NotificationItemAttachment({
             loading: 'lazy',
             alt: `Cover preview of: ${title}`,
             src: image,
-            className: 'h-16 w-24 rounded-16 object-cover',
+            className: '!h-16 w-24 !rounded-16 object-cover',
           }}
           videoProps={{ size: IconSize.XLarge }}
         />


### PR DESCRIPTION
## Changes

### Describe what this PR does
- With introducion of CardCover which has `h-40` this case would take `h-40` not the set `h-16` (Same for border)

@sshanzel I see you also [did](https://github.com/dailydotdev/apps/commit/46efc2bd2badd55f7c81828e09ac17abd39a63ab#diff-2bf1ebec09bd7c77dae66efcdb5eb936257ce95cf0bb79a5c27ea889018bc8f3L36) this on `SharedPostCardFooter` here luckily `h-auto` will take priority. Are there any edge-cases you can think of though?

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
