### PR TITLE
feat: add a drawer selector on the mobile main footer action

### DIFF
--- a/packages/shared/src/components/post/write/CreatePostButton.tsx
+++ b/packages/shared/src/components/post/write/CreatePostButton.tsx
@@ -5,7 +5,12 @@ import { useAuthContext } from '../../../contexts/AuthContext';
 import { useSquad, useViewSize, ViewSize } from '../../../hooks';
 import { verifyPermission } from '../../../graphql/squads';
 import { SourcePermissions } from '../../../graphql/sources';
-import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
+import {
+  AllowedTags,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../buttons/Button';
 import { PlusIcon } from '../../icons';
 import ConditionalWrapper from '../../ConditionalWrapper';
 import { SimpleTooltip } from '../../tooltips';
@@ -14,12 +19,14 @@ interface CreatePostButtonProps {
   className?: string;
   compact?: boolean;
   sidebar?: boolean;
+  onClick?: () => void;
 }
 
 export function CreatePostButton({
   className,
   compact,
   sidebar,
+  onClick,
 }: CreatePostButtonProps): ReactElement {
   const { user, squads } = useAuthContext();
   const { route, query } = useRouter();
@@ -50,6 +57,12 @@ export function CreatePostButton({
   const href =
     link.post.create + (squad && allowedToPost ? `?sid=${squad.handle}` : '');
 
+  const buttonProps: {
+    tag?: AllowedTags;
+    href?: string;
+    onClick?: () => void;
+  } = onClick ? { onClick } : { tag: 'a', href };
+
   return (
     <ConditionalWrapper
       condition={compact}
@@ -60,13 +73,12 @@ export function CreatePostButton({
       )}
     >
       <Button
+        {...buttonProps}
         variant={sidebar ? ButtonVariant.Float : ButtonVariant.Secondary}
         className={className}
         disabled={getIsDisabled()}
         icon={compact && <PlusIcon />}
-        tag="a"
         size={isLaptop || sidebar ? ButtonSize.Medium : ButtonSize.Small}
-        href={href}
       >
         {!compact ? 'New post' : null}
       </Button>

--- a/packages/webapp/pages/squads/create.tsx
+++ b/packages/webapp/pages/squads/create.tsx
@@ -21,6 +21,8 @@ import { SquadsDropdown } from '@dailydotdev/shared/src/components/post/write';
 import Unauthorized from '@dailydotdev/shared/src/components/errors/Unauthorized';
 import { verifyPermission } from '@dailydotdev/shared/src/graphql/squads';
 import { SourcePermissions } from '@dailydotdev/shared/src/graphql/sources';
+import { useMobileUxExperiment } from '@dailydotdev/shared/src/hooks/useMobileUxExperiment';
+import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
 import { getLayout as getMainLayout } from '../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 
@@ -45,6 +47,8 @@ function CreatePost(): ReactElement {
   const squad = activeSquads?.[selected];
   const [display, setDisplay] = useState(WriteFormTab.NewPost);
   const { displayToast } = useToastNotification();
+  const { isNewMobileLayout } = useMobileUxExperiment();
+  const isTablet = useViewSize(ViewSize.Tablet);
   const {
     onAskConfirmation,
     draft,
@@ -74,6 +78,7 @@ function CreatePost(): ReactElement {
   });
 
   const param = isRouteReady && activeSquads?.length && (query.sid as string);
+  const shareParam = query.share as string;
 
   useEffect(() => {
     if (!param) {
@@ -85,6 +90,14 @@ function CreatePost(): ReactElement {
     );
     setSelected((value) => (value >= 0 ? value : preselected));
   }, [activeSquads, param]);
+
+  useEffect(() => {
+    if (!shareParam) {
+      return;
+    }
+
+    setDisplay(WriteFormTab.Share);
+  }, [shareParam]);
 
   const onClickSubmit = (e: FormEvent<HTMLFormElement>, params) => {
     if (isPosting || isSuccess) {
@@ -125,12 +138,19 @@ function CreatePost(): ReactElement {
           controlledActive={display}
           shouldMountInactive={false}
           className={{ header: 'px-1' }}
+          showHeader={!isNewMobileLayout || isTablet}
         >
           <Tab label={WriteFormTab.NewPost} className="px-5">
+            {isNewMobileLayout && !isTablet && (
+              <h2 className="pt-2 font-bold typo-title3">New post</h2>
+            )}
             <SquadsDropdown onSelect={setSelected} selected={selected} />
             <WriteFreeformContent className="mt-6" />
           </Tab>
           <Tab label={WriteFormTab.Share} className="px-5">
+            {isNewMobileLayout && !isTablet && (
+              <h2 className="pt-2 font-bold typo-title3">Share a link</h2>
+            )}
             <SquadsDropdown onSelect={setSelected} selected={selected} />
             <ShareLink
               squad={squad}


### PR DESCRIPTION
## Changes

- the drawer is triggered only on mobile and when we are on the new mobile UX implementation

---
### Mobile

https://github.com/dailydotdev/apps/assets/1225100/c2f2d67f-617f-4f1c-84d5-5721e4f7192b

---

### Tablet

<img width="803" alt="Screenshot 2024-04-02 at 07 52 59" src="https://github.com/dailydotdev/apps/assets/1225100/1f45ac39-848e-4e18-b6f1-2a22ea786f8d">


## Events

N / A

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-252


### Preview domain
https://mi-252-mobile-main-action-drawer.preview.app.daily.dev