### PR TITLE
fix: retain profile menu for community picks

### DIFF
--- a/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
+++ b/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
@@ -89,6 +89,11 @@ const useMenuItems = (): NavItemProps[] => {
         isHeader: true,
       },
       {
+        label: 'Community picks',
+        icon: <DocsIcon />,
+        onClick: () => openModal({ type: LazyModal.SubmitArticle }),
+      },
+      {
         label: 'Suggest new source',
         icon: <EmbedIcon />,
         onClick: () => openModal({ type: LazyModal.NewSource }),


### PR DESCRIPTION
## Changes
- On tablet mode, there is option to open the drawer for sharing a community link.
- Retain as per discussion.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-tablet-community.preview.app.daily.dev