### PR TITLE
fix: post share loop showing on downvote

### DIFF
--- a/packages/shared/src/hooks/post/usePostShareLoop.spec.ts
+++ b/packages/shared/src/hooks/post/usePostShareLoop.spec.ts
@@ -1,0 +1,103 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { usePostShareLoop } from './usePostShareLoop';
+import { Post, UserVote } from '../../graphql/posts';
+import {
+  UseMutationSubscriptionProps,
+  useMutationSubscription,
+} from '../mutationSubscription';
+
+const post = { id: '1' } as Post;
+const feedName = 'testFeed';
+
+// Mock the useActiveFeedNameContext hook to return the mock feedName
+jest.mock('../../contexts', () => {
+  const original = jest.requireActual('../../contexts');
+  return {
+    ...original,
+    useActiveFeedNameContext: jest.fn().mockReturnValue({ feedName }),
+  };
+});
+
+// Mock the useMutationSubscription hook
+jest.mock('../mutationSubscription', () => ({
+  useMutationSubscription: jest.fn(),
+}));
+
+const mockUseMutationSubscription =
+  useMutationSubscription as jest.MockedFunction<
+    typeof useMutationSubscription
+  >;
+
+describe('usePostShareLoop', () => {
+  let callback: UseMutationSubscriptionProps['callback'] = null;
+
+  beforeEach(() => {
+    callback = null;
+    jest.clearAllMocks();
+
+    mockUseMutationSubscription.mockImplementationOnce(
+      (props: UseMutationSubscriptionProps) => {
+        callback = props.callback;
+      },
+    );
+  });
+
+  it('should set shouldShowOverlay to true when justUpvoted is true and hasInteracted is false', () => {
+    const { result } = renderHook(() => usePostShareLoop(post));
+
+    act(() => {
+      expect(mockUseMutationSubscription).toHaveBeenCalledTimes(1);
+
+      // Simulate a successful vote mutation with the same post id and vote type as Up
+      callback({
+        variables: { id: post.id, vote: UserVote.Up },
+        status: null,
+        mutation: null,
+        queryClient: null,
+      });
+    });
+
+    expect(result.current.shouldShowOverlay).toBe(true);
+  });
+
+  // Regression test for https://dailydotdev.atlassian.net/browse/MI-281
+  it('should set shouldShowOverlay to false when downvoting', () => {
+    const { result } = renderHook(() => usePostShareLoop(post));
+
+    act(() => {
+      expect(mockUseMutationSubscription).toHaveBeenCalledTimes(1);
+
+      // Simulate a successful vote mutation with the same post id and vote type as Up
+      callback({
+        variables: { id: post.id, vote: UserVote.Down },
+        status: null,
+        mutation: null,
+        queryClient: null,
+      });
+    });
+
+    expect(result.current.shouldShowOverlay).toBe(false);
+  });
+
+  it('should set shouldShowOverlay to false when onInteract is called', () => {
+    const { result } = renderHook(() => usePostShareLoop(post));
+
+    act(() => {
+      expect(mockUseMutationSubscription).toHaveBeenCalledTimes(1);
+
+      // Simulate a successful vote mutation with the same post id and vote type as Up
+      callback({
+        variables: { id: post.id, vote: UserVote.Up },
+        status: null,
+        mutation: null,
+        queryClient: null,
+      });
+    });
+
+    act(() => {
+      result.current.onInteract();
+    });
+
+    expect(result.current.shouldShowOverlay).toBe(false);
+  });
+});

--- a/packages/shared/src/hooks/post/usePostShareLoop.ts
+++ b/packages/shared/src/hooks/post/usePostShareLoop.ts
@@ -6,7 +6,7 @@ import {
   UserVoteEntity,
   createVoteMutationKey,
 } from '../vote';
-import { Post } from '../../graphql/posts';
+import { Post, UserVote } from '../../graphql/posts';
 
 interface UsePostShareLoop {
   shouldShowOverlay: boolean;
@@ -38,7 +38,7 @@ export const usePostShareLoop = (post: Post): UsePostShareLoop => {
         return;
       }
 
-      setJustUpvoted(!!vars.vote);
+      setJustUpvoted(vars.vote === UserVote.Up);
     },
   });
 


### PR DESCRIPTION
## Changes

Fixed the `usePostShareLoop` hook so that it only returns `shouldShowOverlay === true` when it should - on user upvote action. Downvote or None should not cause the share loop to be shown.

Added unit test for the `usePostShareLoop` hook as well.

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [ ] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-281 #done


### Preview domain
https://mi-281-fix-downvote-share-loop.preview.app.daily.dev