### PR TITLE
changed the z-index of header

### DIFF
--- a/packages/shared/tailwind.config.ts
+++ b/packages/shared/tailwind.config.ts
@@ -99,7 +99,7 @@ export default {
       2: '2',
       3: '3',
       rank: '30',
-      header: '75',
+      header: '10000',
       postNavigation: '76',
       sidebar: '70',
       sidebarOverlay: '77',


### PR DESCRIPTION
## Changes

### Describe what this PR does
- Fixed the overflow issue of the tooltip (`div` with id `tippy`) that appears on hovering over any profile in the feed.
- Adjusted the `z-header` value in the Tailwind configuration from 75 to 10000 to ensure the header component sits above the tooltip which has z-index of 9999.
- This change prevents the tooltip from overlapping the header, improving the user interface.
- This issue was raised in the [dailydotdev/daily #1463](https://github.com/dailydotdev/daily/issues/1463) repository.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [x] iOS (Chrome and Safari)
- [ ] Android

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-1463 #done
or
MI-{number} #done
-->

AS-1463 #done
