### PR TITLE
chore: remove mobile app bookmark prompt

### DIFF
--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -430,9 +430,6 @@ describe('Feed', () => {
 
   it('should send remove bookmark mutation', async () => {
     let mutationCalled = false;
-    mockGraphQL(
-      completeActionMock({ action: ActionType.BookmarkPromoteMobile }),
-    );
     renderComponent([
       createFeedMock({
         pageInfo: defaultFeedPage.pageInfo,

--- a/packages/shared/src/components/modals/generic/common.ts
+++ b/packages/shared/src/components/modals/generic/common.ts
@@ -1,5 +1,5 @@
 import { cloudinary } from '../../../lib/image';
-import { bookmarkLoops, migrateUserToStreaks } from '../../../lib/constants';
+import { migrateUserToStreaks } from '../../../lib/constants';
 import { MarketingCta, MarketingCtaVariant } from '../../marketingCta/common';
 
 export const promotion: Record<string, MarketingCta> = {
@@ -16,21 +16,6 @@ export const promotion: Record<string, MarketingCta> = {
       ctaUrl: migrateUserToStreaks,
       tagColor: 'avocado',
       tagText: 'New Release',
-    },
-  },
-  bookmarkPromoteMobile: {
-    campaignId: 'bookmarks on mobile',
-    createdAt: new Date(2024, 3, 19),
-    variant: MarketingCtaVariant.Popover,
-    flags: {
-      title: 'Get back to your bookmarks on the go',
-      description:
-        'Your saved posts are waiting for you on daily.dev mobile. Perfect for reading anytime, anywhere.',
-      image: cloudinary.promotions.bookmarkLoops,
-      ctaText: 'Install the app',
-      ctaUrl: bookmarkLoops,
-      tagColor: 'cabbage',
-      tagText: 'Mobile version',
     },
   },
 };

--- a/packages/shared/src/components/widgets/FurtherReading.spec.tsx
+++ b/packages/shared/src/components/widgets/FurtherReading.spec.tsx
@@ -151,9 +151,6 @@ describe('further reading', () => {
 
   it('should send add bookmark mutation', async () => {
     let mutationCalled = false;
-    mockGraphQL(
-      completeActionMock({ action: ActionType.BookmarkPromoteMobile }),
-    );
     renderComponent([
       createFeedMock(),
       {
@@ -178,9 +175,6 @@ describe('further reading', () => {
 
   it('should send remove bookmark mutation', async () => {
     let mutationCalled = false;
-    mockGraphQL(
-      completeActionMock({ action: ActionType.BookmarkPromoteMobile }),
-    );
     renderComponent([
       createFeedMock([
         { ...defaultFeedPage.edges[0].node, trending: 50, bookmarked: true },

--- a/packages/shared/src/hooks/useBookmarkPost.ts
+++ b/packages/shared/src/hooks/useBookmarkPost.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useMemo } from 'react';
+import { useCallback, useContext } from 'react';
 import {
   MutationKey,
   useMutation,
@@ -24,9 +24,6 @@ import {
 } from '../lib/feed';
 import { FeedItem, PostItem, UpdateFeedPost } from './useFeed';
 import { ActionType } from '../graphql/actions';
-import { LazyModal } from '../components/modals/common/types';
-import { promotion } from '../components/modals/generic';
-import { useLazyModal } from './useLazyModal';
 import { useActions } from './useActions';
 
 export type ToggleBookmarkProps = {
@@ -81,13 +78,7 @@ const useBookmarkPost = ({
   const { displayToast } = useToastNotification();
   const { user, showLogin } = useContext(AuthContext);
   const { logEvent } = useContext(LogContext);
-  const { openModal } = useLazyModal();
-  const { completeAction, checkHasCompleted, isActionsFetched } = useActions();
-  const seenBookmarkPromotion = useMemo(
-    () =>
-      isActionsFetched && checkHasCompleted(ActionType.BookmarkPromoteMobile),
-    [checkHasCompleted, isActionsFetched],
-  );
+  const { completeAction } = useActions();
 
   const defaultOnMutate = ({ id }) => {
     updatePostCache(client, id, (post) => ({ bookmarked: !post.bookmarked }));
@@ -164,26 +155,8 @@ const useBookmarkPost = ({
 
       await addBookmark({ id: post.id });
       displayToast('Post was added to your bookmarks');
-
-      if (!seenBookmarkPromotion) {
-        completeAction(ActionType.BookmarkPromoteMobile);
-        openModal({
-          type: LazyModal.MarketingCta,
-          props: { marketingCta: promotion.bookmarkPromoteMobile },
-        });
-      }
     },
-    [
-      addBookmark,
-      completeAction,
-      displayToast,
-      openModal,
-      removeBookmark,
-      seenBookmarkPromotion,
-      showLogin,
-      logEvent,
-      user,
-    ],
+    [addBookmark, displayToast, removeBookmark, showLogin, logEvent, user],
   );
 
   return { toggleBookmark };


### PR DESCRIPTION
## Changes

We no longer want to show the mobile app prompt after bookmarking (photo for reference)

![Screenshot 2024-10-03 at 14 24 39](https://github.com/user-attachments/assets/daa30fbc-6b26-4401-81ae-7e4a9d695a75)

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-632 #done 


### Preview domain
https://as-632-remove-bookmark-prompt.preview.app.daily.dev