### PR TITLE
fix: accidently added version to this query

### DIFF
--- a/packages/shared/src/graphql/search.ts
+++ b/packages/shared/src/graphql/search.ts
@@ -95,8 +95,8 @@ export const SEARCH_POST_RECOMMENDATION = gql`
 `;
 
 export const SEARCH_SESSION_QUERY = gql`
-  query SearchSession($id: String!, $version: Int) {
-    searchSession(id: $id, version: $version) {
+  query SearchSession($id: String!) {
+    searchSession(id: $id) {
       id
       createdAt
       chunks {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- This endpoint doesn't have version, must have missed this in my implementation

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://hotfix-remove-version-search-session.preview.app.daily.dev