### PR TITLE
feat: send page active event

### DIFF
--- a/packages/shared/src/hooks/analytics/useTrackLifecycleEvents.ts
+++ b/packages/shared/src/hooks/analytics/useTrackLifecycleEvents.ts
@@ -20,6 +20,9 @@ export default function useTrackLifecycleEvents(
       if (event.detail.newState === 'active') {
         setEnabled(true);
         contextData.trackEventEnd('page inactive');
+        contextData.trackEvent({
+          event_name: 'page active',
+        });
         // Update events page state to active
         durationEventsQueue.current.forEach((value, key) => {
           if (


### PR DESCRIPTION
When page is getting active again, send a dedicate event to signal that. Requested by Dave


### Preview domain
https://page-active.preview.app.daily.dev