### PR TITLE
fix: public squads todo comments and privacy update

### DIFF
--- a/packages/shared/src/components/squads/Details.tsx
+++ b/packages/shared/src/components/squads/Details.tsx
@@ -77,13 +77,12 @@ export function SquadDetails({
   } = form;
   const isRequestsEnabled =
     !createMode && !form.public && !form.flags?.totalPosts && !!form?.id;
-  const { status } = usePublicSquadRequests({
+  const { status, daysLeft } = usePublicSquadRequests({
     isQueryEnabled: isRequestsEnabled,
     sourceId: form?.id,
   });
   const [activeHandle, setActiveHandle] = useState(handle);
   const [privacy, setPrivacy] = useState(
-    // TODO: MI-344 once the API is updated to handle privacy change eligibility, we should hook this value to the mutation
     form.public ? PrivacyOption.Public : PrivacyOption.Private,
   );
   const [imageChanged, setImageChanged] = useState(false);
@@ -101,7 +100,6 @@ export function SquadDetails({
   const [memberInviteRole, setMemberInviteRole] = useState(
     () => initialMemberInviteRole || SourceMemberRole.Member,
   );
-  const daysLeft = 14; // TODO: MI-344 this needs to be dynamic
 
   const { mutateAsync: onValidateHandle } = useMutation(checkExistingHandle, {
     onError: (err) => {

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -15,6 +15,7 @@ import { Post, ExternalLinkPreview } from './posts';
 import { base64ToFile } from '../lib/base64';
 import { EmptyResponse } from './emptyResponse';
 import { generateStorageKey, StorageTopic } from '../lib/storage';
+import { PrivacyOption } from '../hooks/squads/useSquadPrivacyOptions';
 
 export interface SquadForm
   extends Pick<
@@ -28,6 +29,7 @@ export interface SquadForm
   memberPostingRole?: SourceMemberRole;
   memberInviteRole?: SourceMemberRole;
   public?: boolean;
+  status?: PrivacyOption;
 }
 
 type SharedSquadInput = {
@@ -37,6 +39,7 @@ type SharedSquadInput = {
   image?: File;
   memberPostingRole?: SourceMemberRole;
   memberInviteRole?: SourceMemberRole;
+  isPrivate?: boolean;
 };
 
 type EditSquadInput = SharedSquadInput & {
@@ -165,6 +168,7 @@ export const EDIT_SQUAD_MUTATION = gql`
     $image: Upload
     $memberPostingRole: String
     $memberInviteRole: String
+    $isPrivate: Boolean
   ) {
     editSquad(
       sourceId: $sourceId
@@ -174,6 +178,7 @@ export const EDIT_SQUAD_MUTATION = gql`
       image: $image
       memberPostingRole: $memberPostingRole
       memberInviteRole: $memberInviteRole
+      isPrivate: $isPrivate
     ) {
       ...SourceBaseInfo
     }
@@ -465,7 +470,7 @@ export async function createSquad(
 
 type EditSquadForm = Pick<
   SquadForm,
-  'name' | 'description' | 'handle' | 'file'
+  'name' | 'description' | 'handle' | 'file' | 'public'
 > & {
   memberPostingRole?: SourceMemberRole;
   memberInviteRole?: SourceMemberRole;
@@ -483,6 +488,7 @@ export async function editSquad(
     image: form.file ? await base64ToFile(form.file, 'image.jpg') : undefined,
     memberPostingRole: form.memberPostingRole,
     memberInviteRole: form.memberInviteRole,
+    isPrivate: !form.public,
   };
   const data = await request<EditSquadOutput>(
     graphqlUrl,

--- a/packages/shared/src/lib/config.ts
+++ b/packages/shared/src/lib/config.ts
@@ -13,3 +13,4 @@ export const fallbackImages = {
 };
 
 export const MAX_VISIBLE_PRIVILEGED_MEMBERS = 3;
+export const PUBLIC_SQUAD_REQUEST_COOLDOWN = 14;

--- a/packages/webapp/pages/squads/[handle]/edit.tsx
+++ b/packages/webapp/pages/squads/[handle]/edit.tsx
@@ -21,6 +21,8 @@ import {
   generateQueryKey,
   RequestKey,
 } from '@dailydotdev/shared/src/lib/query';
+import { PrivacyOption } from '@dailydotdev/shared/src/hooks/squads/useSquadPrivacyOptions';
+import { isNullOrUndefined } from '@dailydotdev/shared/src/lib/func';
 import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
 import { getLayout as getMainLayout } from '../../../components/layouts/MainLayout';
 
@@ -56,6 +58,9 @@ const EditSquad = ({ handle }: EditSquadPageProps): ReactElement => {
       file: form.file,
       memberPostingRole: form.memberPostingRole,
       memberInviteRole: form.memberInviteRole,
+      public: isNullOrUndefined(form.status)
+        ? undefined
+        : form.status === PrivacyOption.Public,
     };
     const editedSquad = await editSquad(squad.id, formJson);
     if (editedSquad) {


### PR DESCRIPTION
## Changes
- Cleanup of TODO comments.
- Update the form to handle toggling of privacy status based from [this PR](https://github.com/dailydotdev/daily-api/pull/1934).

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-public-squads.preview.app.daily.dev