### PR TITLE
fix: post page button colors

### DIFF
--- a/packages/shared/src/components/post/PostActions.tsx
+++ b/packages/shared/src/components/post/PostActions.tsx
@@ -159,8 +159,7 @@ export function PostActions({
             icon={<CommentIcon secondary={post.commented} />}
             aria-label="Comment"
             responsiveLabelClass={actionsClassName}
-            variant={ButtonVariant.Tertiary}
-            color={ButtonColor.BlueCheese}
+            className="btn-tertiary-blueCheese"
           >
             Comment
           </QuaternaryButton>
@@ -180,9 +179,10 @@ export function PostActions({
             onClick={() => onCopyLinkClick(post)}
             icon={<LinkIcon />}
             responsiveLabelClass={actionsClassName}
-            className={shareExperience && 'hidden tablet:flex'}
-            variant={ButtonVariant.Tertiary}
-            color={ButtonColor.Cabbage}
+            className={classNames(
+              'btn-tertiary-cabbage',
+              shareExperience && 'hidden tablet:flex',
+            )}
           >
             Copy
           </QuaternaryButton>
@@ -192,9 +192,7 @@ export function PostActions({
               onClick={() => openNativeShareOrPopup({ post })}
               icon={<ShareIcon />}
               responsiveLabelClass={actionsClassName}
-              className="flex tablet:hidden"
-              variant={ButtonVariant.Tertiary}
-              color={ButtonColor.Cabbage}
+              className="btn-tertiary-cabbage flex tablet:hidden"
             />
           )}
         </div>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- QuarternaryButton doesn't work with passing variant-color it should for now always work based of solid className.

| Before | After |
|--------|--------|
| ![Screenshot 2024-04-26 at 14 17 17](https://github.com/dailydotdev/apps/assets/554874/5cc6ccbd-553d-4243-9e15-7e74a8ce799b) | ![Screenshot 2024-04-26 at 14 42 39](https://github.com/dailydotdev/apps/assets/554874/648a9020-7242-47dc-b25f-124fffda08e3) | 
   ## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://as-275-post-page-button.preview.app.daily.dev