### PR TITLE
fix: squad page header skeleton

### DIFF
--- a/packages/shared/src/components/errors/SquadLoading.tsx
+++ b/packages/shared/src/components/errors/SquadLoading.tsx
@@ -53,6 +53,11 @@ function SquadLoading({
           <Actions className="hidden laptop:flex laptopL:ml-auto" />
           <Actions className="mt-8 flex laptop:hidden" />
         </div>
+        <FlexRow className="mt-6 gap-3">
+          <RectangleElement className="h-12 w-32" />
+          <RectangleElement className="h-12 w-12 tablet:w-32" />
+          <RectangleElement className="hidden h-12 w-32 tablet:flex" />
+        </FlexRow>
         <RectangleElement className="relative bottom-0 mt-8 flex h-16 w-full max-w-[30.25rem] flex-col  pt-8 tablet:absolute tablet:translate-y-1/2 tablet:flex-row tablet:p-0 laptop:mt-6 laptop:max-w-[38.25rem] laptopL:px-0" />
       </FlexCol>
       <ColumnContainer className="relative max-h-page w-full overflow-hidden px-16 pt-7">


### PR DESCRIPTION
## Changes
- Update skeleton loader.

Previews:

![Screenshot 2024-06-03 at 10 46 41 PM](https://github.com/dailydotdev/apps/assets/13744167/b12172a2-3823-4b7b-bb48-2ceb6911d96a)
![Screenshot 2024-06-03 at 10 44 30 PM](https://github.com/dailydotdev/apps/assets/13744167/1e07250c-21c5-4197-a755-29b90aae7ce8)
![Screenshot 2024-06-03 at 10 43 37 PM](https://github.com/dailydotdev/apps/assets/13744167/c35b1ff5-b4e1-458d-8b53-cc3013dc9c78)


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-370 #done


### Preview domain
https://mi-370.preview.app.daily.dev