### PR TITLE
fix: refactor active states on mobile footer nav

### DIFF
--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -1,10 +1,9 @@
 import classNames from 'classnames';
-import React, { ReactElement, useMemo } from 'react';
+import React, { ReactElement } from 'react';
 import { Tab, TabContainer } from '../tabs/TabContainer';
 import NotificationsBell from '../notifications/NotificationsBell';
 import { useActiveFeedNameContext } from '../../contexts';
-import { SharedFeedPage } from '../utilities';
-import { OtherFeedPage } from '../../lib/query';
+import useActiveNav from '../../hooks/useActiveNav';
 
 enum FeedNavTab {
   ForYou = 'For you',
@@ -15,18 +14,7 @@ enum FeedNavTab {
 
 function FeedNav(): ReactElement {
   const { feedName } = useActiveFeedNameContext();
-
-  const shouldRenderNav = useMemo(() => {
-    return [
-      SharedFeedPage.MyFeed,
-      SharedFeedPage.Popular,
-      SharedFeedPage.Upvoted,
-      SharedFeedPage.Discussed,
-      OtherFeedPage.Bookmarks,
-      OtherFeedPage.History,
-      OtherFeedPage.Notifications,
-    ].includes(feedName);
-  }, [feedName]);
+  const { home: shouldRenderNav } = useActiveNav(feedName);
 
   if (!shouldRenderNav) {
     return null;

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, useContext, useMemo } from 'react';
 import classNames from 'classnames';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 import SettingsContext from '../../contexts/SettingsContext';
 import {
   Nav,
@@ -40,8 +39,7 @@ import {
 import { AiIcon, HomeIcon, SourceIcon, UserIcon } from '../icons';
 import { IconSize } from '../Icon';
 import { CreatePostButton } from '../post/write';
-import { SharedFeedPage } from '../utilities';
-import { OtherFeedPage } from '../../lib/query';
+import useActiveNav from '../../hooks/useActiveNav';
 
 export default function Sidebar({
   promotionalBannerActive = false,
@@ -57,7 +55,6 @@ export default function Sidebar({
   onShowDndClick,
   onLogoClick,
 }: SidebarProps): ReactElement {
-  const router = useRouter();
   const { user, isLoggedIn } = useContext(AuthContext);
   const { alerts } = useContext(AlertContext);
   const {
@@ -75,19 +72,9 @@ export default function Sidebar({
     hasUser: !!user,
     hasFiltered: !alerts?.filter,
   });
+
+  const activeNav = useActiveNav(feedName);
   const activePage = `/${feedName}`;
-  const isProfilePage = router.pathname?.includes('/[userId]');
-  const isHomeActive = useMemo(() => {
-    return [
-      SharedFeedPage.MyFeed,
-      SharedFeedPage.Popular,
-      SharedFeedPage.Upvoted,
-      SharedFeedPage.Discussed,
-      OtherFeedPage.Bookmarks,
-      OtherFeedPage.History,
-      OtherFeedPage.Notifications,
-    ].includes(feedName);
-  }, [feedName]);
 
   useHideMobileSidebar({
     state: openMobileSidebar,
@@ -132,10 +119,12 @@ export default function Sidebar({
           <Button
             {...buttonProps}
             tag="a"
-            icon={<HomeIcon secondary={isHomeActive} size={IconSize.Medium} />}
+            icon={
+              <HomeIcon secondary={activeNav.home} size={IconSize.Medium} />
+            }
             iconPosition={ButtonIconPosition.Top}
             variant={ButtonVariant.Option}
-            pressed={isHomeActive}
+            pressed={activeNav.home}
           >
             Home
           </Button>
@@ -146,14 +135,11 @@ export default function Sidebar({
             {...buttonProps}
             tag="a"
             icon={
-              <AiIcon
-                secondary={feedName === SharedFeedPage.Search}
-                size={IconSize.Medium}
-              />
+              <AiIcon secondary={activeNav.search} size={IconSize.Medium} />
             }
             iconPosition={ButtonIconPosition.Top}
             variant={ButtonVariant.Option}
-            pressed={feedName === SharedFeedPage.Search}
+            pressed={activeNav.search}
           >
             Search
           </Button>
@@ -164,14 +150,11 @@ export default function Sidebar({
             {...buttonProps}
             tag="a"
             icon={
-              <SourceIcon
-                secondary={feedName === OtherFeedPage.Squad}
-                size={IconSize.Medium}
-              />
+              <SourceIcon secondary={activeNav.squads} size={IconSize.Medium} />
             }
             iconPosition={ButtonIconPosition.Top}
             variant={ButtonVariant.Option}
-            pressed={feedName === OtherFeedPage.Squad}
+            pressed={activeNav.squads}
           >
             Squads
           </Button>
@@ -181,10 +164,12 @@ export default function Sidebar({
           <Button
             {...buttonProps}
             tag="a"
-            icon={<UserIcon secondary={isProfilePage} size={IconSize.Medium} />}
+            icon={
+              <UserIcon secondary={activeNav.profile} size={IconSize.Medium} />
+            }
             iconPosition={ButtonIconPosition.Top}
             variant={ButtonVariant.Option}
-            pressed={isProfilePage}
+            pressed={activeNav.profile}
           >
             Profile
           </Button>

--- a/packages/shared/src/hooks/useActiveNav.tsx
+++ b/packages/shared/src/hooks/useActiveNav.tsx
@@ -1,0 +1,36 @@
+import { useRouter } from 'next/router';
+import { useMemo } from 'react';
+import { AllFeedPages, OtherFeedPage } from '../lib/query';
+import { SharedFeedPage } from '../components/utilities';
+
+export default function useActiveNav(activeFeed: AllFeedPages): {
+  home: boolean;
+  profile: boolean;
+  search: boolean;
+  squads: boolean;
+} {
+  const router = useRouter();
+
+  const isHomeActive = useMemo(() => {
+    return [
+      SharedFeedPage.MyFeed,
+      SharedFeedPage.Popular,
+      SharedFeedPage.Upvoted,
+      SharedFeedPage.Discussed,
+      OtherFeedPage.Bookmarks,
+      OtherFeedPage.History,
+      OtherFeedPage.Notifications,
+    ].includes(activeFeed);
+  }, [activeFeed]);
+
+  const isProfileActive = router.pathname?.includes('/[userId]');
+  const isSearchActive = activeFeed === SharedFeedPage.Search;
+  const isSquadActive = activeFeed === OtherFeedPage.Squad;
+
+  return {
+    home: isHomeActive,
+    profile: isProfileActive,
+    search: isSearchActive,
+    squads: isSquadActive,
+  };
+}


### PR DESCRIPTION
## Changes

- adding a new hook to be used on the sidebar and feed nav as well

https://github.com/dailydotdev/apps/assets/1225100/550980a1-bf1b-4e69-a19b-8c6c1bbfef32

## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-259 #done


### Preview domain
https://mi-259-footer-nav-active-states.preview.app.daily.dev