### PR TITLE
fix: add section for top sources covering this tag

### DIFF
--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -107,3 +107,18 @@ export const SOURCE_RELATED_TAGS_QUERY = gql`
     }
   }
 `;
+
+export const SOURCES_BY_TAG_QUERY = gql`
+  query SourcesByTag($tag: String!, $first: Int) {
+    sourcesByTag(tag: $tag, first: $first) {
+      edges {
+        node {
+          id
+          name
+          image
+          permalink
+        }
+      }
+    }
+  }
+`;

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -105,6 +105,7 @@ export enum RequestKey {
   AccountNavigation = 'account_navigation',
   RecommendedTags = 'recommended_tags',
   SourceRelatedTags = 'source_related_tags',
+  SourceByTag = 'source_by_tag',
 }
 
 export type HasConnection<

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -49,6 +49,13 @@ import {
   TagsData,
 } from '@dailydotdev/shared/src/graphql/feedSettings';
 import { RecommendedTags } from '@dailydotdev/shared/src/components/RecommendedTags';
+import Link from 'next/link';
+import {
+  SOURCES_BY_TAG_QUERY,
+  Source,
+} from '@dailydotdev/shared/src/graphql/sources';
+import { Connection } from '@dailydotdev/shared/src/graphql/common';
+import { ElementPlaceholder } from '@dailydotdev/shared/src/components/ElementPlaceholder';
 import { getLayout } from '../../components/layouts/FeedLayout';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
@@ -76,6 +83,74 @@ const TagRecommendedTags = ({ tag, blockedTags }): ReactElement => {
       isLoading={isLoading}
       tags={recommendedTags?.recommendedTags?.tags}
     />
+  );
+};
+
+const TagTopSources = ({ tag }: { tag: string }) => {
+  const { data: topSources, isLoading } = useQuery(
+    [RequestKey.SourceByTag, null, tag],
+    async () =>
+      await request<{ sourcesByTag: Connection<Source> }>(
+        graphqlUrl,
+        SOURCES_BY_TAG_QUERY,
+        {
+          tag,
+        },
+      ),
+    {
+      enabled: !!tag,
+      staleTime: StaleTime.OneHour,
+    },
+  );
+
+  if (isLoading) {
+    return (
+      <div className="mb-10 w-full">
+        <ElementPlaceholder className="mb-3 h-10 w-1/5 rounded-12" />
+        <div className="flex gap-2">
+          <ElementPlaceholder className="w-24 rounded-16 px-4 py-3 text-center">
+            <ElementPlaceholder className="mx-auto size-10 rounded-full" />
+            <ElementPlaceholder className="mt-1.5 h-5 w-full rounded-8" />
+          </ElementPlaceholder>
+        </div>
+      </div>
+    );
+  }
+
+  const sources = topSources?.sourcesByTag?.edges?.map((edge) => edge.node);
+  if (!sources || sources.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-10 w-full">
+      <p className="mb-3 h-10 font-bold typo-body">
+        🔔 Top sources covering it
+      </p>
+      <div className="no-scrollbar flex gap-2 overflow-x-auto">
+        {sources.map((source) => {
+          return (
+            <Link
+              href={source.permalink}
+              passHref
+              key={source.id}
+              prefetch={false}
+            >
+              <a className="flex w-24 flex-col rounded-16 border border-border-subtlest-tertiary px-4 py-3 text-center">
+                <img
+                  src={source.image}
+                  alt={`${source.name} logo`}
+                  className="mx-auto size-10 rounded-full"
+                />
+                <p className="mt-1.5 truncate font-bold typo-callout">
+                  {source.name}
+                </p>
+              </a>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
   );
 };
 
@@ -190,6 +265,7 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
           />
         )}
       </PageInfoHeader>
+      <TagTopSources tag={tag} />
       <Feed
         feedName={OtherFeedPage.Tag}
         feedQueryKey={[


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Top sources covering a tag section
- Will refactor into component once I do the source implementation

![Screenshot 2024-04-12 at 11 30 49](https://github.com/dailydotdev/apps/assets/554874/fbcbc26e-9e09-47e8-ab35-b8453b049b45)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
