### PR TITLE
fix: total reading days ui

### DIFF
--- a/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
+++ b/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
@@ -83,7 +83,7 @@ export function ReadingStreakPopup({
         <StreakSection streak={streak.max} label="Longest streak 🏆" />
       </div>
       <div className="mt-6 flex flex-row gap-2">{streaks}</div>
-      <div className="mt-4 rounded-10 font-bold leading-8 text-theme-label-tertiary">
+      <div className="mt-4 rounded-10 text-center font-bold leading-8 text-theme-label-tertiary">
         Total reading days: {streak.total}
       </div>
     </div>

--- a/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
+++ b/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
@@ -83,7 +83,7 @@ export function ReadingStreakPopup({
         <StreakSection streak={streak.max} label="Longest streak 🏆" />
       </div>
       <div className="mt-6 flex flex-row gap-2">{streaks}</div>
-      <div className="mt-4 rounded-10 bg-theme-float text-center font-bold leading-8 text-theme-label-tertiary">
+      <div className="mt-4 rounded-10 font-bold leading-8 text-theme-label-tertiary">
         Total reading days: {streak.total}
       </div>
     </div>

--- a/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
+++ b/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
@@ -83,7 +83,7 @@ export function ReadingStreakPopup({
         <StreakSection streak={streak.max} label="Longest streak 🏆" />
       </div>
       <div className="mt-6 flex flex-row gap-2">{streaks}</div>
-      <div className="mt-4 rounded-10 text-center font-bold leading-8 text-theme-label-tertiary">
+      <div className="mt-4 text-center font-bold leading-8 text-theme-label-tertiary">
         Total reading days: {streak.total}
       </div>
     </div>


### PR DESCRIPTION
## Changes
- Removal of background for total reading days.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
