### PR TITLE
fix: squad card weird look

### DIFF
--- a/packages/shared/src/components/cards/squad/SquadGrid.spec.tsx
+++ b/packages/shared/src/components/cards/squad/SquadGrid.spec.tsx
@@ -97,11 +97,11 @@ it('should render the component with basic props', async () => {
 
 it('should render the component with basic props with border and banner', async () => {
   renderComponent();
-  admin.source.borderColor = '!border-accent-avocado-default';
+  admin.source.color = '!border-accent-avocado-default';
   const element = screen.getByRole('article');
 
   expect(screen.getByText(admin.source.name)).toBeInTheDocument();
-  expect(element).toHaveClass(admin.source.borderColor);
+  expect(element).toHaveClass(admin.source.color);
 });
 
 it('should render the component with an image', () => {

--- a/packages/shared/src/components/cards/squad/SquadGrid.tsx
+++ b/packages/shared/src/components/cards/squad/SquadGrid.tsx
@@ -46,9 +46,17 @@ export const SquadGrid = ({
   className,
 }: UnFeaturedSquadCardProps): ReactElement => {
   const router = useRouter();
-  const { banner, image, name, handle, description, permalink, membersCount } =
-    source;
-  const borderColor = source.borderColor || SourceCardBorderColor.Avocado;
+  const {
+    headerImage,
+    image,
+    color,
+    name,
+    handle,
+    description,
+    permalink,
+    membersCount,
+  } = source;
+  const borderColor = color || SourceCardBorderColor.Avocado;
 
   return (
     <Card
@@ -61,7 +69,7 @@ export const SquadGrid = ({
       <div className="h-24 rounded-t-16 bg-accent-onion-bolder">
         <Image
           className="h-full w-full object-cover"
-          src={banner || cloudinary.squads.directory.cardBannerDefault}
+          src={headerImage || cloudinary.squads.directory.cardBannerDefault}
           alt="Banner image for source"
         />
       </div>

--- a/packages/shared/src/components/cards/squad/SquadGrid.tsx
+++ b/packages/shared/src/components/cards/squad/SquadGrid.tsx
@@ -74,7 +74,7 @@ export const SquadGrid = ({
         />
       </div>
       <div className="-mt-12 flex flex-1 flex-col rounded-t-16 bg-background-subtle p-4">
-        <div className="mb-3 flex items-end justify-between">
+        <div className="-mt-14 mb-3 flex items-end justify-between">
           <a href={permalink}>
             <Image
               className="size-24 rounded-full"

--- a/packages/shared/src/components/cards/squad/SquadGrid.tsx
+++ b/packages/shared/src/components/cards/squad/SquadGrid.tsx
@@ -8,6 +8,8 @@ import { cloudinary } from '../../../lib/image';
 import { UnFeaturedSquadCardProps } from './common/types';
 import { SquadJoinButton } from '../../squads/SquadJoinButton';
 import { Origin } from '../../../lib/log';
+import { ButtonVariant } from '../../buttons/common';
+import { useViewSize, ViewSize } from '../../../hooks';
 
 export enum SourceCardBorderColor {
   Avocado = 'avocado',
@@ -57,6 +59,7 @@ export const SquadGrid = ({
     membersCount,
   } = source;
   const borderColor = color || SourceCardBorderColor.Avocado;
+  const isMobile = useViewSize(ViewSize.MobileL);
 
   return (
     <Card
@@ -105,11 +108,15 @@ export const SquadGrid = ({
 
           <SquadJoinButton
             showViewSquad
-            className={{ button: '!btn-secondary z-0 w-full' }}
+            className={{ button: 'z-0 w-full' }}
             squad={source}
             origin={Origin.SquadDirectory}
             onSuccess={() => router.push(source.permalink)}
             data-testid="squad-action"
+            buttonVariants={[
+              ButtonVariant.Secondary,
+              isMobile ? ButtonVariant.Float : ButtonVariant.Secondary,
+            ]}
           />
         </div>
       </div>

--- a/packages/shared/src/components/cards/squad/SquadGrid.tsx
+++ b/packages/shared/src/components/cards/squad/SquadGrid.tsx
@@ -64,19 +64,17 @@ export const SquadGrid = ({
   return (
     <Card
       className={classNames(
-        'overflow-hidden !p-0',
+        'relative overflow-hidden !p-0',
         borderColorToClassName[borderColor],
         className,
       )}
     >
-      <div className="h-24 rounded-t-16 bg-accent-onion-bolder">
-        <Image
-          className="h-full w-full object-cover"
-          src={headerImage || cloudinary.squads.directory.cardBannerDefault}
-          alt="Banner image for source"
-        />
-      </div>
-      <div className="-mt-12 flex flex-1 flex-col rounded-t-16 bg-background-subtle p-4">
+      <Image
+        className="absolute left-0 right-0 top-0 h-24 w-full rounded-t-16 bg-accent-onion-bolder object-cover"
+        src={headerImage || cloudinary.squads.directory.cardBannerDefault}
+        alt="Banner image for source"
+      />
+      <div className="z-1 mt-12 flex flex-1 flex-col rounded-t-16 bg-background-subtle p-4">
         <div className="-mt-14 mb-3 flex items-end justify-between">
           <a href={permalink}>
             <Image

--- a/packages/shared/src/components/cards/squad/SquadList.tsx
+++ b/packages/shared/src/components/cards/squad/SquadList.tsx
@@ -62,7 +62,7 @@ export const SquadList = ({
         copy={{ join: 'Join', view: 'View' }}
         data-testid="squad-action"
         showViewSquad
-        buttonVariants={[ButtonVariant.Secondary, ButtonVariant.Secondary]}
+        buttonVariants={[ButtonVariant.Secondary, ButtonVariant.Float]}
       />
     </div>
   );

--- a/packages/shared/src/components/squads/SquadJoinButton.tsx
+++ b/packages/shared/src/components/squads/SquadJoinButton.tsx
@@ -174,6 +174,7 @@ export const SquadJoinButton = ({
       <Link href={squad.permalink}>
         <Button
           {...rest}
+          className={className?.button}
           tag="a"
           href={squad.permalink}
           variant={memberVariant}

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -62,8 +62,6 @@ export interface Squad extends Source {
   memberPostingRole: SourceMemberRole;
   memberInviteRole: SourceMemberRole;
   referralUrl?: string;
-  banner?: string;
-  borderColor?: string;
   category?: SourceCategory;
 }
 


### PR DESCRIPTION
## Changes
- The reason why the cards looked weird was, it was missing the border color, header image, and alignment of the elements.
- It was aliased to a different property to fit the previous card. But since we don't need the previous card anymore, we don't have to alias it. Also to avoid future confusion that it is actually part of the schema.

Preview:

<img width="1568" alt="Screenshot 2024-09-12 at 2 01 50 PM" src="https://github.com/user-attachments/assets/ec5f5098-f186-4ffd-acc5-16d99935aa2b">

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

MI-526

### Preview domain
https://mi-526.preview.app.daily.dev