### PR TITLE
feat: follow button

### DIFF
--- a/packages/shared/src/components/contentPreference/FollowButton.tsx
+++ b/packages/shared/src/components/contentPreference/FollowButton.tsx
@@ -1,0 +1,79 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import {
+  ContentPreferenceStatus,
+  ContentPreferenceType,
+} from '../../graphql/contentPreference';
+import { ButtonVariant } from '../buttons/Button';
+import { useContentPreference } from '../../hooks/contentPreference/useContentPreference';
+import SourceActionsNotify from '../sources/SourceActions/SourceActionsNotify';
+import SourceActionsFollow from '../sources/SourceActions/SourceActionsFollow';
+
+export type FollowButtonProps = {
+  className?: string;
+  userId: string;
+  status?: ContentPreferenceStatus;
+  type: ContentPreferenceType;
+  entityName: string;
+};
+
+export const FollowButton = ({
+  className,
+  userId,
+  entityName,
+  status: currentStatus,
+  type,
+}: FollowButtonProps): ReactElement => {
+  const { follow, unfollow, subscribe, unsubscribe } = useContentPreference();
+
+  const onButtonClick = async () => {
+    if (!currentStatus) {
+      await follow({
+        id: userId,
+        entity: type,
+        entityName,
+      });
+    } else {
+      await unfollow({
+        id: userId,
+        entity: type,
+        entityName,
+      });
+    }
+  };
+
+  const onNotifyClick = async () => {
+    if (currentStatus !== ContentPreferenceStatus.Subscribed) {
+      await subscribe({
+        id: userId,
+        entity: type,
+        entityName,
+      });
+    } else {
+      await unsubscribe({
+        id: userId,
+        entity: type,
+        entityName,
+      });
+    }
+  };
+
+  return (
+    <div className={classNames('inline-flex gap-2', className)}>
+      <SourceActionsFollow
+        isSubscribed={!!currentStatus}
+        isFetching={false}
+        variant={ButtonVariant.Secondary}
+        onClick={onButtonClick}
+      />
+      {!!currentStatus && (
+        <SourceActionsNotify
+          haveNotificationsOn={
+            currentStatus === ContentPreferenceStatus.Subscribed
+          }
+          onClick={onNotifyClick}
+        />
+      )}
+    </div>
+  );
+};

--- a/packages/shared/src/components/sources/SourceActions/SourceActionsFollow.tsx
+++ b/packages/shared/src/components/sources/SourceActions/SourceActionsFollow.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement } from 'react';
 import classNames from 'classnames';
 import { ButtonSize, ButtonVariant } from '../../buttons/common';
 import { Button } from '../../buttons/Button';
@@ -13,34 +13,28 @@ interface SourceActionsFollowProps {
 
 const SourceActionsFollow = (props: SourceActionsFollowProps): ReactElement => {
   const { className, isSubscribed, isFetching, onClick, variant } = props;
-  const [isHovered, setIsHovered] = useState(false);
-
-  let label = isSubscribed ? 'Following' : 'Follow';
-
-  if (isHovered && isSubscribed) {
-    label = 'Unfollow';
-  }
 
   return (
     <Button
-      aria-label={label}
+      aria-label={`Toggle follow status, currently you are ${
+        isSubscribed ? 'following' : 'not following'
+      }`}
       className={classNames(
         isSubscribed &&
-          'min-w-24 hover:bg-overlay-float-ketchup hover:text-accent-ketchup-default',
+          'group min-w-24 hover:bg-overlay-float-ketchup hover:text-accent-ketchup-default',
         className,
       )}
       disabled={isFetching}
       onClick={onClick}
       size={ButtonSize.Small}
       variant={isSubscribed ? ButtonVariant.Subtle : variant}
-      onMouseEnter={() => {
-        setIsHovered(true);
-      }}
-      onMouseOut={() => {
-        setIsHovered(false);
-      }}
     >
-      {label}
+      <span className="group-hover:hidden">
+        {isSubscribed ? 'Following' : 'Follow'}
+      </span>
+      <span className="hidden group-hover:block">
+        {isSubscribed ? 'Unfollow' : 'Follow'}
+      </span>
     </Button>
   );
 };

--- a/packages/shared/src/components/sources/SourceActions/SourceActionsFollow.tsx
+++ b/packages/shared/src/components/sources/SourceActions/SourceActionsFollow.tsx
@@ -1,4 +1,5 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, useState } from 'react';
+import classNames from 'classnames';
 import { ButtonSize, ButtonVariant } from '../../buttons/common';
 import { Button } from '../../buttons/Button';
 
@@ -12,15 +13,32 @@ interface SourceActionsFollowProps {
 
 const SourceActionsFollow = (props: SourceActionsFollowProps): ReactElement => {
   const { className, isSubscribed, isFetching, onClick, variant } = props;
-  const label = isSubscribed ? 'Unfollow' : 'Follow';
+  const [isHovered, setIsHovered] = useState(false);
+
+  let label = isSubscribed ? 'Following' : 'Follow';
+
+  if (isHovered && isSubscribed) {
+    label = 'Unfollow';
+  }
+
   return (
     <Button
       aria-label={label}
-      className={className}
+      className={classNames(
+        isSubscribed &&
+          'min-w-24 hover:bg-overlay-float-ketchup hover:text-accent-ketchup-default',
+        className,
+      )}
       disabled={isFetching}
       onClick={onClick}
       size={ButtonSize.Small}
-      variant={isSubscribed ? ButtonVariant.Tertiary : variant}
+      variant={isSubscribed ? ButtonVariant.Subtle : variant}
+      onMouseEnter={() => {
+        setIsHovered(true);
+      }}
+      onMouseOut={() => {
+        setIsHovered(false);
+      }}
     >
       {label}
     </Button>

--- a/packages/shared/src/components/sources/SourceActions/SourceActionsNotify.tsx
+++ b/packages/shared/src/components/sources/SourceActions/SourceActionsNotify.tsx
@@ -15,7 +15,7 @@ const SourceActionsNotify = (props: SourceActionsNotifyProps): ReactElement => {
   const icon = haveNotificationsOn ? <BellSubscribedIcon /> : <BellAddIcon />;
   const label = `${haveNotificationsOn ? 'Disable' : 'Enable'} notifications`;
   const variant = haveNotificationsOn
-    ? ButtonVariant.Tertiary
+    ? ButtonVariant.Subtle
     : ButtonVariant.Secondary;
 
   return (

--- a/packages/shared/src/components/widgets/PostUsersHighlights.tsx
+++ b/packages/shared/src/components/widgets/PostUsersHighlights.tsx
@@ -226,7 +226,7 @@ export const UserHighlight = (props: UserHighlightProps): ReactElement => {
       )}
       {isUserType && (
         <FollowButton
-          userId="testuser"
+          userId={id}
           type={ContentPreferenceType.User}
           status={(user as CommentAuthor).contentPreference?.status}
           entityName={`@${handleOrUsernameOrId}`}

--- a/packages/shared/src/components/widgets/PostUsersHighlights.tsx
+++ b/packages/shared/src/components/widgets/PostUsersHighlights.tsx
@@ -20,6 +20,8 @@ import { SourceActions } from '../sources/SourceActions';
 import { Source as ISource } from '../../graphql/sources';
 import { TruncateText } from '../utilities';
 import { VerifiedCompanyUserBadge } from '../VerifiedCompanyUserBadge';
+import { FollowButton } from '../contentPreference/FollowButton';
+import { ContentPreferenceType } from '../../graphql/contentPreference';
 
 interface PostAuthorProps {
   post: Post;
@@ -106,6 +108,8 @@ const Image = (props: ImageProps) => {
   );
 };
 
+const userTypes = [UserType.Author, UserType.Scout];
+
 export const UserHighlight = (props: UserHighlightProps): ReactElement => {
   const { userType, ...user } = props;
   const {
@@ -124,6 +128,7 @@ export const UserHighlight = (props: UserHighlightProps): ReactElement => {
 
   const Icon = getUserIcon(userType);
   const isUserTypeSource = userType === UserType.Source && 'handle' in user;
+  const isUserType = userTypes.includes(userType);
   const { feedSettings } = useFeedSettings();
 
   const isSourceBlocked = useMemo(() => {
@@ -217,6 +222,14 @@ export const UserHighlight = (props: UserHighlightProps): ReactElement => {
           }}
           hideBlock
           source={user}
+        />
+      )}
+      {isUserType && (
+        <FollowButton
+          userId="testuser"
+          type={ContentPreferenceType.User}
+          status={(user as CommentAuthor).contentPreference?.status}
+          entityName={`@${handleOrUsernameOrId}`}
         />
       )}
     </div>

--- a/packages/shared/src/graphql/comments.ts
+++ b/packages/shared/src/graphql/comments.ts
@@ -5,6 +5,7 @@ import { EmptyResponse } from './emptyResponse';
 import { UserShortProfile } from '../lib/user';
 import type { Post, UserVote } from './posts';
 import { Company } from '../lib/userCompany';
+import { ContentPreference } from './contentPreference';
 
 export interface Author {
   __typename?: string;
@@ -17,6 +18,7 @@ export interface Author {
   createdAt?: string;
   reputation?: number;
   companies?: Company[];
+  contentPreference?: ContentPreference;
 }
 
 export type Scout = Author;

--- a/packages/shared/src/graphql/contentPreference.ts
+++ b/packages/shared/src/graphql/contentPreference.ts
@@ -13,7 +13,7 @@ export enum ContentPreferenceStatus {
 
 export type ContentPreference = {
   referenceId: string;
-  user: UserShortProfile;
+  user: Pick<UserShortProfile, 'id' | 'name' | 'image' | 'username'>;
   type: ContentPreferenceType;
   createdAt: Date;
   status: ContentPreferenceStatus;
@@ -57,3 +57,23 @@ export const USER_FOLLOWERS_QUERY = gql`
 `;
 
 export const DEFAULT_FOLLOW_LIMIT = 20;
+
+export const CONTENT_PREFERENCE_FOLLOW_MUTATION = gql`
+  mutation Follow(
+    $id: ID!
+    $entity: ContentPreferenceType!
+    $status: FollowStatus!
+  ) {
+    follow(id: $id, entity: $entity, status: $status) {
+      _
+    }
+  }
+`;
+
+export const CONTENT_PREFERENCE_UNFOLLOW_MUTATION = gql`
+  mutation Unfollow($id: ID!, $entity: ContentPreferenceType!) {
+    unfollow(id: $id, entity: $entity) {
+      _
+    }
+  }
+`;

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -32,6 +32,46 @@ export const USER_SHORT_INFO_FRAGMENT = gql`
   }
 `;
 
+export const CONTENT_PREFERENCE_FRAMENT = gql`
+  fragment ContentPreferenceFragment on ContentPreference {
+    referenceId
+    user {
+      id
+      name
+      image
+      username
+    }
+    type
+    status
+  }
+  ${USER_SHORT_INFO_FRAGMENT}
+`;
+
+export const USER_FOLLOW_FRAGMENT = gql`
+  fragment UserFollow on ContentPreferenceConnection {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    edges {
+      node {
+        ...ContentPreferenceFragment
+      }
+    }
+  }
+  ${CONTENT_PREFERENCE_FRAMENT}
+`;
+
+export const USER_AUTHOR_FRAGMENT = gql`
+  fragment UserAuthor on User {
+    ...UserShortInfo
+    contentPreference {
+      ...ContentPreferenceFragment
+    }
+  }
+  ${CONTENT_PREFERENCE_FRAMENT}
+`;
+
 export const SOURCE_DIRECTORY_INFO_FRAGMENT = gql`
   fragment SourceDirectoryInfo on Source {
     id
@@ -143,7 +183,7 @@ export const SHARED_POST_INFO_FRAGMENT = gql`
       ...UserShortInfo
     }
     author {
-      ...UserShortInfo
+      ...UserAuthor
     }
     type
     tags
@@ -164,7 +204,7 @@ export const SHARED_POST_INFO_FRAGMENT = gql`
     domain
   }
   ${SOURCE_BASE_FRAGMENT}
-  ${USER_SHORT_INFO_FRAGMENT}
+  ${USER_AUTHOR_FRAGMENT}
 `;
 
 export const COMMENT_FRAGMENT = gql`
@@ -176,13 +216,13 @@ export const COMMENT_FRAGMENT = gql`
     permalink
     numUpvotes
     author {
-      ...UserShortInfo
+      ...UserAuthor
     }
     userState {
       vote
     }
   }
-  ${USER_SHORT_INFO_FRAGMENT}
+  ${USER_AUTHOR_FRAGMENT}
 `;
 
 export const RELATED_POST_FRAGMENT = gql`
@@ -231,32 +271,4 @@ export const USER_STREAK_FRAGMENT = gql`
     lastViewAt
     weekStart
   }
-`;
-
-export const CONTENT_PREFERENCE_FRAMENT = gql`
-  fragment ContentPreferenceFragment on ContentPreference {
-    referenceId
-    user {
-      ...UserShortInfo
-    }
-    type
-    createdAt
-    status
-  }
-  ${USER_SHORT_INFO_FRAGMENT}
-`;
-
-export const USER_FOLLOW_FRAGMENT = gql`
-  fragment UserFollow on ContentPreferenceConnection {
-    pageInfo {
-      endCursor
-      hasNextPage
-    }
-    edges {
-      node {
-        ...ContentPreferenceFragment
-      }
-    }
-  }
-  ${CONTENT_PREFERENCE_FRAMENT}
 `;

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -180,7 +180,7 @@ export const SHARED_POST_INFO_FRAGMENT = gql`
       remindAt
     }
     scout {
-      ...UserShortInfo
+      ...UserAuthor
     }
     author {
       ...UserAuthor

--- a/packages/shared/src/graphql/furtherReading.ts
+++ b/packages/shared/src/graphql/furtherReading.ts
@@ -23,7 +23,7 @@ const FURTHER_READING_FRAGMENT = gql`
       ...SourceShortInfo
     }
     scout {
-      ...UserShortInfo
+      ...UserAuthor
     }
     author {
       ...UserAuthor

--- a/packages/shared/src/graphql/furtherReading.ts
+++ b/packages/shared/src/graphql/furtherReading.ts
@@ -1,8 +1,5 @@
 import { gql } from 'graphql-request';
-import {
-  SOURCE_SHORT_INFO_FRAGMENT,
-  USER_SHORT_INFO_FRAGMENT,
-} from './fragments';
+import { SOURCE_SHORT_INFO_FRAGMENT, USER_AUTHOR_FRAGMENT } from './fragments';
 import { Post } from './posts';
 
 export type FurtherReadingData = {
@@ -29,11 +26,11 @@ const FURTHER_READING_FRAGMENT = gql`
       ...UserShortInfo
     }
     author {
-      ...UserShortInfo
+      ...UserAuthor
     }
   }
   ${SOURCE_SHORT_INFO_FRAGMENT}
-  ${USER_SHORT_INFO_FRAGMENT}
+  ${USER_AUTHOR_FRAGMENT}
 `;
 
 export const FURTHER_READING_QUERY = gql`

--- a/packages/shared/src/hooks/contentPreference/types.ts
+++ b/packages/shared/src/hooks/contentPreference/types.ts
@@ -1,0 +1,44 @@
+import {
+  ContentPreferenceStatus,
+  ContentPreferenceType,
+} from '../../graphql/contentPreference';
+import { RequestKey } from '../../lib/query';
+import { PropsParameters } from '../../types';
+import { UseMutationMatcher } from '../mutationSubscription/types';
+
+export type ContentPreferenceMutation = ({
+  id,
+  entity,
+  entityName,
+}: {
+  id: string;
+  entity: ContentPreferenceType;
+  entityName: string;
+}) => Promise<void>;
+
+export const contentPreferenceMutationMatcher: UseMutationMatcher<
+  PropsParameters<ContentPreferenceMutation>
+> = ({ status, mutation }) => {
+  const [requestKey] = Array.isArray(mutation.options.mutationKey)
+    ? mutation.options.mutationKey
+    : [];
+
+  return (
+    status === 'success' &&
+    [
+      RequestKey.ContentPreferenceFollow,
+      RequestKey.ContentPreferenceUnfollow,
+      RequestKey.ContentPreferenceSubscribe,
+      RequestKey.ContentPreferenceUnsubscribe,
+    ].includes(requestKey as RequestKey)
+  );
+};
+
+export const mutationKeyToContentPreferenceStatusMap: Partial<
+  Record<RequestKey, ContentPreferenceStatus | null>
+> = {
+  [RequestKey.ContentPreferenceFollow]: ContentPreferenceStatus.Follow,
+  [RequestKey.ContentPreferenceUnfollow]: null,
+  [RequestKey.ContentPreferenceSubscribe]: ContentPreferenceStatus.Subscribed,
+  [RequestKey.ContentPreferenceUnsubscribe]: ContentPreferenceStatus.Follow,
+};

--- a/packages/shared/src/hooks/contentPreference/useContentPreference.ts
+++ b/packages/shared/src/hooks/contentPreference/useContentPreference.ts
@@ -93,7 +93,7 @@ export const useContentPreference = (): UseContentPreference => {
         status: ContentPreferenceStatus.Follow,
       });
 
-      displayToast(`✅ You are no longer subscribed to ${entityName}`);
+      displayToast(`⛔️ You are no longer subscribed to ${entityName}`);
     },
     {
       mutationKey: generateQueryKey(

--- a/packages/shared/src/hooks/contentPreference/useContentPreference.ts
+++ b/packages/shared/src/hooks/contentPreference/useContentPreference.ts
@@ -1,0 +1,122 @@
+import { useMutation } from '@tanstack/react-query';
+import {
+  CONTENT_PREFERENCE_FOLLOW_MUTATION,
+  CONTENT_PREFERENCE_UNFOLLOW_MUTATION,
+  ContentPreferenceStatus,
+  ContentPreferenceType,
+} from '../../graphql/contentPreference';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { gqlClient } from '../../graphql/common';
+import { PropsParameters } from '../../types';
+import { generateQueryKey, RequestKey } from '../../lib/query';
+import { useToastNotification } from '../useToastNotification';
+
+type ContentPreferenceMutation = ({
+  id,
+  entity,
+  entityName,
+}: {
+  id: string;
+  entity: ContentPreferenceType;
+  entityName: string;
+}) => Promise<void>;
+
+export type UseContentPreference = {
+  follow: ContentPreferenceMutation;
+  unfollow: ContentPreferenceMutation;
+  subscribe: ContentPreferenceMutation;
+  unsubscribe: ContentPreferenceMutation;
+};
+
+export const useContentPreference = (): UseContentPreference => {
+  const { user } = useAuthContext();
+  const { displayToast } = useToastNotification();
+
+  const { mutateAsync: follow } = useMutation(
+    async ({
+      id,
+      entity,
+      entityName,
+    }: PropsParameters<UseContentPreference['follow']>) => {
+      await gqlClient.request(CONTENT_PREFERENCE_FOLLOW_MUTATION, {
+        id,
+        entity,
+        status: ContentPreferenceStatus.Follow,
+      });
+
+      displayToast(`✅ You are now following ${entityName}`);
+    },
+    {
+      mutationKey: generateQueryKey(RequestKey.ContentPreferenceFollow, user),
+    },
+  );
+
+  const { mutateAsync: unfollow } = useMutation(
+    async ({
+      id,
+      entity,
+      entityName,
+    }: PropsParameters<UseContentPreference['unfollow']>) => {
+      await gqlClient.request(CONTENT_PREFERENCE_UNFOLLOW_MUTATION, {
+        id,
+        entity,
+      });
+
+      displayToast(`⛔️ You are no longer following ${entityName}`);
+    },
+    {
+      mutationKey: generateQueryKey(RequestKey.ContentPreferenceUnfollow, user),
+    },
+  );
+
+  const { mutateAsync: subscribe } = useMutation(
+    async ({
+      id,
+      entity,
+      entityName,
+    }: PropsParameters<UseContentPreference['subscribe']>) => {
+      await gqlClient.request(CONTENT_PREFERENCE_FOLLOW_MUTATION, {
+        id,
+        entity,
+        status: ContentPreferenceStatus.Subscribed,
+      });
+
+      displayToast(`✅ You are now subscribed to ${entityName}`);
+    },
+    {
+      mutationKey: generateQueryKey(
+        RequestKey.ContentPreferenceSubscribe,
+        user,
+      ),
+    },
+  );
+
+  const { mutateAsync: unsubscribe } = useMutation(
+    async ({
+      id,
+      entity,
+      entityName,
+    }: PropsParameters<UseContentPreference['subscribe']>) => {
+      await gqlClient.request(CONTENT_PREFERENCE_FOLLOW_MUTATION, {
+        id,
+        entity,
+        status: ContentPreferenceStatus.Follow,
+      });
+
+      displayToast(`✅ You are no longer subscribed to ${entityName}`);
+    },
+    {
+      mutationKey: generateQueryKey(
+        RequestKey.ContentPreferenceUnsubscribe,
+        user,
+      ),
+    },
+  );
+
+  return {
+    follow,
+    unfollow,
+    subscribe,
+    unsubscribe,
+  };
+};

--- a/packages/shared/src/hooks/contentPreference/useContentPreference.ts
+++ b/packages/shared/src/hooks/contentPreference/useContentPreference.ts
@@ -3,23 +3,13 @@ import {
   CONTENT_PREFERENCE_FOLLOW_MUTATION,
   CONTENT_PREFERENCE_UNFOLLOW_MUTATION,
   ContentPreferenceStatus,
-  ContentPreferenceType,
 } from '../../graphql/contentPreference';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { gqlClient } from '../../graphql/common';
 import { PropsParameters } from '../../types';
 import { generateQueryKey, RequestKey } from '../../lib/query';
 import { useToastNotification } from '../useToastNotification';
-
-type ContentPreferenceMutation = ({
-  id,
-  entity,
-  entityName,
-}: {
-  id: string;
-  entity: ContentPreferenceType;
-  entityName: string;
-}) => Promise<void>;
+import { ContentPreferenceMutation } from './types';
 
 export type UseContentPreference = {
   follow: ContentPreferenceMutation;

--- a/packages/shared/src/hooks/usePostById.ts
+++ b/packages/shared/src/hooks/usePostById.ts
@@ -14,8 +14,19 @@ import {
   RelatedPost,
 } from '../graphql/posts';
 import { PostCommentsData } from '../graphql/comments';
-import { generateQueryKey, RequestKey } from '../lib/query';
+import {
+  generateQueryKey,
+  RequestKey,
+  updateAuthorContentPreference,
+} from '../lib/query';
 import { Connection, gqlClient } from '../graphql/common';
+import { useMutationSubscription } from './mutationSubscription/useMutationSubscription';
+import {
+  ContentPreferenceMutation,
+  contentPreferenceMutationMatcher,
+  mutationKeyToContentPreferenceStatusMap,
+} from './contentPreference/types';
+import { PropsParameters } from '../types';
 
 interface UsePostByIdProps {
   id: string;
@@ -114,6 +125,52 @@ const usePostById = ({ id, options = {} }: UsePostByIdProps): UsePostById => {
     },
   );
   const post = postById || (options?.initialData as PostData);
+
+  useMutationSubscription({
+    matcher: contentPreferenceMutationMatcher,
+    callback: ({ mutation, variables: mutationVariables, queryClient }) => {
+      const currentData = queryClient.getQueryData(key);
+      const [requestKey] = mutation.options.mutationKey as [
+        RequestKey,
+        ...unknown[],
+      ];
+
+      if (!currentData) {
+        return;
+      }
+
+      queryClient.setQueryData<PostData>(key, (data) => {
+        const { id: entityId, entity } =
+          mutationVariables as PropsParameters<ContentPreferenceMutation>;
+
+        const nextStatus = mutationKeyToContentPreferenceStatusMap[requestKey];
+
+        if (typeof nextStatus === 'undefined') {
+          return data;
+        }
+
+        const newData = structuredClone(data);
+
+        if (newData.post?.author?.id === entityId) {
+          newData.post.author = updateAuthorContentPreference({
+            data: newData.post.author,
+            status: nextStatus,
+            entity,
+          });
+        }
+
+        if (newData.post?.scout?.id === entityId) {
+          newData.post.scout = updateAuthorContentPreference({
+            data: newData.post.scout,
+            status: nextStatus,
+            entity,
+          });
+        }
+
+        return newData;
+      });
+    },
+  });
 
   return useMemo(
     () => ({

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -13,6 +13,11 @@ import { LoggedUser } from './user';
 import { FeedData, Post, ReadHistoryPost } from '../graphql/posts';
 import { ReadHistoryInfiniteData } from '../hooks/useInfiniteReadingHistory';
 import { SharedFeedPage } from '../components/utilities';
+import { Author as UserAuthor } from '../graphql/comments';
+import {
+  ContentPreferenceStatus,
+  ContentPreferenceType,
+} from '../graphql/contentPreference';
 
 export enum OtherFeedPage {
   Tag = 'tag',
@@ -315,4 +320,37 @@ export const updateReadingHistoryListPost = ({
   return () => {
     queryClient.setQueryData(queryKey, oldData);
   };
+};
+
+export const updateAuthorContentPreference = ({
+  data,
+  status,
+  entity,
+}: {
+  data: UserAuthor;
+  status: ContentPreferenceStatus | null;
+  entity: ContentPreferenceType;
+}): UserAuthor => {
+  const newData = structuredClone(data);
+
+  if (!status) {
+    delete newData.contentPreference;
+
+    return newData;
+  }
+
+  newData.contentPreference = {
+    status,
+    type: entity,
+    referenceId: newData.id,
+    createdAt: new Date(),
+    user: {
+      id: newData.id,
+      name: newData.name,
+      image: newData.image,
+      username: newData.username,
+    },
+  };
+
+  return newData;
 };

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -147,6 +147,10 @@ export enum RequestKey {
   ContentPreference = 'content_preference',
   UserFollowers = 'user_followers',
   UserFollowing = 'user_following',
+  ContentPreferenceFollow = 'content_preference_follow',
+  ContentPreferenceUnfollow = 'content_preference_unfollow',
+  ContentPreferenceSubscribe = 'content_preference_subscribe',
+  ContentPreferenceUnsubscribe = 'content_preference_unsubscribe',
 }
 
 export type HasConnection<

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,0 +1,3 @@
+export type PropsParameters<
+  T extends (props: Record<string, unknown>) => unknown,
+> = T extends (props: infer P) => unknown ? P : never;

--- a/packages/webapp/__tests__/SourcePage.tsx
+++ b/packages/webapp/__tests__/SourcePage.tsx
@@ -183,8 +183,8 @@ it('should show follow button', async () => {
     createSourcesSettingsMock({ excludeSources: [] }),
   ]);
   await waitForNock();
-  const button = await screen.findByText('Follow');
-  expect(button).toBeInTheDocument();
+  const button = await screen.findAllByText('Follow');
+  expect(button[0]).toBeInTheDocument();
 });
 
 it('should show notify button if following', async () => {
@@ -205,7 +205,7 @@ it('should show notify button if following', async () => {
     }),
   ]);
   await waitForNock();
-  const unfollowButton = await screen.findByText('Following');
+  const unfollowButton = await screen.findByText('Unfollow');
   expect(unfollowButton).toBeInTheDocument();
   const notifyButton = await screen.findByLabelText('Enable notifications');
   expect(notifyButton).toBeInTheDocument();

--- a/packages/webapp/__tests__/SourcePage.tsx
+++ b/packages/webapp/__tests__/SourcePage.tsx
@@ -205,7 +205,7 @@ it('should show notify button if following', async () => {
     }),
   ]);
   await waitForNock();
-  const unfollowButton = await screen.findByText('Unfollow');
+  const unfollowButton = await screen.findByText('Following');
   expect(unfollowButton).toBeInTheDocument();
   const notifyButton = await screen.findByLabelText('Enable notifications');
   expect(notifyButton).toBeInTheDocument();


### PR DESCRIPTION
## Changes

- reuse base components from `SourceActions` components (also adjusted them to match new follow designs)
- add `useContentPreference` hook for related mutations AS-580
- add `FollowButton` component (~~currently sends mutation but page refresh is needed to view new state~~)
- add support for follow of author/scout AS-572
- adjust fragments/queries 

TODO:
- [x] handle mutations and optimistic query data update
- [x] e2e test a bit more (merging to unblock other tasks)

**!!! Opening this for review until I figure out invalidation of local cache. We can also probably merge this and use it to add the button around the app to not block other tasks.**

**!!! Update mutations handled for single post page only, we should be able to apply the concept elsewhere**

<img width="493" alt="image" src="https://github.com/user-attachments/assets/11b2f896-7657-49b3-ac6c-61b386a6a811">

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira
-->

AS-571


### Preview domain
https://as-571-follow-button.preview.app.daily.dev