### PR TITLE
fix: feed filters open menu by default

### DIFF
--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -29,7 +29,7 @@ type FeedFiltersProps = ModalProps;
 
 export default function FeedFilters(props: FeedFiltersProps): ReactElement {
   const isMobile = useViewSize(ViewSize.MobileL);
-  const [isNavOpen, setIsNavOpen] = useState(false);
+  const [isNavOpen, setIsNavOpen] = useState(true);
   const { showPrompt } = usePrompt();
   const unBlockPrompt = async ({ action, source, tag }: UnblockItem) => {
     const description = tag ? (


### PR DESCRIPTION
## Changes
- Open the menu by default.


Uploading Screen Recording 2024-04-01 at 6.13.48 PM.mov…



## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-244 #done
