### PR TITLE
fix: adjust discussed feed styles to match new mobile UX

### DIFF
--- a/packages/shared/src/components/CommentFeed.tsx
+++ b/packages/shared/src/components/CommentFeed.tsx
@@ -103,10 +103,7 @@ export default function CommentFeed<T>({
         isFetchingNextPage={queryResult.isFetchingNextPage}
         canFetchMore={checkFetchMore(queryResult)}
         fetchNextPage={queryResult.fetchNextPage}
-        className={classNames(
-          'w-full',
-          isNewMobileLayout && isMainFeed && 'px-4',
-        )}
+        className="w-full"
       >
         {queryResult.data.pages.flatMap((page) =>
           page.page.edges.map(({ node }, index) => (

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -117,7 +117,7 @@ const getQueryBasedOnLogin = (
 const DEFAULT_ALGORITHM_KEY = 'feed:algorithm';
 
 const commentClassName = {
-  container: 'rounded-none border-0 border-b border-x',
+  container: 'rounded-none border-0 border-b tablet:border-x',
   commentBox: {
     container: 'relative border-0 rounded-none',
   },

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -113,7 +113,7 @@ export default function Sidebar({
       variant: ButtonVariant.Tertiary,
       size: ButtonSize.Large,
       className:
-        'w-full !bg-transparent active:bg-transparent aria-pressed:bg-transparent typo-caption2',
+        'w-full !bg-transparent active:bg-transparent aria-pressed:bg-transparent typo-caption1',
     };
 
     return (

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -113,7 +113,7 @@ export default function Sidebar({
       variant: ButtonVariant.Tertiary,
       size: ButtonSize.Large,
       className:
-        'w-full !bg-transparent active:bg-transparent aria-pressed:bg-transparent',
+        'w-full !bg-transparent active:bg-transparent aria-pressed:bg-transparent typo-caption2',
     };
 
     return (


### PR DESCRIPTION
## Changes

### New UI

<img width="726" alt="Screenshot 2024-04-01 at 14 15 40" src="https://github.com/dailydotdev/apps/assets/1225100/f5821504-7bdd-4377-9843-d573541eba8b">

### Previous UI

<img width="688" alt="Screenshot 2024-04-02 at 12 24 32" src="https://github.com/dailydotdev/apps/assets/1225100/812e7181-d4b5-4d5d-98be-5f5395cccce6">

---

### New UI

<img width="967" alt="Screenshot 2024-04-01 at 14 14 12" src="https://github.com/dailydotdev/apps/assets/1225100/1e2dc542-2090-4047-a094-04aad199349c">

### Previous UI

<img width="1177" alt="Screenshot 2024-04-02 at 12 24 53" src="https://github.com/dailydotdev/apps/assets/1225100/c1d2bc28-b66c-4da6-b1e2-6a5d5163d68e">

## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-252
