### PR TITLE
fix: unnecessary border

### DIFF
--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -178,7 +178,7 @@ export function Modal({
     overlayClassName,
   );
   const modalClassName = classNames(
-    'modal relative flex max-w-full flex-col items-center border border-theme-divider-secondary bg-accent-pepper-subtlest antialiased shadow-2 focus:outline-none',
+    'modal relative flex max-w-full flex-col items-center border-theme-divider-secondary bg-accent-pepper-subtlest antialiased shadow-2 focus:outline-none tablet:border',
     'h-full w-full tablet:h-auto tablet:rounded-16',
     modalKindToClassName[kind],
     modalSizeToClassName[size],


### PR DESCRIPTION
## Changes
- Since on mobile, all Modals are on full-screen, we don't need the borders on mobile anymore.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-unnecessary-border.preview.app.daily.dev