### PR TITLE
fix: close modal on submission and hiding of card

### DIFF
--- a/packages/shared/src/components/modals/squads/SubmitSquadForReviewModal.tsx
+++ b/packages/shared/src/components/modals/squads/SubmitSquadForReviewModal.tsx
@@ -57,6 +57,9 @@ const SubmitSquadForReviewModal = ({
 
   const { submitForReview, isSubmitLoading } = usePublicSquadRequests({
     sourceId: squad?.id,
+    onSuccessfulSubmission: () => {
+      onRequestClose(null);
+    },
   });
 
   if (!isFetched || !squad) {

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -213,15 +213,16 @@ export default function useFeed<T>(
       );
     }
     return newItems;
-    // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     feedQuery.data,
     feedQuery.isFetching,
-    adsQuery.data,
-    adsQuery.isFetching,
-    settings.showAcquisitionForm,
     settings.marketingCta,
+    settings.showAcquisitionForm,
+    showPublicSquadsEligibility,
+    isAdsQueryEnabled,
+    adSpot,
+    adsQuery.data?.pages,
+    placeholdersPerPage,
   ]);
 
   const updatePost = updateCachedPagePost(feedQueryKey, queryClient);

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -248,7 +248,8 @@ const SquadPage = ({
           ]}
           showPublicSquadsEligibility={
             isRequestsEnabled &&
-            (!dismissedCard || !hiddenCardStatuses.includes(status))
+            !dismissedCard &&
+            !hiddenCardStatuses.includes(status)
           }
           query={SOURCE_FEED_QUERY}
           variables={queryVariables}


### PR DESCRIPTION
## Changes
- Fix the submission modal to automatically close and invalidate the query to reflect the correct status for the card.
- Fix the dismissal of card not reflecting immediately. After investigation, it was due to missing dependencies. 
- Fixed the condition for displaying the eligibility card.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-359 #done


### Preview domain
https://mi-359.preview.app.daily.dev