### PR TITLE
fix: smaller evaluation to fit text

### DIFF
--- a/packages/shared/src/components/cards/PostTags.tsx
+++ b/packages/shared/src/components/cards/PostTags.tsx
@@ -14,10 +14,10 @@ export default function PostTags({ tags }: PostTagsProps): ReactElement {
     let totalLength = 0;
     return tags.reduce((acc, tag) => {
       totalLength += tag.length;
-      if (totalLength >= 15 && acc.length > 2) {
+      if (totalLength >= 12 && acc.length >= 2) {
         return acc;
       }
-      if (totalLength >= 20 && acc.length > 0) {
+      if (totalLength >= 18 && acc.length > 0) {
         return acc;
       }
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We still had a few options where text would break outside the bounding area so decided to make it slightly smaller.
- This could mean we show 1 less tag in general, but better then breaking the view.

![Screenshot 2024-04-11 at 09 01 07](https://github.com/dailydotdev/apps/assets/554874/ac2f0b48-b113-42ef-8898-007ac81b268b)
![Screenshot 2024-04-11 at 08 54 05](https://github.com/dailydotdev/apps/assets/554874/e020801c-2d5d-451e-9ea5-d2dd0d70ed72)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
