### PR TITLE
fix: new default URL

### DIFF
--- a/packages/extension/src/newtab/dnd.ts
+++ b/packages/extension/src/newtab/dnd.ts
@@ -14,7 +14,7 @@ export enum CustomTime {
 }
 
 const DEFAULT_URL = 'https://www.google.com';
-const CHROME_DEFAULT_URL = 'chrome-search://local-ntp/local-ntp.html';
+const CHROME_DEFAULT_URL = 'chrome://newtab';
 const BRAVE_DEFAULT_URL = 'chrome://new-tab-page';
 
 const browserTest = () =>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Not really sure when this changed, can't really find any documentation on this matter 🤯

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
