### PR TITLE
fix: clear out url after sharing an external link for moderation.

### DIFF
--- a/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
+++ b/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
@@ -37,6 +37,11 @@ export function CreateSharedPostModal({
   const [link, setLink] = useState(preview?.permalink ?? preview?.url ?? '');
   const { shouldShowCta, isEnabled, onToggle, onSubmitted } =
     useNotificationToggle();
+  const onSuccess = () => {
+    onSharedSuccessfully?.();
+    onSubmitted();
+    onRequestClose(null);
+  };
   const {
     getLinkPreview,
     isLoadingPreview,
@@ -45,14 +50,8 @@ export function CreateSharedPostModal({
     onSubmitPost,
   } = usePostToSquad({
     initialPreview: preview,
-    onPostSuccess: () => {
-      onSharedSuccessfully?.();
-      onSubmitted();
-      onRequestClose(null);
-    },
-    onSourcePostModerationSuccess: () => {
-      onRequestClose(null);
-    },
+    onPostSuccess: onSuccess,
+    onSourcePostModerationSuccess: onSuccess,
   });
 
   const onFormSubmit: FormEventHandler<HTMLFormElement> = (e) => {

--- a/packages/shared/src/hooks/squads/usePostToSquad.ts
+++ b/packages/shared/src/hooks/squads/usePostToSquad.ts
@@ -80,7 +80,6 @@ export const usePostToSquad = ({
   onError,
   onExternalLinkSuccess,
   onSourcePostModerationSuccess,
-
   initialPreview,
 }: UsePostToSquadProps = {}): UsePostToSquad => {
   const { displayToast } = useToastNotification();

--- a/packages/webapp/pages/squads/new.tsx
+++ b/packages/webapp/pages/squads/new.tsx
@@ -21,6 +21,7 @@ import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
 import { useIntegrationQuery } from '@dailydotdev/shared/src/hooks/integrations/useIntegrationQuery';
 
 import { useSlackConnectSourceMutation } from '@dailydotdev/shared/src/hooks/integrations/slack/useSlackConnectSourceMutation';
+import { SourceMemberRole } from '@dailydotdev/shared/src/graphql/sources';
 import { getLayout as getMainLayout } from '../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 import { getTemplatedTitle } from '../../components/layouts/utils';
@@ -92,6 +93,8 @@ const NewSquad = (): ReactElement => {
         initialData={{
           name: data?.name,
           handle: initialHandle,
+          memberPostingRole: SourceMemberRole.Member,
+          moderationRequired: true,
         }}
         integrationId={integrationId}
       >


### PR DESCRIPTION
## Changes
- Fix the callback when moderation was a success. This tells the component to clear out the URL.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://mi-628.preview.app.daily.dev