### PR TITLE
refactor: fetch instance id from query param

### DIFF
--- a/packages/shared/src/components/auth/OnboardingLogs.tsx
+++ b/packages/shared/src/components/auth/OnboardingLogs.tsx
@@ -124,6 +124,7 @@ export const TiktokTracking = (): ReactElement => {
 
 interface LogSignUpProps {
   experienceLevel: keyof typeof UserExperienceLevel;
+  instanceId?: string;
 }
 
 const EXPERIENCE_TO_SENIORITY: Record<
@@ -139,9 +140,16 @@ const EXPERIENCE_TO_SENIORITY: Record<
   NOT_ENGINEER: 'not_engineer',
 };
 
-export const logSignUp = ({ experienceLevel }: LogSignUpProps): void => {
+export const logSignUp = ({
+  experienceLevel,
+  instanceId,
+}: LogSignUpProps): void => {
   if (typeof globalThis.gtag === 'function') {
-    globalThis.gtag('event', 'signup');
+    let props: Record<string, unknown>;
+    if (instanceId) {
+      props = { client_id: instanceId };
+    }
+    globalThis.gtag('event', 'signup', props);
   }
 
   if (typeof globalThis.fbq === 'function') {

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -217,7 +217,10 @@ export function OnboardPage(): ReactElement {
   };
 
   const onSuccessfulRegistration = (userRefetched: LoggedUser) => {
-    logSignUp({ experienceLevel: userRefetched?.experienceLevel });
+    logSignUp({
+      experienceLevel: userRefetched?.experienceLevel,
+      instanceId: router.query.aiid.toString(),
+    });
     setActiveScreen(OnboardingStep.EditTag);
   };
 


### PR DESCRIPTION
Android app starts the PWA with additional query param (aiid) that should be attached to our GA event
