### PR TITLE
fix: only query reading streak if logged in

### DIFF
--- a/packages/shared/src/hooks/streaks/useReadingStreak.ts
+++ b/packages/shared/src/hooks/streaks/useReadingStreak.ts
@@ -17,12 +17,12 @@ interface UserReadingStreak {
 }
 
 export const useReadingStreak = (): UserReadingStreak => {
-  const { user } = useAuthContext();
+  const { user, isLoggedIn } = useAuthContext();
   const { optOutReadingStreak, loadedSettings } = useContext(SettingsContext);
   const { data: streak, isLoading } = useQuery(
     generateQueryKey(RequestKey.UserStreak, user),
     getReadingStreak,
-    { staleTime: StaleTime.Default },
+    { staleTime: StaleTime.Default, enabled: isLoggedIn },
   );
   const { checkHasCompleted } = useActions();
   const hasReadToday =


### PR DESCRIPTION
Noticed that we try to fetch user streaks if not logged in.
Can be seen if you browse pages like https://app.daily.dev/squads when not logged in

### Preview domain
https://fix-streaks-only-if-logged-in.preview.app.daily.dev