### PR TITLE
fix: feed nav reacts to route changes

### DIFF
--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -33,7 +33,8 @@ function FeedNav(): ReactElement {
   const { feedName } = useActiveFeedNameContext();
   const { sortingEnabled } = useContext(SettingsContext);
   const { isSortableFeed } = useFeedName({ feedName });
-  const { home: shouldRenderNav, notifications } = useActiveNav(feedName);
+  const { home: shouldRenderNav } = useActiveNav(feedName);
+
   const isMobile = useViewSize(ViewSize.MobileL);
   const [selectedAlgo, setSelectedAlgo] = usePersistentContext(
     DEFAULT_ALGORITHM_KEY,
@@ -54,7 +55,7 @@ function FeedNav(): ReactElement {
     >
       {isMobile && <MobileFeedActions />}
       <TabContainer
-        controlledActive={notifications ? 'notifications' : undefined}
+        shouldMatchUrl
         shouldMountInactive
         className={{
           header: classNames(

--- a/packages/shared/src/components/tabs/TabContainer.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.tsx
@@ -8,6 +8,7 @@ import React, {
 import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import TabList, { TabListProps } from './TabList';
+import { useRouterOnChange } from '../../hooks/router/useRouterOnChange';
 
 export interface TabProps<T extends string> {
   key?: number;
@@ -47,6 +48,7 @@ export interface TabContainerProps<T extends string> {
   controlledActive?: string;
   tabListProps?: Pick<TabListProps, 'className' | 'autoScrollActive'>;
   showBorder?: boolean;
+  shouldMatchUrl?: boolean;
 }
 
 export function TabContainer<T extends string = string>({
@@ -59,6 +61,7 @@ export function TabContainer<T extends string = string>({
   showBorder = true,
   controlledActive,
   tabListProps = {},
+  shouldMatchUrl = false,
 }: TabContainerProps<T>): ReactElement {
   const router = useRouter();
 
@@ -73,6 +76,15 @@ export function TabContainer<T extends string = string>({
     }
 
     return defaultLabel;
+  });
+
+  useRouterOnChange({
+    onChange: (url) => {
+      const match = children.find((c) => c.props.url === url);
+
+      setActive(match ? match.props.label : undefined);
+    },
+    enabled: shouldMatchUrl,
   });
 
   const currentActive = controlledActive ?? active;

--- a/packages/shared/src/hooks/router/useRouterOnChange.spec.ts
+++ b/packages/shared/src/hooks/router/useRouterOnChange.spec.ts
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRouter } from 'next/router';
+import { useRouterOnChange } from './useRouterOnChange';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+const mockedRouter = useRouter as jest.Mock;
+
+describe('useRouterOnChange', () => {
+  let mockRouter = null;
+
+  beforeEach(() => {
+    mockRouter = {
+      isReady: true,
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+      },
+    };
+
+    mockedRouter.mockReturnValue(mockRouter);
+  });
+
+  it('should subscribe to route changes when enabled', () => {
+    const onChange = jest.fn();
+    renderHook(() => useRouterOnChange({ onChange, enabled: true }));
+
+    expect(mockRouter.events.on).toHaveBeenCalledWith(
+      'routeChangeStart',
+      onChange,
+    );
+  });
+
+  it('should not subscribe to route changes when not enabled', () => {
+    const onChange = jest.fn();
+    renderHook(() => useRouterOnChange({ onChange, enabled: false }));
+
+    expect(mockRouter.events.on).not.toHaveBeenCalled();
+  });
+
+  it('should unsubscribe from route changes when enabled is set to false', () => {
+    const onChange = jest.fn();
+    const { rerender } = renderHook(
+      ({ enabled }) => useRouterOnChange({ onChange, enabled }),
+      {
+        initialProps: { enabled: true },
+      },
+    );
+
+    expect(mockRouter.events.on).toHaveBeenCalledWith(
+      'routeChangeStart',
+      onChange,
+    );
+
+    rerender({ enabled: false });
+
+    expect(mockRouter.events.off).toHaveBeenCalledWith(
+      'routeChangeStart',
+      onChange,
+    );
+  });
+
+  it('should not subscribe or unsubscribe if router is not ready', () => {
+    mockRouter.isReady = false;
+    const onChange = jest.fn();
+    renderHook(() => useRouterOnChange({ onChange, enabled: true }));
+
+    expect(mockRouter.events.on).not.toHaveBeenCalled();
+    expect(mockRouter.events.off).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/hooks/router/useRouterOnChange.ts
+++ b/packages/shared/src/hooks/router/useRouterOnChange.ts
@@ -1,0 +1,36 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+interface Props {
+  onChange: (url: string) => void;
+  enabled?: boolean;
+}
+
+export function useRouterOnChange({ onChange, enabled = true }: Props): void {
+  const router = useRouter();
+  const [isEnabled, setIsEnabled] = useState(enabled);
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return null;
+    }
+
+    if (enabled !== isEnabled && !enabled) {
+      router.events.off('routeChangeStart', onChange);
+      setIsEnabled(enabled);
+      return null;
+    }
+
+    setIsEnabled(enabled);
+
+    if (enabled) {
+      router.events.on('routeChangeStart', onChange);
+
+      return () => {
+        router.events.off('routeChangeStart', onChange);
+      };
+    }
+
+    return null;
+  }, [router, onChange, enabled, isEnabled, setIsEnabled]);
+}


### PR DESCRIPTION
## Changes

- Added new hook `useRouterOnChange` which handles subscribing to nextjs router path changes
- Added new prop `shouldMatchUrl` to `TabContainer` that uses this hook to match the active tab to the current route
- Use the `shouldMatchUrl` prop in the `FeedNav` component, so that selected tab always reflects current route
- Unit test for the new hook

## Related issue
- https://dailydotdev.atlassian.net/browse/MI-282

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-282 #done


### Preview domain
https://mi-282-feed-nav-fix.preview.app.daily.dev