### PR TITLE
fix: mobile ux layout fixes

### DIFF
--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -173,7 +173,7 @@ export const FeedContainer = ({
                 className={classNames(
                   'flex flex-col rounded-16 border border-theme-divider-tertiary tablet:mt-6',
                   isSearch && 'mt-6',
-                  isNewMobileLayout && 'border-0 mobileL:mt-2 tablet:mt-2',
+                  isNewMobileLayout && '!mt-2 border-0',
                 )}
               >
                 <span className="flex w-full flex-row items-center justify-between px-6 py-4">

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -173,6 +173,7 @@ export const FeedContainer = ({
                 className={classNames(
                   'flex flex-col rounded-16 border border-theme-divider-tertiary tablet:mt-6',
                   isSearch && 'mt-6',
+                  isNewMobileLayout && 'border-0 mobileL:mt-2 tablet:mt-2',
                 )}
               >
                 <span className="flex w-full flex-row items-center justify-between px-6 py-4">

--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -51,7 +51,7 @@ function FeedNav(): ReactElement {
         <Tab label={FeedNavTab.History} url="/history" />
       </TabContainer>
 
-      <div className="fixed right-0 top-0 my-1 flex h-12 w-36 items-center justify-end bg-gradient-to-r from-transparent via-background-default via-60% to-background-default pr-1">
+      <div className="fixed right-0 top-0 my-1 flex h-12 w-20 items-center justify-end bg-gradient-to-r from-transparent via-background-default via-40% to-background-default pr-1">
         <NotificationsBell compact />
       </div>
     </div>

--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -41,7 +41,7 @@ function FeedNav(): ReactElement {
       <TabContainer
         shouldMountInactive
         className={{
-          header: 'no-scrollbar overflow-x-auto px-1',
+          header: 'no-scrollbar overflow-x-auto px-1 pr-28',
         }}
         tabListProps={{ className: { indicator: '!w-6' } }}
       >
@@ -51,7 +51,7 @@ function FeedNav(): ReactElement {
         <Tab label={FeedNavTab.History} url="/history" />
       </TabContainer>
 
-      <div className="fixed right-0 top-0 my-1 mr-1 flex h-12 w-36 items-center justify-end bg-gradient-to-r from-transparent via-background-default via-60% to-background-default">
+      <div className="fixed right-0 top-0 my-1 flex h-12 w-36 items-center justify-end bg-gradient-to-r from-transparent via-background-default via-60% to-background-default pr-1">
         <NotificationsBell compact />
       </div>
     </div>

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -106,15 +106,17 @@ export const SearchControlHeader = ({
       condition={isNewMobileLayout}
       wrapper={(children) => (
         <div className="flex w-full items-center justify-between">
-          {isPopular || isUpvoted || isDiscussed ? (
-            <FeedSelector />
-          ) : (
-            isStreaksEnabled && (
-              <ReadingStreakButton streak={streak} isLoading={isLoading} />
-            )
-          )}
+          <div className="flex-0">
+            {isPopular || isUpvoted || isDiscussed ? (
+              <FeedSelector />
+            ) : (
+              isStreaksEnabled && (
+                <ReadingStreakButton streak={streak} isLoading={isLoading} />
+              )
+            )}
+          </div>
 
-          <div>{children}</div>
+          <div className="flex gap-2">{children}</div>
         </div>
       )}
     >

--- a/packages/shared/src/components/notifications/NotificationsBell.tsx
+++ b/packages/shared/src/components/notifications/NotificationsBell.tsx
@@ -40,6 +40,7 @@ function NotificationsBell({ compact }: { compact?: boolean }): ReactElement {
           variant={
             isNewMobileLayout ? ButtonVariant.Option : ButtonVariant.Float
           }
+          className={classNames(isNewMobileLayout && 'justify-center')}
           onClick={onNavigateNotifications}
           icon={
             <BellIcon


### PR DESCRIPTION
## Changes

Fixes the following:
- [x] The notification button is not having the correct background when active
- [x] Feed actions are not in a single row (sorting enabled)
- [x] Make the tabs header scrollable to access the items in the far right
- [x] Unnecessary margin on the right of the notification bell
- [x] Reduce top spacing on feeds

---

<img width="689" alt="Screenshot 2024-03-29 at 10 09 05" src="https://github.com/dailydotdev/apps/assets/1225100/6fcea8e5-4779-41dd-9e84-033b80e1115f">

---

<img width="689" alt="Screenshot 2024-03-29 at 10 08 55" src="https://github.com/dailydotdev/apps/assets/1225100/03c269df-f947-4bce-a173-bd0955f04633">

---

<img width="689" alt="Screenshot 2024-03-29 at 10 02 56" src="https://github.com/dailydotdev/apps/assets/1225100/e8b34455-400f-4adc-b120-91ec3bfbfc0f">

---

<img width="689" alt="Screenshot 2024-03-29 at 10 15 06" src="https://github.com/dailydotdev/apps/assets/1225100/8f755334-3c97-48bf-a759-ee7cc0c80de6">

## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-252


### Preview domain
https://mi-252-mobile-layout-fixes.preview.app.daily.dev