### PR TITLE
fix: deletion of custom feeds

### DIFF
--- a/packages/shared/src/components/tabs/TabList.tsx
+++ b/packages/shared/src/components/tabs/TabList.tsx
@@ -57,7 +57,12 @@ function TabList<T extends string = string>({
       }
 
       const scrollableParent =
-        currentActiveTab.current.parentElement.parentElement;
+        currentActiveTab.current.parentElement?.parentElement;
+
+      if (!scrollableParent) {
+        return;
+      }
+
       const scrollableParentRect = scrollableParent.getBoundingClientRect();
 
       if (


### PR DESCRIPTION
## Changes

Due to callback getting called before redirect happens this item no longer exists.
(Mobile only issue)

Solves:
https://github.com/dailydotdev/daily/issues/1430

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://fix-deletion-custom-feeds.preview.app.daily.dev