### PR TITLE
fix: don't render shared post if not loaded

### DIFF
--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -31,6 +31,10 @@ function SharePostContent({
     onReadArticle();
   };
 
+  if (!post.sharedPost) {
+    return <></>;
+  }
+
   const shouldUseInternalLink =
     isSharedPostSquadPost(post) || isInternalReadType(post.sharedPost);
 

--- a/packages/shared/src/components/post/ShareYouTubeContent.tsx
+++ b/packages/shared/src/components/post/ShareYouTubeContent.tsx
@@ -18,6 +18,10 @@ function ShareYouTubeContent({
   post,
   onReadArticle,
 }: ShareYouTubeContentProps): ReactElement {
+  if (!post.sharedPost) {
+    return <></>;
+  }
+
   const isUnknownSource = post.sharedPost.source.id === 'unknown';
 
   return (


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Just the temp fix to not render these if sharedPost is not available yet (SSR render)
- This ideally needs to render the placeholder (will do this separate tomorrow)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
