### PR TITLE
fix: show toast when hiding shortcuts v1

### DIFF
--- a/packages/extension/src/newtab/ShortcutLinks.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.tsx
@@ -24,7 +24,10 @@ import {
   ShortcutsSourceType,
   TargetType,
 } from '@dailydotdev/shared/src/lib/analytics';
-import { useConditionalFeature } from '@dailydotdev/shared/src/hooks';
+import {
+  useConditionalFeature,
+  useToastNotification,
+} from '@dailydotdev/shared/src/hooks';
 import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import useContextMenu from '@dailydotdev/shared/src/hooks/useContextMenu';
@@ -116,6 +119,7 @@ export default function ShortcutLinks({
   const { showTopSites, toggleShowTopSites } = useContext(SettingsContext);
   const [showModal, setShowModal] = useState(false);
   const [showOptions, setShowOptions] = useState(false);
+  const { displayToast } = useToastNotification();
   const { trackEvent } = useContext(AnalyticsContext);
   const {
     askTopSitesPermission,
@@ -222,6 +226,13 @@ export default function ShortcutLinks({
     });
   };
 
+  const onV1Hide = () => {
+    displayToast(
+      'Get your shortcuts back by turning it on from the customize options on the sidebar',
+    );
+    toggleShowTopSites();
+  };
+
   const ShortcutV1 = () => {
     return (
       <div
@@ -252,7 +263,7 @@ export default function ShortcutLinks({
             ))}
             <Button
               variant={ButtonVariant.Tertiary}
-              onClick={toggleShowTopSites}
+              onClick={onV1Hide}
               size={ButtonSize.Small}
               icon={<ClearIcon secondary />}
               className="mt-2"
@@ -324,7 +335,7 @@ export default function ShortcutLinks({
       )}
       <ShortcutOptionsMenu
         isOpen={isOpen}
-        onHide={toggleShowTopSites}
+        onHide={onV1Hide}
         onManage={onOptionsOpen}
       />
     </>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Show a toast when hiding the shortcuts on V1

![Screenshot 2024-04-16 at 11 32 13](https://github.com/dailydotdev/apps/assets/554874/7e7986fb-75ba-4a7d-9a40-2834a6eea59c)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-toast-for-hiding-shortcuts.preview.app.daily.dev