### PR TITLE
fix: show header login buttons if not logged in

### DIFF
--- a/packages/shared/__tests__/helpers/boot.tsx
+++ b/packages/shared/__tests__/helpers/boot.tsx
@@ -66,6 +66,7 @@ export const TestBootProvider = ({
             tokenRefreshed: true,
             getRedirectUri: jest.fn(),
             isFetched: true,
+            isLoggedIn: true,
             ...auth,
           }}
         >

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -41,7 +41,7 @@ function MainLayoutHeader({
   additionalButtons,
   onLogoClick,
 }: MainLayoutHeaderProps): ReactElement {
-  const { user, isAuthReady, isLoggedIn } = useAuthContext();
+  const { user, isLoggedIn } = useAuthContext();
   const { loadedSettings } = useSettingsContext();
   const { streak, isStreaksEnabled } = useReadingStreak();
   const isStreakLarge = streak?.current > 99; // if we exceed 100, we need to display it differently in the UI
@@ -102,7 +102,7 @@ function MainLayoutHeader({
     [isLoggedIn, loadedSettings, isSearchPage],
   );
 
-  if (isAuthReady && !isLaptop) {
+  if (loadedSettings && !isLaptop) {
     return (
       <>
         <FeedNav />


### PR DESCRIPTION
## Changes

Adds the missing login and signup button in the header

<table>
<tr>
<td>Before
<td>After
<tr>
<td><img src="https://github.com/dailydotdev/apps/assets/1681525/0a03902a-bdac-4797-bba7-b6d84b2dbcf3">
<td><img src="https://github.com/dailydotdev/apps/assets/1681525/f3c68667-37c7-461c-b8d1-c9debacab42f">
</table>

### Preview domain
https://fix-login-button-in-header.preview.app.daily.dev