### PR TITLE
fix: margin on freeform cards

### DIFF
--- a/packages/shared/src/components/cards/list/WelcomePostList.tsx
+++ b/packages/shared/src/components/cards/list/WelcomePostList.tsx
@@ -128,7 +128,7 @@ export const WelcomePostList = forwardRef(function SharePostCard(
           onCommentClick={onCommentClick}
           onCopyLinkClick={onCopyLinkClick}
           onBookmarkClick={onBookmarkClick}
-          className="mt-4 laptop:mt-auto"
+          className={classNames('mt-4', image && 'laptop:mt-auto')}
         />
       </Container>
       {children}

--- a/packages/shared/src/components/cards/list/WelcomePostList.tsx
+++ b/packages/shared/src/components/cards/list/WelcomePostList.tsx
@@ -128,7 +128,7 @@ export const WelcomePostList = forwardRef(function SharePostCard(
           onCommentClick={onCommentClick}
           onCopyLinkClick={onCopyLinkClick}
           onBookmarkClick={onBookmarkClick}
-          className={classNames('mt-4', image && 'laptop:mt-auto')}
+          className={classNames('mt-4', !!image && 'laptop:mt-auto')}
         />
       </Container>
       {children}


### PR DESCRIPTION
## Changes
- adds margin when there's not image for laptop

### Describe what this PR does
- fixes issues reported:
- https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1716906432720569

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-399 #done


### Preview domain
https://mi-399-list-card-no-image.preview.app.daily.dev