### PR TITLE
fix: round of placeholder cleaning

### DIFF
--- a/packages/shared/src/components/errors/SquadLoading.tsx
+++ b/packages/shared/src/components/errors/SquadLoading.tsx
@@ -2,6 +2,7 @@ import React, { HTMLAttributes, ReactElement } from 'react';
 import classNames from 'classnames';
 import classed from '../../lib/classed';
 import { FlexRow } from '../utilities';
+import { Squad } from '../../graphql/sources';
 
 const PlaceholderElement = classed('div', 'bg-accent-pepper-subtlest');
 const RectangleElement = classed(PlaceholderElement, 'rounded-12');
@@ -26,20 +27,43 @@ const Actions = ({ className }: HTMLAttributes<HTMLDivElement>) => (
   </FlexRow>
 );
 
-function SquadLoading(): ReactElement {
+function SquadLoading({
+  squad,
+  sidebarRendered,
+}: {
+  squad: Pick<Squad, 'image' | 'description' | 'name' | 'public'>;
+  sidebarRendered: boolean;
+}): ReactElement {
   return (
-    <ColumnContainer className="max-h-page w-full overflow-hidden px-16 pt-7">
-      <FlexRow className="w-full">
+    <ColumnContainer className="relative max-h-page w-full overflow-hidden px-16 pt-7">
+      <div
+        className={classNames(
+          'squad-background-fade absolute top-0 z-0 h-full w-full',
+          sidebarRendered && '-left-full translate-x-[60%]',
+        )}
+      />
+      <FlexRow className="z-1 w-full">
         <ColumnContainer className="w-full laptop:w-auto">
-          <PlaceholderElement className="h-14 w-14 rounded-full tablet:h-24 tablet:w-24" />
-          <TitleDescription />
-          <TitleDescription className="mt-4 flex laptop:hidden" />
+          <PlaceholderElement className="h-16 w-16 rounded-full tablet:h-24 tablet:w-24" />
+          {squad?.description && (
+            <>
+              <TitleDescription />
+              <TitleDescription className="mt-4 flex laptop:hidden" />
+            </>
+          )}
         </ColumnContainer>
         <Actions className="ml-auto hidden laptop:flex" />
       </FlexRow>
-      <RectangleElement className="mt-8 h-16 w-full max-w-[10rem] laptop:mt-14 laptop:max-w-[38.5rem]" />
+      <RectangleElement className="mt-8 h-16 w-full max-w-[30.25rem] laptop:mt-6" />
       <Actions className="mt-8 flex laptop:hidden" />
-      <RectangleElement className="mt-8 h-96 w-full tablet:w-64 laptop:mt-16" />
+      <RectangleElement className="my-6 h-10 w-52 self-end" />
+      <div className="mx-auto w-full">
+        <div className="grid grid-cols-3 gap-8">
+          <RectangleElement className="h-96 w-full" />
+          <RectangleElement className="h-96 w-full" />
+          <RectangleElement className="h-96 w-full" />
+        </div>
+      </div>
     </ColumnContainer>
   );
 }

--- a/packages/shared/src/components/modals/BasePostModal.tsx
+++ b/packages/shared/src/components/modals/BasePostModal.tsx
@@ -39,7 +39,6 @@ function BasePostModal({
         <PostLoadingSkeleton
           hasNavigation
           type={postType}
-          source={source}
           className={loadingClassName}
         />
       ) : (

--- a/packages/shared/src/components/post/PostLoadingSkeleton.tsx
+++ b/packages/shared/src/components/post/PostLoadingSkeleton.tsx
@@ -3,45 +3,20 @@ import classNames from 'classnames';
 import { PostType } from '../../graphql/posts';
 import { PostLoadingPlaceholder } from './PostLoadingPlaceholder';
 import PostContentContainer from './PostContentContainer';
-import { Source } from '../../graphql/sources';
-import { isSourcePublicSquad } from '../../graphql/squads';
 
 interface PostLoadingSkeletonProps {
   type: PostType;
-  source?: Source;
   className?: string;
   hasNavigation?: boolean;
 }
 
 function PostLoadingSkeleton({
   type,
-  source,
   className,
   hasNavigation,
 }: PostLoadingSkeletonProps): ReactElement {
   if (!type) {
     return null;
-  }
-  const publicSquadPost = isSourcePublicSquad(source);
-
-  if (type === PostType.Share) {
-    return (
-      <PostContentContainer
-        className={classNames(className, {
-          'm-auto': !publicSquadPost,
-          'tablet:pb-0 tablet:flex-row': publicSquadPost,
-        })}
-        hasNavigation={hasNavigation}
-      >
-        <PostLoadingPlaceholder
-          className={classNames({
-            'tablet:border-r tablet:border-theme-divider-tertiary':
-              publicSquadPost,
-          })}
-          shouldShowWidgets={publicSquadPost}
-        />
-      </PostContentContainer>
-    );
   }
 
   return (

--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -15,11 +15,27 @@ import { combinedClicks } from '../../lib/click';
 import { SharedLinkContainer } from './common/SharedLinkContainer';
 import { SharedPostLink } from './common/SharedPostLink';
 import { ButtonVariant } from '../buttons/Button';
+import { ElementPlaceholder } from '../ElementPlaceholder';
 
 interface SharePostContentProps {
   post: Post;
   onReadArticle: () => Promise<void>;
 }
+
+const SharePostContentSkeleton = () => (
+  <>
+    <ElementPlaceholder className="mt-6 h-6 w-2/4 rounded-10" />
+    <div className="mb-5 mt-8 rounded-16 border border-theme-divider-tertiary">
+      <div className="flex max-w-full flex-col p-4 pt-5 laptop:flex-row">
+        <div className="flex flex-1 flex-col gap-9">
+          <ElementPlaceholder className="h-6 w-20 rounded-10" />
+          <ElementPlaceholder className="h-6 w-20 rounded-10" />
+        </div>
+        <ElementPlaceholder className="ml-2 h-36 w-70 rounded-16" />
+      </div>
+    </div>
+  </>
+);
 
 function SharePostContent({
   post,
@@ -32,7 +48,7 @@ function SharePostContent({
   };
 
   if (!post.sharedPost) {
-    return <></>;
+    return <SharePostContentSkeleton />;
   }
 
   const shouldUseInternalLink =

--- a/packages/shared/src/components/post/ShareYouTubeContent.tsx
+++ b/packages/shared/src/components/post/ShareYouTubeContent.tsx
@@ -8,6 +8,7 @@ import YoutubeVideo from '../video/YoutubeVideo';
 import { formatReadTime, SelectableLink } from '../utilities';
 import { combinedClicks } from '../../lib/click';
 import ConditionalWrapper from '../ConditionalWrapper';
+import { ElementPlaceholder } from '../ElementPlaceholder';
 
 interface ShareYouTubeContentProps {
   post: Post;
@@ -18,8 +19,13 @@ function ShareYouTubeContent({
   post,
   onReadArticle,
 }: ShareYouTubeContentProps): ReactElement {
-  if (!post.sharedPost) {
-    return <></>;
+  if (!post.sharedPost?.id) {
+    return (
+      <>
+        <ElementPlaceholder className="mt-6 h-6 w-2/4 rounded-10" />
+        <ElementPlaceholder className="my-5 w-full rounded-16 pt-[56.25%]" />
+      </>
+    );
   }
 
   const isUnknownSource = post.sharedPost.source.id === 'unknown';

--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -1,7 +1,11 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import { ProfileTooltip } from '../profile/ProfileTooltip';
-import { ProfileImageSize, ProfilePicture } from '../ProfilePicture';
+import {
+  getProfilePictureClasses,
+  ProfileImageSize,
+  ProfilePicture,
+} from '../ProfilePicture';
 import SquadMemberBadge from '../squads/SquadMemberBadge';
 import { Author } from '../../graphql/comments';
 import { SourceMemberRole } from '../../graphql/sources';
@@ -9,6 +13,7 @@ import { Separator } from '../cards/common';
 import { ReputationUserBadge } from '../ReputationUserBadge';
 import { TruncateText, DateFormat } from '../utilities';
 import { TimeFormatType } from '../../lib/dateFormat';
+import { ElementPlaceholder } from '../ElementPlaceholder';
 
 interface SquadPostAuthorProps {
   className?: Partial<{
@@ -23,6 +28,23 @@ interface SquadPostAuthorProps {
   date?: string;
 }
 
+const SquadPostAuthorSkeleton = ({
+  size,
+  className,
+}: Pick<SquadPostAuthorProps, 'className' | 'size'>) => {
+  return (
+    <span
+      className={classNames('flex flex-row items-center', className?.container)}
+    >
+      <ElementPlaceholder className={getProfilePictureClasses(size)} />
+      <div className="ml-4 flex flex-1 flex-col gap-1">
+        <ElementPlaceholder className="h-6 w-20 rounded-10" />
+        <ElementPlaceholder className="h-6 w-28 rounded-10" />
+      </div>
+    </span>
+  );
+};
+
 function SquadPostAuthor({
   className,
   author,
@@ -30,6 +52,10 @@ function SquadPostAuthor({
   size = 'xxxlarge',
   date,
 }: SquadPostAuthorProps): ReactElement {
+  if (!author) {
+    return <SquadPostAuthorSkeleton className={className} size={size} />;
+  }
+
   return (
     <span
       className={classNames('flex flex-row items-center', className?.container)}

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -117,14 +117,12 @@ function SquadPostContent({
               source={post.source}
               className={classNames('!typo-body', customNavigation && 'mt-6')}
             />
-            {post.author && (
-              <SquadPostAuthor
-                author={post.author}
-                role={role}
-                date={post.createdAt}
-                className={{ container: 'mt-3' }}
-              />
-            )}
+            <SquadPostAuthor
+              author={post?.author}
+              role={role}
+              date={post.createdAt}
+              className={{ container: 'mt-3' }}
+            />
             <Content post={post} onReadArticle={onReadArticle} />
           </BasePostContent>
         </div>

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -35,9 +35,6 @@ import SquadPostPageNavigation from '@dailydotdev/shared/src/components/post/Squ
 import usePostById from '@dailydotdev/shared/src/hooks/usePostById';
 import { ApiError } from '@dailydotdev/shared/src/graphql/common';
 import { ONBOARDING_OFFSET } from '@dailydotdev/shared/src/components/post/BasePostContent';
-import { modalSizeToClassName } from '@dailydotdev/shared/src/components/modals/common/Modal';
-import { ModalSize } from '@dailydotdev/shared/src/components/modals/common/types';
-import useSidebarRendered from '@dailydotdev/shared/src/hooks/useSidebarRendered';
 import PostLoadingSkeleton from '@dailydotdev/shared/src/components/post/PostLoadingSkeleton';
 import classNames from 'classnames';
 import { ArrowIcon } from '@dailydotdev/shared/src/components/icons';
@@ -58,15 +55,34 @@ import {
 } from '@dailydotdev/shared/src/hooks';
 import LoginButton from '@dailydotdev/shared/src/components/LoginButton';
 import { getTemplatedTitle } from '../../../components/layouts/utils';
-import { getLayout as getMainLayout } from '../../../components/layouts/MainLayout';
 import {
   getSeoDescription,
   PostSEOSchema,
 } from '../../../components/PostSEOSchema';
+import { getLayout } from '../../../components/layouts/MainLayout';
 
 const Custom404 = dynamic(
   () => import(/* webpackChunkName: "404" */ '../../404'),
 );
+
+const CustomPostBanner = () => {
+  const { shouldShowAuthBanner } = useOnboarding();
+  const isLaptop = useViewSize(ViewSize.Laptop);
+  return (
+    shouldShowAuthBanner &&
+    !isLaptop && (
+      <LoginButton
+        className={{
+          container: classNames(
+            authGradientBg,
+            'sticky left-0 top-0 z-max w-full justify-center gap-2 border-b border-theme-color-cabbage px-4 py-2',
+          ),
+          button: 'flex-1 tablet:max-w-[9rem]',
+        }}
+      />
+    )
+  );
+};
 
 export interface Props {
   id: string;
@@ -93,7 +109,6 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     useState<CSSProperties['position']>('relative');
   const router = useRouter();
   const { shouldUseMobileFeedLayout } = useFeedLayout({ feedRelated: false });
-  const { sidebarRendered } = useSidebarRendered();
   const { isFallback } = router;
   const { shouldShowAuthBanner } = useOnboarding();
   const isLaptop = useViewSize(ViewSize.Laptop);
@@ -103,11 +118,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
   });
   const containerClass = classNames(
     'max-w-screen-laptop pb-20 laptop:min-h-page laptop:pb-6 laptopL:pb-0',
-    [PostType.Share, PostType.Welcome, PostType.Freeform].includes(
-      post?.type,
-    ) &&
-      sidebarRendered &&
-      modalSizeToClassName[ModalSize.Large],
+    [PostType.Share, PostType.Welcome, PostType.Freeform].includes(post?.type),
   );
   const seoTitle = () => {
     if (post?.type === PostType.Share && post?.title === null) {
@@ -190,7 +201,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
     return <Custom404 />;
   }
 
-  return getMainLayout(
+  return (
     <>
       <Head>
         <link rel="preload" as="image" href={post?.image} />
@@ -218,23 +229,14 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
         }}
       />
       {shouldShowAuthBanner && isLaptop && <AuthenticationBanner />}
-    </>,
-    {},
-    {
-      screenCentered: false,
-      customBanner: shouldShowAuthBanner && !isLaptop && (
-        <LoginButton
-          className={{
-            container: classNames(
-              authGradientBg,
-              'sticky left-0 top-0 z-max w-full justify-center gap-2 border-b border-theme-color-cabbage px-4 py-2',
-            ),
-            button: 'flex-1 tablet:max-w-[9rem]',
-          }}
-        />
-      ),
-    },
-  ) as ReactElement;
+    </>
+  );
+};
+
+PostPage.getLayout = getLayout;
+PostPage.layoutProps = {
+  screenCentered: false,
+  customBanner: <CustomPostBanner />,
 };
 
 export default PostPage;

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -162,7 +162,7 @@ const SquadPage = ({
     return (
       <>
         {seo}
-        <SquadLoading />
+        <SquadLoading squad={seoData} sidebarRendered={sidebarRendered} />
       </>
     );
   }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since we now fully leverage SSR better we needed to fix some placeholders.
- Nuance: private post have blocking render (expected)
- Squad overview is not perfect but should render lot better now

Videos:

https://github.com/dailydotdev/apps/assets/554874/d750f7cd-3d11-4eec-aa7d-43ab92f338e2


https://github.com/dailydotdev/apps/assets/554874/c04a8456-bdf4-4b05-9e1f-20d76acf6b80


https://github.com/dailydotdev/apps/assets/554874/3ecdde77-ae7e-4ab1-a8eb-5a4350d91f50


https://github.com/dailydotdev/apps/assets/554874/b29412b5-e9bf-418e-8587-6c9ed79e3ba1

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
