### PR TITLE
feat: prompt modal on edit

### DIFF
--- a/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
+++ b/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
@@ -45,9 +45,12 @@ export function CreateSharedPostModal({
     onSubmitPost,
   } = usePostToSquad({
     initialPreview: preview,
-    onSettled: () => {
+    onPostSuccess: () => {
       onSharedSuccessfully?.();
       onSubmitted();
+      onRequestClose(null);
+    },
+    onSourcePostModerationSuccess: () => {
       onRequestClose(null);
     },
   });

--- a/packages/shared/src/components/post/write/ShareLink.tsx
+++ b/packages/shared/src/components/post/write/ShareLink.tsx
@@ -61,7 +61,7 @@ export function ShareLink({
 
     if (post?.id) {
       if (commentary !== post?.title) {
-        onUpdatePost(e, post.id, commentary);
+        onUpdatePost(e, post.id, commentary, squad);
       }
       return push(squad.permalink);
     }

--- a/packages/shared/src/components/post/write/ShareLink.tsx
+++ b/packages/shared/src/components/post/write/ShareLink.tsx
@@ -40,7 +40,7 @@ export function ShareLink({
     preview,
     isPosting,
     onSubmitPost,
-    onUpdatePost,
+    onUpdateSharePost,
     onUpdatePreview,
   } = usePostToSquad({
     onPostSuccess,
@@ -96,7 +96,7 @@ export function ShareLink({
         });
       }
 
-      return onUpdatePost(e, fetchedPost.id, commentary, squad);
+      return onUpdateSharePost(e, fetchedPost.id, commentary, squad);
     }
 
     if (squads.some(({ id }) => squad.id === id)) {

--- a/packages/shared/src/components/squads/SharePostBar.tsx
+++ b/packages/shared/src/components/squads/SharePostBar.tsx
@@ -59,7 +59,7 @@ function SharePostBar({
     });
 
   const { getLinkPreview, isLoadingPreview } = usePostToSquad({
-    callback: { onSuccess: onOpenCreatePost },
+    onExternalLinkSuccess: onOpenCreatePost,
   });
 
   const onSubmit = async (e: FormEvent) => {

--- a/packages/shared/src/components/squads/utils.tsx
+++ b/packages/shared/src/components/squads/utils.tsx
@@ -66,6 +66,13 @@ export const createModerationPromptProps: PromptOptions = {
   icon: <TimerIcon size={IconSize.XXXLarge} />,
 };
 
+export const editModerationPromptProps: PromptOptions = {
+  ...createModerationPromptProps,
+  title: 'Your edit has been submitted for review',
+  description:
+    "Your edit is now waiting for the admin's approval. We'll notify you once it's been reviewed.",
+};
+
 export interface SquadSettingsProps {
   handle: string;
 }

--- a/packages/shared/src/contexts/WritePostContext.tsx
+++ b/packages/shared/src/contexts/WritePostContext.tsx
@@ -6,7 +6,7 @@ import React, {
   useContext,
 } from 'react';
 import { useRouter } from 'next/router';
-import { Post, SharedPost } from '../graphql/posts';
+import { EditPostProps, Post, SharedPost } from '../graphql/posts';
 import { Squad } from '../graphql/sources';
 import ConditionalWrapper from '../components/ConditionalWrapper';
 import { useViewSize, ViewSize } from '../hooks';
@@ -28,7 +28,10 @@ export interface MergedWriteObject
 }
 
 export interface WritePostProps {
-  onSubmitForm: (e: FormEvent<HTMLFormElement>, prop: WriteForm) => void;
+  onSubmitForm: (
+    e: FormEvent<HTMLFormElement>,
+    prop: WriteForm & EditPostProps,
+  ) => void;
   isPosting: boolean;
   squad: Squad;
   post?: Post;

--- a/packages/shared/src/contexts/WritePostContext.tsx
+++ b/packages/shared/src/contexts/WritePostContext.tsx
@@ -30,7 +30,7 @@ export interface MergedWriteObject
 export interface WritePostProps {
   onSubmitForm: (
     e: FormEvent<HTMLFormElement>,
-    prop: WriteForm & EditPostProps,
+    prop: WriteForm & Omit<EditPostProps, 'id'>,
   ) => void;
   isPosting: boolean;
   squad: Squad;

--- a/packages/shared/src/contexts/WritePostContext.tsx
+++ b/packages/shared/src/contexts/WritePostContext.tsx
@@ -6,7 +6,7 @@ import React, {
   useContext,
 } from 'react';
 import { useRouter } from 'next/router';
-import { Post, SourcePostModeration } from '../graphql/posts';
+import { Post } from '../graphql/posts';
 import { Squad } from '../graphql/sources';
 import ConditionalWrapper from '../components/ConditionalWrapper';
 import { useViewSize, ViewSize } from '../hooks';
@@ -20,10 +20,7 @@ export interface WriteForm {
 }
 
 export interface WritePostProps {
-  onSubmitForm: (
-    e: FormEvent<HTMLFormElement>,
-    prop: WriteForm,
-  ) => Promise<Post | SourcePostModeration>;
+  onSubmitForm: (e: FormEvent<HTMLFormElement>, prop: WriteForm) => void;
   isPosting: boolean;
   squad: Squad;
   post?: Post;

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -561,20 +561,18 @@ export interface CreatePostProps
   sourceId: string;
 }
 
-export type CreatePostModerationProps =
-  | {
-      title?: string;
-      content?: string;
-      sourceId: string;
-      type: PostType;
-      sharedPostId?: string;
-      externalLink?: string;
-      imageUrl?: string;
-      image?: File;
-      commentary?: string;
-      postId?: string;
-    }
-  | { postId: string; type?: PostType; image: File };
+export type CreatePostModerationProps = {
+  title?: string;
+  content?: string;
+  sourceId: string;
+  type: PostType;
+  sharedPostId?: string;
+  externalLink?: string;
+  imageUrl?: string;
+  image?: File;
+  commentary?: string;
+  postId?: string;
+};
 
 export type SourcePostModeration = {
   id: string;

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -554,7 +554,6 @@ export interface EditPostProps {
   title: string;
   content: string;
   image: File;
-  type: PostType;
 }
 
 export interface CreatePostProps

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -553,6 +553,7 @@ export interface EditPostProps {
   title: string;
   content: string;
   image: File;
+  type: PostType;
 }
 
 export interface CreatePostProps
@@ -560,17 +561,20 @@ export interface CreatePostProps
   sourceId: string;
 }
 
-export type CreatePostModerationProps = {
-  title?: string;
-  content?: string;
-  sourceId: string;
-  type: PostType;
-  sharedPostId?: string;
-  externalLink?: string;
-  imageUrl?: string;
-  image?: File;
-  commentary?: string;
-};
+export type CreatePostModerationProps =
+  | {
+      title?: string;
+      content?: string;
+      sourceId: string;
+      type: PostType;
+      sharedPostId?: string;
+      externalLink?: string;
+      imageUrl?: string;
+      image?: File;
+      commentary?: string;
+      postId?: string;
+    }
+  | { postId: string; type?: PostType; image: File };
 
 export type SourcePostModeration = {
   id: string;
@@ -583,6 +587,8 @@ export type SourcePostModeration = {
   sourceId: string;
   sharedPostId?: string;
   externalLink?: string;
+  post?: Post;
+  source: Source;
 };
 
 export const editPost = async (
@@ -638,6 +644,7 @@ export const CREATE_SOURCE_POST_MODERATION_MUTATION = gql`
     $image: Upload
     $imageUrl: String
     $externalLink: String
+    $postId: ID
   ) {
     createSourcePostModeration(
       sourceId: $sourceId
@@ -649,6 +656,7 @@ export const CREATE_SOURCE_POST_MODERATION_MUTATION = gql`
       image: $image
       imageUrl: $imageUrl
       externalLink: $externalLink
+      postId: $postId
     ) {
       id
       title
@@ -657,6 +665,10 @@ export const CREATE_SOURCE_POST_MODERATION_MUTATION = gql`
       type
       sourceId
       externalLink
+      source {
+        handle
+        permalink
+      }
     }
   }
 `;

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -669,6 +669,9 @@ export const CREATE_SOURCE_POST_MODERATION_MUTATION = gql`
         handle
         permalink
       }
+      post {
+        id
+      }
     }
   }
 `;

--- a/packages/shared/src/hooks/source/useSourcePostModeration.ts
+++ b/packages/shared/src/hooks/source/useSourcePostModeration.ts
@@ -36,8 +36,8 @@ const useSourcePostModeration = ({
     onSuccess: async (moderatedPost) => {
       await showPrompt(
         moderatedPost.post
-          ? createModerationPromptProps
-          : editModerationPromptProps,
+          ? editModerationPromptProps
+          : createModerationPromptProps,
       );
       onSuccess?.(moderatedPost);
     },

--- a/packages/shared/src/hooks/source/useSourcePostModeration.ts
+++ b/packages/shared/src/hooks/source/useSourcePostModeration.ts
@@ -16,13 +16,13 @@ import { SourcePostModeration } from '../../graphql/squads';
 interface UseSourcePostModeration {
   isPending: boolean;
   isSuccess: boolean;
-onCreatePostModeration: (
+  onCreatePostModeration: (
     post: CreatePostModerationProps,
   ) => Promise<SourcePostModeration>;
   onUpdatePostModeration: (
     post: UpdatePostModerationProps,
   ) => Promise<SourcePostModeration>;
-};
+}
 
 interface UseSquadModerationProps {
   onSuccess?: (data: SourcePostModeration) => void;
@@ -63,9 +63,9 @@ const useSourcePostModeration = ({
     isSuccess: isUpdateSuccess,
   } = useMutation({
     mutationFn: updateSourcePostModeration,
-    onSuccess: async () => {
+    onSuccess: async (data) => {
       await showPrompt(editModerationPromptProps);
-      onSuccess?.();
+      onSuccess?.(data);
     },
     onError,
     onSettled,

--- a/packages/shared/src/hooks/source/useSourcePostModeration.ts
+++ b/packages/shared/src/hooks/source/useSourcePostModeration.ts
@@ -5,26 +5,26 @@ import {
   SourcePostModeration,
 } from '../../graphql/posts';
 import { usePrompt } from '../usePrompt';
-import { createModerationPromptProps } from '../../components/squads/utils';
+import {
+  createModerationPromptProps,
+  editModerationPromptProps,
+} from '../../components/squads/utils';
+import { ApiErrorResult } from '../../graphql/common';
 
 type UseSourcePostModeration = {
   isPending: boolean;
   isSuccess: boolean;
-  onCreatePostModeration: (
-    post: CreatePostModerationProps,
-  ) => Promise<SourcePostModeration>;
+  onCreatePostModeration: (post: CreatePostModerationProps) => Promise<unknown>;
 };
 
 type UseSquadModerationProps = {
-  onSuccess?: () => void;
-  onError?: () => void;
-  onSettled?: () => void;
+  onSuccess?: (data: SourcePostModeration) => void;
+  onError?: (error: ApiErrorResult) => void;
 };
 
 const useSourcePostModeration = ({
   onSuccess,
   onError,
-  onSettled,
 }: UseSquadModerationProps = {}): UseSourcePostModeration => {
   const { showPrompt } = usePrompt();
   const {
@@ -33,12 +33,15 @@ const useSourcePostModeration = ({
     isSuccess,
   } = useMutation({
     mutationFn: createSourcePostModeration,
-    onSuccess: async () => {
-      await showPrompt(createModerationPromptProps);
-      onSuccess?.();
+    onSuccess: async (moderatedPost) => {
+      await showPrompt(
+        moderatedPost.post
+          ? createModerationPromptProps
+          : editModerationPromptProps,
+      );
+      onSuccess?.(moderatedPost);
     },
     onError,
-    onSettled,
   });
 
   return {

--- a/packages/shared/src/hooks/squads/usePostToSquad.ts
+++ b/packages/shared/src/hooks/squads/usePostToSquad.ts
@@ -13,7 +13,6 @@ import {
   getExternalLinkPreview,
   Post,
   PostType,
-  SourcePostModeration,
   SubmitExternalLink,
   submitExternalLink,
 } from '../../graphql/posts';
@@ -24,7 +23,11 @@ import {
   getApiError,
 } from '../../graphql/common';
 import { useToastNotification } from '../useToastNotification';
-import { addPostToSquad, updateSquadPost } from '../../graphql/squads';
+import {
+  addPostToSquad,
+  SourcePostModeration,
+  updateSquadPost,
+} from '../../graphql/squads';
 import { ActionType } from '../../graphql/actions';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useActions } from '../useActions';
@@ -126,8 +129,8 @@ export const usePostToSquad = ({
     isPending: isPostModerationLoading,
   } = useSourcePostModeration({
     onSuccess: (data) => {
+      onSourcePostModerationSuccess(data);
       completeAction(ActionType.SquadFirstPost);
-      onSourcePostModerationSuccess
     },
     onError: () => {
       displayToast(DEFAULT_ERROR);

--- a/packages/shared/src/hooks/squads/usePostToSquad.ts
+++ b/packages/shared/src/hooks/squads/usePostToSquad.ts
@@ -131,24 +131,29 @@ export const usePostToSquad = ({
     },
   });
 
-  const onEditPost = async (
-    editedPost: EditPostProps,
-    squad: Squad,
-  ): Promise<void> => {
-    if (isEditLoading || isEditPostSuccess) {
+  const onEditPost = useCallback<UsePostToSquad['onEditPost']>(
+    async (editedPost: EditPostProps, squad: Squad): Promise<void> => {
+      if (isEditLoading || isEditPostSuccess) {
+        return null;
+      }
+      if (moderationRequired(squad)) {
+        onCreatePostModeration({
+          ...editedPost,
+          postId: editedPost.id,
+          sourceId: squad.id,
+        });
+      } else {
+        editPostMutation(editedPost);
+      }
       return null;
-    }
-    if (moderationRequired(squad)) {
-      onCreatePostModeration({
-        ...editedPost,
-        postId: editedPost.id,
-        sourceId: squad.id,
-      });
-    } else {
-      editPostMutation(editedPost);
-    }
-    return null;
-  };
+    },
+    [
+      editPostMutation,
+      onCreatePostModeration,
+      isEditLoading,
+      isEditPostSuccess,
+    ],
+  );
 
   const onSharedPostSuccessfully = async (update = false) => {
     displayToast(
@@ -301,18 +306,23 @@ export const usePostToSquad = ({
     [updatePost, isUpdating, onCreatePostModeration],
   );
 
-  const onSubmitFreeformPost = (post: CreatePostProps, squad: Squad) => {
-    if (moderationRequired(squad)) {
-      onCreatePostModeration({
-        ...post,
-        sourceId: squad.id,
-        type: PostType.Freeform,
-      });
-    } else {
-      onCreatePost({ ...post, sourceId: squad.id });
-    }
-    return null;
-  };
+  const onSubmitFreeformPost = useCallback<
+    UsePostToSquad['onSubmitFreeformPost']
+  >(
+    (post: CreatePostProps, squad: Squad) => {
+      if (moderationRequired(squad)) {
+        onCreatePostModeration({
+          ...post,
+          sourceId: squad.id,
+          type: PostType.Freeform,
+        });
+      } else {
+        onCreatePost({ ...post, sourceId: squad.id });
+      }
+      return null;
+    },
+    [onCreatePost, onCreatePostModeration],
+  );
 
   return {
     isLoadingPreview,

--- a/packages/shared/src/hooks/squads/usePostToSquad.ts
+++ b/packages/shared/src/hooks/squads/usePostToSquad.ts
@@ -57,7 +57,7 @@ interface UsePostToSquad {
     commentary: string,
   ) => Promise<unknown>;
   onSubmitFreeformPost: (post: CreatePostProps, squad: Squad) => Promise<void>;
-  onUpdatePost: (
+  onUpdateSharePost: (
     e: BaseSyntheticEvent,
     postId: Post['id'],
     commentary: string,
@@ -294,7 +294,7 @@ export const usePostToSquad = ({
     ],
   );
 
-  const onUpdatePost = useCallback<UsePostToSquad['onUpdatePost']>(
+  const onUpdateSharePost = useCallback<UsePostToSquad['onUpdateSharePost']>(
     (e, postId, commentary, squad) => {
       e.preventDefault();
 
@@ -339,7 +339,7 @@ export const usePostToSquad = ({
     isLoadingPreview,
     getLinkPreview,
     onSubmitPost,
-    onUpdatePost,
+    onUpdateSharePost,
     isPosting,
     onEditFreeformPost,
     preview,

--- a/packages/shared/src/hooks/squads/usePostToSquad.ts
+++ b/packages/shared/src/hooks/squads/usePostToSquad.ts
@@ -47,7 +47,10 @@ interface UsePostToSquad {
     ApiErrorResult,
     string
   >;
-  onEditPost: (editedPost: EditPostProps, squad: Squad) => Promise<void>;
+  onEditFreeformPost: (
+    editedPost: EditPostProps,
+    squad: Squad,
+  ) => Promise<void>;
   onSubmitPost: (
     e: BaseSyntheticEvent,
     squad: Squad,
@@ -137,14 +140,16 @@ export const usePostToSquad = ({
     },
   });
 
-  const onEditPost = useCallback<UsePostToSquad['onEditPost']>(
+  const onEditFreeformPost = useCallback<UsePostToSquad['onEditFreeformPost']>(
     async (editedPost: EditPostProps, squad: Squad): Promise<void> => {
       if (isEditLoading || isEditPostSuccess) {
         return null;
       }
+
       if (moderationRequired(squad)) {
         onCreatePostModeration({
           ...editedPost,
+          type: PostType.Freeform,
           postId: editedPost.id,
           sourceId: squad.id,
         });
@@ -336,7 +341,7 @@ export const usePostToSquad = ({
     onSubmitPost,
     onUpdatePost,
     isPosting,
-    onEditPost,
+    onEditFreeformPost,
     preview,
     isSuccess,
     onSubmitFreeformPost,

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -58,7 +58,7 @@ function EditPost(): ReactElement {
     formRef,
     clearDraft,
   } = useDiscardPost({ post: fetchedPost });
-  const { onEditPost, isPosting, isSuccess } = usePostToSquad({
+  const { onEditFreeformPost, isPosting, isSuccess } = usePostToSquad({
     onPostSuccess: async (data) => {
       onAskConfirmation(false);
       clearDraft();
@@ -104,7 +104,7 @@ function EditPost(): ReactElement {
       });
     }
 
-    return onEditPost({ ...params, id: post.id }, squad);
+    return onEditFreeformPost({ ...params, id: post.id }, squad);
   };
 
   const seo: NextSeoProps = {

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -5,7 +5,7 @@ import {
   WritePage,
   WritePostHeader,
 } from '@dailydotdev/shared/src/components/post/freeform';
-import { PostType } from '@dailydotdev/shared/src/graphql/posts';
+import { EditPostProps, PostType } from '@dailydotdev/shared/src/graphql/posts';
 import usePostById from '@dailydotdev/shared/src/hooks/usePostById';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
@@ -87,7 +87,10 @@ function EditPost(): ReactElement {
       push(squad.permalink);
     },
   });
-  const onClickSubmit = (e: FormEvent<HTMLFormElement>, params) => {
+  const onClickSubmit = (
+    e: FormEvent<HTMLFormElement>,
+    params: EditPostProps,
+  ) => {
     if (isPosting || isPending || isSuccess) {
       return null;
     }

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -89,7 +89,7 @@ function EditPost(): ReactElement {
   });
   const onClickSubmit = (
     e: FormEvent<HTMLFormElement>,
-    params: EditPostProps,
+    params: Omit<EditPostProps, 'id'>,
   ) => {
     if (isPosting || isPending || isSuccess) {
       return null;

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -79,8 +79,8 @@ function EditPost(): ReactElement {
       onAskConfirmation(true);
     },
   });
-      
-const { onUpdatePostModeration, isPending } = useSourcePostModeration({
+
+  const { onUpdatePostModeration, isPending } = useSourcePostModeration({
     onSuccess: async () => {
       onAskConfirmation(false);
       clearDraft();

--- a/packages/webapp/pages/squads/create.tsx
+++ b/packages/webapp/pages/squads/create.tsx
@@ -95,12 +95,12 @@ function CreatePost(): ReactElement {
     clearDraft,
     isUpdatingDraft,
   } = useDiscardPost({ draftIdentifier: squad?.id });
-  const onPostSuccess = (link: string) => {
+  const onPostSuccess = async (link: string) => {
     onAskConfirmation(false);
     clearDraft();
-    await push(data.source.permalink);
     completeAction(ActionType.SquadFirstPost);
-  }
+    await push(link);
+  };
   const { onSubmitFreeformPost, isPosting, isSuccess } = usePostToSquad({
     onPostSuccess: async (data) => {
       onPostSuccess(data.commentsPermalink);


### PR DESCRIPTION
## Changes
Added prompt modal on edit, as well as moving remaining create/edit flows into usePostToSquad.

Originally when I updated this I tried to consolidate everything in as few callbacks as possible. That was a mistake. Made it confusing to work with and caused some weird behaviors, so I decided on just giving each action its own callback.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or

-->
MI-584 #done
MI-619 #done

[MI-584]: https://dailydotdev.atlassian.net/browse/MI-584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ