### PR TITLE
feat: add the right preconnect headers

### DIFF
--- a/packages/extension/views/companion.html
+++ b/packages/extension/views/companion.html
@@ -8,7 +8,6 @@
     <title>Companion</title>
     <link rel="preconnect" href="https://api.daily.dev" />
     <link rel="preconnect" href="https://sso.daily.dev" />
-    <link rel="preconnect" href="https://sso.daily.dev" />
     <link rel="preconnect" href="https://res.cloudinary.com" />
     <link rel="preconnect" href="https://daily-now-res.cloudinary.com" />
   </head>

--- a/packages/extension/views/companion.html
+++ b/packages/extension/views/companion.html
@@ -6,8 +6,11 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link rel="icon" href="/icons/action_32.png" />
     <title>Companion</title>
-    <link rel="preconnect" href="https://res.cloudinary.com" />
     <link rel="preconnect" href="https://api.daily.dev" />
+    <link rel="preconnect" href="https://sso.daily.dev" />
+    <link rel="preconnect" href="https://sso.daily.dev" />
+    <link rel="preconnect" href="https://res.cloudinary.com" />
+    <link rel="preconnect" href="https://daily-now-res.cloudinary.com" />
   </head>
   <body class='companion'>
     <noscript>

--- a/packages/extension/views/newtab.html
+++ b/packages/extension/views/newtab.html
@@ -8,7 +8,6 @@
   <title>New Tab</title>
   <link rel="preconnect" href="https://api.daily.dev" />
   <link rel="preconnect" href="https://sso.daily.dev" />
-  <link rel="preconnect" href="https://sso.daily.dev" />
   <link rel="preconnect" href="https://res.cloudinary.com" />
   <link rel="preconnect" href="https://daily-now-res.cloudinary.com" />
 </head>

--- a/packages/extension/views/newtab.html
+++ b/packages/extension/views/newtab.html
@@ -6,8 +6,11 @@
   <meta name='viewport' content='width=device-width,initial-scale=1.0'>
   <link rel='icon' href='/icons/action_32.png'>
   <title>New Tab</title>
-  <link rel="preconnect" href="https://res.cloudinary.com" />
   <link rel="preconnect" href="https://api.daily.dev" />
+  <link rel="preconnect" href="https://sso.daily.dev" />
+  <link rel="preconnect" href="https://sso.daily.dev" />
+  <link rel="preconnect" href="https://res.cloudinary.com" />
+  <link rel="preconnect" href="https://daily-now-res.cloudinary.com" />
 </head>
 <body>
 <noscript>

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -166,7 +166,11 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
           }}
         />
 
+        <link rel="preconnect" href="https://api.daily.dev" />
+        <link rel="preconnect" href="https://sso.daily.dev" />
+        <link rel="preconnect" href="https://sso.daily.dev" />
         <link rel="preconnect" href="https://res.cloudinary.com" />
+        <link rel="preconnect" href="https://daily-now-res.cloudinary.com" />
       </Head>
       <DefaultSeo
         {...Seo}

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -168,7 +168,6 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
 
         <link rel="preconnect" href="https://api.daily.dev" />
         <link rel="preconnect" href="https://sso.daily.dev" />
-        <link rel="preconnect" href="https://sso.daily.dev" />
         <link rel="preconnect" href="https://res.cloudinary.com" />
         <link rel="preconnect" href="https://daily-now-res.cloudinary.com" />
       </Head>


### PR DESCRIPTION
## Changes

We have 3 apps that inject preconnect headers added all 3 now.

We should probably consider merging the 2 cloudinary ones into 1.
Discussion: https://dailydotdev.slack.com/archives/C02E2C3C13R/p1728887218700339

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

WT-2198 #done 

### Preview domain
https://wt-2198-preconnect-headers.preview.app.daily.dev