### PR TITLE
fix: search issue

### DIFF
--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -81,7 +81,7 @@ function MainLayoutHeader({
             container: classNames(
               'left-0 top-0 z-header mr-auto items-center py-3 tablet:left-16 laptop:left-0 laptopL:mx-auto laptopL:w-full',
               isSearchPage
-                ? 'right-0 tablet:absolute laptop:relative laptop:top-0'
+                ? 'relative right-0 tablet:absolute laptop:relative laptop:top-0'
                 : 'hidden laptop:flex',
               hasBanner && 'tablet:top-18',
             ),


### PR DESCRIPTION
## Changes

On mobile the search bar used to be `absolute` but to fix the `alertBanner` we made it `static` (default) which does't support z-index.
To fully fix it we move to `relative` to ensure it keeps it's `z-index` and won't break with alert banner.

Fixes:
https://github.com/dailydotdev/daily/issues/1284

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-451 #done 

### Preview domain
https://as-451-search-issue.preview.app.daily.dev