### PR TITLE
hotfix: close post modal on navigation change

### DIFF
--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -1,4 +1,5 @@
 import { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { Post, PostType } from '../graphql/posts';
 import { postAnalyticsEvent } from '../lib/feed';
@@ -31,6 +32,7 @@ export const usePostModalNavigation = (
   updatePost: UpdateFeedPost,
   canFetchMore: boolean,
 ): UsePostModalNavigation => {
+  const router = useRouter();
   const [currentPage, setCurrentPage] = useState<string>();
   const isExtension = checkIsExtension();
   const [openedPostIndex, setOpenedPostIndex] = useState<number>(null);
@@ -87,11 +89,20 @@ export const usePostModalNavigation = (
   };
 
   useEffect(() => {
+    router.events.on('routeChangeStart', onCloseModal);
+
+    return () => {
+      router.events.off('routeChangeStart', onCloseModal);
+    };
+  }, [onCloseModal, router.events]);
+
+  useEffect(() => {
     if (isExtension) {
       return null;
     }
 
     const onPopState = () => {
+      console.log('popstate trigger');
       const url = new URL(window.location.href);
       if (url.pathname.indexOf('/posts/') !== 0) {
         onCloseModal(true);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Looked at injecting where we close the lazyModals, but it's missing too many references to the hook, so this was the cleanest implementation and keeps it close to where it needs to be.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
