### PR TITLE
fix: streak restore cache update on success

### DIFF
--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -532,10 +532,10 @@ export const USER_STREAK_RECOVER_QUERY = gql`
 export const USER_STREAK_RECOVER_MUTATION = gql`
   mutation RecoverStreak {
     recoverStreak {
-      current
-      lastViewAt
+      ...UserStreakFragment
     }
   }
+  ${USER_STREAK_FRAGMENT}
 `;
 
 export const DEV_CARD_QUERY = gql`

--- a/packages/shared/src/hooks/streaks/useStreakRecover.ts
+++ b/packages/shared/src/hooks/streaks/useStreakRecover.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useToggle } from '../useToggle';
 import { useActions } from '../useActions';
 import {
@@ -14,6 +14,7 @@ import { useToastNotification } from '../useToastNotification';
 import { useLogContext } from '../../contexts/LogContext';
 import { LogEvent, TargetType } from '../../lib/log';
 import { useAlertsContext } from '../../contexts/AlertContext';
+import { useAuthContext } from '../../contexts/AuthContext';
 
 interface UseStreakRecoverProps {
   onAfterClose?: () => void;
@@ -36,6 +37,10 @@ export interface UseStreakRecoverReturn {
   };
 }
 
+interface StreakQueryData {
+  streakRecover: UserStreakRecoverData;
+}
+
 export const useStreakRecover = ({
   onAfterClose,
   onRequestClose,
@@ -45,10 +50,9 @@ export const useStreakRecover = ({
   const { displayToast } = useToastNotification();
   const { logEvent } = useLogContext();
   const { updateAlerts } = useAlertsContext();
-
-  const { data, isLoading } = useQuery<{
-    streakRecover: UserStreakRecoverData;
-  }>({
+  const { user } = useAuthContext();
+  const client = useQueryClient();
+  const { data, isLoading } = useQuery<StreakQueryData>({
     queryKey: generateQueryKey(RequestKey.UserStreakRecover),
     queryFn: async () => await gqlClient.request(USER_STREAK_RECOVER_QUERY),
   });
@@ -63,6 +67,8 @@ export const useStreakRecover = ({
       logEvent({
         event_name: LogEvent.StreakRecover,
       });
+
+      client.invalidateQueries(generateQueryKey(RequestKey.UserStreak, user));
     },
   });
 


### PR DESCRIPTION
## Changes
- After restoring the streak, we need to update FE local cache to reflect the right value in the header.
- Tried to just set it manually based on the response, but UI was not changing. Used invalidate queries, and the UI updated.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->
