### PR TITLE
fix: second evaluation would have cache

### DIFF
--- a/packages/shared/src/hooks/useConditionalFeature.ts
+++ b/packages/shared/src/hooks/useConditionalFeature.ts
@@ -35,7 +35,7 @@ export const useConditionalFeature = <T extends JSONValue>({
     queryKey,
     () => {
       if (!shouldEvaluate) {
-        return false as WidenPrimitives<T>;
+        return feature.defaultValue as WidenPrimitives<T>;
       }
       return growthbook
         ? growthbook.getFeatureValue(feature.id, feature.defaultValue)

--- a/packages/shared/src/hooks/useConditionalFeature.ts
+++ b/packages/shared/src/hooks/useConditionalFeature.ts
@@ -24,11 +24,19 @@ export const useConditionalFeature = <T extends JSONValue>({
   const { user } = useContext(AuthContext);
   const { growthbook } = useGrowthBookContext();
   const { ready } = useFeaturesReadyContext();
-  const queryKey = generateQueryKey(RequestKey.Feature, user, feature.id);
+  const queryKey = generateQueryKey(
+    RequestKey.Feature,
+    user,
+    feature.id,
+    shouldEvaluate,
+  );
 
   const { data: featureValue, isLoading } = useQuery(
     queryKey,
     () => {
+      if (!shouldEvaluate) {
+        return false as WidenPrimitives<T>;
+      }
       return growthbook
         ? growthbook.getFeatureValue(feature.id, feature.defaultValue)
         : (feature.defaultValue as WidenPrimitives<T>);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We had a small issue with onboarding if you where in the experiment, then complete onboarding the `shouldEvaluate` becomes false, but it would not retrigger unless you did a hard refresh on the page.
- This introduces a second trigger to always return false when already evaluated and this value changes

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-second-eval-fix.preview.app.daily.dev