### PR TITLE
fix: squad role in post page

### DIFF
--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -87,7 +87,7 @@ function SquadPostAuthor({
               {!!role && (
                 <SquadMemberBadge
                   key="squadMemberRole"
-                  role={SourceMemberRole.Admin}
+                  role={role}
                   removeMargins
                 />
               )}


### PR DESCRIPTION
## Changes
- role was set to admin not considering the value, changed to role

### Preview domain
https://mi-500-squad-member-role-fix.preview.app.daily.dev