### PR TITLE
fix: add login trigger to subscribe button

### DIFF
--- a/packages/shared/src/components/post/collection/CollectionSubscribeButton.tsx
+++ b/packages/shared/src/components/post/collection/CollectionSubscribeButton.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import {
   checkHasStatusPreference,
   useNotificationPreference,
@@ -9,6 +9,8 @@ import { BellDisabledIcon, BellIcon } from '../../icons';
 import { Post } from '../../../graphql/posts';
 import { SimpleTooltip } from '../../tooltips';
 import { Button, ButtonVariant } from '../../buttons/Button';
+import { AuthTriggers } from '../../../lib/auth';
+import AuthContext, { useAuthContext } from '../../../contexts/AuthContext';
 
 export type CollectionSubscribeButtonProps = {
   post: Post;
@@ -59,6 +61,7 @@ export const CollectionSubscribeButton = ({
   post,
   isCondensed,
 }: CollectionSubscribeButtonProps): ReactElement => {
+  const { isLoggedIn, showLogin } = useAuthContext();
   const {
     preferences,
     subscribeNotification,
@@ -84,6 +87,12 @@ export const CollectionSubscribeButton = ({
   );
 
   const onClick = () => {
+    if (!isLoggedIn) {
+      showLogin({ trigger: AuthTriggers.CollectionSubscribe });
+
+      return;
+    }
+
     const notificationPreferenceParams = {
       type: NotificationType.CollectionUpdated,
       referenceId: post.id,

--- a/packages/shared/src/components/post/collection/CollectionSubscribeButton.tsx
+++ b/packages/shared/src/components/post/collection/CollectionSubscribeButton.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement } from 'react';
 import {
   checkHasStatusPreference,
   useNotificationPreference,
@@ -10,7 +10,7 @@ import { Post } from '../../../graphql/posts';
 import { SimpleTooltip } from '../../tooltips';
 import { Button, ButtonVariant } from '../../buttons/Button';
 import { AuthTriggers } from '../../../lib/auth';
-import AuthContext, { useAuthContext } from '../../../contexts/AuthContext';
+import { useAuthContext } from '../../../contexts/AuthContext';
 
 export type CollectionSubscribeButtonProps = {
   post: Post;

--- a/packages/shared/src/lib/auth.ts
+++ b/packages/shared/src/lib/auth.ts
@@ -58,6 +58,7 @@ export enum AuthTriggers {
   LoginPage = 'login page',
   GenericReferral = 'generic referral',
   Roast = 'roast',
+  CollectionSubscribe = 'collection subscribe',
 }
 
 export type AuthTriggersType =


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Just waiting for confirmation from analytics team [here](https://dailydotdev.slack.com/archives/C015T1Y237Z/p1709901184845719)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change | open signup  | extra: { trigger: 'collection subscribe' } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-173 #done
