### PR TITLE
fix: add close button to sort drawer and feed selector

### DIFF
--- a/packages/shared/src/components/FeedSelector.tsx
+++ b/packages/shared/src/components/FeedSelector.tsx
@@ -84,6 +84,7 @@ export default function FeedSelector({
       )}
       options={feedOptions.map((f) => f.text)}
       onChange={(feed: SharedFeedPage) => handleSwitchFeed(feed)}
+      drawerProps={{ displayCloseButton: true }}
     />
   );
 }

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -96,6 +96,7 @@ export const SearchControlHeader = ({
         selectedIndex={selectedAlgo}
         options={algorithmsList}
         onChange={(_, index) => setSelectedAlgo(index)}
+        drawerProps={{ displayCloseButton: true }}
       />
     ) : null,
   ];


### PR DESCRIPTION
## Changes
add close button to sort drawer and feed selector

<img width="521" alt="Screenshot 2024-03-29 at 5 01 12 PM" src="https://github.com/dailydotdev/apps/assets/36197304/c87c2553-17f2-4253-a805-fb8bda0191cd">
<img width="497" alt="Screenshot 2024-03-29 at 5 05 58 PM" src="https://github.com/dailydotdev/apps/assets/36197304/6fcbf4d1-4d54-4d0d-be79-76d772e1550c">

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-245 #done


### Preview domain
https://mi-245-sort-drawer.preview.app.daily.dev