### PR TITLE
fix: need fully qualified URL

### DIFF
--- a/packages/shared/src/contexts/PaymentContext.tsx
+++ b/packages/shared/src/contexts/PaymentContext.tsx
@@ -51,8 +51,6 @@ export const PaymentContextProvider = ({
     });
   }, []);
 
-  console.log('url', plusSuccessUrl);
-
   const openCheckout = useCallback(
     ({ priceId }: { priceId: string }) => {
       paddle?.Checkout.open({

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -60,7 +60,8 @@ export const webappUrl = process.env.NEXT_PUBLIC_WEBAPP_URL;
 export const onboardingUrl = `${webappUrl}onboarding`;
 export const plusUrl = `${webappUrl}plus`;
 export const managePlusUrl = `${webappUrl}manage-plus`;
-export const plusSuccessUrl = `${webappUrl}plus/success`;
+// Needs to be fully qualified URL for Paddle to recognize it
+export const plusSuccessUrl = `https://app.daily.dev/plus/success`;
 
 export const authUrl =
   process.env.NEXT_PUBLIC_AUTH_URL || 'http://127.0.0.1:4433';


### PR DESCRIPTION
## Changes

I noticed our default webappUrl is actually set to `/` now (on prod as well)
but Paddle expects fully qualified domain, so just hardcoding it for now. (didn't have better solution)

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->



### Preview domain
https://fix-qualified-url.preview.app.daily.dev