### PR TITLE
feat: add option to make TabList button be a element

### DIFF
--- a/packages/shared/src/components/header/FeedExploreHeader.tsx
+++ b/packages/shared/src/components/header/FeedExploreHeader.tsx
@@ -106,6 +106,7 @@ export function FeedExploreHeader({
               container: className.tabBarContainer,
             }}
             shouldMountInactive
+            tabTag="a"
           >
             {Object.entries(urlToTab).map(([url, label]) => (
               <Tab key={label} label={label} url={url} />

--- a/packages/shared/src/components/tabs/TabContainer.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import classNames from 'classnames';
 import { useRouter } from 'next/router';
-import TabList, { TabListProps } from './TabList';
+import TabList, { AllowedTabTags, TabListProps } from './TabList';
 import { RenderTab } from './common';
 
 export interface TabProps<T extends string> {
@@ -48,6 +48,7 @@ export interface TabContainerProps<T extends string = string> {
   tabListProps?: Pick<TabListProps, 'className' | 'autoScrollActive'>;
   showBorder?: boolean;
   renderTab?: RenderTab;
+  tabTag?: AllowedTabTags;
 }
 
 export function TabContainer<T extends string = string>({
@@ -61,6 +62,7 @@ export function TabContainer<T extends string = string>({
   controlledActive,
   tabListProps = {},
   renderTab,
+  tabTag,
 }: TabContainerProps<T>): ReactElement {
   const router = useRouter();
 
@@ -144,6 +146,7 @@ export function TabContainer<T extends string = string>({
           active={currentActive}
           className={tabListProps?.className}
           autoScrollActive={tabListProps?.autoScrollActive}
+          tag={tabTag}
         />
       </header>
       {render}

--- a/packages/shared/src/components/tabs/TabList.tsx
+++ b/packages/shared/src/components/tabs/TabList.tsx
@@ -45,6 +45,7 @@ function TabList<T extends string = string>({
     offset: 0,
     indicatorOffset: 0,
   });
+  const isAnchor = Tag === 'a';
 
   const scrollIfNotInView = useCallback(() => {
     const { activeTabRect, offset } = dimensions;
@@ -130,6 +131,7 @@ function TabList<T extends string = string>({
               className.item,
               'relative p-2 py-4 text-center font-bold typo-callout',
               isActive ? '' : 'text-text-tertiary',
+              isAnchor && 'cursor-pointer',
             )}
             onClick={() => onClick(tab)}
             type="button"

--- a/packages/shared/src/components/tabs/TabList.tsx
+++ b/packages/shared/src/components/tabs/TabList.tsx
@@ -134,8 +134,12 @@ function TabList<T extends string = string>({
               isAnchor && 'cursor-pointer',
             )}
             onClick={() => onClick(tab)}
-            type="button"
-            role="menuitem"
+            {...(isAnchor
+              ? {
+                  'aria-label': tab,
+                  title: tab,
+                }
+              : { type: 'button', role: 'menuitem' })}
           >
             {renderedTab}
           </Tag>

--- a/packages/shared/src/components/tabs/TabList.tsx
+++ b/packages/shared/src/components/tabs/TabList.tsx
@@ -8,6 +8,8 @@ import React, {
 } from 'react';
 import { RenderTab } from './common';
 
+export type AllowedTabTags = keyof Pick<JSX.IntrinsicElements, 'a' | 'button'>;
+
 interface ClassName {
   indicator?: string;
   item?: string;
@@ -25,6 +27,7 @@ export interface TabListProps<T extends string = string> {
   className?: ClassName;
   autoScrollActive?: boolean;
   renderTab?: RenderTab;
+  tag?: AllowedTabTags;
 }
 
 function TabList<T extends string = string>({
@@ -34,6 +37,7 @@ function TabList<T extends string = string>({
   className = {},
   autoScrollActive,
   renderTab,
+  tag: Tag = 'button',
 }: TabListProps<T>): ReactElement {
   const hasActive = items.includes(active);
   const currentActiveTab = useRef<HTMLButtonElement>(null);
@@ -113,7 +117,7 @@ function TabList<T extends string = string>({
         );
 
         return (
-          <button
+          <Tag
             key={tab}
             ref={(el) => {
               if (!el || !isActive) {
@@ -132,7 +136,7 @@ function TabList<T extends string = string>({
             role="menuitem"
           >
             {renderedTab}
-          </button>
+          </Tag>
         );
       })}
       {!!indicatorOffset && hasActive && (


### PR DESCRIPTION
## Changes

- Converts tabs on explore page to use `a` instead of `button`

### Preview domain
https://as-543-buttons-to-links.preview.app.daily.dev