### PR TITLE
feat: edit source post moderation entity

### DIFF
--- a/packages/shared/src/components/cards/Freeform/FreeformList.tsx
+++ b/packages/shared/src/components/cards/Freeform/FreeformList.tsx
@@ -44,7 +44,7 @@ export const FreeformList = forwardRef(function SharePostCard(
     [post.contentHtml],
   );
 
-  const { title } = useTruncatedSummary(post, content);
+  const { title } = useTruncatedSummary(post?.title, content);
 
   return (
     <FeedItemContainer

--- a/packages/shared/src/components/cards/article/ArticleList.tsx
+++ b/packages/shared/src/components/cards/article/ArticleList.tsx
@@ -49,7 +49,7 @@ export const ArticleList = forwardRef(function ArticleList(
 
   const { showFeedback } = usePostFeedback({ post });
   const isFeedPreview = useFeedPreviewMode();
-  const { title } = useTruncatedSummary(post);
+  const { title } = useTruncatedSummary(post?.title);
 
   return (
     <FeedItemContainer

--- a/packages/shared/src/components/cards/collection/CollectionList.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionList.tsx
@@ -35,7 +35,7 @@ export const CollectionList = forwardRef(function CollectionCard(
   ref: Ref<HTMLElement>,
 ) {
   const image = usePostImage(post);
-  const { title } = useTruncatedSummary(post);
+  const { title } = useTruncatedSummary(post?.title);
 
   return (
     <FeedItemContainer

--- a/packages/shared/src/components/cards/share/ShareList.tsx
+++ b/packages/shared/src/components/cards/share/ShareList.tsx
@@ -39,10 +39,7 @@ export const ShareList = forwardRef(function ShareList(
   const containerRef = useRef<HTMLDivElement>();
   const isFeedPreview = useFeedPreviewMode();
   const isVideoType = isVideoPost(post);
-  const { title } = useTruncatedSummary({
-    ...post,
-    ...(!post.title && { title: post.sharedPost.title }),
-  });
+  const { title } = useTruncatedSummary(post?.title || post?.sharedPost?.title);
 
   return (
     <FeedItemContainer

--- a/packages/shared/src/components/modals/squads/PostModerationModal.tsx
+++ b/packages/shared/src/components/modals/squads/PostModerationModal.tsx
@@ -50,7 +50,7 @@ function PostModerationModal({
     content,
     contentHtml,
     sharedPost,
-    sourceId,
+    source,
   } = data;
   const onReadArticle = useReadArticle({
     origin: Origin.ArticleModal,
@@ -70,8 +70,8 @@ function PostModerationModal({
       <Modal.Body className="gap-6">
         {isModerator && (
           <SquadModerationActions
-            onReject={() => onReject([id], sourceId)}
-            onApprove={() => onApprove([id], sourceId)}
+            onReject={() => onReject([id], source.id)}
+            onApprove={() => onApprove([id], source.id)}
           />
         )}
         <div className="flex flex-row items-center justify-between">

--- a/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
+++ b/packages/shared/src/components/post/freeform/write/WriteFreeformContent.tsx
@@ -9,11 +9,7 @@ import { CameraIcon } from '../../../icons';
 import { TextField } from '../../../fields/TextField';
 import MarkdownInput from '../../../fields/MarkdownInput';
 import { WritePageMain } from './common';
-import {
-  EditPostProps,
-  Post,
-  imageSizeLimitMB,
-} from '../../../../graphql/posts';
+import { EditPostProps, imageSizeLimitMB } from '../../../../graphql/posts';
 import { formToJson } from '../../../../lib/form';
 import useDebounceFn from '../../../../hooks/useDebounceFn';
 import AlertPointer, { AlertPlacement } from '../../../alert/AlertPointer';
@@ -21,7 +17,11 @@ import { useActions, useViewSize, ViewSize } from '../../../../hooks';
 import { ActionType } from '../../../../graphql/actions';
 import useSidebarRendered from '../../../../hooks/useSidebarRendered';
 import { base64ToFile } from '../../../../lib/base64';
-import { useWritePostContext, WriteForm } from '../../../../contexts';
+import {
+  MergedWriteObject,
+  useWritePostContext,
+  WriteForm,
+} from '../../../../contexts';
 import { defaultMarkdownCommands } from '../../../../hooks/input';
 import { WriteFooter } from '../../write';
 
@@ -32,7 +32,7 @@ export const checkSavedProperty = (
   prop: keyof WriteForm,
   form: EditPostProps,
   draft: Partial<WriteForm>,
-  post?: Post,
+  post?: MergedWriteObject,
 ): boolean =>
   !form[prop] || (form[prop] === draft?.[prop] && form[prop] !== post?.[prop]);
 
@@ -53,7 +53,7 @@ export function WriteFreeformContent({
     onSubmitForm,
     isPosting,
     squad,
-    post,
+    fetchedPost,
     draft,
     updateDraft,
     isUpdatingDraft,
@@ -115,7 +115,7 @@ export function WriteFreeformContent({
         closeable
         fileSizeLimitMB={imageSizeLimitMB}
         name="image"
-        initialValue={draft?.image ?? post?.image}
+        initialValue={draft?.image ?? fetchedPost?.image}
         onChange={(base64, file) =>
           updateDraft({
             ...draft,
@@ -157,7 +157,7 @@ export function WriteFreeformContent({
           label="Post Title*"
           placeholder="Give your post a title"
           required
-          defaultValue={draft?.title ?? post?.title}
+          defaultValue={draft?.title ?? fetchedPost?.title}
           onInput={onFormUpdate}
           maxLength={MAX_TITLE_LENGTH}
         />
@@ -166,7 +166,7 @@ export function WriteFreeformContent({
         className={{ container: 'mt-4' }}
         sourceId={squad?.id}
         onValueUpdate={onFormUpdate}
-        initialContent={draft?.content ?? post?.content ?? ''}
+        initialContent={draft?.content ?? fetchedPost?.content ?? ''}
         textareaProps={{ name: 'content' }}
         enabledCommand={{ ...defaultMarkdownCommands, upload: true }}
         isUpdatingDraft={isUpdatingDraft}

--- a/packages/shared/src/components/post/write/ShareLink.tsx
+++ b/packages/shared/src/components/post/write/ShareLink.tsx
@@ -53,11 +53,12 @@ export function ShareLink({
       }),
   });
   const { push } = useRouter();
-  const { onUpdatePostModeration, isPending } = useSourcePostModeration({
-    onSuccess: async () => push(squad.permalink),
-  });
+  const { onUpdatePostModeration, isPending: isPostingModeration } =
+    useSourcePostModeration({
+      onSuccess: async () => push(squad.permalink),
+    });
 
-  const { onCreateSquad, isLoading } = useSquadCreate({
+  const { onCreateSquad, isLoading: isCreatingSquad } = useSquadCreate({
     onSuccess: (newSquad) => {
       onSubmitPost(null, newSquad, commentary);
       return push(newSquad.permalink);
@@ -68,7 +69,7 @@ export function ShareLink({
   const onSubmit: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
 
-    if (isPosting || isPending || isLoading) {
+    if (isPosting || isPostingModeration || isCreatingSquad) {
       return null;
     }
 

--- a/packages/shared/src/components/post/write/ShareLink.tsx
+++ b/packages/shared/src/components/post/write/ShareLink.tsx
@@ -7,27 +7,32 @@ import { WriteFooter } from './WriteFooter';
 import { SubmitExternalLink } from './SubmitExternalLink';
 import { usePostToSquad } from '../../../hooks';
 import { useToastNotification } from '../../../hooks/useToastNotification';
-import { Post } from '../../../graphql/posts';
+import { Post, PostType } from '../../../graphql/posts';
 import { WriteLinkPreview } from './WriteLinkPreview';
 import { generateDefaultSquad } from './SquadsDropdown';
 import { useSquadCreate } from '../../../hooks/squads/useSquadCreate';
 import { useAuthContext } from '../../../contexts/AuthContext';
+import useSourcePostModeration from '../../../hooks/source/useSourcePostModeration';
+import { SourcePostModeration } from '../../../graphql/squads';
 
 interface ShareLinkProps {
   squad: Squad;
   post?: Post;
+  moderated?: SourcePostModeration;
   className?: string;
   onPostSuccess: (post: Post, url: string) => void;
 }
 
 export function ShareLink({
   squad,
-  post,
   className,
   onPostSuccess,
+  post,
+  moderated,
 }: ShareLinkProps): ReactElement {
+  const fetchedPost = post || moderated;
   const { displayToast } = useToastNotification();
-  const [commentary, setCommentary] = useState(post?.title ?? '');
+  const [commentary, setCommentary] = useState(fetchedPost?.title ?? '');
   const { squads, user } = useAuthContext();
   const {
     getLinkPreview,
@@ -37,8 +42,20 @@ export function ShareLink({
     onSubmitPost,
     onUpdatePost,
     onUpdatePreview,
-  } = usePostToSquad({ onPostSuccess, initialPreview: post?.sharedPost });
+  } = usePostToSquad({
+    onPostSuccess,
+    initialPreview:
+      fetchedPost?.sharedPost ||
+      (moderated && {
+        url: moderated.externalLink,
+        title: moderated.title,
+        image: moderated.image,
+      }),
+  });
   const { push } = useRouter();
+  const { onUpdatePostModeration, isPending } = useSourcePostModeration({
+    onSuccess: async () => push(squad.permalink),
+  });
 
   const { onCreateSquad, isLoading } = useSquadCreate({
     onSuccess: (newSquad) => {
@@ -51,7 +68,7 @@ export function ShareLink({
   const onSubmit: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
 
-    if (isPosting || isLoading) {
+    if (isPosting || isPending || isLoading) {
       return null;
     }
 
@@ -59,11 +76,26 @@ export function ShareLink({
       return displayToast('You must select a Squad to post to!');
     }
 
-    if (post?.id) {
-      if (commentary !== post?.title) {
-        onUpdatePost(e, post.id, commentary);
+    if (fetchedPost?.id) {
+      if (
+        commentary === fetchedPost?.title ||
+        commentary === moderated?.content
+      ) {
+        return push(squad.permalink);
       }
-      return push(squad.permalink);
+
+      if (moderated) {
+        return onUpdatePostModeration({
+          type: PostType.Share,
+          sourceId: squad.id,
+          id: moderated.id,
+          title: moderated.sharedPost ? commentary : preview.title,
+          content: moderated.sharedPost ? null : commentary,
+          imageUrl: moderated.sharedPost ? null : preview.image,
+        });
+      }
+
+      return onUpdatePost(e, fetchedPost.id, commentary);
     }
 
     if (squads.some(({ id }) => squad.id === id)) {
@@ -80,15 +112,15 @@ export function ShareLink({
       onSubmit={onSubmit}
       id="write-post-link"
     >
-      {post?.id ? (
+      {fetchedPost?.sharedPost ? (
         <WriteLinkPreview
-          link={post.sharedPost.permalink}
-          preview={post.sharedPost}
+          link={fetchedPost.sharedPost.permalink}
+          preview={fetchedPost.sharedPost}
           showPreviewLink={false}
         />
       ) : (
         <SubmitExternalLink
-          preview={preview || post?.sharedPost}
+          preview={preview || fetchedPost?.sharedPost}
           getLinkPreview={getLinkPreview}
           isLoadingPreview={isLoadingPreview}
           onSelectedHistory={onUpdatePreview}
@@ -96,7 +128,7 @@ export function ShareLink({
       )}
 
       <MarkdownInput
-        initialContent={commentary || post?.title || ''}
+        initialContent={commentary || fetchedPost?.title || ''}
         enabledCommand={{ mention: true }}
         showMarkdownGuide={false}
         onValueUpdate={setCommentary}

--- a/packages/shared/src/components/squads/moderation/SquadModerationItem.tsx
+++ b/packages/shared/src/components/squads/moderation/SquadModerationItem.tsx
@@ -33,11 +33,9 @@ export function SquadModerationItem(
     status === SourcePostModerationStatus.Rejected ? WarningIcon : TimerIcon;
 
   const post = data.sharedPost || data.post;
-  const { title } = useTruncatedSummary({
-    ...data,
-    ...post,
-    ...(!post?.title && !data.title && { title: post?.sharedPost?.title }),
-  });
+  const { title } = useTruncatedSummary(
+    data?.title || data.sharedPost?.title || data.post?.title,
+  );
 
   return (
     <div className="relative flex flex-col gap-4 p-6 hover:bg-surface-hover">

--- a/packages/shared/src/components/squads/moderation/SquadModerationItemContextMenu.tsx
+++ b/packages/shared/src/components/squads/moderation/SquadModerationItemContextMenu.tsx
@@ -43,7 +43,7 @@ export const SquadModerationItemContextMenu = ({
         options={[
           {
             label: 'Edit post',
-            action: () => router.push(`/posts/${id}/edit`),
+            action: () => router.push(`/posts/${id}/edit?moderation=true`),
             icon: <EditIcon aria-hidden />,
           },
           {

--- a/packages/shared/src/components/squads/moderation/SquadModerationItemContextMenu.tsx
+++ b/packages/shared/src/components/squads/moderation/SquadModerationItemContextMenu.tsx
@@ -1,10 +1,11 @@
 import React, { ReactElement, useId } from 'react';
-import { SourcePostModeration } from '../../../graphql/posts';
+import { useRouter } from 'next/router';
 import OptionsButton from '../../buttons/OptionsButton';
 import ContextMenu from '../../fields/ContextMenu';
-import { TrashIcon } from '../../icons';
+import { EditIcon, TrashIcon } from '../../icons';
 import useContextMenu from '../../../hooks/useContextMenu';
 import { usePrompt } from '../../../hooks/usePrompt';
+import { SourcePostModeration } from '../../../graphql/squads';
 
 interface SquadModerationItemContextMenuProps
   extends Pick<SourcePostModeration, 'id'> {
@@ -18,6 +19,7 @@ export const SquadModerationItemContextMenu = ({
   const contextMenuId = useId();
   const { isOpen, onMenuClick } = useContextMenu({ id: contextMenuId });
   const { showPrompt } = usePrompt();
+  const router = useRouter();
 
   const handleDelete = async () => {
     const confirm = await showPrompt({
@@ -39,11 +41,11 @@ export const SquadModerationItemContextMenu = ({
       />
       <ContextMenu
         options={[
-          // {
-          //   label: 'Edit post',
-          //   action: () => console.log('Edit'), // todo: implement after SourcePostModeration edit page is created
-          //   icon: <EditIcon aria-hidden />,
-          // },
+          {
+            label: 'Edit post',
+            action: () => router.push(`/posts/${id}/edit`),
+            icon: <EditIcon aria-hidden />,
+          },
           {
             label: 'Delete post',
             action: handleDelete,

--- a/packages/shared/src/components/squads/utils.tsx
+++ b/packages/shared/src/components/squads/utils.tsx
@@ -66,6 +66,13 @@ export const createModerationPromptProps: PromptOptions = {
   icon: <TimerIcon size={IconSize.XXXLarge} />,
 };
 
+export const editModerationPromptProps: PromptOptions = {
+  ...createModerationPromptProps,
+  title: 'Your edit has been submitted for review',
+  description:
+    'Your edit is now waiting for the admin’s approval. We’ll notify you once it’s been reviewed.',
+};
+
 export interface SquadSettingsProps {
   handle: string;
 }

--- a/packages/shared/src/contexts/WritePostContext.tsx
+++ b/packages/shared/src/contexts/WritePostContext.tsx
@@ -6,17 +6,25 @@ import React, {
   useContext,
 } from 'react';
 import { useRouter } from 'next/router';
-import { Post, SourcePostModeration } from '../graphql/posts';
+import { Post, SharedPost } from '../graphql/posts';
 import { Squad } from '../graphql/sources';
 import ConditionalWrapper from '../components/ConditionalWrapper';
 import { useViewSize, ViewSize } from '../hooks';
 import { FormWrapper } from '../components/fields/form';
+import { SourcePostModeration } from '../graphql/squads';
 
 export interface WriteForm {
   title: string;
   content: string;
   image: string;
   filename?: string;
+}
+
+export interface MergedWriteObject
+  extends Partial<Pick<WriteForm, 'title' | 'content' | 'image'>> {
+  id?: string;
+  type?: string;
+  sharedPost?: SharedPost;
 }
 
 export interface WritePostProps {
@@ -27,6 +35,8 @@ export interface WritePostProps {
   isPosting: boolean;
   squad: Squad;
   post?: Post;
+  moderated?: SourcePostModeration;
+  fetchedPost?: MergedWriteObject;
   enableUpload: boolean;
   formRef?: MutableRefObject<HTMLFormElement>;
   draft?: Partial<WriteForm>;

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -12,6 +12,7 @@ import {
 } from './fragments';
 import { acceptedTypesList, MEGABYTE } from '../components/fields/ImageInput';
 import { Bookmark } from './bookmarks';
+import { SourcePostModeration } from './squads';
 
 export type TocItem = { text: string; id?: string; children?: TocItem[] };
 export type Toc = TocItem[];
@@ -560,7 +561,7 @@ export interface CreatePostProps
   sourceId: string;
 }
 
-export type CreatePostModerationProps = {
+export interface CreatePostModerationProps {
   title?: string;
   content?: string;
   sourceId: string;
@@ -569,20 +570,11 @@ export type CreatePostModerationProps = {
   externalLink?: string;
   imageUrl?: string;
   image?: File;
-};
+}
 
-export type SourcePostModeration = {
+export interface UpdatePostModerationProps extends CreatePostModerationProps {
   id: string;
-  title: string;
-  titleHtml?: string;
-  image: string;
-  content?: string;
-  contentHtml?: string;
-  type: PostType;
-  sourceId: string;
-  sharedPostId?: string;
-  externalLink?: string;
-};
+}
 
 export const editPost = async (
   variables: Partial<EditPostProps>,
@@ -652,7 +644,6 @@ export const CREATE_SOURCE_POST_MODERATION_MUTATION = gql`
       image
       content
       type
-      sourceId
       externalLink
     }
   }
@@ -692,15 +683,41 @@ export const createPost = async (
   return res.createFreeformPost;
 };
 
-export const createSourcePostModeration = async (
-  variables: Partial<CreatePostModerationProps>,
-): Promise<SourcePostModeration> => {
-  const res = await gqlClient.request(
-    CREATE_SOURCE_POST_MODERATION_MUTATION,
-    variables,
-  );
+export const SOURCE_POST_MODERATION_QUERY = gql`
+  query SourcePostModeration($id: ID!) {
+    sourcePostModeration(id: $id) {
+      id
+      type
+      title
+      content
+      externalLink
+      image
+      createdBy {
+        id
+      }
+      source {
+        id
+      }
+      sharedPost {
+        id
+        title
+        image
+        permalink
+      }
+    }
+  }
+`;
 
-  return res.createSourcePostModeration;
+interface GetSourcePostModerationProps {
+  id: string;
+}
+
+export const getSourcePostModeration = async ({
+  id,
+}: GetSourcePostModerationProps): Promise<SourcePostModeration> => {
+  const res = await gqlClient.request(SOURCE_POST_MODERATION_QUERY, { id });
+
+  return res.sourcePostModeration;
 };
 
 export const UPLOAD_IMAGE_MUTATION = gql`
@@ -789,3 +806,58 @@ export const POST_CODE_SNIPPETS_QUERY = gql`
   }
   ${POST_CODE_SNIPPET_FRAGMENT}
 `;
+
+export const createSourcePostModeration = async (
+  variables: Partial<CreatePostModerationProps>,
+): Promise<SourcePostModeration> => {
+  const res = await gqlClient.request(
+    CREATE_SOURCE_POST_MODERATION_MUTATION,
+    variables,
+  );
+
+  return res.createSourcePostModeration;
+};
+
+export const UPDATE_SOURCE_POST_MODERATION_MUTATION = gql`
+  mutation EditSourcePostModeration(
+    $id: ID!
+    $sourceId: ID!
+    $type: String!
+    $title: String
+    $content: String
+    $sharedPostId: ID
+    $image: Upload
+    $imageUrl: String
+    $externalLink: String
+  ) {
+    editSourcePostModeration(
+      id: $id
+      sourceId: $sourceId
+      type: $type
+      title: $title
+      content: $content
+      sharedPostId: $sharedPostId
+      image: $image
+      imageUrl: $imageUrl
+      externalLink: $externalLink
+    ) {
+      id
+      title
+      image
+      content
+      type
+      externalLink
+    }
+  }
+`;
+
+export const updateSourcePostModeration = async (
+  variables: Partial<UpdatePostModerationProps>,
+): Promise<SourcePostModeration> => {
+  const res = await gqlClient.request(
+    UPDATE_SOURCE_POST_MODERATION_MUTATION,
+    variables,
+  );
+
+  return res.updateSourcePostModeration;
+};

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -18,6 +18,7 @@ export enum SourcePermissions {
   View = 'view',
   ViewBlockedMembers = 'view_blocked_members',
   Post = 'post',
+  PostRequest = 'post_request',
   PostLimit = 'post_limit',
   PostPin = 'post_pin',
   PostDelete = 'post_delete',

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -17,7 +17,7 @@ import {
   SourceType,
   Squad,
 } from './sources';
-import { Post } from './posts';
+import type { Post } from './posts';
 import { EmptyResponse } from './emptyResponse';
 import { generateStorageKey, StorageTopic } from '../lib/storage';
 import { PrivacyOption } from '../components/squads/settings/SquadPrivacySection';
@@ -357,23 +357,6 @@ export const SQUAD_INVITATION_QUERY = gql`
   ${USER_SHORT_INFO_FRAGMENT}
 `;
 
-export const PUBLIC_SQUAD_REQUESTS = gql`
-  query PublicSquadRequests($sourceId: String!, $first: Int) {
-    requests: publicSquadRequests(sourceId: $sourceId, first: $first) {
-      pageInfo {
-        endCursor
-        hasNextPage
-      }
-      edges {
-        node {
-          requestorId
-          status
-        }
-      }
-    }
-  }
-`;
-
 export const SQUAD_JOIN_MUTATION = gql`
   mutation JoinSquad($sourceId: ID!, $token: String) {
     source: joinSource(sourceId: $sourceId, token: $token) {
@@ -589,6 +572,7 @@ export enum SourcePostModerationStatus {
 
 type PostRequestContentProps = Pick<
   Post,
+  | 'type'
   | 'title'
   | 'titleHtml'
   | 'content'
@@ -599,7 +583,6 @@ type PostRequestContentProps = Pick<
 >;
 
 interface PostRequestContent extends PostRequestContentProps {
-  createdById: string;
   createdBy: Author;
 }
 
@@ -609,14 +592,14 @@ export interface SourcePostModeration extends Partial<PostRequestContent> {
   status: SourcePostModerationStatus;
   reason?: PostModerationReason;
   moderatorMessage?: string;
-  sourceId: Source['id'];
+  source?: Source;
+  externalLink?: string;
 }
 
 const SOURCE_POST_MODERATION_FRAGMENT = gql`
   fragment SourcePostModerationFragment on SourcePostModeration {
     id
     title
-    sourceId
     status
     rejectionReason
     moderatorMessage

--- a/packages/shared/src/hooks/input/useDiscardPost.ts
+++ b/packages/shared/src/hooks/input/useDiscardPost.ts
@@ -1,7 +1,7 @@
 import { MutableRefObject, useCallback, useRef } from 'react';
 import { del as deleteCache } from 'idb-keyval';
 import { formToJson } from '../../lib/form';
-import { EditPostProps, Post } from '../../graphql/posts';
+import { EditPostProps } from '../../graphql/posts';
 import {
   checkSavedProperty,
   generateWritePostKey,
@@ -11,10 +11,10 @@ import {
   useExitConfirmation,
 } from '../useExitConfirmation';
 import usePersistentContext from '../usePersistentContext';
-import { WriteForm, WritePostProps } from '../../contexts';
+import { MergedWriteObject, WriteForm, WritePostProps } from '../../contexts';
 
 interface UseDiscardPostProps {
-  post?: Post;
+  post?: MergedWriteObject;
   draftIdentifier?: string;
 }
 

--- a/packages/shared/src/hooks/source/useSourcePostModeration.ts
+++ b/packages/shared/src/hooks/source/useSourcePostModeration.ts
@@ -2,35 +2,45 @@ import { useMutation } from '@tanstack/react-query';
 import {
   CreatePostModerationProps,
   createSourcePostModeration,
-  SourcePostModeration,
+  UpdatePostModerationProps,
+  updateSourcePostModeration,
 } from '../../graphql/posts';
 import { usePrompt } from '../usePrompt';
-import { createModerationPromptProps } from '../../components/squads/utils';
+import {
+  createModerationPromptProps,
+  editModerationPromptProps,
+} from '../../components/squads/utils';
+import { SourcePostModeration } from '../../graphql/squads';
 
-type UseSourcePostModeration = {
+interface UseSourcePostModeration {
   isPending: boolean;
   isSuccess: boolean;
   onCreatePostModeration: (
     post: CreatePostModerationProps,
   ) => Promise<SourcePostModeration>;
-};
+  onUpdatePostModeration: (
+    post: UpdatePostModerationProps,
+  ) => Promise<SourcePostModeration>;
+}
 
-type UseSquadModerationProps = {
+interface UseSquadModerationProps {
   onSuccess?: () => void;
   onError?: () => void;
   onSettled?: () => void;
-};
+  onMutate?: () => void;
+}
 
 const useSourcePostModeration = ({
   onSuccess,
   onError,
   onSettled,
+  onMutate,
 }: UseSquadModerationProps = {}): UseSourcePostModeration => {
   const { showPrompt } = usePrompt();
   const {
     mutateAsync: onCreatePostModeration,
-    isPending,
-    isSuccess,
+    isPending: isCreatePending,
+    isSuccess: isCreateSuccess,
   } = useMutation({
     mutationFn: createSourcePostModeration,
     onSuccess: async () => {
@@ -39,12 +49,29 @@ const useSourcePostModeration = ({
     },
     onError,
     onSettled,
+    onMutate,
+  });
+
+  const {
+    mutateAsync: onUpdatePostModeration,
+    isPending: isUpdatePending,
+    isSuccess: isUpdateSuccess,
+  } = useMutation({
+    mutationFn: updateSourcePostModeration,
+    onSuccess: async () => {
+      await showPrompt(editModerationPromptProps);
+      onSuccess?.();
+    },
+    onError,
+    onSettled,
+    onMutate,
   });
 
   return {
     onCreatePostModeration,
-    isPending,
-    isSuccess,
+    onUpdatePostModeration,
+    isPending: isCreatePending || isUpdatePending,
+    isSuccess: isCreateSuccess || isUpdateSuccess,
   };
 };
 

--- a/packages/shared/src/hooks/source/useSourcePostModerationById.ts
+++ b/packages/shared/src/hooks/source/useSourcePostModerationById.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import { SourcePostModeration } from '../../graphql/squads';
+import { generateQueryKey, RequestKey } from '../../lib/query';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { getSourcePostModeration } from '../../graphql/posts';
+
+interface UseSourcePostModerationById {
+  moderated: SourcePostModeration;
+  isLoading: boolean;
+}
+
+interface UseSourcePostModerationByIdProps {
+  id: string | null;
+}
+
+export const useSourcePostModerationById = ({
+  id,
+}: UseSourcePostModerationByIdProps): UseSourcePostModerationById => {
+  const { user } = useAuthContext();
+  const { data, isLoading } = useQuery({
+    queryKey: generateQueryKey(RequestKey.SourcePostModeration, user, id),
+    queryFn: () => getSourcePostModeration({ id }),
+    enabled: !!id,
+  });
+
+  return {
+    moderated: data,
+    isLoading,
+  };
+};

--- a/packages/shared/src/hooks/source/useSourcePostModerationById.ts
+++ b/packages/shared/src/hooks/source/useSourcePostModerationById.ts
@@ -11,16 +11,18 @@ interface UseSourcePostModerationById {
 
 interface UseSourcePostModerationByIdProps {
   id: string | null;
+  enabled?: boolean;
 }
 
 export const useSourcePostModerationById = ({
   id,
+  enabled = true,
 }: UseSourcePostModerationByIdProps): UseSourcePostModerationById => {
   const { user } = useAuthContext();
   const { data, isLoading } = useQuery({
     queryKey: generateQueryKey(RequestKey.SourcePostModeration, user, id),
     queryFn: () => getSourcePostModeration({ id }),
-    enabled: !!id,
+    enabled: !!id && enabled,
   });
 
   return {

--- a/packages/shared/src/hooks/useTruncatedSummary.ts
+++ b/packages/shared/src/hooks/useTruncatedSummary.ts
@@ -1,13 +1,11 @@
-import { Post } from '../graphql/posts';
-
 export const useTruncatedSummary = (
-  post: Post,
+  titleProp: string,
   sanitizedSummary?: string,
 ): { summary?: string; title: string } => {
   const title =
-    post.title?.length > 300 ? `${post.title.slice(0, 300)}...` : post.title;
-  const maxSummaryLength = Math.max(0, 300 - post.title?.length || 0);
-  const summary = sanitizedSummary || post.summary;
+    titleProp?.length > 300 ? `${titleProp.slice(0, 300)}...` : titleProp;
+  const maxSummaryLength = Math.max(0, 300 - titleProp?.length || 0);
+  const summary = sanitizedSummary;
   const truncatedSummary =
     summary && summary.length > maxSummaryLength
       ? `${summary.slice(0, maxSummaryLength)}...`

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -101,6 +101,7 @@ export enum RequestKey {
   Bookmarks = 'bookmarks',
   PostComments = 'post_comments',
   PostCommentsMutations = 'post_comments_mutations',
+  SourcePostModeration = 'source_post_moderation',
   Actions = 'actions',
   Squad = 'squad',
   SquadPostRequests = 'squad_post_requests',

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -32,9 +32,13 @@ function EditPost(): ReactElement {
   const { completeAction } = useActions();
   const { query, isReady, push } = useRouter();
   const idQuery = query.id as string;
-  const { post, isLoading } = usePostById({ id: idQuery });
+  const isModeration = query.moderation === 'true';
+  const { post, isLoading } = usePostById({
+    id: idQuery,
+    options: { enabled: !isModeration },
+  });
   const { moderated, isLoading: isModerationLoading } =
-    useSourcePostModerationById({ id: idQuery });
+    useSourcePostModerationById({ id: idQuery, enabled: isModeration });
   const { squads, user } = useAuthContext();
   const formId =
     post?.type === PostType.Share


### PR DESCRIPTION
## Changes
- Make the edit page be reusable to post moderation request.
- At first I thought of writing a whole edit page solely for the post moderation, but realized that it would be just the same and whole lot of copy-pasting. Would love to hear some thoughts if anyone thinks a dedicated page is a good option. Keep in mind that the internal components updated here would still have the same changes.
- Also updated the types and graphql schemas to better reflect our standard when it comes to related entities.
- I've tested both freeform and sharing internal posts.

TODO:
- [ ] Test external link process flow.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

MI-622 #done


### Preview domain
https://mi-622.preview.app.daily.dev