### PR TITLE
chore: cleanup share_experience experiment

### DIFF
--- a/packages/shared/src/components/post/PostActions.tsx
+++ b/packages/shared/src/components/post/PostActions.tsx
@@ -7,17 +7,11 @@ import {
   BookmarkIcon,
   DownvoteIcon,
   LinkIcon,
-  ShareIcon,
 } from '../icons';
 import { Post, UserVote } from '../../graphql/posts';
 import { QuaternaryButton } from '../buttons/QuaternaryButton';
 import { PostOrigin } from '../../hooks/log/useLogContextData';
-import {
-  useConditionalFeature,
-  useViewSize,
-  useVotePost,
-  ViewSize,
-} from '../../hooks';
+import { useVotePost } from '../../hooks';
 import { Origin } from '../../lib/log';
 import { Card } from '../cards/Card';
 import ConditionalWrapper from '../ConditionalWrapper';
@@ -30,8 +24,6 @@ import {
   mutateBookmarkFeedPost,
   useBookmarkPost,
 } from '../../hooks/useBookmarkPost';
-import { useSharePost } from '../../hooks/useSharePost';
-import { feature } from '../../lib/featureManagement';
 import { ButtonColor, ButtonVariant } from '../buttons/Button';
 
 interface PostActionsProps {
@@ -54,12 +46,6 @@ export function PostActions({
   const { showTagsPanel } = data;
   const { queryKey: feedQueryKey, items } = useContext(ActiveFeedContext);
   const queryClient = useQueryClient();
-  const { openNativeShareOrPopup } = useSharePost(origin);
-  const isMobile = useViewSize(ViewSize.MobileL);
-  const shareExperience = useConditionalFeature({
-    feature: feature.shareExperience,
-    shouldEvaluate: isMobile,
-  });
 
   const { toggleUpvote, toggleDownvote } = useVotePost({
     variables: { feedName: feedQueryKey },
@@ -187,22 +173,10 @@ export function PostActions({
             onClick={() => onCopyLinkClick(post)}
             icon={<LinkIcon />}
             responsiveLabelClass={actionsClassName}
-            className={classNames(
-              'btn-tertiary-cabbage',
-              shareExperience && 'hidden tablet:flex',
-            )}
+            className="btn-tertiary-cabbage"
           >
             Copy
           </QuaternaryButton>
-          {shareExperience && (
-            <QuaternaryButton
-              id="share-post-btn"
-              onClick={() => openNativeShareOrPopup({ post })}
-              icon={<ShareIcon />}
-              responsiveLabelClass={actionsClassName}
-              className="btn-tertiary-cabbage flex tablet:hidden"
-            />
-          )}
         </div>
       </div>
     </ConditionalWrapper>

--- a/packages/shared/src/hooks/useSharePost.ts
+++ b/packages/shared/src/hooks/useSharePost.ts
@@ -17,7 +17,6 @@ interface UseSharePost {
   openSharePost: (props: FuncProps) => void;
   copyLink: (props: FuncProps) => void;
   openNativeSharePost?: (post: Post) => void;
-  openNativeShareOrPopup: (props: FuncProps) => void;
 }
 
 export function useSharePost(origin: Origin): UseSharePost {
@@ -73,21 +72,9 @@ export function useSharePost(origin: Origin): UseSharePost {
     [getShortUrl, origin, logEvent],
   );
 
-  const openNativeShareOrPopup = useCallback(
-    (props: FuncProps) => {
-      if (globalThis.navigator?.share) {
-        return openNativeSharePost(props.post);
-      }
-
-      return openSharePost(props);
-    },
-    [openNativeSharePost, openSharePost],
-  );
-
   return {
     openSharePost,
     copyLink: copyLinkShare,
     openNativeSharePost,
-    openNativeShareOrPopup,
   };
 }

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -23,7 +23,6 @@ const feature = {
   feedAdSpot: new Feature('feed_ad_spot', 0),
   searchVersion: new Feature('search_version', 1),
   readingReminder: new Feature('reading_reminder', false),
-  shareExperience: new Feature('share_experience', false),
   featureTheme: new Feature('feature_theme', {}),
   shortcutsUI: new Feature('shortcuts_ui', ShortcutsUIExperiment.Control),
   showRoadmap: new Feature('show_roadmap', false),


### PR DESCRIPTION
## Changes

Cleanup share_experience experiment (lost)
Also decided to remove openNativeShareOrPopup as it wasn't used and makes the hook a bit leaner.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-433 #done 


### Preview domain
https://as-433-cleanup-share-experience.preview.app.daily.dev