### PR TITLE
feat: add top reader badges widget to user profile

### DIFF
--- a/packages/shared/src/components/badges/TopReaderBadge.tsx
+++ b/packages/shared/src/components/badges/TopReaderBadge.tsx
@@ -14,6 +14,8 @@ import { cloudinaryTopReaderBadgeBackground } from '../../lib/image';
 import { formatDate, TimeFormatType } from '../../lib/dateFormat';
 
 export type TopReader = {
+  id: string;
+  total: number;
   user: Pick<LoggedUser, 'name' | 'image' | 'username'>;
   issuedAt: Date | string;
   keyword: Pick<Keyword, 'value' | 'flags'>;

--- a/packages/shared/src/components/badges/TopReaderBadge.tsx
+++ b/packages/shared/src/components/badges/TopReaderBadge.tsx
@@ -26,7 +26,7 @@ export const TopReaderBadge = ({
   user,
   issuedAt,
   keyword,
-}: TopReader): ReactElement => {
+}: Pick<TopReader, 'user' | 'issuedAt' | 'keyword'>): ReactElement => {
   const { name, username, image } = user;
   const formattedDate = formatDate({
     value: issuedAt,

--- a/packages/shared/src/components/profile/ActivitySection.tsx
+++ b/packages/shared/src/components/profile/ActivitySection.tsx
@@ -5,6 +5,7 @@ import classed from '../../lib/classed';
 import { IconSize } from '../Icon';
 import { FeedData } from '../../graphql/feed';
 import { Post } from '../../graphql/posts';
+import type { WithClassNameProps } from '../utilities';
 
 export const ActivityContainer = classed('section', 'flex flex-col');
 
@@ -33,14 +34,13 @@ export const ActivitySectionHeader = ({
   title,
   children,
   Icon,
-}: ActivitySectionHeaderProps): ReactElement => {
+  className,
+}: ActivitySectionHeaderProps & WithClassNameProps): ReactElement => {
   return (
-    <ActivitySectionTitle>
-      <span className="flex flex-col">
-        <span className="flex align-middle">
-          {Icon && <Icon size={IconSize.Small} secondary className="mr-2" />}
-          {title}
-        </span>
+    <ActivitySectionTitle className={className}>
+      <span className="flex align-middle">
+        {Icon && <Icon size={IconSize.Small} secondary className="mr-2" />}
+        {title}
       </span>
       {children}
     </ActivitySectionTitle>

--- a/packages/shared/src/components/profile/TopReaderWidget.tsx
+++ b/packages/shared/src/components/profile/TopReaderWidget.tsx
@@ -1,0 +1,103 @@
+import { useQuery } from '@tanstack/react-query';
+import React, { ReactElement } from 'react';
+import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
+import { fetchTopReaders } from '../../lib/topReader';
+import { disabledRefetch } from '../../lib/func';
+import { ActivityContainer, ActivitySectionHeader } from './ActivitySection';
+import { docs } from '../../lib/constants';
+import { MedalBadgeIcon } from '../icons';
+import { IconSize } from '../Icon';
+import { BadgeIconGoldGradient } from '../badges/BadgeIcon';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../typography/Typography';
+import { formatDate, TimeFormatType } from '../../lib/dateFormat';
+import type { PublicProfile } from '../../lib/user';
+
+export const TopReaderWidget = ({
+  user,
+}: {
+  user: PublicProfile;
+}): ReactElement => {
+  const { data: topReader, isLoading: isTopReaderLoading } = useQuery({
+    queryKey: generateQueryKey(RequestKey.TopReaderBadge, user, 'latest'),
+    queryFn: async () => {
+      return await fetchTopReaders(5, user.id);
+    },
+    staleTime: StaleTime.OneHour,
+    ...disabledRefetch,
+  });
+
+  if (isTopReaderLoading) {
+    return null;
+  }
+
+  return (
+    <ActivityContainer>
+      <ActivitySectionHeader
+        title="Badges"
+        subtitle="Understand more how this is computed in"
+        clickableTitle="daily.dev docs"
+        // TODO: add link to specific page in docs
+        link={docs}
+      />
+
+      {/* TODO: add a null state when the user has no badges */}
+
+      <div className="w-60 rounded-10 border border-border-subtlest-tertiary p-3">
+        <div className="flex">
+          <MedalBadgeIcon
+            secondary
+            size={IconSize.XLarge}
+            fill="url(#goldGradient)"
+          />
+          <BadgeIconGoldGradient />
+          <div className="flex flex-col">
+            <Typography
+              type={TypographyType.Body}
+              color={TypographyColor.Primary}
+              bold
+            >
+              X{topReader[0]?.total ?? 0}
+            </Typography>
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+            >
+              Top reader
+            </Typography>
+          </div>
+        </div>
+
+        {topReader.length > 0 && (
+          <div className="mt-3 flex flex-col gap-3">
+            {topReader.map((badge) => {
+              return (
+                <div className="flex justify-between" key={`badge-${badge.id}`}>
+                  <Typography
+                    type={TypographyType.Caption1}
+                    color={TypographyColor.Primary}
+                    className="rounded-6 border border-border-subtlest-tertiary px-2.5 py-0.5"
+                  >
+                    {badge.keyword.flags.title}
+                  </Typography>
+                  <Typography
+                    type={TypographyType.Caption2}
+                    color={TypographyColor.Quaternary}
+                  >
+                    {formatDate({
+                      value: badge.issuedAt,
+                      type: TimeFormatType.TopReaderBadge,
+                    })}
+                  </Typography>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </ActivityContainer>
+  );
+};

--- a/packages/shared/src/components/profile/TopReaderWidget.tsx
+++ b/packages/shared/src/components/profile/TopReaderWidget.tsx
@@ -30,7 +30,7 @@ export const TopReaderWidget = ({
     ...disabledRefetch,
   });
 
-  if (isTopReaderLoading) {
+  if (isTopReaderLoading || topReader.length === 0) {
     return null;
   }
 

--- a/packages/shared/src/components/profile/TopReaderWidget.tsx
+++ b/packages/shared/src/components/profile/TopReaderWidget.tsx
@@ -1,8 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
 import React, { ReactElement } from 'react';
-import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
-import { fetchTopReaders } from '../../lib/topReader';
-import { disabledRefetch } from '../../lib/func';
 import {
   ActivityContainer,
   ActivitySectionHeader,
@@ -20,22 +16,27 @@ import {
 import { formatDate, TimeFormatType } from '../../lib/dateFormat';
 import type { PublicProfile } from '../../lib/user';
 import { ClickableText } from '../buttons/ClickableText';
+import { useTopReader } from '../../hooks/useTopReader';
 
 export const TopReaderWidget = ({
   user,
 }: {
   user: PublicProfile;
 }): ReactElement => {
-  const { data: topReader, isLoading: isTopReaderLoading } = useQuery({
-    queryKey: generateQueryKey(RequestKey.TopReaderBadge, user, 'latest'),
-    queryFn: async () => {
-      return await fetchTopReaders(5, user.id);
-    },
-    staleTime: StaleTime.OneHour,
-    ...disabledRefetch,
+  const { data: topReaders, isLoading: isTopReaderLoading } = useTopReader({
+    user,
+    limit: 5,
   });
+  // const { data: topReader, isLoading: isTopReaderLoading } = useQuery({
+  //   queryKey: generateQueryKey(RequestKey.TopReaderBadge, user, 'latest'),
+  //   queryFn: async () => {
+  //     return await fetchTopReaders(5, user.id);
+  //   },
+  //   staleTime: StaleTime.OneHour,
+  //   ...disabledRefetch,
+  // });
 
-  if (isTopReaderLoading || topReader.length === 0) {
+  if (isTopReaderLoading || topReaders?.length === 0) {
     return null;
   }
 
@@ -69,7 +70,7 @@ export const TopReaderWidget = ({
               color={TypographyColor.Primary}
               bold
             >
-              X{topReader[0]?.total ?? 0}
+              X{topReaders[0]?.total ?? 0}
             </Typography>
             <Typography
               type={TypographyType.Footnote}
@@ -80,9 +81,9 @@ export const TopReaderWidget = ({
           </div>
         </div>
 
-        {topReader.length > 0 && (
+        {topReaders.length > 0 && (
           <div className="mt-3 flex flex-col gap-3">
-            {topReader.map((badge) => {
+            {topReaders.map((badge) => {
               return (
                 <div className="flex justify-between" key={`badge-${badge.id}`}>
                   <Typography

--- a/packages/shared/src/components/profile/TopReaderWidget.tsx
+++ b/packages/shared/src/components/profile/TopReaderWidget.tsx
@@ -43,8 +43,6 @@ export const TopReaderWidget = ({
         link={topReaderBadgeDocs}
       />
 
-      {/* TODO: add a null state when the user has no badges */}
-
       <div className="w-60 rounded-10 border border-border-subtlest-tertiary p-3">
         <div className="flex">
           <MedalBadgeIcon

--- a/packages/shared/src/components/profile/TopReaderWidget.tsx
+++ b/packages/shared/src/components/profile/TopReaderWidget.tsx
@@ -27,14 +27,6 @@ export const TopReaderWidget = ({
     user,
     limit: 5,
   });
-  // const { data: topReader, isLoading: isTopReaderLoading } = useQuery({
-  //   queryKey: generateQueryKey(RequestKey.TopReaderBadge, user, 'latest'),
-  //   queryFn: async () => {
-  //     return await fetchTopReaders(5, user.id);
-  //   },
-  //   staleTime: StaleTime.OneHour,
-  //   ...disabledRefetch,
-  // });
 
   if (isTopReaderLoading || topReaders?.length === 0) {
     return null;

--- a/packages/shared/src/components/profile/TopReaderWidget.tsx
+++ b/packages/shared/src/components/profile/TopReaderWidget.tsx
@@ -81,32 +81,30 @@ export const TopReaderWidget = ({
           </div>
         </div>
 
-        {topReaders.length > 0 && (
-          <div className="mt-3 flex flex-col gap-3">
-            {topReaders.map((badge) => {
-              return (
-                <div className="flex justify-between" key={`badge-${badge.id}`}>
-                  <Typography
-                    type={TypographyType.Caption1}
-                    color={TypographyColor.Primary}
-                    className="rounded-6 border border-border-subtlest-tertiary px-2.5 py-0.5"
-                  >
-                    {badge.keyword.flags.title}
-                  </Typography>
-                  <Typography
-                    type={TypographyType.Caption2}
-                    color={TypographyColor.Quaternary}
-                  >
-                    {formatDate({
-                      value: badge.issuedAt,
-                      type: TimeFormatType.TopReaderBadge,
-                    })}
-                  </Typography>
-                </div>
-              );
-            })}
-          </div>
-        )}
+        <div className="mt-3 flex flex-col gap-3">
+          {topReaders.map((badge) => {
+            return (
+              <div className="flex justify-between" key={`badge-${badge.id}`}>
+                <Typography
+                  type={TypographyType.Caption1}
+                  color={TypographyColor.Primary}
+                  className="rounded-6 border border-border-subtlest-tertiary px-2.5 py-0.5"
+                >
+                  {badge.keyword.flags.title}
+                </Typography>
+                <Typography
+                  type={TypographyType.Caption2}
+                  color={TypographyColor.Quaternary}
+                >
+                  {formatDate({
+                    value: badge.issuedAt,
+                    type: TimeFormatType.TopReaderBadge,
+                  })}
+                </Typography>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </ActivityContainer>
   );

--- a/packages/shared/src/components/profile/TopReaderWidget.tsx
+++ b/packages/shared/src/components/profile/TopReaderWidget.tsx
@@ -3,7 +3,11 @@ import React, { ReactElement } from 'react';
 import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
 import { fetchTopReaders } from '../../lib/topReader';
 import { disabledRefetch } from '../../lib/func';
-import { ActivityContainer, ActivitySectionHeader } from './ActivitySection';
+import {
+  ActivityContainer,
+  ActivitySectionHeader,
+  ActivitySectionSubTitle,
+} from './ActivitySection';
 import { topReaderBadgeDocs } from '../../lib/constants';
 import { MedalBadgeIcon } from '../icons';
 import { IconSize } from '../Icon';
@@ -15,6 +19,7 @@ import {
 } from '../typography/Typography';
 import { formatDate, TimeFormatType } from '../../lib/dateFormat';
 import type { PublicProfile } from '../../lib/user';
+import { ClickableText } from '../buttons/ClickableText';
 
 export const TopReaderWidget = ({
   user,
@@ -36,12 +41,19 @@ export const TopReaderWidget = ({
 
   return (
     <ActivityContainer>
-      <ActivitySectionHeader
-        title="Badges"
-        subtitle="Understand more how this is computed in"
-        clickableTitle="daily.dev docs"
-        link={topReaderBadgeDocs}
-      />
+      <ActivitySectionHeader className="flex-wrap" title="Badges">
+        <ActivitySectionSubTitle className="w-full">
+          Understand more how this is computed in
+          <ClickableText
+            tag="a"
+            target="_blank"
+            className="ml-1"
+            href={topReaderBadgeDocs}
+          >
+            daily.dev docs
+          </ClickableText>
+        </ActivitySectionSubTitle>
+      </ActivitySectionHeader>
 
       <div className="w-60 rounded-10 border border-border-subtlest-tertiary p-3">
         <div className="flex">

--- a/packages/shared/src/components/profile/TopReaderWidget.tsx
+++ b/packages/shared/src/components/profile/TopReaderWidget.tsx
@@ -23,7 +23,7 @@ export const TopReaderWidget = ({
 }: {
   user: PublicProfile;
 }): ReactElement => {
-  const { data: topReaders, isLoading: isTopReaderLoading } = useTopReader({
+  const { data: topReaders, isPending: isTopReaderLoading } = useTopReader({
     user,
     limit: 5,
   });

--- a/packages/shared/src/components/profile/TopReaderWidget.tsx
+++ b/packages/shared/src/components/profile/TopReaderWidget.tsx
@@ -4,7 +4,7 @@ import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
 import { fetchTopReaders } from '../../lib/topReader';
 import { disabledRefetch } from '../../lib/func';
 import { ActivityContainer, ActivitySectionHeader } from './ActivitySection';
-import { docs } from '../../lib/constants';
+import { topReaderBadgeDocs } from '../../lib/constants';
 import { MedalBadgeIcon } from '../icons';
 import { IconSize } from '../Icon';
 import { BadgeIconGoldGradient } from '../badges/BadgeIcon';
@@ -40,8 +40,7 @@ export const TopReaderWidget = ({
         title="Badges"
         subtitle="Understand more how this is computed in"
         clickableTitle="daily.dev docs"
-        // TODO: add link to specific page in docs
-        link={docs}
+        link={topReaderBadgeDocs}
       />
 
       {/* TODO: add a null state when the user has no badges */}

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -336,6 +336,7 @@ export const TOP_READER_BADGE_FRAGMENT = gql`
     id
     issuedAt
     image
+    total
     keyword {
       value
       flags {

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -654,7 +654,7 @@ export const USER_INTEGRATION_BY_ID = gql`
 `;
 
 export const TOP_READER_BADGE = gql`
-  query TopReaderBadge($limit: Int, $userId: ID) {
+  query TopReaderBadge($userId: ID!, $limit: Int) {
     topReaderBadge(limit: $limit, userId: $userId) {
       ...TopReader
     }

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -654,8 +654,8 @@ export const USER_INTEGRATION_BY_ID = gql`
 `;
 
 export const TOP_READER_BADGE = gql`
-  query TopReaderBadge($limit: Int!) {
-    topReaderBadge(limit: $limit) {
+  query TopReaderBadge($limit: Int, $userId: ID) {
+    topReaderBadge(limit: $limit, userId: $userId) {
       ...TopReader
     }
   }

--- a/packages/shared/src/hooks/useTopReader.ts
+++ b/packages/shared/src/hooks/useTopReader.ts
@@ -1,0 +1,41 @@
+import { useQuery } from '@tanstack/react-query';
+import { generateQueryKey, RequestKey, StaleTime } from '../lib/query';
+import { fetchTopReaderById, fetchTopReaders } from '../lib/topReader';
+import { disabledRefetch } from '../lib/func';
+import type { LoggedUser, PublicProfile } from '../lib/user';
+import type { TopReader } from '../components/badges/TopReaderBadge';
+
+type UseTopReaderProps = {
+  user: LoggedUser | PublicProfile;
+  limit?: number;
+  badgeId?: string;
+};
+
+type UseTopReader = (props: UseTopReaderProps) => {
+  data: TopReader[];
+  isLoading: boolean;
+};
+
+export const useTopReader: UseTopReader = ({ limit = 5, user, badgeId }) => {
+  const { data, isLoading } = useQuery({
+    queryKey: generateQueryKey(
+      RequestKey.TopReaderBadge,
+      user,
+      badgeId ?? `latest:${limit}`,
+    ),
+    queryFn: async () => {
+      if (badgeId) {
+        return [await fetchTopReaderById(badgeId)];
+      }
+
+      return fetchTopReaders(limit, user.id);
+    },
+    staleTime: StaleTime.OneHour,
+    ...disabledRefetch,
+  });
+
+  return {
+    data,
+    isLoading,
+  };
+};

--- a/packages/shared/src/hooks/useTopReader.ts
+++ b/packages/shared/src/hooks/useTopReader.ts
@@ -13,11 +13,11 @@ type UseTopReaderProps = {
 
 type UseTopReader = (props: UseTopReaderProps) => {
   data: TopReader[];
-  isLoading: boolean;
+  isPending: boolean;
 };
 
 export const useTopReader: UseTopReader = ({ limit = 5, user, badgeId }) => {
-  const { data, isLoading } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: generateQueryKey(
       RequestKey.TopReaderBadge,
       user,
@@ -36,6 +36,6 @@ export const useTopReader: UseTopReader = ({ limit = 5, user, badgeId }) => {
 
   return {
     data,
-    isLoading,
+    isPending,
   };
 };

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -67,6 +67,7 @@ export const heimdallUrl = isDevelopment
 
 export const bookmarkLoops = 'https://r.daily.dev/bookmarkloops';
 export const migrateUserToStreaks = 'https://r.daily.dev/streaks';
+export const topReaderBadgeDocs = 'https://r.daily.dev/top-reader-badge';
 
 export const squadCategoriesPaths = {
   'My Squads': '/squads/discover/my',

--- a/packages/shared/src/lib/topReader.ts
+++ b/packages/shared/src/lib/topReader.ts
@@ -2,11 +2,15 @@ import type { TopReader } from '../components/badges/TopReaderBadge';
 import { gqlClient } from '../graphql/common';
 import { TOP_READER_BADGE, TOP_READER_BADGE_BY_ID } from '../graphql/users';
 
-export const fetchTopReaders = async (limit = 5): Promise<TopReader[]> => {
+export const fetchTopReaders = async (
+  limit = 5,
+  userId?: string,
+): Promise<TopReader[]> => {
   const { topReaderBadge } = await gqlClient.request<{
     topReaderBadge: TopReader[];
   }>(TOP_READER_BADGE, {
     limit,
+    userId,
   });
 
   return topReaderBadge;

--- a/packages/shared/src/lib/topReader.ts
+++ b/packages/shared/src/lib/topReader.ts
@@ -4,7 +4,7 @@ import { TOP_READER_BADGE, TOP_READER_BADGE_BY_ID } from '../graphql/users';
 
 export const fetchTopReaders = async (
   limit = 5,
-  userId?: string,
+  userId: string,
 ): Promise<TopReader[]> => {
   const { topReaderBadge } = await gqlClient.request<{
     topReaderBadge: TopReader[];

--- a/packages/webapp/pages/[userId]/index.tsx
+++ b/packages/webapp/pages/[userId]/index.tsx
@@ -28,6 +28,7 @@ import {
   ProfileLayoutProps,
 } from '../../components/layouts/ProfileLayout';
 import { ReadingStreaksWidget } from '../../../shared/src/components/profile/ReadingStreaksWidget';
+import { TopReaderWidget } from '../../../shared/src/components/profile/TopReaderWidget';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ProfilePage = ({
@@ -70,12 +71,13 @@ const ProfilePage = ({
   const seo: NextSeoProps = {
     ...getProfileSeoDefaults(user, {}, noindex),
   };
-
   return (
     <>
       <NextSeo {...seo} />
       <div className="flex flex-col gap-6 px-4 py-6 tablet:px-6">
         <Readme user={user} />
+
+        <TopReaderWidget user={user} />
         {isStreaksEnabled && readingHistory?.userStreakProfile && (
           <ReadingStreaksWidget
             streak={readingHistory?.userStreakProfile}


### PR DESCRIPTION
## Changes

Depends on https://github.com/dailydotdev/daily-api/pull/2381

TODO:

- [x] add link to specific page in docs
- [x] add a null state when the user has no badges?

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-661


### Preview domain
https://as-661-profile-top-reader.preview.app.daily.dev