### PR TITLE
fix: mobile ux modal should use default bg color

### DIFF
--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -178,7 +178,7 @@ export function Modal({
     overlayClassName,
   );
   const modalClassName = classNames(
-    'modal relative flex max-w-full flex-col items-center border-border-subtlest-secondary bg-accent-pepper-subtlest antialiased shadow-2 focus:outline-none tablet:border',
+    'modal relative flex max-w-full flex-col items-center border-border-subtlest-secondary bg-background-default tablet:bg-accent-pepper-subtlest antialiased shadow-2 focus:outline-none tablet:border',
     'h-full w-full tablet:h-auto tablet:rounded-16',
     modalKindToClassName[kind],
     modalSizeToClassName[size],

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -178,7 +178,7 @@ export function Modal({
     overlayClassName,
   );
   const modalClassName = classNames(
-    'modal relative flex max-w-full flex-col items-center border-border-subtlest-secondary bg-background-default tablet:bg-accent-pepper-subtlest antialiased shadow-2 focus:outline-none tablet:border',
+    'modal relative flex max-w-full flex-col items-center border-border-subtlest-secondary bg-background-default antialiased shadow-2 focus:outline-none tablet:border tablet:bg-accent-pepper-subtlest',
     'h-full w-full tablet:h-auto tablet:rounded-16',
     modalKindToClassName[kind],
     modalSizeToClassName[size],


### PR DESCRIPTION
## Changes

### Before
<img width="393" alt="Screenshot 2024-04-09 at 10 03 47" src="https://github.com/dailydotdev/apps/assets/9974711/cea626a4-7434-4b56-ad66-7b88af416963">
<img width="393" alt="Screenshot 2024-04-09 at 10 04 08" src="https://github.com/dailydotdev/apps/assets/9974711/5bc23fec-3ec8-4d4e-a545-301087d8c195">


### After

<img width="390" alt="Screenshot 2024-04-09 at 10 04 49" src="https://github.com/dailydotdev/apps/assets/9974711/3ccf1e26-618f-4412-8359-359987e3ec44">
<img width="391" alt="Screenshot 2024-04-09 at 10 04 38" src="https://github.com/dailydotdev/apps/assets/9974711/08d3a7fa-ce7a-4370-8910-9e82ae50f116">

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-284 #done


### Preview domain
https://mi-284-upvoted-by-modal-bg.preview.app.daily.dev