### PR TITLE
fix: reply feed author not existing

### DIFF
--- a/packages/shared/src/components/comments/CommentContainer.tsx
+++ b/packages/shared/src/components/comments/CommentContainer.tsx
@@ -79,7 +79,7 @@ export default function CommentContainer({
       {children}
       {showContextHeader && (
         <header className="mb-4 line-clamp-1 text-text-tertiary typo-footnote">
-          {comment.parent ? (
+          {comment.parent?.author ? (
             <p>
               Replied to <strong>@{comment.parent.author.username}</strong>
             </p>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- @kopancek I think with the addition of parent to global comment we broke this.
- Added conditional author check now to ensure rendering
- Solves: https://github.com/dailydotdev/daily/issues/1108

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://hotfix-reply-feed.preview.app.daily.dev