### PR TITLE
fix: added privacy prompt for firefox

### DIFF
--- a/packages/extension/src/contexts/ExtensionContext.tsx
+++ b/packages/extension/src/contexts/ExtensionContext.tsx
@@ -9,6 +9,7 @@ import {
   getContentScriptPermission,
   getHostPermission,
   HOST_PERMISSIONS,
+  promptUninstallExtension,
 } from '../lib/extensionScripts';
 
 export type ExtensionContextProviderProps = {
@@ -34,6 +35,7 @@ export const ExtensionContextProvider = ({
       origins: HOST_PERMISSIONS,
       currentPage,
       setCurrentPage,
+      promptUninstallExtension,
     }),
     [client, currentPage, setCurrentPage, logEvent],
   );

--- a/packages/extension/src/lib/extensionScripts.ts
+++ b/packages/extension/src/lib/extensionScripts.ts
@@ -120,3 +120,8 @@ export const getHostPermission = (): Promise<boolean> =>
   browser.permissions.contains({
     origins: HOST_PERMISSIONS,
   });
+
+export const promptUninstallExtension = (): Promise<void> =>
+  browser.management.uninstallSelf({
+    showConfirmDialog: true,
+  });

--- a/packages/shared/src/components/modals/common.tsx
+++ b/packages/shared/src/components/modals/common.tsx
@@ -131,6 +131,13 @@ const PrivilegedMemberModal = dynamic(
     ),
 );
 
+const FirefoxPrivacyModal = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "firefoxPrivacyModal" */ './firefoxPrivacy/FirefoxPrivacyModal'
+    ),
+);
+
 export const modals = {
   [LazyModal.SquadMember]: SquadMemberModal,
   [LazyModal.UpvotedPopup]: UpvotedPopupModal,
@@ -154,6 +161,7 @@ export const modals = {
   [LazyModal.Share]: ShareModal,
   [LazyModal.SubmitSquadForReview]: SubmitSquadForReviewModal,
   [LazyModal.PrivilegedMembers]: PrivilegedMemberModal,
+  [LazyModal.FirefoxPrivacy]: FirefoxPrivacyModal,
 };
 
 type GetComponentProps<T> = T extends

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -193,6 +193,7 @@ export function Modal({
       overlayClassName={modalOverlayClassName}
       onRequestClose={onRequestClose}
       className={modalClassName}
+      shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
       {...props}
     >
       {content}

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -52,6 +52,7 @@ export enum LazyModal {
   Share = 'share',
   SubmitSquadForReview = 'submitSquadForReview',
   PrivilegedMembers = 'privilegedMembers',
+  FirefoxPrivacy = 'firefoxPrivacy',
 }
 
 export type ModalTabItem = {

--- a/packages/shared/src/components/modals/firefoxPrivacy/FirefoxPrivacyModal.tsx
+++ b/packages/shared/src/components/modals/firefoxPrivacy/FirefoxPrivacyModal.tsx
@@ -30,18 +30,18 @@ function FirefoxPrivacyModal({
         </h1>
         <div className="mb-6 mt-4 text-center text-text-secondary typo-callout">
           <p>
-            We{' '}
+            We collect{' '}
             <a
               href={privacyPolicy}
               target="_blank"
               rel={anchorDefaultRel}
               className="font-bold underline"
             >
-              collect
+              user data
             </a>{' '}
-            user data to provide a personalized experience on daily.dev. Instead
-            of just collecting data right away, we would like to ask for your
-            approval. We promise to never misuse it.
+            to provide a personalized experience on daily.dev. Instead of just
+            collecting data right away, we would like to ask for your approval.
+            We promise to never misuse it.
             <br />
             <br />
             Do you agree to opt-in?

--- a/packages/shared/src/components/modals/firefoxPrivacy/FirefoxPrivacyModal.tsx
+++ b/packages/shared/src/components/modals/firefoxPrivacy/FirefoxPrivacyModal.tsx
@@ -3,6 +3,8 @@ import { Modal, ModalProps } from '../common/Modal';
 import { ModalSize } from '../common/types';
 import { ButtonVariant } from '../../buttons/common';
 import { Button } from '../../buttons/Button';
+import { privacyPolicy } from '../../../lib/constants';
+import { anchorDefaultRel } from '../../../lib/strings';
 
 export interface FirefoxPrivacyModalProps extends ModalProps {
   onAccept: () => void;
@@ -28,9 +30,18 @@ function FirefoxPrivacyModal({
         </h1>
         <div className="mb-6 mt-4 text-center text-text-secondary typo-callout">
           <p>
-            We collect user data to provide a personalized experience on
-            daily.dev. Instead of just collecting data right away, we would like
-            to ask for your approval. We promise to never misuse it.
+            We{' '}
+            <a
+              href={privacyPolicy}
+              target="_blank"
+              rel={anchorDefaultRel}
+              className="font-bold underline"
+            >
+              collect
+            </a>{' '}
+            user data to provide a personalized experience on daily.dev. Instead
+            of just collecting data right away, we would like to ask for your
+            approval. We promise to never misuse it.
             <br />
             <br />
             Do you agree to opt-in?

--- a/packages/shared/src/components/modals/firefoxPrivacy/FirefoxPrivacyModal.tsx
+++ b/packages/shared/src/components/modals/firefoxPrivacy/FirefoxPrivacyModal.tsx
@@ -1,0 +1,60 @@
+import React, { ReactElement } from 'react';
+import { Modal, ModalProps } from '../common/Modal';
+import { ModalSize } from '../common/types';
+import { ButtonVariant } from '../../buttons/common';
+import { Button } from '../../buttons/Button';
+
+export interface FirefoxPrivacyModalProps extends ModalProps {
+  onAccept: () => void;
+  onDecline: () => void;
+}
+
+function FirefoxPrivacyModal({
+  onAccept,
+  onDecline,
+  onRequestClose,
+  ...props
+}: FirefoxPrivacyModalProps): ReactElement {
+  const actionAndClose = (action: () => void, e: React.MouseEvent) => {
+    action();
+    onRequestClose(e);
+  };
+
+  return (
+    <Modal {...props} shouldCloseOnOverlayClick={false} size={ModalSize.Medium}>
+      <Modal.Body>
+        <h1 className="text-center font-bold typo-title3">
+          Your privacy stays yours
+        </h1>
+        <div className="mb-6 mt-4 text-center text-text-secondary typo-callout">
+          <p>
+            We collect user data to provide a personalized experience on
+            daily.dev. Instead of just collecting data right away, we would like
+            to ask for your approval. We promise to never misuse it.
+            <br />
+            <br />
+            Do you agree to opt-in?
+          </p>
+        </div>
+        <div className="flex flex-col items-center justify-center gap-4 self-stretch tablet:flex-row">
+          <Button
+            variant={ButtonVariant.Secondary}
+            onClick={(e) => actionAndClose(onDecline, e)}
+            className="w-full tablet:w-auto"
+          >
+            Decline and uninstall
+          </Button>
+          <Button
+            variant={ButtonVariant.Primary}
+            onClick={(e) => actionAndClose(onAccept, e)}
+            className="w-full tablet:w-auto"
+          >
+            Yes, thanks for asking
+          </Button>
+        </div>
+      </Modal.Body>
+    </Modal>
+  );
+}
+
+export default FirefoxPrivacyModal;

--- a/packages/shared/src/contexts/ExtensionContext.tsx
+++ b/packages/shared/src/contexts/ExtensionContext.tsx
@@ -15,6 +15,7 @@ export interface ExtensionContextData {
   origins?: string[];
   currentPage?: string;
   setCurrentPage?: React.Dispatch<React.SetStateAction<string>>;
+  promptUninstallExtension?: () => Promise<void>;
 }
 
 // This is an empty context when used outside the extension

--- a/packages/shared/src/hooks/profile/useProfile.ts
+++ b/packages/shared/src/hooks/profile/useProfile.ts
@@ -2,7 +2,8 @@ import { useContext } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getProfile, PublicProfile } from '../../lib/user';
 import AuthContext from '../../contexts/AuthContext';
-import { generateQueryKey, RequestKey } from '../../lib/query';
+import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
+import { disabledRefetch } from '../../lib/func';
 
 export function useProfile(initialUser?: PublicProfile): PublicProfile {
   const { user: loggedUser } = useContext(AuthContext);
@@ -12,11 +13,9 @@ export function useProfile(initialUser?: PublicProfile): PublicProfile {
     generateQueryKey(RequestKey.Profile, initialUser),
     () => getProfile(initialUser?.id),
     {
-      placeholderData: initialUser,
-      refetchOnReconnect: false,
-      refetchOnMount: false,
-      refetchOnWindowFocus: false,
-      // Make sure the logged in user's profile is always up to date
+      ...disabledRefetch,
+      cacheTime: StaleTime.OneHour,
+      initialData: initialUser,
       enabled: !!initialUser && isSameUser,
     },
   );


### PR DESCRIPTION
## Changes

Firefox has very strict privacy rules and thus we need to comply and offer a clear first interaction privacy setup.
As we don't provide any way for user to turn it off/deny it we need to present a "uninstall extension" prompt.
*ONLY SHOWS ON FF

Video of usecase:
https://github.com/dailydotdev/apps/assets/554874/8f9f1469-a18e-4ed6-b0f4-348ca5ab3d55

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-429 #done


### Preview domain
https://as-429-firefox-uninstaller.preview.app.daily.dev