### PR TITLE
fix: unable to open context menu in squads from mobile;

### DIFF
--- a/packages/shared/src/components/squads/SquadHeaderMenu.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.tsx
@@ -27,6 +27,7 @@ import { useSquadInvitation } from '../../hooks/useSquadInvitation';
 import { Origin } from '../../lib/log';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { ContextMenu as ContextMenuIds } from '../../hooks/constants';
+import useContextMenu from '../../hooks/useContextMenu';
 
 const ContextMenu = dynamic(
   () => import(/* webpackChunkName: "contextMenu" */ '../fields/ContextMenu'),
@@ -50,6 +51,7 @@ export default function SquadHeaderMenu({
   const router = useRouter();
   const { openModal } = useLazyModal();
   const { editSquad } = useSquadNavigation();
+  const { isOpen } = useContextMenu({ id: ContextMenuIds.SquadMenuContext });
 
   const { onDeleteSquad } = useDeleteSquad({
     squad,
@@ -144,6 +146,7 @@ export default function SquadHeaderMenu({
       className="menu-primary"
       animation="fade"
       options={items}
+      isOpen={isOpen}
     />
   );
 }


### PR DESCRIPTION
## Changes
- Update ContextMenu with status that comes from context;
- fixes [#1260](https://github.com/dailydotdev/daily/issues/1260) ;

## Manual Testing

From mobile:

```
1. Go to 'Squads' 
2. Click on 'Your Squad X > option'
3. Open menu  '3 vertical dots' on the squad landing page
4. Observe
```

#### Did you test on actual mobile devices?
- [x] iOS (Chrome and Safari)
- [ ] Android


### Preview domain
https://mi-419-fix-unable-to-leave-squad-on-mobile.preview.app.daily.dev/squads/nextjs