### PR TITLE
fix: ensure max length

### DIFF
--- a/packages/shared/src/components/cards/PostTags.tsx
+++ b/packages/shared/src/components/cards/PostTags.tsx
@@ -14,7 +14,7 @@ export default function PostTags({ tags }: PostTagsProps): ReactElement {
     let totalLength = 0;
     return tags.reduce((acc, tag) => {
       totalLength += tag.length;
-      if (totalLength >= 15 && acc.length > 0) {
+      if (totalLength >= 20 && acc.length > 0) {
         return acc;
       }
 

--- a/packages/shared/src/components/cards/PostTags.tsx
+++ b/packages/shared/src/components/cards/PostTags.tsx
@@ -13,12 +13,12 @@ export default function PostTags({ tags }: PostTagsProps): ReactElement {
   const tagList = useMemo(() => {
     let totalLength = 0;
     return tags.reduce((acc, tag) => {
-      if (totalLength >= 15) {
+      totalLength += tag.length;
+      if (totalLength >= 15 && acc.length > 0) {
         return acc;
       }
 
       acc.push(tag);
-      totalLength += tag.length;
       return acc;
     }, []);
   }, [tags]);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Some edge-cases where long words at certain positions in the list would break.
- Added additional check to ensure atleast one tag even if longer

| Before    | After |
| -------- | ------- |
| <img width="713" alt="Screenshot 2024-04-09 at 05 52 43" src="https://github.com/dailydotdev/apps/assets/554874/9be9bb93-81fc-4731-a157-41eddc824be5"> | <img width="696" alt="Screenshot 2024-04-09 at 05 54 17" src="https://github.com/dailydotdev/apps/assets/554874/74bc59bc-c2e5-4803-953f-d9f7555a2a97"> |

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-tags-max-length.preview.app.daily.dev