### PR TITLE
feat: add shortcuts ui experiment

### DIFF
--- a/packages/extension/src/newtab/ShortcutLinks.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.tsx
@@ -240,7 +240,7 @@ export default function ShortcutLinks({
     ];
 
     return (
-      <div className="mb-6 flex flex-col gap-6 px-4 laptop:items-center">
+      <div className="mb-6 hidden flex-col gap-6 px-4 tablet:flex laptop:items-center">
         <h4 className="font-bold text-text-primary typo-title3">
           Choose your most visited sites.
         </h4>

--- a/packages/extension/src/newtab/ShortcutLinks.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.tsx
@@ -131,7 +131,7 @@ export default function ShortcutLinks({
 }: ShortcutLinksProps): ReactElement {
   const className = !shouldUseListFeedLayout
     ? 'ml-auto'
-    : 'mt-4 w-fit [@media(width<=680px)]:mx-6';
+    : 'mt-4 w-fit mx-4 laptop:mx-0';
   const { checkHasCompleted, isActionsFetched, completeAction } = useActions();
   const shortcutsUIFeature = useFeature(feature.shortcutsUI);
   const isShortcutsUIV1 = shortcutsUIFeature === ShortcutsUIExperiment.V1;

--- a/packages/extension/src/newtab/ShortcutLinks.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.tsx
@@ -39,6 +39,8 @@ import { combinedClicks } from '@dailydotdev/shared/src/lib/click';
 import { ActionType } from '@dailydotdev/shared/src/graphql/actions';
 import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
 import { ShortcutsUIExperiment } from '@dailydotdev/shared/src/lib/featureValues';
+import { cloudinary } from '@dailydotdev/shared/src/lib/image';
+import { useThemedAsset } from '@dailydotdev/shared/src/hooks/utils';
 import CustomLinksModal from './ShortcutLinksModal';
 import MostVisitedSitesModal from './MostVisitedSitesModal';
 import { CustomLinks } from './CustomLinks';
@@ -225,6 +227,8 @@ export default function ShortcutLinks({
     toggleShowTopSites();
   };
 
+  const { githubShortcut } = useThemedAsset();
+
   if (
     showTopSites &&
     isActionsFetched &&
@@ -232,28 +236,22 @@ export default function ShortcutLinks({
     isShortcutsUIV1
   ) {
     const placeholderShortcutLinks = [
-      'https://gmail.com',
-      'https://github.com',
-      'https://reddit.com',
-      'https://openai.com',
-      'https://stackoverflow.com',
+      cloudinary.shortcuts.icons.gmail,
+      githubShortcut,
+      cloudinary.shortcuts.icons.reddit,
+      cloudinary.shortcuts.icons.openai,
+      cloudinary.shortcuts.icons.stackoverflow,
     ];
 
     return (
       <div className="mb-6 hidden flex-col gap-6 px-4 tablet:flex laptop:items-center">
         <h4 className="font-bold text-text-primary typo-title3">
-          Choose your most visited sites.
+          Choose your most visited sites
         </h4>
         <div className="flex gap-4">
           {placeholderShortcutLinks.map((url) => (
             <ShortcutUIItemPlaceholder key={url}>
-              <img
-                src={`https://api.daily.dev/icon?url=${encodeURIComponent(
-                  url,
-                )}&size=${iconSize}`}
-                alt={url}
-                className="size-6"
-              />
+              <img src={url} alt={url} className="size-6 object-contain" />
             </ShortcutUIItemPlaceholder>
           ))}
           <ShortcutUIItemPlaceholder>

--- a/packages/shared/src/components/filters/MyFeedHeading.tsx
+++ b/packages/shared/src/components/filters/MyFeedHeading.tsx
@@ -10,7 +10,13 @@ import {
 } from '../buttons/Button';
 import AnalyticsContext from '../../contexts/AnalyticsContext';
 import { AnalyticsEvent } from '../../lib/analytics';
-import { useActions, useFeedLayout, useViewSize, ViewSize } from '../../hooks';
+import {
+  useActions,
+  useConditionalFeature,
+  useFeedLayout,
+  useViewSize,
+  ViewSize,
+} from '../../hooks';
 import { feature } from '../../lib/featureManagement';
 import { useFeature } from '../GrowthBookProvider';
 import { setShouldRefreshFeed } from '../../lib/refreshFeed';
@@ -31,6 +37,7 @@ interface MyFeedHeadingProps {
 function MyFeedHeading({
   onOpenFeedFilters,
 }: MyFeedHeadingProps): ReactElement {
+  const isExtension = checkIsExtension();
   const router = useRouter();
   const { checkHasCompleted } = useActions();
   const { showTopSites, toggleShowTopSites } = useSettingsContext();
@@ -42,7 +49,10 @@ function MyFeedHeading({
   const isLaptop = useViewSize(ViewSize.Laptop);
   const feedName = getFeedName(router.pathname);
   const { isCustomFeed } = useFeedName({ feedName });
-  const shortcutsUIFeature = useFeature(feature.shortcutsUI);
+  const { value: shortcutsUIFeature } = useConditionalFeature({
+    feature: feature.shortcutsUI,
+    shouldEvaluate: isExtension,
+  });
   const isShortcutsUIV1 = shortcutsUIFeature === ShortcutsUIExperiment.V1;
 
   const onClick = () => {
@@ -100,7 +110,7 @@ function MyFeedHeading({
       >
         {!isMobile ? feedFiltersLabel : null}
       </Button>
-      {checkIsExtension() &&
+      {isExtension &&
         checkHasCompleted(ActionType.FirstShortcutsSession) &&
         !showTopSites &&
         isShortcutsUIV1 && (

--- a/packages/shared/src/graphql/actions.ts
+++ b/packages/shared/src/graphql/actions.ts
@@ -27,6 +27,7 @@ export enum ActionType {
   MakeSquadPublic = 'make_squad_public',
   CustomFeed = 'custom_feed',
   DisableReadingStreakMilestone = 'disable_reading_streak_milestone',
+  FirstShortcutsSession = 'first_shortcuts_session',
 }
 
 export interface Action {

--- a/packages/shared/src/hooks/utils/useThemedAsset.ts
+++ b/packages/shared/src/hooks/utils/useThemedAsset.ts
@@ -8,6 +8,7 @@ interface UseAsset {
   scrollBlock: string;
   notFound: string;
   themeColor: string;
+  githubShortcut: string;
 }
 
 export const useThemedAsset = (): UseAsset => {
@@ -32,5 +33,8 @@ export const useThemedAsset = (): UseAsset => {
       ? cloudinary.generic.notFound.light
       : cloudinary.generic.notFound.dark,
     themeColor: isLight ? colors.salt['0'] : colors.pepper['90'],
+    githubShortcut: isLight
+      ? cloudinary.shortcuts.icons.github.light
+      : cloudinary.shortcuts.icons.github.dark,
   };
 };

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -4,6 +4,7 @@ import {
   TagSourceSocialProof,
   FeedListLayoutExperiment,
   CustomFeedsExperiment,
+  ShortcutsUIExperiment,
 } from './featureValues';
 import { cloudinary } from './image';
 
@@ -54,6 +55,7 @@ const feature = {
   searchGoogle: new Feature('search_google', false),
   onboardingFlip: new Feature('onboarding_flip', false),
   improvedSharedPostCard: new Feature('improved_shared_post_card', false),
+  shortcutsUI: new Feature('shortcuts_ui', ShortcutsUIExperiment.Control),
 };
 
 export { feature };

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -24,6 +24,7 @@ const feature = {
   bookmarkOnCard: new Feature('bookmark_on_card', false),
   onboardingVisual: new Feature('onboarding_visual', {
     showCompanies: true,
+    fullBackground: false,
     image: cloudinary.onboarding.default,
   }),
   forceRefresh: new Feature('force_refresh', false),

--- a/packages/shared/src/lib/featureValues.ts
+++ b/packages/shared/src/lib/featureValues.ts
@@ -26,6 +26,11 @@ export enum CustomFeedsExperiment {
   V1 = 'v1',
 }
 
+export enum ShortcutsUIExperiment {
+  Control = 'control',
+  V1 = 'v1',
+}
+
 export interface FeatureThemeVariant {
   logo?: string;
   logoText?: string;

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -183,6 +183,23 @@ export const cloudinary = {
     bookmarkLoops:
       'https://res.cloudinary.com/daily-now/image/upload/s--n2t9TCqZ--/f_auto/v1713991549/public/daily',
   },
+  shortcuts: {
+    icons: {
+      gmail:
+        'https://res.cloudinary.com/daily-now/image/upload/s--QYLzNTIV--/f_auto/v1717506847/public/Gmail%20Shortcut',
+      github: {
+        light:
+          'https://res.cloudinary.com/daily-now/image/upload/s--M5XOonZ3--/f_auto/v1717513011/public/GitHub%20Shortcut%20-%20Light%20mode',
+        dark: 'https://res.cloudinary.com/daily-now/image/upload/s--qyAG2NPK--/f_auto/v1717513011/public/GitHub%20Shortcut%20-%20Dark%20mode',
+      },
+      reddit:
+        'https://res.cloudinary.com/daily-now/image/upload/s--9UfrZdCc--/f_auto/v1717506847/public/Reddit%20Shortcut',
+      openai:
+        'https://res.cloudinary.com/daily-now/image/upload/s--D__WRZ3a--/f_auto/v1717506847/public/ChatGPT%20Shortcut',
+      stackoverflow:
+        'https://res.cloudinary.com/daily-now/image/upload/s--B_87VDub--/f_auto/v1717506847/public/Stackoverflow%20Shortcut',
+    },
+  },
 };
 
 export const smallPostImage = (url: string): string => {

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -150,6 +150,12 @@ export const cloudinary = {
     glow: 'https://daily-now-res.cloudinary.com/image/upload/v1694596741/Glow_o9ehvn.svg',
     default:
       'https://daily-now-res.cloudinary.com/image/upload/s--eQyhCzPZ--/f_auto/v1715169755/Master_image_mzjgot',
+    fullBackground: {
+      mobile:
+        'https://daily-now-res.cloudinary.com/image/upload/s--EwsBTBt6--/f_auto/v1716969841/dailydev_where_developers_suffer_together_mobile_shkn1w',
+      desktop:
+        'https://daily-now-res.cloudinary.com/image/upload/s--r2ffZPB4--/f_auto/v1716969841/dailydev_where_developers_suffer_together_sfvfog',
+    },
   },
   generic: {
     notFound: {

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -73,6 +73,17 @@ import { LoggedUser } from '@dailydotdev/shared/src/lib/user';
 import { defaultOpenGraph, defaultSeo } from '../next-seo';
 import styles from '../components/layouts/Onboarding/index.module.css';
 
+type OnboardingVisual = {
+  showCompanies?: boolean;
+  fullBackground?:
+    | {
+        mobile?: string;
+        desktop?: string;
+      }
+    | false;
+  image?: string;
+};
+
 const Title = classed('h2', 'font-bold');
 
 const maxAuthWidth = 'tablet:max-w-[30rem]';
@@ -115,10 +126,6 @@ export function OnboardPage(): ReactElement {
   } = auth;
   const isPageReady = growthbook?.ready && isAuthReady;
   const { feedSettings } = useFeedSettings();
-  type OnboardingVisual = {
-    showCompanies?: boolean;
-    image?: string;
-  };
   const isMobile = useViewSize(ViewSize.MobileL);
   const onboardingVisual: OnboardingVisual = useFeature(
     feature.onboardingVisual,
@@ -266,6 +273,9 @@ export function OnboardPage(): ReactElement {
           activeScreen === OnboardingStep.Intro && onboardingFlip
             ? 'tablet:mr-auto'
             : 'tablet:ml-auto',
+          activeScreen === OnboardingStep.Intro &&
+            onboardingVisual.fullBackground &&
+            'flex-1',
         )}
       >
         {activeScreen === OnboardingStep.ReadingReminder && (
@@ -308,27 +318,28 @@ export function OnboardPage(): ReactElement {
             )}
           </>
         )}
-        {activeScreen === OnboardingStep.Intro && (
-          <div className="block flex-1">
-            <div
-              className={classNames(
-                'tablet:min-h-[800px]:pt-[100%] relative overflow-y-clip tablet:overflow-y-visible tablet:pt-[80%]',
-              )}
-            >
-              <img
-                src={onboardingVisual.image}
-                alt="Onboarding cover"
+        {activeScreen === OnboardingStep.Intro &&
+          !onboardingVisual.fullBackground && (
+            <div className="block flex-1">
+              <div
                 className={classNames(
-                  'relative tablet:absolute tablet:left-0 tablet:top-0 tablet:-z-1',
-                  styles.image,
+                  'tablet:min-h-[800px]:pt-[100%] relative overflow-y-clip tablet:overflow-y-visible tablet:pt-[80%]',
                 )}
-              />
+              >
+                <img
+                  src={onboardingVisual.image}
+                  alt="Onboarding cover"
+                  className={classNames(
+                    'relative tablet:absolute tablet:left-0 tablet:top-0 tablet:-z-1',
+                    styles.image,
+                  )}
+                />
+              </div>
+              {onboardingVisual.showCompanies && (
+                <TrustedCompanies className="hidden tablet:block" />
+              )}
             </div>
-            {onboardingVisual.showCompanies && (
-              <TrustedCompanies className="hidden tablet:block" />
-            )}
-          </div>
-        )}
+          )}
       </div>
     );
   };
@@ -357,7 +368,24 @@ export function OnboardPage(): ReactElement {
   }
 
   return (
-    <div className="z-3 flex h-full max-h-screen min-h-screen w-full flex-1 flex-col items-center overflow-x-hidden">
+    <div
+      className={classNames(
+        'z-3 flex h-full max-h-screen min-h-screen w-full flex-1 flex-col items-center overflow-x-hidden',
+        showOnboardingPage &&
+          onboardingVisual.fullBackground &&
+          'bg-cover tablet:bg-center',
+      )}
+      style={{
+        ...(showOnboardingPage &&
+          onboardingVisual.fullBackground && {
+            backgroundImage: `url(${
+              isMobile
+                ? onboardingVisual.fullBackground.mobile
+                : onboardingVisual.fullBackground.desktop
+            })`,
+          }),
+      }}
+    >
       <NextSeo {...seo} titleTemplate="%s | daily.dev" />
       <PixelTracking />
       <GtagTracking />
@@ -381,7 +409,12 @@ export function OnboardPage(): ReactElement {
         )}
       >
         {showOnboardingPage && (
-          <div className="mt-5 flex flex-1 flex-col tablet:mt-0 laptop:mr-8 laptop:max-w-[27.5rem]">
+          <div
+            className={classNames(
+              'mt-5 flex flex-1 flex-col tablet:mt-0 laptop:mr-8 laptop:max-w-[27.5rem]',
+              onboardingVisual.fullBackground && 'flex-grow-0 tablet:flex-grow',
+            )}
+          >
             <OnboardingHeadline
               className={{
                 title: 'tablet:typo-mega-1 typo-large-title',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- add shortcuts ui experiment
- add new one first session UI
- add new "Shortcuts +" button when dismissed

TODO:

- [x] see why openai logo is not resolving - opened [PR](https://github.com/dailydotdev/daily-scraper/pull/590) - openai has bot detection, I'll just use static images for this placeholder element
- [x] see if reordering of feed heading is [needed from design](https://www.figma.com/design/nmfWPS7x3kzLUvYMkBx2kW/daily.dev---Dev-Mode?node-id=9910-29515&m=dev) - asked [here](https://dailydotdev.slack.com/archives/C06LW384AF6/p1717428461931389)
- [x] see if we want to cleanup `onboardingMostVisited` experiment? - not yet

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-352 #done


### Preview domain
https://as-352-shortcuts-ui.preview.app.daily.dev