### PR TITLE
feat: change status bar background based on theme color

### DIFF
--- a/packages/shared/src/hooks/utils/useThemedAsset.ts
+++ b/packages/shared/src/hooks/utils/useThemedAsset.ts
@@ -1,14 +1,16 @@
 import { useMemo } from 'react';
 import { ThemeMode, useSettingsContext } from '../../contexts/SettingsContext';
+import colors from '../../styles/colors';
 import { cloudinary } from '../../lib/image';
 
-interface UseCloudinaryAsset {
+interface UseAsset {
   onboardingIntroduction: string;
   scrollBlock: string;
   notFound: string;
+  themeColor: string;
 }
 
-export const useThemedAsset = (): UseCloudinaryAsset => {
+export const useThemedAsset = (): UseAsset => {
   const { themeMode } = useSettingsContext();
   const isLight = useMemo(() => {
     if (themeMode === ThemeMode.Auto) {
@@ -29,5 +31,6 @@ export const useThemedAsset = (): UseCloudinaryAsset => {
     notFound: isLight
       ? cloudinary.generic.notFound.light
       : cloudinary.generic.notFound.dark,
+    themeColor: isLight ? colors.salt['0'] : colors.pepper['90'],
   };
 };

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -37,6 +37,7 @@ import { useWebVitals } from '@dailydotdev/shared/src/hooks/useWebVitals';
 import { LazyModalElement } from '@dailydotdev/shared/src/components/modals/LazyModalElement';
 import { useManualScrollRestoration } from '@dailydotdev/shared/src/hooks';
 import { PushNotificationContextProvider } from '@dailydotdev/shared/src/contexts/PushNotificationContext';
+import { useThemedAsset } from '@dailydotdev/shared/src/hooks/utils';
 import Seo from '../next-seo';
 import useWebappVersion from '../hooks/useWebappVersion';
 
@@ -107,6 +108,8 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
     (Component as ComponentGetLayout).getLayout || ((page) => page);
   const { layoutProps } = Component as ComponentGetLayout;
 
+  const { themeColor } = useThemedAsset();
+
   return (
     <>
       <Head>
@@ -114,18 +117,17 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
           name="viewport"
           content="initial-scale=1.0, width=device-width, viewport-fit=cover"
         />
-        <meta name="theme-color" content="#151618" />
-        <meta name="msapplication-nav" content="#151618" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="#151618" />
+        <meta name="theme-color" content={themeColor} />
+        <meta
+          name="apple-mobile-web-app-status-bar-style"
+          content={themeColor}
+        />
 
         <meta name="application-name" content="daily.dev" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="apple-mobile-web-app-title" content="daily.dev" />
         <meta name="format-detection" content="telephone=no" />
         <meta name="mobile-web-app-capable" content="yes" />
-        <meta name="msapplication-TileColor" content="#151618" />
-        <meta name="msapplication-tap-highlight" content="no" />
 
         <link
           rel="apple-touch-icon"


### PR DESCRIPTION
## Changes

- Removed meta tags that were only useful for Internet Explorer or Windows 8 (both unsupported anymore)
- Changed the value of theme-color meta tag to reflect the selected theme default background color

### Screenshots

#### Dark

<img alt="Simulator Screenshot - iPhone 15 Pro - 2024-04-05 at 16 14 25" src="https://github.com/dailydotdev/apps/assets/9974711/ad3c2f7e-d52e-4c60-8519-9c9882b25dcc" width="400" />

#### Light

<img alt="Simulator Screenshot - iPhone 15 Pro - 2024-04-05 at 16 14 34" src="https://github.com/dailydotdev/apps/assets/9974711/12ef4f70-ffa1-494c-8f5b-6abb6d402353" width="400" />

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-275 #done


### Preview domain
https://mobile-ux-status-bar-color.preview.app.daily.dev