### PR TITLE
feat: refetch custom feed after edit

### DIFF
--- a/packages/shared/src/graphql/feed.ts
+++ b/packages/shared/src/graphql/feed.ts
@@ -386,12 +386,16 @@ export const CUSTOM_FEED_QUERY = gql`
     $after: String
     $first: Int
     ${SUPPORTED_TYPES}
+    $version: Int
+    $ranking: Ranking
   ) {
     page: customFeed(
       feedId: $feedId
       after: $after
       first: $first
       supportedTypes: $supportedTypes
+      version: $version
+      ranking: $ranking
     ) {
       ...FeedPostConnection
     }

--- a/packages/webapp/pages/feeds/[slugOrId]/edit.tsx
+++ b/packages/webapp/pages/feeds/[slugOrId]/edit.tsx
@@ -44,6 +44,8 @@ import { withExperiment } from '@dailydotdev/shared/src/components/withExperimen
 import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { CustomFeedsExperiment } from '@dailydotdev/shared/src/lib/featureValues';
 import { useAnalyticsContext } from '@dailydotdev/shared/src/contexts/AnalyticsContext';
+import { generateQueryKey } from '@dailydotdev/shared/src/lib/query';
+import { SharedFeedPage } from '@dailydotdev/shared/src/components/utilities';
 import { mainFeedLayoutProps } from '../../../components/layouts/MainFeedPage';
 import { getLayout } from '../../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
@@ -135,6 +137,9 @@ const EditFeedPage = (): ReactElement => {
         });
 
         queryClient.removeQueries(getFeedSettingsQueryKey(user, feedId));
+        queryClient.removeQueries(
+          generateQueryKey(SharedFeedPage.Custom, user),
+        );
 
         onAskConfirmation(false);
         router.replace(`${webappUrl}feeds/${data.id}`);


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://refetch-custom-feed-after-edit.preview.app.daily.dev