### PR TITLE
fix: advancedSettings can be undefined before fetched

### DIFF
--- a/packages/shared/src/components/filters/ContentTypesFilter.tsx
+++ b/packages/shared/src/components/filters/ContentTypesFilter.tsx
@@ -11,7 +11,7 @@ export function ContentTypesFilter(): ReactElement {
    * Point being, we have to send multiple mutation requests at the same time if the user toggles the switch.
    * We should instead introduce a new mutation to handle an array of settings to toggle.
    * */
-  const videos = advancedSettings.find(({ title }) => title === 'Videos');
+  const videos = advancedSettings?.find(({ title }) => title === 'Videos');
 
   return (
     <section className="flex flex-col gap-6 px-6" aria-busy={isLoading}>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- If you navigated to feed filters on mobile it would crash the app due to `advancedSettings` being `undefined` still

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-content-filters-crashing.preview.app.daily.dev