### PR TITLE
feat: update tabs components to work with URLs as well

### DIFF
--- a/packages/shared/src/components/tabs/TabContainer.spec.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.spec.tsx
@@ -6,6 +6,8 @@ import {
   screen,
 } from '@testing-library/react';
 import nock from 'nock';
+import { NextRouter, useRouter } from 'next/router';
+import { mocked } from 'ts-jest/utils';
 import { Tab, TabContainer, TabContainerProps } from './TabContainer';
 
 beforeEach(() => {
@@ -20,6 +22,22 @@ const renderComponent = (props: TabContainerProps = {}): RenderResult => {
       <Tab label="First">Sample</Tab>
       <Tab label="Second">Test</Tab>
       <Tab label="Third">Try</Tab>
+    </TabContainer>,
+  );
+};
+
+const renderUrlComponent = (props: TabContainerProps = {}): RenderResult => {
+  return render(
+    <TabContainer {...props} onActiveChange={onActiveClick}>
+      <Tab label="First" url="/first">
+        Sample
+      </Tab>
+      <Tab label="Second" url="/second">
+        Test
+      </Tab>
+      <Tab label="Third" url="/third">
+        Try
+      </Tab>
     </TabContainer>,
   );
 };
@@ -53,5 +71,47 @@ describe('tab container component', () => {
     const third = screen.queryByText('Try');
     expect(third).toBeInTheDocument();
     expect(third).toHaveStyle({ display: 'none' });
+  });
+
+  describe('with URLs', () => {
+    jest.mock('next/router', () => ({
+      useRouter() {
+        return {
+          isFallback: false,
+        };
+      },
+    }));
+
+    beforeAll(() => {
+      const mockPathname = '/second';
+      mocked(useRouter).mockImplementation(
+        () =>
+          ({
+            pathname: mockPathname,
+            push: jest.fn(),
+          } as unknown as NextRouter),
+      );
+    });
+
+    it('should set the active tab based on the current path', async () => {
+      renderUrlComponent({ shouldMountInactive: true });
+
+      const active = await screen.findByText('Second');
+      const inactive1 = await screen.findByText('First');
+      const inactive2 = await screen.findByText('Third');
+
+      expect(active).toHaveClass('bg-theme-active');
+      expect(inactive1).not.toHaveClass('bg-theme-active');
+      expect(inactive2).not.toHaveClass('bg-theme-active');
+    });
+
+    it('should redirect to the given URL on tab click', async () => {
+      const router = useRouter();
+      renderUrlComponent({ shouldMountInactive: true });
+
+      const first = await screen.findByText('First');
+      fireEvent.click(first);
+      expect(router.push).toHaveBeenCalledWith('/first');
+    });
   });
 });

--- a/packages/shared/src/components/tabs/TabContainer.spec.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.spec.tsx
@@ -42,6 +42,8 @@ const renderUrlComponent = (props: TabContainerProps = {}): RenderResult => {
   );
 };
 
+const routerPush = jest.fn();
+
 describe('tab container component', () => {
   it('should render all the tabs', async () => {
     renderComponent();
@@ -88,7 +90,7 @@ describe('tab container component', () => {
         () =>
           ({
             pathname: mockPathname,
-            push: jest.fn(),
+            push: routerPush,
           } as unknown as NextRouter),
       );
     });
@@ -106,12 +108,11 @@ describe('tab container component', () => {
     });
 
     it('should redirect to the given URL on tab click', async () => {
-      const router = useRouter();
       renderUrlComponent({ shouldMountInactive: true });
 
       const first = await screen.findByText('First');
       fireEvent.click(first);
-      expect(router.push).toHaveBeenCalledWith('/first');
+      expect(routerPush).toHaveBeenCalledWith('/first');
     });
   });
 });

--- a/packages/shared/src/components/tabs/TabContainer.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import classNames from 'classnames';
+import { useRouter } from 'next/router';
 import TabList, { TabListProps } from './TabList';
 
 export interface TabProps<T extends string> {
@@ -15,6 +16,7 @@ export interface TabProps<T extends string> {
   className?: string;
   style?: CSSProperties;
   showHeader?: boolean;
+  url?: string;
 }
 
 export const Tab = <T extends string>({
@@ -58,15 +60,30 @@ export function TabContainer<T extends string = string>({
   controlledActive,
   tabListProps = {},
 }: TabContainerProps<T>): ReactElement {
-  const [active, setActive] = useState(children[0].props.label);
+  const router = useRouter();
+  const [active, setActive] = useState(
+    children[0].props.url
+      ? children.find((c) => c.props.url === router.pathname)?.props?.label
+      : children[0].props.label,
+  );
   const currentActive = controlledActive ?? active;
   const onClick = (label: T) => {
+    const child = children.find((c) => c.props.label === label);
     setActive(label);
     onActiveChange?.(label);
+
+    if (child?.props?.url) {
+      router.push(child.props.url);
+    }
   };
 
-  const isTabActive = (child: ReactElement<TabProps<T>>) =>
-    child.props.label === currentActive;
+  const isTabActive = (child: ReactElement<TabProps<T>>) => {
+    if (child.props.url) {
+      return router.pathname === child.props.url;
+    }
+
+    return child.props.label === currentActive;
+  };
 
   const renderSingleComponent = () => {
     if (!shouldMountInactive) {

--- a/packages/shared/src/components/tabs/TabContainer.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.tsx
@@ -61,11 +61,20 @@ export function TabContainer<T extends string = string>({
   tabListProps = {},
 }: TabContainerProps<T>): ReactElement {
   const router = useRouter();
-  const [active, setActive] = useState(
-    children[0].props.url
-      ? children.find((c) => c.props.url === router.pathname)?.props?.label
-      : children[0].props.label,
-  );
+
+  const [active, setActive] = useState(() => {
+    const defaultLabel = children[0].props.label;
+
+    if (children[0].props.url) {
+      const matchingChild = children.find(
+        (c) => c.props.url === router.pathname,
+      );
+      return matchingChild ? matchingChild.props.label : defaultLabel;
+    }
+
+    return defaultLabel;
+  });
+
   const currentActive = controlledActive ?? active;
   const onClick = (label: T) => {
     const child = children.find((c) => c.props.label === label);
@@ -77,12 +86,14 @@ export function TabContainer<T extends string = string>({
     }
   };
 
-  const isTabActive = (child: ReactElement<TabProps<T>>) => {
-    if (child.props.url) {
-      return router.pathname === child.props.url;
+  const isTabActive = ({
+    props: { url, label },
+  }: ReactElement<TabProps<T>>) => {
+    if (url) {
+      return router.pathname === url;
     }
 
-    return child.props.label === currentActive;
+    return label === currentActive;
   };
 
   const renderSingleComponent = () => {


### PR DESCRIPTION
## Changes

- adding a `url` prop to tabs
- trigger router navigation if tabs have urls

## Events

N / A

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-136 #done
