### PR TITLE
fix: wrong type, was causing error on onSuccess callback

### DIFF
--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -693,12 +693,16 @@ export interface SquadPostRejectionProps extends SquadPostModerationProps {
 export const squadApproveMutation = ({
   postIds,
   sourceId,
-}: SquadPostModerationProps): Promise<SourcePostModeration[]> => {
-  return gqlClient.request(SQUAD_MODERATE_POST_MUTATION, {
-    postIds,
-    sourceId,
-    status: SourcePostModerationStatus.Approved,
-  });
+}: SquadPostModerationProps): Promise<{
+  moderateSourcePosts: SourcePostModeration[];
+}> => {
+  return gqlClient
+    .request(SQUAD_MODERATE_POST_MUTATION, {
+      postIds,
+      sourceId,
+      status: SourcePostModerationStatus.Approved,
+    })
+    .then((res) => res.moderateSourcePosts);
 };
 
 export const squadRejectMutation = ({
@@ -706,14 +710,18 @@ export const squadRejectMutation = ({
   sourceId,
   reason,
   note,
-}: SquadPostRejectionProps): Promise<SourcePostModeration[]> => {
-  return gqlClient.request(SQUAD_MODERATE_POST_MUTATION, {
-    postIds,
-    sourceId,
-    status: SourcePostModerationStatus.Rejected,
-    rejectionReason: reason,
-    moderatorMessage: note,
-  });
+}: SquadPostRejectionProps): Promise<{
+  moderateSourcePosts: SourcePostModeration[];
+}> => {
+  return gqlClient
+    .request(SQUAD_MODERATE_POST_MUTATION, {
+      postIds,
+      sourceId,
+      status: SourcePostModerationStatus.Rejected,
+      rejectionReason: reason,
+      moderatorMessage: note,
+    })
+    .then((res) => res.moderateSourcePosts);
 };
 
 const DELETE_PENDING_POST_MUTATION = gql`


### PR DESCRIPTION
## Changes
wrong type, was causing error on onSuccess callback.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->
