### PR TITLE
fix: mobile xl

### DIFF
--- a/packages/shared/src/components/cards/v1/Card.tsx
+++ b/packages/shared/src/components/cards/v1/Card.tsx
@@ -44,7 +44,7 @@ export const CardContent = classed('div', 'flex flex-col mobileXL:flex-row');
 
 export const CardImage = classed(
   Image,
-  'rounded-12 min-h-[10rem] max-h-[12.5rem] object-cover w-full h-auto',
+  'rounded-12 min-h-[10rem] max-h-[12.5rem] object-cover w-full h-auto mobileXL:max-h-40 mobileXL:w-40 mobileXXL:max-h-56 mobileXXL:w-56',
 );
 
 export const CardSpace = classed('div', 'flex-1');

--- a/packages/shared/src/components/cards/v1/SharedPostCardFooter.tsx
+++ b/packages/shared/src/components/cards/v1/SharedPostCardFooter.tsx
@@ -20,11 +20,13 @@ export const SharedPostCardFooter = ({
   return (
     <div
       className={classNames(
-        'mb-2 flex h-auto min-h-0 w-full flex-auto flex-col gap-3 rounded-12 border border-theme-divider-tertiary p-3',
+        'mb-2 flex h-auto min-h-0 w-full flex-auto flex-col gap-3 rounded-12 border border-theme-divider-tertiary p-3 mobileXXL:flex-row',
       )}
     >
-      <div className={classNames('flex flex-col mobileL:flex-1')}>
-        <span className="line-clamp-1">{sharedPost.title}</span>
+      <div className={classNames('flex flex-col')}>
+        <p className="line-clamp-3 text-text-secondary typo-body">
+          {sharedPost.title}
+        </p>
       </div>
 
       <CardCover

--- a/packages/shared/src/components/cards/v1/SharedPostCardFooter.tsx
+++ b/packages/shared/src/components/cards/v1/SharedPostCardFooter.tsx
@@ -23,12 +23,9 @@ export const SharedPostCardFooter = ({
         'mb-2 flex h-auto min-h-0 w-full flex-auto flex-col gap-3 rounded-12 border border-theme-divider-tertiary p-3 mobileXXL:flex-row',
       )}
     >
-      <div className={classNames('flex flex-col')}>
-        <p className="line-clamp-3 text-text-secondary typo-body">
-          {sharedPost.title}
-        </p>
+      <div className={classNames('flex flex-col mobileXL:flex-1')}>
+        <span className="line-clamp-1">{sharedPost.title}</span>
       </div>
-
       <CardCover
         data-testid="sharedPostImage"
         isVideoType={isVideoType}
@@ -38,7 +35,8 @@ export const SharedPostCardFooter = ({
           loading: 'lazy',
           alt: 'Shared Post Cover image',
           src: sharedPost.image,
-          className: 'min-h-0 w-full',
+          className:
+            'w-full mobileXXL:!w-40 mobileXXL:!h-20 mobileXXL:!min-h-0',
         }}
         videoProps={{ size: IconSize.XXXLarge }}
       />


### PR DESCRIPTION
## Changes
- From Figma, the title and image should be side by side on mobile XL.
  - https://www.figma.com/file/nmfWPS7x3kzLUvYMkBx2kW/daily.dev---Dev-Mode?node-id=2681%3A18553&mode=dev

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
