### PR TITLE
feat: ad-free feed when plus user

### DIFF
--- a/packages/shared/src/components/post/PostEngagements.tsx
+++ b/packages/shared/src/components/post/PostEngagements.tsx
@@ -26,6 +26,7 @@ import { PostContentReminder } from './common/PostContentReminder';
 import { Typography, TypographyType } from '../typography/Typography';
 import { Button, ButtonIconPosition, ButtonSize } from '../buttons/Button';
 import { TimeSortIcon } from '../icons/Sort/Time';
+import { usePlusSubscription } from '../../hooks/usePlusSubscription';
 
 const AuthorOnboarding = dynamic(
   () => import(/* webpackChunkName: "authorOnboarding" */ './AuthorOnboarding'),
@@ -48,6 +49,7 @@ function PostEngagements({
   const postQueryKey = ['post', post.id];
   const [sortBy, setSortBy] = useState(SortCommentsBy.OldestFirst);
   const { user, showLogin } = useAuthContext();
+  const { isPlus } = usePlusSubscription();
   const commentRef = useRef<NewCommentRef>();
   const [authorOnboarding, setAuthorOnboarding] = useState(false);
   const [permissionNotificationCommentId, setPermissionNotificationCommentId] =
@@ -136,7 +138,7 @@ function PostEngagements({
         ref={commentRef}
         onCommented={onCommented}
       />
-      <AdAsComment postId={post.id} />
+      {!isPlus && <AdAsComment postId={post.id} />}
       <PostComments
         post={post}
         sortBy={sortBy}


### PR DESCRIPTION
## Changes

Removes ads from feed and comments if user is plus user.

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->

AS-740

### Preview domain
https://as-740-ad-free.preview.app.daily.dev