### PR TITLE
fix: we only need to randomize once

### DIFF
--- a/packages/shared/src/components/tags/TagSelection.tsx
+++ b/packages/shared/src/components/tags/TagSelection.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo } from 'react';
+import React, { ReactElement, useMemo, useState } from 'react';
 import classNames from 'classnames';
 import {
   QueryFilters,
@@ -53,6 +53,7 @@ export function TagSelection({
   searchOrigin = Origin.EditTag,
   shouldShuffleTags = false,
 }: TagSelectionProps): ReactElement {
+  const [isShuffled, setIsShuffled] = useState(false);
   const queryClient = useQueryClient();
 
   const { feedSettings } = useFeedSettings({ feedId });
@@ -106,12 +107,13 @@ export function TagSelection({
   );
 
   const onboardingTags = useMemo(() => {
-    if (!shouldShuffleTags) {
+    if (!shouldShuffleTags || isShuffled || !onboardingTagsRaw) {
       return onboardingTagsRaw;
     }
 
+    setIsShuffled(true);
     return onboardingTagsRaw?.sort(() => Math.random() - 0.5);
-  }, [shouldShuffleTags, onboardingTagsRaw]);
+  }, [shouldShuffleTags, isShuffled, onboardingTagsRaw]);
 
   const excludedTags = useMemo(() => {
     if (!onboardingTags) {


### PR DESCRIPTION
## Changes

The random elements only need to happen on the first load of tags.
Before it would randomize every time you selected a different tag.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-638 #done 


### Preview domain
https://as-638-randomize-onboarding-only.preview.app.daily.dev