### PR TITLE
refactor: use native close button in drawer instead

### DIFF
--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -3,6 +3,7 @@ import React, {
   MutableRefObject,
   ReactElement,
   ReactNode,
+  useEffect,
   useImperativeHandle,
   useRef,
   useState,
@@ -40,7 +41,8 @@ interface ClassName {
 }
 
 export interface DrawerProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'title'> {
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'title'>,
+    Pick<ReactModal.Props, 'onAfterOpen' | 'onAfterClose'> {
   children: ReactNode;
   className?: ClassName;
   position?: DrawerPosition;
@@ -82,6 +84,8 @@ function BaseDrawer({
   title,
   onClose,
   displayCloseButton,
+  onAfterOpen,
+  onAfterClose,
   ...props
 }: DrawerProps): ReactElement {
   const container = useRef<HTMLDivElement>();
@@ -90,6 +94,13 @@ function BaseDrawer({
   const classes = className?.drawer ?? 'px-4 py-3';
   useOutsideClick(container, onClose, closeOnOutsideClick && hasAnimated);
   const isAnimating = !hasAnimated || isClosing;
+
+  useEffect(() => {
+    onAfterOpen?.();
+    return () => {
+      onAfterClose?.();
+    };
+  }, [onAfterClose, onAfterOpen]);
 
   return (
     <div

--- a/packages/shared/src/components/modals/badges/TopReaderBadgeModal.tsx
+++ b/packages/shared/src/components/modals/badges/TopReaderBadgeModal.tsx
@@ -13,6 +13,7 @@ import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent, TargetId, TargetType, type Origin } from '../../../lib/log';
 import { formatDate, TimeFormatType } from '../../../lib/dateFormat';
 import { useTopReader } from '../../../hooks/useTopReader';
+import { ModalClose } from '../common/ModalClose';
 
 type TopReaderBadgeModalProps = {
   badgeId?: string;
@@ -91,6 +92,8 @@ const TopReaderBadgeModal = (
       }}
     >
       <Modal.Body className="flex flex-col items-center justify-center gap-4 text-center">
+        <ModalClose top="2" onClick={onRequestClose} />
+
         <h1 className="font-bold typo-title1">
           You&apos;ve earned the top reader badge!
         </h1>
@@ -110,16 +113,6 @@ const TopReaderBadgeModal = (
         >
           Download badge
         </Button>
-
-        {!isMobile && (
-          <Button
-            className="w-full max-w-80"
-            variant={ButtonVariant.Float}
-            onClick={onRequestClose}
-          >
-            Close
-          </Button>
-        )}
       </Modal.Body>
     </Modal>
   );

--- a/packages/shared/src/components/modals/badges/TopReaderBadgeModal.tsx
+++ b/packages/shared/src/components/modals/badges/TopReaderBadgeModal.tsx
@@ -89,9 +89,6 @@ const TopReaderBadgeModal = (
 
         onAfterOpen?.();
       }}
-      drawerProps={{
-        displayCloseButton: false,
-      }}
     >
       <Modal.Body className="flex flex-col items-center justify-center gap-4 text-center">
         <h1 className="font-bold typo-title1">
@@ -114,13 +111,15 @@ const TopReaderBadgeModal = (
           Download badge
         </Button>
 
-        <Button
-          className={classNames('w-full', !isMobile && 'max-w-80')}
-          variant={ButtonVariant.Float}
-          onClick={onRequestClose}
-        >
-          Close
-        </Button>
+        {!isMobile && (
+          <Button
+            className="w-full max-w-80"
+            variant={ButtonVariant.Float}
+            onClick={onRequestClose}
+          >
+            Close
+          </Button>
+        )}
       </Modal.Body>
     </Modal>
   );

--- a/packages/shared/src/components/modals/common/Modal.tsx
+++ b/packages/shared/src/components/modals/common/Modal.tsx
@@ -165,15 +165,9 @@ export function Modal({
         displayCloseButton
         {...drawerProps}
         isOpen
-        onClose={() => {
-          if (onRequestClose) {
-            onRequestClose(null);
-          }
-
-          if (props.onAfterClose) {
-            props.onAfterClose();
-          }
-        }}
+        onAfterClose={props?.onAfterClose}
+        onAfterOpen={props?.onAfterOpen}
+        onClose={onRequestClose}
         closeOnOutsideClick={shouldCloseOnOverlayClick}
       >
         {content}


### PR DESCRIPTION
## Changes AS-680

### Refactor to use the native drawer close button

The close button in the modal called `onRequestClose` directly, which unmounted the component and didn't let the drawer close properly.
So now I just hide the button on mobile, and use the native close button in the drawer. Now it also animates the closing.

### Fixed issue where we did not trigger `onAfterOpen` after drawer was opened

I noticed that modals/drawers on mobile did not trigger the `onAfterOpen` which is often used to send analytics events. This might've caused some events not being sent from mobile.

It now uses a `useEffect` to call `onAfterOpen` once on mount, and then `onAfterClose` once upon unmount, similar to how `ReactModal` uses  `componentWillMount`/`componentWillUnmount` 


### Preview domain
https://as-680-fix-drawer-close.preview.app.daily.dev