### PR TITLE
fix: flaky date format tests

### DIFF
--- a/packages/shared/src/components/utilities/DateFormat.spec.tsx
+++ b/packages/shared/src/components/utilities/DateFormat.spec.tsx
@@ -24,6 +24,16 @@ const renderComponent = ({
   );
 };
 
+const date = new Date(2024, 6, 6, 12, 30, 30);
+
+beforeEach(() => {
+  jest.useFakeTimers('modern').setSystemTime(date);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 describe('date format post type', () => {
   it('should render post time format', async () => {
     renderComponent({
@@ -35,14 +45,12 @@ describe('date format post type', () => {
   });
 
   it('should render post time format as now', async () => {
-    const date = new Date();
     renderComponent({ date, type: TimeFormatType.Post });
     const element = screen.getByRole('time');
     expect(element).toHaveTextContent('Now');
   });
 
   it('should render post time format as today', async () => {
-    const date = new Date();
     renderComponent({
       date: date.setHours(date.getHours() - 2),
       type: TimeFormatType.Post,
@@ -52,7 +60,6 @@ describe('date format post type', () => {
   });
 
   it('should render post time format as yesterday', async () => {
-    const date = new Date();
     renderComponent({
       date: date.setDate(date.getDate() - 1),
       type: TimeFormatType.Post,
@@ -73,7 +80,6 @@ describe('date format comment type', () => {
   });
 
   it('should render comment time format as now', async () => {
-    const date = new Date();
     renderComponent({
       date,
       type: TimeFormatType.Comment,
@@ -83,7 +89,6 @@ describe('date format comment type', () => {
   });
 
   it('should render comment time format as minutes', async () => {
-    const date = new Date();
     renderComponent({
       date: date.setMinutes(date.getMinutes() - 2),
       type: TimeFormatType.Comment,
@@ -93,7 +98,6 @@ describe('date format comment type', () => {
   });
 
   it('should render comment time format as hours', async () => {
-    const date = new Date();
     renderComponent({
       date: date.setHours(date.getHours() - 2),
       type: TimeFormatType.Comment,
@@ -114,7 +118,6 @@ describe('date format read history type', () => {
   });
 
   it('should render comment time format as today', async () => {
-    const date = new Date();
     renderComponent({
       date: date.setMinutes(date.getMinutes() - 2),
       type: TimeFormatType.ReadHistory,
@@ -124,7 +127,6 @@ describe('date format read history type', () => {
   });
 
   it('should render comment time format as yesterday', async () => {
-    const date = new Date();
     renderComponent({
       date: date.setDate(date.getDate() - 1),
       type: TimeFormatType.ReadHistory,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Noticed that due to relative time we can have flaky date format tests, [see test runs](https://app.circleci.com/pipelines/github/dailydotdev/apps?branch=experiments-helpers-story)
- For example if it is `01:00` subtracting 2 hours from current hours makes it `-1` which then makes `should render post time format as today` fail 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
