### PR TITLE
fix: placeholder for streaks button

### DIFF
--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -85,10 +85,22 @@ function MainLayoutHeader({
     });
   };
 
+  const getStreakButton = () => {
+    if (isLoading) {
+      return <div className="h-10 w-20 rounded-12 bg-surface-float" />;
+    }
+
+    if (!isStreaksEnabled || !streak) {
+      return null;
+    }
+
+    return <ReadingStreakButton streak={streak} />;
+  };
+
   const RenderButtons = () => {
     return (
       <div className="flex gap-3">
-        {streak && <ReadingStreakButton streak={streak} />}
+        {getStreakButton()}
         <CreatePostButton compact={isStreaksEnabled} />
         {!hideButton && user && (
           <>


### PR DESCRIPTION
## Changes
- Placeholder for reading streaks button.

Sample size side-by-side:
![Screenshot 2024-03-07 at 12 28 40 PM](https://github.com/dailydotdev/apps/assets/13744167/657b4059-3489-464c-b5f3-1d74d2386ea2)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-209 #done
