### PR TITLE
fix: card cover image

### DIFF
--- a/packages/shared/src/components/cards/Card.tsx
+++ b/packages/shared/src/components/cards/Card.tsx
@@ -43,7 +43,10 @@ export const ListCardTitle = classed(Title, 'mr-2');
 
 export const CardTextContainer = classed('div', 'flex flex-col mx-4');
 
-export const CardImage = classed(Image, 'rounded-12 h-40 object-cover');
+export const CardImage = classed(
+  Image,
+  'rounded-12 max-h-[12.5rem] w-full tablet:max-h-[10rem] h-full object-cover',
+);
 
 export const CardSpace = classed('div', 'flex-1');
 

--- a/packages/shared/src/components/cards/v1/Card.tsx
+++ b/packages/shared/src/components/cards/v1/Card.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames';
 import { ReactElement } from 'react-markdown/lib/react-markdown';
 import classed from '../../../lib/classed';
 import { Image } from '../../image/Image';
-import VideoImage from '../../image/VideoImage';
 
 type TitleProps = HTMLAttributes<HTMLHeadingElement> & {
   lineClamp?: `line-clamp-${number}`;
@@ -45,11 +44,7 @@ export const CardContent = classed('div', 'flex flex-col mobileXL:flex-row');
 
 export const CardImage = classed(
   Image,
-  'rounded-12 max-h-[calc(100vw-34px)] mobileXL:aspect-auto mobileXL:max-h-40 mobileXL:w-40 mobileXXL:max-h-56 mobileXXL:w-56',
-);
-export const CardVideoImage = classed(
-  VideoImage,
-  'rounded-12 max-h-[calc(100vw-34px)] mobileXL:max-h-40 mobileXL:w-40 mobileXXL:max-h-56 mobileXXL:w-56',
+  'rounded-12 max-h-[12.5rem] w-full mobileXL:aspect-auto mobileXL:max-h-40 mobileXL:w-40 mobileXXL:max-h-56 mobileXXL:w-56',
 );
 
 export const CardSpace = classed('div', 'flex-1');


### PR DESCRIPTION
## Changes
- Fix the height of card cover images across mobile screen sizes.

Previews:
![Screenshot 2024-03-12 at 4 51 04 PM](https://github.com/dailydotdev/apps/assets/13744167/a0a7ad4c-7c98-415f-b279-f589acb6ffa3)
![Screenshot 2024-03-12 at 4 50 27 PM](https://github.com/dailydotdev/apps/assets/13744167/cc6432f7-17d5-45e6-a75a-0af04d0701b7)
![Screenshot 2024-03-12 at 4 48 58 PM](https://github.com/dailydotdev/apps/assets/13744167/3ee391f7-915c-4008-aa7e-3a9615c3cbb4)
![Screenshot 2024-03-12 at 4 48 50 PM](https://github.com/dailydotdev/apps/assets/13744167/a15f024a-0224-4bd7-83fd-4757e961a45f)
![Screenshot 2024-03-12 at 4 48 43 PM](https://github.com/dailydotdev/apps/assets/13744167/af68aa84-4a61-46aa-b910-f12609ae866d)
![Screenshot 2024-03-12 at 4 48 35 PM](https://github.com/dailydotdev/apps/assets/13744167/08700521-3978-4167-b603-8707117a2d55)
![Screenshot 2024-03-12 at 4 46 59 PM](https://github.com/dailydotdev/apps/assets/13744167/165dd150-7198-4285-9c39-d5f0a3968ea9)



## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
