### PR TITLE
fix: flaky extension test for shortcut links

### DIFF
--- a/packages/extension/src/newtab/ShortcutLinks.spec.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.spec.tsx
@@ -70,14 +70,7 @@ jest.mock('webextension-polyfill', () => {
   };
 });
 
-beforeEach(() => {
-  nock.cleanAll();
-  jest.clearAllMocks();
-});
-
-const defaultAlerts: Alerts = { filter: true, rankLastSeen: null };
-
-const defaultSettings: RemoteSettings = {
+const settings: RemoteSettings = {
   theme: 'bright',
   openNewTab: false,
   spaciness: 'roomy',
@@ -97,6 +90,16 @@ const defaultSettings: RemoteSettings = {
   ],
   onboardingChecklistView: ChecklistViewState.Hidden,
 };
+
+let defaultSettings: RemoteSettings;
+
+beforeEach(() => {
+  nock.cleanAll();
+  jest.clearAllMocks();
+  defaultSettings = settings;
+});
+
+const defaultAlerts: Alerts = { filter: true, rankLastSeen: null };
 
 const defaultBootData: BootCacheData = {
   alerts: defaultAlerts,
@@ -171,8 +174,10 @@ describe('shortcut links component', () => {
 
   it('should display top sites if permission is previously granted', async () => {
     await browser.permissions.request({ permissions: ['topSites'] });
+    defaultSettings.customLinks = null;
     renderComponent();
 
+    await act(() => new Promise((resolve) => setTimeout(resolve, 10)));
     const shortcuts = await screen.findAllByRole('link');
     expect(shortcuts.length).toEqual(3);
 
@@ -316,7 +321,7 @@ describe('shortcut links component', () => {
     expect(mutationCalled).toBeTruthy();
 
     const updated = await screen.findAllByRole('link');
-    expect(updated.length).toEqual(6);
+    expect(updated.length).toEqual(5);
 
     expect(logEvent).toHaveBeenCalledWith({
       event_name: LogEvent.SaveShortcutAccess,

--- a/packages/extension/src/newtab/ShortcutLinks.spec.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.spec.tsx
@@ -70,7 +70,14 @@ jest.mock('webextension-polyfill', () => {
   };
 });
 
-const settings: RemoteSettings = {
+beforeEach(() => {
+  nock.cleanAll();
+  jest.clearAllMocks();
+});
+
+const defaultAlerts: Alerts = { filter: true, rankLastSeen: null };
+
+const defaultSettings: RemoteSettings = {
   theme: 'bright',
   openNewTab: false,
   spaciness: 'roomy',
@@ -90,16 +97,6 @@ const settings: RemoteSettings = {
   ],
   onboardingChecklistView: ChecklistViewState.Hidden,
 };
-
-let defaultSettings: RemoteSettings;
-
-beforeEach(() => {
-  nock.cleanAll();
-  jest.clearAllMocks();
-  defaultSettings = settings;
-});
-
-const defaultAlerts: Alerts = { filter: true, rankLastSeen: null };
 
 const defaultBootData: BootCacheData = {
   alerts: defaultAlerts,
@@ -174,8 +171,10 @@ describe('shortcut links component', () => {
 
   it('should display top sites if permission is previously granted', async () => {
     await browser.permissions.request({ permissions: ['topSites'] });
-    defaultSettings.customLinks = null;
-    renderComponent();
+    renderComponent({
+      ...defaultBootData,
+      settings: { ...defaultBootData.settings, customLinks: null },
+    });
 
     await act(() => new Promise((resolve) => setTimeout(resolve, 10)));
     const shortcuts = await screen.findAllByRole('link');

--- a/packages/extension/src/newtab/ShortcutLinks.spec.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.spec.tsx
@@ -176,7 +176,6 @@ describe('shortcut links component', () => {
       settings: { ...defaultBootData.settings, customLinks: null },
     });
 
-    await act(() => new Promise((resolve) => setTimeout(resolve, 10)));
     const shortcuts = await screen.findAllByRole('link');
     expect(shortcuts.length).toEqual(3);
 

--- a/packages/extension/src/newtab/ShortcutLinks.spec.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks.spec.tsx
@@ -94,7 +94,6 @@ const defaultSettings: RemoteSettings = {
     'http://custom2.com',
     'http://custom3.com',
     'http://custom4.com',
-    'http://custom5.com',
   ],
   onboardingChecklistView: ChecklistViewState.Hidden,
 };
@@ -260,7 +259,7 @@ describe('shortcut links component', () => {
     renderComponent();
 
     const shortcuts = await screen.findAllByRole('link');
-    expect(shortcuts.length).toEqual(5);
+    expect(shortcuts.length).toEqual(4);
   });
 
   it('should allow user to customize shortcut links', async () => {
@@ -282,7 +281,7 @@ describe('shortcut links component', () => {
     renderComponent();
 
     const shortcuts = await screen.findAllByRole('link');
-    expect(shortcuts.length).toEqual(5);
+    expect(shortcuts.length).toEqual(4);
 
     const edit = await screen.findByLabelText('Edit shortcuts');
     fireEvent.click(edit);


### PR DESCRIPTION
## Changes
- Fix the extension flaky test. Sometimes the evaluation happens without the re-render not yet finished. Hence, flaky result.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://fix-flaky-extension.preview.app.daily.dev