### PR TITLE
fix: header spacing on both squad and collections posts.

### DIFF
--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -86,6 +86,7 @@ function SquadPostContent({
         className={classNames(
           'relative flex-1 flex-col tablet:flex-row tablet:pb-0',
           className?.container,
+          isPostPage && 'pt-6 tablet:pt-0',
         )}
         hasNavigation={hasNavigation}
       >

--- a/packages/shared/src/components/post/collection/CollectionPostContent.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPostContent.tsx
@@ -98,15 +98,6 @@ export const CollectionPostContent = ({
         className={classNames('relative', className?.content)}
         data-testid="postContainer"
       >
-        {!hasNavigation && (
-          <CollectionPostHeaderActions
-            post={post}
-            onClose={onClose}
-            className="flex tablet:hidden"
-            contextMenuId="post-widgets-context"
-          />
-        )}
-
         <BasePostContent
           className={{
             ...className,


### PR DESCRIPTION
## Changes
- Since our new header navigation has all the necessary actions, the old one is not needed anymore.
- Fixed squad post spacing.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-242 #done
