### PR TITLE
fix: set hour dropdown to up when there's no push enabled

### DIFF
--- a/packages/webapp/pages/account/notifications.tsx
+++ b/packages/webapp/pages/account/notifications.tsx
@@ -403,7 +403,10 @@ const AccountNotificationsPage = (): ReactElement => {
               </h3>
             </div>
             <HourDropdown
-              className={{ container: 'w-40' }}
+              className={{
+                container: 'w-40',
+                ...(!isPushSupported && { menu: '-translate-y-[19rem]' }),
+              }}
               hourIndex={digestTimeIndex}
               setHourIndex={(hour) =>
                 setCustomTime(


### PR DESCRIPTION
## Changes

Changes the dropdown for the personalized digest time to drop up when there is no push notifications enabled.
This is a hotfix, and we should probably make it a bit more spatially aware to automagically select drop down direction

<img width="738" alt="image" src="https://github.com/user-attachments/assets/729b0545-5b05-4129-9cc5-8d61697e7fb2">



### Preview domain
https://hotfix-digest-dropdown.preview.app.daily.dev