### PR TITLE
fix: use user instead of anonymous to generate short_url query key

### DIFF
--- a/packages/shared/src/hooks/utils/useGetShortUrl.ts
+++ b/packages/shared/src/hooks/utils/useGetShortUrl.ts
@@ -27,7 +27,7 @@ export const useGetShortUrl = (): UseGetShortUrlResult => {
         : url;
       const shortUrlKey = generateQueryKey(
         RequestKey.ShortUrl,
-        null,
+        user,
         trackingUrl,
       );
 


### PR DESCRIPTION
## Changes

This is my own doing, used the `generateQueryKey` function, but did not provide the user parameter. Which resulted in query keys being generated for `"anonymous"`, even though we only generate it for logged in users. Using the user ID there actually makes more sense, especially when debugging react query.

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
