### PR TITLE
feat: search focus experiment

### DIFF
--- a/packages/shared/src/components/fields/SearchField.tsx
+++ b/packages/shared/src/components/fields/SearchField.tsx
@@ -18,6 +18,11 @@ import {
 import { getFieldFontColor } from './BaseFieldContainer';
 import { IconProps } from '../Icon';
 
+export enum SearchStyleVersion {
+  Default = 'default',
+  AlwaysFocus = 'always_focus',
+}
+
 export interface SearchFieldProps
   extends Pick<
     InputHTMLAttributes<HTMLInputElement>,
@@ -45,6 +50,7 @@ export interface SearchFieldProps
   showIcon?: boolean;
   fieldType?: 'primary' | 'secondary';
   rightButtonProps?: ButtonProps<'button'> | false;
+  styleVersion?: SearchStyleVersion;
 }
 
 const ButtonIcon = ({
@@ -79,6 +85,7 @@ export const SearchField = forwardRef(function SearchField(
     onBlur: externalOnBlur,
     onFocus: externalOnFocus,
     showIcon = true,
+    styleVersion = SearchStyleVersion.Default,
     ...props
   }: SearchFieldProps,
   ref: ForwardedRef<HTMLDivElement>,
@@ -99,6 +106,7 @@ export const SearchField = forwardRef(function SearchField(
     setInput(null);
   };
 
+  const isFocusVersion = styleVersion === SearchStyleVersion.AlwaysFocus;
   const isPrimary = fieldType === 'primary';
   const isSecondary = fieldType === 'secondary';
   const sizeClass =
@@ -108,7 +116,10 @@ export const SearchField = forwardRef(function SearchField(
     <BaseField
       {...props}
       className={classNames(
-        'items-center !border !border-border-subtlest-tertiary !bg-background-default',
+        'items-center !border !bg-background-default',
+        isFocusVersion
+          ? '!tablet:max-w-[26.25rem] !border-accent-salt-baseline font-bold text-white'
+          : '!border-border-subtlest-tertiary',
         sizeClass,
         className,
         { focused },
@@ -136,10 +147,10 @@ export const SearchField = forwardRef(function SearchField(
             aria-hidden
             className="icon mr-2 text-2xl"
             role="presentation"
-            secondary={focused}
+            secondary={focused || isFocusVersion}
             style={{
               color:
-                focused || hasInput
+                focused || hasInput || isFocusVersion
                   ? 'var(--theme-text-primary)'
                   : 'var(--field-placeholder-color)',
             }}
@@ -167,6 +178,7 @@ export const SearchField = forwardRef(function SearchField(
         autoComplete="off"
         className={classNames(
           'flex-1',
+          isFocusVersion ? '!placeholder-white' : undefined,
           sizeClass,
           getFieldFontColor({ readOnly, disabled, hasInput, focused }),
         )}

--- a/packages/shared/src/components/fields/SearchField.tsx
+++ b/packages/shared/src/components/fields/SearchField.tsx
@@ -116,13 +116,16 @@ export const SearchField = forwardRef(function SearchField(
     <BaseField
       {...props}
       className={classNames(
-        'items-center !border !bg-background-default',
+        'items-center !border has-[:focus]:!border-2 has-[:focus]:!border-surface-focus',
+        isFocusVersion && hasInput
+          ? '!bg-surface-float font-bold'
+          : '!bg-background-default',
         isFocusVersion
-          ? '!tablet:max-w-[26.25rem] !border-accent-salt-baseline font-bold text-white'
-          : '!border-border-subtlest-tertiary',
+          ? '!tablet:max-w-[26.25rem] !border-accent-salt-baseline text-white hover:!bg-surface-hover has-[:focus]:!bg-surface-hover'
+          : '!border-border-subtlest-tertiary !bg-background-default',
         sizeClass,
         className,
-        { focused },
+        { focused: isFocusVersion ? false : focused },
       )}
       onClick={focusInput}
       data-testid="searchField"
@@ -178,7 +181,7 @@ export const SearchField = forwardRef(function SearchField(
         autoComplete="off"
         className={classNames(
           'flex-1',
-          isFocusVersion ? '!placeholder-white' : undefined,
+          isFocusVersion ? '!placeholder-text-secondary' : undefined,
           sizeClass,
           getFieldFontColor({ readOnly, disabled, hasInput, focused }),
         )}

--- a/packages/shared/src/components/fields/common.tsx
+++ b/packages/shared/src/components/fields/common.tsx
@@ -5,7 +5,7 @@ import styles from './fields.module.css';
 
 export const FieldInput = classed(
   'input',
-  'min-w-0  bg-transparent typo-body caret-text-link focus:outline-none',
+  'min-w-0 bg-transparent typo-body caret-text-link focus:outline-none',
 );
 
 export const BaseField = classed(

--- a/packages/shared/src/components/onboarding/EditTag.tsx
+++ b/packages/shared/src/components/onboarding/EditTag.tsx
@@ -11,6 +11,7 @@ import { useFeature } from '../GrowthBookProvider';
 import { feature } from '../../lib/featureManagement';
 import { CreateFeedButton } from './CreateFeedButton';
 import { TagSelection } from '../tags/TagSelection';
+import { SearchStyleVersion } from '../fields/SearchField';
 
 interface EditTagProps {
   feedSettings: FeedSettings;
@@ -30,6 +31,9 @@ export const EditTag = ({
   const tagsCount = feedSettings?.includeTags?.length || 0;
   const isPreviewEnabled = tagsCount >= REQUIRED_TAGS_THRESHOLD;
   const shouldShuffleTags = useFeature(feature.onboardingShuffleTags);
+  const searchStyleVersion = useFeature(
+    feature.searchStyleVersion,
+  ) as SearchStyleVersion;
 
   return (
     <>
@@ -39,6 +43,7 @@ export const EditTag = ({
       <TagSelection
         className="mt-10 max-w-4xl"
         shouldShuffleTags={shouldShuffleTags}
+        searchStyleVersion={searchStyleVersion}
       />
       <FeedPreviewControls
         isOpen={isPreviewVisible}

--- a/packages/shared/src/components/tags/TagSelection.tsx
+++ b/packages/shared/src/components/tags/TagSelection.tsx
@@ -16,7 +16,7 @@ import {
 import { disabledRefetch, getRandomNumber } from '../../lib/func';
 import { SearchField, SearchStyleVersion } from '../fields/SearchField';
 import useDebounceFn from '../../hooks/useDebounceFn';
-import { useTagSearch } from '../../hooks';
+import { useTagSearch, useViewSize, ViewSize } from '../../hooks';
 import type { FilterOnboardingProps } from '../onboarding/FilterOnboarding';
 import useTagAndSource from '../../hooks/useTagAndSource';
 import { Origin } from '../../lib/log';
@@ -56,7 +56,7 @@ export function TagSelection({
   searchStyleVersion,
 }: TagSelectionProps): ReactElement {
   const queryClient = useQueryClient();
-
+  const isMobile = useViewSize(ViewSize.MobileL);
   const { feedSettings } = useFeedSettings({ feedId });
   const selectedTags = useMemo(() => {
     return new Set(feedSettings?.includeTags || []);
@@ -202,7 +202,7 @@ export function TagSelection({
     <div className={classNames(className, 'flex w-full flex-col items-center')}>
       <SearchField
         aria-label="Pick tags that are relevant to you"
-        autoFocus
+        autoFocus={!isMobile}
         className="mb-10 w-full tablet:max-w-xs"
         inputId="search-filters"
         placeholder="Search javascript, php, git, etc…"

--- a/packages/shared/src/components/tags/TagSelection.tsx
+++ b/packages/shared/src/components/tags/TagSelection.tsx
@@ -14,7 +14,7 @@ import {
   TagsData,
 } from '../../graphql/feedSettings';
 import { disabledRefetch, getRandomNumber } from '../../lib/func';
-import { SearchField } from '../fields/SearchField';
+import { SearchField, SearchStyleVersion } from '../fields/SearchField';
 import useDebounceFn from '../../hooks/useDebounceFn';
 import { useTagSearch } from '../../hooks';
 import type { FilterOnboardingProps } from '../onboarding/FilterOnboarding';
@@ -40,6 +40,7 @@ export type TagSelectionProps = {
   onClickTag?: ({ tag, action }: OnSelectTagProps) => void;
   origin?: Origin;
   searchOrigin?: Origin;
+  searchStyleVersion?: SearchStyleVersion;
   shouldShuffleTags?: boolean;
 } & Omit<FilterOnboardingProps, 'onSelectedTopics'>;
 
@@ -52,6 +53,7 @@ export function TagSelection({
   origin = Origin.Onboarding,
   searchOrigin = Origin.EditTag,
   shouldShuffleTags = false,
+  searchStyleVersion,
 }: TagSelectionProps): ReactElement {
   const queryClient = useQueryClient();
 
@@ -203,8 +205,9 @@ export function TagSelection({
         autoFocus
         className="mb-10 w-full tablet:max-w-xs"
         inputId="search-filters"
-        placeholder="javascript, php, git, etc…"
+        placeholder="Search javascript, php, git, etc…"
         valueChanged={onSearch}
+        styleVersion={searchStyleVersion}
       />
       <div
         role="list"

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -1,6 +1,7 @@
 import { JSONValue } from '@growthbook/growthbook';
 import { ShortcutsUIExperiment } from './featureValues';
 import { cloudinary } from './image';
+import { SearchStyleVersion } from '../components/fields/SearchField';
 
 export class Feature<T extends JSONValue> {
   readonly id: string;
@@ -32,6 +33,10 @@ const feature = {
   showCodeSnippets: new Feature('show_code_snippets', false),
   searchPlaceholder: new Feature('search_placeholder', 'Search'),
   onboardingShuffleTags: new Feature('onboarding_shuffle_tags', false),
+  searchStyleVersion: new Feature(
+    'search_style_version',
+    SearchStyleVersion.AlwaysFocus,
+  ),
 };
 
 export { feature };

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -35,7 +35,7 @@ const feature = {
   onboardingShuffleTags: new Feature('onboarding_shuffle_tags', false),
   searchStyleVersion: new Feature(
     'search_style_version',
-    SearchStyleVersion.AlwaysFocus,
+    SearchStyleVersion.Default,
   ),
 };
 


### PR DESCRIPTION
## Changes

Changed to the following states: (Already checked with Tomer)
We also added focus blue ring to default and disable the autofocus on mobile.

![Screenshot 2024-10-08 at 09 23 06](https://github.com/user-attachments/assets/9931ff1c-2d8b-484b-9442-a4729cc5cceb)

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-633 #done 

### Preview domain
https://as-633-search-focus-experiment.preview.app.daily.dev