### PR TITLE
fix: remove email color option

### DIFF
--- a/packages/shared/src/components/widgets/SocialShareList.tsx
+++ b/packages/shared/src/components/widgets/SocialShareList.tsx
@@ -109,7 +109,6 @@ export function SocialShareList({
       <SocialShareButton
         icon={<MailIcon />}
         variant={ButtonVariant.Primary}
-        className="bg-theme-bg-email text-theme-label-primary"
         onClick={() => openShareLink(ShareProvider.Email)}
         label="Email"
       />
@@ -117,7 +116,6 @@ export function SocialShareList({
         <SocialShareButton
           icon={<MenuIcon size={IconSize.Large} className="rotate-90" />}
           variant={ButtonVariant.Primary}
-          className="bg-theme-bg-email text-theme-label-primary"
           onClick={onNativeShare}
           label="Share via..."
         />

--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -348,7 +348,6 @@ body {
   --theme-color-water: theme('colors.raw.water.40');
   --theme-color-salt: theme('colors.raw.salt.40');
   --theme-color-pepper: theme('colors.raw.pepper.40');
-  --theme-color-email: theme('colors.raw.pepper.10');
 }
 
 @define-mixin light-mode {
@@ -663,7 +662,6 @@ body {
   --theme-color-water: theme('colors.raw.water.60');
   --theme-color-salt: theme('colors.raw.pepper.40');
   --theme-color-pepper: theme('colors.raw.pepper.60');
-  --theme-color-email: theme('colors.raw.pepper.10');
 }
 
 @media (prefers-color-scheme: light) {

--- a/packages/shared/tailwind.config.ts
+++ b/packages/shared/tailwind.config.ts
@@ -50,7 +50,6 @@ export default {
         hover: 'var(--theme-hover)',
         rank: 'var(--rank-color)',
         bg: {
-          email: 'var(--theme-color-email)',
           'cabbage-blur': 'var(--theme-background-cabbage-blur)',
           bun: 'var(--theme-background-bun)',
           onion: 'var(--theme-background-onion)',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Chatted to Tsahi and this was actually a wrong color, should just be primary button color.

![Screenshot 2024-03-13 at 08 37 55](https://github.com/dailydotdev/apps/assets/554874/5cd8c9ba-789f-4caf-8fd4-ed820c0548ea)
![Screenshot 2024-03-13 at 08 38 25](https://github.com/dailydotdev/apps/assets/554874/5d20c75c-0e65-4ed0-832c-a0a831a20b87)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
