### PR TITLE
feat: migrating existing user to reading streak

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -44,6 +44,7 @@ import {
   useFeedLayout,
   useScrollRestoration,
   useConditionalFeature,
+  useActions,
 } from '../hooks';
 import { feature } from '../lib/featureManagement';
 import { isDevelopment } from '../lib/constants';
@@ -54,6 +55,10 @@ import { COMMENT_FEED_QUERY } from '../graphql/comments';
 import { ProfileEmptyScreen } from './profile/ProfileEmptyScreen';
 import { Origin } from '../lib/analytics';
 import { OnboardingFeedHeader } from './onboarding/OnboardingFeedHeader';
+import { useLazyModal } from '../hooks/useLazyModal';
+import { LazyModal } from './modals/common/types';
+import { useStreakExperiment } from '../hooks/streaks';
+import { ActionType } from '../graphql/actions';
 
 const SearchEmptyScreen = dynamic(
   () =>
@@ -294,6 +299,19 @@ export default function MainFeedLayout({
 
   const disableTopPadding =
     isFinder || shouldUseMobileFeedLayout || shouldUseCommentFeedLayout;
+
+  const { openModal } = useLazyModal();
+  const { shouldShowPopup } = useStreakExperiment();
+  const { completeAction } = useActions();
+
+  useEffect(() => {
+    if (!shouldShowPopup) {
+      return;
+    }
+
+    openModal({ type: LazyModal.MigrateUserStreak });
+    completeAction(ActionType.ExistingUserSeenStreaks);
+  }, [completeAction, openModal, shouldShowPopup]);
 
   return (
     <FeedPageComponent

--- a/packages/shared/src/components/modals/common.tsx
+++ b/packages/shared/src/components/modals/common.tsx
@@ -118,6 +118,13 @@ const UserSettingsModal = dynamic(
     import(/* webpackChunkName: "userSettingsModal" */ './UserSettingsModal'),
 );
 
+const MigrateUserStreakModal = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "migrateUserStreakModal" */ './streaks/MigrateUserStreakModal'
+    ),
+);
+
 export const modals = {
   [LazyModal.SquadMember]: SquadMemberModal,
   [LazyModal.UpvotedPopup]: UpvotedPopupModal,
@@ -139,6 +146,7 @@ export const modals = {
   [LazyModal.ReputationPrivileges]: ReputationPrivilegesModal,
   [LazyModal.MarketingCta]: MarketingCtaModal,
   [LazyModal.UserSettings]: UserSettingsModal,
+  [LazyModal.MigrateUserStreak]: MigrateUserStreakModal,
 };
 
 type GetComponentProps<T> = T extends

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -50,6 +50,7 @@ export enum LazyModal {
   ReputationPrivileges = 'reputationPrivileges',
   MarketingCta = 'marketingCta',
   UserSettings = 'userSettings',
+  MigrateUserStreak = 'migrateUserStreak',
 }
 
 export type ModalTabItem = {

--- a/packages/shared/src/components/modals/streaks/MigrateUserStreakModal.tsx
+++ b/packages/shared/src/components/modals/streaks/MigrateUserStreakModal.tsx
@@ -1,0 +1,60 @@
+import React, { ReactElement } from 'react';
+import { LazyModalCommonProps, Modal } from '../common/Modal';
+import { Button, ButtonVariant } from '../../buttons/Button';
+import { ModalClose } from '../common/ModalClose';
+import { Pill } from '../../Pill';
+import { Image } from '../../image/Image';
+import { cloudinary } from '../../../lib/image';
+
+export default function MigrateUserStreakModal({
+  onRequestClose,
+  ...props
+}: LazyModalCommonProps): ReactElement {
+  return (
+    <Modal
+      {...props}
+      onRequestClose={onRequestClose}
+      kind={Modal.Kind.FlexibleCenter}
+      size={Modal.Size.Small}
+      isDrawerOnMobile
+    >
+      <Modal.Body className="items-center !pt-4 tablet:items-start">
+        <div className="flex w-full flex-row items-center justify-between">
+          <Pill
+            label="New Release"
+            className="bg-theme-overlay-float-avocado text-status-success"
+          />
+          <ModalClose
+            position="relative"
+            className="right-0"
+            onClick={onRequestClose}
+          />
+        </div>
+        <div className="mt-5 flex flex-col gap-6">
+          <h1 className="font-bold typo-large-title">
+            Goodbye weekly goals,
+            <br />
+            Welcome reading streaks!
+          </h1>
+          <p>
+            Unlock the magic of consistently learning with our new reading
+            streaks system
+          </p>
+          <Image
+            src={cloudinary.streak.migrate}
+            className="w-full object-cover"
+          />
+          <Button
+            tag="a"
+            // href={links} awaiting product decision
+            className="w-full"
+            variant={ButtonVariant.Primary}
+            onClick={onRequestClose}
+          >
+            Tell me more
+          </Button>
+        </div>
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/packages/shared/src/graphql/actions.ts
+++ b/packages/shared/src/graphql/actions.ts
@@ -20,6 +20,7 @@ export enum ActionType {
   DevCardGenerate = 'dev_card_generate',
   AckRep250 = 'ack_rep_250',
   CommentFeed = 'comment_feed',
+  ExistingUserSeenStreaks = 'existing_user_seen_streaks',
 }
 
 export interface Action {

--- a/packages/shared/src/hooks/streaks/useStreakExperiment.ts
+++ b/packages/shared/src/hooks/streaks/useStreakExperiment.ts
@@ -1,15 +1,22 @@
 import { useFeature } from '../../components/GrowthBookProvider';
 import { feature } from '../../lib/featureManagement';
 import { ReadingStreaksExperiment } from '../../lib/featureValues';
+import { useActions } from '../useActions';
+import { ActionType } from '../../graphql/actions';
 
 interface UseStreakExperiment {
   shouldShowStreak: boolean;
+  shouldShowPopup: boolean;
 }
 
 export const useStreakExperiment = (): UseStreakExperiment => {
   const streak = useFeature(feature.readingStreaks);
+  const { checkHasCompleted } = useActions();
 
   return {
-    shouldShowStreak: streak === ReadingStreaksExperiment.V1,
+    shouldShowStreak: streak !== ReadingStreaksExperiment.Control,
+    shouldShowPopup:
+      streak === ReadingStreaksExperiment.V2 &&
+      !checkHasCompleted(ActionType.ExistingUserSeenStreaks),
   };
 };

--- a/packages/shared/src/lib/featureValues.ts
+++ b/packages/shared/src/lib/featureValues.ts
@@ -9,6 +9,7 @@ export enum ExperimentWinner {
 export enum ReadingStreaksExperiment {
   Control = 'control',
   V1 = 'v1',
+  V2 = 'v2',
 }
 
 export enum PostPageOnboarding {

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -166,6 +166,8 @@ export const cloudinary = {
     splash:
       'https://daily-now-res.cloudinary.com/image/upload/v1705386465/Splash_v1lxjk.svg',
     fire: 'https://daily-now-res.cloudinary.com/image/upload/v1705386465/Hot_nrqvv5.svg',
+    migrate:
+      'https://s3-alpha-sig.figma.com/img/731c/e6c6/6ec82bc2e65e3f3e79728a611d84c608?Expires=1714348800&Key-Pair-Id=APKAQ4GOSFWCVNEHN3O4&Signature=QRQP6JMrkMwGfq6DMl9PCcUBGAI9QocNoFdrNgTnKTA98TogOi9aqAQcxWfwNIVJsE-IkhWJYalj4O~A85ep6TrbMjDVJCBhX9qd2goOtYriYs~TzgvTrsGTuh2b-Jo~~9-hloE1~bFlGgJuCMQqvCR~Zx1GU-trOH1z44CDVlds1wB-rqv1V~dsYSvRrMJxYERyNDTq2CM1pj1mxhHqkzw-slxzOdeHvS0Kcq9Yw3MJTOVBhRul9jocRJXp3KsStLKD6cuDA4wzlK68bRmB4ebhvLFcQh7~3vOIKEL4i10FRVcTxNptrFIxgRq2kA8vZfNs3jAwtUeaCrqhu0KgZw__',
   },
   devcard: {
     defaultCoverImage:


### PR DESCRIPTION
## Changes
- Display the popup once for users under v2 as they will be migrated to the new user streaks.

Blocker: awaiting product's decision on where to redirect after clicking the CTA.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-296 #done
