### PR TITLE
feat: source subscribe push notifications

### DIFF
--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -48,6 +48,11 @@ const sourceRenderTextCloseButton: Record<NotificationPromptSource, boolean> = {
   [NotificationPromptSource.SourceSubscribe]: true,
 };
 
+const sourceToButtonText: Partial<Record<NotificationPromptSource, string>> = {
+  [NotificationPromptSource.SquadPostModal]: 'Subscribe',
+  [NotificationPromptSource.SourceSubscribe]: 'Enable',
+};
+
 function EnableNotification({
   source = NotificationPromptSource.NotificationsPage,
   contentName,
@@ -80,6 +85,7 @@ function EnableNotification({
   const message = sourceToMessage[source];
   const classes = containerClassName[source];
   const showTextCloseButton = sourceRenderTextCloseButton[source];
+  const buttonText = sourceToButtonText[source] ?? 'Enable notifications';
 
   if (source === NotificationPromptSource.SquadPostModal) {
     return (
@@ -97,7 +103,7 @@ function EnableNotification({
           size={ButtonSize.XSmall}
           onClick={onEnable}
         >
-          Subscribe
+          {buttonText}
         </Button>
         <CloseButton className="absolute right-3" onClick={onDismiss} />
       </span>
@@ -166,9 +172,7 @@ function EnableNotification({
             className="mr-4"
             onClick={onEnable}
           >
-            {source === NotificationPromptSource.SourceSubscribe
-              ? 'Enable'
-              : 'Enable notifications'}
+            {buttonText}
           </Button>
         )}
         {showTextCloseButton && (

--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -32,6 +32,7 @@ const containerClassName: Record<NotificationPromptSource, string> = {
   [NotificationPromptSource.SquadPostModal]:
     'laptop:rounded-16 laptop:rounded-bl-[0] laptop:rounded-br-[0]',
   [NotificationPromptSource.SquadChecklist]: '',
+  [NotificationPromptSource.SourceSubscribe]: 'w-full px-3 !pt-0 !pb-2',
 };
 
 const sourceRenderTextCloseButton: Record<NotificationPromptSource, boolean> = {
@@ -44,6 +45,7 @@ const sourceRenderTextCloseButton: Record<NotificationPromptSource, boolean> = {
   [NotificationPromptSource.SquadPostModal]: false,
   [NotificationPromptSource.NotificationItem]: false,
   [NotificationPromptSource.SquadChecklist]: false,
+  [NotificationPromptSource.SourceSubscribe]: true,
 };
 
 function EnableNotification({
@@ -73,6 +75,7 @@ function EnableNotification({
     [NotificationPromptSource.SquadPostCommentary]: '',
     [NotificationPromptSource.SquadPage]: `Get notified whenever something important happens on ${contentName}.`,
     [NotificationPromptSource.SquadChecklist]: '',
+    [NotificationPromptSource.SourceSubscribe]: `Get notified whenever there are new posts from ${contentName}`,
   };
   const message = sourceToMessage[source];
   const classes = containerClassName[source];
@@ -117,22 +120,40 @@ function EnableNotification({
           }`}
         </span>
       )}
-      <p className="mt-2 w-full text-theme-label-tertiary tablet:w-3/5">
-        {acceptedJustNow ? (
-          <>
-            Changing your{' '}
-            <a
-              className="underline hover:no-underline"
-              href={`${webappUrl}account/notifications`}
-            >
-              notification settings
-            </a>{' '}
-            can be done anytime through your account details
-          </>
-        ) : (
-          message
+      <div className="mt-2 flex justify-between gap-2">
+        <p
+          className={classNames(
+            'w-full text-theme-label-tertiary tablet:w-3/5',
+            source === NotificationPromptSource.SourceSubscribe && 'flex-1',
+          )}
+        >
+          {acceptedJustNow ? (
+            <>
+              Changing your{' '}
+              <a
+                className="underline hover:no-underline"
+                href={`${webappUrl}account/notifications`}
+              >
+                notification settings
+              </a>{' '}
+              can be done anytime through your account details
+            </>
+          ) : (
+            message
+          )}
+        </p>
+        {source === NotificationPromptSource.SourceSubscribe && (
+          <img
+            className={classNames('h-16 w-auto')}
+            src={
+              acceptedJustNow
+                ? cloudinary.notifications.browser_enabled
+                : cloudinary.notifications.browser
+            }
+            alt="A sample browser notification"
+          />
         )}
-      </p>
+      </div>
       <div className="align-center mt-4 flex">
         {!acceptedJustNow && (
           <Button
@@ -142,7 +163,9 @@ function EnableNotification({
             className="mr-4"
             onClick={onEnable}
           >
-            Enable notifications
+            {source === NotificationPromptSource.SourceSubscribe
+              ? 'Enable'
+              : 'Enable notifications'}
           </Button>
         )}
         {showTextCloseButton && (
@@ -155,18 +178,20 @@ function EnableNotification({
           </Button>
         )}
       </div>
-      <img
-        className={classNames(
-          'absolute -bottom-2 hidden w-[7.5rem] tablet:flex',
-          acceptedJustNow ? 'right-14' : 'right-4',
-        )}
-        src={
-          acceptedJustNow
-            ? cloudinary.notifications.browser_enabled
-            : cloudinary.notifications.browser
-        }
-        alt="A sample browser notification"
-      />
+      {source !== NotificationPromptSource.SourceSubscribe && (
+        <img
+          className={classNames(
+            'absolute -bottom-2 hidden w-[7.5rem] tablet:flex',
+            acceptedJustNow ? 'right-14' : 'right-4',
+          )}
+          src={
+            acceptedJustNow
+              ? cloudinary.notifications.browser_enabled
+              : cloudinary.notifications.browser
+          }
+          alt="A sample browser notification"
+        />
+      )}
       {!showTextCloseButton && (
         <CloseButton
           size={ButtonSize.XSmall}

--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -75,7 +75,7 @@ function EnableNotification({
     [NotificationPromptSource.SquadPostCommentary]: '',
     [NotificationPromptSource.SquadPage]: `Get notified whenever something important happens on ${contentName}.`,
     [NotificationPromptSource.SquadChecklist]: '',
-    [NotificationPromptSource.SourceSubscribe]: `Get notified whenever there are new posts from ${contentName}`,
+    [NotificationPromptSource.SourceSubscribe]: `Get notified whenever there are new posts from ${contentName}.`,
   };
   const message = sourceToMessage[source];
   const classes = containerClassName[source];
@@ -142,17 +142,20 @@ function EnableNotification({
             message
           )}
         </p>
-        {source === NotificationPromptSource.SourceSubscribe && (
-          <img
-            className={classNames('h-16 w-auto')}
-            src={
-              acceptedJustNow
-                ? cloudinary.notifications.browser_enabled
-                : cloudinary.notifications.browser
-            }
-            alt="A sample browser notification"
-          />
-        )}
+        <img
+          className={classNames(
+            source === NotificationPromptSource.SourceSubscribe
+              ? 'h-16 w-auto'
+              : 'absolute -bottom-2 hidden w-[7.5rem] tablet:flex',
+            acceptedJustNow ? 'right-14' : 'right-4',
+          )}
+          src={
+            acceptedJustNow
+              ? cloudinary.notifications.browser_enabled
+              : cloudinary.notifications.browser
+          }
+          alt="A sample browser notification"
+        />
       </div>
       <div className="align-center mt-4 flex">
         {!acceptedJustNow && (
@@ -178,20 +181,6 @@ function EnableNotification({
           </Button>
         )}
       </div>
-      {source !== NotificationPromptSource.SourceSubscribe && (
-        <img
-          className={classNames(
-            'absolute -bottom-2 hidden w-[7.5rem] tablet:flex',
-            acceptedJustNow ? 'right-14' : 'right-4',
-          )}
-          src={
-            acceptedJustNow
-              ? cloudinary.notifications.browser_enabled
-              : cloudinary.notifications.browser
-          }
-          alt="A sample browser notification"
-        />
-      )}
       {!showTextCloseButton && (
         <CloseButton
           size={ButtonSize.XSmall}

--- a/packages/shared/src/components/widgets/PostUsersHighlights.tsx
+++ b/packages/shared/src/components/widgets/PostUsersHighlights.tsx
@@ -20,6 +20,7 @@ import useFeedSettings from '../../hooks/useFeedSettings';
 import EnableNotification from '../notifications/EnableNotification';
 import { NotificationPromptSource } from '../../lib/analytics';
 import { withExperiment } from '../withExperiment';
+import { useSourceSubscription } from '../../hooks';
 
 interface PostAuthorProps {
   post: Post;
@@ -193,16 +194,32 @@ const EnableNotificationWithExperiment = withExperiment(EnableNotification, {
   value: SourceSubscribeExperiment.V1,
 });
 
+const EnableNotificationSourceSubscribe = ({
+  source,
+}: Pick<Post, 'source'>) => {
+  const { isSubscribed } = useSourceSubscription({
+    source,
+  });
+
+  if (!isSubscribed) {
+    return null;
+  }
+
+  return (
+    <EnableNotificationWithExperiment
+      source={NotificationPromptSource.SourceSubscribe}
+      contentName={source.name}
+    />
+  );
+};
+
 export function PostUsersHighlights({ post }: PostAuthorProps): ReactElement {
   const { author, scout, source } = post;
 
   return (
     <WidgetContainer className="flex flex-col">
       <UserHighlight {...source} userType={UserType.Source} />
-      <EnableNotificationWithExperiment
-        source={NotificationPromptSource.SourceSubscribe}
-        contentName={source.name}
-      />
+      <EnableNotificationSourceSubscribe source={source} />
       {author && <UserHighlight {...author} userType={UserType.Author} />}
       {scout && <UserHighlight {...scout} userType={UserType.Scout} />}
     </WidgetContainer>

--- a/packages/shared/src/components/widgets/PostUsersHighlights.tsx
+++ b/packages/shared/src/components/widgets/PostUsersHighlights.tsx
@@ -17,6 +17,9 @@ import { useFeature } from '../GrowthBookProvider';
 import { feature } from '../../lib/featureManagement';
 import { SourceSubscribeExperiment } from '../../lib/featureValues';
 import useFeedSettings from '../../hooks/useFeedSettings';
+import EnableNotification from '../notifications/EnableNotification';
+import { NotificationPromptSource } from '../../lib/analytics';
+import { withExperiment } from '../withExperiment';
 
 interface PostAuthorProps {
   post: Post;
@@ -185,12 +188,21 @@ const UserHighlight = (props: SourceAuthorProps) => {
   );
 };
 
+const EnableNotificationWithExperiment = withExperiment(EnableNotification, {
+  feature: feature.sourceSubscribe,
+  value: SourceSubscribeExperiment.V1,
+});
+
 export function PostUsersHighlights({ post }: PostAuthorProps): ReactElement {
   const { author, scout, source } = post;
 
   return (
     <WidgetContainer className="flex flex-col">
       <UserHighlight {...source} userType={UserType.Source} />
+      <EnableNotificationWithExperiment
+        source={NotificationPromptSource.SourceSubscribe}
+        contentName={source.name}
+      />
       {author && <UserHighlight {...author} userType={UserType.Author} />}
       {scout && <UserHighlight {...scout} userType={UserType.Scout} />}
     </WidgetContainer>

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -210,6 +210,7 @@ export enum NotificationPromptSource {
   SquadPostCommentary = 'squad post commentary',
   SquadPostModal = 'squad post modal',
   SquadChecklist = 'squad checklist',
+  SourceSubscribe = 'source subscribe',
 }
 
 export enum ShortcutsSourceType {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Offer to subscribe to push notifications after source subscribe
- Available to test on [preview](https://preview2.app.daily.dev/)

Offer:
<img width="1026" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/f87270b2-6177-4235-b40a-a9c81a1da2a9">

Subscribed:
<img width="1035" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/e491b26a-2e85-4f86-8fe5-684ed77a14a8">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-154 #done
