### PR TITLE
fix: allow for toggling sources via content curation

### DIFF
--- a/packages/shared/src/components/filters/FeedFilters.tsx
+++ b/packages/shared/src/components/filters/FeedFilters.tsx
@@ -12,7 +12,7 @@ import { Source } from '../../graphql/sources';
 
 enum FilterMenuTitle {
   Tags = 'Manage tags',
-  Advanced = 'Advanced',
+  ManageCategories = 'Manage categories',
   ContentTypes = 'Content types',
   Blocked = 'Blocked items',
 }
@@ -49,7 +49,7 @@ export default function FeedFilters(props: FeedFiltersProps): ReactElement {
       options: { icon: <HashtagIcon /> },
     },
     {
-      title: FilterMenuTitle.Advanced,
+      title: FilterMenuTitle.ManageCategories,
       options: { icon: <FilterIcon /> },
     },
     {
@@ -77,7 +77,7 @@ export default function FeedFilters(props: FeedFiltersProps): ReactElement {
           <Modal.Body view={FilterMenuTitle.Tags}>
             <TagsFilter tagCategoryLayout={TagCategoryLayout.Settings} />
           </Modal.Body>
-          <Modal.Body view={FilterMenuTitle.Advanced}>
+          <Modal.Body view={FilterMenuTitle.ManageCategories}>
             <AdvancedSettingsFilter />
           </Modal.Body>
           <Modal.Body view={FilterMenuTitle.ContentTypes}>

--- a/packages/shared/src/graphql/feedSettings.ts
+++ b/packages/shared/src/graphql/feedSettings.ts
@@ -1,9 +1,12 @@
 import { gql } from 'graphql-request';
 import { Source } from './sources';
+import { SOURCE_SHORT_INFO_FRAGMENT } from './fragments';
 
 export enum AdvancedSettingsGroup {
   Advanced = 'advanced',
   ContentTypes = 'content_types',
+  ContentCuration = 'content_curation',
+  ContentSource = 'content_source',
 }
 
 export interface AdvancedSettings {
@@ -12,6 +15,10 @@ export interface AdvancedSettings {
   description: string;
   defaultEnabledState: boolean;
   group: AdvancedSettingsGroup;
+  options?: {
+    source?: Source;
+    type?: string;
+  };
 }
 
 export interface FeedAdvancedSettings {
@@ -97,8 +104,15 @@ export const FEED_SETTINGS_QUERY = gql`
       description
       defaultEnabledState
       group
+      options {
+        source {
+          ...SourceShortInfo
+        }
+        type
+      }
     }
   }
+  ${SOURCE_SHORT_INFO_FRAGMENT}
 `;
 
 export const FEED_FILTERS_FROM_REGISTRATION = gql`


### PR DESCRIPTION
## Changes

### Describe what this PR does
- New format to use `content_curation` and `content_source` for advanced settings.
- Blocked by: https://github.com/dailydotdev/daily-api/pull/1904
- Blocked by: manual query to insert these new advanced settings

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-313 #done
