### PR TITLE
chore: rename GraphQL operation name `Sources` to `Squads`

### DIFF
--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -98,7 +98,7 @@ export const DELETE_SQUAD_MUTATION = gql`
 `;
 
 export const SQUAD_DIRECTORY_SOURCES = gql`
-  query Sources($filterOpenSquads: Boolean, $featured: Boolean) {
+  query Squads($filterOpenSquads: Boolean, $featured: Boolean) {
     sources(filterOpenSquads: $filterOpenSquads, featured: $featured) {
       pageInfo {
         endCursor


### PR DESCRIPTION
## Changes

Makes it a little bit easier to differentiate in metrics that this is actually querying Squads and not Sources (even though squads are sources)

### Preview domain
https://chore-rename-sources-query.preview.app.daily.dev