### PR TITLE
fix: also trigger on `ready_for_review`

### DIFF
--- a/.github/workflows/add-preview-domain.yml
+++ b/.github/workflows/add-preview-domain.yml
@@ -2,7 +2,7 @@ name: Assign preview-domain
 on:
   # Trigger when a pull request is opened or reopened
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, ready_for_review]
 
 permissions:
   contents: read


### PR DESCRIPTION
Trigger preview domain on `ready_for_review` events, even though it should still work on a new draft PR...

### Preview domain
https://ombratteng-patch-1.preview.app.daily.dev