### PR TITLE
fix: missing submit article modal button

### DIFF
--- a/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
+++ b/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
@@ -9,7 +9,6 @@ import {
   DevCardIcon,
   ExitIcon,
   EmbedIcon,
-  LinkIcon,
   DocsIcon,
   TerminalIcon,
   FeedbackIcon,
@@ -74,11 +73,6 @@ const useMenuItems = (): NavItemProps[] => {
       {
         label: 'Contribute',
         isHeader: true,
-      },
-      {
-        label: 'Submit article',
-        icon: <LinkIcon />,
-        onClick: () => openModal({ type: LazyModal.SubmitArticle }),
       },
       {
         label: 'Suggest new source',

--- a/packages/webapp/components/footer/FooterPlusButton.tsx
+++ b/packages/webapp/components/footer/FooterPlusButton.tsx
@@ -3,10 +3,12 @@ import { Drawer } from '@dailydotdev/shared/src/components/drawers';
 import {
   AllowedTags,
   Button,
+  ButtonProps,
   ButtonSize,
   ButtonVariant,
 } from '@dailydotdev/shared/src/components/buttons/Button';
 import {
+  DocsIcon,
   EditIcon,
   LinkIcon,
   PlusIcon,
@@ -14,9 +16,30 @@ import {
 import { link } from '@dailydotdev/shared/src/lib/links';
 import { RootPortal } from '@dailydotdev/shared/src/components/tooltips/Portal';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
+import { useLazyModal } from '@dailydotdev/shared/src/hooks/useLazyModal';
+import { LazyModal } from '@dailydotdev/shared/src/components/modals/common/types';
+
+const ActionButton = <TagName extends AllowedTags>({
+  children,
+  ...props
+}: ButtonProps<TagName>) => {
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <Button
+        {...props}
+        size={ButtonSize.Large}
+        variant={ButtonVariant.Float}
+      />
+      <span className="font-normal text-text-tertiary typo-callout">
+        {children}
+      </span>
+    </div>
+  );
+};
 
 export function FooterPlusButton(): ReactElement {
   const { user } = useAuthContext();
+  const { openModal } = useLazyModal();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const props = user
     ? { onClick: () => setIsDrawerOpen(true) }
@@ -36,33 +59,23 @@ export function FooterPlusButton(): ReactElement {
           isOpen={isDrawerOpen}
           onClose={() => setIsDrawerOpen(false)}
         >
-          <div className="flex h-auto justify-around p-4">
-            <div className="flex flex-col items-center gap-2">
-              <Button
-                size={ButtonSize.XLarge}
-                icon={<EditIcon />}
-                variant={ButtonVariant.Float}
-                tag="a"
-                href={link.post.create}
-              />
-
-              <span className="font-normal text-text-tertiary">New post</span>
-            </div>
-
-            <div className="flex flex-col items-center gap-2">
-              <Button
-                size={ButtonSize.XLarge}
-                className="flex flex-col"
-                tag="a"
-                variant={ButtonVariant.Float}
-                href={`${link.post.create}?share=true`}
-                icon={<LinkIcon />}
-              />
-
-              <span className="font-normal text-text-tertiary">
-                Share a link
-              </span>
-            </div>
+          <div className="mb-1 flex h-auto justify-around">
+            <ActionButton tag="a" icon={<EditIcon />} href={link.post.create}>
+              New post
+            </ActionButton>
+            <ActionButton
+              tag="a"
+              icon={<LinkIcon />}
+              href={`${link.post.create}?share=true`}
+            >
+              Share a link
+            </ActionButton>
+            <ActionButton
+              icon={<DocsIcon />}
+              onClick={() => openModal({ type: LazyModal.SubmitArticle })}
+            >
+              Submit article
+            </ActionButton>
           </div>
         </Drawer>
       </RootPortal>


### PR DESCRIPTION
## Changes
- Move the capacity to open the submit article modal to the plus button on the footer.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-269 #done


### Preview domain
https://mi-269.preview.app.daily.dev