### PR TITLE
fix: form content lost when switching tabs

### DIFF
--- a/packages/webapp/pages/squads/create.tsx
+++ b/packages/webapp/pages/squads/create.tsx
@@ -191,7 +191,7 @@ function CreatePost(): ReactElement {
         <TabContainer<WriteFormTab>
           onActiveChange={(active) => setDisplay(active)}
           controlledActive={display}
-          shouldMountInactive={false}
+          shouldMountInactive={true}
           className={{ header: 'px-1' }}
           showHeader={isTablet}
         >


### PR DESCRIPTION
## Changes
Linked Issue: (https://github.com/dailydotdev/daily/issues/1261)

The issue here is that when we switch the tabs between `New Post` and `Share a link` the form content in the `Share a link` gets lost if we navigate to `New Post` and again navigate back to `Share a link`.  By default, shouldMountInactive is set to `false`. This means that when a tab is inactive, its content is unmounted from the DOM. So I have come up with this fix. But not sure if this is a good approach or not.

Before

https://github.com/user-attachments/assets/448d80ce-1313-418a-b8cf-a2610f2e6114

After

https://github.com/user-attachments/assets/a42ca0c8-9eb1-4c83-b7f0-7afe4a9d3958


<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->
