### PR TITLE
Feat new fb event

### DIFF
--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -207,6 +207,9 @@ function AuthOptions({
         onSignBackLogin(data.user as LoggedUser, provider as SignBackProvider);
       }
 
+      console.log('user?.experienceLevel at valid registration: ', data, user);
+      trackAnalyticsSignUp({ experienceLevel: data?.user?.experienceLevel });
+
       await syncSettings(data?.user?.id);
       onSetActiveDisplay(AuthDisplay.EmailSent);
       onSuccessfulRegistration?.();

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -210,6 +210,8 @@ function AuthOptions({
       // trackAnalyticsSignUp({ experienceLevel: data?.user?.experienceLevel });
 
       await syncSettings(data?.user?.id);
+      console.log('user?.experienceLevel at valid registration: ', data, user);
+
       onSetActiveDisplay(AuthDisplay.EmailSent);
       onSuccessfulRegistration?.(data);
     },
@@ -239,6 +241,8 @@ function AuthOptions({
   });
   const onProfileSuccess = async () => {
     await refetchBoot();
+    console.log('user?.experienceLevel at profile success: ', data, user);
+
     onSuccessfulRegistration?.();
     onClose?.(null, true);
   };

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -89,7 +89,7 @@ export interface AuthOptionsProps {
   onClose?: CloseAuthModalFunc;
   onAuthStateUpdate?: (props: Partial<AuthProps>) => void;
   onSuccessfulLogin?: () => unknown;
-  onSuccessfulRegistration?: () => unknown;
+  onSuccessfulRegistration?: (data: unknown) => unknown;
   formRef: MutableRefObject<HTMLFormElement>;
   trigger: AuthTriggersType;
   defaultDisplay?: AuthDisplay;

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -208,7 +208,7 @@ function AuthOptions({
       }
 
       console.log('user?.experienceLevel at valid registration: ', data, user);
-      trackAnalyticsSignUp({ experienceLevel: data?.user?.experienceLevel });
+      // trackAnalyticsSignUp({ experienceLevel: data?.user?.experienceLevel });
 
       await syncSettings(data?.user?.id);
       onSetActiveDisplay(AuthDisplay.EmailSent);

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -49,11 +49,10 @@ import {
   SIGNIN_METHOD_KEY,
   useSignBack,
 } from '../../hooks/auth/useSignBack';
-import { LoggedUser } from '../../lib/user';
+import { AnonymousUser, LoggedUser } from '../../lib/user';
 import { labels } from '../../lib';
 import OnboardingRegistrationForm from './OnboardingRegistrationForm';
 import EmailCodeVerification from './EmailCodeVerification';
-import { trackAnalyticsSignUp } from './OnboardingAnalytics';
 import { ButtonProps } from '../buttons/Button';
 import { OnboardingRegistrationForm4d5 } from './OnboardingRegistrationForm4d5';
 
@@ -89,7 +88,7 @@ export interface AuthOptionsProps {
   onClose?: CloseAuthModalFunc;
   onAuthStateUpdate?: (props: Partial<AuthProps>) => void;
   onSuccessfulLogin?: () => unknown;
-  onSuccessfulRegistration?: (data?: unknown | null) => unknown;
+  onSuccessfulRegistration?: (user?: LoggedUser | AnonymousUser) => unknown;
   formRef: MutableRefObject<HTMLFormElement>;
   trigger: AuthTriggersType;
   defaultDisplay?: AuthDisplay;
@@ -206,14 +205,9 @@ function AuthOptions({
         const provider = chosenProvider || 'password';
         onSignBackLogin(data.user as LoggedUser, provider as SignBackProvider);
       }
-
-      // trackAnalyticsSignUp({ experienceLevel: data?.user?.experienceLevel });
-
       await syncSettings(data?.user?.id);
-      console.log('user?.experienceLevel at valid registration: ', data, user);
-
       onSetActiveDisplay(AuthDisplay.EmailSent);
-      onSuccessfulRegistration?.(data);
+      onSuccessfulRegistration?.(data?.user);
     },
     onInvalidRegistration: setRegistrationHints,
     onRedirectFail: () => {
@@ -241,9 +235,7 @@ function AuthOptions({
   });
   const onProfileSuccess = async () => {
     const { data } = await refetchBoot();
-    console.log('user?.experienceLevel at profile success: ', data, user);
-
-    onSuccessfulRegistration?.();
+    onSuccessfulRegistration?.(data?.user);
     onClose?.(null, true);
   };
   const {

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -207,12 +207,11 @@ function AuthOptions({
         onSignBackLogin(data.user as LoggedUser, provider as SignBackProvider);
       }
 
-      console.log('user?.experienceLevel at valid registration: ', data, user);
       // trackAnalyticsSignUp({ experienceLevel: data?.user?.experienceLevel });
 
       await syncSettings(data?.user?.id);
       onSetActiveDisplay(AuthDisplay.EmailSent);
-      onSuccessfulRegistration?.();
+      onSuccessfulRegistration?.(data);
     },
     onInvalidRegistration: setRegistrationHints,
     onRedirectFail: () => {

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -89,7 +89,7 @@ export interface AuthOptionsProps {
   onClose?: CloseAuthModalFunc;
   onAuthStateUpdate?: (props: Partial<AuthProps>) => void;
   onSuccessfulLogin?: () => unknown;
-  onSuccessfulRegistration?: (data: unknown) => unknown;
+  onSuccessfulRegistration?: (data?: unknown | null) => unknown;
   formRef: MutableRefObject<HTMLFormElement>;
   trigger: AuthTriggersType;
   defaultDisplay?: AuthDisplay;

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -240,7 +240,7 @@ function AuthOptions({
     },
   });
   const onProfileSuccess = async () => {
-    await refetchBoot();
+    const { data } = await refetchBoot();
     console.log('user?.experienceLevel at profile success: ', data, user);
 
     onSuccessfulRegistration?.();

--- a/packages/shared/src/components/auth/AuthOptions.tsx
+++ b/packages/shared/src/components/auth/AuthOptions.tsx
@@ -199,7 +199,6 @@ function AuthOptions({
       onSetActiveDisplay(AuthDisplay.EmailVerification);
     },
     onValidRegistration: async () => {
-      trackAnalyticsSignUp();
       setIsRegistration(true);
       const { data } = await refetchBoot();
 

--- a/packages/shared/src/components/auth/OnboardingAnalytics.tsx
+++ b/packages/shared/src/components/auth/OnboardingAnalytics.tsx
@@ -135,7 +135,9 @@ export const trackAnalyticsSignUp = ({
 
   if (typeof globalThis.fbq === 'function') {
     globalThis.fbq('track', 'signup');
-    globalThis.fbq('track', 'signup_experience_level', experienceLevel);
+    if (experienceLevel) {
+      globalThis.fbq('track', 'signup_experience_level', experienceLevel);
+    }
   }
 
   if (typeof globalThis.twq === 'function') {

--- a/packages/shared/src/components/auth/OnboardingAnalytics.tsx
+++ b/packages/shared/src/components/auth/OnboardingAnalytics.tsx
@@ -127,11 +127,6 @@ export const trackAnalyticsSignUp = ({ experienceLevel }): void => {
   }
 
   if (typeof globalThis.fbq === 'function') {
-    console.log(
-      'user?.experienceLevel at tracking registration: ',
-      experienceLevel,
-    );
-
     globalThis.fbq('track', 'signup');
     globalThis.fbq('track', 'signup_experience_level', experienceLevel);
   }

--- a/packages/shared/src/components/auth/OnboardingAnalytics.tsx
+++ b/packages/shared/src/components/auth/OnboardingAnalytics.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import Script from 'next/script';
 import { isProduction } from '../../lib/constants';
+import { UserExperienceLevel } from '../../lib/user';
 
 export const FB_PIXEL_ID = '519268979315924';
 export const GA_TRACKING_ID = 'AW-619408403';
@@ -121,7 +122,13 @@ export const TiktokTracking = (): ReactElement => {
   );
 };
 
-export const trackAnalyticsSignUp = ({ experienceLevel }): void => {
+interface TrackAnalyticsSignUpProps {
+  experienceLevel: keyof typeof UserExperienceLevel;
+}
+
+export const trackAnalyticsSignUp = ({
+  experienceLevel,
+}: TrackAnalyticsSignUpProps): void => {
   if (typeof globalThis.gtag === 'function') {
     globalThis.gtag('event', 'signup');
   }

--- a/packages/shared/src/components/auth/OnboardingAnalytics.tsx
+++ b/packages/shared/src/components/auth/OnboardingAnalytics.tsx
@@ -121,13 +121,19 @@ export const TiktokTracking = (): ReactElement => {
   );
 };
 
-export const trackAnalyticsSignUp = (): void => {
+export const trackAnalyticsSignUp = ({ experienceLevel }): void => {
   if (typeof globalThis.gtag === 'function') {
     globalThis.gtag('event', 'signup');
   }
 
   if (typeof globalThis.fbq === 'function') {
+    console.log(
+      'user?.experienceLevel at tracking registration: ',
+      experienceLevel,
+    );
+
     globalThis.fbq('track', 'signup');
+    globalThis.fbq('track', 'signup_experience_level', experienceLevel);
   }
 
   if (typeof globalThis.twq === 'function') {

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -41,7 +41,7 @@ const feature = {
   ),
   experienceLevel: new Feature(
     'experience_level',
-    ExperienceLevelExperiment.Control,
+    ExperienceLevelExperiment.V1,
   ),
   featureTheme: new Feature('feature_theme', {}),
   searchTags: new Feature('search_tags', false),

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -41,7 +41,7 @@ const feature = {
   ),
   experienceLevel: new Feature(
     'experience_level',
-    ExperienceLevelExperiment.V1,
+    ExperienceLevelExperiment.Control,
   ),
   featureTheme: new Feature('feature_theme', {}),
   searchTags: new Feature('search_tags', false),

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -92,6 +92,7 @@ export interface LoggedUser extends UserProfile, AnonymousUser {
   canSubmitArticle?: boolean;
   password?: string;
   acquisitionChannel?: string;
+  experienceLevel?: keyof typeof UserExperienceLevel;
 }
 
 interface BaseError {

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -69,6 +69,8 @@ import {
 } from '@dailydotdev/shared/src/hooks';
 import { ReadingReminder } from '@dailydotdev/shared/src/components/auth/ReadingReminder';
 import { GenericLoader } from '@dailydotdev/shared/src/components/utilities/loaders';
+import { Boot } from '@dailydotdev/shared/src/lib/boot';
+import { AnonymousUser, LoggedUser } from '@dailydotdev/shared/src/lib/user';
 import { defaultOpenGraph, defaultSeo } from '../next-seo';
 import styles from '../components/layouts/Onboarding/index.module.css';
 
@@ -180,12 +182,12 @@ export function OnboardPage(): ReactElement {
     router.replace('/');
   };
 
-  const onSuccessfulRegistration = (data) => {
+  const onSuccessfulRegistration = (userRefetched: LoggedUser) => {
     console.log(
       'user?.experienceLevel at succesful registration: ',
-      data,
-      user,
+      userRefetched,
     );
+    trackAnalyticsSignUp({ experienceLevel: userRefetched?.experienceLevel });
     setActiveScreen(OnboardingStep.EditTag);
   };
 

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -183,10 +183,6 @@ export function OnboardPage(): ReactElement {
   };
 
   const onSuccessfulRegistration = (userRefetched: LoggedUser) => {
-    console.log(
-      'user?.experienceLevel at succesful registration: ',
-      userRefetched,
-    );
     trackAnalyticsSignUp({ experienceLevel: userRefetched?.experienceLevel });
     setActiveScreen(OnboardingStep.EditTag);
   };

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -69,8 +69,7 @@ import {
 } from '@dailydotdev/shared/src/hooks';
 import { ReadingReminder } from '@dailydotdev/shared/src/components/auth/ReadingReminder';
 import { GenericLoader } from '@dailydotdev/shared/src/components/utilities/loaders';
-import { Boot } from '@dailydotdev/shared/src/lib/boot';
-import { AnonymousUser, LoggedUser } from '@dailydotdev/shared/src/lib/user';
+import { LoggedUser } from '@dailydotdev/shared/src/lib/user';
 import { defaultOpenGraph, defaultSeo } from '../next-seo';
 import styles from '../components/layouts/Onboarding/index.module.css';
 

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -181,11 +181,6 @@ export function OnboardPage(): ReactElement {
   };
 
   const onSuccessfulRegistration = () => {
-    console.log(
-      'user?.experienceLevel at successful registration: ',
-      user?.experienceLevel,
-    );
-    trackAnalyticsSignUp({ experienceLevel: user?.experienceLevel });
     setActiveScreen(OnboardingStep.EditTag);
   };
 

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -180,7 +180,8 @@ export function OnboardPage(): ReactElement {
     router.replace('/');
   };
 
-  const onSuccessfulRegistration = () => {
+  const onSuccessfulRegistration = (data) => {
+    console.log('user?.experienceLevel at valid registration: ', data, user);
     setActiveScreen(OnboardingStep.EditTag);
   };
 

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -181,7 +181,11 @@ export function OnboardPage(): ReactElement {
   };
 
   const onSuccessfulRegistration = () => {
-    trackAnalyticsSignUp();
+    console.log(
+      'user?.experienceLevel at successful registration: ',
+      user?.experienceLevel,
+    );
+    trackAnalyticsSignUp({ experienceLevel: user?.experienceLevel });
     setActiveScreen(OnboardingStep.EditTag);
   };
 

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -181,7 +181,11 @@ export function OnboardPage(): ReactElement {
   };
 
   const onSuccessfulRegistration = (data) => {
-    console.log('user?.experienceLevel at valid registration: ', data, user);
+    console.log(
+      'user?.experienceLevel at succesful registration: ',
+      data,
+      user,
+    );
     setActiveScreen(OnboardingStep.EditTag);
   };
 


### PR DESCRIPTION
## Changes
- only call trackAnalyticsSignUp on onboarding
- pass new user fetched data to the tracking function
- create event with experience level fb  

### Describe what this PR does
- Requested by Ido to have tracking on fb for experience


### Preview domain
https://feat-new-fb-event.preview.app.daily.dev