### PR TITLE
fix: change onCloseModal hook in usePostModalNavigation.ts

### DIFF
--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -87,20 +87,17 @@ export const usePostModalNavigation = (
     onChangeSelected(index, fromPopState);
   };
 
-  const onCloseModal = useCallback(
-    (fromPopState = false) => {
-      setOpenedPostIndex(null);
-      setCurrentPage(undefined);
-      if (!fromPopState) {
-        window.scrollTo(0, scrollPositionOnFeed.current);
+  const onCloseModal = useCallback((fromPopState = false) => {
+    setOpenedPostIndex(null);
+    setCurrentPage(undefined);
+    if (!fromPopState) {
+      window.scrollTo(0, scrollPositionOnFeed.current);
 
-        changeHistory({}, `Feed`, currentPage);
-      }
+      window.history.back();
+    }
 
-      scrollPositionOnFeed.current = 0;
-    },
-    [changeHistory, currentPage],
-  );
+    scrollPositionOnFeed.current = 0;
+  }, [],);
 
   useEffect(() => {
     if (isTesting) {


### PR DESCRIPTION
## Changes

- changed the onCloseModal hook in usePostModalNavigation.ts
- Now when the user closes the modal by clicking on any area outside the modal, the navigation works fine.
- There was one extra redundant history being pushed on closing the modal(specifically by clicking outside) which caused the issue.

### Describe what this PR does
- fixes the issue mentioned here: https://github.com/dailydotdev/daily/issues/1216

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

WT-{number} #done
