### PR TITLE
fix: adspot correction

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -145,6 +145,7 @@ export default function Feed<T>({
     (router.query?.[acquisitionKey] as string)?.toLocaleLowerCase() ===
       'true' &&
     !user?.acquisitionChannel;
+
   const adSpot = useFeature(feature.feedAdSpot);
 
   const {

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -4,7 +4,6 @@ import {
   OnboardingV4dot5,
   PostPageOnboarding,
   UserAcquisition,
-  FeedAdSpot,
   PublishTimeFormat,
 } from './featureValues';
 import { cloudinary } from './image';
@@ -45,7 +44,8 @@ const feature = {
   onboardingOptimizations: new Feature('onboarding_optimizations', false),
   userAcquisition: new Feature('user_acquisition', UserAcquisition.Control),
   forceRefresh: new Feature('force_refresh', false),
-  feedAdSpot: new Feature('feed_ad_spot', FeedAdSpot.Control),
+  // Feed ad spot should only impact desktop users
+  feedAdSpot: new Feature('feed_ad_spot', 0),
   shareLoops: new Feature('share_loops', false),
   publishTimeFormat: new Feature(
     'publish_time_format',

--- a/packages/shared/src/lib/featureValues.ts
+++ b/packages/shared/src/lib/featureValues.ts
@@ -28,11 +28,6 @@ export enum UserAcquisition {
   V1 = 'v1',
 }
 
-export enum FeedAdSpot {
-  Control = defaultFeedContextData.adSpot,
-  V1 = 0,
-}
-
 export enum PublishTimeFormat {
   Control = 'control',
   V1 = 'v1',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We accidentally set the adspot to 3 should be 0
- Double checked mobile/squads was still good.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
