### PR TITLE
fix: added possibility to clear profile & cover photos

### DIFF
--- a/packages/webapp/components/layouts/AccountLayout/Profile/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Profile/index.tsx
@@ -163,11 +163,11 @@ const ProfileIndex = ({
         your comments and contributions easily!"
       >
         <div className="relative mt-6 flex">
-          <div className="absolute left-0 top-0 flex w-full">
+          <div className="absolute w-full max-w-[19.25rem] left-0 top-0 flex">
             <ImageInput
               id={coverId}
               className={{
-                root: 'w-full max-w-[19.25rem]',
+                root: 'w-full',
                 container:
                   'border-0 bg-background-subtle hover:bg-accent-pepper-subtlest',
                 img: 'object-cover',
@@ -181,6 +181,7 @@ const ProfileIndex = ({
               onChange={(fileName, file) =>
                 onImageInputChange(file, fileName, true)
               }
+              closeable
             />
           </div>
           <ImageInput
@@ -192,6 +193,7 @@ const ProfileIndex = ({
             initialValue={user?.image}
             hoverIcon={<CameraIcon size={IconSize.Large} />}
             onChange={(_, file) => onImageInputChange(file)}
+            closeable
           />
         </div>
       </AccountContentSection>


### PR DESCRIPTION
## Changes

I've added a 'X' button at the top right corner of the profile and cover images at /account/profile to enable the user to clear the image.


## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

