### PR TITLE
fix: add marketing CTA card component

### DIFF
--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -24,6 +24,7 @@ import { UseVotePost, useFeedLayout } from '../hooks';
 import { CollectionCard } from './cards/CollectionCard';
 import { CollectionCard as CollectionCardV1 } from './cards/v1/CollectionCard';
 import { AcquisitionFormCard } from './cards/AcquisitionFormCard';
+import { MarketingCTACard, MarketingCTAList } from './cards';
 
 const CommentPopup = dynamic(
   () => import(/* webpackChunkName: "commentPopup" */ './cards/CommentPopup'),
@@ -118,12 +119,14 @@ const getTags = (
       PostTag: PostTypeToTagV1[postType] ?? ArticlePostCardV1,
       AdTag: AdCardV1,
       PlaceholderTag: PlaceholderCardV1,
+      MarketingCTATag: MarketingCTACard,
     };
   }
   return {
     PostTag: isList ? PostList : PostTypeToTag[postType] ?? ArticlePostCard,
     AdTag: isList ? AdList : AdCard,
     PlaceholderTag: isList ? PlaceholderList : PlaceholderCard,
+    MarketingCTATag: isList ? MarketingCTAList : MarketingCTACard,
   };
 };
 
@@ -167,7 +170,7 @@ export default function FeedItemComponent({
   );
 
   const { shouldUseMobileFeedLayout } = useFeedLayout();
-  const { PostTag, AdTag, PlaceholderTag } = getTags(
+  const { PostTag, AdTag, PlaceholderTag, MarketingCTATag } = getTags(
     isList,
     shouldUseMobileFeedLayout,
     (item as PostItem).post?.type,
@@ -256,6 +259,14 @@ export default function FeedItemComponent({
       );
     case 'userAcquisition': {
       return <AcquisitionFormCard key="user-acquisition-card" />;
+    }
+    case 'marketingCTA': {
+      return (
+        <MarketingCTATag
+          key="marketing-cta-card"
+          marketingCTA={item.marketingCTA}
+        />
+      );
     }
     default:
       return <PlaceholderTag showImage={!insaneMode} />;

--- a/packages/shared/src/components/Pill.tsx
+++ b/packages/shared/src/components/Pill.tsx
@@ -2,11 +2,13 @@ import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 
 export enum PillSize {
+  Small = 'small',
   Medium = 'medium',
 }
 
 const pillSizeToClassName: Record<PillSize, string> = {
-  [PillSize.Medium]: 'font-bold typo-caption1',
+  [PillSize.Small]: 'font-bold typo-footnote rounded-8 p-1 px-2',
+  [PillSize.Medium]: 'font-bold typo-caption1 rounded-10 p-2',
 };
 
 interface Props {
@@ -14,12 +16,14 @@ interface Props {
   tag?: keyof Pick<JSX.IntrinsicElements, 'a' | 'div'>;
   size?: PillSize;
   className?: string;
+  alignment?: string;
 }
 
 export const Pill = ({
   label,
   tag: Tag = 'div',
   size = PillSize.Medium,
+  alignment = 'self-start',
   className,
   ...props
 }: Props): ReactElement => {
@@ -27,8 +31,9 @@ export const Pill = ({
     <Tag
       {...props}
       className={classNames(
+        alignment,
         pillSizeToClassName[size],
-        'inline-flex items-center self-start rounded-10 p-2',
+        'inline-flex items-center',
         className,
       )}
     >

--- a/packages/shared/src/components/cards/MarketingCTA/MarketingCTACard.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/MarketingCTACard.tsx
@@ -10,37 +10,27 @@ export function MarketingCTACard({
 }: {
   marketingCTA: MarketingCTA;
 }): ReactElement {
+  const { tagColor, tagText, title, description, image, ctaUrl, ctaText } =
+    marketingCTA;
   const { shouldUseMobileFeedLayout } = useFeedLayout();
   const CardComponent = shouldUseMobileFeedLayout ? CardV1 : Card;
 
   return (
     <CardComponent className="p-4">
-      {marketingCTA.tagColor && marketingCTA.tagText && (
-        <Header
-          tagColor={marketingCTA.tagColor}
-          tagText={marketingCTA.tagText}
-        />
-      )}
-      <Title>{marketingCTA.title}</Title>
-      {marketingCTA.description && (
-        <Description>{marketingCTA.description}</Description>
-      )}
-      {marketingCTA.image && (
+      {tagColor && tagText && <Header tagColor={tagColor} tagText={tagText} />}
+      <Title>{title}</Title>
+      {description && <Description>{description}</Description>}
+      {image && (
         <CardCover
           imageProps={{
             loading: 'lazy',
-            alt: 'Post Cover image',
-            src: marketingCTA.image,
+            alt: 'Post Cover',
+            src: image,
             className: 'w-full my-3',
           }}
         />
       )}
-      {marketingCTA.ctaUrl && marketingCTA.ctaText && (
-        <CTAButton
-          ctaUrl={marketingCTA.ctaUrl}
-          ctaText={marketingCTA.ctaText}
-        />
-      )}
+      {ctaUrl && ctaText && <CTAButton ctaUrl={ctaUrl} ctaText={ctaText} />}
     </CardComponent>
   );
 }

--- a/packages/shared/src/components/cards/MarketingCTA/MarketingCTACard.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/MarketingCTACard.tsx
@@ -11,7 +11,7 @@ export function MarketingCTACard({
   marketingCTA: MarketingCTA;
 }): ReactElement {
   const { tagColor, tagText, title, description, image, ctaUrl, ctaText } =
-    marketingCTA;
+    marketingCTA.flags;
   const { shouldUseMobileFeedLayout } = useFeedLayout();
   const CardComponent = shouldUseMobileFeedLayout ? CardV1 : Card;
 

--- a/packages/shared/src/components/cards/MarketingCTA/MarketingCTACard.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/MarketingCTACard.tsx
@@ -1,0 +1,46 @@
+import React, { ReactElement } from 'react';
+import { Card } from '../Card';
+import { CardCover } from '../common/CardCover';
+import { CTAButton, Description, Header, MarketingCTA, Title } from './common';
+import { Card as CardV1 } from '../v1/Card';
+import { useFeedLayout } from '../../../hooks';
+
+export function MarketingCTACard({
+  marketingCTA,
+}: {
+  marketingCTA: MarketingCTA;
+}): ReactElement {
+  const { shouldUseMobileFeedLayout } = useFeedLayout();
+  const CardComponent = shouldUseMobileFeedLayout ? CardV1 : Card;
+
+  return (
+    <CardComponent className="p-4">
+      {marketingCTA.tagColor && marketingCTA.tagText && (
+        <Header
+          tagColor={marketingCTA.tagColor}
+          tagText={marketingCTA.tagText}
+        />
+      )}
+      <Title>{marketingCTA.title}</Title>
+      {marketingCTA.description && (
+        <Description>{marketingCTA.description}</Description>
+      )}
+      {marketingCTA.image && (
+        <CardCover
+          imageProps={{
+            loading: 'lazy',
+            alt: 'Post Cover image',
+            src: marketingCTA.image,
+            className: 'w-full my-3',
+          }}
+        />
+      )}
+      {marketingCTA.ctaUrl && marketingCTA.ctaText && (
+        <CTAButton
+          ctaUrl={marketingCTA.ctaUrl}
+          ctaText={marketingCTA.ctaText}
+        />
+      )}
+    </CardComponent>
+  );
+}

--- a/packages/shared/src/components/cards/MarketingCTA/MarketingCTAList.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/MarketingCTAList.tsx
@@ -8,7 +8,7 @@ export function MarketingCTAList({
   marketingCTA: MarketingCTA;
 }): ReactElement {
   const { tagColor, tagText, title, description, ctaUrl, ctaText } =
-    marketingCTA;
+    marketingCTA.flags;
   return (
     <Card className="p-4">
       {tagColor && tagText && <Header tagColor={tagColor} tagText={tagText} />}

--- a/packages/shared/src/components/cards/MarketingCTA/MarketingCTAList.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/MarketingCTAList.tsx
@@ -1,0 +1,31 @@
+import React, { ReactElement } from 'react';
+import { Card } from '../Card';
+import { CTAButton, Description, Header, MarketingCTA, Title } from './common';
+
+export function MarketingCTAList({
+  marketingCTA,
+}: {
+  marketingCTA: MarketingCTA;
+}): ReactElement {
+  return (
+    <Card className="p-4">
+      {marketingCTA.tagColor && marketingCTA.tagText && (
+        <Header
+          tagColor={marketingCTA.tagColor}
+          tagText={marketingCTA.tagText}
+        />
+      )}
+      <Title>{marketingCTA.title}</Title>
+      {marketingCTA.description && (
+        <Description>{marketingCTA.description}</Description>
+      )}
+      {marketingCTA.ctaUrl && marketingCTA.ctaText && (
+        <CTAButton
+          className="mt-4 max-w-64"
+          ctaUrl={marketingCTA.ctaUrl}
+          ctaText={marketingCTA.ctaText}
+        />
+      )}
+    </Card>
+  );
+}

--- a/packages/shared/src/components/cards/MarketingCTA/MarketingCTAList.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/MarketingCTAList.tsx
@@ -7,23 +7,18 @@ export function MarketingCTAList({
 }: {
   marketingCTA: MarketingCTA;
 }): ReactElement {
+  const { tagColor, tagText, title, description, ctaUrl, ctaText } =
+    marketingCTA;
   return (
     <Card className="p-4">
-      {marketingCTA.tagColor && marketingCTA.tagText && (
-        <Header
-          tagColor={marketingCTA.tagColor}
-          tagText={marketingCTA.tagText}
-        />
-      )}
-      <Title>{marketingCTA.title}</Title>
-      {marketingCTA.description && (
-        <Description>{marketingCTA.description}</Description>
-      )}
-      {marketingCTA.ctaUrl && marketingCTA.ctaText && (
+      {tagColor && tagText && <Header tagColor={tagColor} tagText={tagText} />}
+      <Title>{title}</Title>
+      {description && <Description>{description}</Description>}
+      {ctaUrl && ctaText && (
         <CTAButton
           className="mt-4 max-w-64"
-          ctaUrl={marketingCTA.ctaUrl}
-          ctaText={marketingCTA.ctaText}
+          ctaUrl={ctaUrl}
+          ctaText={ctaText}
         />
       )}
     </Card>

--- a/packages/shared/src/components/cards/MarketingCTA/common.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/common.tsx
@@ -7,17 +7,21 @@ import { anchorDefaultRel } from '../../../lib/strings';
 import { Pill, PillSize } from '../../Pill';
 
 export interface MarketingCTA {
+  campaignId: string;
+  createdAt: Date;
   variant: 'card' | 'popover';
-  tagText?: string;
-  tagColor?: string;
-  title: string;
-  description?: string;
-  image?: string;
-  ctaUrl: string;
-  ctaText: string;
+  flags: {
+    image?: string;
+    title: string;
+    ctaUrl: string;
+    ctaText: string;
+    tagText?: string;
+    tagColor?: string;
+    description?: string;
+  };
 }
 
-type HeaderProps = Pick<MarketingCTA, 'tagText' | 'tagColor'>;
+type HeaderProps = Pick<MarketingCTA['flags'], 'tagText' | 'tagColor'>;
 const tagColorMap: Record<string, string> = {
   avocado: 'bg-action-upvote-float text-action-upvote-default',
 };
@@ -46,7 +50,7 @@ export const Description = classed(
   'text-theme-label-secondary typo-callout',
 );
 
-type CTAButtonType = Pick<MarketingCTA, 'ctaText' | 'ctaUrl'> & {
+type CTAButtonType = Pick<MarketingCTA['flags'], 'ctaText' | 'ctaUrl'> & {
   className?: string;
 };
 export const CTAButton = ({

--- a/packages/shared/src/components/cards/MarketingCTA/common.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/common.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement } from 'react';
-import classNames from 'classnames';
 import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
 import { MiniCloseIcon } from '../../icons';
 import { CardTitle } from '../Card';

--- a/packages/shared/src/components/cards/MarketingCTA/common.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/common.tsx
@@ -34,7 +34,7 @@ export const Header = ({ tagText, tagColor }: HeaderProps): ReactElement => (
       size={ButtonSize.Small}
       variant={ButtonVariant.Tertiary}
       icon={<MiniCloseIcon />}
-      aria-label="Close acquisition form"
+      aria-label="Close post"
     />
   </div>
 );

--- a/packages/shared/src/components/cards/MarketingCTA/common.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/common.tsx
@@ -5,6 +5,7 @@ import { MiniCloseIcon } from '../../icons';
 import { CardTitle } from '../Card';
 import classed from '../../../lib/classed';
 import { anchorDefaultRel } from '../../../lib/strings';
+import { Pill, PillSize } from '../../Pill';
 
 export interface MarketingCTA {
   variant: 'card' | 'popover';
@@ -23,14 +24,12 @@ const tagColorMap: Record<string, string> = {
 };
 export const Header = ({ tagText, tagColor }: HeaderProps): ReactElement => (
   <div className="flex w-full flex-row items-center">
-    <span
-      className={classNames(
-        'rounded-8 p-1 px-2 font-bold typo-footnote',
-        tagColorMap[tagColor],
-      )}
-    >
-      {tagText}
-    </span>
+    <Pill
+      label={tagText}
+      className={tagColorMap[tagColor]}
+      size={PillSize.Small}
+      alignment={null}
+    />
     <Button
       className="ml-auto"
       size={ButtonSize.Small}

--- a/packages/shared/src/components/cards/MarketingCTA/common.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/common.tsx
@@ -25,7 +25,7 @@ export const Header = ({ tagText, tagColor }: HeaderProps): ReactElement => (
   <div className="flex w-full flex-row items-center">
     <Pill
       label={tagText}
-      className={tagColorMap[tagColor]}
+      className={tagColorMap[tagColor || 'avocado']}
       size={PillSize.Small}
       alignment={null}
     />

--- a/packages/shared/src/components/cards/MarketingCTA/common.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/common.tsx
@@ -1,0 +1,69 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
+import { MiniCloseIcon } from '../../icons';
+import { CardTitle } from '../Card';
+import classed from '../../../lib/classed';
+import { anchorDefaultRel } from '../../../lib/strings';
+
+export interface MarketingCTA {
+  type: 'card' | 'popover';
+  tagText?: string;
+  tagColor?: string;
+  title: string;
+  description?: string;
+  image?: string;
+  ctaUrl: string;
+  ctaText: string;
+}
+
+type HeaderProps = Pick<MarketingCTA, 'tagText' | 'tagColor'>;
+const tagColorMap: Record<string, string> = {
+  avocado: 'bg-action-upvote-float text-action-upvote-default',
+};
+export const Header = ({ tagText, tagColor }: HeaderProps): ReactElement => (
+  <div className="flex w-full flex-row items-center">
+    <span
+      className={classNames(
+        'rounded-8  p-1 px-2 font-bold  typo-footnote',
+        tagColorMap[tagColor],
+      )}
+    >
+      {tagText}
+    </span>
+    <Button
+      className="ml-auto"
+      size={ButtonSize.Small}
+      variant={ButtonVariant.Tertiary}
+      icon={<MiniCloseIcon />}
+      aria-label="Close acquisition form"
+    />
+  </div>
+);
+
+export const Title = classed(CardTitle, 'my-2');
+
+export const Description = classed(
+  'p',
+  'text-theme-label-secondary typo-callout',
+);
+
+type CTAButtonType = Pick<MarketingCTA, 'ctaText' | 'ctaUrl'> & {
+  className?: string;
+};
+export const CTAButton = ({
+  ctaUrl,
+  ctaText,
+  className = 'mt-auto w-full',
+}: CTAButtonType): ReactElement => (
+  <Button
+    tag="a"
+    rel={anchorDefaultRel}
+    href={ctaUrl}
+    className={className}
+    variant={ButtonVariant.Primary}
+    size={ButtonSize.Small}
+  >
+    {ctaText}
+  </Button>
+);

--- a/packages/shared/src/components/cards/MarketingCTA/common.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/common.tsx
@@ -25,7 +25,7 @@ export const Header = ({ tagText, tagColor }: HeaderProps): ReactElement => (
   <div className="flex w-full flex-row items-center">
     <span
       className={classNames(
-        'rounded-8  p-1 px-2 font-bold  typo-footnote',
+        'rounded-8 p-1 px-2 font-bold typo-footnote',
         tagColorMap[tagColor],
       )}
     >

--- a/packages/shared/src/components/cards/MarketingCTA/common.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/common.tsx
@@ -7,7 +7,7 @@ import classed from '../../../lib/classed';
 import { anchorDefaultRel } from '../../../lib/strings';
 
 export interface MarketingCTA {
-  type: 'card' | 'popover';
+  variant: 'card' | 'popover';
   tagText?: string;
   tagColor?: string;
   title: string;

--- a/packages/shared/src/components/cards/MarketingCTA/index.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/index.tsx
@@ -1,3 +1,2 @@
 export * from './MarketingCTACard';
 export * from './MarketingCTAList';
-export * from './common';

--- a/packages/shared/src/components/cards/MarketingCTA/index.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/index.tsx
@@ -1,0 +1,3 @@
+export * from './MarketingCTACard';
+export * from './MarketingCTAList';
+export * from './common';

--- a/packages/shared/src/components/cards/index.ts
+++ b/packages/shared/src/components/cards/index.ts
@@ -1,1 +1,2 @@
 export * from './FeedbackCard';
+export * from './MarketingCTA';

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -22,7 +22,7 @@ import {
   updateCachedPagePost,
 } from '../lib/query';
 import { getShouldRefreshFeed } from '../lib/refreshFeed';
-import type { MarketingCTA } from '../components';
+import { MarketingCTA } from '../components/cards/MarketingCTA/common';
 
 export type PostItem = {
   type: 'post';

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -22,6 +22,7 @@ import {
   updateCachedPagePost,
 } from '../lib/query';
 import { getShouldRefreshFeed } from '../lib/refreshFeed';
+import type { MarketingCTA } from '../components';
 
 export type PostItem = {
   type: 'post';
@@ -32,11 +33,16 @@ export type PostItem = {
 export type AdItem = { type: 'ad'; ad: Ad };
 export type PlaceholderItem = { type: 'placeholder' };
 export type UserAcquisitionItem = { type: 'userAcquisition' };
+export type MarketingCTAItem = {
+  type: 'marketingCTA';
+  marketingCTA: MarketingCTA;
+};
 export type FeedItem =
   | PostItem
   | AdItem
   | PlaceholderItem
-  | UserAcquisitionItem;
+  | UserAcquisitionItem
+  | MarketingCTAItem;
 
 export type UpdateFeedPost = (page: number, index: number, post: Post) => void;
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added the marketing card (split up the tasks so they smaller to review)

Card:
![Screenshot 2024-03-12 at 13 10 31](https://github.com/dailydotdev/apps/assets/554874/f1b98e0c-8b7e-43f8-9b3d-821c4e4ec2ba)

List:
![Screenshot 2024-03-12 at 13 10 09](https://github.com/dailydotdev/apps/assets/554874/c79f9448-074c-491b-83dc-95d28a0083a3)

Mobile:
![Screenshot 2024-03-12 at 13 10 17](https://github.com/dailydotdev/apps/assets/554874/e30f55ca-7f2a-46b1-b34d-c1e2f828a966)

## Demo data
You can add the following in useFeed to enable it locally.

```js
          posts.splice(0, 0, {
            variant: 'marketingCTA',
            marketingCTA: {
              type: 'card',
              tagText: 'New release',
              tagColor: 'avocado',
              title: 'Introducing the Daily.dev browser extension',
              description:
                'Get the latest dev news and articles right in your browser.',
              ctaUrl:
                'https://chrome.google.com/webstore/detail/dailydev/hkngfbomfjfgbkejgjhgkemfkegjgjai',
              ctaText: 'Install now',
              image:
                'https://res.cloudinary.com/daily-now/image/upload/f_auto,q_auto/v1/posts/156488021afcf2237083924ab90b5469?_a=AQAEufR',
            },
          });
```

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-164 #done
