### PR TITLE
feat: add loading state while feed is refreshing

### DIFF
--- a/packages/shared/src/components/filters/MyFeedHeading.tsx
+++ b/packages/shared/src/components/filters/MyFeedHeading.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useContext } from 'react';
 import classNames from 'classnames';
 import { useRouter } from 'next/router';
-import { useQueryClient } from '@tanstack/react-query';
+import { useIsFetching, useQueryClient } from '@tanstack/react-query';
 import { FilterIcon, RefreshIcon } from '../icons';
 import {
   Button,
@@ -96,6 +96,13 @@ function MyFeedHeading({
     setShouldRefreshFeed(false);
   };
 
+  const isFetchingFeed =
+    useIsFetching({ queryKey: [SharedFeedPage.MyFeed] }) > 0;
+  const feedQueryState = queryClient.getQueryState([SharedFeedPage.MyFeed], {
+    exact: false,
+  });
+  const isRefreshing = feedQueryState?.status === 'success' && isFetchingFeed;
+
   return (
     <>
       {forceRefresh && (
@@ -110,6 +117,7 @@ function MyFeedHeading({
           iconPosition={
             shouldUseMobileFeedLayout ? ButtonIconPosition.Right : undefined
           }
+          loading={isRefreshing}
         >
           {!isMobile ? 'Refresh feed' : null}
         </Button>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- add loading state while refreshing
- make sure loading state is not displayed first time the feed is fetching

<img width="572" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/fb683122-8fe9-44a5-9d51-bb657caa8248">


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-179 #done
