### PR TITLE
fix: account pages when not logged in

### DIFF
--- a/packages/shared/src/lib/auth.ts
+++ b/packages/shared/src/lib/auth.ts
@@ -51,6 +51,7 @@ export enum AuthTriggers {
   ReportComment = 'report comment',
   SearchReferral = 'search referral',
   CreateFeedFilters = 'create feed filters',
+  AccountPage = 'account page',
   NewComment = 'new comment',
   SearchInput = 'search input',
   SearchSuggestion = 'search suggestion',

--- a/packages/webapp/components/layouts/AccountLayout/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/index.tsx
@@ -1,10 +1,4 @@
-import React, {
-  ReactElement,
-  ReactNode,
-  useContext,
-  useEffect,
-  useState,
-} from 'react';
+import React, { ReactElement, ReactNode, useContext, useEffect } from 'react';
 import classNames from 'classnames';
 import { PublicProfile } from '@dailydotdev/shared/src/lib/user';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
@@ -21,9 +15,7 @@ import { useQueryState } from '@dailydotdev/shared/src/hooks/utils/useQueryState
 import { useRouter } from 'next/router';
 import { useFeatureTheme } from '@dailydotdev/shared/src/hooks/utils/useFeatureTheme';
 import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
-import AuthOptions, {
-  AuthDisplay,
-} from '@dailydotdev/shared/src/components/auth/AuthOptions';
+import AuthOptions from '@dailydotdev/shared/src/components/auth/AuthOptions';
 import useAuthForms from '@dailydotdev/shared/src/hooks/useAuthForms';
 import { getLayout as getMainLayout } from '../MainLayout';
 import { getTemplatedTitle } from '../utils';

--- a/packages/webapp/components/layouts/AccountLayout/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/index.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, ReactNode, useContext, useEffect } from 'react';
+import React, {
+  ReactElement,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
 import classNames from 'classnames';
 import { PublicProfile } from '@dailydotdev/shared/src/lib/user';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
@@ -14,6 +20,11 @@ import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
 import { useQueryState } from '@dailydotdev/shared/src/hooks/utils/useQueryState';
 import { useRouter } from 'next/router';
 import { useFeatureTheme } from '@dailydotdev/shared/src/hooks/utils/useFeatureTheme';
+import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
+import AuthOptions, {
+  AuthDisplay,
+} from '@dailydotdev/shared/src/components/auth/AuthOptions';
+import useAuthForms from '@dailydotdev/shared/src/hooks/useAuthForms';
 import { getLayout as getMainLayout } from '../MainLayout';
 import { getTemplatedTitle } from '../utils';
 import SidebarNav from './SidebarNav';
@@ -50,7 +61,21 @@ export default function AccountLayout({
     };
   }, [router.events, setIsOpen]);
 
-  if (!profile || !Object.keys(profile).length || (isFetched && !profile)) {
+  const { formRef } = useAuthForms();
+
+  if (isFetched && !profile) {
+    return (
+      <div className="flex w-full items-center justify-center pt-10">
+        <AuthOptions
+          simplified
+          formRef={formRef}
+          trigger={AuthTriggers.AccountPage}
+        />
+      </div>
+    );
+  }
+
+  if (!profile || !Object.keys(profile).length) {
     return null;
   }
 

--- a/packages/webapp/components/layouts/AccountLayout/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/index.tsx
@@ -68,6 +68,7 @@ export default function AccountLayout({
       <div className="flex w-full items-center justify-center pt-10">
         <AuthOptions
           simplified
+          isLoginFlow
           formRef={formRef}
           trigger={AuthTriggers.AccountPage}
         />


### PR DESCRIPTION
## Changes
- Display the login screen when viewing an account page as an anonymous user.

Feel free to check the preview deployment.

Previews:
![Screenshot 2024-06-06 at 9 27 44 PM](https://github.com/dailydotdev/apps/assets/13744167/d8dc8c62-362d-4c09-a917-6f691b77c3fb)

![Screenshot 2024-06-06 at 9 31 34 PM](https://github.com/dailydotdev/apps/assets/13744167/9ecc24a7-1b95-4277-823f-688a8d6ca33e)

![Screenshot 2024-06-06 at 9 28 18 PM](https://github.com/dailydotdev/apps/assets/13744167/007fee4d-c14b-428e-a6d3-24ab874d4e60)

https://github.com/dailydotdev/apps/assets/13744167/16469448-d74e-468a-a463-e73b3795382d

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-380 #done


### Preview domain
https://mi-380.preview.app.daily.dev