### PR TITLE
fix: similar post empty state text

### DIFF
--- a/packages/shared/src/components/feeds/SimilarEmptyScreen.tsx
+++ b/packages/shared/src/components/feeds/SimilarEmptyScreen.tsx
@@ -15,7 +15,9 @@ function SquadEmptyScreen({ post }: { post: Post }): ReactElement {
         className="text-text-disabled"
       />
       <p className="my-4 font-bold text-text-primary typo-title2">
-        We couldn&apos;t find posts similar to &quot;{post?.title}&quot;
+        {post?.title
+          ? `We couldn't find posts similar to "${post?.title}"`
+          : `We couldn't find any similar posts`}
       </p>
       {post?.tags?.length > 0 && (
         <>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Request to show different text if post title is not available/found.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-333 #done


### Preview domain
https://as-333-similar-post-empty-state.preview.app.daily.dev