### PR TITLE
fix: in forced tag selection we shouldn't auto update

### DIFF
--- a/packages/shared/src/components/onboarding/FilterOnboarding.tsx
+++ b/packages/shared/src/components/onboarding/FilterOnboarding.tsx
@@ -7,6 +7,7 @@ import { Origin } from '../../lib/analytics';
 
 export interface FilterOnboardingProps {
   onSelectedTopics?(tags: Record<string, boolean>): void;
+  shouldUpdateAlerts?: boolean;
   className?: string;
 }
 

--- a/packages/shared/src/components/onboarding/FilterOnboardingV4.tsx
+++ b/packages/shared/src/components/onboarding/FilterOnboardingV4.tsx
@@ -38,6 +38,7 @@ const placeholderTags = new Array(24)
   );
 
 export function FilterOnboardingV4({
+  shouldUpdateAlerts = true,
   className,
 }: FilterOnboardingProps): ReactElement {
   const queryClient = useQueryClient();
@@ -48,7 +49,7 @@ export function FilterOnboardingV4({
   }, [feedSettings?.includeTags]);
   const { onFollowTags, onUnfollowTags } = useTagAndSource({
     origin: Origin.Onboarding,
-    shouldUpdateAlerts: true,
+    shouldUpdateAlerts,
   });
 
   const [refetchFeed] = useDebounce(() => {

--- a/packages/shared/src/components/onboarding/OnboardingFeedHeader.tsx
+++ b/packages/shared/src/components/onboarding/OnboardingFeedHeader.tsx
@@ -116,7 +116,10 @@ export const OnboardingFeedHeader = ({
       </div>
 
       <div className="flex w-full max-w-full flex-col">
-        <FilterOnboardingV4 className="mt-44 px-4 pt-6 tablet:px-10 tablet:pt-0" />
+        <FilterOnboardingV4
+          className="mt-44 px-4 pt-6 tablet:px-10 tablet:pt-0"
+          shouldUpdateAlerts={false}
+        />
         <div className="mt-10 flex items-center justify-center gap-10 text-text-quaternary typo-callout">
           <div className="h-px flex-1 bg-theme-divider-tertiary" />
           <Button


### PR DESCRIPTION
## Changes

### Describe what this PR does
- In forced tag selection we wan't to make sure users follow the picking of 5 tags before they can get enrolled in my feed alert.
- Do note they actually get assigned the tags, but only get my feed trigger once they click the button 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-should-update-optional.preview.app.daily.dev