### PR TITLE
refactor: squads directory to filter threshold validity

### DIFF
--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -73,6 +73,7 @@ interface SourceFlags {
   totalPosts: number;
   totalViews: number;
   totalUpvotes: number;
+  publicThreshold: boolean;
 }
 
 export interface Source {

--- a/packages/shared/src/hooks/source/useSources.ts
+++ b/packages/shared/src/hooks/source/useSources.ts
@@ -20,6 +20,7 @@ export interface SourcesQueryProps {
   featured?: boolean;
   categoryId?: string;
   sortByMembersCount?: boolean;
+  publicThreshold?: boolean;
   first?: number;
 }
 

--- a/packages/webapp/pages/squads/discover/[id].tsx
+++ b/packages/webapp/pages/squads/discover/[id].tsx
@@ -44,6 +44,7 @@ function SquadCategoryPage({ category }: SquadCategoryPageProps): ReactElement {
       sortByMembersCount: true,
       categoryId: category.id,
       isPublic: true,
+      publicThreshold: true,
     },
   });
   const { isInitialLoading } = result;

--- a/packages/webapp/pages/squads/discover/index.tsx
+++ b/packages/webapp/pages/squads/discover/index.tsx
@@ -66,6 +66,7 @@ function SquadDiscoveryPage(): ReactElement {
             isPublic: true,
             first: limit,
             sortByMembersCount: true,
+            publicThreshold: true,
           }}
         />
       ))}


### PR DESCRIPTION
## Changes
- Allow the directory to be filtered by threshold validity.
- **Note:** we should not merge this until API is merged, and until the cron has run for the first time (I will do the verification on this one before merging).

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

MI-558


### Preview domain
https://mi-558.preview.app.daily.dev