### PR TITLE
fix: weekly goal option when on reading streaks

### DIFF
--- a/packages/shared/src/components/Settings.tsx
+++ b/packages/shared/src/components/Settings.tsx
@@ -19,6 +19,7 @@ import AuthContext from '../contexts/AuthContext';
 import { AuthTriggers } from '../lib/auth';
 import { checkIsExtension } from '../lib/func';
 import { useFeedLayout } from '../hooks';
+import { useStreakExperiment } from '../hooks/streaks';
 
 const densities = [
   { label: 'Eco', value: 'eco' },
@@ -61,6 +62,7 @@ export default function Settings({
   ...props
 }: HTMLAttributes<HTMLDivElement>): ReactElement {
   const isExtension = checkIsExtension();
+  const { shouldShowStreak } = useStreakExperiment();
   const { shouldUseMobileFeedLayout } = useFeedLayout({ feedRelated: false });
   const { user, showLogin } = useContext(AuthContext);
   const {
@@ -168,13 +170,15 @@ export default function Settings({
           >
             Show feed sorting menu
           </SettingsSwitch>
-          <SettingsSwitch
-            name="weekly-goal-widget"
-            checked={!optOutWeeklyGoal}
-            onToggle={() => onToggleForLoggedInUsers(toggleOptOutWeeklyGoal)}
-          >
-            Show Weekly Goal widget
-          </SettingsSwitch>
+          {!shouldShowStreak && (
+            <SettingsSwitch
+              name="weekly-goal-widget"
+              checked={!optOutWeeklyGoal}
+              onToggle={() => onToggleForLoggedInUsers(toggleOptOutWeeklyGoal)}
+            >
+              Show Weekly Goal widget
+            </SettingsSwitch>
+          )}
           <SettingsSwitch
             name="hide-companion"
             checked={!optOutCompanion}


### PR DESCRIPTION
## Changes
- Hide the Weekly goal option when you are under streaks experiment.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-306 #done


### Preview domain
https://mi-306.preview.app.daily.dev