### PR TITLE
fix: footer navbar spacing

### DIFF
--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -70,7 +70,7 @@ export default function FooterNavBar({
       className={classNames(
         'fixed !bottom-0 left-0 z-2 w-full',
         isNewMobileLayout
-          ? 'bg-gradient-to-t from-blur-baseline via-blur-bg via-70% to-transparent p-2'
+          ? 'bg-gradient-to-t from-blur-baseline via-blur-bg via-70% to-transparent p-2 pb-6'
           : post && 'bg-blur-bg backdrop-blur-20',
       )}
     >
@@ -92,12 +92,12 @@ export default function FooterNavBar({
         spring="veryGentle"
         element="nav"
         className={classNames(
-          'grid h-14 w-full grid-flow-col items-center justify-between px-3',
+          'grid w-full grid-flow-col items-center justify-between px-3',
           !showNav && 'hidden',
           styles.footerNavBar,
           isNewMobileLayout
             ? classNames('rounded-16', !post && activeClasses)
-            : 'rounded-t-24 bg-background-default',
+            : 'h-14 rounded-t-24 bg-background-default',
           !post && 'border-t border-theme-divider-tertiary',
         )}
       >

--- a/packages/webapp/components/footer/FooterNavBarV1.tsx
+++ b/packages/webapp/components/footer/FooterNavBarV1.tsx
@@ -58,7 +58,7 @@ const Tab = ({ tab, isActive }: TabProps) => {
   return (
     <FooterNavBarItem
       isActive={isActive}
-      className="flex h-full flex-col items-center justify-center"
+      className="flex h-full flex-col items-center justify-center py-2"
     >
       <Link
         href={


### PR DESCRIPTION
## Changes
- The fix here is very similar to the previous one, but the core issue was where we placed the padding. In here we put it on the actual main container.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-256 #done


### Preview domain
https://mi-256-padding.preview.app.daily.dev