### PR TITLE
feat: use a drawer for the streaks tooltip on mobile

### DIFF
--- a/packages/shared/src/components/streak/ReadingStreakButton.tsx
+++ b/packages/shared/src/components/streak/ReadingStreakButton.tsx
@@ -10,6 +10,9 @@ import { isTesting } from '../../lib/constants';
 import { useAnalyticsContext } from '../../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../../lib/analytics';
 import { useMobileUxExperiment } from '../../hooks/useMobileUxExperiment';
+import { RootPortal } from '../tooltips/Portal';
+import { Drawer } from '../drawers';
+import ConditionalWrapper from '../ConditionalWrapper';
 
 interface ReadingStreakButtonProps {
   streak: UserStreak;
@@ -86,31 +89,52 @@ export function ReadingStreakButton({
   }
 
   return (
-    <Tooltip
-      content="Current streak"
-      streak={streak}
-      shouldShowStreaks={shouldShowStreaks}
-      setShouldShowStreaks={setShouldShowStreaks}
-    >
-      <Button
-        type="button"
-        icon={<ReadingStreakIcon secondary={hasReadToday} />}
-        variant={
-          isNewMobileLayout && isMobile
-            ? ButtonVariant.Tertiary
-            : ButtonVariant.Float
-        }
-        onClick={handleToggle}
-        className={classnames('gap-1', compact && 'text-theme-color-bacon')}
-        size={
-          (isLaptop || !compact) && !isMobile
-            ? ButtonSize.Medium
-            : ButtonSize.Small
-        }
+    <>
+      <ConditionalWrapper
+        condition={!isMobile}
+        wrapper={(children: ReactElement) => (
+          <Tooltip
+            content="Current streak"
+            streak={streak}
+            shouldShowStreaks={shouldShowStreaks}
+            setShouldShowStreaks={setShouldShowStreaks}
+          >
+            {children}
+          </Tooltip>
+        )}
       >
-        {streak?.current}
-        {!compact && ' reading days'}
-      </Button>
-    </Tooltip>
+        <Button
+          type="button"
+          icon={<ReadingStreakIcon secondary={hasReadToday} />}
+          variant={
+            isNewMobileLayout && isMobile
+              ? ButtonVariant.Tertiary
+              : ButtonVariant.Float
+          }
+          onClick={handleToggle}
+          className={classnames('gap-1', compact && 'text-theme-color-bacon')}
+          size={
+            (isLaptop || !compact) && !isMobile
+              ? ButtonSize.Medium
+              : ButtonSize.Small
+          }
+        >
+          {streak?.current}
+          {!compact && ' reading days'}
+        </Button>
+      </ConditionalWrapper>
+
+      {isMobile && (
+        <RootPortal>
+          <Drawer
+            displayCloseButton
+            isOpen={shouldShowStreaks}
+            onClose={handleToggle}
+          >
+            <ReadingStreakPopup streak={streak} fullWidth />
+          </Drawer>
+        </RootPortal>
+      )}
+    </>
   );
 }

--- a/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
+++ b/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useMemo } from 'react';
 import { addDays, isSameDay, subDays } from 'date-fns';
 import { useQuery } from '@tanstack/react-query';
+import classNames from 'classnames';
 import { StreakSection } from './StreakSection';
 import { DayStreak, Streak } from './DayStreak';
 import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
@@ -24,10 +25,12 @@ const streakDays = [
 
 interface ReadingStreakPopupProps {
   streak: UserStreak;
+  fullWidth?: boolean;
 }
 
 export function ReadingStreakPopup({
   streak,
+  fullWidth,
 }: ReadingStreakPopupProps): ReactElement {
   const { user } = useAuthContext();
   const { data: history } = useQuery(
@@ -83,7 +86,14 @@ export function ReadingStreakPopup({
         <StreakSection streak={streak.current} label="Current streak" />
         <StreakSection streak={streak.max} label="Longest streak 🏆" />
       </div>
-      <div className="mt-6 flex flex-row gap-2">{streaks}</div>
+      <div
+        className={classNames(
+          'mt-6 flex flex-row gap-2',
+          fullWidth && 'justify-between',
+        )}
+      >
+        {streaks}
+      </div>
       <div className="mt-4 text-center font-bold leading-8 text-text-tertiary">
         Total reading days: {streak.total}
       </div>


### PR DESCRIPTION
## Changes

<img width="562" alt="Screenshot 2024-04-04 at 11 01 04" src="https://github.com/dailydotdev/apps/assets/1225100/0d4cbcd1-c3a8-4d04-801a-df6deb4632bb">

---

<img width="806" alt="Screenshot 2024-04-04 at 11 01 20" src="https://github.com/dailydotdev/apps/assets/1225100/c542e5a4-0207-4415-a664-e33e0d9fd12c">

---

<img width="1169" alt="Screenshot 2024-04-04 at 11 01 33" src="https://github.com/dailydotdev/apps/assets/1225100/6b5da947-dd9b-4bdb-a2a6-b5c61106c3e2">


## Events

N / A

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-267 #done


### Preview domain
https://mi-267-streaks-drawer-mobile.preview.app.daily.dev