### PR TITLE
fix: add initial query params to analytics events

### DIFF
--- a/packages/shared/src/hooks/analytics/useAnalyticsSharedProps.ts
+++ b/packages/shared/src/hooks/analytics/useAnalyticsSharedProps.ts
@@ -35,7 +35,23 @@ export default function useAnalyticsSharedProps(
       return;
     }
 
-    const queryStr = JSON.stringify(query);
+    const queryObject = { ...query };
+
+    const initialQuerySearchParams = new URLSearchParams(
+      window.location.search,
+    );
+
+    // initial useRouter.query can be empty on prerendered static pages
+    // so we add any missing initial query params to the query object
+    // that we pass to tracking
+    initialQuerySearchParams.forEach((value, key) => {
+      if (!queryObject[key]) {
+        queryObject[key] = value;
+      }
+    });
+
+    const queryStr = JSON.stringify(queryObject);
+
     (sharedPropsRef.current?.device_id
       ? Promise.resolve(sharedPropsRef.current.device_id)
       : Promise.resolve(deviceId)


### PR DESCRIPTION
## Changes

### Describe what this PR does
- While fixing https://github.com/dailydotdev/apps/pull/2972 I noticed `query_params` in events are not sent on initial page load for static pre-rendered pages until `useRouter.query` is hydrated
- I now merge them with `window.location.search` to include any initial params like `utm_`

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
