### PR TITLE
fix: breadcrumb state more inline with design

### DIFF
--- a/packages/webapp/components/common.tsx
+++ b/packages/webapp/components/common.tsx
@@ -35,7 +35,7 @@ export const ListItem = ({
 
 const BreadCrumbsWrapper = classed(
   'div',
-  'hidden h-10 items-center p-1.5 text-border-subtlest-tertiary laptop:flex',
+  'hidden h-10 gap-0.5 items-center p-1.5 text-border-subtlest-tertiary laptop:flex',
 );
 
 export const BreadCrumbs = ({
@@ -52,7 +52,10 @@ export const BreadCrumbs = ({
         href={process.env.NEXT_PUBLIC_WEBAPP_URL}
         size={ButtonSize.XSmall}
       />
-      /{children}
+      <span>/</span>
+      <div className="flex flex-row items-center gap-1 px-2 font-bold text-text-primary typo-callout">
+        {children}
+      </div>
     </BreadCrumbsWrapper>
   );
 };

--- a/packages/webapp/pages/sources/index.tsx
+++ b/packages/webapp/pages/sources/index.tsx
@@ -2,9 +2,15 @@ import React, { ReactElement } from 'react';
 import { UserHighlight } from '@dailydotdev/shared/src/components/widgets/PostUsersHighlights';
 import {
   Button,
+  ButtonIconPosition,
+  ButtonSize,
   ButtonVariant,
 } from '@dailydotdev/shared/src/components/buttons/Button';
-import { PlusIcon, SitesIcon } from '@dailydotdev/shared/src/components/icons';
+import {
+  HashtagIcon,
+  PlusIcon,
+  SitesIcon,
+} from '@dailydotdev/shared/src/components/icons';
 import { LazyModal } from '@dailydotdev/shared/src/components/modals/common/types';
 import { useLazyModal } from '@dailydotdev/shared/src/hooks/useLazyModal';
 import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
@@ -21,6 +27,7 @@ import {
   TRENDING_SOURCES_QUERY,
 } from '@dailydotdev/shared/src/graphql/sources';
 import { ElementPlaceholder } from '@dailydotdev/shared/src/components/ElementPlaceholder';
+import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import { getLayout } from '../../components/layouts/MainLayout';
 import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
 import { BreadCrumbs, ListItem, TopList } from '../../components/common';
@@ -112,13 +119,9 @@ const SourcesPage = (): ReactElement => {
     <main className="py-6 tablet:px-4 laptop:px-10">
       <div className="flex justify-between">
         <BreadCrumbs>
-          <Button
-            variant={ButtonVariant.Tertiary}
-            icon={<SitesIcon secondary />}
-            disabled
-          >
-            Sources
-          </Button>
+          <>
+            <SitesIcon size={IconSize.XSmall} secondary /> Sources
+          </>
         </BreadCrumbs>
         <Button
           icon={<PlusIcon />}

--- a/packages/webapp/pages/tags/index.tsx
+++ b/packages/webapp/pages/tags/index.tsx
@@ -15,13 +15,16 @@ import { TagLink } from '@dailydotdev/shared/src/components/TagLinks';
 import classed from '@dailydotdev/shared/src/lib/classed';
 import {
   Button,
+  ButtonIconPosition,
+  ButtonSize,
   ButtonVariant,
 } from '@dailydotdev/shared/src/components/buttons/Button';
 import { HashtagIcon } from '@dailydotdev/shared/src/components/icons';
 import { ElementPlaceholder } from '@dailydotdev/shared/src/components/ElementPlaceholder';
+import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
 import { getLayout } from '../../components/layouts/MainLayout';
-import { ListItem, BreadCrumbs, TopList } from '../../components/common';
+import { BreadCrumbs, ListItem, TopList } from '../../components/common';
 
 const PlaceholderList = classed(
   ElementPlaceholder,
@@ -114,13 +117,9 @@ const TagsPage = (): ReactElement => {
   return (
     <main className="flex flex-col gap-4 p-0 tablet:px-10 tablet:py-6">
       <BreadCrumbs>
-        <Button
-          variant={ButtonVariant.Tertiary}
-          icon={<HashtagIcon secondary />}
-          disabled
-        >
-          Tags
-        </Button>
+        <>
+          <HashtagIcon size={IconSize.XSmall} secondary /> Tags
+        </>
       </BreadCrumbs>
       <div className="grid grid-cols-1 gap-0 tablet:grid-cols-2 tablet:gap-6 laptopL:grid-cols-3">
         <TagTopList


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Short and concise, bullet points can help
- Screenshots if applicable can also help

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://hotfix-breadcrumbs.preview.app.daily.dev