### PR TITLE
fix: minor spacing issues and spacing for mobile

### DIFF
--- a/packages/shared/src/components/fields/MarkdownInput/SavingLabel.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/SavingLabel.tsx
@@ -21,10 +21,10 @@ export function SavingLabel({
 
   const getLabel = () => {
     if (isUpdating) {
-      return 'Saving changes';
+      return 'Saving';
     }
 
-    return isUptoDate ? 'All changes saved' : '';
+    return isUptoDate ? 'Saved' : '';
   };
 
   const getIcon = () => {
@@ -38,7 +38,7 @@ export function SavingLabel({
   return (
     <span
       className={classNames(
-        'flex flex-row items-center gap-1 font-bold text-theme-label-tertiary typo-callout',
+        'flex flex-row items-center gap-1 px-2 font-bold text-theme-label-tertiary typo-callout',
         className,
       )}
     >

--- a/packages/shared/src/components/tabs/TabList.tsx
+++ b/packages/shared/src/components/tabs/TabList.tsx
@@ -41,7 +41,7 @@ function TabList({
             setOffset(value);
           }}
           className={classNames(
-            'relative p-4 text-center font-bold typo-callout',
+            'relative p-2 py-4 text-center font-bold typo-callout',
             tab === active ? '' : 'text-theme-label-tertiary',
           )}
           onClick={() => onClick(tab)}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The tablist had different padding then design intented
- We changed the saving text to be more minimal (@sshanzel I actually noticed we don't really use the `isUpdatingDraft` in many places, so not showing the `Saving` text was this known/intented?)

![Screenshot 2024-03-13 at 14 32 18](https://github.com/dailydotdev/apps/assets/554874/17fc7a3e-1c6a-4d56-8702-45fdf9d32eea)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-189 #done
