### PR TITLE
fix: prevent flash of new

### DIFF
--- a/packages/shared/src/components/sidebar/DiscoverSection.tsx
+++ b/packages/shared/src/components/sidebar/DiscoverSection.tsx
@@ -20,8 +20,9 @@ export function DiscoverSection({
   ...defaultRenderSectionProps
 }: DiscoverSectionProps): ReactElement {
   const hasCommentFeed = useFeature(feature.commentFeed);
-  const { checkHasCompleted, completeAction } = useActions();
-  const hasCompletedCommentFeed = checkHasCompleted(ActionType.CommentFeed);
+  const { checkHasCompleted, completeAction, isActionsFetched } = useActions();
+  const hasCompletedCommentFeed =
+    !isActionsFetched || checkHasCompleted(ActionType.CommentFeed);
   const discoverMenuItems: SidebarMenuItem[] = [
     {
       icon: (active: boolean) => (


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since we don't wait for isActionsFetched it would always flash the new badge quickly.
- Decided to add this as raised [here](https://dailydotdev.slack.com/archives/C06LMML6A8N/p1711120684667839?thread_ts=1711120611.841409&cid=C06LMML6A8N). 
- Maybe we should actually add it to the default of `checkHasCompleted`? (not really sure though)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-new-flash.preview.app.daily.dev