### PR TITLE
feat: add twitter tracking to onboarding

### DIFF
--- a/packages/shared/src/components/auth/OnboardingAnalytics.tsx
+++ b/packages/shared/src/components/auth/OnboardingAnalytics.tsx
@@ -4,6 +4,7 @@ import { isProduction } from '../../lib/constants';
 
 export const FB_PIXEL_ID = '519268979315924';
 export const GA_TRACKING_ID = 'AW-619408403';
+export const TWITTER_TRACKING_ID = 'o6izs';
 
 export const PixelTracking = (): ReactElement => {
   if (!isProduction) {
@@ -52,6 +53,21 @@ export const GtagTracking = (): ReactElement => {
   );
 };
 
+export const TwitterTracking = (): ReactElement => {
+  if (!isProduction) {
+    return null;
+  }
+
+  return (
+    <Script
+      id="twitter-pixel"
+      src="/scripts/twitter.js"
+      strategy="afterInteractive"
+      data-twitter-id={TWITTER_TRACKING_ID}
+    />
+  );
+};
+
 export const trackAnalyticsSignUp = (): void => {
   if (typeof globalThis.gtag === 'function') {
     globalThis.gtag('event', 'signup');
@@ -59,5 +75,9 @@ export const trackAnalyticsSignUp = (): void => {
 
   if (typeof globalThis.fbq === 'function') {
     globalThis.fbq('track', 'signup');
+  }
+
+  if (typeof globalThis.twq === 'function') {
+    globalThis.twq('event', 'tw-o6izs-okoq6', {});
   }
 };

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -62,6 +62,7 @@ import { ArrowIcon } from '@dailydotdev/shared/src/components/icons';
 import {
   GtagTracking,
   PixelTracking,
+  TwitterTracking,
 } from '@dailydotdev/shared/src/components/auth/OnboardingAnalytics';
 import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import {
@@ -416,6 +417,7 @@ export function OnboardPage(): ReactElement {
       <NextSeo {...seo} titleTemplate="%s | daily.dev" />
       <PixelTracking />
       <GtagTracking />
+      <TwitterTracking />
       {getProgressBar()}
       <OnboardingHeader
         showOnboardingPage={showOnboardingPage}

--- a/packages/webapp/public/scripts/twitter.js
+++ b/packages/webapp/public/scripts/twitter.js
@@ -1,0 +1,23 @@
+const TWITTER_PIXEL_ID = document.currentScript.getAttribute("data-twitter-id");
+
+function initializeTwitterPixel(e,t,n,s,u,a) {
+  e.twq ||
+  (s = e.twq = function(){
+    s.exe ? s.exe.apply(s,arguments) : s.queue.push(arguments);
+  },
+    s.version = '1.1',
+    s.queue = [],
+    u = t.createElement(n),
+    u.async = !0,
+    u.src = 'https://static.ads-twitter.com/uwt.js',
+    a = t.getElementsByTagName(n)[0],
+    a.parentNode.insertBefore(u,a))
+}
+
+initializeTwitterPixel(
+  window,
+  document,
+  "script",
+);
+
+window.twq("config", TWITTER_PIXEL_ID);


### PR DESCRIPTION
Request to add twitter tracking on onboarding just as we did for gtag and fb.

Slack message here: https://dailydotdev.slack.com/archives/C038JGDR2JK/p1710745205293519

<img width="620" alt="Screenshot 2024-03-18 at 2 56 03 PM" src="https://github.com/dailydotdev/apps/assets/36197304/cba9673a-1a34-45c1-86e9-2d29642f45ef">

