### PR TITLE
fix: squads dropdown

### DIFF
--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -34,17 +34,18 @@ interface ClassName {
   overlay?: string;
   drawer?: string;
   close?: string;
+  title?: string;
 }
 
 export interface DrawerProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'className'> {
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'title'> {
   children: ReactNode;
   className?: ClassName;
   position?: DrawerPosition;
   closeOnOutsideClick?: boolean;
   isFullScreen?: boolean;
   isClosing?: boolean;
-  title?: string;
+  title?: ReactNode;
   onClose: PopupCloseFunc;
   displayCloseButton?: boolean;
 }
@@ -116,7 +117,12 @@ function BaseDrawer({
         }}
       >
         {title && (
-          <h3 className="border-b border-theme-divider-tertiary p-4 font-bold typo-title3">
+          <h3
+            className={classNames(
+              'flex flex-row items-center border-b border-theme-divider-tertiary p-4 font-bold typo-title3',
+              className?.title,
+            )}
+          >
             {title}
           </h3>
         )}

--- a/packages/shared/src/components/drawers/ListDrawer.tsx
+++ b/packages/shared/src/components/drawers/ListDrawer.tsx
@@ -8,6 +8,7 @@ interface ListDrawerProps extends Pick<ListDrawerItemProps, 'customItem'> {
   options: string[];
   selected: number; // index
   onSelectedChange(props: SelectParams): void;
+  shouldIndicateSelected?: boolean;
 }
 
 export function ListDrawer({
@@ -16,6 +17,7 @@ export function ListDrawer({
   selected,
   options,
   customItem,
+  shouldIndicateSelected,
 }: ListDrawerProps): ReactElement {
   const ref = React.useRef<DrawerRef>();
 
@@ -27,7 +29,9 @@ export function ListDrawer({
           value={value}
           index={index}
           customItem={customItem}
-          isSelected={index === selected}
+          isSelected={
+            shouldIndicateSelected === false ? false : index === selected
+          }
           onClick={(params) => {
             onSelectedChange({ ...params, index });
             ref.current?.onClose();

--- a/packages/shared/src/components/drawers/ListDrawerItem.tsx
+++ b/packages/shared/src/components/drawers/ListDrawerItem.tsx
@@ -27,7 +27,7 @@ export function ListDrawerItem({
       role="menuitem"
       type="button"
       className={classNames(
-        'flex flex-row items-center overflow-hidden text-ellipsis whitespace-nowrap p-2 typo-callout',
+        'flex min-h-[2.5rem] flex-row items-center overflow-hidden text-ellipsis whitespace-nowrap px-2 typo-callout',
         isSelected ? 'font-bold' : 'text-theme-label-tertiary',
       )}
       onClick={(event) => onClick({ value, event })}

--- a/packages/shared/src/components/drawers/ListDrawerItem.tsx
+++ b/packages/shared/src/components/drawers/ListDrawerItem.tsx
@@ -27,7 +27,7 @@ export function ListDrawerItem({
       role="menuitem"
       type="button"
       className={classNames(
-        'flex h-10 flex-row items-center overflow-hidden text-ellipsis whitespace-nowrap px-2 typo-callout',
+        'flex flex-row items-center overflow-hidden text-ellipsis whitespace-nowrap px-2 py-2 typo-callout',
         isSelected ? 'font-bold' : 'text-theme-label-tertiary',
       )}
       onClick={(event) => onClick({ value, event })}

--- a/packages/shared/src/components/drawers/ListDrawerItem.tsx
+++ b/packages/shared/src/components/drawers/ListDrawerItem.tsx
@@ -27,7 +27,7 @@ export function ListDrawerItem({
       role="menuitem"
       type="button"
       className={classNames(
-        'flex flex-row items-center overflow-hidden text-ellipsis whitespace-nowrap px-2 py-2 typo-callout',
+        'flex flex-row items-center overflow-hidden text-ellipsis whitespace-nowrap p-2 typo-callout',
         isSelected ? 'font-bold' : 'text-theme-label-tertiary',
       )}
       onClick={(event) => onClick({ value, event })}

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -19,6 +19,7 @@ import { ListDrawer } from '../drawers/ListDrawer';
 import { SelectParams } from '../drawers/common';
 import { RootPortal } from '../tooltips/Portal';
 import { DrawerProps } from '../drawers';
+import { Button, ButtonSize } from '../buttons/Button';
 
 interface ClassName {
   container?: string;
@@ -164,11 +165,23 @@ export function Dropdown({
               ...drawerProps,
               isOpen: isVisible,
               onClose: () => setVisibility(false),
+              title: drawerProps?.title ? (
+                <>
+                  <Button
+                    size={ButtonSize.Small}
+                    className="mr-2"
+                    icon={<ArrowIcon className="-rotate-90" secondary />}
+                    onClick={handleMenuTrigger}
+                  />
+                  {drawerProps.title}
+                </>
+              ) : null,
             }}
             options={options}
             customItem={renderItem}
             selected={selectedIndex}
             onSelectedChange={handleChange}
+            shouldIndicateSelected={shouldIndicateSelected}
           />
         </RootPortal>
       ) : (

--- a/packages/shared/src/components/post/write/SquadsDropdown.tsx
+++ b/packages/shared/src/components/post/write/SquadsDropdown.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import { SourceAvatar, SourceShortInfo } from '../../profile/source';
-import { SquadIcon } from '../../icons';
+import { ArrowIcon, SquadIcon } from '../../icons';
 import { Dropdown } from '../../fields/Dropdown';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { verifyPermission } from '../../../graphql/squads';
@@ -25,7 +25,14 @@ export function SquadsDropdown({
   const renderDropdownItem = (value: string, index: number) => {
     const source = activeSquads[index];
 
-    return <SourceShortInfo source={source} className="pl-1" />;
+    return (
+      <SourceShortInfo
+        source={source}
+        className="w-full items-center pl-1 tablet:w-auto"
+      >
+        <ArrowIcon className="ml-auto rotate-90" secondary />
+      </SourceShortInfo>
+    );
   };
 
   return (
@@ -44,13 +51,18 @@ export function SquadsDropdown({
         menu: 'menu-secondary',
         item: 'h-auto',
       }}
+      shouldIndicateSelected={false}
       selectedIndex={selected}
       onChange={(_, index) => onSelect(index)}
       options={squadsList}
       scrollable
       data-testid="timezone_dropdown"
       renderItem={renderDropdownItem}
-      drawerProps={{ isFullScreen: true }}
+      drawerProps={{
+        isFullScreen: true,
+        title: 'Choose a Squad',
+        className: { drawer: 'p-0 pr-2 gap-4', title: 'mb-4' },
+      }}
     />
   );
 }

--- a/packages/shared/src/components/post/write/SquadsDropdown.tsx
+++ b/packages/shared/src/components/post/write/SquadsDropdown.tsx
@@ -6,6 +6,7 @@ import { useAuthContext } from '../../../contexts/AuthContext';
 import { verifyPermission } from '../../../graphql/squads';
 import { SourcePermissions } from '../../../graphql/sources';
 import { ButtonSize } from '../../buttons/common';
+import { useViewSize, ViewSize } from '../../../hooks';
 
 interface SquadsDropdownProps {
   onSelect: (index: number) => void;
@@ -17,6 +18,7 @@ export function SquadsDropdown({
   selected,
 }: SquadsDropdownProps): ReactElement {
   const { squads } = useAuthContext();
+  const isMobile = useViewSize(ViewSize.MobileL);
   const activeSquads = squads?.filter(
     (squad) => squad?.active && verifyPermission(squad, SourcePermissions.Post),
   );
@@ -28,7 +30,8 @@ export function SquadsDropdown({
     return (
       <SourceShortInfo
         source={source}
-        className="w-full items-center pl-1 tablet:w-auto"
+        size={isMobile ? 'xxlarge' : undefined}
+        className="w-full items-center pl-1 tablet:w-auto tablet:py-3"
       >
         <ArrowIcon className="ml-auto rotate-90" secondary />
       </SourceShortInfo>
@@ -61,7 +64,7 @@ export function SquadsDropdown({
       drawerProps={{
         isFullScreen: true,
         title: 'Choose a Squad',
-        className: { drawer: 'p-0 pr-2 gap-4', title: 'mb-4' },
+        className: { drawer: 'p-0 pr-2', title: 'mb-4' },
       }}
     />
   );

--- a/packages/shared/src/components/post/write/SquadsDropdown.tsx
+++ b/packages/shared/src/components/post/write/SquadsDropdown.tsx
@@ -64,7 +64,7 @@ export function SquadsDropdown({
       drawerProps={{
         isFullScreen: true,
         title: 'Choose a Squad',
-        className: { drawer: 'p-0 pr-2', title: 'mb-4' },
+        className: { drawer: 'p-0 pr-2 gap-3', title: 'mb-4' },
       }}
     />
   );

--- a/packages/shared/src/components/profile/source/SourceShortInfo.tsx
+++ b/packages/shared/src/components/profile/source/SourceShortInfo.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
 import { Source } from '../../../graphql/sources';
 import { FlexRow } from '../../utilities';
@@ -7,11 +7,13 @@ import { SourceAvatar } from './SourceAvatar';
 interface SourceShortInfoProps {
   source: Source;
   className?: string;
+  children?: ReactNode;
 }
 
 export function SourceShortInfo({
   source,
   className,
+  children,
 }: SourceShortInfoProps): ReactElement {
   if (!source) {
     return null;
@@ -24,6 +26,7 @@ export function SourceShortInfo({
         <h3 className="font-bold">{source.name}</h3>
         <p className="text-theme-label-quaternary">@{source.handle}</p>
       </span>
+      {children}
     </FlexRow>
   );
 }

--- a/packages/shared/src/components/profile/source/SourceShortInfo.tsx
+++ b/packages/shared/src/components/profile/source/SourceShortInfo.tsx
@@ -1,27 +1,29 @@
 import React, { ReactElement, ReactNode } from 'react';
-import classNames from 'classnames';
 import { Source } from '../../../graphql/sources';
 import { FlexRow } from '../../utilities';
 import { SourceAvatar } from './SourceAvatar';
+import { ProfileImageSize } from '../../ProfilePicture';
 
 interface SourceShortInfoProps {
   source: Source;
   className?: string;
   children?: ReactNode;
+  size?: ProfileImageSize;
 }
 
 export function SourceShortInfo({
   source,
   className,
   children,
+  size,
 }: SourceShortInfoProps): ReactElement {
   if (!source) {
     return null;
   }
 
   return (
-    <FlexRow className={classNames('py-3', className)}>
-      <SourceAvatar source={source} />
+    <FlexRow className={className}>
+      <SourceAvatar source={source} size={size} />
       <span className="flex flex-col typo-callout">
         <h3 className="font-bold">{source.name}</h3>
         <p className="text-theme-label-quaternary">@{source.handle}</p>


### PR DESCRIPTION
## Changes
- The dropdown for selecting Squads behave differently and should use the fullscreen as opposed to most of our dropdowns.

P.S. not a fan.

![Screenshot 2024-03-25 at 11 57 28 PM](https://github.com/dailydotdev/apps/assets/13744167/1c6c9f7a-b9cd-43c6-a51e-9b5093ea1085)

![Screenshot 2024-03-25 at 11 47 52 PM](https://github.com/dailydotdev/apps/assets/13744167/016284be-5352-4b50-b9f8-34f8696eea26)

![Screenshot 2024-03-25 at 11 48 01 PM](https://github.com/dailydotdev/apps/assets/13744167/2d3672cd-058d-47ac-8899-77804dcc30e4)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-squads-dropdown.preview.app.daily.dev