### PR TITLE
fix: push notification for read it later

### DIFF
--- a/packages/shared/src/components/notifications/EnableNotification.tsx
+++ b/packages/shared/src/components/notifications/EnableNotification.tsx
@@ -34,7 +34,7 @@ const containerClassName: Record<NotificationPromptSource, string> = {
   [NotificationPromptSource.SquadChecklist]: '',
   [NotificationPromptSource.SourceSubscribe]: 'w-full px-3 !pt-0 !pb-2',
   [NotificationPromptSource.ReadingReminder]: '',
-  [NotificationPromptSource.ReadItLater]: '',
+  [NotificationPromptSource.BookmarkReminder]: '',
 };
 
 const sourceRenderTextCloseButton: Record<NotificationPromptSource, boolean> = {
@@ -49,7 +49,7 @@ const sourceRenderTextCloseButton: Record<NotificationPromptSource, boolean> = {
   [NotificationPromptSource.SquadChecklist]: false,
   [NotificationPromptSource.SourceSubscribe]: true,
   [NotificationPromptSource.ReadingReminder]: false,
-  [NotificationPromptSource.ReadItLater]: false,
+  [NotificationPromptSource.BookmarkReminder]: false,
 };
 
 const sourceToButtonText: Partial<Record<NotificationPromptSource, string>> = {
@@ -86,7 +86,7 @@ function EnableNotification({
     [NotificationPromptSource.SquadChecklist]: '',
     [NotificationPromptSource.SourceSubscribe]: `Get notified whenever there are new posts from ${contentName}.`,
     [NotificationPromptSource.ReadingReminder]: '',
-    [NotificationPromptSource.ReadItLater]: '',
+    [NotificationPromptSource.BookmarkReminder]: '',
   };
   const message = sourceToMessage[source];
   const classes = containerClassName[source];

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -241,7 +241,7 @@ export enum NotificationTarget {
 }
 
 export enum NotificationPromptSource {
-  ReadItLater = 'read it later',
+  BookmarkReminder = 'bookmark reminder',
   NotificationsPage = 'notifications page',
   NewComment = 'new comment',
   CommunityPicks = 'community picks modal',


### PR DESCRIPTION
## Changes
- Went back to the specs to confirm everything. When setting a reminder, we should trigger the PN.

![Screenshot 2024-07-24 at 5 32 45 AM](https://github.com/user-attachments/assets/6f1cba0f-f46d-432e-8854-5ab5f13f6b63)


## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->
