### PR TITLE
fix: small boot prompt rules

### DIFF
--- a/packages/shared/src/components/modals/BootPopups.tsx
+++ b/packages/shared/src/components/modals/BootPopups.tsx
@@ -65,9 +65,19 @@ export const BootPopups = (): null => {
       addBootPopup({
         type: LazyModal.ReputationPrivileges,
         persistOnRouteChange: true,
+        props: {
+          onAfterClose: () => {
+            updateLastBootPopup();
+          },
+        },
       });
     }
-  }, [checkHasCompleted, isActionsFetched, user?.reputation]);
+  }, [
+    checkHasCompleted,
+    isActionsFetched,
+    user?.reputation,
+    updateLastBootPopup,
+  ]);
 
   /**
    * Boot popup based on marketing CTA
@@ -85,10 +95,13 @@ export const BootPopups = (): null => {
               target_id: marketingCta.campaignId,
             });
           },
+          onAfterClose: () => {
+            updateLastBootPopup();
+          },
         },
       });
     }
-  }, [marketingCta, trackEvent]);
+  }, [marketingCta, trackEvent, updateLastBootPopup]);
 
   /** *
    * Boot popup for generic referral campaign
@@ -100,8 +113,13 @@ export const BootPopups = (): null => {
 
     addBootPopup({
       type: LazyModal.GenericReferral,
+      props: {
+        onAfterOpen: () => {
+          updateLastBootPopup();
+        },
+      },
     });
-  }, [alerts?.showGenericReferral]);
+  }, [alerts?.showGenericReferral, updateLastBootPopup]);
 
   /**
    * Boot popup for migrate streaks
@@ -116,11 +134,17 @@ export const BootPopups = (): null => {
       props: {
         marketingCta: promotion.migrateStreaks,
         onAfterOpen: () => {
+          updateLastBootPopup();
           completeAction(ActionType.ExistingUserSeenStreaks);
         },
       },
     });
-  }, [completeAction, isActionsFetched, shouldShowStreaksPopup]);
+  }, [
+    completeAction,
+    isActionsFetched,
+    shouldShowStreaksPopup,
+    updateLastBootPopup,
+  ]);
 
   /**
    * Boot popup for streaks milestone
@@ -136,11 +160,12 @@ export const BootPopups = (): null => {
         currentStreak: streak?.current,
         maxStreak: streak?.max,
         onAfterClose: () => {
+          updateLastBootPopup();
           updateAlerts({ showStreakMilestone: false });
         },
       },
     });
-  }, [shouldHideStreaksModal, streak, updateAlerts]);
+  }, [shouldHideStreaksModal, streak, updateAlerts, updateLastBootPopup]);
 
   /**
    * Actual rendering of the boot popup that's first in line
@@ -150,15 +175,8 @@ export const BootPopups = (): null => {
       return;
     }
     openModal(bootPopups.values().next().value);
-    updateLastBootPopup();
     setBootPopups(new Map());
-  }, [
-    alerts?.bootPopup,
-    bootPopups,
-    loadedAlerts,
-    openModal,
-    updateLastBootPopup,
-  ]);
+  }, [alerts?.bootPopup, bootPopups, loadedAlerts, openModal]);
 
   return null;
 };

--- a/packages/shared/src/hooks/useActions.ts
+++ b/packages/shared/src/hooks/useActions.ts
@@ -64,7 +64,7 @@ export const useActions = (): UseActions => {
 
         return {
           actions: [...old?.actions, optimisticAction],
-          serverLoaded: old?.serverLoaded,
+          serverLoaded: !!old?.serverLoaded,
         };
       });
 

--- a/packages/shared/src/hooks/useActions.ts
+++ b/packages/shared/src/hooks/useActions.ts
@@ -47,7 +47,7 @@ export const useActions = (): UseActions => {
   );
 
   const actions = data?.actions;
-  const isActionsFetched = !isLoading && data?.serverLoaded;
+  const isActionsFetched = !isLoading && !!data?.serverLoaded;
 
   const { mutateAsync: completeAction } = useMutation(completeUserAction, {
     onMutate: (type) => {
@@ -71,7 +71,7 @@ export const useActions = (): UseActions => {
       return () =>
         client.setQueryData<ActionQueryData>(actionsKey, {
           actions,
-          serverLoaded: data?.serverLoaded,
+          serverLoaded: !!data?.serverLoaded,
         });
     },
     onError: (_, __, rollback: () => void) => {

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -392,7 +392,7 @@ export function OnboardPage(): ReactElement {
   }
 
   return (
-    <div className="z-max flex h-full max-h-screen min-h-screen w-full flex-1 flex-col items-center overflow-x-hidden bg-[#0e1019]">
+    <div className="z-3 flex h-full max-h-screen min-h-screen w-full flex-1 flex-col items-center overflow-x-hidden bg-[#0e1019]">
       <NextSeo {...seo} titleTemplate="%s | daily.dev" />
       <PixelTracking />
       <GtagTracking />


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixes two things:
- 1. We use the same rule per prompt on when it should set the lastBootPopup (for some it's on show, some on close)
- 2. There was a issue with useActions hook where potentially it could return `isLoading: false` while no data was loaded, it's caused by react query mutations making isLoading to be false and data to exist.
- To solve 2 I introduced a internal state return that indicates whether data is loaded from the server, it should fix some edge-cases but not impact the existing hasAction check that happens for mutated data.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-boot-popup-rules.preview.app.daily.dev