### PR TITLE
fix: flaky test

### DIFF
--- a/packages/shared/__tests__/fixture/auth.ts
+++ b/packages/shared/__tests__/fixture/auth.ts
@@ -1308,9 +1308,9 @@ export const mockSettingsValidation = (
   params: Partial<EmptyObjectLiteral>,
   result: unknown = successfulSettingsFlowData,
   code = 200,
-): void => {
+): nock.Scope => {
   const url = new URL(settingsFlowMockData.ui.action);
-  nock(authUrl, {
+  return nock(authUrl, {
     reqheaders: {
       'Content-Type': 'application/json',
       'X-CSRF-Token': params.csrf_token,

--- a/packages/webapp/__tests__/AccountSecurityPage.tsx
+++ b/packages/webapp/__tests__/AccountSecurityPage.tsx
@@ -121,12 +121,10 @@ const verifySession = async (email = defaultLoggedUser.email) => {
     method: 'password',
   };
   mockKratosPost({ action, params }, verifiedLoginData);
-  await act(async () => {
-    const submitLogin = await screen.findByText('Verify');
-    fireEvent.click(submitLogin);
-    await waitForNock();
-    expect(refetchBoot).toHaveBeenCalled();
-  });
+  const submitLogin = await screen.findByText('Verify');
+  fireEvent.click(submitLogin);
+  await waitForNock();
+  expect(refetchBoot).toHaveBeenCalled();
   return true;
 };
 

--- a/packages/webapp/__tests__/AccountSecurityPage.tsx
+++ b/packages/webapp/__tests__/AccountSecurityPage.tsx
@@ -248,6 +248,8 @@ it('should allow setting new password but require to verify session', async () =
   fireEvent.input(screen.getByPlaceholderText('Password'), {
     target: { value: password },
   });
+  const el = await screen.findByPlaceholderText('Password');
+  expect(el).toHaveValue('#123xAbc');
   const { nodes } = settingsFlowMockData.ui;
   const token = getNodeValue('csrf_token', nodes);
   const params = {
@@ -260,10 +262,10 @@ it('should allow setting new password but require to verify session', async () =
   const submitResetPassword = await screen.findByText('Set password');
   fireEvent.click(submitResetPassword);
   await waitForNock();
-  mockSettingsValidation(params);
+  const mock = mockSettingsValidation(params);
   await verifySession();
-  const input = await screen.findByPlaceholderText('Password');
-  expect(input).toHaveValue('#123xAbc');
+  await waitForNock();
+  expect(mock.isDone()).toBeTruthy();
 });
 
 it('should allow linking social providers', async () => {


### PR DESCRIPTION
## Changes
- Checking the value of the input box at the end doesn't really prove anything.
- It may have some relevance, but at the start of the flow. Hence, moved it.
- The important factor is whether the mock of updating the settings was executed. Should be tested here now.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->
