### PR TITLE
fix(squads): match query in ssr to avoid pre-render difference

### DIFF
--- a/packages/webapp/pages/squads/index.tsx
+++ b/packages/webapp/pages/squads/index.tsx
@@ -218,6 +218,7 @@ export async function getStaticProps(): Promise<GetStaticPropsResult<Props>> {
   try {
     const initialData = await request(graphqlUrl, SQUAD_DIRECTORY_SOURCES, {
       filterOpenSquads: true,
+      featured: true,
       first: 100,
       after: undefined,
     });


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Missing param results in different query fired during ssr pre-rendering

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-squads-ssr.preview.app.daily.dev