### PR TITLE
feat: add feed layout without filters

### DIFF
--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -46,7 +46,7 @@ export default function MainFeedPage({
   const [feedName, setFeedName] = useState<string>('default');
   const [searchQuery, setSearchQuery] = useState<string>();
   const [showDnd, setShowDnd] = useState(false);
-  const { shouldUseMobileFeedLayout } = useFeedLayout({ feedRelated: false });
+  const { shouldUseMobileFeedLayout } = useFeedLayout();
   useCompanionSettings();
   const { isActive: isDndActive } = useContext(DndContext);
   const enableSearch = () => {

--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -12,13 +12,19 @@ import {
   supportedTypesForPrivateSources,
 } from '../graphql/feed';
 import AuthContext from '../contexts/AuthContext';
-import { CustomFeedHeader, FeedPage, FeedPageHeader } from './utilities';
+import {
+  CustomFeedHeader,
+  FeedPage,
+  FeedPageHeader,
+  FeedPageLayoutMobile,
+} from './utilities';
 import SearchEmptyScreen from './SearchEmptyScreen';
 import Feed, { FeedProps } from './Feed';
 import BookmarkEmptyScreen from './BookmarkEmptyScreen';
 import { Button, ButtonVariant } from './buttons/Button';
 import { ShareIcon } from './icons';
 import { generateQueryKey, OtherFeedPage, RequestKey } from '../lib/query';
+import { useFeedLayout } from '../hooks';
 
 export type BookmarkFeedLayoutProps = {
   searchQuery?: string;
@@ -39,6 +45,7 @@ export default function BookmarkFeedLayout({
   searchChildren,
   children,
 }: BookmarkFeedLayoutProps): ReactElement {
+  const { shouldUseMobileFeedLayout } = useFeedLayout();
   const { user, tokenRefreshed } = useContext(AuthContext);
   const [showEmptyScreen, setShowEmptyScreen] = useState(false);
   const [showSharedBookmarks, setShowSharedBookmarks] = useState(false);
@@ -85,13 +92,17 @@ export default function BookmarkFeedLayout({
     </Button>
   );
 
+  const MobileOrDesktopLayout = shouldUseMobileFeedLayout
+    ? FeedPageLayoutMobile
+    : FeedPage;
+
   return (
-    <FeedPage>
+    <MobileOrDesktopLayout>
       {children}
       <FeedPageHeader className="mb-5">
         <h3 className="font-bold typo-callout">Bookmarks</h3>
       </FeedPageHeader>
-      <CustomFeedHeader className="mb-6 flex">
+      <CustomFeedHeader className="mb-6 flex px-4">
         {searchChildren}
         {shareBookmarksButton('hidden laptop:flex ml-4', 'Share bookmarks')}
         {shareBookmarksButton('flex laptop:hidden ml-4')}
@@ -104,6 +115,6 @@ export default function BookmarkFeedLayout({
         />
       )}
       {tokenRefreshed && <Feed {...feedProps} />}
-    </FeedPage>
+    </MobileOrDesktopLayout>
   );
 }

--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -46,7 +46,8 @@ export default function BookmarkFeedLayout({
   searchChildren,
   children,
 }: BookmarkFeedLayoutProps): ReactElement {
-  const { shouldUseMobileFeedLayout } = useFeedLayout();
+  const { shouldUseMobileFeedLayout, FeedPageLayoutComponent } =
+    useFeedLayout();
   const { user, tokenRefreshed } = useContext(AuthContext);
   const [showEmptyScreen, setShowEmptyScreen] = useState(false);
   const [showSharedBookmarks, setShowSharedBookmarks] = useState(false);
@@ -93,12 +94,8 @@ export default function BookmarkFeedLayout({
     </Button>
   );
 
-  const MobileOrDesktopLayout = shouldUseMobileFeedLayout
-    ? FeedPageLayoutMobile
-    : FeedPage;
-
   return (
-    <MobileOrDesktopLayout>
+    <FeedPageLayoutComponent>
       {children}
       <FeedPageHeader className="mb-5">
         <h3 className="font-bold typo-callout">Bookmarks</h3>
@@ -118,6 +115,6 @@ export default function BookmarkFeedLayout({
         />
       )}
       {tokenRefreshed && <Feed {...feedProps} />}
-    </MobileOrDesktopLayout>
+    </FeedPageLayoutComponent>
   );
 }

--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import dynamic from 'next/dynamic';
+import classNames from 'classnames';
 import {
   BOOKMARKS_FEED_QUERY,
   SEARCH_BOOKMARKS_QUERY,
@@ -102,7 +103,9 @@ export default function BookmarkFeedLayout({
       <FeedPageHeader className="mb-5">
         <h3 className="font-bold typo-callout">Bookmarks</h3>
       </FeedPageHeader>
-      <CustomFeedHeader className="mb-6 flex px-4">
+      <CustomFeedHeader
+        className={classNames('mb-6 flex', shouldUseMobileFeedLayout && 'px-4')}
+      >
         {searchChildren}
         {shareBookmarksButton('hidden laptop:flex ml-4', 'Share bookmarks')}
         {shareBookmarksButton('flex laptop:hidden ml-4')}

--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -13,12 +13,7 @@ import {
   supportedTypesForPrivateSources,
 } from '../graphql/feed';
 import AuthContext from '../contexts/AuthContext';
-import {
-  CustomFeedHeader,
-  FeedPage,
-  FeedPageHeader,
-  FeedPageLayoutMobile,
-} from './utilities';
+import { CustomFeedHeader, FeedPageHeader } from './utilities';
 import SearchEmptyScreen from './SearchEmptyScreen';
 import Feed, { FeedProps } from './Feed';
 import BookmarkEmptyScreen from './BookmarkEmptyScreen';

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -70,6 +70,7 @@ import { removeQueryParam } from '../lib/links';
 import { SharedFeedPage } from './utilities';
 import { AllFeedPages } from '../lib/query';
 import { UserVoteEntity } from '../hooks';
+import * as hooks from '../hooks/useViewSize';
 
 const showLogin = jest.fn();
 let nextCallback: (value: PostsEngaged) => unknown = null;
@@ -223,6 +224,9 @@ it('should add one placeholder when loading', async () => {
 });
 
 it('should replace placeholders with posts and ad', async () => {
+  // is desktop
+  jest.spyOn(hooks, 'useViewSize').mockImplementation(() => true);
+
   renderComponent();
   await waitForNock();
   const elements = await screen.findAllByTestId('postItem');
@@ -245,6 +249,9 @@ it('should replace placeholders with posts and ad', async () => {
 });
 
 it('should render feed with sorting ranking by date', async () => {
+  // is desktop
+  jest.spyOn(hooks, 'useViewSize').mockImplementation(() => true);
+
   variables = { ...defaultVariables, ranking: 'TIME' };
   renderComponent(
     [createFeedMock(defaultFeedPage, ANONYMOUS_FEED_QUERY)],
@@ -356,6 +363,9 @@ it('should open login modal on anonymous upvote', async () => {
 });
 
 it('should send add bookmark mutation', async () => {
+  // is desktop
+  jest.spyOn(hooks, 'useViewSize').mockImplementation(() => true);
+
   let mutationCalled = false;
   renderComponent([
     createFeedMock({
@@ -386,6 +396,9 @@ it('should send add bookmark mutation', async () => {
 });
 
 it('should send remove bookmark mutation', async () => {
+  // is desktop
+  jest.spyOn(hooks, 'useViewSize').mockImplementation(() => true);
+
   let mutationCalled = false;
   renderComponent([
     createFeedMock({
@@ -416,6 +429,9 @@ it('should send remove bookmark mutation', async () => {
 });
 
 it('should open login modal on anonymous bookmark', async () => {
+  // is desktop
+  jest.spyOn(hooks, 'useViewSize').mockImplementation(() => true);
+
   renderComponent(
     [
       createFeedMock(
@@ -442,6 +458,9 @@ it('should open login modal on anonymous bookmark', async () => {
 });
 
 it('should increase reading rank progress', async () => {
+  // is desktop
+  jest.spyOn(hooks, 'useViewSize').mockImplementation(() => true);
+
   renderComponent([
     createFeedMock({
       pageInfo: defaultFeedPage.pageInfo,
@@ -501,6 +520,9 @@ it('should not increase reading rank progress when read today', async () => {
 });
 
 it('should increase reading rank progress and rank', async () => {
+  // is desktop
+  jest.spyOn(hooks, 'useViewSize').mockImplementation(() => true);
+
   renderComponent([
     createFeedMock({
       pageInfo: defaultFeedPage.pageInfo,
@@ -554,6 +576,9 @@ it('should not increase reading rank progress when reached final rank', async ()
 });
 
 it('should increase reading rank progress for anonymous users', async () => {
+  // is desktop
+  jest.spyOn(hooks, 'useViewSize').mockImplementation(() => true);
+
   renderComponent(
     [
       createFeedMock(
@@ -599,6 +624,9 @@ it('should increase reading rank progress for anonymous users', async () => {
 });
 
 it('should update feed item on subscription message', async () => {
+  // is desktop
+  jest.spyOn(hooks, 'useViewSize').mockImplementation(() => true);
+
   renderComponent([
     createFeedMock({
       pageInfo: defaultFeedPage.pageInfo,
@@ -907,6 +935,9 @@ it('should block a tag', async () => {
 });
 
 it('should open a modal to view post details', async () => {
+  // is desktop
+  jest.spyOn(hooks, 'useViewSize').mockImplementation(() => true);
+
   renderComponent();
   await waitForNock();
   const [first] = await screen.findAllByLabelText('Comments');
@@ -959,6 +990,9 @@ const createPostMock = (
 });
 
 it('should be able to navigate through posts', async () => {
+  // is desktop
+  jest.spyOn(hooks, 'useViewSize').mockImplementation(() => true);
+
   const [firstPost, secondPost] = defaultFeedPage.edges;
   renderComponent();
   await waitForNock();

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -11,12 +11,7 @@ import classNames from 'classnames';
 import Feed, { FeedProps } from './Feed';
 import AuthContext from '../contexts/AuthContext';
 import { LoggedUser } from '../lib/user';
-import {
-  CommentFeedPage,
-  FeedPage,
-  FeedPageLayoutMobile,
-  SharedFeedPage,
-} from './utilities';
+import { CommentFeedPage, SharedFeedPage } from './utilities';
 import {
   ANONYMOUS_FEED_QUERY,
   FEED_QUERY,

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -145,7 +145,8 @@ export default function MainFeedLayout({
   const searchVersion = useFeature(feature.searchVersion);
   const hasCommentFeed = useFeature(feature.commentFeed);
   const { isUpvoted, isPopular, isSortableFeed } = useFeedName({ feedName });
-  const { shouldUseMobileFeedLayout } = useFeedLayout();
+  const { shouldUseMobileFeedLayout, FeedPageLayoutComponent } =
+    useFeedLayout();
   const [isPreviewFeedVisible, setPreviewFeedVisible] = useState(false);
   const [isPreviewFeedEnabled, setPreviewFeedEnabled] = useState(false);
   const shouldUseCommentFeedLayout =
@@ -285,12 +286,9 @@ export default function MainFeedLayout({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortingEnabled, selectedAlgo, loadedSettings, loadedAlgo]);
 
-  const MobileOrDesktopLayout = shouldUseMobileFeedLayout
-    ? FeedPageLayoutMobile
-    : FeedPage;
   const FeedPageComponent = shouldUseCommentFeedLayout
     ? CommentFeedPage
-    : MobileOrDesktopLayout;
+    : FeedPageLayoutComponent;
 
   const disableTopPadding =
     isFinder || shouldUseMobileFeedLayout || shouldUseCommentFeedLayout;

--- a/packages/shared/src/components/RecommendedTags.tsx
+++ b/packages/shared/src/components/RecommendedTags.tsx
@@ -15,7 +15,7 @@ export const RecommendedTags = ({
     return (
       <div>
         <ElementPlaceholder className="mb-3 h-4 w-1/5 rounded-12" />
-        <div className="flex flex-wrap gap-2">
+        <div className="flex gap-2">
           <ElementPlaceholder className="h-6 w-12 rounded-8" />
           <ElementPlaceholder className="h-6 w-12 rounded-8" />
           <ElementPlaceholder className="h-6 w-12 rounded-8" />

--- a/packages/shared/src/components/RecommendedTags.tsx
+++ b/packages/shared/src/components/RecommendedTags.tsx
@@ -15,7 +15,7 @@ export const RecommendedTags = ({
     return (
       <div>
         <ElementPlaceholder className="mb-3 h-4 w-1/5 rounded-12" />
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           <ElementPlaceholder className="h-6 w-12 rounded-8" />
           <ElementPlaceholder className="h-6 w-12 rounded-8" />
           <ElementPlaceholder className="h-6 w-12 rounded-8" />

--- a/packages/shared/src/components/Settings.tsx
+++ b/packages/shared/src/components/Settings.tsx
@@ -61,7 +61,7 @@ export default function Settings({
   ...props
 }: HTMLAttributes<HTMLDivElement>): ReactElement {
   const isExtension = checkIsExtension();
-  const { shouldUseMobileFeedLayout } = useFeedLayout({ feedRelated: false });
+  const { shouldUseMobileFeedLayout } = useFeedLayout();
   const { user, showLogin } = useContext(AuthContext);
   const {
     spaciness,

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -193,7 +193,10 @@ export const FeedContainer = ({
                 )}
               >
                 <ConditionalWrapper
-                  condition={!isNewMobileLayout}
+                  condition={
+                    !isNewMobileLayout &&
+                    (feedNameToHeading[feedName] || actionButtons)
+                  }
                   wrapper={(component) => (
                     <span className="flex w-full flex-row items-center justify-between px-6 py-4">
                       <strong className="typo-title3">

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -15,9 +15,9 @@ import {
   ToastSubject,
   useToastNotification,
   useConditionalFeature,
+  FeedPagesWithMobileLayout,
 } from '../../hooks';
 import ConditionalWrapper from '../ConditionalWrapper';
-import { SharedFeedPage } from '../utilities';
 import { useActiveFeedNameContext } from '../../contexts';
 import { useMobileUxExperiment } from '../../hooks/useMobileUxExperiment';
 import { useReadingStreak } from '../../hooks/streaks';
@@ -87,12 +87,13 @@ const getStyle = (isList: boolean, space: Spaciness): CSSProperties => {
   return {};
 };
 
-const feedNameToHeading: Record<SharedFeedPage, string> = {
+const feedNameToHeading: Record<FeedPagesWithMobileLayout, string> = {
   search: 'Search',
   'my-feed': 'For you',
   popular: 'Popular',
   upvoted: 'Most upvoted',
   discussed: 'Best discussions',
+  bookmarks: 'Bookmarks',
 };
 
 export const FeedContainer = ({

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -87,7 +87,13 @@ const getStyle = (isList: boolean, space: Spaciness): CSSProperties => {
   return {};
 };
 
-const feedNameToHeading: Record<FeedPagesWithMobileLayout, string> = {
+const feedNameToHeading: Record<
+  Exclude<
+    FeedPagesWithMobileLayout,
+    FeedPagesWithMobileLayout.UserUpvoted | FeedPagesWithMobileLayout.UserPosts
+  >,
+  string
+> = {
   search: 'Search',
   'my-feed': 'For you',
   popular: 'Popular',

--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -1,45 +1,26 @@
-import { useMemo } from 'react';
-import { SharedFeedPage } from '../components/utilities';
-import { AllFeedPages } from '../lib/query';
-import { useActiveFeedNameContext } from '../contexts/ActiveFeedNameContext';
 import { useViewSize, ViewSize } from './useViewSize';
-
-interface UseFeedLayoutProps {
-  feedName?: AllFeedPages;
-  feedRelated?: boolean;
-}
 
 interface UseFeedLayout {
   shouldUseMobileFeedLayout: boolean;
 }
 
+export enum FeedPagesWithMobileLayout {
+  MyFeed = 'my-feed',
+  Popular = 'popular',
+  Search = 'search',
+  Upvoted = 'upvoted',
+  Discussed = 'discussed',
+  Bookmarks = 'bookmarks',
+}
+
 export const FeedLayoutMobileFeedPages = new Set(
-  Object.values(SharedFeedPage).filter(
-    (feedPage) => feedPage !== SharedFeedPage.Search,
-  ),
+  Object.values(FeedPagesWithMobileLayout),
 );
 
-const checkShouldUseMobileFeedLayout = (feedName: SharedFeedPage): boolean =>
-  FeedLayoutMobileFeedPages.has(feedName) && feedName !== SharedFeedPage.Search;
-
-export const useFeedLayout = ({
-  feedName: feedNameProp,
-  feedRelated = true,
-}: UseFeedLayoutProps = {}): UseFeedLayout => {
-  const { feedName } = useActiveFeedNameContext();
-  const isLaptop = useViewSize(ViewSize.Laptop);
-  const name = (feedNameProp ?? feedName) as SharedFeedPage;
-  const isIncludedFeed = useMemo(
-    () => checkShouldUseMobileFeedLayout(name),
-    [name],
-  );
-
-  const isNotLaptopAndIsIncludedFeed = !isLaptop && isIncludedFeed;
-  const shouldUseMobileFeedLayout = feedRelated
-    ? isNotLaptopAndIsIncludedFeed
-    : !isLaptop;
+export const useFeedLayout = (): UseFeedLayout => {
+  const isMobile = useViewSize(ViewSize.MobileL);
 
   return {
-    shouldUseMobileFeedLayout,
+    shouldUseMobileFeedLayout: isMobile,
   };
 };

--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -1,9 +1,11 @@
 import { useViewSize, ViewSize } from './useViewSize';
 import { useActiveFeedNameContext } from '../contexts/ActiveFeedNameContext';
 import { OtherFeedPage } from '../lib/query';
+import { FeedPage, FeedPageLayoutMobile } from '../components/utilities';
 
 interface UseFeedLayout {
   shouldUseMobileFeedLayout: boolean;
+  FeedPageLayoutComponent: React.ComponentType;
 }
 
 export enum FeedPagesWithMobileLayout {
@@ -28,7 +30,14 @@ export const useFeedLayout = (): UseFeedLayout => {
     feedName === OtherFeedPage.UserPosts ||
     feedName === OtherFeedPage.UserUpvoted;
 
+  const shouldUseMobileFeedLayout = !isLaptop || isUserProfileFeed;
+
+  const FeedPageLayoutComponent = shouldUseMobileFeedLayout
+    ? FeedPageLayoutMobile
+    : FeedPage;
+
   return {
-    shouldUseMobileFeedLayout: !isLaptop || isUserProfileFeed,
+    shouldUseMobileFeedLayout,
+    FeedPageLayoutComponent,
   };
 };

--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -18,9 +18,9 @@ export const FeedLayoutMobileFeedPages = new Set(
 );
 
 export const useFeedLayout = (): UseFeedLayout => {
-  const isMobile = useViewSize(ViewSize.MobileL);
+  const isLaptop = useViewSize(ViewSize.Laptop);
 
   return {
-    shouldUseMobileFeedLayout: isMobile,
+    shouldUseMobileFeedLayout: !isLaptop,
   };
 };

--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -13,6 +13,8 @@ export enum FeedPagesWithMobileLayout {
   Upvoted = 'upvoted',
   Discussed = 'discussed',
   Bookmarks = 'bookmarks',
+  UserPosts = 'user-posts',
+  UserUpvoted = 'user-upvoted',
 }
 
 export const FeedLayoutMobileFeedPages = new Set(
@@ -22,11 +24,11 @@ export const FeedLayoutMobileFeedPages = new Set(
 export const useFeedLayout = (): UseFeedLayout => {
   const isLaptop = useViewSize(ViewSize.Laptop);
   const { feedName } = useActiveFeedNameContext();
+  const isUserProfileFeed =
+    feedName === OtherFeedPage.UserPosts ||
+    feedName === OtherFeedPage.UserUpvoted;
 
   return {
-    shouldUseMobileFeedLayout:
-      !isLaptop ||
-      feedName === OtherFeedPage.UserPosts ||
-      feedName === OtherFeedPage.UserUpvoted,
+    shouldUseMobileFeedLayout: !isLaptop || isUserProfileFeed,
   };
 };

--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -1,4 +1,6 @@
 import { useViewSize, ViewSize } from './useViewSize';
+import { useActiveFeedNameContext } from '../contexts/ActiveFeedNameContext';
+import { OtherFeedPage } from '../lib/query';
 
 interface UseFeedLayout {
   shouldUseMobileFeedLayout: boolean;
@@ -19,8 +21,12 @@ export const FeedLayoutMobileFeedPages = new Set(
 
 export const useFeedLayout = (): UseFeedLayout => {
   const isLaptop = useViewSize(ViewSize.Laptop);
+  const { feedName } = useActiveFeedNameContext();
 
   return {
-    shouldUseMobileFeedLayout: !isLaptop,
+    shouldUseMobileFeedLayout:
+      !isLaptop ||
+      feedName === OtherFeedPage.UserPosts ||
+      feedName === OtherFeedPage.UserUpvoted,
   };
 };

--- a/packages/shared/src/hooks/useOnPostClick.ts
+++ b/packages/shared/src/hooks/useOnPostClick.ts
@@ -98,7 +98,7 @@ export default function useOnPostClick({
   const { trackEvent } = useContext(AnalyticsContext);
   const { incrementReadingRank } = useIncrementReadingRank();
   const { queryKey: feedQueryKey, items } = useContext(ActiveFeedContext);
-  const { shouldUseMobileFeedLayout } = useFeedLayout({ feedRelated: false });
+  const { shouldUseMobileFeedLayout } = useFeedLayout();
 
   const { isLowImpsEnabled } = usePostFeedback();
 

--- a/packages/shared/src/lib/feed.ts
+++ b/packages/shared/src/lib/feed.ts
@@ -4,7 +4,7 @@ import { AnalyticsEvent } from '../hooks/analytics/useAnalyticsQueue';
 import { PostBootData } from './boot';
 import { Origin } from './analytics';
 import { SharedFeedPage } from '../components/utilities';
-import { AllFeedPages } from './query';
+import { AllFeedPages, OtherFeedPage } from './query';
 
 export function optimisticPostUpdateInFeed(
   items: FeedItem[],
@@ -175,9 +175,14 @@ export const getFeedName = (
   if (defaultFeedConditions.some((condition) => condition === feed)) {
     return getDefaultFeed(options);
   }
-
   if (feed.startsWith('search')) {
     return SharedFeedPage.Search;
+  }
+  if (feed === '[userId]upvoted') {
+    return OtherFeedPage.UserUpvoted;
+  }
+  if (feed === '[userId]posts') {
+    return OtherFeedPage.UserPosts;
   }
 
   const [page] = feed.split('?');

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -22,6 +22,7 @@ export enum OtherFeedPage {
   Preview = 'preview',
   Author = 'author',
   UserUpvoted = 'user-upvoted',
+  UserPosts = 'user-posts',
   History = 'history',
   Notifications = 'notifications',
 }

--- a/packages/webapp/pages/[userId]/posts.tsx
+++ b/packages/webapp/pages/[userId]/posts.tsx
@@ -6,6 +6,8 @@ import { OtherFeedPage } from '@dailydotdev/shared/src/lib/query';
 import { MyProfileEmptyScreen } from '@dailydotdev/shared/src/components/profile/MyProfileEmptyScreen';
 import { ProfileEmptyScreen } from '@dailydotdev/shared/src/components/profile/ProfileEmptyScreen';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import { useFeedLayout } from '@dailydotdev/shared/src/hooks';
+import classNames from 'classnames';
 import {
   getLayout as getProfileLayout,
   getStaticPaths as getProfileStaticPaths,
@@ -19,6 +21,7 @@ export const getStaticPaths = getProfileStaticPaths;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ProfilePostsPage = ({ user }: ProfileLayoutProps): ReactElement => {
   const { user: loggedUser } = useContext(AuthContext);
+  const { shouldUseMobileFeedLayout } = useFeedLayout();
   const isSameUser = loggedUser?.id === user.id;
 
   const userId = user?.id;
@@ -46,7 +49,12 @@ const ProfilePostsPage = ({ user }: ProfileLayoutProps): ReactElement => {
     ),
   };
 
-  return <Feed {...feedProps} className="px-4 py-6" />;
+  return (
+    <Feed
+      {...feedProps}
+      className={classNames('py-6', !shouldUseMobileFeedLayout && 'px-4')}
+    />
+  );
 };
 
 ProfilePostsPage.getLayout = getProfileLayout;

--- a/packages/webapp/pages/[userId]/upvoted.tsx
+++ b/packages/webapp/pages/[userId]/upvoted.tsx
@@ -5,6 +5,8 @@ import { USER_UPVOTED_FEED_QUERY } from '@dailydotdev/shared/src/graphql/feed';
 import { MyProfileEmptyScreen } from '@dailydotdev/shared/src/components/profile/MyProfileEmptyScreen';
 import { ProfileEmptyScreen } from '@dailydotdev/shared/src/components/profile/ProfileEmptyScreen';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import { useFeedLayout } from '@dailydotdev/shared/src/hooks';
+import classNames from 'classnames';
 import {
   ProfileLayoutProps,
   getStaticPaths as getProfileStaticPaths,
@@ -18,6 +20,8 @@ export const getStaticPaths = getProfileStaticPaths;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ProfileUpvotedPage = ({ user }: ProfileLayoutProps): ReactElement => {
   const { user: loggedUser } = useContext(AuthContext);
+  const { shouldUseMobileFeedLayout } = useFeedLayout();
+
   const isSameUser = loggedUser?.id === user.id;
 
   const userId = user?.id;
@@ -45,7 +49,12 @@ const ProfileUpvotedPage = ({ user }: ProfileLayoutProps): ReactElement => {
     ),
   };
 
-  return <Feed {...feedProps} className="px-4 py-6" />;
+  return (
+    <Feed
+      {...feedProps}
+      className={classNames('py-6', !shouldUseMobileFeedLayout && 'px-4')}
+    />
+  );
 };
 
 ProfileUpvotedPage.getLayout = getProfileLayout;

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -117,7 +117,7 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
   return (
     <MobileOrDesktopLayout>
       <NextSeo {...seo} />
-      <CustomFeedHeader>
+      <CustomFeedHeader className={shouldUseMobileFeedLayout && 'px-4'}>
         <img
           src={source.image}
           alt={`${source.name} logo`}

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -153,7 +153,7 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
   return (
     <MobileOrDesktopLayout>
       <NextSeo {...seo} />
-      <PageInfoHeader className={shouldUseMobileFeedLayout && 'px-4'}>
+      <PageInfoHeader className={shouldUseMobileFeedLayout && 'mx-4 !w-auto'}>
         <div className="flex items-center font-bold">
           <img
             src={source.image}

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -25,11 +25,7 @@ import {
   ButtonSize,
   ButtonVariant,
 } from '@dailydotdev/shared/src/components/buttons/Button';
-import {
-  FeedPage,
-  FeedPageLayoutMobile,
-  PageInfoHeader,
-} from '@dailydotdev/shared/src/components/utilities';
+import { PageInfoHeader } from '@dailydotdev/shared/src/components/utilities';
 import { PlusIcon, BlockIcon } from '@dailydotdev/shared/src/components/icons';
 import useFeedSettings from '@dailydotdev/shared/src/hooks/useFeedSettings';
 import useTagAndSource from '@dailydotdev/shared/src/hooks/useTagAndSource';

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -27,6 +27,7 @@ import {
 import {
   CustomFeedHeader,
   FeedPage,
+  FeedPageLayoutMobile,
 } from '@dailydotdev/shared/src/components/utilities';
 import { PlusIcon, BlockIcon } from '@dailydotdev/shared/src/components/icons';
 import useFeedSettings from '@dailydotdev/shared/src/hooks/useFeedSettings';
@@ -37,6 +38,7 @@ import { OtherFeedPage } from '@dailydotdev/shared/src/lib/query';
 import { Origin } from '@dailydotdev/shared/src/lib/analytics';
 import { PostType } from '@dailydotdev/shared/src/graphql/posts';
 import { SourceSubscribeButton } from '@dailydotdev/shared/src/components';
+import { useFeedLayout } from '@dailydotdev/shared/src/hooks';
 import Custom404 from '../404';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
@@ -60,7 +62,7 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
     }),
     [source?.id],
   );
-
+  const { shouldUseMobileFeedLayout } = useFeedLayout();
   const { feedSettings } = useFeedSettings();
   const { onFollowSource, onUnfollowSource } = useTagAndSource({
     origin: Origin.SourcePage,
@@ -108,8 +110,12 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
     variant: ButtonVariant.Float,
   };
 
+  const MobileOrDesktopLayout = shouldUseMobileFeedLayout
+    ? FeedPageLayoutMobile
+    : FeedPage;
+
   return (
-    <FeedPage>
+    <MobileOrDesktopLayout>
       <NextSeo {...seo} />
       <CustomFeedHeader>
         <img
@@ -140,7 +146,7 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
         query={SOURCE_FEED_QUERY}
         variables={queryVariables}
       />
-    </FeedPage>
+    </MobileOrDesktopLayout>
   );
 };
 

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -97,7 +97,8 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
     }),
     [source?.id],
   );
-  const { shouldUseMobileFeedLayout } = useFeedLayout();
+  const { shouldUseMobileFeedLayout, FeedPageLayoutComponent } =
+    useFeedLayout();
   const { feedSettings } = useFeedSettings();
   const { onFollowSource, onUnfollowSource } = useTagAndSource({
     origin: Origin.SourcePage,
@@ -146,12 +147,8 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
     variant: ButtonVariant.Float,
   };
 
-  const MobileOrDesktopLayout = shouldUseMobileFeedLayout
-    ? FeedPageLayoutMobile
-    : FeedPage;
-
   return (
-    <MobileOrDesktopLayout>
+    <FeedPageLayoutComponent>
       <NextSeo {...seo} />
       <PageInfoHeader className={shouldUseMobileFeedLayout && 'mx-4 !w-auto'}>
         <div className="flex items-center font-bold">
@@ -186,7 +183,7 @@ const SourcePage = ({ source }: SourcePageProps): ReactElement => {
         query={SOURCE_FEED_QUERY}
         variables={queryVariables}
       />
-    </MobileOrDesktopLayout>
+    </FeedPageLayoutComponent>
   );
 };
 

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -30,7 +30,11 @@ import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext'
 import dynamic from 'next/dynamic';
 import useSidebarRendered from '@dailydotdev/shared/src/hooks/useSidebarRendered';
 import classNames from 'classnames';
-import { useJoinReferral, useSquad } from '@dailydotdev/shared/src/hooks';
+import {
+  useFeedLayout,
+  useJoinReferral,
+  useSquad,
+} from '@dailydotdev/shared/src/hooks';
 import { oneHour } from '@dailydotdev/shared/src/lib/dateFormat';
 import request, { ClientError } from 'graphql-request';
 import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
@@ -89,6 +93,7 @@ const SquadPage = ({
   useJoinReferral();
   const { trackEvent } = useContext(AnalyticsContext);
   const { sidebarRendered } = useSidebarRendered();
+  const { shouldUseMobileFeedLayout } = useFeedLayout();
   const { user, isFetched: isBootFetched } = useContext(AuthContext);
   const [trackedImpression, setTrackedImpression] = useState(false);
   const { squad, isLoading, isFetched, isForbidden } = useSquad({ handle });
@@ -188,7 +193,10 @@ const SquadPage = ({
         />
         <SquadPageHeader squad={squad} members={squadMembers} />
         <Feed
-          className="px-6 pt-14 laptop:pt-10"
+          className={classNames(
+            'pt-14 laptop:pt-10',
+            shouldUseMobileFeedLayout ? 'px-0' : 'px-6',
+          )}
           feedName={OtherFeedPage.Squad}
           feedQueryKey={[
             'sourceFeed',

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -87,7 +87,8 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
   // Must be memoized to prevent refreshing the feed
   const queryVariables = useMemo(() => ({ tag, ranking: 'TIME' }), [tag]);
   const { feedSettings } = useFeedSettings();
-  const { shouldUseMobileFeedLayout } = useFeedLayout();
+  const { shouldUseMobileFeedLayout, FeedPageLayoutComponent } =
+    useFeedLayout();
   const { onFollowTags, onUnfollowTags, onBlockTags, onUnblockTags } =
     useTagAndSource({ origin: Origin.TagPage });
   const title = initialData?.flags?.title || tag;
@@ -155,12 +156,8 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
     },
   };
 
-  const MobileOrDesktopLayout = shouldUseMobileFeedLayout
-    ? FeedPageLayoutMobile
-    : FeedPage;
-
   return (
-    <MobileOrDesktopLayout>
+    <FeedPageLayoutComponent>
       <NextSeo {...seo} />
       <PageInfoHeader className={shouldUseMobileFeedLayout && 'mx-4 !w-auto'}>
         <div className="flex items-center font-bold">
@@ -207,7 +204,7 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
         query={TAG_FEED_QUERY}
         variables={queryVariables}
       />
-    </MobileOrDesktopLayout>
+    </FeedPageLayoutComponent>
   );
 };
 

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -24,7 +24,10 @@ import {
   ButtonSize,
   ButtonVariant,
 } from '@dailydotdev/shared/src/components/buttons/Button';
-import { FeedPage } from '@dailydotdev/shared/src/components/utilities';
+import {
+  FeedPage,
+  FeedPageLayoutMobile,
+} from '@dailydotdev/shared/src/components/utilities';
 import useTagAndSource from '@dailydotdev/shared/src/hooks/useTagAndSource';
 import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
 import { OtherFeedPage, RequestKey } from '@dailydotdev/shared/src/lib/query';
@@ -43,6 +46,7 @@ import {
   TagsData,
 } from '@dailydotdev/shared/src/graphql/feedSettings';
 import { ElementPlaceholder } from '@dailydotdev/shared/src/components/ElementPlaceholder';
+import { useFeedLayout } from '@dailydotdev/shared/src/hooks';
 import { getLayout } from '../../components/layouts/FeedLayout';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
@@ -99,6 +103,7 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
   // Must be memoized to prevent refreshing the feed
   const queryVariables = useMemo(() => ({ tag, ranking: 'TIME' }), [tag]);
   const { feedSettings } = useFeedSettings();
+  const { shouldUseMobileFeedLayout } = useFeedLayout();
   const { onFollowTags, onUnfollowTags, onBlockTags, onUnblockTags } =
     useTagAndSource({ origin: Origin.TagPage });
   const title = initialData?.flags?.title || tag;
@@ -166,8 +171,12 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
     },
   };
 
+  const MobileOrDesktopLayout = shouldUseMobileFeedLayout
+    ? FeedPageLayoutMobile
+    : FeedPage;
+
   return (
-    <FeedPage>
+    <MobileOrDesktopLayout>
       <NextSeo {...seo} />
       <div className="mb-10 flex w-full flex-col gap-5 rounded-16 border border-border-subtlest-tertiary p-4">
         <div className="flex items-center font-bold">
@@ -211,7 +220,7 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
         query={TAG_FEED_QUERY}
         variables={queryVariables}
       />
-    </FeedPage>
+    </MobileOrDesktopLayout>
   );
 };
 

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -54,6 +54,7 @@ import {
 } from '@dailydotdev/shared/src/graphql/sources';
 import { Connection } from '@dailydotdev/shared/src/graphql/common';
 import { ElementPlaceholder } from '@dailydotdev/shared/src/components/ElementPlaceholder';
+import classNames from 'classnames';
 import { getLayout } from '../../components/layouts/FeedLayout';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
@@ -85,6 +86,7 @@ const TagRecommendedTags = ({ tag, blockedTags }): ReactElement => {
 };
 
 const TagTopSources = ({ tag }: { tag: string }) => {
+  const { shouldUseMobileFeedLayout } = useFeedLayout();
   const { data: topSources, isLoading } = useQuery(
     [RequestKey.SourceByTag, null, tag],
     async () =>
@@ -122,7 +124,12 @@ const TagTopSources = ({ tag }: { tag: string }) => {
   }
 
   return (
-    <div className="mb-10 w-full">
+    <div
+      className={classNames(
+        'mb-10 w-full',
+        shouldUseMobileFeedLayout && 'mx-4',
+      )}
+    >
       <p className="mb-3 h-10 font-bold typo-body">
         🔔 Top sources covering it
       </p>

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -24,11 +24,7 @@ import {
   ButtonSize,
   ButtonVariant,
 } from '@dailydotdev/shared/src/components/buttons/Button';
-import {
-  FeedPage,
-  FeedPageLayoutMobile,
-  PageInfoHeader,
-} from '@dailydotdev/shared/src/components/utilities';
+import { PageInfoHeader } from '@dailydotdev/shared/src/components/utilities';
 import useTagAndSource from '@dailydotdev/shared/src/hooks/useTagAndSource';
 import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
 import {

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -47,6 +47,7 @@ import {
 } from '@dailydotdev/shared/src/graphql/feedSettings';
 import { ElementPlaceholder } from '@dailydotdev/shared/src/components/ElementPlaceholder';
 import { useFeedLayout } from '@dailydotdev/shared/src/hooks';
+import classNames from 'classnames';
 import { getLayout } from '../../components/layouts/FeedLayout';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
@@ -86,7 +87,7 @@ const RecommendedTags = ({ tag, blockedTags }): ReactElement => {
       {recommendedTags?.recommendedTags?.tags.length > 0 && (
         <div>
           <p className="mb-3 text-text-tertiary typo-caption1">Related tags:</p>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             {recommendedTags?.recommendedTags?.tags.map((relatedTag) => (
               <TagLink key={relatedTag.name} tag={relatedTag.name} />
             ))}
@@ -178,7 +179,12 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
   return (
     <MobileOrDesktopLayout>
       <NextSeo {...seo} />
-      <div className="mb-10 flex w-full flex-col gap-5 rounded-16 border border-border-subtlest-tertiary p-4">
+      <div
+        className={classNames(
+          'mb-10 flex flex-col gap-5 rounded-16 border border-border-subtlest-tertiary p-4',
+          shouldUseMobileFeedLayout ? 'mx-4 w-auto' : 'w-full',
+        )}
+      >
         <div className="flex items-center font-bold">
           <HashtagIcon size={IconSize.XXLarge} />
           <h1 className="ml-2 typo-title2">{title}</h1>

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -49,9 +49,7 @@ import {
   GET_RECOMMENDED_TAGS_QUERY,
   TagsData,
 } from '@dailydotdev/shared/src/graphql/feedSettings';
-import { ElementPlaceholder } from '@dailydotdev/shared/src/components/ElementPlaceholder';
 import { useFeedLayout } from '@dailydotdev/shared/src/hooks';
-import classNames from 'classnames';
 import { RecommendedTags } from '@dailydotdev/shared/src/components/RecommendedTags';
 import { getLayout } from '../../components/layouts/FeedLayout';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
@@ -164,7 +162,7 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
   return (
     <MobileOrDesktopLayout>
       <NextSeo {...seo} />
-      <PageInfoHeader className={shouldUseMobileFeedLayout ? 'mx-4 w-auto' : 'w-full'}>
+      <PageInfoHeader className={shouldUseMobileFeedLayout && 'mx-4 !w-auto'}>
         <div className="flex items-center font-bold">
           <HashtagIcon size={IconSize.XXLarge} />
           <h1 className="ml-2 typo-title2">{title}</h1>


### PR DESCRIPTION
## Changes
- removal all feed related filters from feed layout hook
- added profile feeds on feedlayout hook to render the new cards
- adjusted some paddings and margins for the new cards on new feeds
- adjusted tests for desktop view

### Describe what this PR does
- Set the new cards in all feeds on mobile (bookmarks/squad feed/tags/sources)
- Set the new cards in profile posts & upvotes for both mobile and desktop
- We no longer open post modals in mobile/tablet in any feed

## Events

Did you introduce any new tracking events? No
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-254 #done
MI-255 #done
MI-119 #done


### Preview domain
https://mi-254-feed-layout.preview.app.daily.dev