### PR TITLE
fix: marketing modal

### DIFF
--- a/packages/shared/src/components/cards/MarketingCTA/common.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/common.tsx
@@ -17,11 +17,19 @@ export interface MarketingCTA {
   ctaText: string;
 }
 
-type HeaderProps = Pick<MarketingCTA, 'tagText' | 'tagColor'>;
+type HeaderProps = Pick<MarketingCTA, 'tagText' | 'tagColor'> & {
+  onClose?: (e?: React.MouseEvent | React.KeyboardEvent) => void;
+  buttonSize?: ButtonSize;
+};
 const tagColorMap: Record<string, string> = {
   avocado: 'bg-action-upvote-float text-action-upvote-default',
 };
-export const Header = ({ tagText, tagColor }: HeaderProps): ReactElement => (
+export const Header = ({
+  tagText,
+  tagColor,
+  onClose,
+  buttonSize = ButtonSize.Small,
+}: HeaderProps): ReactElement => (
   <div className="flex w-full flex-row items-center">
     <span
       className={classNames(
@@ -33,10 +41,11 @@ export const Header = ({ tagText, tagColor }: HeaderProps): ReactElement => (
     </span>
     <Button
       className="ml-auto"
-      size={ButtonSize.Small}
+      size={buttonSize}
       variant={ButtonVariant.Tertiary}
       icon={<MiniCloseIcon />}
       aria-label="Close acquisition form"
+      onClick={onClose}
     />
   </div>
 );
@@ -49,12 +58,16 @@ export const Description = classed(
 );
 
 type CTAButtonType = Pick<MarketingCTA, 'ctaText' | 'ctaUrl'> & {
+  onClick?: (e?: React.MouseEvent | React.KeyboardEvent) => void;
   className?: string;
+  buttonSize?: ButtonSize;
 };
 export const CTAButton = ({
   ctaUrl,
   ctaText,
+  onClick,
   className = 'mt-auto w-full',
+  buttonSize = ButtonSize.Small,
 }: CTAButtonType): ReactElement => (
   <Button
     tag="a"
@@ -62,7 +75,8 @@ export const CTAButton = ({
     href={ctaUrl}
     className={className}
     variant={ButtonVariant.Primary}
-    size={ButtonSize.Small}
+    onClick={onClick}
+    size={buttonSize}
   >
     {ctaText}
   </Button>

--- a/packages/shared/src/components/modals/MarketingCTAModal.tsx
+++ b/packages/shared/src/components/modals/MarketingCTAModal.tsx
@@ -1,0 +1,66 @@
+import React, { ReactElement } from 'react';
+import { Modal, ModalProps } from './common/Modal';
+import { ButtonSize } from '../buttons/Button';
+import type { MarketingCTA } from '../cards';
+import { CTAButton, Description, Header, Title } from '../cards';
+import { CardCover } from '../cards/common/CardCover';
+
+export interface NewRankModalProps extends ModalProps {
+  marketingCTA: MarketingCTA;
+}
+export const MarketingCTAModal = ({
+  marketingCTA,
+  onRequestClose,
+  ...modalProps
+}: NewRankModalProps): ReactElement => {
+  const { tagColor, tagText, title, description, image, ctaUrl, ctaText } =
+    marketingCTA;
+
+  const onModalClose: typeof onRequestClose = (param) => {
+    onRequestClose(param);
+  };
+
+  return (
+    <Modal
+      {...modalProps}
+      kind={Modal.Kind.FlexibleCenter}
+      size={Modal.Size.Small}
+      onRequestClose={onModalClose}
+    >
+      <div className="p-6 !pt-4">
+        {tagColor && tagText && (
+          <Header
+            onClose={onModalClose}
+            tagColor={tagColor}
+            tagText={tagText}
+            buttonSize={ButtonSize.Medium}
+          />
+        )}
+        <Title className="!typo-large-title">{title}</Title>
+        {description && (
+          <Description className="!typo-body">{description}</Description>
+        )}
+        {image && (
+          <CardCover
+            imageProps={{
+              loading: 'lazy',
+              alt: 'Post Cover',
+              src: image,
+              className: 'w-full my-6 !h-50',
+            }}
+          />
+        )}
+        {ctaUrl && ctaText && (
+          <CTAButton
+            ctaUrl={ctaUrl}
+            ctaText={ctaText}
+            onClick={onModalClose}
+            buttonSize={ButtonSize.Medium}
+          />
+        )}
+      </div>
+    </Modal>
+  );
+};
+
+export default MarketingCTAModal;

--- a/packages/shared/src/components/modals/common.tsx
+++ b/packages/shared/src/components/modals/common.tsx
@@ -108,6 +108,11 @@ const ReputationPrivilegesModal = dynamic(
     ),
 );
 
+const MarketingCTAModal = dynamic(
+  () =>
+    import(/* webpackChunkName: "marketingCTAModal" */ './MarketingCTAModal'),
+);
+
 export const modals = {
   [LazyModal.SquadMember]: SquadMemberModal,
   [LazyModal.UpvotedPopup]: UpvotedPopupModal,
@@ -127,6 +132,7 @@ export const modals = {
   [LazyModal.NewStreak]: NewStreakModal,
   [LazyModal.FirstStreak]: FirstStreakModal,
   [LazyModal.ReputationPrivileges]: ReputationPrivilegesModal,
+  [LazyModal.MarketingCTA]: MarketingCTAModal,
 };
 
 type GetComponentProps<T> = T extends

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -42,6 +42,7 @@ export enum LazyModal {
   NewStreak = 'newStreak',
   FirstStreak = 'firstStreak',
   ReputationPrivileges = 'reputationPrivileges',
+  MarketingCTA = 'marketingCTA',
 }
 
 export type ModalTabItem = {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added the marketing modal option

![Screenshot 2024-03-12 at 15 10 34](https://github.com/dailydotdev/apps/assets/554874/60ce09e0-470f-4787-b870-de447fc85136)

## Test run:
Add this code for example in `Feed`

```js
  const { openModal } = useLazyModal<LazyModal.MarketingCTA>();
  useEffect(() => {
    openModal({
      type: LazyModal.MarketingCTA,
      props: {
        marketingCTA: {
          variant: 'popover',
          tagText: 'New release',
          tagColor: 'avocado',
          title: 'Introducing the Daily.dev browser extension',
          description:
            'Get the latest dev news and articles right in your browser.',
          ctaUrl:
            'https://chrome.google.com/webstore/detail/dailydev/hkngfbomfjfgbkejgjhgkemfkegjgjai',
          ctaText: 'Install now',
          image:
            'https://res.cloudinary.com/daily-now/image/upload/f_auto,q_auto/v1/posts/156488021afcf2237083924ab90b5469?_a=AQAEufR',
        },
      },
    });
  }, []);
```

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-184 #done
