### PR TITLE
feat: fixes for starwars theme on mobile

### DIFF
--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -103,7 +103,7 @@ function MainLayoutHeader({
       <SearchPanel
         className={{
           container: classNames(
-            'left-0 top-0 z-header mx-auto bg-background-default py-3 tablet:left-16 laptop:left-0 laptop:bg-transparent',
+            'left-0 top-0 z-header mx-auto py-3 tablet:left-16 laptop:left-0',
             isSearchPage
               ? 'absolute right-0 laptop:relative laptop:top-0'
               : 'hidden laptop:flex',

--- a/packages/shared/src/hooks/utils/useFeatureTheme.ts
+++ b/packages/shared/src/hooks/utils/useFeatureTheme.ts
@@ -42,17 +42,21 @@ export const useFeatureTheme = (): UseFeatureThemeResult | undefined => {
     }
 
     if (featureTheme?.cursor) {
-      bodyStyles.push(`cursor: url('${featureTheme.cursor}'), auto; }`);
+      bodyStyles.push(`cursor: url('${featureTheme.cursor}'), auto`);
     }
-    const body = `body { ${bodyStyles.join('; ')} }`;
+    let css = `body { ${bodyStyles.join('; ')} }`;
+
+    if (featureTheme?.[theme]?.body?.background) {
+      css = `${css} .modal { background: ${featureTheme[theme].body.background}; }`;
+    }
 
     const oldStyleElem = document.getElementById(id);
-    if (oldStyleElem?.innerText === body) {
+    if (oldStyleElem?.innerText === css) {
       // nothing to do, styles were alreay applied
       return;
     }
 
-    styleElement.textContent = body;
+    styleElement.textContent = css;
 
     if (oldStyleElem) {
       document.head.replaceChild(styleElement, oldStyleElem);


### PR DESCRIPTION
## Changes

- search bar had a background, we do not need to specify it, so I removed it
- modals now have the same background as body

<img width="416" alt="Screenshot 2024-04-30 at 17 20 37" src="https://github.com/dailydotdev/apps/assets/9974711/1610cbef-5456-41d5-a1a7-3a2b447a4337">

<img width="410" alt="Screenshot 2024-04-30 at 17 21 36" src="https://github.com/dailydotdev/apps/assets/9974711/943a7b74-4363-478a-b908-1a5d3f322399">
<img width="767" alt="Screenshot 2024-04-30 at 17 21 48" src="https://github.com/dailydotdev/apps/assets/9974711/da7b5136-65f0-43e9-adac-0683199b17d2">
<img width="1448" alt="Screenshot 2024-04-30 at 17 22 16" src="https://github.com/dailydotdev/apps/assets/9974711/fe9b18bf-0025-4012-8fdc-b24f5fc4b6da">

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-329 #done


### Preview domain
https://mi-329-starwars-mobile-fixes.preview.app.daily.dev