### PR TITLE
fix: subscribe state of oneSignal

### DIFF
--- a/packages/shared/src/hooks/useSquadChecklist.tsx
+++ b/packages/shared/src/hooks/useSquadChecklist.tsx
@@ -37,7 +37,6 @@ const useSquadChecklist = ({
 }: UseSquadChecklistProps): UseSquadChecklist => {
   const { actions, isActionsFetched: isChecklistReady } = useActions();
   const { isInitialized, isPushSupported } = usePushNotificationContext();
-  console.log('is supported', isPushSupported);
 
   const stepsMap = useMemo<
     Partial<Record<ActionType, ChecklistStepType>>

--- a/packages/shared/src/hooks/useSquadChecklist.tsx
+++ b/packages/shared/src/hooks/useSquadChecklist.tsx
@@ -37,6 +37,7 @@ const useSquadChecklist = ({
 }: UseSquadChecklistProps): UseSquadChecklist => {
   const { actions, isActionsFetched: isChecklistReady } = useActions();
   const { isInitialized, isPushSupported } = usePushNotificationContext();
+  console.log('is supported', isPushSupported);
 
   const stepsMap = useMemo<
     Partial<Record<ActionType, ChecklistStepType>>
@@ -149,7 +150,7 @@ const useSquadChecklist = ({
           component: NotificationChecklistStep,
         },
         actions,
-        condition: () => isPushSupported,
+        condition: () => !!isPushSupported,
       }),
     };
   }, [isChecklistReady, isInitialized, actions, squad, isPushSupported]);


### PR DESCRIPTION
## Changes

Brave browser blocks OneSignal SDK from loading thus resulting the `isPushSupported` to return as `undefined`.
This fix ensures we cast to boolean to prevent falsy values.

Issue:
![Screenshot 2024-11-04 at 16 07 23](https://github.com/user-attachments/assets/d51b80df-4940-4283-b9cd-c0312218b210)

Solves:
https://github.com/dailydotdev/daily/issues/1558

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://fix-subscribe-state.preview.app.daily.dev