### PR TITLE
fix: pass props for shared post card

### DIFF
--- a/packages/shared/src/components/cards/PostCardFooter.tsx
+++ b/packages/shared/src/components/cards/PostCardFooter.tsx
@@ -14,10 +14,12 @@ interface PostCardFooterProps extends CommonCardCoverProps {
   openNewTab: boolean;
   post: Post;
   className: PostCardFooterClassName;
+  image?: string;
 }
 
 export const PostCardFooter = ({
   post,
+  image,
   className,
   onShare,
 }: PostCardFooterProps): ReactElement => {
@@ -31,7 +33,7 @@ export const PostCardFooter = ({
         imageProps={{
           loading: 'lazy',
           alt: 'Post Cover image',
-          src: post.image,
+          src: image ?? post.image,
           className: classNames(
             'w-full',
             className.image,

--- a/packages/shared/src/components/cards/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.tsx
@@ -52,9 +52,6 @@ export const SharePostCard = forwardRef(function SharePostCard(
   const improvedSharedPostCard = useFeature(feature.improvedSharedPostCard);
 
   const postImage = improvedSharedPostCard ? post.sharedPost.image : post.image;
-  const postCreatedAt = improvedSharedPostCard
-    ? post.createdAt
-    : post.sharedPost.createdAt;
 
   return (
     <FeedItemContainer
@@ -88,7 +85,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
             <CardSpace />
             <PostTags tags={post.sharedPost.tags} />
             <PostMetadata
-              createdAt={postCreatedAt}
+              createdAt={post.createdAt}
               readTime={post.sharedPost.readTime}
               isVideoType={isVideoType}
               className="mx-4"

--- a/packages/shared/src/components/cards/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.tsx
@@ -105,7 +105,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
           <SquadPostCardHeader
             author={post.author}
             source={post.source}
-            createdAt={postCreatedAt}
+            createdAt={post.createdAt}
             enableSourceHeader={enableSourceHeader}
           />
           <SharedPostText

--- a/packages/shared/src/components/cards/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.tsx
@@ -51,15 +51,10 @@ export const SharePostCard = forwardRef(function SharePostCard(
   const isVideoType = isVideoPost(post);
   const improvedSharedPostCard = useFeature(feature.improvedSharedPostCard);
 
-  // Just for this experiment, we are modifying the post object to use set the
-  // image from the shared post, this is just to avoid modifying the `PostCardFooter`
-  // component to handle this case just for this experiment.
-  if (improvedSharedPostCard) {
-    // eslint-disable-next-line no-param-reassign
-    post.image = post.sharedPost.image;
-    // eslint-disable-next-line no-param-reassign
-    post.sharedPost.createdAt = post.createdAt;
-  }
+  const postImage = improvedSharedPostCard ? post.sharedPost.image : post.image;
+  const postCreatedAt = improvedSharedPostCard
+    ? post.createdAt
+    : post.sharedPost.createdAt;
 
   return (
     <FeedItemContainer
@@ -93,7 +88,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
             <CardSpace />
             <PostTags tags={post.sharedPost.tags} />
             <PostMetadata
-              createdAt={post.sharedPost.createdAt}
+              createdAt={postCreatedAt}
               readTime={post.sharedPost.readTime}
               isVideoType={isVideoType}
               className="mx-4"
@@ -110,7 +105,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
           <SquadPostCardHeader
             author={post.author}
             source={post.source}
-            createdAt={post.createdAt}
+            createdAt={postCreatedAt}
             enableSourceHeader={enableSourceHeader}
           />
           <SharedPostText
@@ -124,9 +119,15 @@ export const SharePostCard = forwardRef(function SharePostCard(
         className={!improvedSharedPostCard && 'min-h-0 justify-end'}
       >
         {improvedSharedPostCard ? (
-          <PostCardFooter openNewTab={openNewTab} post={post} className={{}} />
+          <PostCardFooter
+            image={postImage}
+            openNewTab={openNewTab}
+            post={post}
+            className={{}}
+          />
         ) : (
           <SharedPostCardFooter
+            image={postImage}
             sharedPost={post.sharedPost}
             isShort={isSharedPostShort}
             isVideoType={isVideoType}

--- a/packages/shared/src/components/cards/SharedPostCardFooter.tsx
+++ b/packages/shared/src/components/cards/SharedPostCardFooter.tsx
@@ -10,6 +10,7 @@ interface SharedPostCardFooterProps
     CommonCardCoverProps {
   isShort: boolean;
   isVideoType?: boolean;
+  image?: string;
 }
 
 export const SharedPostCardFooter = ({
@@ -18,6 +19,7 @@ export const SharedPostCardFooter = ({
   isVideoType,
   onShare,
   post,
+  image,
 }: SharedPostCardFooterProps): ReactElement => {
   return (
     <div
@@ -44,7 +46,7 @@ export const SharedPostCardFooter = ({
           imageProps={{
             loading: 'lazy',
             alt: 'Shared Post Cover image',
-            src: sharedPost.image,
+            src: image ?? sharedPost.image,
             className: classNames(
               'h-auto min-h-0',
               isShort ? 'aspect-square' : 'w-full',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- @capJavert Added a temporary workaround for this override.
- It's not ideal as the full implementation would take many, many changes but think for now it's safer atleast, let me know what you think.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done


### Preview domain
https://fix-pass-props.preview.app.daily.dev