### PR TITLE
fix: mobile list count

### DIFF
--- a/packages/shared/src/components/squads/Members/PrivilegedMemberItem.tsx
+++ b/packages/shared/src/components/squads/Members/PrivilegedMemberItem.tsx
@@ -20,7 +20,7 @@ export function PrivilegedMemberItem({
     <PrivilegedMemberContainer>
       <ProfilePicture user={user} size="large" />
       <div className="flex-col">
-        <span className="ml-2.5 text-text-tertiary typo-subhead">
+        <span className="ml-2.5 flex overflow-hidden text-ellipsis whitespace-nowrap text-text-tertiary typo-subhead">
           {user.name}
         </span>
         <SquadMemberBadge role={role} />

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 import classNames from 'classnames';
-import { Squad, SourceMember, SourcePermissions } from '../../graphql/sources';
+import { SourceMember, SourcePermissions, Squad } from '../../graphql/sources';
 import { SquadHeaderBar } from './SquadHeaderBar';
 import { SquadImage } from './SquadImage';
 import EnableNotification from '../notifications/EnableNotification';
@@ -29,7 +29,11 @@ import {
   PrivilegedMemberItem,
 } from './Members/PrivilegedMemberItem';
 import { formatMonthYearOnly } from '../../lib/dateFormat';
-import { MAX_VISIBLE_PRIVILEGED_MEMBERS } from '../../lib/config';
+import {
+  MAX_VISIBLE_PRIVILEGED_MEMBERS_LAPTOP,
+  MAX_VISIBLE_PRIVILEGED_MEMBERS_MOBILE,
+} from '../../lib/config';
+import { useViewSize, ViewSize } from '../../hooks';
 
 interface SquadPageHeaderProps {
   squad: Squad;
@@ -83,6 +87,10 @@ export function SquadPageHeader({
     ? formatMonthYearOnly(squad.createdAt)
     : null;
   const privilegedLength = squad.privilegedMembers?.length || 0;
+  const isMobile = useViewSize(ViewSize.MobileL);
+  const listMax = isMobile
+    ? MAX_VISIBLE_PRIVILEGED_MEMBERS_MOBILE
+    : MAX_VISIBLE_PRIVILEGED_MEMBERS_LAPTOP;
 
   return (
     <FlexCol
@@ -174,14 +182,12 @@ export function SquadPageHeader({
         Moderated by
       </span>
       <div className="mt-2 flex flex-row items-center gap-3">
-        {squad.privilegedMembers
-          ?.slice(0, MAX_VISIBLE_PRIVILEGED_MEMBERS)
-          .map((member) => (
-            <PrivilegedMemberItem key={member.user.id} member={member} />
-          ))}
-        {privilegedLength > MAX_VISIBLE_PRIVILEGED_MEMBERS && (
+        {squad.privilegedMembers?.slice(0, listMax).map((member) => (
+          <PrivilegedMemberItem key={member.user.id} member={member} />
+        ))}
+        {privilegedLength > listMax && (
           <PrivilegedMemberContainer className="h-fit font-bold text-text-tertiary typo-callout">
-            +{privilegedLength - MAX_VISIBLE_PRIVILEGED_MEMBERS}
+            +{privilegedLength - listMax}
           </PrivilegedMemberContainer>
         )}
       </div>

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -34,6 +34,7 @@ import {
   MAX_VISIBLE_PRIVILEGED_MEMBERS_MOBILE,
 } from '../../lib/config';
 import { useViewSize, ViewSize } from '../../hooks';
+import { largeNumberFormat } from '../../lib';
 
 interface SquadPageHeaderProps {
   squad: Squad;
@@ -51,7 +52,9 @@ interface SquadStatProps {
 
 const SquadStat = ({ count, label }: SquadStatProps) => (
   <span className="flex flex-row text-text-tertiary typo-footnote">
-    <strong className="mr-1 text-text-primary typo-subhead">{count}</strong>
+    <strong className="mr-1 text-text-primary typo-subhead">
+      {largeNumberFormat(count)}
+    </strong>
     {label}
   </span>
 );

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -141,7 +141,7 @@ export function SquadPageHeader({
               <span className="typo-caption2">Created {createdAt}</span>
             )}
           </div>
-          <div className="mt-4 flex flex-row items-center gap-2">
+          <div className="mt-4 flex flex-col items-center gap-2 tablet:flex-row">
             <Button
               icon={props.icon}
               size={ButtonSize.Small}
@@ -161,9 +161,16 @@ export function SquadPageHeader({
                 </>
               )}
             </Button>
-            <SquadStat count={squad.flags?.totalPosts} label="Posts" />
-            <SquadStat count={squad.flags?.totalViews} label="Views" />
-            <SquadStat count={squad.flags?.totalUpvotes} label="Upvotes" />
+            <ConditionalWrapper
+              condition={isMobile}
+              wrapper={(component) => (
+                <div className="flex flex-row gap-2">{component}</div>
+              )}
+            >
+              <SquadStat count={squad.flags?.totalPosts} label="Posts" />
+              <SquadStat count={squad.flags?.totalViews} label="Views" />
+              <SquadStat count={squad.flags?.totalUpvotes} label="Upvotes" />
+            </ConditionalWrapper>
           </div>
         </FlexCol>
       </div>

--- a/packages/shared/src/lib/config.ts
+++ b/packages/shared/src/lib/config.ts
@@ -12,5 +12,6 @@ export const fallbackImages = {
     'https://daily-now-res.cloudinary.com/image/upload/f_auto/v1664367305/placeholders/placeholder3',
 };
 
-export const MAX_VISIBLE_PRIVILEGED_MEMBERS = 3;
+export const MAX_VISIBLE_PRIVILEGED_MEMBERS_LAPTOP = 3;
+export const MAX_VISIBLE_PRIVILEGED_MEMBERS_MOBILE = 1;
 export const PUBLIC_SQUAD_REQUEST_COOLDOWN = 14;


### PR DESCRIPTION
## Changes
- Fix the amount of items to display when on mobile.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-mobile-list.preview.app.daily.dev