### PR TITLE
fix: layout shift on sidebar movement

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -77,12 +77,8 @@ function MainLayoutComponent({
   const { sidebarRendered } = useSidebarRendered();
   const { isAvailable: isBannerAvailable } = useBanner();
   const [openMobileSidebar, setOpenMobileSidebar] = useState(false);
-  const {
-    sidebarExpanded,
-    optOutWeeklyGoal,
-    autoDismissNotifications,
-    loadedSettings,
-  } = useContext(SettingsContext);
+  const { sidebarExpanded, optOutWeeklyGoal, autoDismissNotifications } =
+    useContext(SettingsContext);
   const [hasTrackedImpression, setHasTrackedImpression] = useState(false);
 
   const isLaptopXL = useViewSize(ViewSize.LaptopXL);
@@ -167,7 +163,7 @@ function MainLayoutComponent({
 
   if (
     (!isPageReady && isPageApplicableForOnboarding) ||
-    shouldRedirectOnboarding ||
+    shouldRedirectOnboarding
   ) {
     return null;
   }
@@ -195,9 +191,7 @@ function MainLayoutComponent({
         className={classNames(
           'flex flex-col tablet:pl-16 laptop:pl-11',
           className,
-            !isScreenCentered &&
-            sidebarExpanded &&
-            'laptop:!pl-60',
+          !isScreenCentered && sidebarExpanded && 'laptop:!pl-60',
           isBannerAvailable && 'laptop:pt-8',
         )}
       >

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -77,8 +77,12 @@ function MainLayoutComponent({
   const { sidebarRendered } = useSidebarRendered();
   const { isAvailable: isBannerAvailable } = useBanner();
   const [openMobileSidebar, setOpenMobileSidebar] = useState(false);
-  const { sidebarExpanded, optOutWeeklyGoal, autoDismissNotifications } =
-    useContext(SettingsContext);
+  const {
+    sidebarExpanded,
+    optOutWeeklyGoal,
+    autoDismissNotifications,
+    loadedSettings,
+  } = useContext(SettingsContext);
   const [hasTrackedImpression, setHasTrackedImpression] = useState(false);
 
   const isLaptopXL = useViewSize(ViewSize.LaptopXL);
@@ -163,7 +167,8 @@ function MainLayoutComponent({
 
   if (
     (!isPageReady && isPageApplicableForOnboarding) ||
-    shouldRedirectOnboarding
+    shouldRedirectOnboarding ||
+    !loadedSettings
   ) {
     return null;
   }

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -168,7 +168,6 @@ function MainLayoutComponent({
   if (
     (!isPageReady && isPageApplicableForOnboarding) ||
     shouldRedirectOnboarding ||
-    !loadedSettings
   ) {
     return null;
   }
@@ -196,7 +195,6 @@ function MainLayoutComponent({
         className={classNames(
           'flex flex-col tablet:pl-16 laptop:pl-11',
           className,
-          isAuthReady &&
             !isScreenCentered &&
             sidebarExpanded &&
             'laptop:!pl-60',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since we use padding to determine center of the main content we need to wait for settings to be loaded.
- We need to make sure this doesn't introduce weird UX
- We need to ensure it doesn't affect SEO crawler

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-layout-shift.preview.app.daily.dev