### PR TITLE
feat: add share via experiment

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -22,6 +22,7 @@ import {
   PinIcon,
   BellSubscribedIcon,
   BellIcon,
+  ShareIcon,
 } from './icons';
 import { ReportedCallback } from './modals';
 import useTagAndSource from '../hooks/useTagAndSource';
@@ -30,6 +31,7 @@ import { postAnalyticsEvent } from '../lib/feed';
 import { MenuIcon } from './MenuIcon';
 import {
   ToastSubject,
+  useConditionalFeature,
   useFeedLayout,
   useSourceSubscription,
   useToastNotification,
@@ -58,6 +60,8 @@ import { feature } from '../lib/featureManagement';
 import { ContextMenu as ContextMenuTypes } from '../hooks/constants';
 import useContextMenu from '../hooks/useContextMenu';
 import { SourceType } from '../graphql/sources';
+import { isNullOrUndefined } from '../lib/func';
+import { useSharePost } from '../hooks/useSharePost';
 
 const ContextMenu = dynamic(
   () => import(/* webpackChunkName: "contextMenu" */ './fields/ContextMenu'),
@@ -107,6 +111,7 @@ export default function PostOptionsMenu({
   const { onUpdateSettings } = useAdvancedSettings({ enabled: false });
   const { trackEvent } = useContext(AnalyticsContext);
   const { hidePost, unhidePost } = useReportPost();
+  const { openSharePost } = useSharePost(origin);
 
   const { openModal } = useLazyModal();
   const {
@@ -317,6 +322,23 @@ export default function PostOptionsMenu({
   const bookmarkLoops = useFeature(feature.bookmarkLoops);
   const bookmarkOnCard = useFeature(feature.bookmarkOnCard);
   const shouldShowBookmark = bookmarkLoops || bookmarkOnCard;
+
+  const { value: shareVia } = useConditionalFeature({
+    feature: feature.shareVia,
+    shouldEvaluate: !isNullOrUndefined(post),
+  });
+
+  if (shareVia) {
+    postOptions.unshift({
+      icon: <MenuIcon Icon={ShareIcon} />,
+      label: 'Share via',
+      action: () =>
+        openSharePost({
+          post,
+          ...trackingOpts,
+        }),
+    });
+  }
 
   if (!shouldShowBookmark && !shouldUseListFeedLayout) {
     postOptions.push({

--- a/packages/shared/src/components/modals/ShareModal.tsx
+++ b/packages/shared/src/components/modals/ShareModal.tsx
@@ -36,6 +36,9 @@ export default function ShareModal({
           variant: ExperimentWinner.PostCardShareVersion,
           ...(comment && { commentId: comment.id }),
         },
+        columns,
+        column,
+        row,
       }),
     );
 

--- a/packages/shared/src/hooks/feed/useFeedContextMenu.ts
+++ b/packages/shared/src/hooks/feed/useFeedContextMenu.ts
@@ -4,7 +4,7 @@ import { Post } from '../../graphql/posts';
 import { ContextMenu } from '../constants';
 import useReportPostMenu from '../useReportPostMenu';
 
-type PostMenuLocation = {
+export type PostLocation = {
   index: number;
   row: number;
   column: number;
@@ -25,8 +25,8 @@ type FeedContextMenu = {
     column: number,
   ) => void;
   postMenuIndex: number;
-  postMenuLocation: PostMenuLocation;
-  setPostMenuIndex: (value: PostMenuLocation | undefined) => void;
+  postMenuLocation: PostLocation;
+  setPostMenuIndex: (value: PostLocation | undefined) => void;
 };
 
 type FeedContextMenuProps = {
@@ -36,7 +36,7 @@ type FeedContextMenuProps = {
 export default function useFeedContextMenu({
   contextId,
 }: FeedContextMenuProps): FeedContextMenu {
-  const [postMenuLocation, setPostMenuLocation] = useState<PostMenuLocation>();
+  const [postMenuLocation, setPostMenuLocation] = useState<PostLocation>();
   const postMenuIndex = postMenuLocation?.index;
   const { showReportMenu } = useReportPostMenu(contextId);
   const { onMenuClick: showShareMenu } = useContextMenu({

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -53,6 +53,7 @@ const feature = {
   feedSettingsFeedback: new Feature('feed_settings_feedback', false),
   onboardingLinks: new Feature('onboarding_links', false),
   shortcutsUI: new Feature('shortcuts_ui', ShortcutsUIExperiment.Control),
+  shareVia: new Feature('share_via', false),
 };
 
 export { feature };


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Instead of doing all the prop drilling agian I decided to leverage the context addition I recently made.
- But now also add the right tracking opts for when a post modal is open

Event for feed:
![Screenshot 2024-06-06 at 10 05 05](https://github.com/dailydotdev/apps/assets/554874/8d746838-c0ea-46ed-a7b3-24c59942fd8a)

Event for modal:
![Screenshot 2024-06-06 at 10 05 19](https://github.com/dailydotdev/apps/assets/554874/57c548f0-0bfe-45cf-99e3-40eda4c5df2a)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-362 #done


### Preview domain
https://as-362-share-via-experiment.preview.app.daily.dev