### PR TITLE
fix: add new experiment to show tags on cards

### DIFF
--- a/packages/shared/src/components/cards/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.tsx
@@ -23,6 +23,7 @@ import CardOverlay from './common/CardOverlay';
 import { useFeature } from '../GrowthBookProvider';
 import { feature } from '../../lib/featureManagement';
 import { TrendingFlag } from '../../lib/featureValues';
+import PostTags from './PostTags';
 
 export const ArticlePostCard = forwardRef(function PostCard(
   {
@@ -44,6 +45,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ): ReactElement {
+  const tagsOnCard = useFeature(feature.tagsOnCard);
   const trendingFlag = useFeature(feature.trendingFlag);
   const isTrendingFlagV1 = trendingFlag === TrendingFlag.V1;
   const { className, style } = domProps;
@@ -114,6 +116,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
         {!showFeedback && (
           <Container>
             <CardSpace />
+            {tagsOnCard && <PostTags tags={post.tags} />}
             <PostMetadata
               createdAt={post.createdAt}
               readTime={post.readTime}

--- a/packages/shared/src/components/cards/Card.tsx
+++ b/packages/shared/src/components/cards/Card.tsx
@@ -41,7 +41,7 @@ export const CardTitle = classed(Title, 'mt-2 break-words');
 
 export const ListCardTitle = classed(Title, 'mr-2');
 
-export const CardTextContainer = classed('div', 'flex flex-col mx-4');
+export const CardTextContainer = classed('div', 'flex flex-col mx-2');
 
 export const CardImage = classed(Image, 'rounded-12 h-40 object-cover');
 export const CardSpace = classed('div', 'flex-1');
@@ -58,7 +58,7 @@ export const CardLink = classed('a', clickableCardClasses);
 export const Card = classed(
   'article',
   styles.card,
-  'relative max-h-card h-full flex flex-col p-2 rounded-16 bg-background-subtle border border-border-subtlest-tertiary hover:border-border-subtlest-secondary shadow-2',
+  'relative max-h-cardLarge h-full flex flex-col p-2 rounded-16 bg-background-subtle border border-border-subtlest-tertiary hover:border-border-subtlest-secondary shadow-2',
 );
 
 export const ChecklistCardComponent = classed(

--- a/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
@@ -9,6 +9,9 @@ import ActionButtons from '../ActionButtons';
 import PostMetadata from '../PostMetadata';
 import { usePostImage } from '../../../hooks/post/usePostImage';
 import CardOverlay from '../common/CardOverlay';
+import PostTags from '../PostTags';
+import { useFeature } from '../../GrowthBookProvider';
+import { feature } from '../../../lib/featureManagement';
 
 export const CollectionCard = forwardRef(function CollectionCard(
   {
@@ -26,6 +29,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ) {
+  const tagsOnCard = useFeature(feature.tagsOnCard);
   const image = usePostImage(post);
   const onPostCardClick = () => onPostClick(post);
   return (
@@ -57,6 +61,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
       </FreeformCardTitle>
 
       {!!post.image && <CardSpace />}
+      {tagsOnCard && <PostTags tags={post.tags} />}
       <PostMetadata
         createdAt={post.createdAt}
         readTime={post.readTime}

--- a/packages/shared/src/components/cards/PostTags.tsx
+++ b/packages/shared/src/components/cards/PostTags.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo, useRef } from 'react';
+import React, { ReactElement, useMemo } from 'react';
 import { Post } from '../../graphql/posts';
 import Classed from '../../lib/classed';
 

--- a/packages/shared/src/components/cards/PostTags.tsx
+++ b/packages/shared/src/components/cards/PostTags.tsx
@@ -1,0 +1,39 @@
+import React, { ReactElement, useMemo, useRef } from 'react';
+import classNames from 'classnames';
+import { Post } from '../../graphql/posts';
+import Classed from '../../lib/classed';
+
+type PostTagsProps = Pick<Post, 'tags'>;
+
+const Chip = Classed(
+  'div',
+  'rounded-8 border border-border-subtlest-tertiary px-2 h-6 flex items-center justify-center typo-footnote text-text-quaternary my-2',
+);
+
+export default function PostTags({ tags }: PostTagsProps): ReactElement {
+  const totalLength = useRef(0);
+  const tagList = useMemo(() => {
+    return tags.reduce((acc, tag) => {
+      if (totalLength.current >= 15) {
+        return acc;
+      }
+
+      acc.push(tag);
+      totalLength.current += tag.length;
+      return acc;
+    }, []);
+  }, [tags]);
+
+  const remainingTags = tags.length - tagList.length;
+
+  return (
+    <div className="flex items-center tablet:mx-2">
+      {tagList.map((tag) => (
+        <Chip key={tag} className="mr-2">
+          #{tag}
+        </Chip>
+      ))}
+      {remainingTags > 0 && <Chip>+{remainingTags} tags</Chip>}
+    </div>
+  );
+}

--- a/packages/shared/src/components/cards/PostTags.tsx
+++ b/packages/shared/src/components/cards/PostTags.tsx
@@ -10,15 +10,15 @@ const Chip = Classed(
 );
 
 export default function PostTags({ tags }: PostTagsProps): ReactElement {
-  const totalLength = useRef(0);
   const tagList = useMemo(() => {
+    let totalLength = 0;
     return tags.reduce((acc, tag) => {
-      if (totalLength.current >= 15) {
+      if (totalLength >= 15) {
         return acc;
       }
 
       acc.push(tag);
-      totalLength.current += tag.length;
+      totalLength += tag.length;
       return acc;
     }, []);
   }, [tags]);

--- a/packages/shared/src/components/cards/PostTags.tsx
+++ b/packages/shared/src/components/cards/PostTags.tsx
@@ -1,5 +1,4 @@
 import React, { ReactElement, useMemo, useRef } from 'react';
-import classNames from 'classnames';
 import { Post } from '../../graphql/posts';
 import Classed from '../../lib/classed';
 

--- a/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/v1/ArticlePostCard.tsx
@@ -17,6 +17,9 @@ import SourceButton from '../SourceButton';
 import { isVideoPost } from '../../../graphql/posts';
 import PostReadTime from './PostReadTime';
 import { CardCover } from '../common/CardCover';
+import PostTags from '../PostTags';
+import { useFeature } from '../../GrowthBookProvider';
+import { feature } from '../../../lib/featureManagement';
 
 export const ArticlePostCard = forwardRef(function PostCard(
   {
@@ -37,6 +40,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ): ReactElement {
+  const tagsOnCard = useFeature(feature.tagsOnCard);
   const { className, style } = domProps;
   const { type, pinnedAt, trending } = post;
   const isVideoType = isVideoPost(post);
@@ -106,13 +110,19 @@ export const ArticlePostCard = forwardRef(function PostCard(
             </PostCardHeader>
 
             <CardContent>
-              <div className="mr-4 flex-1">
+              <div className="mr-4 flex flex-1 flex-col">
                 <CardTitle
                   lineClamp={undefined}
                   className={!!post.read && 'text-text-tertiary'}
                 >
                   {title}
                 </CardTitle>
+                {tagsOnCard && (
+                  <>
+                    <div className="flex flex-1" />
+                    <PostTags tags={post.tags} />
+                  </>
+                )}
               </div>
 
               <CardCover

--- a/packages/shared/src/components/cards/v1/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/v1/CollectionCard.tsx
@@ -15,6 +15,9 @@ import { PostCardHeader } from './PostCardHeader';
 import { CollectionPillSources } from '../../post/collection';
 import { cloudinary } from '../../../lib/image';
 import { useTruncatedSummary } from '../../../hooks';
+import PostTags from '../PostTags';
+import { useFeature } from '../../GrowthBookProvider';
+import { feature } from '../../../lib/featureManagement';
 
 export const CollectionCard = forwardRef(function CollectionCard(
   {
@@ -32,6 +35,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ) {
+  const tagsOnCard = useFeature(feature.tagsOnCard);
   const image = usePostImage(post);
   const { title } = useTruncatedSummary(post);
 
@@ -66,7 +70,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
         </PostCardHeader>
 
         <CardContent>
-          <div className="mb-4 mr-4 flex-1">
+          <div className="mb-4 mr-4 flex flex-1 flex-col">
             <CardTitle
               className={classNames(
                 generateTitleClamp({
@@ -77,6 +81,12 @@ export const CollectionCard = forwardRef(function CollectionCard(
             >
               {title}
             </CardTitle>
+            {tagsOnCard && (
+              <>
+                <div className="flex flex-1" />
+                <PostTags tags={post.tags} />
+              </>
+            )}
           </div>
 
           {image && (

--- a/packages/shared/src/components/post/collection/CollectionPostContent.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPostContent.tsx
@@ -22,6 +22,7 @@ import { useAuthContext } from '../../../contexts/AuthContext';
 import { webappUrl } from '../../../lib/constants';
 import { useViewPost } from '../../../hooks/post/useViewPost';
 import { DateFormat } from '../../utilities';
+import { TagLinks } from '../../TagLinks';
 
 export const CollectionPostContent = ({
   post,
@@ -139,6 +140,7 @@ export const CollectionPostContent = ({
             >
               {post.title}
             </h1>
+            <TagLinks tags={post.tags || []} />
             {!!updatedAt && (
               <div className="flex items-center text-text-tertiary typo-footnote">
                 <span>Last updated</span> <Separator />

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -44,7 +44,7 @@ const feature = {
   forcedTagSelection: new Feature('forced_tag_selection', false),
   mobileUxLayout: new Feature('mobile_ux_layout', false),
   readingReminder: new Feature('reading_reminder', false),
-  trendingFlag: new Feature('trending_flag', TrendingFlag.V1),
+  trendingFlag: new Feature('trending_flag', TrendingFlag.Control),
   tagsOnCard: new Feature('tags_on_card', false),
 };
 

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -44,7 +44,8 @@ const feature = {
   forcedTagSelection: new Feature('forced_tag_selection', false),
   mobileUxLayout: new Feature('mobile_ux_layout', false),
   readingReminder: new Feature('reading_reminder', false),
-  trendingFlag: new Feature('trending_flag', TrendingFlag.Control),
+  trendingFlag: new Feature('trending_flag', TrendingFlag.V1),
+  tagsOnCard: new Feature('tags_on_card', false),
 };
 
 export { feature };

--- a/packages/shared/tailwind.config.ts
+++ b/packages/shared/tailwind.config.ts
@@ -186,6 +186,7 @@ export default {
         page: 'calc(100vh - 4rem)',
         commentBox: '18.25rem',
         card: '24rem',
+        cardLarge: '27rem',
       },
       minHeight: {
         page: 'calc(100vh - 4rem)',

--- a/packages/webapp/components/FooterNavBar.tsx
+++ b/packages/webapp/components/FooterNavBar.tsx
@@ -60,8 +60,11 @@ export default function FooterNavBar({
     return active?.title;
   }, [activeNav, router?.pathname]);
 
-  const activeClasses =
-    'bg-blur-highlight shadow-[0_4px_30px_rgba(0,0,0.1)] backdrop-blur-[2.5rem]';
+  const blurClasses = 'bg-blur-highlight backdrop-blur-[2.5rem]';
+  const activeClasses = classNames(
+    blurClasses,
+    'shadow-[0_4px_30px_rgba(0,0,0.1)]',
+  );
 
   const Component = isNewMobileLayout ? FooterNavBarV1 : FooterNavBarControl;
 
@@ -78,10 +81,15 @@ export default function FooterNavBar({
         <div className="absolute bottom-0 left-0 right-0 h-[calc(100%-1.25rem)] backdrop-blur-[2.5rem]" />
       )}
       {post ? (
-        <div className="mb-2 w-full px-2 tablet:hidden">
+        <div className="my-2 w-full px-2 tablet:hidden">
           <NewComment
             post={post}
-            className={{ container: classNames(activeClasses, 'h-12') }}
+            className={{
+              container: classNames(
+                blurClasses,
+                'h-12 shadow-[0_0.25rem_1.5rem_0_var(--theme-shadow-shadow1)]',
+              ),
+            }}
           />
         </div>
       ) : (


### PR DESCRIPTION
## Changes

### Describe what this PR does
- New experiment to show tags on the cards
- Also fixed a minor issue with articles cards having wrong margings
- And collections missing the tags on the modal/page

![Screenshot 2024-04-08 at 16 18 12](https://github.com/dailydotdev/apps/assets/554874/6f4e3aa4-66a1-42c0-8bed-ec93ee830f91)

![Screenshot 2024-04-08 at 16 18 17](https://github.com/dailydotdev/apps/assets/554874/a63e688d-0707-4538-bed9-0f929cc6f540)

![Screenshot 2024-04-08 at 16 08 19](https://github.com/dailydotdev/apps/assets/554874/deac107c-c6e9-4db1-96ed-0e253ccbb7d2)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-236 #done


### Preview domain
https://as-236-micro-show-tags-on-card.preview.app.daily.dev