### PR TITLE
fix: streaks placeholder

### DIFF
--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -43,17 +43,16 @@ const SearchPanel = dynamic(
 );
 
 interface StreakButtonProps {
-  isEnabled: boolean;
   isLoading: boolean;
   streak: UserStreak;
 }
 
-const StreakButton = ({ streak, isEnabled, isLoading }: StreakButtonProps) => {
+const StreakButton = ({ streak, isLoading }: StreakButtonProps) => {
   if (isLoading) {
     return <div className="h-10 w-20 rounded-12 bg-surface-float" />;
   }
 
-  if (!isEnabled || !streak) {
+  if (!streak) {
     return null;
   }
 
@@ -107,11 +106,9 @@ function MainLayoutHeader({
   const RenderButtons = () => {
     return (
       <div className="flex gap-3">
-        <StreakButton
-          streak={streak}
-          isLoading={isLoading}
-          isEnabled={isStreaksEnabled}
-        />
+        {isStreaksEnabled && (
+          <StreakButton streak={streak} isLoading={isLoading} />
+        )}
         <CreatePostButton compact={isStreaksEnabled} />
         {!hideButton && user && (
           <>


### PR DESCRIPTION
## Changes
- Conditionally render the component so that when it is not enabled, we won't show even the loading state.

Preview:
![Screenshot 2024-03-07 at 10 02 15 PM](https://github.com/dailydotdev/apps/assets/13744167/3d3eaee5-75cd-416d-b22e-69a0713d17eb)



## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
