### PR TITLE
fix: render search bar on the new mobile layout

### DIFF
--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -95,8 +95,31 @@ function MainLayoutHeader({
     );
   };
 
+  const RenderSearchPanel = () =>
+    !!user && (
+      <SearchPanel
+        className={{
+          container: classNames(
+            'mx-auto bg-background-default py-3 laptop:bg-transparent',
+            isNewMobileLayout
+              ? 'left-0 top-0 z-header tablet:left-16'
+              : 'left-0 top-14',
+            isSearchPage
+              ? 'absolute right-0 laptop:relative laptop:top-0'
+              : 'hidden laptop:flex',
+          ),
+          field: 'mx-2 laptop:mx-auto',
+        }}
+      />
+    );
+
   if (isNewMobileLayout) {
-    return <FeedNav />;
+    return (
+      <>
+        <FeedNav />
+        <RenderSearchPanel />
+      </>
+    );
   }
 
   return (
@@ -132,19 +155,7 @@ function MainLayoutHeader({
               greeting={false}
             />
           </div>
-          {!!user && (
-            <SearchPanel
-              className={{
-                container: classNames(
-                  'mx-auto bg-background-default py-3 laptop:bg-transparent',
-                  isSearchPage
-                    ? 'absolute left-0 right-0 top-14 laptop:relative laptop:top-0'
-                    : 'hidden laptop:flex',
-                ),
-                field: 'mx-2 laptop:mx-auto',
-              }}
-            />
-          )}
+          <RenderSearchPanel />
           <RenderButtons />
         </>
       )}


### PR DESCRIPTION
## Changes

- adds back the search bar on mobile/tablet with the new layout

---

<img width="689" alt="Screenshot 2024-03-29 at 12 42 05" src="https://github.com/dailydotdev/apps/assets/1225100/b47084a4-a0dc-4770-88b7-6df8edf21762">

---

<img width="689" alt="Screenshot 2024-03-29 at 12 41 52" src="https://github.com/dailydotdev/apps/assets/1225100/c7f893b4-ee6f-4bcf-96a2-eb03c4077919">


## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-252


### Preview domain
https://mi-252-add-search-panel-to-search-mobile.preview.app.daily.dev