### PR TITLE
fix: render experience level dropdown as absolute on profile page

### DIFF
--- a/packages/webapp/pages/account/profile.tsx
+++ b/packages/webapp/pages/account/profile.tsx
@@ -196,9 +196,10 @@ const AccountProfilePage = (): ReactElement => {
             defaultValue={user.experienceLevel}
             name="experienceLevel"
             className={{
-              container: 'mt-6 max-w-sm',
+              container: 'mt-6 max-w-sm tablet:relative',
               button:
                 'hover:shadow-[inset_0.125rem_0_0_var(--theme-text-primary)]',
+              menu: 'absolute !left-0 !right-0 !top-[3.5rem] transform-none',
             }}
           />
         )}


### PR DESCRIPTION
## Changes

Render dropdown menu as absolute on profile page.

Our dropdown component uses react-contexify library. This in turn renders the dropdown menu as a `position: fixed` component. When we scroll, this will be scrolled as well. The library circumvents this by adding `window.addEventListener` to the `'scroll'` event and hiding the dropdown menu when scroll happens. The problem is, that on profile page, it's not the window that scrolls, but the page container itself. The scroll event is not bubbled up by default, which causes this hiding not to happen.

Simple CSS fix is IMO preferable to touching the library and modifying the event handling. On other pages where `Dropdown` component is used, we don't have this problem. There's either no scrolling or the scrolling is done on the window object.

Mobile view is not affected, because there we render a drawer instead of a context menu.

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android


### Preview domain
https://fix-dropdown-scroll.preview.app.daily.dev