### PR TITLE
fix: squad list modal

### DIFF
--- a/packages/shared/src/components/modals/SquadMemberModal.tsx
+++ b/packages/shared/src/components/modals/SquadMemberModal.tsx
@@ -16,12 +16,13 @@ import { LinkIcon } from '../icons';
 import { useSquadInvitation } from '../../hooks/useSquadInvitation';
 import { FlexCentered } from '../utilities';
 import { useSquadActions } from '../../hooks';
-import SquadMemberItemAdditionalContent from '../squads/SquadMemberItemAdditionalContent';
+import SquadMemberItemRole from '../squads/SquadMemberItemRole';
 import { verifyPermission } from '../../graphql/squads';
 import useDebounceFn from '../../hooks/useDebounceFn';
 import { defaultSearchDebounceMs } from '../../lib/func';
 import { BlockedMembersPlaceholder } from '../squads/Members';
 import { ContextMenu } from '../../hooks/constants';
+import SquadMemberItemOptionsButton from '../squads/SquadMemberItemOptionsButton';
 
 enum SquadMemberTab {
   AllMembers = 'Squad members',
@@ -122,8 +123,13 @@ export function SquadMemberModal({
           onScroll: hideMenu,
         }}
         userListProps={{
-          additionalContent: (user, index) => (
-            <SquadMemberItemAdditionalContent
+          additionalContent: (user, index) => [
+            <SquadMemberItemRole
+              member={members[index]}
+              key={`squad_role_${user.id}`}
+            />,
+            <SquadMemberItemOptionsButton
+              key={`squad_option_${user.id}`}
               member={members[index]}
               onUnblock={() =>
                 onUnblock({ sourceId: squad.id, memberId: user.id })
@@ -132,8 +138,8 @@ export function SquadMemberModal({
                 e.preventDefault();
                 onOptionsClick(e, members[index]);
               }}
-            />
-          ),
+            />,
+          ],
           emptyPlaceholder: query ? (
             <FlexCentered className="p-10 text-text-tertiary typo-callout">
               No user found

--- a/packages/shared/src/components/profile/UserList.tsx
+++ b/packages/shared/src/components/profile/UserList.tsx
@@ -11,7 +11,10 @@ export interface UserListProps {
   scrollingProps: Omit<InfiniteScrollingProps, 'children'>;
   users: UserShortProfile[];
   placeholderAmount?: number;
-  additionalContent?: (user: UserShortProfile, index: number) => ReactNode;
+  additionalContent?: (
+    user: UserShortProfile,
+    index: number,
+  ) => [ReactNode, ReactNode?];
   initialItem?: ReactElement;
   isLoading?: boolean;
   emptyPlaceholder?: JSX.Element;
@@ -50,8 +53,9 @@ function UserList({
               tag="a"
               href={user.permalink}
               user={user}
+              endChildren={additionalContent?.(user, i)[1]}
             >
-              {additionalContent?.(user, i)}
+              {additionalContent?.(user, i)[0]}
             </UserShortInfo>
           </Link>
         ))}

--- a/packages/shared/src/components/profile/UserShortInfo.tsx
+++ b/packages/shared/src/components/profile/UserShortInfo.tsx
@@ -32,6 +32,7 @@ export interface UserShortInfoProps<
   scrollingContainer?: HTMLElement;
   appendTooltipTo?: HTMLElement;
   children?: ReactNode;
+  endChildren?: ReactNode;
   showDescription?: boolean;
   transformUsername?(user: UserShortProfile): ReactNode;
   onClick?: () => void;
@@ -52,6 +53,7 @@ const UserShortInfoComponent = <Tag extends React.ElementType>(
     scrollingContainer,
     appendTooltipTo,
     children,
+    endChildren,
     showDescription = true,
     transformUsername,
     ...props
@@ -116,6 +118,7 @@ const UserShortInfoComponent = <Tag extends React.ElementType>(
         status={(user as LoggedUser).contentPreference?.status}
         entityName={`@${user.name}`}
       />
+      {endChildren}
     </Element>
   );
 };

--- a/packages/shared/src/components/squads/SquadMemberItemOptionsButton.tsx
+++ b/packages/shared/src/components/squads/SquadMemberItemOptionsButton.tsx
@@ -4,7 +4,6 @@ import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { BlockIcon, MenuIcon } from '../icons';
 import { SimpleTooltip } from '../tooltips/SimpleTooltip';
 import { useAuthContext } from '../../contexts/AuthContext';
-import SquadMemberBadge from './SquadMemberBadge';
 import { PromptOptions, usePrompt } from '../../hooks/usePrompt';
 import { UserShortInfo } from '../profile/UserShortInfo';
 import { useToastNotification } from '../../hooks';
@@ -15,7 +14,7 @@ interface SquadMemberActionsProps {
   onOptionsClick: React.MouseEventHandler;
 }
 
-function SquadMemberItemAdditionalContent({
+function SquadMemberItemOptionsButton({
   member,
   onUnblock,
   onOptionsClick,
@@ -58,7 +57,7 @@ function SquadMemberItemAdditionalContent({
     return (
       <SimpleTooltip content="Unblock">
         <Button
-          className="my-auto"
+          className="my-auto ml-2"
           variant={ButtonVariant.Tertiary}
           icon={<BlockIcon />}
           onClick={onConfirmUnblock}
@@ -72,7 +71,7 @@ function SquadMemberItemAdditionalContent({
       <Button
         size={ButtonSize.Small}
         variant={ButtonVariant.Tertiary}
-        className="m-auto mr-0"
+        className="m-auto ml-2 mr-0"
         onClick={onOptionsClick}
         icon={<MenuIcon />}
       />
@@ -82,19 +81,7 @@ function SquadMemberItemAdditionalContent({
   const sameUser = loggedUser && loggedUser.id === user.id;
   const hideOption = sameUser || !loggedUser;
 
-  if (role !== SourceMemberRole.Member) {
-    return (
-      <>
-        <SquadMemberBadge
-          className={sameUser ? 'mr-10' : 'mr-2'}
-          role={member.role}
-        />
-        {hideOption ? null : option}
-      </>
-    );
-  }
-
   return hideOption ? null : option;
 }
 
-export default SquadMemberItemAdditionalContent;
+export default SquadMemberItemOptionsButton;

--- a/packages/shared/src/components/squads/SquadMemberItemRole.tsx
+++ b/packages/shared/src/components/squads/SquadMemberItemRole.tsx
@@ -1,0 +1,30 @@
+import React, { ReactElement } from 'react';
+import { SourceMember, SourceMemberRole } from '../../graphql/sources';
+import { useAuthContext } from '../../contexts/AuthContext';
+import SquadMemberBadge from './SquadMemberBadge';
+
+interface SquadMemberItemRoleProps {
+  member: SourceMember;
+}
+
+function SquadMemberItemRole({
+  member,
+}: SquadMemberItemRoleProps): ReactElement {
+  const { user: loggedUser } = useAuthContext();
+  const { role, user } = member;
+
+  const sameUser = loggedUser && loggedUser.id === user.id;
+
+  if (role === SourceMemberRole.Member) {
+    return null;
+  }
+
+  return (
+    <SquadMemberBadge
+      className={sameUser ? 'mr-10' : 'mr-2'}
+      role={member.role}
+    />
+  );
+}
+
+export default SquadMemberItemRole;


### PR DESCRIPTION
## Changes

Added some changes so we can render items before and after the follow button in UserShortInfo (needed for squads now)

<img width="584" alt="Screenshot 2024-09-20 at 13 53 40" src="https://github.com/user-attachments/assets/b4b6274d-1eb5-46d0-8f31-aea0335dc3c1">

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-593 #done 
