### PR TITLE
fix: remove a param-reassign

### DIFF
--- a/packages/shared/src/components/cards/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.tsx
@@ -57,8 +57,6 @@ export const SharePostCard = forwardRef(function SharePostCard(
   if (improvedSharedPostCard) {
     // eslint-disable-next-line no-param-reassign
     post.image = post.sharedPost.image;
-    // eslint-disable-next-line no-param-reassign
-    post.sharedPost.createdAt = post.createdAt;
   }
 
   return (
@@ -93,7 +91,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
             <CardSpace />
             <PostTags tags={post.sharedPost.tags} />
             <PostMetadata
-              createdAt={post.sharedPost.createdAt}
+              createdAt={post.createdAt}
               readTime={post.sharedPost.readTime}
               isVideoType={isVideoType}
               className="mx-4"


### PR DESCRIPTION
Removed in #3221 but got reverted in #3223.
This one we can keep, instead of re-assigning the variable when it is only used inside a ternary


### Preview domain
https://ombratteng-patch-1.preview.app.daily.dev