### PR TITLE
fix: undefined append to tooltip - global error event

### DIFF
--- a/packages/shared/src/components/comments/CommentActionButtons.tsx
+++ b/packages/shared/src/components/comments/CommentActionButtons.tsx
@@ -175,7 +175,7 @@ export default function CommentActionButtons({
     });
   }
 
-  const appendTo = isCompanion ? getCompanionWrapper : undefined;
+  const appendTo = isCompanion ? getCompanionWrapper : 'parent';
 
   return (
     <div className={classNames('flex flex-row items-center', className)}>


### PR DESCRIPTION
Issue reported here: https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1724128120556129

Fixes global error event thrown on extension when hovering over the action buttons of a comment. Seems to be caused by the tooltip wrapping the actions.
To fix changed appendTo parent instead of undefined. 

Tested webapp and chrome extension

### Preview domain
https://fix-global-error-event.preview.app.daily.dev