### PR TITLE
fix: shared post card long lines

### DIFF
--- a/packages/shared/src/components/cards/SharedPostCardFooter.tsx
+++ b/packages/shared/src/components/cards/SharedPostCardFooter.tsx
@@ -26,14 +26,14 @@ export const SharedPostCardFooter = ({
         isShort ? 'flex-row items-center' : 'flex-col',
       )}
     >
-      <div
+      <p
         className={classNames(
-          'flex text-theme-label-secondary typo-footnote',
+          'text-theme-label-secondary typo-footnote',
           isShort ? 'line-clamp-4 w-8/12 pr-3' : 'line-clamp-2',
         )}
       >
         {sharedPost.title}
-      </div>
+      </p>
 
       <div className={classNames('flex h-auto flex-auto overflow-auto')}>
         <CardCover


### PR DESCRIPTION
## Changes
- By adding `flex` - we override the `display: -webkit-box` from the `line-clamp-*`.
- Removed flex to make the class work.
- Also changed the div to p to be semantically correct.

Quick link: https://preview3.app.daily.dev/squads/rustdevs

Preview:
![Screenshot 2024-03-06 at 6 55 33 PM](https://github.com/dailydotdev/apps/assets/13744167/14fb0f79-8491-40d5-bf79-03f2f9473f5d)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-208 #done
