### PR TITLE
fix: remove max width on feed desktop

### DIFF
--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -99,6 +99,7 @@ const feedNameToHeading: Record<
   >,
   string
 > = {
+  search: 'Search',
   'my-feed': 'For you',
   popular: 'Popular',
   upvoted: 'Most upvoted',

--- a/packages/shared/src/components/utilities/common.tsx
+++ b/packages/shared/src/components/utilities/common.tsx
@@ -103,7 +103,7 @@ export const FeedPage = classed(
 export const FeedPageLayoutMobile = classed(
   BasePageContainer,
   pageContainerClassNames,
-  'pt-10 tablet:px-6 !ml-auto !px-0 tablet:!max-w-none laptop:max-w-[42.5rem]',
+  'pt-10 !ml-auto !px-0 tablet:!max-w-full laptop:!w-full laptop:!px-16',
   styles.feedPage,
 );
 

--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -26,7 +26,6 @@ export type FeedPagesWithMobileLayoutType = Exclude<
   | 'squads'
   | 'source'
   | 'tag'
-  | 'search'
 >;
 
 export type UserProfileFeedType = Extract<
@@ -35,9 +34,7 @@ export type UserProfileFeedType = Extract<
 >;
 
 export const FeedLayoutMobileFeedPages = new Set([
-  ...Object.values(SharedFeedPage).filter(
-    (page) => page !== SharedFeedPage.Search,
-  ),
+  ...Object.values(SharedFeedPage),
   OtherFeedPage.TagPage,
   OtherFeedPage.SourcePage,
   OtherFeedPage.SquadPage,


### PR DESCRIPTION
## Changes
- removed max width on mobile layout component that somehow shows up in desktop
- fixed paddings for mobile layout component 

### Describe what this PR does
- fixes search/sources/tags feed - [thread1](https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1713373206302179), [thread2](https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1713252987081529)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android


### Preview domain
https://fix-feed-desktop.preview.app.daily.dev