### PR TITLE
fix: profile update fixes

### DIFF
--- a/packages/shared/src/hooks/useInputFieldFunctions.ts
+++ b/packages/shared/src/hooks/useInputFieldFunctions.ts
@@ -82,9 +82,7 @@ function useInputFieldFunctions<
     if (validInput !== undefined && valid !== undefined) {
       setValidInput(valid);
     }
-    // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [valid]);
+  }, [valid, validInput]);
 
   const onBlur = () => {
     clearIdleTimeout();

--- a/packages/shared/src/hooks/useProfileForm.ts
+++ b/packages/shared/src/hooks/useProfileForm.ts
@@ -23,6 +23,7 @@ export interface ProfileFormHint {
 
 export interface UpdateProfileParameters extends Partial<UserProfile> {
   image?: File;
+  onUpdateSuccess?: () => void;
 }
 
 interface UseProfileForm {
@@ -89,15 +90,16 @@ const useProfileForm = ({
     ResponseError,
     UpdateProfileParameters
   >(
-    ({ image, ...data }) =>
+    ({ image, onUpdateSuccess, ...data }) =>
       request(graphqlUrl, UPDATE_USER_PROFILE_MUTATION, {
         data,
         upload: image,
       }),
     {
-      onSuccess: async (_, { image, ...vars }) => {
+      onSuccess: async (_, { image, onUpdateSuccess, ...vars }) => {
         setHint({});
         await updateUser({ ...user, ...vars });
+        onUpdateSuccess?.();
         onSuccess?.();
       },
       onError: (err) => {

--- a/packages/webapp/pages/account/profile.tsx
+++ b/packages/webapp/pages/account/profile.tsx
@@ -77,9 +77,9 @@ const AccountProfilePage = (): ReactElement => {
       github: values.github,
       portfolio: values.portfolio,
       experienceLevel: values.experienceLevel,
+      onUpdateSuccess: () => router.push(`/${values.username}`),
     };
     updateUserProfile(params);
-    router.push(`/${values.username}`);
   };
 
   const { mutate: uploadCoverImage } = useMutation<


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Solves two issues
- 1. Before we just to always redirect to the profile you where changing too, but on fails this would be invalid and show you someone else profile. So now we only redirect if mutation succeeds
- 2. The error wasn't shown in red (app wide issue) which this PR solves due to memo issue.

Disclaimer:
There is still a separate issue where it will reset what you filled out on error but tackling it as separate ticket.

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-411  #done


### Preview domain
https://as-411-username-update-fail.preview.app.daily.dev