### PR TITLE
fix: height change of squad member list button when images are loaded

### DIFF
--- a/packages/shared/src/components/squads/SquadMemberShortList.tsx
+++ b/packages/shared/src/components/squads/SquadMemberShortList.tsx
@@ -35,7 +35,7 @@ function SquadMemberShortList({
       <button
         type="button"
         className={classNames(
-          'flex flex-row-reverse items-center rounded-12 border border-theme-divider-secondary p-1 pl-3 hover:bg-theme-hover active:bg-theme-active',
+          'flex h-10 flex-row-reverse items-center rounded-12 border border-theme-divider-secondary p-1 pl-3 hover:bg-theme-hover active:bg-theme-active',
           className,
         )}
         onClick={openMemberListModal}


### PR DESCRIPTION
## Changes

Fixes something that has annoyed me for ages. The height changes on the squad member list button once images have been loaded.

<table>
<tr>
 <td>Before
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/e469c798-d728-4b8b-b7b9-d17ee2820b94">
<tr>
 <td>After
 <td><img src="https://github.com/dailydotdev/apps/assets/1681525/187c660b-8d29-4627-9ef1-8bdd70def64d">
</table>