### PR TITLE
fix: clicking the alert's close button submits form

### DIFF
--- a/packages/shared/src/components/alert/AlertPointer.tsx
+++ b/packages/shared/src/components/alert/AlertPointer.tsx
@@ -129,6 +129,7 @@ export default function AlertPointer({
             onClick={onClose}
             size={ButtonSize.XSmall}
             className="absolute right-2 top-2"
+            type="button"
           />
         </AlertPointerMessage>
       </AlertPointerContainer>


### PR DESCRIPTION
## Changes
- Noticed an issue when writing a post. After clicking the dismiss (close) button on the Alert, it submits the form.
- On regular buttons, lint always tells to add a type on buttons. We can maybe incorporate it into our Button component.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

#done


### Preview domain
https://fix-alert-close.preview.app.daily.dev