### PR TITLE
chore: remove `post-scraper-one-ai` from Tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -2,7 +2,6 @@ load('ext://uibutton', 'cmd_button', 'location')
 
 include('../daily-api/Tiltfile')
 include('../heimdall/Tiltfile')
-include('../post-scraper-one-ai/Tiltfile')
 
 def get_daily_dir(app=""):
   parent = os.path.dirname(os.getcwd())


### PR DESCRIPTION
Deprecated, so not needed locally

### Preview domain
https://ombratteng-patch-1.preview.app.daily.dev