### PR TITLE
chore: change copy for the Submit Article modal and triggers of it

### DIFF
--- a/packages/shared/src/components/modals/SubmitArticleModal.spec.tsx
+++ b/packages/shared/src/components/modals/SubmitArticleModal.spec.tsx
@@ -64,7 +64,7 @@ it('should disable the button on invalid URL', async () => {
   renderComponent();
   const input = await screen.findByRole('textbox');
   userEvent.type(input, 'fakeURL');
-  const btn = await screen.findByLabelText('Submit article');
+  const btn = await screen.findByLabelText('Submit');
   expect(btn).toBeDisabled();
 });
 
@@ -74,7 +74,7 @@ it('should submit a valid URL', async () => {
   const input = (await screen.findByRole('textbox')) as HTMLInputElement;
   userEvent.type(input, link);
   input.value = link;
-  const btn = await screen.findByLabelText('Submit article');
+  const btn = await screen.findByLabelText('Submit');
   await waitFor(() => expect(btn).toBeEnabled());
   btn.click();
 
@@ -184,7 +184,7 @@ it('should feedback existing article', async () => {
   const input = (await screen.findByRole('textbox')) as HTMLInputElement;
   userEvent.type(input, link);
   input.value = link;
-  const btn = await screen.findByLabelText('Submit article');
+  const btn = await screen.findByLabelText('Submit');
   await waitFor(() => expect(btn).toBeEnabled());
   btn.click();
   // Wait for promise to resolve
@@ -215,7 +215,7 @@ it('should feedback already submitted article', async () => {
   const input = (await screen.findByRole('textbox')) as HTMLInputElement;
   userEvent.type(input, link);
   input.value = link;
-  const btn = await screen.findByLabelText('Submit article');
+  const btn = await screen.findByLabelText('Submit');
   await waitFor(() => expect(btn).toBeEnabled());
   btn.click();
 
@@ -246,7 +246,7 @@ it('should feedback submitted article is deleted', async () => {
   const input = (await screen.findByRole('textbox')) as HTMLInputElement;
   userEvent.type(input, link);
   input.value = link;
-  const btn = await screen.findByLabelText('Submit article');
+  const btn = await screen.findByLabelText('Submit');
   await waitFor(() => expect(btn).toBeEnabled());
   btn.click();
 

--- a/packages/shared/src/components/modals/SubmitArticleModal.tsx
+++ b/packages/shared/src/components/modals/SubmitArticleModal.tsx
@@ -38,6 +38,7 @@ import { Justify } from '../utilities';
 import { ReputationAlert } from './ReputationAlert';
 
 const defaultErrorMessage = 'Something went wrong, try again';
+const formTitle = 'Community picks';
 
 export default function SubmitArticleModal({
   onRequestClose,
@@ -189,7 +190,7 @@ export default function SubmitArticleModal({
   }
 
   const submitButtonProps = {
-    'aria-label': 'Submit article',
+    'aria-label': 'Submit',
     loading: isValidating,
     disabled: !enableSubmission || !isEnabled || !!existingArticle,
   };
@@ -202,11 +203,11 @@ export default function SubmitArticleModal({
       onRequestClose={onRequestClose}
       formProps={{
         form: 'submit-article',
-        title: FeedItemTitle.SubmitArticle,
+        title: formTitle,
         rightButtonProps: submitButtonProps,
       }}
     >
-      <Modal.Header title={FeedItemTitle.SubmitArticle} />
+      <Modal.Header title={formTitle} />
       <Modal.Body>
         <form
           ref={submitFormRef}
@@ -289,16 +290,14 @@ export default function SubmitArticleModal({
             type="submit"
             form="submit-article"
           >
-            <span className={isValidating ? 'invisible' : ''}>
-              Submit article
-            </span>
+            <span className={isValidating ? 'invisible' : ''}>Submit</span>
           </Button>
         )}
         {isSubmitted && (
           <Button
             className="max-w-[22.5rem] flex-1"
             variant={ButtonVariant.Primary}
-            aria-label="Close submit article modal"
+            aria-label="Close community picks modal"
             onClick={onRequestClose}
           >
             Close

--- a/packages/shared/src/components/sidebar/ContributeSection.tsx
+++ b/packages/shared/src/components/sidebar/ContributeSection.tsx
@@ -20,7 +20,7 @@ export function ContributeSection(props: SectionCommonProps): ReactElement {
       icon: (active: boolean) => (
         <ListIcon Icon={() => <LinkIcon secondary={active} />} />
       ),
-      title: 'Submit article',
+      title: 'Community picks',
       action: openSubmitArticle,
       active: modal?.type === LazyModal.SubmitArticle,
     },

--- a/packages/webapp/components/footer/FooterPlusButton.tsx
+++ b/packages/webapp/components/footer/FooterPlusButton.tsx
@@ -79,7 +79,7 @@ export function FooterPlusButton(): ReactElement {
                 openModal({ type: LazyModal.SubmitArticle });
               }}
             >
-              Submit article
+              Community picks
             </ActionButton>
           </div>
         </Drawer>


### PR DESCRIPTION
## Changes

Slack thread here: https://dailydotdev.slack.com/archives/C0650M2KX8E/p1712666428589889

Changed the copy from `Submit article` to `Community picks` in:
- footer navbar when clicking on the plus button
- sidebar
- submit article modal header
  - changed the copy of the submit button on the modal to just `Submit`

### Screenshots
<img width="413" alt="Screenshot 2024-04-10 at 15 11 50" src="https://github.com/dailydotdev/apps/assets/9974711/7e8aba4a-79e7-4c87-bd32-1a25d01d6fda">
<img width="574" alt="Screenshot 2024-04-10 at 15 11 25" src="https://github.com/dailydotdev/apps/assets/9974711/7dcc30f3-61d7-48af-ad3c-4c1b8933ba1a">
<img width="241" alt="Screenshot 2024-04-10 at 15 02 15" src="https://github.com/dailydotdev/apps/assets/9974711/7ae32fe5-91d1-414e-8498-4790a0340240">


## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-286 #done


### Preview domain
https://mi-286-submit-article-copy.preview.app.daily.dev