### PR TITLE
fix: remove refresh feed button

### DIFF
--- a/packages/shared/src/components/filters/MyFeedHeading.tsx
+++ b/packages/shared/src/components/filters/MyFeedHeading.tsx
@@ -1,15 +1,12 @@
-import React, { ReactElement, useContext } from 'react';
-import { useIsFetching, useQueryClient } from '@tanstack/react-query';
+import React, { ReactElement } from 'react';
 import { useRouter } from 'next/router';
-import { FilterIcon, PlusIcon, RefreshIcon } from '../icons';
+import { FilterIcon, PlusIcon } from '../icons';
 import {
   Button,
   ButtonIconPosition,
   ButtonSize,
   ButtonVariant,
 } from '../buttons/Button';
-import LogContext from '../../contexts/LogContext';
-import { LogEvent } from '../../lib/log';
 import {
   useActions,
   useConditionalFeature,
@@ -18,9 +15,6 @@ import {
   ViewSize,
 } from '../../hooks';
 import { feature } from '../../lib/featureManagement';
-import { useFeature } from '../GrowthBookProvider';
-import { setShouldRefreshFeed } from '../../lib/refreshFeed';
-import { SharedFeedPage } from '../utilities';
 import { getFeedName } from '../../lib/feed';
 import { useFeedName } from '../../hooks/feed/useFeedName';
 import { checkIsExtension } from '../../lib/func';
@@ -41,10 +35,7 @@ function MyFeedHeading({
   const { checkHasCompleted } = useActions();
   const { showTopSites, toggleShowTopSites } = useSettingsContext();
   const isMobile = useViewSize(ViewSize.MobileL);
-  const { logEvent } = useContext(LogContext);
   const { shouldUseListFeedLayout } = useFeedLayout();
-  const queryClient = useQueryClient();
-  const forceRefresh = useFeature(feature.forceRefresh);
   const isLaptop = useViewSize(ViewSize.Laptop);
   const feedName = getFeedName(router.pathname);
   const { isCustomFeed } = useFeedName({ feedName });
@@ -53,22 +44,6 @@ function MyFeedHeading({
     shouldEvaluate: isExtension,
   });
   const isShortcutsUIV1 = shortcutsUIFeature === ShortcutsUIExperiment.V1;
-
-  const onRefresh = async () => {
-    logEvent({ event_name: LogEvent.RefreshFeed });
-    setShouldRefreshFeed(true);
-    await queryClient.refetchQueries({ queryKey: [SharedFeedPage.MyFeed] });
-    setShouldRefreshFeed(false);
-  };
-
-  const isFetchingFeed =
-    useIsFetching({ queryKey: [SharedFeedPage.MyFeed] }) > 0;
-  const feedQueryState = queryClient.getQueryState([SharedFeedPage.MyFeed], {
-    exact: false,
-  });
-  const isRefreshing = feedQueryState?.status === 'success' && isFetchingFeed;
-  const shouldShowFeedRefresh = forceRefresh && !isCustomFeed;
-
   let feedFiltersLabel = 'Feed settings';
 
   if (isCustomFeed) {
@@ -77,21 +52,6 @@ function MyFeedHeading({
 
   return (
     <>
-      {shouldShowFeedRefresh && (
-        <Button
-          size={ButtonSize.Medium}
-          variant={isMobile ? ButtonVariant.Tertiary : ButtonVariant.Float}
-          className="mr-auto"
-          onClick={onRefresh}
-          icon={<RefreshIcon />}
-          iconPosition={
-            shouldUseListFeedLayout ? ButtonIconPosition.Right : undefined
-          }
-          loading={isRefreshing}
-        >
-          {isLaptop ? 'Refresh feed' : null}
-        </Button>
-      )}
       <FeedSettingsButton
         onClick={onOpenFeedFilters}
         className="mr-auto"

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -21,7 +21,6 @@ import {
   RequestKey,
   updateCachedPagePost,
 } from '../lib/query';
-import { getShouldRefreshFeed } from '../lib/refreshFeed';
 import { MarketingCta } from '../components/marketingCta/common';
 import { FeedItemType } from '../components/cards/common';
 
@@ -122,7 +121,6 @@ export default function useFeed<T>(
     ({ pageParam }) =>
       request(graphqlUrl, query, {
         ...variables,
-        ...(getShouldRefreshFeed() && { refresh: true }),
         first: pageSize,
         after: pageParam,
         loggedIn: !!user,

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -25,7 +25,6 @@ const feature = {
     fullBackground: false,
     image: cloudinary.onboarding.default,
   }),
-  forceRefresh: new Feature('force_refresh', false),
   feedAdSpot: new Feature('feed_ad_spot', 0),
   searchVersion: new Feature('search_version', 1),
   readingReminder: new Feature('reading_reminder', false),

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -148,8 +148,6 @@ export enum LogEvent {
   ScheduleStreakReminder = 'schedule streak reminder',
   // 404 page
   View404Page = '404 page',
-  // Refresh feed
-  RefreshFeed = 'refresh feed',
   // source
   SubscribeSource = 'subscribe source',
   UnsubscribeSource = 'unsubscribe source',

--- a/packages/shared/src/lib/refreshFeed.ts
+++ b/packages/shared/src/lib/refreshFeed.ts
@@ -1,9 +1,0 @@
-let shouldRefreshFeed = false;
-
-export const setShouldRefreshFeed = (value: boolean): void => {
-  shouldRefreshFeed = value;
-};
-
-export const getShouldRefreshFeed = (): boolean => {
-  return shouldRefreshFeed;
-};


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Removal of the refresh feed button
- Decided to leave the option in FEED_QUERY and the icons :) 

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-408 #done


### Preview domain
https://as-408-remove-feed-refresh.preview.app.daily.dev