### PR TITLE
fix: upvote modal spacing

### DIFF
--- a/packages/shared/src/components/modals/UserListModal.tsx
+++ b/packages/shared/src/components/modals/UserListModal.tsx
@@ -42,7 +42,7 @@ function UserListModal({
       {...props}
     >
       {header ?? <Modal.Header title={title} />}
-      <Modal.Body className="px-0 py-0" onScroll={onScroll} ref={container}>
+      <Modal.Body className="!p-0" onScroll={onScroll} ref={container}>
         {onSearch && (
           <SearchField
             className="mx-6 my-4"


### PR DESCRIPTION
## Changes
- Fix the spacing on upvote modal.

![Screenshot 2024-03-20 at 8 24 44 PM](https://github.com/dailydotdev/apps/assets/13744167/190f7fd7-6b61-40f0-b14d-6a191681fe76)
![Screenshot 2024-03-20 at 8 24 42 PM](https://github.com/dailydotdev/apps/assets/13744167/e5ae18ee-313a-4f2b-a63d-080b1d2d07b1)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
