### PR TITLE
fix: display spinner instead of first comment

### DIFF
--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -82,16 +82,16 @@ export function PostComments({
     }
   }, [commentsCount, scrollToComment]);
 
+  if (isLoadingComments || isNullOrUndefined(comments)) {
+    return <PlaceholderCommentList placeholderAmount={post.numComments} />;
+  }
+
   if (commentsCount === 0) {
     return (
       <div className="mb-12 mt-8 text-center text-text-quaternary typo-subhead">
         Be the first to comment.
       </div>
     );
-  }
-
-  if (isLoadingComments || isNullOrUndefined(comments)) {
-    return <PlaceholderCommentList placeholderAmount={post.numComments} />;
   }
 
   return (


### PR DESCRIPTION
Fix [Add a loader until the comments load](https://github.com/dailydotdev/daily/issues/1194)

## Changes

### Describe what this PR does
-  Due to the default value of the `commentsCount ` variable being 0, when comments are loading, `commentsCount` is always equal to 0. I swapped the logic to render the loading component before rendering any other component.

## Manual Testing

### Screens

#### Chrome 125

![image](https://github.com/dailydotdev/apps/assets/34316683/3ba69d22-0987-4a3e-9194-fae320aceed1)

#### Firefox 126.0.1

![image](https://github.com/dailydotdev/apps/assets/34316683/aa972391-d13d-40b2-a7cc-855392eaaf61)

### On those affected packages:
- [x] Have you done sanity checks in the webapp ?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?


### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)