### PR TITLE
fix: after close modal

### DIFF
--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -156,8 +156,13 @@ export function Modal({
         {...drawerProps}
         isOpen
         onClose={() => {
-          onRequestClose(null);
-          props.onAfterClose();
+          if (onRequestClose) {
+            onRequestClose(null);
+          }
+
+          if (props.onAfterClose) {
+            props.onAfterClose();
+          }
         }}
         closeOnOutsideClick={shouldCloseOnOverlayClick}
       >

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -155,7 +155,10 @@ export function Modal({
         displayCloseButton
         {...drawerProps}
         isOpen
-        onClose={onRequestClose}
+        onClose={() => {
+          onRequestClose(null);
+          props.onAfterClose();
+        }}
         closeOnOutsideClick={shouldCloseOnOverlayClick}
       >
         {content}


### PR DESCRIPTION
## Changes
- There is currently no distinction between at the time of closing and after close in our Drawer. Hence, executing both.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
