### PR TITLE
fix: timer test

### DIFF
--- a/packages/shared/src/components/notifications/Toast.spec.tsx
+++ b/packages/shared/src/components/notifications/Toast.spec.tsx
@@ -64,47 +64,49 @@ it('should display a toast notification', async () => {
 });
 
 it('should display a toast notification and be dismissable', async () => {
+  jest.useFakeTimers();
   renderComponent();
   const button = await screen.findByText('Regular Toast');
   fireEvent.click(button);
   const alertEl = await screen.findByRole('alert');
   expect(alertEl).toBeInTheDocument();
+  expect(setInterval).toHaveBeenCalledTimes(1);
   const dismiss = await screen.findByLabelText('Dismiss toast notification');
   expect(dismiss).toBeInTheDocument();
   fireEvent.click(dismiss);
-  await waitForElementToBeRemoved(() => screen.queryByRole('alert'), {
-    timeout: 1000,
-  });
+  jest.advanceTimersByTime(500);
+  await waitForElementToBeRemoved(() => screen.queryByRole('alert'));
 });
 
 it('should display a toast notification and do not automatically close', async () => {
+  jest.useFakeTimers();
   renderComponent(false);
   const button = await screen.findByText('Regular Toast');
   fireEvent.click(button);
   const alertEl = await screen.findByRole('alert');
   expect(alertEl).toBeInTheDocument();
-  await new Promise((resolve) => setTimeout(resolve, 10));
+  expect(setInterval).toHaveBeenCalledTimes(1);
   const dismiss = await screen.findByLabelText('Dismiss toast notification');
   expect(dismiss).toBeInTheDocument();
   fireEvent.click(dismiss);
-  await waitForElementToBeRemoved(() => screen.queryByRole('alert'), {
-    timeout: 1000,
-  });
+  jest.advanceTimersByTime(500);
+  await waitForElementToBeRemoved(() => screen.queryByRole('alert'));
 });
 
 it('should display a toast notification and undoable action', async () => {
+  jest.useFakeTimers();
   renderComponent();
   const button = await screen.findByText('Undoable Toast');
   fireEvent.click(button);
   const alertEl = await screen.findByRole('alert');
   expect(alertEl).toBeInTheDocument();
+  expect(setInterval).toHaveBeenCalledTimes(1);
   const el = await screen.findByText('Undoable Notification');
   expect(el).toBeInTheDocument();
   const undoBtn = await screen.findByLabelText('Undo action');
   expect(undoBtn).toBeInTheDocument();
   fireEvent.click(undoBtn);
-  await waitForElementToBeRemoved(() => screen.queryByRole('alert'), {
-    timeout: 1000,
-  });
+  jest.advanceTimersByTime(500);
+  await waitForElementToBeRemoved(() => screen.queryByRole('alert'));
   expect(undo).toBeCalled();
 });

--- a/packages/shared/src/components/notifications/Toast.spec.tsx
+++ b/packages/shared/src/components/notifications/Toast.spec.tsx
@@ -50,22 +50,27 @@ const renderComponent = (autoDismissNotifications = true) => {
 };
 
 it('should display a toast notification', async () => {
+  jest.useFakeTimers();
   renderComponent();
   const button = await screen.findByText('Regular Toast');
   fireEvent.click(button);
-  await screen.findByRole('alert');
-  await screen.findByText('Sample Notification');
-  await waitForElementToBeRemoved(() => screen.queryByRole('alert'), {
-    timeout: 1000,
-  });
+  const alertEl = await screen.findByRole('alert');
+  expect(alertEl).toBeInTheDocument();
+  expect(setInterval).toHaveBeenCalledTimes(1);
+  const el = await screen.findByText('Sample Notification');
+  expect(el).toBeInTheDocument();
+  jest.advanceTimersByTime(500);
+  await waitForElementToBeRemoved(() => screen.queryByRole('alert'));
 });
 
 it('should display a toast notification and be dismissable', async () => {
   renderComponent();
   const button = await screen.findByText('Regular Toast');
   fireEvent.click(button);
-  await screen.findByRole('alert');
+  const alertEl = await screen.findByRole('alert');
+  expect(alertEl).toBeInTheDocument();
   const dismiss = await screen.findByLabelText('Dismiss toast notification');
+  expect(dismiss).toBeInTheDocument();
   fireEvent.click(dismiss);
   await waitForElementToBeRemoved(() => screen.queryByRole('alert'), {
     timeout: 1000,
@@ -76,9 +81,11 @@ it('should display a toast notification and do not automatically close', async (
   renderComponent(false);
   const button = await screen.findByText('Regular Toast');
   fireEvent.click(button);
-  await screen.findByRole('alert');
+  const alertEl = await screen.findByRole('alert');
+  expect(alertEl).toBeInTheDocument();
   await new Promise((resolve) => setTimeout(resolve, 10));
   const dismiss = await screen.findByLabelText('Dismiss toast notification');
+  expect(dismiss).toBeInTheDocument();
   fireEvent.click(dismiss);
   await waitForElementToBeRemoved(() => screen.queryByRole('alert'), {
     timeout: 1000,
@@ -89,9 +96,12 @@ it('should display a toast notification and undoable action', async () => {
   renderComponent();
   const button = await screen.findByText('Undoable Toast');
   fireEvent.click(button);
-  await screen.findByRole('alert');
-  await screen.findByText('Undoable Notification');
+  const alertEl = await screen.findByRole('alert');
+  expect(alertEl).toBeInTheDocument();
+  const el = await screen.findByText('Undoable Notification');
+  expect(el).toBeInTheDocument();
   const undoBtn = await screen.findByLabelText('Undo action');
+  expect(undoBtn).toBeInTheDocument();
   fireEvent.click(undoBtn);
   await waitForElementToBeRemoved(() => screen.queryByRole('alert'), {
     timeout: 1000,


### PR DESCRIPTION
## Changes

Attempt to fix flaky test.
Basically due to timer inside Toast that cause re-renders (not within act, but we can't do that since we want it to render before)

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://fix-timer-test.preview.app.daily.dev