### PR TITLE
fix: add submit search tracking to panel actions

### DIFF
--- a/packages/shared/src/components/search/SearchPanel/SearchPanel.tsx
+++ b/packages/shared/src/components/search/SearchPanel/SearchPanel.tsx
@@ -26,6 +26,8 @@ import { ArrowKeyEnum } from '../../../lib/func';
 import { ArrowIcon } from '../../icons';
 import { useSearchProvider } from '../../../hooks/search';
 import { SearchPanelCustomAction } from './SearchPanelCustomAction';
+import { AnalyticsEvent } from '../../../lib/analytics';
+import { useAnalyticsContext } from '../../../contexts/AnalyticsContext';
 
 export type SearchPanelProps = {
   className?: SearchPanelClassName;
@@ -40,6 +42,7 @@ export const SearchPanel = ({ className }: SearchPanelProps): ReactElement => {
   useContext(SettingsContext);
   const { search } = useSearchProvider();
   const { query } = useRouter();
+  const { trackEvent } = useAnalyticsContext();
 
   const [state, setState] = useState(() => {
     return {
@@ -177,6 +180,14 @@ export const SearchPanel = ({ className }: SearchPanelProps): ReactElement => {
                 <SearchPanelCustomAction
                   provider={SearchProviderEnum.Posts}
                   onClick={() => {
+                    trackEvent({
+                      event_name: AnalyticsEvent.SubmitSearch,
+                      extra: JSON.stringify({
+                        query: state.query,
+                        provider: SearchProviderEnum.Posts,
+                      }),
+                    });
+
                     search({
                       provider: SearchProviderEnum.Posts,
                       query: state.query,

--- a/packages/shared/src/components/search/SearchPanel/SearchPanelAction.tsx
+++ b/packages/shared/src/components/search/SearchPanel/SearchPanelAction.tsx
@@ -11,6 +11,8 @@ import {
   providerToLabelTextMap,
 } from './common';
 import { IconSize } from '../../Icon';
+import { useAnalyticsContext } from '../../../contexts/AnalyticsContext';
+import { AnalyticsEvent } from '../../../lib/analytics';
 
 export type SearchPanelActionProps = {
   provider: SearchProviderEnum;
@@ -25,11 +27,17 @@ export const SearchPanelAction = ({
   const itemProps = useSearchPanelAction({ provider });
   const isDefaultProvider = provider === defaultSearchProvider;
   const isDefaultActive = !searchPanel.provider && isDefaultProvider;
+  const { trackEvent } = useAnalyticsContext();
 
   return (
     <SearchPanelItem
       icon={<Icon className="rounded-6 p-0.5" size={IconSize.Small} />}
       onClick={() => {
+        trackEvent({
+          event_name: AnalyticsEvent.SubmitSearch,
+          extra: JSON.stringify({ query: searchPanel.query, provider }),
+        });
+
         search({ provider, query: searchPanel.query });
       }}
       className={classNames(isDefaultActive && 'bg-theme-float')}


### PR DESCRIPTION
## Changes

### Describe what this PR does
Track search submit:
- when using provider actions
- when using "See more posts"

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
