### PR TITLE
fix: use query can fetch by default for pagination

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -127,7 +127,7 @@ export default function Feed<T>({
   shortcuts,
   actionButtons,
   disableAds,
-  allowFetchMore = true,
+  allowFetchMore,
   pageSize,
   isHorizontal = false,
   feedContainerRef,


### PR DESCRIPTION
## Changes

### Describe what this PR does

Fix loading placeholder always showing on squad pages. 

`const canFetchMore = allowFetchMore ?? queryCanFetchMore` would evaluate to `true` always because `??` only works with `null | undefined`.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-source-feed-fetch.preview.app.daily.dev