### PR TITLE
feat: add kformat to upvotes/comments

### DIFF
--- a/packages/extension/src/companion/CompanionEngagements.tsx
+++ b/packages/extension/src/companion/CompanionEngagements.tsx
@@ -3,6 +3,7 @@ import { PostBootData } from '@dailydotdev/shared/src/lib/boot';
 import { ClickableText } from '@dailydotdev/shared/src/components/buttons/ClickableText';
 import { useQueryClient } from '@tanstack/react-query';
 import { useRawBackgroundRequest } from '@dailydotdev/shared/src/hooks/companion';
+import { largeNumberFormat } from '@dailydotdev/shared/src/lib';
 
 interface CompanionEngagementsProps {
   post: PostBootData;
@@ -42,12 +43,13 @@ export function CompanionEngagements({
       {post.numUpvotes <= 0 && <span>Be the first to upvote</span>}
       {post.numUpvotes > 0 && (
         <ClickableText onClick={onUpvotesClick}>
-          {post.numUpvotes} Upvote{post.numUpvotes > 1 ? 's' : ''}
+          {largeNumberFormat(post.numUpvotes)} Upvote
+          {post.numUpvotes > 1 ? 's' : ''}
         </ClickableText>
       )}
       {post.numComments > 0 && (
         <span>
-          {post.numComments.toLocaleString()}
+          {largeNumberFormat(post.numComments)}
           {` Comment${post.numComments === 1 ? '' : 's'}`}
         </span>
       )}

--- a/packages/shared/src/components/InteractionCounter.tsx
+++ b/packages/shared/src/components/InteractionCounter.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useEffect, useState } from 'react';
 import { requestIdleCallback } from 'next/dist/client/request-idle-callback';
 import classNames from 'classnames';
+import { largeNumberFormat } from '../lib';
 
 export type InteractionCounterProps = {
   className?: string;
@@ -35,7 +36,7 @@ export default function InteractionCounter({
   if (shownValue === value) {
     return (
       <span className={elementClassName} {...props}>
-        {shownValue}
+        {largeNumberFormat(shownValue)}
       </span>
     );
   }
@@ -56,7 +57,7 @@ export default function InteractionCounter({
           animate ? '-translate-y-full opacity-0' : 'translate-y-0 opacity-100',
         )}
       >
-        {shownValue}
+        {largeNumberFormat(shownValue)}
       </span>
       <span
         className={classNames(
@@ -65,7 +66,7 @@ export default function InteractionCounter({
         )}
         onTransitionEnd={updateShownValue}
       >
-        {value}
+        {largeNumberFormat(value)}
       </span>
     </span>
   );

--- a/packages/shared/src/components/cards/PostMetadata.tsx
+++ b/packages/shared/src/components/cards/PostMetadata.tsx
@@ -6,6 +6,7 @@ import { Post } from '../../graphql/posts';
 import { PlayIcon } from '../icons';
 import { IconSize } from '../Icon';
 import { formatReadTime, TruncateText, DateFormat } from '../utilities';
+import { largeNumberFormat } from '../../lib';
 
 interface PostMetadataProps
   extends Pick<Post, 'createdAt' | 'readTime' | 'numUpvotes'> {
@@ -59,7 +60,7 @@ export default function PostMetadata({
       {(!!createdAt || showReadTime) && !!numUpvotes && <Separator />}
       {!!numUpvotes && (
         <span data-testid="numUpvotes">
-          {numUpvotes} upvote{numUpvotes > 1 ? 's' : ''}
+          {largeNumberFormat(numUpvotes)} upvote{numUpvotes > 1 ? 's' : ''}
         </span>
       )}
       {children}

--- a/packages/shared/src/components/cards/SimilarPosts/PostEngagementCounts.tsx
+++ b/packages/shared/src/components/cards/SimilarPosts/PostEngagementCounts.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import { separatorCharacter } from '../common';
+import { largeNumberFormat } from '../../../lib';
 
 interface PostEngagementCountsProps {
   upvotes: number;
@@ -18,9 +19,9 @@ export function PostEngagementCounts({
       className={classNames('truncate typo-footnote', className)}
       data-testid="post-engagements-count"
     >
-      {upvotes ? `${upvotes} Upvotes` : ''}
+      {upvotes ? `${largeNumberFormat(upvotes)} Upvotes` : ''}
       {upvotes && comments ? <> {separatorCharacter} </> : ''}
-      {comments ? `${comments} Comments` : ''}
+      {comments ? `${largeNumberFormat(comments)} Comments` : ''}
     </p>
   );
 }

--- a/packages/shared/src/components/comments/CommentActionButtons.tsx
+++ b/packages/shared/src/components/comments/CommentActionButtons.tsx
@@ -30,7 +30,7 @@ import OptionsButton from '../buttons/OptionsButton';
 import { SourcePermissions } from '../../graphql/sources';
 import { LazyModal } from '../modals/common/types';
 import { useLazyModal } from '../../hooks/useLazyModal';
-import { labels } from '../../lib';
+import { labels, largeNumberFormat } from '../../lib';
 import { useToastNotification } from '../../hooks/useToastNotification';
 import {
   VoteEntityPayload,
@@ -253,7 +253,8 @@ export default function CommentActionButtons({
             className="ml-auto"
             onClick={() => onShowUpvotes(comment.id, voteState.numUpvotes)}
           >
-            {voteState.numUpvotes} upvote{voteState.numUpvotes === 1 ? '' : 's'}
+            {largeNumberFormat(voteState.numUpvotes)} upvote
+            {voteState.numUpvotes === 1 ? '' : 's'}
           </ClickableText>
         </SimpleTooltip>
       )}

--- a/packages/shared/src/components/post/PostUpvotesCommentsCount.tsx
+++ b/packages/shared/src/components/post/PostUpvotesCommentsCount.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Post } from '../../graphql/posts';
 import { ClickableText } from '../buttons/ClickableText';
+import { largeNumberFormat } from '../../lib';
 
 interface PostUpvotesCommentsCountProps {
   post: Post;
@@ -23,15 +24,15 @@ export function PostUpvotesCommentsCount({
       className="mb-5 flex items-center gap-x-4 text-text-tertiary typo-callout"
       data-testid="statsBar"
     >
-      {post.views > 0 && <span>{post.views.toLocaleString()} Views</span>}
+      {post.views > 0 && <span>{largeNumberFormat(post.views)} Views</span>}
       {upvotes > 0 && (
         <ClickableText onClick={() => onUpvotesClick(upvotes)}>
-          {upvotes} Upvote{upvotes > 1 ? 's' : ''}
+          {largeNumberFormat(upvotes)} Upvote{upvotes > 1 ? 's' : ''}
         </ClickableText>
       )}
       {comments > 0 && (
         <span>
-          {comments.toLocaleString()}
+          {largeNumberFormat(comments)}
           {` Comment${comments === 1 ? '' : 's'}`}
         </span>
       )}

--- a/packages/shared/src/lib/numberFormat.ts
+++ b/packages/shared/src/lib/numberFormat.ts
@@ -1,4 +1,7 @@
 export function largeNumberFormat(value: number): string {
+  if (typeof value !== 'number') {
+    return null;
+  }
   let newValue = value;
   const suffixes = ['', 'K', 'M', 'B', 'T'];
   let suffixNum = 0;


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Format large numbers as kFormat (Mainly affected upvotes/comments

<img width="349" alt="Screenshot 2024-05-07 at 19 30 26" src="https://github.com/dailydotdev/apps/assets/554874/dd4da5b1-f006-4794-b458-5fc3f7459cd9">
<img width="266" alt="Screenshot 2024-05-07 at 19 35 50" src="https://github.com/dailydotdev/apps/assets/554874/9ce5bfad-60d6-4a31-8c0b-0f3bcde606c4">
<img width="347" alt="Screenshot 2024-05-07 at 20 06 32" src="https://github.com/dailydotdev/apps/assets/554874/3c583c4c-4684-4e38-a915-2103c6aacbf0">


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-309 #done
