### PR TITLE
fix: add posts pages to use the new feed layout

### DIFF
--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -10,6 +10,7 @@ import {
 } from '../components/utilities';
 import { AllFeedPages, OtherFeedPage } from '../lib/query';
 import SettingsContext from '../contexts/SettingsContext';
+import { isNullOrUndefined } from '../lib/func';
 
 interface UseFeedLayoutReturn {
   shouldUseListFeedLayout: boolean;
@@ -92,7 +93,8 @@ const getFeedPageLayoutComponent = ({
 export const useFeedLayout = ({
   feedRelated = true,
 }: UseFeedLayoutProps = {}): UseFeedLayoutReturn => {
-  const isLaptop = useViewSize(ViewSize.Laptop);
+  const isLaptopSize = useViewSize(ViewSize.Laptop);
+  const isLaptop = isNullOrUndefined(isLaptopSize) || isLaptopSize;
   const { feedName } = useActiveFeedNameContext();
   const { insaneMode: isListMode } = useContext(SettingsContext);
 

--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -58,6 +58,10 @@ export const FeedLayoutMobileFeedPages = new Set([
   OtherFeedPage.SearchBookmarks,
   OtherFeedPage.UserUpvoted,
   OtherFeedPage.UserPosts,
+  OtherFeedPage.Explore,
+  OtherFeedPage.ExploreLatest,
+  OtherFeedPage.ExploreDiscussed,
+  OtherFeedPage.ExploreUpvoted,
 ]);
 
 export const UserProfileFeedPages = new Set([

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -56,7 +56,6 @@ import {
   logSignUp,
   PixelTracking,
   TiktokTracking,
-  HotJarTracking,
 } from '@dailydotdev/shared/src/components/auth/OnboardingLogs';
 import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { OnboardingHeadline } from '@dailydotdev/shared/src/components/auth';
@@ -417,7 +416,6 @@ export function OnboardPage(): ReactElement {
       <NextSeo {...seo} titleTemplate="%s | daily.dev" />
       <PixelTracking />
       <GtagTracking />
-      <HotJarTracking />
       <TiktokTracking />
       {getProgressBar()}
       {showGenerigLoader && <GenericLoader />}


### PR DESCRIPTION
## Changes
- added pages to the set we use to validate

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-394 #done


### Preview domain
https://mi-394-posts-layout.preview.app.daily.dev