### PR TITLE
fix: tldr height for shared links

### DIFF
--- a/packages/shared/src/components/cards/PostSummary.tsx
+++ b/packages/shared/src/components/cards/PostSummary.tsx
@@ -18,6 +18,7 @@ function PostSummary(
   return (
     <SummaryContainer ref={ref} {...props}>
       <ShowMoreContent
+        className="overflow-hidden"
         content={summary}
         charactersLimit={330}
         threshold={50}

--- a/packages/shared/src/components/post/common/SharedLinkContainer.tsx
+++ b/packages/shared/src/components/post/common/SharedLinkContainer.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, useMemo, useState } from 'react';
+import React, { ReactElement, ReactNode, useState } from 'react';
 import classNames from 'classnames';
 import PostSummary from '../../cards/PostSummary';
 import { ArrowIcon } from '../../icons';
@@ -16,29 +16,13 @@ export function SharedLinkContainer({
   className,
   Wrapper,
 }: SharedLinkContainerProps): ReactElement {
-  const [height, setHeight] = useState<number>(null);
   const [shouldShowSummary, setShouldShowSummary] = useState(true);
-  const tldrHeight = useMemo(() => {
-    if (height === null) {
-      return 'auto';
-    }
-
-    return shouldShowSummary ? height : 0;
-  }, [shouldShowSummary, height]);
 
   const postSummary = (
     <PostSummary
-      ref={(el) => {
-        if (!el?.offsetHeight || height !== null) {
-          return;
-        }
-
-        setHeight(el.offsetHeight);
-      }}
-      style={{ height: tldrHeight }}
       className={classNames(
-        'mx-4 transition-all duration-300 ease-in-out',
-        shouldShowSummary && 'mb-4',
+        'mx-4 !grid transition-all duration-300 ease-in-out',
+        shouldShowSummary ? 'mb-4 grid-rows-[1fr]' : 'grid-rows-[0fr]',
       )}
       summary={summary}
     />


### PR DESCRIPTION
## Changes

We have this [edge case](https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1720729579314099) when sharing posts in squads.
This is a place where we render the TLDR with the option to hide it.
For this we use some JS calculations, which don't take the `show more` rendered height into account.

(Doesn't affect existing implementations as it just renders without the need for height wrapping.

Instead of relying on JS calculations I've decided to simply fix it with CSS magic :) 
First time ever using a [youtube video](https://www.youtube.com/watch?v=B_n4YONte5A) as a resource 😅

In action: (with CSS only)
https://github.com/user-attachments/assets/d79c2903-8be0-4498-b0de-314adbe0ae03

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-452 #done 

### Preview domain
https://as-452-tldr-height.preview.app.daily.dev