### PR TITLE
hotfix: shortcut options

### DIFF
--- a/packages/extension/src/newtab/ShortcutLinks/ShortcutOptionsMenu.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks/ShortcutOptionsMenu.tsx
@@ -39,10 +39,6 @@ export default function ShortcutOptionsMenu({
     },
   ];
 
-  if (!React.isValidElement(ContextMenu)) {
-    return null;
-  }
-
   return (
     <ContextMenu
       options={options}

--- a/packages/extension/src/newtab/ShortcutLinks/experiments/ShortcutLinksUIV1.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks/experiments/ShortcutLinksUIV1.tsx
@@ -114,6 +114,7 @@ function ShortcutUIItemPlaceholder({ children }: PropsWithChildren) {
 export function ShortcutLinksUIV1(props: ShortcutLinksV1Props): ReactElement {
   const {
     onLinkClick,
+    onMenuClick,
     onOptionsOpen,
     onV1Hide,
     shortcutLinks,
@@ -196,7 +197,7 @@ export function ShortcutLinksUIV1(props: ShortcutLinksV1Props): ReactElement {
             variant={ButtonVariant.Tertiary}
             size={ButtonSize.Small}
             icon={<MenuIcon className="rotate-90" secondary />}
-            onClick={onOptionsOpen}
+            onClick={onMenuClick}
             className="mt-2"
           />
         </>


### PR DESCRIPTION
## Changes

On v1 we should open a context menu.
If I recall @ilasw added this specific react null render for storybook purpose so just removing for the sake of fixing the render (Tagging you so you aware)

(Control wasn't changes)

Now looks like:
<img width="291" alt="Screenshot 2024-07-11 at 20 00 40" src="https://github.com/dailydotdev/apps/assets/554874/58dfd267-4ed0-48ab-8c37-d9b2a056eb89">

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://hotfix-shortcut-options.preview.app.daily.dev