### PR TITLE
fix: vertically aligns the reputation badge

### DIFF
--- a/packages/shared/src/components/ReputationUserBadge.tsx
+++ b/packages/shared/src/components/ReputationUserBadge.tsx
@@ -32,7 +32,7 @@ export const ReputationUserBadge = ({
       content="Reputation"
       placement="bottom"
     >
-      <div>
+      <div className="flex items-center">
         <UserBadge
           {...rest}
           className={classNames(className, 'text-text-primary')}


### PR DESCRIPTION
Just fixes a small annoyance of mine 😬 

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><img src=https://github.com/dailydotdev/apps/assets/1681525/7b740efc-0272-4a5d-a341-31e589a305b4>
 <td><img src=https://github.com/dailydotdev/apps/assets/1681525/14884e4f-509b-4fef-93d9-99ef337f50c5>
<tr>
 <td colspan=2>Difference
<tr>
 <td colspan=2><img src="https://github.com/dailydotdev/apps/assets/1681525/5b5b2ec6-624e-46da-a0d9-f99c592af6a4">
</table>




### Preview domain
https://fix-misaligned-reputation.preview.app.daily.dev