### PR TITLE
fix: card image clickable

### DIFF
--- a/packages/shared/src/components/cards/common/CardCover.tsx
+++ b/packages/shared/src/components/cards/common/CardCover.tsx
@@ -55,7 +55,7 @@ export function CardCover({
   }
 
   return (
-    <div className="relative flex flex-1">
+    <div className="pointer-events-none relative flex flex-1">
       {shouldShowOverlay && coverShare}
       <ImageComponent
         {...imageProps}


### PR DESCRIPTION
## Changes
- make card image clickable by adding pointer-events-none

### Describe what this PR does
- issue raised in slack https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1713608497628029

## Events

Did you introduce any new tracking events? No
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion? no

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-325 #done
