### PR TITLE
fix: go back navigation

### DIFF
--- a/packages/shared/src/components/post/PostContentHeaderMobile.tsx
+++ b/packages/shared/src/components/post/PostContentHeaderMobile.tsx
@@ -12,10 +12,10 @@ export function PostContentHeaderMobile({
 }: Pick<PostNavigationProps, 'onReadArticle' | 'post'>): ReactElement {
   const router = useRouter();
   const canGoBack =
-    globalThis?.history &&
-    !!globalThis.history.length &&
+    !!globalThis?.history?.length &&
+    globalThis?.history?.state &&
     isNullOrUndefined(globalThis.history.state.options.shallow) &&
-    !globalThis.document.referrer; // empty referrer means you are from the same site
+    !globalThis?.document?.referrer; // empty referrer means you are from the same site
 
   return (
     <span className="-mx-4 flex flex-row items-center border-b border-border-subtlest-tertiary px-4 py-2 tablet:hidden">

--- a/packages/shared/src/components/post/PostContentHeaderMobile.tsx
+++ b/packages/shared/src/components/post/PostContentHeaderMobile.tsx
@@ -4,32 +4,18 @@ import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { ArrowIcon } from '../icons';
 import { PostHeaderActions } from './PostHeaderActions';
 import { PostNavigationProps } from './common';
-import { SourceType } from '../../graphql/sources';
+import { isNullOrUndefined } from '../../lib/func';
 
 export function PostContentHeaderMobile({
   post,
   onReadArticle,
 }: Pick<PostNavigationProps, 'onReadArticle' | 'post'>): ReactElement {
   const router = useRouter();
-  const canGoBack = !!globalThis?.window?.history?.length;
-  const routedFromSquad = router?.query?.squad;
-  const squadLink = `/squads/${router.query.squad}`;
-
-  const onBackClick = () => {
-    if (canGoBack) {
-      return router.back();
-    }
-
-    if (routedFromSquad) {
-      return router.push(squadLink);
-    }
-
-    if (post.source.type === SourceType.Squad) {
-      return router.push(post.source.permalink);
-    }
-
-    return null;
-  };
+  const canGoBack =
+    globalThis?.history &&
+    !!globalThis.history.length &&
+    isNullOrUndefined(globalThis.history.state.options.shallow) &&
+    !globalThis.document.referrer; // empty referrer means you are from the same site
 
   return (
     <span className="-mx-4 flex flex-row items-center border-b border-border-subtlest-tertiary px-4 py-2 tablet:hidden">
@@ -37,13 +23,8 @@ export function PostContentHeaderMobile({
         icon={<ArrowIcon className="-rotate-90" />}
         size={ButtonSize.Small}
         variant={ButtonVariant.Tertiary}
-        onClick={onBackClick}
-        className={
-          !canGoBack &&
-          !routedFromSquad &&
-          post.source.type !== SourceType.Squad &&
-          'invisible'
-        }
+        onClick={router.back}
+        className={!canGoBack && 'invisible'}
       />
       <PostHeaderActions
         post={post}


### PR DESCRIPTION
## Changes
- The back button should purely act as the history back button.
- Thread: https://dailydotdev.slack.com/archives/C0650M2KX8E/p1711444583148789?thread_ts=1711372461.259189&cid=C0650M2KX8E

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-navigation.preview.app.daily.dev