### PR TITLE
feat: generate tldr button experiment

### DIFF
--- a/packages/extension/src/companion/CompanionContent.tsx
+++ b/packages/extension/src/companion/CompanionContent.tsx
@@ -19,6 +19,7 @@ import { postLogEvent } from '@dailydotdev/shared/src/lib/feed';
 import { ShareProvider } from '@dailydotdev/shared/src/lib/share';
 import { Origin } from '@dailydotdev/shared/src/lib/log';
 import LogContext from '@dailydotdev/shared/src/contexts/LogContext';
+import { PostSummaryButton } from '@dailydotdev/shared/src/components/post/PostSummaryButton';
 import { CompanionEngagements } from './CompanionEngagements';
 import { CompanionDiscussion } from './CompanionDiscussion';
 import { useBackgroundPaginatedRequest } from './useBackgroundPaginatedRequest';
@@ -82,7 +83,8 @@ export default function CompanionContent({
           />
         </SimpleTooltip>
       </div>
-      <p className="my-4 flex-1 break-words typo-callout">
+      <p className="relative my-4 flex-1 break-words typo-callout">
+        {!!post?.summary && <PostSummaryButton summary={post.summary} />}
         <TLDRText>TLDR -</TLDRText>
         <span>
           {post?.summary ||

--- a/packages/shared/src/components/cards/PostSummary.tsx
+++ b/packages/shared/src/components/cards/PostSummary.tsx
@@ -4,8 +4,10 @@ import React, {
   ReactElement,
   RefObject,
 } from 'react';
+import classNames from 'classnames';
 import { SummaryContainer, TLDRText } from '../utilities';
 import ShowMoreContent from './ShowMoreContent';
+import { PostSummaryButton } from '../post/PostSummaryButton';
 
 interface SummaryProps extends HTMLAttributes<HTMLDivElement> {
   summary: string;
@@ -16,7 +18,12 @@ function PostSummary(
   ref: RefObject<HTMLDivElement>,
 ): ReactElement {
   return (
-    <SummaryContainer ref={ref} {...props}>
+    <SummaryContainer
+      ref={ref}
+      {...props}
+      className={classNames('relative', props.className)}
+    >
+      <PostSummaryButton summary={summary} />
       <ShowMoreContent
         className="overflow-hidden"
         content={summary}

--- a/packages/shared/src/components/post/PostSummaryButton.tsx
+++ b/packages/shared/src/components/post/PostSummaryButton.tsx
@@ -1,0 +1,38 @@
+import React, { ReactElement } from 'react';
+import { useSummaryActivation } from '../../hooks/experiments';
+import { Loader } from '../Loader';
+import { MagicIcon } from '../icons';
+import { ButtonIconPosition, ButtonVariant } from '../buttons/common';
+import { Button, ButtonColor } from '../buttons/Button';
+
+interface PostSummaryButtonProps {
+  summary: string;
+}
+
+export function PostSummaryButton({
+  summary,
+}: PostSummaryButtonProps): ReactElement {
+  const { shouldShowOverlay, isLoading, onClickSummary } = useSummaryActivation(
+    { summary },
+  );
+
+  if (!shouldShowOverlay) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="absolute inset-0 bg-gradient-to-t from-background-default from-60% to-overlay-primary-pepper" />
+      <Button
+        icon={isLoading ? <Loader /> : <MagicIcon secondary />}
+        iconPosition={ButtonIconPosition.Right}
+        variant={ButtonVariant.Primary}
+        color={ButtonColor.Cabbage}
+        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
+        onClick={onClickSummary}
+      >
+        Auto-summarize
+      </Button>
+    </>
+  );
+}

--- a/packages/shared/src/components/post/PostSummaryButton.tsx
+++ b/packages/shared/src/components/post/PostSummaryButton.tsx
@@ -6,7 +6,7 @@ import { ButtonIconPosition, ButtonVariant } from '../buttons/common';
 import { Button, ButtonColor } from '../buttons/Button';
 
 interface PostSummaryButtonProps {
-  summary: string;
+  summary?: string;
 }
 
 export function PostSummaryButton({
@@ -30,6 +30,7 @@ export function PostSummaryButton({
         color={ButtonColor.Cabbage}
         className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2"
         onClick={onClickSummary}
+        disabled={isLoading}
       >
         Auto-summarize
       </Button>

--- a/packages/shared/src/graphql/actions.ts
+++ b/packages/shared/src/graphql/actions.ts
@@ -33,6 +33,7 @@ export enum ActionType {
   BookmarkPost = 'bookmark_post',
   DigestConfig = 'digest_config',
   StreakMilestone = 'streak_milestone',
+  ShowSummary = 'show_summary',
 }
 
 export interface Action {

--- a/packages/shared/src/hooks/experiments/index.ts
+++ b/packages/shared/src/hooks/experiments/index.ts
@@ -1,0 +1,1 @@
+export * from './useSummaryActivation';

--- a/packages/shared/src/hooks/experiments/useSummaryActivation.ts
+++ b/packages/shared/src/hooks/experiments/useSummaryActivation.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ActionType } from '../../graphql/actions';
+import { useToastNotification } from '../useToastNotification';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { useActions } from '../useActions';
+import { useConditionalFeature } from '../useConditionalFeature';
+import { feature } from '../../lib/featureManagement';
+
+interface UseSummaryActivationProps {
+  summary: string;
+}
+
+interface UseSummaryActivation {
+  onClickSummary: () => void;
+  shouldShowOverlay: boolean;
+  isLoading: boolean;
+}
+
+export const useSummaryActivation = ({
+  summary,
+}: UseSummaryActivationProps): UseSummaryActivation => {
+  const { displayToast } = useToastNotification();
+  const { user } = useAuthContext();
+  const timeoutRef = useRef<number>(null);
+  const { isActionsFetched, checkHasCompleted, completeAction } = useActions();
+  const shouldEvaluate =
+    !!user &&
+    !!summary &&
+    isActionsFetched &&
+    !checkHasCompleted(ActionType.ShowSummary);
+  const { value: isEnrolled } = useConditionalFeature({
+    shouldEvaluate,
+    feature: feature.generateSummary,
+  });
+  const [isLoading, setIsLoading] = useState(false);
+  const shouldShowOverlay = (isEnrolled && shouldEvaluate) || isLoading;
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const onClickSummary = useCallback(() => {
+    setIsLoading(true);
+    completeAction(ActionType.ShowSummary);
+
+    timeoutRef.current = window.setTimeout(() => {
+      displayToast(
+        `We've got you covered! Auto-summaries are now enabled for all posts in your feed.`,
+      );
+      setIsLoading(false);
+    }, 1000);
+  }, [completeAction, displayToast]);
+
+  return { onClickSummary, isLoading, shouldShowOverlay };
+};

--- a/packages/shared/src/hooks/experiments/useSummaryActivation.ts
+++ b/packages/shared/src/hooks/experiments/useSummaryActivation.ts
@@ -7,7 +7,7 @@ import { useConditionalFeature } from '../useConditionalFeature';
 import { feature } from '../../lib/featureManagement';
 
 interface UseSummaryActivationProps {
-  summary: string;
+  summary?: string;
 }
 
 interface UseSummaryActivation {
@@ -44,8 +44,16 @@ export const useSummaryActivation = ({
   }, []);
 
   const onClickSummary = useCallback(() => {
+    if (isLoading) {
+      return;
+    }
+
     setIsLoading(true);
     completeAction(ActionType.ShowSummary);
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
 
     timeoutRef.current = window.setTimeout(() => {
       displayToast(
@@ -53,7 +61,7 @@ export const useSummaryActivation = ({
       );
       setIsLoading(false);
     }, 1000);
-  }, [completeAction, displayToast]);
+  }, [completeAction, displayToast, isLoading]);
 
   return { onClickSummary, isLoading, shouldShowOverlay };
 };

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -33,6 +33,7 @@ const feature = {
   onboardingContentType: new Feature('onboarding_content_type', false),
   sourceNotifyButton: new Feature('source_notify_button', false),
   cardDownvote: new Feature('card_downvote', false),
+  generateSummary: new Feature('generate_summary', false),
 };
 
 export { feature };


### PR DESCRIPTION
## Changes
- A new experiment about TLDR.
- We will add an overlay when the user hasn't clicked the button yet.
- Should be applied across the app and to Companion.

Preview:

https://github.com/user-attachments/assets/8ca31696-a510-48f3-8315-63cb8c036884

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

MI-450


### Preview domain
https://mi-450.preview.app.daily.dev