### PR TITLE
refactor: animation timing delay in the middle

### DIFF
--- a/packages/shared/src/components/auth/PreparingYourFeed.tsx
+++ b/packages/shared/src/components/auth/PreparingYourFeed.tsx
@@ -39,9 +39,12 @@ export function PreparingYourFeed({
       <span className="flex h-1.5 w-full max-w-[19.125rem] flex-row items-center rounded-12 bg-border-subtlest-tertiary px-0.5">
         <span
           className={classNames(
-            'relative flex h-0.5 w-0 flex-row items-center bg-theme-color-cabbage transition-[width] duration-[2000ms] ease-in-out',
+            'relative flex h-0.5 w-0 flex-row items-center bg-theme-color-cabbage transition-[width] duration-[2500ms]',
             isAnimating && 'w-full',
           )}
+          style={{
+            transitionTimingFunction: 'cubic-bezier(0.1, 0.7, 1.0, 0.1)',
+          }}
         >
           <span className="absolute right-0 h-5 w-5 translate-x-1/2 bg-theme-color-cabbage blur-[10px]" />
         </span>

--- a/packages/shared/src/hooks/auth/useOnboardingAnimation.ts
+++ b/packages/shared/src/hooks/auth/useOnboardingAnimation.ts
@@ -16,7 +16,7 @@ interface UseOnboardingAnimationProps {
   animationMs?: number;
 }
 
-const DEFAULT_ANIMATION_MS = 2000;
+const DEFAULT_ANIMATION_MS = 2750;
 
 export const useOnboardingAnimation = ({
   animationMs = DEFAULT_ANIMATION_MS,


### PR DESCRIPTION
## Changes
- Stopping in the middle to make it look more realistic.
- The JS animation MS and timer on the CSS is intentionally off by 250ms.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
