### PR TITLE
fix: public squad approved notification bell color

### DIFF
--- a/packages/shared/src/components/notifications/utils.ts
+++ b/packages/shared/src/components/notifications/utils.ts
@@ -47,6 +47,7 @@ export enum NotificationType {
   SquadSubscribeNotification = 'squad_subscribe_to_notification',
   CollectionUpdated = 'collection_updated',
   SourcePostAdded = 'source_post_added',
+  SquadPublicApproved = 'squad_public_approved',
 }
 
 export enum NotificationIconType {
@@ -103,6 +104,7 @@ export const notificationTypeTheme: Partial<Record<NotificationType, string>> =
     [NotificationType.SquadSubscribeNotification]: 'text-brand-default',
     [NotificationType.CollectionUpdated]: 'text-brand-default',
     [NotificationType.SourcePostAdded]: 'text-brand-default',
+    [NotificationType.SquadPublicApproved]: 'text-brand-default',
   };
 
 export const notificationsUrl = `/notifications`;


### PR DESCRIPTION
## Changes
- Fix the color of the notification icon.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-notification-color.preview.app.daily.dev