### PR TITLE
fix: consistent naming between services

### DIFF
--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -24,7 +24,7 @@ import { UseVotePost, useFeedLayout } from '../hooks';
 import { CollectionCard } from './cards/CollectionCard';
 import { CollectionCard as CollectionCardV1 } from './cards/v1/CollectionCard';
 import { AcquisitionFormCard } from './cards/AcquisitionFormCard';
-import { MarketingCTACard, MarketingCTAList } from './cards';
+import { MarketingCtaCard, MarketingCtaList } from './cards';
 
 const CommentPopup = dynamic(
   () => import(/* webpackChunkName: "commentPopup" */ './cards/CommentPopup'),
@@ -119,14 +119,14 @@ const getTags = (
       PostTag: PostTypeToTagV1[postType] ?? ArticlePostCardV1,
       AdTag: AdCardV1,
       PlaceholderTag: PlaceholderCardV1,
-      MarketingCTATag: MarketingCTACard,
+      MarketingCtaTag: MarketingCtaCard,
     };
   }
   return {
     PostTag: isList ? PostList : PostTypeToTag[postType] ?? ArticlePostCard,
     AdTag: isList ? AdList : AdCard,
     PlaceholderTag: isList ? PlaceholderList : PlaceholderCard,
-    MarketingCTATag: isList ? MarketingCTAList : MarketingCTACard,
+    MarketingCtaTag: isList ? MarketingCtaList : MarketingCtaCard,
   };
 };
 
@@ -170,7 +170,7 @@ export default function FeedItemComponent({
   );
 
   const { shouldUseMobileFeedLayout } = useFeedLayout();
-  const { PostTag, AdTag, PlaceholderTag, MarketingCTATag } = getTags(
+  const { PostTag, AdTag, PlaceholderTag, MarketingCtaTag } = getTags(
     isList,
     shouldUseMobileFeedLayout,
     (item as PostItem).post?.type,
@@ -260,11 +260,11 @@ export default function FeedItemComponent({
     case 'userAcquisition': {
       return <AcquisitionFormCard key="user-acquisition-card" />;
     }
-    case 'marketingCTA': {
+    case 'marketingCta': {
       return (
-        <MarketingCTATag
+        <MarketingCtaTag
           key="marketing-cta-card"
-          marketingCTA={item.marketingCTA}
+          marketingCta={item.marketingCta}
         />
       );
     }

--- a/packages/shared/src/components/cards/MarketingCTA/index.tsx
+++ b/packages/shared/src/components/cards/MarketingCTA/index.tsx
@@ -1,2 +1,0 @@
-export * from './MarketingCTACard';
-export * from './MarketingCTAList';

--- a/packages/shared/src/components/cards/MarketingCta/MarketingCtaCard.tsx
+++ b/packages/shared/src/components/cards/MarketingCta/MarketingCtaCard.tsx
@@ -1,17 +1,17 @@
 import React, { ReactElement } from 'react';
 import { Card } from '../Card';
 import { CardCover } from '../common/CardCover';
-import { CTAButton, Description, Header, MarketingCTA, Title } from './common';
+import { CTAButton, Description, Header, MarketingCta, Title } from './common';
 import { Card as CardV1 } from '../v1/Card';
 import { useFeedLayout } from '../../../hooks';
 
-export function MarketingCTACard({
-  marketingCTA,
+export function MarketingCtaCard({
+  marketingCta,
 }: {
-  marketingCTA: MarketingCTA;
+  marketingCta: MarketingCta;
 }): ReactElement {
   const { tagColor, tagText, title, description, image, ctaUrl, ctaText } =
-    marketingCTA.flags;
+    marketingCta.flags;
   const { shouldUseMobileFeedLayout } = useFeedLayout();
   const CardComponent = shouldUseMobileFeedLayout ? CardV1 : Card;
 

--- a/packages/shared/src/components/cards/MarketingCta/MarketingCtaList.tsx
+++ b/packages/shared/src/components/cards/MarketingCta/MarketingCtaList.tsx
@@ -1,14 +1,14 @@
 import React, { ReactElement } from 'react';
 import { Card } from '../Card';
-import { CTAButton, Description, Header, MarketingCTA, Title } from './common';
+import { CTAButton, Description, Header, marketingCta, Title } from './common';
 
-export function MarketingCTAList({
-  marketingCTA,
+export function MarketingCtaList({
+  marketingCta,
 }: {
-  marketingCTA: MarketingCTA;
+  marketingCta: marketingCta;
 }): ReactElement {
   const { tagColor, tagText, title, description, ctaUrl, ctaText } =
-    marketingCTA.flags;
+    marketingCta.flags;
   return (
     <Card className="p-4">
       {tagColor && tagText && <Header tagColor={tagColor} tagText={tagText} />}

--- a/packages/shared/src/components/cards/MarketingCta/common.tsx
+++ b/packages/shared/src/components/cards/MarketingCta/common.tsx
@@ -6,7 +6,7 @@ import classed from '../../../lib/classed';
 import { anchorDefaultRel } from '../../../lib/strings';
 import { Pill, PillSize } from '../../Pill';
 
-export interface MarketingCTA {
+export interface marketingCta {
   campaignId: string;
   createdAt: Date;
   variant: 'card' | 'popover';
@@ -21,7 +21,7 @@ export interface MarketingCTA {
   };
 }
 
-type HeaderProps = Pick<MarketingCTA['flags'], 'tagText' | 'tagColor'> & {
+type HeaderProps = Pick<marketingCta['flags'], 'tagText' | 'tagColor'> & {
   onClose?: (e?: React.MouseEvent | React.KeyboardEvent) => void;
   buttonSize?: ButtonSize;
 };
@@ -59,7 +59,7 @@ export const Description = classed(
   'text-theme-label-secondary typo-callout',
 );
 
-type CTAButtonType = Pick<MarketingCTA['flags'], 'ctaText' | 'ctaUrl'> & {
+type CTAButtonType = Pick<marketingCta['flags'], 'ctaText' | 'ctaUrl'> & {
   onClick?: (e?: React.MouseEvent | React.KeyboardEvent) => void;
   className?: string;
   buttonSize?: ButtonSize;

--- a/packages/shared/src/components/cards/MarketingCta/index.tsx
+++ b/packages/shared/src/components/cards/MarketingCta/index.tsx
@@ -1,0 +1,2 @@
+export * from './MarketingCtaCard';
+export * from './MarketingCtaList';

--- a/packages/shared/src/components/cards/index.ts
+++ b/packages/shared/src/components/cards/index.ts
@@ -1,2 +1,2 @@
 export * from './FeedbackCard';
-export * from './MarketingCTA';
+export * from './MarketingCta';

--- a/packages/shared/src/components/modals/MarketingCtaModal.tsx
+++ b/packages/shared/src/components/modals/MarketingCtaModal.tsx
@@ -2,24 +2,24 @@ import React, { ReactElement } from 'react';
 import { Modal, ModalProps } from './common/Modal';
 import { ButtonSize } from '../buttons/Button';
 import { CardCover } from '../cards/common/CardCover';
-import type { MarketingCTA } from '../cards/MarketingCTA/common';
+import type { MarketingCta } from '../cards/MarketingCta/common';
 import {
   CTAButton,
   Description,
   Header,
   Title,
-} from '../cards/MarketingCTA/common';
+} from '../cards/MarketingCta/common';
 
-export interface NewRankModalProps extends ModalProps {
-  marketingCTA: MarketingCTA;
+export interface MarketingCtaModalProps extends ModalProps {
+  marketingCta: MarketingCta;
 }
-export const MarketingCTAModal = ({
-  marketingCTA,
+export const MarketingCtaModal = ({
+  marketingCta,
   onRequestClose,
   ...modalProps
-}: NewRankModalProps): ReactElement => {
+}: MarketingCtaModalProps): ReactElement => {
   const { tagColor, tagText, title, description, image, ctaUrl, ctaText } =
-    marketingCTA.flags;
+    marketingCta.flags;
 
   const onModalClose: typeof onRequestClose = (param) => {
     onRequestClose(param);
@@ -68,4 +68,4 @@ export const MarketingCTAModal = ({
   );
 };
 
-export default MarketingCTAModal;
+export default MarketingCtaModal;

--- a/packages/shared/src/components/modals/common.tsx
+++ b/packages/shared/src/components/modals/common.tsx
@@ -108,9 +108,9 @@ const ReputationPrivilegesModal = dynamic(
     ),
 );
 
-const MarketingCTAModal = dynamic(
+const MarketingCtaModal = dynamic(
   () =>
-    import(/* webpackChunkName: "marketingCTAModal" */ './MarketingCTAModal'),
+    import(/* webpackChunkName: "marketingCTAModal" */ './MarketingCtaModal'),
 );
 
 export const modals = {
@@ -132,7 +132,7 @@ export const modals = {
   [LazyModal.NewStreak]: NewStreakModal,
   [LazyModal.FirstStreak]: FirstStreakModal,
   [LazyModal.ReputationPrivileges]: ReputationPrivilegesModal,
-  [LazyModal.MarketingCTA]: MarketingCTAModal,
+  [LazyModal.MarketingCta]: MarketingCtaModal,
 };
 
 type GetComponentProps<T> = T extends

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -42,7 +42,7 @@ export enum LazyModal {
   NewStreak = 'newStreak',
   FirstStreak = 'firstStreak',
   ReputationPrivileges = 'reputationPrivileges',
-  MarketingCTA = 'marketingCTA',
+  MarketingCta = 'marketingCta',
 }
 
 export type ModalTabItem = {

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -22,7 +22,7 @@ import {
   updateCachedPagePost,
 } from '../lib/query';
 import { getShouldRefreshFeed } from '../lib/refreshFeed';
-import { MarketingCTA } from '../components/cards/MarketingCTA/common';
+import { marketingCta } from '../components/cards/MarketingCta/common';
 
 export type PostItem = {
   type: 'post';
@@ -33,16 +33,16 @@ export type PostItem = {
 export type AdItem = { type: 'ad'; ad: Ad };
 export type PlaceholderItem = { type: 'placeholder' };
 export type UserAcquisitionItem = { type: 'userAcquisition' };
-export type MarketingCTAItem = {
-  type: 'marketingCTA';
-  marketingCTA: MarketingCTA;
+export type MarketingCtaItem = {
+  type: 'marketingCta';
+  marketingCTA: marketingCta;
 };
 export type FeedItem =
   | PostItem
   | AdItem
   | PlaceholderItem
   | UserAcquisitionItem
-  | MarketingCTAItem;
+  | MarketingCtaItem;
 
 export type UpdateFeedPost = (page: number, index: number, post: Post) => void;
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since we are `Id` kind of people decided to rename `CTA` to `Cta` to be more inline 😿 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
