### PR TITLE
fix: reading streak staletime

### DIFF
--- a/packages/shared/src/hooks/streaks/useReadingStreak.ts
+++ b/packages/shared/src/hooks/streaks/useReadingStreak.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { generateQueryKey, RequestKey } from '../../lib/query';
+import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
 import { getReadingStreak, UserStreak } from '../../graphql/users';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useStreakExperiment } from './useStreakExperiment';
@@ -16,7 +16,7 @@ export const useReadingStreak = (): UserReadingStreak => {
   const { data: streak, isLoading } = useQuery(
     generateQueryKey(RequestKey.UserStreak, user),
     getReadingStreak,
-    { enabled: shouldShowStreak },
+    { enabled: shouldShowStreak, staleTime: StaleTime.Default },
   );
 
   return {


### PR DESCRIPTION
## Changes
- We can even go for longer time but default seems to be reasonable.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-210 #done
