### PR TITLE
feat: add share tracking URL query parameters and shorten the links

### DIFF
--- a/packages/shared/src/components/ShareBar.spec.tsx
+++ b/packages/shared/src/components/ShareBar.spec.tsx
@@ -1,4 +1,10 @@
-import { render, RenderResult, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  RenderResult,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import nock from 'nock';
@@ -116,7 +122,7 @@ describe('ShareBar Test Suite:', () => {
     renderComponent();
     const btn = await screen.findByTestId(`social-share-Facebook`);
 
-    btn.click();
+    fireEvent.click(btn);
 
     await waitFor(() => {
       expect(mockWindowOpen).toHaveBeenCalledWith(

--- a/packages/shared/src/components/ShareBar.spec.tsx
+++ b/packages/shared/src/components/ShareBar.spec.tsx
@@ -63,6 +63,19 @@ const renderComponent = (loggedIn = true, hasSquads = true): RenderResult => {
 };
 
 describe('ShareBar Test Suite:', () => {
+  const mockWindowOpen = jest.fn();
+  let origWindowOpen = null;
+
+  beforeEach(() => {
+    origWindowOpen = window.open;
+    window.open = mockWindowOpen;
+  });
+
+  afterEach(() => {
+    mockWindowOpen.mockClear();
+    window.open = origWindowOpen;
+  });
+
   it('should render the component for anonymous users', async () => {
     renderComponent(false, false);
     expect(
@@ -99,14 +112,18 @@ describe('ShareBar Test Suite:', () => {
     });
   });
 
-  it('should render the Facebook button and have the correct link', async () => {
+  it('should render the Facebook button and navigate to correct link', async () => {
     renderComponent();
-    const link = await screen.findByTestId(`social-share-Facebook`);
+    const btn = await screen.findByTestId(`social-share-Facebook`);
 
-    expect(link).toHaveAttribute(
-      'href',
-      getFacebookShareLink(defaultPost.commentsPermalink),
-    );
+    btn.click();
+
+    await waitFor(() => {
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        getFacebookShareLink(defaultPost.commentsPermalink),
+        '_blank',
+      );
+    });
   });
 
   it('should render the copy link button and copy link to clipboard', async () => {

--- a/packages/shared/src/components/ShareBar.tsx
+++ b/packages/shared/src/components/ShareBar.tsx
@@ -13,7 +13,8 @@ import { Squad } from '../graphql/sources';
 import { SocialShareButton } from './widgets/SocialShareButton';
 import { SquadsToShare } from './squads/SquadsToShare';
 import { ButtonSize, ButtonVariant } from './buttons/common';
-import { ReferralCampaignKey, useGetShortUrl } from '../hooks';
+import { useGetShortUrl } from '../hooks';
+import { ReferralCampaignKey } from '../lib/referral';
 
 interface ShareBarProps {
   post: Post;

--- a/packages/shared/src/components/ShareBar.tsx
+++ b/packages/shared/src/components/ShareBar.tsx
@@ -3,7 +3,7 @@ import { CopyIcon, WhatsappIcon, TwitterIcon, FacebookIcon } from './icons';
 import { Post } from '../graphql/posts';
 import { useCopyPostLink } from '../hooks/useCopyPostLink';
 import {
-  addLinkShareTrackingParams,
+  addLinkShareTrackingQuery,
   getShareLink,
   ShareProvider,
 } from '../lib/share';
@@ -29,7 +29,9 @@ export default function ShareBar({ post }: ShareBarProps): ReactElement {
   const { user, isAuthReady } = useAuthContext();
   const cid = 'share_post';
   const link =
-    isAuthReady && user ? addLinkShareTrackingParams(href, user.id, cid) : href;
+    isAuthReady && user
+      ? addLinkShareTrackingQuery({ link: href, userId: user.id, cid })
+      : href;
   const { getShortUrl } = useGetShortUrl();
   const [copying, copyLink] = useCopyPostLink(link);
   const { trackEvent } = useContext(AnalyticsContext);
@@ -46,7 +48,11 @@ export default function ShareBar({ post }: ShareBarProps): ReactElement {
     trackClick(provider);
 
     const shortLink = await getShortUrl(link);
-    const shareLink = getShareLink(provider, shortLink, post?.title);
+    const shareLink = getShareLink({
+      provider,
+      link: shortLink,
+      text: post?.title,
+    });
     window.open(shareLink, '_blank');
   };
 

--- a/packages/shared/src/components/ShareBar.tsx
+++ b/packages/shared/src/components/ShareBar.tsx
@@ -2,11 +2,7 @@ import React, { ReactElement, useContext } from 'react';
 import { CopyIcon, WhatsappIcon, TwitterIcon, FacebookIcon } from './icons';
 import { Post } from '../graphql/posts';
 import { useCopyPostLink } from '../hooks/useCopyPostLink';
-import {
-  addTrackingQueryParams,
-  getShareLink,
-  ShareProvider,
-} from '../lib/share';
+import { getShareLink, ShareCID, ShareProvider } from '../lib/share';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { postAnalyticsEvent } from '../lib/feed';
 import { WidgetContainer } from './widgets/common';
@@ -17,7 +13,6 @@ import { Squad } from '../graphql/sources';
 import { SocialShareButton } from './widgets/SocialShareButton';
 import { SquadsToShare } from './squads/SquadsToShare';
 import { ButtonSize, ButtonVariant } from './buttons/common';
-import { useAuthContext } from '../contexts/AuthContext';
 import { useGetShortUrl } from '../hooks';
 
 interface ShareBarProps {
@@ -26,14 +21,9 @@ interface ShareBarProps {
 
 export default function ShareBar({ post }: ShareBarProps): ReactElement {
   const href = post.commentsPermalink;
-  const { user, isAuthReady } = useAuthContext();
-  const cid = 'share_post';
-  const link =
-    isAuthReady && user
-      ? addTrackingQueryParams({ link: href, userId: user.id, cid })
-      : href;
+  const cid = ShareCID.Post;
   const { getShortUrl } = useGetShortUrl();
-  const [copying, copyLink] = useCopyPostLink(link);
+  const [copying, copyLink] = useCopyPostLink();
   const { trackEvent } = useContext(AnalyticsContext);
   const { openModal } = useLazyModal();
 
@@ -47,7 +37,7 @@ export default function ShareBar({ post }: ShareBarProps): ReactElement {
   const onClick = async (provider: ShareProvider) => {
     trackShareEvent(provider);
 
-    const shortLink = await getShortUrl(link);
+    const shortLink = await getShortUrl(href, cid);
     const shareLink = getShareLink({
       provider,
       link: shortLink,
@@ -57,7 +47,7 @@ export default function ShareBar({ post }: ShareBarProps): ReactElement {
   };
 
   const trackAndCopyLink = async () => {
-    const shortLink = await getShortUrl(link);
+    const shortLink = await getShortUrl(href, cid);
     copyLink({ link: shortLink });
     trackShareEvent(ShareProvider.CopyLink);
   };

--- a/packages/shared/src/components/ShareBar.tsx
+++ b/packages/shared/src/components/ShareBar.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement, useContext } from 'react';
 import { CopyIcon, WhatsappIcon, TwitterIcon, FacebookIcon } from './icons';
 import { Post } from '../graphql/posts';
 import { useCopyPostLink } from '../hooks/useCopyPostLink';
-import { getShareLink, ShareCID, ShareProvider } from '../lib/share';
+import { getShareLink, ShareProvider } from '../lib/share';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { postAnalyticsEvent } from '../lib/feed';
 import { WidgetContainer } from './widgets/common';
@@ -13,7 +13,7 @@ import { Squad } from '../graphql/sources';
 import { SocialShareButton } from './widgets/SocialShareButton';
 import { SquadsToShare } from './squads/SquadsToShare';
 import { ButtonSize, ButtonVariant } from './buttons/common';
-import { useGetShortUrl } from '../hooks';
+import { ReferralCampaignKey, useGetShortUrl } from '../hooks';
 
 interface ShareBarProps {
   post: Post;
@@ -21,7 +21,7 @@ interface ShareBarProps {
 
 export default function ShareBar({ post }: ShareBarProps): ReactElement {
   const href = post.commentsPermalink;
-  const cid = ShareCID.Post;
+  const cid = ReferralCampaignKey.SharePost;
   const { getShortUrl } = useGetShortUrl();
   const [copying, copyLink] = useCopyPostLink();
   const { trackEvent } = useContext(AnalyticsContext);

--- a/packages/shared/src/components/ShareBar.tsx
+++ b/packages/shared/src/components/ShareBar.tsx
@@ -3,7 +3,7 @@ import { CopyIcon, WhatsappIcon, TwitterIcon, FacebookIcon } from './icons';
 import { Post } from '../graphql/posts';
 import { useCopyPostLink } from '../hooks/useCopyPostLink';
 import {
-  addLinkShareTrackingQuery,
+  addTrackingQueryParams,
   getShareLink,
   ShareProvider,
 } from '../lib/share';
@@ -30,14 +30,14 @@ export default function ShareBar({ post }: ShareBarProps): ReactElement {
   const cid = 'share_post';
   const link =
     isAuthReady && user
-      ? addLinkShareTrackingQuery({ link: href, userId: user.id, cid })
+      ? addTrackingQueryParams({ link: href, userId: user.id, cid })
       : href;
   const { getShortUrl } = useGetShortUrl();
   const [copying, copyLink] = useCopyPostLink(link);
   const { trackEvent } = useContext(AnalyticsContext);
   const { openModal } = useLazyModal();
 
-  const trackClick = (provider: ShareProvider) =>
+  const trackShareEvent = (provider: ShareProvider) =>
     trackEvent(
       postAnalyticsEvent('share post', post, {
         extra: { provider, origin: Origin.ShareBar },
@@ -45,7 +45,7 @@ export default function ShareBar({ post }: ShareBarProps): ReactElement {
     );
 
   const onClick = async (provider: ShareProvider) => {
-    trackClick(provider);
+    trackShareEvent(provider);
 
     const shortLink = await getShortUrl(link);
     const shareLink = getShareLink({
@@ -59,7 +59,7 @@ export default function ShareBar({ post }: ShareBarProps): ReactElement {
   const trackAndCopyLink = async () => {
     const shortLink = await getShortUrl(link);
     copyLink({ link: shortLink });
-    trackClick(ShareProvider.CopyLink);
+    trackShareEvent(ShareProvider.CopyLink);
   };
 
   const onShareToSquad = (squad: Squad) => {

--- a/packages/shared/src/components/ShareOptionsMenu.tsx
+++ b/packages/shared/src/components/ShareOptionsMenu.tsx
@@ -9,11 +9,11 @@ import { postAnalyticsEvent } from '../lib/feed';
 import { MenuIcon } from './MenuIcon';
 import { ShareBookmarkProps } from './post/PostActions';
 import { Origin } from '../lib/analytics';
-import { ShareCID, ShareProvider } from '../lib/share';
+import { ShareProvider } from '../lib/share';
 import { useCopyPostLink } from '../hooks/useCopyPostLink';
 import { useFeature } from './GrowthBookProvider';
 import { feature } from '../lib/featureManagement';
-import { useFeedLayout, useGetShortUrl } from '../hooks';
+import { useFeedLayout, useGetShortUrl, ReferralCampaignKey } from '../hooks';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ './fields/PortalMenu'),
@@ -53,7 +53,7 @@ export default function ShareOptionsMenu({
     );
 
   const trackAndCopyLink = async () => {
-    const shortLink = await getShortUrl(link, ShareCID.Post);
+    const shortLink = await getShortUrl(link, ReferralCampaignKey.SharePost);
     copyLink({ link: shortLink });
     onClick(ShareProvider.CopyLink);
   };

--- a/packages/shared/src/components/ShareOptionsMenu.tsx
+++ b/packages/shared/src/components/ShareOptionsMenu.tsx
@@ -13,7 +13,7 @@ import { ShareProvider } from '../lib/share';
 import { useCopyPostLink } from '../hooks/useCopyPostLink';
 import { useFeature } from './GrowthBookProvider';
 import { feature } from '../lib/featureManagement';
-import { useFeedLayout } from '../hooks';
+import { useFeedLayout, useGetShortUrl } from '../hooks';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ './fields/PortalMenu'),
@@ -41,9 +41,10 @@ export default function ShareOptionsMenu({
   onHidden,
   contextId = 'share-context',
 }: ShareOptionsMenuProps): ReactElement {
-  const link = post && post?.commentsPermalink;
+  const link = post?.commentsPermalink;
   const [, copyLink] = useCopyPostLink(link);
   const { trackEvent } = useContext(AnalyticsContext);
+  const { getShortUrl } = useGetShortUrl();
   const onClick = (provider: ShareProvider) =>
     trackEvent(
       postAnalyticsEvent('share post', post, {
@@ -51,8 +52,9 @@ export default function ShareOptionsMenu({
       }),
     );
 
-  const trackAndCopyLink = () => {
-    copyLink();
+  const trackAndCopyLink = async () => {
+    const shortLink = await getShortUrl(link, 'share_post');
+    copyLink({ link: shortLink });
     onClick(ShareProvider.CopyLink);
   };
 

--- a/packages/shared/src/components/ShareOptionsMenu.tsx
+++ b/packages/shared/src/components/ShareOptionsMenu.tsx
@@ -13,7 +13,8 @@ import { ShareProvider } from '../lib/share';
 import { useCopyPostLink } from '../hooks/useCopyPostLink';
 import { useFeature } from './GrowthBookProvider';
 import { feature } from '../lib/featureManagement';
-import { useFeedLayout, useGetShortUrl, ReferralCampaignKey } from '../hooks';
+import { useFeedLayout, useGetShortUrl } from '../hooks';
+import { ReferralCampaignKey } from '../lib/referral';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ './fields/PortalMenu'),

--- a/packages/shared/src/components/ShareOptionsMenu.tsx
+++ b/packages/shared/src/components/ShareOptionsMenu.tsx
@@ -9,7 +9,7 @@ import { postAnalyticsEvent } from '../lib/feed';
 import { MenuIcon } from './MenuIcon';
 import { ShareBookmarkProps } from './post/PostActions';
 import { Origin } from '../lib/analytics';
-import { ShareProvider } from '../lib/share';
+import { ShareCID, ShareProvider } from '../lib/share';
 import { useCopyPostLink } from '../hooks/useCopyPostLink';
 import { useFeature } from './GrowthBookProvider';
 import { feature } from '../lib/featureManagement';
@@ -53,7 +53,7 @@ export default function ShareOptionsMenu({
     );
 
   const trackAndCopyLink = async () => {
-    const shortLink = await getShortUrl(link, 'share_post');
+    const shortLink = await getShortUrl(link, ShareCID.Post);
     copyLink({ link: shortLink });
     onClick(ShareProvider.CopyLink);
   };

--- a/packages/shared/src/components/modals/ShareModal.spec.tsx
+++ b/packages/shared/src/components/modals/ShareModal.spec.tsx
@@ -68,6 +68,18 @@ const renderComponent = (
 };
 
 describe('ShareModal Test Suite:', () => {
+  const mockWindowOpen = jest.fn();
+  let origWindowOpen = null;
+
+  beforeEach(() => {
+    origWindowOpen = window.open;
+    window.open = mockWindowOpen;
+  });
+
+  afterEach(() => {
+    mockWindowOpen.mockClear();
+    window.open = origWindowOpen;
+  });
   it('should render the component without logged in user', async () => {
     renderComponent(false, false);
     expect(screen.getByText('Share post')).toBeInTheDocument();
@@ -98,26 +110,36 @@ describe('ShareModal Test Suite:', () => {
     expect(modal.type).toEqual(LazyModal.CreateSharedPost);
   });
 
-  it('should render the Facebook button and have the correct link', async () => {
+  it('should render the Facebook button and navigate to the correct link', async () => {
     renderComponent();
-    const link = await screen.findByTestId(`social-share-Facebook`);
+    const btn = await screen.findByTestId(`social-share-Facebook`);
 
-    expect(link).toHaveAttribute(
-      'href',
-      getFacebookShareLink(defaultPost.commentsPermalink),
-    );
+    btn.click();
+
+    await waitFor(() => {
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        getFacebookShareLink(defaultPost.commentsPermalink),
+        '_blank',
+      );
+    });
   });
 
-  it('should render the Facebook button and have the correct comments link', async () => {
+  it('should render the Facebook button and navigate to the correct comments link', async () => {
     renderComponent(false, false, defaultComment);
-    const link = await screen.findByTestId(`social-share-Facebook`);
+    const btn = await screen.findByTestId(`social-share-Facebook`);
 
-    expect(link).toHaveAttribute(
-      'href',
-      getFacebookShareLink(
-        `${defaultPost.commentsPermalink}${getCommentHash(defaultComment.id)}`,
-      ),
-    );
+    btn.click();
+
+    await waitFor(() => {
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        getFacebookShareLink(
+          `${defaultPost.commentsPermalink}${getCommentHash(
+            defaultComment.id,
+          )}`,
+        ),
+        '_blank',
+      );
+    });
   });
 
   it('should render the copy link button and copy link to clipboard', async () => {

--- a/packages/shared/src/components/modals/ShareModal.spec.tsx
+++ b/packages/shared/src/components/modals/ShareModal.spec.tsx
@@ -1,4 +1,10 @@
-import { render, RenderResult, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  RenderResult,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
 import React from 'react';
 import nock from 'nock';
@@ -114,7 +120,7 @@ describe('ShareModal Test Suite:', () => {
     renderComponent();
     const btn = await screen.findByTestId(`social-share-Facebook`);
 
-    btn.click();
+    fireEvent.click(btn);
 
     await waitFor(() => {
       expect(mockWindowOpen).toHaveBeenCalledWith(
@@ -128,7 +134,7 @@ describe('ShareModal Test Suite:', () => {
     renderComponent(false, false, defaultComment);
     const btn = await screen.findByTestId(`social-share-Facebook`);
 
-    btn.click();
+    fireEvent.click(btn);
 
     await waitFor(() => {
       expect(mockWindowOpen).toHaveBeenCalledWith(

--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -6,7 +6,7 @@ import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { useShareOrCopyLink } from '../../hooks/useShareOrCopyLink';
 import { ProfilePicture } from '../ProfilePicture';
 import { largeNumberFormat } from '../../lib/numberFormat';
-import { ShareCID } from '../../lib/share';
+import { ReferralCampaignKey } from '../../hooks';
 
 export type HeaderProps = {
   user: PublicProfile;
@@ -26,7 +26,7 @@ export function Header({
   const [, onShareOrCopyLink] = useShareOrCopyLink({
     text: `Check out ${user.name}'s profile on daily.dev`,
     link: user.permalink,
-    cid: ShareCID.Profile,
+    cid: ReferralCampaignKey.ShareProfile,
     trackObject: () => ({ event_name: 'share profile', target_id: user.id }),
   });
 

--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -6,7 +6,7 @@ import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { useShareOrCopyLink } from '../../hooks/useShareOrCopyLink';
 import { ProfilePicture } from '../ProfilePicture';
 import { largeNumberFormat } from '../../lib/numberFormat';
-import { ReferralCampaignKey } from '../../hooks';
+import { ReferralCampaignKey } from '../../lib/referral';
 
 export type HeaderProps = {
   user: PublicProfile;

--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -6,7 +6,7 @@ import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { useShareOrCopyLink } from '../../hooks/useShareOrCopyLink';
 import { ProfilePicture } from '../ProfilePicture';
 import { largeNumberFormat } from '../../lib/numberFormat';
-import { addTrackingQueryParams } from '../../lib/share';
+import { ShareCID } from '../../lib/share';
 
 export type HeaderProps = {
   user: PublicProfile;
@@ -25,11 +25,8 @@ export function Header({
 }: HeaderProps): ReactElement {
   const [, onShareOrCopyLink] = useShareOrCopyLink({
     text: `Check out ${user.name}'s profile on daily.dev`,
-    link: addTrackingQueryParams({
-      link: user.permalink,
-      userId: user.id,
-      cid: 'share_profile',
-    }),
+    link: user.permalink,
+    cid: ShareCID.Profile,
     trackObject: () => ({ event_name: 'share profile', target_id: user.id }),
   });
 

--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -6,7 +6,7 @@ import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { useShareOrCopyLink } from '../../hooks/useShareOrCopyLink';
 import { ProfilePicture } from '../ProfilePicture';
 import { largeNumberFormat } from '../../lib/numberFormat';
-import { addLinkShareTrackingParams } from '../../lib/share';
+import { addLinkShareTrackingQuery } from '../../lib/share';
 
 export type HeaderProps = {
   user: PublicProfile;
@@ -25,7 +25,11 @@ export function Header({
 }: HeaderProps): ReactElement {
   const [, onShareOrCopyLink] = useShareOrCopyLink({
     text: `Check out ${user.name}'s profile on daily.dev`,
-    link: addLinkShareTrackingParams(user.permalink, user.id, 'share_profile'),
+    link: addLinkShareTrackingQuery({
+      link: user.permalink,
+      userId: user.id,
+      cid: 'share_profile',
+    }),
     trackObject: () => ({ event_name: 'share profile', target_id: user.id }),
   });
 

--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -6,6 +6,7 @@ import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { useShareOrCopyLink } from '../../hooks/useShareOrCopyLink';
 import { ProfilePicture } from '../ProfilePicture';
 import { largeNumberFormat } from '../../lib/numberFormat';
+import { addLinkShareTrackingParams } from '../../lib/share';
 
 export type HeaderProps = {
   user: PublicProfile;
@@ -24,7 +25,7 @@ export function Header({
 }: HeaderProps): ReactElement {
   const [, onShareOrCopyLink] = useShareOrCopyLink({
     text: `Check out ${user.name}'s profile on daily.dev`,
-    link: user.permalink,
+    link: addLinkShareTrackingParams(user.permalink, user.id, 'share_profile'),
     trackObject: () => ({ event_name: 'share profile', target_id: user.id }),
   });
 

--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -6,7 +6,7 @@ import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { useShareOrCopyLink } from '../../hooks/useShareOrCopyLink';
 import { ProfilePicture } from '../ProfilePicture';
 import { largeNumberFormat } from '../../lib/numberFormat';
-import { addLinkShareTrackingQuery } from '../../lib/share';
+import { addTrackingQueryParams } from '../../lib/share';
 
 export type HeaderProps = {
   user: PublicProfile;
@@ -25,7 +25,7 @@ export function Header({
 }: HeaderProps): ReactElement {
   const [, onShareOrCopyLink] = useShareOrCopyLink({
     text: `Check out ${user.name}'s profile on daily.dev`,
-    link: addLinkShareTrackingQuery({
+    link: addTrackingQueryParams({
       link: user.permalink,
       userId: user.id,
       cid: 'share_profile',

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -13,7 +13,8 @@ import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
 import { Squad } from '../../graphql/sources';
 import { SocialShareList } from './SocialShareList';
-import { useGetShortUrl, ReferralCampaignKey } from '../../hooks';
+import { useGetShortUrl } from '../../hooks';
+import { ReferralCampaignKey } from '../../lib/referral';
 import { useAuthContext } from '../../contexts/AuthContext';
 
 interface SocialShareProps {

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useContext } from 'react';
-import { ShareProvider } from '../../lib/share';
+import { ShareProvider, addLinkShareTrackingParams } from '../../lib/share';
 import { Post } from '../../graphql/posts';
 import { FeedItemPosition, postAnalyticsEvent } from '../../lib/feed';
 import { AnalyticsEvent, Origin } from '../../lib/analytics';
@@ -13,6 +13,8 @@ import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
 import { Squad } from '../../graphql/sources';
 import { SocialShareList } from './SocialShareList';
+import { useGetShortUrl } from '../../hooks';
+import { useAuthContext } from '../../contexts/AuthContext';
 
 interface SocialShareProps {
   origin: Origin;
@@ -32,13 +34,15 @@ export const SocialShare = ({
   onSquadShare,
 }: SocialShareProps & FeedItemPosition): ReactElement => {
   const isComment = !!comment;
+  const { user, isAuthReady } = useAuthContext();
   const href = isComment
     ? `${post?.commentsPermalink}${getCommentHash(comment.id)}`
     : post?.commentsPermalink;
-  const [copying, copyLink] = useCopyLink(() => href);
-  const link = isComment
-    ? `${post?.commentsPermalink}${getCommentHash(comment.id)}`
-    : post?.commentsPermalink;
+  const cid = isComment ? 'share_comment' : 'share_post';
+  const link =
+    isAuthReady && user ? addLinkShareTrackingParams(href, user.id, cid) : href;
+  const { getShortUrl } = useGetShortUrl();
+  const [copying, copyLink] = useCopyLink();
   const { openModal } = useLazyModal();
   const { trackEvent } = useContext(AnalyticsContext);
   const { openNativeSharePost } = useSharePost(Origin.Share);
@@ -52,8 +56,9 @@ export const SocialShare = ({
       }),
     );
 
-  const trackAndCopyLink = () => {
-    copyLink();
+  const trackAndCopyLink = async () => {
+    const shortLink = await getShortUrl(link);
+    copyLink({ link: shortLink });
     trackClick(ShareProvider.CopyLink);
   };
 

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useContext } from 'react';
-import { ShareProvider, addLinkShareTrackingQuery } from '../../lib/share';
+import { ShareProvider, addTrackingQueryParams } from '../../lib/share';
 import { Post } from '../../graphql/posts';
 import { FeedItemPosition, postAnalyticsEvent } from '../../lib/feed';
 import { AnalyticsEvent, Origin } from '../../lib/analytics';
@@ -41,7 +41,7 @@ export const SocialShare = ({
   const cid = isComment ? 'share_comment' : 'share_post';
   const link =
     isAuthReady && user
-      ? addLinkShareTrackingQuery({ link: href, userId: user.id, cid })
+      ? addTrackingQueryParams({ link: href, userId: user.id, cid })
       : href;
   const { getShortUrl } = useGetShortUrl();
   const [copying, copyLink] = useCopyLink();

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -1,9 +1,5 @@
 import React, { ReactElement, useContext } from 'react';
-import {
-  ShareCID,
-  ShareProvider,
-  addTrackingQueryParams,
-} from '../../lib/share';
+import { ShareProvider, addTrackingQueryParams } from '../../lib/share';
 import { Post } from '../../graphql/posts';
 import { FeedItemPosition, postAnalyticsEvent } from '../../lib/feed';
 import { AnalyticsEvent, Origin } from '../../lib/analytics';
@@ -17,7 +13,7 @@ import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
 import { Squad } from '../../graphql/sources';
 import { SocialShareList } from './SocialShareList';
-import { useGetShortUrl } from '../../hooks';
+import { useGetShortUrl, ReferralCampaignKey } from '../../hooks';
 import { useAuthContext } from '../../contexts/AuthContext';
 
 interface SocialShareProps {
@@ -42,7 +38,9 @@ export const SocialShare = ({
   const href = isComment
     ? `${post?.commentsPermalink}${getCommentHash(comment.id)}`
     : post?.commentsPermalink;
-  const cid = isComment ? ShareCID.Comment : ShareCID.Post;
+  const cid = isComment
+    ? ReferralCampaignKey.ShareComment
+    : ReferralCampaignKey.SharePost;
   // precompute the share link here, because it's used for copy link
   // as well as passed into the SocialShareList component
   const link =

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useContext } from 'react';
-import { ShareProvider, addLinkShareTrackingParams } from '../../lib/share';
+import { ShareProvider, addLinkShareTrackingQuery } from '../../lib/share';
 import { Post } from '../../graphql/posts';
 import { FeedItemPosition, postAnalyticsEvent } from '../../lib/feed';
 import { AnalyticsEvent, Origin } from '../../lib/analytics';
@@ -40,7 +40,9 @@ export const SocialShare = ({
     : post?.commentsPermalink;
   const cid = isComment ? 'share_comment' : 'share_post';
   const link =
-    isAuthReady && user ? addLinkShareTrackingParams(href, user.id, cid) : href;
+    isAuthReady && user
+      ? addLinkShareTrackingQuery({ link: href, userId: user.id, cid })
+      : href;
   const { getShortUrl } = useGetShortUrl();
   const [copying, copyLink] = useCopyLink();
   const { openModal } = useLazyModal();

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -1,5 +1,9 @@
 import React, { ReactElement, useContext } from 'react';
-import { ShareProvider, addTrackingQueryParams } from '../../lib/share';
+import {
+  ShareCID,
+  ShareProvider,
+  addTrackingQueryParams,
+} from '../../lib/share';
 import { Post } from '../../graphql/posts';
 import { FeedItemPosition, postAnalyticsEvent } from '../../lib/feed';
 import { AnalyticsEvent, Origin } from '../../lib/analytics';
@@ -38,7 +42,9 @@ export const SocialShare = ({
   const href = isComment
     ? `${post?.commentsPermalink}${getCommentHash(comment.id)}`
     : post?.commentsPermalink;
-  const cid = isComment ? 'share_comment' : 'share_post';
+  const cid = isComment ? ShareCID.Comment : ShareCID.Post;
+  // precompute the share link here, because it's used for copy link
+  // as well as passed into the SocialShareList component
   const link =
     isAuthReady && user
       ? addTrackingQueryParams({ link: href, userId: user.id, cid })

--- a/packages/shared/src/components/widgets/SocialShareList.tsx
+++ b/packages/shared/src/components/widgets/SocialShareList.tsx
@@ -39,7 +39,7 @@ export function SocialShareList({
 }: SocialShareListProps): ReactElement {
   const { getShortUrl } = useGetShortUrl();
 
-  const onClick = async (provider: ShareProvider) => {
+  const openShareLink = async (provider: ShareProvider) => {
     onClickSocial(provider);
 
     const shortLink = shortenUrl ? await getShortUrl(link) : link;
@@ -68,12 +68,12 @@ export function SocialShareList({
         icon={<TwitterIcon />}
         variant={ButtonVariant.Primary}
         color={ButtonColor.Twitter}
-        onClick={() => onClick(ShareProvider.Twitter)}
+        onClick={() => openShareLink(ShareProvider.Twitter)}
         label="X"
       />
       <SocialShareButton
         icon={<WhatsappIcon />}
-        onClick={() => onClick(ShareProvider.WhatsApp)}
+        onClick={() => openShareLink(ShareProvider.WhatsApp)}
         variant={ButtonVariant.Primary}
         color={ButtonColor.WhatsApp}
         label="WhatsApp"
@@ -82,35 +82,35 @@ export function SocialShareList({
         icon={<FacebookIcon />}
         variant={ButtonVariant.Primary}
         color={ButtonColor.Facebook}
-        onClick={() => onClick(ShareProvider.Facebook)}
+        onClick={() => openShareLink(ShareProvider.Facebook)}
         label="Facebook"
       />
       <SocialShareButton
         icon={<RedditIcon />}
         variant={ButtonVariant.Primary}
         color={ButtonColor.Reddit}
-        onClick={() => onClick(ShareProvider.Reddit)}
+        onClick={() => openShareLink(ShareProvider.Reddit)}
         label="Reddit"
       />
       <SocialShareButton
         icon={<LinkedInIcon />}
         variant={ButtonVariant.Primary}
         color={ButtonColor.LinkedIn}
-        onClick={() => onClick(ShareProvider.LinkedIn)}
+        onClick={() => openShareLink(ShareProvider.LinkedIn)}
         label="LinkedIn"
       />
       <SocialShareButton
         icon={<TelegramIcon />}
         variant={ButtonVariant.Primary}
         color={ButtonColor.Telegram}
-        onClick={() => onClick(ShareProvider.Telegram)}
+        onClick={() => openShareLink(ShareProvider.Telegram)}
         label="Telegram"
       />
       <SocialShareButton
         icon={<MailIcon />}
         variant={ButtonVariant.Primary}
         className="bg-theme-bg-email text-theme-label-primary"
-        onClick={() => onClick(ShareProvider.Email)}
+        onClick={() => openShareLink(ShareProvider.Email)}
         label="Email"
       />
       {'share' in globalThis?.navigator && (

--- a/packages/shared/src/components/widgets/SocialShareList.tsx
+++ b/packages/shared/src/components/widgets/SocialShareList.tsx
@@ -1,15 +1,6 @@
 import React, { ReactElement } from 'react';
 import { SocialShareButton } from './SocialShareButton';
-import {
-  getEmailShareLink,
-  getFacebookShareLink,
-  getLinkedInShareLink,
-  getRedditShareLink,
-  getTelegramShareLink,
-  getTwitterShareLink,
-  getWhatsappShareLink,
-  ShareProvider,
-} from '../../lib/share';
+import { getShareLink, ShareProvider } from '../../lib/share';
 import {
   MenuIcon,
   MailIcon,
@@ -23,6 +14,7 @@ import {
 } from '../icons';
 import { IconSize } from '../Icon';
 import { ButtonColor, ButtonVariant } from '../buttons/Button';
+import { useGetShortUrl } from '../../hooks';
 
 interface SocialShareListProps {
   link: string;
@@ -32,6 +24,7 @@ interface SocialShareListProps {
   onCopy?(): void;
   onNativeShare(): void;
   onClickSocial(provider: ShareProvider): void;
+  shortenUrl?: boolean;
 }
 
 export function SocialShareList({
@@ -42,7 +35,24 @@ export function SocialShareList({
   onCopy,
   onNativeShare,
   onClickSocial,
+  shortenUrl = true,
 }: SocialShareListProps): ReactElement {
+  const { getShortUrl } = useGetShortUrl();
+
+  const onClick = async (provider: ShareProvider) => {
+    onClickSocial(provider);
+
+    const shortLink = shortenUrl ? await getShortUrl(link) : link;
+    const shareLink = getShareLink(
+      provider,
+      shortLink,
+      provider === ShareProvider.Email
+        ? emailTitle ?? description
+        : description,
+    );
+    window.open(shareLink, '_blank');
+  };
+
   return (
     <>
       {onCopy && (
@@ -54,59 +64,52 @@ export function SocialShareList({
         />
       )}
       <SocialShareButton
-        href={getTwitterShareLink(link, description)}
         icon={<TwitterIcon />}
         variant={ButtonVariant.Primary}
         color={ButtonColor.Twitter}
-        onClick={() => onClickSocial(ShareProvider.Twitter)}
+        onClick={() => onClick(ShareProvider.Twitter)}
         label="X"
       />
       <SocialShareButton
-        href={getWhatsappShareLink(link)}
         icon={<WhatsappIcon />}
-        onClick={() => onClickSocial(ShareProvider.WhatsApp)}
+        onClick={() => onClick(ShareProvider.WhatsApp)}
         variant={ButtonVariant.Primary}
         color={ButtonColor.WhatsApp}
         label="WhatsApp"
       />
       <SocialShareButton
-        href={getFacebookShareLink(link)}
         icon={<FacebookIcon />}
         variant={ButtonVariant.Primary}
         color={ButtonColor.Facebook}
-        onClick={() => onClickSocial(ShareProvider.Facebook)}
+        onClick={() => onClick(ShareProvider.Facebook)}
         label="Facebook"
       />
       <SocialShareButton
-        href={getRedditShareLink(link, description)}
         icon={<RedditIcon />}
         variant={ButtonVariant.Primary}
         color={ButtonColor.Reddit}
-        onClick={() => onClickSocial(ShareProvider.Reddit)}
+        onClick={() => onClick(ShareProvider.Reddit)}
         label="Reddit"
       />
       <SocialShareButton
-        href={getLinkedInShareLink(link)}
         icon={<LinkedInIcon />}
         variant={ButtonVariant.Primary}
         color={ButtonColor.LinkedIn}
-        onClick={() => onClickSocial(ShareProvider.LinkedIn)}
+        onClick={() => onClick(ShareProvider.LinkedIn)}
         label="LinkedIn"
       />
       <SocialShareButton
-        href={getTelegramShareLink(link, description)}
         icon={<TelegramIcon />}
         variant={ButtonVariant.Primary}
         color={ButtonColor.Telegram}
-        onClick={() => onClickSocial(ShareProvider.Telegram)}
+        onClick={() => onClick(ShareProvider.Telegram)}
         label="Telegram"
       />
       <SocialShareButton
-        href={getEmailShareLink(link, emailTitle ?? description)}
         icon={<MailIcon />}
         variant={ButtonVariant.Primary}
         className="bg-theme-bg-email text-theme-label-primary"
-        onClick={() => onClickSocial(ShareProvider.Email)}
+        onClick={() => onClick(ShareProvider.Email)}
         label="Email"
       />
       {'share' in globalThis?.navigator && (

--- a/packages/shared/src/components/widgets/SocialShareList.tsx
+++ b/packages/shared/src/components/widgets/SocialShareList.tsx
@@ -43,13 +43,14 @@ export function SocialShareList({
     onClickSocial(provider);
 
     const shortLink = shortenUrl ? await getShortUrl(link) : link;
-    const shareLink = getShareLink(
+    const shareLink = getShareLink({
       provider,
-      shortLink,
-      provider === ShareProvider.Email
-        ? emailTitle ?? description
-        : description,
-    );
+      link: shortLink,
+      text:
+        provider === ShareProvider.Email
+          ? emailTitle ?? description
+          : description,
+    });
     window.open(shareLink, '_blank');
   };
 

--- a/packages/shared/src/graphql/urlShortener.ts
+++ b/packages/shared/src/graphql/urlShortener.ts
@@ -1,0 +1,11 @@
+import { gql } from 'graphql-request';
+
+export interface GetShortUrlQueryResult {
+  getShortUrl: string;
+}
+
+export const GET_SHORT_URL_QUERY = gql`
+  query GetShortUrl($url: String!) {
+    getShortUrl(url: $url)
+  }
+`;

--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -21,3 +21,4 @@ export * from './usePrevious';
 export * from './useEventListener';
 export * from './useTruncatedSummary';
 export * from './useScrollRestoration';
+export * from './utils/useGetShortUrl';

--- a/packages/shared/src/hooks/referral/useReferralCampaign.ts
+++ b/packages/shared/src/hooks/referral/useReferralCampaign.ts
@@ -9,6 +9,8 @@ import { Feature } from '../../lib/featureManagement';
 import { useFeatureIsOn } from '../../components/GrowthBookProvider';
 import { isTesting } from '../../lib/constants';
 
+export { ReferralCampaignKey } from '../../lib/referral';
+
 export interface ReferralCampaign {
   referredUsersCount: number;
   referralCountLimit: number;
@@ -21,14 +23,6 @@ export interface UseReferralCampaign extends ReferralCampaign {
   isReady: boolean;
   availableCount: number;
   noKeysAvailable: boolean;
-}
-
-export enum ReferralCampaignKey {
-  Generic = 'generic',
-  Search = 'search',
-  SharePost = 'share_post',
-  ShareComment = 'share_comment',
-  ShareProfile = 'share_profile',
 }
 
 export type UseReferralCampaignProps = {

--- a/packages/shared/src/hooks/referral/useReferralCampaign.ts
+++ b/packages/shared/src/hooks/referral/useReferralCampaign.ts
@@ -26,7 +26,9 @@ export interface UseReferralCampaign extends ReferralCampaign {
 export enum ReferralCampaignKey {
   Generic = 'generic',
   Search = 'search',
-  Share = 'share',
+  SharePost = 'share_post',
+  ShareComment = 'share_comment',
+  ShareProfile = 'share_profile',
 }
 
 export type UseReferralCampaignProps = {

--- a/packages/shared/src/hooks/referral/useReferralCampaign.ts
+++ b/packages/shared/src/hooks/referral/useReferralCampaign.ts
@@ -9,7 +9,9 @@ import { Feature } from '../../lib/featureManagement';
 import { useFeatureIsOn } from '../../components/GrowthBookProvider';
 import { isTesting } from '../../lib/constants';
 
-export { ReferralCampaignKey } from '../../lib/referral';
+import { ReferralCampaignKey } from '../../lib/referral';
+
+export { ReferralCampaignKey };
 
 export interface ReferralCampaign {
   referredUsersCount: number;

--- a/packages/shared/src/hooks/useShareComment.ts
+++ b/packages/shared/src/hooks/useShareComment.ts
@@ -2,11 +2,12 @@ import { useContext, useEffect, useMemo, useState } from 'react';
 import { Post } from '../graphql/posts';
 import { postAnalyticsEvent } from '../lib/feed';
 import AnalyticsContext from '../contexts/AnalyticsContext';
-import { ShareCID, ShareProvider } from '../lib/share';
+import { ShareProvider } from '../lib/share';
 import { Origin } from '../lib/analytics';
 import { Comment, getCommentHash } from '../graphql/comments';
 import useDebounce from './useDebounce';
 import { useGetShortUrl } from './utils/useGetShortUrl';
+import { ReferralCampaignKey } from './referral';
 
 interface UseShareComment {
   shareComment: Comment;
@@ -42,7 +43,7 @@ export function useShareComment(
           try {
             const shortUrl = await getShortUrl(
               `${post.commentsPermalink}${getCommentHash(comment.id)}`,
-              ShareCID.Comment,
+              ReferralCampaignKey.ShareComment,
             );
             await navigator.share({
               text: `${post.title}\n${shortUrl}$}`,

--- a/packages/shared/src/hooks/useShareComment.ts
+++ b/packages/shared/src/hooks/useShareComment.ts
@@ -2,7 +2,7 @@ import { useContext, useEffect, useMemo, useState } from 'react';
 import { Post } from '../graphql/posts';
 import { postAnalyticsEvent } from '../lib/feed';
 import AnalyticsContext from '../contexts/AnalyticsContext';
-import { ShareProvider } from '../lib/share';
+import { ShareCID, ShareProvider } from '../lib/share';
 import { Origin } from '../lib/analytics';
 import { Comment, getCommentHash } from '../graphql/comments';
 import useDebounce from './useDebounce';
@@ -42,7 +42,7 @@ export function useShareComment(
           try {
             const shortUrl = await getShortUrl(
               `${post.commentsPermalink}${getCommentHash(comment.id)}`,
-              'share_comment',
+              ShareCID.Comment,
             );
             await navigator.share({
               text: `${post.title}\n${shortUrl}$}`,

--- a/packages/shared/src/hooks/useShareComment.ts
+++ b/packages/shared/src/hooks/useShareComment.ts
@@ -6,6 +6,7 @@ import { ShareProvider } from '../lib/share';
 import { Origin } from '../lib/analytics';
 import { Comment, getCommentHash } from '../graphql/comments';
 import useDebounce from './useDebounce';
+import { useGetShortUrl } from './utils/useGetShortUrl';
 
 interface UseShareComment {
   shareComment: Comment;
@@ -23,6 +24,7 @@ export function useShareComment(
   const [shareModal, setShareModal] = useState<Comment>(null);
   const [showShareNewComment, setShowShareNewComment] = useState(null);
   const [showNewComment] = useDebounce((id) => setShowShareNewComment(id), 700);
+  const { getShortUrl } = useGetShortUrl();
 
   useEffect(() => {
     if (enableShowShareNewComment) {
@@ -38,10 +40,12 @@ export function useShareComment(
       openShareComment: async (comment, post) => {
         if ('share' in navigator) {
           try {
+            const shortUrl = await getShortUrl(
+              `${post.commentsPermalink}${getCommentHash(comment.id)}`,
+              'share_comment',
+            );
             await navigator.share({
-              text: `${post.title}\n${post.commentsPermalink}${getCommentHash(
-                comment.id,
-              )}`,
+              text: `${post.title}\n${shortUrl}$}`,
             });
             trackEvent(
               postAnalyticsEvent('share post', post, {

--- a/packages/shared/src/hooks/useShareComment.ts
+++ b/packages/shared/src/hooks/useShareComment.ts
@@ -7,7 +7,7 @@ import { Origin } from '../lib/analytics';
 import { Comment, getCommentHash } from '../graphql/comments';
 import useDebounce from './useDebounce';
 import { useGetShortUrl } from './utils/useGetShortUrl';
-import { ReferralCampaignKey } from './referral';
+import { ReferralCampaignKey } from '../lib/referral';
 
 interface UseShareComment {
   shareComment: Comment;

--- a/packages/shared/src/hooks/useShareOrCopyLink.ts
+++ b/packages/shared/src/hooks/useShareOrCopyLink.ts
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { CopyNotifyFunction, useCopyLink } from './useCopy';
-import { ShareProvider } from '../lib/share';
+import { ShareCID, ShareProvider } from '../lib/share';
 import { AnalyticsEvent } from './analytics/useAnalyticsQueue';
 import { useGetShortUrl } from './utils/useGetShortUrl';
 
@@ -10,19 +10,20 @@ interface UseShareOrCopyLinkProps {
   text: string;
   trackObject?: (provider: ShareProvider) => AnalyticsEvent;
   shortenUrl?: boolean;
+  cid?: ShareCID;
 }
 export function useShareOrCopyLink({
   link,
   text,
   trackObject,
-  shortenUrl = true,
+  cid,
 }: UseShareOrCopyLinkProps): ReturnType<typeof useCopyLink> {
   const { trackEvent } = useContext(AnalyticsContext);
-  const [copying, copyLink] = useCopyLink(() => link);
+  const [copying, copyLink] = useCopyLink();
   const { getShortUrl } = useGetShortUrl();
 
   const onShareOrCopy: CopyNotifyFunction = async () => {
-    const shortLink = shortenUrl ? await getShortUrl(link) : link;
+    const shortLink = cid ? await getShortUrl(link, cid) : link;
 
     if ('share' in navigator) {
       try {

--- a/packages/shared/src/hooks/useShareOrCopyLink.ts
+++ b/packages/shared/src/hooks/useShareOrCopyLink.ts
@@ -3,25 +3,31 @@ import AnalyticsContext from '../contexts/AnalyticsContext';
 import { CopyNotifyFunction, useCopyLink } from './useCopy';
 import { ShareProvider } from '../lib/share';
 import { AnalyticsEvent } from './analytics/useAnalyticsQueue';
+import { useGetShortUrl } from './utils/useGetShortUrl';
 
 interface UseShareOrCopyLinkProps {
   link: string;
   text: string;
   trackObject?: (provider: ShareProvider) => AnalyticsEvent;
+  shortenUrl?: boolean;
 }
 export function useShareOrCopyLink({
   link,
   text,
   trackObject,
+  shortenUrl = true,
 }: UseShareOrCopyLinkProps): ReturnType<typeof useCopyLink> {
   const { trackEvent } = useContext(AnalyticsContext);
   const [copying, copyLink] = useCopyLink(() => link);
+  const { getShortUrl } = useGetShortUrl();
 
-  const onShareOrCopy: CopyNotifyFunction = async (...args) => {
+  const onShareOrCopy: CopyNotifyFunction = async () => {
+    const shortLink = shortenUrl ? await getShortUrl(link) : link;
+
     if ('share' in navigator) {
       try {
         await navigator.share({
-          text: `${text}\n${link}`,
+          text: `${text}\n${shortLink}`,
         });
         trackEvent(trackObject(ShareProvider.Native));
       } catch (err) {
@@ -29,7 +35,7 @@ export function useShareOrCopyLink({
       }
     } else {
       trackEvent(trackObject(ShareProvider.CopyLink));
-      copyLink(...args);
+      copyLink({ link: shortLink });
     }
   };
 

--- a/packages/shared/src/hooks/useShareOrCopyLink.ts
+++ b/packages/shared/src/hooks/useShareOrCopyLink.ts
@@ -1,16 +1,17 @@
 import { useContext } from 'react';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { CopyNotifyFunction, useCopyLink } from './useCopy';
-import { ShareCID, ShareProvider } from '../lib/share';
+import { ShareProvider } from '../lib/share';
 import { AnalyticsEvent } from './analytics/useAnalyticsQueue';
 import { useGetShortUrl } from './utils/useGetShortUrl';
+import { ReferralCampaignKey } from './referral';
 
 interface UseShareOrCopyLinkProps {
   link: string;
   text: string;
   trackObject?: (provider: ShareProvider) => AnalyticsEvent;
   shortenUrl?: boolean;
-  cid?: ShareCID;
+  cid?: ReferralCampaignKey;
 }
 export function useShareOrCopyLink({
   link,

--- a/packages/shared/src/hooks/useShareOrCopyLink.ts
+++ b/packages/shared/src/hooks/useShareOrCopyLink.ts
@@ -4,7 +4,7 @@ import { CopyNotifyFunction, useCopyLink } from './useCopy';
 import { ShareProvider } from '../lib/share';
 import { AnalyticsEvent } from './analytics/useAnalyticsQueue';
 import { useGetShortUrl } from './utils/useGetShortUrl';
-import { ReferralCampaignKey } from './referral';
+import { ReferralCampaignKey } from '../lib/referral';
 
 interface UseShareOrCopyLinkProps {
   link: string;

--- a/packages/shared/src/hooks/useSharePost.ts
+++ b/packages/shared/src/hooks/useSharePost.ts
@@ -2,10 +2,11 @@ import { useContext, useMemo, useState } from 'react';
 import { Post } from '../graphql/posts';
 import { FeedItemPosition, postAnalyticsEvent } from '../lib/feed';
 import AnalyticsContext from '../contexts/AnalyticsContext';
-import { ShareCID, ShareProvider } from '../lib/share';
+import { ShareProvider } from '../lib/share';
 import { Origin } from '../lib/analytics';
 import { useCopyPostLink } from './useCopyPostLink';
 import { useGetShortUrl } from './utils/useGetShortUrl';
+import { ReferralCampaignKey } from './referral';
 
 export function useSharePost(origin: Origin): {
   sharePost: Post;
@@ -55,7 +56,7 @@ export function useSharePost(origin: Origin): {
         );
         const shortLink = await getShortUrl(
           post.commentsPermalink,
-          ShareCID.Post,
+          ReferralCampaignKey.SharePost,
         );
         copyLink({ link: shortLink });
       },
@@ -73,7 +74,7 @@ export function useSharePost(origin: Origin): {
         try {
           const shortLink = await getShortUrl(
             post.commentsPermalink,
-            ShareCID.Post,
+            ReferralCampaignKey.SharePost,
           );
           await navigator.share({
             title: post.title,

--- a/packages/shared/src/hooks/useSharePost.ts
+++ b/packages/shared/src/hooks/useSharePost.ts
@@ -6,7 +6,7 @@ import { ShareProvider } from '../lib/share';
 import { Origin } from '../lib/analytics';
 import { useCopyPostLink } from './useCopyPostLink';
 import { useGetShortUrl } from './utils/useGetShortUrl';
-import { ReferralCampaignKey } from './referral';
+import { ReferralCampaignKey } from '../lib/referral';
 
 export function useSharePost(origin: Origin): {
   sharePost: Post;

--- a/packages/shared/src/hooks/useSharePost.ts
+++ b/packages/shared/src/hooks/useSharePost.ts
@@ -2,7 +2,7 @@ import { useContext, useMemo, useState } from 'react';
 import { Post } from '../graphql/posts';
 import { FeedItemPosition, postAnalyticsEvent } from '../lib/feed';
 import AnalyticsContext from '../contexts/AnalyticsContext';
-import { ShareProvider } from '../lib/share';
+import { ShareCID, ShareProvider } from '../lib/share';
 import { Origin } from '../lib/analytics';
 import { useCopyPostLink } from './useCopyPostLink';
 import { useGetShortUrl } from './utils/useGetShortUrl';
@@ -55,7 +55,7 @@ export function useSharePost(origin: Origin): {
         );
         const shortLink = await getShortUrl(
           post.commentsPermalink,
-          'share_post',
+          ShareCID.Post,
         );
         copyLink({ link: shortLink });
       },
@@ -73,7 +73,7 @@ export function useSharePost(origin: Origin): {
         try {
           const shortLink = await getShortUrl(
             post.commentsPermalink,
-            'share_post',
+            ShareCID.Post,
           );
           await navigator.share({
             title: post.title,

--- a/packages/shared/src/hooks/useSharePost.ts
+++ b/packages/shared/src/hooks/useSharePost.ts
@@ -5,6 +5,7 @@ import AnalyticsContext from '../contexts/AnalyticsContext';
 import { ShareProvider } from '../lib/share';
 import { Origin } from '../lib/analytics';
 import { useCopyPostLink } from './useCopyPostLink';
+import { useGetShortUrl } from './utils/useGetShortUrl';
 
 export function useSharePost(origin: Origin): {
   sharePost: Post;
@@ -19,6 +20,7 @@ export function useSharePost(origin: Origin): {
   const [, copyLink] = useCopyPostLink();
   const [sharePostFeedLocation, setSharePostFeedLocation] =
     useState<FeedItemPosition>({});
+  const { getShortUrl } = useGetShortUrl();
 
   return useMemo(
     () => ({
@@ -51,7 +53,11 @@ export function useSharePost(origin: Origin): {
             extra: { provider: ShareProvider.CopyLink, origin },
           }),
         );
-        copyLink({ link: post.commentsPermalink });
+        const shortLink = await getShortUrl(
+          post.commentsPermalink,
+          'share_post',
+        );
+        copyLink({ link: shortLink });
       },
       openNativeSharePost: async (
         post: Post,
@@ -65,9 +71,13 @@ export function useSharePost(origin: Origin): {
           row,
         });
         try {
+          const shortLink = await getShortUrl(
+            post.commentsPermalink,
+            'share_post',
+          );
           await navigator.share({
             title: post.title,
-            url: post.commentsPermalink,
+            url: shortLink,
           });
           trackEvent(
             postAnalyticsEvent('share post', post, {

--- a/packages/shared/src/hooks/useSquadInvitation.ts
+++ b/packages/shared/src/hooks/useSquadInvitation.ts
@@ -4,6 +4,8 @@ import { AnalyticsEvent } from '../lib/analytics';
 import { Squad } from '../graphql/sources';
 import { useActions } from './useActions';
 import { ActionType } from '../graphql/actions';
+import { addLinkShareTrackingParams } from '../lib/share';
+import { useAuthContext } from '../contexts/AuthContext';
 
 export interface UseSquadInvitationProps {
   squad: Squad;
@@ -22,8 +24,13 @@ export const useSquadInvitation = ({
 }: UseSquadInvitationProps): UseSquadInvitation => {
   const { trackEvent } = useAnalyticsContext();
   const { completeAction } = useActions();
+  const { user } = useAuthContext();
 
-  const invitation = squad.referralUrl;
+  const invitation = addLinkShareTrackingParams(
+    squad.referralUrl,
+    user?.id,
+    'squad_invite',
+  );
   const [copying, copyLink] = useCopyLink(() => invitation);
 
   const trackAndCopyLink = () => {

--- a/packages/shared/src/hooks/useSquadInvitation.ts
+++ b/packages/shared/src/hooks/useSquadInvitation.ts
@@ -4,8 +4,6 @@ import { AnalyticsEvent } from '../lib/analytics';
 import { Squad } from '../graphql/sources';
 import { useActions } from './useActions';
 import { ActionType } from '../graphql/actions';
-import { addLinkShareTrackingParams } from '../lib/share';
-import { useAuthContext } from '../contexts/AuthContext';
 
 export interface UseSquadInvitationProps {
   squad: Squad;
@@ -24,13 +22,8 @@ export const useSquadInvitation = ({
 }: UseSquadInvitationProps): UseSquadInvitation => {
   const { trackEvent } = useAnalyticsContext();
   const { completeAction } = useActions();
-  const { user } = useAuthContext();
 
-  const invitation = addLinkShareTrackingParams(
-    squad.referralUrl,
-    user?.id,
-    'squad_invite',
-  );
+  const invitation = squad.referralUrl;
   const [copying, copyLink] = useCopyLink(() => invitation);
 
   const trackAndCopyLink = () => {

--- a/packages/shared/src/hooks/utils/useGetShortUrl.ts
+++ b/packages/shared/src/hooks/utils/useGetShortUrl.ts
@@ -42,7 +42,7 @@ export const useGetShortUrl = (): UseGetShortUrlResult => {
         );
         return data.getShortUrl;
       } catch (err) {
-        return url;
+        return trackingUrl;
       }
     },
   };

--- a/packages/shared/src/hooks/utils/useGetShortUrl.ts
+++ b/packages/shared/src/hooks/utils/useGetShortUrl.ts
@@ -4,11 +4,12 @@ import { useCallback } from 'react';
 import { graphqlUrl } from '../../lib/config';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { GET_SHORT_URL_QUERY } from '../../graphql/urlShortener';
-import { ShareCID, addTrackingQueryParams } from '../../lib/share';
+import { addTrackingQueryParams } from '../../lib/share';
 import { RequestKey, generateQueryKey } from '../../lib/query';
+import { ReferralCampaignKey } from '../referral';
 
 interface UseGetShortUrlResult {
-  getShortUrl: (url: string, cid?: ShareCID) => Promise<string>;
+  getShortUrl: (url: string, cid?: ReferralCampaignKey) => Promise<string>;
 }
 
 export const useGetShortUrl = (): UseGetShortUrlResult => {
@@ -16,7 +17,7 @@ export const useGetShortUrl = (): UseGetShortUrlResult => {
   const queryClient = useQueryClient();
 
   const getShortUrl = useCallback(
-    async (url: string, cid?: ShareCID) => {
+    async (url: string, cid?: ReferralCampaignKey) => {
       if (!url || !isAuthReady || !user) {
         return url;
       }

--- a/packages/shared/src/hooks/utils/useGetShortUrl.ts
+++ b/packages/shared/src/hooks/utils/useGetShortUrl.ts
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
 import { graphqlUrl } from '../../lib/config';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { GET_SHORT_URL_QUERY } from '../../graphql/urlShortener';
-import { addLinkShareTrackingQuery } from '../../lib/share';
+import { addTrackingQueryParams } from '../../lib/share';
 
 interface UseGetShortUrlResult {
   getShortUrl: (url: string, cid?: string) => Promise<string>;
@@ -21,7 +21,7 @@ export const useGetShortUrl = (): UseGetShortUrlResult => {
       }
 
       const trackingUrl = cid
-        ? addLinkShareTrackingQuery({ link: url, userId: user?.id, cid })
+        ? addTrackingQueryParams({ link: url, userId: user?.id, cid })
         : url;
       const shortUrlKey = ['short_url', trackingUrl];
 

--- a/packages/shared/src/hooks/utils/useGetShortUrl.ts
+++ b/packages/shared/src/hooks/utils/useGetShortUrl.ts
@@ -1,0 +1,49 @@
+import { useQueryClient } from '@tanstack/react-query';
+import request from 'graphql-request';
+import { graphqlUrl } from '../../lib/config';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { GET_SHORT_URL_QUERY } from '../../graphql/urlShortener';
+import { addLinkShareTrackingParams } from '../../lib/share';
+
+interface UseGetShortUrlResult {
+  getShortUrl: (url: string, cid?: string) => Promise<string>;
+}
+
+export const useGetShortUrl = (): UseGetShortUrlResult => {
+  const { user, isAuthReady } = useAuthContext();
+  const queryClient = useQueryClient();
+
+  if (!isAuthReady || !user) {
+    return {
+      getShortUrl: async (url: string) => {
+        return url;
+      },
+    };
+  }
+
+  return {
+    getShortUrl: async (url: string, cid?: string) => {
+      if (!url) {
+        return url;
+      }
+
+      const trackingUrl = cid
+        ? addLinkShareTrackingParams(url, user?.id, cid)
+        : url;
+      const shortUrlKey = ['short_url', trackingUrl];
+
+      try {
+        const data = await queryClient.fetchQuery(
+          shortUrlKey,
+          () => request(graphqlUrl, GET_SHORT_URL_QUERY, { url: trackingUrl }),
+          {
+            staleTime: Infinity,
+          },
+        );
+        return data.getShortUrl;
+      } catch (err) {
+        return url;
+      }
+    },
+  };
+};

--- a/packages/shared/src/hooks/utils/useGetShortUrl.ts
+++ b/packages/shared/src/hooks/utils/useGetShortUrl.ts
@@ -6,7 +6,7 @@ import { useAuthContext } from '../../contexts/AuthContext';
 import { GET_SHORT_URL_QUERY } from '../../graphql/urlShortener';
 import { addTrackingQueryParams } from '../../lib/share';
 import { RequestKey, generateQueryKey } from '../../lib/query';
-import { ReferralCampaignKey } from '../referral';
+import { ReferralCampaignKey } from '../../lib/referral';
 
 interface UseGetShortUrlResult {
   getShortUrl: (url: string, cid?: ReferralCampaignKey) => Promise<string>;

--- a/packages/shared/src/hooks/utils/useGetShortUrl.ts
+++ b/packages/shared/src/hooks/utils/useGetShortUrl.ts
@@ -4,10 +4,11 @@ import { useCallback } from 'react';
 import { graphqlUrl } from '../../lib/config';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { GET_SHORT_URL_QUERY } from '../../graphql/urlShortener';
-import { addTrackingQueryParams } from '../../lib/share';
+import { ShareCID, addTrackingQueryParams } from '../../lib/share';
+import { RequestKey, generateQueryKey } from '../../lib/query';
 
 interface UseGetShortUrlResult {
-  getShortUrl: (url: string, cid?: string) => Promise<string>;
+  getShortUrl: (url: string, cid?: ShareCID) => Promise<string>;
 }
 
 export const useGetShortUrl = (): UseGetShortUrlResult => {
@@ -15,7 +16,7 @@ export const useGetShortUrl = (): UseGetShortUrlResult => {
   const queryClient = useQueryClient();
 
   const getShortUrl = useCallback(
-    async (url: string, cid?: string) => {
+    async (url: string, cid?: ShareCID) => {
       if (!url || !isAuthReady || !user) {
         return url;
       }
@@ -23,7 +24,11 @@ export const useGetShortUrl = (): UseGetShortUrlResult => {
       const trackingUrl = cid
         ? addTrackingQueryParams({ link: url, userId: user?.id, cid })
         : url;
-      const shortUrlKey = ['short_url', trackingUrl];
+      const shortUrlKey = generateQueryKey(
+        RequestKey.ShortUrl,
+        null,
+        trackingUrl,
+      );
 
       try {
         const data = await queryClient.fetchQuery(

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -94,6 +94,7 @@ export enum RequestKey {
   OneSignal = 'onesignal',
   ActiveUsers = 'active_users',
   PushNotification = 'push_notification',
+  ShortUrl = 'short_url',
 }
 
 export type HasConnection<

--- a/packages/shared/src/lib/referral.ts
+++ b/packages/shared/src/lib/referral.ts
@@ -1,0 +1,7 @@
+export enum ReferralCampaignKey {
+  Generic = 'generic',
+  Search = 'search',
+  SharePost = 'share_post',
+  ShareComment = 'share_comment',
+  ShareProfile = 'share_profile',
+}

--- a/packages/shared/src/lib/share.spec.ts
+++ b/packages/shared/src/lib/share.spec.ts
@@ -1,0 +1,121 @@
+import {
+  AddLinkShareTrackingQueryParams,
+  ShareProvider,
+  addLinkShareTrackingQuery,
+  getShareLink,
+} from './share';
+
+describe('getShareLink tests', () => {
+  const link = 'https://foo.bar';
+  const text = 'hello world';
+  it('should return WhatsApp share link', () => {
+    const result = getShareLink({
+      provider: ShareProvider.WhatsApp,
+      link,
+      text,
+    });
+    expect(result).toEqual(`https://wa.me/?text=${encodeURIComponent(link)}`);
+  });
+
+  it('should return Twitter share link', () => {
+    const result = getShareLink({
+      provider: ShareProvider.Twitter,
+      link,
+      text,
+    });
+    expect(result).toEqual(
+      `http://twitter.com/share?url=${encodeURIComponent(
+        link,
+      )}&text=${encodeURIComponent(`${text} via @dailydotdev`)}`,
+    );
+  });
+
+  it('should return Facebook share link', () => {
+    const result = getShareLink({
+      provider: ShareProvider.Facebook,
+      link,
+    });
+    expect(result).toEqual(
+      `https://www.facebook.com/sharer/sharer.php?display=page&u=${encodeURIComponent(
+        link,
+      )}`,
+    );
+  });
+
+  it('should return Reddit share link', () => {
+    const result = getShareLink({
+      provider: ShareProvider.Reddit,
+      link,
+      text,
+    });
+    expect(result).toEqual(
+      `https://reddit.com/submit?url=${encodeURIComponent(link)}&title=${text}`,
+    );
+  });
+
+  it('should return LinkedIn share link', () => {
+    const result = getShareLink({
+      provider: ShareProvider.LinkedIn,
+      link,
+    });
+    expect(result).toEqual(
+      `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
+        link,
+      )}`,
+    );
+  });
+
+  it('should return Telegram share link', () => {
+    const result = getShareLink({
+      provider: ShareProvider.Telegram,
+      link,
+      text,
+    });
+    expect(result).toEqual(
+      `https://t.me/share/url?url=${encodeURIComponent(link)}&text=${text}`,
+    );
+  });
+
+  it('should return Email share link', () => {
+    const result = getShareLink({
+      provider: ShareProvider.Email,
+      link,
+      text,
+    });
+    expect(result).toEqual(
+      `mailto:?subject=${text}&body=${encodeURIComponent(link)}`,
+    );
+  });
+});
+
+describe('addLinkShareTrackingQuery tests', () => {
+  const link = 'https://foo.bar';
+  const userId = '42';
+  const cid = 'share_post';
+
+  const runTest = (params: AddLinkShareTrackingQueryParams, expected: any) => {
+    const result = addLinkShareTrackingQuery(params);
+    expect(result).toEqual(expected);
+  };
+  it('should return link as is if not provided', () => {
+    runTest({ link: undefined, userId, cid }, undefined);
+  });
+
+  it('should return link as is if userId not provided', () => {
+    runTest({ link, userId: null, cid }, link);
+  });
+
+  it('should add userId and cid query params', () => {
+    runTest(
+      { link, userId, cid },
+      `https://foo.bar/?userId=${userId}&cid=${cid}`,
+    );
+  });
+
+  it('should replace userId and cid query params', () => {
+    runTest(
+      { link: 'https://foo.bar/?userId=123&cid=share_comment', userId, cid },
+      `https://foo.bar/?userId=${userId}&cid=${cid}`,
+    );
+  });
+});

--- a/packages/shared/src/lib/share.spec.ts
+++ b/packages/shared/src/lib/share.spec.ts
@@ -1,5 +1,6 @@
 import {
   AddLinkShareTrackingQueryParams,
+  ShareCID,
   ShareProvider,
   addTrackingQueryParams,
   getShareLink,
@@ -91,7 +92,7 @@ describe('getShareLink tests', () => {
 describe('addTrackingQueryParams tests', () => {
   const link = 'https://foo.bar';
   const userId = '42';
-  const cid = 'share_post';
+  const cid = ShareCID.Post;
 
   const runTest = (
     params: AddLinkShareTrackingQueryParams,

--- a/packages/shared/src/lib/share.spec.ts
+++ b/packages/shared/src/lib/share.spec.ts
@@ -112,14 +112,14 @@ describe('addTrackingQueryParams tests', () => {
   it('should add userId and cid query params', () => {
     runTest(
       { link, userId, cid },
-      `https://foo.bar/?userId=${userId}&cid=${cid}`,
+      `https://foo.bar/?userid=${userId}&cid=${cid}`,
     );
   });
 
   it('should replace userId and cid query params', () => {
     runTest(
-      { link: 'https://foo.bar/?userId=123&cid=share_comment', userId, cid },
-      `https://foo.bar/?userId=${userId}&cid=${cid}`,
+      { link: 'https://foo.bar/?userid=123&cid=share_comment', userId, cid },
+      `https://foo.bar/?userid=${userId}&cid=${cid}`,
     );
   });
 });

--- a/packages/shared/src/lib/share.spec.ts
+++ b/packages/shared/src/lib/share.spec.ts
@@ -93,7 +93,10 @@ describe('addLinkShareTrackingQuery tests', () => {
   const userId = '42';
   const cid = 'share_post';
 
-  const runTest = (params: AddLinkShareTrackingQueryParams, expected: any) => {
+  const runTest = (
+    params: AddLinkShareTrackingQueryParams,
+    expected: string | undefined,
+  ) => {
     const result = addLinkShareTrackingQuery(params);
     expect(result).toEqual(expected);
   };

--- a/packages/shared/src/lib/share.spec.ts
+++ b/packages/shared/src/lib/share.spec.ts
@@ -1,4 +1,4 @@
-import { ReferralCampaignKey } from '../hooks';
+import { ReferralCampaignKey } from './referral';
 import {
   AddLinkShareTrackingQueryParams,
   ShareProvider,

--- a/packages/shared/src/lib/share.spec.ts
+++ b/packages/shared/src/lib/share.spec.ts
@@ -1,7 +1,7 @@
 import {
   AddLinkShareTrackingQueryParams,
   ShareProvider,
-  addLinkShareTrackingQuery,
+  addTrackingQueryParams,
   getShareLink,
 } from './share';
 
@@ -88,7 +88,7 @@ describe('getShareLink tests', () => {
   });
 });
 
-describe('addLinkShareTrackingQuery tests', () => {
+describe('addTrackingQueryParams tests', () => {
   const link = 'https://foo.bar';
   const userId = '42';
   const cid = 'share_post';
@@ -97,7 +97,7 @@ describe('addLinkShareTrackingQuery tests', () => {
     params: AddLinkShareTrackingQueryParams,
     expected: string | undefined,
   ) => {
-    const result = addLinkShareTrackingQuery(params);
+    const result = addTrackingQueryParams(params);
     expect(result).toEqual(expected);
   };
   it('should return link as is if not provided', () => {

--- a/packages/shared/src/lib/share.spec.ts
+++ b/packages/shared/src/lib/share.spec.ts
@@ -1,6 +1,6 @@
+import { ReferralCampaignKey } from '../hooks';
 import {
   AddLinkShareTrackingQueryParams,
-  ShareCID,
   ShareProvider,
   addTrackingQueryParams,
   getShareLink,
@@ -92,7 +92,7 @@ describe('getShareLink tests', () => {
 describe('addTrackingQueryParams tests', () => {
   const link = 'https://foo.bar';
   const userId = '42';
-  const cid = ShareCID.Post;
+  const cid = ReferralCampaignKey.SharePost;
 
   const runTest = (
     params: AddLinkShareTrackingQueryParams,

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -1,4 +1,4 @@
-import { ReferralCampaignKey } from '../hooks';
+import { ReferralCampaignKey } from './referral';
 
 export enum ShareProvider {
   Native = 'native',

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -62,7 +62,7 @@ export const getShareLink = ({
   }
 };
 
-interface AddLinkShareTrackingQueryParams {
+export interface AddLinkShareTrackingQueryParams {
   link: string | undefined;
   userId: string | undefined;
   cid: string;

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -68,18 +68,13 @@ export interface AddLinkShareTrackingQueryParams {
   cid: string;
 }
 
-export const addLinkShareTrackingQuery = ({
+export const addTrackingQueryParams = ({
   link,
   userId,
   cid,
 }: AddLinkShareTrackingQueryParams): string => {
   // return link as is if not provided
-  if (!link) {
-    return link;
-  }
-
-  // return link as is if params are not provided
-  if (!userId || !cid) {
+  if (!link || !userId || !cid) {
     return link;
   }
 

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -80,7 +80,7 @@ export const addTrackingQueryParams = ({
   }
 
   const url = new URL(link);
-  url.searchParams.set('userId', userId);
+  url.searchParams.set('userid', userId);
   url.searchParams.set('cid', cid);
 
   return url.toString();

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -30,3 +30,47 @@ export const getTelegramShareLink = (link: string, text: string): string =>
   `https://t.me/share/url?url=${encodeURIComponent(link)}&text=${text}`;
 export const getEmailShareLink = (link: string, subject: string): string =>
   `mailto:?subject=${subject}&body=${encodeURIComponent(link)}`;
+
+export const getShareLink = (
+  provider: ShareProvider,
+  link: string,
+  text?: string,
+): string => {
+  switch (provider) {
+    case ShareProvider.WhatsApp:
+      return getWhatsappShareLink(link);
+    case ShareProvider.Twitter:
+      return getTwitterShareLink(link, text ?? '');
+    case ShareProvider.Facebook:
+      return getFacebookShareLink(link);
+    case ShareProvider.Reddit:
+      return getRedditShareLink(link, text ?? '');
+    case ShareProvider.LinkedIn:
+      return getLinkedInShareLink(link);
+    case ShareProvider.Telegram:
+      return getTelegramShareLink(link, text ?? '');
+    case ShareProvider.Email:
+      return getEmailShareLink(link, text ?? '');
+    default:
+      return link;
+  }
+};
+
+export const addLinkShareTrackingParams = (
+  link: string | undefined,
+  userId: string | undefined,
+  cid: string,
+): string => {
+  if (!link) {
+    return null;
+  }
+
+  if (!userId) {
+    return link;
+  }
+
+  const url = new URL(link);
+  url.searchParams.set('userId', userId);
+  url.searchParams.set('cid', cid);
+  return url.toString();
+};

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -31,11 +31,17 @@ export const getTelegramShareLink = (link: string, text: string): string =>
 export const getEmailShareLink = (link: string, subject: string): string =>
   `mailto:?subject=${subject}&body=${encodeURIComponent(link)}`;
 
-export const getShareLink = (
-  provider: ShareProvider,
-  link: string,
-  text?: string,
-): string => {
+interface GetShareLinkParams {
+  provider: ShareProvider;
+  link: string;
+  text?: string;
+}
+
+export const getShareLink = ({
+  provider,
+  link,
+  text,
+}: GetShareLinkParams): string => {
   switch (provider) {
     case ShareProvider.WhatsApp:
       return getWhatsappShareLink(link);
@@ -56,21 +62,30 @@ export const getShareLink = (
   }
 };
 
-export const addLinkShareTrackingParams = (
-  link: string | undefined,
-  userId: string | undefined,
-  cid: string,
-): string => {
+interface AddLinkShareTrackingQueryParams {
+  link: string | undefined;
+  userId: string | undefined;
+  cid: string;
+}
+
+export const addLinkShareTrackingQuery = ({
+  link,
+  userId,
+  cid,
+}: AddLinkShareTrackingQueryParams): string => {
+  // return link as is if not provided
   if (!link) {
-    return null;
+    return link;
   }
 
-  if (!userId) {
+  // return link as is if params are not provided
+  if (!userId || !cid) {
     return link;
   }
 
   const url = new URL(link);
   url.searchParams.set('userId', userId);
   url.searchParams.set('cid', cid);
+
   return url.toString();
 };

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -1,3 +1,5 @@
+import { ReferralCampaignKey } from '../hooks';
+
 export enum ShareProvider {
   Native = 'native',
   CopyLink = 'copy link',
@@ -61,16 +63,10 @@ export const getShareLink = ({
       return link;
   }
 };
-
-export enum ShareCID {
-  Post = 'share_post',
-  Comment = 'share_comment',
-  Profile = 'share_profile',
-}
 export interface AddLinkShareTrackingQueryParams {
   link: string | undefined;
   userId: string | undefined;
-  cid: ShareCID;
+  cid: ReferralCampaignKey;
 }
 
 export const addTrackingQueryParams = ({

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -62,10 +62,15 @@ export const getShareLink = ({
   }
 };
 
+export enum ShareCID {
+  Post = 'share_post',
+  Comment = 'share_comment',
+  Profile = 'share_profile',
+}
 export interface AddLinkShareTrackingQueryParams {
   link: string | undefined;
   userId: string | undefined;
-  cid: string;
+  cid: ShareCID;
 }
 
 export const addTrackingQueryParams = ({

--- a/packages/webapp/pages/[userId]/index.tsx
+++ b/packages/webapp/pages/[userId]/index.tsx
@@ -18,6 +18,7 @@ import {
 import { Readme } from '@dailydotdev/shared/src/components/profile/Readme';
 import { useProfile } from '@dailydotdev/shared/src/hooks/profile/useProfile';
 import { useStreakExperiment } from '@dailydotdev/shared/src/hooks/streaks';
+import { useJoinReferral } from '@dailydotdev/shared/src/hooks';
 import {
   getLayout as getProfileLayout,
   getStaticPaths as getProfileStaticPaths,
@@ -29,6 +30,7 @@ import {
 const ProfilePage = ({
   user: initialUser,
 }: ProfileLayoutProps): ReactElement => {
+  useJoinReferral();
   const { tokenRefreshed } = useContext(AuthContext);
   const { shouldShowStreak } = useStreakExperiment();
 

--- a/packages/webapp/pages/account/invite.tsx
+++ b/packages/webapp/pages/account/invite.tsx
@@ -49,6 +49,7 @@ const AccountInvitePage = (): ReactElement => {
   const [, onShareOrCopyLink] = useShareOrCopyLink({
     text: labels.referral.generic.inviteText,
     link: inviteLink,
+    shortenUrl: false,
     trackObject: () => ({
       event_name: AnalyticsEvent.CopyReferralLink,
       target_id: TargetId.InviteFriendsPage,
@@ -103,6 +104,7 @@ const AccountInvitePage = (): ReactElement => {
           description={labels.referral.generic.inviteText}
           onNativeShare={onShareOrCopyLink}
           onClickSocial={onTrackShare}
+          shortenUrl={false}
         />
       </div>
       <AccountContentSection

--- a/packages/webapp/pages/account/invite.tsx
+++ b/packages/webapp/pages/account/invite.tsx
@@ -49,7 +49,6 @@ const AccountInvitePage = (): ReactElement => {
   const [, onShareOrCopyLink] = useShareOrCopyLink({
     text: labels.referral.generic.inviteText,
     link: inviteLink,
-    shortenUrl: false,
     trackObject: () => ({
       event_name: AnalyticsEvent.CopyReferralLink,
       target_id: TargetId.InviteFriendsPage,

--- a/packages/webapp/pages/join.tsx
+++ b/packages/webapp/pages/join.tsx
@@ -18,9 +18,11 @@ import { Referral } from '../components/invite/Referral';
 type ReferralRecord<T> = Record<ReferralCampaignKey, T>;
 
 const componentsMap: ReferralRecord<FunctionComponent<JoinPageProps>> = {
-  search: AISearchInvite,
-  generic: Referral,
-  share: null,
+  [ReferralCampaignKey.Search]: AISearchInvite,
+  [ReferralCampaignKey.Generic]: Referral,
+  [ReferralCampaignKey.SharePost]: Referral,
+  [ReferralCampaignKey.ShareComment]: Referral,
+  [ReferralCampaignKey.ShareProfile]: Referral,
 };
 
 const Page = ({


### PR DESCRIPTION
## Changes

Adds `userId` and `cid` query params to all shared URLs.
Minifies the URL before sharing.
Modifies `copyLink` to send the same URL as well, in case `copyLink` feature flag is on. 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-188 #done
