### PR TITLE
fix: squad page header

### DIFF
--- a/packages/shared/src/components/squads/Members/PrivilegedMemberItem.tsx
+++ b/packages/shared/src/components/squads/Members/PrivilegedMemberItem.tsx
@@ -2,19 +2,22 @@ import React, { ReactElement } from 'react';
 import { ProfilePicture } from '../../ProfilePicture';
 import SquadMemberBadge from '../SquadMemberBadge';
 import { SourceMember } from '../../../graphql/sources';
+import classed from '../../../lib/classed';
 
 interface PrivilegedMemberItemProps {
   member: SourceMember;
 }
 
+export const PrivilegedMemberContainer = classed(
+  'div',
+  'flex flex-row items-center rounded-10 border border-border-subtlest-tertiary p-2',
+);
+
 export function PrivilegedMemberItem({
   member: { user, role },
 }: PrivilegedMemberItemProps): ReactElement {
   return (
-    <div
-      key={user.id}
-      className="flex flex-row items-center rounded-10 border border-border-subtlest-tertiary p-2"
-    >
+    <PrivilegedMemberContainer>
       <ProfilePicture user={user} size="large" />
       <div className="flex-col">
         <span className="ml-2.5 text-text-tertiary typo-subhead">
@@ -22,6 +25,6 @@ export function PrivilegedMemberItem({
         </span>
         <SquadMemberBadge role={role} />
       </div>
-    </div>
+    </PrivilegedMemberContainer>
   );
 }

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -64,7 +64,7 @@ export function SquadPageHeader({
     tourIndex === TourScreenIndex.Post ||
     (isChecklistVisible && openStep === ActionType.SquadFirstPost);
   const isSquadMember = !!squad.currentMember;
-  const isFeatured = squad.flags.featured;
+  const isFeatured = squad.flags?.featured;
 
   const props = (() => {
     if (isFeatured) {
@@ -125,9 +125,9 @@ export function SquadPageHeader({
                 </>
               )}
             </Button>
-            <SquadStat count={squad.flags.totalPosts} label="Posts" />
-            <SquadStat count={squad.flags.totalViews} label="Views" />
-            <SquadStat count={squad.flags.totalUpvotes} label="Upvotes" />
+            <SquadStat count={squad.flags?.totalPosts} label="Posts" />
+            <SquadStat count={squad.flags?.totalViews} label="Views" />
+            <SquadStat count={squad.flags?.totalUpvotes} label="Upvotes" />
           </div>
         </FlexCol>
       </div>

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -24,7 +24,10 @@ import { link } from '../../lib/links';
 import SquadChecklistCard from '../checklist/SquadChecklistCard';
 import { Separator } from '../cards/common';
 import { EarthIcon, LockIcon, SourceIcon, SparkleIcon } from '../icons';
-import { PrivilegedMemberItem } from './Members/PrivilegedMemberItem';
+import {
+  PrivilegedMemberContainer,
+  PrivilegedMemberItem,
+} from './Members/PrivilegedMemberItem';
 import { formatMonthYearOnly } from '../../lib/dateFormat';
 
 interface SquadPageHeaderProps {
@@ -47,6 +50,8 @@ const SquadStat = ({ count, label }: SquadStatProps) => (
   </span>
 );
 
+const MAX_PRIVILEGED_MEMBERS = 3;
+
 export function SquadPageHeader({
   squad,
   members,
@@ -59,23 +64,24 @@ export function SquadPageHeader({
     tourIndex === TourScreenIndex.Post ||
     (isChecklistVisible && openStep === ActionType.SquadFirstPost);
   const isSquadMember = !!squad.currentMember;
-  const isFeatured = squad?.flags?.featured;
+  const isFeatured = squad.flags.featured;
 
   const props = (() => {
     if (isFeatured) {
       return { icon: <SourceIcon secondary />, copy: 'Featured' };
     }
 
-    if (squad?.public) {
+    if (squad.public) {
       return { icon: <EarthIcon />, copy: 'Public' };
     }
 
     return { icon: <LockIcon />, copy: 'Private' };
   })();
 
-  const createdAt = squad?.createdAt
+  const createdAt = squad.createdAt
     ? formatMonthYearOnly(squad.createdAt)
     : null;
+  const privilegedLength = squad.privilegedMembers?.length || 0;
 
   return (
     <FlexCol
@@ -119,10 +125,9 @@ export function SquadPageHeader({
                 </>
               )}
             </Button>
-            {/* TODO: As mentioned in the JIRA ticket, the value would be replaced in a different PR */}
-            <SquadStat count={1} label="Posts" />
-            <SquadStat count={1} label="Views" />
-            <SquadStat count={1} label="Upvotes" />
+            <SquadStat count={squad.flags.totalPosts} label="Posts" />
+            <SquadStat count={squad.flags.totalViews} label="Views" />
+            <SquadStat count={squad.flags.totalUpvotes} label="Upvotes" />
           </div>
         </FlexCol>
       </div>
@@ -139,10 +144,17 @@ export function SquadPageHeader({
       <span className="mt-6 text-text-quaternary typo-footnote">
         Moderated by
       </span>
-      <div className="mt-2">
-        {squad?.privilegedMembers?.map((member) => (
-          <PrivilegedMemberItem key={member.user.id} member={member} />
-        ))}
+      <div className="mt-2 flex flex-row items-center gap-3">
+        {squad.privilegedMembers
+          ?.slice(0, MAX_PRIVILEGED_MEMBERS)
+          .map((member) => (
+            <PrivilegedMemberItem key={member.user.id} member={member} />
+          ))}
+        {privilegedLength > 3 && (
+          <PrivilegedMemberContainer className="h-fit font-bold text-text-tertiary typo-callout">
+            +{privilegedLength - MAX_PRIVILEGED_MEMBERS}
+          </PrivilegedMemberContainer>
+        )}
       </div>
       <SquadHeaderBar
         squad={squad}
@@ -175,7 +187,7 @@ export function SquadPageHeader({
               </FlexCentered>
               <Button
                 tag="a"
-                href={`${link.post.create}?sid=${squad?.handle}`}
+                href={`${link.post.create}?sid=${squad.handle}`}
                 variant={ButtonVariant.Primary}
                 color={ButtonColor.Cabbage}
                 className="w-full tablet:w-auto"

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -29,6 +29,7 @@ import {
   PrivilegedMemberItem,
 } from './Members/PrivilegedMemberItem';
 import { formatMonthYearOnly } from '../../lib/dateFormat';
+import { MAX_PRIVILEGED_MEMBERS } from '../../lib/config';
 
 interface SquadPageHeaderProps {
   squad: Squad;
@@ -49,8 +50,6 @@ const SquadStat = ({ count, label }: SquadStatProps) => (
     {label}
   </span>
 );
-
-const MAX_PRIVILEGED_MEMBERS = 3;
 
 export function SquadPageHeader({
   squad,

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -29,7 +29,7 @@ import {
   PrivilegedMemberItem,
 } from './Members/PrivilegedMemberItem';
 import { formatMonthYearOnly } from '../../lib/dateFormat';
-import { MAX_PRIVILEGED_MEMBERS } from '../../lib/config';
+import { MAX_VISIBLE_PRIVILEGED_MEMBERS } from '../../lib/config';
 
 interface SquadPageHeaderProps {
   squad: Squad;
@@ -145,13 +145,13 @@ export function SquadPageHeader({
       </span>
       <div className="mt-2 flex flex-row items-center gap-3">
         {squad.privilegedMembers
-          ?.slice(0, MAX_PRIVILEGED_MEMBERS)
+          ?.slice(0, MAX_VISIBLE_PRIVILEGED_MEMBERS)
           .map((member) => (
             <PrivilegedMemberItem key={member.user.id} member={member} />
           ))}
-        {privilegedLength > MAX_PRIVILEGED_MEMBERS && (
+        {privilegedLength > MAX_VISIBLE_PRIVILEGED_MEMBERS && (
           <PrivilegedMemberContainer className="h-fit font-bold text-text-tertiary typo-callout">
-            +{privilegedLength - MAX_PRIVILEGED_MEMBERS}
+            +{privilegedLength - MAX_VISIBLE_PRIVILEGED_MEMBERS}
           </PrivilegedMemberContainer>
         )}
       </div>

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -150,7 +150,7 @@ export function SquadPageHeader({
           .map((member) => (
             <PrivilegedMemberItem key={member.user.id} member={member} />
           ))}
-        {privilegedLength > 3 && (
+        {privilegedLength > MAX_PRIVILEGED_MEMBERS && (
           <PrivilegedMemberContainer className="h-fit font-bold text-text-tertiary typo-callout">
             +{privilegedLength - MAX_PRIVILEGED_MEMBERS}
           </PrivilegedMemberContainer>

--- a/packages/shared/src/lib/config.ts
+++ b/packages/shared/src/lib/config.ts
@@ -12,4 +12,4 @@ export const fallbackImages = {
     'https://daily-now-res.cloudinary.com/image/upload/f_auto/v1664367305/placeholders/placeholder3',
 };
 
-export const MAX_PRIVILEGED_MEMBERS = 3;
+export const MAX_VISIBLE_PRIVILEGED_MEMBERS = 3;

--- a/packages/shared/src/lib/config.ts
+++ b/packages/shared/src/lib/config.ts
@@ -11,3 +11,5 @@ export const fallbackImages = {
   avatar:
     'https://daily-now-res.cloudinary.com/image/upload/f_auto/v1664367305/placeholders/placeholder3',
 };
+
+export const MAX_PRIVILEGED_MEMBERS = 3;


### PR DESCRIPTION
## Changes
- Fix the privileged member list orientation.
- Fix the dummy stats.

Before:
<img width="422" alt="Screenshot 2024-05-23 at 4 56 58 PM" src="https://github.com/dailydotdev/apps/assets/13744167/65c2afc4-b232-4dce-b3a8-14fe3e56f159">

After:
<img width="466" alt="Screenshot 2024-05-23 at 4 58 44 PM" src="https://github.com/dailydotdev/apps/assets/13744167/cd76a930-eb5a-412a-8fa8-c53da541ab4c">

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-squad-header.preview.app.daily.dev