### PR TITLE
fix: margin spacing when logo only

### DIFF
--- a/packages/shared/src/components/post/GoBackHeaderMobile.tsx
+++ b/packages/shared/src/components/post/GoBackHeaderMobile.tsx
@@ -29,7 +29,11 @@ export function GoBackHeaderMobile({
   const isLaptop = useViewSize(ViewSize.Laptop);
   const goHome = useCallback(() => router.push('/'), [router]);
   const logoButton = (
-    <Logo onLogoClick={goHome} position={LogoPosition.Initial} />
+    <Logo
+      className="my-2"
+      onLogoClick={goHome}
+      position={LogoPosition.Initial}
+    />
   );
 
   const canGoBack =


### PR DESCRIPTION
## Changes
- The spacing seems lacking when the logo is only available.

Before:
![Screenshot 2024-04-26 at 3 01 49 PM](https://github.com/dailydotdev/apps/assets/13744167/413aac04-e8d0-4b3e-8d46-706b956e80b8)

After:
![Screenshot 2024-04-26 at 3 01 45 PM](https://github.com/dailydotdev/apps/assets/13744167/d578efe0-fb08-4824-9bba-3fa2498486e6)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-header-spacing-logo.preview.app.daily.dev