### PR TITLE
fix: squad graphql query

### DIFF
--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -23,7 +23,6 @@ export const USER_SHORT_INFO_FRAGMENT = gql`
     permalink
     username
     bio
-    createdAt
     reputation
   }
 `;

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -483,6 +483,7 @@ export const DEV_CARD_QUERY = gql`
       id
       user {
         ...UserShortInfo
+        createdAt
         cover
       }
       createdAt


### PR DESCRIPTION
## Changes

[More details on slack](https://dailydotdev.slack.com/archives/C06CUKX1P3N/p1715760110448429)

TLDR: our graphorm implementation cannot deal with children having timestamps without timezone. The `createdAt` field on `UserShortInfo` fragment was added to serve devcard requests. Easy fix was to remove the `createdAt` from the fragment and add the field directly to the devcard request. This is the easy fix.

Root cause fix would be to fix the graphorm implementation, but that's out of scope of public squad work.

## Manual Testing

### On those affected packages:
- [X] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android


### Preview domain
https://fix-squad-graphql-query.preview.app.daily.dev