### PR TITLE
refactor: community picks close on submission

### DIFF
--- a/packages/shared/src/components/modals/SubmitArticleModal.spec.tsx
+++ b/packages/shared/src/components/modals/SubmitArticleModal.spec.tsx
@@ -1,4 +1,10 @@
-import { render, RenderResult, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  RenderResult,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
@@ -17,6 +23,7 @@ import SubmitArticleModal from './SubmitArticleModal';
 import user from '../../../__tests__/fixture/loggedUser';
 import { NotificationsContextProvider } from '../../contexts/NotificationsContext';
 import { waitForNock } from '../../../__tests__/helpers/utilities';
+import Toast from '../notifications/Toast';
 
 const onRequestClose = jest.fn();
 
@@ -53,6 +60,7 @@ const renderComponent = (
         loadedUserFromCache
       >
         <NotificationsContextProvider>
+          <Toast />
           <SubmitArticleModal isOpen onRequestClose={onRequestClose} />
         </NotificationsContextProvider>
       </AuthContextProvider>
@@ -76,7 +84,7 @@ it('should submit a valid URL', async () => {
   input.value = link;
   const btn = await screen.findByLabelText('Submit');
   await waitFor(() => expect(btn).toBeEnabled());
-  btn.click();
+  fireEvent.click(btn);
 
   mockGraphQL({
     request: {


### PR DESCRIPTION
## Changes
- Rather than wait for the user to close the modal after submission, we will instead close it and send a toast message.
- We should probably inform the product team about this engineering decsion.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

MI-416 #done

### Preview domain
https://mi-416.preview.app.daily.dev