### PR TITLE
fix: actually use pagination variable in MY_SQUADS_QUERY

### DIFF
--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -212,7 +212,7 @@ export const SQUAD_QUERY = gql`
 
 export const MY_SQUADS_QUERY = gql`
   query MySquads($first: Int!) {
-    mySourceMemberships(first: 100, type: squad) {
+    mySourceMemberships(first: $first, type: squad) {
       pageInfo {
         endCursor
         hasNextPage


### PR DESCRIPTION
## Changes

Fixed my own mistake - forgot to use the variable value in graphql query 🤦 

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-324 #done


### Preview domain
https://mi-324-hotfix.preview.app.daily.dev