### PR TITLE
fix: use tertiary variant for feed action buttons on mobile

### DIFF
--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -39,7 +39,7 @@ function FeedNav(): ReactElement {
         <Tab label={FeedNavTab.History} url="/history" />
       </TabContainer>
 
-      <div className="fixed right-0 top-0 my-1 flex h-12 w-20 items-center justify-end bg-gradient-to-r from-transparent via-background-default via-40% to-background-default pr-1">
+      <div className="fixed right-0 top-0 my-1 flex h-12 w-20 items-center justify-end bg-gradient-to-r from-transparent via-background-default via-40% to-background-default pr-2">
         <NotificationsBell compact />
       </div>
     </div>

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -51,19 +51,6 @@ export interface DropdownProps {
   openFullScreen?: boolean;
 }
 
-const getButtonSizeClass = (buttonSize: string): string => {
-  if (buttonSize === 'select') {
-    return 'h-9 rounded-10 text-text-primary typo-body';
-  }
-  if (buttonSize === 'medium') {
-    return 'h-10 rounded-12 min-w-[2.5rem]';
-  }
-  if (buttonSize === 'small') {
-    return 'h-8 rounded-10';
-  }
-  return 'h-12 rounded-14';
-};
-
 export function Dropdown({
   icon,
   className = {},

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -19,7 +19,7 @@ import { ListDrawer } from '../drawers/ListDrawer';
 import { SelectParams } from '../drawers/common';
 import { RootPortal } from '../tooltips/Portal';
 import { DrawerProps } from '../drawers';
-import { Button, ButtonSize } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { IconProps } from '../Icon';
 
 interface ClassName {
@@ -41,7 +41,8 @@ export interface DropdownProps {
   selectedIndex: number;
   options: string[];
   onChange: (value: string, index: number) => unknown;
-  buttonSize?: 'small' | 'medium' | 'large' | 'select';
+  buttonSize?: ButtonSize;
+  buttonVariant?: ButtonVariant;
   scrollable?: boolean;
   renderItem?: (value: string, index: number) => ReactNode;
   placeholder?: string;
@@ -71,7 +72,8 @@ export function Dropdown({
   onChange,
   dynamicMenuWidth,
   shouldIndicateSelected,
-  buttonSize = 'large',
+  buttonSize = ButtonSize.Large,
+  buttonVariant = ButtonVariant.Float,
   scrollable = false,
   renderItem,
   placeholder = '',
@@ -132,12 +134,13 @@ export function Dropdown({
       className={classNames(styles.dropdown, className.container)}
       {...props}
     >
-      <button
+      <Button
         type="button"
         ref={triggerRef}
+        variant={buttonVariant}
+        size={buttonSize}
         className={classNames(
-          'group flex w-full items-center bg-theme-float px-3 font-normal text-text-tertiary typo-body hover:bg-theme-hover hover:text-text-primary',
-          getButtonSizeClass(buttonSize),
+          'group flex w-full items-center px-3 font-normal text-text-tertiary typo-body hover:bg-theme-hover hover:text-text-primary',
           className?.button,
           iconOnly && 'items-center justify-center',
         )}
@@ -165,7 +168,7 @@ export function Dropdown({
             className.chevron,
           )}
         />
-      </button>
+      </Button>
       {fullScreen ? (
         <RootPortal>
           <ListDrawer

--- a/packages/shared/src/components/filters/MyFeedHeading.tsx
+++ b/packages/shared/src/components/filters/MyFeedHeading.tsx
@@ -58,7 +58,11 @@ function MyFeedHeading({
           size={
             shouldUseMobileFeedLayout ? ButtonSize.Small : ButtonSize.Medium
           }
-          variant={ButtonVariant.Float}
+          variant={
+            isMobile && isNewMobileLayout
+              ? ButtonVariant.Tertiary
+              : ButtonVariant.Float
+          }
           className="mr-auto"
           onClick={onRefresh}
           icon={<RefreshIcon />}
@@ -72,7 +76,11 @@ function MyFeedHeading({
       )}
       <Button
         size={shouldUseMobileFeedLayout ? ButtonSize.Small : ButtonSize.Medium}
-        variant={ButtonVariant.Float}
+        variant={
+          isMobile && isNewMobileLayout
+            ? ButtonVariant.Tertiary
+            : ButtonVariant.Float
+        }
         className="mr-auto"
         onClick={onClick}
         icon={<FilterIcon />}

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -10,13 +10,13 @@ import MyFeedHeading from '../filters/MyFeedHeading';
 import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
 import { Dropdown, DropdownProps } from '../fields/Dropdown';
-import { ButtonSize } from '../buttons/common';
+import { ButtonSize, ButtonVariant } from '../buttons/common';
 import { CalendarIcon, SortIcon } from '../icons';
 import { IconSize } from '../Icon';
 import { RankingAlgorithm } from '../../graphql/feed';
 import SettingsContext from '../../contexts/SettingsContext';
 import { useFeedName } from '../../hooks/feed/useFeedName';
-import { useFeedLayout } from '../../hooks';
+import { useFeedLayout, useViewSize, ViewSize } from '../../hooks';
 import ConditionalWrapper from '../ConditionalWrapper';
 import { useMobileUxExperiment } from '../../hooks/useMobileUxExperiment';
 import FeedSelector from '../FeedSelector';
@@ -61,6 +61,7 @@ export const SearchControlHeader = ({
   });
   const { shouldUseMobileFeedLayout } = useFeedLayout();
   const { isNewMobileLayout } = useMobileUxExperiment();
+  const isMobile = useViewSize(ViewSize.MobileL);
   const { streak, isEnabled: isStreaksEnabled, isLoading } = useReadingStreak();
   const openFeedFilters = () =>
     openModal({ type: LazyModal.FeedFilters, persistOnRouteChange: true });
@@ -73,6 +74,10 @@ export const SearchControlHeader = ({
       ? ButtonSize.Small
       : ButtonSize.Medium,
     iconOnly: true,
+    buttonVariant:
+      isNewMobileLayout && isMobile
+        ? ButtonVariant.Tertiary
+        : ButtonVariant.Float,
   };
   const actionButtons = [
     feedName === SharedFeedPage.MyFeed ? (

--- a/packages/shared/src/components/streak/ReadingStreakButton.tsx
+++ b/packages/shared/src/components/streak/ReadingStreakButton.tsx
@@ -9,6 +9,7 @@ import { useViewSize, ViewSize } from '../../hooks';
 import { isTesting } from '../../lib/constants';
 import { useAnalyticsContext } from '../../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../../lib/analytics';
+import { useMobileUxExperiment } from '../../hooks/useMobileUxExperiment';
 
 interface ReadingStreakButtonProps {
   streak: UserStreak;
@@ -57,6 +58,7 @@ export function ReadingStreakButton({
   const { trackEvent } = useAnalyticsContext();
   const isLaptop = useViewSize(ViewSize.Laptop);
   const isMobile = useViewSize(ViewSize.MobileL);
+  const { isNewMobileLayout } = useMobileUxExperiment();
   const [shouldShowStreaks, setShouldShowStreaks] = useState(false);
   const hasReadToday =
     new Date(streak?.lastViewAt).getDate() === new Date().getDate();
@@ -93,7 +95,11 @@ export function ReadingStreakButton({
       <Button
         type="button"
         icon={<ReadingStreakIcon secondary={hasReadToday} />}
-        variant={ButtonVariant.Float}
+        variant={
+          isNewMobileLayout && isMobile
+            ? ButtonVariant.Tertiary
+            : ButtonVariant.Float
+        }
         onClick={handleToggle}
         className={classnames('gap-1', compact && 'text-theme-color-bacon')}
         size={


### PR DESCRIPTION
## Changes

<img width="1012" alt="Screenshot 2024-04-02 at 18 52 17" src="https://github.com/dailydotdev/apps/assets/1225100/9468661a-3248-4022-ac31-54d93f472f47">

---

<img width="728" alt="Screenshot 2024-04-02 at 18 52 08" src="https://github.com/dailydotdev/apps/assets/1225100/0d9b321a-ce76-4af4-94e1-375202c43616">

---

<img width="481" alt="Screenshot 2024-04-02 at 18 59 45" src="https://github.com/dailydotdev/apps/assets/1225100/8e596348-3a3f-4796-87cb-a5822764b2c4">

## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-261 #done


### Preview domain
https://mi-261-layout-action-buttons.preview.app.daily.dev