### PR TITLE
feat: do not show squads and adjust allocations

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext, useMemo } from 'react';
+import React, { ReactElement, ReactNode, useContext, useMemo } from 'react';
 import { Item } from '@dailydotdev/react-contexify';
 import dynamic from 'next/dynamic';
 import { useQueryClient } from '@tanstack/react-query';
@@ -89,6 +89,14 @@ export interface PostOptionsMenuProps extends ShareBookmarkProps {
   allowPin?: boolean;
   isOpen?: boolean;
 }
+
+const PostOptionSourceSubscribe = withExperiment(
+  ({ children }: { children: ReactNode }) => <>{children}</>,
+  {
+    feature: feature.sourceSubscribe,
+    value: SourceSubscribeExperiment.V1,
+  },
+);
 
 export default function PostOptionsMenu({
   postIndex,
@@ -358,10 +366,7 @@ export default function PostOptionsMenu({
         sourceSubscribe.isSubscribed ? 'Unsubscribe from' : 'Subscribe to'
       } ${post?.source?.name}`,
       action: sourceSubscribe.isReady ? sourceSubscribe.onSubscribe : undefined,
-      Wrapper: withExperiment(({ children }) => <>{children}</>, {
-        feature: feature.sourceSubscribe,
-        value: SourceSubscribeExperiment.V1,
-      }),
+      Wrapper: PostOptionSourceSubscribe,
     });
   }
 

--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -63,6 +63,8 @@ import { feature } from '../lib/featureManagement';
 import { ContextMenuDrawer } from './drawers/ContextMenuDrawer';
 import { RootPortal } from './tooltips/Portal';
 import { SourceSubscribeExperiment } from '../lib/featureValues';
+import { SourceType } from '../graphql/sources';
+import { withExperiment } from './withExperiment';
 
 const PortalMenu = dynamic(
   () => import(/* webpackChunkName: "portalMenu" */ './fields/PortalMenu'),
@@ -125,8 +127,6 @@ export default function PostOptionsMenu({
     postId: post?.id,
     shouldInvalidateQueries: false,
   });
-  const isSourceSubscribeV1 =
-    useFeature(feature.sourceSubscribe) === SourceSubscribeExperiment.V1;
 
   const sourceSubscribe = useSourceSubscription({
     source: post?.source,
@@ -344,7 +344,10 @@ export default function PostOptionsMenu({
     });
   }
 
-  if (isLoggedIn && isSourceSubscribeV1 && !isSourceBlocked) {
+  const shouldShowSubscribe =
+    isLoggedIn && !isSourceBlocked && post?.source?.type === SourceType.Machine;
+
+  if (shouldShowSubscribe) {
     postOptions.push({
       icon: (
         <MenuIcon
@@ -355,6 +358,10 @@ export default function PostOptionsMenu({
         sourceSubscribe.isSubscribed ? 'Unsubscribe from' : 'Subscribe to'
       } ${post?.source?.name}`,
       action: sourceSubscribe.isReady ? sourceSubscribe.onSubscribe : undefined,
+      Wrapper: withExperiment(({ children }) => <>{children}</>, {
+        feature: feature.sourceSubscribe,
+        value: SourceSubscribeExperiment.V1,
+      }),
     });
   }
 

--- a/packages/shared/src/components/drawers/ContextMenuDrawer.tsx
+++ b/packages/shared/src/components/drawers/ContextMenuDrawer.tsx
@@ -1,13 +1,15 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React, { ComponentType, ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
 import { Drawer, DrawerRef, DrawerWrapperProps } from './Drawer';
 import { SelectParams } from './common';
+import ConditionalWrapper from '../ConditionalWrapper';
 
 interface ContextMenuDrawerItem {
   label: string;
   icon?: ReactNode;
   anchorProps?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
   action?(params: SelectParams): void;
+  Wrapper?: ComponentType<{ children: ReactNode }>;
 }
 
 interface ContextMenuDrawerProps {
@@ -23,7 +25,7 @@ export function ContextMenuDrawer({
 
   return (
     <Drawer {...drawerProps} ref={ref}>
-      {options.map(({ label, icon, action, anchorProps }, index) => {
+      {options.map(({ label, icon, action, anchorProps, Wrapper }, index) => {
         const classes =
           'flex h-10 flex-row items-center overflow-hidden text-ellipsis whitespace-nowrap px-2 text-theme-label-tertiary typo-callout';
         const content = (
@@ -33,26 +35,32 @@ export function ContextMenuDrawer({
           </>
         );
 
-        return anchorProps ? (
-          <a
+        return (
+          <ConditionalWrapper
             key={label}
-            {...anchorProps}
-            className={classNames(classes, anchorProps.className)}
+            condition={!!Wrapper}
+            wrapper={(children) => <Wrapper>{children}</Wrapper>}
           >
-            {content}
-          </a>
-        ) : (
-          <button
-            key={label}
-            type="button"
-            className={classes}
-            onClick={(event) => {
-              action({ value: label, index, event });
-              ref.current.onClose();
-            }}
-          >
-            {content}
-          </button>
+            {anchorProps ? (
+              <a
+                {...anchorProps}
+                className={classNames(classes, anchorProps.className)}
+              >
+                {content}
+              </a>
+            ) : (
+              <button
+                type="button"
+                className={classes}
+                onClick={(event) => {
+                  action({ value: label, index, event });
+                  ref.current.onClose();
+                }}
+              >
+                {content}
+              </button>
+            )}
+          </ConditionalWrapper>
         );
       })}
     </Drawer>

--- a/packages/shared/src/components/fields/PortalMenu.tsx
+++ b/packages/shared/src/components/fields/PortalMenu.tsx
@@ -1,4 +1,9 @@
-import React, { AnchorHTMLAttributes, ReactElement } from 'react';
+import React, {
+  AnchorHTMLAttributes,
+  ComponentType,
+  ReactElement,
+  ReactNode,
+} from 'react';
 import { Item, Menu, MenuProps } from '@dailydotdev/react-contexify';
 import { RootPortal } from '../tooltips/Portal';
 import ConditionalWrapper from '../ConditionalWrapper';
@@ -32,6 +37,7 @@ export interface MenuItemProps<
   label: string;
   action?: (...args: TArgs) => TReturn;
   anchorProps?: TAnchorProps;
+  Wrapper?: ComponentType<{ children: ReactNode }>;
 }
 
 interface ContextMenuProps extends Omit<MenuProps, 'children'> {
@@ -48,17 +54,23 @@ export const ContextMenu = ({
     animation="fade"
     {...props}
   >
-    {options.map(({ label, icon, action, anchorProps }) => (
-      <Item key={label} className="typo-callout" onClick={action}>
-        <ConditionalWrapper
-          condition={!!anchorProps}
-          wrapper={(children) => <a {...anchorProps}>{children}</a>}
-        >
-          <span className="flex w-full items-center gap-2 typo-callout">
-            {icon} {label}
-          </span>
-        </ConditionalWrapper>
-      </Item>
+    {options.map(({ label, icon, action, anchorProps, Wrapper }) => (
+      <ConditionalWrapper
+        key={label}
+        condition={!!Wrapper}
+        wrapper={(children) => <Wrapper>{children}</Wrapper>}
+      >
+        <Item className="typo-callout" onClick={action}>
+          <ConditionalWrapper
+            condition={!!anchorProps}
+            wrapper={(children) => <a {...anchorProps}>{children}</a>}
+          >
+            <span className="flex w-full items-center gap-2 typo-callout">
+              {icon} {label}
+            </span>
+          </ConditionalWrapper>
+        </Item>
+      </ConditionalWrapper>
     ))}
   </PortalMenu>
 );

--- a/packages/shared/src/components/post/PostHeaderActions.tsx
+++ b/packages/shared/src/components/post/PostHeaderActions.tsx
@@ -51,33 +51,38 @@ export function PostHeaderActions({
   ...props
 }: PostHeaderActionsProps): ReactElement {
   const { openNewTab } = useContext(SettingsContext);
-  const isSourceSubscribeV1 =
-    useFeature(feature.sourceSubscribe) === SourceSubscribeExperiment.V1;
 
   const readButtonText = getReadPostButtonText(post);
   const isCollection = post?.type === PostType.Collection;
 
+  const ButtonWithExperiment = () => {
+    const isSourceSubscribeV1 =
+      useFeature(feature.sourceSubscribe) === SourceSubscribeExperiment.V1;
+
+    return (
+      <SimpleTooltip
+        placement="bottom"
+        content={readButtonText}
+        disabled={!inlineActions}
+      >
+        <Button
+          variant={getButtonVariant({ inlineActions, isSourceSubscribeV1 })}
+          tag="a"
+          href={post.sharedPost?.permalink ?? post.permalink}
+          target={openNewTab ? '_blank' : '_self'}
+          icon={<OpenLinkIcon />}
+          onClick={onReadArticle}
+          data-testid="postActionsRead"
+        >
+          {!inlineActions && readButtonText}
+        </Button>
+      </SimpleTooltip>
+    );
+  };
+
   return (
     <Container {...props} className={classNames('gap-2', className)}>
-      {!isInternalReadType(post) && !!onReadArticle && (
-        <SimpleTooltip
-          placement="bottom"
-          content={readButtonText}
-          disabled={!inlineActions}
-        >
-          <Button
-            variant={getButtonVariant({ inlineActions, isSourceSubscribeV1 })}
-            tag="a"
-            href={post.sharedPost?.permalink ?? post.permalink}
-            target={openNewTab ? '_blank' : '_self'}
-            icon={<OpenLinkIcon />}
-            onClick={onReadArticle}
-            data-testid="postActionsRead"
-          >
-            {!inlineActions && readButtonText}
-          </Button>
-        </SimpleTooltip>
-      )}
+      {!isInternalReadType(post) && !!onReadArticle && <ButtonWithExperiment />}
       {isCollection && <CollectionSubscribeButton post={post} isCondensed />}
       <PostMenuOptions
         onShare={onShare}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fix allocations
  - no longer allocates on feeds when post options container renders invisible, it only allocates if menu is open by user
  - no longer allocates on other post types from read button
- No longer show subscribe options for squads since they have their own subscription from squad notification settings

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
