### PR TITLE
fix: only members with allowPin can move pins

### DIFF
--- a/packages/shared/src/hooks/usePostMenuActions.ts
+++ b/packages/shared/src/hooks/usePostMenuActions.ts
@@ -87,7 +87,7 @@ export const usePostMenuActions = ({
     SourcePermissions.PostPin,
   );
 
-  const canSwap = post?.pinnedAt;
+  const canSwap = canPin && post?.pinnedAt;
 
   const { mutateAsync: onPinPost } = useMutation(
     () => updatePinnedPost({ id: post.id, pinned: !post.pinnedAt }),


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Only members that can pin should be able to move pinned post ordering

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-188 #done
