### PR TITLE
fix: do not execute optimistic action if no user id

### DIFF
--- a/packages/shared/src/hooks/useActions.ts
+++ b/packages/shared/src/hooks/useActions.ts
@@ -51,6 +51,10 @@ export const useActions = (): UseActions => {
 
   const { mutateAsync: completeAction } = useMutation(completeUserAction, {
     onMutate: (type) => {
+      if (!user?.id) {
+        return () => undefined;
+      }
+
       client.setQueryData<ActionQueryData>(actionsKey, (old) => {
         const optimisticAction = {
           userId: user.id,


### PR DESCRIPTION
## Changes

### Describe what this PR does
- On some places `completeAction` can get called on anonymous pages for users, this then throws an error, I think we skip optimistic since no point in storing without user id

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
