### PR TITLE
fix: share post edit in a squad

### DIFF
--- a/packages/shared/src/components/PostOptionsMenu.tsx
+++ b/packages/shared/src/components/PostOptionsMenu.tsx
@@ -98,9 +98,10 @@ export default function PostOptionsMenu({
   const router = useRouter();
   const { user, isLoggedIn } = useContext(AuthContext);
   const { displayToast } = useToastNotification();
-  const { isOpen: isPostOptionsOpen } = useContextMenu({
-    id: contextId,
-  });
+  const { isOpen: isPostOptionsOpen, onHide: closePostOptions } =
+    useContextMenu({
+      id: contextId,
+    });
   const { feedSettings, advancedSettings, checkSettingsEnabledState } =
     useFeedSettings({ enabled: isPostOptionsOpen });
   const { onUpdateSettings } = useAdvancedSettings({ enabled: false });
@@ -447,7 +448,11 @@ export default function PostOptionsMenu({
     postOptions.push({
       icon: <MenuIcon Icon={EditIcon} />,
       label: 'Edit post',
-      action: () => router.push(`${post.commentsPermalink}/edit`),
+      action: () => {
+        router.push(`${post.commentsPermalink}/edit`).then(() => {
+          closePostOptions();
+        });
+      },
     });
   }
   if (onConfirmDeletePost) {

--- a/packages/shared/src/components/post/write/ShareLink.tsx
+++ b/packages/shared/src/components/post/write/ShareLink.tsx
@@ -27,7 +27,7 @@ export function ShareLink({
   onPostSuccess,
 }: ShareLinkProps): ReactElement {
   const { displayToast } = useToastNotification();
-  const [commentary, setCommentary] = useState('');
+  const [commentary, setCommentary] = useState(post?.title ?? '');
   const { squads, user } = useAuthContext();
 
   const {
@@ -61,7 +61,9 @@ export function ShareLink({
     }
 
     if (post?.id) {
-      onUpdatePost(e, post.id, commentary);
+      if (commentary !== post?.title) {
+        onUpdatePost(e, post.id, commentary);
+      }
       return push(squad.permalink);
     }
 
@@ -95,7 +97,7 @@ export function ShareLink({
       )}
 
       <MarkdownInput
-        initialContent={commentary || post?.title}
+        initialContent={commentary || post?.title || ''}
         enabledCommand={{ mention: true }}
         showMarkdownGuide={false}
         onValueUpdate={setCommentary}

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -108,6 +108,7 @@ function EditPost(): ReactElement {
     >
       <NextSeo {...seo} noindex nofollow />
       <WritePage
+        isEdit
         isLoading={!isReady || isLoading || !isDraftReady}
         isForbidden={!isVerified || !squad || !canEdit}
       >


### PR DESCRIPTION
## Changes
- Trigger close `PostOptionsMenu` on `Edit post` click;
- Fix deleting `post.title` on form submit without doing any changes;

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://mi-461-fix-share-post-edit-in-a-squad.preview.app.daily.dev