### PR TITLE
fix: allow discussed feed to be public

### DIFF
--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -24,8 +24,8 @@ import { useFeatureTheme } from '../../hooks/utils/useFeatureTheme';
 import { webappUrl } from '../../lib/constants';
 import NotificationsBell from '../notifications/NotificationsBell';
 import classed from '../../lib/classed';
-import { SharedFeedPage } from '../utilities';
 import { useAuthContext } from '../../contexts/AuthContext';
+import { OtherFeedPage } from '../../lib/query';
 
 const OnboardingChecklistBar = dynamic(
   () =>
@@ -90,7 +90,7 @@ function FeedNav(): ReactElement {
 
     return {
       ...urls,
-      [`${webappUrl}${SharedFeedPage.Discussed}`]: FeedNavTab.Discussions,
+      [`${webappUrl}${OtherFeedPage.Discussed}`]: FeedNavTab.Discussions,
       [`${webappUrl}tags`]: FeedNavTab.Tags,
       [`${webappUrl}sources`]: FeedNavTab.Sources,
       [`${webappUrl}users`]: FeedNavTab.Leaderboard,

--- a/packages/shared/src/components/sidebar/DiscoverSection.tsx
+++ b/packages/shared/src/components/sidebar/DiscoverSection.tsx
@@ -9,11 +9,11 @@ import {
 import { ListIcon, SidebarMenuItem } from './common';
 import { Section, SectionCommonProps } from './Section';
 import { useActions } from '../../hooks';
-import { ActionType } from '../../graphql/actions';
 import { checkIsExtension } from '../../lib/func';
 import { webappUrl } from '../../lib/constants';
-import { SharedFeedPage } from '../utilities';
 import { OtherFeedPage } from '../../lib/query';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { ActionType } from '../../graphql/actions';
 
 interface DiscoverSectionProps extends SectionCommonProps {
   isItemsButton?: boolean;
@@ -30,10 +30,11 @@ export function DiscoverSection({
   enableSearch,
   ...defaultRenderSectionProps
 }: DiscoverSectionProps): ReactElement {
+  const { user } = useAuthContext();
   const { completeAction } = useActions();
 
   const discoverMenuItems: SidebarMenuItem[] = useMemo(() => {
-    const pushToDiscussed = locationPush(SharedFeedPage.Discussed);
+    const pushToDiscussed = locationPush(OtherFeedPage.Discussed);
     const isExtension = checkIsExtension();
     const feeds = {
       icon: (active: boolean) => (
@@ -51,7 +52,9 @@ export function DiscoverSection({
       title: 'Discussions',
       path: '/discussed',
       action: () => {
-        completeAction(ActionType.CommentFeed);
+        if (user) {
+          completeAction(ActionType.CommentFeed);
+        }
         if (isExtension) {
           pushToDiscussed();
         }

--- a/packages/shared/src/components/sidebar/DiscoverSection.tsx
+++ b/packages/shared/src/components/sidebar/DiscoverSection.tsx
@@ -89,7 +89,7 @@ export function DiscoverSection({
         action: isExtension ? locationPush('/users') : undefined,
       },
     ];
-  }, [completeAction, onNavTabClick]);
+  }, [completeAction, user, onNavTabClick]);
 
   return (
     <Section

--- a/packages/shared/src/components/utilities/common.tsx
+++ b/packages/shared/src/components/utilities/common.tsx
@@ -170,7 +170,6 @@ export enum SharedFeedPage {
   Popular = 'popular',
   Search = 'search',
   Upvoted = 'upvoted',
-  Discussed = 'discussed',
   Custom = 'custom',
   CustomForm = 'custom-form',
 }

--- a/packages/shared/src/hooks/feed/useFeedName.ts
+++ b/packages/shared/src/hooks/feed/useFeedName.ts
@@ -46,7 +46,7 @@ export const useFeedName = ({ feedName }: UseFeedNameProps): UseFeedName => {
     isExploreLatest: feedName === OtherFeedPage.ExploreLatest,
     isExploreUpvoted: feedName === OtherFeedPage.ExploreUpvoted,
     isExploreDiscussed: feedName === OtherFeedPage.ExploreDiscussed,
-    isDiscussed: feedName === SharedFeedPage.Discussed,
+    isDiscussed: feedName === OtherFeedPage.Discussed,
     isCustomFeed: customFeeds.includes(feedName),
     isSortableFeed: sortableFeeds.includes(feedName),
   };

--- a/packages/shared/src/hooks/useActiveNav.tsx
+++ b/packages/shared/src/hooks/useActiveNav.tsx
@@ -22,7 +22,7 @@ export default function useActiveNav(activeFeed: AllFeedPages): UseActiveNav {
       SharedFeedPage.MyFeed,
       SharedFeedPage.Popular,
       SharedFeedPage.Upvoted,
-      SharedFeedPage.Discussed,
+      OtherFeedPage.Discussed,
       OtherFeedPage.History,
       SharedFeedPage.Custom,
       SharedFeedPage.CustomForm,

--- a/packages/shared/src/hooks/useFeedLayout.ts
+++ b/packages/shared/src/hooks/useFeedLayout.ts
@@ -133,7 +133,7 @@ export const useFeedLayout = ({
       shouldUseListMode
     : isListMode || !isLaptop;
 
-  const shouldUseCommentFeedLayout = feedName === SharedFeedPage.Discussed;
+  const shouldUseCommentFeedLayout = feedName === OtherFeedPage.Discussed;
 
   const FeedPageLayoutComponent = getFeedPageLayoutComponent({
     shouldUseListMode,

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -42,6 +42,7 @@ export enum OtherFeedPage {
   ExploreUpvoted = 'postsupvoted',
   FeedByIds = 'feed-by-ids',
   Welcome = 'welcome',
+  Discussed = 'discussed',
 }
 
 const ONE_MINUTE = 60 * 1000;


### PR DESCRIPTION
## Changes

Discussed feed should be public available

API: https://github.com/dailydotdev/daily-api/pull/2265

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-563 #done

### Preview domain
https://as-563-public-discussed-feed.preview.app.daily.dev