### PR TITLE
chore: properly lazy load mobile footer

### DIFF
--- a/packages/webapp/components/footer/FooterWrapper.tsx
+++ b/packages/webapp/components/footer/FooterWrapper.tsx
@@ -1,0 +1,60 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import { Post } from '@dailydotdev/shared/src/graphql/posts';
+import dynamic from 'next/dynamic';
+import { blurClasses } from './common';
+
+const NewComment = dynamic(() =>
+  import(
+    /* webpackChunkName: "newComment" */ '@dailydotdev/shared/src/components/post/NewComment'
+  ).then((mod) => mod.NewComment),
+);
+
+const ScrollToTopButton = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "scrollToTopButton" */ '@dailydotdev/shared/src/components/ScrollToTopButton'
+    ),
+);
+
+const MobileFooterNavbar = dynamic(
+  () =>
+    import(/* webpackChunkName: "mobileFooterNavbar" */ './MobileFooterNavbar'),
+);
+
+interface FooterNavBarProps {
+  showNav?: boolean;
+  post?: Post;
+}
+
+export default function FooterWrapper({
+  showNav = false,
+  post,
+}: FooterNavBarProps): ReactElement {
+  return (
+    <div
+      className={classNames(
+        'fixed !bottom-0 left-0 z-3 w-full',
+        showNav &&
+          'footer-navbar bg-gradient-to-t from-background-subtle from-70% to-transparent px-2 pt-2',
+      )}
+    >
+      {post ? (
+        <div className="my-2 w-full px-2 tablet:hidden">
+          <NewComment
+            post={post}
+            className={{
+              container: classNames(
+                blurClasses,
+                'h-12 shadow-[0_0.25rem_1.5rem_0_var(--theme-shadow-shadow1)]',
+              ),
+            }}
+          />
+        </div>
+      ) : (
+        <ScrollToTopButton />
+      )}
+      {showNav && <MobileFooterNavbar isPostPage={!!post} />}
+    </div>
+  );
+}

--- a/packages/webapp/components/footer/MobileFooterNavbar.tsx
+++ b/packages/webapp/components/footer/MobileFooterNavbar.tsx
@@ -5,17 +5,8 @@ import React, {
   useContext,
   useMemo,
 } from 'react';
-import { Flipper } from 'react-flip-toolkit';
 import classNames from 'classnames';
-import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
-import { useRouter } from 'next/router';
-import ScrollToTopButton from '@dailydotdev/shared/src/components/ScrollToTopButton';
-import { Post } from '@dailydotdev/shared/src/graphql/posts';
-import { NewComment } from '@dailydotdev/shared/src/components/post/NewComment';
-import useActiveNav, {
-  UseActiveNav,
-} from '@dailydotdev/shared/src/hooks/useActiveNav';
-import { getFeedName } from '@dailydotdev/shared/src/lib/feed';
+import { Flipper } from 'react-flip-toolkit';
 import {
   AiIcon,
   BellIcon,
@@ -23,18 +14,19 @@ import {
   SourceIcon,
 } from '@dailydotdev/shared/src/components/icons';
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
+import useActiveNav, {
+  UseActiveNav,
+} from '@dailydotdev/shared/src/hooks/useActiveNav';
 import { squadCategoriesPaths } from '@dailydotdev/shared/src/lib/constants';
+import { useRouter } from 'next/router';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import { getFeedName } from '@dailydotdev/shared/src/lib/feed';
 import { useNotificationContext } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import { Bubble } from '@dailydotdev/shared/src/components/tooltips/utils';
 import { getUnreadText } from '@dailydotdev/shared/src/components/notifications/utils';
-import { FooterTab } from './footer/common';
-import { FooterNavBarTabs } from './footer/FooterNavBarTabs';
-import { FooterPlusButton } from './footer/FooterPlusButton';
-
-interface FooterNavBarProps {
-  showNav?: boolean;
-  post?: Post;
-}
+import { blurClasses, FooterTab } from './common';
+import { FooterPlusButton } from './FooterPlusButton';
+import { FooterNavBarTabs } from './FooterNavBarTabs';
 
 const Notifications = ({ active }: { active: boolean }): JSX.Element => {
   const { unreadCount } = useNotificationContext();
@@ -60,10 +52,11 @@ const selectedMapToTitle: Record<keyof UseActiveNav, string> = {
   profile: 'Profile',
 };
 
-export default function FooterNavBar({
-  showNav = false,
-  post,
-}: FooterNavBarProps): ReactElement {
+const MobileFooterNavbar = ({
+  isPostPage,
+}: {
+  isPostPage: boolean;
+}): ReactElement => {
   const router = useRouter();
   const { user, squads } = useContext(AuthContext);
   const feedName = getFeedName(router.pathname, { hasUser: !!user });
@@ -124,49 +117,25 @@ export default function FooterNavBar({
     return active?.title;
   }, [activeNav, router?.pathname, tabs]);
 
-  const blurClasses = 'bg-blur-baseline backdrop-blur-[2.5rem]';
   const activeClasses = classNames(
     blurClasses,
     'shadow-[0_4px_30px_rgba(0,0,0.1)]',
   );
 
   return (
-    <div
+    <Flipper
+      flipKey={activeTab}
+      spring="veryGentle"
+      element="nav"
       className={classNames(
-        'fixed !bottom-0 left-0 z-3 w-full',
-        showNav &&
-          'footer-navbar bg-gradient-to-t from-background-subtle from-70% to-transparent px-2 pt-2',
+        'grid w-full auto-cols-fr grid-flow-col items-center justify-between rounded-16',
+        !isPostPage && activeClasses,
+        !isPostPage && 'border-t border-border-subtlest-tertiary',
       )}
     >
-      {post ? (
-        <div className="my-2 w-full px-2 tablet:hidden">
-          <NewComment
-            post={post}
-            className={{
-              container: classNames(
-                blurClasses,
-                'h-12 shadow-[0_0.25rem_1.5rem_0_var(--theme-shadow-shadow1)]',
-              ),
-            }}
-          />
-        </div>
-      ) : (
-        <ScrollToTopButton />
-      )}
-      {showNav && (
-        <Flipper
-          flipKey={activeTab}
-          spring="veryGentle"
-          element="nav"
-          className={classNames(
-            'grid w-full auto-cols-fr grid-flow-col items-center justify-between rounded-16',
-            !post && activeClasses,
-            !post && 'border-t border-border-subtlest-tertiary',
-          )}
-        >
-          <FooterNavBarTabs activeTab={activeTab} tabs={tabs} />
-        </Flipper>
-      )}
-    </div>
+      <FooterNavBarTabs activeTab={activeTab} tabs={tabs} />
+    </Flipper>
   );
-}
+};
+
+export default MobileFooterNavbar;

--- a/packages/webapp/components/footer/common.ts
+++ b/packages/webapp/components/footer/common.ts
@@ -21,3 +21,5 @@ export const getNavPath = (
 ): string => {
   return typeof path === 'string' ? path : path(user);
 };
+
+export const blurClasses = 'bg-blur-baseline backdrop-blur-[2.5rem]';

--- a/packages/webapp/components/layouts/FooterNavBarLayout.tsx
+++ b/packages/webapp/components/layouts/FooterNavBarLayout.tsx
@@ -4,8 +4,9 @@ import ProgressiveEnhancementContext from '@dailydotdev/shared/src/contexts/Prog
 import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
 import { Post } from '@dailydotdev/shared/src/graphql/posts';
 
-const FooterNavBar = dynamic(
-  () => import(/* webpackChunkName: "footerNavBar" */ '../FooterNavBar'),
+const FooterWrapper = dynamic(
+  () =>
+    import(/* webpackChunkName: "footerWrapper" */ '../footer/FooterWrapper'),
 );
 
 interface FooterNavBarLayoutProps {
@@ -26,7 +27,7 @@ export default function FooterNavBarLayout({
     <>
       {children}
       {showNav && <div className={post ? 'h-40' : 'h-28'} />}
-      <FooterNavBar showNav={showNav} post={post} />
+      <FooterWrapper showNav={showNav} post={post} />
     </>
   );
 }


### PR DESCRIPTION
## Changes
- properly lazy load components and separate concerns to avoid unused javascript loaded
- moved js for footer navbar needed only on mobile to it's own file and lazy load the component

Reports:
- Before: https://pagespeed.web.dev/analysis/https-app-daily-dev-posts-why-generalists-own-the-future-zavawfet1/33ckmjhzr9?form_factor=mobile
- After: https://pagespeed.web.dev/analysis/https-wt-2203-footer-navbar-lazy-load-preview-app-daily-dev-posts-why-generalists-own-the-future-zavawfet1/wvd02thnl7?form_factor=mobile

Analysis on unused JS for footer
Before: 
<img width="1725" alt="Screenshot 2024-10-15 at 1 02 48 PM" src="https://github.com/user-attachments/assets/811af08e-75b9-484d-9780-91e7c28e376f">
After:
<img width="1728" alt="Screenshot 2024-10-15 at 1 03 00 PM" src="https://github.com/user-attachments/assets/dff188eb-8f9d-4060-bb6f-fcdb1b838d2f">


<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->

WT-2203 #done


### Preview domain
https://wt-2203-footer-navbar-lazy-load.preview.app.daily.dev