### PR TITLE
feat: add google search provider

### DIFF
--- a/packages/shared/src/components/search/SearchPanel/SearchPanel.tsx
+++ b/packages/shared/src/components/search/SearchPanel/SearchPanel.tsx
@@ -20,7 +20,7 @@ import {
 import { SearchPanelAction } from './SearchPanelAction';
 import { SearchPanelPostSuggestions } from './SearchPanelPostSuggestions';
 import SettingsContext from '../../../contexts/SettingsContext';
-import { useEventListener } from '../../../hooks';
+import { useConditionalFeature, useEventListener } from '../../../hooks';
 import { defaultSearchProvider, providerToLabelTextMap } from './common';
 import { ArrowKeyEnum } from '../../../lib/func';
 import { ArrowIcon } from '../../icons';
@@ -29,6 +29,7 @@ import { SearchPanelCustomAction } from './SearchPanelCustomAction';
 import { AnalyticsEvent } from '../../../lib/analytics';
 import { useAnalyticsContext } from '../../../contexts/AnalyticsContext';
 import { SearchPanelTagSuggestions } from './SearchPanelTagSuggestions';
+import { feature } from '../../../lib/featureManagement';
 
 export type SearchPanelProps = {
   className?: SearchPanelClassName;
@@ -138,6 +139,11 @@ export const SearchPanel = ({ className }: SearchPanelProps): ReactElement => {
   const showDropdown =
     state.isActive && state.query.length >= minSearchQueryLength;
 
+  const { value: isGoogleSearchEnabled } = useConditionalFeature({
+    feature: feature.searchGoogle,
+    shouldEvaluate: showDropdown,
+  });
+
   return (
     <SearchPanelContext.Provider value={searchPanel}>
       <div
@@ -181,6 +187,9 @@ export const SearchPanel = ({ className }: SearchPanelProps): ReactElement => {
               <div className="flex flex-1 flex-col">
                 <SearchPanelAction provider={SearchProviderEnum.Posts} />
                 <SearchPanelAction provider={SearchProviderEnum.Chat} />
+                {isGoogleSearchEnabled && (
+                  <SearchPanelAction provider={SearchProviderEnum.Google} />
+                )}
                 <SearchPanelTagSuggestions title="Tags" />
                 <SearchPanelPostSuggestions title="Posts on daily.dev" />
                 <SearchPanelCustomAction

--- a/packages/shared/src/components/search/SearchPanel/common.tsx
+++ b/packages/shared/src/components/search/SearchPanel/common.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react';
 import classNames from 'classnames';
 import { SearchProviderEnum } from '../../../graphql/search';
 import { IconProps } from '../../Icon';
-import { MagicIcon, SearchIcon } from '../../icons';
+import { GoogleIcon, MagicIcon, SearchIcon } from '../../icons';
 
 export const defaultSearchProvider = SearchProviderEnum.Posts;
 
@@ -10,6 +10,7 @@ export const providerToLabelTextMap: Record<SearchProviderEnum, string> = {
   [SearchProviderEnum.Posts]: 'Search posts',
   [SearchProviderEnum.Chat]: 'Ask daily.dev AI',
   [SearchProviderEnum.Tags]: 'Search tags',
+  [SearchProviderEnum.Google]: 'Search on Google',
 };
 
 export const providerToIconMap: Record<
@@ -28,4 +29,11 @@ export const providerToIconMap: Record<
     />
   ),
   [SearchProviderEnum.Tags]: SearchIcon,
+  [SearchProviderEnum.Google]: ({ className, ...rest }: IconProps) => (
+    <GoogleIcon
+      className={classNames(className, 'bg-white')}
+      secondary
+      {...rest}
+    />
+  ),
 };

--- a/packages/shared/src/graphql/search.ts
+++ b/packages/shared/src/graphql/search.ts
@@ -10,6 +10,7 @@ export enum SearchProviderEnum {
   Posts = 'posts',
   Chat = 'chat',
   Tags = 'tags',
+  Google = 'google',
 }
 
 const searchPageUrl = `${webappUrl}search`;
@@ -268,6 +269,14 @@ interface SearchUrlParams {
   provider: SearchProviderEnum;
 }
 
+const externalSearchProviders: Partial<
+  Record<SearchProviderEnum, { url: URL }>
+> = {
+  [SearchProviderEnum.Google]: {
+    url: new URL('https://www.google.com/search'),
+  },
+};
+
 export const getSearchUrl = (params: SearchUrlParams): string => {
   const { id, query, provider = SearchProviderEnum.Posts } = params;
   const searchParams = new URLSearchParams();
@@ -276,7 +285,9 @@ export const getSearchUrl = (params: SearchUrlParams): string => {
     throw new Error('provider is required');
   }
 
-  if (provider !== SearchProviderEnum.Posts) {
+  const externalSearchProvider = externalSearchProviders[provider];
+
+  if (provider !== SearchProviderEnum.Posts && !externalSearchProvider) {
     searchParams.append('provider', provider);
   }
 
@@ -286,11 +297,10 @@ export const getSearchUrl = (params: SearchUrlParams): string => {
     searchParams.append('q', query);
   }
 
+  const searchUrl = externalSearchProvider?.url || searchPageUrl;
   const searchParamsString = searchParams.toString();
 
-  return `${searchPageUrl}${
-    searchParamsString ? `?${searchParamsString}` : ''
-  }`;
+  return `${searchUrl}${searchParamsString ? `?${searchParamsString}` : ''}`;
 };
 
 export const searchQueryUrl = `${apiUrl}/search/query`;

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -50,6 +50,7 @@ const feature = {
   ),
   customFeeds: new Feature('custom_feeds', CustomFeedsExperiment.Control),
   hypeCampaign: new Feature('hype_campaign', false),
+  searchGoogle: new Feature('search_google', false),
 };
 
 export { feature };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Add google search provider
- User enrolled only when they actually see search panel action (same as tag experiment)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-347 #done


### Preview domain
https://as-347-google-search-provider.preview.app.daily.dev