### PR TITLE
fix: search enrollment event

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -140,7 +140,10 @@ export default function MainFeedLayout({
     hasUser: !!user,
   });
   const feedVersion = useFeature(feature.feedVersion);
-  const searchVersion = useFeature(feature.searchVersion);
+  const { value: searchVersion } = useConditionalFeature({
+    feature: feature.searchVersion,
+    shouldEvaluate: isSearchOn && !!searchQuery,
+  });
   const { isUpvoted, isPopular, isSortableFeed } = useFeedName({ feedName });
   const {
     shouldUseMobileFeedLayout,

--- a/packages/shared/src/components/PostsSearch.tsx
+++ b/packages/shared/src/components/PostsSearch.tsx
@@ -67,7 +67,7 @@ export default function PostsSearch({
   const [items, setItems] = useState<string[]>([]);
   const { value: searchVersion } = useConditionalFeature({
     feature: feature.searchVersion,
-    shouldEvaluate: !!query,
+    shouldEvaluate: !!query && suggestionType === 'searchPostSuggestions',
   });
   const SEARCH_URL = SEARCH_TYPES[suggestionType];
 

--- a/packages/shared/src/components/PostsSearch.tsx
+++ b/packages/shared/src/components/PostsSearch.tsx
@@ -19,8 +19,8 @@ import {
 } from '../graphql/search';
 import { SEARCH_BOOKMARKS_SUGGESTIONS } from '../graphql/feed';
 import { SEARCH_READING_HISTORY_SUGGESTIONS } from '../graphql/users';
-import { useFeature } from './GrowthBookProvider';
 import { feature } from '../lib/featureManagement';
+import { useConditionalFeature } from '../hooks';
 
 const AutoCompleteMenu = dynamic(
   () =>
@@ -57,7 +57,6 @@ export default function PostsSearch({
   onFocus,
 }: PostsSearchProps): ReactElement {
   const searchBoxRef = useRef<HTMLDivElement>();
-  const searchVersion = useFeature(feature.searchVersion);
   const [initialQuery, setInitialQuery] = useState<string>();
   const [query, setQuery] = useState<string>();
   const [menuPosition, setMenuPosition] = useState<{
@@ -66,6 +65,10 @@ export default function PostsSearch({
     width: number;
   }>(null);
   const [items, setItems] = useState<string[]>([]);
+  const { value: searchVersion } = useConditionalFeature({
+    feature: feature.searchVersion,
+    shouldEvaluate: !!query,
+  });
   const SEARCH_URL = SEARCH_TYPES[suggestionType];
 
   const { data: searchResults, isLoading } = useQuery<{

--- a/packages/shared/src/hooks/search/useSearchProvider.ts
+++ b/packages/shared/src/hooks/search/useSearchProvider.ts
@@ -10,7 +10,7 @@ import {
 } from '../../graphql/search';
 import { useRequestProtocol } from '../useRequestProtocol';
 import { graphqlUrl } from '../../lib/config';
-import { useFeature } from '../../components/GrowthBookProvider';
+import { useFeaturesReadyContext } from '../../components/GrowthBookProvider';
 import { feature } from '../../lib/featureManagement';
 
 export type UseSearchProviderProps = {
@@ -46,7 +46,7 @@ const searchProviderExtractResultMap: Partial<
 export const useSearchProvider = (): UseSearchProvider => {
   const router = useRouter();
   const { requestMethod } = useRequestProtocol();
-  const searchVersion = useFeature(feature.searchVersion);
+  const { getFeatureValue } = useFeaturesReadyContext();
 
   return {
     search: useCallback(
@@ -66,6 +66,8 @@ export const useSearchProvider = (): UseSearchProvider => {
           };
         }
 
+        const searchVersion = getFeatureValue(feature.searchVersion);
+
         const result = await requestMethod(graphqlUrl, graphqlQuery, {
           query,
           version: searchVersion,
@@ -74,7 +76,7 @@ export const useSearchProvider = (): UseSearchProvider => {
 
         return resultExtractor(result);
       },
-      [requestMethod, searchVersion],
+      [getFeatureValue, requestMethod],
     ),
   };
 };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since this feature was created pre the new hooks and rules we didn't wait for enrollment
- This adjustment ensures we only enroll on query/search

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://as-296-search-enrollment.preview.app.daily.dev