### PR TITLE
fix: post modal navigation with slugs

### DIFF
--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -138,7 +138,7 @@ export const usePostModalNavigation = (
           return false;
         }
 
-        return item.post.id === postId;
+        return item.post.id === postId || item.post.slug === postId;
       });
 
       if (index === -1) {


### PR DESCRIPTION
## Changes
- The primary reason it is not found anymore by our modal processing is that we are now using the slug.
- Fix the check whether the slug matches the query.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-305 #done
