### PR TITLE
fix: screen centered on profile

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -94,7 +94,7 @@ function MainLayoutComponent({
   const { openModal } = useLazyModal<LazyModal.MarketingCta>();
 
   const isLaptopXL = useViewSize(ViewSize.LaptopXL);
-  const { shouldUseMobileFeedLayout } = useFeedLayout();
+  const { screenCenteredOnMobileLayout } = useFeedLayout();
   const { isNewMobileLayout } = useMobileUxExperiment();
 
   const { isNotificationsReady, unreadCount } = useNotificationContext();
@@ -204,7 +204,7 @@ function MainLayoutComponent({
     return null;
   }
   const isScreenCentered =
-    isLaptopXL && shouldUseMobileFeedLayout ? true : screenCentered;
+    isLaptopXL && screenCenteredOnMobileLayout ? true : screenCentered;
 
   return (
     <div className="antialiased">

--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -10,6 +10,7 @@ import { AllFeedPages, OtherFeedPage } from '../lib/query';
 interface UseFeedLayoutReturn {
   shouldUseMobileFeedLayout: boolean;
   FeedPageLayoutComponent: React.ComponentType;
+  screenCenteredOnMobileLayout?: boolean;
 }
 
 interface UseFeedLayoutProps {
@@ -76,5 +77,8 @@ export const useFeedLayout = ({
   return {
     shouldUseMobileFeedLayout,
     FeedPageLayoutComponent,
+    screenCenteredOnMobileLayout:
+      shouldUseMobileFeedLayout &&
+      !UserProfileFeedPages.has(feedName as UserProfileFeedType),
   };
 };


### PR DESCRIPTION
## Changes
- screen centered should not be on profile

### Describe what this PR does
- Fixes bug mentioned in [thread](https://dailydotdev.slack.com/archives/C013BS9KXQA/p1713355130016499?thread_ts=1713355014.587089&cid=C013BS9KXQA)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android



### Preview domain
https://fix-screen-profile-posts.preview.app.daily.dev