### PR TITLE
feat: cleanup discussion feed experiment

### DIFF
--- a/packages/shared/src/components/CommentFeed.tsx
+++ b/packages/shared/src/components/CommentFeed.tsx
@@ -10,12 +10,11 @@ import { Origin } from '../lib/analytics';
 import { useShareComment } from '../hooks/useShareComment';
 import { useUpvoteQuery } from '../hooks/useUpvoteQuery';
 import { useDeleteComment } from '../hooks/comments/useDeleteComment';
-import { Comment } from '../graphql/comments';
 import { graphqlUrl } from '../lib/config';
-import { Connection } from '../graphql/common';
 import PlaceholderCommentList from './comments/PlaceholderCommentList';
 import { CommentClassName } from './comments/common';
 import { useMobileUxExperiment } from '../hooks/useMobileUxExperiment';
+import { CommentFeedData } from '../graphql/comments';
 
 interface CommentFeedProps<T> {
   feedQueryKey: unknown[];
@@ -27,9 +26,6 @@ interface CommentFeedProps<T> {
   isMainFeed?: boolean;
 }
 
-interface CommentFeedData {
-  page: Connection<Comment>;
-}
 export default function CommentFeed<T>({
   feedQueryKey,
   query,

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -11,7 +11,7 @@ import classNames from 'classnames';
 import Feed, { FeedProps } from './Feed';
 import AuthContext from '../contexts/AuthContext';
 import { LoggedUser } from '../lib/user';
-import { CommentFeedPage, SharedFeedPage } from './utilities';
+import { SharedFeedPage } from './utilities';
 import {
   ANONYMOUS_FEED_QUERY,
   FEED_QUERY,
@@ -143,14 +143,14 @@ export default function MainFeedLayout({
   });
   const feedVersion = useFeature(feature.feedVersion);
   const searchVersion = useFeature(feature.searchVersion);
-  const hasCommentFeed = useFeature(feature.commentFeed);
   const { isUpvoted, isPopular, isSortableFeed } = useFeedName({ feedName });
-  const { shouldUseMobileFeedLayout, FeedPageLayoutComponent } =
-    useFeedLayout();
+  const {
+    shouldUseMobileFeedLayout,
+    FeedPageLayoutComponent,
+    shouldUseCommentFeedLayout,
+  } = useFeedLayout();
   const [isPreviewFeedVisible, setPreviewFeedVisible] = useState(false);
   const [isPreviewFeedEnabled, setPreviewFeedEnabled] = useState(false);
-  const shouldUseCommentFeedLayout =
-    hasCommentFeed && feedName === SharedFeedPage.Discussed;
   const shouldEnrollInForcedTagSelection =
     alerts?.filter && feedName === SharedFeedPage.MyFeed;
   const { value: showForcedTagSelectionFeature } = useConditionalFeature({
@@ -286,10 +286,6 @@ export default function MainFeedLayout({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sortingEnabled, selectedAlgo, loadedSettings, loadedAlgo]);
 
-  const FeedPageComponent = shouldUseCommentFeedLayout
-    ? CommentFeedPage
-    : FeedPageLayoutComponent;
-
   const disableTopPadding =
     isFinder || shouldUseMobileFeedLayout || shouldUseCommentFeedLayout;
 
@@ -307,7 +303,7 @@ export default function MainFeedLayout({
   }, [completeAction, openModal, shouldShowPopup]);
 
   return (
-    <FeedPageComponent
+    <FeedPageLayoutComponent
       className={classNames(
         'relative',
         disableTopPadding && '!pt-0',
@@ -351,6 +347,6 @@ export default function MainFeedLayout({
         )
       )}
       {children}
-    </FeedPageComponent>
+    </FeedPageLayoutComponent>
   );
 }

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -146,8 +146,8 @@ export default function MainFeedLayout({
   const { isUpvoted, isPopular, isSortableFeed } = useFeedName({ feedName });
   const {
     shouldUseMobileFeedLayout,
-    FeedPageLayoutComponent,
     shouldUseCommentFeedLayout,
+    FeedPageLayoutComponent,
   } = useFeedLayout();
   const [isPreviewFeedVisible, setPreviewFeedVisible] = useState(false);
   const [isPreviewFeedEnabled, setPreviewFeedEnabled] = useState(false);

--- a/packages/shared/src/components/sidebar/DiscoverSection.tsx
+++ b/packages/shared/src/components/sidebar/DiscoverSection.tsx
@@ -2,8 +2,6 @@ import React, { ReactElement } from 'react';
 import { DiscussIcon, HotIcon, SearchIcon, UpvoteIcon } from '../icons';
 import { ListIcon, SidebarMenuItem } from './common';
 import { Section, SectionCommonProps } from './Section';
-import { useFeature } from '../GrowthBookProvider';
-import { feature } from '../../lib/featureManagement';
 import { useActions } from '../../hooks';
 import { ActionType } from '../../graphql/actions';
 
@@ -19,11 +17,28 @@ export function DiscoverSection({
   enableSearch,
   ...defaultRenderSectionProps
 }: DiscoverSectionProps): ReactElement {
-  const hasCommentFeed = useFeature(feature.commentFeed);
   const { checkHasCompleted, completeAction, isActionsFetched } = useActions();
   const hasCompletedCommentFeed =
     !isActionsFetched || checkHasCompleted(ActionType.CommentFeed);
   const discoverMenuItems: SidebarMenuItem[] = [
+    {
+      icon: (active: boolean) => (
+        <ListIcon Icon={() => <DiscussIcon secondary={active} />} />
+      ),
+      title: 'Discussions',
+      path: '/discussed',
+      action: () => {
+        completeAction(ActionType.CommentFeed);
+        onNavTabClick?.('discussed');
+      },
+      ...(!hasCompletedCommentFeed && {
+        rightIcon: () => (
+          <span className="flex h-4 items-center rounded-6 bg-brand-default px-1 font-bold text-white typo-caption2">
+            NEW
+          </span>
+        ),
+      }),
+    },
     {
       icon: (active: boolean) => (
         <ListIcon Icon={() => <HotIcon secondary={active} />} />
@@ -51,40 +66,6 @@ export function DiscoverSection({
       showActiveAsH1: true,
     },
   ];
-
-  const completeCommentFeed = () => completeAction(ActionType.CommentFeed);
-  const discussedAction = () => {
-    completeCommentFeed();
-    onNavTabClick?.('discussed');
-  };
-
-  if (hasCommentFeed) {
-    discoverMenuItems.unshift({
-      icon: (active: boolean) => (
-        <ListIcon Icon={() => <DiscussIcon secondary={active} />} />
-      ),
-      title: 'Discussions',
-      path: '/discussed',
-      onClick: completeCommentFeed,
-      action: discussedAction,
-      ...(!hasCompletedCommentFeed && {
-        rightIcon: () => (
-          <span className="flex h-4 items-center rounded-6 bg-brand-default px-1 font-bold text-white typo-caption2">
-            NEW
-          </span>
-        ),
-      }),
-    });
-  } else {
-    discoverMenuItems.splice(2, 0, {
-      icon: (active: boolean) => (
-        <ListIcon Icon={() => <DiscussIcon secondary={active} />} />
-      ),
-      title: 'Best discussions',
-      path: '/discussed',
-      action: () => onNavTabClick?.('discussed'),
-    });
-  }
 
   return (
     <Section

--- a/packages/shared/src/components/sidebar/Sidebar.spec.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.spec.tsx
@@ -148,7 +148,7 @@ it('should show the my feed items if the user has filters', async () => {
 const sidebarItems = [
   ['Popular', '/popular'],
   ['Most upvoted', '/upvoted'],
-  ['Best discussions', '/discussed'],
+  ['Discussions', '/discussed'],
   ['Search', '/search'],
   ['Bookmarks', '/bookmarks'],
   ['History', '/history'],

--- a/packages/shared/src/graphql/comments.ts
+++ b/packages/shared/src/graphql/comments.ts
@@ -252,3 +252,7 @@ export const COMMENT_BY_ID_QUERY = gql`
     }
   }
 `;
+
+export type CommentFeedData = {
+  page: Connection<Comment>;
+};

--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -1,6 +1,7 @@
 import { useViewSize, ViewSize } from './useViewSize';
 import { useActiveFeedNameContext } from '../contexts/ActiveFeedNameContext';
 import {
+  CommentFeedPage,
   FeedPage,
   FeedPageLayoutMobile,
   SharedFeedPage,
@@ -9,8 +10,9 @@ import { AllFeedPages, OtherFeedPage } from '../lib/query';
 
 interface UseFeedLayoutReturn {
   shouldUseMobileFeedLayout: boolean;
-  FeedPageLayoutComponent: React.ComponentType;
+  FeedPageLayoutComponent: React.ComponentType<{ className?: string }>;
   screenCenteredOnMobileLayout?: boolean;
+  shouldUseCommentFeedLayout: boolean;
 }
 
 interface UseFeedLayoutProps {
@@ -57,6 +59,24 @@ const checkShouldUseMobileFeedLayout = (
     FeedLayoutMobileFeedPages.has(feedName as FeedPagesWithMobileLayoutType)) ||
   UserProfileFeedPages.has(feedName as UserProfileFeedType);
 
+const getFeedPageLayoutComponent = ({
+  shouldUseMobileFeedLayout,
+  shouldUseCommentFeedLayout,
+}: Pick<
+  UseFeedLayoutReturn,
+  'shouldUseMobileFeedLayout' | 'shouldUseCommentFeedLayout'
+>): UseFeedLayoutReturn['FeedPageLayoutComponent'] => {
+  if (shouldUseCommentFeedLayout) {
+    return CommentFeedPage;
+  }
+
+  if (shouldUseMobileFeedLayout) {
+    return FeedPageLayoutMobile;
+  }
+
+  return FeedPage;
+};
+
 export const useFeedLayout = ({
   feedRelated = true,
 }: UseFeedLayoutProps = {}): UseFeedLayoutReturn => {
@@ -66,13 +86,16 @@ export const useFeedLayout = ({
   const shouldUseMobileFeedLayout = feedRelated
     ? checkShouldUseMobileFeedLayout(isLaptop, feedName)
     : !isLaptop;
+  const shouldUseCommentFeedLayout = feedName === SharedFeedPage.Discussed;
 
-  const FeedPageLayoutComponent = shouldUseMobileFeedLayout
-    ? FeedPageLayoutMobile
-    : FeedPage;
+  const FeedPageLayoutComponent = getFeedPageLayoutComponent({
+    shouldUseMobileFeedLayout,
+    shouldUseCommentFeedLayout,
+  });
 
   return {
     shouldUseMobileFeedLayout,
+    shouldUseCommentFeedLayout,
     FeedPageLayoutComponent,
     screenCenteredOnMobileLayout:
       shouldUseMobileFeedLayout &&

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -39,7 +39,6 @@ const feature = {
   feedAdSpot: new Feature('feed_ad_spot', 0),
   onboardingCopy: new Feature('onboarding_copy', OnboardingCopy.Control),
   searchVersion: new Feature('search_version', 1),
-  commentFeed: new Feature('comment_feed', false),
   forcedTagSelection: new Feature('forced_tag_selection', false),
   mobileUxLayout: new Feature('mobile_ux_layout', false),
   readingReminder: new Feature('reading_reminder', false),

--- a/packages/webapp/__tests__/MostDiscussedPage.tsx
+++ b/packages/webapp/__tests__/MostDiscussedPage.tsx
@@ -15,7 +15,12 @@ import {
   mockGraphQL,
 } from '@dailydotdev/shared/__tests__/helpers/graphql';
 import { TestBootProvider } from '@dailydotdev/shared/__tests__/helpers/boot';
+import {
+  COMMENT_FEED_QUERY,
+  CommentFeedData,
+} from '@dailydotdev/shared/src/graphql/comments';
 import Discussed from '../pages/discussed';
+import { defaultCommentsPage } from './ProfileRepliesPage';
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -51,6 +56,24 @@ const createFeedMock = (
   },
 });
 
+const createCommentFeedMock = (
+  page = defaultCommentsPage,
+  query: string = COMMENT_FEED_QUERY,
+  variables: unknown = {
+    first: 20,
+  },
+): MockedGraphQLResponse<CommentFeedData> => ({
+  request: {
+    query,
+    variables,
+  },
+  result: {
+    data: {
+      page,
+    },
+  },
+});
+
 const renderComponent = (
   mocks: MockedGraphQLResponse[] = [createFeedMock()],
   user: LoggedUser = defaultUser,
@@ -67,32 +90,15 @@ const renderComponent = (
 };
 
 it('should request most discussed feed when logged-in', async () => {
-  renderComponent([
-    createFeedMock(defaultFeedPage, MOST_DISCUSSED_FEED_QUERY, {
-      first: 7,
-      loggedIn: true,
-      version: 15,
-    }),
-  ]);
+  renderComponent([createCommentFeedMock()]);
   await waitFor(async () => {
-    const elements = await screen.findAllByTestId('postItem');
+    const elements = await screen.findAllByTestId('comment');
     expect(elements.length).toBeTruthy();
   });
 });
 
-it('should request most discussed feed when not logged-in', async () => {
-  renderComponent(
-    [
-      createFeedMock(defaultFeedPage, MOST_DISCUSSED_FEED_QUERY, {
-        first: 7,
-        loggedIn: false,
-        version: 15,
-      }),
-    ],
-    null,
-  );
-  await waitFor(async () => {
-    const elements = await screen.findAllByTestId('postItem');
-    expect(elements.length).toBeTruthy();
-  });
+it('should not request most discussed feed when not logged-in', async () => {
+  renderComponent([createCommentFeedMock()], null);
+  const elements = screen.queryAllByTestId('comment');
+  expect(elements.length).toBeFalsy();
 });

--- a/packages/webapp/__tests__/ProfileRepliesPage.tsx
+++ b/packages/webapp/__tests__/ProfileRepliesPage.tsx
@@ -42,7 +42,7 @@ const defaultProfile: PublicProfile = {
   permalink: 'https://daily.dev/dailydotdev',
 };
 
-const defaultCommentsPage: Connection<Comment> = {
+export const defaultCommentsPage: Connection<Comment> = {
   pageInfo: {
     hasNextPage: true,
     endCursor: '',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Discussion feed won

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-267 #done


### Preview domain
https://as-267-cleanup-discussion-feed.preview.app.daily.dev