### PR TITLE
fix: don't override ← or → keys in search panel

### DIFF
--- a/packages/shared/src/components/search/SearchPanel/SearchPanel.tsx
+++ b/packages/shared/src/components/search/SearchPanel/SearchPanel.tsx
@@ -115,6 +115,11 @@ export const SearchPanel = ({ className }: SearchPanelProps): ReactElement => {
       [ArrowKeyEnum.Down]: 1,
     };
 
+    if (activeElementIndex !== 0) {
+      keyToIndexModifier[ArrowKeyEnum.Left] = -1;
+      keyToIndexModifier[ArrowKeyEnum.Right] = 1;
+    }
+
     const supportedKeys = Object.keys(keyToIndexModifier);
 
     const pressedKey = supportedKeys.find((key) => key === event.key);

--- a/packages/shared/src/components/search/SearchPanel/SearchPanel.tsx
+++ b/packages/shared/src/components/search/SearchPanel/SearchPanel.tsx
@@ -113,8 +113,6 @@ export const SearchPanel = ({ className }: SearchPanelProps): ReactElement => {
     const keyToIndexModifier: Partial<Record<ArrowKeyEnum, number>> = {
       [ArrowKeyEnum.Up]: -1,
       [ArrowKeyEnum.Down]: 1,
-      [ArrowKeyEnum.Left]: -1,
-      [ArrowKeyEnum.Right]: 1,
     };
 
     const supportedKeys = Object.keys(keyToIndexModifier);


### PR DESCRIPTION
Gives back control of `←` or `→` keys when inside input element so it is possible to navigate in input text.

AS-330

### Preview domain
https://as-330-fix-arrow-keys-in-search-bar.preview.app.daily.dev