### PR TITLE
hotfix: mobile search results

### DIFF
--- a/packages/shared/src/components/search/SearchBarSuggestion.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestion.tsx
@@ -80,7 +80,7 @@ export const SearchBarSuggestion = ({
       onClick={handleSuggestionsClick}
       {...props}
     >
-      <span className="w-fit tablet:!line-clamp-1">{children}</span>
+      <span className="line-clamp-1 w-fit">{children}</span>
     </Button>
   );
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Every resolution should only return one line for search history for now.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://hotfix-search-mobile.preview.app.daily.dev