### PR TITLE
fix: query 100 temporary for this experiment

### DIFF
--- a/packages/webapp/pages/posts/[id]/similar.tsx
+++ b/packages/webapp/pages/posts/[id]/similar.tsx
@@ -97,6 +97,7 @@ const SimilarFeed = ({ id, initialData }: Props): ReactElement => {
           query={id && SIMILAR_POSTS_FEED_QUERY}
           emptyScreen={<SimilarEmptyScreen post={post} />}
           variables={queryVariables}
+          pageSize={100}
         />
       </FeedPageLayoutComponent>
     </>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since the vector provider doesn't support proper pagination yet we decided to query 100 by default to run the experiment on.
- https://dailydotdev.slack.com/archives/C04UN615UAF/p1715151579135949?thread_ts=1715072074.942399&cid=C04UN615UAF

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://hotfix-query-100-for-similar-feed.preview.app.daily.dev