### PR TITLE
feat: feed nav horizontal scroll

### DIFF
--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -31,7 +31,10 @@ function FeedNav(): ReactElement {
         className={{
           header: 'no-scrollbar overflow-x-auto px-1 pr-28',
         }}
-        tabListProps={{ className: { indicator: '!w-6', item: 'px-1' } }}
+        tabListProps={{
+          className: { indicator: '!w-6', item: 'px-1' },
+          autoScrollActive: true,
+        }}
       >
         <Tab label={FeedNavTab.ForYou} url="/" />
         <Tab label={FeedNavTab.Popular} url="/popular" />

--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -31,7 +31,7 @@ function FeedNav(): ReactElement {
         className={{
           header: 'no-scrollbar overflow-x-auto px-1 pr-28',
         }}
-        tabListProps={{ className: { indicator: '!w-6' } }}
+        tabListProps={{ className: { indicator: '!w-6', item: 'px-1' } }}
       >
         <Tab label={FeedNavTab.ForYou} url="/" />
         <Tab label={FeedNavTab.Popular} url="/popular" />

--- a/packages/shared/src/components/tabs/TabContainer.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.tsx
@@ -45,7 +45,7 @@ export interface TabContainerProps<T extends string> {
   style?: CSSProperties;
   showHeader?: boolean;
   controlledActive?: string;
-  tabListProps?: Pick<TabListProps, 'className'>;
+  tabListProps?: Pick<TabListProps, 'className' | 'autoScrollActive'>;
   showBorder?: boolean;
 }
 
@@ -139,6 +139,7 @@ export function TabContainer<T extends string = string>({
           onClick={onClick}
           active={currentActive}
           className={tabListProps?.className}
+          autoScrollActive={tabListProps?.autoScrollActive}
         />
       </header>
       {render}

--- a/packages/shared/src/components/tabs/TabList.tsx
+++ b/packages/shared/src/components/tabs/TabList.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement, useEffect, useRef, useState } from 'react';
 
 interface ClassName {
   indicator?: string;
@@ -11,6 +11,7 @@ export interface TabListProps {
   active: string;
   onClick?: (label: string) => unknown;
   className?: ClassName;
+  autoScrollActive?: boolean;
 }
 
 function TabList({
@@ -18,8 +19,20 @@ function TabList({
   active,
   onClick,
   className = {},
+  autoScrollActive,
 }: TabListProps): ReactElement {
-  const [offset, setOffset] = useState<number>(undefined);
+  const [offset, setOffset] = useState<number>(0);
+  const [indicatorOffset, setIndicatorOffset] = useState<number>(undefined);
+  const currentActiveTab = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (autoScrollActive && currentActiveTab.current) {
+      currentActiveTab.current.parentElement.parentElement.scrollTo({
+        left: offset,
+        behavior: 'smooth',
+      });
+    }
+  }, [offset, autoScrollActive]);
 
   return (
     <ul className="relative flex flex-row">
@@ -31,15 +44,17 @@ function TabList({
               return;
             }
 
+            currentActiveTab.current = el;
             const rect = el.getBoundingClientRect();
 
             if (rect.width === 0) {
               return;
             }
 
-            const size = rect.width / 2;
-            const value = size + el.offsetLeft;
-            setOffset(value);
+            const size = rect.width;
+            const leftOffset = el.offsetLeft;
+            setOffset(leftOffset);
+            setIndicatorOffset(size / 2 + leftOffset);
           }}
           className={classNames(
             className.item,
@@ -60,13 +75,13 @@ function TabList({
           </span>
         </button>
       ))}
-      {offset !== undefined && (
+      {indicatorOffset !== undefined && (
         <div
           className={classNames(
             'absolute bottom-0 mx-auto h-0.5 w-12 -translate-x-1/2 rounded-4 bg-text-primary transition-[left] ease-linear',
             className?.indicator,
           )}
-          style={{ left: offset }}
+          style={{ left: indicatorOffset }}
         />
       )}
     </ul>

--- a/packages/shared/src/components/tabs/TabList.tsx
+++ b/packages/shared/src/components/tabs/TabList.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement, useState } from 'react';
 
 interface ClassName {
   indicator?: string;
+  item?: string;
 }
 
 export interface TabListProps {
@@ -41,6 +42,7 @@ function TabList({
             setOffset(value);
           }}
           className={classNames(
+            className.item,
             'relative p-2 py-4 text-center font-bold typo-callout',
             tab === active ? '' : 'text-text-tertiary',
           )}


### PR DESCRIPTION
## Changes

- make spacing tighter between feed nav tabs
- auto-scroll the active tab into view on the feed nav

_screenshots pending preview deploy_

## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-266 #done
