### PR TITLE
fix: prompt by using drawer on mobile

### DIFF
--- a/packages/shared/src/components/modals/Prompt.tsx
+++ b/packages/shared/src/components/modals/Prompt.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import classNames from 'classnames';
 import { usePrompt } from '../../hooks/usePrompt';
 import { Button, ButtonVariant } from '../buttons/Button';
 import classed from '../../lib/classed';
@@ -9,7 +10,10 @@ const Description = classed(
   'div',
   'mt-4 mb-6 text-theme-label-secondary text-center typo-callout',
 );
-const Buttons = classed('div', 'flex items-center justify-around self-stretch');
+const Buttons = classed(
+  'div',
+  'flex items-center justify-around self-stretch flex-col tablet:flex-row gap-4',
+);
 
 export function PromptElement(props: Partial<ModalProps>): ReactElement {
   const { prompt } = usePrompt();
@@ -37,6 +41,8 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement {
       onRequestClose={onFail}
       className={className.modal}
       overlayClassName="!z-max"
+      isDrawerOnMobile
+      drawerProps={{ displayCloseButton: false }}
       {...props}
     >
       <Modal.Body>
@@ -56,6 +62,10 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement {
               iconPosition={cancelButton.iconPosition}
               onClick={onFail}
               {...cancelButton}
+              className={classNames(
+                'w-full tablet:w-auto',
+                cancelButton.className,
+              )}
             >
               {cancelButton?.title ?? 'Cancel'}
             </Button>
@@ -68,6 +78,7 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement {
               iconPosition={okButton.iconPosition}
               onClick={onSuccess}
               {...okButton}
+              className={classNames('w-full tablet:w-auto', okButton.className)}
             >
               {okButton?.title ?? 'Ok'}
             </Button>


### PR DESCRIPTION
## Changes
- Use Drawer on mobile for the prompt. Should also make the buttons max width on mobile.

![Screenshot 2024-03-21 at 4 58 56 PM](https://github.com/dailydotdev/apps/assets/13744167/06882085-67da-4b31-9624-fa5fe4a216a2)
![Screenshot 2024-03-21 at 4 58 49 PM](https://github.com/dailydotdev/apps/assets/13744167/cf1207ad-8fc8-462a-8096-7b5544842b84)
![Screenshot 2024-03-21 at 4 58 36 PM](https://github.com/dailydotdev/apps/assets/13744167/754194d1-89ba-4ce0-a7a3-c6104c21fba6)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
