### PR TITLE
fix: cmd/ctrl + enter to submit a comment

### DIFF
--- a/packages/shared/src/components/comments/CommentInputPage.tsx
+++ b/packages/shared/src/components/comments/CommentInputPage.tsx
@@ -1,9 +1,15 @@
-import React, { ReactElement, useEffect, useMemo, useState } from 'react';
+import React, {
+  ReactElement,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import { FormWrapper } from '../fields/form';
 import { CommentMarkdownInput } from '../fields/MarkdownInput/CommentMarkdownInput';
-import { useMutateComment } from '../../hooks/post/useMutateComment';
+import { UseMutateCommentResult } from '../../hooks/post/useMutateComment';
 import { useVisualViewport } from '../../hooks/utils/useVisualViewport';
 import { COMMENT_BY_ID_WITH_POST_QUERY } from '../../graphql/comments';
 import useCommentById from '../../hooks/comments/useCommentById';
@@ -59,13 +65,8 @@ const CommentInputPage = ({
     () => comment?.parent?.id ?? replyCommentId,
     [comment, replyCommentId],
   );
-
-  const { mutateComment, isLoading } = useMutateComment({
-    post,
-    editCommentId: isEdit && editCommentId,
-    parentCommentId,
-    onCommented: router.back,
-  });
+  const mutateRef = useRef<UseMutateCommentResult>();
+  const { mutateComment, isLoading, isSuccess } = mutateRef?.current ?? {};
 
   const { height } = useVisualViewport();
   const replyHeight = height > 0 ? replySize : 0;
@@ -110,6 +111,7 @@ const CommentInputPage = ({
             mutateComment(value);
           },
           loading: isLoading,
+          disabled: isSuccess,
         }}
         className={{
           container: 'flex-1 first:!border-none',

--- a/packages/shared/src/components/fields/MarkdownInput/CommentMarkdownInput.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/CommentMarkdownInput.tsx
@@ -3,6 +3,7 @@ import React, {
   FormEventHandler,
   ReactElement,
   useEffect,
+  useImperativeHandle,
   useRef,
 } from 'react';
 import classNames from 'classnames';
@@ -11,7 +12,10 @@ import MarkdownInput, { MarkdownRef } from './index';
 import { Comment } from '../../../graphql/comments';
 import { formToJson } from '../../../lib/form';
 import { Post } from '../../../graphql/posts';
-import { useMutateComment } from '../../../hooks/post/useMutateComment';
+import {
+  useMutateComment,
+  UseMutateCommentResult,
+} from '../../../hooks/post/useMutateComment';
 
 export interface CommentClassName {
   container?: string;
@@ -36,6 +40,7 @@ export interface CommentMarkdownInputProps {
   showSubmit?: boolean;
   showUserAvatar?: boolean;
   onChange?: (value: string) => void;
+  mutateRef?: React.MutableRefObject<UseMutateCommentResult>;
 }
 
 export function CommentMarkdownInput({
@@ -50,17 +55,22 @@ export function CommentMarkdownInput({
   onChange,
   showSubmit = true,
   showUserAvatar = true,
+  mutateRef,
 }: CommentMarkdownInputProps): ReactElement {
   const postId = post?.id;
   const sourceId = post?.source?.id;
   const markdownRef = useRef<MarkdownRef>();
-
   const { mutateComment, isLoading, isSuccess } = useMutateComment({
     post,
     editCommentId,
     parentCommentId,
     onCommented,
   });
+  useImperativeHandle(mutateRef, () => ({
+    mutateComment,
+    isLoading,
+    isSuccess,
+  }));
 
   const onSubmitForm: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();

--- a/packages/shared/src/hooks/post/useMutateComment.ts
+++ b/packages/shared/src/hooks/post/useMutateComment.ts
@@ -43,7 +43,8 @@ interface UseMutateCommentProps {
 interface MutateCommentResult {
   comment?: Comment;
 }
-interface UseMutateCommentResult {
+
+export interface UseMutateCommentResult {
   mutateComment: (content: string) => Promise<MutateCommentResult>;
   isLoading: boolean;
   isSuccess: boolean;


### PR DESCRIPTION
## Changes
- The primary reason it was not working out of the box was, that there are two instances of the `useCommentHook` and they have their states that manage whether the mutation is loading or done. Even though we have two instances, they are basically the same thing (same result and same props).
- It was just a matter of placement where the button for submission was rendered that made the difference and required two instances.
- To avoid having multiple separate states, we will just pass the ref of the hook being utilized. Otherwise, we will have to introduce a local state and send callbacks to monitor the submission of the form.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-250 #done


### Preview domain
https://mi-250.preview.app.daily.dev