### PR TITLE
fix: existing session issue

### DIFF
--- a/packages/shared/src/lib/kratos.ts
+++ b/packages/shared/src/lib/kratos.ts
@@ -94,6 +94,7 @@ export interface InitializationData {
   ui: InitializationUI;
   requested_aal?: AuthenticatorLevel;
   state?: string;
+  error?: KratosError;
 }
 
 interface KratosEmailData {
@@ -199,6 +200,7 @@ export interface KratosError {
   code: number;
   message: string;
   reason: string;
+  id?: string;
   debug?: string;
 }
 
@@ -384,4 +386,8 @@ export const KRATOS_ERROR = Object.freeze<Record<string, number>>({
   NO_STRATEGY_TO_LOGIN: 4010002,
   NO_STRATEGY_TO_SIGNUP: 4010003,
   UNVERIFIED: 4000010,
+});
+
+export const KRATOS_ERROR_MESSAGE = Object.freeze<Record<string, string>>({
+  SESSION_ALREADY_AVAILABLE: 'session_already_available',
 });


### PR DESCRIPTION
## Changes

### Describe what this PR does
- There is this edge-case issue where people have multiple accounts - logout - one cookie still persists, while others might be cleared
- When this happens you'd experience a freeze on the frontend
- To avoid this we detect (and now log) when this specific error is thrown and log you out 

NOTE:
- Do note with this user will see a automatic redirect on the auth page (this is the logout behaviour)
- Potential edge-case might be it's an infinite loop (however unlikely unless we break some code ourselves 😅)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-181 #done
