### PR TITLE
fix: missing close buttons

### DIFF
--- a/packages/shared/src/components/checklist/SquadChecklistCard.tsx
+++ b/packages/shared/src/components/checklist/SquadChecklistCard.tsx
@@ -52,7 +52,10 @@ const SquadChecklistCard = ({ squad }: { squad: Squad }): ReactElement => {
   return (
     <InteractivePopup
       isDrawerOnMobile
-      drawerProps={{ className: { drawer: 'pb-4' } }}
+      drawerProps={{
+        className: { drawer: 'pb-4', close: 'px-4' },
+        displayCloseButton: true,
+      }}
       position={InteractivePopupPosition.RightEnd}
       className="flex w-full max-w-[21.5rem] justify-center rounded-none"
       onClose={onRequestClose}

--- a/packages/webapp/pages/account/others.tsx
+++ b/packages/webapp/pages/account/others.tsx
@@ -55,6 +55,10 @@ const AccountOthersPage = (): ReactElement => {
           options={timeZoneValues}
           scrollable
           data-testid="timezone_dropdown"
+          drawerProps={{
+            displayCloseButton: true,
+            className: { close: 'pb-4' },
+          }}
         />
       </AccountContentSection>
       <AccountContentSection title="Newsletter">


### PR DESCRIPTION
## Changes
- Fix missing close buttons of: timezone, feed options, and squad checklist.

Previews:
![Screenshot 2024-04-02 at 9 44 21 PM](https://github.com/dailydotdev/apps/assets/13744167/b8778751-fc32-4840-8da6-7eafdd55eb7f)
![Screenshot 2024-04-02 at 9 43 08 PM](https://github.com/dailydotdev/apps/assets/13744167/d4eb1a93-6ab1-429e-b294-48f52c3938ee)
![Screenshot 2024-04-02 at 9 39 38 PM](https://github.com/dailydotdev/apps/assets/13744167/52c581ea-a2bf-45c2-b1f1-7192454be03d)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-close-buttons.preview.app.daily.dev