### PR TITLE
fix: acquisition card visuals on mobile

### DIFF
--- a/packages/shared/src/components/cards/AcquisitionFormCard.tsx
+++ b/packages/shared/src/components/cards/AcquisitionFormCard.tsx
@@ -3,6 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
 import classNames from 'classnames';
 import { Card } from './Card';
+import { Card as CardV1 } from './v1/Card';
 import { Radio } from '../fields/Radio';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { AcquisitionChannel, updateUserAcquisition } from '../../graphql/users';
@@ -79,14 +80,10 @@ export function AcquisitionFormCard(): ReactElement {
     return null;
   }
 
+  const CardComponent = shouldUseMobileFeedLayout ? CardV1 : Card;
+
   return (
-    <Card
-      data-testid="acquisitionFormCard"
-      className={classNames(
-        'p-4',
-        shouldUseMobileFeedLayout && '!bg-theme-bg-primary',
-      )}
-    >
+    <CardComponent data-testid="acquisitionFormCard" className="p-4">
       <OnboardingTitleGradient className="flex w-full flex-row items-center whitespace-nowrap pb-1 typo-body">
         How did you hear about us?
         <Button
@@ -117,6 +114,6 @@ export function AcquisitionFormCard(): ReactElement {
       >
         Submit
       </Button>
-    </Card>
+    </CardComponent>
   );
 }


### PR DESCRIPTION
## Changes

The bottom border should not appear on the card. Switched to using CardV1 on mobile instead.

### Before

<img width="433" alt="Screenshot 2024-03-08 at 14 02 40" src="https://github.com/dailydotdev/apps/assets/9974711/f336563b-60ae-4e9a-b028-1ab493b27d9e">


### After

<img width="400" alt="Screenshot 2024-03-08 at 14 19 39" src="https://github.com/dailydotdev/apps/assets/9974711/38bea1c4-7011-4df3-a767-77709316ca52">

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-188 #done
