### PR TITLE
feat: experiment on sidebar state

### DIFF
--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -18,6 +18,8 @@ import AuthContext from './AuthContext';
 import { graphqlUrl } from '../lib/config';
 import { capitalize } from '../lib/strings';
 import { storageWrapper } from '../lib/storageWrapper';
+import { useFeaturesReadyContext } from '../components/GrowthBookProvider';
+import { feature } from '../lib/featureManagement';
 
 export enum ThemeMode {
   Dark = 'dark',
@@ -120,6 +122,7 @@ export const SettingsContextProvider = ({
 }: SettingsContextProviderProps): ReactElement => {
   const { user } = useContext(AuthContext);
   const userId = user?.id;
+  const { getFeatureValue } = useFeaturesReadyContext();
 
   useEffect(() => {
     if (!loadedSettings) {
@@ -174,7 +177,17 @@ export const SettingsContextProvider = ({
   };
 
   const syncSettings = async (bootUserId?: string) => {
-    await updateRemoteSettingsFn(settings, bootUserId);
+    const updatedSettings = settings;
+
+    if (settings.sidebarExpanded) {
+      const sidebarClosed = getFeatureValue(feature.sidebarClosed);
+
+      if (sidebarClosed) {
+        updatedSettings.sidebarExpanded = false;
+      }
+    }
+
+    await updateRemoteSettingsFn(updatedSettings, bootUserId);
   };
 
   const contextData = useMemo<SettingsContextData>(

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -36,6 +36,7 @@ const feature = {
   onboardingMostVisited: new Feature('onboarding_most_visited', false),
   shareExperience: new Feature('share_experience', false),
   bookmarkLoops: new Feature('bookmark_loops', false),
+  sidebarClosed: new Feature('sidebar_closed', false),
 };
 
 export { feature };


### PR DESCRIPTION
## Changes
- Whenever registration happens, we sync the local settings of our user, for example, when they switched to light mode, etc.
- In this case, we can be sure we will only apply the experiment on new users to set their default sidebar state value.

Kudos to @capJavert for the great idea.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-317 #done


### Preview domain
https://mi-317-post-registration.preview.app.daily.dev