### PR TITLE
fix: link collections to internal URL

### DIFF
--- a/packages/shared/src/components/post/RelatedPostsWidget.tsx
+++ b/packages/shared/src/components/post/RelatedPostsWidget.tsx
@@ -84,10 +84,8 @@ export const RelatedPostsWidget = ({
               >
                 <CardLink
                   className="cursor-pointer"
-                  href={relatedPost.permalink}
+                  href={relatedPost.commentsPermalink}
                   title={relatedPost.title}
-                  rel="noopener"
-                  target="_blank"
                 />
                 <div className="flex overflow-hidden">
                   <SourceAvatar source={relatedPost.source} size="small" />

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -132,7 +132,7 @@ export const COMMENT_FRAGMENT = gql`
 export const RELATED_POST_FRAGMENT = gql`
   fragment RelatedPost on Post {
     id
-    permalink
+    commentsPermalink
     title
     summary
     createdAt

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -125,7 +125,7 @@ export interface Post {
 
 export type RelatedPost = Pick<
   Post,
-  'id' | 'permalink' | 'title' | 'summary' | 'createdAt'
+  'id' | 'commentsPermalink' | 'title' | 'summary' | 'createdAt'
 > & {
   source: Pick<Source, 'id' | 'handle' | 'name' | 'image'>;
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Ensure we link to internal posts

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

As-172 #done
