### PR TITLE
refactor: squads directory to fetch featured public squads only

### DIFF
--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -90,8 +90,8 @@ export const DELETE_SQUAD_MUTATION = gql`
 `;
 
 export const SQUAD_DIRECTORY_SOURCES = gql`
-  query Sources($filterOpenSquads: Boolean) {
-    sources(filterOpenSquads: $filterOpenSquads) {
+  query Sources($filterOpenSquads: Boolean, $featured: Boolean) {
+    sources(filterOpenSquads: $filterOpenSquads, featured: $featured) {
       pageInfo {
         endCursor
         hasNextPage

--- a/packages/webapp/pages/squads/index.tsx
+++ b/packages/webapp/pages/squads/index.tsx
@@ -69,6 +69,7 @@ const SquadsPage = ({ initialData }: Props): ReactElement => {
     ({ pageParam }) =>
       request(graphqlUrl, SQUAD_DIRECTORY_SOURCES, {
         filterOpenSquads: true,
+        featured: true,
         first: 100,
         after: pageParam,
       }),


### PR DESCRIPTION
## Changes
- In coordination with making the API accept a boolean property to filter by flags.
- Reference: https://github.com/dailydotdev/daily-api/pull/1902

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-348 #done


### Preview domain
https://mi-348.preview.app.daily.dev