### PR TITLE
fix: do not fetch notification preference on squad post options

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -136,8 +136,17 @@ export default function PostOptionsMenu({
     shouldInvalidateQueries: false,
   });
 
+  const isSourceBlocked = useMemo(() => {
+    return !!feedSettings?.excludeSources?.some(
+      (excludedSource) => excludedSource.id === post?.source?.id,
+    );
+  }, [feedSettings?.excludeSources, post?.source?.id]);
+
+  const shouldShowSubscribe =
+    isLoggedIn && !isSourceBlocked && post?.source?.type === SourceType.Machine;
+
   const sourceSubscribe = useSourceSubscription({
-    source: post?.source,
+    source: shouldShowSubscribe ? post?.source : undefined,
   });
 
   const { toggleBookmark } = useBookmarkPost({
@@ -304,12 +313,6 @@ export default function PostOptionsMenu({
     );
   };
 
-  const isSourceBlocked = useMemo(() => {
-    return !!feedSettings?.excludeSources?.some(
-      (excludedSource) => excludedSource.id === post?.source?.id,
-    );
-  }, [feedSettings?.excludeSources, post?.source?.id]);
-
   const postOptions: MenuItemProps[] = [
     {
       icon: <MenuIcon Icon={EyeIcon} />,
@@ -351,9 +354,6 @@ export default function PostOptionsMenu({
       action: onToggleDownvotePost,
     });
   }
-
-  const shouldShowSubscribe =
-    isLoggedIn && !isSourceBlocked && post?.source?.type === SourceType.Machine;
 
   if (shouldShowSubscribe) {
     postOptions.push({


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We now fetch notification preference on post pages with source subscribe experiment
- This avoid fetching it for squad posts which don't have the option in the first place

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
