### PR TITLE
fix: layout shift when leaving/entering feed

### DIFF
--- a/packages/shared/src/components/filters/MyFeedHeading.tsx
+++ b/packages/shared/src/components/filters/MyFeedHeading.tsx
@@ -56,7 +56,9 @@ function MyFeedHeading({
       {forceRefresh && (
         <Button
           size={
-            shouldUseMobileFeedLayout ? ButtonSize.Small : ButtonSize.Medium
+            shouldUseMobileFeedLayout && !isNewMobileLayout
+              ? ButtonSize.Small
+              : ButtonSize.Medium
           }
           variant={
             isMobile && isNewMobileLayout


### PR DESCRIPTION
## Changes

Reported on slack: https://dailydotdev.slack.com/archives/C0650M2KX8E/p1712771505063679

The problem was caused by refresh icon changing it's size depending on if the user is on the feed page or not. Fixed that so that in new mobile layout, it does not change the refresh icon size. We already use the same condition for the feed settings icon.

### Video


https://github.com/dailydotdev/apps/assets/9974711/a5700598-e198-4c44-a1f1-5cee9824b8d9



## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-290 #done


### Preview domain
https://mi-290-fix-header-layout-shift.preview.app.daily.dev