### PR TITLE
fix: clicking shortcuts options did nothing

### DIFF
--- a/packages/extension/src/newtab/ShortcutLinks/experiments/ShortcutLinksUIV1.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks/experiments/ShortcutLinksUIV1.tsx
@@ -114,7 +114,6 @@ function ShortcutUIItemPlaceholder({ children }: PropsWithChildren) {
 export function ShortcutLinksUIV1(props: ShortcutLinksV1Props): ReactElement {
   const {
     onLinkClick,
-    onMenuClick,
     onOptionsOpen,
     onV1Hide,
     shortcutLinks,
@@ -197,7 +196,7 @@ export function ShortcutLinksUIV1(props: ShortcutLinksV1Props): ReactElement {
             variant={ButtonVariant.Tertiary}
             size={ButtonSize.Small}
             icon={<MenuIcon className="rotate-90" secondary />}
-            onClick={onMenuClick}
+            onClick={onOptionsOpen}
             className="mt-2"
           />
         </>


### PR DESCRIPTION
## Changes

Not sure when it broke but when testing something else I noticed the below button does nothing. I pushed it to use the same method to open menu as control version.

<img width="1489" alt="image" src="https://github.com/dailydotdev/apps/assets/9803078/175e73ae-3d6c-4673-96f4-f4f311e2f2fa">


## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->
