### PR TITLE
chore: cleanup items passing

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -417,14 +417,14 @@ export default function Feed<T>({
         isHorizontal={isHorizontal}
         feedContainerRef={feedContainerRef}
       >
-        {items.map((_, index) => (
+        {items.map((item, index) => (
           <FeedItemComponent
-            items={items}
+            item={item}
             index={index}
             row={calculateRow(index, virtualizedNumCards)}
             column={calculateColumn(index, virtualizedNumCards)}
             columns={virtualizedNumCards}
-            key={getFeedItemKey(items, index)}
+            key={getFeedItemKey(item, index)}
             openNewTab={openNewTab}
             postMenuIndex={postMenuIndex}
             showCommentPopupId={showCommentPopupId}

--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -31,7 +31,7 @@ const CommentPopup = dynamic(
 );
 
 export type FeedItemComponentProps = {
-  items: FeedItem[];
+  item: FeedItem;
   index: number;
   row: number;
   column: number;
@@ -77,8 +77,7 @@ export type FeedItemComponentProps = {
   onAdClick: (ad: Ad, row: number, column: number) => void;
 } & Pick<UseVotePost, 'toggleUpvote' | 'toggleDownvote'>;
 
-export function getFeedItemKey(items: FeedItem[], index: number): string {
-  const item = items[index];
+export function getFeedItemKey(item: FeedItem, index: number): string {
   switch (item.type) {
     case 'post':
       return item.post.id;
@@ -130,7 +129,7 @@ const getTags = ({
 };
 
 export default function FeedItemComponent({
-  items,
+  item,
   index,
   row,
   column,
@@ -155,7 +154,6 @@ export default function FeedItemComponent({
   onAdClick,
   onReadArticleClick,
 }: FeedItemComponentProps): ReactElement {
-  const item = items[index];
   const inViewRef = useLogImpression(
     item,
     index,


### PR DESCRIPTION
## Changes

Probably legacy reasons we used to pass all items to each FeedItemComponent.
To only extract the one we need inside.

Instead we now can just pass the item we want to avoid spamming a big array each time.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://chore-cleanup-item-passing.preview.app.daily.dev