### PR TITLE
fix: add click tracking to search rec

### DIFF
--- a/packages/shared/src/components/search/SearchBarSuggestion.tsx
+++ b/packages/shared/src/components/search/SearchBarSuggestion.tsx
@@ -14,7 +14,7 @@ import {
 } from '../buttons/Button';
 import { AiIcon } from '../icons';
 import { AnalyticsEvent, Origin, TargetType } from '../../lib/analytics';
-import { SearchQuestion } from '../../graphql/search';
+import { SearchProviderEnum, SearchQuestion } from '../../graphql/search';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 
 export type SuggestionOrigin =
@@ -67,7 +67,7 @@ export const SearchBarSuggestion = ({
           : TargetType.SearchRecommendation,
         target_id: suggestionId,
         feed_item_title: prompt,
-        extra: JSON.stringify({ origin }),
+        extra: JSON.stringify({ origin, provider: SearchProviderEnum.Chat }),
       });
     }
   }, [origin, suggestionId, prompt, trackEvent, isHistory]);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added search recommendation tracking to click events
- Modify to include provider (matches other search queries

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change| click - search rec | extra: { origin: Home Page, provider: posts } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-search-rec-click.preview.app.daily.dev