### PR TITLE
mobile-ux: fix: bottom navbar position:fixed instead of sticky

### DIFF
--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -68,7 +68,7 @@ export default function FooterNavBar({
   return (
     <div
       className={classNames(
-        'sticky bottom-0 left-0 z-2 mt-auto w-full pb-6',
+        'fixed !bottom-0 left-0 z-2 w-full pb-6',
         isNewMobileLayout
           ? 'bg-gradient-to-t from-blur-baseline via-blur-bg via-70% to-transparent p-2'
           : post && 'bg-blur-bg backdrop-blur-20',

--- a/packages/webapp/components/layouts/FooterNavBarLayout.tsx
+++ b/packages/webapp/components/layouts/FooterNavBarLayout.tsx
@@ -39,6 +39,7 @@ export default function FooterNavBarLayout({
   return (
     <>
       {children}
+      <div className={post ? 'h-40' : 'h-28'} />
       <FooterNavBar showNav={showNav} post={post} />
     </>
   );


### PR DESCRIPTION
## Changes

Made the bottom navbar `fixed` instead of `sticky`. This reverts to previous behavior.

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- N/A Have you done sanity checks in the extension?
- N/A Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-274 #done


### Preview domain
https://mi-274-make-bottom-navbar-fixed-again.preview.app.daily.dev