### PR TITLE
feat: hype campaign

### DIFF
--- a/packages/shared/src/components/ProfileMenu.tsx
+++ b/packages/shared/src/components/ProfileMenu.tsx
@@ -23,10 +23,13 @@ import { UserMetadata } from './profile/UserMetadata';
 import { HeroImage } from './profile/HeroImage';
 import { anchorDefaultRel } from '../lib/strings';
 import { LogoutReason } from '../lib/user';
+import { useFeature } from './GrowthBookProvider';
+import { feature } from '../lib/featureManagement';
 
 interface ListItem {
   title: string;
   buttonProps?: ButtonProps<AllowedTags>;
+  rightEmoji?: string;
 }
 
 interface ProfileMenuProps {
@@ -37,6 +40,8 @@ export default function ProfileMenu({
   onClose,
 }: ProfileMenuProps): ReactElement {
   const { user, logout } = useContext(AuthContext);
+  const hypeCampaign = useFeature(feature.hypeCampaign);
+
   const items: ListItem[] = useMemo(() => {
     const list: ListItem[] = [
       {
@@ -80,6 +85,7 @@ export default function ProfileMenu({
           icon: <InviteIcon />,
           href: `${webappUrl}account/invite`,
         },
+        rightEmoji: hypeCampaign && '👕',
       },
       {
         title: 'Logout',
@@ -91,7 +97,7 @@ export default function ProfileMenu({
     ];
 
     return list;
-  }, [logout, user]);
+  }, [hypeCampaign, logout, user.permalink]);
 
   if (!user) {
     return <></>;
@@ -127,13 +133,15 @@ export default function ProfileMenu({
         className="gap-3 p-4"
       />
       <div className="flex flex-col border-t border-border-subtlest-tertiary py-2">
-        {items.map(({ title, buttonProps }) => (
+        {items.map(({ title, buttonProps, rightEmoji }) => (
           <Button
             key={title}
             {...buttonProps}
             className="btn-tertiary w-full !justify-start !px-5 font-normal"
           >
             {title}
+
+            {rightEmoji && <span className="ml-auto">{rightEmoji}</span>}
           </Button>
         ))}
       </div>

--- a/packages/shared/src/components/drawers/NavDrawerItem.tsx
+++ b/packages/shared/src/components/drawers/NavDrawerItem.tsx
@@ -8,6 +8,7 @@ export type NavItemProps = ButtonProps<'a'> & {
   label: string;
   isHeader?: boolean;
   drawerRef?: MutableRefObject<DrawerRef>;
+  rightEmoji?: string;
 };
 
 const NavDrawerHeaderItem = ({ label }: { label: string }): ReactElement => (
@@ -21,6 +22,7 @@ export function NavDrawerItem({
   href,
   label,
   drawerRef,
+  rightEmoji,
   ...rest
 }: NavItemProps): ReactElement {
   if (isHeader) {
@@ -41,6 +43,7 @@ export function NavDrawerItem({
         {...rest}
       >
         {label}
+        {rightEmoji && <span className="ml-auto">{rightEmoji}</span>}
       </Button>
     </ConditionalWrapper>
   );

--- a/packages/shared/src/components/feeds/MobileFeedActions.tsx
+++ b/packages/shared/src/components/feeds/MobileFeedActions.tsx
@@ -10,12 +10,16 @@ import { useLazyModal } from '../../hooks/useLazyModal';
 import { useReadingStreak } from '../../hooks/streaks';
 import { ButtonIconPosition } from '../buttons/common';
 import { useFeatureTheme } from '../../hooks/utils/useFeatureTheme';
+import { useFeature } from '../GrowthBookProvider';
+import { feature } from '../../lib/featureManagement';
+import { HypeButton } from '../referral';
 
 export function MobileFeedActions(): ReactElement {
   const router = useRouter();
   const { openModal } = useLazyModal();
   const { streak, isLoading } = useReadingStreak();
   const featureTheme = useFeatureTheme();
+  const hypeCampaign = useFeature(feature.hypeCampaign);
 
   return (
     <div className="flex flex-row justify-between px-4 py-1">
@@ -25,6 +29,7 @@ export function MobileFeedActions(): ReactElement {
         onLogoClick={() => router.push('/')}
         featureTheme={featureTheme}
       />
+      {hypeCampaign && <HypeButton />}
       <span className="flex flex-row items-center gap-2">
         <ReadingStreakButton
           isLoading={isLoading}

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -17,6 +17,9 @@ import NotificationsBell from '../notifications/NotificationsBell';
 import FeedNav from '../feeds/FeedNav';
 import { useFeatureTheme } from '../../hooks/utils/useFeatureTheme';
 import { useScrollTopClassName } from '../../hooks/useScrollTopClassName';
+import { feature } from '../../lib/featureManagement';
+import { useFeature } from '../GrowthBookProvider';
+import { HypeButton } from '../referral';
 
 export interface MainLayoutHeaderProps {
   hasBanner?: boolean;
@@ -47,6 +50,7 @@ function MainLayoutHeader({
   const featureTheme = useFeatureTheme();
   const scrollClassName = useScrollTopClassName({ enabled: !!featureTheme });
   const isLaptop = useViewSize(ViewSize.Laptop);
+  const hypeCampaign = useFeature(feature.hypeCampaign);
 
   const headerButton = (() => {
     if (!user) {
@@ -135,6 +139,7 @@ function MainLayoutHeader({
               onLogoClick={onLogoClick}
               greeting={false}
             />
+            {hypeCampaign && <HypeButton className="ml-4" />}
           </div>
           <RenderSearchPanel />
           <RenderButtons />

--- a/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
+++ b/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
@@ -140,7 +140,7 @@ const useMenuItems = (): NavItemProps[] => {
         rel: anchorDefaultRel,
       },
     ],
-    [onLogout, openModal],
+    [hypeCampaign, onLogout, openModal],
   );
 };
 

--- a/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
+++ b/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
@@ -29,6 +29,8 @@ import { LogoutReason } from '../../lib/user';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { usePrompt } from '../../hooks/usePrompt';
 import { ButtonColor } from '../buttons/Button';
+import { useFeature } from '../GrowthBookProvider';
+import { feature } from '../../lib/featureManagement';
 
 const useMenuItems = (): NavItemProps[] => {
   const { logout } = useAuthContext();
@@ -45,6 +47,7 @@ const useMenuItems = (): NavItemProps[] => {
       logout(LogoutReason.ManualLogout);
     }
   }, [logout, showPrompt]);
+  const hypeCampaign = useFeature(feature.hypeCampaign);
 
   return useMemo(
     () => [
@@ -57,6 +60,7 @@ const useMenuItems = (): NavItemProps[] => {
         label: 'Invite friends',
         icon: <AddUserIcon />,
         href: '/account/invite',
+        rightEmoji: hypeCampaign && '👕',
       },
       { label: 'Devcard', icon: <DevCardIcon />, href: '/devcard' },
       {

--- a/packages/shared/src/components/referral/HypeButton.tsx
+++ b/packages/shared/src/components/referral/HypeButton.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { hypeLink } from './HypeCampaign';
+import { DevCardTheme, themeToLinearGradient } from '../profile/devcard';
+
+export const HypeButton = ({
+  className,
+}: {
+  className?: string;
+}): JSX.Element => {
+  return (
+    <a
+      href={hypeLink}
+      className={classNames('rounded-12 p-1', className)}
+      style={{
+        backgroundImage: themeToLinearGradient[DevCardTheme.Diamond],
+      }}
+    >
+      <div className="flex rounded-8 bg-background-default px-3 !leading-10 typo-title3">
+        👕
+      </div>
+    </a>
+  );
+};

--- a/packages/shared/src/components/referral/HypeButton.tsx
+++ b/packages/shared/src/components/referral/HypeButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import { hypeLink } from './HypeCampaign';
 import { DevCardTheme, themeToLinearGradient } from '../profile/devcard';
+import { link } from '../../lib/links';
 
 export const HypeButton = ({
   className,
@@ -10,7 +10,7 @@ export const HypeButton = ({
 }): JSX.Element => {
   return (
     <a
-      href={hypeLink}
+      href={link.referral.hypeLink}
       className={classNames('rounded-12 p-1', className)}
       style={{
         backgroundImage: themeToLinearGradient[DevCardTheme.Diamond],

--- a/packages/shared/src/components/referral/HypeButton.tsx
+++ b/packages/shared/src/components/referral/HypeButton.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import { DevCardTheme, themeToLinearGradient } from '../profile/devcard';
 import { link } from '../../lib/links';
+import { anchorDefaultRel } from '../../lib/strings';
 
 export const HypeButton = ({
   className,
@@ -12,6 +13,8 @@ export const HypeButton = ({
     <a
       href={link.referral.hypeLink}
       className={classNames('rounded-12 p-1', className)}
+      target="_blank"
+      rel={anchorDefaultRel}
       style={{
         backgroundImage: themeToLinearGradient[DevCardTheme.Diamond],
       }}

--- a/packages/shared/src/components/referral/HypeCampaign.tsx
+++ b/packages/shared/src/components/referral/HypeCampaign.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import Link from 'next/link';
+import { DevCardTheme, themeToLinearGradient } from '../profile/devcard';
+import { anchorDefaultRel } from '../../lib/strings';
+import { Button, ButtonSize } from '../buttons/Button';
+import { LazyImage } from '../LazyImage';
+import { cloudinary } from '../../lib/image';
+
+export const HypeCampaign = (): JSX.Element => {
+  const href = 'https://r.daily.dev/kawaii ';
+
+  return (
+    <div
+      className="mb-8 flex flex-col rounded-16 p-1"
+      style={{
+        backgroundImage: themeToLinearGradient[DevCardTheme.Diamond],
+      }}
+    >
+      <div className="flex max-w-full flex-col rounded-12 bg-background-default p-4 pt-5 laptop:flex-row">
+        <div className="mb-5 flex-1 laptop:mb-0">
+          <Link href={href}>
+            <a
+              className="mb-4 mt-0 flex flex-wrap bg-clip-text font-bold text-transparent typo-title2"
+              target="_blank"
+              style={{
+                backgroundImage: themeToLinearGradient[DevCardTheme.Diamond],
+              }}
+              rel={anchorDefaultRel}
+            >
+              Want to win a free t-shirt?
+            </a>
+          </Link>
+
+          <p className="mb-4 typo-callout">
+            <strong>Welcome to the daily.dev June ambassador program!</strong>{' '}
+            For the entire month of June, every 24 hours, we&apos;re giving away
+            a free, limited-edition t-shirt.
+          </p>
+
+          <Button
+            size={ButtonSize.Small}
+            style={{
+              background: themeToLinearGradient[DevCardTheme.Diamond],
+            }}
+            tag="a"
+            target="_blank"
+            rel={anchorDefaultRel}
+            href={href}
+          >
+            I want that shirt!
+          </Button>
+        </div>
+
+        <Link href={href}>
+          <a
+            className="block h-fit cursor-pointer overflow-hidden rounded-10 laptop:ml-3 laptop:w-[244px]"
+            target="_blank"
+            rel={anchorDefaultRel}
+          >
+            <LazyImage
+              imgSrc={cloudinary.referralCampaign.hypeCampaign}
+              imgAlt="daily.dev June ambassador program t-shirt"
+              ratio="72%"
+              eager
+            />
+          </a>
+        </Link>
+      </div>
+    </div>
+  );
+};

--- a/packages/shared/src/components/referral/HypeCampaign.tsx
+++ b/packages/shared/src/components/referral/HypeCampaign.tsx
@@ -6,9 +6,9 @@ import { Button, ButtonSize } from '../buttons/Button';
 import { LazyImage } from '../LazyImage';
 import { cloudinary } from '../../lib/image';
 
-export const HypeCampaign = (): JSX.Element => {
-  const href = 'https://r.daily.dev/kawaii ';
+export const hypeLink = 'https://r.daily.dev/kawaii ';
 
+export const HypeCampaign = (): JSX.Element => {
   return (
     <div
       className="mb-8 flex flex-col rounded-16 p-1"
@@ -18,7 +18,7 @@ export const HypeCampaign = (): JSX.Element => {
     >
       <div className="flex max-w-full flex-col rounded-12 bg-background-default p-4 pt-5 laptop:flex-row">
         <div className="mb-5 flex-1 laptop:mb-0">
-          <Link href={href}>
+          <Link href={hypeLink}>
             <a
               className="mb-4 mt-0 flex flex-wrap bg-clip-text font-bold text-transparent typo-title2"
               target="_blank"
@@ -45,13 +45,13 @@ export const HypeCampaign = (): JSX.Element => {
             tag="a"
             target="_blank"
             rel={anchorDefaultRel}
-            href={href}
+            href={hypeLink}
           >
             I want that shirt!
           </Button>
         </div>
 
-        <Link href={href}>
+        <Link href={hypeLink}>
           <a
             className="block h-fit cursor-pointer overflow-hidden rounded-10 laptop:ml-3 laptop:w-[244px]"
             target="_blank"

--- a/packages/shared/src/components/referral/HypeCampaign.tsx
+++ b/packages/shared/src/components/referral/HypeCampaign.tsx
@@ -5,8 +5,7 @@ import { anchorDefaultRel } from '../../lib/strings';
 import { Button, ButtonSize } from '../buttons/Button';
 import { LazyImage } from '../LazyImage';
 import { cloudinary } from '../../lib/image';
-
-export const hypeLink = 'https://r.daily.dev/kawaii ';
+import { link } from '../../lib/links';
 
 export const HypeCampaign = (): JSX.Element => {
   return (
@@ -18,7 +17,7 @@ export const HypeCampaign = (): JSX.Element => {
     >
       <div className="flex max-w-full flex-col rounded-12 bg-background-default p-4 pt-5 laptop:flex-row">
         <div className="mb-5 flex-1 laptop:mb-0">
-          <Link href={hypeLink}>
+          <Link href={link.referral.hypeLink}>
             <a
               className="mb-4 mt-0 flex flex-wrap bg-clip-text font-bold text-transparent typo-title2"
               target="_blank"
@@ -45,13 +44,13 @@ export const HypeCampaign = (): JSX.Element => {
             tag="a"
             target="_blank"
             rel={anchorDefaultRel}
-            href={hypeLink}
+            href={link.referral.hypeLink}
           >
             I want that shirt!
           </Button>
         </div>
 
-        <Link href={hypeLink}>
+        <Link href={link.referral.hypeLink}>
           <a
             className="block h-fit cursor-pointer overflow-hidden rounded-10 laptop:ml-3 laptop:w-[244px]"
             target="_blank"

--- a/packages/shared/src/components/referral/index.ts
+++ b/packages/shared/src/components/referral/index.ts
@@ -1,0 +1,2 @@
+export * from './InviteLinkInput';
+export * from './HypeCampaign';

--- a/packages/shared/src/components/referral/index.ts
+++ b/packages/shared/src/components/referral/index.ts
@@ -1,2 +1,3 @@
 export * from './InviteLinkInput';
 export * from './HypeCampaign';
+export * from './HypeButton';

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -55,6 +55,7 @@ import { ActionType } from '../../graphql/actions';
 import { useFeature } from '../GrowthBookProvider';
 import { CustomFeedsExperiment } from '../../lib/featureValues';
 import { feature } from '../../lib/featureManagement';
+import { HypeButton } from '../referral';
 
 export default function Sidebar({
   promotionalBannerActive = false,
@@ -86,6 +87,7 @@ export default function Sidebar({
   const featureTheme = useFeatureTheme();
   const { checkHasCompleted, isActionsFetched } = useActions();
   const customFeedsVersion = useFeature(feature.customFeeds);
+  const hypeCampaign = useFeature(feature.hypeCampaign);
   const hasCustomFeedsEnabled =
     customFeedsVersion !== CustomFeedsExperiment.Control;
 
@@ -141,6 +143,8 @@ export default function Sidebar({
           className={classNames('h-10 pt-4')}
           featureTheme={featureTheme}
         />
+
+        {hypeCampaign && <HypeButton />}
 
         <Link href={`${webappUrl}`} prefetch={false} passHref>
           <Button

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -49,6 +49,7 @@ const feature = {
     FeedListLayoutExperiment.Control,
   ),
   customFeeds: new Feature('custom_feeds', CustomFeedsExperiment.Control),
+  hypeCampaign: new Feature('hype_campaign', false),
 };
 
 export { feature };

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -128,6 +128,8 @@ export const cloudinary = {
       'https://daily-now-res.cloudinary.com/image/upload/s--YzB9MTQz--/v1686039108/main-background_ciqmr7.svg',
     purpleEdgeGlow:
       'https://daily-now-res.cloudinary.com/image/upload/s--Va9xODJM--/v1686074969/Glow_fjelt5.svg',
+    hypeCampaign:
+      'https://daily-now-res.cloudinary.com/image/upload/s--WLukth0U--/f_auto/v1716900469/dailydev_kawaii_tshirt__jwxmqw',
   },
   search: {
     og: 'https://daily-now-res.cloudinary.com/image/upload/s--Lq4XRH5V--/f_auto/v1693378429/public/dailv.dev_-_OG_Search',

--- a/packages/shared/src/lib/links.ts
+++ b/packages/shared/src/lib/links.ts
@@ -35,5 +35,6 @@ export const link = {
   },
   referral: {
     defaultUrl: 'https://daily.dev',
+    hypeLink: 'https://r.daily.dev/kawaii',
   },
 };

--- a/packages/webapp/pages/account/invite.tsx
+++ b/packages/webapp/pages/account/invite.tsx
@@ -30,8 +30,13 @@ import {
 } from '@dailydotdev/shared/src/lib/analytics';
 import { ShareProvider } from '@dailydotdev/shared/src/lib/share';
 import { useShareOrCopyLink } from '@dailydotdev/shared/src/hooks/useShareOrCopyLink';
-import { InviteLinkInput } from '@dailydotdev/shared/src/components/referral/InviteLinkInput';
+import {
+  InviteLinkInput,
+  HypeCampaign,
+} from '@dailydotdev/shared/src/components/referral';
 import { TruncateText } from '@dailydotdev/shared/src/components/utilities';
+import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import AccountContentSection from '../../components/layouts/AccountLayout/AccountContentSection';
 import { AccountPageContainer } from '../../components/layouts/AccountLayout/AccountPageContainer';
 import { getAccountLayout } from '../../components/layouts/AccountLayout';
@@ -77,6 +82,8 @@ const AccountInvitePage = (): ReactElement => {
     return list;
   }, [usersResult]);
 
+  const hypeCampaign = useFeature(feature.hypeCampaign);
+
   const onTrackShare = (provider: ShareProvider) => {
     trackEvent({
       event_name: AnalyticsEvent.InviteReferral,
@@ -87,6 +94,8 @@ const AccountInvitePage = (): ReactElement => {
 
   return (
     <AccountPageContainer title="Invite friends">
+      {hypeCampaign && <HypeCampaign />}
+
       <InviteLinkInput
         link={inviteLink}
         trackingProps={{


### PR DESCRIPTION
AS-341

Some things might be a bit dirty code wise, as we hope to have it released in extension by tomorrow

# Adds t-shirt 👕 to profile menu
![image](https://github.com/dailydotdev/apps/assets/1681525/1e7b410e-e4ab-46e9-8eb0-20de347d8ecf)
<img width="414" alt="image" src="https://github.com/dailydotdev/apps/assets/1681525/edc7b6d6-d0bb-4d65-80b3-57c34e8e2d19">

# Adds hype button next to logo
<img width="424" alt="image" src="https://github.com/dailydotdev/apps/assets/1681525/cb558022-e0e1-4950-a808-defbaebffa2e">
<img width="210" alt="image" src="https://github.com/dailydotdev/apps/assets/1681525/7e86ed5e-6f26-4efa-a78e-ae24b88e470b">
<img width="254" alt="image" src="https://github.com/dailydotdev/apps/assets/1681525/96ccf393-af72-4eeb-b646-5c80613e136e">

# Adds hype CTA to invite friends page
<img width="664" alt="image" src="https://github.com/dailydotdev/apps/assets/1681525/6a240d86-cba1-4ae7-85f3-3277050c608f">



### Preview domain
https://as-341-hype-campaign.preview.app.daily.dev