### PR TITLE
fix: update to growthbook sdk that works with their dev extension

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -6,7 +6,7 @@ function switchDependency(pkg, dep, newDep) {
 
 function readPackage(pkg) {
   if (pkg.dependencies) {
-    switchDependency(pkg, '@growthbook/growthbook', 'https://gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?a0d1a3add257acdbf5353dfd690547feebbada92');
+    switchDependency(pkg, '@growthbook/growthbook', 'https://gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?b8f31f9e80879fe2bcc42b275087b50e1357f1cb');
   }
   return pkg
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -106,7 +106,7 @@
     "typescript": "4.9.5"
   },
   "dependencies": {
-    "@growthbook/growthbook": "https://gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?a0d1a3add257acdbf5353dfd690547feebbada92",
+    "@growthbook/growthbook": "https://gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?b8f31f9e80879fe2bcc42b275087b50e1357f1cb",
     "@growthbook/growthbook-react": "^0.17.0",
     "@tippyjs/react": "^4.2.5",
     "balloon-css": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,8 +382,8 @@ importers:
   packages/shared:
     dependencies:
       '@growthbook/growthbook':
-        specifier: https://gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?a0d1a3add257acdbf5353dfd690547feebbada92
-        version: '@gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?a0d1a3add257acdbf5353dfd690547feebbada92'
+        specifier: https://gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?b8f31f9e80879fe2bcc42b275087b50e1357f1cb
+        version: '@gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?b8f31f9e80879fe2bcc42b275087b50e1357f1cb'
       '@growthbook/growthbook-react':
         specifier: ^0.17.0
         version: 0.17.0(react@17.0.2)
@@ -4638,7 +4638,7 @@ packages:
     peerDependencies:
       react: ^16.8.0-0 || ^17.0.0-0 || ^18.0.0-0
     dependencies:
-      '@growthbook/growthbook': '@gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?a0d1a3add257acdbf5353dfd690547feebbada92'
+      '@growthbook/growthbook': '@gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?b8f31f9e80879fe2bcc42b275087b50e1357f1cb'
       react: 17.0.2
     dev: false
 
@@ -20326,8 +20326,8 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
 
-  '@gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?a0d1a3add257acdbf5353dfd690547feebbada92':
-    resolution: {registry: https://registry.npmjs.org/, tarball: https://gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?a0d1a3add257acdbf5353dfd690547feebbada92}
+  '@gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?b8f31f9e80879fe2bcc42b275087b50e1357f1cb':
+    resolution: {tarball: https://gitpkg.now.sh/dailydotdev/growthbook/packages/sdk-js?b8f31f9e80879fe2bcc42b275087b50e1357f1cb}
     name: '@growthbook/growthbook'
     version: 0.27.0
     engines: {node: '>=10'}


### PR DESCRIPTION
SDK adds missing `getApiInfo` https://github.com/dailydotdev/growthbook/pull/1
