### PR TITLE
refactor: post options menu to utilize drawer on mobile

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -28,7 +28,13 @@ import useTagAndSource from '../hooks/useTagAndSource';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { postAnalyticsEvent } from '../lib/feed';
 import { MenuIcon } from './MenuIcon';
-import { ToastSubject, useFeedLayout, useToastNotification } from '../hooks';
+import {
+  ToastSubject,
+  useFeedLayout,
+  useToastNotification,
+  useViewSize,
+  ViewSize,
+} from '../hooks';
 import {
   AllFeedPages,
   generateQueryKey,
@@ -51,6 +57,8 @@ import { ActiveFeedContext } from '../contexts';
 import { useAdvancedSettings } from '../hooks/feed';
 import { useFeature } from './GrowthBookProvider';
 import { feature } from '../lib/featureManagement';
+import { ContextMenuDrawer } from './drawers/ContextMenuDrawer';
+import { RootPortal } from './tooltips/Portal';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ './fields/PortalMenu'),
@@ -426,23 +434,34 @@ export default function PostOptionsMenu({
     });
   }
 
+  const isMobile = useViewSize(ViewSize.MobileL);
+
+  if (isMobile) {
+    return (
+      <RootPortal>
+        <ContextMenuDrawer
+          drawerProps={{ isOpen, onClose: onHidden, displayCloseButton: true }}
+          options={postOptions}
+        />
+      </RootPortal>
+    );
+  }
+
   return (
-    <>
-      <PortalMenu
-        disableBoundariesCheck
-        id={contextId}
-        className="menu-primary"
-        animation="fade"
-        onHidden={onHidden}
-      >
-        {postOptions.map(({ icon, label, action }) => (
-          <Item key={label} className="typo-callout" onClick={action}>
-            <span className="flex w-full items-center typo-callout">
-              {icon} {label}
-            </span>
-          </Item>
-        ))}
-      </PortalMenu>
-    </>
+    <PortalMenu
+      disableBoundariesCheck
+      id={contextId}
+      className="menu-primary"
+      animation="fade"
+      onHidden={onHidden}
+    >
+      {postOptions.map(({ icon, label, action }) => (
+        <Item key={label} className="typo-callout" onClick={action}>
+          <span className="flex w-full items-center typo-callout">
+            {icon} {label}
+          </span>
+        </Item>
+      ))}
+    </PortalMenu>
   );
 }

--- a/packages/shared/src/components/drawers/ListDrawer.tsx
+++ b/packages/shared/src/components/drawers/ListDrawer.tsx
@@ -1,9 +1,7 @@
 import React, { ReactElement } from 'react';
-import classNames from 'classnames';
 import { Drawer, DrawerRef, DrawerWrapperProps } from './Drawer';
-import { VIcon } from '../icons';
-import { IconSize } from '../Icon';
-import { SelectParams } from './common';
+import type { SelectParams } from './common';
+import { ListDrawerItem } from './ListDrawerItem';
 
 interface ListDrawerProps {
   drawerProps: Omit<DrawerWrapperProps, 'children'>;
@@ -22,30 +20,17 @@ export function ListDrawer({
 
   return (
     <Drawer {...drawerProps} ref={ref} role="menu">
-      {options.map((value, index) => {
-        const isSelected = index === selected;
-
-        return (
-          <button
-            key={value}
-            role="menuitem"
-            type="button"
-            className={classNames(
-              'flex h-10 flex-row items-center overflow-hidden text-ellipsis whitespace-nowrap px-2 typo-callout',
-              index === selected ? 'font-bold' : 'text-theme-label-tertiary',
-            )}
-            onClick={(event) => {
-              onSelectedChange({ value, index, event });
-              ref.current.onClose();
-            }}
-          >
-            {value}
-            {isSelected && (
-              <VIcon secondary size={IconSize.Small} className="ml-auto" />
-            )}
-          </button>
-        );
-      })}
+      {options.map((value, index) => (
+        <ListDrawerItem
+          key={value}
+          value={value}
+          isSelected={index === selected}
+          onClick={(params) => {
+            onSelectedChange({ ...params, index });
+            ref.current?.onClose();
+          }}
+        />
+      ))}
     </Drawer>
   );
 }

--- a/packages/shared/src/components/drawers/ListDrawerItem.tsx
+++ b/packages/shared/src/components/drawers/ListDrawerItem.tsx
@@ -1,0 +1,35 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import { VIcon } from '../icons';
+import { IconSize } from '../Icon';
+import type { SelectParams } from './common';
+
+interface ListDrawerItemProps {
+  value: string;
+  isSelected: boolean;
+  onClick: (params: Omit<SelectParams, 'index'>) => void;
+}
+
+export function ListDrawerItem({
+  value,
+  onClick,
+  isSelected,
+}: ListDrawerItemProps): ReactElement {
+  return (
+    <button
+      key={value}
+      role="menuitem"
+      type="button"
+      className={classNames(
+        'flex h-10 flex-row items-center overflow-hidden text-ellipsis whitespace-nowrap px-2 typo-callout',
+        isSelected ? 'font-bold' : 'text-theme-label-tertiary',
+      )}
+      onClick={(event) => onClick({ value, event })}
+    >
+      {value}
+      {isSelected && (
+        <VIcon secondary size={IconSize.Small} className="ml-auto" />
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## Changes
- Refactor the post options menu to utilize the drawer component on mobile.

Preview:

https://github.com/dailydotdev/apps/assets/13744167/280070e8-9661-4401-b682-569076901b93

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-127 #done
