### PR TITLE
fix: scroll to top button size on mobile

### DIFF
--- a/packages/shared/src/components/ScrollToTopButton.tsx
+++ b/packages/shared/src/components/ScrollToTopButton.tsx
@@ -17,7 +17,13 @@ export default function ScrollToTopButton(): ReactElement {
   const [show, setShow] = useState(false);
   const isLaptop = useViewSize(ViewSize.Laptop);
   const isTablet = useViewSize(ViewSize.Tablet);
-  const touchDeviceSize = isTablet ? ButtonSize.Large : ButtonSize.Small;
+  const size = (() => {
+    if (isLaptop) {
+      return ButtonSize.XLarge;
+    }
+
+    return isTablet ? ButtonSize.Large : ButtonSize.Small;
+  })();
 
   useEffect(() => {
     const callback = () => {
@@ -48,7 +54,7 @@ export default function ScrollToTopButton(): ReactElement {
       {...props}
       className="absolute -top-12 right-4 z-2 tablet:-top-18 laptop:-top-24 laptop:right-8"
       variant={ButtonVariant.Primary}
-      size={isLaptop ? ButtonSize.XLarge : touchDeviceSize}
+      size={size}
       style={style}
     />
   );

--- a/packages/shared/src/components/ScrollToTopButton.tsx
+++ b/packages/shared/src/components/ScrollToTopButton.tsx
@@ -16,6 +16,8 @@ const baseStyle: CSSProperties = {
 export default function ScrollToTopButton(): ReactElement {
   const [show, setShow] = useState(false);
   const isLaptop = useViewSize(ViewSize.Laptop);
+  const isTablet = useViewSize(ViewSize.Tablet);
+  const toucheDeviceSize = isTablet ? ButtonSize.Large : ButtonSize.Small;
 
   useEffect(() => {
     const callback = () => {
@@ -44,9 +46,9 @@ export default function ScrollToTopButton(): ReactElement {
     <Button
       aria-label="scroll to top"
       {...props}
-      className="absolute -top-18 right-4 z-2 laptop:-top-24 laptop:right-8"
+      className="absolute -top-12 right-4 z-2 tablet:-top-18 laptop:-top-24 laptop:right-8"
       variant={ButtonVariant.Primary}
-      size={isLaptop ? ButtonSize.XLarge : ButtonSize.Large}
+      size={isLaptop ? ButtonSize.XLarge : toucheDeviceSize}
       style={style}
     />
   );

--- a/packages/shared/src/components/ScrollToTopButton.tsx
+++ b/packages/shared/src/components/ScrollToTopButton.tsx
@@ -17,7 +17,7 @@ export default function ScrollToTopButton(): ReactElement {
   const [show, setShow] = useState(false);
   const isLaptop = useViewSize(ViewSize.Laptop);
   const isTablet = useViewSize(ViewSize.Tablet);
-  const toucheDeviceSize = isTablet ? ButtonSize.Large : ButtonSize.Small;
+  const touchDeviceSize = isTablet ? ButtonSize.Large : ButtonSize.Small;
 
   useEffect(() => {
     const callback = () => {
@@ -48,7 +48,7 @@ export default function ScrollToTopButton(): ReactElement {
       {...props}
       className="absolute -top-12 right-4 z-2 tablet:-top-18 laptop:-top-24 laptop:right-8"
       variant={ButtonVariant.Primary}
-      size={isLaptop ? ButtonSize.XLarge : toucheDeviceSize}
+      size={isLaptop ? ButtonSize.XLarge : touchDeviceSize}
       style={style}
     />
   );


### PR DESCRIPTION
## Changes
Preview:

![Screenshot 2024-03-20 at 4 12 08 PM](https://github.com/dailydotdev/apps/assets/13744167/7487e694-0446-4af0-8799-07a4852bf91e)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
