### PR TITLE
fix: cleanup origin_domain experiment

### DIFF
--- a/packages/shared/__tests__/fixture/feed.ts
+++ b/packages/shared/__tests__/fixture/feed.ts
@@ -35,6 +35,7 @@ const feed: Connection<Post> = {
         upvoted: false,
         commented: true,
         type: PostType.Article,
+        domain: 'medium.com',
       },
     },
     {
@@ -65,6 +66,7 @@ const feed: Connection<Post> = {
         commented: true,
         bookmarked: true,
         type: PostType.Article,
+        domain: 'medium.com',
       },
     },
     {
@@ -94,6 +96,7 @@ const feed: Connection<Post> = {
         upvoted: true,
         commented: true,
         type: PostType.Article,
+        domain: 'medium.com',
       },
     },
     {
@@ -124,6 +127,7 @@ const feed: Connection<Post> = {
         upvoted: true,
         commented: true,
         type: PostType.Article,
+        domain: 'medium.com',
       },
     },
     {
@@ -153,6 +157,7 @@ const feed: Connection<Post> = {
         upvoted: true,
         commented: true,
         type: PostType.Article,
+        domain: 'medium.com',
       },
     },
     {
@@ -182,6 +187,7 @@ const feed: Connection<Post> = {
         upvoted: true,
         commented: true,
         type: PostType.Article,
+        domain: 'medium.com',
       },
     },
     {
@@ -211,6 +217,7 @@ const feed: Connection<Post> = {
         upvoted: false,
         commented: true,
         type: PostType.Article,
+        domain: 'medium.com',
       },
     },
   ],

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -17,8 +17,6 @@ import { PostContainer, PostContentProps, PostNavigationProps } from './common';
 import YoutubeVideo from '../video/YoutubeVideo';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useViewPost } from '../../hooks/post';
-import { feature } from '../../lib/featureManagement';
-import { useFeature } from '../GrowthBookProvider';
 import { TruncateText } from '../utilities';
 
 export const SCROLL_OFFSET = 80;
@@ -50,7 +48,6 @@ export function PostContent({
   });
   const { onCopyPostLink, onReadArticle } = engagementActions;
   const onSendViewPost = useViewPost(post);
-  const showOriginDomain = useFeature(feature.originDomain);
 
   const hasNavigation = !!onPreviousPost || !!onNextPost;
   const isVideoType = isVideoPost(post);
@@ -161,7 +158,6 @@ export function PostContent({
             )}
             domain={
               !isVideoType &&
-              showOriginDomain &&
               post.domain.length > 0 && (
                 <TruncateText>
                   From{' '}

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -32,7 +32,6 @@ const feature = {
   sourceNotifyButton: new Feature('source_notify_button', false),
   cardDownvote: new Feature('card_downvote', false),
   generateSummary: new Feature('generate_summary', false),
-  originDomain: new Feature('origin_domain', false),
 };
 
 export { feature };

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -15,8 +15,8 @@ import {
   Post,
   POST_BY_ID_QUERY,
   PostData,
-  REMOVE_BOOKMARK_MUTATION,
   PostType,
+  REMOVE_BOOKMARK_MUTATION,
   UserVote,
   VIEW_POST_MUTATION,
 } from '@dailydotdev/shared/src/graphql/posts';
@@ -120,6 +120,7 @@ const defaultPost = {
   commentsPermalink: 'https://localhost:5002/posts/9CuRpr5NiEY5',
   numUpvotes: 0,
   numComments: 0,
+  domain: 'medium.com',
 };
 
 const createPostMock = (
@@ -215,6 +216,12 @@ it('should show source image', async () => {
     'src',
     'https://res.cloudinary.com/daily-now/image/upload/t_logo,f_auto/v1/logos/tds',
   );
+});
+
+it('should show domain', async () => {
+  renderPost();
+  const el = await screen.findByText('medium.com');
+  expect(el).toBeInTheDocument();
 });
 
 it('should show source name', async () => {


### PR DESCRIPTION
## Changes

Experiment was bypassed as winning.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-501 #done 

### Preview domain
https://as-501-cleanup-origin-domain.preview.app.daily.dev