### PR TITLE
fix: rendering of shared post date for exp

### DIFF
--- a/packages/shared/src/components/cards/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.tsx
@@ -57,6 +57,8 @@ export const SharePostCard = forwardRef(function SharePostCard(
   if (improvedSharedPostCard) {
     // eslint-disable-next-line no-param-reassign
     post.image = post.sharedPost.image;
+    // eslint-disable-next-line no-param-reassign
+    post.sharedPost.createdAt = post.createdAt;
   }
 
   return (


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We need to render the share date not the actual post date

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-372 #done


### Preview domain
https://as-372-fix-shared-post-date.preview.app.daily.dev