### PR TITLE
fix: toggle follow if parent setting is toggled

### DIFF
--- a/packages/webapp/__tests__/AccountNotificationsPage.tsx
+++ b/packages/webapp/__tests__/AccountNotificationsPage.tsx
@@ -142,6 +142,7 @@ it('should change user all email subscription', async () => {
   const data: UpdateProfileParameters = {
     acceptedMarketing: true,
     notificationEmail: true,
+    followingEmail: true,
   };
   mockGraphQL(updateProfileMock(data));
   let personalizedDigestMutationCalled = false;
@@ -191,11 +192,13 @@ it('should unsubscribe from all email campaigns', async () => {
     ...defaultLoggedUser,
     acceptedMarketing: true,
     notificationEmail: true,
+    followingEmail: true,
   });
 
   const data: UpdateProfileParameters = {
     acceptedMarketing: false,
     notificationEmail: false,
+    followingEmail: false,
   };
   mockGraphQL(updateProfileMock(data));
 

--- a/packages/webapp/__tests__/AccountNotificationsPage.tsx
+++ b/packages/webapp/__tests__/AccountNotificationsPage.tsx
@@ -442,3 +442,45 @@ it('should change hour for personalized digest subscription', async () => {
     extra: JSON.stringify({ hour: 0, frequency: 'weekly' }),
   });
 });
+
+it('should subscribe to user email following subscription', async () => {
+  renderComponent();
+  const data = { followingEmail: true };
+  mockGraphQL(updateProfileMock(data));
+  const subscription = await screen.findByTestId('following-switch');
+  expect(subscription).not.toBeChecked();
+  subscription.click();
+  await act(() => new Promise((resolve) => setTimeout(resolve, 100)));
+  await waitForNock();
+  expect(updateUser).toBeCalledWith({ ...defaultLoggedUser, ...data });
+
+  expect(logEvent).toHaveBeenCalledTimes(1);
+  expect(logEvent).toHaveBeenCalledWith({
+    event_name: 'enable notification',
+    extra: JSON.stringify({
+      channel: 'email',
+      category: 'following',
+    }),
+  });
+});
+
+it('should unsubscribe to user email following subscription', async () => {
+  renderComponent({ ...defaultLoggedUser, followingEmail: true });
+  const data = { followingEmail: false };
+  mockGraphQL(updateProfileMock(data));
+  const subscription = await screen.findByTestId('following-switch');
+  expect(subscription).toBeChecked();
+  subscription.click();
+  await act(() => new Promise((resolve) => setTimeout(resolve, 100)));
+  await waitForNock();
+  expect(updateUser).toBeCalledWith({ ...defaultLoggedUser, ...data });
+
+  expect(logEvent).toHaveBeenCalledTimes(1);
+  expect(logEvent).toHaveBeenCalledWith({
+    event_name: 'disable notification',
+    extra: JSON.stringify({
+      channel: 'email',
+      category: 'following',
+    }),
+  });
+});

--- a/packages/webapp/pages/account/notifications.tsx
+++ b/packages/webapp/pages/account/notifications.tsx
@@ -103,7 +103,10 @@ const AccountNotificationsPage = (): ReactElement => {
     followNotifications,
   } = user ?? {};
   const emailNotification =
-    acceptedMarketing || notificationEmail || !!personalizedDigest;
+    acceptedMarketing ||
+    notificationEmail ||
+    !!personalizedDigest ||
+    followingEmail;
 
   const onToggleEmailSettings = () => {
     const value = !emailNotification;
@@ -134,6 +137,7 @@ const AccountNotificationsPage = (): ReactElement => {
     updateUserProfile({
       acceptedMarketing: value,
       notificationEmail: value,
+      followingEmail: value,
     });
 
     if (value) {


### PR DESCRIPTION
## Changes

Just noticed while testing cio issues. There was a missing condition to toggle follow when pressing parent email notification toggle.

<img width="664" alt="image" src="https://github.com/user-attachments/assets/80c338a5-1adf-4ce0-b9b2-c0a4ed1065e8">


## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://fix-toggle-follow-email-settings.preview.app.daily.dev