### PR TITLE
fix: spacing issue when sorting action is enabled on mobile

### DIFF
--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -83,7 +83,7 @@ function FeedNav(): ReactElement {
         ))}
       </TabContainer>
       {isMobile && sortingEnabled && isSortableFeed && (
-        <div className="sticky flex h-11 w-20 -translate-y-12 translate-x-[calc(100vw-100%)] items-center justify-end bg-gradient-to-r from-transparent via-background-default via-40% to-background-default pr-4">
+        <div className="fixed flex h-11 w-20 -translate-y-12 translate-x-[calc(100vw-100%)] items-center justify-end bg-gradient-to-r from-transparent via-background-default via-40% to-background-default pr-4">
           <Dropdown
             className={{ label: 'hidden', chevron: 'hidden', button: '!px-1' }}
             dynamicMenuWidth


### PR DESCRIPTION
## Changes

- using `sticky` makes it so the element still takes space in the dom

### Before

<img width="590" alt="Screenshot 2024-04-15 at 10 23 14" src="https://github.com/dailydotdev/apps/assets/1225100/657f6525-12b6-45d2-8393-70e4411db0a0">

### After

<img width="590" alt="Screenshot 2024-04-15 at 10 22 49" src="https://github.com/dailydotdev/apps/assets/1225100/55f44584-3663-4140-94af-7b0f1f700db9">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
