### PR TITLE
chore: cleanup video support onboarding page

### DIFF
--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -22,9 +22,7 @@ const feature = {
   bookmarkOnCard: new Feature('bookmark_on_card', false),
   onboardingVisual: new Feature('onboarding_visual', {
     showCompanies: true,
-    poster: cloudinary.onboarding.video.poster,
-    webm: cloudinary.onboarding.video.webm,
-    mp4: cloudinary.onboarding.video.mp4,
+    image: cloudinary.onboarding.default,
   }),
   forceRefresh: new Feature('force_refresh', false),
   feedAdSpot: new Feature('feed_ad_spot', 0),

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -144,12 +144,8 @@ export const cloudinary = {
   },
   onboarding: {
     glow: 'https://daily-now-res.cloudinary.com/image/upload/v1694596741/Glow_o9ehvn.svg',
-    video: {
-      poster:
-        'https://daily-now-res.cloudinary.com/image/upload/s--MKLW6QIT--/f_auto/v1695808608/daily.dev_onboarding_wall_image_mewo9v',
-      mp4: 'https://daily-now-res.cloudinary.com/video/upload/v1695807779/daily.dev_onboarding_wall_video_qzmrzm.mp4',
-      webm: 'https://daily-now-res.cloudinary.com/video/upload/v1695808184/daily.dev_onboarding_wall_video_qzmrzm_iroigf.webm',
-    },
+    default:
+      'https://daily-now-res.cloudinary.com/image/upload/s--eQyhCzPZ--/f_auto/v1715169755/Master_image_mzjgot',
   },
   generic: {
     notFound: {

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -117,9 +117,6 @@ export function OnboardPage(): ReactElement {
   type OnboardingVisual = {
     showCompanies?: boolean;
     image?: string;
-    poster?: string;
-    webm?: string;
-    mp4?: string;
   };
   const isMobile = useViewSize(ViewSize.MobileL);
   const onboardingVisual: OnboardingVisual = useFeature(
@@ -338,31 +335,14 @@ export function OnboardPage(): ReactElement {
                 'tablet:min-h-[800px]:pt-[100%] relative overflow-y-clip tablet:overflow-y-visible tablet:pt-[80%]',
               )}
             >
-              {onboardingVisual?.poster ? (
-                // eslint-disable-next-line jsx-a11y/media-has-caption
-                <video
-                  loop
-                  autoPlay
-                  muted
-                  className={classNames(
-                    'tablet:absolute tablet:left-0 tablet:top-0 tablet:-z-1',
-                    styles.video,
-                  )}
-                  poster={onboardingVisual.poster}
-                >
-                  <source src={onboardingVisual.webm} type="video/webm" />
-                  <source src={onboardingVisual.mp4} type="video/mp4" />
-                </video>
-              ) : (
-                <img
-                  src={onboardingVisual.image}
-                  alt="Onboarding cover"
-                  className={classNames(
-                    'relative tablet:absolute tablet:left-0 tablet:top-0 tablet:-z-1',
-                    styles.image,
-                  )}
-                />
-              )}
+              <img
+                src={onboardingVisual.image}
+                alt="Onboarding cover"
+                className={classNames(
+                  'relative tablet:absolute tablet:left-0 tablet:top-0 tablet:-z-1',
+                  styles.image,
+                )}
+              />
             </div>
             {onboardingVisual.showCompanies && (
               <TrustedCompanies className="hidden tablet:block" />
@@ -392,7 +372,7 @@ export function OnboardPage(): ReactElement {
   }
 
   return (
-    <div className="z-3 flex h-full max-h-screen min-h-screen w-full flex-1 flex-col items-center overflow-x-hidden bg-[#0e1019]">
+    <div className="z-3 flex h-full max-h-screen min-h-screen w-full flex-1 flex-col items-center overflow-x-hidden">
       <NextSeo {...seo} titleTemplate="%s | daily.dev" />
       <PixelTracking />
       <GtagTracking />


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We decided to no longer support video on onboarding page

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-326 #done


### Preview domain
https://as-326-cleanup-video-support.preview.app.daily.dev