### PR TITLE
fix: post options menu multiple instances

### DIFF
--- a/packages/shared/src/components/post/FixedPostNavigation.tsx
+++ b/packages/shared/src/components/post/FixedPostNavigation.tsx
@@ -24,6 +24,7 @@ function FixedPostNavigation({
       {...props}
       inlineActions
       post={post}
+      contextMenuId="fixed-post-navigation-context"
       className={{
         container: classNames(
           'fixed z-postNavigation ml-0 w-full border border-theme-divider-tertiary bg-theme-bg-secondary px-6 py-4',

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -103,7 +103,7 @@ export function PostContent({
             post={post}
             onClose={onClose}
             className="mb-4 flex tablet:hidden"
-            contextMenuId="post-widgets-context"
+            contextMenuId="post-header-actions-context"
           />
         )}
 

--- a/packages/shared/src/components/post/PostMenuOptions.tsx
+++ b/packages/shared/src/components/post/PostMenuOptions.tsx
@@ -36,8 +36,7 @@ export function PostMenuOptions({
 }: PostMenuOptionssProps): ReactElement {
   const { user } = useContext(AuthContext);
   const { showPrompt } = usePrompt();
-  const { onMenuClick, isOpen } = useContextMenu({ id: contextMenuId });
-
+  const { onMenuClick, isOpen, onHide } = useContextMenu({ id: contextMenuId });
   const isModerator = user?.roles?.includes(Roles.Moderator);
 
   const banPostPrompt = async () => {
@@ -103,6 +102,7 @@ export function PostMenuOptions({
         contextId={contextMenuId}
         origin={origin}
         isOpen={isOpen}
+        onHidden={onHide}
       />
     </>
   );

--- a/packages/shared/src/components/post/PostNavigation.tsx
+++ b/packages/shared/src/components/post/PostNavigation.tsx
@@ -13,6 +13,7 @@ function PostNavigation({
   onNextPost,
   className = {},
   children,
+  contextMenuId = 'post-navigation-context',
   ...props
 }: PostNavigationProps): ReactElement {
   return (
@@ -54,7 +55,7 @@ function PostNavigation({
         {...props}
         className={classNames('flex', className?.actions)}
         notificationClassName="ml-4"
-        contextMenuId="post-navigation-context"
+        contextMenuId={contextMenuId}
       />
     </div>
   );

--- a/packages/shared/src/components/post/common.tsx
+++ b/packages/shared/src/components/post/common.tsx
@@ -46,6 +46,7 @@ export interface PostNavigationProps extends PostActions {
   className?: PostNavigationClassName;
   children?: ReactNode;
   isBannerVisible?: boolean;
+  contextMenuId?: string;
 }
 
 export type PassedPostNavigationProps = Pick<


### PR DESCRIPTION
## Changes
- Fix duplicated post context menu.
- Fix on hide to set the state.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
