### PR TITLE
fix: catch unknown source as it exists but is forbidden to 404

### DIFF
--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -183,7 +183,11 @@ export async function getStaticProps({
       revalidate: 60,
     };
   } catch (err) {
-    if (err?.response?.errors?.[0].extensions.code === ApiError.NotFound) {
+    if (
+      [ApiError.NotFound, ApiError.Forbidden].includes(
+        err?.response?.errors?.[0]?.extensions?.code,
+      )
+    ) {
       return {
         props: {
           source: null,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since we actually own the `unknown` source it would throw a nextJS error if you try to visit the source feed.
- This fixes by throwing frontend 404 if not found or forbidden (forbidden only case at the moment is unknown)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
