### PR TITLE
Mi 246 profile page

### DIFF
--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -54,7 +54,7 @@ export function Header({
       )}
       {isSameUser && (
         <Button
-          className="ml-auto mr-2 hidden tablet:flex"
+          className="ml-auto mr-2 hidden laptop:flex"
           variant={ButtonVariant.Float}
           size={ButtonSize.Small}
           tag="a"
@@ -64,7 +64,7 @@ export function Header({
         </Button>
       )}
       <Button
-        className={classNames('ml-auto', isSameUser && 'tablet:ml-0')}
+        className={classNames('ml-auto', isSameUser && 'laptop:ml-0')}
         variant={ButtonVariant.Float}
         size={ButtonSize.Small}
         icon={<ShareIcon />}
@@ -73,7 +73,7 @@ export function Header({
       {isSameUser && (
         <>
           <Button
-            className="ml-2 tablet:hidden"
+            className="ml-2 laptop:hidden"
             variant={ButtonVariant.Float}
             size={ButtonSize.Small}
             icon={<SettingsIcon />}

--- a/packages/shared/src/components/profile/ProfileWidgets.tsx
+++ b/packages/shared/src/components/profile/ProfileWidgets.tsx
@@ -42,7 +42,7 @@ export function ProfileWidgets({
 
   return (
     <div
-      className={classNames('my-4 flex flex-col gap-6 tablet:my-0', className)}
+      className={classNames('my-4 flex flex-col gap-6 laptop:my-0', className)}
     >
       <Header user={user} isSameUser={isSameUser} className="-mb-2" />
       {!hideSticky && (
@@ -98,7 +98,7 @@ export function ProfileWidgets({
         </div>
       )}
       {isSameUser && (
-        <ReferralWidget url={referralUrl} className="hidden tablet:flex" />
+        <ReferralWidget url={referralUrl} className="hidden laptop:flex" />
       )}
     </div>
   );

--- a/packages/shared/src/components/profile/ProfileWidgets.tsx
+++ b/packages/shared/src/components/profile/ProfileWidgets.tsx
@@ -51,7 +51,7 @@ export function ProfileWidgets({
           logout={logout}
           isSameUser={isSameUser}
           sticky
-          className="fixed left-0 top-0 z-3 w-full bg-background-default pl-20 transition-transform duration-75"
+          className="fixed left-0 top-0 z-3 w-full bg-background-default transition-transform duration-75 tablet:pl-20"
           style={{ transform: `translateY(${(stickyProgress - 1) * 100}%)` }}
         />
       )}

--- a/packages/shared/src/components/profile/ProfileWidgets.tsx
+++ b/packages/shared/src/components/profile/ProfileWidgets.tsx
@@ -51,7 +51,7 @@ export function ProfileWidgets({
           logout={logout}
           isSameUser={isSameUser}
           sticky
-          className="fixed left-0 top-0 z-3 w-full bg-background-default transition-transform duration-75"
+          className="fixed left-0 top-0 z-3 w-full bg-background-default pl-20 transition-transform duration-75"
           style={{ transform: `translateY(${(stickyProgress - 1) * 100}%)` }}
         />
       )}

--- a/packages/shared/src/components/profile/SocialChips.tsx
+++ b/packages/shared/src/components/profile/SocialChips.tsx
@@ -61,7 +61,7 @@ export function SocialChips({ links }: SocialChipsProps): ReactElement {
   }
 
   return (
-    <div className="no-scrollbar flex items-center gap-2 overflow-x-auto px-4 tablet:flex-wrap">
+    <div className="no-scrollbar flex items-center gap-2 overflow-x-auto px-4 laptop:flex-wrap">
       {elements}
     </div>
   );

--- a/packages/shared/src/components/profile/SquadsList.tsx
+++ b/packages/shared/src/components/profile/SquadsList.tsx
@@ -186,7 +186,7 @@ export function SquadsList({
   }
 
   return (
-    <div className="no-scrollbar flex items-center gap-2 overflow-x-auto tablet:flex-col tablet:items-stretch tablet:px-4">
+    <div className="no-scrollbar flex items-center gap-2 overflow-x-auto laptop:flex-col laptop:items-stretch laptop:px-4">
       {edges.map(({ node }) => (
         <SquadItem key={node.source.id} membership={node} loading={loading} />
       ))}

--- a/packages/webapp/components/layouts/ProfileLayout/NavBar.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/NavBar.tsx
@@ -50,7 +50,7 @@ export default function NavBar({
   return (
     <div
       className={classNames(
-        'sticky top-14 z-3 -mt-px flex justify-around bg-background-default tablet:top-14 tablet:justify-start',
+        'sticky top-12 z-3 -mt-px flex justify-around bg-background-default tablet:top-14 tablet:justify-start',
         styles.nav,
         isNewMobileLayout && 'tablet:!top-0',
       )}

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -75,7 +75,7 @@ export default function ProfileLayout({
   };
 
   return (
-    <div className="m-auto flex w-full max-w-screen-laptop flex-col pb-12 tablet:flex-row tablet:pb-0 laptop:min-h-page laptop:border-l laptop:border-r laptop:border-theme-divider-tertiary laptop:pb-6 laptopL:pb-0">
+    <div className="m-auto flex w-full max-w-screen-laptop flex-col pb-12 tablet:pb-0 laptop:min-h-page laptop:flex-row laptop:border-l laptop:border-r laptop:border-theme-divider-tertiary laptop:pb-6 laptopL:pb-0">
       <Head>
         <link rel="preload" as="image" href={user.image} />
       </Head>
@@ -86,12 +86,12 @@ export default function ProfileLayout({
           userStats={userStats}
           sources={sources}
           enableSticky
-          className="tablet:hidden"
+          className="laptop:hidden"
         />
         <NavBar selectedTab={selectedTab} profile={user} />
         {children}
       </main>
-      <PageWidgets className="hidden !px-0 tablet:flex">
+      <PageWidgets className="hidden !px-0 laptop:flex">
         <ProfileWidgets
           user={user}
           userStats={userStats}


### PR DESCRIPTION
## Changes
- bring gear icon in profile tablet
- make profile look like in mobile when in tablet
- open the menu like in mobile when clicking gear button in tablet

### Describe what this PR does
This ticket is done based on what was requested in title. 

I noticed that now after opening the new menu with gear like in mobile - if we click on the options, they do not behave like in mobile (customisation is open in a small modal not a full screen one). 

Personally think everything should open like in mobile from that menu, but would suggest also to check with product if we want everything to open like in mobile on that menu. 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-246 #done


### Preview domain
https://mi-246-profile-page.preview.app.daily.dev