### PR TITLE
fix: trigger tracking on signup only

### DIFF
--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -199,6 +199,7 @@ function AuthOptions({
       onSetActiveDisplay(AuthDisplay.EmailVerification);
     },
     onValidRegistration: async () => {
+      trackAnalyticsSignUp();
       setIsRegistration(true);
       const { data } = await refetchBoot();
 
@@ -249,7 +250,6 @@ function AuthOptions({
 
   const isReady = isTesting ? true : isLoginReady && isRegistrationReady;
   const onProviderClick = (provider: string, login = true) => {
-    trackAnalyticsSignUp();
     trackEvent({
       event_name: 'click',
       target_type: login

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -61,6 +61,7 @@ import {
   GtagTracking,
   PixelTracking,
   TiktokTracking,
+  trackAnalyticsSignUp,
 } from '@dailydotdev/shared/src/components/auth/OnboardingAnalytics';
 import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { OnboardingHeadline } from '@dailydotdev/shared/src/components/auth';
@@ -178,6 +179,7 @@ export function OnboardPage(): ReactElement {
   };
 
   const onSuccessfulRegistration = () => {
+    trackAnalyticsSignUp();
     setActiveScreen(OnboardingStep.EditTag);
   };
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We should only trigger the tracking on successful signup.
- This now happens on signup callback before choosing the tags

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-marketing-tracking-signup-only.preview.app.daily.dev