### PR TITLE
fix: add back previous footer nav items on mobile

### DIFF
--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -6,6 +6,10 @@ import {
   AiIcon,
   SourceIcon,
   UserIcon,
+  BookmarkIcon,
+  SearchIcon,
+  BellIcon,
+  FilterIcon,
 } from '@dailydotdev/shared/src/components/icons';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { useRouter } from 'next/router';
@@ -32,6 +36,9 @@ import { Post } from '@dailydotdev/shared/src/graphql/posts';
 import { NewComment } from '@dailydotdev/shared/src/components/post/NewComment';
 import { CreatePostButton } from '@dailydotdev/shared/src/components/post/write';
 import { LoggedUser } from '@dailydotdev/shared/src/lib/user';
+import { Bubble } from '@dailydotdev/shared/src/components/tooltips/utils';
+import { getUnreadText } from '@dailydotdev/shared/src/components/notifications/utils';
+import { useMobileUxExperiment } from '@dailydotdev/shared/src/hooks/useMobileUxExperiment';
 import styles from './FooterNavBar.module.css';
 
 type Tab = {
@@ -45,7 +52,56 @@ type Tab = {
 };
 
 const notificationsPath = '/notifications';
+
 export const tabs: Tab[] = [
+  {
+    path: '/',
+    title: 'Home',
+    icon: (active: boolean) => (
+      <HomeIcon secondary={active} size={IconSize.Medium} />
+    ),
+  },
+  {
+    path: '/bookmarks',
+    title: 'Bookmarks',
+    icon: (active: boolean) => (
+      <BookmarkIcon secondary={active} size={IconSize.Medium} />
+    ),
+    shouldShowLogin: true,
+  },
+  {
+    path: '/search',
+    title: 'Search',
+    icon: (active: boolean) => (
+      <SearchIcon secondary={active} size={IconSize.Medium} />
+    ),
+  },
+  {
+    requiresLogin: true,
+    shouldShowLogin: true,
+    path: notificationsPath,
+    title: 'Notifications',
+    icon: (active: boolean, unreadCount) => (
+      <span className="relative">
+        {unreadCount > 0 ? (
+          <Bubble className="right-0 top-0 translate-x-1/2 px-1">
+            {getUnreadText(unreadCount)}
+          </Bubble>
+        ) : null}
+        <BellIcon secondary={active} size={IconSize.Medium} />
+      </span>
+    ),
+  },
+  {
+    path: '/filters',
+    title: 'Filters',
+    icon: (active: boolean) => (
+      <FilterIcon secondary={active} size={IconSize.Medium} />
+    ),
+  },
+];
+
+export const mobileUxTabs: Tab[] = [
   {
     path: '/',
     title: 'Home',
@@ -102,6 +158,7 @@ export default function FooterNavBar({
   const { trackEvent } = useAnalyticsContext();
   const router = useRouter();
   const selectedTab = tabs.findIndex((tab) => tab.path === router?.pathname);
+  const { isNewMobileLayout } = useMobileUxExperiment();
 
   const buttonProps: ButtonProps<'a' | 'button'> = {
     variant: ButtonVariant.Tertiary,
@@ -149,7 +206,7 @@ export default function FooterNavBar({
           styles.footerNavBar,
         )}
       >
-        {tabs.map(
+        {(isNewMobileLayout ? mobileUxTabs : tabs).map(
           (tab, index) =>
             tab.component ||
             (tab.requiresLogin && !user ? null : (


### PR DESCRIPTION

## Changes
- set the new navigation tabs behind a feature flag
- https://dailydotdev.slack.com/archives/C0650M2KX8E/p1711691923737429

<img width="464" alt="Screenshot 2024-03-29 at 08 19 45" src="https://github.com/dailydotdev/apps/assets/1225100/fa6bc1a4-e6c6-43ff-9dff-4312e3a3855a">

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android



### Preview domain
https://130-footer-mobile-behind-feature-flag.preview.app.daily.dev