### PR TITLE
fix: pass correct post id from forbidden error

### DIFF
--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -204,15 +204,8 @@ export async function getStaticProps({
     if (errors.includes(clientError?.response?.errors?.[0]?.extensions?.code)) {
       const { postId } = clientError.response.errors[0].extensions;
 
-      if (!postId) {
-        return {
-          notFound: true,
-          revalidate: 60,
-        };
-      }
-
       return {
-        props: { id: postId },
+        props: { id: postId || id },
         revalidate: 60,
       };
     }

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -202,8 +202,17 @@ export async function getStaticProps({
     const clientError = err as ClientError;
     const errors = Object.values(ApiError);
     if (errors.includes(clientError?.response?.errors?.[0]?.extensions?.code)) {
+      const { postId } = clientError.response.errors[0].extensions;
+
+      if (!postId) {
+        return {
+          notFound: true,
+          revalidate: 60,
+        };
+      }
+
       return {
-        props: { id },
+        props: { id: postId },
         revalidate: 60,
       };
     }


### PR DESCRIPTION
## Changes

### Describe what this PR does

Similar to https://github.com/dailydotdev/apps/pull/2940 the `id` passed in case of forbidden error from API was actually slug. `extensions.postId` was added to API to allow frontend to query it once it knows the user and its access.

https://github.com/dailydotdev/daily-api/pull/1811

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-private-post-id.preview.app.daily.dev