### PR TITLE
fix: collection card actions

### DIFF
--- a/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
@@ -70,7 +70,6 @@ export const CollectionCard = forwardRef(function CollectionCard(
           onUpvoteClick={onUpvoteClick}
           onCommentClick={onCommentClick}
           onCopyLinkClick={onCopyLinkClick}
-          className={classNames('mx-4 mt-auto justify-between')}
           onBookmarkClick={onBookmarkClick}
         />
       </Container>


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Just removed `className`, it was a leftover from initial implementation and it caused the different spacing

Before:
<img width="340" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/1fd5d782-285f-4efb-842c-028d1882a381">

After:
<img width="335" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/5c335f7a-452c-4ba0-856a-7396c4a06dca">


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-378 #done


### Preview domain
https://as-378-fix-collection-card-actions.preview.app.daily.dev