### PR TITLE
fix: comment tracking

### DIFF
--- a/packages/shared/src/components/CommentFeed.tsx
+++ b/packages/shared/src/components/CommentFeed.tsx
@@ -106,7 +106,10 @@ export default function CommentFeed<T>({
               postScoutId={null}
               appendTooltipTo={() => document.body}
               linkToComment
+              lazy
               showContextHeader
+              trackImpression
+              trackClick
             />
           )),
         )}

--- a/packages/shared/src/components/comments/CommentContainer.tsx
+++ b/packages/shared/src/components/comments/CommentContainer.tsx
@@ -35,6 +35,7 @@ export interface CommentContainerProps {
   linkToComment?: boolean;
   showContextHeader?: boolean;
   actions?: ReactNode;
+  onClick?: () => void;
 }
 
 export default function CommentContainer({
@@ -50,6 +51,7 @@ export default function CommentContainer({
   linkToComment,
   showContextHeader,
   actions,
+  onClick,
 }: CommentContainerProps): ReactElement {
   const isCommentReferenced = commentHash === getCommentHash(comment.id);
   const { role } = useMemberRoleForSource({
@@ -71,7 +73,7 @@ export default function CommentContainer({
     >
       {linkToComment && (
         <Link href={comment.permalink} prefetch={false} passHref>
-          <CardLink />
+          <CardLink onClick={onClick} />
         </Link>
       )}
       {children}

--- a/packages/shared/src/lib/analytics.ts
+++ b/packages/shared/src/lib/analytics.ts
@@ -175,6 +175,7 @@ export enum TargetType {
   StreaksMilestone = 'streaks milestone',
   MarketingCtaCard = 'promotion_card',
   MarketingCtaPopover = 'promotion_popover',
+  Comment = 'comment',
 }
 
 export enum TargetId {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added optional impression and click tracking
- Had to modify the inView render a bit as we needed it to be absolute

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
