### PR TITLE
fix: move new feed button to below custom feeds

### DIFF
--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -268,24 +268,6 @@ export default function Sidebar({
                 }
               />
             )}
-            <MyFeedButton
-              {...defaultRenderSectionProps}
-              isButton={false}
-              title="New feed"
-              path={`${webappUrl}feeds/new`}
-              icon={
-                <div className="rounded-6 bg-background-subtle">
-                  <PlusIcon />
-                </div>
-              }
-              rightIcon={() =>
-                showCustomFeedsBetaBadge ? (
-                  <div className="absolute -right-3 -top-2 h-4 w-10">
-                    <img src={cloudinary.feed.betaTag} alt="Beta" />
-                  </div>
-                ) : undefined
-              }
-            />
             {feeds?.edges?.map((feed) => {
               const feedPath = `${webappUrl}feeds/${feed.node.id}`;
 
@@ -306,6 +288,24 @@ export default function Sidebar({
                 />
               );
             })}
+            <MyFeedButton
+              {...defaultRenderSectionProps}
+              isButton={false}
+              title="New feed"
+              path={`${webappUrl}feeds/new`}
+              icon={
+                <div className="rounded-6 bg-background-subtle">
+                  <PlusIcon />
+                </div>
+              }
+              rightIcon={() =>
+                showCustomFeedsBetaBadge ? (
+                  <div className="absolute -right-3 -top-2 h-4 w-10">
+                    <img src={cloudinary.feed.betaTag} alt="Beta" />
+                  </div>
+                ) : undefined
+              }
+            />
             <SquadSection {...defaultRenderSectionProps} />
             <DiscoverSection
               {...defaultRenderSectionProps}


### PR DESCRIPTION
## Changes

New feed button should render below the feeds

Now:
![Screenshot 2024-07-01 at 11 51 57](https://github.com/dailydotdev/apps/assets/554874/caaba0dd-0e48-429e-9220-59133c7008bf)

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-416 #done 