### PR TITLE
feat: add social proof banner to source/tag pages

### DIFF
--- a/packages/shared/src/components/auth/CustomAuthBanner.tsx
+++ b/packages/shared/src/components/auth/CustomAuthBanner.tsx
@@ -5,6 +5,9 @@ import { useAuthContext } from '../../contexts/AuthContext';
 import { useViewSize, ViewSize } from '../../hooks';
 import LoginButton from '../LoginButton';
 import { authGradientBg } from './AuthenticationBanner';
+import { withExperiment } from '../withExperiment';
+import { TagSourceSocialProof } from '../../lib/featureValues';
+import { feature } from '../../lib/featureManagement';
 
 const CustomAuthBanner = (): ReactElement => {
   const { shouldShowAuthBanner } = useOnboarding();
@@ -32,3 +35,11 @@ const CustomAuthBanner = (): ReactElement => {
 };
 
 export default CustomAuthBanner;
+
+export const TagSourceCustomAuthBannerExperiment = withExperiment(
+  CustomAuthBanner,
+  {
+    feature: feature.tagSourceSocialProof,
+    value: TagSourceSocialProof.V1,
+  },
+);

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -1,5 +1,8 @@
 import { JSONValue } from '@growthbook/growthbook';
-import { ReadingStreaksExperiment } from './featureValues';
+import {
+  ReadingStreaksExperiment,
+  TagSourceSocialProof,
+} from './featureValues';
 import { cloudinary } from './image';
 
 export class Feature<T extends JSONValue> {
@@ -35,6 +38,10 @@ const feature = {
   readingReminder: new Feature('reading_reminder', false),
   onboardingMostVisited: new Feature('onboarding_most_visited', false),
   shareExperience: new Feature('share_experience', false),
+  tagSourceSocialProof: new Feature(
+    'tag_source_social_proof',
+    TagSourceSocialProof.Control,
+  ),
 };
 
 export { feature };

--- a/packages/shared/src/lib/featureValues.ts
+++ b/packages/shared/src/lib/featureValues.ts
@@ -11,3 +11,8 @@ export enum ReadingStreaksExperiment {
   V1 = 'v1',
   V2 = 'v2',
 }
+
+export enum TagSourceSocialProof {
+  Control = 'control',
+  V1 = 'v1',
+}

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -45,7 +45,11 @@ import {
   GET_RECOMMENDED_TAGS_QUERY,
   TagsData,
 } from '@dailydotdev/shared/src/graphql/feedSettings';
-import { useFeedLayout } from '@dailydotdev/shared/src/hooks';
+import {
+  useFeedLayout,
+  useViewSize,
+  ViewSize,
+} from '@dailydotdev/shared/src/hooks';
 import { RecommendedTags } from '@dailydotdev/shared/src/components/RecommendedTags';
 import {
   SOURCES_BY_TAG_QUERY,
@@ -53,6 +57,12 @@ import {
 } from '@dailydotdev/shared/src/graphql/sources';
 import { Connection } from '@dailydotdev/shared/src/graphql/common';
 import { RelatedSources } from '@dailydotdev/shared/src/components/RelatedSources';
+import { TagSourceCustomAuthBannerExperiment } from '@dailydotdev/shared/src/components/auth/CustomAuthBanner';
+import { AuthenticationBanner } from '@dailydotdev/shared/src/components/auth';
+import { useOnboarding } from '@dailydotdev/shared/src/hooks/auth';
+import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
+import { TagSourceSocialProof } from '@dailydotdev/shared/src/lib/featureValues';
 import { getLayout } from '../../components/layouts/FeedLayout';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
@@ -119,6 +129,13 @@ const TagTopSources = ({ tag }: { tag: string }) => {
 
 const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
   const { isFallback } = useRouter();
+  const isLaptop = useViewSize(ViewSize.Laptop);
+  const { shouldShowAuthBanner } = useOnboarding();
+  const tagSourceFeatureValue = useFeature(feature.tagSourceSocialProof);
+  const shouldShowTagSourceSocialProof =
+    shouldShowAuthBanner &&
+    tagSourceFeatureValue === TagSourceSocialProof.V1 &&
+    isLaptop;
   const { user, showLogin } = useContext(AuthContext);
   // Must be memoized to prevent refreshing the feed
   const queryVariables = useMemo(() => ({ tag, ranking: 'TIME' }), [tag]);
@@ -243,12 +260,16 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
         query={TAG_FEED_QUERY}
         variables={queryVariables}
       />
+      {shouldShowTagSourceSocialProof && <AuthenticationBanner />}
     </FeedPageLayoutComponent>
   );
 };
 
 TagPage.getLayout = getLayout;
-TagPage.layoutProps = mainFeedLayoutProps;
+TagPage.layoutProps = {
+  ...mainFeedLayoutProps,
+  customBanner: <TagSourceCustomAuthBannerExperiment />,
+};
 
 export default TagPage;
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since we need to use the layout withExperiment for the mobile version it made no sense to only enroll anonymous users.
- This is something we can handle through GB for this specific experiment (also since it most likely will win)

![Screenshot 2024-04-23 at 15 41 39](https://github.com/dailydotdev/apps/assets/554874/31eb1741-48d2-487e-b093-e427faf36578)
![Screenshot 2024-04-23 at 15 41 30](https://github.com/dailydotdev/apps/assets/554874/c0df6549-20e5-4e7e-bd88-603533808be2)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-273 #done
