### PR TITLE
fix: more posts from source issue

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extension",
-  "version": "3.33.3",
+  "version": "3.33.4",
   "scripts": {
     "dev:chrome": "cross-env NODE_ENV=development cross-env TARGET_BROWSER=chrome webpack --watch",
     "dev:firefox": "cross-env NODE_ENV=development cross-env TARGET_BROWSER=firefox webpack --watch",

--- a/packages/shared/src/components/squads/SquadPostListItem.tsx
+++ b/packages/shared/src/components/squads/SquadPostListItem.tsx
@@ -53,7 +53,7 @@ export const SquadPostListItem = ({
             date={post.createdAt}
           />
         )}
-        <p className="mt-2 line-clamp-3 text-text-primary typo-callout">
+        <p className="mr-6 mt-1 line-clamp-3 text-text-primary typo-callout">
           {post.title}
         </p>
       </div>

--- a/packages/shared/src/components/squads/SquadPostListItem.tsx
+++ b/packages/shared/src/components/squads/SquadPostListItem.tsx
@@ -54,7 +54,7 @@ export const SquadPostListItem = ({
           />
         )}
         <p className="mr-6 mt-1 line-clamp-3 text-text-primary typo-callout">
-          {post.title}
+          {post.title ?? post.sharedPost.title}
         </p>
       </div>
       <SimpleTooltip content={post.bookmarked ? 'Remove bookmark' : 'Bookmark'}>

--- a/packages/shared/src/components/widgets/BestDiscussions.tsx
+++ b/packages/shared/src/components/widgets/BestDiscussions.tsx
@@ -92,7 +92,7 @@ export default function BestDiscussions({
 
   return (
     <BestDiscussionsContainer className={className}>
-      <h4 className="py-3 pl-6 pr-4 text-text-tertiary typo-body">
+      <h4 className="my-0.5 px-4 py-3 text-text-tertiary typo-body">
         Best discussions
       </h4>
       {Separator}

--- a/packages/shared/src/components/widgets/FurtherReading.tsx
+++ b/packages/shared/src/components/widgets/FurtherReading.tsx
@@ -110,7 +110,7 @@ export default function FurtherReading({
         tags,
       });
     },
-    { ...disabledRefetch, enabled: !!postId && !!currentPost.source },
+    { ...disabledRefetch },
   );
 
   const { toggleBookmark } = useBookmarkPost({

--- a/packages/shared/src/components/widgets/FurtherReading.tsx
+++ b/packages/shared/src/components/widgets/FurtherReading.tsx
@@ -11,7 +11,7 @@ import {
   useBookmarkPost,
 } from '../../hooks/useBookmarkPost';
 import { Post, PostType } from '../../graphql/posts';
-import SimilarPosts from './SimilarPosts';
+import SimilarPosts, { SimilarPostsProps } from './SimilarPosts';
 import BestDiscussions from './BestDiscussions';
 import PostToc from './PostToc';
 import { Origin } from '../../lib/log';
@@ -146,6 +146,16 @@ export default function FurtherReading({
   };
 
   const showToc = currentPost.toc?.length > 0;
+
+  const publicSquadProps: Partial<SimilarPostsProps> = {
+    title: `More posts from ${currentPost.source.name}`,
+    moreButtonProps: {
+      href: currentPost.source.permalink,
+      text: 'Show more',
+    },
+    ListItem: SquadPostListItem,
+  };
+
   return (
     <div className={classNames(className, 'flex flex-col gap-6')}>
       {showToc && <PostToc post={currentPost} className="hidden laptop:flex" />}
@@ -154,16 +164,7 @@ export default function FurtherReading({
           posts={similarPosts}
           isLoading={isLoading}
           onBookmark={onToggleBookmark}
-          title={
-            isPublicSquad
-              ? `More posts from ${currentPost.source.name}`
-              : undefined
-          }
-          moreButtonProps={{
-            href: isPublicSquad ? currentPost.source.permalink : undefined,
-            text: isPublicSquad ? 'Show more' : undefined,
-          }}
-          ListItem={isPublicSquad ? SquadPostListItem : undefined}
+          {...(isPublicSquad && publicSquadProps)}
         />
       )}
       {(isLoading || posts?.discussedPosts?.length > 0) && (

--- a/packages/shared/src/components/widgets/FurtherReading.tsx
+++ b/packages/shared/src/components/widgets/FurtherReading.tsx
@@ -110,7 +110,7 @@ export default function FurtherReading({
         tags,
       });
     },
-    { ...disabledRefetch },
+    { ...disabledRefetch, enabled: !!postId && !!currentPost.source },
   );
 
   const { toggleBookmark } = useBookmarkPost({

--- a/packages/shared/src/components/widgets/SimilarPosts.tsx
+++ b/packages/shared/src/components/widgets/SimilarPosts.tsx
@@ -148,7 +148,7 @@ export default function SimilarPosts({
         className,
       )}
     >
-      <h4 className="py-3 pl-6 pr-4 text-text-tertiary typo-body">{title}</h4>
+      <h4 className="my-0.5 px-4 py-3 text-text-tertiary typo-body">{title}</h4>
       {Separator}
       {isLoading ? (
         <>

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -49,6 +49,7 @@ export const SOURCE_SHORT_INFO_FRAGMENT = gql`
     image
     type
     active
+    public
   }
 `;
 


### PR DESCRIPTION
## Changes
- Aligned card heading and post titles in `SimilarPosts`;
- Fix bookmark icon ends on post title text;
- Added `public` field in `SourceShortInfo` fragment;
 
Static props from `packages/webapp/pages/posts/[id]/index.tsx` were loaded without the source's `public` field, causing query to pick from global feed. 

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->

Mi-456


### Preview domain
https://mi-456-more-posts-from-issues.preview.app.daily.dev