### PR TITLE
fix: add all nav items to the footer even for anon users

### DIFF
--- a/packages/shared/src/components/post/write/CreatePostButton.tsx
+++ b/packages/shared/src/components/post/write/CreatePostButton.tsx
@@ -19,6 +19,7 @@ interface CreatePostButtonProps {
   className?: string;
   compact?: boolean;
   sidebar?: boolean;
+  footer?: boolean;
   onClick?: () => void;
 }
 
@@ -26,6 +27,7 @@ export function CreatePostButton({
   className,
   compact,
   sidebar,
+  footer,
   onClick,
 }: CreatePostButtonProps): ReactElement {
   const { user, squads } = useAuthContext();
@@ -38,7 +40,7 @@ export function CreatePostButton({
     verifyPermission(item, SourcePermissions.Post),
   );
 
-  if (!user || !squads?.length) {
+  if (!footer && (!user || !squads?.length)) {
     return null;
   }
 
@@ -74,11 +76,15 @@ export function CreatePostButton({
     >
       <Button
         {...buttonProps}
-        variant={sidebar ? ButtonVariant.Float : ButtonVariant.Secondary}
+        variant={
+          sidebar || footer ? ButtonVariant.Float : ButtonVariant.Secondary
+        }
         className={className}
         disabled={getIsDisabled()}
         icon={compact && <PlusIcon />}
-        size={isLaptop || sidebar ? ButtonSize.Medium : ButtonSize.Small}
+        size={
+          isLaptop || sidebar || footer ? ButtonSize.Medium : ButtonSize.Small
+        }
       >
         {!compact ? 'New post' : null}
       </Button>

--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -126,12 +126,11 @@ export const mobileUxTabs: Tab[] = [
   {
     component: (onClick: () => void) => (
       <div key="new-post" className="text-center">
-        <CreatePostButton onClick={onClick} compact sidebar className="h-8" />
+        <CreatePostButton onClick={onClick} compact footer className="h-8" />
       </div>
     ),
   },
   {
-    requiresLogin: true,
     shouldShowLogin: true,
     path: '/squads',
     title: 'Squads',
@@ -140,7 +139,6 @@ export const mobileUxTabs: Tab[] = [
     ),
   },
   {
-    requiresLogin: true,
     shouldShowLogin: true,
     path: (user) => user?.permalink,
     title: 'Profile',


### PR DESCRIPTION
## Changes

<img width="583" alt="Screenshot 2024-04-03 at 18 53 59" src="https://github.com/dailydotdev/apps/assets/1225100/d83b98b3-17f4-4eb8-8286-5f9e5b433298">

## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-265 #done


### Preview domain
https://mi-265-footer-nav-anon-user.preview.app.daily.dev