### PR TITLE
fix: don't show pinned posts if not a member

### DIFF
--- a/packages/shared/src/components/squads/SquadFeedHeading.tsx
+++ b/packages/shared/src/components/squads/SquadFeedHeading.tsx
@@ -15,6 +15,7 @@ function SquadFeedHeading({ squad }: SquadFeedHeadingProps): ReactElement {
     squad,
   });
   const collapsePinnedPosts = squad?.currentMember?.flags?.collapsePinnedPosts;
+  const isSquadMember = !!squad.currentMember;
 
   const onClick = async () => {
     return collapsePinnedPosts
@@ -36,15 +37,17 @@ function SquadFeedHeading({ squad }: SquadFeedHeadingProps): ReactElement {
   return (
     <div className="flex w-full flex-row flex-wrap items-center justify-end gap-4 pb-6">
       <span className="ml-auto flex flex-row gap-3 border-l border-theme-divider-tertiary pl-3">
-        <Button
-          variant={ButtonVariant.Float}
-          onClick={onClick}
-          icon={<PinIcon />}
-        >
-          {collapsePinnedPosts
-            ? `Show pinned posts (${pinnedPostsCount})`
-            : 'Hide pinned posts'}
-        </Button>
+        {isSquadMember && (
+          <Button
+            variant={ButtonVariant.Float}
+            onClick={onClick}
+            icon={<PinIcon />}
+          >
+            {collapsePinnedPosts
+              ? `Show pinned posts (${pinnedPostsCount})`
+              : 'Hide pinned posts'}
+          </Button>
+        )}
       </span>
     </div>
   );


### PR DESCRIPTION
## Changes

### Describe what this PR does
- hide pinned posts button on squad page if they are not a member

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/08e8f2a6-9621-445d-9393-3cc44170a0ba">
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/0a4d7676-996a-4212-b908-ea826e7a57b7">
</table>

AS-159
