### PR TITLE
fix: remove any trailing non-alphanumeric characters from preview domains

### DIFF
--- a/.github/workflows/add-preview-domain.yml
+++ b/.github/workflows/add-preview-domain.yml
@@ -18,8 +18,14 @@ jobs:
         uses: actions/github-script@v7.0.1
         with:
           script: |
-            const subdomain = `${{ github.head_ref }}`.slice(0, 32)
-            const domain = `${subdomain}.${{ vars.PREVIEW_DOMAIN }}`.toLowerCase().replaceAll("_","-")
+            const subdomain = `${{ github.head_ref }}`
+              .slice(0, 32)
+              // Remove any trailing non-alphanumeric characters
+              .replace(/[^a-zA-Z0-9](?=[^a-zA-Z0-9]*$)/, '')
+
+            const domain = `${subdomain}.${{ vars.PREVIEW_DOMAIN }}`
+              .toLowerCase()
+              .replaceAll("_","-")
             core.setOutput('domain', domain)
 
       - name: Comment with the assigned preview-domain

--- a/.github/workflows/remove-preview-domain.yml
+++ b/.github/workflows/remove-preview-domain.yml
@@ -16,8 +16,14 @@ jobs:
         uses: actions/github-script@v7.0.1
         with:
           script: |
-            const subdomain = `${{ github.head_ref }}`.slice(0, 32)
-            const domain = `${subdomain}.${{ vars.PREVIEW_DOMAIN }}`.toLowerCase().replaceAll("_","-")
+            const subdomain = `${{ github.head_ref }}`
+              .slice(0, 32)
+              // Remove any trailing non-alphanumeric characters
+              .replace(/[^a-zA-Z0-9](?=[^a-zA-Z0-9]*$)/, '')
+
+            const domain = `${subdomain}.${{ vars.PREVIEW_DOMAIN }}`
+              .toLowerCase()
+              .replaceAll("_","-")
             core.setOutput('domain', domain)
 
       - name: Unssign preview-domain


### PR DESCRIPTION
Should fix the preview domain issue in #3717

Vercel complains when the subdomain ends with a `-`, which is what happens in #3717, because when the branch `chore-remove-react-intersection-observer` is sliced to 32 chars, it ends up at `chore-remove-react-intersection-`. So this fix should strip out any trailing `-` / non-alphanumeric characters from the subdomain.

### Preview domain
https://fix-preview-domain.preview.app.daily.dev