### PR TITLE
fix: cleanup onboarding_most_visited

### DIFF
--- a/packages/extension/src/newtab/ShortcutLinks.spec.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.spec.tsx
@@ -102,7 +102,7 @@ const defaultSettings: RemoteSettings = {
 
 const defaultBootData: BootCacheData = {
   alerts: defaultAlerts,
-  user: defaultUser,
+  user: { ...defaultUser, createdAt: '2024-02-16T00:00:00.000Z' },
   settings: defaultSettings,
   squads: [],
   notifications: { unreadNotificationsCount: 0 },

--- a/packages/extension/src/newtab/ShortcutLinks.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.tsx
@@ -27,7 +27,6 @@ import {
 } from '@dailydotdev/shared/src/lib/log';
 import {
   useActions,
-  useConditionalFeature,
   useToastNotification,
 } from '@dailydotdev/shared/src/hooks';
 import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
@@ -40,7 +39,10 @@ import { ActionType } from '@dailydotdev/shared/src/graphql/actions';
 import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
 import { ShortcutsUIExperiment } from '@dailydotdev/shared/src/lib/featureValues';
 import { cloudinary } from '@dailydotdev/shared/src/lib/image';
-import { useThemedAsset } from '@dailydotdev/shared/src/hooks/utils';
+import {
+  useShortcuts,
+  useThemedAsset,
+} from '@dailydotdev/shared/src/hooks/utils';
 import CustomLinksModal from './ShortcutLinksModal';
 import MostVisitedSitesModal from './MostVisitedSitesModal';
 import { CustomLinks } from './CustomLinks';
@@ -163,10 +165,7 @@ export default function ShortcutLinks({
   const loggedInitialRef = useRef(false);
   const loggedRef = useRef(false);
 
-  const { value: isShortcutsV1 } = useConditionalFeature({
-    feature: feature.onboardingMostVisited,
-    shouldEvaluate: showTopSites,
-  });
+  const { isShortcutsV1 } = useShortcuts();
   const { onMenuClick, isOpen } = useContextMenu({
     id: ContextMenu.ShortcutContext,
   });

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -15,7 +15,6 @@ import {
   useFeedLayout,
   ToastSubject,
   useToastNotification,
-  useConditionalFeature,
   FeedPagesWithMobileLayoutType,
   useViewSize,
   ViewSize,
@@ -23,10 +22,10 @@ import {
 } from '../../hooks';
 import ConditionalWrapper from '../ConditionalWrapper';
 import { useActiveFeedNameContext } from '../../contexts';
-import { feature } from '../../lib/featureManagement';
 import { SharedFeedPage } from '../utilities';
 import { useFeedName } from '../../hooks/feed/useFeedName';
 import { OtherFeedPage } from '../../lib/query';
+import { useShortcuts } from '../../hooks/utils';
 
 export interface FeedContainerProps {
   children: ReactNode;
@@ -154,10 +153,7 @@ export const FeedContainer = ({
   isHorizontal,
   feedContainerRef,
 }: FeedContainerProps): ReactElement => {
-  const { value: isShortcutsV1 } = useConditionalFeature({
-    feature: feature.onboardingMostVisited,
-    shouldEvaluate: !!shortcuts,
-  });
+  const { isShortcutsV1 } = useShortcuts();
   const currentSettings = useContext(FeedContext);
   const { subject } = useToastNotification();
   const { spaciness, loadedSettings } = useContext(SettingsContext);

--- a/packages/shared/src/hooks/utils/index.ts
+++ b/packages/shared/src/hooks/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './usePagination';
 export * from './useThemedAsset';
+export * from './useShortcuts';

--- a/packages/shared/src/hooks/utils/useShortcuts.ts
+++ b/packages/shared/src/hooks/utils/useShortcuts.ts
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { useAuthContext } from '../../contexts/AuthContext';
+
+interface UseShortcuts {
+  isShortcutsV1: boolean;
+}
+
+/**
+ * Hook to determine if the user is on the old version of shortcuts
+ * More information in this thread: https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1720008775281939
+ * Keywords: shortcutsUI, onboarding_most_visited
+ */
+export const useShortcuts = (): UseShortcuts => {
+  const { user } = useAuthContext();
+
+  const isShortcutsV1 = useMemo(
+    () => user?.createdAt >= '2024-04-16T00:00:00.000Z',
+    [user?.createdAt],
+  );
+
+  return {
+    isShortcutsV1,
+  };
+};

--- a/packages/shared/src/hooks/utils/useShortcuts.ts
+++ b/packages/shared/src/hooks/utils/useShortcuts.ts
@@ -14,7 +14,7 @@ export const useShortcuts = (): UseShortcuts => {
   const { user } = useAuthContext();
 
   const isShortcutsV1 = useMemo(
-    () => user?.createdAt >= '2024-04-16T00:00:00.000Z',
+    () => new Date(user?.createdAt) >= new Date('2024-04-16T00:00:00.000Z'),
     [user?.createdAt],
   );
 

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -27,7 +27,6 @@ const feature = {
   feedAdSpot: new Feature('feed_ad_spot', 0),
   searchVersion: new Feature('search_version', 1),
   readingReminder: new Feature('reading_reminder', false),
-  onboardingMostVisited: new Feature('onboarding_most_visited', false),
   shareExperience: new Feature('share_experience', false),
   featureTheme: new Feature('feature_theme', {}),
   hypeCampaign: new Feature('hype_campaign', false),


### PR DESCRIPTION
## Changes

Cleanup onboarding_most_visited it won but only for users after set date.
Decided for this reason to abstract into a hook so the logic had one source of truth.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-425 #done 


### Preview domain
https://as-425-cleanup-onboarding-most-visited.preview.app.daily.dev