### PR TITLE
fix: add sidebar to private squad so it's uniform

### DIFF
--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -9,7 +9,6 @@ import { ONBOARDING_OFFSET } from '../post/BasePostContent';
 import { PassedPostNavigationProps } from '../post/common';
 import { Post, PostType } from '../../graphql/posts';
 import EnableNotification from '../notifications/EnableNotification';
-import { isSourcePublicSquad } from '../../graphql/squads';
 
 interface PostModalProps extends ModalProps, PassedPostNavigationProps {
   id: string;
@@ -32,13 +31,12 @@ export default function PostModal({
     isDisplayed: props.isOpen,
     offset: showArticleOnboarding ? ONBOARDING_OFFSET : 0,
   });
-  const isPublicSquad = isSourcePublicSquad(post.source);
 
   return (
     <BasePostModal
       {...props}
       onAfterOpen={onLoad}
-      size={isPublicSquad ? Modal.Size.XLarge : Modal.Size.Large}
+      size={Modal.Size.XLarge}
       onRequestClose={onRequestClose}
       postType={PostType.Share}
       source={post.source}

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -84,17 +84,15 @@ function SquadPostContent({
       )}
       <PostContentContainer
         className={classNames(
-          'relative tablet:pb-0',
+          'relative flex-1 flex-col tablet:flex-row tablet:pb-0',
           className?.container,
-          'flex-1 flex-col tablet:flex-row',
         )}
         hasNavigation={hasNavigation}
       >
         <div
           className={classNames(
-            'relative min-w-0 px-4 tablet:px-8',
+            'relative flex min-w-0 flex-1 flex-col px-4 tablet:px-8',
             className?.content,
-            'flex flex-1 flex-col',
           )}
         >
           <BasePostContent
@@ -102,8 +100,8 @@ function SquadPostContent({
               ...className,
               onboarding: classNames('mb-6', className?.onboarding),
               navigation: {
-                actions: classNames('ml-auto', 'tablet:hidden'),
-                container: classNames('mb-6 pt-6'),
+                actions: 'ml-auto tablet:hidden',
+                container: 'mb-6 pt-6',
               },
             }}
             isFallback={isFallback}

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -11,7 +11,6 @@ import SquadPostAuthor from './SquadPostAuthor';
 import SharePostContent from './SharePostContent';
 import MarkdownPostContent from './MarkdownPostContent';
 import { SquadPostWidgets } from './SquadPostWidgets';
-import { isSourcePublicSquad } from '../../graphql/squads';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { PostContentProps, PostNavigationProps } from './common';
 import ShareYouTubeContent from './ShareYouTubeContent';
@@ -50,7 +49,6 @@ function SquadPostContent({
     source: post?.source,
     user: post?.author,
   });
-  const isPublicSquad = isSourcePublicSquad(post?.source);
 
   const navigationProps: PostNavigationProps = {
     post,
@@ -88,7 +86,7 @@ function SquadPostContent({
         className={classNames(
           'relative tablet:pb-0',
           className?.container,
-          isPublicSquad ? 'flex-1 flex-col tablet:flex-row' : '!pb-2',
+          'flex-1 flex-col tablet:flex-row',
         )}
         hasNavigation={hasNavigation}
       >
@@ -96,7 +94,7 @@ function SquadPostContent({
           className={classNames(
             'relative min-w-0 px-4 tablet:px-8',
             className?.content,
-            isPublicSquad && 'flex flex-1 flex-col',
+            'flex flex-1 flex-col',
           )}
         >
           <BasePostContent
@@ -104,10 +102,7 @@ function SquadPostContent({
               ...className,
               onboarding: classNames('mb-6', className?.onboarding),
               navigation: {
-                actions: classNames(
-                  'ml-auto',
-                  isPublicSquad && 'tablet:hidden',
-                ),
+                actions: classNames('ml-auto', 'tablet:hidden'),
                 container: classNames('mb-6 pt-6'),
               },
             }}
@@ -135,16 +130,14 @@ function SquadPostContent({
             <Content post={post} onReadArticle={onReadArticle} />
           </BasePostContent>
         </div>
-        {isPublicSquad && (
-          <SquadPostWidgets
-            onShare={onSharePost}
-            onReadArticle={onReadArticle}
-            post={post}
-            className="mb-6 border-l border-theme-divider-tertiary tablet:mb-0"
-            onClose={onClose}
-            origin={origin}
-          />
-        )}
+        <SquadPostWidgets
+          onShare={onSharePost}
+          onReadArticle={onReadArticle}
+          post={post}
+          className="mb-6 border-l border-theme-divider-tertiary tablet:mb-0"
+          onClose={onClose}
+          origin={origin}
+        />
       </PostContentContainer>
     </>
   );

--- a/packages/shared/src/components/post/SquadPostWidgets.tsx
+++ b/packages/shared/src/components/post/SquadPostWidgets.tsx
@@ -12,7 +12,7 @@ import { SourceMember, Squad } from '../../graphql/sources';
 import { SquadJoinButton } from '../squads/SquadJoinButton';
 import { Origin } from '../../lib/analytics';
 import { useSquad } from '../../hooks';
-import { getSquadMembers } from '../../graphql/squads';
+import { getSquadMembers, isSourcePublicSquad } from '../../graphql/squads';
 import SquadMemberShortList from '../squads/SquadMemberShortList';
 import { PostHeaderActionsProps } from './common';
 
@@ -77,6 +77,7 @@ export function SquadPostWidgets({
 }: PostWidgetsProps): ReactElement {
   const { tokenRefreshed } = useContext(AuthContext);
   const squad = post.source as Squad;
+  const isPublicSquad = isSourcePublicSquad(squad);
 
   return (
     <PageWidgets className={className}>
@@ -88,8 +89,16 @@ export function SquadPostWidgets({
         contextMenuId="post-widgets-context"
       />
       {!!squad && !squad.currentMember && <SquadCard squadSource={squad} />}
-      <ShareBar post={post} />
-      <ShareMobile post={post} share={onShare} link={post.commentsPermalink} />
+      {isPublicSquad && (
+        <>
+          <ShareBar post={post} />
+          <ShareMobile
+            post={post}
+            share={onShare}
+            link={post.commentsPermalink}
+          />
+        </>
+      )}
       {tokenRefreshed && <FurtherReading currentPost={post} />}
     </PageWidgets>
   );


### PR DESCRIPTION
## Changes

### Describe what this PR does
- In prep for the placeholders I decided to tackle this first else it be double work.
- We needed to add the sidebar to all squad post to make a uniform behaviour.
- Minus the share as it's pointless to share private squad posts

![Screenshot 2024-03-15 at 11 42 43](https://github.com/dailydotdev/apps/assets/554874/2a6acb76-9686-410e-b38f-2ea06e84bc05)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-195 #done
