### PR TITLE
feat: create endpoint to render the top reader badge

### DIFF
--- a/packages/shared/src/components/badges/TopReaderBadge.tsx
+++ b/packages/shared/src/components/badges/TopReaderBadge.tsx
@@ -18,7 +18,7 @@ export const TopReaderBadge = ({
   keyword,
 }: {
   user: Pick<LoggedUser, 'name' | 'image' | 'username'>;
-  issuedAt: Date;
+  issuedAt: Date | string;
   keyword: Pick<Keyword, 'value' | 'flags'>;
 }): ReactElement => {
   const { name, username, image } = user;

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -330,3 +330,17 @@ export const POST_CODE_SNIPPET_FRAGMENT = gql`
     content
   }
 `;
+
+export const TOP_READER_BADGE_FRAGMENT = gql`
+  fragment TopReader on UserTopReader {
+    id
+    issuedAt
+    image
+    keyword {
+      value
+      flags {
+        title
+      }
+    }
+  }
+`;

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -2,6 +2,7 @@ import { gql } from 'graphql-request';
 import { subDays } from 'date-fns';
 import {
   SHARED_POST_INFO_FRAGMENT,
+  TOP_READER_BADGE_FRAGMENT,
   USER_SHORT_INFO_FRAGMENT,
   USER_STREAK_FRAGMENT,
 } from './fragments';
@@ -650,4 +651,19 @@ export const USER_INTEGRATION_BY_ID = gql`
       name
     }
   }
+`;
+
+export const TOP_READER_BADGE_BY_ID = gql`
+  query TopReaderBadgeById($id: ID!) {
+    topReaderBadge(id: $id) {
+      ...TopReader
+      user {
+        name
+        username
+        image
+      }
+    }
+  }
+
+  ${TOP_READER_BADGE_FRAGMENT}
 `;

--- a/packages/webapp/pages/badges/[badgeId].tsx
+++ b/packages/webapp/pages/badges/[badgeId].tsx
@@ -19,7 +19,7 @@ interface PageProps {
     id: string;
     user: LoggedUser;
     issuedAt: Date;
-    keyword: Keyword;
+    keyword: Pick<Keyword, 'value' | 'flags'>;
     image: string;
   };
 }

--- a/packages/webapp/pages/badges/[badgeId].tsx
+++ b/packages/webapp/pages/badges/[badgeId].tsx
@@ -1,0 +1,76 @@
+import React, { ReactElement } from 'react';
+import {
+  GetStaticPathsResult,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
+import { TopReaderBadge } from '@dailydotdev/shared/src/components/badges/TopReaderBadge';
+import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
+import type { Keyword } from '@dailydotdev/shared/src/graphql/keywords';
+import { TOP_READER_BADGE_BY_ID } from '@dailydotdev/shared/src/graphql/users';
+
+export async function getStaticPaths(): Promise<GetStaticPathsResult> {
+  return { paths: [], fallback: 'blocking' };
+}
+
+interface PageProps {
+  topReaderBadge: {
+    id: string;
+    user: LoggedUser;
+    issuedAt: Date;
+    keyword: Keyword;
+    image: string;
+  };
+}
+
+export async function getStaticProps({
+  params,
+}: GetStaticPropsContext): Promise<GetStaticPropsResult<PageProps>> {
+  const { badgeId } = params;
+
+  if (!badgeId) {
+    return {
+      notFound: true,
+      revalidate: false,
+    };
+  }
+
+  const badgeRes = await fetch(graphqlUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      query: TOP_READER_BADGE_BY_ID,
+      variables: {
+        id: badgeId,
+      },
+    }),
+    credentials: 'include',
+  });
+
+  const response = await badgeRes.json();
+
+  if (!response?.data?.topReaderBadge) {
+    return {
+      notFound: true,
+      revalidate: false,
+    };
+  }
+
+  return {
+    props: { topReaderBadge: response.data.topReaderBadge },
+    revalidate: 60,
+  };
+}
+
+const DevCardPage = ({ topReaderBadge }: PageProps): ReactElement => {
+  return (
+    <div id="screenshot_wrapper" className="w-fit">
+      <TopReaderBadge topReader={topReaderBadge} />
+    </div>
+  );
+};
+
+export default DevCardPage;

--- a/packages/webapp/pages/badges/[badgeId].tsx
+++ b/packages/webapp/pages/badges/[badgeId].tsx
@@ -4,11 +4,11 @@ import {
   GetStaticPropsContext,
   GetStaticPropsResult,
 } from 'next';
-import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
 import { TopReaderBadge } from '@dailydotdev/shared/src/components/badges/TopReaderBadge';
 import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
 import type { Keyword } from '@dailydotdev/shared/src/graphql/keywords';
 import { TOP_READER_BADGE_BY_ID } from '@dailydotdev/shared/src/graphql/users';
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
 
 export async function getStaticPaths(): Promise<GetStaticPathsResult> {
   return { paths: [], fallback: 'blocking' };
@@ -36,23 +36,14 @@ export async function getStaticProps({
     };
   }
 
-  const badgeRes = await fetch(graphqlUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
+  const { topReaderBadge } = await gqlClient.request<PageProps>(
+    TOP_READER_BADGE_BY_ID,
+    {
+      id: badgeId,
     },
-    body: JSON.stringify({
-      query: TOP_READER_BADGE_BY_ID,
-      variables: {
-        id: badgeId,
-      },
-    }),
-    credentials: 'include',
-  });
+  );
 
-  const response = await badgeRes.json();
-
-  if (!response?.data?.topReaderBadge) {
+  if (!topReaderBadge) {
     return {
       notFound: true,
       revalidate: false,
@@ -60,7 +51,7 @@ export async function getStaticProps({
   }
 
   return {
-    props: { topReaderBadge: response.data.topReaderBadge },
+    props: { topReaderBadge },
     revalidate: 60,
   };
 }

--- a/packages/webapp/pages/badges/[badgeId].tsx
+++ b/packages/webapp/pages/badges/[badgeId].tsx
@@ -65,7 +65,7 @@ export async function getStaticProps({
   };
 }
 
-const DevCardPage = ({ topReaderBadge }: PageProps): ReactElement => {
+const BadgePage = ({ topReaderBadge }: PageProps): ReactElement => {
   return (
     <div id="screenshot_wrapper" className="w-fit">
       <TopReaderBadge topReader={topReaderBadge} />
@@ -73,4 +73,4 @@ const DevCardPage = ({ topReaderBadge }: PageProps): ReactElement => {
   );
 };
 
-export default DevCardPage;
+export default BadgePage;

--- a/packages/webapp/pages/badges/[badgeId].tsx
+++ b/packages/webapp/pages/badges/[badgeId].tsx
@@ -18,7 +18,7 @@ interface PageProps {
   topReaderBadge: {
     id: string;
     user: LoggedUser;
-    issuedAt: Date;
+    issuedAt: string;
     keyword: Pick<Keyword, 'value' | 'flags'>;
     image: string;
   };
@@ -57,9 +57,10 @@ export async function getStaticProps({
 }
 
 const BadgePage = ({ topReaderBadge }: PageProps): ReactElement => {
+  const { user, keyword, issuedAt } = topReaderBadge;
   return (
     <div id="screenshot_wrapper" className="w-fit">
-      <TopReaderBadge topReader={topReaderBadge} />
+      <TopReaderBadge user={user} keyword={keyword} issuedAt={issuedAt} />
     </div>
   );
 };


### PR DESCRIPTION
This is used for generation of the badge image

Depends on https://github.com/dailydotdev/daily-api/pull/2370

## Changes

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-660


### Preview domain
https://as-660-badge-endpoint.preview.app.daily.dev

Demo devcard URL
https://as-660-badge-endpoint.preview.app.daily.dev/badges/e81c38aa-a8d6-4cf4-93e5-db24ec5daf30
