### PR TITLE
feat: add navigation drawer

### DIFF
--- a/packages/shared/src/components/buttons/Button.tsx
+++ b/packages/shared/src/components/buttons/Button.tsx
@@ -90,9 +90,9 @@ function ButtonComponent<TagName extends AllowedTags>(
       ref={ref}
       className={classNames(
         `btn shadow-none focus-outline inline-flex cursor-pointer select-none
-        flex-row items-center
-        justify-center border font-bold no-underline transition
+        flex-row items-center border no-underline transition
         duration-200 ease-in-out typo-callout`,
+        variant !== ButtonVariant.Option && 'justify-center font-bold',
         { iconOnly },
         iconOnly ? IconOnlySizeToClassName[size] : SizeToClassName[size],
         !color && VariantToClassName[variant],

--- a/packages/shared/src/components/buttons/common.ts
+++ b/packages/shared/src/components/buttons/common.ts
@@ -18,6 +18,7 @@ export enum ButtonVariant {
   Tertiary = 'tertiary',
   Float = 'tertiaryFloat',
   Subtle = 'subtle',
+  Option = 'option',
 }
 
 export enum ButtonIconPosition {
@@ -47,6 +48,7 @@ export const VariantToClassName: Record<ButtonVariant, string> = {
   [ButtonVariant.Tertiary]: 'btn-tertiary',
   [ButtonVariant.Float]: 'btn-tertiaryFloat',
   [ButtonVariant.Subtle]: 'btn-subtle',
+  [ButtonVariant.Option]: 'btn-option gap-1',
 };
 
 export const VariantColorToClassName: Record<
@@ -157,6 +159,27 @@ export const VariantColorToClassName: Record<
     [ButtonColor.Twitter]: 'btn-subtle-twitter',
     [ButtonColor.Water]: 'btn-subtle-water',
     [ButtonColor.WhatsApp]: 'btn-subtle-whatsapp',
+  },
+  [ButtonVariant.Option]: {
+    [ButtonColor.Avocado]: 'btn-option-avocado',
+    [ButtonColor.Bacon]: 'btn-option-bacon',
+    [ButtonColor.BlueCheese]: 'btn-option-blueCheese',
+    [ButtonColor.Bun]: 'btn-option-bun',
+    [ButtonColor.Burger]: 'btn-option-burger',
+    [ButtonColor.Cabbage]: 'btn-option-cabbage',
+    [ButtonColor.Cheese]: 'btn-option-cheese',
+    [ButtonColor.Facebook]: 'btn-option-facebook',
+    [ButtonColor.Ketchup]: 'btn-option-ketchup',
+    [ButtonColor.LinkedIn]: 'btn-option-linkedin',
+    [ButtonColor.Lettuce]: 'btn-option-lettuce',
+    [ButtonColor.Onion]: 'btn-option-onion',
+    [ButtonColor.Pepper]: 'btn-option-pepper',
+    [ButtonColor.Salt]: 'btn-option-salt',
+    [ButtonColor.Reddit]: 'btn-option-reddit',
+    [ButtonColor.Telegram]: 'btn-option-telegram',
+    [ButtonColor.Twitter]: 'btn-option-twitter',
+    [ButtonColor.Water]: 'btn-option-water',
+    [ButtonColor.WhatsApp]: 'btn-option-whatsapp',
   },
 };
 

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -17,6 +17,8 @@ import { Button } from '../buttons/Button';
 export enum DrawerPosition {
   Bottom = 'bottom',
   Top = 'top',
+  Left = 'left',
+  Right = 'right',
 }
 
 interface ClassName {
@@ -39,11 +41,15 @@ interface DrawerProps
 const drawerPositionToClassName: Record<DrawerPosition, string> = {
   [DrawerPosition.Bottom]: 'bottom-0 rounded-t-16',
   [DrawerPosition.Top]: 'top-0 rounded-b-16',
+  [DrawerPosition.Left]: 'left-0 rounded-r-16',
+  [DrawerPosition.Right]: 'right-0 rounded-l-16',
 };
 
 const animatePositionClassName: Record<DrawerPosition, string> = {
   [DrawerPosition.Bottom]: 'translate-y-full',
   [DrawerPosition.Top]: '-translate-y-full',
+  [DrawerPosition.Left]: '-translate-x-full',
+  [DrawerPosition.Right]: 'translate-x-full',
 };
 
 function BaseDrawer({
@@ -75,11 +81,10 @@ function BaseDrawer({
       <div
         {...props}
         className={classNames(
-          'absolute flex flex-col overflow-y-auto bg-background-default transition-transform duration-300 ease-in-out',
+          'absolute flex max-h-[calc(100%-5rem)] w-full flex-col overflow-y-auto bg-background-default transition-transform duration-300 ease-in-out',
           isAnimating && animatePositionClassName[position],
           drawerPositionToClassName[position],
           !title && classes,
-          'max-h-[calc(100%-5rem)] w-full',
         )}
         ref={(node) => {
           container.current = node;

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -32,6 +32,7 @@ interface DrawerProps
   className?: ClassName;
   position?: DrawerPosition;
   closeOnOutsideClick?: boolean;
+  isFullScreen?: boolean;
   isClosing?: boolean;
   title?: string;
   onClose(): void;
@@ -57,6 +58,7 @@ function BaseDrawer({
   className = {},
   position = DrawerPosition.Bottom,
   closeOnOutsideClick = true,
+  isFullScreen = false,
   isClosing = false,
   title,
   onClose,
@@ -73,7 +75,8 @@ function BaseDrawer({
   return (
     <div
       className={classNames(
-        'fixed inset-0 z-max bg-overlay-quaternary-onion transition-opacity duration-300 ease-in-out',
+        'fixed inset-0 z-max transition-opacity duration-300 ease-in-out',
+        !isFullScreen && 'bg-overlay-quaternary-onion',
         className?.overlay,
         isAnimating && 'opacity-0',
       )}
@@ -81,9 +84,10 @@ function BaseDrawer({
       <div
         {...props}
         className={classNames(
-          'absolute flex max-h-[calc(100%-5rem)] w-full flex-col overflow-y-auto bg-background-default transition-transform duration-300 ease-in-out',
+          'absolute flex w-full flex-col overflow-y-auto bg-background-default transition-transform duration-300 ease-in-out',
+          isFullScreen ? 'inset-0' : 'max-h-[calc(100%-5rem)]',
+          !isFullScreen && drawerPositionToClassName[position],
           isAnimating && animatePositionClassName[position],
-          drawerPositionToClassName[position],
           !title && classes,
         )}
         ref={(node) => {

--- a/packages/shared/src/components/drawers/NavDrawer.tsx
+++ b/packages/shared/src/components/drawers/NavDrawer.tsx
@@ -43,7 +43,7 @@ export function NavDrawer({
       {...otherDrawerProps}
       closeOnOutsideClick={false}
       displayCloseButton={displayCloseButton}
-      isFullScreen={true}
+      isFullScreen
       position={position ?? DrawerPosition.Left}
       ref={ref}
       role="menu"

--- a/packages/shared/src/components/drawers/NavDrawer.tsx
+++ b/packages/shared/src/components/drawers/NavDrawer.tsx
@@ -18,7 +18,7 @@ interface NavDrawerProps {
 
 const NavDrawerHeader = classed(
   'div',
-  'flex items-center gap-3 px-4 border-b border-theme-divider-tertiary h-12',
+  'flex items-center gap-3 px-4 border-b border-border-subtlest-tertiary h-12',
 );
 
 const NavDrawerContent = classed('div', 'flex flex-col px-4 py-5');
@@ -43,12 +43,12 @@ export function NavDrawer({
       {...otherDrawerProps}
       closeOnOutsideClick={false}
       displayCloseButton={displayCloseButton}
+      isFullScreen={true}
       position={position ?? DrawerPosition.Left}
       ref={ref}
       role="menu"
       className={{
-        drawer: 'bottom-0 top-0 !max-h-none !rounded-none',
-        overlay: 'bg-transparent',
+        drawer: 'py-0',
       }}
     >
       {header && (
@@ -59,7 +59,7 @@ export function NavDrawer({
             onClick={() => ref.current?.onClose()}
             icon={<ArrowIcon className="-rotate-90" />}
           />
-          <NavHeading className="font-bold typo-body">{header}</NavHeading>
+          <NavHeading>{header}</NavHeading>
         </NavDrawerHeader>
       )}
       <NavDrawerContent>

--- a/packages/shared/src/components/drawers/NavDrawer.tsx
+++ b/packages/shared/src/components/drawers/NavDrawer.tsx
@@ -1,0 +1,72 @@
+import React, { ReactElement } from 'react';
+import {
+  Drawer,
+  DrawerPosition,
+  DrawerRef,
+  DrawerWrapperProps,
+} from './Drawer';
+import { NavDrawerItem, NavItemProps } from './NavDrawerItem';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { ArrowIcon } from '../icons';
+import classed from '../../lib/classed';
+
+interface NavDrawerProps {
+  drawerProps: Omit<DrawerWrapperProps, 'children'>;
+  items: NavItemProps[];
+  header?: string;
+}
+
+const NavDrawerHeader = classed(
+  'div',
+  'flex items-center gap-3 px-4 border-b border-theme-divider-tertiary h-12',
+);
+
+const NavDrawerContent = classed('div', 'flex flex-col px-4 py-5');
+
+const NavHeading = classed('h2', 'typo-body font-bold');
+
+export function NavDrawer({
+  drawerProps,
+  header,
+  items,
+}: NavDrawerProps): ReactElement {
+  const ref = React.useRef<DrawerRef>();
+  const {
+    position,
+    displayCloseButton,
+    closeOnOutsideClick,
+    ...otherDrawerProps
+  } = drawerProps;
+
+  return (
+    <Drawer
+      {...otherDrawerProps}
+      closeOnOutsideClick={false}
+      displayCloseButton={displayCloseButton}
+      position={position ?? DrawerPosition.Left}
+      ref={ref}
+      role="menu"
+      className={{
+        drawer: 'bottom-0 top-0 !max-h-none !rounded-none',
+        overlay: 'bg-transparent',
+      }}
+    >
+      {header && (
+        <NavDrawerHeader>
+          <Button
+            variant={ButtonVariant.Tertiary}
+            size={ButtonSize.Small}
+            onClick={() => ref.current?.onClose()}
+            icon={<ArrowIcon className="-rotate-90" />}
+          />
+          <NavHeading className="font-bold typo-body">{header}</NavHeading>
+        </NavDrawerHeader>
+      )}
+      <NavDrawerContent>
+        {items.map((item) => (
+          <NavDrawerItem key={item.label} {...item} />
+        ))}
+      </NavDrawerContent>
+    </Drawer>
+  );
+}

--- a/packages/shared/src/components/drawers/NavDrawerItem.tsx
+++ b/packages/shared/src/components/drawers/NavDrawerItem.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
-import { Button, ButtonProps, ButtonVariant } from '../buttons/Button';
 import Link from 'next/link';
+import { Button, ButtonProps, ButtonVariant } from '../buttons/Button';
 import ConditionalWrapper from '../ConditionalWrapper';
 
 export interface NavItemProps

--- a/packages/shared/src/components/drawers/NavDrawerItem.tsx
+++ b/packages/shared/src/components/drawers/NavDrawerItem.tsx
@@ -1,0 +1,41 @@
+import React, { ReactElement } from 'react';
+import { Button, ButtonProps, ButtonVariant } from '../buttons/Button';
+
+export interface NavItemProps
+  extends Pick<ButtonProps<'a'>, 'href' | 'icon' | 'onClick'> {
+  label: string;
+  isHeader?: boolean;
+}
+
+const NavDrawerHeaderItem = ({ label }: { label: string }): ReactElement => (
+  <h3 className="my-2 flex h-12 items-center font-bold typo-callout first:mt-0">
+    {label}
+  </h3>
+);
+
+export function NavDrawerItem({
+  icon,
+  isHeader = false,
+  href,
+  label,
+  onClick,
+}: NavItemProps): ReactElement {
+  if (isHeader) {
+    return <NavDrawerHeaderItem label={label} />;
+  }
+
+  return (
+    <Button
+      role="menuitem"
+      type="button"
+      icon={icon}
+      className="!justify-start !font-normal"
+      onClick={onClick}
+      href={href}
+      tag={href ? 'a' : 'button'}
+      variant={ButtonVariant.Tertiary}
+    >
+      {label}
+    </Button>
+  );
+}

--- a/packages/shared/src/components/drawers/NavDrawerItem.tsx
+++ b/packages/shared/src/components/drawers/NavDrawerItem.tsx
@@ -1,5 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Button, ButtonProps, ButtonVariant } from '../buttons/Button';
+import Link from 'next/link';
+import ConditionalWrapper from '../ConditionalWrapper';
 
 export interface NavItemProps
   extends Pick<ButtonProps<'a'>, 'href' | 'icon' | 'onClick'> {
@@ -25,17 +27,21 @@ export function NavDrawerItem({
   }
 
   return (
-    <Button
-      role="menuitem"
-      type="button"
-      icon={icon}
-      className="!justify-start !font-normal"
-      onClick={onClick}
-      href={href}
-      tag={href ? 'a' : 'button'}
-      variant={ButtonVariant.Tertiary}
+    <ConditionalWrapper
+      condition={!!href}
+      wrapper={(children) => <Link href={href}>{children}</Link>}
     >
-      {label}
-    </Button>
+      <Button
+        role="menuitem"
+        type="button"
+        icon={icon}
+        onClick={onClick}
+        href={href}
+        tag={href ? 'a' : 'button'}
+        variant={ButtonVariant.Option}
+      >
+        {label}
+      </Button>
+    </ConditionalWrapper>
   );
 }

--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -50,7 +50,7 @@ export function Header({
       )}
       {isSameUser && (
         <Button
-          className="ml-auto mr-2 hidden tablet:flex"
+          className="ml-auto mr-2 hidden laptop:flex"
           variant={ButtonVariant.Float}
           size={ButtonSize.Small}
           tag="a"
@@ -60,7 +60,7 @@ export function Header({
         </Button>
       )}
       <Button
-        className={classNames('ml-auto', isSameUser && 'tablet:ml-0')}
+        className={classNames('ml-auto', isSameUser && 'laptop:ml-0')}
         variant={ButtonVariant.Float}
         size={ButtonSize.Small}
         icon={<ShareIcon />}
@@ -68,13 +68,12 @@ export function Header({
       />
       {isSameUser && (
         <Button
-          className="ml-2 tablet:hidden"
+          className="ml-2 laptop:hidden"
           variant={ButtonVariant.Float}
           size={ButtonSize.Small}
           icon={<SettingsIcon />}
-          tag="a"
-          href={`${process.env.NEXT_PUBLIC_WEBAPP_URL}account/profile`}
-          aria-label="Edit profile"
+          // href={`${process.env.NEXT_PUBLIC_WEBAPP_URL}account/profile`}
+          aria-label="Edit profile mobile"
         />
       )}
     </header>

--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -50,7 +50,7 @@ export function Header({
       )}
       {isSameUser && (
         <Button
-          className="ml-auto mr-2 hidden laptop:flex"
+          className="ml-auto mr-2 hidden tablet:flex"
           variant={ButtonVariant.Float}
           size={ButtonSize.Small}
           tag="a"
@@ -60,7 +60,7 @@ export function Header({
         </Button>
       )}
       <Button
-        className={classNames('ml-auto', isSameUser && 'laptop:ml-0')}
+        className={classNames('ml-auto', isSameUser && 'tablet:ml-0')}
         variant={ButtonVariant.Float}
         size={ButtonSize.Small}
         icon={<ShareIcon />}
@@ -68,12 +68,13 @@ export function Header({
       />
       {isSameUser && (
         <Button
-          className="ml-2 laptop:hidden"
+          className="ml-2 tablet:hidden"
           variant={ButtonVariant.Float}
           size={ButtonSize.Small}
           icon={<SettingsIcon />}
-          // href={`${process.env.NEXT_PUBLIC_WEBAPP_URL}account/profile`}
-          aria-label="Edit profile mobile"
+          tag="a"
+          href={`${process.env.NEXT_PUBLIC_WEBAPP_URL}account/profile`}
+          aria-label="Edit profile"
         />
       )}
     </header>

--- a/packages/shared/tailwind/buttons.ts
+++ b/packages/shared/tailwind/buttons.ts
@@ -167,6 +167,12 @@ const variations = {
       'var(--theme-overlay-active-salt)';
     return states;
   },
+  option: (color) => {
+    const states = variations.tertiary(color);
+    states.darkStates.hover.color = 'var(--theme-label-tertiary)';
+    states.lightStates.hover.color = 'var(--theme-label-tertiary)';
+    return states;
+  },
   tag: (color) => {
     const states = variations.tertiaryFloat(color);
     states.darkStates.default.color = 'var(--theme-label-primary)';

--- a/packages/storybook/stories/Button.stories.tsx
+++ b/packages/storybook/stories/Button.stories.tsx
@@ -14,8 +14,8 @@ const meta: Meta<typeof Button> = {
       expanded: true,
     },
     design: {
-      type: "figma",
-      url: "https://www.figma.com/file/C7n8EiXBwV1sYIEHkQHS8R/daily.dev---Design-System?type=design&node-id=1177-4542&mode=design&t=G2RMnPc48y6jEo5a-0",
+      type: 'figma',
+      url: 'https://www.figma.com/file/C7n8EiXBwV1sYIEHkQHS8R/daily.dev---Design-System?type=design&node-id=1177-4542&mode=design&t=G2RMnPc48y6jEo5a-0',
     },
   },
   argTypes: {
@@ -62,12 +62,12 @@ export const Sizes: Story = {
 
 export const Variants: Story = {
   render: ({ children, variant, ...props }) => (
-    <div className="grid grid-cols-5 gap-4">
-      <h2>Primary</h2>
-      <h2>Secondary</h2>
-      <h2>Tertiary</h2>
-      <h2>Float</h2>
-      <h2>Subtle</h2>
+    <div
+      className={`grid grid-cols-${Object.values(ButtonVariant).length} gap-4`}
+    >
+      {Object.keys(ButtonVariant).map((variantLabel) => (
+        <h2>{variantLabel}</h2>
+      ))}
       {Object.values(ButtonVariant).map((variant) => (
         <span key={variant}>
           <Button {...props} variant={variant}>
@@ -112,8 +112,8 @@ export const Icon: Story = {
   },
   parameters: {
     design: {
-      type: "figma",
-      url: "https://www.figma.com/file/C7n8EiXBwV1sYIEHkQHS8R/daily.dev---Design-System?type=design&node-id=1115-10302&mode=design&t=G2RMnPc48y6jEo5a-0",
+      type: 'figma',
+      url: 'https://www.figma.com/file/C7n8EiXBwV1sYIEHkQHS8R/daily.dev---Design-System?type=design&node-id=1115-10302&mode=design&t=G2RMnPc48y6jEo5a-0',
     },
-  }
+  },
 };

--- a/packages/storybook/stories/drawers/NavDrawer.stories.tsx
+++ b/packages/storybook/stories/drawers/NavDrawer.stories.tsx
@@ -33,7 +33,7 @@ const meta: Meta<typeof NavDrawer> = {
         label: 'Profile',
         isHeader: true,
       },
-      { label: 'Edit', icon: <EditIcon /> },
+      { label: 'Edit', icon: <EditIcon />, href: '/edit' },
       { label: 'Invite', icon: <AddUserIcon /> },
       { label: 'Delete', icon: <TrashIcon /> },
       {
@@ -55,7 +55,6 @@ type Story = StoryObj<typeof NavDrawer>;
 export const Drawer: Story = {
   render: (props) => {
     const [isOpen, setIsOpen] = useState(false);
-    const [selected, setSelected] = useState(-1);
 
     return (
       <>

--- a/packages/storybook/stories/drawers/NavDrawer.stories.tsx
+++ b/packages/storybook/stories/drawers/NavDrawer.stories.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import {
+  Button,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import { NavDrawer } from '@dailydotdev/shared/src/components/drawers/NavDrawer';
+import {
+  AddUserIcon,
+  BellIcon,
+  CardIcon,
+  EditIcon,
+  LockIcon,
+  MenuIcon,
+  TrashIcon,
+} from '@dailydotdev/shared/src/components/icons';
+
+const meta: Meta<typeof NavDrawer> = {
+  component: NavDrawer,
+  parameters: {
+    controls: {
+      expanded: true,
+    },
+    design: {
+      type: 'figma',
+      url: 'https://www.figma.com/file/nmfWPS7x3kzLUvYMkBx2kW/daily.dev---Dev-Mode?node-id=999%3A2766&mode=dev',
+    },
+  },
+  args: {
+    header: 'Settings',
+    items: [
+      {
+        label: 'Profile',
+        isHeader: true,
+      },
+      { label: 'Edit', icon: <EditIcon /> },
+      { label: 'Invite', icon: <AddUserIcon /> },
+      { label: 'Delete', icon: <TrashIcon /> },
+      {
+        label: 'Manage',
+        isHeader: true,
+      },
+      { label: 'Customize', icon: <CardIcon /> },
+      { label: 'Security', icon: <LockIcon /> },
+      { label: 'Notifications', icon: <BellIcon /> },
+      { label: 'Other settings', icon: <MenuIcon className="rotate-90" /> },
+    ],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof NavDrawer>;
+
+export const Drawer: Story = {
+  render: (props) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [selected, setSelected] = useState(-1);
+
+    return (
+      <>
+        <Button variant={ButtonVariant.Primary} onClick={() => setIsOpen(true)}>
+          Trigger
+        </Button>
+        <NavDrawer
+          {...props}
+          drawerProps={{
+            isOpen,
+            onClose: () => setIsOpen(false),
+          }}
+          items={props.items}
+        />
+      </>
+    );
+  },
+  name: 'Nav Drawer',
+};


### PR DESCRIPTION
## Changes

The `NavDrawer` is needed for implementing [Profile settings on mobile](https://www.figma.com/file/nmfWPS7x3kzLUvYMkBx2kW/daily.dev---Dev-Mode?node-id=999%3A2766&mode=dev) and probably some other parts I'm not aware off yet. Splitting it into it's own PR to make it easier to reuse in case others need it.

### Describe what this PR does
- Added `NavDrawer` component that reuses `Drawer` and adds some styling on top of it
- Added `NavDrawer` storybook

The component is not used anywhere, just in storybook for now.

### Screenshot

<img width="275" alt="Screenshot 2024-03-12 at 17 51 26" src="https://github.com/dailydotdev/apps/assets/9974711/2be9b0f7-e45a-4fb1-9dc1-6a31d4cef5c0">

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-131 #done
