### PR TITLE
fix: bring back post modal scroll header

### DIFF
--- a/packages/shared/src/components/modals/ArticlePostModal.tsx
+++ b/packages/shared/src/components/modals/ArticlePostModal.tsx
@@ -26,9 +26,9 @@ export default function ArticlePostModal({
   ...props
 }: ArticlePostModalProps): ReactElement {
   const { showArticleOnboarding } = useContext(OnboardingContext);
-  const { isPostLoadingOrFetching } = usePostById({ id });
+  const { isLoading } = usePostById({ id });
   const position = usePostNavigationPosition({
-    isLoading: isPostLoadingOrFetching,
+    isLoading,
     isDisplayed: props.isOpen,
     offset: showArticleOnboarding ? ONBOARDING_OFFSET : 0,
   });

--- a/packages/shared/src/components/modals/ArticlePostModal.tsx
+++ b/packages/shared/src/components/modals/ArticlePostModal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement, useContext, useRef } from 'react';
 import { Modal, ModalProps, modalSizeToClassName } from './common/Modal';
 import { ONBOARDING_OFFSET, PostContent } from '../post/PostContent';
 import { Origin } from '../../lib/analytics';
@@ -7,6 +7,7 @@ import BasePostModal from './BasePostModal';
 import OnboardingContext from '../../contexts/OnboardingContext';
 import { Post, PostType } from '../../graphql/posts';
 import { PassedPostNavigationProps } from '../post/common';
+import usePostById from '../../hooks/usePostById';
 
 interface ArticlePostModalProps extends ModalProps, PassedPostNavigationProps {
   id: string;
@@ -25,8 +26,9 @@ export default function ArticlePostModal({
   ...props
 }: ArticlePostModalProps): ReactElement {
   const { showArticleOnboarding } = useContext(OnboardingContext);
+  const { isPostLoadingOrFetching } = usePostById({ id });
   const position = usePostNavigationPosition({
-    isLoading: false,
+    isLoading: isPostLoadingOrFetching,
     isDisplayed: props.isOpen,
     offset: showArticleOnboarding ? ONBOARDING_OFFSET : 0,
   });

--- a/packages/shared/src/components/modals/ArticlePostModal.tsx
+++ b/packages/shared/src/components/modals/ArticlePostModal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext, useRef } from 'react';
+import React, { ReactElement, useContext } from 'react';
 import { Modal, ModalProps, modalSizeToClassName } from './common/Modal';
 import { ONBOARDING_OFFSET, PostContent } from '../post/PostContent';
 import { Origin } from '../../lib/analytics';

--- a/packages/shared/src/components/modals/CollectionPostModal.tsx
+++ b/packages/shared/src/components/modals/CollectionPostModal.tsx
@@ -8,6 +8,7 @@ import OnboardingContext from '../../contexts/OnboardingContext';
 import { Post, PostType } from '../../graphql/posts';
 import { PassedPostNavigationProps } from '../post/common';
 import { CollectionPostContent } from '../post/collection';
+import usePostById from '../../hooks/usePostById';
 
 interface CollectionPostModalProps
   extends ModalProps,
@@ -28,8 +29,9 @@ export default function CollectionPostModal({
   ...props
 }: CollectionPostModalProps): ReactElement {
   const { showArticleOnboarding } = useContext(OnboardingContext);
+  const { isPostLoadingOrFetching } = usePostById({ id });
   const position = usePostNavigationPosition({
-    isLoading: false,
+    isLoading: isPostLoadingOrFetching,
     isDisplayed: props.isOpen,
     offset: showArticleOnboarding ? ONBOARDING_OFFSET : 0,
   });

--- a/packages/shared/src/components/modals/CollectionPostModal.tsx
+++ b/packages/shared/src/components/modals/CollectionPostModal.tsx
@@ -29,9 +29,9 @@ export default function CollectionPostModal({
   ...props
 }: CollectionPostModalProps): ReactElement {
   const { showArticleOnboarding } = useContext(OnboardingContext);
-  const { isPostLoadingOrFetching } = usePostById({ id });
+  const { isLoading } = usePostById({ id });
   const position = usePostNavigationPosition({
-    isLoading: isPostLoadingOrFetching,
+    isLoading,
     isDisplayed: props.isOpen,
     offset: showArticleOnboarding ? ONBOARDING_OFFSET : 0,
   });

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -10,6 +10,7 @@ import { PassedPostNavigationProps } from '../post/common';
 import { Post, PostType } from '../../graphql/posts';
 import EnableNotification from '../notifications/EnableNotification';
 import { isSourcePublicSquad } from '../../graphql/squads';
+import usePostById from '../../hooks/usePostById';
 
 interface PostModalProps extends ModalProps, PassedPostNavigationProps {
   id: string;
@@ -28,8 +29,9 @@ export default function PostModal({
   ...props
 }: PostModalProps): ReactElement {
   const { showArticleOnboarding } = useContext(OnboardingContext);
+  const { isPostLoadingOrFetching } = usePostById({ id });
   const position = usePostNavigationPosition({
-    isLoading: false,
+    isLoading: isPostLoadingOrFetching,
     isDisplayed: props.isOpen,
     offset: showArticleOnboarding ? ONBOARDING_OFFSET : 0,
   });

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -29,9 +29,9 @@ export default function PostModal({
   ...props
 }: PostModalProps): ReactElement {
   const { showArticleOnboarding } = useContext(OnboardingContext);
-  const { isPostLoadingOrFetching } = usePostById({ id });
+  const { isLoading } = usePostById({ id });
   const position = usePostNavigationPosition({
-    isLoading: isPostLoadingOrFetching,
+    isLoading,
     isDisplayed: props.isOpen,
     offset: showArticleOnboarding ? ONBOARDING_OFFSET : 0,
   });

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -69,7 +69,7 @@ export function PostComments({
         refetchOnWindowFocus: false,
       },
     );
-  const { hash: commentHash } = window.location;
+  const { hash: commentHash } = globalThis?.window?.location || {};
   const commentsCount = comments?.postComments?.edges?.length || 0;
   const commentRef = useRef<HTMLElement>(null);
   const { deleteComment } = useDeleteComment();

--- a/packages/shared/src/hooks/usePostById.ts
+++ b/packages/shared/src/hooks/usePostById.ts
@@ -24,10 +24,9 @@ interface UsePostByIdProps {
   options?: QueryObserverOptions<PostData>;
 }
 
-interface UsePostById extends Pick<UseQueryResult, 'isError' | 'isFetched'> {
+interface UsePostById extends Pick<UseQueryResult, 'isError' | 'isLoading'> {
   post: Post;
   relatedCollectionPosts?: Connection<RelatedPost>;
-  isPostLoadingOrFetching?: boolean;
 }
 
 const POST_KEY = 'post';
@@ -105,7 +104,6 @@ const usePostById = ({ id, options = {} }: UsePostByIdProps): UsePostById => {
   const {
     data: postById,
     isError,
-    isFetched,
     isLoading,
     isFetching,
     isRefetching,
@@ -124,10 +122,9 @@ const usePostById = ({ id, options = {} }: UsePostByIdProps): UsePostById => {
       post: post?.post,
       relatedCollectionPosts: post?.relatedCollectionPosts,
       isError,
-      isFetched,
-      isPostLoadingOrFetching: (isLoading || isFetching) && !isRefetching,
+      isLoading: (isLoading || isFetching) && !isRefetching,
     }),
-    [post, isError, isFetched, isLoading, isFetching, isRefetching],
+    [post, isError, isLoading, isFetching, isRefetching],
   );
 };
 

--- a/packages/shared/src/hooks/usePostById.ts
+++ b/packages/shared/src/hooks/usePostById.ts
@@ -105,8 +105,6 @@ const usePostById = ({ id, options = {} }: UsePostByIdProps): UsePostById => {
     data: postById,
     isError,
     isLoading,
-    isFetching,
-    isRefetching,
   } = useQuery<PostData>(
     key,
     () => request(graphqlUrl, POST_BY_ID_QUERY, { id }),
@@ -122,9 +120,9 @@ const usePostById = ({ id, options = {} }: UsePostByIdProps): UsePostById => {
       post: post?.post,
       relatedCollectionPosts: post?.relatedCollectionPosts,
       isError,
-      isLoading: (isLoading || isFetching) && !isRefetching,
+      isLoading,
     }),
-    [post, isError, isLoading, isFetching, isRefetching],
+    [post, isError, isLoading],
   );
 };
 

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -22,7 +22,7 @@ import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
 
 function EditPost(): ReactElement {
   const { query, isReady, push } = useRouter();
-  const { post, isFetched } = usePostById({ id: query.id as string });
+  const { post, isLoading } = usePostById({ id: query.id as string });
   const { squads, user } = useAuthContext();
   const squad = squads?.find(({ id, handle }) =>
     [id, handle].includes(post?.source?.id),
@@ -101,7 +101,7 @@ function EditPost(): ReactElement {
     >
       <NextSeo {...seo} noindex nofollow />
       <WritePage
-        isLoading={!isReady || !isFetched || !isDraftReady}
+        isLoading={!isReady || isLoading || !isDraftReady}
         isForbidden={!isVerified || !squad || !canEdit}
       >
         <WritePostHeader isEdit />

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -97,7 +97,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
   const { isFallback } = router;
   const { shouldShowAuthBanner } = useOnboarding();
   const isLaptop = useViewSize(ViewSize.Laptop);
-  const { post, isError, isFetched, isPostLoadingOrFetching } = usePostById({
+  const { post, isError, isLoading } = usePostById({
     id,
     options: { initialData, retry: false },
   });
@@ -137,7 +137,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     scrollProperty: 'scrollY',
   });
 
-  if (isPostLoadingOrFetching || isFallback || !isFetched) {
+  if (isLoading || isFallback) {
     return (
       <>
         <PostSEOSchema post={post} />


### PR DESCRIPTION
## Changes

### Describe what this PR does
- I see we removed the `isLoading` state [https://github.com/dailydotdev/apps/commit/1d055018a4766bbe30cc0288a4da48eb31ff8824#diff-870e4cc6ee5c55dc1cb1004be[…]b31b354338ae02002a477637d1b9R32](https://github.com/dailydotdev/apps/commit/1d055018a4766bbe30cc0288a4da48eb31ff8824#diff-870e4cc6ee5c55dc1cb1004be92b1ef0237db31b354338ae02002a477637d1b9R32).
- Making it only work if cache for post would exist (so second open)
- Can't really backtrack the need, so decided to reimplement as intended before. (@DragosIorgulescu in case you know)

![Screenshot 2024-03-14 at 12 19 19](https://github.com/dailydotdev/apps/assets/554874/4172db74-a0c1-4ec3-8001-e42381b553fc)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-191 #done
