### PR TITLE
fix: streak popup updating with a delay

### DIFF
--- a/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
+++ b/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
@@ -83,10 +83,10 @@ export function ReadingStreakPopup({
     { staleTime: StaleTime.Default },
   );
 
-  const today = new Date();
-  const dateToday = today.getDate();
+  const dateToday = new Date().getDate();
 
   const streaks = useMemo(() => {
+    const today = new Date();
     const streakDays = getStreakDays(today);
 
     return streakDays.map((value) => {
@@ -102,9 +102,6 @@ export function ReadingStreakPopup({
         />
       );
     });
-    // we cannot depend on today here, since that changes on every render
-    // we depend on dateToday instead, which only changes on day change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [history, dateToday]);
 
   return (

--- a/packages/shared/src/hooks/post/useViewPost.ts
+++ b/packages/shared/src/hooks/post/useViewPost.ts
@@ -7,7 +7,6 @@ import { Post, sendViewPost } from '../../graphql/posts';
 import { generateQueryKey, RequestKey } from '../../lib/query';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { ReadingDay, UserStreak } from '../../graphql/users';
-import { getTodayTz } from '../../lib/dateFormat';
 
 export const useViewPost = (
   post: Post,
@@ -41,17 +40,8 @@ export const useViewPost = (
       const reading = client.getQueryData<ReadingDay[]>(readKey);
 
       if (reading) {
-        const timezoned = getTodayTz(user?.timezone || 'UTC');
-        const date = timezoned.toISOString().split('T')[0];
-        const index = reading.findIndex((read) => read.date === date);
-
-        if (index === -1) {
-          return client.setQueryData(readKey, [...reading, { date, reads: 1 }]);
-        }
-
-        const updatedReading = [...reading];
-        updatedReading[index].reads += 1;
-        return client.setQueryData(readKey, updatedReading);
+        // just mark the query as stale
+        await client.invalidateQueries(readKey);
       }
 
       return null;

--- a/packages/shared/src/lib/dateFormat.spec.ts
+++ b/packages/shared/src/lib/dateFormat.spec.ts
@@ -4,6 +4,7 @@ import {
   commentDateFormat,
   getReadHistoryDateFormat,
   isDateOnlyEqual,
+  getTodayTz,
 } from './dateFormat';
 
 const now = new Date(2020, 5, 1, 12, 0, 0);
@@ -121,5 +122,54 @@ describe('getReadHistoryDateFormat', () => {
     const date = new Date('2018-03-31 07:15:51.247');
     const actual = getReadHistoryDateFormat(date);
     expect(actual).toEqual(expected);
+  });
+});
+
+describe('getTodayTz', () => {
+  const mockDate = new Date('2024-01-01T00:00:00Z');
+
+  it('should return the current date in New York timezone', () => {
+    const date = getTodayTz('America/New_York', mockDate);
+    expect(date).toEqual(new Date('2023-12-31T19:00:00'));
+  });
+
+  it('should return the correct date in Berlin timezone', () => {
+    const date = getTodayTz('Europe/Berlin', mockDate);
+    expect(date).toEqual(new Date('2024-01-01T01:00:00'));
+  });
+
+  it('should return the correct date in India timezone', () => {
+    const date = getTodayTz('Asia/Kolkata', mockDate);
+    expect(date).toEqual(new Date('2024-01-01T05:30:00'));
+  });
+
+  it('should return the current date in UTC timezone', () => {
+    const date = getTodayTz('UTC', mockDate);
+    expect(date).toEqual(new Date('2024-01-01T00:00:00'));
+  });
+
+  it('should return the correct date in New York timezone during daylight saving time', () => {
+    const date = getTodayTz(
+      'America/New_York',
+      new Date('2024-03-11T00:00:00Z'),
+    );
+    expect(date).toEqual(new Date('2024-03-10T20:00:00'));
+  });
+
+  it('should return the correct date in Berlin timezone during daylight saving time', () => {
+    const date = getTodayTz('Europe/Berlin', new Date('2024-04-01T00:00:00Z'));
+    expect(date).toEqual(new Date('2024-04-01T02:00:00'));
+  });
+
+  it('should return same date as today if second argument is not supplied', () => {
+    const dateNow = new Date();
+    const date = getTodayTz('UTC');
+    expect(date.toISOString().slice(0, 10)).toEqual(
+      dateNow.toISOString().slice(0, 10),
+    );
+  });
+
+  it('should throw an error for invalid timezone', () => {
+    expect(() => getTodayTz('Invalid/Timezone')).toThrow();
   });
 });

--- a/packages/shared/src/lib/dateFormat.ts
+++ b/packages/shared/src/lib/dateFormat.ts
@@ -175,9 +175,8 @@ export enum Day {
 
 export const Weekends = [Day.Saturday, Day.Sunday];
 
-export const getTodayTz = (timeZone: string): Date => {
-  const now = new Date();
-  const timeZonedToday = now.toLocaleDateString('en', { timeZone });
+export const getTodayTz = (timeZone: string, now = new Date()): Date => {
+  const timeZonedToday = now.toLocaleString('en', { timeZone });
   return new Date(timeZonedToday);
 };
 


### PR DESCRIPTION
## Changes

Related slack thread: https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1714142180431059

Several issues found with streaks popup have been fixed:
- if user had browser tab opened after date change (midnight), popup would never update correctly, because the streakDays were calculated on the module
- memoization of streaks was not done correctly, because it used the consts defined on the module (as mentioned above)
- `getTodayTz` was giving incorrect dates, e.g. '2024-05-03T13:12:11+02:00' would result in `2024-05-02T00:00:00` on my machine, resulting in -1 day skew
- switched to invalidating of the query for streak history and rely on API call being done instead of calculating and filling the cache on the UI side

## Events

No new events

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [X] MobileL (420px)
- [X] Tablet (656px)
- [X] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-333 #done


### Preview domain
https://mi-333-fix-streaks-delay.preview.app.daily.dev