### PR TITLE
fix: showing streak when disabled

### DIFF
--- a/packages/shared/src/components/modals/BootPopups.tsx
+++ b/packages/shared/src/components/modals/BootPopups.tsx
@@ -16,6 +16,7 @@ import InteractivePopup, {
 } from '../tooltips/InteractivePopup';
 import { MarketingCtaPopoverSmall } from '../marketingCta/MarketingCtaPopoverSmall';
 import { ButtonVariant } from '../buttons/common';
+import { isNullOrUndefined } from '../../lib/func';
 
 const REP_TRESHOLD = 250;
 
@@ -46,19 +47,19 @@ export const BootPopups = (): JSX.Element => {
     isStreaksEnabled,
   } = useReadingStreak();
 
-  // hide modal if feature is not enabled
-  let shouldHideStreaksModal = !isStreaksEnabled;
-  // hide modal if actions are not fetched
-  shouldHideStreaksModal = shouldHideStreaksModal || !isActionsFetched;
-  // hide modal if user already opted out of the milestone
-  shouldHideStreaksModal =
-    shouldHideStreaksModal ||
-    checkHasCompleted(ActionType.DisableReadingStreakMilestone);
-  // hide modal if user already closed it
-  shouldHideStreaksModal =
-    shouldHideStreaksModal || alerts?.showStreakMilestone !== true;
-  // hide modal if there's no streak
-  shouldHideStreaksModal = shouldHideStreaksModal || !streak?.current;
+  const isDisabledMilestone = checkHasCompleted(
+    ActionType.DisableReadingStreakMilestone,
+  );
+  const hideEvaluations = [
+    !isStreaksEnabled,
+    !isActionsFetched,
+    isNullOrUndefined(isDisabledMilestone),
+    isDisabledMilestone,
+    alerts?.showStreakMilestone !== true,
+    !streak?.current,
+  ];
+
+  const shouldHideStreaksModal = hideEvaluations.some(Boolean);
 
   const addBootPopup = (popup) => {
     setBootPopups((prev) => new Map([...prev, [popup.type, popup]]));


### PR DESCRIPTION
## Changes
- Was not able to reproduce the actual issue but I observed all the evaluations we did when not showing the milestone.
- The only evaluation that could be the fault is the checking of actions they've made to hide the popup.
- There could be a race where the value returned is `undefined` which is considered as falsy.
- Also refactored usage of let. Not a fan of it as it is prone to being mutated somewhere else.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

MI-410


### Preview domain
https://mi-410.preview.app.daily.dev