### PR TITLE
feat: notification changes

### DIFF
--- a/packages/shared/src/components/notifications/utils.ts
+++ b/packages/shared/src/components/notifications/utils.ts
@@ -149,7 +149,7 @@ export const notificationMutingCopy: Partial<
   },
   [NotificationType.UserPostAdded]: {
     mute: 'Mute notifications',
-    unmute: 'Mute notifications',
+    unmute: 'Unmute notifications',
   },
 };
 

--- a/packages/shared/src/components/notifications/utils.ts
+++ b/packages/shared/src/components/notifications/utils.ts
@@ -50,6 +50,7 @@ export enum NotificationType {
   CollectionUpdated = 'collection_updated',
   SourcePostAdded = 'source_post_added',
   SquadPublicApproved = 'squad_public_approved',
+  UserPostAdded = 'user_post_added',
 }
 
 export enum NotificationIconType {
@@ -145,6 +146,10 @@ export const notificationMutingCopy: Partial<
   [NotificationType.SquadReply]: {
     mute: 'Mute this thread',
     unmute: 'Unmute this thread',
+  },
+  [NotificationType.UserPostAdded]: {
+    mute: 'Mute notifications',
+    unmute: 'Mute notifications',
   },
 };
 


### PR DESCRIPTION
## Changes

Option to mute user_post_added notification.
Follows common practice in app, we decided to enhance in phase 2 only as it requires many rewrites.

API: https://github.com/dailydotdev/daily-api/pull/2272

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-574 #done 


### Preview domain
https://as-574-notification-changes.preview.app.daily.dev