### PR TITLE
fix: feed filters modal ux inconsistencies for mobile

### DIFF
--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -1,22 +1,14 @@
-import React, { ReactElement, useState } from 'react';
-import {
-  HashtagIcon,
-  FilterIcon,
-  BlockIcon,
-  ArrowIcon,
-  AppIcon,
-} from '../icons';
+import React, { ReactElement } from 'react';
+import { HashtagIcon, FilterIcon, BlockIcon, AppIcon } from '../icons';
 import TagsFilter from './TagsFilter';
 import { TagCategoryLayout } from './TagCategoryDropdown';
 import AdvancedSettingsFilter from './AdvancedSettings';
 import BlockedFilter from './BlockedFilter';
-import { Button, ButtonSize } from '../buttons/Button';
 import { UnblockItem, unBlockPromptOptions } from './FilterMenu';
 import { Modal, ModalProps } from '../modals/common/Modal';
 import { usePrompt } from '../../hooks/usePrompt';
 import { UnblockSourceCopy, UnblockTagCopy } from './UnblockCopy';
 import { ContentTypesFilter } from './ContentTypesFilter';
-import { useViewSize, ViewSize } from '../../hooks';
 
 enum FilterMenuTitle {
   Tags = 'Manage tags',
@@ -28,8 +20,6 @@ enum FilterMenuTitle {
 type FeedFiltersProps = ModalProps;
 
 export default function FeedFilters(props: FeedFiltersProps): ReactElement {
-  const isMobile = useViewSize(ViewSize.MobileL);
-  const [isNavOpen, setIsNavOpen] = useState(true);
   const { showPrompt } = usePrompt();
   const unBlockPrompt = async ({ action, source, tag }: UnblockItem) => {
     const description = tag ? (
@@ -59,6 +49,7 @@ export default function FeedFilters(props: FeedFiltersProps): ReactElement {
       options: { icon: <BlockIcon /> },
     },
   ];
+
   return (
     <Modal
       {...props}
@@ -68,22 +59,9 @@ export default function FeedFilters(props: FeedFiltersProps): ReactElement {
       tabs={tabs}
     >
       <Modal.Sidebar>
-        <Modal.Sidebar.List
-          className="w-74"
-          title="Feed filters"
-          isNavOpen={isNavOpen}
-          setIsNavOpen={setIsNavOpen}
-          onViewChange={() => setIsNavOpen(false)}
-        />
+        <Modal.Sidebar.List className="w-74" title="Feed filters" defaultOpen />
         <Modal.Sidebar.Inner>
-          <Modal.Header showCloseButton={!isMobile}>
-            <Button
-              size={ButtonSize.Small}
-              className="mr-2 flex -rotate-90 tablet:hidden"
-              icon={<ArrowIcon />}
-              onClick={() => setIsNavOpen(true)}
-            />
-          </Modal.Header>
+          <Modal.Header />
           <Modal.Body view={FilterMenuTitle.Tags}>
             <TagsFilter tagCategoryLayout={TagCategoryLayout.Settings} />
           </Modal.Body>

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -104,7 +104,7 @@ export function Modal({
   const isDrawerOpen = isDrawerOnMobile && isMobile;
   const isForm = formProps && isMobile;
   const [activeView, setView] = useState<string | undefined>(
-    defaultView ?? stepTitle ?? tabTitle,
+    isMobile && tabs ? defaultView : defaultView ?? stepTitle ?? tabTitle,
   );
   const setActiveView = (view: string) => {
     if (onViewChange) {
@@ -128,6 +128,7 @@ export function Modal({
         onTrackPrev,
         isDrawer: isDrawerOpen,
         isForm,
+        isMobile,
       }}
     >
       <ConditionalWrapper

--- a/packages/shared/src/components/modals/common/ModalHeader.tsx
+++ b/packages/shared/src/components/modals/common/ModalHeader.tsx
@@ -39,8 +39,15 @@ export function ModalHeader({
   title,
   showCloseButton = true,
 }: ModalHeaderProps): ReactElement {
-  const { activeView, onRequestClose, tabs, isDrawer, isForm } =
-    useContext(ModalPropsContext);
+  const {
+    activeView,
+    setActiveView,
+    onRequestClose,
+    tabs,
+    isDrawer,
+    isForm,
+    isMobile,
+  } = useContext(ModalPropsContext);
 
   if (isDrawer || isForm) {
     return null;
@@ -62,7 +69,13 @@ export function ModalHeader({
           size={ButtonSize.Small}
           className="mr-2 flex -rotate-90 tablet:hidden"
           icon={<ArrowIcon />}
-          onClick={onRequestClose}
+          onClick={(event) => {
+            if (isMobile && tabs) {
+              setActiveView(undefined);
+            } else {
+              onRequestClose(event);
+            }
+          }}
         />
       )}
       {children}

--- a/packages/shared/src/components/modals/common/ModalSidebar.tsx
+++ b/packages/shared/src/components/modals/common/ModalSidebar.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React, { ReactElement, ReactNode, useContext } from 'react';
+import React, { ReactElement, ReactNode, useContext, useState } from 'react';
 import classed from '../../../lib/classed';
 import SidebarList from '../../sidebar/SidebarList';
 import { ModalPropsContext, ModalTabItem } from './types';
@@ -12,19 +12,23 @@ export type ModalSidebarProps = {
 export type ModalSidebarListProps = {
   className?: string;
   title: string;
-  isNavOpen: boolean;
-  setIsNavOpen: (open: boolean) => void;
-  onViewChange?: (view: string) => void;
+  defaultOpen?: boolean;
 };
 
 export function ModalSidebarList({
   className,
-  isNavOpen,
-  onViewChange,
-  setIsNavOpen,
   title,
+  defaultOpen = false,
 }: ModalSidebarListProps): ReactElement {
-  const { activeView, tabs, setActiveView } = useContext(ModalPropsContext);
+  const { activeView, tabs, setActiveView, isMobile } =
+    useContext(ModalPropsContext);
+  const [isNavOpen, setNavOpen] = useState(defaultOpen);
+
+  // open nav if there is no active view
+  if (isMobile && isNavOpen !== !activeView) {
+    setNavOpen(!activeView);
+  }
+
   return (
     <nav className={classNames('z-2 bg-background-default', className)}>
       <SidebarList
@@ -33,7 +37,6 @@ export function ModalSidebarList({
         title={title}
         onItemClick={(tab) => {
           setActiveView(tab);
-          onViewChange?.(tab);
         }}
         items={tabs.map((tab: string | ModalTabItem) =>
           typeof tab === 'string'
@@ -41,7 +44,6 @@ export function ModalSidebarList({
             : { title: tab.title, ...tab.options },
         )}
         isOpen={isNavOpen}
-        onClose={() => setIsNavOpen(false)}
       />
     </nav>
   );
@@ -49,7 +51,7 @@ export function ModalSidebarList({
 
 export const ModalSidebarInner = classed(
   'div',
-  'flex flex-1 flex-col border-l border-border-subtlest-tertiary',
+  'flex flex-1 flex-col tablet:border-l tablet:border-border-subtlest-tertiary',
 );
 
 export function ModalSidebar({

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -77,6 +77,7 @@ export type ModalContextProps = {
   onTrackPrev?: AnalyticsEvent;
   isDrawer?: boolean;
   isForm?: boolean;
+  isMobile?: boolean;
 };
 
 export const ModalPropsContext = createContext<ModalContextProps>({

--- a/packages/shared/src/components/sidebar/SidebarList.tsx
+++ b/packages/shared/src/components/sidebar/SidebarList.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement, ReactNode } from 'react';
 import classNames from 'classnames';
 import SidebarListItem, { SidebarListItemProps } from './SidebarListItem';
-import CloseButton from '../CloseButton';
 import { Button, ButtonSize } from '../buttons/Button';
 import { ArrowIcon } from '../icons';
 import { useModalContext } from '../modals/common/types';
@@ -14,7 +13,6 @@ interface SidebarListProps {
   items: SidebarListItemProps[];
   active: string;
   onItemClick?: (item: string) => void;
-  onClose?: () => void;
 }
 
 function SidebarList({
@@ -24,7 +22,6 @@ function SidebarList({
   isOpen,
   active,
   children,
-  onClose,
   onItemClick,
 }: SidebarListProps): ReactElement {
   const { onRequestClose } = useModalContext();
@@ -33,7 +30,7 @@ function SidebarList({
     <div
       className={classNames(
         'flex flex-col transition-transform ease-in-out tablet:translate-x-[unset] tablet:items-center tablet:px-6 tablet:pt-6',
-        'absolute h-full max-h-[100vh] w-full bg-inherit tablet:relative tablet:h-fit tablet:w-fit',
+        'absolute h-fit max-h-[100vh] w-full bg-inherit tablet:relative tablet:w-fit',
         isOpen ? 'translate-x-0' : ' -translate-x-full',
         className,
       )}
@@ -46,7 +43,6 @@ function SidebarList({
           onClick={onRequestClose}
         />
         <span className="ml-2 font-bold typo-title3">{title}</span>
-        <CloseButton className="hidden tablet:flex" onClick={onClose} />
       </span>
       <div className="px-4 tablet:px-0">
         {items.map((props) => (


### PR DESCRIPTION
## Changes

Related slack thread: https://dailydotdev.slack.com/archives/C0650M2KX8E/p1712672312237649

* Fixed navigation with modal sidebar on modal and refactored to make it easier to use.
* Removed left border
* Removed components that were never rendered

### Refactor
Before the interface was a bit quirky - the consumer of the modal needed to define a few functions and a state to determine if the nav is open. This is now changed in favor of supplying the modal with `defaultOpen` prop, which determines if the modal nav is open when it's first rendered instead.

### Screenshots

#### Before

<img alt="screenshot2" src="https://github.com/dailydotdev/apps/assets/9974711/a5739871-4826-486f-b1d4-e0c312e52c4f" width="350">
<img alt="screenshot1" src="https://github.com/dailydotdev/apps/assets/9974711/ff5e7e13-a00f-4fde-9a2e-ec34d8c13910" width="350">


#### After

<img alt="screenshot4" src="https://github.com/dailydotdev/apps/assets/9974711/8fe1c574-1117-4862-b3d9-b226475601b2" width="350">
<img alt="screenshot3" src="https://github.com/dailydotdev/apps/assets/9974711/8ec96aaf-df4a-411e-bddb-1e4f7d1bfb94" width="350">

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-288 #done


### Preview domain
https://mi-288-feed-filters-fix.preview.app.daily.dev