### PR TITLE
feat: author image on feed card

### DIFF
--- a/packages/shared/src/components/cards/PostCardFooter.tsx
+++ b/packages/shared/src/components/cards/PostCardFooter.tsx
@@ -5,6 +5,8 @@ import { ProfileImageSize, ProfilePicture } from '../ProfilePicture';
 import { isVideoPost, Post } from '../../graphql/posts';
 import { CommonCardCoverProps, visibleOnGroupHover } from './common';
 import { CardCover } from './common/CardCover';
+import { useConditionalFeature } from '../../hooks';
+import { feature } from '../../lib/featureManagement';
 
 interface PostCardFooterClassName {
   image?: string;
@@ -21,6 +23,10 @@ export const PostCardFooter = ({
   className,
   onShare,
 }: PostCardFooterProps): ReactElement => {
+  const { value: shouldShowImage } = useConditionalFeature({
+    shouldEvaluate: !!post?.author,
+    feature: feature.authorImage,
+  });
   const isVideoType = isVideoPost(post);
   return (
     <>
@@ -40,7 +46,8 @@ export const PostCardFooter = ({
         }}
         videoProps={{ className: 'my-2' }}
       />
-      {post.author && (
+      {/* hide the existing hover behavior */}
+      {!shouldShowImage && post.author && (
         <div
           className={classNames(
             'absolute z-1 mt-2 flex w-full items-center rounded-t-12 bg-background-default px-3 py-2 font-bold text-text-secondary typo-callout',

--- a/packages/shared/src/components/cards/PostCardHeader.tsx
+++ b/packages/shared/src/components/cards/PostCardHeader.tsx
@@ -6,7 +6,7 @@ import SourceButton from './SourceButton';
 import { Source } from '../../graphql/sources';
 import { ReadArticleButton } from './ReadArticleButton';
 import { getGroupedHoverContainer } from './common';
-import { useFeedPreviewMode } from '../../hooks';
+import { useConditionalFeature, useFeedPreviewMode } from '../../hooks';
 import { getReadPostButtonText, Post } from '../../graphql/posts';
 import { ButtonVariant } from '../buttons/Button';
 import { FlagProps } from './FeedItemContainer';
@@ -15,6 +15,10 @@ import {
   BookmakProviderHeader,
   headerHiddenClassName,
 } from './BookmarkProviderHeader';
+import { feature } from '../../lib/featureManagement';
+import { ProfileTooltip } from '../profile/ProfileTooltip';
+import { ProfileImageLink } from '../profile/ProfileImageLink';
+import { ProfileImageSize } from '../ProfilePicture';
 
 interface CardHeaderProps {
   post: Post;
@@ -43,6 +47,10 @@ export const PostCardHeader = ({
   showFeedback,
 }: CardHeaderProps): ReactElement => {
   const isFeedPreview = useFeedPreviewMode();
+  const { value: shouldShowImage } = useConditionalFeature({
+    shouldEvaluate: !!post?.author,
+    feature: feature.authorImage,
+  });
   const { highlightBookmarkedPost } = useBookmarkProvider({
     bookmarked: post.bookmarked && !showFeedback,
   });
@@ -59,6 +67,14 @@ export const PostCardHeader = ({
         )}
       >
         <SourceButton source={source} />
+        {shouldShowImage && post.author && (
+          <ProfileTooltip user={post.author}>
+            <ProfileImageLink
+              picture={{ size: ProfileImageSize.Medium }}
+              user={post.author}
+            />
+          </ProfileTooltip>
+        )}
         {children}
         <Container
           className="ml-auto flex flex-row"

--- a/packages/shared/src/components/cards/common/SquadHeaderPicture.tsx
+++ b/packages/shared/src/components/cards/common/SquadHeaderPicture.tsx
@@ -3,6 +3,8 @@ import { ProfileImageSize, ProfilePicture } from '../../ProfilePicture';
 import SourceButton from '../SourceButton';
 import { Author } from '../../../graphql/comments';
 import { Source } from '../../../graphql/sources';
+import { useConditionalFeature } from '../../../hooks';
+import { feature } from '../../../lib/featureManagement';
 
 interface SquadHeaderPictureProps {
   author?: Author;
@@ -15,10 +17,16 @@ export default function SquadHeaderPicture({
   source,
   reverse = false,
 }: SquadHeaderPictureProps): ReactElement {
+  const { value: shouldShowNewAuthorImage } = useConditionalFeature({
+    shouldEvaluate: !!author,
+    feature: feature.authorImage,
+  });
+  const shouldShowAuthor = !!author && !shouldShowNewAuthorImage;
+
   if (reverse) {
     return (
       <div className="relative">
-        {!!author && (
+        {shouldShowAuthor && (
           <ProfilePicture user={author} size={ProfileImageSize.Large} />
         )}
         <SourceButton
@@ -32,7 +40,7 @@ export default function SquadHeaderPicture({
   return (
     <div className="relative">
       <SourceButton size={ProfileImageSize.Large} source={source} />
-      {!!author && (
+      {shouldShowAuthor && (
         <ProfilePicture
           user={author}
           size={ProfileImageSize.XSmall}

--- a/packages/shared/src/components/cards/list/PostCardHeader.tsx
+++ b/packages/shared/src/components/cards/list/PostCardHeader.tsx
@@ -4,7 +4,7 @@ import OptionsButton from '../../buttons/OptionsButton';
 import { CardHeader } from './ListCard';
 import { ReadArticleButton } from '../ReadArticleButton';
 import { getGroupedHoverContainer } from '../common';
-import { useFeedPreviewMode } from '../../../hooks';
+import { useConditionalFeature, useFeedPreviewMode } from '../../../hooks';
 import { Post, PostType } from '../../../graphql/posts';
 import { ButtonVariant } from '../../buttons/common';
 import PostMetadata, { PostMetadataProps } from './PostMetadata';
@@ -12,6 +12,10 @@ import { MenuIcon, OpenLinkIcon } from '../../icons';
 import { useReadPostButtonText } from './hooks';
 import useBookmarkProvider from '../../../hooks/useBookmarkProvider';
 import { BookmakProviderHeader } from './BookmarkProviderHeader';
+import { ProfileImageSize } from '../../ProfilePicture';
+import { feature } from '../../../lib/featureManagement';
+import { ProfileImageLink } from '../../profile/ProfileImageLink';
+import { ProfileTooltip } from '../../profile/ProfileTooltip';
 
 interface CardHeaderProps {
   post: Post;
@@ -44,6 +48,10 @@ export const PostCardHeader = ({
   const { highlightBookmarkedPost } = useBookmarkProvider({
     bookmarked: post.bookmarked,
   });
+  const { value: shouldShowImage } = useConditionalFeature({
+    shouldEvaluate: !!post?.author,
+    feature: feature.authorImage,
+  });
 
   const isCollectionType = post.type === 'collection';
   const showCTA =
@@ -57,6 +65,15 @@ export const PostCardHeader = ({
       )}
       <CardHeader className={className}>
         {children}
+        {shouldShowImage && post.author && (
+          <ProfileTooltip user={post.author}>
+            <ProfileImageLink
+              className="z-1 ml-2"
+              picture={{ size: ProfileImageSize.Large }}
+              user={post.author}
+            />
+          </ProfileTooltip>
+        )}
         <PostMetadata
           className={classNames(
             'mr-2 flex-1',

--- a/packages/shared/src/components/cards/list/PostMetadata.tsx
+++ b/packages/shared/src/components/cards/list/PostMetadata.tsx
@@ -20,9 +20,9 @@ export default function PostMetadata({
   return (
     <div className={classNames('grid items-center', className)}>
       {topLabel && (
-        <div className="line-clamp-1 font-bold typo-footnote">{topLabel}</div>
+        <div className="truncate font-bold typo-footnote">{topLabel}</div>
       )}
-      <div className="line-clamp-1 flex items-center text-text-tertiary typo-footnote">
+      <div className="items-center truncate text-text-tertiary typo-footnote">
         {bottomLabel}
         {!!bottomLabel && !!createdAt && <Separator />}
         {!!createdAt && (

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -29,6 +29,7 @@ const feature = {
   bookmarkReminder: new Feature('bookmark_reminder', false),
   animatedUpvote: new Feature('animated_upvote', false),
   mobileExploreTab: new Feature('mobile_explore_tab', false),
+  authorImage: new Feature('author_image', false),
 };
 
 export { feature };


### PR DESCRIPTION
## Changes
- Experiment to show the author of the post.
- When user is enrolled, do not show the existing hover behavior for displaying the author itself.

Previews:

![Screenshot 2024-07-19 at 6 51 25 PM](https://github.com/user-attachments/assets/5e2c3431-12e2-45f2-8009-e59dd313c8b5)
![Screenshot 2024-07-19 at 6 44 30 PM](https://github.com/user-attachments/assets/93dd209c-f60e-4e7e-802d-b6ceff1f2f44)
![Screenshot 2024-07-19 at 6 44 18 PM](https://github.com/user-attachments/assets/deafbd33-d21d-493d-9778-e2a63cc32fa0)
![Screenshot 2024-07-19 at 6 43 58 PM](https://github.com/user-attachments/assets/ee58a173-b4d0-4305-8baf-cfe6710154c0)
![Screenshot 2024-07-19 at 6 41 15 PM](https://github.com/user-attachments/assets/721ee726-3e34-4eca-8014-737cd999e624)


## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

MI-445 #done


### Preview domain
https://mi-445.preview.app.daily.dev