### PR TITLE
fix: make collection tag clickable

### DIFF
--- a/packages/shared/src/components/Pill.tsx
+++ b/packages/shared/src/components/Pill.tsx
@@ -11,17 +11,21 @@ const pillSizeToClassName: Record<PillSize, string> = {
 
 interface Props {
   label: string;
+  tag?: keyof Pick<JSX.IntrinsicElements, 'a' | 'div'>;
   size?: PillSize;
   className?: string;
 }
 
 export const Pill = ({
   label,
+  tag: Tag = 'div',
   size = PillSize.Medium,
   className,
+  ...props
 }: Props): ReactElement => {
   return (
-    <div
+    <Tag
+      {...props}
       className={classNames(
         pillSizeToClassName[size],
         'inline-flex items-center self-start rounded-10 p-2',
@@ -29,6 +33,6 @@ export const Pill = ({
       )}
     >
       {label}
-    </div>
+    </Tag>
   );
 };

--- a/packages/shared/src/components/post/collection/CollectionPostContent.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPostContent.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React, { ReactElement, useEffect } from 'react';
 import { useMutation } from '@tanstack/react-query';
+import Link from 'next/link';
 import { LazyImage } from '../../LazyImage';
 import {
   ToastSubject,
@@ -25,6 +26,7 @@ import { Pill } from '../../Pill';
 import { CollectionsIntro } from '../widgets';
 import { sendViewPost } from '../../../graphql/posts';
 import { useAuthContext } from '../../../contexts/AuthContext';
+import { webappUrl } from '../../../lib/constants';
 
 export const CollectionPostContent = ({
   post,
@@ -137,11 +139,13 @@ export const CollectionPostContent = ({
             )}
           >
             <CollectionsIntro className="tablet:hidden" />
-            <Pill
-              label="Collection"
-              className="bg-theme-overlay-float-cabbage text-theme-color-cabbage"
-            />
-
+            <Link href={`${webappUrl}/sources/collections`} passHref>
+              <Pill
+                tag="a"
+                label="Collection"
+                className="bg-theme-overlay-float-cabbage text-theme-color-cabbage"
+              />
+            </Link>
             <h1
               className="break-words font-bold typo-large-title"
               data-testid="post-modal-title"


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Make the collection pill on page clickable

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-162 #done
