### PR TITLE
fix: share post link copy needs to be clicked twice

### DIFF
--- a/packages/shared/src/components/modals/SharedBookmarksModal.spec.tsx
+++ b/packages/shared/src/components/modals/SharedBookmarksModal.spec.tsx
@@ -22,6 +22,10 @@ import { waitForNock } from '../../../__tests__/helpers/utilities';
 
 const onRequestClose = jest.fn();
 
+jest.mock('../../hooks/useCopy', () => ({
+  useCopyLink: jest.fn(() => [false, jest.fn()]),
+}));
+
 beforeEach(() => {
   jest.restoreAllMocks();
   jest.clearAllMocks();

--- a/packages/shared/src/hooks/useCopy.ts
+++ b/packages/shared/src/hooks/useCopy.ts
@@ -3,11 +3,13 @@ import {
   NotifyOptionalProps,
   useToastNotification,
 } from './useToastNotification';
+import { useGetShortUrl } from './utils/useGetShortUrl';
 
 type CopyNotifyFunctionProps = NotifyOptionalProps & {
   link?: string;
   message?: string;
   textToCopy?: string;
+  shorten?: boolean;
 };
 
 const defaultMessage = '✅ Copied to clipboard';
@@ -20,15 +22,33 @@ export type CopyNotifyFunction =
 
 export function useCopyLink(
   getLink?: () => string,
+  shorten = false,
 ): [boolean, CopyNotifyFunction] {
   const [copying, setCopying] = useState(false);
   const { displayToast } = useToastNotification();
+  const { getShortUrl } = useGetShortUrl();
 
   const copy: CopyNotifyFunction = async (props = {}) => {
     const link = props.link || getLink();
+    const shortenLink = props.shorten || shorten;
 
     if (link) {
+      // write the link to clipboard
       await navigator.clipboard.writeText(link);
+
+      // try with a shortened link as well, if requested
+      if (shortenLink) {
+        try {
+          const clipBoardItem = new ClipboardItem({
+            'text/plain': getShortUrl(link).then((shortenedLink) => {
+              return new Blob([shortenedLink], { type: 'text/plain' });
+            }),
+          });
+          await navigator.clipboard.write([clipBoardItem]);
+        } catch (e) {
+          console.error('Error copying to clipboard', e);
+        }
+      }
       displayToast(props.message || defaultLinkMessage, props);
     } else {
       displayToast(noLinkErrorMessage, props);

--- a/packages/shared/src/hooks/useCopy.ts
+++ b/packages/shared/src/hooks/useCopy.ts
@@ -46,7 +46,8 @@ export function useCopyLink(
           });
           await navigator.clipboard.write([clipBoardItem]);
         } catch (e) {
-          console.error('Error copying to clipboard', e);
+          // eslint-disable-next-line no-console
+          console.warn('Error copying to clipboard', e);
         }
       }
       displayToast(props.message || defaultLinkMessage, props);

--- a/packages/shared/src/hooks/useCopyPostLink.ts
+++ b/packages/shared/src/hooks/useCopyPostLink.ts
@@ -1,7 +1,7 @@
 import { CopyNotifyFunction, useCopyLink } from './useCopy';
 
 export function useCopyPostLink(link?: string): [boolean, CopyNotifyFunction] {
-  const [copying, copy] = useCopyLink(() => link);
+  const [copying, copy] = useCopyLink(link ? () => link : undefined);
 
   return [copying, copy];
 }

--- a/packages/shared/src/hooks/useSharePost.ts
+++ b/packages/shared/src/hooks/useSharePost.ts
@@ -21,7 +21,7 @@ export function useSharePost(origin: Origin): {
   const [, copyLink] = useCopyPostLink();
   const [sharePostFeedLocation, setSharePostFeedLocation] =
     useState<FeedItemPosition>({});
-  const { getShortUrl } = useGetShortUrl();
+  const { getShortUrl, getTrackedUrl } = useGetShortUrl();
 
   return useMemo(
     () => ({
@@ -54,11 +54,11 @@ export function useSharePost(origin: Origin): {
             extra: { provider: ShareProvider.CopyLink, origin },
           }),
         );
-        const shortLink = await getShortUrl(
+        const trackedLink = getTrackedUrl(
           post.commentsPermalink,
           ReferralCampaignKey.SharePost,
         );
-        copyLink({ link: shortLink });
+        copyLink({ link: trackedLink, shorten: true });
       },
       openNativeSharePost: async (
         post: Post,

--- a/packages/shared/src/hooks/utils/useGetShortUrl.ts
+++ b/packages/shared/src/hooks/utils/useGetShortUrl.ts
@@ -17,6 +17,7 @@ interface LinkAsQuery {
 
 interface UseGetShortUrlResult {
   getShortUrl: (url: string, cid?: ReferralCampaignKey) => Promise<string>;
+  getTrackedUrl: (url: string, cid?: ReferralCampaignKey) => string;
   shareLink: string;
   isLoading: boolean;
 }
@@ -70,6 +71,14 @@ export const useGetShortUrl = ({
     [isAuthReady, user, getProps, queryClient],
   );
 
+  const getTrackedUrl = useCallback(
+    (url: string, cid?: ReferralCampaignKey) => {
+      const { trackedUrl } = getProps(url, cid);
+      return trackedUrl;
+    },
+    [getProps],
+  );
+
   const isEnabled = query?.enabled ?? true;
   const { queryKey, trackedUrl } = query
     ? getProps(query.url, query.cid)
@@ -84,5 +93,5 @@ export const useGetShortUrl = ({
     },
   );
 
-  return { getShortUrl, shareLink, isLoading };
+  return { getShortUrl, getTrackedUrl, shareLink, isLoading };
 };


### PR DESCRIPTION
## Changes

Related issue:
- https://dailydotdev.atlassian.net/browse/MI-291

Fixed the problem, when 2 clicks were required to copy link to clipboard. This was caused by 2 things:
1. Async operation to fetch the shortened URL, which can take 500ms or more.
2. Safari (and other browsers) strict limit on user-triggered events for clipboard operation, but [Safari is especially stringent and weird](https://bugs.webkit.org/show_bug.cgi?id=222262)

Refactored the code and introduced fixes:
- shortening is now part of the useCopy hook instead
- shortening is now a best effort operation
  - if shortening fails, we still have the original URL with query params in the clipboard
- refactored to use `clipboard.write` with a `ClipboardItem` instead of `writeText`. This seems to be better supported in Safari.

### Video

https://github.com/dailydotdev/apps/assets/9974711/177636e9-e099-4c94-b661-edc4da660308

## Events

No new events

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [ ] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [x] Android

MI-291 #done


### Preview domain
https://mi-291-fix-copy-share-link.preview.app.daily.dev