### PR TITLE
fix: my squads to be its own link

### DIFF
--- a/packages/shared/src/components/cards/squad/SquadList.tsx
+++ b/packages/shared/src/components/cards/squad/SquadList.tsx
@@ -30,7 +30,7 @@ export const SquadList = ({
 
   return (
     <div {...attrs} className="relative flex flex-row items-center gap-4">
-      <Link href={permalink}>
+      <Link href={permalink} legacyBehavior>
         <CardLink href={permalink} rel="noopener" title={name} />
       </Link>
       <Image

--- a/packages/shared/src/components/cards/squad/SquadList.tsx
+++ b/packages/shared/src/components/cards/squad/SquadList.tsx
@@ -1,5 +1,6 @@
 import React, { ComponentProps, ReactElement } from 'react';
 import { useRouter } from 'next/router';
+import Link from 'next/link';
 import { Squad } from '../../../graphql/sources';
 import {
   Typography,
@@ -29,7 +30,9 @@ export const SquadList = ({
 
   return (
     <div {...attrs} className="relative flex flex-row items-center gap-4">
-      <CardLink href={permalink} rel="noopener" title={name} />
+      <Link href={permalink}>
+        <CardLink href={permalink} rel="noopener" title={name} />
+      </Link>
       <Image
         className="size-14 rounded-full"
         src={image}

--- a/packages/shared/src/components/squads/layout/SquadDirectoryLayout.tsx
+++ b/packages/shared/src/components/squads/layout/SquadDirectoryLayout.tsx
@@ -22,7 +22,6 @@ import {
 } from './SquadDirectoryNavbar';
 import { PlusIcon } from '../../icons';
 import { useSquadDirectoryLayout } from './useSquadDirectoryLayout';
-import { SquadList } from '../../cards/squad/SquadList';
 import { squadCategoriesPaths } from '../../../lib/constants';
 
 type SquadDirectoryLayoutProps = PropsWithChildren & ComponentProps<'section'>;
@@ -58,8 +57,7 @@ export const SquadDirectoryLayout = (
 
   const id = useId();
   const { pathname } = useRouter();
-  const { squads, categoryPaths, mySquadsTab, isMobileLayout } =
-    useSquadDirectoryLayout();
+  const { categoryPaths, isMobileLayout } = useSquadDirectoryLayout();
   const buttonSize = isMobileLayout ? ButtonSize.XSmall : ButtonSize.Small;
 
   useEffect(() => {
@@ -81,30 +79,14 @@ export const SquadDirectoryLayout = (
         </section>
         <div className="flex max-w-full flex-row flex-nowrap items-center justify-between gap-6 laptop:gap-22">
           <SquadDirectoryNavbar className="min-w-0 flex-1">
-            {mySquadsTab.isVisible && (
-              <SquadDirectoryNavbarItem
-                buttonSize={buttonSize}
-                className="block laptop:hidden"
-                id={`squad-item-my-squads-${id}`}
-                isActive={mySquadsTab.isActive}
-                label="My Squads"
-                onClick={() => mySquadsTab.toggle(true)}
-              />
-            )}
             {Object.entries(categoryPaths ?? {}).map(([category, path]) => (
               <SquadDirectoryNavbarItem
                 buttonSize={buttonSize}
                 id={`squad-item-${category}-${id}`}
-                isActive={pathname === path && !mySquadsTab.isActive}
+                isActive={pathname === path}
                 key={category}
                 label={category}
                 path={path}
-                onClick={(e) => {
-                  if (mySquadsTab.isActive && pathname === path) {
-                    e.preventDefault();
-                    mySquadsTab.toggle(false);
-                  }
-                }}
               />
             ))}
           </SquadDirectoryNavbar>
@@ -117,15 +99,7 @@ export const SquadDirectoryLayout = (
         {...attrs}
         className={classNames('flex w-full flex-col pt-5', className)}
       >
-        {mySquadsTab.isActive && mySquadsTab.isVisible ? (
-          <div className="flex flex-col gap-3">
-            {squads.map((squad) => (
-              <SquadList key={squad.handle} squad={squad} />
-            ))}
-          </div>
-        ) : (
-          children
-        )}
+        {children}
       </section>
     </BaseFeedPage>
   );

--- a/packages/shared/src/components/squads/layout/SquadDirectoryNavbar.tsx
+++ b/packages/shared/src/components/squads/layout/SquadDirectoryNavbar.tsx
@@ -14,7 +14,7 @@ interface SquadNavbarItemProps extends Omit<ComponentProps<'li'>, 'onClick'> {
   buttonSize: ButtonSize;
   isActive: boolean;
   label: string;
-  onClick: ButtonProps<'a'>['onClick'];
+  onClick?: ButtonProps<'a'>['onClick'];
   path?: string;
 }
 

--- a/packages/shared/src/components/squads/layout/useSquadDirectoryLayout.ts
+++ b/packages/shared/src/components/squads/layout/useSquadDirectoryLayout.ts
@@ -26,7 +26,7 @@ export const useSquadDirectoryLayout = (): SquadDirectoryLayoutReturn => {
     }
 
     if (isLaptop || !hasSquad) {
-      delete path.mysquads;
+      delete path['My Squads'];
     }
 
     const flatCategories =

--- a/packages/shared/src/components/squads/layout/useSquadDirectoryLayout.ts
+++ b/packages/shared/src/components/squads/layout/useSquadDirectoryLayout.ts
@@ -1,6 +1,6 @@
+import { useMemo } from 'react';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { squadCategoriesPaths } from '../../../lib/constants';
-import { useToggle } from '../../../hooks/useToggle';
 import { useViewSize, ViewSize } from '../../../hooks';
 import { Squad } from '../../../graphql/sources';
 import { useSquadCategories } from '../../../hooks/squads/useSquadCategories';
@@ -8,11 +8,6 @@ import { useSquadCategories } from '../../../hooks/squads/useSquadCategories';
 interface SquadDirectoryLayoutReturn {
   hasSquad: boolean;
   squads: Squad[];
-  mySquadsTab: {
-    isVisible: boolean;
-    isActive: boolean;
-    toggle: (val?: boolean) => void;
-  };
   categoryPaths: Record<string, string>;
   isMobileLayout: boolean;
 }
@@ -21,24 +16,35 @@ export const useSquadDirectoryLayout = (): SquadDirectoryLayoutReturn => {
   const { squads = [] } = useAuthContext();
   const hasSquad = !!squads?.length;
   const isLaptop = useViewSize(ViewSize.Laptop);
-  const [isMySquadsActive, setIsMySquadsActive] = useToggle(false);
-  const { data: categories } = useSquadCategories();
-  const categoryPaths = categories?.pages.reduce((acc, page) => {
-    page.categories.edges.forEach(({ node }) => {
-      acc[node.title] = `/squads/discover/${node.id}`;
-    });
-    return acc;
-  }, squadCategoriesPaths);
+  const { data: categories, isFetched } = useSquadCategories();
+
+  const tabs = useMemo(() => {
+    const path = { ...squadCategoriesPaths };
+
+    if (!isFetched) {
+      return {};
+    }
+
+    if (isLaptop || !hasSquad) {
+      delete path.mysquads;
+    }
+
+    const flatCategories =
+      categories?.pages.flatMap((page) => page.categories.edges) ?? [];
+
+    return flatCategories.reduce(
+      (result, { node }) => ({
+        ...result,
+        [node.title]: `/squads/discover/${node.id}`,
+      }),
+      path,
+    );
+  }, [hasSquad, isLaptop, categories, isFetched]);
 
   return {
     hasSquad,
     squads,
-    mySquadsTab: {
-      isActive: isMySquadsActive,
-      isVisible: hasSquad && !isLaptop,
-      toggle: setIsMySquadsActive,
-    },
-    categoryPaths,
+    categoryPaths: tabs,
     isMobileLayout: !isLaptop,
   };
 };

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -69,7 +69,7 @@ export const bookmarkLoops = 'https://r.daily.dev/bookmarkloops';
 export const migrateUserToStreaks = 'https://r.daily.dev/streaks';
 
 export const squadCategoriesPaths = {
-  mysquads: '/squads/discover/my',
+  'My Squads': '/squads/discover/my',
   discover: '/squads/discover',
   featured: '/squads/discover/featured',
 };

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -69,6 +69,7 @@ export const bookmarkLoops = 'https://r.daily.dev/bookmarkloops';
 export const migrateUserToStreaks = 'https://r.daily.dev/streaks';
 
 export const squadCategoriesPaths = {
+  mysquads: '/squads/discover/my',
   discover: '/squads/discover',
   featured: '/squads/discover/featured',
 };

--- a/packages/webapp/pages/squads/discover/index.tsx
+++ b/packages/webapp/pages/squads/discover/index.tsx
@@ -13,7 +13,7 @@ function SquadDiscoveryPage(): ReactElement {
   const categories = data?.pages.flatMap((page) => page.categories.edges) ?? [];
 
   return (
-    <SquadDirectoryLayout className="gap-6 ">
+    <SquadDirectoryLayout className="gap-6">
       <NextSeo
         {...defaultSeo}
         title="Squads Directory"

--- a/packages/webapp/pages/squads/discover/my.tsx
+++ b/packages/webapp/pages/squads/discover/my.tsx
@@ -11,7 +11,7 @@ function MySquadsPage(): ReactElement {
   const { squads } = useAuthContext();
 
   return (
-    <SquadDirectoryLayout className="gap-e">
+    <SquadDirectoryLayout className="gap-3">
       <NextSeo {...defaultSeo} title="My Squads" />
       {squads?.map((squad) => (
         <SquadList key={squad.handle} squad={squad} />

--- a/packages/webapp/pages/squads/discover/my.tsx
+++ b/packages/webapp/pages/squads/discover/my.tsx
@@ -1,0 +1,26 @@
+import React, { ReactElement } from 'react';
+import { NextSeo } from 'next-seo';
+import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
+import { SquadList } from '@dailydotdev/shared/src/components/cards/squad/SquadList';
+import { getLayout } from '../../../components/layouts/FeedLayout';
+import { mainFeedLayoutProps } from '../../../components/layouts/MainFeedPage';
+import { SquadDirectoryLayout } from '../../../../shared/src/components/squads/layout/SquadDirectoryLayout';
+import { defaultSeo } from '../../../next-seo';
+
+function MySquadsPage(): ReactElement {
+  const { squads } = useAuthContext();
+
+  return (
+    <SquadDirectoryLayout className="gap-e">
+      <NextSeo {...defaultSeo} title="My Squads" />
+      {squads?.map((squad) => (
+        <SquadList key={squad.handle} squad={squad} />
+      ))}
+    </SquadDirectoryLayout>
+  );
+}
+
+MySquadsPage.getLayout = getLayout;
+MySquadsPage.layoutProps = mainFeedLayoutProps;
+
+export default MySquadsPage;


### PR DESCRIPTION
## Changes
- Previously, there were only two tabs, so it is easier to manage with just the state.
- But now that we have 3 or more tabs that work as a navigation link, making the behavior consistent across the items . Hence, creating a page for your Squads. Also makes it easier to point the user if they ask where to find all their Squads.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->
