### PR TITLE
fix: z-index and pointer events issue on mobile

### DIFF
--- a/packages/shared/src/components/cards/common/CardCoverShare.tsx
+++ b/packages/shared/src/components/cards/common/CardCoverShare.tsx
@@ -23,7 +23,7 @@ export function CardCoverShare({
   };
 
   return (
-    <span className="absolute inset-0 flex flex-col items-center justify-center">
+    <span className="absolute inset-0 z-1 flex flex-col items-center justify-center">
       <p className="font-bold typo-callout">
         Should anyone else see this post?
       </p>

--- a/packages/shared/src/components/image/VideoImage.tsx
+++ b/packages/shared/src/components/image/VideoImage.tsx
@@ -26,7 +26,8 @@ const VideoImage = ({
     <div
       className={classNames(
         className,
-        'pointer-events-none relative flex h-auto max-h-fit w-full items-center justify-center overflow-hidden rounded-12',
+        !overlay && 'pointer-events-none',
+        'relative flex h-auto max-h-fit w-full items-center justify-center overflow-hidden rounded-12',
       )}
     >
       {overlay || defaultOverlay}


### PR DESCRIPTION
## Changes
- On desktop everything works perfectly, but on mobile, the buttons are unclickable.
- Applied a higher z-index to make it above the link wrapper.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
