### PR TITLE
refactor: invalid username error message to clarify the accepter format

### DIFF
--- a/packages/shared/src/hooks/useProfileForm.ts
+++ b/packages/shared/src/hooks/useProfileForm.ts
@@ -76,7 +76,11 @@ const socials: Array<keyof Handles> = [
   'linkedin',
   'mastodon',
 ];
-
+const errormessage = {
+  profile: {
+    invalidUsername: "Username must only contain alphanumeric characters.", // Updated message
+  },
+};
 export const onValidateHandles = (
   before: Partial<Handles>,
   after: Partial<Handles>,
@@ -85,10 +89,10 @@ export const onValidateHandles = (
     const isValid = handleRegex.test(after.username);
 
     if (!isValid) {
-      return { username: errorMessage.profile.invalidUsername };
+      return { username: errormessage.profile.invalidUsername };
     }
   } else if ('username' in after && !after.username) {
-    return { username: errorMessage.profile.invalidUsername };
+    return { username: errormessage.profile.invalidUsername };
   }
 
   return socials.reduce((obj, social) => {


### PR DESCRIPTION
### https://github.com/dailydotdev/docs/issues/400 
This issue is solved in this PR.

### This PR changes the error message seen by user during registering and having their username.
- When people select/enter their username- It was showing username is invalid but not showing what is the requirements.
- This issue is raised in the docs repo of daily.dev.

![image](https://github.com/user-attachments/assets/563c1a2c-6f24-4c7e-8c97-b3d7e251a2a7)

### Summary-
This issue will help users to find out name format so that they can easily register and make their account freely.


