### PR TITLE
fix: render source related tags

### DIFF
--- a/packages/shared/src/components/RecommendedTags.tsx
+++ b/packages/shared/src/components/RecommendedTags.tsx
@@ -24,7 +24,7 @@ export const RecommendedTags = ({
     );
   }
 
-  if (tags.length === 0) {
+  if (!tags || tags.length === 0) {
     return null;
   }
 

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -97,3 +97,13 @@ export const SOURCE_QUERY = gql`
     }
   }
 `;
+
+export const SOURCE_RELATED_TAGS_QUERY = gql`
+  query RelatedTags($sourceId: ID!) {
+    relatedTags(sourceId: $sourceId) {
+      tags: hits {
+        name
+      }
+    }
+  }
+`;

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -104,6 +104,7 @@ export enum RequestKey {
   Feature = 'feature',
   AccountNavigation = 'account_navigation',
   RecommendedTags = 'recommended_tags',
+  SourceRelatedTags = 'source_related_tags',
 }
 
 export type HasConnection<


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Render source related tags from the new endpoint

![Screenshot 2024-04-12 at 09 00 35](https://github.com/dailydotdev/apps/assets/554874/07c429cb-482b-4257-a633-ce901eb3fc87)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://as-247-source-tags.preview.app.daily.dev