### PR TITLE
fix: already public squads don't need to check requests for approval

### DIFF
--- a/packages/shared/src/components/squads/Details.tsx
+++ b/packages/shared/src/components/squads/Details.tsx
@@ -76,10 +76,11 @@ export function SquadDetails({
     memberInviteRole: initialMemberInviteRole,
   } = form;
   const isRequestsEnabled =
-    !createMode && !form.public && !form.flags?.totalPosts && !!form?.id;
+    !createMode && !form.flags?.totalPosts && !!form?.id;
   const { status, daysLeft } = usePublicSquadRequests({
     isQueryEnabled: isRequestsEnabled,
     sourceId: form?.id,
+    isPublic: form?.public,
   });
   const [activeHandle, setActiveHandle] = useState(handle);
   const [privacy, setPrivacy] = useState(

--- a/packages/shared/src/hooks/squads/usePublicSquadRequests.ts
+++ b/packages/shared/src/hooks/squads/usePublicSquadRequests.ts
@@ -38,6 +38,7 @@ interface UsePublicSquadRequestsProps {
   isQueryEnabled?: boolean;
   sourceId: string;
   status?: string;
+  isPublic?: boolean;
   onSuccessfulSubmission?: () => void;
 }
 
@@ -49,6 +50,7 @@ const remoteStatusMap: Record<PublicSquadRequestStatus, SquadStatus> = {
 
 export const usePublicSquadRequests = ({
   isQueryEnabled,
+  isPublic,
   sourceId,
   onSuccessfulSubmission,
 }: UsePublicSquadRequestsProps): UsePublicSquadRequestsResult => {
@@ -62,7 +64,10 @@ export const usePublicSquadRequests = ({
   const { data: requests, isFetched } = useInfiniteQuery(
     key,
     (params) => getPublicSquadRequests({ ...params, sourceId }),
-    { enabled: isQueryEnabled && !!sourceId, staleTime: StaleTime.Default },
+    {
+      enabled: isQueryEnabled && !!sourceId && !isPublic,
+      staleTime: StaleTime.Default,
+    },
   );
 
   const { mutateAsync: submitForReview, isLoading: isSubmitLoading } =
@@ -91,6 +96,10 @@ export const usePublicSquadRequests = ({
   const latestRequest = edges?.[edges?.length - 1]?.node;
 
   const status = useMemo(() => {
+    if (isPublic) {
+      return SquadStatus.Approved;
+    }
+
     if (!latestRequest) {
       return SquadStatus.InProgress;
     }
@@ -104,7 +113,7 @@ export const usePublicSquadRequests = ({
     }
 
     return remoteStatusMap[latestRequest.status];
-  }, [latestRequest]);
+  }, [latestRequest, isPublic]);
 
   const daysLeft = useMemo(() => {
     if (


### PR DESCRIPTION
## Changes
- Existing public Squads, when checked by admins should automatically see the config to put it to private/public.
- To streamline the checking, we will do it at the hook where we return the status.

Slack thread: https://dailydotdev.slack.com/archives/C069XNYMDGV/p1716987326010879

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-already-public-squads.preview.app.daily.dev