### PR TITLE
fix: sorting squads feed by members count

### DIFF
--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -86,6 +86,7 @@ export const SOURCES_QUERY = gql`
     $after: String
     $first: Int
     $categoryId: String
+    $sortByMembersCount: Boolean
   ) {
     sources(
       filterOpenSquads: $filterOpenSquads
@@ -93,6 +94,7 @@ export const SOURCES_QUERY = gql`
       after: $after
       first: $first
       categoryId: $categoryId
+      $sortByMembersCount: $sortByMembersCount
     ) {
       pageInfo {
         endCursor

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -94,7 +94,7 @@ export const SOURCES_QUERY = gql`
       after: $after
       first: $first
       categoryId: $categoryId
-      $sortByMembersCount: $sortByMembersCount
+      sortByMembersCount: $sortByMembersCount
     ) {
       pageInfo {
         endCursor

--- a/packages/shared/src/hooks/source/useSources.ts
+++ b/packages/shared/src/hooks/source/useSources.ts
@@ -19,6 +19,7 @@ export interface SourcesQueryProps {
   isPublic?: boolean;
   featured?: boolean;
   categoryId?: string;
+  sortByMembersCount?: boolean;
   first?: number;
 }
 
@@ -29,7 +30,13 @@ interface UseSourcesProps {
 export const useSources = <T extends Source | Squad>({
   query = {},
 }: UseSourcesProps = {}): UseSources<T> => {
-  const { featured, isPublic, categoryId, first = 100 } = query;
+  const {
+    featured,
+    isPublic,
+    categoryId,
+    first = 100,
+    sortByMembersCount,
+  } = query;
   const result = useInfiniteQuery(
     generateQueryKey(
       RequestKey.Sources,
@@ -46,6 +53,7 @@ export const useSources = <T extends Source | Squad>({
         featured,
         first,
         after: pageParam,
+        sortByMembersCount,
       }),
     {
       getNextPageParam: (lastPage) =>

--- a/packages/webapp/pages/squads/discover/[id].tsx
+++ b/packages/webapp/pages/squads/discover/[id].tsx
@@ -24,7 +24,11 @@ interface SquadCategoryPageProps {
 
 function SquadCategoryPage({ category }: SquadCategoryPageProps): ReactElement {
   const { result } = useSources({
-    query: { categoryId: category.id, isPublic: true },
+    query: {
+      sortByMembersCount: true,
+      categoryId: category.id,
+      isPublic: true,
+    },
   });
   const flatSources =
     result.data?.pages.flatMap((page) => page.sources.edges) ?? [];

--- a/packages/webapp/pages/squads/discover/featured.tsx
+++ b/packages/webapp/pages/squads/discover/featured.tsx
@@ -33,7 +33,7 @@ const seo: NextSeoProps = {
 
 const SquadsPage = (): ReactElement => {
   const { result } = useSources<Squad>({
-    query: { featured: true, isPublic: true },
+    query: { featured: true, isPublic: true, sortByMembersCount: true },
   });
   const flatSquads =
     result.data?.pages.flatMap((page) => page.sources.edges) ?? [];

--- a/packages/webapp/pages/squads/discover/index.tsx
+++ b/packages/webapp/pages/squads/discover/index.tsx
@@ -48,6 +48,7 @@ function SquadDiscoveryPage(): ReactElement {
             isPublic: true,
             featured: false,
             first: limit,
+            sortByMembersCount: true,
           }}
         />
       ))}


### PR DESCRIPTION
## Changes
- Sort the feeds by members count in descending order.
- Preview might not show the right sorting at the moment as we haven't updated the Squads count yet.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://fix-squads-sorting.preview.app.daily.dev