### PR TITLE
feat: new list drawer component

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -28,7 +28,13 @@ import useTagAndSource from '../hooks/useTagAndSource';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { postAnalyticsEvent } from '../lib/feed';
 import { MenuIcon } from './MenuIcon';
-import { ToastSubject, useFeedLayout, useToastNotification } from '../hooks';
+import {
+  ToastSubject,
+  useFeedLayout,
+  useToastNotification,
+  useViewSize,
+  ViewSize,
+} from '../hooks';
 import {
   AllFeedPages,
   generateQueryKey,
@@ -51,6 +57,8 @@ import { ActiveFeedContext } from '../contexts';
 import { useAdvancedSettings } from '../hooks/feed';
 import { useFeature } from './GrowthBookProvider';
 import { feature } from '../lib/featureManagement';
+import { ContextMenuDrawer } from './drawers/ContextMenuDrawer';
+import { RootPortal } from './tooltips/Portal';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ './fields/PortalMenu'),
@@ -426,23 +434,34 @@ export default function PostOptionsMenu({
     });
   }
 
+  const isMobile = useViewSize(ViewSize.MobileL);
+
+  if (isMobile) {
+    return (
+      <RootPortal>
+        <ContextMenuDrawer
+          drawerProps={{ isOpen, onClose: onHidden, displayCloseButton: true }}
+          options={postOptions}
+        />
+      </RootPortal>
+    );
+  }
+
   return (
-    <>
-      <PortalMenu
-        disableBoundariesCheck
-        id={contextId}
-        className="menu-primary"
-        animation="fade"
-        onHidden={onHidden}
-      >
-        {postOptions.map(({ icon, label, action }) => (
-          <Item key={label} className="typo-callout" onClick={action}>
-            <span className="flex w-full items-center typo-callout">
-              {icon} {label}
-            </span>
-          </Item>
-        ))}
-      </PortalMenu>
-    </>
+    <PortalMenu
+      disableBoundariesCheck
+      id={contextId}
+      className="menu-primary"
+      animation="fade"
+      onHidden={onHidden}
+    >
+      {postOptions.map(({ icon, label, action }) => (
+        <Item key={label} className="typo-callout" onClick={action}>
+          <span className="flex w-full items-center typo-callout">
+            {icon} {label}
+          </span>
+        </Item>
+      ))}
+    </PortalMenu>
   );
 }

--- a/packages/shared/src/components/drawers/ContextMenuDrawer.tsx
+++ b/packages/shared/src/components/drawers/ContextMenuDrawer.tsx
@@ -1,0 +1,60 @@
+import React, { ReactElement, ReactNode } from 'react';
+import classNames from 'classnames';
+import { Drawer, DrawerRef, DrawerWrapperProps } from './Drawer';
+import { SelectParams } from './common';
+
+interface ContextMenuDrawerItem {
+  label: string;
+  icon?: ReactNode;
+  anchorProps?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
+  action?(params: SelectParams): void;
+}
+
+interface ContextMenuDrawerProps {
+  drawerProps: Omit<DrawerWrapperProps, 'children'>;
+  options: ContextMenuDrawerItem[];
+}
+
+export function ContextMenuDrawer({
+  drawerProps,
+  options,
+}: ContextMenuDrawerProps): ReactElement {
+  const ref = React.useRef<DrawerRef>();
+
+  return (
+    <Drawer {...drawerProps} ref={ref}>
+      {options.map(({ label, icon, action, anchorProps }, index) => {
+        const classes =
+          'flex h-10 flex-row items-center overflow-hidden text-ellipsis whitespace-nowrap px-2 text-theme-label-tertiary typo-callout';
+        const content = (
+          <>
+            {icon && <span className="mr-1">{icon}</span>}
+            {label}
+          </>
+        );
+
+        return anchorProps ? (
+          <a
+            key={label}
+            {...anchorProps}
+            className={classNames(classes, anchorProps.className)}
+          >
+            {content}
+          </a>
+        ) : (
+          <button
+            key={label}
+            type="button"
+            className={classes}
+            onClick={(event) => {
+              action({ value: label, index, event });
+              ref.current.onClose();
+            }}
+          >
+            {content}
+          </button>
+        );
+      })}
+    </Drawer>
+  );
+}

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -79,7 +79,7 @@ function BaseDrawer({
           isAnimating && animatePositionClassName[position],
           drawerPositionToClassName[position],
           !title && classes,
-          'max-h-[calc(100vh-5rem)] w-full',
+          'max-h-[calc(100%-5rem)] w-full',
         )}
         ref={(node) => {
           container.current = node;

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -1,4 +1,5 @@
 import React, {
+  HTMLAttributes,
   MutableRefObject,
   ReactElement,
   ReactNode,
@@ -23,7 +24,8 @@ interface ClassName {
   drawer?: string;
 }
 
-interface DrawerProps {
+interface DrawerProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'className'> {
   children: ReactNode;
   className?: ClassName;
   position?: DrawerPosition;
@@ -53,6 +55,7 @@ function BaseDrawer({
   title,
   onClose,
   displayCloseButton,
+  ...props
 }: DrawerProps): ReactElement {
   const container = useRef<HTMLDivElement>();
   const [hasAnimated, setHasAnimated] = useState(false);
@@ -70,6 +73,7 @@ function BaseDrawer({
       )}
     >
       <div
+        {...props}
         className={classNames(
           'absolute flex flex-col overflow-y-auto bg-theme-bg-primary transition-transform duration-300 ease-in-out',
           isAnimating && animatePositionClassName[position],

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -107,7 +107,7 @@ function BaseDrawer({
           {children}
         </ConditionalWrapper>
         {displayCloseButton && (
-          <div className="sticky bottom-0 bg-theme-bg-primary">
+          <div className="sticky -bottom-3 bg-theme-bg-primary">
             <Button
               variant={ButtonVariant.Float}
               className="mt-1 w-full"

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -110,7 +110,7 @@ function BaseDrawer({
           <div className="sticky -bottom-3 bg-theme-bg-primary">
             <Button
               variant={ButtonVariant.Float}
-              className="mt-1 w-full"
+              className="mt-3 w-full"
               onClick={onClose}
             >
               Close

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -103,13 +103,15 @@ function BaseDrawer({
           {children}
         </ConditionalWrapper>
         {displayCloseButton && (
-          <Button
-            variant={ButtonVariant.Float}
-            className="mt-4 w-full"
-            onClick={onClose}
-          >
-            Close
-          </Button>
+          <div className="sticky bottom-0 bg-theme-bg-primary">
+            <Button
+              variant={ButtonVariant.Float}
+              className="mt-1 w-full"
+              onClick={onClose}
+            >
+              Close
+            </Button>
+          </div>
         )}
       </div>
     </div>

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -10,6 +10,8 @@ import classNames from 'classnames';
 import useDebounce from '../../hooks/useDebounce';
 import ConditionalWrapper from '../ConditionalWrapper';
 import { useOutsideClick } from '../../hooks/utils/useOutsideClick';
+import { ButtonVariant } from '../buttons/common';
+import { Button } from '../buttons/Button';
 
 export enum DrawerPosition {
   Bottom = 'bottom',
@@ -29,6 +31,7 @@ interface DrawerProps {
   isClosing?: boolean;
   title?: string;
   onClose(): void;
+  displayCloseButton?: boolean;
 }
 
 const drawerPositionToClassName: Record<DrawerPosition, string> = {
@@ -49,6 +52,7 @@ function BaseDrawer({
   isClosing = false,
   title,
   onClose,
+  displayCloseButton,
 }: DrawerProps): ReactElement {
   const container = useRef<HTMLDivElement>();
   const [hasAnimated, setHasAnimated] = useState(false);
@@ -98,18 +102,27 @@ function BaseDrawer({
         >
           {children}
         </ConditionalWrapper>
+        {displayCloseButton && (
+          <Button
+            variant={ButtonVariant.Float}
+            className="mt-4 w-full"
+            onClick={onClose}
+          >
+            Close
+          </Button>
+        )}
       </div>
     </div>
   );
 }
 
-interface DrawerWrapperProps extends Omit<DrawerProps, 'isClosing'> {
+export interface DrawerWrapperProps extends Omit<DrawerProps, 'isClosing'> {
   isOpen: boolean;
 }
 
 const ANIMATION_MS = 300;
 
-interface DrawerRef {
+export interface DrawerRef {
   onClose(): void;
 }
 

--- a/packages/shared/src/components/drawers/ListDrawer.tsx
+++ b/packages/shared/src/components/drawers/ListDrawer.tsx
@@ -3,18 +3,13 @@ import classNames from 'classnames';
 import { Drawer, DrawerRef, DrawerWrapperProps } from './Drawer';
 import { VIcon } from '../icons';
 import { IconSize } from '../Icon';
-
-export interface SelectProps {
-  value: string;
-  index: number;
-  event: React.MouseEvent<HTMLButtonElement>;
-}
+import { SelectParams } from './common';
 
 interface ListDrawerProps {
   drawerProps: Omit<DrawerWrapperProps, 'children'>;
   options: string[];
   selected: number; // index
-  onSelectedChange(props: SelectProps): void;
+  onSelectedChange(props: SelectParams): void;
 }
 
 export function ListDrawer({

--- a/packages/shared/src/components/drawers/ListDrawer.tsx
+++ b/packages/shared/src/components/drawers/ListDrawer.tsx
@@ -21,13 +21,14 @@ export function ListDrawer({
   const ref = React.useRef<DrawerRef>();
 
   return (
-    <Drawer {...drawerProps} ref={ref}>
+    <Drawer {...drawerProps} ref={ref} role="menu">
       {options.map((value, index) => {
         const isSelected = index === selected;
 
         return (
           <button
             key={value}
+            role="menuitem"
             type="button"
             className={classNames(
               'flex h-10 flex-row items-center overflow-hidden text-ellipsis whitespace-nowrap px-2 typo-callout',

--- a/packages/shared/src/components/drawers/ListDrawer.tsx
+++ b/packages/shared/src/components/drawers/ListDrawer.tsx
@@ -1,0 +1,55 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import { Drawer, DrawerRef, DrawerWrapperProps } from './Drawer';
+import { VIcon } from '../icons';
+import { IconSize } from '../Icon';
+
+export interface SelectProps {
+  value: string;
+  index: number;
+  event: React.MouseEvent<HTMLButtonElement>;
+}
+
+interface ListDrawerProps {
+  drawerProps: Omit<DrawerWrapperProps, 'children'>;
+  options: string[];
+  selected: number; // index
+  onSelectedChange(props: SelectProps): void;
+}
+
+export function ListDrawer({
+  onSelectedChange,
+  drawerProps,
+  selected,
+  options,
+}: ListDrawerProps): ReactElement {
+  const ref = React.useRef<DrawerRef>();
+
+  return (
+    <Drawer {...drawerProps} ref={ref}>
+      {options.map((value, index) => {
+        const isSelected = index === selected;
+
+        return (
+          <button
+            key={value}
+            type="button"
+            className={classNames(
+              'flex h-10 flex-row items-center overflow-hidden text-ellipsis whitespace-nowrap px-2 typo-callout',
+              index === selected ? 'font-bold' : 'text-theme-label-tertiary',
+            )}
+            onClick={(event) => {
+              onSelectedChange({ value, index, event });
+              ref.current.onClose();
+            }}
+          >
+            {value}
+            {isSelected && (
+              <VIcon secondary size={IconSize.Small} className="ml-auto" />
+            )}
+          </button>
+        );
+      })}
+    </Drawer>
+  );
+}

--- a/packages/shared/src/components/drawers/ListDrawer.tsx
+++ b/packages/shared/src/components/drawers/ListDrawer.tsx
@@ -1,9 +1,7 @@
 import React, { ReactElement } from 'react';
-import classNames from 'classnames';
 import { Drawer, DrawerRef, DrawerWrapperProps } from './Drawer';
-import { VIcon } from '../icons';
-import { IconSize } from '../Icon';
-import { SelectParams } from './common';
+import type { SelectParams } from './common';
+import { ListDrawerItem } from './ListDrawerItem';
 
 interface ListDrawerProps {
   drawerProps: Omit<DrawerWrapperProps, 'children'>;
@@ -22,30 +20,17 @@ export function ListDrawer({
 
   return (
     <Drawer {...drawerProps} ref={ref} role="menu">
-      {options.map((value, index) => {
-        const isSelected = index === selected;
-
-        return (
-          <button
-            key={value}
-            role="menuitem"
-            type="button"
-            className={classNames(
-              'flex h-10 flex-row items-center overflow-hidden text-ellipsis whitespace-nowrap px-2 typo-callout',
-              index === selected ? 'font-bold' : 'text-theme-label-tertiary',
-            )}
-            onClick={(event) => {
-              onSelectedChange({ value, index, event });
-              ref.current.onClose();
-            }}
-          >
-            {value}
-            {isSelected && (
-              <VIcon secondary size={IconSize.Small} className="ml-auto" />
-            )}
-          </button>
-        );
-      })}
+      {options.map((value, index) => (
+        <ListDrawerItem
+          key={value}
+          value={value}
+          isSelected={index === selected}
+          onClick={(params) => {
+            onSelectedChange({ ...params, index });
+            ref.current?.onClose();
+          }}
+        />
+      ))}
     </Drawer>
   );
 }

--- a/packages/shared/src/components/drawers/ListDrawerItem.tsx
+++ b/packages/shared/src/components/drawers/ListDrawerItem.tsx
@@ -1,0 +1,35 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import { VIcon } from '../icons';
+import { IconSize } from '../Icon';
+import type { SelectParams } from './common';
+
+interface ListDrawerItemProps {
+  value: string;
+  isSelected: boolean;
+  onClick: (params: Omit<SelectParams, 'index'>) => void;
+}
+
+export function ListDrawerItem({
+  value,
+  onClick,
+  isSelected,
+}: ListDrawerItemProps): ReactElement {
+  return (
+    <button
+      key={value}
+      role="menuitem"
+      type="button"
+      className={classNames(
+        'flex h-10 flex-row items-center overflow-hidden text-ellipsis whitespace-nowrap px-2 typo-callout',
+        isSelected ? 'font-bold' : 'text-theme-label-tertiary',
+      )}
+      onClick={(event) => onClick({ value, event })}
+    >
+      {value}
+      {isSelected && (
+        <VIcon secondary size={IconSize.Small} className="ml-auto" />
+      )}
+    </button>
+  );
+}

--- a/packages/shared/src/components/drawers/common.ts
+++ b/packages/shared/src/components/drawers/common.ts
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export interface SelectParams {
+  value: string;
+  index: number;
+  event: React.MouseEvent<HTMLButtonElement>;
+}

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -15,7 +15,8 @@ import {
 import { ArrowIcon, VIcon } from '../icons';
 import styles from './Dropdown.module.css';
 import { useViewSize, ViewSize } from '../../hooks';
-import { ListDrawer, SelectProps } from '../drawers/ListDrawer';
+import { ListDrawer } from '../drawers/ListDrawer';
+import { SelectParams } from '../drawers/common';
 
 interface ClassName {
   container?: string;
@@ -112,7 +113,7 @@ export function Dropdown({
     }
   };
 
-  const handleChange = ({ value, index }: SelectProps): void => {
+  const handleChange = ({ value, index }: SelectParams): void => {
     onChange(value, index);
   };
 

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -17,6 +17,7 @@ import styles from './Dropdown.module.css';
 import { useViewSize, ViewSize } from '../../hooks';
 import { ListDrawer } from '../drawers/ListDrawer';
 import { SelectParams } from '../drawers/common';
+import { RootPortal } from '../tooltips/Portal';
 
 interface ClassName {
   container?: string;
@@ -154,16 +155,18 @@ export function Dropdown({
         />
       </button>
       {isMobile ? (
-        <ListDrawer
-          drawerProps={{
-            isOpen: isVisible,
-            displayCloseButton: true,
-            onClose: () => setVisibility(false),
-          }}
-          options={options}
-          selected={selectedIndex}
-          onSelectedChange={handleChange}
-        />
+        <RootPortal>
+          <ListDrawer
+            drawerProps={{
+              isOpen: isVisible,
+              displayCloseButton: true,
+              onClose: () => setVisibility(false),
+            }}
+            options={options}
+            selected={selectedIndex}
+            onSelectedChange={handleChange}
+          />
+        </RootPortal>
       ) : (
         <Menu
           disableBoundariesCheck

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -8,13 +8,14 @@ import React, {
 import classNames from 'classnames';
 import {
   Item,
-  ItemParams,
   Menu,
   TriggerEvent,
   useContextMenu,
 } from '@dailydotdev/react-contexify';
 import { ArrowIcon, VIcon } from '../icons';
 import styles from './Dropdown.module.css';
+import { useViewSize, ViewSize } from '../../hooks';
+import { ListDrawer, SelectProps } from '../drawers/ListDrawer';
 
 interface ClassName {
   container?: string;
@@ -70,6 +71,7 @@ export function Dropdown({
   iconOnly,
   ...props
 }: DropdownProps): ReactElement {
+  const isMobile = useViewSize(ViewSize.MobileL);
   const [id] = useState(`dropdown-${Math.random().toString(36).substring(7)}`);
   const [isVisible, setVisibility] = useState(false);
   const [menuWidth, setMenuWidth] = useState<number>();
@@ -110,10 +112,8 @@ export function Dropdown({
     }
   };
 
-  const handleChange = ({
-    data,
-  }: ItemParams<unknown, { value: string; index: number }>): void => {
-    onChange(data.value, data.index);
+  const handleChange = ({ value, index }: SelectProps): void => {
+    onChange(value, index);
   };
 
   return (
@@ -152,31 +152,46 @@ export function Dropdown({
           )}
         />
       </button>
-      <Menu
-        disableBoundariesCheck
-        id={id}
-        className={classNames(className.menu || 'menu-primary', { scrollable })}
-        animation="fade"
-        onHidden={() => setVisibility(false)}
-        style={{ width: !dynamicMenuWidth && menuWidth }}
-      >
-        {options.map((option, index) => (
-          <Item
-            key={option}
-            onClick={handleChange}
-            data={{ value: option, index }}
-            className={classNames(styles.item, className?.item)}
-          >
-            {renderItem ? renderItem(option, index) : option}
-            {shouldIndicateSelected && selectedIndex === index && (
-              <VIcon
-                className={classNames('ml-auto', className.indicator)}
-                secondary
-              />
-            )}
-          </Item>
-        ))}
-      </Menu>
+      {isMobile ? (
+        <ListDrawer
+          drawerProps={{
+            isOpen: isVisible,
+            displayCloseButton: true,
+            onClose: () => setVisibility(false),
+          }}
+          options={options}
+          selected={selectedIndex}
+          onSelectedChange={handleChange}
+        />
+      ) : (
+        <Menu
+          disableBoundariesCheck
+          id={id}
+          className={classNames(className.menu || 'menu-primary', {
+            scrollable,
+          })}
+          animation="fade"
+          onHidden={() => setVisibility(false)}
+          style={{ width: !dynamicMenuWidth && menuWidth }}
+        >
+          {options.map((option, index) => (
+            <Item
+              key={option}
+              onClick={({ data, event }) => handleChange({ event, ...data })}
+              data={{ value: option, index }}
+              className={classNames(styles.item, className?.item)}
+            >
+              {renderItem ? renderItem(option, index) : option}
+              {shouldIndicateSelected && selectedIndex === index && (
+                <VIcon
+                  className={classNames('ml-auto', className.indicator)}
+                  secondary
+                />
+              )}
+            </Item>
+          ))}
+        </Menu>
+      )}
     </div>
   );
 }

--- a/packages/storybook/stories/drawers/ListDrawer.stories.tsx
+++ b/packages/storybook/stories/drawers/ListDrawer.stories.tsx
@@ -1,7 +1,5 @@
-import { useState, useRef } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import classed from '@dailydotdev/shared/src/lib/classed';
-import { DrawerPosition } from '@dailydotdev/shared/src/components/drawers/Drawer';
 import {
   Button,
   ButtonVariant,
@@ -21,22 +19,14 @@ const meta: Meta<typeof ListDrawer> = {
       url: "https://www.figma.com/file/nmfWPS7x3kzLUvYMkBx2kW/daily.dev---Dev-Mode?node-id=2384%3A21195&mode=dev",
     },
   },
-  argTypes: {
-    options: {
-      description: 'Comma separated list of options (only in storybook)',
-      control: { type: 'text', separator: ',' },
-      defaultValue: {
-        summary: 'Option 1, Option 2, Option 3',
-      },
-    },
-  },
+  args: {
+    options: ['Option 1', 'Option 2', 'Option 3'],
+  }
 };
 
 export default meta;
 
 type Story = StoryObj<typeof ListDrawer>;
-
-const Container = classed('div', 'px-3 py-4 border-b border-theme-divider-tertiary');
 
 export const Drawer: Story = {
   render: (props) => {
@@ -55,7 +45,7 @@ export const Drawer: Story = {
             displayCloseButton: true,
             onClose: () => setIsOpen(false)
           }}
-          options={props.options?.toString().split(',') ?? []} // only in storybook - for some reason, they are not accepting array properly
+          options={props.options}
           selected={selected}
           onSelectedChange={({ index }) => setSelected(index)}
         />

--- a/packages/storybook/stories/drawers/ListDrawer.stories.tsx
+++ b/packages/storybook/stories/drawers/ListDrawer.stories.tsx
@@ -1,0 +1,67 @@
+import { useState, useRef } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import classed from '@dailydotdev/shared/src/lib/classed';
+import { DrawerPosition } from '@dailydotdev/shared/src/components/drawers/Drawer';
+import {
+  Button,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  ListDrawer
+} from '@dailydotdev/shared/src/components/drawers/ListDrawer';
+
+const meta: Meta<typeof ListDrawer> = {
+  component: ListDrawer,
+  parameters: {
+    controls: {
+      expanded: true,
+    },
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/nmfWPS7x3kzLUvYMkBx2kW/daily.dev---Dev-Mode?node-id=2384%3A21195&mode=dev",
+    },
+  },
+  argTypes: {
+    options: {
+      description: 'Comma separated list of options (only in storybook)',
+      control: { type: 'text', separator: ',' },
+      defaultValue: {
+        summary: 'Option 1, Option 2, Option 3',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ListDrawer>;
+
+const Container = classed('div', 'px-3 py-4 border-b border-theme-divider-tertiary');
+
+export const Drawer: Story = {
+  render: (props) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [selected, setSelected] = useState(-1);
+
+    return (
+      <>
+        <Button variant={ButtonVariant.Primary} onClick={() => setIsOpen(true)}>
+          Trigger
+        </Button>
+        <ListDrawer
+          {...props}
+          drawerProps={{
+            isOpen,
+            displayCloseButton: true,
+            onClose: () => setIsOpen(false)
+          }}
+          options={props.options?.toString().split(',') ?? []} // only in storybook - for some reason, they are not accepting array properly
+          selected={selected}
+          onSelectedChange={({ index }) => setSelected(index)}
+        />
+        <p className="mt-4 typo-footnote text-theme-label-tertiary">One thing to note:<br/>When implementing a custom "Close" button,you will have to utilize injecting a `ref` object which you will use when closing the drawer to keep the exit animation. <br/>The sample code here does that.</p>
+      </>
+    );
+  },
+  name: 'List Drawer',
+};


### PR DESCRIPTION
## Changes
- Drawer component for lists. Mostly utilized on mobile only (for now).
- Feel free to check the storybook component.
  - For some reason, their array control is not working, had to make it comma-separated.

Preview:

https://github.com/dailydotdev/apps/assets/13744167/16e11181-e8d2-439c-830d-1e35ef7efd74

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-125 #done
