### PR TITLE
fix: roadmap links on tag pages

### DIFF
--- a/packages/shared/src/graphql/keywords.ts
+++ b/packages/shared/src/graphql/keywords.ts
@@ -5,6 +5,7 @@ export type KeywordStatus = 'pending' | 'allow' | 'deny' | 'synonym';
 export type KeywordFlags = {
   title?: string;
   description?: string;
+  roadmap?: string;
 };
 
 export interface Keyword {
@@ -76,6 +77,7 @@ export const KEYWORD_QUERY = gql`
       flags {
         title
         description
+        roadmap
       }
     }
   }

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -54,6 +54,7 @@ const feature = {
   onboardingLinks: new Feature('onboarding_links', false),
   shortcutsUI: new Feature('shortcuts_ui', ShortcutsUIExperiment.Control),
   shareVia: new Feature('share_via', false),
+  showRoadmap: new Feature('show_roadmap', false),
 };
 
 export { feature };

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -200,6 +200,10 @@ export const cloudinary = {
         'https://res.cloudinary.com/daily-now/image/upload/s--B_87VDub--/f_auto/v1717506847/public/Stackoverflow%20Shortcut',
     },
   },
+  source: {
+    roadmap:
+      'https://daily-now-res.cloudinary.com/image/upload/s--91LSaHRW--/f_auto,q_auto/v1717766368/roadmap_iambav',
+  },
 };
 
 export const smallPostImage = (url: string): string => {

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -10,6 +10,7 @@ import {
   DiscussIcon,
   HashtagIcon,
   MiniCloseIcon as XIcon,
+  OpenLinkIcon,
   PlusIcon,
   UpvoteIcon,
 } from '@dailydotdev/shared/src/components/icons';
@@ -72,6 +73,9 @@ import { useOnboarding } from '@dailydotdev/shared/src/hooks/auth';
 import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
 import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { TagSourceSocialProof } from '@dailydotdev/shared/src/lib/featureValues';
+import { cloudinary } from '@dailydotdev/shared/src/lib/image';
+import Link from 'next/link';
+import { anchorDefaultRel } from '@dailydotdev/shared/src/lib/strings';
 import { getLayout } from '../../components/layouts/FeedLayout';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
@@ -141,6 +145,7 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
   const isLaptop = useViewSize(ViewSize.Laptop);
   const { shouldShowAuthBanner } = useOnboarding();
   const tagSourceFeatureValue = useFeature(feature.tagSourceSocialProof);
+  const showRoadmap = useFeature(feature.showRoadmap);
   const shouldShowTagSourceSocialProof =
     shouldShowAuthBanner &&
     tagSourceFeatureValue === TagSourceSocialProof.V1 &&
@@ -273,6 +278,34 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
             tag={tag}
             blockedTags={feedSettings?.blockedTags}
           />
+        )}
+        {showRoadmap && initialData?.flags?.roadmap && (
+          <Link href={initialData.flags.roadmap} passHref prefetch={false}>
+            <a
+              target="_blank"
+              rel={anchorDefaultRel}
+              className="mr-auto flex w-auto cursor-pointer items-center rounded-12 border border-border-subtlest-tertiary p-4"
+            >
+              <img
+                src={cloudinary.source.roadmap}
+                alt="roadmap.sh logo"
+                className="size-10 rounded-full"
+              />
+              <div className="mx-3 flex-1">
+                <p className="font-bold typo-callout">
+                  Comprehensive roadmap for {tag}
+                </p>
+                <p className="text-text-tertiary typo-footnote">
+                  By roadmap.sh
+                </p>
+              </div>
+              <Button
+                icon={<OpenLinkIcon />}
+                size={ButtonSize.Small}
+                variant={ButtonVariant.Tertiary}
+              />
+            </a>
+          </Link>
         )}
       </PageInfoHeader>
       <TagTopSources tag={tag} />


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Ability to render roadmap links on tag pages (if flag exist on keyword)
- Related API: https://github.com/dailydotdev/daily-api/pull/1976

![Screenshot 2024-06-07 at 16 40 57](https://github.com/dailydotdev/apps/assets/554874/c01a7087-87f3-4cf3-ac41-c70c53abf87d)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://as-368-roadmap-link.preview.app.daily.dev