### PR TITLE
fix: replace `_` with `-` in preview domain

### DIFF
--- a/.github/workflows/add-preview-domain.yml
+++ b/.github/workflows/add-preview-domain.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/github-script@v7.0.1
         with:
           script: |
-            const domain = `${{ github.head_ref }}.${{ vars.PREVIEW_DOMAIN }}`.toLowerCase()
+            const domain = `${{ github.head_ref }}.${{ vars.PREVIEW_DOMAIN }}`.toLowerCase().replaceAll("_","-")
             core.setOutput('domain', domain)
 
       - name: Comment with the assigned preview-domain


### PR DESCRIPTION
Fixes preview domains that have an underscore in them, replaces them with a `-` instead.
### Preview domain
https://fix-underscore-in-commits.preview.app.daily.dev