### PR TITLE
Mi 392 squad image fix

### DIFF
--- a/packages/shared/src/components/squads/Details.tsx
+++ b/packages/shared/src/components/squads/Details.tsx
@@ -34,6 +34,7 @@ interface SquadDetailsProps {
   createMode: boolean;
   onRequestClose?: () => void;
   children?: ReactNode;
+  isLoading?: boolean;
 }
 
 const getFormData = async (
@@ -67,6 +68,7 @@ export function SquadDetails({
   form,
   createMode = true,
   children,
+  isLoading,
 }: SquadDetailsProps): ReactElement {
   const {
     name,
@@ -168,9 +170,10 @@ export function SquadDetails({
           router.push(createMode ? '/squads' : `/squads/${handle}`),
       }}
       rightButtonProps={{
-        disabled: !canSubmit,
+        disabled: !canSubmit || isLoading,
         variant: ButtonVariant.Primary,
         color: createMode ? ButtonColor.Cabbage : undefined,
+        loading: isLoading,
       }}
     >
       {children}

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -466,10 +466,13 @@ type EditSquadForm = Pick<
   memberInviteRole?: SourceMemberRole;
 };
 
-export async function editSquad(
-  id: string,
-  form: EditSquadForm,
-): Promise<Squad> {
+export async function editSquad({
+  id,
+  form,
+}: {
+  id: string;
+  form: EditSquadForm;
+}): Promise<Squad> {
   const inputData: EditSquadInput = {
     sourceId: id,
     description: form.description,

--- a/packages/webapp/pages/squads/[handle]/edit.tsx
+++ b/packages/webapp/pages/squads/[handle]/edit.tsx
@@ -27,7 +27,6 @@ import {
   parseOrDefault,
 } from '@dailydotdev/shared/src/lib/func';
 import { ApiErrorResult } from '@dailydotdev/shared/src/graphql/common';
-import { getRandom4Digits } from '@dailydotdev/shared/src/lib';
 import { getLayout as getMainLayout } from '../../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
 

--- a/packages/webapp/pages/squads/[handle]/edit.tsx
+++ b/packages/webapp/pages/squads/[handle]/edit.tsx
@@ -9,7 +9,7 @@ import { useBoot } from '@dailydotdev/shared/src/hooks/useBoot';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
 import { ManageSquadPageContainer } from '@dailydotdev/shared/src/components/squads/utils';
 import { MangeSquadPageSkeleton } from '@dailydotdev/shared/src/components/squads/MangeSquadPageSkeleton';
-import { useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useSquad } from '@dailydotdev/shared/src/hooks';
 import {
   GetStaticPathsResult,
@@ -23,8 +23,9 @@ import {
 } from '@dailydotdev/shared/src/lib/query';
 import { PrivacyOption } from '@dailydotdev/shared/src/hooks/squads/useSquadPrivacyOptions';
 import { isNullOrUndefined } from '@dailydotdev/shared/src/lib/func';
-import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
+import { ApiErrorResult } from '@dailydotdev/shared/src/graphql/common';
 import { getLayout as getMainLayout } from '../../../components/layouts/MainLayout';
+import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
 
 type EditSquadPageProps = { handle: string };
 
@@ -47,6 +48,15 @@ const EditSquad = ({ handle }: EditSquadPageProps): ReactElement => {
   const queryClient = useQueryClient();
   const { updateSquad } = useBoot();
   const { displayToast } = useToastNotification();
+  const { mutateAsync: onUpdateSquad, isLoading: isUpdatingSquad } =
+    useMutation(editSquad, {
+      onSuccess: async (data) => {
+        const queryKey = generateQueryKey(RequestKey.Squad, user, data.handle);
+        await queryClient.invalidateQueries(queryKey);
+        updateSquad(data);
+        displayToast('The Squad has been updated');
+      },
+    });
 
   const onSubmit = async (e, form: SquadForm) => {
     e.preventDefault();
@@ -62,17 +72,7 @@ const EditSquad = ({ handle }: EditSquadPageProps): ReactElement => {
         ? undefined
         : form.status === PrivacyOption.Public,
     };
-    const editedSquad = await editSquad(squad.id, formJson);
-    if (editedSquad) {
-      const queryKey = generateQueryKey(
-        RequestKey.Squad,
-        user,
-        editedSquad.handle,
-      );
-      await queryClient.invalidateQueries(queryKey);
-      updateSquad(editedSquad);
-      displayToast('The Squad has been updated');
-    }
+    onUpdateSquad({ id: squad.id, form: formJson });
   };
 
   const isLoading =
@@ -92,7 +92,12 @@ const EditSquad = ({ handle }: EditSquadPageProps): ReactElement => {
   return (
     <ManageSquadPageContainer>
       <NextSeo {...seo} titleTemplate="%s | daily.dev" noindex nofollow />
-      <SquadDetails form={squad} onSubmit={onSubmit} createMode={false} />
+      <SquadDetails
+        form={squad}
+        onSubmit={onSubmit}
+        createMode={false}
+        isLoading={isUpdatingSquad}
+      />
     </ManageSquadPageContainer>
   );
 };

--- a/packages/webapp/pages/squads/[handle]/edit.tsx
+++ b/packages/webapp/pages/squads/[handle]/edit.tsx
@@ -22,8 +22,12 @@ import {
   RequestKey,
 } from '@dailydotdev/shared/src/lib/query';
 import { PrivacyOption } from '@dailydotdev/shared/src/hooks/squads/useSquadPrivacyOptions';
-import { isNullOrUndefined } from '@dailydotdev/shared/src/lib/func';
+import {
+  isNullOrUndefined,
+  parseOrDefault,
+} from '@dailydotdev/shared/src/lib/func';
 import { ApiErrorResult } from '@dailydotdev/shared/src/graphql/common';
+import { getRandom4Digits } from '@dailydotdev/shared/src/lib';
 import { getLayout as getMainLayout } from '../../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
 
@@ -36,6 +40,8 @@ const seo: NextSeoProps = {
   openGraph: { ...defaultOpenGraph },
   ...defaultSeo,
 };
+
+const DEFAULT_ERROR = "Oops! That didn't seem to work. Let's try again!";
 
 const EditSquad = ({ handle }: EditSquadPageProps): ReactElement => {
   const { isReady: isRouteReady } = useRouter();
@@ -55,6 +61,15 @@ const EditSquad = ({ handle }: EditSquadPageProps): ReactElement => {
         await queryClient.invalidateQueries(queryKey);
         updateSquad(data);
         displayToast('The Squad has been updated');
+      },
+      onError: (error: ApiErrorResult) => {
+        const result = parseOrDefault<Record<string, string>>(
+          error?.response?.errors?.[0]?.message,
+        );
+
+        displayToast(
+          typeof result === 'object' ? result.handle : DEFAULT_ERROR,
+        );
       },
     });
 

--- a/packages/webapp/pages/squads/new.tsx
+++ b/packages/webapp/pages/squads/new.tsx
@@ -27,7 +27,7 @@ const seo: NextSeoProps = {
 const NewSquad = (): ReactElement => {
   const { isReady: isRouteReady } = useRouter();
   const { user, isAuthReady, isFetched } = useAuthContext();
-  const { onCreateSquad } = useSquadCreate();
+  const { onCreateSquad, isLoading } = useSquadCreate();
 
   const onCreate = async (e: FormEvent, squadForm: SquadForm) => {
     e.preventDefault();
@@ -55,6 +55,7 @@ const NewSquad = (): ReactElement => {
         onRequestClose={handleClose}
         onSubmit={onCreate}
         createMode
+        isLoading={isLoading}
       >
         <div
           style={{


### PR DESCRIPTION
## Changes
- added loading state to save button on squad edit

### Describe what this PR does
- there is an issue with a squad not being able to update their image, can't replicate properly but from the video looked like they submitted a lot of times and maybe it causes the requests to timeout and not update
- issue here: https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1718680944874529

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-392 #done


### Preview domain
https://mi-392-squad-image-fix.preview.app.daily.dev