### PR TITLE
fix: remove social proof from tag page

### DIFF
--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -52,11 +52,7 @@ import {
   GET_RECOMMENDED_TAGS_QUERY,
   TagsData,
 } from '@dailydotdev/shared/src/graphql/feedSettings';
-import {
-  useFeedLayout,
-  useViewSize,
-  ViewSize,
-} from '@dailydotdev/shared/src/hooks';
+import { useFeedLayout } from '@dailydotdev/shared/src/hooks';
 import { RecommendedTags } from '@dailydotdev/shared/src/components/RecommendedTags';
 import {
   SOURCES_BY_TAG_QUERY,
@@ -67,14 +63,11 @@ import { RelatedSources } from '@dailydotdev/shared/src/components/RelatedSource
 import { ActiveFeedNameContext } from '@dailydotdev/shared/src/contexts';
 import HorizontalFeed from '@dailydotdev/shared/src/components/feeds/HorizontalFeed';
 import { PostType } from '@dailydotdev/shared/src/graphql/posts';
-import { AuthenticationBanner } from '@dailydotdev/shared/src/components/auth';
-import { useOnboarding } from '@dailydotdev/shared/src/hooks/auth';
 import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
 import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { cloudinary } from '@dailydotdev/shared/src/lib/image';
 import Link from 'next/link';
 import { anchorDefaultRel } from '@dailydotdev/shared/src/lib/strings';
-import CustomAuthBanner from '@dailydotdev/shared/src/components/auth/CustomAuthBanner';
 import { getLayout } from '../../components/layouts/FeedLayout';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
@@ -141,10 +134,7 @@ const TagTopSources = ({ tag }: { tag: string }) => {
 
 const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
   const { isFallback } = useRouter();
-  const isLaptop = useViewSize(ViewSize.Laptop);
-  const { shouldShowAuthBanner } = useOnboarding();
   const showRoadmap = useFeature(feature.showRoadmap);
-  const shouldShowTagSourceSocialProof = shouldShowAuthBanner && isLaptop;
   const { user, showLogin } = useContext(AuthContext);
   const mostUpvotedQueryVariables = useMemo(
     () => ({
@@ -361,16 +351,12 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
         query={TAG_FEED_QUERY}
         variables={queryVariables}
       />
-      {shouldShowTagSourceSocialProof && <AuthenticationBanner />}
     </FeedPageLayoutComponent>
   );
 };
 
 TagPage.getLayout = getLayout;
-TagPage.layoutProps = {
-  ...mainFeedLayoutProps,
-  customBanner: <CustomAuthBanner />,
-};
+TagPage.layoutProps = mainFeedLayoutProps;
 
 export default TagPage;
 


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Remove social proof auth banners for tag page (roadmap.sh requirement)

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://chore-remove-social-proof-tag-page.preview.app.daily.dev