### PR TITLE
fix: back button on account settings

### DIFF
--- a/packages/shared/src/components/drawers/NavDrawer.tsx
+++ b/packages/shared/src/components/drawers/NavDrawer.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from 'react';
+import { useRouter } from 'next/router';
 import {
   Drawer,
   DrawerPosition,
@@ -14,6 +15,7 @@ interface NavDrawerProps {
   drawerProps: Omit<DrawerWrapperProps, 'children'>;
   items: NavItemProps[];
   header?: string;
+  shouldGoBack?: boolean;
 }
 
 const NavDrawerHeader = classed(
@@ -29,7 +31,9 @@ export function NavDrawer({
   drawerProps,
   header,
   items,
+  shouldGoBack,
 }: NavDrawerProps): ReactElement {
+  const router = useRouter();
   const ref = React.useRef<DrawerRef>();
   const {
     position,
@@ -56,7 +60,7 @@ export function NavDrawer({
           <Button
             variant={ButtonVariant.Tertiary}
             size={ButtonSize.Small}
-            onClick={() => ref.current?.onClose()}
+            onClick={shouldGoBack ? router.back : ref.current?.onClose}
             icon={<ArrowIcon className="-rotate-90" />}
           />
           <NavHeading>{header}</NavHeading>

--- a/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
+++ b/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
@@ -28,6 +28,7 @@ import type { LazyModalType } from '../modals/common';
 import { anchorDefaultRel } from '../../lib/strings';
 import type { NavItemProps } from '../drawers/NavDrawerItem';
 import { LogoutReason } from '../../lib/user';
+import { isNullOrUndefined } from '../../lib/func';
 
 const createMenuItems = (
   logout: (reason: string) => Promise<void>,
@@ -123,7 +124,7 @@ const createMenuItems = (
 interface ProfileSettingsMenuProps {
   isOpen: boolean;
   logout?: (reason: string) => Promise<void>;
-  onClose: () => void;
+  onClose?: () => void;
 }
 
 export function ProfileSettingsMenu({
@@ -141,6 +142,7 @@ export function ProfileSettingsMenu({
   return (
     <NavDrawer
       header="Settings"
+      shouldGoBack={isNullOrUndefined(onClose)}
       drawerProps={{
         isOpen,
         onClose,

--- a/packages/webapp/components/layouts/AccountLayout/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, useContext } from 'react';
+import React, { ReactElement, ReactNode, useContext, useEffect } from 'react';
 import { PublicProfile } from '@dailydotdev/shared/src/lib/user';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { NextSeoProps } from 'next-seo/lib/types';
@@ -35,6 +35,12 @@ export default function AccountLayout({
   });
   const isMobile = useViewSize(ViewSize.MobileL);
 
+  useEffect(() => {
+    return () => {
+      setIsOpen(false);
+    };
+  }, [setIsOpen]);
+
   if (!profile || !Object.keys(profile).length || (isFetched && !profile)) {
     return null;
   }
@@ -62,11 +68,7 @@ export default function AccountLayout({
       <NextSeo {...Seo} noindex nofollow />
       <main className="relative mx-auto flex w-full flex-1 flex-row items-stretch pt-0 laptop:max-w-[calc(100vw-17.5rem)]">
         {isMobile ? (
-          <ProfileSettingsMenu
-            isOpen={isOpen}
-            logout={logout}
-            onClose={() => setIsOpen(false)}
-          />
+          <ProfileSettingsMenu isOpen={isOpen} logout={logout} />
         ) : (
           <SidebarNav
             className="absolute z-3 ml-auto h-full w-full border-l border-theme-divider-tertiary bg-background-default tablet:relative tablet:w-[unset]"


### PR DESCRIPTION
## Changes
- Refactored the NavDrawer to make it come from the prop whether the back button should go back or just close the popup.
- This fixes the loop-like experience.

https://github.com/dailydotdev/apps/assets/13744167/96eabba8-cbde-48c1-9271-6d1d891aed77


Preview:


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
