### PR TITLE
chore: cleanup all divider colors

### DIFF
--- a/packages/extension/src/companion/CompanionContent.tsx
+++ b/packages/extension/src/companion/CompanionContent.tsx
@@ -60,7 +60,7 @@ export default function CompanionContent({
   return (
     <div
       ref={onContainerChange}
-      className="relative flex h-auto w-[22.5rem] flex-col rounded-tl-16 border border-r-0 border-theme-divider-quaternary bg-background-default p-6"
+      className="relative flex h-auto w-[22.5rem] flex-col rounded-tl-16 border border-r-0 border-border-subtlest-quaternary bg-background-default p-6"
     >
       <div className="flex flex-row items-center gap-3">
         <a href={process.env.NEXT_PUBLIC_WEBAPP_URL} target="_parent">

--- a/packages/extension/src/companion/CompanionDiscussion.tsx
+++ b/packages/extension/src/companion/CompanionDiscussion.tsx
@@ -47,7 +47,7 @@ export function CompanionDiscussion({
       )}
     >
       <span className="px-6" />
-      <div className="mt-5 flex-1 overflow-y-auto overflow-x-hidden border-t border-theme-divider-tertiary px-4">
+      <div className="mt-5 flex-1 overflow-y-auto overflow-x-hidden border-t border-border-subtlest-tertiary px-4">
         <h3 className="mb-6 ml-2 mt-4 font-bold typo-callout">Discussion</h3>
         <NewComment
           size="medium"

--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -210,7 +210,7 @@ export default function CompanionMenu({
   });
 
   return (
-    <div className="group relative my-6 flex w-14 flex-col gap-2 self-center rounded-l-16 border border-theme-divider-quaternary bg-background-default p-2">
+    <div className="group relative my-6 flex w-14 flex-col gap-2 self-center rounded-l-16 border border-border-subtlest-quaternary bg-background-default p-2">
       <CompanionToggle
         companionState={companionState}
         isAlertDisabled={!showCompanionHelper}

--- a/packages/extension/src/newtab/CardSelection.tsx
+++ b/packages/extension/src/newtab/CardSelection.tsx
@@ -20,10 +20,10 @@ export function CardSelection({
   return (
     <button
       className={classNames(
-        'relative flex flex-col items-center gap-1 rounded-16 border border-theme-divider-tertiary px-4 py-3 hover:cursor-pointer',
+        'relative flex flex-col items-center gap-1 rounded-16 border border-border-subtlest-tertiary px-4 py-3 hover:cursor-pointer',
         isActive
-          ? 'border-theme-divider-primary'
-          : 'border-theme-divider-tertiary',
+          ? 'border-border-subtlest-primary'
+          : 'border-border-subtlest-tertiary',
       )}
       onClick={onClick}
       type="button"

--- a/packages/extension/src/newtab/CustomLinks.tsx
+++ b/packages/extension/src/newtab/CustomLinks.tsx
@@ -34,8 +34,8 @@ export function CustomLinks({
       className={classNames(
         'hidden h-fit flex-row gap-2 rounded-14 border p-2',
         shouldUseMobileFeedLayout
-          ? 'border-theme-divider-tertiary tablet:flex'
-          : 'border-theme-divider-secondary laptop:flex',
+          ? 'border-border-subtlest-tertiary tablet:flex'
+          : 'border-border-subtlest-secondary laptop:flex',
         className,
       )}
     >

--- a/packages/shared/src/components/CalendarHeatmap.tsx
+++ b/packages/shared/src/components/CalendarHeatmap.tsx
@@ -33,7 +33,7 @@ const labelStyle: CSSProperties = {
 
 const binsAttributes: React.SVGProps<SVGRectElement>[] = [
   {
-    fill: 'var(--theme-divider-quaternary)',
+    fill: 'var(--theme-border-subtlest-quaternary)',
   },
   {
     fill: 'var(--theme-text-disabled)',

--- a/packages/shared/src/components/CommentFeed.tsx
+++ b/packages/shared/src/components/CommentFeed.tsx
@@ -72,7 +72,7 @@ export default function CommentFeed<T>({
       <PlaceholderCommentList
         placeholderAmount={5}
         className={classNames(
-          '!mt-0 border-theme-divider-tertiary p-4',
+          '!mt-0 border-border-subtlest-tertiary p-4',
           commentClassName?.container,
         )}
         showContextHeader

--- a/packages/shared/src/components/KeyboardShortcutLabel.tsx
+++ b/packages/shared/src/components/KeyboardShortcutLabel.tsx
@@ -28,7 +28,7 @@ export const KeyboadShortcutLabel = ({
       {keys.map((item, index) => {
         return (
           <Fragment key={item}>
-            <kbd className="flex min-w-5 justify-center rounded-8 border border-theme-divider-tertiary bg-background-subtle px-2 py-0.5 font-sans text-text-tertiary typo-footnote">
+            <kbd className="flex min-w-5 justify-center rounded-8 border border-border-subtlest-tertiary bg-background-subtle px-2 py-0.5 font-sans text-text-tertiary typo-footnote">
               {item}
             </kbd>
             {index !== keys.length - 1 && (

--- a/packages/shared/src/components/ProfileMenu.tsx
+++ b/packages/shared/src/components/ProfileMenu.tsx
@@ -102,7 +102,7 @@ export default function ProfileMenu({
       onClose={onClose}
       closeOutsideClick
       position={InteractivePopupPosition.ProfileMenu}
-      className="w-full max-w-64 !rounded-24 border border-theme-divider-tertiary"
+      className="w-full max-w-64 !rounded-24 border border-border-subtlest-tertiary"
       closeButton={{
         variant: ButtonVariant.Primary,
         size: ButtonSize.XSmall,
@@ -126,7 +126,7 @@ export default function ProfileMenu({
         reputation={user.reputation}
         className="gap-3 p-4"
       />
-      <div className="flex flex-col border-t border-theme-divider-tertiary py-2">
+      <div className="flex flex-col border-t border-border-subtlest-tertiary py-2">
         {items.map(({ title, buttonProps }) => (
           <Button
             key={title}

--- a/packages/shared/src/components/RecommendedMention.tsx
+++ b/packages/shared/src/components/RecommendedMention.tsx
@@ -27,7 +27,7 @@ export function RecommendedMention({
 
   return (
     <ul
-      className="flex w-70 flex-col overflow-hidden rounded-16 border border-theme-divider-secondary text-text-primary"
+      className="flex w-70 flex-col overflow-hidden rounded-16 border border-border-subtlest-secondary text-text-primary"
       role="listbox"
     >
       {users.map((user, index) => (

--- a/packages/shared/src/components/ShareNewCommentPopup.tsx
+++ b/packages/shared/src/components/ShareNewCommentPopup.tsx
@@ -45,7 +45,7 @@ export default function ShareNewCommentPopup({
 
   return (
     <div
-      className="fixed bottom-6 right-6 z-3 hidden flex-col rounded-16 border border-theme-divider-secondary bg-accent-pepper-subtlest px-6 pb-6 pt-10 shadow-2 laptop:flex"
+      className="fixed bottom-6 right-6 z-3 hidden flex-col rounded-16 border border-border-subtlest-secondary bg-accent-pepper-subtlest px-6 pb-6 pt-10 shadow-2 laptop:flex"
       style={{ width: '20.625rem' }}
     >
       <ModalClose onClick={onRequestClose} top="2" />

--- a/packages/shared/src/components/auth/OrDivider.tsx
+++ b/packages/shared/src/components/auth/OrDivider.tsx
@@ -14,9 +14,9 @@ function OrDivider({ className, label = 'or' }: OrDividerProps): ReactElement {
         className,
       )}
     >
-      <div className="h-px flex-1 bg-theme-divider-tertiary" />
+      <div className="h-px flex-1 bg-border-subtlest-tertiary" />
       {label && <span className="px-3">{label}</span>}
-      <div className="h-px flex-1 bg-theme-divider-tertiary" />
+      <div className="h-px flex-1 bg-border-subtlest-tertiary" />
     </div>
   );
 }

--- a/packages/shared/src/components/auth/RegistrationForm.tsx
+++ b/packages/shared/src/components/auth/RegistrationForm.tsx
@@ -226,7 +226,7 @@ export const RegistrationForm = ({
             required
           />
         )}
-        <span className="border-b border-theme-divider-tertiary pb-4 text-text-secondary typo-subhead">
+        <span className="border-b border-border-subtlest-tertiary pb-4 text-text-secondary typo-subhead">
           Your email will be used to send you product and community updates
         </span>
         <Checkbox name="optOutMarketing">

--- a/packages/shared/src/components/auth/SignBackButton.tsx
+++ b/packages/shared/src/components/auth/SignBackButton.tsx
@@ -31,7 +31,7 @@ export function SignBackButton({
         )}
         <span className="typo-footnote">{signBack.email}</span>
       </div>
-      <span className="ml-auto rounded-8 border border-theme-divider-secondary p-1 text-surface-invert">
+      <span className="ml-auto rounded-8 border border-border-subtlest-secondary p-1 text-surface-invert">
         {item.icon}
       </span>
     </button>

--- a/packages/shared/src/components/auth/SocialRegistrationForm.tsx
+++ b/packages/shared/src/components/auth/SocialRegistrationForm.tsx
@@ -230,7 +230,7 @@ export const SocialRegistrationForm = ({
             }}
           />
         )}
-        <span className="border-b border-theme-divider-tertiary pb-4 text-text-secondary typo-subhead">
+        <span className="border-b border-border-subtlest-tertiary pb-4 text-text-secondary typo-subhead">
           Your email will be used to send you product and community updates
         </span>
         <Checkbox name="optOutMarketing" className="font-normal">

--- a/packages/shared/src/components/cards/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.tsx
@@ -118,7 +118,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
       <div
         className={classNames(
           showFeedback
-            ? 'overflow-hidden rounded-16 border !border-theme-divider-tertiary p-2'
+            ? 'overflow-hidden rounded-16 border !border-border-subtlest-tertiary p-2'
             : 'flex flex-1 flex-col',
           showFeedback && styles.post,
           showFeedback && styles.read,

--- a/packages/shared/src/components/cards/Card.module.css
+++ b/packages/shared/src/components/cards/Card.module.css
@@ -55,7 +55,7 @@
   }
 
   &.read {
-    border-color: var(--theme-divider-quaternary);
+    border-color: var(--theme-border-subtlest-quaternary);
     background: var(--theme-background-default);
     box-shadow: none;
 

--- a/packages/shared/src/components/cards/Card.tsx
+++ b/packages/shared/src/components/cards/Card.tsx
@@ -58,7 +58,7 @@ export const CardLink = classed('a', clickableCardClasses);
 export const Card = classed(
   'article',
   styles.card,
-  'relative max-h-card h-full flex flex-col p-2 rounded-16 bg-background-subtle border border-theme-divider-tertiary hover:border-theme-divider-secondary shadow-2',
+  'relative max-h-card h-full flex flex-col p-2 rounded-16 bg-background-subtle border border-border-subtlest-tertiary hover:border-border-subtlest-secondary shadow-2',
 );
 
 export const ChecklistCardComponent = classed(
@@ -76,7 +76,7 @@ export const CardHeader = classed(
 export const ListCard = classed(
   'article',
   styles.card,
-  'relative flex items-stretch pt-4 pb-3 pr-4 rounded-16 bg-background-subtle border border-theme-divider-tertiary hover:border-theme-divider-secondary shadow-2',
+  'relative flex items-stretch pt-4 pb-3 pr-4 rounded-16 bg-background-subtle border border-border-subtlest-tertiary hover:border-border-subtlest-secondary shadow-2',
 );
 
 export const ListCardMain = classed(
@@ -86,7 +86,7 @@ export const ListCardMain = classed(
 
 export const ListCardDivider = classed(
   'div',
-  'w-px h-full bg-theme-divider-tertiary',
+  'w-px h-full bg-border-subtlest-tertiary',
 );
 
 export const getPostClassNames = (

--- a/packages/shared/src/components/cards/FeedItemContainer.tsx
+++ b/packages/shared/src/components/cards/FeedItemContainer.tsx
@@ -59,7 +59,7 @@ function FeedItemContainer(
         ref={ref}
         className={classNames(
           domProps.className,
-          !listMode && isFeedPreview && 'hover:border-theme-divider-tertiary',
+          !listMode && isFeedPreview && 'hover:border-border-subtlest-tertiary',
         )}
       >
         {children}

--- a/packages/shared/src/components/cards/SharedPostCardFooter.tsx
+++ b/packages/shared/src/components/cards/SharedPostCardFooter.tsx
@@ -22,7 +22,7 @@ export const SharedPostCardFooter = ({
   return (
     <div
       className={classNames(
-        'mb-2 flex h-auto min-h-0 w-full flex-auto gap-3 rounded-12 border border-theme-divider-tertiary p-3',
+        'mb-2 flex h-auto min-h-0 w-full flex-auto gap-3 rounded-12 border border-border-subtlest-tertiary p-3',
         isShort ? 'flex-row items-center' : 'flex-col',
       )}
     >

--- a/packages/shared/src/components/cards/v1/Card.tsx
+++ b/packages/shared/src/components/cards/v1/Card.tsx
@@ -59,7 +59,7 @@ export const CardLink = classed('a', clickableCardClasses);
 
 export const Card = classed(
   'article',
-  `group relative w-full flex flex-col py-6 px-4 border-t border-theme-divider-tertiary rounded-16
+  `group relative w-full flex flex-col py-6 px-4 border-t border-border-subtlest-tertiary rounded-16
    hover:bg-theme-float
   `,
 );

--- a/packages/shared/src/components/cards/v1/FeedbackCard.tsx
+++ b/packages/shared/src/components/cards/v1/FeedbackCard.tsx
@@ -66,7 +66,7 @@ export const FeedbackCard = ({
         />
       </div>
 
-      <CardContent className="rounded-14 border border-theme-divider-tertiary p-4">
+      <CardContent className="rounded-14 border border-border-subtlest-tertiary p-4">
         <div className="mr-2 flex-1">
           <h2 className="mb-2 line-clamp-1 typo-body">{post.title}</h2>
         </div>

--- a/packages/shared/src/components/cards/v1/SharedPostCardFooter.tsx
+++ b/packages/shared/src/components/cards/v1/SharedPostCardFooter.tsx
@@ -20,7 +20,7 @@ export const SharedPostCardFooter = ({
   return (
     <div
       className={classNames(
-        'mb-2 flex h-auto min-h-0 w-full flex-auto flex-col gap-3 rounded-12 border border-theme-divider-tertiary p-3 mobileXXL:flex-row',
+        'mb-2 flex h-auto min-h-0 w-full flex-auto flex-col gap-3 rounded-12 border border-border-subtlest-tertiary p-3 mobileXXL:flex-row',
       )}
     >
       <div className={classNames('flex flex-col mobileXL:flex-1')}>

--- a/packages/shared/src/components/comments/CommentContainer.tsx
+++ b/packages/shared/src/components/comments/CommentContainer.tsx
@@ -66,7 +66,7 @@ export default function CommentContainer({
         'flex flex-col rounded-24 p-4 hover:bg-theme-hover focus:outline',
         isCommentReferenced
           ? 'border border-theme-color-cabbage'
-          : 'border-theme-divider-tertiary',
+          : 'border-border-subtlest-tertiary',
         className.container,
       )}
       data-testid="comment"

--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -131,7 +131,7 @@ export default function MainComment({
     <section
       ref={inViewRef}
       className={classNames(
-        'flex scroll-mt-16 flex-col items-stretch rounded-24 border-theme-divider-tertiary',
+        'flex scroll-mt-16 flex-col items-stretch rounded-24 border-border-subtlest-tertiary',
         className?.container,
         inView && 'border',
       )}

--- a/packages/shared/src/components/containers/FeedTopicCard.tsx
+++ b/packages/shared/src/components/containers/FeedTopicCard.tsx
@@ -48,7 +48,7 @@ function FeedFilterCard({
       onClick={onClick}
       className={classNames(
         'group relative flex aspect-square w-full min-w-[8rem] max-w-[8rem] items-center justify-center rounded-14 transition-[background] typo-callout hover:bg-theme-color-cabbage hover:shadow-2-black tablet:min-w-full',
-        isActive ? 'bg-theme-color-cabbage' : 'bg-theme-divider-tertiary',
+        isActive ? 'bg-theme-color-cabbage' : 'bg-border-subtlest-tertiary',
       )}
     >
       <BackgroundLayer className="invisible -z-1 opacity-64 group-hover:visible group-hover:-rotate-12" />

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -119,7 +119,7 @@ function BaseDrawer({
         {title && (
           <h3
             className={classNames(
-              'flex flex-row items-center border-b border-theme-divider-tertiary p-4 font-bold typo-title3',
+              'flex flex-row items-center border-b border-border-subtlest-tertiary p-4 font-bold typo-title3',
               className?.title,
             )}
           >

--- a/packages/shared/src/components/errors/SquadLoading.tsx
+++ b/packages/shared/src/components/errors/SquadLoading.tsx
@@ -46,7 +46,7 @@ function SquadLoading({
           sidebarRendered && '-left-full translate-x-[60%]',
         )}
       />
-      <FlexCol className="relative min-h-20 w-full items-center border-theme-divider-tertiary px-6 tablet:mb-6 tablet:border-b tablet:pb-20 laptopL:items-start laptopL:px-18 laptopL:pb-14">
+      <FlexCol className="relative min-h-20 w-full items-center border-border-subtlest-tertiary px-6 tablet:mb-6 tablet:border-b tablet:pb-20 laptopL:items-start laptopL:px-18 laptopL:pb-14">
         <PlaceholderElement className="h-16 w-16 rounded-full tablet:h-24 tablet:w-24" />
         {squad?.description && <TitleDescription />}
         <div className="mt-8 flex h-fit w-full flex-row justify-center gap-4 tablet:w-auto laptopL:absolute laptopL:right-18 laptopL:top-0 laptopL:mt-0">

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -155,7 +155,7 @@ export const FeedContainer = ({
               {!!actionButtons && (
                 <span
                   className={classNames(
-                    'mr-auto flex flex-row gap-3 border-theme-divider-tertiary pr-3',
+                    'mr-auto flex flex-row gap-3 border-border-subtlest-tertiary pr-3',
                     isNewMobileLayout && isStreaksEnabled && 'w-full',
                   )}
                 >
@@ -171,7 +171,7 @@ export const FeedContainer = ({
             wrapper={(child) => (
               <div
                 className={classNames(
-                  'flex flex-col rounded-16 border border-theme-divider-tertiary tablet:mt-6',
+                  'flex flex-col rounded-16 border border-border-subtlest-tertiary tablet:mt-6',
                   isSearch && 'mt-6',
                   isNewMobileLayout && '!mt-2 border-0',
                 )}

--- a/packages/shared/src/components/fields/Checkbox.tsx
+++ b/packages/shared/src/components/fields/Checkbox.tsx
@@ -69,7 +69,7 @@ export const Checkbox = forwardRef(function Checkbox(
       />
       <div
         className={classNames(
-          'relative z-1 mr-3 flex h-5 w-5 items-center justify-center rounded-6 border-2 border-theme-divider-primary',
+          'relative z-1 mr-3 flex h-5 w-5 items-center justify-center rounded-6 border-2 border-border-subtlest-primary',
           styles.checkmark,
         )}
       >

--- a/packages/shared/src/components/fields/ImageInput.tsx
+++ b/packages/shared/src/components/fields/ImageInput.tsx
@@ -116,7 +116,7 @@ function ImageInput({
         type="button"
         onClick={onClick}
         className={classNames(
-          'group relative flex items-center justify-center overflow-hidden border border-theme-divider-primary',
+          'group relative flex items-center justify-center overflow-hidden border border-border-subtlest-primary',
           componentSize[size],
           className?.container,
         )}

--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -208,7 +208,7 @@ function MarkdownInput(
           wrapper={(component) => (
             <span className="relative flex flex-col">
               <Divider
-                className="absolute left-8 !h-10 !bg-theme-divider-tertiary"
+                className="absolute left-8 !h-10 !bg-border-subtlest-tertiary"
                 vertical
               />
               {timeline}
@@ -262,7 +262,7 @@ function MarkdownInput(
         appendTo={parentSelector}
       />
       {footer ?? (
-        <span className="flex flex-row items-center gap-3 border-theme-divider-tertiary p-3 px-4 text-text-tertiary laptop:justify-end laptop:border-t">
+        <span className="flex flex-row items-center gap-3 border-border-subtlest-tertiary p-3 px-4 text-text-tertiary laptop:justify-end laptop:border-t">
           {!!onUploadCommand && (
             <Button
               size={actionButtonSizes}

--- a/packages/shared/src/components/fields/SearchField.tsx
+++ b/packages/shared/src/components/fields/SearchField.tsx
@@ -96,7 +96,7 @@ export const SearchField = forwardRef(function SearchField(
     <BaseField
       {...props}
       className={classNames(
-        'items-center !border !border-theme-divider-tertiary !bg-background-default',
+        'items-center !border !border-border-subtlest-tertiary !bg-background-default',
         sizeClass,
         className,
         { focused },

--- a/packages/shared/src/components/fields/form/FormWrapper.tsx
+++ b/packages/shared/src/components/fields/form/FormWrapper.tsx
@@ -40,7 +40,7 @@ export function FormWrapper({
     <div className={classNames('flex flex-col', containerClassName)}>
       <div
         className={classNames(
-          'flex flex-row justify-between border-b border-theme-divider-tertiary px-4 py-2',
+          'flex flex-row justify-between border-b border-border-subtlest-tertiary px-4 py-2',
           headerClassName,
         )}
         ref={headerRef}

--- a/packages/shared/src/components/filters/TagCategoryDropdown.tsx
+++ b/packages/shared/src/components/filters/TagCategoryDropdown.tsx
@@ -56,7 +56,7 @@ export default function TagCategoryDropdown({
     <Container>
       <Summary
         className={classNames(
-          isSettings && 'rounded-14 bg-theme-divider-tertiary px-4 py-5',
+          isSettings && 'rounded-14 bg-border-subtlest-tertiary px-4 py-5',
           isSettings &&
             categoryFollowed &&
             'border-l-4 border-accent-cabbage-default',

--- a/packages/shared/src/components/filters/common.tsx
+++ b/packages/shared/src/components/filters/common.tsx
@@ -28,7 +28,7 @@ export const BaseTagCategoryDetails = classed(
 
 export const TagCategoryDetails = classed(
   BaseTagCategoryDetails,
-  'border-t border-b border-theme-divider-tertiary',
+  'border-t border-b border-border-subtlest-tertiary',
 );
 
 export const BaseTagCategorySummary = classed(

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -125,7 +125,7 @@ function MainLayoutHeader({
   return (
     <header
       className={classNames(
-        'sticky top-0 z-header flex h-14 flex-row items-center justify-between gap-3 border-b border-theme-divider-tertiary bg-background-default px-4 py-3 tablet:px-8 laptop:left-0 laptop:h-16 laptop:w-full laptop:flex-row laptop:px-4',
+        'sticky top-0 z-header flex h-14 flex-row items-center justify-between gap-3 border-b border-border-subtlest-tertiary bg-background-default px-4 py-3 tablet:px-8 laptop:left-0 laptop:h-16 laptop:w-full laptop:flex-row laptop:px-4',
         hasBanner && 'laptop:top-8',
         isSearchPage && 'mb-16 laptop:mb-0',
       )}

--- a/packages/shared/src/components/markdown.module.css
+++ b/packages/shared/src/components/markdown.module.css
@@ -28,10 +28,10 @@
     @apply typo-markdown my-5 relative;
   }
   & :where(blockquote) {
-    @apply typo-markdown italic pl-7 my-5 border-l border-theme-divider-secondary;
+    @apply typo-markdown italic pl-7 my-5 border-l border-border-subtlest-secondary;
   }
   & :where(pre) {
-    @apply typo-markdown relative bg-theme-float py-7 px-6 my-5 rounded-12 border border-theme-divider-quaternary;
+    @apply typo-markdown relative bg-theme-float py-7 px-6 my-5 rounded-12 border border-border-subtlest-quaternary;
   }
 
   & :where(pre) > code {
@@ -39,7 +39,7 @@
     color: var(--theme-highlight-label);
   }
   & :not(pre) > code {
-    @apply bg-theme-float typo-footnote border border-theme-divider-quaternary px-1 rounded-6 box-decoration-clone;
+    @apply bg-theme-float typo-footnote border border-border-subtlest-quaternary px-1 rounded-6 box-decoration-clone;
   }
   & :where(ul) {
     @apply list-disc my-5 pl-7;
@@ -70,7 +70,7 @@
     }
   }
   & :where(hr) {
-    @apply border-theme-divider-secondary my-10;
+    @apply border-border-subtlest-secondary my-10;
   }
   & :where(img) {
     @apply rounded-16 max-h-img-mobile tablet:max-h-img-desktop;

--- a/packages/shared/src/components/modals/RanksModal/RankBadgeItem.tsx
+++ b/packages/shared/src/components/modals/RanksModal/RankBadgeItem.tsx
@@ -52,7 +52,7 @@ const RankBadgeItem = ({
           className={
             rankCompleted
               ? itemRank.background
-              : 'bg-theme-divider-tertiary opacity-32'
+              : 'bg-border-subtlest-tertiary opacity-32'
           }
         />
       )}
@@ -60,7 +60,7 @@ const RankBadgeItem = ({
         className={classNames(
           rankCompleted
             ? itemRank.border
-            : 'border-theme-divider-tertiary border-opacity-32',
+            : 'border-border-subtlest-tertiary border-opacity-32',
           showRank === itemRank.level
             ? 'h-16 w-16'
             : 'h-10 w-10 rounded-12 border',

--- a/packages/shared/src/components/modals/RanksModal/RankTagItem.tsx
+++ b/packages/shared/src/components/modals/RanksModal/RankTagItem.tsx
@@ -7,7 +7,7 @@ import { RankTag, RankTagPill, RankTagProps } from './common';
 const RankTagItem = ({ tag, isColorPrimary }: RankTagProps): ReactElement => {
   const isPlaceholder = tag === undefined || tag === null;
   const className = isPlaceholder
-    ? 'w-24 rounded-8 border border-theme-divider-secondary'
+    ? 'w-24 rounded-8 border border-border-subtlest-secondary'
     : 'flex-shrink w-auto bg-theme-float';
 
   return (

--- a/packages/shared/src/components/modals/RanksModal/common.tsx
+++ b/packages/shared/src/components/modals/RanksModal/common.tsx
@@ -60,7 +60,7 @@ export const RankBadgeName = classed('strong', 'mt-2');
 /** Rank tag */
 export const RanksTagsSection = classed(
   'div',
-  'p-4 mb-4 rounded-16 border bg-background-subtle border-theme-divider-tertiary',
+  'p-4 mb-4 rounded-16 border bg-background-subtle border-border-subtlest-tertiary',
 );
 export const RanksTagsList = classed(
   'ul',

--- a/packages/shared/src/components/modals/SharedBookmarksModal.tsx
+++ b/packages/shared/src/components/modals/SharedBookmarksModal.tsx
@@ -97,7 +97,7 @@ export default function SharedBookmarksModal({
             />
           </div>
         )}
-        <div className="mt-4 rounded-16 border border-theme-divider-tertiary p-6">
+        <div className="mt-4 rounded-16 border border-border-subtlest-tertiary p-6">
           <p className="text-text-tertiary typo-callout">
             Need inspiration? we prepared some tutorials explaining some best
             practices of integrating your bookmarks with other platforms.

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -178,7 +178,7 @@ export function Modal({
     overlayClassName,
   );
   const modalClassName = classNames(
-    'modal relative flex max-w-full flex-col items-center border-theme-divider-secondary bg-accent-pepper-subtlest antialiased shadow-2 focus:outline-none tablet:border',
+    'modal relative flex max-w-full flex-col items-center border-border-subtlest-secondary bg-accent-pepper-subtlest antialiased shadow-2 focus:outline-none tablet:border',
     'h-full w-full tablet:h-auto tablet:rounded-16',
     modalKindToClassName[kind],
     modalSizeToClassName[size],

--- a/packages/shared/src/components/modals/common/ModalFooter.tsx
+++ b/packages/shared/src/components/modals/common/ModalFooter.tsx
@@ -29,7 +29,7 @@ export function ModalFooter({
   return (
     <footer
       className={classNames(
-        'flex h-16 w-full items-center gap-3 border-t border-theme-divider-tertiary p-3',
+        'flex h-16 w-full items-center gap-3 border-t border-border-subtlest-tertiary p-3',
         justify,
         className,
       )}

--- a/packages/shared/src/components/modals/common/ModalHeader.tsx
+++ b/packages/shared/src/components/modals/common/ModalHeader.tsx
@@ -53,7 +53,7 @@ export function ModalHeader({
     <ModalHeaderOuter
       className={classNames(
         'relative h-14 items-center',
-        (modalTitle || children) && 'border-b border-theme-divider-tertiary',
+        (modalTitle || children) && 'border-b border-border-subtlest-tertiary',
         className,
       )}
     >
@@ -81,7 +81,7 @@ export function ModalHeader({
 export function ModalHeaderTabs(props: ModalTabsProps): ReactElement {
   const { onRequestClose } = useContext(ModalPropsContext);
   return (
-    <ModalHeaderOuter className="h-auto flex-col items-start gap-2 border-b border-theme-divider-tertiary tablet:h-14 tablet:flex-row tablet:items-center">
+    <ModalHeaderOuter className="h-auto flex-col items-start gap-2 border-b border-border-subtlest-tertiary tablet:h-14 tablet:flex-row tablet:items-center">
       {onRequestClose && (
         <Button
           size={ButtonSize.Small}

--- a/packages/shared/src/components/modals/common/ModalSidebar.tsx
+++ b/packages/shared/src/components/modals/common/ModalSidebar.tsx
@@ -49,7 +49,7 @@ export function ModalSidebarList({
 
 export const ModalSidebarInner = classed(
   'div',
-  'flex flex-1 flex-col border-l border-theme-divider-tertiary',
+  'flex flex-1 flex-col border-l border-border-subtlest-tertiary',
 );
 
 export function ModalSidebar({

--- a/packages/shared/src/components/modals/post/CommentModal.tsx
+++ b/packages/shared/src/components/modals/post/CommentModal.tsx
@@ -226,7 +226,7 @@ export default function CommentModal({
                   postScoutId={post?.scout?.id}
                 />
                 <div
-                  className="ml-12 flex gap-2 border-l border-theme-divider-tertiary py-3 pl-5 text-text-tertiary typo-caption1"
+                  className="ml-12 flex gap-2 border-l border-border-subtlest-tertiary py-3 pl-5 text-text-tertiary typo-caption1"
                   ref={replyRef}
                 >
                   Reply to

--- a/packages/shared/src/components/multiLevelMenu/MultiLevelMenuDetail.tsx
+++ b/packages/shared/src/components/multiLevelMenu/MultiLevelMenuDetail.tsx
@@ -14,7 +14,7 @@ export default function MultiLevelMenuDetail({
 }): ReactElement {
   return (
     <>
-      <div className="mb-6 border-b border-theme-divider-tertiary px-4 py-1">
+      <div className="mb-6 border-b border-border-subtlest-tertiary px-4 py-1">
         <Button
           className="btn-quaternary p-0 text-text-tertiary typo-callout"
           onClick={() => setMultiLevelMenuDetail(null, null)}

--- a/packages/shared/src/components/multiLevelMenu/MultiLevelMenuMaster.tsx
+++ b/packages/shared/src/components/multiLevelMenu/MultiLevelMenuMaster.tsx
@@ -18,7 +18,7 @@ export default function MultiLevelMenuMaster({
     <ul className="mt-6">
       {menuItems.map((item) => (
         <li
-          className="cursor-pointer border-b border-theme-divider-tertiary first:border-t"
+          className="cursor-pointer border-b border-border-subtlest-tertiary first:border-t"
           key={item.title}
         >
           <MenuButton

--- a/packages/shared/src/components/notifications/NotificationItemAttachment.tsx
+++ b/packages/shared/src/components/notifications/NotificationItemAttachment.tsx
@@ -12,7 +12,7 @@ function NotificationItemAttachment({
   type,
 }: NotificationAttachment): ReactElement {
   return (
-    <div className="mt-2 flex flex-row items-center rounded-16 border border-theme-divider-tertiary p-4">
+    <div className="mt-2 flex flex-row items-center rounded-16 border border-border-subtlest-tertiary p-4">
       <div>
         <CardCover
           data-testid="postImage"

--- a/packages/shared/src/components/notifications/utils.ts
+++ b/packages/shared/src/components/notifications/utils.ts
@@ -17,7 +17,7 @@ import { NotificationPromptSource } from '../../lib/analytics';
 
 export const NotifContainer = classed(
   'div',
-  'fixed left-1/2 flex flex-col justify-center bg-text-primary p-2 rounded-14 border-theme-divider-primary shadow-2',
+  'fixed left-1/2 flex flex-col justify-center bg-text-primary p-2 rounded-14 border-border-subtlest-primary shadow-2',
 );
 export const NotifContent = classed(
   'div',

--- a/packages/shared/src/components/onboarding/OnboardingFeedHeader.tsx
+++ b/packages/shared/src/components/onboarding/OnboardingFeedHeader.tsx
@@ -121,7 +121,7 @@ export const OnboardingFeedHeader = ({
           shouldUpdateAlerts={false}
         />
         <div className="mt-10 flex items-center justify-center gap-10 text-text-quaternary typo-callout">
-          <div className="h-px flex-1 bg-theme-divider-tertiary" />
+          <div className="h-px flex-1 bg-border-subtlest-tertiary" />
           <Button
             variant={ButtonVariant.Float}
             disabled={!isPreviewFeedEnabled}
@@ -139,7 +139,7 @@ export const OnboardingFeedHeader = ({
               ? `${isPreviewFeedVisible ? 'Hide' : 'Show'} feed preview`
               : `${tagsCount}/${REQUIRED_TAGS_THRESHOLD} to show feed preview`}
           </Button>
-          <div className="h-px flex-1 bg-theme-divider-tertiary" />
+          <div className="h-px flex-1 bg-border-subtlest-tertiary" />
         </div>
       </div>
     </LayoutHeader>

--- a/packages/shared/src/components/pagination/PaginationActions.tsx
+++ b/packages/shared/src/components/pagination/PaginationActions.tsx
@@ -25,7 +25,7 @@ export const PaginationActions = ({
   onPrevious,
 }: PaginationActionsProps): ReactElement => {
   return (
-    <div className="hidden items-center justify-between border-t border-theme-divider-tertiary p-3 laptop:flex">
+    <div className="hidden items-center justify-between border-t border-border-subtlest-tertiary p-3 laptop:flex">
       <p className="ml-1 text-text-tertiary typo-callout">
         {current}/{max}
       </p>
@@ -62,7 +62,7 @@ export const InfinitePaginationActions = ({
   onPrevious,
 }: InfinitePaginationActionsProps): ReactElement => {
   return (
-    <div className="flex items-center justify-end border-t border-theme-divider-tertiary p-3">
+    <div className="flex items-center justify-end border-t border-border-subtlest-tertiary p-3">
       <Button
         {...buttonProps}
         icon={<ArrowIcon className="-rotate-90" />}

--- a/packages/shared/src/components/post/FixedPostNavigation.tsx
+++ b/packages/shared/src/components/post/FixedPostNavigation.tsx
@@ -28,7 +28,7 @@ function FixedPostNavigation({
       contextMenuId="fixed-post-navigation-context"
       className={{
         container: classNames(
-          'fixed z-postNavigation ml-0 w-full border border-theme-divider-tertiary bg-background-subtle px-6 py-4',
+          'fixed z-postNavigation ml-0 w-full border border-border-subtlest-tertiary bg-background-subtle px-6 py-4',
           'max-w-full laptop:left-[unset]',
           isBannerVisible ? 'top-14' : 'top-0',
           className?.container,

--- a/packages/shared/src/components/post/NewComment.tsx
+++ b/packages/shared/src/components/post/NewComment.tsx
@@ -113,7 +113,7 @@ function NewCommentComponent(
     <button
       type="button"
       className={classNames(
-        'flex w-full items-center gap-4 rounded-16 border-t border-theme-divider-tertiary bg-blur-highlight p-3 typo-callout hover:border-theme-divider-primary hover:bg-theme-hover tablet:border tablet:bg-theme-float',
+        'flex w-full items-center gap-4 rounded-16 border-t border-border-subtlest-tertiary bg-blur-highlight p-3 typo-callout hover:border-border-subtlest-primary hover:bg-theme-hover tablet:border tablet:bg-theme-float',
         className?.container,
       )}
       onClick={() => onCommentClick(Origin.StartDiscussion)}

--- a/packages/shared/src/components/post/PostActions.tsx
+++ b/packages/shared/src/components/post/PostActions.tsx
@@ -105,10 +105,10 @@ export function PostActions({
         </div>
       )}
     >
-      <div className="flex items-center rounded-16 border border-theme-divider-tertiary">
+      <div className="flex items-center rounded-16 border border-border-subtlest-tertiary">
         <Card
           className={classNames(
-            'flex !flex-row gap-2 hover:border-theme-divider-tertiary',
+            'flex !flex-row gap-2 hover:border-border-subtlest-tertiary',
             {
               'border-theme-color-avocado hover:!border-theme-color-avocado bg-theme-overlay-float-avocado':
                 post?.userState?.vote === UserVote.Up,

--- a/packages/shared/src/components/post/PostContentContainer.tsx
+++ b/packages/shared/src/components/post/PostContentContainer.tsx
@@ -20,7 +20,7 @@ const BodyContainer = classed(
 
 const PageBodyContainer = classed(
   BodyContainer,
-  'm-auto w-full laptop:border-x laptop:border-theme-divider-tertiary',
+  'm-auto w-full laptop:border-x laptop:border-border-subtlest-tertiary',
 );
 
 function PostContentContainer({

--- a/packages/shared/src/components/post/PostLoadingSkeleton.tsx
+++ b/packages/shared/src/components/post/PostLoadingSkeleton.tsx
@@ -24,7 +24,7 @@ function PostLoadingSkeleton({
       hasNavigation={hasNavigation}
       className={classNames(className, 'tablet:flex-row tablet:pb-0')}
     >
-      <PostLoadingPlaceholder className="tablet:border-r tablet:border-theme-divider-tertiary" />
+      <PostLoadingPlaceholder className="tablet:border-r tablet:border-border-subtlest-tertiary" />
     </PostContentContainer>
   );
 }

--- a/packages/shared/src/components/post/PostPreview.tsx
+++ b/packages/shared/src/components/post/PostPreview.tsx
@@ -36,7 +36,7 @@ function PostPreview({
   return (
     <div
       className={classNames(
-        'flex w-full items-center gap-4 rounded-12 border border-theme-divider-tertiary px-4 py-2',
+        'flex w-full items-center gap-4 rounded-12 border border-border-subtlest-tertiary px-4 py-2',
         className,
       )}
     >

--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -25,7 +25,7 @@ interface SharePostContentProps {
 const SharePostContentSkeleton = () => (
   <>
     <ElementPlaceholder className="mt-6 h-6 w-2/4 rounded-10" />
-    <div className="mb-5 mt-8 rounded-16 border border-theme-divider-tertiary">
+    <div className="mb-5 mt-8 rounded-16 border border-border-subtlest-tertiary">
       <div className="flex max-w-full flex-col p-4 pt-5 laptop:flex-row">
         <div className="flex flex-1 flex-col gap-9">
           <ElementPlaceholder className="h-6 w-20 rounded-10" />

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -133,7 +133,7 @@ function SquadPostContent({
         onShare={onCopyPostLink}
         onReadArticle={onReadArticle}
         post={post}
-        className="mb-6 border-l border-theme-divider-tertiary tablet:mb-0"
+        className="mb-6 border-l border-border-subtlest-tertiary tablet:mb-0"
         onClose={onClose}
         origin={origin}
       />

--- a/packages/shared/src/components/post/SquadPostWidgets.tsx
+++ b/packages/shared/src/components/post/SquadPostWidgets.tsx
@@ -31,7 +31,7 @@ const SquadCard = ({ squadSource }: { squadSource: Squad }) => {
   }
 
   return (
-    <div className="rounded-16 border border-theme-divider-tertiary p-4">
+    <div className="rounded-16 border border-border-subtlest-tertiary p-4">
       <div className="flex flex-row justify-between">
         <SourceButton source={squad} size="xxxlarge" />
         <SquadMemberShortList

--- a/packages/shared/src/components/post/block/PostBlockedPanel.tsx
+++ b/packages/shared/src/components/post/block/PostBlockedPanel.tsx
@@ -18,7 +18,7 @@ export function PostBlockedPanel({
   return (
     <span
       className={classNames(
-        'relative flex flex-row items-center rounded-16 border border-theme-divider-tertiary p-4',
+        'relative flex flex-row items-center rounded-16 border border-border-subtlest-tertiary p-4',
         className,
       )}
     >

--- a/packages/shared/src/components/post/block/PostTagsPanel.tsx
+++ b/packages/shared/src/components/post/block/PostTagsPanel.tsx
@@ -78,7 +78,7 @@ export function PostTagsPanel({
   return (
     <div
       className={classNames(
-        'relative flex flex-col rounded-16 border border-theme-divider-tertiary p-4 pb-0',
+        'relative flex flex-col rounded-16 border border-border-subtlest-tertiary p-4 pb-0',
         className,
       )}
     >
@@ -116,7 +116,7 @@ export function PostTagsPanel({
           />
         ))}
       </span>
-      <span className="-mx-4 mt-4 flex flex-row gap-2 border-t border-theme-divider-tertiary p-3">
+      <span className="-mx-4 mt-4 flex flex-row gap-2 border-t border-border-subtlest-tertiary p-3">
         <Button
           className="ml-auto"
           variant={ButtonVariant.Tertiary}

--- a/packages/shared/src/components/post/common.tsx
+++ b/packages/shared/src/components/post/common.tsx
@@ -88,7 +88,7 @@ export interface PostContentProps
 
 export const PostContainer = classed(
   'main',
-  'flex flex-col flex-1 px-4 tablet:px-8 tablet:border-r tablet:border-theme-divider-tertiary',
+  'flex flex-col flex-1 px-4 tablet:px-8 tablet:border-r tablet:border-border-subtlest-tertiary',
 );
 
 export interface BasePostContentProps extends UsePostContentProps {

--- a/packages/shared/src/components/post/common/SharedLinkContainer.tsx
+++ b/packages/shared/src/components/post/common/SharedLinkContainer.tsx
@@ -47,7 +47,7 @@ export function SharedLinkContainer({
   return (
     <div
       className={classNames(
-        'flex flex-col rounded-16 border border-theme-divider-tertiary hover:border-theme-divider-secondary',
+        'flex flex-col rounded-16 border border-border-subtlest-tertiary hover:border-border-subtlest-secondary',
         className,
       )}
     >
@@ -57,7 +57,7 @@ export function SharedLinkContainer({
           {Wrapper ? <Wrapper>{postSummary}</Wrapper> : postSummary}
           <button
             type="button"
-            className="flex w-full flex-row justify-center border-t border-theme-divider-tertiary py-2 font-bold typo-callout hover:underline"
+            className="flex w-full flex-row justify-center border-t border-border-subtlest-tertiary py-2 font-bold typo-callout hover:underline"
             onClick={() => setShouldShowSummary(!shouldShowSummary)}
           >
             {shouldShowSummary ? 'Hide' : 'Show'} TLDR{' '}

--- a/packages/shared/src/components/post/freeform/write/WritePostHeader.tsx
+++ b/packages/shared/src/components/post/freeform/write/WritePostHeader.tsx
@@ -12,7 +12,7 @@ export function WritePostHeader({
   const { squad } = useWritePostContext();
 
   return (
-    <header className="flex h-14 flex-row items-center border-b border-theme-divider-tertiary px-6 py-4">
+    <header className="flex h-14 flex-row items-center border-b border-border-subtlest-tertiary px-6 py-4">
       <h1 className="font-bold typo-title3">{isEdit ? 'Edit' : 'New'} post</h1>
       {squad && (
         <>

--- a/packages/shared/src/components/post/write/SubmitExternalLink.tsx
+++ b/packages/shared/src/components/post/write/SubmitExternalLink.tsx
@@ -56,7 +56,7 @@ export function SubmitExternalLink({
     <span
       className={classNames(
         'relative flex flex-col items-center tablet:flex-row',
-        isMobile ? 'rounded-16 border border-theme-divider-tertiary' : '',
+        isMobile ? 'rounded-16 border border-border-subtlest-tertiary' : '',
       )}
     >
       <TextField

--- a/packages/shared/src/components/post/write/WriteFooter.tsx
+++ b/packages/shared/src/components/post/write/WriteFooter.tsx
@@ -41,7 +41,7 @@ export function WriteFooter({
         </Switch>
       )}
       {shouldShowCta && (
-        <div className="absolute -left-4 mt-1 h-px w-[calc(100%+2rem)] bg-theme-divider-tertiary tablet:hidden" />
+        <div className="absolute -left-4 mt-1 h-px w-[calc(100%+2rem)] bg-border-subtlest-tertiary tablet:hidden" />
       )}
       <Button
         type="submit"

--- a/packages/shared/src/components/post/write/common.ts
+++ b/packages/shared/src/components/post/write/common.ts
@@ -6,7 +6,7 @@ export const previewImageClass =
 
 export const WritePreviewContainer = classed(
   FlexCol,
-  'rounded-16 border border-theme-divider-tertiary',
+  'rounded-16 border border-border-subtlest-tertiary',
 );
 
 export const WritePreviewContent = classed(

--- a/packages/shared/src/components/profile/ProfileTooltip.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltip.tsx
@@ -21,7 +21,7 @@ export interface ProfileTooltipProps extends ProfileTooltipContentProps {
 export const profileTooltipClasses = {
   padding: 'p-6',
   roundness: 'rounded-16',
-  classNames: 'w-72 shadow-2 border border-theme-divider-secondary',
+  classNames: 'w-72 shadow-2 border border-border-subtlest-secondary',
   background: 'bg-background-default',
 };
 

--- a/packages/shared/src/components/profile/ReadingHeatmapWidget.tsx
+++ b/packages/shared/src/components/profile/ReadingHeatmapWidget.tsx
@@ -88,7 +88,7 @@ export function ReadingHeatmapWidget({
         <div className="flex items-center">
           <div className="mr-2">Less</div>
           <div
-            className="mr-0.5 h-2 w-2 border border-theme-divider-quaternary"
+            className="mr-0.5 h-2 w-2 border border-border-subtlest-quaternary"
             style={{ borderRadius: '0.1875rem' }}
           />
           <div

--- a/packages/shared/src/components/profile/SquadsList.tsx
+++ b/packages/shared/src/components/profile/SquadsList.tsx
@@ -179,8 +179,8 @@ export function SquadsList({
           icon={<PlusIcon />}
           aria-label="Create a new Squad"
         />
-        <div className="flex-[3] rounded-16 border border-theme-divider-tertiary" />
-        <div className="flex-[2] rounded-l-16 border border-theme-divider-tertiary" />
+        <div className="flex-[3] rounded-16 border border-border-subtlest-tertiary" />
+        <div className="flex-[2] rounded-l-16 border border-border-subtlest-tertiary" />
       </div>
     );
   }

--- a/packages/shared/src/components/search/MobileSearch.tsx
+++ b/packages/shared/src/components/search/MobileSearch.tsx
@@ -88,7 +88,7 @@ export function MobileSearch({
           />
         </span>
         <input
-          className="mb-2 border-b border-theme-divider-secondary bg-transparent p-4 caret-theme-color-cabbage outline-none typo-body"
+          className="mb-2 border-b border-border-subtlest-secondary bg-transparent p-4 caret-theme-color-cabbage outline-none typo-body"
           type="text"
           value={input}
           ref={inputRef}

--- a/packages/shared/src/components/search/SearchBarInput.tsx
+++ b/packages/shared/src/components/search/SearchBarInput.tsx
@@ -168,7 +168,7 @@ function SearchBarInputComponent(
         <BaseField
           {...props}
           className={classNames(
-            'relative h-16 items-center rounded-14 border !border-theme-divider-tertiary !bg-background-default px-3',
+            'relative h-16 items-center rounded-14 border !border-border-subtlest-tertiary !bg-background-default px-3',
             className?.field,
             { focused },
           )}
@@ -213,7 +213,7 @@ function SearchBarInputComponent(
                 type="button"
               />
             )}
-            <div className="h-8 border border-theme-divider-quaternary" />
+            <div className="h-8 border border-border-subtlest-quaternary" />
             <SearchHistoryButton />
             <SearchSubmitButton
               buttonProps={{ disabled: !hasInput }}

--- a/packages/shared/src/components/search/SearchFeedback.tsx
+++ b/packages/shared/src/components/search/SearchFeedback.tsx
@@ -38,7 +38,7 @@ export const SearchFeedback = ({
         User guide
       </Button>
     </div>
-    <p className="border-t border-theme-divider-tertiary px-4 py-3 text-text-quaternary typo-subhead">
+    <p className="border-t border-border-subtlest-tertiary px-4 py-3 text-text-quaternary typo-subhead">
       daily.dev Search is in beta and can make mistakes. Verify important
       information.
     </p>

--- a/packages/shared/src/components/search/SearchPanel/SearchPanel.tsx
+++ b/packages/shared/src/components/search/SearchPanel/SearchPanel.tsx
@@ -170,7 +170,7 @@ export const SearchPanel = ({ className }: SearchPanelProps): ReactElement => {
           {showDropdown && (
             <div
               className={classNames(
-                'absolute w-full items-center rounded-b-16 border-0 border-theme-divider-tertiary bg-background-default px-3 py-2 laptop:h-auto laptop:border-x laptop:border-b laptop:bg-background-subtle laptop:shadow-2',
+                'absolute w-full items-center rounded-b-16 border-0 border-border-subtlest-tertiary bg-background-default px-3 py-2 laptop:h-auto laptop:border-x laptop:border-b laptop:bg-background-subtle laptop:shadow-2',
               )}
             >
               <div className="flex flex-1 flex-col">

--- a/packages/shared/src/components/search/SearchPanel/SearchPanelInput.tsx
+++ b/packages/shared/src/components/search/SearchPanel/SearchPanelInput.tsx
@@ -176,7 +176,7 @@ export const SearchPanelInput = ({
             className?.field,
             { focused },
             searchPanel.isActive &&
-              '!border-theme-divider-tertiary laptop:shadow-2',
+              '!border-border-subtlest-tertiary laptop:shadow-2',
             searchPanel.isActive && showDropdown
               ? 'laptop:rounded-b-none laptop:rounded-t-16'
               : 'laptop:rounded-16',

--- a/packages/shared/src/components/search/SearchPanel/SearchPanelPostSuggestions.tsx
+++ b/packages/shared/src/components/search/SearchPanel/SearchPanelPostSuggestions.tsx
@@ -79,11 +79,11 @@ export const SearchPanelPostSuggestions = ({
   return (
     <div className={classNames(className, 'flex flex-col')}>
       <div className="relative my-2 flex items-center justify-start gap-2">
-        <hr className="w-2 border-theme-divider-tertiary" />
+        <hr className="w-2 border-border-subtlest-tertiary" />
         <span className="relative inline-flex font-bold typo-footnote">
           {title}
         </span>
-        <hr className="flex-1 border-theme-divider-tertiary" />
+        <hr className="flex-1 border-border-subtlest-tertiary" />
       </div>
       {suggestions?.hits?.map((suggestion) => {
         return (

--- a/packages/shared/src/components/search/SearchPanel/SearchProviderButton.tsx
+++ b/packages/shared/src/components/search/SearchPanel/SearchProviderButton.tsx
@@ -30,7 +30,7 @@ export const SearchProviderButton = ({
     <Button
       className={classNames(
         className,
-        'border-theme-divider-tertiary text-text-tertiary typo-subhead',
+        'border-border-subtlest-tertiary text-text-tertiary typo-subhead',
       )}
       icon={<Icon className="mr-2 rounded-6 p-0.5" />}
       iconPosition={ButtonIconPosition.Left}

--- a/packages/shared/src/components/search/SearchSourceList.tsx
+++ b/packages/shared/src/components/search/SearchSourceList.tsx
@@ -38,7 +38,7 @@ export const SearchSourceList = ({
 
   return (
     <PageWidgets tablet={false} className={classNames(className, 'relative')}>
-      <i className="absolute -left-8 top-8 hidden h-px w-12 bg-theme-divider-tertiary laptop:block" />
+      <i className="absolute -left-8 top-8 hidden h-px w-12 bg-border-subtlest-tertiary laptop:block" />
       <div className={classNames('flex flex-col', widgetClasses)}>
         <div
           className={classNames(

--- a/packages/shared/src/components/sidebar/SidebarList.tsx
+++ b/packages/shared/src/components/sidebar/SidebarList.tsx
@@ -38,7 +38,7 @@ function SidebarList({
         className,
       )}
     >
-      <span className="mb-6 flex w-full flex-row items-center border-b border-theme-divider-tertiary p-2 px-4 tablet:hidden">
+      <span className="mb-6 flex w-full flex-row items-center border-b border-border-subtlest-tertiary p-2 px-4 tablet:hidden">
         <Button
           size={ButtonSize.Small}
           className="flex -rotate-90 tablet:hidden"

--- a/packages/shared/src/components/sidebar/SidebarListItem.tsx
+++ b/packages/shared/src/components/sidebar/SidebarListItem.tsx
@@ -22,7 +22,7 @@ function SidebarListItem({
 }: SidebarListItemProps): ReactElement {
   const containerClass = classNames(
     'flex w-full flex-row rounded-16 p-4 tablet:w-64',
-    isActive && 'border border-theme-divider-tertiary bg-theme-active',
+    isActive && 'border border-border-subtlest-tertiary bg-theme-active',
     isActive && 'p-[0.9375rem]', // to avoid layout shift for when the border (1px) is displayed being active
     className,
   );

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -73,7 +73,7 @@ export const SidebarBackdrop = classed(
 );
 export const SidebarAside = classed(
   'aside',
-  'flex flex-col z-sidebarOverlay laptop:z-sidebar laptop:-translate-x-0 left-0 bg-background-default border-r border-theme-divider-tertiary transition-[width,transform] duration-300 ease-in-out group fixed top-0  h-full ',
+  'flex flex-col z-sidebarOverlay laptop:z-sidebar laptop:-translate-x-0 left-0 bg-background-default border-r border-border-subtlest-tertiary transition-[width,transform] duration-300 ease-in-out group fixed top-0  h-full ',
 );
 export const SidebarScrollWrapper = classed(
   'div',

--- a/packages/shared/src/components/squads/SharePostBar.tsx
+++ b/packages/shared/src/components/squads/SharePostBar.tsx
@@ -71,7 +71,7 @@ function SharePostBar({
     return (
       <Card
         className={classNames(
-          'flex !flex-row items-center gap-1.5 px-3 py-5 text-text-quaternary hover:border-theme-divider-tertiary',
+          'flex !flex-row items-center gap-1.5 px-3 py-5 text-text-quaternary hover:border-border-subtlest-tertiary',
           className,
         )}
       >
@@ -86,7 +86,7 @@ function SharePostBar({
       onSubmit={onSubmit}
       className={classNames(
         'flex flex-col items-center overflow-hidden rounded-16 border typo-callout tablet:flex-row',
-        'border-theme-divider-tertiary bg-theme-float focus-within:border-theme-divider-primary hover:border-theme-divider-primary',
+        'border-border-subtlest-tertiary bg-theme-float focus-within:border-border-subtlest-primary hover:border-border-subtlest-primary',
         className,
       )}
     >
@@ -134,7 +134,7 @@ function SharePostBar({
         </Button>
       </span>
       <button
-        className="flex w-full items-center justify-center border-t border-theme-divider-tertiary py-5 font-bold text-text-tertiary typo-callout tablet:hidden"
+        className="flex w-full items-center justify-center border-t border-border-subtlest-tertiary py-5 font-bold text-text-tertiary typo-callout tablet:hidden"
         type="button"
         onClick={onOpenHistory}
       >

--- a/packages/shared/src/components/squads/SquadFeedHeading.tsx
+++ b/packages/shared/src/components/squads/SquadFeedHeading.tsx
@@ -36,7 +36,7 @@ function SquadFeedHeading({ squad }: SquadFeedHeadingProps): ReactElement {
 
   return (
     <div className="flex w-full flex-row flex-wrap items-center justify-end gap-4 pb-6">
-      <span className="ml-auto flex flex-row gap-3 border-l border-theme-divider-tertiary pl-3">
+      <span className="ml-auto flex flex-row gap-3 border-l border-border-subtlest-tertiary pl-3">
         {isSquadMember && (
           <Button
             variant={ButtonVariant.Float}

--- a/packages/shared/src/components/squads/SquadMemberShortList.tsx
+++ b/packages/shared/src/components/squads/SquadMemberShortList.tsx
@@ -35,7 +35,7 @@ function SquadMemberShortList({
       <button
         type="button"
         className={classNames(
-          'flex h-10 flex-row-reverse items-center rounded-12 border border-theme-divider-secondary p-1 pl-3 hover:bg-theme-hover active:bg-theme-active',
+          'flex h-10 flex-row-reverse items-center rounded-12 border border-border-subtlest-secondary p-1 pl-3 hover:bg-theme-hover active:bg-theme-active',
           className,
         )}
         onClick={openMemberListModal}

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -25,7 +25,7 @@ interface SquadPageHeaderProps {
 }
 
 const MAX_WIDTH = 'laptopL:max-w-[38.5rem]';
-const Divider = classed('span', 'flex flex-1 h-px bg-theme-divider-tertiary');
+const Divider = classed('span', 'flex flex-1 h-px bg-border-subtlest-tertiary');
 
 export function SquadPageHeader({
   squad,
@@ -43,7 +43,7 @@ export function SquadPageHeader({
   return (
     <FlexCol
       className={classNames(
-        'relative min-h-20 w-full items-center border-theme-divider-tertiary px-6 tablet:mb-6 tablet:border-b tablet:pb-20 laptopL:items-start laptopL:px-18 laptopL:pb-14',
+        'relative min-h-20 w-full items-center border-border-subtlest-tertiary px-6 tablet:mb-6 tablet:border-b tablet:pb-20 laptopL:items-start laptopL:px-18 laptopL:pb-14',
       )}
     >
       {isChecklistVisible && <SquadChecklistCard squad={squad} />}
@@ -99,7 +99,7 @@ export function SquadPageHeader({
               <Divider />
               {children}
               <FlexCentered className="relative mx-2 my-2 w-full text-text-tertiary typo-callout tablet:w-auto">
-                <span className="absolute -left-6 flex h-px w-[calc(100%+3rem)] bg-theme-divider-tertiary tablet:hidden" />
+                <span className="absolute -left-6 flex h-px w-[calc(100%+3rem)] bg-border-subtlest-tertiary tablet:hidden" />
                 <span className="z-0 bg-background-default px-4">or</span>
               </FlexCentered>
               <Button

--- a/packages/shared/src/components/squads/utils.tsx
+++ b/packages/shared/src/components/squads/utils.tsx
@@ -21,10 +21,10 @@ export const ManageSquadPageMain = classed('div', 'flex flex-1 flex-col');
 
 export const ManageSquadPageFooter = classed(
   'footer',
-  'flex sticky flex-row gap-3 items-center py-4 px-6 h-16 border-t border-theme-divider-tertiary',
+  'flex sticky flex-row gap-3 items-center py-4 px-6 h-16 border-t border-border-subtlest-tertiary',
 );
 
 export const ManageSquadPageHeader = classed(
   'header',
-  'flex sticky flex-row gap-3 items-center py-4 px-6 h-16 border-b border-theme-divider-tertiary',
+  'flex sticky flex-row gap-3 items-center py-4 px-6 h-16 border-b border-border-subtlest-tertiary',
 );

--- a/packages/shared/src/components/streak/ReadingStreakButton.tsx
+++ b/packages/shared/src/components/streak/ReadingStreakButton.tsx
@@ -43,7 +43,7 @@ function CustomStreaksTooltip({
         paddingClassName: 'p-4',
         bgClassName: 'bg-accent-pepper-subtlest',
         textClassName: 'text-text-primary typo-callout',
-        className: 'border border-theme-divider-tertiary',
+        className: 'border border-border-subtlest-tertiary',
       }}
       content={<ReadingStreakPopup streak={streak} />}
       onClickOutside={() => setShouldShowStreaks(false)}

--- a/packages/shared/src/components/streak/popup/DayStreak.tsx
+++ b/packages/shared/src/components/streak/popup/DayStreak.tsx
@@ -24,7 +24,7 @@ interface DayStreakProps {
 const dayInitial = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 const Circle = classed(
   'div',
-  'rounded-full border border-theme-divider-tertiary',
+  'rounded-full border border-border-subtlest-tertiary',
 );
 
 export function DayStreak({

--- a/packages/shared/src/components/tabs/TabContainer.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.tsx
@@ -131,7 +131,7 @@ export function TabContainer<T extends string = string>({
         className={classNames(
           'flex flex-row',
           className?.header,
-          showBorder && 'border-b border-theme-divider-tertiary',
+          showBorder && 'border-b border-border-subtlest-tertiary',
         )}
       >
         <TabList

--- a/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
+++ b/packages/shared/src/components/tooltips/ChangelogTooltip.tsx
@@ -91,7 +91,7 @@ function ChangelogTooltip(): ReactElement {
           variant: ButtonVariant.Tertiary,
         }}
       >
-        <header className="flex flex-1 items-center border-b border-theme-divider-tertiary px-4 py-3">
+        <header className="flex flex-1 items-center border-b border-border-subtlest-tertiary px-4 py-3">
           <h3
             className="font-bold text-text-primary typo-title3"
             data-testid="changelogNewReleaseTag"
@@ -163,7 +163,7 @@ function ChangelogTooltip(): ReactElement {
             </QuaternaryButton>
           </div>
         </section>
-        <footer className="flex h-16 w-full items-center justify-between border-t border-theme-divider-tertiary p-3">
+        <footer className="flex h-16 w-full items-center justify-between border-t border-border-subtlest-tertiary p-3">
           <Button
             onClick={dismissChangelog}
             tag="a"

--- a/packages/shared/src/components/utilities/Divider.tsx
+++ b/packages/shared/src/components/utilities/Divider.tsx
@@ -7,7 +7,7 @@ interface DividerProps {
   vertical?: boolean;
 }
 
-const DividerBase = classed('span', 'bg-theme-divider-primary');
+const DividerBase = classed('span', 'bg-border-subtlest-primary');
 
 export const Divider = ({
   className,

--- a/packages/shared/src/components/utilities/common.tsx
+++ b/packages/shared/src/components/utilities/common.tsx
@@ -28,7 +28,7 @@ export const upvoteCommentEventName = (upvoted: boolean): string =>
   upvoted ? 'upvote comment' : 'remove comment upvote';
 
 export const pageBorders =
-  'laptop:border-r laptop:border-l border-theme-divider-tertiary';
+  'laptop:border-r laptop:border-l border-border-subtlest-tertiary';
 
 const pagePaddings = 'px-4 tablet:px-8';
 const basePageClassNames = classNames(

--- a/packages/shared/src/components/widgets/BestDiscussions.tsx
+++ b/packages/shared/src/components/widgets/BestDiscussions.tsx
@@ -24,7 +24,7 @@ export type BestDiscussionsProps = {
   className?: string;
 };
 
-const Separator = <div className="h-px bg-theme-divider-tertiary" />;
+const Separator = <div className="h-px bg-border-subtlest-tertiary" />;
 
 type PostProps = {
   post: Post;

--- a/packages/shared/src/components/widgets/PostToc.tsx
+++ b/packages/shared/src/components/widgets/PostToc.tsx
@@ -14,7 +14,7 @@ export type PostTocProps = {
   collapsible?: boolean;
 };
 
-const Separator = <div className="mb-3 h-px bg-theme-divider-tertiary" />;
+const Separator = <div className="mb-3 h-px bg-border-subtlest-tertiary" />;
 
 const generateTocLink = (post: Post, item: TocItem): string => {
   if (!item.id) {
@@ -53,7 +53,7 @@ export default function PostToc({
   );
 
   const titleClass =
-    'flex items-center py-3 px-4 typo-body text-text-tertiary border border-theme-divider-quaternary';
+    'flex items-center py-3 px-4 typo-body text-text-tertiary border border-border-subtlest-quaternary';
   if (collapsible) {
     return (
       <details
@@ -78,7 +78,7 @@ export default function PostToc({
   return (
     <WidgetContainer
       className={classNames(
-        'flex-col overflow-hidden rounded-16 border border-theme-divider-quaternary pb-3',
+        'flex-col overflow-hidden rounded-16 border border-border-subtlest-quaternary pb-3',
         className,
       )}
     >

--- a/packages/shared/src/components/widgets/SimilarPosts.tsx
+++ b/packages/shared/src/components/widgets/SimilarPosts.tsx
@@ -144,7 +144,7 @@ export default function SimilarPosts({
   return (
     <section
       className={classNames(
-        'flex flex-col rounded-16 border border-theme-divider-tertiary',
+        'flex flex-col rounded-16 border border-border-subtlest-tertiary',
         className,
       )}
     >

--- a/packages/shared/src/components/widgets/ThemeWidget.tsx
+++ b/packages/shared/src/components/widgets/ThemeWidget.tsx
@@ -33,7 +33,7 @@ function ThemeWidget({
   return (
     <label
       htmlFor={option.value}
-      className="relative flex h-24 w-full flex-row items-center overflow-hidden rounded-14 bg-theme-divider-tertiary pl-4 hover:cursor-pointer"
+      className="relative flex h-24 w-full flex-row items-center overflow-hidden rounded-14 bg-border-subtlest-tertiary pl-4 hover:cursor-pointer"
     >
       <RadioItem
         {...props}

--- a/packages/shared/src/components/widgets/common.ts
+++ b/packages/shared/src/components/widgets/common.ts
@@ -1,7 +1,8 @@
 import classed from '../../lib/classed';
 import { ElementPlaceholder } from '../ElementPlaceholder';
 
-export const widgetClasses = 'border border-theme-divider-tertiary rounded-16';
+export const widgetClasses =
+  'border border-border-subtlest-tertiary rounded-16';
 
 export const WidgetContainer = classed('div', widgetClasses);
 
@@ -12,5 +13,5 @@ export const TextPlaceholder = classed(
 
 export const PlaceholderSeparator = classed(
   'div',
-  'h-px bg-theme-divider-tertiary',
+  'h-px bg-border-subtlest-tertiary',
 );

--- a/packages/shared/src/lib/rank.ts
+++ b/packages/shared/src/lib/rank.ts
@@ -31,8 +31,8 @@ export const RANKS: Rank[] = [
     name: 'Iron',
     steps: 1,
     level: 1,
-    background: 'bg-theme-divider-primary',
-    border: 'border-theme-divider-primary',
+    background: 'bg-border-subtlest-primary',
+    border: 'border-border-subtlest-primary',
     color: 'text-text-tertiary',
   },
   {

--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -242,11 +242,6 @@ body {
   /* stylelint-disable-next-line unit-no-unknown */
   --theme-hover: theme('colors.raw.salt.90')1F;
 
-  --theme-divider-primary: theme('colors.raw.salt.90');
-  --theme-divider-secondary: theme('colors.raw.salt.90')66;
-  --theme-divider-tertiary: theme('colors.raw.salt.90')33;
-  --theme-divider-quaternary: theme('colors.raw.salt.90')14;
-
   --accent-cabbage-default-invert: theme('colors.raw.cabbage.60');
   --accent-cabbage-default: theme('colors.raw.cabbage.40');
 
@@ -529,11 +524,6 @@ body {
   --theme-float: theme('colors.raw.pepper.10')14;
   /* stylelint-disable-next-line unit-no-unknown */
   --theme-hover: theme('colors.raw.pepper.10')1F;
-
-  --theme-divider-primary: theme('colors.raw.pepper.10');
-  --theme-divider-secondary: theme('colors.raw.pepper.10')66;
-  --theme-divider-tertiary: theme('colors.raw.pepper.10')33;
-  --theme-divider-quaternary: theme('colors.raw.pepper.10')14;
 
   --accent-cabbage-default: theme('colors.raw.cabbage.60');
   --accent-cabbage-default-invert: theme('colors.raw.cabbage.40');

--- a/packages/shared/src/styles/components/menu.css
+++ b/packages/shared/src/styles/components/menu.css
@@ -3,7 +3,7 @@
   opacity: 0;
   user-select: none;
   z-index: 1000;
-  @apply py-1 px-0 m-0 bg-background-subtle rounded-12 border border-theme-divider-secondary shadow-2 -translate-x-full;
+  @apply py-1 px-0 m-0 bg-background-subtle rounded-12 border border-border-subtlest-secondary shadow-2 -translate-x-full;
 
   &.scrollable {
     height: 15rem;

--- a/packages/shared/tailwind.config.ts
+++ b/packages/shared/tailwind.config.ts
@@ -51,12 +51,6 @@ export default {
         float: 'var(--theme-float)',
         hover: 'var(--theme-hover)',
         rank: 'var(--rank-color)',
-        divider: {
-          primary: 'var(--theme-divider-primary)',
-          secondary: 'var(--theme-divider-secondary)',
-          tertiary: 'var(--theme-divider-tertiary)',
-          quaternary: 'var(--theme-divider-quaternary)',
-        },
         overlay: {
           quaternary: 'var(--theme-overlay-quaternary)',
           water: 'var(--theme-overlay-water)',

--- a/packages/storybook/stories/drawers/Drawer.stories.tsx
+++ b/packages/storybook/stories/drawers/Drawer.stories.tsx
@@ -41,7 +41,7 @@ export default meta;
 
 type Story = StoryObj<typeof DrawerComponent>;
 
-const Container = classed('div', 'px-3 py-4 border-b border-theme-divider-tertiary');
+const Container = classed('div', 'px-3 py-4 border-b border-border-subtlest-tertiary');
 
 export const Drawer: Story = {
   render: ({ children, ...props }) => {

--- a/packages/webapp/components/CookieBanner.tsx
+++ b/packages/webapp/components/CookieBanner.tsx
@@ -21,7 +21,7 @@ export default function CookieBanner({
   };
 
   return (
-    <div className="fixed bottom-0 left-0 z-max flex w-full flex-col border-t border-theme-divider-secondary bg-accent-pepper-subtlest py-4 pl-4 pr-14 text-text-secondary typo-footnote laptop:bottom-6 laptop:left-[unset] laptop:right-6 laptop:w-48 laptop:items-center laptop:rounded-16 laptop:border laptop:p-6 laptop:text-center">
+    <div className="fixed bottom-0 left-0 z-max flex w-full flex-col border-t border-border-subtlest-secondary bg-accent-pepper-subtlest py-4 pl-4 pr-14 text-text-secondary typo-footnote laptop:bottom-6 laptop:left-[unset] laptop:right-6 laptop:w-48 laptop:items-center laptop:rounded-16 laptop:border laptop:p-6 laptop:text-center">
       <ModalClose onClick={close} top="2" />
       <CookieIcon
         size={IconSize.XXLarge}

--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -98,7 +98,7 @@ export default function FooterNavBar({
           isNewMobileLayout
             ? classNames('rounded-16', !post && activeClasses)
             : 'rounded-t-24 bg-background-default',
-          !post && 'border-t border-theme-divider-tertiary',
+          !post && 'border-t border-border-subtlest-tertiary',
         )}
       >
         <Component activeTab={activeTab} />

--- a/packages/webapp/components/layouts/AccountLayout/AccountPageContainer.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/AccountPageContainer.tsx
@@ -80,7 +80,7 @@ export const AccountPageContainer = ({
       {footer && (
         <div
           className={classNames(
-            'sticky flex flex-row gap-3 border-t border-theme-divider-tertiary p-3',
+            'sticky flex flex-row gap-3 border-t border-border-subtlest-tertiary p-3',
             className.footer,
           )}
         >

--- a/packages/webapp/components/layouts/AccountLayout/SidebarNav.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/SidebarNav.tsx
@@ -64,7 +64,7 @@ function SidebarNav({
         className,
       )}
     >
-      <span className="mb-6 flex w-full flex-row items-center justify-between border-b border-theme-divider-tertiary p-2 tablet:hidden">
+      <span className="mb-6 flex w-full flex-row items-center justify-between border-b border-border-subtlest-tertiary p-2 tablet:hidden">
         <span className="ml-4 font-bold typo-title3">Account Settings</span>
         <CloseButton onClick={closeSideNav} />
       </span>

--- a/packages/webapp/components/layouts/AccountLayout/SidebarNavItem.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/SidebarNavItem.tsx
@@ -23,7 +23,7 @@ function SidebarNavItem({
       <a
         className={classNames(
           'flex w-full flex-row rounded-16 p-4 tablet:w-64',
-          isActive && 'border border-theme-divider-tertiary bg-theme-active',
+          isActive && 'border border-border-subtlest-tertiary bg-theme-active',
           isActive && 'p-[0.9375rem]', // to avoid layout shift for when the border (1px) is displayed being active
           className,
         )}

--- a/packages/webapp/components/layouts/AccountLayout/common.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/common.tsx
@@ -145,12 +145,12 @@ export const AccountPageSection = classed(
 );
 export const AccountPageHeading = classed(
   'h1',
-  'font-bold typo-title3 py-4 px-6 border-b border-theme-divider-tertiary w-full flex flex-row items-center',
+  'font-bold typo-title3 py-4 px-6 border-b border-border-subtlest-tertiary w-full flex flex-row items-center',
 );
 
 export const CommonTextField = classed(TextField, { container: 'max-w-sm' });
 export const AccountTextField = classed(CommonTextField, { container: 'mt-6' });
 export const AccountSidebarPagesSection = classed(
   'div',
-  'flex flex-col py-4 px-5 gap-3 mt-10 w-full rounded-16 border border-theme-divider-tertiary',
+  'flex flex-col py-4 px-5 gap-3 mt-10 w-full rounded-16 border border-border-subtlest-tertiary',
 );

--- a/packages/webapp/components/layouts/AccountLayout/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/index.tsx
@@ -81,7 +81,7 @@ export default function AccountLayout({
           />
         ) : (
           <SidebarNav
-            className="absolute z-3 ml-auto h-full w-full border-l border-theme-divider-tertiary bg-background-default tablet:relative tablet:w-[unset]"
+            className="absolute z-3 ml-auto h-full w-full border-l border-border-subtlest-tertiary bg-background-default tablet:relative tablet:w-[unset]"
             basePath="account"
           />
         )}

--- a/packages/webapp/components/layouts/ProfileLayout/NavBar.module.css
+++ b/packages/webapp/components/layouts/ProfileLayout/NavBar.module.css
@@ -7,7 +7,7 @@
     right: 0;
     height: 0.063rem;
     margin: 0 auto;
-    background: var(--theme-divider-tertiary);
+    background: var(--theme-border-subtlest-quaternary);
   }
 
   & > div {

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -76,12 +76,12 @@ export default function ProfileLayout({
   };
 
   return (
-    <div className="m-auto flex w-full max-w-screen-laptop flex-col pb-12 tablet:pb-0 laptop:min-h-page laptop:flex-row laptop:border-l laptop:border-r laptop:border-theme-divider-tertiary laptop:pb-6 laptopL:pb-0">
+    <div className="m-auto flex w-full max-w-screen-laptop flex-col pb-12 tablet:pb-0 laptop:min-h-page laptop:flex-row laptop:border-l laptop:border-r laptop:border-border-subtlest-tertiary laptop:pb-6 laptopL:pb-0">
       <Head>
         <link rel="preload" as="image" href={user.image} />
       </Head>
       <NextSeo {...Seo} />
-      <main className="relative flex flex-1 flex-col tablet:border-r tablet:border-theme-divider-tertiary">
+      <main className="relative flex flex-1 flex-col tablet:border-r tablet:border-border-subtlest-tertiary">
         <ProfileWidgets
           user={user}
           userStats={userStats}

--- a/packages/webapp/pages/account/notifications.tsx
+++ b/packages/webapp/pages/account/notifications.tsx
@@ -147,7 +147,7 @@ const AccountNotificationsPage = (): ReactElement => {
             title="Push notifications"
             description="The daily.dev notification system notifies you of important events such as replies, mentions, updates, etc."
           />
-          <div className="mx-4 h-full w-px bg-theme-divider-tertiary" />
+          <div className="mx-4 h-full w-px bg-border-subtlest-tertiary" />
           <Switch
             data-testid="push_notification-switch"
             inputId="push_notification-switch"
@@ -195,7 +195,7 @@ const AccountNotificationsPage = (): ReactElement => {
           title="Email notifications"
           description="Tailor your email notifications by selecting the types of emails that are important to you."
         />
-        <div className="mx-4 h-full w-px bg-theme-divider-tertiary" />
+        <div className="mx-4 h-full w-px bg-border-subtlest-tertiary" />
         <Switch
           data-testid="email_notification-switch"
           inputId="email_notification-switch"

--- a/packages/webapp/pages/history.tsx
+++ b/packages/webapp/pages/history.tsx
@@ -70,7 +70,7 @@ const History = (): ReactElement => {
   return (
     <ProtectedPage seo={seo}>
       {!isNewMobileLayout && (
-        <div className="absolute left-0 top-[6.75rem] flex h-px w-full bg-theme-divider-tertiary laptop:hidden" />
+        <div className="absolute left-0 top-[6.75rem] flex h-px w-full bg-border-subtlest-tertiary laptop:hidden" />
       )}
 
       <ResponsivePageContainer className="relative !p-0" role="main">

--- a/packages/webapp/pages/popup/notifications/enable.tsx
+++ b/packages/webapp/pages/popup/notifications/enable.tsx
@@ -29,7 +29,7 @@ const BrowserIcon = isChrome() ? ChromePermissionIcon : BrowserPermissionIcon;
 
 const InstructionContainer = classed(
   'div',
-  'flex flex-col items-start p-4 mt-5 rounded-8 border border-theme-divider-tertiary',
+  'flex flex-col items-start p-4 mt-5 rounded-8 border border-border-subtlest-tertiary',
 );
 
 const iconClasses = 'flex flex-grow mt-2';


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Removed all the old divider colors in favor of new border naming

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://chore-cleanup-divider-colors.preview.app.daily.dev