### PR TITLE
fix: correctly ignore webapp for companion boot

### DIFF
--- a/packages/extension/src/background/index.ts
+++ b/packages/extension/src/background/index.ts
@@ -17,7 +17,7 @@ const client = new GraphQLClient(graphqlUrl, { fetch: globalThis.fetch });
 const excludedCompanionOrigins = [
   'http://127.0.0.1:5002',
   'http://localhost',
-  'http://app.daily.dev',
+  'https://app.daily.dev',
   'https://twitter.com',
   'https://www.google.com',
   'https://stackoverflow.com',


### PR DESCRIPTION
## Changes

I noticed that the companion sends boot requests when you visit the webapp because we check for `http` protocol instead of `https`

### Preview domain
https://ext-ignore-webapp.preview.app.daily.dev