### PR TITLE
fix: failing tests

### DIFF
--- a/packages/shared/src/components/auth/ForgotPasswordForm.spec.tsx
+++ b/packages/shared/src/components/auth/ForgotPasswordForm.spec.tsx
@@ -86,7 +86,7 @@ it('should post sending email recovery including token', async () => {
   const email = 'sshanzel@yahoo.com';
   renderComponent();
   await waitForNock();
-  fireEvent.input(screen.getByPlaceholderText('Email'), {
+  fireEvent.input(screen.getByLabelText('Email'), {
     target: { value: email },
   });
   const form = await screen.findByTestId('recovery_form');

--- a/packages/shared/src/components/auth/LoginForm.spec.tsx
+++ b/packages/shared/src/components/auth/LoginForm.spec.tsx
@@ -116,7 +116,7 @@ const renderLogin = async (email: string) => {
 it('should post login including token', async () => {
   const email = 'sshanzel@yahoo.com';
   await renderLogin(email);
-  fireEvent.input(screen.getByLabelText('Password'), {
+  fireEvent.input(screen.getByTestId('login_password'), {
     target: { value: '#123xAbc' },
   });
   const form = await screen.findByTestId('login_form');
@@ -134,7 +134,7 @@ it('should display error messages', async () => {
   user = null;
   await renderLogin(email);
 
-  fireEvent.input(screen.getByLabelText('Password'), {
+  fireEvent.input(screen.getByTestId('login_password'), {
     target: { value: '#123xAbc' },
   });
   const form = await screen.findByTestId('login_form');

--- a/packages/shared/src/components/auth/RegistrationForm.spec.tsx
+++ b/packages/shared/src/components/auth/RegistrationForm.spec.tsx
@@ -96,11 +96,11 @@ const renderRegistration = async (
     },
   });
   await screen.findByTestId('registration_form');
-  const nameInput = screen.getByPlaceholderText('Name');
+  const nameInput = screen.getByLabelText('Name');
   fireEvent.input(screen.getByPlaceholderText('Enter a username'), {
     target: { value: username },
   });
-  fireEvent.input(screen.getByPlaceholderText('Name'), {
+  fireEvent.input(screen.getByLabelText('Name'), {
     target: { value: name },
   });
   simulateTextboxInput(nameInput as HTMLTextAreaElement, name);


### PR DESCRIPTION
## Changes
 
The a11y PR seem to have broken some tests because of how we focus the first elements on the forms (now either showing the label or placeholder). Not sure why these tests didn't fail on CI before the PR was merged. 


### Preview domain
https://fix-tests.preview.app.daily.dev