### PR TITLE
fix: fallback to keyword value when title does not exist

### DIFF
--- a/packages/shared/src/components/badges/TopReaderBadge.tsx
+++ b/packages/shared/src/components/badges/TopReaderBadge.tsx
@@ -84,7 +84,7 @@ export const TopReaderBadge = ({
               bold
               className="relative z-1 text-black"
             >
-              {keyword.flags?.title}
+              {keyword.flags?.title || keyword.value}
             </Typography>
             <div
               className="absolute left-0 top-0 z-0 h-full w-full -scale-x-100"

--- a/packages/shared/src/components/modals/badges/TopReaderBadgeModal.tsx
+++ b/packages/shared/src/components/modals/badges/TopReaderBadgeModal.tsx
@@ -60,9 +60,11 @@ const TopReaderBadgeModal = (
       type: TimeFormatType.TopReaderBadge,
     });
 
+    const keyword = topReader.keyword.flags?.title || topReader.keyword.value;
+
     await onDownloadUrl({
       url: topReader.image,
-      filename: `${formattedDate} Top Reader in ${topReader.keyword.flags.title}.png`,
+      filename: `${formattedDate} Top Reader in ${keyword}.png`,
     });
 
     logModalEvent(LogEvent.TopReaderBadgeDownload);

--- a/packages/shared/src/components/profile/TopReaderWidget.tsx
+++ b/packages/shared/src/components/profile/TopReaderWidget.tsx
@@ -89,7 +89,7 @@ export const TopReaderWidget = ({
                     color={TypographyColor.Primary}
                     className="rounded-6 border border-border-subtlest-tertiary px-2.5 py-0.5 transition duration-200 hover:bg-background-popover"
                   >
-                    {badge.keyword.flags.title}
+                    {badge.keyword.flags?.title || badge.keyword.value}
                   </Typography>
                 </Link>
                 <Typography


### PR DESCRIPTION
## Changes

Some keywords does not have a title, so we need to fallback to using the value instead

<table>
  <tr>
    <td>Before
    <td>After
  <tr>
    <td><img src=https://github.com/user-attachments/assets/bde39c71-4bd7-4fdb-b49f-bfab49c1b8b3>
    <td><img src=https://github.com/user-attachments/assets/788edd36-3e6d-4ed3-b7ec-2c74749519d6>
</table>

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://as-510-keyword-fallback.preview.app.daily.dev