### PR TITLE
chore: remove sidebar closed experiment

### DIFF
--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -183,11 +183,7 @@ export const SettingsContextProvider = ({
     const updatedSettings = settings;
 
     if (settings.sidebarExpanded) {
-      const sidebarClosed = getFeatureValue(feature.sidebarClosed);
-
-      if (sidebarClosed) {
-        updatedSettings.sidebarExpanded = false;
-      }
+      updatedSettings.sidebarExpanded = false;
     }
 
     await updateRemoteSettingsFn(updatedSettings, bootUserId);

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -35,7 +35,6 @@ const feature = {
   onboardingMostVisited: new Feature('onboarding_most_visited', false),
   shareExperience: new Feature('share_experience', false),
   bookmarkLoops: new Feature('bookmark_loops', false),
-  sidebarClosed: new Feature('sidebar_closed', false),
   tagSourceSocialProof: new Feature(
     'tag_source_social_proof',
     TagSourceSocialProof.Control,


### PR DESCRIPTION
## Changes
- remove sidebar closed experiment since it won

### Describe what this PR does
- see thread https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1717669215632889

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-383 #done
