### PR TITLE
fix: link placement

### DIFF
--- a/packages/shared/src/components/profile/SocialChips.tsx
+++ b/packages/shared/src/components/profile/SocialChips.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { GitHubIcon, TwitterIcon, LinkIcon } from '../icons';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { withHttps } from '../../lib/links';
 
 export interface SocialChipsProps {
   links: { github?: string; twitter?: string; portfolio?: string };
@@ -26,7 +27,7 @@ const handlers: Record<
   },
   portfolio: {
     icon: <LinkIcon />,
-    href: (x) => x,
+    href: (x) => withHttps(x),
     // Strip protocol from url
     label: (x) => x.replace(/(^\w+:|^)\/\//, ''),
   },

--- a/packages/shared/src/lib/links.spec.ts
+++ b/packages/shared/src/lib/links.spec.ts
@@ -1,0 +1,17 @@
+import { withHttps } from './links';
+
+describe('lib/links tests', () => {
+  it('should return links as https links', () => {
+    const urls = {
+      'www.google.com': 'https://www.google.com',
+      'google.com': 'https://google.com',
+      '//google.com': 'https://google.com',
+      'http://www.google.com': 'http://www.google.com',
+      'https://www.google.com': 'https://www.google.com',
+      'ftp://www.google.com': 'https://www.google.com',
+    };
+    Object.entries(urls).forEach(([input, expected]) => {
+      expect(withHttps(input)).toEqual(expected);
+    });
+  });
+});

--- a/packages/shared/src/lib/links.ts
+++ b/packages/shared/src/lib/links.ts
@@ -13,6 +13,12 @@ export function isValidHttpUrl(link: string): boolean {
   }
 }
 
+const validSchema = ['http:', 'https:'];
+export const withHttps = (url: string): string =>
+  url.replace(/^(?:(.*:)?\/\/)?(.*)/i, (match, schema, nonSchemaUrl) => {
+    return validSchema.includes(schema) ? match : `https://${nonSchemaUrl}`;
+  });
+
 export const stripLinkParameters = (link: string): string => {
   const { origin, pathname } = new URL(link);
 


### PR DESCRIPTION
## Changes

There was a issue if users pasted links as `google.com` or `www.google.com` it would simply redirect to app.daily.dev/URL.

Added a neater validation to ensure valid URL redirects, also strip unwanted protocols (like ftp)

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-430 #done 

### Preview domain
https://as-430-parse-as-links.preview.app.daily.dev