### PR TITLE
feat: ignore syntax highlighter assets in pwa

### DIFF
--- a/packages/webapp/cache.js
+++ b/packages/webapp/cache.js
@@ -79,7 +79,8 @@ module.exports = [
     },
   },
   {
-    urlPattern: /\.(?:js)$/i,
+    urlPattern:
+      /^(?!.*react-syntax-highlighter|reactSyntaxHighlighterLanguages).*\.js$/i,
     handler: 'StaleWhileRevalidate',
     options: {
       cacheName: 'static-js-assets',

--- a/packages/webapp/cache.js
+++ b/packages/webapp/cache.js
@@ -79,8 +79,7 @@ module.exports = [
     },
   },
   {
-    urlPattern:
-      /^(?!.*react-syntax-highlighter|reactSyntaxHighlighterLanguages).*\.js$/i,
+    urlPattern: /\.(?:js)$/i,
     handler: 'StaleWhileRevalidate',
     options: {
       cacheName: 'static-js-assets',

--- a/packages/webapp/next.config.js
+++ b/packages/webapp/next.config.js
@@ -21,6 +21,7 @@ module.exports = withTM(
       dest: 'public',
       disable: process.env.NODE_ENV === 'development',
       runtimeCaching,
+      buildExcludes: [/react-syntax-highlighter|reactSyntaxHighlighter/]
     },
       ...withBundleAnalyzer({
         i18n: {


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Do not precache syntax highlighter chunks with [buildExcludes](https://github.com/shadowwalker/next-pwa?tab=readme-ov-file#:~:text=buildExcludes%20%2D%20an%20array%20of%20extra%20pattern%20or%20function%20to%20exclude%20files%20from%20being%20precached)

Before:
<img width="467" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/af5d4c0d-45d5-4cda-9c91-990c1742aef6">

After:
<img width="439" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/17c9ad8f-b904-41d9-8b4a-0400c14ffd76">


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-pwa-syntax-highlighter.preview.app.daily.dev