### PR TITLE
fix: change squad activeFeed name to reflect new path;

### DIFF
--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -109,29 +109,14 @@ const getStyle = (isList: boolean, space: Spaciness): CSSProperties => {
 };
 
 const feedNameToHeading: Record<
-  Exclude<
+  Extract<
     FeedPagesWithMobileLayoutType,
-    | 'user-upvoted'
-    | 'user-posts'
-    | 'squads[handle]'
-    | 'tags[tag]'
-    | 'sources[source]'
-    | 'search-bookmarks'
-    | 'sources[source]/most-upvoted'
-    | 'sources[source]/best-discussed'
-    | 'tags[tag]/most-upvoted'
-    | 'tags[tag]/best-discussed'
-    | SharedFeedPage.Custom
-    | SharedFeedPage.CustomForm
-    | OtherFeedPage.Explore
-    | OtherFeedPage.ExploreLatest
-    | OtherFeedPage.ExploreUpvoted
-    | OtherFeedPage.ExploreDiscussed
-    | OtherFeedPage.Tags
-    | OtherFeedPage.Sources
-    | OtherFeedPage.Leaderboard
-    | OtherFeedPage.FeedByIds
-    | OtherFeedPage.Welcome
+    | SharedFeedPage.Search
+    | SharedFeedPage.MyFeed
+    | SharedFeedPage.Popular
+    | SharedFeedPage.Upvoted
+    | OtherFeedPage.Discussed
+    | OtherFeedPage.Bookmarks
   >,
   string
 > = {

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -26,8 +26,8 @@ import {
 export enum OtherFeedPage {
   Tag = 'tag',
   Tags = 'tags',
-  Squad = 'squads',
-  SquadPage = 'squads[handle]',
+  Squad = 'squadsdiscover',
+  SquadPage = 'squadsdiscover[id]',
   Source = 'source',
   Sources = 'sources',
   Leaderboard = 'users',


### PR DESCRIPTION
## Changes
On mobile Squad directory page was not marked as active on navigation, quickly checked and was a 2 line fix

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://fix-squad-mobile-tab-item-active.preview.app.daily.dev