### PR TITLE
fix: horizontal back button

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -72,7 +72,7 @@ export interface FeedProps<T>
   allowFetchMore?: boolean;
   pageSize?: number;
   isHorizontal?: boolean;
-  feedContainerRef?: React.RefObject<HTMLDivElement>;
+  feedContainerRef?: React.Ref<HTMLDivElement>;
 }
 
 interface RankVariables {

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -34,7 +34,7 @@ export interface FeedContainerProps {
   shortcuts?: ReactNode;
   actionButtons?: ReactNode;
   isHorizontal?: boolean;
-  feedContainerRef?: React.RefObject<HTMLDivElement>;
+  feedContainerRef?: React.Ref<HTMLDivElement>;
 }
 
 const listGaps = {

--- a/packages/shared/src/components/feeds/HorizontalFeed.tsx
+++ b/packages/shared/src/components/feeds/HorizontalFeed.tsx
@@ -1,10 +1,4 @@
-import React, {
-  ReactElement,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { ReactElement, useContext, useEffect, useState } from 'react';
 import classnames from 'classnames';
 import Feed from '../Feed';
 import { OtherFeedPage } from '../../lib/query';

--- a/packages/shared/src/components/feeds/HorizontalFeed.tsx
+++ b/packages/shared/src/components/feeds/HorizontalFeed.tsx
@@ -27,7 +27,9 @@ export default function HorizontalFeed<T>({
   title,
   ...props
 }: HorizontalFeedProps<T>): ReactElement {
-  const feedContainerRef = useRef<HTMLDivElement>(null);
+  const [feedContainerRef, setFeedContainerRef] =
+    useState<HTMLDivElement>(null);
+
   const [feedScrolledPosition, setFeedScrolledPosition] = useState(0);
   const currentSettings = useContext(FeedContext);
   const { spaciness, insaneMode } = useContext(SettingsContext);
@@ -35,7 +37,7 @@ export default function HorizontalFeed<T>({
   const { isListModeV1 } = useFeedLayout();
 
   useEffect(() => {
-    const element = feedContainerRef.current;
+    const element = feedContainerRef;
     if (!element) {
       return null;
     }
@@ -49,12 +51,12 @@ export default function HorizontalFeed<T>({
     return () => {
       element.removeEventListener('scrollend', onScroll);
     };
-  }, []);
+  }, [feedContainerRef]);
 
   const onClickNext = () => {
-    if (feedContainerRef.current) {
-      const currentPosition = feedContainerRef.current.scrollLeft;
-      feedContainerRef.current.scrollLeft = Math.max(
+    if (feedContainerRef) {
+      const currentPosition = feedContainerRef.scrollLeft;
+      feedContainerRef.scrollLeft = Math.max(
         0,
         currentPosition + numCards * 320,
       );
@@ -62,10 +64,10 @@ export default function HorizontalFeed<T>({
   };
 
   const onClickPrevious = () => {
-    if (feedContainerRef.current) {
-      const currentPosition = feedContainerRef.current.scrollLeft;
+    if (feedContainerRef) {
+      const currentPosition = feedContainerRef.scrollLeft;
       const newPosition = Math.max(0, currentPosition - numCards * 320);
-      feedContainerRef.current.scrollLeft = newPosition < 150 ? 0 : newPosition;
+      feedContainerRef.scrollLeft = newPosition < 150 ? 0 : newPosition;
     }
   };
 
@@ -105,7 +107,7 @@ export default function HorizontalFeed<T>({
         'mx-4 mb-10',
         insaneMode && isListModeV1 && 'laptop:mx-auto',
       )}
-      feedContainerRef={feedContainerRef}
+      feedContainerRef={(ref) => setFeedContainerRef(ref)}
     />
   );
 }


### PR DESCRIPTION
## Changes

### Describe what this PR does
- In SSR mode sometimes the feed would not render yet (due to waiting for settings to load)
- Thus the horizontal feed would miss it's execution for useEffect saying ref is empty.
- By moving to state we can set it as dependency (Thank @capJavert )

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://as-327-horizontal-back-button-fix.preview.app.daily.dev