### PR TITLE
fix: comment input header bg

### DIFF
--- a/packages/shared/src/components/fields/MarkdownInput/index.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/index.tsx
@@ -192,7 +192,7 @@ function MarkdownInput(
             tabListProps={{ className: { indicator: '!w-6' } }}
           >
             <Tab label={CommentTab.Write}>{children}</Tab>
-            <Tab label={CommentTab.Preview} className="p-4">
+            <Tab label={CommentTab.Preview} className="min-h-[11.125rem] p-4">
               <MarkdownPreview
                 input={input}
                 sourceId={sourceId}

--- a/packages/shared/src/components/tabs/TabContainer.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.tsx
@@ -134,7 +134,7 @@ export function TabContainer<T extends string = string>({
           'flex flex-row',
           className?.header,
           showBorder &&
-            'border-b border-border-subtlest-tertiary bg-background-default',
+            'border-b border-border-subtlest-tertiary bg-background-default tablet:bg-[unset]',
         )}
       >
         <TabList<T>


### PR DESCRIPTION
## Changes
- After further investigation, the issue seems to be not the border but the bg.
- After the mobile UX project, we made the bg to use the `default` but that should only be on the popup which is available on mobile only.
- For tablet and up, it should be `float`.
- For reference: https://www.figma.com/design/nmfWPS7x3kzLUvYMkBx2kW/daily.dev---Dev-Mode?node-id=6718-24966&m=dev
- Also fixed the minimum height issue when toggling left and right. 

Preview from Figma:
![Screenshot 2024-06-24 at 9 57 07 PM](https://github.com/dailydotdev/apps/assets/13744167/d7a082e7-a00a-4ff9-8d2c-6a5cd1f8009f)

Fix recording:
https://github.com/dailydotdev/apps/assets/13744167/749e4782-9692-4820-a1bd-22c1fe675828

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-395 #done
