### PR TITLE
feat: remove digest preferred timezone

### DIFF
--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -372,13 +372,11 @@ export const GET_REFERRING_USER_QUERY = gql`
 export type UserPersonalizedDigest = {
   preferredDay: number;
   preferredHour: number;
-  preferredTimezone: string;
 };
 
 export type UserPersonalizedDigestSubscribe = {
   day?: number;
   hour?: number;
-  timezone?: string;
 };
 
 export const GET_PERSONALIZED_DIGEST_SETTINGS = gql`
@@ -386,7 +384,6 @@ export const GET_PERSONALIZED_DIGEST_SETTINGS = gql`
     personalizedDigest {
       preferredDay
       preferredHour
-      preferredTimezone
     }
   }
 `;
@@ -409,15 +406,10 @@ export const REFERRED_USERS_QUERY = gql`
 `;
 
 export const SUBSCRIBE_PERSONALIZED_DIGEST_MUTATION = gql`
-  mutation SubscribePersonalizedDigest(
-    $hour: Int
-    $day: Int
-    $timezone: String
-  ) {
-    subscribePersonalizedDigest(hour: $hour, day: $day, timezone: $timezone) {
+  mutation SubscribePersonalizedDigest($hour: Int, $day: Int) {
+    subscribePersonalizedDigest(hour: $hour, day: $day) {
       preferredDay
       preferredHour
-      preferredTimezone
     }
   }
 `;

--- a/packages/shared/src/hooks/usePersonalizedDigest.spec.tsx
+++ b/packages/shared/src/hooks/usePersonalizedDigest.spec.tsx
@@ -46,7 +46,6 @@ describe('usePersonalizedDigest hook', () => {
           personalizedDigest: {
             preferredDay: 1,
             preferredHour: 9,
-            preferredTimezone: 'Etc/UTC',
           },
         },
       },
@@ -64,7 +63,6 @@ describe('usePersonalizedDigest hook', () => {
     expect(result.current.personalizedDigest).toMatchObject({
       preferredDay: 1,
       preferredHour: 9,
-      preferredTimezone: 'Etc/UTC',
     });
   });
 
@@ -91,7 +89,6 @@ describe('usePersonalizedDigest hook', () => {
             subscribePersonalizedDigest: {
               preferredDay: 1,
               preferredHour: 9,
-              preferredTimezone: 'Etc/UTC',
             },
           },
         };

--- a/packages/shared/src/hooks/usePersonalizedDigest.ts
+++ b/packages/shared/src/hooks/usePersonalizedDigest.ts
@@ -60,7 +60,6 @@ export const usePersonalizedDigest = (): UsePersonalizedDigest => {
       >(graphqlUrl, SUBSCRIBE_PERSONALIZED_DIGEST_MUTATION, {
         day: 3,
         hour: 8,
-        timezone: user?.timezone || undefined,
       });
 
       queryClient.setQueryData(queryKey, result.subscribePersonalizedDigest);

--- a/packages/shared/src/lib/timezones.ts
+++ b/packages/shared/src/lib/timezones.ts
@@ -502,6 +502,10 @@ const TIME_ZONES: TimeZoneItem[] = [
     value: 'Pacific/Kiritimati',
     label: 'Kiritimati Island',
   },
+  {
+    value: 'Etc/UTC',
+    label: 'Universal Time Coordinated',
+  },
 ];
 
 const timeZoneCurrentOffsetLabel = (timeZone: TimeZoneItem) => {

--- a/packages/webapp/__tests__/AccountNotificationsPage.tsx
+++ b/packages/webapp/__tests__/AccountNotificationsPage.tsx
@@ -155,7 +155,6 @@ it('should change user all email subscription', async () => {
           subscribePersonalizedDigest: {
             preferredDay: 1,
             preferredHour: 9,
-            preferredTimezone: 'Etc/UTC',
           },
         },
       };
@@ -210,7 +209,6 @@ it('should subscribe to personalized digest subscription', async () => {
         subscribePersonalizedDigest: {
           preferredDay: 1,
           preferredHour: 9,
-          preferredTimezone: 'Etc/UTC',
         },
       },
     },
@@ -235,7 +233,6 @@ it('should unsubscribe from personalized digest subscription', async () => {
         personalizedDigest: {
           preferredDay: 1,
           preferredHour: 9,
-          preferredTimezone: 'Etc/UTC',
         },
       },
     },


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Removing `preferredTimezone` property since it was removed on API https://github.com/dailydotdev/daily-api/pull/1794

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://remove-digest-preferred-timezone.preview.app.daily.dev