### PR TITLE
fix: cleanup experiment and apply to comments

### DIFF
--- a/packages/shared/src/components/utilities/DateFormat.tsx
+++ b/packages/shared/src/components/utilities/DateFormat.tsx
@@ -1,8 +1,5 @@
 import React, { ReactElement, useMemo } from 'react';
 import { formatDate, TimeFormatType } from '../../lib/dateFormat';
-import { useFeature } from '../GrowthBookProvider';
-import { feature } from '../../lib/featureManagement';
-import { PublishTimeFormat } from '../../lib/featureValues';
 
 interface DateFormatProps {
   date: string | number | Date;
@@ -17,12 +14,7 @@ export const DateFormat = ({
   prefix,
 }: DateFormatProps): ReactElement => {
   const convertedDate = new Date(date);
-  const publishTimeFormat = useFeature(feature.publishTimeFormat);
-  const timeFormat =
-    publishTimeFormat === PublishTimeFormat.V1 &&
-    type !== TimeFormatType.ReadHistory
-      ? TimeFormatType.Generic
-      : type;
+  const timeFormat = type;
 
   const renderDate = useMemo(
     () => date && formatDate({ value: date, type: timeFormat }),

--- a/packages/shared/src/lib/dateFormat.ts
+++ b/packages/shared/src/lib/dateFormat.ts
@@ -14,7 +14,7 @@ const oneWeek = 7 * oneDay;
 const oneMonth = 28 * oneDay;
 export const oneYear = oneDay * 365;
 
-const publishTimeV1 = (
+const publishTimeRelative = (
   value: Date | number | string,
   now = new Date(),
 ): string => {
@@ -57,7 +57,6 @@ const publishTimeV1 = (
 };
 
 export enum TimeFormatType {
-  Generic = 'generic',
   Post = 'post',
   Comment = 'comment',
   ReadHistory = 'readHistory',
@@ -190,16 +189,12 @@ interface FormatDateProps {
 export const formatDate = ({ value, type }: FormatDateProps): string => {
   const date = new Date(value);
 
-  if (type === TimeFormatType.Generic) {
-    return publishTimeV1(date);
-  }
-
   if (type === TimeFormatType.Post) {
     return postDateFormat(date);
   }
 
   if (type === TimeFormatType.Comment) {
-    return commentDateFormat(date);
+    return publishTimeRelative(date);
   }
 
   if (type === TimeFormatType.ReadHistory) {

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -3,7 +3,6 @@ import {
   ReadingStreaksExperiment,
   PostPageOnboarding,
   UserAcquisition,
-  PublishTimeFormat,
   OnboardingCopy,
   SourceSubscribeExperiment,
 } from './featureValues';
@@ -44,10 +43,6 @@ const feature = {
   forceRefresh: new Feature('force_refresh', false),
   feedAdSpot: new Feature('feed_ad_spot', 0),
   shareLoops: new Feature('share_loops', false),
-  publishTimeFormat: new Feature(
-    'publish_time_format',
-    PublishTimeFormat.Control,
-  ),
   onboardingOnlineUsers: new Feature('onboarding_online_users', false),
   onboardingCopy: new Feature('onboarding_copy', OnboardingCopy.Control),
   sourceSubscribe: new Feature(

--- a/packages/shared/src/lib/featureValues.ts
+++ b/packages/shared/src/lib/featureValues.ts
@@ -21,11 +21,6 @@ export enum UserAcquisition {
   V1 = 'v1',
 }
 
-export enum PublishTimeFormat {
-  Control = 'control',
-  V1 = 'v1',
-}
-
 export enum OnboardingCopy {
   Control = 'control',
   V1 = 'v1',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Cleanup experiment (lost overall)
- We decided to apply to comments anyway

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-204 #done
