### PR TITLE
fix: recommended image for squad post

### DIFF
--- a/packages/shared/src/components/cards/SimilarPosts/SidePost.tsx
+++ b/packages/shared/src/components/cards/SimilarPosts/SidePost.tsx
@@ -5,6 +5,7 @@ import { CardCover } from '../common/CardCover';
 import { IconSize } from '../../Icon';
 import PostReadTime from '../v1/PostReadTime';
 import { PostEngagementCounts } from './PostEngagementCounts';
+import { usePostImage } from '../../../hooks/post/usePostImage';
 
 interface SidePostProps {
   post: Post;
@@ -13,6 +14,7 @@ interface SidePostProps {
 
 export function SidePost({ post, onLinkClick }: SidePostProps): ReactElement {
   const isVideoType = post.type === PostType.VideoYouTube;
+  const image = usePostImage(post);
 
   return (
     <Link href={post.commentsPermalink} passHref>
@@ -26,7 +28,7 @@ export function SidePost({ post, onLinkClick }: SidePostProps): ReactElement {
           imageProps={{
             loading: 'lazy',
             alt: `Cover preview of: ${post.title}`,
-            src: post.image,
+            src: image,
             className: 'w-full !h-24 !rounded-8',
           }}
           videoProps={{ size: IconSize.Large }}

--- a/packages/shared/src/hooks/post/usePostImage.ts
+++ b/packages/shared/src/hooks/post/usePostImage.ts
@@ -3,7 +3,7 @@ import { Post } from '../../graphql/posts';
 
 export const usePostImage = (post: Post): string =>
   useMemo(() => {
-    const baseImage = post?.image ?? post.sharedPost?.image;
+    const baseImage = post?.image ?? post?.sharedPost?.image;
 
     if (baseImage) {
       return baseImage;
@@ -17,4 +17,4 @@ export const usePostImage = (post: Post): string =>
     }
 
     return undefined;
-  }, [post?.contentHtml, post?.image, post.sharedPost?.image]);
+  }, [post?.contentHtml, post?.image, post?.sharedPost?.image]);

--- a/packages/shared/src/hooks/post/usePostImage.ts
+++ b/packages/shared/src/hooks/post/usePostImage.ts
@@ -3,8 +3,10 @@ import { Post } from '../../graphql/posts';
 
 export const usePostImage = (post: Post): string =>
   useMemo(() => {
-    if (post?.image) {
-      return post?.image;
+    const baseImage = post?.image ?? post.sharedPost?.image;
+
+    if (baseImage) {
+      return baseImage;
     }
 
     const parser = new DOMParser();
@@ -15,4 +17,4 @@ export const usePostImage = (post: Post): string =>
     }
 
     return undefined;
-  }, [post?.contentHtml, post?.image]);
+  }, [post?.contentHtml, post?.image, post.sharedPost?.image]);


### PR DESCRIPTION
## Changes
- Fix the image to use when the recommended image is a shared post.

Deployed at preview: 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
