### PR TITLE
fix: min-height of cards.

### DIFF
--- a/packages/shared/src/components/cards/Card.tsx
+++ b/packages/shared/src/components/cards/Card.tsx
@@ -45,7 +45,7 @@ export const CardTextContainer = classed('div', 'flex flex-col mx-4');
 
 export const CardImage = classed(
   Image,
-  'rounded-12 max-h-[12.5rem] w-full tablet:max-h-[10rem] object-cover',
+  'rounded-12 max-h-[12.5rem] min-h-[10rem] w-full tablet:max-h-[10rem] object-cover',
 );
 
 export const CardSpace = classed('div', 'flex-1');


### PR DESCRIPTION
## Changes
- Since we don't have the static height anymore, we need to have a min height.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
