### PR TITLE
fix: do not update streak cache on posts that were read already

### DIFF
--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -46,7 +46,7 @@ export function PostContent({
     post,
   });
   const { onCopyPostLink, onReadArticle } = engagementActions;
-  const onSendViewPost = useViewPost();
+  const onSendViewPost = useViewPost(post);
 
   const hasNavigation = !!onPreviousPost || !!onNextPost;
   const isVideoType = isVideoPost(post);

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -40,7 +40,7 @@ function SquadPostContent({
   isPostPage,
 }: PostContentProps): ReactElement {
   const { user } = useAuthContext();
-  const onSendViewPost = useViewPost();
+  const onSendViewPost = useViewPost(post);
   const hasNavigation = !!onPreviousPost || !!onNextPost;
   const engagementActions = usePostContent({ origin, post });
   const { onReadArticle, onCopyPostLink } = engagementActions;

--- a/packages/shared/src/components/post/collection/CollectionPostContent.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPostContent.tsx
@@ -68,7 +68,7 @@ export const CollectionPostContent = ({
     onRemovePost,
   };
 
-  const onSendViewPost = useViewPost();
+  const onSendViewPost = useViewPost(post);
 
   useEffect(() => {
     if (!post?.id || !user?.id) {


### PR DESCRIPTION
## Changes

Do not update streak query cache when post is viewed, but was already read before.

Related issue:
https://dailydotdev.atlassian.net/browse/MI-230

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-230 #done


### Preview domain
https://mi-230-fix-streak-cache-read-posts.preview.app.daily.dev