### PR TITLE
fix: close drawer after clicking

### DIFF
--- a/packages/webapp/components/footer/FooterPlusButton.tsx
+++ b/packages/webapp/components/footer/FooterPlusButton.tsx
@@ -72,7 +72,10 @@ export function FooterPlusButton(): ReactElement {
             </ActionButton>
             <ActionButton
               icon={<DocsIcon />}
-              onClick={() => openModal({ type: LazyModal.SubmitArticle })}
+              onClick={() => {
+                setIsDrawerOpen(false);
+                openModal({ type: LazyModal.SubmitArticle });
+              }}
             >
               Submit article
             </ActionButton>

--- a/packages/webapp/components/footer/FooterPlusButton.tsx
+++ b/packages/webapp/components/footer/FooterPlusButton.tsx
@@ -1,5 +1,5 @@
-import React, { ReactElement, useState } from 'react';
-import { Drawer } from '@dailydotdev/shared/src/components/drawers';
+import React, { ReactElement, useRef, useState } from 'react';
+import { Drawer, DrawerRef } from '@dailydotdev/shared/src/components/drawers';
 import {
   AllowedTags,
   Button,
@@ -40,6 +40,7 @@ const ActionButton = <TagName extends AllowedTags>({
 export function FooterPlusButton(): ReactElement {
   const { user } = useAuthContext();
   const { openModal } = useLazyModal();
+  const drawerRef = useRef<DrawerRef>();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const props = user
     ? { onClick: () => setIsDrawerOpen(true) }
@@ -55,6 +56,7 @@ export function FooterPlusButton(): ReactElement {
       />
       <RootPortal>
         <Drawer
+          ref={drawerRef}
           displayCloseButton
           isOpen={isDrawerOpen}
           onClose={() => setIsDrawerOpen(false)}
@@ -73,7 +75,7 @@ export function FooterPlusButton(): ReactElement {
             <ActionButton
               icon={<DocsIcon />}
               onClick={() => {
-                setIsDrawerOpen(false);
+                drawerRef?.current?.onClose();
                 openModal({ type: LazyModal.SubmitArticle });
               }}
             >


### PR DESCRIPTION
## Changes
- When opening the submit article screen, we should close the drawer.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
