### PR TITLE
fix: add missing link to `Back home` on unauthorized page

### DIFF
--- a/packages/shared/src/components/errors/Unauthorized.tsx
+++ b/packages/shared/src/components/errors/Unauthorized.tsx
@@ -3,6 +3,7 @@ import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { LockIcon } from '../icons';
 import { PageContainerCentered } from '../utilities';
 import { IconSize } from '../Icon';
+import { webappUrl } from '../../lib/constants';
 
 interface UnauthorizedProps {
   children?: ReactNode;
@@ -34,6 +35,8 @@ function Unauthorized({
         className="mt-6 w-fit"
         variant={ButtonVariant.Primary}
         size={ButtonSize.Large}
+        tag="a"
+        href={webappUrl}
       >
         Back home
       </Button>


### PR DESCRIPTION
Fixes https://github.com/dailydotdev/daily/issues/1182

### Preview domain
https://fix-back-home-button.preview.app.daily.dev