### PR TITLE
fix: logout on mobile (drawer not showing)

### DIFF
--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -13,6 +13,7 @@ import ConditionalWrapper from '../ConditionalWrapper';
 import { useOutsideClick } from '../../hooks/utils/useOutsideClick';
 import { ButtonVariant } from '../buttons/common';
 import { Button } from '../buttons/Button';
+import { RootPortal } from '../tooltips/Portal';
 
 export type PopupEventType =
   | MouseEvent
@@ -48,6 +49,7 @@ export interface DrawerProps
   title?: ReactNode;
   onClose: PopupCloseFunc;
   displayCloseButton?: boolean;
+  appendOnRoot?: boolean;
 }
 
 export interface DrawerOnMobileProps {
@@ -168,7 +170,7 @@ export interface DrawerRef {
 }
 
 function AnimatedDrawer(
-  { isOpen, onClose, ...props }: DrawerWrapperProps,
+  { isOpen, onClose, appendOnRoot, ...props }: DrawerWrapperProps,
   ref: MutableRefObject<DrawerRef>,
 ): ReactElement {
   const [isClosing, setIsClosing] = useState(false);
@@ -188,7 +190,14 @@ function AnimatedDrawer(
     return null;
   }
 
-  return <BaseDrawer {...props} isClosing={isClosing} onClose={onClosing} />;
+  return (
+    <ConditionalWrapper
+      condition={appendOnRoot}
+      wrapper={(component) => <RootPortal>{component}</RootPortal>}
+    >
+      <BaseDrawer {...props} isClosing={isClosing} onClose={onClosing} />
+    </ConditionalWrapper>
+  );
 }
 
 export const Drawer = React.forwardRef(AnimatedDrawer);

--- a/packages/shared/src/components/modals/Prompt.tsx
+++ b/packages/shared/src/components/modals/Prompt.tsx
@@ -42,7 +42,7 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement {
       className={className.modal}
       overlayClassName="!z-max"
       isDrawerOnMobile
-      drawerProps={{ displayCloseButton: false }}
+      drawerProps={{ displayCloseButton: false, appendOnRoot: true }}
       {...props}
     >
       <Modal.Body>


### PR DESCRIPTION
## Changes
- Fix logout on mobile. The root cause was the drawer's placement that causes it to be behind the opened sidebar.

<img width="857" alt="Screenshot 2024-04-24 at 11 47 26 AM" src="https://github.com/dailydotdev/apps/assets/13744167/a7c491ee-f736-47a6-9ca4-097b85d6771a">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-326 #done
