### PR TITLE
feat: add auth banner to profile & squad pages

### DIFF
--- a/packages/shared/src/components/auth/CustomAuthBanner.tsx
+++ b/packages/shared/src/components/auth/CustomAuthBanner.tsx
@@ -1,0 +1,34 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import { useOnboarding } from '../../hooks/auth';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { useViewSize, ViewSize } from '../../hooks';
+import LoginButton from '../LoginButton';
+import { authGradientBg } from './AuthenticationBanner';
+
+const CustomAuthBanner = (): ReactElement => {
+  const { shouldShowAuthBanner } = useOnboarding();
+  const { shouldShowLogin } = useAuthContext();
+  const isLaptop = useViewSize(ViewSize.Laptop);
+  const isTablet = useViewSize(ViewSize.Tablet);
+  const isValid =
+    shouldShowAuthBanner && !isLaptop && (isTablet || !shouldShowLogin);
+
+  if (!isValid) {
+    return null;
+  }
+
+  return (
+    <LoginButton
+      className={{
+        container: classNames(
+          authGradientBg,
+          'sticky left-0 top-0 z-max w-full justify-center gap-2 border-b border-theme-color-cabbage px-4 py-2',
+        ),
+        button: 'flex-1 tablet:max-w-[9rem]',
+      }}
+    />
+  );
+};
+
+export default CustomAuthBanner;

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -177,18 +177,22 @@ export default function Sidebar({
           </Button>
         </Link>
 
-        <Link href={user.permalink} prefetch={false} passHref>
-          <Button
-            {...buttonProps}
-            tag="a"
-            icon={<UserIcon secondary={isProfilePage} size={IconSize.Medium} />}
-            iconPosition={ButtonIconPosition.Top}
-            variant={ButtonVariant.Option}
-            pressed={isProfilePage}
-          >
-            Profile
-          </Button>
-        </Link>
+        {isLoggedIn && (
+          <Link href={user.permalink} prefetch={false} passHref>
+            <Button
+              {...buttonProps}
+              tag="a"
+              icon={
+                <UserIcon secondary={isProfilePage} size={IconSize.Medium} />
+              }
+              iconPosition={ButtonIconPosition.Top}
+              variant={ButtonVariant.Option}
+              pressed={isProfilePage}
+            >
+              Profile
+            </Button>
+          </Link>
+        )}
 
         <CreatePostButton compact sidebar />
       </SidebarAside>

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -166,7 +166,10 @@ export default function Sidebar({
               {...buttonProps}
               tag="a"
               icon={
-                <UserIcon secondary={activeNav.profile} size={IconSize.Medium} />
+                <UserIcon
+                  secondary={activeNav.profile}
+                  size={IconSize.Medium}
+                />
               }
               iconPosition={ButtonIconPosition.Top}
               variant={ButtonVariant.Option}

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -18,6 +18,7 @@ import { NextSeo } from 'next-seo';
 import { NextSeoProps } from 'next-seo/lib/types';
 import { PageWidgets } from '@dailydotdev/shared/src/components/utilities';
 import { useProfile } from '@dailydotdev/shared/src/hooks/profile/useProfile';
+import CustomAuthBanner from '@dailydotdev/shared/src/components/auth/CustomAuthBanner';
 import { getLayout as getFooterNavBarLayout } from '../FooterNavBarLayout';
 import { getLayout as getMainLayout } from '../MainLayout';
 import NavBar, { tabs } from './NavBar';
@@ -110,6 +111,7 @@ export const getLayout = (
   getFooterNavBarLayout(
     getMainLayout(<ProfileLayout {...props}>{page}</ProfileLayout>, null, {
       screenCentered: false,
+      customBanner: <CustomAuthBanner />,
     }),
   );
 

--- a/packages/webapp/pages/account/profile.tsx
+++ b/packages/webapp/pages/account/profile.tsx
@@ -36,6 +36,7 @@ import { ResponseError } from '@dailydotdev/shared/src/graphql/common';
 import { FormWrapper } from '@dailydotdev/shared/src/components/fields/form';
 import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
 import { useRouter } from 'next/router';
+import CustomAuthBanner from '@dailydotdev/shared/src/components/auth/CustomAuthBanner';
 import { AccountTextField } from '../../components/layouts/AccountLayout/common';
 import { AccountPageContainer } from '../../components/layouts/AccountLayout/AccountPageContainer';
 import AccountContentSection from '../../components/layouts/AccountLayout/AccountContentSection';
@@ -283,5 +284,8 @@ const AccountProfilePage = (): ReactElement => {
 };
 
 AccountProfilePage.getLayout = getAccountLayout;
+AccountProfilePage.layoutProps = {
+  customBanner: <CustomAuthBanner />,
+};
 
 export default AccountProfilePage;

--- a/packages/webapp/pages/account/profile.tsx
+++ b/packages/webapp/pages/account/profile.tsx
@@ -36,7 +36,6 @@ import { ResponseError } from '@dailydotdev/shared/src/graphql/common';
 import { FormWrapper } from '@dailydotdev/shared/src/components/fields/form';
 import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
 import { useRouter } from 'next/router';
-import CustomAuthBanner from '@dailydotdev/shared/src/components/auth/CustomAuthBanner';
 import { AccountTextField } from '../../components/layouts/AccountLayout/common';
 import { AccountPageContainer } from '../../components/layouts/AccountLayout/AccountPageContainer';
 import AccountContentSection from '../../components/layouts/AccountLayout/AccountContentSection';
@@ -284,8 +283,5 @@ const AccountProfilePage = (): ReactElement => {
 };
 
 AccountProfilePage.getLayout = getAccountLayout;
-AccountProfilePage.layoutProps = {
-  customBanner: <CustomAuthBanner />,
-};
 
 export default AccountProfilePage;

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -36,18 +36,14 @@ import { ONBOARDING_OFFSET } from '@dailydotdev/shared/src/components/post/BaseP
 import PostLoadingSkeleton from '@dailydotdev/shared/src/components/post/PostLoadingSkeleton';
 import classNames from 'classnames';
 import { CollectionPostContent } from '@dailydotdev/shared/src/components/post/collection';
-import {
-  AuthenticationBanner,
-  authGradientBg,
-} from '@dailydotdev/shared/src/components/auth';
+import { AuthenticationBanner } from '@dailydotdev/shared/src/components/auth';
 import { useOnboarding } from '@dailydotdev/shared/src/hooks/auth/useOnboarding';
 import {
   useJoinReferral,
   useViewSize,
   ViewSize,
 } from '@dailydotdev/shared/src/hooks';
-import LoginButton from '@dailydotdev/shared/src/components/LoginButton';
-import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
+import CustomAuthBanner from '@dailydotdev/shared/src/components/auth/CustomAuthBanner';
 import { getTemplatedTitle } from '../../../components/layouts/utils';
 import { getLayout } from '../../../components/layouts/MainLayout';
 import FooterNavBarLayout from '../../../components/layouts/FooterNavBarLayout';
@@ -59,31 +55,6 @@ import {
 const Custom404 = dynamic(
   () => import(/* webpackChunkName: "404" */ '../../404'),
 );
-
-const CustomPostBanner = () => {
-  const { shouldShowAuthBanner } = useOnboarding();
-  const { shouldShowLogin } = useAuthContext();
-  const isLaptop = useViewSize(ViewSize.Laptop);
-  const isTablet = useViewSize(ViewSize.Tablet);
-  const isValid =
-    shouldShowAuthBanner && !isLaptop && (isTablet || !shouldShowLogin);
-
-  if (!isValid) {
-    return null;
-  }
-
-  return (
-    <LoginButton
-      className={{
-        container: classNames(
-          authGradientBg,
-          'sticky left-0 top-0 z-max w-full justify-center gap-2 border-b border-theme-color-cabbage px-4 py-2',
-        ),
-        button: 'flex-1 tablet:max-w-[9rem]',
-      }}
-    />
-  );
-};
 
 export interface Props {
   id: string;
@@ -199,7 +170,7 @@ const PostPage = ({ id, initialData }: Props): ReactElement => {
 PostPage.getLayout = getLayout;
 PostPage.layoutProps = {
   screenCentered: false,
-  customBanner: <CustomPostBanner />,
+  customBanner: <CustomAuthBanner />,
 };
 
 export default PostPage;

--- a/packages/webapp/pages/squads/index.tsx
+++ b/packages/webapp/pages/squads/index.tsx
@@ -42,6 +42,7 @@ import {
   ViewSize,
 } from '@dailydotdev/shared/src/hooks';
 import { Origin } from '@dailydotdev/shared/src/lib/analytics';
+import CustomAuthBanner from '@dailydotdev/shared/src/components/auth/CustomAuthBanner';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
 import FeedLayout, { getLayout } from '../../components/layouts/FeedLayout';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
@@ -207,7 +208,10 @@ const SquadsPage = ({ initialData }: Props): ReactElement => {
 };
 
 SquadsPage.getLayout = getLayout;
-SquadsPage.layoutProps = mainFeedLayoutProps;
+SquadsPage.layoutProps = {
+  ...mainFeedLayoutProps,
+  customBanner: <CustomAuthBanner />,
+};
 
 export async function getStaticProps(): Promise<GetStaticPropsResult<Props>> {
   try {


### PR DESCRIPTION
## Changes

- extract out the banner component into the shared lib

### Profile

<img width="728" alt="Screenshot 2024-04-02 at 13 46 40" 
src="https://github.com/dailydotdev/apps/assets/1225100/5bb98a59-fcbc-44af-a606-2f8717172f37">

---

### Squads

<img width="728" alt="Screenshot 2024-04-02 at 13 37 04" src="https://github.com/dailydotdev/apps/assets/1225100/c78ee172-45a9-451c-9eb4-440bc5d4b87e">

## Events

N / A

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-243 #done


### Preview domain
https://mi-243-anonymous-top-banner.preview.app.daily.dev