### PR TITLE
feat: slack private channels

### DIFF
--- a/packages/shared/src/components/modals/SlackIntegrationModal/SlackIntegrationModal.tsx
+++ b/packages/shared/src/components/modals/SlackIntegrationModal/SlackIntegrationModal.tsx
@@ -25,6 +25,7 @@ import { Bubble } from '../../tooltips/utils';
 import { useLogContext } from '../../../contexts/LogContext';
 import { UserIntegrationType } from '../../../graphql/integrations';
 import { LogEvent } from '../../../lib/log';
+import { slackIntegration } from '../../../lib/constants';
 
 export type SlackIntegrationModalProps = Omit<ModalProps, 'children'> & {
   source: Pick<Source, 'id' | 'handle' | 'type' | 'image' | 'name'>;
@@ -220,6 +221,16 @@ const SlackIntegrationModal = ({
               />
             )}
           </div>
+          <Typography
+            className="mb-2 flex items-center"
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+          >
+            Can&apos;t find your private channel?
+            <a className="ml-1 underline" href={slackIntegration}>
+              Read here
+            </a>
+          </Typography>
           <Button
             type="button"
             variant={ButtonVariant.Primary}

--- a/packages/shared/src/hooks/integrations/slack/useSlack.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlack.ts
@@ -30,7 +30,7 @@ export type UseSlack = {
   isFeatureEnabled: boolean;
 };
 
-const scopes = ['channels:read', 'chat:write', 'channels:join'];
+const scopes = ['channels:read', 'chat:write', 'channels:join', 'groups:read'];
 
 export const useSlack = (): UseSlack => {
   const { user, isLoggedIn } = useAuthContext();


### PR DESCRIPTION
## Changes

Additional permissions for slack oauth to be able to access private channels.

API https://github.com/dailydotdev/daily-api/pull/2141

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-521 #done


### Preview domain
https://as-521-slack-private-channels.preview.app.daily.dev