### PR TITLE
fix: add sitemap and rel

### DIFF
--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -147,6 +147,12 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
           href="/favicon-16x16.png"
         />
         <link rel="manifest" href="/manifest.json" />
+        <link
+          rel="sitemap"
+          type="application/xml"
+          title="Sitemap"
+          href="/sitemap.xml"
+        />
 
         <script
           dangerouslySetInnerHTML={{

--- a/packages/webapp/public/sitemap.xml
+++ b/packages/webapp/public/sitemap.xml
@@ -14,11 +14,11 @@
     </url>
     <url>
       <loc>https://app.daily.dev/devcard</loc>
-      <lastmod>2024-03-31</lastmod>
+      <lastmod>2024-03-12</lastmod>
     </url>
     <url>
       <loc>https://app.daily.dev/roast</loc>
-      <lastmod>2024-02-31</lastmod>
+      <lastmod>2024-02-26</lastmod>
     </url>
   </urlset>
 </xml>

--- a/packages/webapp/public/sitemap.xml
+++ b/packages/webapp/public/sitemap.xml
@@ -1,0 +1,24 @@
+<xml version="1.0" encoding="UTF-8">
+  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+      <loc>https://app.daily.dev/sources</loc>
+      <lastmod>2024-05-31</lastmod>
+    </url>
+    <url>
+      <loc>https://app.daily.dev/squads</loc>
+      <lastmod>2024-05-31</lastmod>
+    </url>
+    <url>
+      <loc>https://app.daily.dev/tags</loc>
+      <lastmod>2024-05-31</lastmod>
+    </url>
+    <url>
+      <loc>https://app.daily.dev/devcard</loc>
+      <lastmod>2024-03-31</lastmod>
+    </url>
+    <url>
+      <loc>https://app.daily.dev/roast</loc>
+      <lastmod>2024-02-31</lastmod>
+    </url>
+  </urlset>
+</xml>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Since we have very little pages public available/changing I decided to do a fully static sitemap (faster as well)
- Also added a rel to link it.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://as-361-sitemap-rel.preview.app.daily.dev