### PR TITLE
fix: weekly goal displayed for anonymous user

### DIFF
--- a/packages/webapp/__tests__/ProfileIndexPage.tsx
+++ b/packages/webapp/__tests__/ProfileIndexPage.tsx
@@ -9,7 +9,6 @@ import {
   ProfileReadingData,
 } from '@dailydotdev/shared/src/graphql/users';
 import { QueryClient } from '@tanstack/react-query';
-import { RANKS } from '@dailydotdev/shared/src/lib/rank';
 import { startOfTomorrow, subDays, subMonths } from 'date-fns';
 import {
   MockedGraphQLResponse,
@@ -101,18 +100,6 @@ const renderComponent = (
     </TestBootProvider>,
   );
 };
-
-it('should show the reading rank history of the user', async () => {
-  renderComponent();
-  await waitForNock();
-  const counts = [0, 5, 0, 0, 3];
-  await Promise.all(
-    counts.map(async (count, index) => {
-      const el = await screen.findByLabelText(`${RANKS[index].name}: ${count}`);
-      expect(el).toBeInTheDocument();
-    }),
-  );
-});
 
 it('should show the top reading tags of the user', async () => {
   renderComponent();

--- a/packages/webapp/pages/[userId]/index.tsx
+++ b/packages/webapp/pages/[userId]/index.tsx
@@ -6,7 +6,9 @@ import {
 } from '@dailydotdev/shared/src/graphql/users';
 import request from 'graphql-request';
 import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
-import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import AuthContext, {
+  useAuthContext,
+} from '@dailydotdev/shared/src/contexts/AuthContext';
 import { RanksWidget } from '@dailydotdev/shared/src/components/profile/RanksWidget';
 import { useActivityTimeFilter } from '@dailydotdev/shared/src/hooks/profile/useActivityTimeFilter';
 import { ReadingTagsWidget } from '@dailydotdev/shared/src/components/profile/ReadingTagsWidget';
@@ -33,6 +35,7 @@ const ProfilePage = ({
   useJoinReferral();
   const { tokenRefreshed } = useContext(AuthContext);
   const { shouldShowStreak } = useStreakExperiment();
+  const { user: loggedUser } = useAuthContext();
 
   const {
     selectedHistoryYear,
@@ -68,7 +71,7 @@ const ProfilePage = ({
       <Readme user={user} />
       {readingHistory?.userReadingRankHistory && (
         <>
-          {!shouldShowStreak && (
+          {!shouldShowStreak && !!loggedUser && (
             <RanksWidget
               rankHistory={readingHistory?.userReadingRankHistory}
               yearOptions={yearOptions}


### PR DESCRIPTION
## Changes
- The weekly goal should not be shown for anonymous users since we are now moving to reading streaks.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-307 #done


### Preview domain
https://mi-307.preview.app.daily.dev