### PR TITLE
fix: set default link color

### DIFF
--- a/packages/shared/src/components/auth/ReadingReminder.tsx
+++ b/packages/shared/src/components/auth/ReadingReminder.tsx
@@ -141,7 +141,7 @@ export const ReadingReminder = ({
             />
           ) : (
             <ClickableText
-              className="ml-3 inline-flex !text-text-link"
+              className="ml-3 inline-flex"
               onClick={() => setIsEditingTimezone(true)}
             >
               edit timezone


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Set text link to default design standard: https://dailydotdev.slack.com/archives/C0381BQUEN9/p1713274207359549?thread_ts=1712057885.487599&cid=C0381BQUEN9

![Screenshot 2024-04-16 at 15 32 03](https://github.com/dailydotdev/apps/assets/554874/7473b16e-607d-44a9-87ea-8a133b2c19d0)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-default-link-color.preview.app.daily.dev