### PR TITLE
feat: shortcuts followup experiment

### DIFF
--- a/packages/extension/src/newtab/ShortcutLinks/ShortcutLinks.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks/ShortcutLinks.tsx
@@ -208,6 +208,7 @@ export default function ShortcutLinks({
             shouldUseListFeedLayout,
             showTopSites,
             toggleShowTopSites,
+            hasCheckedPermission,
           }}
         />
       ) : (

--- a/packages/extension/src/newtab/ShortcutLinks/experiments/ShortcutLinksUIV1.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks/experiments/ShortcutLinksUIV1.tsx
@@ -34,6 +34,7 @@ type ShortcutLinksV1Props = {
   shouldUseListFeedLayout: boolean;
   showTopSites: boolean;
   toggleShowTopSites: () => void;
+  hasCheckedPermission: boolean;
 };
 
 function ShortCutV1Placeholder({
@@ -121,12 +122,18 @@ export function ShortcutLinksUIV1(props: ShortcutLinksV1Props): ReactElement {
     shouldUseListFeedLayout,
     showTopSites,
     toggleShowTopSites,
+    hasCheckedPermission,
   } = props;
 
   const { checkHasCompleted, isActionsFetched, completeAction } = useActions();
   const { githubShortcut } = useThemedAsset();
 
+  if (!hasCheckedPermission) {
+    return null;
+  }
+
   if (
+    !shortcutLinks?.length &&
     showTopSites &&
     isActionsFetched &&
     !checkHasCompleted(ActionType.FirstShortcutsSession)

--- a/packages/shared/src/hooks/utils/useShortcuts.ts
+++ b/packages/shared/src/hooks/utils/useShortcuts.ts
@@ -3,6 +3,7 @@ import { useAuthContext } from '../../contexts/AuthContext';
 import { feature } from '../../lib/featureManagement';
 import { ShortcutsUIExperiment } from '../../lib/featureValues';
 import { useConditionalFeature } from '../useConditionalFeature';
+import { isExtension } from '../../lib/func';
 
 interface UseShortcuts {
   isShortcutsV1: boolean;
@@ -17,7 +18,7 @@ export const useShortcuts = (): UseShortcuts => {
   const { isLoggedIn, user } = useAuthContext();
   const { value: shortcutsUIVersion } = useConditionalFeature({
     feature: feature.shortcutsUI,
-    shouldEvaluate: isLoggedIn,
+    shouldEvaluate: isLoggedIn && isExtension,
   });
 
   const isShortcutsV1 = useMemo(

--- a/packages/shared/src/hooks/utils/useShortcuts.ts
+++ b/packages/shared/src/hooks/utils/useShortcuts.ts
@@ -1,5 +1,8 @@
 import { useMemo } from 'react';
 import { useAuthContext } from '../../contexts/AuthContext';
+import { feature } from '../../lib/featureManagement';
+import { ShortcutsUIExperiment } from '../../lib/featureValues';
+import { useConditionalFeature } from '../useConditionalFeature';
 
 interface UseShortcuts {
   isShortcutsV1: boolean;
@@ -11,13 +14,15 @@ interface UseShortcuts {
  * Keywords: shortcutsUI, onboarding_most_visited
  */
 export const useShortcuts = (): UseShortcuts => {
-  const { user } = useAuthContext();
+  const { isLoggedIn, user } = useAuthContext();
+  const { value: shortcutsUIVersion } = useConditionalFeature({
+    feature: feature.shortcutsUI,
+    shouldEvaluate: isLoggedIn,
+  });
 
   const isShortcutsV1 = useMemo(
-    () =>
-      user?.isTeamMember ||
-      new Date(user?.createdAt) >= new Date('2024-04-16T00:00:00.000Z'),
-    [user?.isTeamMember, user?.createdAt],
+    () => user?.isTeamMember || shortcutsUIVersion === ShortcutsUIExperiment.V1,
+    [user?.isTeamMember, shortcutsUIVersion],
   );
 
   return {

--- a/packages/storybook/stories/extension/ShortcutLinks.stories.tsx
+++ b/packages/storybook/stories/extension/ShortcutLinks.stories.tsx
@@ -113,6 +113,7 @@ export const ExperimentV1: Story = {
       shouldUseListFeedLayout: args.shouldUseListFeedLayout,
       showTopSites,
       toggleShowTopSites: () => setShowTopSites(!showTopSites),
+      hasCheckedPermission: true,
     };
     return (
       <ExtensionProviders>


### PR DESCRIPTION
## Changes

- experiment is now going to work for existing users
- connect existing feature flag again instead of hardcoded
- do not show the popup if user already has some top sites

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-468 #done


### Preview domain
https://as-468-shortcuts-followup.preview.app.daily.dev