### PR TITLE
fix: pass the post on share post card footer component

### DIFF
--- a/packages/shared/src/components/cards/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.tsx
@@ -78,6 +78,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
           sharedPost={post.sharedPost}
           isShort={isSharedPostShort}
           isVideoType={isVideoType}
+          post={post}
         />
         <ActionButtons
           openNewTab={openNewTab}

--- a/packages/shared/src/hooks/post/usePostShareLoop.ts
+++ b/packages/shared/src/hooks/post/usePostShareLoop.ts
@@ -29,7 +29,7 @@ export const usePostShareLoop = (post: Post): UsePostShareLoop => {
     callback: ({ variables }) => {
       const vars = variables as UseVotePostMutationProps;
 
-      if (vars.id !== post.id || !shareLoopsEnabled) {
+      if (vars.id !== post?.id || !shareLoopsEnabled) {
         return;
       }
 


### PR DESCRIPTION
- not sure yet if this is the only root cause of the issue

Before 
---
https://github.com/dailydotdev/apps/assets/1225100/109209be-6f33-4109-b1cb-3d26e961d6f3 

After
---
https://github.com/dailydotdev/apps/assets/1225100/6fe35fc1-3e83-4a1f-9208-370f89592452

## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-216 #done
