### PR TITLE
fix: two layout shift issues

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -110,7 +110,7 @@ function MainLayoutComponent({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isNotificationsReady, unreadCount, hasTrackedImpression]);
 
-  const renderSidebar = () => {
+  const RenderSidebar = () => {
     if (sidebarRendered === null || (sidebarRendered && !showSidebar)) {
       return null;
     }
@@ -191,11 +191,14 @@ function MainLayoutComponent({
         className={classNames(
           'flex flex-col tablet:pl-16 laptop:pl-11',
           className,
-          !isScreenCentered && sidebarExpanded && 'laptop:!pl-60',
+          isAuthReady &&
+            !isScreenCentered &&
+            sidebarExpanded &&
+            'laptop:!pl-60',
           isBannerAvailable && 'laptop:pt-8',
         )}
       >
-        {renderSidebar()}
+        <RenderSidebar />
         {children}
       </main>
     </div>

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -43,7 +43,7 @@ function MainLayoutHeader({
   onLogoClick,
   onMobileSidebarToggle,
 }: MainLayoutHeaderProps): ReactElement {
-  const { user } = useContext(AuthContext);
+  const { user, isAuthReady } = useContext(AuthContext);
   const { streak, isEnabled: isStreaksEnabled, isLoading } = useReadingStreak();
   const isMobile = useViewSize(ViewSize.MobileL);
   const isStreakLarge = streak?.current > 99; // if we exceed 100, we need to display it differently in the UI
@@ -109,7 +109,7 @@ function MainLayoutHeader({
       />
     );
 
-  if (!isLaptop) {
+  if (isAuthReady && !isLaptop) {
     return (
       <>
         <FeedNav />


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We had two layout shift issues
- 1. Introduced by `!isLaptop` causing first load to be false, then true making the header not render
- 2. Introduced by a extra padding left which should only render after second load (same issue by defaults)

| Before | After |
|--------|--------|
| https://github.com/dailydotdev/apps/assets/554874/d9b4df99-b2fa-4f02-828b-47f170ba4fcd | https://github.com/dailydotdev/apps/assets/554874/04ead7f6-629c-43b5-bc71-8fa3208f8699 | 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-280 #done


### Preview domain
https://as-280-layout-shift-issues.preview.app.daily.dev