### PR TITLE
fix: image prioritization order

### DIFF
--- a/packages/shared/src/hooks/post/usePostImage.ts
+++ b/packages/shared/src/hooks/post/usePostImage.ts
@@ -3,7 +3,7 @@ import { Post } from '../../graphql/posts';
 
 export const usePostImage = (post: Post): string =>
   useMemo(() => {
-    const baseImage = post?.image ?? post?.sharedPost?.image;
+    const baseImage = post?.sharedPost?.image ?? post?.image;
 
     if (baseImage) {
       return baseImage;


### PR DESCRIPTION
## Changes
- Prioritize usage of shared post image over the post.image since the post.image falls back to the default image if API finds out it is empty.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
