### PR TITLE
feat: add card downvote

### DIFF
--- a/packages/shared/src/components/buttons/QuaternaryButton.tsx
+++ b/packages/shared/src/components/buttons/QuaternaryButton.tsx
@@ -13,6 +13,7 @@ export type QuaternaryButtonProps<TagName extends AllowedTags> =
   ButtonProps<TagName> & {
     reverse?: boolean;
     responsiveLabelClass?: string;
+    labelClassName?: string;
   };
 
 function QuaternaryButtonComponent<TagName extends AllowedTags>(
@@ -24,6 +25,7 @@ function QuaternaryButtonComponent<TagName extends AllowedTags>(
     reverse,
     responsiveLabelClass,
     tag = 'button',
+    labelClassName,
     ...props
   }: QuaternaryButtonProps<TagName>,
   ref?: Ref<ButtonElementType<TagName>>,
@@ -73,6 +75,7 @@ function QuaternaryButtonComponent<TagName extends AllowedTags>(
             'cursor-pointer items-center font-bold typo-callout',
             labelDisplay,
             { readOnly: props.disabled },
+            labelClassName,
           )}
         >
           {children}

--- a/packages/shared/src/components/cards/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.tsx
@@ -50,7 +50,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
   if (data?.showTagsPanel && post.tags.length > 0) {
     return (
       <PostTagsPanel
-        className="h-full max-h-[23.5rem] overflow-hidden"
+        className="h-full overflow-hidden"
         post={post}
         toastOnSuccess
       />

--- a/packages/shared/src/components/cards/ArticlePostCard.tsx
+++ b/packages/shared/src/components/cards/ArticlePostCard.tsx
@@ -134,6 +134,7 @@ export const ArticlePostCard = forwardRef(function PostCard(
               onCommentClick={onCommentClick}
               onCopyLinkClick={onCopyLinkClick}
               onBookmarkClick={onBookmarkClick}
+              onDownvoteClick={onDownvoteClick}
             />
           )}
         </Container>

--- a/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
+++ b/packages/shared/src/components/cards/CollectionCard/CollectionCard.tsx
@@ -22,6 +22,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
     onCopyLinkClick,
     onPostClick,
     onBookmarkClick,
+    onDownvoteClick,
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ) {
@@ -74,6 +75,7 @@ export const CollectionCard = forwardRef(function CollectionCard(
           onCopyLinkClick={onCopyLinkClick}
           onBookmarkClick={onBookmarkClick}
           className="mt-auto"
+          onDownvoteClick={onDownvoteClick}
         />
       </Container>
       {children}

--- a/packages/shared/src/components/cards/SharePostCard.tsx
+++ b/packages/shared/src/components/cards/SharePostCard.tsx
@@ -28,6 +28,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
     children,
     onReadArticleClick,
     domProps = {},
+    onDownvoteClick,
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ): ReactElement {
@@ -94,6 +95,7 @@ export const SharePostCard = forwardRef(function SharePostCard(
           onCommentClick={onCommentClick}
           onCopyLinkClick={onCopyLinkClick}
           onBookmarkClick={onBookmarkClick}
+          onDownvoteClick={onDownvoteClick}
         />
       </Container>
       {children}

--- a/packages/shared/src/components/cards/WelcomePostCard.tsx
+++ b/packages/shared/src/components/cards/WelcomePostCard.tsx
@@ -26,6 +26,7 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
     children,
     enableSourceHeader = false,
     domProps = {},
+    onDownvoteClick,
   }: PostCardProps,
   ref: Ref<HTMLElement>,
 ): ReactElement {
@@ -92,6 +93,7 @@ export const WelcomePostCard = forwardRef(function SharePostCard(
           onCopyLinkClick={onCopyLinkClick}
           onBookmarkClick={onBookmarkClick}
           className="mt-auto"
+          onDownvoteClick={onDownvoteClick}
         />
       </Container>
       {children}

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -32,6 +32,7 @@ const feature = {
   authorImage: new Feature('author_image', false),
   onboardingContentType: new Feature('onboarding_content_type', false),
   sourceNotifyButton: new Feature('source_notify_button', false),
+  cardDownvote: new Feature('card_downvote', false),
 };
 
 export { feature };


### PR DESCRIPTION
## Changes

- add downvote to desktop cards
- downvote panel also added
- adjusted spacing based on new design
- all small icons per new design
- events send the same as from options -> downvote (which we already had)

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-446 #done


### Preview domain
https://as-446-card-downvote.preview.app.daily.dev