### PR TITLE
Revert "updated utility.css to solve missing border issue"

### DIFF
--- a/packages/shared/src/styles/utilities.css
+++ b/packages/shared/src/styles/utilities.css
@@ -4,7 +4,6 @@
 
     &:focus-visible {
       box-shadow: 0 0 0 0.125rem var(--theme-accent-blueCheese-default);
-      border-radius: 1rem;
     }
   }
 }


### PR DESCRIPTION
Reverts dailydotdev/apps#3574

This affected the focus on the buttons. The fix should be exclusive to the card itself only.

<img width="282" alt="Screenshot 2024-09-26 at 3 17 12 PM" src="https://github.com/user-attachments/assets/4c05fb70-d414-4396-b084-573ccff04923">



### Preview domain
https://revert-3574-card-border-missing.preview.app.daily.dev