### PR TITLE
fix: cleanup source_subscribe experiment (won)

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -56,11 +56,9 @@ import { ActiveFeedContext } from '../contexts';
 import { useAdvancedSettings } from '../hooks/feed';
 import { useFeature } from './GrowthBookProvider';
 import { feature } from '../lib/featureManagement';
-import { SourceSubscribeExperiment } from '../lib/featureValues';
 import { ContextMenu as ContextMenuTypes } from '../hooks/constants';
 import useContextMenu from '../hooks/useContextMenu';
 import { SourceType } from '../graphql/sources';
-import { withExperiment } from './withExperiment';
 
 const ContextMenu = dynamic(
   () => import(/* webpackChunkName: "contextMenu" */ './fields/ContextMenu'),
@@ -84,14 +82,6 @@ export interface PostOptionsMenuProps {
   origin: Origin;
   allowPin?: boolean;
 }
-
-const PostOptionSourceSubscribe = withExperiment(
-  ({ children }: { children: ReactNode }) => <>{children}</>,
-  {
-    feature: feature.sourceSubscribe,
-    value: SourceSubscribeExperiment.V1,
-  },
-);
 
 export default function PostOptionsMenu({
   postIndex,
@@ -364,7 +354,7 @@ export default function PostOptionsMenu({
         sourceSubscribe.isSubscribed ? 'Unsubscribe from' : 'Subscribe to'
       } ${post?.source?.name}`,
       action: sourceSubscribe.isReady ? sourceSubscribe.onSubscribe : undefined,
-      Wrapper: PostOptionSourceSubscribe,
+      Wrapper: ({ children }: { children: ReactNode }) => <>{children}</>,
     });
   }
 

--- a/packages/shared/src/components/post/PostHeaderActions.tsx
+++ b/packages/shared/src/components/post/PostHeaderActions.tsx
@@ -14,31 +14,22 @@ import { PostHeaderActionsProps } from './common';
 import { PostMenuOptions } from './PostMenuOptions';
 import { Origin } from '../../lib/analytics';
 import { CollectionSubscribeButton } from './collection/CollectionSubscribeButton';
-import { SourceSubscribeExperiment } from '../../lib/featureValues';
-import { feature } from '../../lib/featureManagement';
-import { useFeature } from '../GrowthBookProvider';
 import { useViewSize, ViewSize } from '../../hooks';
 
 const Container = classed('div', 'flex flex-row items-center');
 
 interface GetButtonVariantProps {
   inlineActions: boolean;
-  isSourceSubscribeV1: boolean;
 }
 
 const getButtonVariant = ({
   inlineActions,
-  isSourceSubscribeV1,
 }: GetButtonVariantProps): ButtonVariant => {
   if (inlineActions) {
     return ButtonVariant.Tertiary;
   }
 
-  if (isSourceSubscribeV1) {
-    return ButtonVariant.Primary;
-  }
-
-  return ButtonVariant.Secondary;
+  return ButtonVariant.Primary;
 };
 
 export function PostHeaderActions({
@@ -59,9 +50,6 @@ export function PostHeaderActions({
   const isCollection = post?.type === PostType.Collection;
   const isEnlarged = isFixedNavigation || !isMobile;
   const ButtonWithExperiment = () => {
-    const isSourceSubscribeV1 =
-      useFeature(feature.sourceSubscribe) === SourceSubscribeExperiment.V1;
-
     return (
       <SimpleTooltip
         placement="bottom"
@@ -71,7 +59,7 @@ export function PostHeaderActions({
         <Button
           variant={
             isEnlarged
-              ? getButtonVariant({ inlineActions, isSourceSubscribeV1 })
+              ? getButtonVariant({ inlineActions })
               : ButtonVariant.Float
           }
           tag="a"

--- a/packages/shared/src/components/sources/SourceSubscribeButton.tsx
+++ b/packages/shared/src/components/sources/SourceSubscribeButton.tsx
@@ -6,9 +6,6 @@ import { SimpleTooltip } from '../tooltips';
 import { Source } from '../../graphql/sources';
 import { isTesting } from '../../lib/constants';
 import { useSourceSubscription } from '../../hooks';
-import { withExperiment } from '../withExperiment';
-import { feature } from '../../lib/featureManagement';
-import { SourceSubscribeExperiment } from '../../lib/featureValues';
 import { useAuthContext } from '../../contexts/AuthContext';
 
 export type SourceSubscribeButtonProps = {
@@ -86,9 +83,4 @@ const SourceSubscribeButton = ({
   );
 };
 
-const SourceSubscribeButtonExperiment = withExperiment(SourceSubscribeButton, {
-  feature: feature.sourceSubscribe,
-  value: SourceSubscribeExperiment.V1,
-});
-
-export { SourceSubscribeButtonExperiment as SourceSubscribeButton };
+export { SourceSubscribeButton };

--- a/packages/shared/src/components/widgets/PostUsersHighlights.tsx
+++ b/packages/shared/src/components/widgets/PostUsersHighlights.tsx
@@ -13,13 +13,9 @@ import ConditionalWrapper from '../ConditionalWrapper';
 import { ReputationUserBadge } from '../ReputationUserBadge';
 import { SourceSubscribeButton } from '../sources';
 import { ButtonVariant } from '../buttons/common';
-import { useFeature } from '../GrowthBookProvider';
-import { feature } from '../../lib/featureManagement';
-import { SourceSubscribeExperiment } from '../../lib/featureValues';
 import useFeedSettings from '../../hooks/useFeedSettings';
 import EnableNotification from '../notifications/EnableNotification';
 import { NotificationPromptSource } from '../../lib/analytics';
-import { withExperiment } from '../withExperiment';
 import { useSourceSubscription } from '../../hooks';
 
 interface PostAuthorProps {
@@ -104,9 +100,7 @@ const UserHighlight = (props: SourceAuthorProps) => {
   } = props;
   const Icon = getUserIcon(userType);
   const isUserTypeSource = userType === UserType.Source;
-  const isSourceSubscribeV1 =
-    useFeature(feature.sourceSubscribe) === SourceSubscribeExperiment.V1;
-  const { feedSettings } = useFeedSettings({ enabled: isSourceSubscribeV1 });
+  const { feedSettings } = useFeedSettings();
 
   const isSourceBlocked = useMemo(() => {
     if (!isUserTypeSource) {
@@ -189,11 +183,6 @@ const UserHighlight = (props: SourceAuthorProps) => {
   );
 };
 
-const EnableNotificationWithExperiment = withExperiment(EnableNotification, {
-  feature: feature.sourceSubscribe,
-  value: SourceSubscribeExperiment.V1,
-});
-
 const EnableNotificationSourceSubscribe = ({
   source,
 }: Pick<Post, 'source'>) => {
@@ -206,7 +195,7 @@ const EnableNotificationSourceSubscribe = ({
   }
 
   return (
-    <EnableNotificationWithExperiment
+    <EnableNotification
       source={NotificationPromptSource.SourceSubscribe}
       contentName={source.name}
     />

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -4,7 +4,6 @@ import {
   PostPageOnboarding,
   UserAcquisition,
   OnboardingCopy,
-  SourceSubscribeExperiment,
 } from './featureValues';
 import { cloudinary } from './image';
 
@@ -44,10 +43,6 @@ const feature = {
   shareLoops: new Feature('share_loops', false),
   onboardingOnlineUsers: new Feature('onboarding_online_users', false),
   onboardingCopy: new Feature('onboarding_copy', OnboardingCopy.Control),
-  sourceSubscribe: new Feature(
-    'source_subscribe',
-    SourceSubscribeExperiment.Control,
-  ),
   searchVersion: new Feature('search_version', 1),
   commentFeed: new Feature('comment_feed', false),
   forcedTagSelection: new Feature('forced_tag_selection', false),

--- a/packages/shared/src/lib/featureValues.ts
+++ b/packages/shared/src/lib/featureValues.ts
@@ -25,8 +25,3 @@ export enum OnboardingCopy {
   Control = 'control',
   V1 = 'v1',
 }
-
-export enum SourceSubscribeExperiment {
-  Control = 'control',
-  V1 = 'v1',
-}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Cleanup for source_subscribe experiment

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
