### PR TITLE
refactor: submit article and new source modal to be wrapped in a form

### DIFF
--- a/packages/shared/src/components/fields/form/FormWrapper.tsx
+++ b/packages/shared/src/components/fields/form/FormWrapper.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, ReactNode, MouseEventHandler } from 'react';
 import classNames from 'classnames';
-import { Button, ButtonVariant } from '../../buttons/Button';
+import { Button, ButtonProps, ButtonVariant } from '../../buttons/Button';
 
 interface Copy {
   left?: string;
@@ -12,8 +12,8 @@ export interface FormWrapperProps {
   className?: string;
   form: string;
   copy?: Copy;
-  onLeftClick?: MouseEventHandler;
-  onRightClick?: MouseEventHandler;
+  leftButtonProps?: ButtonProps<'button'>;
+  rightButtonProps?: ButtonProps<'button'>;
   title?: string;
 }
 
@@ -22,19 +22,19 @@ export function FormWrapper({
   className,
   form,
   copy = {},
-  onLeftClick,
-  onRightClick,
+  leftButtonProps = {},
+  rightButtonProps = {},
   title,
 }: FormWrapperProps): ReactElement {
   return (
     <div className={classNames('flex flex-col', className)}>
       <div className="flex flex-row justify-between border-b border-theme-divider-tertiary px-4 py-2">
-        <Button variant={ButtonVariant.Tertiary} onClick={onLeftClick}>
+        <Button {...leftButtonProps} variant={ButtonVariant.Tertiary}>
           {copy?.left ?? 'Cancel'}
         </Button>
         <Button
+          {...rightButtonProps}
           variant={ButtonVariant.Primary}
-          onClick={onRightClick}
           form={form}
         >
           {copy?.right ?? 'Submit'}

--- a/packages/shared/src/components/fields/form/FormWrapper.tsx
+++ b/packages/shared/src/components/fields/form/FormWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, MouseEventHandler } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
 import { Button, ButtonProps, ButtonVariant } from '../../buttons/Button';
 

--- a/packages/shared/src/components/fields/form/FormWrapper.tsx
+++ b/packages/shared/src/components/fields/form/FormWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode } from 'react';
+import React, { ReactElement, ReactNode, MouseEventHandler } from 'react';
 import classNames from 'classnames';
 import { Button, ButtonVariant } from '../../buttons/Button';
 
@@ -7,13 +7,14 @@ interface Copy {
   right?: string;
 }
 
-interface FormWrapperProps {
+export interface FormWrapperProps {
   children: ReactNode;
   className?: string;
   form: string;
   copy?: Copy;
-  onLeftClick?(): void;
-  onRightClick?(): void;
+  onLeftClick?: MouseEventHandler;
+  onRightClick?: MouseEventHandler;
+  title?: string;
 }
 
 export function FormWrapper({
@@ -23,6 +24,7 @@ export function FormWrapper({
   copy = {},
   onLeftClick,
   onRightClick,
+  title,
 }: FormWrapperProps): ReactElement {
   return (
     <div className={classNames('flex flex-col', className)}>
@@ -38,6 +40,7 @@ export function FormWrapper({
           {copy?.right ?? 'Submit'}
         </Button>
       </div>
+      {title && <p className="mt-5 px-4 font-bold typo-body">{title}</p>}
       {children}
     </div>
   );

--- a/packages/shared/src/components/modals/NewSourceModal.tsx
+++ b/packages/shared/src/components/modals/NewSourceModal.tsx
@@ -236,8 +236,24 @@ export default function NewSourceModal(props: ModalProps): ReactElement {
     return <PushNotificationModal {...modalProps} />;
   }
 
+  const linkHasFeed = !!feeds?.length;
+
   return (
-    <Modal {...modalProps}>
+    <Modal
+      {...modalProps}
+      formProps={{
+        form: linkHasFeed ? 'select-feed' : 'submit-source',
+        copy: { right: linkHasFeed ? 'Submit for review' : 'Check link' },
+        rightButtonProps: {
+          disabled: linkHasFeed
+            ? !selectedFeed || !!existingSource
+            : !enableSubmission || !isEnabled,
+          loading: linkHasFeed
+            ? checkingIfExists || requestingSource
+            : isScraping,
+        },
+      }}
+    >
       <Modal.Header title="Suggest new source" />
       <Modal.Body>
         <Modal.Text>

--- a/packages/shared/src/components/modals/SubmitArticleModal.tsx
+++ b/packages/shared/src/components/modals/SubmitArticleModal.tsx
@@ -194,6 +194,7 @@ export default function SubmitArticleModal({
       kind={Modal.Kind.FlexibleTop}
       size={Modal.Size.Medium}
       onRequestClose={onRequestClose}
+      formProps={{ form: 'submit-article', title: FeedItemTitle.SubmitArticle }}
     >
       <Modal.Header title={FeedItemTitle.SubmitArticle} />
       <Modal.Body>

--- a/packages/shared/src/components/modals/SubmitArticleModal.tsx
+++ b/packages/shared/src/components/modals/SubmitArticleModal.tsx
@@ -188,13 +188,23 @@ export default function SubmitArticleModal({
     return <></>;
   }
 
+  const submitButtonProps = {
+    'aria-label': 'Submit article',
+    loading: isValidating,
+    disabled: !enableSubmission || !isEnabled || !!existingArticle,
+  };
+
   return (
     <Modal
       {...modalProps}
       kind={Modal.Kind.FlexibleTop}
       size={Modal.Size.Medium}
       onRequestClose={onRequestClose}
-      formProps={{ form: 'submit-article', title: FeedItemTitle.SubmitArticle }}
+      formProps={{
+        form: 'submit-article',
+        title: FeedItemTitle.SubmitArticle,
+        rightButtonProps: submitButtonProps,
+      }}
     >
       <Modal.Header title={FeedItemTitle.SubmitArticle} />
       <Modal.Body>
@@ -274,11 +284,9 @@ export default function SubmitArticleModal({
       <Modal.Footer justify={isSubmitted ? Justify.Center : Justify.End}>
         {(!isSubmitted || !!existingArticle) && (
           <Button
+            {...submitButtonProps}
             variant={ButtonVariant.Primary}
             type="submit"
-            aria-label="Submit article"
-            disabled={!enableSubmission || !isEnabled || !!existingArticle}
-            loading={isValidating}
             form="submit-article"
           >
             <span className={isValidating ? 'invisible' : ''}>

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -133,7 +133,13 @@ export function Modal({
       <ConditionalWrapper
         condition={!!formProps && isMobile}
         wrapper={(component) => (
-          <FormWrapper {...formProps} onLeftClick={onRequestClose}>
+          <FormWrapper
+            {...formProps}
+            leftButtonProps={{
+              ...(formProps.leftButtonProps ?? {}),
+              onClick: onRequestClose,
+            }}
+          >
             {component}
           </FormWrapper>
         )}

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -131,7 +131,7 @@ export function Modal({
       }}
     >
       <ConditionalWrapper
-        condition={!!formProps && isMobile}
+        condition={isForm}
         wrapper={(component) => (
           <FormWrapper
             {...formProps}

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -18,6 +18,8 @@ import { ModalStepsWrapper } from './ModalStepsWrapper';
 import { AnalyticsEvent } from '../../../lib/analytics';
 import { useViewSize, ViewSize } from '../../../hooks';
 import { Drawer, DrawerOnMobileProps } from '../../drawers';
+import { FormWrapper, FormWrapperProps } from '../../fields/form';
+import ConditionalWrapper from '../../ConditionalWrapper';
 
 export interface ModalProps extends ReactModal.Props, DrawerOnMobileProps {
   children?: React.ReactNode;
@@ -30,6 +32,7 @@ export interface ModalProps extends ReactModal.Props, DrawerOnMobileProps {
   onTrackNext?: AnalyticsEvent;
   onTrackPrev?: AnalyticsEvent;
   isDrawerOnMobile?: boolean;
+  formProps?: Omit<FormWrapperProps, 'children' | 'onLeftClick'>;
 }
 
 export type LazyModalCommonProps = Pick<
@@ -92,12 +95,14 @@ export function Modal({
   isDrawerOnMobile,
   drawerProps,
   shouldCloseOnOverlayClick,
+  formProps,
   ...props
 }: ModalProps): ReactElement {
   const stepTitle = steps ? steps?.[0].key : undefined;
   const tabTitle = tabs ? modalTabTitle(tabs[0]) : undefined;
   const isMobile = useViewSize(ViewSize.MobileL);
   const isDrawerOpen = isDrawerOnMobile && isMobile;
+  const isForm = formProps && isMobile;
   const [activeView, setView] = useState<string | undefined>(
     defaultView ?? stepTitle ?? tabTitle,
   );
@@ -122,9 +127,19 @@ export function Modal({
         onTrackNext,
         onTrackPrev,
         isDrawer: isDrawerOpen,
+        isForm,
       }}
     >
-      {children}
+      <ConditionalWrapper
+        condition={!!formProps && isMobile}
+        wrapper={(component) => (
+          <FormWrapper {...formProps} onLeftClick={onRequestClose}>
+            {component}
+          </FormWrapper>
+        )}
+      >
+        {children}
+      </ConditionalWrapper>
     </ModalPropsContext.Provider>
   );
 

--- a/packages/shared/src/components/modals/common/ModalBody.tsx
+++ b/packages/shared/src/components/modals/common/ModalBody.tsx
@@ -23,8 +23,8 @@ function ModalBodyComponent(
   const { activeView, kind, size, isDrawer } = useContext(ModalPropsContext);
   const sectionClassName = classNames(
     'relative flex h-full max-h-full w-full shrink flex-col overflow-auto',
-    kind === ModalKind.FlexibleTop && bigModals.includes(size) && 'mobileL:p-8',
-    isDrawer ? 'p-0' : 'p-6',
+    kind === ModalKind.FlexibleTop && bigModals.includes(size) && 'tablet:p-8',
+    isDrawer ? 'p-0' : 'p-4 tablet:p-6',
     className,
   );
   if (view && view !== activeView) {

--- a/packages/shared/src/components/modals/common/ModalFooter.tsx
+++ b/packages/shared/src/components/modals/common/ModalFooter.tsx
@@ -16,10 +16,16 @@ export function ModalFooter({
   justify = Justify.End,
   view,
 }: ModalFooterProps): ReactElement {
-  const { activeView, isDrawer } = useContext(ModalPropsContext);
-  if ((view && view !== activeView) || isDrawer) {
+  const { activeView, isDrawer, isForm } = useContext(ModalPropsContext);
+
+  if (isForm || isDrawer) {
     return null;
   }
+
+  if (view && view !== activeView) {
+    return null;
+  }
+
   return (
     <footer
       className={classNames(

--- a/packages/shared/src/components/modals/common/ModalHeader.tsx
+++ b/packages/shared/src/components/modals/common/ModalHeader.tsx
@@ -39,10 +39,10 @@ export function ModalHeader({
   title,
   showCloseButton = true,
 }: ModalHeaderProps): ReactElement {
-  const { activeView, onRequestClose, tabs, isDrawer } =
+  const { activeView, onRequestClose, tabs, isDrawer, isForm } =
     useContext(ModalPropsContext);
 
-  if (isDrawer) {
+  if (isDrawer || isForm) {
     return null;
   }
 

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -76,6 +76,7 @@ export type ModalContextProps = {
   onTrackNext?: AnalyticsEvent;
   onTrackPrev?: AnalyticsEvent;
   isDrawer?: boolean;
+  isForm?: boolean;
 };
 
 export const ModalPropsContext = createContext<ModalContextProps>({

--- a/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
+++ b/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
@@ -3,13 +3,8 @@ import { Modal, ModalProps } from '../common/Modal';
 import { ExternalLinkPreview } from '../../../graphql/posts';
 import MarkdownInput, { MarkdownRef } from '../../fields/MarkdownInput';
 import { WriteLinkPreview, WritePreviewSkeleton } from '../../post/write';
-import { usePostToSquad, useViewSize, ViewSize } from '../../../hooks';
-import {
-  Button,
-  ButtonColor,
-  ButtonSize,
-  ButtonVariant,
-} from '../../buttons/Button';
+import { usePostToSquad } from '../../../hooks';
+import { Button, ButtonSize } from '../../buttons/Button';
 import { AtIcon } from '../../icons';
 import { Divider, Justify } from '../../utilities';
 import SourceButton from '../../cards/SourceButton';
@@ -36,7 +31,6 @@ export function CreateSharedPostModal({
   const [link, setLink] = useState(preview?.permalink ?? preview?.url ?? '');
   const { shouldShowCta, isEnabled, onToggle, onSubmitted } =
     useNotificationToggle();
-  const isMobile = useViewSize(ViewSize.MobileL);
   const {
     getLinkPreview,
     isLoadingPreview,
@@ -72,41 +66,32 @@ export function CreateSharedPostModal({
     checkUrl(value);
   };
 
+  const footer = (
+    <>
+      <Button
+        icon={<AtIcon />}
+        className="btn-tertiary"
+        size={ButtonSize.Small}
+        onClick={markdownRef?.current?.onMentionCommand}
+      />
+      <Divider vertical />
+      <SourceButton source={squad} size="small" />
+      <span className="-ml-1 flex-1">
+        <strong>{squad.name}</strong>
+        <span className="ml-1 text-theme-label-tertiary">@{squad.handle}</span>
+      </span>
+    </>
+  );
+
   return (
     <Modal
       kind={Modal.Kind.FlexibleCenter}
       size={Modal.Size.Medium}
       onRequestClose={onRequestClose}
       {...props}
+      formProps={{ form: 'share_post', title: 'New post' }}
     >
-      <Modal.Header
-        showCloseButton={!isMobile}
-        title={isMobile ? null : 'New post'}
-      >
-        {isMobile && (
-          <div className="flex flex-1 flex-row items-center justify-between">
-            <Button
-              variant={ButtonVariant.Tertiary}
-              size={ButtonSize.Small}
-              type="button"
-              onClick={onRequestClose}
-            >
-              Cancel
-            </Button>
-
-            <Button
-              variant={ButtonVariant.Primary}
-              color={ButtonColor.Cabbage}
-              disabled={isPosting}
-              loading={isPosting}
-              form="share_post"
-              size={ButtonSize.Small}
-            >
-              Post
-            </Button>
-          </div>
-        )}
-      </Modal.Header>
+      <Modal.Header title="New post" />
       <form
         className="flex w-full flex-col p-3"
         action="#"
@@ -151,32 +136,20 @@ export function CreateSharedPostModal({
           </Switch>
         )}
       </form>
+      <span className="flex flex-row items-center gap-2 px-4 tablet:hidden">
+        {footer}
+      </span>
       <Modal.Footer className="typo-caption1" justify={Justify.Start}>
-        <Button
-          icon={<AtIcon />}
-          className="btn-tertiary"
-          size={ButtonSize.Small}
-          onClick={markdownRef?.current?.onMentionCommand}
-        />
-        <Divider vertical />
-        <SourceButton source={squad} size="small" />
-        <span className="-ml-1 flex-1">
-          <strong>{squad.name}</strong>
-          <span className="ml-1 text-theme-label-tertiary">
-            @{squad.handle}
-          </span>
-        </span>
+        {footer}
 
-        {!isMobile && (
-          <Button
-            className="btn-primary-cabbage ml-auto"
-            disabled={isPosting}
-            loading={isPosting}
-            form="share_post"
-          >
-            Post
-          </Button>
-        )}
+        <Button
+          className="btn-primary-cabbage ml-auto"
+          disabled={isPosting}
+          loading={isPosting}
+          form="share_post"
+        >
+          Post
+        </Button>
       </Modal.Footer>
     </Modal>
   );

--- a/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
+++ b/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
@@ -75,8 +75,8 @@ export function CreateSharedPostModal({
     <>
       <Button
         icon={<AtIcon />}
-        className="btn-tertiary"
         size={ButtonSize.Small}
+        variant={ButtonVariant.Tertiary}
         onClick={markdownRef?.current?.onMentionCommand}
       />
       <Divider vertical />

--- a/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
+++ b/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
@@ -4,7 +4,12 @@ import { ExternalLinkPreview } from '../../../graphql/posts';
 import MarkdownInput, { MarkdownRef } from '../../fields/MarkdownInput';
 import { WriteLinkPreview, WritePreviewSkeleton } from '../../post/write';
 import { usePostToSquad } from '../../../hooks';
-import { Button, ButtonSize } from '../../buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonSize,
+  ButtonVariant,
+} from '../../buttons/Button';
 import { AtIcon } from '../../icons';
 import { Divider, Justify } from '../../utilities';
 import SourceButton from '../../cards/SourceButton';
@@ -83,13 +88,25 @@ export function CreateSharedPostModal({
     </>
   );
 
+  const submitProps = {
+    color: ButtonColor.Cabbage,
+    variant: ButtonVariant.Primary,
+    disabled: isPosting,
+    loading: isPosting,
+  };
+
   return (
     <Modal
       kind={Modal.Kind.FlexibleCenter}
       size={Modal.Size.Medium}
       onRequestClose={onRequestClose}
       {...props}
-      formProps={{ form: 'share_post', title: 'New post' }}
+      formProps={{
+        form: 'share_post',
+        title: 'New post',
+        rightButtonProps: submitProps,
+        copy: { right: 'Post' },
+      }}
     >
       <Modal.Header title="New post" />
       <form
@@ -142,12 +159,7 @@ export function CreateSharedPostModal({
       <Modal.Footer className="typo-caption1" justify={Justify.Start}>
         {footer}
 
-        <Button
-          className="btn-primary-cabbage ml-auto"
-          disabled={isPosting}
-          loading={isPosting}
-          form="share_post"
-        >
+        <Button {...submitProps} className="ml-auto" form="share_post">
           Post
         </Button>
       </Modal.Footer>


### PR DESCRIPTION
## Changes
- Wrap the Modal with form buttons when it is an action modal (definition from design team).
- Wrap New Source Modal.
- Wrap Submit Article Modal.

Previews:
![Screenshot 2024-03-20 at 4 07 09 PM](https://github.com/dailydotdev/apps/assets/13744167/d28cc5a4-f0b1-4455-bdad-c6326ea4b159)
![Screenshot 2024-03-20 at 4 07 02 PM](https://github.com/dailydotdev/apps/assets/13744167/0686bbd6-dad9-47c3-8166-3022fda422a9)
![Screenshot 2024-03-20 at 4 06 49 PM](https://github.com/dailydotdev/apps/assets/13744167/265e1a85-4765-4cc2-81bf-9c32b8454964)
![Screenshot 2024-03-20 at 4 06 40 PM](https://github.com/dailydotdev/apps/assets/13744167/d2133db5-0352-42d5-b825-c3ec487463ef)
![Screenshot 2024-03-20 at 5 03 29 PM](https://github.com/dailydotdev/apps/assets/13744167/64721f49-49b9-4aa3-b56d-c3e70f1e20d8)
![Screenshot 2024-03-20 at 5 03 08 PM](https://github.com/dailydotdev/apps/assets/13744167/ac38e8bc-332f-4e2f-9870-85e4f969bec5)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-227 #done
