### PR TITLE
fix: add empty screen

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -329,7 +329,7 @@ export default function PostOptionsMenu({
   });
   if (showSimilarPosts) {
     postOptions.push({
-      icon: <MenuIcon Icon={MagicIcon} secondary />,
+      icon: <MenuIcon Icon={MagicIcon} />,
       label: 'Show similar posts',
       anchorProps: {
         onClick: onClickSimilarPosts,

--- a/packages/shared/src/components/feeds/SimilarEmptyScreen.tsx
+++ b/packages/shared/src/components/feeds/SimilarEmptyScreen.tsx
@@ -1,0 +1,37 @@
+import React, { ReactElement } from 'react';
+import { FlexCentered } from '../utilities';
+import { MagicIcon } from '../icons';
+import { IconSize } from '../Icon';
+import { Post } from '../../graphql/posts';
+import { ButtonSize } from '../buttons/Button';
+import { TagLinks } from '../TagLinks';
+
+function SquadEmptyScreen({ post }: { post: Post }): ReactElement {
+  return (
+    <FlexCentered className="mt-20 w-full flex-col text-center">
+      <MagicIcon
+        size={IconSize.XXXLarge}
+        secondary
+        className="text-text-disabled"
+      />
+      <p className="my-4 font-bold text-text-primary typo-title2">
+        We couldn&apos;t find posts similar to &quot;{post?.title}&quot;
+      </p>
+      {post?.tags?.length > 0 && (
+        <>
+          <p className="text-text-tertiary typo-callout">
+            Try exploring some related tags instead:
+          </p>
+          <div className="mt-6 flex gap-3">
+            <TagLinks
+              tags={post.tags || []}
+              buttonProps={{ size: ButtonSize.Large }}
+            />
+          </div>
+        </>
+      )}
+    </FlexCentered>
+  );
+}
+
+export default SquadEmptyScreen;

--- a/packages/webapp/pages/posts/[id]/similar.tsx
+++ b/packages/webapp/pages/posts/[id]/similar.tsx
@@ -11,7 +11,10 @@ import {
 import { OtherFeedPage } from '@dailydotdev/shared/src/lib/query';
 import { SIMILAR_POSTS_FEED_QUERY } from '@dailydotdev/shared/src/graphql/feed';
 import Feed from '@dailydotdev/shared/src/components/Feed';
-import { FeedPageHeader } from '@dailydotdev/shared/src/components/utilities';
+import {
+  FeedPageHeader,
+  truncateTextClassNames,
+} from '@dailydotdev/shared/src/components/utilities';
 import {
   GetStaticPathsResult,
   GetStaticPropsContext,
@@ -22,6 +25,8 @@ import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
 import { ApiError } from '@dailydotdev/shared/src/graphql/common';
 import usePostById from '@dailydotdev/shared/src/hooks/usePostById';
 import SimilarEmptyScreen from '@dailydotdev/shared/src/components/feeds/SimilarEmptyScreen';
+import { GoBackHeaderMobile } from '@dailydotdev/shared/src/components/post/GoBackHeaderMobile';
+import classNames from 'classnames';
 import { getLayout } from '../../../components/layouts/FeedLayout';
 import { mainFeedLayoutProps } from '../../../components/layouts/MainFeedPage';
 import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
@@ -62,26 +67,37 @@ const SimilarFeed = ({ id, initialData }: Props): ReactElement => {
     return <Custom404 />;
   }
 
+  const Title = () => (
+    <h1
+      className={classNames('font-bold typo-callout', truncateTextClassNames)}
+    >
+      Posts similar to &quot;{post?.title}&quot;
+    </h1>
+  );
+
   return (
-    <FeedPageLayoutComponent className="overflow-x-hidden">
-      <NextSeo {...seo} />
-      <FeedPageHeader className="mb-5">
-        <h1 className="font-bold typo-callout">
-          Posts similar to &quot;{post?.title}&quot;
-        </h1>
-      </FeedPageHeader>
-      <Feed
-        feedName={OtherFeedPage.SimilarPosts}
-        feedQueryKey={[
-          'similarPostsFeed',
-          user?.id ?? 'anonymous',
-          Object.values(queryVariables),
-        ]}
-        query={id && SIMILAR_POSTS_FEED_QUERY}
-        emptyScreen={<SimilarEmptyScreen post={post} />}
-        variables={queryVariables}
-      />
-    </FeedPageLayoutComponent>
+    <>
+      <GoBackHeaderMobile>
+        <Title />
+      </GoBackHeaderMobile>
+      <FeedPageLayoutComponent className="overflow-x-hidden">
+        <NextSeo {...seo} />
+        <FeedPageHeader className="mb-5">
+          <Title />
+        </FeedPageHeader>
+        <Feed
+          feedName={OtherFeedPage.SimilarPosts}
+          feedQueryKey={[
+            'similarPostsFeed',
+            user?.id ?? 'anonymous',
+            Object.values(queryVariables),
+          ]}
+          query={id && SIMILAR_POSTS_FEED_QUERY}
+          emptyScreen={<SimilarEmptyScreen post={post} />}
+          variables={queryVariables}
+        />
+      </FeedPageLayoutComponent>
+    </>
   );
 };
 

--- a/packages/webapp/pages/posts/[id]/similar.tsx
+++ b/packages/webapp/pages/posts/[id]/similar.tsx
@@ -82,10 +82,12 @@ const SimilarFeed = ({ id, initialData }: Props): ReactElement => {
       </GoBackHeaderMobile>
       <FeedPageLayoutComponent className="overflow-x-hidden">
         <NextSeo {...seo} />
-        <FeedPageHeader className="mb-5">
-          <Title />
-        </FeedPageHeader>
         <Feed
+          header={
+            <FeedPageHeader className="mb-5">
+              <Title />
+            </FeedPageHeader>
+          }
           feedName={OtherFeedPage.SimilarPosts}
           feedQueryKey={[
             'similarPostsFeed',

--- a/packages/webapp/pages/posts/[id]/similar.tsx
+++ b/packages/webapp/pages/posts/[id]/similar.tsx
@@ -21,6 +21,7 @@ import request, { ClientError } from 'graphql-request';
 import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
 import { ApiError } from '@dailydotdev/shared/src/graphql/common';
 import usePostById from '@dailydotdev/shared/src/hooks/usePostById';
+import SimilarEmptyScreen from '@dailydotdev/shared/src/components/feeds/SimilarEmptyScreen';
 import { getLayout } from '../../../components/layouts/FeedLayout';
 import { mainFeedLayoutProps } from '../../../components/layouts/MainFeedPage';
 import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
@@ -77,6 +78,7 @@ const SimilarFeed = ({ id, initialData }: Props): ReactElement => {
           Object.values(queryVariables),
         ]}
         query={id && SIMILAR_POSTS_FEED_QUERY}
+        emptyScreen={<SimilarEmptyScreen post={post} />}
         variables={queryVariables}
       />
     </FeedPageLayoutComponent>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Added a empty state for similar posts
- Added a back navigation for mobile/tablet

<img width="1133" alt="Screenshot 2024-05-07 at 18 47 56" src="https://github.com/dailydotdev/apps/assets/554874/acde2993-232c-4f95-a209-933c8f21d641">
<img width="792" alt="Screenshot 2024-05-07 at 18 47 51" src="https://github.com/dailydotdev/apps/assets/554874/d3b5e7bb-f966-4f27-b9aa-d25f50166fcf">
<img width="360" alt="Screenshot 2024-05-07 at 18 47 45" src="https://github.com/dailydotdev/apps/assets/554874/33f2fe4a-b81b-4a2e-b250-0fa4cdf36038">
<img width="1237" alt="Screenshot 2024-05-07 at 15 48 07" src="https://github.com/dailydotdev/apps/assets/554874/0ac59004-303b-4b59-9c7c-5c8505625d8f">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-298 #done


### Preview domain
https://as-298-empty-state.preview.app.daily.dev