### PR TITLE
fix: enable switching of search via gb

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -126,6 +126,7 @@ export default function MainFeedLayout({
   });
   const feedVersion = useFeature(feature.feedVersion);
   const onboardingV4dot5 = useFeature(feature.onboardingV4dot5);
+  const searchVersion = useFeature(feature.searchVersion);
   const isOnboardingV4dot5 = onboardingV4dot5 === OnboardingV4dot5.V4dot5;
   const { isUpvoted, isSortableFeed } = useFeedName({ feedName });
   const { shouldUseMobileFeedLayout } = useFeedLayout();
@@ -200,7 +201,7 @@ export default function MainFeedLayout({
           searchQuery,
         ),
         query: SEARCH_POSTS_QUERY,
-        variables: { query: searchQuery },
+        variables: { query: searchQuery, version: searchVersion },
         emptyScreen: <SearchEmptyScreen />,
       };
     }

--- a/packages/shared/src/components/PostsSearch.tsx
+++ b/packages/shared/src/components/PostsSearch.tsx
@@ -19,6 +19,8 @@ import {
 } from '../graphql/search';
 import { SEARCH_BOOKMARKS_SUGGESTIONS } from '../graphql/feed';
 import { SEARCH_READING_HISTORY_SUGGESTIONS } from '../graphql/users';
+import { useFeature } from './GrowthBookProvider';
+import { feature } from '../lib/featureManagement';
 
 const AutoCompleteMenu = dynamic(
   () =>
@@ -55,6 +57,7 @@ export default function PostsSearch({
   onFocus,
 }: PostsSearchProps): ReactElement {
   const searchBoxRef = useRef<HTMLDivElement>();
+  const searchVersion = useFeature(feature.searchVersion);
   const [initialQuery, setInitialQuery] = useState<string>();
   const [query, setQuery] = useState<string>();
   const [menuPosition, setMenuPosition] = useState<{
@@ -69,7 +72,7 @@ export default function PostsSearch({
     [suggestionType: string]: { hits: { title: string }[] };
   }>(
     [suggestionType, query],
-    () => request(graphqlUrl, SEARCH_URL, { query }),
+    () => request(graphqlUrl, SEARCH_URL, { query, version: searchVersion }),
     {
       enabled: !!query,
     },

--- a/packages/shared/src/graphql/feed.ts
+++ b/packages/shared/src/graphql/feed.ts
@@ -250,8 +250,9 @@ export const SEARCH_POSTS_QUERY = gql`
     $after: String
     $query: String!
     ${SUPPORTED_TYPES}
+    $version: Int
   ) {
-    page: searchPosts(first: $first, after: $after, query: $query, supportedTypes: $supportedTypes) {
+    page: searchPosts(first: $first, after: $after, query: $query, supportedTypes: $supportedTypes, version: $version) {
       ...FeedPostConnection
     }
   }

--- a/packages/shared/src/graphql/search.ts
+++ b/packages/shared/src/graphql/search.ts
@@ -74,8 +74,8 @@ export interface SearchHistoryData {
 
 // Search control version suggestions
 export const SEARCH_POST_SUGGESTIONS = gql`
-  query SearchPostSuggestions($query: String!) {
-    searchPostSuggestions(query: $query) {
+  query SearchPostSuggestions($query: String!, $version: Int) {
+    searchPostSuggestions(query: $query, version: $version) {
       hits {
         id
         title
@@ -95,8 +95,8 @@ export const SEARCH_POST_RECOMMENDATION = gql`
 `;
 
 export const SEARCH_SESSION_QUERY = gql`
-  query SearchSession($id: String!) {
-    searchSession(id: $id) {
+  query SearchSession($id: String!, $version: Int) {
+    searchSession(id: $id, version: $version) {
       id
       createdAt
       chunks {

--- a/packages/shared/src/hooks/search/useSearchProvider.spec.tsx
+++ b/packages/shared/src/hooks/search/useSearchProvider.spec.tsx
@@ -122,6 +122,7 @@ describe('useSearchProvider hook', () => {
         query: SEARCH_POST_SUGGESTIONS,
         variables: {
           query: 'apples',
+          version: 1,
         },
       },
       result: () => {

--- a/packages/shared/src/hooks/search/useSearchProvider.ts
+++ b/packages/shared/src/hooks/search/useSearchProvider.ts
@@ -8,6 +8,8 @@ import {
 } from '../../graphql/search';
 import { useRequestProtocol } from '../useRequestProtocol';
 import { graphqlUrl } from '../../lib/config';
+import { useFeature } from '../../components/GrowthBookProvider';
+import { feature } from '../../lib/featureManagement';
 
 export type UseSearchProviderProps = {
   provider: SearchProviderEnum;
@@ -30,6 +32,7 @@ const searchProviderSuggestionsQueryMap: Partial<
 export const useSearchProvider = (): UseSearchProvider => {
   const router = useRouter();
   const { requestMethod } = useRequestProtocol();
+  const searchVersion = useFeature(feature.searchVersion);
 
   return {
     search: useCallback(
@@ -52,6 +55,7 @@ export const useSearchProvider = (): UseSearchProvider => {
           searchPostSuggestions: SearchSuggestionResult;
         }>(graphqlUrl, searchProviderSuggestionsQueryMap[provider], {
           query,
+          version: searchVersion,
         });
 
         return result.searchPostSuggestions;

--- a/packages/shared/src/hooks/search/useSearchProvider.ts
+++ b/packages/shared/src/hooks/search/useSearchProvider.ts
@@ -60,7 +60,7 @@ export const useSearchProvider = (): UseSearchProvider => {
 
         return result.searchPostSuggestions;
       },
-      [requestMethod],
+      [requestMethod, searchVersion],
     ),
   };
 };

--- a/packages/shared/src/hooks/search/useSearchProviderSuggestions.spec.tsx
+++ b/packages/shared/src/hooks/search/useSearchProviderSuggestions.spec.tsx
@@ -66,6 +66,7 @@ describe('useSearchProviderSuggestions hook', () => {
         query: SEARCH_POST_SUGGESTIONS,
         variables: {
           query: 'apples',
+          version: 1,
         },
       },
       result: () => {

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -58,6 +58,7 @@ const feature = {
     'source_subscribe',
     SourceSubscribeExperiment.Control,
   ),
+  searchVersion: new Feature('search_version', 1),
 };
 
 export { feature };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Option to experiment with different search versions

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
