### PR TITLE
fix: remove cabbage blur color

### DIFF
--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -233,7 +233,6 @@ body {
   /* stylelint-disable-next-line unit-no-unknown */
   --theme-hover: theme('colors.raw.salt.90')1F;
 
-  --theme-background-cabbage-blur: theme('colors.raw.cabbage.90')99;
   --theme-background-bun: theme('colors.raw.bun.80');
   --theme-background-onion: theme('colors.raw.onion.80');
   --theme-background-pepper: theme('colors.raw.pepper.20');
@@ -546,7 +545,6 @@ body {
   /* stylelint-disable-next-line unit-no-unknown */
   --theme-hover: theme('colors.raw.pepper.10')1F;
 
-  --theme-background-cabbage-blur: theme('colors.raw.cabbage.10')99;
   --theme-background-bacon: theme('colors.raw.bacon.20');
   --theme-background-bun: theme('colors.raw.bun.20');
   --theme-background-onion: theme('colors.raw.onion.20');

--- a/packages/shared/tailwind.config.ts
+++ b/packages/shared/tailwind.config.ts
@@ -51,7 +51,6 @@ export default {
         rank: 'var(--rank-color)',
         bg: {
           email: 'var(--theme-color-email)',
-          'cabbage-blur': 'var(--theme-background-cabbage-blur)',
           bun: 'var(--theme-background-bun)',
           onion: 'var(--theme-background-onion)',
           pepper: 'var(--theme-background-pepper)',

--- a/packages/webapp/pages/popup/notifications/enable.tsx
+++ b/packages/webapp/pages/popup/notifications/enable.tsx
@@ -69,7 +69,7 @@ function Enable(): React.ReactElement {
   return (
     <main className="flex h-screen max-h-[100%] w-screen max-w-[100%] flex-col items-center justify-center overflow-hidden bg-theme-overlay-float-cabbage px-20 text-center">
       <h1 className="relative bg-transparent font-bold typo-mega3">
-        <div className="absolute inset-0 -z-1 size-52 -translate-y-[25%] rounded-50 bg-theme-bg-cabbage-blur opacity-64 blur-[3.125rem]" />
+        <div className="absolute inset-0 -z-1 size-52 -translate-y-[25%] rounded-50 bg-accent-cabbage-bolder opacity-64 blur-[3.125rem]" />
         Click allow
       </h1>
       <p className="mt-6 text-theme-label-secondary typo-body">


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Chatted to Tsahi and he's happy having it as this color variant. *(instead of the 60% opacity of 90 it was)

![Screenshot 2024-03-13 at 10 19 52](https://github.com/dailydotdev/apps/assets/554874/c81f692f-568b-4d38-8fb3-009030f5ef4a)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
