### PR TITLE
fix: copy link on mobile

### DIFF
--- a/packages/shared/src/components/post/common/PostContentShare.tsx
+++ b/packages/shared/src/components/post/common/PostContentShare.tsx
@@ -20,12 +20,12 @@ export function PostContentShare({
   }
 
   return (
-    <div className="mt-6 flex flex-row items-center rounded-16 border border-border-subtlest-tertiary px-4 py-2">
+    <div className="mt-6 flex flex-col items-center gap-2 rounded-16 border border-border-subtlest-tertiary px-4 py-2 tablet:flex-row tablet:gap-4">
       <span className="font-bold text-theme-label-tertiary typo-callout">
         Should anyone else see this post?
       </span>
       <InviteLinkInput
-        className={{ container: 'ml-4 flex-1' }}
+        className={{ container: 'w-full flex-1' }}
         link={post.commentsPermalink}
         onCopy={onInteract}
         trackingProps={postAnalyticsEvent('share post', post, {


### PR DESCRIPTION
## Changes
- On mobile, we need to display the copy link input and button vertically.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
