### PR TITLE
chore: reduce number of fields we fetch for post comments

### DIFF
--- a/packages/shared/src/components/modals/post/CommentModal.tsx
+++ b/packages/shared/src/components/modals/post/CommentModal.tsx
@@ -94,8 +94,8 @@ export default function CommentModal({
   const isReply = !isEdit && !!replyToCommentId;
 
   const { comment: commentById } = useCommentById({
-    id: isEdit ? editCommentId : parentCommentId,
-    options: { enabled: !!editCommentId || !!parentCommentId },
+    id: editCommentId,
+    options: { enabled: !!editCommentId },
   });
 
   const refCallback = useCallback(

--- a/packages/shared/src/components/modals/post/CommentModal.tsx
+++ b/packages/shared/src/components/modals/post/CommentModal.tsx
@@ -24,6 +24,7 @@ import { Switch } from '../../fields/Switch';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import CommentContainer from '../../comments/CommentContainer';
 import { WriteCommentContext } from '../../../contexts/WriteCommentContext';
+import useCommentById from '../../../hooks/comments/useCommentById';
 
 const getCommentFromCache = ({
   client,
@@ -92,6 +93,11 @@ export default function CommentModal({
   const isEdit = !!editCommentId;
   const isReply = !isEdit && !!replyToCommentId;
 
+  const { comment: commentById } = useCommentById({
+    id: isEdit ? editCommentId : parentCommentId,
+    options: { enabled: !!editCommentId || !!parentCommentId },
+  });
+
   const refCallback = useCallback(
     (node) => {
       if (node) {
@@ -134,7 +140,7 @@ export default function CommentModal({
   const mutateCommentResult = useMutateComment({
     post,
     editCommentId: isEdit && editCommentId,
-    parentCommentId: isEdit ? comment?.parent?.id : parentCommentId,
+    parentCommentId,
     onCommented: onSuccess,
   });
   const { isLoading, isSuccess } = mutateCommentResult;
@@ -162,7 +168,7 @@ export default function CommentModal({
     if (isEdit) {
       return {
         submitCopy: 'Save',
-        initialContent: comment?.content,
+        initialContent: commentById?.content,
       };
     }
     if (isReply) {
@@ -175,7 +181,7 @@ export default function CommentModal({
       };
     }
     return { submitCopy: 'Comment' };
-  }, [isEdit, isReply, comment, user?.id]);
+  }, [isEdit, isReply, comment, commentById, user?.id]);
 
   return (
     <Modal

--- a/packages/shared/src/graphql/comments.ts
+++ b/packages/shared/src/graphql/comments.ts
@@ -1,10 +1,6 @@
 import request, { gql } from 'graphql-request';
 import { Connection } from './common';
-import {
-  COMMENT_FRAGMENT,
-  SHARED_POST_INFO_FRAGMENT,
-  USER_SHORT_INFO_FRAGMENT,
-} from './fragments';
+import { COMMENT_FRAGMENT, USER_SHORT_INFO_FRAGMENT } from './fragments';
 import { EmptyResponse } from './emptyResponse';
 import { UserShortProfile } from '../lib/user';
 import { graphqlUrl } from '../lib/config';

--- a/packages/shared/src/graphql/comments.ts
+++ b/packages/shared/src/graphql/comments.ts
@@ -268,28 +268,3 @@ export const COMMENT_BY_ID_QUERY = gql`
     }
   }
 `;
-
-export const COMMENT_BY_ID_WITH_POST_QUERY = gql`
-  query CommentByIDWithPost($id: ID!) {
-    comment(id: $id) {
-      id
-      content
-      contentHtml
-      createdAt
-      lastUpdatedAt
-      permalink
-      upvoted
-      numUpvotes
-      parent {
-        id
-      }
-      author {
-        ...UserShortInfo
-      }
-      post {
-        ...SharedPostInfo
-      }
-    }
-  }
-  ${SHARED_POST_INFO_FRAGMENT}
-`;

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -117,15 +117,11 @@ export const COMMENT_FRAGMENT = gql`
   fragment CommentFragment on Comment {
     id
     contentHtml
-    content
     createdAt
     lastUpdatedAt
     permalink
     upvoted
     numUpvotes
-    parent {
-      id
-    }
     author {
       ...UserShortInfo
     }


### PR DESCRIPTION
We originally added more fields to facilitate comment modal dialog. However we can get the same data by querying comment by Id when the modal itself is opened instead. That way, we do not unnecessary query fields, that we don't need to have most of the time.

See comments on the original PR:
- https://github.com/dailydotdev/apps/pull/2912#discussion_r1550978383
- https://github.com/dailydotdev/apps/pull/2912#discussion_r1550979025

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android


### Preview domain
https://chore-graphql-comment-fields.preview.app.daily.dev