### PR TITLE
hotfix: make whole a href clickable

### DIFF
--- a/packages/shared/src/components/fields/ContextMenu.tsx
+++ b/packages/shared/src/components/fields/ContextMenu.tsx
@@ -96,7 +96,11 @@ export default function ContextMenu({
           <Item className="typo-callout" onClick={action}>
             <ConditionalWrapper
               condition={!!anchorProps}
-              wrapper={(children) => <a {...anchorProps}>{children}</a>}
+              wrapper={(children) => (
+                <a className="w-full" {...anchorProps}>
+                  {children}
+                </a>
+              )}
             >
               <span className="flex w-full items-center gap-2 typo-callout">
                 {icon} {label}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- The current menu drawer a href was not spanning the whole width, this solves that issue making the whole line clickable

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://hotfix-make-a-clickable.preview.app.daily.dev