### PR TITLE
fix: share to squad on mobile

### DIFF
--- a/packages/shared/src/components/modals/ShareModal.tsx
+++ b/packages/shared/src/components/modals/ShareModal.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext, useEffect } from 'react';
+import React, { ReactElement, useContext, useEffect, useState } from 'react';
 import { useSwipeable } from 'react-swipeable';
 import { SocialShare } from '../widgets/SocialShare';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
@@ -6,6 +6,8 @@ import { postAnalyticsEvent } from '../../lib/feed';
 import { Modal, ModalProps } from './common/Modal';
 import { ExperimentWinner } from '../../lib/featureValues';
 import { ShareProps } from './post/common';
+import { Squad } from '../../graphql/sources';
+import { useViewSize, ViewSize } from '../../hooks';
 
 export default function ShareModal({
   post,
@@ -19,6 +21,7 @@ export default function ShareModal({
   ...props
 }: ShareProps & ModalProps): ReactElement {
   const isComment = !!comment;
+  const isMobile = useViewSize(ViewSize.MobileL);
   const { trackEvent } = useContext(AnalyticsContext);
 
   const baseTrackingEvent = (
@@ -53,6 +56,7 @@ export default function ShareModal({
   };
 
   const handlers = useSwipeable({ onSwipedDown });
+  const squadState = useState<Squad>();
 
   return (
     <Modal
@@ -63,6 +67,7 @@ export default function ShareModal({
       parentSelector={parentSelector}
       className="overflow-hidden"
       isDrawerOnMobile
+      shouldCloseOnOverlayClick={!isMobile || !squadState[0]}
     >
       <Modal.Header title={isComment ? 'Share comment' : 'Share post'} />
       <Modal.Body {...handlers}>
@@ -75,6 +80,7 @@ export default function ShareModal({
           row={row}
           onClose={() => onRequestClose(null)}
           parentSelector={parentSelector}
+          shareToSquadState={squadState}
         />
       </Modal.Body>
     </Modal>

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useContext, useState } from 'react';
+import React, { Dispatch, ReactElement, useContext } from 'react';
 import { ShareProvider, addTrackingQueryParams } from '../../lib/share';
 import { Post } from '../../graphql/posts';
 import { FeedItemPosition, postAnalyticsEvent } from '../../lib/feed';
@@ -23,6 +23,7 @@ interface SocialShareProps extends Pick<ModalProps, 'parentSelector'> {
   comment?: Comment;
   onClose?: () => void;
   commentary?: string;
+  shareToSquadState: [Squad, Dispatch<Squad>];
 }
 
 export const SocialShare = ({
@@ -34,6 +35,7 @@ export const SocialShare = ({
   row,
   onClose,
   parentSelector,
+  shareToSquadState,
 }: SocialShareProps & FeedItemPosition): ReactElement => {
   const isComment = !!comment;
   const { user, isAuthReady } = useAuthContext();
@@ -53,7 +55,7 @@ export const SocialShare = ({
   const [copying, copyLink] = useCopyLink();
   const { trackEvent } = useContext(AnalyticsContext);
   const { openNativeSharePost } = useSharePost(Origin.Share);
-  const [squadToShare, setSquadToShare] = useState<Squad>();
+  const [squadToShare, setSquadToShare] = shareToSquadState;
   const trackClick = (provider: ShareProvider) =>
     trackEvent(
       postAnalyticsEvent('share post', post, {
@@ -103,6 +105,7 @@ export const SocialShare = ({
           squad={squadToShare}
           onSharedSuccessfully={onSharedSuccessfully}
           parentSelector={parentSelector}
+          onRequestClose={() => setSquadToShare(null)}
         />
       )}
     </>


### PR DESCRIPTION
## Changes
- There are two instances of Drawers, and since it closes on an outside click, the first Drawer thinks the user is clicking outside when in fact they were clicking on the second Drawer, which in fact is true.
- In order to understand when should we disable the close on outside click for the parent Drawer, we should track the state.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-share-squad.preview.app.daily.dev