### PR TITLE
fix: always pass post id as ssr prop

### DIFF
--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -193,7 +193,7 @@ export async function getStaticProps({
     );
     return {
       props: {
-        id,
+        id: initialData.post.id,
         initialData,
       },
       revalidate: 60,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- `query.id` was actually slug when accessing new slug URL for post page which would then propagate invalid id for stuff like vote mutations

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-correct-post-id.preview.app.daily.dev