### PR TITLE
fix: condition when to display eligibility card

### DIFF
--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -176,14 +176,16 @@ const SquadPage = ({
     [checkHasCompleted, isActionsFetched],
   );
 
-  const isRequestsEnabled =
+  const isQueryEnabled =
     !!squadId &&
     !!user &&
+    !squad?.public &&
     squad?.currentMember?.role === SourceMemberRole.Admin;
   const { isFetched: isRequestsFetched, status } = usePublicSquadRequests({
     sourceId: squadId,
-    isQueryEnabled: isRequestsEnabled,
+    isQueryEnabled,
   });
+  const isRequestsEnabled = isQueryEnabled && status !== SquadStatus.Approved;
   const isRequestsLoading =
     isRequestsEnabled && (!isRequestsFetched || !isActionsFetched);
 


### PR DESCRIPTION
## Changes
- The condition should include the check whether the squad is already public or was approved in the past.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-361 #done


### Preview domain
https://mi-361.preview.app.daily.dev