### PR TITLE
refactor: avoid unnecessary calls and properties in squads directory page

### DIFF
--- a/packages/shared/src/components/HorizontalScroll/HorizontalScroll.tsx
+++ b/packages/shared/src/components/HorizontalScroll/HorizontalScroll.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, ReactNode, useId } from 'react';
+import React, {
+  forwardRef,
+  MutableRefObject,
+  ReactElement,
+  ReactNode,
+  useId,
+} from 'react';
 import classNames from 'classnames';
 import {
   UseHorizontalScrollHeaderProps,
@@ -16,18 +22,20 @@ interface HorizontalScrollProps {
   scrollProps: UseHorizontalScrollHeaderProps;
 }
 
-export default function HorizontalScroll({
-  children,
-  className,
-  scrollProps,
-}: HorizontalScrollProps): ReactElement {
+function HorizontalScrollComponent(
+  { children, className, scrollProps }: HorizontalScrollProps,
+  propRef: MutableRefObject<HTMLDivElement>,
+): ReactElement {
   const { ref, Header } = useHorizontalScrollHeader(scrollProps);
 
   const id = useId();
   const titleId = `horizontal-scroll-title-${id}`;
 
   return (
-    <div className={classNames('flex flex-col', className?.container)}>
+    <div
+      className={classNames('flex flex-col', className?.container)}
+      ref={propRef}
+    >
       <Header titleId={titleId} />
       <div
         ref={ref}
@@ -43,3 +51,7 @@ export default function HorizontalScroll({
     </div>
   );
 }
+
+const HorizontalScroll = forwardRef(HorizontalScrollComponent);
+
+export default HorizontalScroll;

--- a/packages/shared/src/components/cards/squad/SquadsDirectoryFeed.tsx
+++ b/packages/shared/src/components/cards/squad/SquadsDirectoryFeed.tsx
@@ -59,7 +59,7 @@ export function SquadsDirectoryFeed({
 
   if (isMobile) {
     return (
-      <div className="relative flex flex-col gap-3 pb-6">
+      <div ref={ref} className="relative flex flex-col gap-3 pb-6">
         {children}
         <header className="mb-2 flex flex-row items-center justify-between">
           {title}

--- a/packages/shared/src/components/cards/squad/SquadsDirectoryFeed.tsx
+++ b/packages/shared/src/components/cards/squad/SquadsDirectoryFeed.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode, useRef } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { Squad } from '../../../graphql/sources';
 import {
@@ -42,8 +42,7 @@ export function SquadsDirectoryFeed({
   className,
   children,
 }: SquadHorizontalListProps): ReactElement {
-  const ref = useRef<HTMLDivElement>();
-  const { inView } = useInView({
+  const { ref, inView } = useInView({
     triggerOnce: true,
   });
   const { result } = useSources<Squad>({ query, isEnabled: inView });

--- a/packages/shared/src/components/cards/squad/SquadsDirectoryFeed.tsx
+++ b/packages/shared/src/components/cards/squad/SquadsDirectoryFeed.tsx
@@ -46,14 +46,14 @@ export function SquadsDirectoryFeed({
     triggerOnce: true,
   });
   const { result } = useSources<Squad>({ query, isEnabled: inView });
-  const { isInitialLoading } = result;
+  const { isFetched } = result;
   const isMobile = useViewSize(ViewSize.MobileL);
-  const isLoading = isInitialLoading || (!inView && !result.data);
+  const isLoading = !isFetched || (!inView && !result.data);
 
   const flatSources =
     result.data?.pages.flatMap((page) => page.sources.edges) ?? [];
 
-  if (flatSources.length === 0 && !isInitialLoading) {
+  if (flatSources.length === 0 && isFetched) {
     return null;
   }
 

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -138,27 +138,10 @@ export const SQUAD_BASE_FRAGMENT = `
       id
       title
     }
-    privilegedMembers {
-      user {
-        id
-        name
-        image
-        permalink
-        username
-        bio
-        reputation
-        companies {
-          name
-          image
-        }
-        contentPreference {
-          status
-        }
-      }
-      role
-    }
+    ...PrivilegedMembers
   }
   ${SOURCE_BASE_FRAGMENT}
+  ${PRIVILEGED_MEMBERS_FRAGMENT}
 `;
 
 export const SHARED_POST_INFO_FRAGMENT = gql`

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -76,6 +76,30 @@ export const SOURCE_SHORT_INFO_FRAGMENT = gql`
   }
 `;
 
+export const PRIVILEGED_MEMBERS_FRAGMENT = gql`
+  fragment PrivilegedMembers on Source {
+    privilegedMembers {
+      user {
+        id
+        name
+        image
+        permalink
+        username
+        bio
+        reputation
+        companies {
+          name
+          image
+        }
+        contentPreference {
+          status
+        }
+      }
+      role
+    }
+  }
+`;
+
 // this query should use UserShortInfo fragment once the createdAt issue is fixed.
 // for the mean time, we should not include the said property on privilegedMembers.
 export const SOURCE_BASE_FRAGMENT = gql`
@@ -90,16 +114,6 @@ export const SOURCE_BASE_FRAGMENT = gql`
     description
     image
     membersCount
-    privilegedMembers {
-      user {
-        id
-      }
-      role
-    }
-    category {
-      id
-      title
-    }
     currentMember {
       ...CurrentMember
     }
@@ -119,6 +133,10 @@ export const SQUAD_BASE_FRAGMENT = `
       totalPosts
       totalViews
       totalUpvotes
+    }
+    category {
+      id
+      title
     }
     privilegedMembers {
       user {
@@ -175,6 +193,7 @@ export const SHARED_POST_INFO_FRAGMENT = gql`
     tags
     source {
       ...SourceBaseInfo
+      ...PrivilegedMembers
     }
     downvoted
     flags {
@@ -189,6 +208,7 @@ export const SHARED_POST_INFO_FRAGMENT = gql`
     slug
     domain
   }
+  ${PRIVILEGED_MEMBERS_FRAGMENT}
   ${SOURCE_BASE_FRAGMENT}
   ${USER_AUTHOR_FRAGMENT}
 `;

--- a/packages/shared/src/hooks/source/useSources.ts
+++ b/packages/shared/src/hooks/source/useSources.ts
@@ -25,10 +25,12 @@ export interface SourcesQueryProps {
 
 interface UseSourcesProps {
   query?: SourcesQueryProps;
+  isEnabled?: boolean;
 }
 
 export const useSources = <T extends Source | Squad>({
   query = {},
+  isEnabled = true,
 }: UseSourcesProps = {}): UseSources<T> => {
   const {
     featured,
@@ -60,6 +62,7 @@ export const useSources = <T extends Source | Squad>({
         lastPage?.sources?.pageInfo?.hasNextPage &&
         lastPage?.sources?.pageInfo?.endCursor,
       staleTime: StaleTime.Default,
+      enabled: isEnabled,
     },
   );
 

--- a/packages/webapp/pages/squads/index.tsx
+++ b/packages/webapp/pages/squads/index.tsx
@@ -1,13 +1,6 @@
 import React, { ReactElement } from 'react';
-import { InfiniteData } from '@tanstack/react-query';
 import { GetServerSidePropsResult } from 'next';
-import { Squad } from '@dailydotdev/shared/src/graphql/sources';
-import { SourcesQueryData } from '@dailydotdev/shared/src/hooks/source/useSources';
 import { squadCategoriesPaths } from '@dailydotdev/shared/src/lib/constants';
-
-export type Props = {
-  initialData?: InfiniteData<SourcesQueryData<Squad>>;
-};
 
 const SquadsPage = (): ReactElement => {
   return <></>;


### PR DESCRIPTION
## Changes
- Adjusted the fragments so that only the necessary (or at least not heavy) properties are fetched for the cards.
- Utilized in view to check whether the element is in view to decide only then we will fetch the values.

Preview:

https://github.com/user-attachments/assets/88da62bc-0183-40fa-8061-66e1166eeb35

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

MI-561


### Preview domain
https://mi-561.preview.app.daily.dev