### PR TITLE
fix: add missing `createdAt` from user fragment

### DIFF
--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -23,6 +23,7 @@ export const USER_SHORT_INFO_FRAGMENT = gql`
     permalink
     username
     bio
+    createdAt
     reputation
   }
 `;


### PR DESCRIPTION
This caused the invitations page to fail

Fixes https://github.com/dailydotdev/daily/issues/1190

### Preview domain
https://fix-missing-createdat-in-user.preview.app.daily.dev