### PR TITLE
feat: mobile feed layout & nav bar

### DIFF
--- a/packages/shared/src/components/BookmarkEmptyScreen.tsx
+++ b/packages/shared/src/components/BookmarkEmptyScreen.tsx
@@ -1,12 +1,21 @@
 import React, { ReactElement } from 'react';
 import Link from 'next/link';
+import classNames from 'classnames';
 import { BookmarkIcon } from './icons';
 import { Button, ButtonSize, ButtonVariant } from './buttons/Button';
 import { EmptyScreenIcon } from './EmptyScreen';
+import { useMobileUxExperiment } from '../hooks/useMobileUxExperiment';
 
 export default function BookmarkEmptyScreen(): ReactElement {
+  const { isNewMobileLayout } = useMobileUxExperiment();
+
   return (
-    <main className="withNavBar inset-0 mx-auto mt-12 flex max-w-full flex-col items-center justify-center px-6 text-theme-label-secondary">
+    <main
+      className={classNames(
+        'withNavBar inset-0 mx-auto mt-12 flex max-w-full flex-col items-center justify-center px-6 text-theme-label-secondary',
+        isNewMobileLayout && 'tablet:pl-22',
+      )}
+    >
       <BookmarkIcon
         className="icon m-0 text-theme-label-tertiary"
         style={EmptyScreenIcon.style}

--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import dynamic from 'next/dynamic';
+import classNames from 'classnames';
 import {
   BOOKMARKS_FEED_QUERY,
   SEARCH_BOOKMARKS_QUERY,
@@ -19,6 +20,7 @@ import BookmarkEmptyScreen from './BookmarkEmptyScreen';
 import { Button, ButtonVariant } from './buttons/Button';
 import { ShareIcon } from './icons';
 import { generateQueryKey, OtherFeedPage, RequestKey } from '../lib/query';
+import { useMobileUxExperiment } from '../hooks/useMobileUxExperiment';
 
 export type BookmarkFeedLayoutProps = {
   searchQuery?: string;
@@ -43,6 +45,7 @@ export default function BookmarkFeedLayout({
   const [showEmptyScreen, setShowEmptyScreen] = useState(false);
   const [showSharedBookmarks, setShowSharedBookmarks] = useState(false);
   const defaultKey = generateQueryKey(RequestKey.Bookmarks, user);
+  const { isNewMobileLayout } = useMobileUxExperiment();
   const feedProps = useMemo<FeedProps<unknown>>(() => {
     if (searchQuery) {
       return {
@@ -86,7 +89,7 @@ export default function BookmarkFeedLayout({
   );
 
   return (
-    <FeedPage>
+    <FeedPage className={classNames(isNewMobileLayout && 'tablet:pl-22')}>
       {children}
       <FeedPageHeader className="mb-5">
         <h3 className="font-bold typo-callout">Bookmarks</h3>

--- a/packages/shared/src/components/EmptyScreen.tsx
+++ b/packages/shared/src/components/EmptyScreen.tsx
@@ -6,7 +6,7 @@ import { Button, ButtonProps, ButtonVariant } from './buttons/Button';
 
 export const EmptyScreenContainer = classed(
   'div',
-  'flex flex-col justify-center items-center px-6 w-full max-w-screen-tablet h-screen max-h-full -mt-12',
+  'flex flex-col justify-center items-center px-6 w-full max-w-screen-tablet h-[calc(100vh-3rem)] max-h-full',
 );
 
 export const EmptyScreenTitle = classed('h2', 'my-4 text-center typo-title1');

--- a/packages/shared/src/components/FeedEmptyScreen.tsx
+++ b/packages/shared/src/components/FeedEmptyScreen.tsx
@@ -7,34 +7,44 @@ import {
   EmptyScreenTitle,
 } from './EmptyScreen';
 import { FilterIcon } from './icons';
-import { PageContainer } from './utilities';
+import { PageContainer, SharedFeedPage } from './utilities';
 import { ButtonSize } from './buttons/common';
 import { useLazyModal } from '../hooks/useLazyModal';
 import { LazyModal } from './modals/common/types';
+import FeedSelector from './FeedSelector';
 
-function FeedEmptyScreen(): ReactElement {
+interface FeedEmptyScreenProps {
+  feedName: SharedFeedPage;
+}
+
+function FeedEmptyScreen({ feedName }: FeedEmptyScreenProps): ReactElement {
   const { openModal } = useLazyModal();
 
   return (
-    <PageContainer className="mx-auto">
-      <EmptyScreenContainer>
-        <FilterIcon
-          className={EmptyScreenIcon.className}
-          style={EmptyScreenIcon.style}
-        />
-        <EmptyScreenTitle>Your feed filters are too specific.</EmptyScreenTitle>
-        <EmptyScreenDescription>
-          We couldn&apos;t fetch enough posts based on your selected tags. Try
-          adding more tags using the feed settings.
-        </EmptyScreenDescription>
-        <EmptyScreenButton
-          onClick={() => openModal({ type: LazyModal.FeedFilters })}
-          size={ButtonSize.Large}
-        >
-          Feed filters
-        </EmptyScreenButton>
-      </EmptyScreenContainer>
-    </PageContainer>
+    <>
+      <PageContainer className="mx-auto">
+        <FeedSelector currentFeed={feedName} className="self-start" />
+        <EmptyScreenContainer>
+          <FilterIcon
+            className={EmptyScreenIcon.className}
+            style={EmptyScreenIcon.style}
+          />
+          <EmptyScreenTitle>
+            Your feed filters are too specific.
+          </EmptyScreenTitle>
+          <EmptyScreenDescription>
+            We couldn&apos;t fetch enough posts based on your selected tags. Try
+            adding more tags using the feed settings.
+          </EmptyScreenDescription>
+          <EmptyScreenButton
+            onClick={() => openModal({ type: LazyModal.FeedFilters })}
+            size={ButtonSize.Large}
+          >
+            Feed filters
+          </EmptyScreenButton>
+        </EmptyScreenContainer>
+      </PageContainer>
+    </>
   );
 }
 

--- a/packages/shared/src/components/FeedSelector.tsx
+++ b/packages/shared/src/components/FeedSelector.tsx
@@ -1,0 +1,78 @@
+import React, { ReactElement, useCallback } from 'react';
+import { useRouter } from 'next/router';
+import { Dropdown } from './fields/Dropdown';
+import { ButtonSize } from './buttons/common';
+import { SharedFeedPage } from './utilities';
+import { DiscussIcon, HotIcon, UpvoteIcon } from './icons';
+import { IconSize } from './Icon';
+
+interface FeedSelectorProps {
+  currentFeed: SharedFeedPage;
+  className?: string;
+}
+
+const feedOptions = [
+  {
+    value: SharedFeedPage.Popular,
+    text: 'Popular',
+    icon: (active: boolean) => (
+      <HotIcon secondary={active} size={IconSize.Medium} className="mr-1" />
+    ),
+  },
+  {
+    value: SharedFeedPage.Upvoted,
+    text: 'Most upvoted',
+    icon: (active: boolean) => (
+      <UpvoteIcon secondary={active} size={IconSize.Medium} className="mr-1" />
+    ),
+  },
+  {
+    value: SharedFeedPage.Discussed,
+    text: 'Best discussions',
+    icon: (active: boolean) => (
+      <DiscussIcon secondary={active} size={IconSize.Medium} className="mr-1" />
+    ),
+  },
+];
+
+export default function FeedSelector({
+  currentFeed,
+  className,
+}: FeedSelectorProps): ReactElement {
+  const router = useRouter();
+  const selectedFeedIdx = feedOptions.findIndex((f) => f.value === currentFeed);
+  const handleSwitchFeed = useCallback(
+    (feed: SharedFeedPage) => {
+      const feedKey = feedOptions.find((f) => f.text === feed)?.value;
+      if (feedKey === SharedFeedPage.MyFeed) {
+        router.push('/');
+      } else {
+        router.push(`/${feedKey}`);
+      }
+    },
+    [router],
+  );
+
+  return (
+    <Dropdown
+      dynamicMenuWidth
+      shouldIndicateSelected
+      buttonSize={ButtonSize.Medium}
+      className={{ button: 'px-1', label: 'mr-5', container: className }}
+      iconOnly={false}
+      key="feed"
+      icon={feedOptions[selectedFeedIdx].icon(true)}
+      selectedIndex={selectedFeedIdx}
+      renderItem={(_, index) => (
+        <>
+          <div className="pr-2">
+            {feedOptions[index].icon(selectedFeedIdx === index)}
+          </div>
+          <span className="typo-callout">{feedOptions[index].text}</span>
+        </>
+      )}
+      options={feedOptions.map((f) => f.text)}
+      onChange={(feed: SharedFeedPage) => handleSwitchFeed(feed)}
+    />
+  );
+}

--- a/packages/shared/src/components/FeedSelector.tsx
+++ b/packages/shared/src/components/FeedSelector.tsx
@@ -58,7 +58,12 @@ export default function FeedSelector({
       dynamicMenuWidth
       shouldIndicateSelected
       buttonSize={ButtonSize.Medium}
-      className={{ button: 'px-1', label: 'mr-5', container: className }}
+      className={{
+        button: 'px-1',
+        label: 'mr-5',
+        container: className,
+        indicator: '!ml-2',
+      }}
       iconOnly={false}
       key="feed"
       icon={feedOptions[selectedFeedIdx].icon(true)}

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -140,9 +140,9 @@ export default function MainFeedLayout({
   const feedVersion = useFeature(feature.feedVersion);
   const searchVersion = useFeature(feature.searchVersion);
   const hasCommentFeed = useFeature(feature.commentFeed);
-  const { isUpvoted, isSortableFeed } = useFeedName({ feedName });
+  const { isUpvoted, isPopular, isSortableFeed } = useFeedName({ feedName });
   const { shouldUseMobileFeedLayout } = useFeedLayout();
-  const { useNewMobileLayout } = useMobileUxExperiment();
+  const { isNewMobileLayout } = useMobileUxExperiment();
   const shouldUseCommentFeedLayout =
     hasCommentFeed && feedName === SharedFeedPage.Discussed;
   let query: { query: string; variables?: Record<string, unknown> };
@@ -184,7 +184,7 @@ export default function MainFeedLayout({
   );
 
   const feedProps = useMemo<FeedProps<unknown>>(() => {
-    const feedWithActions = isUpvoted || isSortableFeed;
+    const feedWithActions = isUpvoted || isPopular || isSortableFeed;
     // in v1 search by default we do not show any results but empty state
     // so returning false so feed does not do any requests
     if (isSearchOn && !searchQuery) {
@@ -234,7 +234,7 @@ export default function MainFeedLayout({
       ),
       query: query.query,
       variables,
-      emptyScreen: <FeedEmptyScreen />,
+      emptyScreen: <FeedEmptyScreen feedName={feedName} />,
       header: null,
       actionButtons: feedWithActions && (
         <SearchControlHeader {...searchProps} />
@@ -276,7 +276,7 @@ export default function MainFeedLayout({
       className={classNames(
         'relative',
         disableTopPadding && '!pt-0',
-        useNewMobileLayout && 'tablet:pl-22',
+        isNewMobileLayout && 'tablet:pl-22',
       )}
     >
       {isSearchOn && search}

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -46,7 +46,6 @@ import CommentFeed from './CommentFeed';
 import { COMMENT_FEED_QUERY } from '../graphql/comments';
 import { ProfileEmptyScreen } from './profile/ProfileEmptyScreen';
 import { Origin } from '../lib/analytics';
-import FeedNav from './feeds/FeedNav';
 import { useMobileUxExperiment } from '../hooks/useMobileUxExperiment';
 
 const SearchEmptyScreen = dynamic(

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -46,6 +46,8 @@ import CommentFeed from './CommentFeed';
 import { COMMENT_FEED_QUERY } from '../graphql/comments';
 import { ProfileEmptyScreen } from './profile/ProfileEmptyScreen';
 import { Origin } from '../lib/analytics';
+import FeedNav from './feeds/FeedNav';
+import { useMobileUxExperiment } from '../hooks/useMobileUxExperiment';
 
 const SearchEmptyScreen = dynamic(
   () =>
@@ -140,6 +142,7 @@ export default function MainFeedLayout({
   const hasCommentFeed = useFeature(feature.commentFeed);
   const { isUpvoted, isSortableFeed } = useFeedName({ feedName });
   const { shouldUseMobileFeedLayout } = useFeedLayout();
+  const { useNewMobileLayout } = useMobileUxExperiment();
   const shouldUseCommentFeedLayout =
     hasCommentFeed && feedName === SharedFeedPage.Discussed;
   let query: { query: string; variables?: Record<string, unknown> };
@@ -270,7 +273,11 @@ export default function MainFeedLayout({
 
   return (
     <FeedPageComponent
-      className={classNames('relative', disableTopPadding && '!pt-0')}
+      className={classNames(
+        'relative',
+        disableTopPadding && '!pt-0',
+        useNewMobileLayout && 'tablet:pl-22',
+      )}
     >
       {isSearchOn && search}
       {shouldUseCommentFeedLayout ? (

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -41,7 +41,6 @@ import { ReputationPrivilegesModalTrigger } from './modals';
 import { MarketingCtaVariant } from './cards/MarketingCta/common';
 import { useLazyModal } from '../hooks/useLazyModal';
 import { LazyModal } from './modals/common/types';
-import { useMobileUxExperiment } from '../hooks/useMobileUxExperiment';
 
 export interface MainLayoutProps
   extends Omit<MainLayoutHeaderProps, 'onMobileSidebarToggle'>,
@@ -92,7 +91,6 @@ function MainLayoutComponent({
 
   const isLaptopXL = useViewSize(ViewSize.LaptopXL);
   const { shouldUseMobileFeedLayout } = useFeedLayout();
-  const { isNewMobileLayout } = useMobileUxExperiment();
 
   const { isNotificationsReady, unreadCount } = useNotificationContext();
   useAuthErrors();

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -41,6 +41,7 @@ import { ReputationPrivilegesModalTrigger } from './modals';
 import { MarketingCtaVariant } from './cards/MarketingCta/common';
 import { useLazyModal } from '../hooks/useLazyModal';
 import { LazyModal } from './modals/common/types';
+import { useMobileUxExperiment } from '../hooks/useMobileUxExperiment';
 
 export interface MainLayoutProps
   extends Omit<MainLayoutHeaderProps, 'onMobileSidebarToggle'>,
@@ -91,6 +92,7 @@ function MainLayoutComponent({
 
   const isLaptopXL = useViewSize(ViewSize.LaptopXL);
   const { shouldUseMobileFeedLayout } = useFeedLayout();
+  const { useNewMobileLayout } = useMobileUxExperiment();
 
   const { isNotificationsReady, unreadCount } = useNotificationContext();
   useAuthErrors();
@@ -224,6 +226,7 @@ function MainLayoutComponent({
           !isScreenCentered && sidebarExpanded
             ? 'laptop:pl-60'
             : 'laptop:pl-11',
+
           isBannerAvailable && 'laptop:pt-8',
         )}
       >

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -92,7 +92,7 @@ function MainLayoutComponent({
 
   const isLaptopXL = useViewSize(ViewSize.LaptopXL);
   const { shouldUseMobileFeedLayout } = useFeedLayout();
-  const { useNewMobileLayout } = useMobileUxExperiment();
+  const { isNewMobileLayout } = useMobileUxExperiment();
 
   const { isNotificationsReady, unreadCount } = useNotificationContext();
   useAuthErrors();

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -14,6 +14,7 @@ import { useFeedLayout, ToastSubject, useToastNotification } from '../../hooks';
 import ConditionalWrapper from '../ConditionalWrapper';
 import { SharedFeedPage } from '../utilities';
 import { useActiveFeedNameContext } from '../../contexts';
+import { useMobileUxExperiment } from '../../hooks/useMobileUxExperiment';
 
 export interface FeedContainerProps {
   children: ReactNode;
@@ -106,6 +107,7 @@ export const FeedContainer = ({
     loadedSettings,
   } = useContext(SettingsContext);
   const { shouldUseMobileFeedLayout } = useFeedLayout();
+  const { useNewMobileLayout } = useMobileUxExperiment();
   const { feedName } = useActiveFeedNameContext();
   const router = useRouter();
   const numCards = currentSettings.numCards[spaciness ?? 'eco'];
@@ -149,7 +151,7 @@ export const FeedContainer = ({
           {isSearch && !shouldUseMobileFeedLayout && (
             <span className="flex flex-1 flex-row items-center">
               {!!actionButtons && (
-                <span className="mr-auto flex flex-row gap-3 border-theme-divider-tertiary pr-3">
+                <span className="mr-auto flex w-full flex-row gap-3 border-theme-divider-tertiary pr-3">
                   {actionButtons}
                 </span>
               )}
@@ -167,10 +169,19 @@ export const FeedContainer = ({
                 )}
               >
                 <span className="flex w-full flex-row items-center justify-between px-6 py-4">
-                  <strong className="typo-title3">
-                    {feedNameToHeading[feedName] ?? ''}
-                  </strong>
-                  <span className="flex flex-row gap-3">{actionButtons}</span>
+                  {!useNewMobileLayout && (
+                    <strong className="typo-title3">
+                      {feedNameToHeading[feedName] ?? ''}
+                    </strong>
+                  )}
+                  <span
+                    className={classNames(
+                      'flex flex-row gap-3',
+                      useNewMobileLayout && 'w-full',
+                    )}
+                  >
+                    {actionButtons}
+                  </span>
                 </span>
                 {child}
               </div>

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -107,7 +107,7 @@ export const FeedContainer = ({
     loadedSettings,
   } = useContext(SettingsContext);
   const { shouldUseMobileFeedLayout } = useFeedLayout();
-  const { useNewMobileLayout } = useMobileUxExperiment();
+  const { isNewMobileLayout } = useMobileUxExperiment();
   const { feedName } = useActiveFeedNameContext();
   const router = useRouter();
   const numCards = currentSettings.numCards[spaciness ?? 'eco'];
@@ -169,7 +169,7 @@ export const FeedContainer = ({
                 )}
               >
                 <span className="flex w-full flex-row items-center justify-between px-6 py-4">
-                  {!useNewMobileLayout && (
+                  {!isNewMobileLayout && (
                     <strong className="typo-title3">
                       {feedNameToHeading[feedName] ?? ''}
                     </strong>
@@ -177,7 +177,7 @@ export const FeedContainer = ({
                   <span
                     className={classNames(
                       'flex flex-row gap-3',
-                      useNewMobileLayout && 'w-full',
+                      isNewMobileLayout && 'w-full',
                     )}
                   >
                     {actionButtons}

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -15,6 +15,7 @@ import ConditionalWrapper from '../ConditionalWrapper';
 import { SharedFeedPage } from '../utilities';
 import { useActiveFeedNameContext } from '../../contexts';
 import { useMobileUxExperiment } from '../../hooks/useMobileUxExperiment';
+import { useReadingStreak } from '../../hooks/streaks';
 
 export interface FeedContainerProps {
   children: ReactNode;
@@ -108,6 +109,7 @@ export const FeedContainer = ({
   } = useContext(SettingsContext);
   const { shouldUseMobileFeedLayout } = useFeedLayout();
   const { isNewMobileLayout } = useMobileUxExperiment();
+  const { isEnabled: isStreaksEnabled } = useReadingStreak();
   const { feedName } = useActiveFeedNameContext();
   const router = useRouter();
   const numCards = currentSettings.numCards[spaciness ?? 'eco'];
@@ -151,7 +153,12 @@ export const FeedContainer = ({
           {isSearch && !shouldUseMobileFeedLayout && (
             <span className="flex flex-1 flex-row items-center">
               {!!actionButtons && (
-                <span className="mr-auto flex w-full flex-row gap-3 border-theme-divider-tertiary pr-3">
+                <span
+                  className={classNames(
+                    'mr-auto flex flex-row gap-3 border-theme-divider-tertiary pr-3',
+                    isNewMobileLayout && isStreaksEnabled && 'w-full',
+                  )}
+                >
                   {actionButtons}
                 </span>
               )}

--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -42,7 +42,7 @@ function FeedNav(): ReactElement {
         <Tab label={FeedNavTab.History} url="/history" />
       </TabContainer>
 
-      <div className="fixed right-0 top-0 my-1 flex h-12 w-36 items-center justify-end bg-gradient-to-r from-transparent via-background-default via-60% to-background-default">
+      <div className="fixed right-0 top-0 my-1 mr-0.5 flex h-12 w-36 items-center justify-end bg-gradient-to-r from-transparent via-background-default via-60% to-background-default">
         <NotificationsBell />
       </div>
     </div>

--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -14,7 +14,7 @@ enum FeedNavTab {
 function FeedNav(): ReactElement {
   const router = useRouter();
   const shouldRenderNav = useMemo(() => {
-    return /(\/|\/popular|\/bookmarks|\/history|\/notifications)$/.test(
+    return /(\/|\/my-feed|\/popular|\/upvoted|\/discussed|\/bookmarks|\/history|\/notifications)$/.test(
       router?.pathname,
     );
   }, [router?.pathname]);

--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -13,8 +13,9 @@ enum FeedNavTab {
 
 function FeedNav(): ReactElement {
   const router = useRouter();
+
   const shouldRenderNav = useMemo(() => {
-    return /(\/|\/my-feed|\/popular|\/upvoted|\/discussed|\/bookmarks|\/history|\/notifications)$/.test(
+    return /(?<!\/.+)\/(?:my-feed|popular|upvoted|discussed|bookmarks|history|notifications|)$/.test(
       router?.pathname,
     );
   }, [router?.pathname]);
@@ -42,7 +43,7 @@ function FeedNav(): ReactElement {
         <Tab label={FeedNavTab.History} url="/history" />
       </TabContainer>
 
-      <div className="fixed right-0 top-0 my-1 mr-0.5 flex h-12 w-36 items-center justify-end bg-gradient-to-r from-transparent via-background-default via-60% to-background-default">
+      <div className="fixed right-0 top-0 my-1 mr-1 flex h-12 w-36 items-center justify-end bg-gradient-to-r from-transparent via-background-default via-60% to-background-default">
         <NotificationsBell />
       </div>
     </div>

--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -1,0 +1,52 @@
+import classNames from 'classnames';
+import React, { ReactElement, useMemo } from 'react';
+import { useRouter } from 'next/router';
+import { Tab, TabContainer } from '../tabs/TabContainer';
+import NotificationsBell from '../notifications/NotificationsBell';
+
+enum FeedNavTab {
+  ForYou = 'For you',
+  Popular = 'Popular',
+  Bookmarks = 'Bookmarks',
+  History = 'History',
+}
+
+function FeedNav(): ReactElement {
+  const router = useRouter();
+  const shouldRenderNav = useMemo(() => {
+    return /(\/|\/popular|\/bookmarks|\/history|\/notifications)$/.test(
+      router?.pathname,
+    );
+  }, [router?.pathname]);
+
+  if (!shouldRenderNav) {
+    return null;
+  }
+
+  return (
+    <div
+      className={classNames(
+        'sticky top-0 z-header h-14 w-full bg-background-default tablet:pl-16',
+      )}
+    >
+      <TabContainer
+        shouldMountInactive
+        className={{
+          header: 'no-scrollbar overflow-x-auto px-1',
+        }}
+        tabListProps={{ className: { indicator: '!w-6' } }}
+      >
+        <Tab label={FeedNavTab.ForYou} url="/" />
+        <Tab label={FeedNavTab.Popular} url="/popular" />
+        <Tab label={FeedNavTab.Bookmarks} url="/bookmarks" />
+        <Tab label={FeedNavTab.History} url="/history" />
+      </TabContainer>
+
+      <div className="fixed right-0 top-0 my-1 flex h-12 w-36 items-center justify-end bg-gradient-to-r from-transparent via-background-default via-60% to-background-default">
+        <NotificationsBell />
+      </div>
+    </div>
+  );
+}
+
+export default FeedNav;

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -20,6 +20,7 @@ import { SelectParams } from '../drawers/common';
 import { RootPortal } from '../tooltips/Portal';
 import { DrawerProps } from '../drawers';
 import { Button, ButtonSize } from '../buttons/Button';
+import { IconProps } from '../Icon';
 
 interface ClassName {
   container?: string;
@@ -143,7 +144,10 @@ export function Dropdown({
         aria-expanded={isVisible}
       >
         {icon &&
-          React.cloneElement(icon as ReactElement, { secondary: isVisible })}
+          React.cloneElement(icon as ReactElement<IconProps>, {
+            secondary:
+              (icon as ReactElement<IconProps>).props.secondary ?? isVisible,
+          })}
         <span
           className={classNames('mr-1 flex flex-1 truncate', className.label)}
         >

--- a/packages/shared/src/components/filters/MyFeedHeading.tsx
+++ b/packages/shared/src/components/filters/MyFeedHeading.tsx
@@ -15,9 +15,6 @@ import { useFeature } from '../GrowthBookProvider';
 import { setShouldRefreshFeed } from '../../lib/refreshFeed';
 import { SharedFeedPage } from '../utilities';
 import { useMobileUxExperiment } from '../../hooks/useMobileUxExperiment';
-import ConditionalWrapper from '../ConditionalWrapper';
-import { useReadingStreak } from '../../hooks/streaks';
-import { ReadingStreakButton } from '../streak/ReadingStreakButton';
 
 export const filterAlertMessage = 'Edit your personal feed preferences here';
 
@@ -34,7 +31,6 @@ function MyFeedHeading({
   const queryClient = useQueryClient();
   const forceRefresh = useFeature(feature.forceRefresh);
   const { isNewMobileLayout } = useMobileUxExperiment();
-  const { streak, isEnabled: isStreaksEnabled, isLoading } = useReadingStreak();
 
   const onClick = () => {
     trackEvent({ event_name: AnalyticsEvent.ManageTags });
@@ -92,20 +88,6 @@ function MyFeedHeading({
       </>
     );
   };
-
-  if (isNewMobileLayout) {
-    return (
-      <div className="flex w-full justify-between">
-        {isStreaksEnabled && (
-          <ReadingStreakButton streak={streak} isLoading={isLoading} />
-        )}
-
-        <div>
-          <RenderFeedActions />
-        </div>
-      </div>
-    );
-  }
 
   return <RenderFeedActions />;
 }

--- a/packages/shared/src/components/history/ReadingHistoryEmptyScreen.tsx
+++ b/packages/shared/src/components/history/ReadingHistoryEmptyScreen.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import React, { ReactElement } from 'react';
+import classNames from 'classnames';
 import {
   EmptyScreenButton,
   EmptyScreenDescription,
@@ -8,10 +9,18 @@ import {
 } from '../EmptyScreen';
 import { EyeIcon } from '../icons';
 import { ButtonSize } from '../buttons/common';
+import { useMobileUxExperiment } from '../../hooks/useMobileUxExperiment';
 
 function ReadingHistoryEmptyScreen(): ReactElement {
+  const { isNewMobileLayout } = useMobileUxExperiment();
+
   return (
-    <div className="mt-20 flex flex-1 flex-col items-center justify-center px-6">
+    <div
+      className={classNames(
+        'mt-20 flex flex-1 flex-col items-center justify-center px-6',
+        isNewMobileLayout && 'tablet:pl-22',
+      )}
+    >
       <EyeIcon
         className={EmptyScreenIcon.className}
         style={EmptyScreenIcon.style}

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -16,7 +16,6 @@ import { useViewSize, ViewSize } from '../../hooks';
 import { ReadingStreakButton } from '../streak/ReadingStreakButton';
 import { useReadingStreak } from '../../hooks/streaks';
 import { LogoPosition } from '../Logo';
-import { UserStreak } from '../../graphql/users';
 import { useMobileUxExperiment } from '../../hooks/useMobileUxExperiment';
 import NotificationsBell from '../notifications/NotificationsBell';
 import FeedNav from '../feeds/FeedNav';

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -28,6 +28,8 @@ import { useFeedLayout } from '../../hooks';
 import ConditionalWrapper from '../ConditionalWrapper';
 import { useMobileUxExperiment } from '../../hooks/useMobileUxExperiment';
 import FeedSelector from '../FeedSelector';
+import { ReadingStreakButton } from '../streak/ReadingStreakButton';
+import { useReadingStreak } from '../../hooks/streaks';
 
 type State<T> = [T, Dispatch<SetStateAction<T>>];
 
@@ -66,6 +68,7 @@ export const SearchControlHeader = ({
   });
   const { shouldUseMobileFeedLayout } = useFeedLayout();
   const { isNewMobileLayout } = useMobileUxExperiment();
+  const { streak, isEnabled: isStreaksEnabled, isLoading } = useReadingStreak();
   const openFeedFilters = () =>
     openModal({ type: LazyModal.FeedFilters, persistOnRouteChange: true });
 
@@ -107,10 +110,17 @@ export const SearchControlHeader = ({
 
   return (
     <ConditionalWrapper
-      condition={isNewMobileLayout && (isPopular || isUpvoted || isDiscussed)}
+      condition={isNewMobileLayout}
       wrapper={(children) => (
-        <div className="flex items-center justify-between">
-          <FeedSelector currentFeed={feedName} />
+        <div className="flex w-full items-center justify-between">
+          {isPopular ||
+            isUpvoted ||
+            (isDiscussed && <FeedSelector currentFeed={feedName} />)}
+
+          {isStreaksEnabled && (
+            <ReadingStreakButton streak={streak} isLoading={isLoading} />
+          )}
+
           <div>{children}</div>
         </div>
       )}

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -2,10 +2,8 @@ import React, {
   Dispatch,
   ReactElement,
   SetStateAction,
-  useCallback,
   useContext,
 } from 'react';
-import { useRouter } from 'next/router';
 import classed from '../../lib/classed';
 import { SharedFeedPage } from '../utilities';
 import MyFeedHeading from '../filters/MyFeedHeading';
@@ -13,13 +11,7 @@ import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
 import { Dropdown, DropdownProps } from '../fields/Dropdown';
 import { ButtonSize } from '../buttons/common';
-import {
-  CalendarIcon,
-  DiscussIcon,
-  HotIcon,
-  SortIcon,
-  UpvoteIcon,
-} from '../icons';
+import { CalendarIcon, SortIcon } from '../icons';
 import { IconSize } from '../Icon';
 import { RankingAlgorithm } from '../../graphql/feed';
 import SettingsContext from '../../contexts/SettingsContext';

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -113,12 +113,12 @@ export const SearchControlHeader = ({
       condition={isNewMobileLayout}
       wrapper={(children) => (
         <div className="flex w-full items-center justify-between">
-          {isPopular ||
-            isUpvoted ||
-            (isDiscussed && <FeedSelector currentFeed={feedName} />)}
-
-          {isStreaksEnabled && (
-            <ReadingStreakButton streak={streak} isLoading={isLoading} />
+          {isPopular || isUpvoted || isDiscussed ? (
+            <FeedSelector currentFeed={feedName} />
+          ) : (
+            isStreaksEnabled && (
+              <ReadingStreakButton streak={streak} isLoading={isLoading} />
+            )
           )}
 
           <div>{children}</div>

--- a/packages/shared/src/components/notifications/NotificationsBell.tsx
+++ b/packages/shared/src/components/notifications/NotificationsBell.tsx
@@ -14,7 +14,7 @@ import { LinkWithTooltip } from '../tooltips/LinkWithTooltip';
 function NotificationsBell(): ReactElement {
   const { trackEvent } = useAnalyticsContext();
   const { unreadCount } = useNotificationContext();
-  const { useNewMobileLayout } = useMobileUxExperiment();
+  const { isNewMobileLayout } = useMobileUxExperiment();
   const hasNotification = !!unreadCount;
   const atNotificationsPage = checkAtNotificationsPage();
   const onNavigateNotifications = () => {
@@ -33,12 +33,12 @@ function NotificationsBell(): ReactElement {
       <div
         className={classNames(
           'relative laptop:flex',
-          !useNewMobileLayout && 'hidden',
+          !isNewMobileLayout && 'hidden',
         )}
       >
         <Button
           variant={
-            useNewMobileLayout ? ButtonVariant.Option : ButtonVariant.Float
+            isNewMobileLayout ? ButtonVariant.Option : ButtonVariant.Float
           }
           onClick={onNavigateNotifications}
           icon={

--- a/packages/shared/src/components/notifications/NotificationsBell.tsx
+++ b/packages/shared/src/components/notifications/NotificationsBell.tsx
@@ -1,0 +1,64 @@
+import classNames from 'classnames';
+import React, { ReactElement } from 'react';
+import { Button, ButtonVariant } from '../buttons/Button';
+import { BellIcon } from '../icons';
+import { Bubble } from '../tooltips/utils';
+import { checkAtNotificationsPage, getUnreadText } from './utils';
+import { useNotificationContext } from '../../contexts/NotificationsContext';
+import { AnalyticsEvent, NotificationTarget } from '../../lib/analytics';
+import { useAnalyticsContext } from '../../contexts/AnalyticsContext';
+import { useMobileUxExperiment } from '../../hooks/useMobileUxExperiment';
+import { webappUrl } from '../../lib/constants';
+import { LinkWithTooltip } from '../tooltips/LinkWithTooltip';
+
+function NotificationsBell(): ReactElement {
+  const { trackEvent } = useAnalyticsContext();
+  const { unreadCount } = useNotificationContext();
+  const { useNewMobileLayout } = useMobileUxExperiment();
+  const hasNotification = !!unreadCount;
+  const atNotificationsPage = checkAtNotificationsPage();
+  const onNavigateNotifications = () => {
+    trackEvent({
+      event_name: AnalyticsEvent.ClickNotificationIcon,
+      target_id: NotificationTarget.Header,
+      extra: JSON.stringify({ notifications_number: unreadCount }),
+    });
+  };
+
+  return (
+    <LinkWithTooltip
+      tooltip={{ placement: 'bottom', content: 'Notifications' }}
+      href={`${webappUrl}notifications`}
+    >
+      <div
+        className={classNames(
+          'relative laptop:flex',
+          !useNewMobileLayout && 'hidden',
+        )}
+      >
+        <Button
+          variant={
+            useNewMobileLayout ? ButtonVariant.Option : ButtonVariant.Float
+          }
+          onClick={onNavigateNotifications}
+          icon={
+            <BellIcon
+              className={classNames(
+                'hover:text-theme-label-primary',
+                atNotificationsPage && 'text-theme-label-primary',
+              )}
+              secondary={atNotificationsPage}
+            />
+          }
+        />
+        {hasNotification && (
+          <Bubble className="-right-1.5 -top-1.5 cursor-pointer px-1">
+            {getUnreadText(unreadCount)}
+          </Bubble>
+        )}
+      </div>
+    </LinkWithTooltip>
+  );
+}
+
+export default NotificationsBell;

--- a/packages/shared/src/components/streak/ReadingStreakButton.tsx
+++ b/packages/shared/src/components/streak/ReadingStreakButton.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, useCallback, useState } from 'react';
+import classnames from 'classnames';
 import { ReadingStreakPopup } from './popup';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { ReadingStreakIcon } from '../icons';
@@ -11,6 +12,8 @@ import { AnalyticsEvent } from '../../lib/analytics';
 
 interface ReadingStreakButtonProps {
   streak: UserStreak;
+  isLoading: boolean;
+  compact?: boolean;
 }
 
 interface CustomStreaksTooltipProps {
@@ -48,12 +51,15 @@ function CustomStreaksTooltip({
 
 export function ReadingStreakButton({
   streak,
+  isLoading,
+  compact,
 }: ReadingStreakButtonProps): ReactElement {
   const { trackEvent } = useAnalyticsContext();
   const isLaptop = useViewSize(ViewSize.Laptop);
+  const isMobile = useViewSize(ViewSize.MobileL);
   const [shouldShowStreaks, setShouldShowStreaks] = useState(false);
   const hasReadToday =
-    new Date(streak.lastViewAt).getDate() === new Date().getDate();
+    new Date(streak?.lastViewAt).getDate() === new Date().getDate();
 
   const handleToggle = useCallback(() => {
     setShouldShowStreaks((state) => !state);
@@ -67,6 +73,16 @@ export function ReadingStreakButton({
 
   const Tooltip = shouldShowStreaks ? CustomStreaksTooltip : SimpleTooltip;
 
+  if (isLoading) {
+    return (
+      <div className="h-8 w-14 rounded-12 bg-surface-float laptop:h-10 laptop:w-20" />
+    );
+  }
+
+  if (!streak) {
+    return null;
+  }
+
   return (
     <Tooltip
       content="Current streak"
@@ -79,10 +95,15 @@ export function ReadingStreakButton({
         icon={<ReadingStreakIcon secondary={hasReadToday} />}
         variant={ButtonVariant.Float}
         onClick={handleToggle}
-        className="gap-1 text-theme-color-bacon"
-        size={isLaptop ? ButtonSize.Medium : ButtonSize.Small}
+        className={classnames('gap-1', compact && 'text-theme-color-bacon')}
+        size={
+          (isLaptop || !compact) && !isMobile
+            ? ButtonSize.Medium
+            : ButtonSize.Small
+        }
       >
         {streak?.current}
+        {!compact && ' reading days'}
       </Button>
     </Tooltip>
   );

--- a/packages/shared/src/components/tabs/TabContainer.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.tsx
@@ -11,7 +11,7 @@ import TabList, { TabListProps } from './TabList';
 
 export interface TabProps<T extends string> {
   key?: number;
-  children: ReactNode;
+  children?: ReactNode;
   label: T;
   className?: string;
   style?: CSSProperties;

--- a/packages/shared/src/hooks/feed/useFeedName.ts
+++ b/packages/shared/src/hooks/feed/useFeedName.ts
@@ -6,6 +6,8 @@ interface UseFeedNameProps {
 
 interface UseFeedName {
   isUpvoted: boolean;
+  isPopular: boolean;
+  isDiscussed: boolean;
   isSortableFeed: boolean;
 }
 
@@ -13,7 +15,9 @@ const sortableFeeds = [SharedFeedPage.Popular, SharedFeedPage.MyFeed];
 
 export const useFeedName = ({ feedName }: UseFeedNameProps): UseFeedName => {
   return {
-    isUpvoted: feedName === 'upvoted',
+    isUpvoted: feedName === SharedFeedPage.Upvoted,
+    isPopular: feedName === SharedFeedPage.Popular,
+    isDiscussed: feedName === SharedFeedPage.Discussed,
     isSortableFeed: sortableFeeds.includes(feedName),
   };
 };

--- a/packages/webapp/components/history/reading.tsx
+++ b/packages/webapp/components/history/reading.tsx
@@ -16,8 +16,6 @@ import {
   RequestKey,
 } from '@dailydotdev/shared/src/lib/query';
 import ReadingHistoryEmptyScreen from '@dailydotdev/shared/src/components/history/ReadingHistoryEmptyScreen';
-import { useMobileUxExperiment } from '@dailydotdev/shared/src/hooks/useMobileUxExperiment';
-import classNames from 'classnames';
 
 const PostsSearch = dynamic(
   () =>

--- a/packages/webapp/components/history/reading.tsx
+++ b/packages/webapp/components/history/reading.tsx
@@ -16,6 +16,8 @@ import {
   RequestKey,
 } from '@dailydotdev/shared/src/lib/query';
 import ReadingHistoryEmptyScreen from '@dailydotdev/shared/src/components/history/ReadingHistoryEmptyScreen';
+import { useMobileUxExperiment } from '@dailydotdev/shared/src/hooks/useMobileUxExperiment';
+import classNames from 'classnames';
 
 const PostsSearch = dynamic(
   () =>

--- a/packages/webapp/components/layouts/AccountLayout/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/index.tsx
@@ -4,6 +4,8 @@ import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { NextSeoProps } from 'next-seo/lib/types';
 import Head from 'next/head';
 import { NextSeo } from 'next-seo';
+import classNames from 'classnames';
+import { useMobileUxExperiment } from '@dailydotdev/shared/src/hooks/useMobileUxExperiment';
 import { ProfileSettingsMenu } from '@dailydotdev/shared/src/components/profile/ProfileSettingsMenu';
 import {
   generateQueryKey,
@@ -28,6 +30,7 @@ export const navigationKey = generateQueryKey(
 export default function AccountLayout({
   children,
 }: AccountLayoutProps): ReactElement {
+  const { isNewMobileLayout } = useMobileUxExperiment();
   const { user: profile, isFetched, logout } = useContext(AuthContext);
   const [isOpen, setIsOpen] = useQueryState({
     key: navigationKey,
@@ -60,7 +63,12 @@ export default function AccountLayout({
         <link rel="preload" as="image" href={profile.image} />
       </Head>
       <NextSeo {...Seo} noindex nofollow />
-      <main className="relative mx-auto flex w-full flex-1 flex-row items-stretch pt-0 laptop:max-w-[calc(100vw-17.5rem)]">
+      <main
+        className={classNames(
+          'relative mx-auto flex w-full flex-1 flex-row items-stretch pt-0 laptop:max-w-[calc(100vw-17.5rem)]',
+          isNewMobileLayout && 'tablet:pl-16',
+        )}
+      >
         {isMobile ? (
           <ProfileSettingsMenu
             isOpen={isOpen}

--- a/packages/webapp/components/layouts/ProfileLayout/NavBar.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/NavBar.tsx
@@ -8,6 +8,7 @@ import {
   ButtonVariant,
 } from '@dailydotdev/shared/src/components/buttons/Button';
 import classNames from 'classnames';
+import { useMobileUxExperiment } from '@dailydotdev/shared/src/hooks/useMobileUxExperiment';
 import styles from './NavBar.module.css';
 
 export type Tab = { path: string; title: string };
@@ -41,14 +42,17 @@ export default function NavBar({
   selectedTab,
   profile,
 }: NavBarProps): ReactElement {
+  const { isNewMobileLayout } = useMobileUxExperiment();
+
   const getTabHref = (tab: Tab) =>
     tab.path.replace('[userId]', profile.username || profile.id);
 
   return (
     <div
       className={classNames(
-        'sticky top-12 z-3 -mt-px flex justify-around bg-background-default tablet:top-14 tablet:justify-start',
+        'sticky top-14 z-3 -mt-px flex justify-around bg-background-default tablet:top-14 tablet:justify-start',
         styles.nav,
+        isNewMobileLayout && 'tablet:!top-0',
       )}
     >
       {tabs.map((tab, index) => (

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -18,6 +18,8 @@ import { NextSeo } from 'next-seo';
 import { NextSeoProps } from 'next-seo/lib/types';
 import { PageWidgets } from '@dailydotdev/shared/src/components/utilities';
 import { useProfile } from '@dailydotdev/shared/src/hooks/profile/useProfile';
+import classNames from 'classnames';
+import { useMobileUxExperiment } from '@dailydotdev/shared/src/hooks/useMobileUxExperiment';
 import { getLayout as getFooterNavBarLayout } from '../FooterNavBarLayout';
 import { getLayout as getMainLayout } from '../MainLayout';
 import NavBar, { tabs } from './NavBar';
@@ -43,6 +45,7 @@ export default function ProfileLayout({
   const router = useRouter();
   const { isFallback } = router;
   const user = useProfile(initialUser);
+  const { isNewMobileLayout } = useMobileUxExperiment();
 
   if (!isFallback && !user) {
     return <Custom404 />;
@@ -75,7 +78,12 @@ export default function ProfileLayout({
   };
 
   return (
-    <div className="m-auto flex w-full max-w-screen-laptop flex-col pb-12 tablet:flex-row tablet:pb-0 laptop:min-h-page laptop:border-l laptop:border-r laptop:border-theme-divider-tertiary laptop:pb-6 laptopL:pb-0">
+    <div
+      className={classNames(
+        'm-auto flex w-full max-w-screen-laptop flex-col pb-12 tablet:flex-row tablet:pb-0 laptop:min-h-page laptop:border-l laptop:border-r laptop:border-theme-divider-tertiary laptop:pb-6 laptopL:pb-0',
+        isNewMobileLayout && 'tablet:pl-16',
+      )}
+    >
       <Head>
         <link rel="preload" as="image" href={user.image} />
       </Head>

--- a/packages/webapp/pages/history.tsx
+++ b/packages/webapp/pages/history.tsx
@@ -6,10 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { NextSeo } from 'next-seo';
-import {
-  ResponsivePageContainer,
-  SharedFeedPage,
-} from '@dailydotdev/shared/src/components/utilities';
+import { ResponsivePageContainer } from '@dailydotdev/shared/src/components/utilities';
 import { useRouter } from 'next/router';
 import {
   Tab,
@@ -23,12 +20,6 @@ import classNames from 'classnames';
 import { useMobileUxExperiment } from '@dailydotdev/shared/src/hooks/useMobileUxExperiment';
 import { ButtonSize } from '@dailydotdev/shared/src/components/buttons/common';
 import { Dropdown } from '@dailydotdev/shared/src/components/fields/Dropdown';
-import {
-  DiscussIcon,
-  HotIcon,
-  UpvoteIcon,
-} from '@dailydotdev/shared/src/components/icons';
-import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import { HistoryType, ReadingHistory } from '../components/history';
 import ProtectedPage from '../components/ProtectedPage';
 import { getLayout } from '../components/layouts/MainLayout';

--- a/packages/webapp/pages/notifications.tsx
+++ b/packages/webapp/pages/notifications.tsx
@@ -35,6 +35,7 @@ import {
 import { usePromotionModal } from '@dailydotdev/shared/src/hooks/notifications/usePromotionModal';
 import { NotificationPreferenceMenu } from '@dailydotdev/shared/src/components/tooltips/notifications';
 import { usePushNotificationContext } from '@dailydotdev/shared/src/contexts/PushNotificationContext';
+import { useMobileUxExperiment } from '@dailydotdev/shared/src/hooks/useMobileUxExperiment';
 import { getLayout as getFooterNavBarLayout } from '../components/layouts/FooterNavBarLayout';
 import { getLayout } from '../components/layouts/MainLayout';
 import ProtectedPage from '../components/ProtectedPage';
@@ -58,6 +59,8 @@ const Notifications = (): ReactElement => {
   const { trackEvent } = useAnalyticsContext();
   const { clearUnreadCount } = useNotificationContext();
   const { isSubscribed } = usePushNotificationContext();
+  const { isNewMobileLayout } = useMobileUxExperiment();
+
   const { mutateAsync: readNotifications } = useMutation(
     () => request(graphqlUrl, READ_NOTIFICATIONS_MUTATION),
     { onSuccess: clearUnreadCount },
@@ -127,7 +130,12 @@ const Notifications = (): ReactElement => {
   return (
     <ProtectedPage seo={seo}>
       <main
-        className={classNames(pageBorders, pageContainerClassNames, 'pb-12')}
+        className={classNames(
+          pageBorders,
+          pageContainerClassNames,
+          'pb-12',
+          isNewMobileLayout && 'tablet:pl-28',
+        )}
       >
         <EnableNotification />
         <h2

--- a/packages/webapp/pages/squads/[handle]/[token].tsx
+++ b/packages/webapp/pages/squads/[handle]/[token].tsx
@@ -42,6 +42,8 @@ import { useJoinSquad } from '@dailydotdev/shared/src/hooks';
 import { labels } from '@dailydotdev/shared/src/lib';
 import { SimpleSquadJoinButton } from '@dailydotdev/shared/src/components/squads/SquadJoinButton';
 import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
+import classNames from 'classnames';
+import { useMobileUxExperiment } from '@dailydotdev/shared/src/hooks/useMobileUxExperiment';
 import { getLayout } from '../../../components/layouts/MainLayout';
 import { getSquadOpenGraph } from '../../../next-seo';
 
@@ -79,6 +81,7 @@ const SquadReferral = ({
   const { displayToast } = useToastNotification();
   const { showLogin, user: loggedUser } = useAuthContext();
   const [trackedImpression, setTrackedImpression] = useState(false);
+  const { isNewMobileLayout } = useMobileUxExperiment();
   const { data: member, isFetched } = useQuery(
     ['squad_referral', token, loggedUser?.id],
     () => getSquadInvitation(token),
@@ -205,7 +208,12 @@ const SquadReferral = ({
   }
 
   return (
-    <PageContainer className="relative items-center pt-10 tablet:pt-20">
+    <PageContainer
+      className={classNames(
+        'relative items-center pt-10 tablet:pt-20',
+        isNewMobileLayout && 'tablet:pl-16',
+      )}
+    >
       <NextSeo {...seo} />
       <div className="squad-background-fade absolute -top-4 left-0 right-0 h-40 max-w-[100vw] rounded-26 tablet:-left-20 tablet:-right-20" />
       <h1 className="typo-title1">You are invited to join {source.name}</h1>

--- a/packages/webapp/pages/squads/[handle]/edit.tsx
+++ b/packages/webapp/pages/squads/[handle]/edit.tsx
@@ -31,6 +31,8 @@ import {
   generateQueryKey,
   RequestKey,
 } from '@dailydotdev/shared/src/lib/query';
+import classNames from 'classnames';
+import { useMobileUxExperiment } from '@dailydotdev/shared/src/hooks/useMobileUxExperiment';
 import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
 import { getLayout as getMainLayout } from '../../../components/layouts/MainLayout';
 
@@ -55,6 +57,7 @@ const EditSquad = ({ handle }: EditSquadPageProps): ReactElement => {
   const queryClient = useQueryClient();
   const { updateSquad } = useBoot();
   const { displayToast } = useToastNotification();
+  const { isNewMobileLayout } = useMobileUxExperiment();
 
   const onSubmit = async (e, form: SquadForm) => {
     e.preventDefault();
@@ -97,7 +100,9 @@ const EditSquad = ({ handle }: EditSquadPageProps): ReactElement => {
   return (
     <ManageSquadPageContainer>
       <NextSeo {...seo} titleTemplate="%s | daily.dev" noindex nofollow />
-      <ManageSquadPageMain>
+      <ManageSquadPageMain
+        className={classNames(isNewMobileLayout && 'tablet:pl-16')}
+      >
         <ManageSquadPageHeader>
           <Button
             className="mr-2"

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -38,6 +38,7 @@ import { ApiError } from '@dailydotdev/shared/src/graphql/common';
 import { PublicProfile } from '@dailydotdev/shared/src/lib/user';
 import { GET_REFERRING_USER_QUERY } from '@dailydotdev/shared/src/graphql/users';
 import { OtherFeedPage } from '@dailydotdev/shared/src/lib/query';
+import { useMobileUxExperiment } from '@dailydotdev/shared/src/hooks/useMobileUxExperiment';
 import { mainFeedLayoutProps } from '../../../components/layouts/MainFeedPage';
 import { getLayout } from '../../../components/layouts/FeedLayout';
 import ProtectedPage, {
@@ -92,6 +93,7 @@ const SquadPage = ({
   const { user, isFetched: isBootFetched } = useContext(AuthContext);
   const [trackedImpression, setTrackedImpression] = useState(false);
   const { squad, isLoading, isFetched, isForbidden } = useSquad({ handle });
+  const { isNewMobileLayout } = useMobileUxExperiment();
 
   const squadId = squad?.id;
 
@@ -179,7 +181,12 @@ const SquadPage = ({
       fallback={<></>}
       shouldFallback={!user}
     >
-      <BaseFeedPage className="relative mb-4 pt-2 laptop:pt-8">
+      <BaseFeedPage
+        className={classNames(
+          'relative mb-4 pt-2 laptop:pt-8',
+          isNewMobileLayout && 'tablet:pl-16',
+        )}
+      >
         <div
           className={classNames(
             'squad-background-fade absolute top-0 h-full w-full',

--- a/packages/webapp/pages/squads/index.tsx
+++ b/packages/webapp/pages/squads/index.tsx
@@ -42,6 +42,7 @@ import {
   ViewSize,
 } from '@dailydotdev/shared/src/hooks';
 import { Origin } from '@dailydotdev/shared/src/lib/analytics';
+import { useMobileUxExperiment } from '@dailydotdev/shared/src/hooks/useMobileUxExperiment';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
 import FeedLayout, { getLayout } from '../../components/layouts/FeedLayout';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
@@ -62,6 +63,7 @@ const seo: NextSeoProps = {
 const SquadsPage = ({ initialData }: Props): ReactElement => {
   const { user, squads } = useContext(AuthContext);
   const { openNewSquad } = useSquadNavigation();
+  const { isNewMobileLayout } = useMobileUxExperiment();
 
   const queryResult = useInfiniteQuery(
     ['sourcesFeed'],
@@ -87,7 +89,12 @@ const SquadsPage = ({ initialData }: Props): ReactElement => {
       <NextSeo {...seo} />
 
       <FeedLayout>
-        <BaseFeedPage className="relative mb-4 flex-col pt-2 laptop:pt-8">
+        <BaseFeedPage
+          className={classNames(
+            'relative mb-4 flex-col pt-2 laptop:pt-8',
+            isNewMobileLayout && 'tablet:pl-16',
+          )}
+        >
           <span
             className={classNames(
               'flex w-full flex-row items-center justify-between px-4 pb-2 typo-body laptop:hidden',

--- a/packages/webapp/pages/squads/new.tsx
+++ b/packages/webapp/pages/squads/new.tsx
@@ -21,6 +21,8 @@ import { MangeSquadPageSkeleton } from '@dailydotdev/shared/src/components/squad
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import { ActionType } from '@dailydotdev/shared/src/graphql/actions';
 import { useActions } from '@dailydotdev/shared/src/hooks/useActions';
+import { useMobileUxExperiment } from '@dailydotdev/shared/src/hooks/useMobileUxExperiment';
+import classNames from 'classnames';
 import { getLayout as getMainLayout } from '../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 
@@ -39,6 +41,7 @@ const NewSquad = (): ReactElement => {
   const { displayToast } = useToastNotification();
   const { addSquad } = useBoot();
   const { completeAction } = useActions();
+  const { isNewMobileLayout } = useMobileUxExperiment();
   const [form] = useState<Partial<SquadForm>>({
     public: false,
   });
@@ -78,7 +81,9 @@ const NewSquad = (): ReactElement => {
   return (
     <ManageSquadPageContainer>
       <NextSeo {...seo} titleTemplate="%s | daily.dev" noindex nofollow />
-      <ManageSquadPageMain>
+      <ManageSquadPageMain
+        className={classNames(isNewMobileLayout && 'tablet:pl-16')}
+      >
         <div
           style={{
             backgroundImage: `url(${cloudinary.squads.createSquad})`,


### PR DESCRIPTION
## Changes
- adding a `FeedNav` at the top of the feed layout
- updating footer nav items
- moving reading streaks to the top of the `for you` feed

TODO:
- [x] go through all pages and make sure the layout is not broken
- [x] validate the previous layout still looks the same if the feature flag is disabled


## Previews

<img width="1001" alt="Screenshot 2024-03-25 at 10 20 32" src="https://github.com/dailydotdev/apps/assets/1225100/065f26ff-0c9f-4172-a129-0bfd379abd98">

---

<img width="509" alt="Screenshot 2024-03-25 at 10 20 20" src="https://github.com/dailydotdev/apps/assets/1225100/69143ba5-8d3b-4387-bc74-8bac13d4d7f4">

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-130


### Preview domain
https://mi-130-layout-feed.preview.app.daily.dev