### PR TITLE
fix: set default laptop value even if undefined

### DIFF
--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -10,6 +10,7 @@ import {
 } from '../components/utilities';
 import { AllFeedPages, OtherFeedPage } from '../lib/query';
 import SettingsContext from '../contexts/SettingsContext';
+import { isNullOrUndefined } from '../lib/func';
 
 interface UseFeedLayoutReturn {
   shouldUseListFeedLayout: boolean;
@@ -92,7 +93,8 @@ const getFeedPageLayoutComponent = ({
 export const useFeedLayout = ({
   feedRelated = true,
 }: UseFeedLayoutProps = {}): UseFeedLayoutReturn => {
-  const isLaptop = useViewSize(ViewSize.Laptop);
+  const isLaptopSize = useViewSize(ViewSize.Laptop);
+  const isLaptop = isNullOrUndefined(isLaptopSize) ? true : isLaptopSize;
   const { feedName } = useActiveFeedNameContext();
   const { insaneMode: isListMode } = useContext(SettingsContext);
 

--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -94,7 +94,7 @@ export const useFeedLayout = ({
   feedRelated = true,
 }: UseFeedLayoutProps = {}): UseFeedLayoutReturn => {
   const isLaptopSize = useViewSize(ViewSize.Laptop);
-  const isLaptop = isNullOrUndefined(isLaptopSize) ? true : isLaptopSize;
+  const isLaptop = isNullOrUndefined(isLaptopSize) || isLaptopSize;
   const { feedName } = useActiveFeedNameContext();
   const { insaneMode: isListMode } = useContext(SettingsContext);
 


### PR DESCRIPTION
## Changes
- brought back isNullorUndefined for isLaptop with a slight change to what we had before
- now if isLaptop is null or undefined we set it to true, so the default layout is always the one in laptop, else we set it to whatever value isLaptop is
- This only introduced the edge cases we did mention before on tags/sources/bookmarks etc pages when doing SSR on mobile, which we deemed at that time not an issue since usually in mobile we move through page by client side rendering. (The issue is just an extra padding which doesn't look bad anyways) - decision this was ok was done here https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1716278512251279

### Describe what this PR does
- fix on issue mentioned here https://dailydotdev.slack.com/archives/C02E2C3C13R/p1718888840253379
- this started happening again since we removed isNullorUndefined from useFeedLayout on SEO sidebar changes [PR](https://github.com/dailydotdev/apps/pull/3215)
- though isNullorUndefined wasn't implemented properly at that time (thus the change on implementation now), and brought issues on the PR above which removed it.

Ps.
this is just a hack still to fix the issue, to have this evaluations more rely on css yes it's a better solution, and also to unify our layouts since we have a few at the moment very similar yet different to each other, we just need to find the time to do this.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-393 #done


### Preview domain
https://mi-393-fix-layouts.preview.app.daily.dev