### PR TITLE
fix: ensure trending works for all post types

### DIFF
--- a/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
@@ -13,6 +13,10 @@ import { WelcomePostCardFooter } from '../WelcomePostCardFooter';
 import ActionButtons from '../ActionButtons';
 import PostMetadata from '../PostMetadata';
 import { usePostImage } from '../../../hooks/post/usePostImage';
+import { useFeature } from '../../GrowthBookProvider';
+import { feature } from '../../../lib/featureManagement';
+import { TrendingFlag } from '../../../lib/featureValues';
+import { TrendingFlag as TrendingFlagComponent } from '../common/TrendingFlag';
 
 export const CollectionCard = forwardRef(function CollectionCard(
   {
@@ -30,6 +34,9 @@ export const CollectionCard = forwardRef(function CollectionCard(
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ) {
+  const trendingFlag = useFeature(feature.trendingFlag);
+  const isTrendingFlagV1 = trendingFlag === TrendingFlag.V1;
+  const { pinnedAt, trending } = post;
   const image = usePostImage(post);
 
   return (
@@ -39,10 +46,12 @@ export const CollectionCard = forwardRef(function CollectionCard(
         className: getPostClassNames(post, domProps.className, 'min-h-card'),
       }}
       ref={ref}
-      flagProps={{ pinnedAt: post.pinnedAt }}
+      flagProps={{ pinnedAt, ...(!isTrendingFlagV1 && { trending }) }}
     >
       <CardButton title={post.title} onClick={() => onPostClick(post)} />
-
+      {trending && isTrendingFlagV1 && (
+        <TrendingFlagComponent className={{ container: 'right-3 top-3' }} />
+      )}
       <CollectionCardHeader
         sources={post.collectionSources}
         totalSources={post.numCollectionSources}

--- a/packages/shared/src/components/cards/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.tsx
@@ -63,7 +63,10 @@ export const SharePostCard = forwardRef(function SharePostCard(
         <CardButton title={post.title} onClick={onPostCardClick} />
       )}
       {trending && isTrendingFlagV1 && (
-        <TrendingFlagComponent className={{ container: 'right-2 top-2' }} />
+        <TrendingFlagComponent
+          iconOnly
+          className={{ container: 'right-2 top-2' }}
+        />
       )}
       <OptionsButton
         className="absolute right-2 top-2 group-hover:flex laptop:hidden"

--- a/packages/shared/src/components/cards/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCard.tsx
@@ -13,6 +13,10 @@ import { PostType } from '../../graphql/posts';
 import { useFeedPreviewMode } from '../../hooks';
 import { SquadPostCardHeader } from './common/SquadPostCardHeader';
 import { usePostImage } from '../../hooks/post/usePostImage';
+import { TrendingFlag as TrendingFlagComponent } from './common/TrendingFlag';
+import { useFeature } from '../GrowthBookProvider';
+import { feature } from '../../lib/featureManagement';
+import { TrendingFlag } from '../../lib/featureValues';
 
 export const WelcomePostCard = forwardRef(function SharePostCard(
   {
@@ -31,7 +35,9 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ): ReactElement {
-  const { pinnedAt, type: postType } = post;
+  const trendingFlag = useFeature(feature.trendingFlag);
+  const isTrendingFlagV1 = trendingFlag === TrendingFlag.V1;
+  const { pinnedAt, type: postType, trending } = post;
   const onPostCardClick = () => onPostClick(post);
   const containerRef = useRef<HTMLDivElement>();
   const isFeedPreview = useFeedPreviewMode();
@@ -59,12 +65,17 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
         ),
       }}
       ref={ref}
-      flagProps={{ pinnedAt }}
+      flagProps={{ pinnedAt, ...(!isTrendingFlagV1 && { trending }) }}
     >
       {!isFeedPreview && (
         <CardButton title={post.title} onClick={onPostCardClick} />
       )}
-
+      {trending && isTrendingFlagV1 && (
+        <TrendingFlagComponent
+          iconOnly
+          className={{ container: 'right-2 top-2' }}
+        />
+      )}
       <OptionsButton
         className="absolute right-2 top-2 group-hover:flex laptop:hidden"
         onClick={(event) => onMenuClick?.(event, post)}

--- a/packages/shared/src/components/cards/common/TrendingFlag.tsx
+++ b/packages/shared/src/components/cards/common/TrendingFlag.tsx
@@ -4,21 +4,29 @@ import { TrendingIcon } from '../../icons';
 import { IconSize } from '../../Icon';
 
 interface TrendingFlagProps {
+  iconOnly?: boolean;
   className?: {
     container?: string;
   };
 }
 export const TrendingFlag = ({
+  iconOnly = false,
   className,
 }: TrendingFlagProps): ReactElement => {
   return (
     <div
       className={classNames(
-        'absolute z-1 flex h-8 items-center rounded-10 bg-action-downvote-default px-3 py-1 font-bold text-white typo-callout laptop:mouse:group-hover:invisible',
+        'absolute z-1 flex h-8 items-center rounded-10 bg-action-downvote-default py-1 font-bold text-white typo-callout laptop:mouse:group-hover:invisible',
+        iconOnly ? 'px-1' : 'px-3',
         className?.container,
       )}
     >
-      Trending <TrendingIcon className="ml-1" secondary size={IconSize.Small} />
+      {!iconOnly && 'Trending'}
+      <TrendingIcon
+        className={classNames(!iconOnly && 'ml-1')}
+        secondary
+        size={IconSize.Small}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We decided to support trending/hot for all content types

https://github.com/dailydotdev/apps/assets/554874/893401b4-242b-480c-9e8f-164adfca3281
![Screenshot 2024-04-05 at 16 03 32](https://github.com/dailydotdev/apps/assets/554874/ce1b64ca-9bf5-443a-9037-2390dc3b3609)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
