### PR TITLE
fix: tabbar background addition

### DIFF
--- a/packages/shared/src/components/tabs/TabContainer.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.tsx
@@ -133,7 +133,8 @@ export function TabContainer<T extends string = string>({
         className={classNames(
           'flex flex-row',
           className?.header,
-          showBorder && 'border-b border-border-subtlest-tertiary',
+          showBorder &&
+            'border-b border-border-subtlest-tertiary bg-background-default',
         )}
       >
         <TabList<T>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixed a background on the tab container

| Before | After |
|--------|--------|
| ![Screenshot 2024-06-12 at 10 55 23](https://github.com/dailydotdev/apps/assets/554874/8534ec88-3537-4d89-85ea-757eb31e4fdc) | ![Screenshot 2024-06-12 at 10 55 29](https://github.com/dailydotdev/apps/assets/554874/9d7152b7-c84c-423a-be75-2b2439a535bb) |

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-tab-bar-bg.preview.app.daily.dev