### PR TITLE
fix: squad page header and animation

### DIFF
--- a/packages/shared/src/components/post/SquadPostWidgets.tsx
+++ b/packages/shared/src/components/post/SquadPostWidgets.tsx
@@ -48,7 +48,7 @@ const SquadCard = ({ squadSource }: { squadSource: Squad }) => {
         </p>
       )}
       <SquadJoinButton
-        className="mt-3 w-full"
+        className={{ button: 'mt-3 w-full' }}
         squad={squad}
         origin={Origin.ArticleModal}
       />

--- a/packages/shared/src/components/sources/SourceCard.tsx
+++ b/packages/shared/src/components/sources/SourceCard.tsx
@@ -141,7 +141,7 @@ export const SourceCard = ({
           action?.type === 'action' &&
           source?.type === SourceType.Squad ? (
             <SquadJoinButton
-              className="!btn-secondary w-full"
+              className={{ button: '!btn-secondary w-full' }}
               squad={source}
               origin={Origin.SquadDirectory}
               onSuccess={() => router.push(source?.permalink)}

--- a/packages/shared/src/components/squads/SquadHeaderBar.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderBar.tsx
@@ -76,10 +76,7 @@ export function SquadHeaderBar({
       )}
       {showJoinButton && (
         <SquadJoinButton
-          className={classNames(
-            'flex w-full flex-1 tablet:ml-auto tablet:w-auto tablet:flex-initial',
-            firstItemClasses,
-          )}
+          className={{ wrapper: firstItemClasses }}
           squad={squad}
           origin={Origin.SquadPage}
         />

--- a/packages/shared/src/components/squads/SquadHeaderBar.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderBar.tsx
@@ -48,12 +48,13 @@ export function SquadHeaderBar({
   const totalStepsCount = steps.length;
   const checklistTooltipText = `${completedStepsCount}/${totalStepsCount}`;
   const showJoinButton = squad.public && !squad.currentMember;
+  const firstItemClasses = 'order-5 tablet:order-1';
 
   return (
     <div
       {...props}
       className={classNames(
-        'no-scrollbar flex h-fit w-full flex-row justify-center gap-4 overflow-x-auto pr-4 tablet:w-auto tablet:pr-0',
+        'flex h-fit w-full flex-row flex-wrap justify-center gap-4 tablet:w-auto',
         className,
       )}
     >
@@ -61,7 +62,7 @@ export function SquadHeaderBar({
         <Button
           variant={ButtonVariant.Secondary}
           className={classNames(
-            'ml-14 tablet:ml-0',
+            firstItemClasses,
             tourIndex === TourScreenIndex.CopyInvitation && 'highlight-pulse',
           )}
           onClick={() => {
@@ -75,12 +76,19 @@ export function SquadHeaderBar({
       )}
       {showJoinButton && (
         <SquadJoinButton
-          className="flex w-full flex-1 tablet:ml-auto tablet:w-auto tablet:flex-initial"
+          className={classNames(
+            'flex w-full flex-1 tablet:ml-auto tablet:w-auto tablet:flex-initial',
+            firstItemClasses,
+          )}
           squad={squad}
           origin={Origin.SquadPage}
         />
       )}
-      <SquadMemberShortList squad={squad} members={members} />
+      <SquadMemberShortList
+        className="tablet:2 order-1"
+        squad={squad}
+        members={members}
+      />
       {!!squad.currentMember && (
         <SimpleTooltip
           forceLoad={!isTesting}
@@ -94,6 +102,7 @@ export function SquadHeaderBar({
         >
           <Button
             data-testid="squad-checklist-button"
+            className="tablet:3 order-2"
             variant={ButtonVariant.Float}
             icon={<ChecklistBIcon secondary size={IconSize.Small} />}
             onClick={() => {
@@ -110,6 +119,7 @@ export function SquadHeaderBar({
         >
           <Button
             data-testid="squad-notification-button"
+            className="tablet:4 order-3"
             variant={ButtonVariant.Float}
             icon={
               <BellIcon
@@ -128,6 +138,7 @@ export function SquadHeaderBar({
       )}
       <SimpleTooltip placement="top" content="Squad options">
         <Button
+          className="tablet:5 order-4"
           variant={ButtonVariant.Float}
           icon={<MenuIcon size={IconSize.Small} />}
           onClick={onMenuClick}

--- a/packages/shared/src/components/squads/SquadHeaderBar.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderBar.tsx
@@ -82,7 +82,7 @@ export function SquadHeaderBar({
         />
       )}
       <SquadMemberShortList
-        className="tablet:2 order-1"
+        className="order-1 tablet:order-2"
         squad={squad}
         members={members}
       />
@@ -99,7 +99,7 @@ export function SquadHeaderBar({
         >
           <Button
             data-testid="squad-checklist-button"
-            className="tablet:3 order-2"
+            className="order-2 tablet:order-3"
             variant={ButtonVariant.Float}
             icon={<ChecklistBIcon secondary size={IconSize.Small} />}
             onClick={() => {
@@ -116,7 +116,7 @@ export function SquadHeaderBar({
         >
           <Button
             data-testid="squad-notification-button"
-            className="tablet:4 order-3"
+            className="order-3 tablet:order-4"
             variant={ButtonVariant.Float}
             icon={
               <BellIcon
@@ -135,7 +135,7 @@ export function SquadHeaderBar({
       )}
       <SimpleTooltip placement="top" content="Squad options">
         <Button
-          className="tablet:5 order-4"
+          className="order-4 tablet:order-5"
           variant={ButtonVariant.Float}
           icon={<MenuIcon size={IconSize.Small} />}
           onClick={onMenuClick}

--- a/packages/shared/src/components/squads/SquadJoinButton.tsx
+++ b/packages/shared/src/components/squads/SquadJoinButton.tsx
@@ -14,8 +14,13 @@ import { UserShortProfile } from '../../lib/user';
 import { generateQueryKey, RequestKey } from '../../lib/query';
 import { AuthTriggers } from '../../lib/auth';
 
-type SquadJoinProps = {
-  className?: string;
+interface ClassName {
+  wrapper?: string;
+  button?: string;
+}
+
+interface SquadJoinProps {
+  className?: ClassName;
   squad: Squad;
   joinText?: string;
   leaveText?: string;
@@ -23,7 +28,7 @@ type SquadJoinProps = {
   origin: Origin;
   inviterMember?: Pick<UserShortProfile, 'id'>;
   onSuccess?: () => void;
-};
+}
 
 export const SimpleSquadJoinButton = <T extends 'a' | 'button'>({
   className,
@@ -74,7 +79,7 @@ export const SimpleSquadJoinButton = <T extends 'a' | 'button'>({
 };
 
 export const SquadJoinButton = ({
-  className,
+  className = {},
   squad,
   joinText = 'Join Squad',
   leaveText = 'Leave Squad',
@@ -157,13 +162,13 @@ export const SquadJoinButton = ({
       disabled={!isMemberBlocked}
       content={blockedTooltipText}
     >
-      <div>
+      <div className={className?.wrapper}>
         <SimpleSquadJoinButton
           {...rest}
           variant={
             isCurrentMember ? ButtonVariant.Secondary : ButtonVariant.Primary
           }
-          className={className}
+          className={className?.button}
           squad={squad}
           disabled={isMemberBlocked || isLoading}
           onClick={onLeaveSquad}

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -114,8 +114,8 @@ export function SquadPageHeader({
               {props.copy} Squad
               {isFeatured && (
                 <>
-                  <SparkleIcon className="absolute -top-2.5 right-0" />
-                  <SparkleIcon className="absolute -bottom-2.5 left-0" />
+                  <SparkleIcon className="absolute -top-2.5 right-0 animate-scale-down-pulse delay-[625ms]" />
+                  <SparkleIcon className="absolute -bottom-2.5 left-0 animate-scale-down-pulse" />
                 </>
               )}
             </Button>

--- a/packages/shared/tailwind.config.ts
+++ b/packages/shared/tailwind.config.ts
@@ -211,6 +211,16 @@ export default {
       blur: {
         20: '1.25rem',
       },
+      keyframes: {
+        'scale-down-pulse': {
+          '0%, 100%': { transform: 'scale(1)', opacity: '1' },
+          '50%': { transform: 'scale(0.7)', opacity: '0.5' },
+        },
+      },
+      animation: {
+        'scale-down-pulse':
+          'scale-down-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+      },
     },
     lineClamp: {
       1: '1',


### PR DESCRIPTION
## Changes
- [Add animation](https://dailydotdev.slack.com/archives/C069XNYMDGV/p1714371978328689?thread_ts=1714147361.826129&cid=C069XNYMDGV) on the sparkle based on Tomer's specs.
- [Fix the ordering](https://dailydotdev.slack.com/archives/C069XNYMDGV/p1714372075393149?thread_ts=1714022816.959379&cid=C069XNYMDGV) of the header items.

<img width="1376" alt="Screenshot 2024-04-29 at 11 24 22 PM" src="https://github.com/dailydotdev/apps/assets/13744167/8fbc62da-597a-433b-bd4f-60355fd6b615">
<img width="713" alt="Screenshot 2024-04-29 at 11 24 01 PM" src="https://github.com/dailydotdev/apps/assets/13744167/ddee283a-d08b-4206-958f-c7e02dd0c55c">

<img width="700" alt="Screenshot 2024-04-29 at 11 23 46 PM" src="https://github.com/dailydotdev/apps/assets/13744167/167645bd-f8d7-4f9b-8375-6af3bccba5f0">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
