### PR TITLE
fix: back button now correctly refreshes route

### DIFF
--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -107,11 +107,8 @@ export const usePostModalNavigation = (
       return null;
     }
 
-    const routeHandler = (newRoute: string) => {
-      if (newRoute.includes('/posts/')) {
-        return;
-      }
-      onCloseModal();
+    const routeHandler = () => {
+      onCloseModal(true);
     };
     router.events.on('routeChangeStart', routeHandler);
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- looks like close handler for modal introduced issue with back button not working because `onCloseModal` changed history to interfere with Next.js router
- back button now works when you are navigating between multiple tag pages by constantly selecting them eg. go to /tags/php (select tag) -> /tags/javascript -> back -> /tags/php (before URL would change but the page would stay the same as if you are on javascript page)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-back-button-on-feed-pages.preview.app.daily.dev