### PR TITLE
feat: add user experience dropdown to signup and account/profile

### DIFF
--- a/packages/shared/src/components/auth/RegistrationForm.tsx
+++ b/packages/shared/src/components/auth/RegistrationForm.tsx
@@ -30,6 +30,9 @@ import { AuthFormProps } from './common';
 import ConditionalWrapper from '../ConditionalWrapper';
 import AuthContainer from './AuthContainer';
 import { onValidateHandles } from '../../hooks/useProfileForm';
+import { useFeature } from '../GrowthBookProvider';
+import { feature } from '../../lib/featureManagement';
+import ExperienceLevelDropdown from '../profile/ExperienceLevelDropdown';
 
 export interface RegistrationFormProps extends AuthFormProps {
   email: string;
@@ -63,6 +66,7 @@ export const RegistrationForm = ({
   const [name, setName] = useState('');
   const isAuthorOnboarding = trigger === AuthTriggers.Author;
   const { username, setUsername } = useGenerateUsername(name);
+  const showExperienceLevel = useFeature(feature.experienceLevel);
 
   useEffect(() => {
     trackEvent({
@@ -96,7 +100,11 @@ export const RegistrationForm = ({
       formRef?.current ?? form,
     );
 
-    if (!values['traits.name']?.length || !values['traits.username']?.length) {
+    if (
+      !values['traits.name']?.length ||
+      !values['traits.username']?.length ||
+      (showExperienceLevel && !values['traits.experienceLevel']?.length)
+    ) {
       const setHints = { ...hints };
 
       if (!values['traits.name']?.length) {
@@ -104,6 +112,9 @@ export const RegistrationForm = ({
       }
       if (!values['traits.username']?.length) {
         setHints['traits.username'] = 'Please provide username.';
+      }
+      if (!values['traits.experienceLevel']?.length) {
+        setHints['traits.experienceLevel'] = 'Please provide experience level.';
       }
 
       onUpdateHints(setHints);
@@ -141,6 +152,8 @@ export const RegistrationForm = ({
 
   const isNameValid = !hints?.['traits.name'] && isSubmitted;
   const isUsernameValid = !hints?.['traits.username'] && isSubmitted;
+  const isExperienceLevelValid =
+    !isSubmitted || !hints?.['traits.experienceLevel'];
 
   return (
     <>
@@ -224,6 +237,19 @@ export const RegistrationForm = ({
             label="X"
             type="text"
             required
+          />
+        )}
+        {showExperienceLevel && (
+          <ExperienceLevelDropdown
+            className={{ container: 'w-full' }}
+            name="traits.experienceLevel"
+            valid={isExperienceLevelValid}
+            hint={hints?.['traits.experienceLevel']}
+            onChange={() =>
+              hints?.['traits.experienceLevel'] &&
+              onUpdateHints({ ...hints, 'traits.experienceLevel': '' })
+            }
+            saveHintSpace
           />
         )}
         <span className="border-b border-border-subtlest-tertiary pb-4 text-text-secondary typo-subhead">

--- a/packages/shared/src/components/auth/SocialRegistrationForm.tsx
+++ b/packages/shared/src/components/auth/SocialRegistrationForm.tsx
@@ -30,6 +30,9 @@ import { useGenerateUsername } from '../../hooks';
 import AuthContainer from './AuthContainer';
 import ConditionalWrapper from '../ConditionalWrapper';
 import { SignBackProvider, useSignBack } from '../../hooks/auth/useSignBack';
+import { feature } from '../../lib/featureManagement';
+import { useFeature } from '../GrowthBookProvider';
+import ExperienceLevelDropdown from '../profile/ExperienceLevelDropdown';
 
 export interface SocialRegistrationFormProps extends AuthFormProps {
   className?: string;
@@ -65,10 +68,12 @@ export const SocialRegistrationForm = ({
   const [nameHint, setNameHint] = useState<string>(null);
   const [usernameHint, setUsernameHint] = useState<string>(null);
   const [twitterHint, setTwitterHint] = useState<string>(null);
+  const [experienceLevelHint, setExperienceLevelHint] = useState<string>(null);
   const [name, setName] = useState(user?.name);
   const isAuthorOnboarding = trigger === AuthTriggers.Author;
   const { username, setUsername } = useGenerateUsername(name);
   const { onUpdateSignBack } = useSignBack();
+  const showExperienceLevel = useFeature(feature.experienceLevel);
 
   useEffect(() => {
     trackEvent({
@@ -114,6 +119,12 @@ export const SocialRegistrationForm = ({
     if (!values.username) {
       trackError('Username not provided');
       setUsernameHint('Please choose a username');
+      return;
+    }
+
+    if (!values.experienceLevel && showExperienceLevel) {
+      trackError('Experience level not provided');
+      setExperienceLevelHint('Please select your experience level');
       return;
     }
 
@@ -228,6 +239,20 @@ export const SocialRegistrationForm = ({
                 setTwitterHint('');
               }
             }}
+          />
+        )}
+        {showExperienceLevel && (
+          <ExperienceLevelDropdown
+            className={{ container: 'w-full' }}
+            name="experienceLevel"
+            onChange={() => {
+              if (experienceLevelHint) {
+                setExperienceLevelHint(null);
+              }
+            }}
+            valid={experienceLevelHint === null}
+            hint={experienceLevelHint}
+            saveHintSpace
           />
         )}
         <span className="border-b border-border-subtlest-tertiary pb-4 text-text-secondary typo-subhead">

--- a/packages/shared/src/components/fields/Dropdown.tsx
+++ b/packages/shared/src/components/fields/Dropdown.tsx
@@ -2,6 +2,7 @@ import React, {
   CSSProperties,
   ReactElement,
   ReactNode,
+  useEffect,
   useRef,
   useState,
 } from 'react';
@@ -22,7 +23,7 @@ import { DrawerProps } from '../drawers';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { IconProps } from '../Icon';
 
-interface ClassName {
+export interface DropdownClassName {
   container?: string;
   menu?: string;
   label?: string;
@@ -36,7 +37,7 @@ export interface DropdownProps {
   icon?: ReactNode;
   shouldIndicateSelected?: boolean;
   dynamicMenuWidth?: boolean;
-  className?: ClassName;
+  className?: DropdownClassName;
   style?: CSSProperties;
   selectedIndex: number;
   options: string[];
@@ -49,6 +50,7 @@ export interface DropdownProps {
   iconOnly?: boolean;
   drawerProps?: Omit<DrawerProps, 'children' | 'onClose'>;
   openFullScreen?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function Dropdown({
@@ -57,6 +59,7 @@ export function Dropdown({
   selectedIndex,
   options,
   onChange,
+  onOpenChange,
   dynamicMenuWidth,
   shouldIndicateSelected,
   buttonSize = ButtonSize.Large,
@@ -75,6 +78,10 @@ export function Dropdown({
   const [menuWidth, setMenuWidth] = useState<number>();
   const triggerRef = useRef<HTMLButtonElement>();
   const { show, hideAll } = useContextMenu({ id });
+
+  useEffect(() => {
+    onOpenChange?.(isVisible);
+  }, [isVisible, onOpenChange]);
 
   const showMenu = (event: TriggerEvent): void => {
     const { right, bottom, width } = triggerRef.current.getBoundingClientRect();

--- a/packages/shared/src/components/profile/ExperienceLevelDropdown.tsx
+++ b/packages/shared/src/components/profile/ExperienceLevelDropdown.tsx
@@ -1,0 +1,109 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import { Dropdown, DropdownClassName } from '../fields/Dropdown';
+import { TerminalIcon } from '../icons';
+import { BaseFieldProps } from '../fields/BaseFieldContainer';
+import { UserExperienceLevel } from '../../lib/user';
+
+interface ClassName extends DropdownClassName {
+  hint?: string;
+  dropdown?: string;
+}
+
+export type UserExperienceLevelKey = keyof typeof UserExperienceLevel;
+
+interface Props
+  extends Pick<BaseFieldProps, 'name' | 'valid' | 'hint' | 'saveHintSpace'> {
+  className?: ClassName;
+  defaultValue?: UserExperienceLevelKey;
+  onChange?: (value: UserExperienceLevelKey, index: number) => void;
+}
+
+const ExperienceLevelDropdown = ({
+  className = {},
+  onChange,
+  hint = '',
+  valid = true,
+  defaultValue,
+  name,
+  saveHintSpace = false,
+}: Props): ReactElement => {
+  const [open, setOpen] = React.useState(false);
+  const [selectedIndex, setSelectedIndex] = React.useState(
+    Object.keys(UserExperienceLevel).indexOf(defaultValue),
+  );
+
+  const {
+    hint: hintClassName,
+    label: labelClassName,
+    button: buttonClassName,
+    menu: menuClassName,
+    item: itemClassName,
+    container: containerClassName,
+    dropdown: dropdownClassName,
+  } = className;
+
+  return (
+    <div
+      className={classNames(
+        'relative flex flex-col items-stretch',
+        containerClassName,
+      )}
+    >
+      <Dropdown
+        className={{
+          label: classNames(labelClassName, 'typo-body'),
+          button: classNames(
+            buttonClassName,
+            '!px-3',
+            !open &&
+              !valid &&
+              '!shadow-[inset_0.125rem_0_0_var(--status-error)]',
+            selectedIndex > -1 && '!text-text-primary',
+          ),
+          menu: classNames(
+            menuClassName,
+            'menu-primary max-h-[15.375rem] overflow-y-auto p-1',
+          ), // fit 6 items
+          item: classNames(itemClassName, '*:min-h-10 *:!typo-callout'),
+          container: dropdownClassName,
+        }}
+        selectedIndex={selectedIndex}
+        options={Object.values(UserExperienceLevel)}
+        onChange={(_, index) => {
+          const val = Object.keys(UserExperienceLevel)[
+            index
+          ] as UserExperienceLevelKey;
+          onChange?.(val, index);
+          setSelectedIndex(index);
+        }}
+        onOpenChange={setOpen}
+        placeholder="Experience level"
+        icon={<TerminalIcon className="mr-2" />}
+      />
+      {name && selectedIndex > -1 && (
+        <input
+          type="text"
+          className="hidden"
+          name={name}
+          value={Object.keys(UserExperienceLevel)[selectedIndex]}
+        />
+      )}
+      {(hint?.length > 0 || saveHintSpace) && (
+        <div
+          role={!valid ? 'alert' : undefined}
+          className={classNames(
+            'mt-1 px-2 typo-caption1',
+            !valid ? 'text-status-error' : 'text-text-quaternary',
+            saveHintSpace && 'h-4',
+            hintClassName,
+          )}
+        >
+          {hint}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ExperienceLevelDropdown;

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -326,6 +326,7 @@ export const UPDATE_USER_PROFILE_MUTATION = gql`
       createdAt
       infoConfirmed
       timezone
+      experienceLevel
     }
   }
 `;
@@ -535,6 +536,20 @@ export const VOTE_MUTATION = gql`
   mutation Vote($id: ID!, $entity: UserVoteEntity!, $vote: Int!) {
     vote(id: $id, entity: $entity, vote: $vote) {
       _
+    }
+  }
+`;
+
+export interface UserExperienceLevelData {
+  user: {
+    experienceLevel: string;
+  };
+}
+
+export const GET_USER_EXPERIENCE_LEVEL = gql`
+  query GetUserProfile($id: ID!) {
+    user(id: $id) {
+      experienceLevel
     }
   }
 `;

--- a/packages/shared/src/lib/auth.ts
+++ b/packages/shared/src/lib/auth.ts
@@ -105,6 +105,7 @@ export interface SocialRegistrationParameters {
   file?: string;
   acceptedMarketing?: boolean;
   optOutMarketing?: boolean;
+  experienceLevel?: string;
 }
 
 export interface RegistrationParameters {
@@ -122,6 +123,7 @@ export interface RegistrationParameters {
   'traits.username': string;
   'traits.image': string;
   'traits.acceptedMarketing'?: boolean;
+  'traits.experienceLevel'?: string;
   optOutMarketing?: boolean;
 }
 

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -35,6 +35,7 @@ const feature = {
   readingReminder: new Feature('reading_reminder', false),
   onboardingMostVisited: new Feature('onboarding_most_visited', false),
   shareExperience: new Feature('share_experience', false),
+  experienceLevel: new Feature('experience_level', false),
 };
 
 export { feature };

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -111,6 +111,7 @@ export enum RequestKey {
   SourceRelatedTags = 'source_related_tags',
   SourceByTag = 'source_by_tag',
   SimilarSources = 'similar_sources',
+  UserExperienceLevel = 'user_experience_level',
 }
 
 export type HasConnection<

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -40,6 +40,16 @@ export interface PublicProfile {
   readme?: string;
 }
 
+export enum UserExperienceLevel {
+  LESS_THAN_1_YEAR = 'Aspiring engineer (<1 year)',
+  MORE_THAN_1_YEAR = 'Entry-level (1 year)',
+  MORE_THAN_2_YEARS = 'Mid-level (2-3 years)',
+  MORE_THAN_4_YEARS = 'Experienced (4-5 years)',
+  MORE_THAN_6_YEARS = 'Highly experienced (6-10 years)',
+  MORE_THAN_10_YEARS = `I've suffered enough (10+ years)`,
+  NOT_ENGINEER = `I'm not an engineer`,
+}
+
 export interface UserProfile {
   name: string;
   email?: string;
@@ -55,6 +65,7 @@ export interface UserProfile {
   notificationEmail?: boolean;
   timezone?: string;
   cover?: string;
+  experienceLevel?: UserExperienceLevel;
 }
 
 export interface UserShortProfile


### PR DESCRIPTION
## Changes

Related issue: https://dailydotdev.atlassian.net/browse/MI-314

Adds experience level dropdown to signup pages and to the edit account profile page.

Depends on API changes PR: 
- https://github.com/dailydotdev/daily-api/pull/1851

- new feature `experienceLevel`, default `false`
- adds experience level dropdown (required param) to the signup page if feature is on
- adds experience level dropdown to the edit account profile page, if feature is on

### Screenshots

#### Profile page

<img width="607" alt="Screenshot 2024-04-23 at 14 08 36" src="https://github.com/dailydotdev/apps/assets/9974711/7449dba1-1e48-448f-9ec9-dab8a435443a">
<img width="415" alt="Screenshot 2024-04-23 at 14 08 44" src="https://github.com/dailydotdev/apps/assets/9974711/b5754a30-c4c9-4f7e-9b52-ec1cf128af59">
<img width="416" alt="Screenshot 2024-04-23 at 14 08 53" src="https://github.com/dailydotdev/apps/assets/9974711/69780567-c3c5-4873-8def-88adb1c2dd3e">

#### Social signup

<img width="408" alt="Screenshot 2024-04-23 at 14 12 23" src="https://github.com/dailydotdev/apps/assets/9974711/85eedbcc-a2c9-4a4e-b863-36a1e158b912">
<img width="393" alt="Screenshot 2024-04-23 at 14 13 22" src="https://github.com/dailydotdev/apps/assets/9974711/14940c2f-7cee-49eb-a027-3d0c0607d244">
<img width="418" alt="Screenshot 2024-04-23 at 14 13 33" src="https://github.com/dailydotdev/apps/assets/9974711/0fcd38b4-8671-4814-96e2-cf1e50fb3dcb">

#### Email signup

<img width="408" alt="Screenshot 2024-04-23 at 14 09 33" src="https://github.com/dailydotdev/apps/assets/9974711/56e8394e-1391-413e-8c10-4ba88022619f">
<img width="438" alt="Screenshot 2024-04-23 at 14 10 50" src="https://github.com/dailydotdev/apps/assets/9974711/2840a8b5-474e-4f54-a2b1-c8379dd29bb3">
<img width="428" alt="Screenshot 2024-04-23 at 14 11 10" src="https://github.com/dailydotdev/apps/assets/9974711/2c1cb16c-e989-4314-b39b-9e010ebf2eb6">

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [ ] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-314 #done
