### PR TITLE
fix: handle join state for modal

### DIFF
--- a/packages/shared/src/components/squads/SquadCommentJoinBanner.tsx
+++ b/packages/shared/src/components/squads/SquadCommentJoinBanner.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { Origin } from '../../lib/log';
@@ -28,7 +28,7 @@ export const SquadCommentJoinBanner = ({
   post,
 }: SquadCommentJoinBannerProps): ReactElement => {
   const queryClient = useQueryClient();
-  const isSquadMember = !!squad?.currentMember;
+  const [isSquadMember, setIsSquadMember] = useState(!!squad?.currentMember);
   const isMobile = useViewSize(ViewSize.MobileL);
   const { displayToast } = useToastNotification();
   const [isJoinSquadBannerDismissed, setJoinSquadBannerDismissed] =
@@ -42,7 +42,7 @@ export const SquadCommentJoinBanner = ({
     {
       onSuccess: () => {
         displayToast(`🙌 You joined the Squad ${squad.name}`);
-
+        setIsSquadMember(true);
         if (post?.id) {
           queryClient.invalidateQueries(['post', post.id]);
         }


### PR DESCRIPTION
## Changes

Small edge-case where we didn't leverage state on modals for the just joined state.
It already worked on the actual page.

Video:
https://github.com/user-attachments/assets/a53dfb92-b4cb-40c4-ac88-049cbd6038fb

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-479 #done 


### Preview domain
https://as-479-squad-join-comment-fix.preview.app.daily.dev