### PR TITLE
feat: mobile view flow

### DIFF
--- a/packages/shared/src/components/plus/PlusDesktop.tsx
+++ b/packages/shared/src/components/plus/PlusDesktop.tsx
@@ -1,0 +1,42 @@
+import React, { ReactElement, useCallback, useState } from 'react';
+import { usePaymentContext } from '../../contexts/PaymentContext';
+
+import { PlusInfo } from './PlusInfo';
+
+export const PlusDesktop = (): ReactElement => {
+  const { openCheckout, productOptions } = usePaymentContext();
+  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+
+  const toggleCheckoutOption = useCallback(
+    (priceId) => {
+      setSelectedOption(priceId);
+      openCheckout({ priceId });
+    },
+    [openCheckout],
+  );
+
+  return (
+    <div className="flex flex-1 items-center justify-center gap-20">
+      <div className="ml-6 flex w-[28.5rem] flex-col">
+        <PlusInfo
+          productOptions={productOptions}
+          selectedOption={selectedOption}
+          onChange={toggleCheckoutOption}
+        />
+      </div>
+      <div
+        ref={(element) => {
+          if (!element) {
+            return;
+          }
+
+          if (productOptions?.[0]?.value && !selectedOption) {
+            setSelectedOption(productOptions?.[0]?.value);
+            openCheckout({ priceId: productOptions?.[0]?.value });
+          }
+        }}
+        className="checkout-container mr-6 min-h-40 w-[28.5rem] rounded-16 border border-border-subtlest-tertiary bg-background-default p-5"
+      />
+    </div>
+  );
+};

--- a/packages/shared/src/components/plus/PlusInfo.tsx
+++ b/packages/shared/src/components/plus/PlusInfo.tsx
@@ -1,0 +1,166 @@
+import React, { ReactElement } from 'react';
+import classNames from 'classnames';
+import { PlusUser } from '../PlusUser';
+import { IconSize } from '../Icon';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../typography/Typography';
+import { RadioItem } from '../fields/RadioItem';
+import { PlusList } from './PlusList';
+import { plusInfo } from '../../lib/constants';
+import { anchorDefaultRel } from '../../lib/strings';
+import { ProductOption } from '../../contexts/PaymentContext';
+import {
+  Button,
+  ButtonColor,
+  ButtonSize,
+  ButtonVariant,
+} from '../buttons/Button';
+
+type PlusInfoProps = {
+  productOptions: ProductOption[];
+  selectedOption: string | null;
+  onChange: (priceId: string) => void;
+  onContinue?: () => void;
+};
+export const PlusInfo = ({
+  productOptions,
+  selectedOption,
+  onChange,
+  onContinue,
+}: PlusInfoProps): ReactElement => {
+  return (
+    <>
+      <PlusUser
+        iconSize={IconSize.Large}
+        typographyType={TypographyType.Title1}
+        className="mb-6"
+      />
+      <Typography
+        tag={TypographyTag.H1}
+        type={TypographyType.Mega2}
+        color={TypographyColor.Primary}
+        className="mb-2"
+        bold
+      >
+        Unlock more with Plus
+      </Typography>
+      <Typography
+        tag={TypographyTag.H2}
+        type={TypographyType.Title3}
+        color={TypographyColor.Secondary}
+        className="mb-6"
+      >
+        Upgrade to daily.dev Plus for an enhanced, ad-free experience with
+        exclusive features and perks to level up your game.
+      </Typography>
+      <Typography
+        tag={TypographyTag.P}
+        type={TypographyType.Callout}
+        color={TypographyColor.Tertiary}
+        className="mb-4"
+        bold
+      >
+        Billing cycle
+      </Typography>
+      <div className="min-h-[6.125rem] rounded-10 border border-border-subtlest-tertiary">
+        {productOptions.map((option) => {
+          const { label, value, price, currencyCode, extraLabel } = option;
+          const checked = selectedOption === value;
+          return (
+            <div
+              key={label}
+              className={classNames(
+                'flex h-12 items-center justify-between rounded-10 p-2',
+                checked
+                  ? 'border border-border-subtlest-primary bg-surface-float'
+                  : undefined,
+              )}
+            >
+              <div className="flex items-center">
+                <RadioItem
+                  name={label}
+                  id={`${label}-${value}`}
+                  value={value}
+                  checked={checked}
+                  onChange={() => onChange(value)}
+                  className={{
+                    content: 'truncate',
+                  }}
+                >
+                  <Typography
+                    tag={TypographyTag.Span}
+                    type={TypographyType.Callout}
+                    color={TypographyColor.Primary}
+                  >
+                    {option.label}
+                  </Typography>
+                </RadioItem>
+                {extraLabel ? (
+                  <Typography
+                    tag={TypographyTag.Span}
+                    type={TypographyType.Caption1}
+                    color={TypographyColor.StatusSuccess}
+                    className="rounded-10 bg-action-upvote-float px-2 py-1"
+                    bold
+                  >
+                    {extraLabel}
+                  </Typography>
+                ) : undefined}
+              </div>
+              <div className="mr-1 flex items-center gap-1">
+                <Typography
+                  tag={TypographyTag.Span}
+                  type={TypographyType.Body}
+                  color={TypographyColor.Primary}
+                  bold
+                >
+                  {price}
+                </Typography>
+                <Typography
+                  tag={TypographyTag.Span}
+                  type={TypographyType.Body}
+                  color={TypographyColor.Secondary}
+                >
+                  {currencyCode}
+                </Typography>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {onContinue ? (
+        <div className="py-6">
+          <Button
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Primary}
+            color={ButtonColor.Bacon}
+            className="w-full !text-white"
+            onClick={onContinue}
+          >
+            Continue »
+          </Button>
+        </div>
+      ) : undefined}
+      <PlusList />
+      <Typography
+        tag={TypographyTag.Span}
+        type={TypographyType.Callout}
+        color={TypographyColor.Tertiary}
+      >
+        Still on the fence?{' '}
+        <a
+          className="text-text-link hover:underline"
+          href={plusInfo}
+          target="_blank"
+          rel={anchorDefaultRel}
+        >
+          See what’s inside!
+        </a>
+      </Typography>
+    </>
+  );
+};

--- a/packages/shared/src/components/plus/PlusMobile.tsx
+++ b/packages/shared/src/components/plus/PlusMobile.tsx
@@ -1,0 +1,41 @@
+import React, { ReactElement, useCallback, useState } from 'react';
+import { useRouter } from 'next/router';
+import { PlusInfo } from './PlusInfo';
+import { usePaymentContext } from '../../contexts/PaymentContext';
+import { webappUrl } from '../../lib/constants';
+
+export const PlusMobile = (): ReactElement => {
+  const router = useRouter();
+  const { productOptions } = usePaymentContext();
+  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+
+  const selectionChange = useCallback((priceId) => {
+    setSelectedOption(priceId);
+  }, []);
+
+  const onContinue = useCallback(() => {
+    router.replace(`${webappUrl}plus/payment?pid=${selectedOption}`);
+  }, [router, selectedOption]);
+
+  return (
+    <div
+      className="flex flex-col p-6"
+      ref={(element) => {
+        if (!element) {
+          return;
+        }
+
+        if (productOptions?.[0]?.value && !selectedOption) {
+          setSelectedOption(productOptions?.[0]?.value);
+        }
+      }}
+    >
+      <PlusInfo
+        productOptions={productOptions}
+        selectedOption={selectedOption}
+        onChange={selectionChange}
+        onContinue={onContinue}
+      />
+    </div>
+  );
+};

--- a/packages/webapp/pages/plus/index.tsx
+++ b/packages/webapp/pages/plus/index.tsx
@@ -1,177 +1,28 @@
-import React, { ReactElement, useCallback, useMemo, useState } from 'react';
-import { usePaymentContext } from '@dailydotdev/shared/src/contexts/PaymentContext';
-import {
-  Typography,
-  TypographyColor,
-  TypographyTag,
-  TypographyType,
-} from '@dailydotdev/shared/src/components/typography/Typography';
-import { PlusList } from '@dailydotdev/shared/src/components/plus/PlusList';
-import { RadioItem } from '@dailydotdev/shared/src/components/fields/RadioItem';
-import classNames from 'classnames';
-import { plusInfo } from '@dailydotdev/shared/src/lib/constants';
-import { anchorDefaultRel } from '@dailydotdev/shared/src/lib/strings';
-import { PlusUser } from '@dailydotdev/shared/src/components/PlusUser';
-import { IconSize } from '@dailydotdev/shared/src/components/Icon';
+import React, { ReactElement } from 'react';
+
+import dynamic from 'next/dynamic';
+import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
 import { getPlusLayout } from '../../components/layouts/PlusLayout/PlusLayout';
 
+const PlusMobile = dynamic(() =>
+  import(
+    /* webpackChunkName: "plusMobile" */ '@dailydotdev/shared/src/components/plus/PlusMobile'
+  ).then((mod) => mod.PlusMobile),
+);
+const PlusDesktop = dynamic(() =>
+  import(
+    /* webpackChunkName: "plusDesktop" */ '@dailydotdev/shared/src/components/plus/PlusDesktop'
+  ).then((mod) => mod.PlusDesktop),
+);
+
 const PlusPage = (): ReactElement => {
-  const { openCheckout, productPrices } = usePaymentContext();
+  const isLaptop = useViewSize(ViewSize.Laptop);
 
-  const [selectedOption, setSelectedOption] = useState<string | null>(null);
-  const productOptions = useMemo(
-    () =>
-      productPrices?.data?.details?.lineItems?.map((item) => ({
-        label: item.price.description,
-        value: item.price.id,
-        price: item.formattedTotals.total,
-        currencyCode: productPrices?.data.currencyCode,
-        extraLabel: item.price.customData?.label as string,
-      })) ?? [],
-    [productPrices?.data.currencyCode, productPrices?.data?.details?.lineItems],
-  );
+  if (isLaptop) {
+    return <PlusDesktop />;
+  }
 
-  const toggleCheckoutOption = useCallback(
-    (priceId) => {
-      setSelectedOption(priceId);
-      openCheckout({ priceId });
-    },
-    [openCheckout],
-  );
-
-  return (
-    <div className="flex flex-1 items-center justify-center gap-20">
-      <div className="ml-6 flex w-[28.5rem] flex-col">
-        <PlusUser
-          iconSize={IconSize.Large}
-          typographyType={TypographyType.Title1}
-          className="mb-6"
-        />
-        <Typography
-          tag={TypographyTag.H1}
-          type={TypographyType.Mega2}
-          color={TypographyColor.Primary}
-          className="mb-2"
-          bold
-        >
-          Unlock more with Plus
-        </Typography>
-        <Typography
-          tag={TypographyTag.H2}
-          type={TypographyType.Title3}
-          color={TypographyColor.Secondary}
-          className="mb-6"
-        >
-          Upgrade to daily.dev Plus for an enhanced, ad-free experience with
-          exclusive features and perks to level up your game.
-        </Typography>
-        <Typography
-          tag={TypographyTag.P}
-          type={TypographyType.Callout}
-          color={TypographyColor.Tertiary}
-          className="mb-4"
-          bold
-        >
-          Billing cycle
-        </Typography>
-        <div className="min-h-[6.125rem] rounded-10 border border-border-subtlest-tertiary">
-          {productOptions.map((option) => {
-            const { label, value, price, currencyCode, extraLabel } = option;
-            const checked = selectedOption === value;
-            return (
-              <div
-                key={label}
-                className={classNames(
-                  'flex h-12 items-center justify-between rounded-10 p-2',
-                  checked
-                    ? 'border border-border-subtlest-primary bg-surface-float'
-                    : undefined,
-                )}
-              >
-                <div className="flex items-center">
-                  <RadioItem
-                    name={label}
-                    id={`${label}-${value}`}
-                    value={value}
-                    checked={checked}
-                    onChange={() => toggleCheckoutOption(value)}
-                    className={{
-                      content: 'truncate',
-                    }}
-                  >
-                    <Typography
-                      tag={TypographyTag.Span}
-                      type={TypographyType.Callout}
-                      color={TypographyColor.Primary}
-                    >
-                      {option.label}
-                    </Typography>
-                  </RadioItem>
-                  {extraLabel ? (
-                    <Typography
-                      tag={TypographyTag.Span}
-                      type={TypographyType.Caption1}
-                      color={TypographyColor.StatusSuccess}
-                      className="rounded-10 bg-action-upvote-float px-2 py-1"
-                      bold
-                    >
-                      {extraLabel}
-                    </Typography>
-                  ) : undefined}
-                </div>
-                <div className="mr-1 flex items-center gap-1">
-                  <Typography
-                    tag={TypographyTag.Span}
-                    type={TypographyType.Body}
-                    color={TypographyColor.Primary}
-                    bold
-                  >
-                    {price}
-                  </Typography>
-                  <Typography
-                    tag={TypographyTag.Span}
-                    type={TypographyType.Body}
-                    color={TypographyColor.Secondary}
-                  >
-                    {currencyCode}
-                  </Typography>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-        <PlusList />
-        <Typography
-          tag={TypographyTag.Span}
-          type={TypographyType.Callout}
-          color={TypographyColor.Tertiary}
-        >
-          Still on the fence?{' '}
-          <a
-            className="text-text-link hover:underline"
-            href={plusInfo}
-            target="_blank"
-            rel={anchorDefaultRel}
-          >
-            See what’s inside!
-          </a>
-        </Typography>
-      </div>
-      <div
-        ref={(element) => {
-          if (!element) {
-            return;
-          }
-
-          if (productOptions?.[0]?.value && !selectedOption) {
-            setSelectedOption(productOptions?.[0]?.value);
-            openCheckout({ priceId: productOptions?.[0]?.value });
-          }
-        }}
-        className="checkout-container mr-6 min-h-40 w-[28.5rem] rounded-16 border border-border-subtlest-tertiary bg-background-default p-5"
-      />
-    </div>
-  );
+  return <PlusMobile />;
 };
 
 PlusPage.getLayout = getPlusLayout;

--- a/packages/webapp/pages/plus/payment.tsx
+++ b/packages/webapp/pages/plus/payment.tsx
@@ -1,0 +1,41 @@
+import React, { ReactElement, useEffect } from 'react';
+import { usePaymentContext } from '@dailydotdev/shared/src/contexts/PaymentContext';
+
+import { useRouter } from 'next/router';
+import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
+import { getPlusLayout } from '../../components/layouts/PlusLayout/PlusLayout';
+
+const PlusPaymentPage = (): ReactElement => {
+  const isLaptop = useViewSize(ViewSize.Laptop);
+  const { openCheckout } = usePaymentContext();
+  const router = useRouter();
+  const { pid } = router.query;
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+    if (!pid || isLaptop) {
+      router.replace(`${webappUrl}plus`);
+    }
+  }, [isLaptop, pid, router]);
+
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <div
+        ref={(element) => {
+          if (!element) {
+            return;
+          }
+
+          openCheckout({ priceId: pid as string });
+        }}
+        className="checkout-container h-full w-full bg-background-default p-5"
+      />
+    </div>
+  );
+};
+
+PlusPaymentPage.getLayout = getPlusLayout;
+
+export default PlusPaymentPage;

--- a/packages/webapp/pages/plus/payment.tsx
+++ b/packages/webapp/pages/plus/payment.tsx
@@ -3,6 +3,7 @@ import { usePaymentContext } from '@dailydotdev/shared/src/contexts/PaymentConte
 
 import { useRouter } from 'next/router';
 import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
+import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import { getPlusLayout } from '../../components/layouts/PlusLayout/PlusLayout';
 
 const PlusPaymentPage = (): ReactElement => {


### PR DESCRIPTION
## Changes

Decided to split into lazy loaded components and render different on view.
(mobile+tablet is one and desktop)

This way we can better control how things load and look.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-719 #done 


### Preview domain
https://as-719-mobile-flow.preview.app.daily.dev