### PR TITLE
fix: final fallback image

### DIFF
--- a/packages/shared/src/components/image/Image.tsx
+++ b/packages/shared/src/components/image/Image.tsx
@@ -31,7 +31,7 @@ const ImageComponent = (
     fallbackSrc ?? fallbackSrcByType[props.type ?? ImageType.Post];
 
   const onError = (event: SyntheticEvent<HTMLImageElement>): void => {
-    if (fallbackSrc && fallbackSrc !== event.currentTarget.src) {
+    if (finalFallbackSrc && finalFallbackSrc !== event.currentTarget.src) {
       // eslint-disable-next-line no-param-reassign
       event.currentTarget.src = finalFallbackSrc;
     }


### PR DESCRIPTION
## Changes
- The final fallback src was not used.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
