### PR TITLE
refactor: move feed settings from MainFeedLayout to OnboardingFeedHeader

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -52,8 +52,6 @@ import { COMMENT_FEED_QUERY } from '../graphql/comments';
 import { ProfileEmptyScreen } from './profile/ProfileEmptyScreen';
 import { Origin } from '../lib/analytics';
 import { OnboardingFeedHeader } from './onboarding/OnboardingFeedHeader';
-import useFeedSettings from '../hooks/useFeedSettings';
-import { REQUIRED_TAGS_THRESHOLD } from './onboarding/common';
 
 const SearchEmptyScreen = dynamic(
   () =>
@@ -149,7 +147,6 @@ export default function MainFeedLayout({
   const { isUpvoted, isSortableFeed } = useFeedName({ feedName });
   const { shouldUseMobileFeedLayout } = useFeedLayout();
   const [isPreviewFeedVisible, setPreviewFeedVisible] = useState(false);
-  const { feedSettings } = useFeedSettings();
   const shouldUseCommentFeedLayout =
     hasCommentFeed && feedName === SharedFeedPage.Discussed;
   const shouldEnrollInForcedTagSelection =
@@ -295,9 +292,6 @@ export default function MainFeedLayout({
   const disableTopPadding =
     isFinder || shouldUseMobileFeedLayout || shouldUseCommentFeedLayout;
 
-  const tagsCount = feedSettings?.includeTags?.length || 0;
-  const isFeedPreviewEnabled = tagsCount >= REQUIRED_TAGS_THRESHOLD;
-
   return (
     <FeedPageComponent
       className={classNames(
@@ -310,8 +304,6 @@ export default function MainFeedLayout({
         <OnboardingFeedHeader
           isPreviewFeedVisible={isPreviewFeedVisible}
           setPreviewFeedVisible={setPreviewFeedVisible}
-          isFeedPreviewEnabled={isFeedPreviewEnabled}
-          tagsCount={tagsCount}
         />
       )}
       {isSearchOn && search}

--- a/packages/shared/src/components/onboarding/OnboardingFeedHeader.tsx
+++ b/packages/shared/src/components/onboarding/OnboardingFeedHeader.tsx
@@ -17,6 +17,7 @@ import { useMyFeed } from '../../hooks/useMyFeed';
 import { useAlertsContext } from '../../contexts/AlertContext';
 import { useAnalyticsContext } from '../../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../../lib/analytics';
+import useFeedSettings from '../../hooks/useFeedSettings';
 
 const promptConfig = {
   title: 'Discard tag selection?',
@@ -30,21 +31,21 @@ const promptConfig = {
 type OnboardingFeedHeaderProps = {
   isPreviewFeedVisible: boolean;
   setPreviewFeedVisible: React.Dispatch<React.SetStateAction<boolean>>;
-  isFeedPreviewEnabled: boolean;
-  tagsCount: number;
 };
 
 export const OnboardingFeedHeader = ({
   isPreviewFeedVisible,
   setPreviewFeedVisible,
-  isFeedPreviewEnabled,
-  tagsCount,
 }: OnboardingFeedHeaderProps): JSX.Element => {
   const { updateAlerts } = useAlertsContext();
+  const { feedSettings } = useFeedSettings();
   const { trackEvent } = useAnalyticsContext();
   const { showPrompt } = usePrompt();
   const router = useRouter();
   const { registerLocalFilters } = useMyFeed();
+
+  const tagsCount = feedSettings?.includeTags?.length || 0;
+  const isFeedPreviewEnabled = tagsCount >= REQUIRED_TAGS_THRESHOLD;
 
   const completeOnboarding = useCallback(() => {
     registerLocalFilters();


### PR DESCRIPTION
# Changes

Moves `useFeedSettings` from `MainFeedLayout` to `OnboardingFeedHeader`, as it does a query `FeedPreferences` query in every feed right now when it is not needed.