### PR TITLE
fix: use google favicon provider

### DIFF
--- a/packages/extension/src/newtab/CustomLinks.tsx
+++ b/packages/extension/src/newtab/CustomLinks.tsx
@@ -10,6 +10,7 @@ import React, { MouseEventHandler, ReactElement } from 'react';
 import { WithClassNameProps } from '@dailydotdev/shared/src/components/utilities';
 import { combinedClicks } from '@dailydotdev/shared/src/lib/click';
 import { useFeedLayout } from '@dailydotdev/shared/src/hooks';
+import { SiteImage } from './ShortcutLinks/SiteImage';
 
 interface CustomLinksProps extends WithClassNameProps {
   links: string[];
@@ -50,13 +51,7 @@ export function CustomLinks({
           key={url}
           {...combinedClicks(onLinkClick)}
         >
-          <img
-            src={`https://api.daily.dev/icon?url=${encodeURIComponent(
-              url,
-            )}&size=${iconSize}`}
-            alt={url}
-            className="h-full w-full"
-          />
+          <SiteImage url={url} className="size-full" iconSize={iconSize} />
         </a>
       ))}
       <SimpleTooltip placement="left" content="Edit shortcuts">

--- a/packages/extension/src/newtab/ShortcutLinks/SiteImage.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks/SiteImage.tsx
@@ -1,0 +1,24 @@
+import React, { ReactElement, SyntheticEvent } from 'react';
+import { WithClassNameProps } from '@dailydotdev/shared/src/components/utilities';
+
+interface SiteImageProps extends WithClassNameProps {
+  url: string;
+  iconSize: number;
+}
+export const SiteImage = ({
+  url,
+  iconSize,
+  className,
+}: SiteImageProps): ReactElement => {
+  const cleanUrl = encodeURIComponent(url);
+  const src = `https://www.google.com/s2/favicons?sz=${iconSize}&domain=${cleanUrl}`;
+  const fallbackSrc = `https://api.daily.dev/icon?url=${cleanUrl}&size=${iconSize}`;
+  const onError = (event: SyntheticEvent<HTMLImageElement>): void => {
+    if (fallbackSrc && fallbackSrc !== event.currentTarget.src) {
+      // eslint-disable-next-line no-param-reassign
+      event.currentTarget.src = fallbackSrc;
+    }
+  };
+
+  return <img src={src} alt={url} className={className} onError={onError} />;
+};

--- a/packages/extension/src/newtab/ShortcutLinks/experiments/ShortcutLinksUIV1.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks/experiments/ShortcutLinksUIV1.tsx
@@ -26,6 +26,7 @@ import {
   cloudinaryShortcutsIconsStackoverflow,
 } from '@dailydotdev/shared/src/lib/image';
 import { useThemedAsset } from '@dailydotdev/shared/src/hooks/utils';
+import { SiteImage } from '../SiteImage';
 
 const pixelRatio = globalThis?.window.devicePixelRatio ?? 1;
 const iconSize = Math.round(24 * pixelRatio);
@@ -91,13 +92,7 @@ function ShortcutV1Item({
       className="group mr-4 flex flex-col items-center"
     >
       <div className="mb-2 flex size-12 items-center justify-center rounded-full bg-surface-float text-text-secondary">
-        <img
-          src={`https://api.daily.dev/icon?url=${encodeURIComponent(
-            url,
-          )}&size=${iconSize}`}
-          alt={url}
-          className="size-6"
-        />
+        <SiteImage url={url} iconSize={iconSize} className="size-6" />
       </div>
       <span className="max-w-12 truncate text-text-tertiary typo-caption2">
         {cleanUrl}


### PR DESCRIPTION
## Changes

Long lasting report of either images not loading or being wrong, i've decided to revamp our shortcut icons to use google favicon provider by default and fallback to our iconserver on error.

There's no infinite loop as we check for same value in the onError callback. (same as lazyimage basically)

Solves: https://github.com/dailydotdev/daily/issues/1399

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://fix-google-favicon-provider.preview.app.daily.dev