### PR TITLE
MI-324 reapply loading squads from graphql

### DIFF
--- a/packages/extension/src/companion/App.tsx
+++ b/packages/extension/src/companion/App.tsx
@@ -31,14 +31,7 @@ const router = new CustomRouter();
 
 export type CompanionData = { url: string; deviceId: string } & Pick<
   Boot,
-  | 'postData'
-  | 'settings'
-  | 'alerts'
-  | 'user'
-  | 'visit'
-  | 'accessToken'
-  | 'squads'
-  | 'exp'
+  'postData' | 'settings' | 'alerts' | 'user' | 'visit' | 'accessToken' | 'exp'
 >;
 
 const app = BootApp.Companion;
@@ -52,7 +45,6 @@ export default function App({
   alerts,
   visit,
   accessToken,
-  squads,
   exp,
 }: CompanionData): ReactElement {
   useError();
@@ -102,7 +94,6 @@ export default function App({
               tokenRefreshed
               getRedirectUri={() => browser.runtime.getURL('index.html')}
               updateUser={() => null}
-              squads={squads}
             >
               <SettingsContextProvider settings={settings}>
                 <AlertContextProvider alerts={alerts}>

--- a/packages/extension/src/companion/Companion.spec.tsx
+++ b/packages/extension/src/companion/Companion.spec.tsx
@@ -77,7 +77,6 @@ const renderComponent = (postdata, settings): RenderResult => {
       user={defaultUser}
       deviceId="123"
       accessToken={{ token: '', expiresIn: '' }}
-      squads={[]}
     />,
   );
 };

--- a/packages/extension/src/newtab/ShortcutLinks.spec.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.spec.tsx
@@ -102,7 +102,6 @@ const defaultBootData: BootCacheData = {
   alerts: defaultAlerts,
   user: defaultUser,
   settings: defaultSettings,
-  squads: [],
   notifications: { unreadNotificationsCount: 0 },
 };
 

--- a/packages/shared/__tests__/fixture/squads.ts
+++ b/packages/shared/__tests__/fixture/squads.ts
@@ -1,6 +1,7 @@
 import { GraphQLResult } from '../helpers/graphql';
 import { Edge } from '../../src/graphql/common';
 import {
+  MySourcesData,
   SourceMember,
   SourceMemberRole,
   SourcePermissions,
@@ -415,3 +416,19 @@ export const generateMembersList = (
   },
   ...members,
 ];
+
+export const generateSquadsResult = (squads: Squad[]): MySourcesData => {
+  const edges: Edge<SourceMember>[] =
+    squads?.map((squad) => ({
+      node: {
+        source: squad,
+      },
+    })) ?? [];
+
+  return {
+    mySourceMemberships: {
+      edges,
+      pageInfo: { endCursor: 'dGltZToxNjc1MjYyMTM0NTY4', hasNextPage: false },
+    },
+  };
+};

--- a/packages/shared/src/components/Settings.spec.tsx
+++ b/packages/shared/src/components/Settings.spec.tsx
@@ -315,6 +315,7 @@ it('should mutate show weekly goals widget setting', () =>
       // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
       queryByText(el.parentElement, 'Show Weekly Goal widget'),
     ) as HTMLInputElement;
+    expect(checkbox).toBeDefined();
     fireEvent.click(checkbox);
   }));
 

--- a/packages/shared/src/components/ShareBar.spec.tsx
+++ b/packages/shared/src/components/ShareBar.spec.tsx
@@ -13,10 +13,15 @@ import ShareBar from './ShareBar';
 import Post from '../../__tests__/fixture/post';
 import { AuthContextProvider } from '../contexts/AuthContext';
 import loggedUser from '../../__tests__/fixture/loggedUser';
-import { generateTestSquad } from '../../__tests__/fixture/squads';
+import {
+  generateSquadsResult,
+  generateTestSquad,
+} from '../../__tests__/fixture/squads';
 import { getFacebookShareLink } from '../lib/share';
 import { LazyModalElement } from './modals/LazyModalElement';
 import { NotificationsContextProvider } from '../contexts/NotificationsContext';
+import { mockGraphQL } from '../../__tests__/helpers/graphql';
+import { MY_SQUADS_QUERY } from '../graphql/squads';
 
 const defaultPost = Post;
 Object.defineProperty(window, 'matchMedia', {
@@ -48,6 +53,11 @@ const squads = [generateTestSquad()];
 const renderComponent = (loggedIn = true, hasSquads = true): RenderResult => {
   const client = new QueryClient();
 
+  mockGraphQL({
+    request: { query: MY_SQUADS_QUERY, variables: { first: 100 } },
+    result: { data: generateSquadsResult(hasSquads ? squads : []) },
+  });
+
   return render(
     <QueryClientProvider client={client}>
       <AuthContextProvider
@@ -57,7 +67,6 @@ const renderComponent = (loggedIn = true, hasSquads = true): RenderResult => {
         getRedirectUri={jest.fn()}
         loadingUser={false}
         loadedUserFromCache
-        squads={hasSquads ? squads : []}
       >
         <NotificationsContextProvider>
           <LazyModalElement />

--- a/packages/shared/src/components/modals/ShareModal.spec.tsx
+++ b/packages/shared/src/components/modals/ShareModal.spec.tsx
@@ -16,8 +16,13 @@ import { Origin } from '../../lib/analytics';
 import Comment from '../../../__tests__/fixture/comment';
 import { getCommentHash } from '../../graphql/comments';
 import loggedUser from '../../../__tests__/fixture/loggedUser';
-import { generateTestSquad } from '../../../__tests__/fixture/squads';
+import {
+  generateSquadsResult,
+  generateTestSquad,
+} from '../../../__tests__/fixture/squads';
 import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import { mockGraphQL } from '../../../__tests__/helpers/graphql';
+import { MY_SQUADS_QUERY } from '../../graphql/squads';
 
 const defaultPost = Post;
 const defaultComment = Comment;
@@ -44,6 +49,11 @@ const renderComponent = (
   hasSquads = true,
   comment?,
 ): RenderResult => {
+  mockGraphQL({
+    request: { query: MY_SQUADS_QUERY, variables: { first: 100 } },
+    result: { data: generateSquadsResult(hasSquads ? squads : []) },
+  });
+
   return render(
     <TestBootProvider
       client={client}
@@ -54,7 +64,6 @@ const renderComponent = (
         getRedirectUri: jest.fn(),
         loadingUser: false,
         loadedUserFromCache: true,
-        squads: hasSquads ? squads : [],
       }}
     >
       <ShareModal

--- a/packages/shared/src/components/post/write/CreatePostButton.tsx
+++ b/packages/shared/src/components/post/write/CreatePostButton.tsx
@@ -14,6 +14,7 @@ import {
 import { PlusIcon } from '../../icons';
 import ConditionalWrapper from '../../ConditionalWrapper';
 import { SimpleTooltip } from '../../tooltips';
+import { useSquads } from '../../../hooks/squads/useSquads';
 
 interface CreatePostButtonProps {
   className?: string;
@@ -30,7 +31,8 @@ export function CreatePostButton({
   footer,
   onClick,
 }: CreatePostButtonProps): ReactElement {
-  const { user, squads } = useAuthContext();
+  const { user } = useAuthContext();
+  const { squads } = useSquads();
   const { route, query } = useRouter();
   const isLaptop = useViewSize(ViewSize.Laptop);
   const handle = route === '/squads/[handle]' ? (query.handle as string) : '';

--- a/packages/shared/src/components/post/write/SquadsDropdown.tsx
+++ b/packages/shared/src/components/post/write/SquadsDropdown.tsx
@@ -2,11 +2,11 @@ import React, { ReactElement } from 'react';
 import { SourceAvatar, SourceShortInfo } from '../../profile/source';
 import { ArrowIcon, SquadIcon } from '../../icons';
 import { Dropdown } from '../../fields/Dropdown';
-import { useAuthContext } from '../../../contexts/AuthContext';
 import { verifyPermission } from '../../../graphql/squads';
 import { SourcePermissions } from '../../../graphql/sources';
 import { ButtonSize } from '../../buttons/common';
 import { useViewSize, ViewSize } from '../../../hooks';
+import { useSquads } from '../../../hooks/squads/useSquads';
 
 interface SquadsDropdownProps {
   onSelect: (index: number) => void;
@@ -17,7 +17,7 @@ export function SquadsDropdown({
   onSelect,
   selected,
 }: SquadsDropdownProps): ReactElement {
-  const { squads } = useAuthContext();
+  const { squads } = useSquads();
   const isLaptop = useViewSize(ViewSize.Laptop);
   const activeSquads = squads?.filter(
     (squad) => squad?.active && verifyPermission(squad, SourcePermissions.Post),

--- a/packages/shared/src/components/sidebar/SquadSection.tsx
+++ b/packages/shared/src/components/sidebar/SquadSection.tsx
@@ -1,14 +1,14 @@
-import React, { ReactElement, useContext } from 'react';
+import React, { ReactElement } from 'react';
 import { ListIcon, SidebarMenuItem } from './common';
 import { Section, SectionCommonProps } from './Section';
 import { NewSquadIcon, DefaultSquadIcon, SourceIcon } from '../icons';
 import { Origin } from '../../lib/analytics';
 import { useSquadNavigation } from '../../hooks';
-import AuthContext from '../../contexts/AuthContext';
 import { SquadImage } from '../squads/SquadImage';
+import { useSquads } from '../../hooks/squads/useSquads';
 
 export function SquadSection(props: SectionCommonProps): ReactElement {
-  const { squads } = useContext(AuthContext);
+  const { squads } = useSquads();
   const { openNewSquad } = useSquadNavigation();
 
   const squadMenuItems: SidebarMenuItem[] = [

--- a/packages/shared/src/components/squads/SquadsToShare.tsx
+++ b/packages/shared/src/components/squads/SquadsToShare.tsx
@@ -3,12 +3,12 @@ import { verifyPermission } from '../../graphql/squads';
 import { SourcePermissions, Squad } from '../../graphql/sources';
 import SourceProfilePicture from '../profile/SourceProfilePicture';
 import { SocialShareButton } from '../widgets/SocialShareButton';
-import { useAuthContext } from '../../contexts/AuthContext';
 import { Origin } from '../../lib/analytics';
 import { PlusIcon } from '../icons';
 import { useSquadNavigation } from '../../hooks';
 import { ButtonColor, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { ProfileImageSize } from '../ProfilePicture';
+import { useSquads } from '../../hooks/squads/useSquads';
 
 interface SquadsToShareProps {
   isLoading?: boolean;
@@ -23,7 +23,7 @@ export function SquadsToShare({
   size = ButtonSize.Large,
   squadAvatarSize = 'xlarge',
 }: SquadsToShareProps): ReactElement {
-  const { squads } = useAuthContext();
+  const { squads } = useSquads();
   const { openNewSquad } = useSquadNavigation();
 
   const list = useMemo(

--- a/packages/shared/src/contexts/AuthContext.tsx
+++ b/packages/shared/src/contexts/AuthContext.tsx
@@ -16,7 +16,6 @@ import {
 import { AccessToken, Boot, Visit } from '../lib/boot';
 import { isCompanionActivated } from '../lib/element';
 import { AuthTriggers, AuthTriggersType } from '../lib/auth';
-import { Squad } from '../graphql/sources';
 import { checkIsExtension, isNullOrUndefined } from '../lib/func';
 
 export interface LoginState {
@@ -58,7 +57,6 @@ export interface AuthContextData {
   deleteAccount?: () => Promise<void>;
   refetchBoot?: () => Promise<QueryObserverResult<Boot>>;
   accessToken?: AccessToken;
-  squads?: Squad[];
   isAuthReady?: boolean;
 }
 const isExtension = checkIsExtension();
@@ -111,7 +109,6 @@ export type AuthContextProviderProps = {
   | 'loadedUserFromCache'
   | 'visit'
   | 'accessToken'
-  | 'squads'
 >;
 
 export const AuthContextProvider = ({
@@ -128,7 +125,6 @@ export const AuthContextProvider = ({
   isLegacyLogout,
   firstLoad,
   accessToken,
-  squads,
 }: AuthContextProviderProps): ReactElement => {
   const [loginState, setLoginState] = useState<LoginState | null>(null);
   const endUser = user && 'providers' in user ? user : null;
@@ -177,7 +173,6 @@ export const AuthContextProvider = ({
         refetchBoot,
         deleteAccount,
         accessToken,
-        squads,
       }}
     >
       {children}

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -64,7 +64,6 @@ const updateLocalBootData = (
     'notifications',
     'user',
     'lastModifier',
-    'squads',
     'exp',
   ]);
 
@@ -93,8 +92,7 @@ export const BootDataProvider = ({
     useState<Partial<BootCacheData>>();
   const [initialLoad, setInitialLoad] = useState<boolean>(null);
   const loadedFromCache = !!cachedBootData;
-  const { user, settings, alerts, notifications, squads } =
-    cachedBootData || {};
+  const { user, settings, alerts, notifications } = cachedBootData || {};
   const loggedUser = !!(user && 'providers' in user && user?.id);
   const {
     data: bootRemoteData,
@@ -205,7 +203,6 @@ export const BootDataProvider = ({
         isLegacyLogout={bootRemoteData?.isLegacyLogout}
         firstLoad={initialLoad}
         accessToken={bootRemoteData?.accessToken}
-        squads={squads}
       >
         <SettingsContextProvider
           settings={settings}

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -32,10 +32,10 @@ export type SourceMemberFlag = Partial<{
 }>;
 
 export interface SourceMember {
-  role: SourceMemberRole;
-  user: UserShortProfile;
+  role?: SourceMemberRole;
+  user?: UserShortProfile;
   source: Squad;
-  referralToken: string;
+  referralToken?: string;
   permissions?: SourcePermissions[];
   flags?: SourceMemberFlag;
 }
@@ -85,6 +85,10 @@ export interface Source {
 }
 
 export type SourceData = { source: Source };
+
+export interface MySourcesData {
+  mySourceMemberships: Connection<SourceMember>;
+}
 
 export const SOURCE_QUERY = gql`
   query Source($id: ID!) {

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -212,7 +212,7 @@ export const SQUAD_QUERY = gql`
 
 export const MY_SQUADS_QUERY = gql`
   query MySquads($first: Int!) {
-    mySourceMemberships(first: 100, type: squad) {
+    mySourceMemberships(first: $first, type: squad) {
       pageInfo {
         endCursor
         hasNextPage

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -1,8 +1,13 @@
 import request, { gql } from 'graphql-request';
-import { SOURCE_BASE_FRAGMENT, USER_SHORT_INFO_FRAGMENT } from './fragments';
+import {
+  SOURCE_BASE_FRAGMENT,
+  SOURCE_SHORT_INFO_FRAGMENT,
+  USER_SHORT_INFO_FRAGMENT,
+} from './fragments';
 import { graphqlUrl } from '../lib/config';
 import { Connection } from './common';
 import {
+  MySourcesData,
   Source,
   SourceMember,
   SourceMemberRole,
@@ -205,6 +210,30 @@ export const SQUAD_QUERY = gql`
   ${SOURCE_BASE_FRAGMENT}
 `;
 
+export const MY_SQUADS_QUERY = gql`
+  query MySquads($first: Int!) {
+    mySourceMemberships(first: 100, type: squad) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      edges {
+        node {
+          source {
+            ...SourceShortInfo
+            public
+            currentMember {
+              role
+              permissions
+            }
+          }
+        }
+      }
+    }
+  }
+  ${SOURCE_SHORT_INFO_FRAGMENT}
+`;
+
 export const SQUAD_STATIC_FIELDS_QUERY = gql`
   query Source($handle: ID!) {
     source(id: $handle) {
@@ -350,6 +379,20 @@ export async function getSquad(handle: string): Promise<Squad> {
   });
   return res.source;
 }
+
+export const getCurrentUserSquads =
+  (requestMethod: typeof request, queryKey: unknown[]) =>
+  async (): Promise<MySourcesData> => {
+    const res = await requestMethod<MySourcesData>(
+      graphqlUrl,
+      MY_SQUADS_QUERY,
+      {
+        first: 100,
+      },
+      { requestKey: JSON.stringify(queryKey) },
+    );
+    return res;
+  };
 
 export async function getSquadMembers(id: string): Promise<SourceMember[]> {
   const res = await request<SquadEdgesData>(graphqlUrl, SQUAD_MEMBERS_QUERY, {

--- a/packages/shared/src/hooks/notifications/usePromotionModal.ts
+++ b/packages/shared/src/hooks/notifications/usePromotionModal.ts
@@ -1,12 +1,12 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useLazyModal } from '../useLazyModal';
-import { useAuthContext } from '../../contexts/AuthContext';
 import { LazyModal } from '../../components/modals/common/types';
+import { useSquads } from '../squads/useSquads';
 
 export const usePromotionModal = (): void => {
   const { query, replace } = useRouter();
-  const { squads } = useAuthContext();
+  const { squads } = useSquads();
   const { openModal } = useLazyModal();
 
   useEffect(() => {

--- a/packages/shared/src/hooks/squads/useSquads.ts
+++ b/packages/shared/src/hooks/squads/useSquads.ts
@@ -1,0 +1,98 @@
+import { useQuery, useQueryClient, QueryKey } from '@tanstack/react-query';
+import { ClientError } from 'graphql-request';
+import { useMemo } from 'react';
+import { MySourcesData, Squad } from '../../graphql/sources';
+import { getCurrentUserSquads } from '../../graphql/squads';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
+import { useRequestProtocol } from '../useRequestProtocol';
+import { useBackgroundRequest } from '../companion';
+
+interface UseSquadsResult {
+  squads: Squad[];
+  isLoading: boolean;
+  isFetched: boolean;
+  error: ClientError | null;
+  addSquad: (squad: Squad) => Promise<void>;
+  updateSquad: (squad: Squad) => Promise<void>;
+  deleteSquad: (squadId: string) => Promise<void>;
+}
+
+const sortByName = (squads: Squad[]): Squad[] =>
+  [...squads].sort((a, b) =>
+    a.name.toLocaleLowerCase() > b.name.toLocaleLowerCase() ? 1 : -1,
+  );
+
+const getCached = async (
+  client: ReturnType<typeof useQueryClient>,
+  queryKey: QueryKey,
+): Promise<Squad[]> => {
+  return (await client.getQueryData<Squad[]>(queryKey)) || [];
+};
+
+export const useSquads = (): UseSquadsResult => {
+  const { user } = useAuthContext();
+  const client = useQueryClient();
+  const { requestMethod, isCompanion } = useRequestProtocol();
+  const queryKey = generateQueryKey(RequestKey.Squads, user);
+  useBackgroundRequest(queryKey, { enabled: isCompanion });
+
+  const { data, isLoading, isFetched, error } = useQuery<
+    MySourcesData,
+    ClientError
+  >(
+    queryKey,
+    getCurrentUserSquads(requestMethod, isCompanion ? queryKey : undefined),
+    {
+      enabled: !!user?.id,
+      staleTime: StaleTime.Default,
+    },
+  );
+
+  const squads: Squad[] = useMemo(
+    () =>
+      data?.mySourceMemberships?.edges
+        ?.map((edge) => edge.node.source)
+        ?.sort((a, b) =>
+          a.name.toLocaleLowerCase().localeCompare(b.name.toLocaleLowerCase()),
+        ) ?? [],
+    [data],
+  );
+
+  const addSquad = async (squad: Squad) => {
+    const currentSquads = await getCached(client, queryKey);
+
+    const squadExists = currentSquads.some((item) => item.id === squad.id);
+
+    if (squadExists) {
+      return;
+    }
+
+    const newSquads = sortByName([...currentSquads, squad]);
+    client.setQueryData<Squad[]>(queryKey, newSquads);
+  };
+
+  const deleteSquad = async (squadId: string) => {
+    const currentSquads = await getCached(client, queryKey);
+    const newSquads = currentSquads.filter((squad) => squad.id !== squadId);
+    client.setQueryData<Squad[]>(queryKey, newSquads);
+  };
+
+  const updateSquad = async (squad: Squad) => {
+    const currentSquads = await getCached(client, queryKey);
+    const newSquads = currentSquads?.map((cachedSquad) =>
+      squad.id !== cachedSquad.id ? cachedSquad : squad,
+    );
+    client.setQueryData<Squad[]>(queryKey, newSquads);
+  };
+
+  return {
+    squads,
+    isLoading,
+    isFetched,
+    error,
+    addSquad,
+    updateSquad,
+    deleteSquad,
+  };
+};

--- a/packages/shared/src/hooks/useBoot.ts
+++ b/packages/shared/src/hooks/useBoot.ts
@@ -1,7 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import request from 'graphql-request';
 import { BOOT_QUERY_KEY } from '../contexts/common';
-import { Squad } from '../graphql/sources';
 import { Boot } from '../lib/boot';
 import {
   MarketingCta,
@@ -11,51 +10,13 @@ import { CLEAR_MARKETING_CTA_MUTATION } from '../graphql/users';
 import { graphqlUrl } from '../lib/config';
 
 type UseBoot = {
-  addSquad: (squad: Squad) => void;
-  deleteSquad: (squadId: string) => void;
-  updateSquad: (squad: Squad) => void;
   getMarketingCta: (variant: MarketingCtaVariant) => MarketingCta | null;
   clearMarketingCta: (campaignId: string) => void;
 };
 
-const sortByName = (squads: Squad[]): Squad[] =>
-  [...squads].sort((a, b) =>
-    a.name.toLocaleLowerCase() > b.name.toLocaleLowerCase() ? 1 : -1,
-  );
-
 export const useBoot = (): UseBoot => {
   const client = useQueryClient();
   const getBootData = () => client.getQueryData<Boot>(BOOT_QUERY_KEY);
-
-  const addSquad = (squad: Squad) => {
-    const bootData = getBootData();
-    const currentSquads = bootData?.squads || [];
-    const squadExists = currentSquads.some((item) => item.id === squad.id);
-
-    if (squadExists) {
-      return;
-    }
-
-    const squads = sortByName([...currentSquads, squad]);
-    client.setQueryData<Boot>(BOOT_QUERY_KEY, { ...bootData, squads });
-  };
-
-  const deleteSquad = (squadId: string) => {
-    const bootData = getBootData();
-    const squads = bootData.squads?.filter((squad) => squad.id !== squadId);
-    client.setQueryData<Boot>(BOOT_QUERY_KEY, { ...bootData, squads });
-  };
-
-  const updateSquad = (squad: Squad) => {
-    const bootData = getBootData();
-    const squads = bootData.squads?.map((bootSquad) =>
-      squad.id !== bootSquad.id ? bootSquad : squad,
-    );
-    client.setQueryData<Boot>(BOOT_QUERY_KEY, {
-      ...bootData,
-      squads: sortByName(squads ?? []),
-    });
-  };
 
   const getMarketingCta = (
     variant: MarketingCtaVariant,
@@ -85,9 +46,6 @@ export const useBoot = (): UseBoot => {
   };
 
   return {
-    addSquad,
-    deleteSquad,
-    updateSquad,
     getMarketingCta,
     clearMarketingCta,
   };

--- a/packages/shared/src/hooks/useDeleteSquad.ts
+++ b/packages/shared/src/hooks/useDeleteSquad.ts
@@ -2,10 +2,10 @@ import { useContext, useMemo } from 'react';
 import { deleteSquad } from '../graphql/squads';
 import { Squad } from '../graphql/sources';
 import { PromptOptions, usePrompt } from './usePrompt';
-import { useBoot } from './useBoot';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../lib/analytics';
 import { ButtonColor } from '../components/buttons/Button';
+import { useSquads } from './squads/useSquads';
 
 interface UseDeleteSquadModal {
   onDeleteSquad: () => void;
@@ -22,7 +22,7 @@ export const useDeleteSquad = ({
 }: UseDeleteSquadProps): UseDeleteSquadModal => {
   const { trackEvent } = useContext(AnalyticsContext);
   const { showPrompt } = usePrompt();
-  const { deleteSquad: deleteCachedSquad } = useBoot();
+  const { deleteSquad: deleteCachedSquad } = useSquads();
 
   // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -43,7 +43,7 @@ export const useDeleteSquad = ({
         extra: JSON.stringify({ squad: squad.id }),
       });
       await deleteSquad(squad.id);
-      deleteCachedSquad(squad.id);
+      await deleteCachedSquad(squad.id);
       await callback?.();
     }
   };

--- a/packages/shared/src/hooks/useJoinSquad.ts
+++ b/packages/shared/src/hooks/useJoinSquad.ts
@@ -4,10 +4,10 @@ import { joinSquadInvitation, SquadInvitationProps } from '../graphql/squads';
 import { useAnalyticsContext } from '../contexts/AnalyticsContext';
 import { Squad } from '../graphql/sources';
 import { AnalyticsEvent } from '../lib/analytics';
-import { useBoot } from './useBoot';
 import { generateQueryKey, RequestKey } from '../lib/query';
 import { ActionType } from '../graphql/actions';
 import { useActions } from './useActions';
+import { useSquads } from './squads/useSquads';
 
 type UseJoinSquadProps = {
   squad: Pick<Squad, 'id' | 'handle'>;
@@ -21,7 +21,7 @@ export const useJoinSquad = ({
   referralToken,
 }: UseJoinSquadProps): UseJoinSquad => {
   const queryClient = useQueryClient();
-  const { addSquad } = useBoot();
+  const { addSquad } = useSquads();
   const { trackEvent } = useAnalyticsContext();
   const { completeAction } = useActions();
 
@@ -44,7 +44,7 @@ export const useJoinSquad = ({
       }),
     });
 
-    addSquad(result);
+    await addSquad(result);
 
     const queryKey = generateQueryKey(
       RequestKey.Squad,

--- a/packages/shared/src/hooks/useLeaveSquad.ts
+++ b/packages/shared/src/hooks/useLeaveSquad.ts
@@ -2,10 +2,10 @@ import { useCallback, useContext } from 'react';
 import { leaveSquad } from '../graphql/squads';
 import { Squad } from '../graphql/sources';
 import { PromptOptions, usePrompt } from './usePrompt';
-import { useBoot } from './useBoot';
 import AnalyticsContext from '../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../lib/analytics';
 import { ButtonColor } from '../components/buttons/Button';
+import { useSquads } from './squads/useSquads';
 
 type UseLeaveSquad = () => Promise<boolean>;
 
@@ -17,7 +17,7 @@ type UseLeaveSquadProps = {
 export const useLeaveSquad = ({ squad }: UseLeaveSquadProps): UseLeaveSquad => {
   const { trackEvent } = useContext(AnalyticsContext);
   const { showPrompt } = usePrompt();
-  const { deleteSquad: deleteCachedSquad } = useBoot();
+  const { deleteSquad: deleteCachedSquad } = useSquads();
 
   const onLeaveSquad = useCallback(async () => {
     const options: PromptOptions = {
@@ -36,7 +36,7 @@ export const useLeaveSquad = ({ squad }: UseLeaveSquadProps): UseLeaveSquad => {
         extra: JSON.stringify({ squad: squad.id }),
       });
       await leaveSquad(squad.id);
-      deleteCachedSquad(squad.id);
+      await deleteCachedSquad(squad.id);
     }
 
     return left;

--- a/packages/shared/src/lib/boot.ts
+++ b/packages/shared/src/lib/boot.ts
@@ -4,7 +4,6 @@ import { apiUrl } from './config';
 import { Alerts } from '../graphql/alerts';
 import { RemoteSettings } from '../graphql/settings';
 import { Post } from '../graphql/posts';
-import { Squad } from '../graphql/sources';
 import { decrypt } from '../components/crypto';
 import { MarketingCta } from '../components/cards/MarketingCta/common';
 
@@ -52,7 +51,6 @@ export type Boot = {
   visit: Visit;
   notifications: NotificationsBootData;
   settings: RemoteSettings;
-  squads: Squad[];
   postData?: PostBootData;
   isLegacyLogout?: boolean;
   exp?: {
@@ -66,13 +64,7 @@ export type Boot = {
 
 export type BootCacheData = Pick<
   Boot,
-  | 'user'
-  | 'alerts'
-  | 'settings'
-  | 'postData'
-  | 'notifications'
-  | 'squads'
-  | 'exp'
+  'user' | 'alerts' | 'settings' | 'postData' | 'notifications' | 'exp'
 > & { lastModifier?: string };
 
 export async function getBootData(app: string, url?: string): Promise<Boot> {

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -75,6 +75,7 @@ export enum RequestKey {
   PostCommentsMutations = 'post_comments_mutations',
   Actions = 'actions',
   Squad = 'squad',
+  Squads = 'squads',
   SquadMembers = 'squad_members',
   Search = 'search',
   SearchHistory = 'searchHistory',

--- a/packages/webapp/__tests__/SquadFeedPage.tsx
+++ b/packages/webapp/__tests__/SquadFeedPage.tsx
@@ -29,15 +29,18 @@ import {
   generateMembersList,
   generateMembersResult,
   generateNotFoundSquadResult,
+  generateSquadsResult,
   generateTestSquad,
 } from '@dailydotdev/shared/__tests__/fixture/squads';
 import {
+  MY_SQUADS_QUERY,
   SQUAD_MEMBERS_QUERY,
   SQUAD_QUERY,
   SquadData,
   SquadEdgesData,
 } from '@dailydotdev/shared/src/graphql/squads';
 import {
+  MySourcesData,
   SourceMemberRole,
   SourcePermissions,
   Squad,
@@ -131,6 +134,13 @@ const createSourceMembersMock = (
   result: { data: result },
 });
 
+const getSquadsMock = (
+  result = generateSquadsResult([defaultSquad]),
+): MockedGraphQLResponse<MySourcesData> => ({
+  request: { query: MY_SQUADS_QUERY, variables: { first: 100 } },
+  result: { data: result },
+});
+
 let client: QueryClient;
 
 const renderComponent = (
@@ -139,9 +149,9 @@ const renderComponent = (
     createSourceMock(handle),
     createSourceMembersMock(),
     createFeedMock(),
+    getSquadsMock(),
   ],
   user: LoggedUser = defaultUser,
-  squads = [defaultSquad],
 ): RenderResult => {
   client = new QueryClient();
 
@@ -151,7 +161,7 @@ const renderComponent = (
   return render(
     <TestBootProvider
       client={client}
-      auth={{ user, squads }}
+      auth={{ user }}
       notification={{
         app: BootApp.Webapp,
         isNotificationsReady: true,

--- a/packages/webapp/__tests__/SquadTokenPage.tsx
+++ b/packages/webapp/__tests__/SquadTokenPage.tsx
@@ -102,7 +102,6 @@ const renderComponent = (
           tokenRefreshed: true,
           getRedirectUri: jest.fn(),
           closeLogin: jest.fn(),
-          squads: [],
         }}
       >
         <SettingsContext.Provider value={defaultTestSettings}>

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -17,13 +17,15 @@ import { WritePostContextProvider } from '@dailydotdev/shared/src/contexts';
 import { verifyPermission } from '@dailydotdev/shared/src/graphql/squads';
 import { SourcePermissions } from '@dailydotdev/shared/src/graphql/sources';
 import { ShareLink } from '@dailydotdev/shared/src/components/post/write/ShareLink';
+import { useSquads } from '@dailydotdev/shared/src/hooks/squads/useSquads';
 import { getLayout as getMainLayout } from '../../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
 
 function EditPost(): ReactElement {
   const { query, isReady, push } = useRouter();
   const { post, isLoading } = usePostById({ id: query.id as string });
-  const { squads, user } = useAuthContext();
+  const { user } = useAuthContext();
+  const { squads } = useSquads();
   const squad = squads?.find(({ id, handle }) =>
     [id, handle].includes(post?.source?.id),
   );

--- a/packages/webapp/pages/squads/[handle]/edit.tsx
+++ b/packages/webapp/pages/squads/[handle]/edit.tsx
@@ -5,7 +5,6 @@ import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import Unauthorized from '@dailydotdev/shared/src/components/errors/Unauthorized';
 import { SquadDetails } from '@dailydotdev/shared/src/components/squads/Details';
 import { SquadForm, editSquad } from '@dailydotdev/shared/src/graphql/squads';
-import { useBoot } from '@dailydotdev/shared/src/hooks/useBoot';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
 import {
   ManageSquadPageContainer,
@@ -31,6 +30,7 @@ import {
   generateQueryKey,
   RequestKey,
 } from '@dailydotdev/shared/src/lib/query';
+import { useSquads } from '@dailydotdev/shared/src/hooks/squads/useSquads';
 import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
 import { getLayout as getMainLayout } from '../../../components/layouts/MainLayout';
 
@@ -46,14 +46,15 @@ const seo: NextSeoProps = {
 
 const EditSquad = ({ handle }: EditSquadPageProps): ReactElement => {
   const { isReady: isRouteReady } = useRouter();
-  const { squads, user, isAuthReady, isFetched } = useAuthContext();
+  const { user, isAuthReady, isFetched } = useAuthContext();
+  const { squads } = useSquads();
   const {
     squad,
     isLoading: isSquadLoading,
     isForbidden,
   } = useSquad({ handle });
   const queryClient = useQueryClient();
-  const { updateSquad } = useBoot();
+  const { updateSquad } = useSquads();
   const { displayToast } = useToastNotification();
 
   const onSubmit = async (e, form: SquadForm) => {
@@ -75,7 +76,7 @@ const EditSquad = ({ handle }: EditSquadPageProps): ReactElement => {
         editedSquad.handle,
       );
       await queryClient.invalidateQueries(queryKey);
-      updateSquad(editedSquad);
+      await updateSquad(editedSquad);
       displayToast('The Squad has been updated');
     }
   };

--- a/packages/webapp/pages/squads/create.tsx
+++ b/packages/webapp/pages/squads/create.tsx
@@ -22,6 +22,7 @@ import Unauthorized from '@dailydotdev/shared/src/components/errors/Unauthorized
 import { verifyPermission } from '@dailydotdev/shared/src/graphql/squads';
 import { SourcePermissions } from '@dailydotdev/shared/src/graphql/sources';
 import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
+import { useSquads } from '@dailydotdev/shared/src/hooks/squads/useSquads';
 import { getLayout as getMainLayout } from '../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 
@@ -38,7 +39,8 @@ enum WriteFormTab {
 
 function CreatePost(): ReactElement {
   const { push, isReady: isRouteReady, query } = useRouter();
-  const { squads, user, isAuthReady, isFetched } = useAuthContext();
+  const { user, isAuthReady, isFetched } = useAuthContext();
+  const { squads } = useSquads();
   const [selected, setSelected] = useState(-1);
   const activeSquads = squads?.filter(
     (squad) => squad?.active && verifyPermission(squad, SourcePermissions.Post),

--- a/packages/webapp/pages/squads/index.tsx
+++ b/packages/webapp/pages/squads/index.tsx
@@ -43,6 +43,7 @@ import {
 } from '@dailydotdev/shared/src/hooks';
 import { Origin } from '@dailydotdev/shared/src/lib/analytics';
 import CustomAuthBanner from '@dailydotdev/shared/src/components/auth/CustomAuthBanner';
+import { useSquads } from '@dailydotdev/shared/src/hooks/squads/useSquads';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
 import FeedLayout, { getLayout } from '../../components/layouts/FeedLayout';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
@@ -61,7 +62,8 @@ const seo: NextSeoProps = {
 };
 
 const SquadsPage = ({ initialData }: Props): ReactElement => {
-  const { user, squads } = useContext(AuthContext);
+  const { user } = useContext(AuthContext);
+  const { squads } = useSquads();
   const { openNewSquad } = useSquadNavigation();
 
   const queryResult = useInfiniteQuery(

--- a/packages/webapp/pages/squads/new.tsx
+++ b/packages/webapp/pages/squads/new.tsx
@@ -6,7 +6,6 @@ import Unauthorized from '@dailydotdev/shared/src/components/errors/Unauthorized
 import { SquadDetails } from '@dailydotdev/shared/src/components/squads/Details';
 import AnalyticsContext from '@dailydotdev/shared/src/contexts/AnalyticsContext';
 import { SquadForm, createSquad } from '@dailydotdev/shared/src/graphql/squads';
-import { useBoot } from '@dailydotdev/shared/src/hooks/useBoot';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
 import { AnalyticsEvent } from '@dailydotdev/shared/src/lib/analytics';
 import {
@@ -16,6 +15,7 @@ import {
 import { MangeSquadPageSkeleton } from '@dailydotdev/shared/src/components/squads/MangeSquadPageSkeleton';
 import { ActionType } from '@dailydotdev/shared/src/graphql/actions';
 import { useActions } from '@dailydotdev/shared/src/hooks/useActions';
+import { useSquads } from '@dailydotdev/shared/src/hooks/squads/useSquads';
 import { getLayout as getMainLayout } from '../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 
@@ -32,7 +32,7 @@ const NewSquad = (): ReactElement => {
   const { user, isAuthReady, isFetched } = useAuthContext();
   const { trackEvent } = useContext(AnalyticsContext);
   const { displayToast } = useToastNotification();
-  const { addSquad } = useBoot();
+  const { addSquad } = useSquads();
   const { completeAction } = useActions();
 
   const onCreate = async (e, newSquadForm: SquadForm) => {
@@ -46,7 +46,7 @@ const NewSquad = (): ReactElement => {
         event_name: AnalyticsEvent.CompleteSquadCreation,
       });
 
-      addSquad(newSquad);
+      await addSquad(newSquad);
       completeAction(ActionType.CreateSquad);
 
       await router.replace(newSquad.permalink);


### PR DESCRIPTION
## Changes

Related PRs:
- https://github.com/dailydotdev/apps/pull/3084
- https://github.com/dailydotdev/apps/pull/3096

Reintroducing the reverted code. Tested in production, that it works as intended.

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [X] Have you done sanity checks in the extension?
- [X] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-324 #done


### Preview domain
https://mi-324-reapply-loading-squads-from-graphql.preview.app.daily.dev