### PR TITLE
fix: menu options click history tab

### DIFF
--- a/packages/shared/src/components/post/PostItemCard.tsx
+++ b/packages/shared/src/components/post/PostItemCard.tsx
@@ -173,6 +173,7 @@ export default function PostItemCard({
                   icon={<MenuIcon />}
                   onClick={(event) => {
                     event.stopPropagation();
+                    event.preventDefault();
                     onContextMenu(event, postItem);
                   }}
                   size={ButtonSize.Small}


### PR DESCRIPTION
## Changes
- add prevent default

### Describe what this PR does
- Fixes issue on mobile where options click opens the post on history tab
- issue: https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1716473698164619

## Events

Did you introduce any new tracking events?
Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

### **Please make sure existing components are not breaking/affected by this PR**

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

MI-402 #done


### Preview domain
https://mi-402-history-options.preview.app.daily.dev