### PR TITLE
fix: moderation flow small UI issues

### DIFF
--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -172,7 +172,7 @@ export const SearchControlHeader = ({
 
 export const PageHeader = classed(
   'div',
-  'flex flex-row items-center border-b border-border-subtlest-tertiary px-4 py-2',
+  'flex flex-row items-center border-b border-border-subtlest-tertiary px-4 py-2 gap-1',
 );
 
 export const PageHeaderTitle = ({

--- a/packages/webapp/pages/squads/[handle]/edit.tsx
+++ b/packages/webapp/pages/squads/[handle]/edit.tsx
@@ -83,7 +83,6 @@ const EditSquad = ({ handle }: SquadSettingsProps): ReactElement => {
     return (
       <MangeSquadPageSkeleton>
         <DefaultSquadHeader className="border-b-0" />
-        <SquadTabs active={SquadTab.Settings} handle={handle} showSettings />
       </MangeSquadPageSkeleton>
     );
   }
@@ -105,7 +104,7 @@ const EditSquad = ({ handle }: SquadSettingsProps): ReactElement => {
         isLoading={isUpdatingSquad}
       >
         {squad?.moderationRequired && (
-          <SquadTabs active={SquadTab.Settings} handle={handle} showSettings />
+          <SquadTabs active={SquadTab.Settings} squad={squad} />
         )}
       </SquadDetails>
     </ManageSquadPageContainer>

--- a/packages/webapp/pages/squads/[handle]/moderate.tsx
+++ b/packages/webapp/pages/squads/[handle]/moderate.tsx
@@ -17,9 +17,7 @@ import {
   ButtonVariant,
 } from '@dailydotdev/shared/src/components/buttons/Button';
 import { ArrowIcon } from '@dailydotdev/shared/src/components/icons';
-import { verifyPermission } from '@dailydotdev/shared/src/graphql/squads';
 import { useSquad } from '@dailydotdev/shared/src/hooks';
-import { SourcePermissions } from '@dailydotdev/shared/src/graphql/sources';
 import { useRouter } from 'next/router';
 import {
   GetStaticPathsResult,
@@ -34,7 +32,6 @@ export default function ModerateSquadPage({
 }: SquadSettingsProps): ReactElement {
   const router = useRouter();
   const { squad, isLoading, isFetched } = useSquad({ handle });
-  const isModerator = verifyPermission(squad, SourcePermissions.ModeratePost);
 
   useEffect(() => {
     if (isLoading || !isFetched) {
@@ -66,12 +63,7 @@ export default function ModerateSquadPage({
         />
         <PageHeaderTitle className="typo-title3">Squad</PageHeaderTitle>
       </PageHeader>
-      <SquadTabs
-        active={SquadTab.PendingPosts}
-        handle={handle}
-        pendingCount={squad?.moderationPostCount}
-        showSettings={isModerator}
-      />
+      <SquadTabs active={SquadTab.PendingPosts} squad={squad} />
       <SquadModerationList squad={squad} />
     </ManageSquadPageContainer>
   );


### PR DESCRIPTION
## Changes

- Add gap between button and title
- SquadTabs was rendered on loading showing `Pending Posts` even if the squad have no moderation settings. I removed this component from the loading state and refactored to make it consistent through the pages 

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://fix-moderation-ui.preview.app.daily.dev