### PR TITLE
fix: bookmarking for collection list

### DIFF
--- a/packages/shared/src/components/cards/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/ActionButtons.tsx
@@ -21,10 +21,10 @@ import { useFeedPreviewMode } from '../../hooks';
 
 export interface ActionButtonsProps {
   post: Post;
-  onUpvoteClick?: (post: Post) => unknown;
-  onCommentClick?: (post: Post) => unknown;
-  onBookmarkClick?: (post: Post) => unknown;
-  onCopyLinkClick?: (event: React.MouseEvent, post: Post) => unknown;
+  onUpvoteClick: (post: Post) => unknown;
+  onCommentClick: (post: Post) => unknown;
+  onBookmarkClick: (post: Post) => unknown;
+  onCopyLinkClick: (event: React.MouseEvent, post: Post) => unknown;
   className?: string;
 }
 

--- a/packages/shared/src/components/cards/list/CollectionList.tsx
+++ b/packages/shared/src/components/cards/list/CollectionList.tsx
@@ -28,6 +28,7 @@ export const CollectionList = forwardRef(function CollectionCard(
     onMenuClick,
     onCopyLinkClick,
     onPostClick,
+    onBookmarkClick,
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ) {
@@ -101,6 +102,7 @@ export const CollectionList = forwardRef(function CollectionCard(
           onDownvoteClick={onDownvoteClick}
           onCommentClick={onCommentClick}
           onCopyLinkClick={onCopyLinkClick}
+          onBookmarkClick={onBookmarkClick}
         />
       </Container>
       {children}


### PR DESCRIPTION
## Changes

### Describe what this PR does
- We somehow missed the onBookmarkClick for this list collection.
- I double checked all other usage of `ActionButton` inside `cards` pass it

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-400 #done


### Preview domain
https://as-400-bookmark-collection-list.preview.app.daily.dev