### PR TITLE
fix: don't render item if you not a member

### DIFF
--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo } from 'react';
+import React, { ReactElement, useContext, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useMutation } from '@tanstack/react-query';
@@ -25,6 +25,7 @@ import { squadFeedback } from '../../lib/constants';
 import { MenuItemProps } from '../fields/PortalMenu';
 import { useSquadInvitation } from '../../hooks/useSquadInvitation';
 import { Origin } from '../../lib/analytics';
+import AuthContext from '../../contexts/AuthContext';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ '../fields/PortalMenu'),
@@ -40,6 +41,7 @@ interface SquadHeaderMenuProps {
 export default function SquadHeaderMenu({
   squad,
 }: SquadHeaderMenuProps): ReactElement {
+  const { isLoggedIn } = useContext(AuthContext);
   const { trackAndCopyLink } = useSquadInvitation({
     squad,
     origin: Origin.SquadPage,
@@ -77,7 +79,7 @@ export default function SquadHeaderMenu({
       });
     }
 
-    if (!squad.currentMember && squad.public) {
+    if (!squad.currentMember && squad.public && isLoggedIn) {
       list.push({
         icon: <ContextMenuIcon Icon={LinkIcon} />,
         action: () => trackAndCopyLink(),

--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -136,6 +136,7 @@ export default function SquadHeaderMenu({
     onLeaveSquad,
     openModal,
     squad,
+    isLoggedIn,
   ]);
 
   return (

--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext, useMemo } from 'react';
+import React, { ReactElement, useMemo } from 'react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useMutation } from '@tanstack/react-query';
@@ -25,7 +25,7 @@ import { squadFeedback } from '../../lib/constants';
 import { MenuItemProps } from '../fields/PortalMenu';
 import { useSquadInvitation } from '../../hooks/useSquadInvitation';
 import { Origin } from '../../lib/analytics';
-import AuthContext from '../../contexts/AuthContext';
+import { useAuthContext } from '../../contexts/AuthContext';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ '../fields/PortalMenu'),
@@ -41,7 +41,7 @@ interface SquadHeaderMenuProps {
 export default function SquadHeaderMenu({
   squad,
 }: SquadHeaderMenuProps): ReactElement {
-  const { isLoggedIn } = useContext(AuthContext);
+  const { isLoggedIn } = useAuthContext();
   const { trackAndCopyLink } = useSquadInvitation({
     squad,
     origin: Origin.SquadPage,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We shouldn't render this item if you're not a user

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-174 #done
