### PR TITLE
fix: unnecessary element on tablet or greater size

### DIFF
--- a/packages/webapp/components/layouts/FooterNavBarLayout.tsx
+++ b/packages/webapp/components/layouts/FooterNavBarLayout.tsx
@@ -25,7 +25,7 @@ export default function FooterNavBarLayout({
   return (
     <>
       {children}
-      <div className={post ? 'h-40' : 'h-28'} />
+      {showNav && <div className={post ? 'h-40' : 'h-28'} />}
       <FooterNavBar showNav={showNav} post={post} />
     </>
   );


### PR DESCRIPTION
## Changes
- The extra padding was created for mobile, and the extra space we experience is due to it.

Before:
![Screenshot 2024-06-18 at 8 17 04 PM](https://github.com/dailydotdev/apps/assets/13744167/c2b2a136-a07d-426c-b47a-42e4545bf187)

After:


## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
