### PR TITLE
feat: add logging for empty feed from FE

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -176,6 +176,7 @@ export default function Feed<T>({
         adPostLength: isSquadFeed ? 2 : undefined,
         showAcquisitionForm,
         ...(showMarketingCta && { marketingCta }),
+        feedName,
       },
     },
   );

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -26,6 +26,8 @@ import { FeedItemType } from '../components/cards/common/common';
 import { GARMR_ERROR, gqlClient } from '../graphql/common';
 import { usePlusSubscription } from './usePlusSubscription';
 import { fetchAd } from '../lib/ads';
+import { LogEvent } from '../lib/log';
+import { useLogContext } from '../contexts/LogContext';
 
 interface FeedItemBase<T extends FeedItemType> {
   type: T;
@@ -90,6 +92,7 @@ type UseFeedSettingParams = {
   disableAds?: boolean;
   showAcquisitionForm?: boolean;
   marketingCta?: MarketingCta;
+  feedName?: string;
 };
 
 export interface UseFeedOptionalParams<T> {
@@ -110,6 +113,7 @@ export default function useFeed<T>(
   placeholdersPerPage: number,
   params: UseFeedOptionalParams<T> = {},
 ): FeedReturnType {
+  const { logEvent } = useLogContext();
   const { query, variables, options = {}, settings, onEmptyFeed } = params;
   const { user, tokenRefreshed } = useContext(AuthContext);
   const { isPlus } = usePlusSubscription();
@@ -126,12 +130,19 @@ export default function useFeed<T>(
         loggedIn: !!user,
       });
 
-      if (
+      const isEmpty =
         !feedQuery?.data?.pages[0]?.page.edges.length &&
-        !res?.page?.edges?.length &&
-        onEmptyFeed
-      ) {
-        onEmptyFeed();
+        !res?.page?.edges?.length;
+
+      if (isEmpty) {
+        logEvent({
+          event_name: LogEvent.FeedEmpty,
+          target_id: params?.settings?.feedName,
+          extra: JSON.stringify({ ...params?.variables }),
+        });
+        if (onEmptyFeed) {
+          onEmptyFeed();
+        }
       }
 
       return res;

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -138,7 +138,7 @@ export default function useFeed<T>(
         logEvent({
           event_name: LogEvent.FeedEmpty,
           target_id: params?.settings?.feedName,
-          extra: JSON.stringify({ ...params?.variables }),
+          extra: params?.variables ? JSON.stringify({ ...params?.variables }) : undefined,
         });
         if (onEmptyFeed) {
           onEmptyFeed();

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -138,7 +138,9 @@ export default function useFeed<T>(
         logEvent({
           event_name: LogEvent.FeedEmpty,
           target_id: params?.settings?.feedName,
-          extra: params?.variables ? JSON.stringify({ ...params?.variables }) : undefined,
+          extra: params?.variables
+            ? JSON.stringify({ ...params?.variables })
+            : undefined,
         });
         if (onEmptyFeed) {
           onEmptyFeed();

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -74,6 +74,7 @@ export enum LogEvent {
   ClickArticleAnonymousCTA = 'click article anonymous cta',
   ClickScrollBlock = 'click scroll block',
   KeyboardShortcutTriggered = 'keyboard shortcut triggered',
+  FeedEmpty = 'feed empty',
   // notifications - start
   ClickNotificationIcon = 'click notification icon',
   OpenNotificationList = 'open notification list',


### PR DESCRIPTION
## Changes

Add event to track frontend empty feeds.

Example return:

```js
{
    "event_name": "feed empty",
    "target_id": "postsupvoted",
    "extra": "{\"version\":1,\"period\":7}"
}
```

## Events

Did you introduce any new tracking events?

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| New | feed empty  | extra: { feed variables (dynamic object) } |

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-783 #done 


### Preview domain
https://as-783-feed-empty-log.preview.app.daily.dev