### PR TITLE
fix: when user subscribe, complete action

### DIFF
--- a/packages/shared/src/contexts/PushNotificationContext.tsx
+++ b/packages/shared/src/contexts/PushNotificationContext.tsx
@@ -16,6 +16,8 @@ import { generateQueryKey, RequestKey } from '../lib/query';
 import { isTesting } from '../lib/constants';
 import { useLogContext } from './LogContext';
 import { SubscriptionCallback } from '../components/notifications/utils';
+import { useActions } from '../hooks';
+import { ActionType } from '../graphql/actions';
 
 export interface PushNotificationsContextData {
   OneSignal: typeof OneSignal;
@@ -125,6 +127,22 @@ export function PushNotificationContextProvider({
     (source) => subscriptionCallbackRef.current?.(true, source, true),
     [],
   );
+
+  const { completeAction, checkHasCompleted, isActionsFetched } = useActions();
+  const isPushEnabled =
+    isPushSupported && isSuccess && isEnabled && isActionsFetched;
+  const hasCompletedAction =
+    isPushEnabled &&
+    isSubscribed &&
+    checkHasCompleted(ActionType.EnableNotification);
+
+  useEffect(() => {
+    if (!hasCompletedAction) {
+      return;
+    }
+
+    completeAction(ActionType.EnableNotification);
+  }, [hasCompletedAction, completeAction]);
 
   useEffect(() => {
     if (!OneSignalCache) {

--- a/packages/shared/src/contexts/PushNotificationContext.tsx
+++ b/packages/shared/src/contexts/PushNotificationContext.tsx
@@ -129,9 +129,9 @@ export function PushNotificationContextProvider({
   );
 
   const { completeAction, checkHasCompleted, isActionsFetched } = useActions();
-  const isPushEnabled =
-    isPushSupported && isSuccess && isEnabled && isActionsFetched;
+  const isPushEnabled = isPushSupported && isSuccess && isEnabled;
   const hasCompletedAction =
+    isActionsFetched &&
     isPushEnabled &&
     isSubscribed &&
     checkHasCompleted(ActionType.EnableNotification);


### PR DESCRIPTION
## Changes
- I checked the component, and there was really no handler where if it was clicked, we complete the action.
- Rather than basing it off only on the Checklist, once the user subscribe, we should complete it automatically.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

MI-615 #done


### Preview domain
https://mi-615.preview.app.daily.dev