### PR TITLE
feat: entry points plus

### DIFF
--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -122,7 +122,7 @@ export default function BookmarkFeedLayout({
         />
       )}
       {showPlusSubscription && (
-        <div className="mb-4 px-4 tablet:hidden">
+        <div className="mb-4 px-4 laptop:hidden">
           <Button
             className="w-full"
             variant={ButtonVariant.Tertiary}

--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -18,9 +18,12 @@ import SearchEmptyScreen from './SearchEmptyScreen';
 import Feed, { FeedProps } from './Feed';
 import BookmarkEmptyScreen from './BookmarkEmptyScreen';
 import { Button, ButtonVariant } from './buttons/Button';
-import { ShareIcon } from './icons';
+import { PlusIcon, ShareIcon } from './icons';
 import { generateQueryKey, OtherFeedPage, RequestKey } from '../lib/query';
-import { useFeedLayout } from '../hooks';
+import { useFeedLayout, usePlusSubscription } from '../hooks';
+import { useLazyModal } from '../hooks/useLazyModal';
+import { LazyModal } from './modals/common/types';
+import { IconSize } from './Icon';
 
 export type BookmarkFeedLayoutProps = {
   searchQuery?: string;
@@ -46,6 +49,8 @@ export default function BookmarkFeedLayout({
     FeedPageLayoutComponent,
     shouldUseListMode,
   } = useFeedLayout();
+  const { openModal } = useLazyModal();
+  const { showPlusSubscription } = usePlusSubscription();
   const { user, tokenRefreshed } = useContext(AuthContext);
   const [showEmptyScreen, setShowEmptyScreen] = useState(false);
   const [showSharedBookmarks, setShowSharedBookmarks] = useState(false);
@@ -115,6 +120,25 @@ export default function BookmarkFeedLayout({
           isOpen={showSharedBookmarks}
           onRequestClose={() => setShowSharedBookmarks(false)}
         />
+      )}
+      {showPlusSubscription && (
+        <div className="mb-4 px-4 tablet:hidden">
+          <Button
+            className="w-full"
+            variant={ButtonVariant.Tertiary}
+            onClick={() => {
+              openModal({
+                type: LazyModal.BookmarkFolderSoon,
+                props: {},
+              });
+            }}
+          >
+            <div className="flex items-center justify-center rounded-6 bg-background-subtle">
+              <PlusIcon size={IconSize.Small} />
+            </div>
+            <div className="w-full pl-4 text-left">New folder</div>
+          </Button>
+        </div>
       )}
       {tokenRefreshed && <Feed {...feedProps} />}
     </FeedPageLayoutComponent>

--- a/packages/shared/src/components/filters/ContentTypesFilter.tsx
+++ b/packages/shared/src/components/filters/ContentTypesFilter.tsx
@@ -109,7 +109,6 @@ export function ContentTypesFilter(): ReactElement {
           <Divider className="bg-border-subtlest-tertiary" />
         </>
       )}
-
       <section className="flex flex-col gap-4" aria-busy={isLoading}>
         <div className="flex flex-col">
           <Typography

--- a/packages/shared/src/components/filters/ContentTypesFilter.tsx
+++ b/packages/shared/src/components/filters/ContentTypesFilter.tsx
@@ -19,6 +19,7 @@ import { usePlusSubscription } from '../../hooks';
 import { LogEvent, TargetId } from '../../lib/log';
 import { Switch } from '../fields/Switch';
 import { PlusUser } from '../PlusUser';
+import { webappUrl } from '../../lib/constants';
 
 export function ContentTypesFilter(): ReactElement {
   const { advancedSettings, isLoading } = useFeedSettings();
@@ -86,7 +87,7 @@ export function ContentTypesFilter(): ReactElement {
                   type="button"
                   variant={ButtonVariant.Primary}
                   size={ButtonSize.Medium}
-                  href="/plus"
+                  href={`${webappUrl}plus`}
                   icon={<DevPlusIcon className="text-action-plus-default" />}
                   onClick={() => {
                     logSubscriptionEvent({

--- a/packages/shared/src/components/filters/ContentTypesFilter.tsx
+++ b/packages/shared/src/components/filters/ContentTypesFilter.tsx
@@ -13,11 +13,19 @@ import { Divider } from '../utilities';
 import { LanguageDropdown } from '../profile/LanguageDropdown';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useLanguage } from '../../hooks/useLanguage';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { DevPlusIcon } from '../icons';
+import { usePlusSubscription } from '../../hooks';
+import { LogEvent, TargetId } from '../../lib/log';
+import { Switch } from '../fields/Switch';
+import { PlusUser } from '../PlusUser';
 
 export function ContentTypesFilter(): ReactElement {
   const { advancedSettings, isLoading } = useFeedSettings();
   const { selectedSettings, onToggleSettings } = useAdvancedSettings();
   const { user } = useAuthContext();
+  const { isPlus, showPlusSubscription, logSubscriptionEvent } =
+    usePlusSubscription();
 
   const videoSetting = getVideoSetting(advancedSettings);
 
@@ -25,6 +33,82 @@ export function ContentTypesFilter(): ReactElement {
 
   return (
     <div className="flex flex-col gap-4">
+      {showPlusSubscription && (
+        <>
+          <section className="flex flex-col gap-4" aria-busy={isLoading}>
+            <div className="flex flex-col">
+              <div className="flex items-center gap-2">
+                <Typography
+                  tag={TypographyTag.H3}
+                  color={TypographyColor.Primary}
+                  type={TypographyType.Body}
+                  bold
+                  className="mb-1"
+                >
+                  Clickbait Shield
+                </Typography>
+                <PlusUser />
+              </div>
+              <Typography
+                className="pr-24"
+                color={TypographyColor.Tertiary}
+                type={TypographyType.Callout}
+              >
+                Clickbait Shield uses AI to automatically optimize post titles
+                by fixing common problems like clickbait, lack of clarity, and
+                overly promotional language. The result is clearer, more
+                informative titles that help you quickly find the content you
+                actually need.
+              </Typography>
+            </div>
+            <Switch
+              inputId="clickbait-shield-switch"
+              name="clickbait_shield"
+              compact={false}
+              disabled
+            >
+              Optimize title quality
+            </Switch>
+            {!isPlus && (
+              <div className="flex items-center justify-center gap-4 rounded-10 border border-border-subtlest-tertiary bg-action-plus-float p-4">
+                <Typography
+                  className="flex flex-1"
+                  type={TypographyType.Body}
+                  color={TypographyColor.Primary}
+                >
+                  Upgrade to daily.dev Plus today, get an early adopter discount
+                  and be among the first to experience it as soon as it
+                  launches!
+                </Typography>
+                <Button
+                  className="flex"
+                  tag="a"
+                  type="button"
+                  variant={ButtonVariant.Primary}
+                  size={ButtonSize.Medium}
+                  href="/plus"
+                  icon={<DevPlusIcon className="text-action-plus-default" />}
+                  onClick={() => {
+                    logSubscriptionEvent({
+                      event_name: LogEvent.UpgradeSubscription,
+                      target_id: TargetId.FeedSettings,
+                    });
+                  }}
+                >
+                  Upgrade to Plus
+                </Button>
+              </div>
+            )}
+            <div className="absolute -right-14 top-8 w-52 rotate-45 bg-action-plus-default px-2 py-1 text-center text-white">
+              <Typography type={TypographyType.Callout} bold>
+                Coming soon
+              </Typography>
+            </div>
+          </section>
+          <Divider className="bg-border-subtlest-tertiary" />
+        </>
+      )}
+
       <section className="flex flex-col gap-4" aria-busy={isLoading}>
         <div className="flex flex-col">
           <Typography

--- a/packages/shared/src/components/modals/common.tsx
+++ b/packages/shared/src/components/modals/common.tsx
@@ -184,6 +184,20 @@ const TopReaderBadgeModal = dynamic(
     ),
 );
 
+const AdvancedCustomFeedSoonModal = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "advancedCustomFeedSoonModal" */ './soon/AdvancedCustomFeedSoonModal'
+    ),
+);
+
+const BookmarkFolderSoonModal = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "bookmarkFolderSoonModal" */ './soon/BookmarkFolderSoonModal'
+    ),
+);
+
 export const modals = {
   [LazyModal.SquadMember]: SquadMemberModal,
   [LazyModal.UpvotedPopup]: UpvotedPopupModal,
@@ -216,6 +230,8 @@ export const modals = {
   [LazyModal.PostModeration]: PostModerationModal,
   [LazyModal.NewSquad]: NewSquadModal,
   [LazyModal.TopReaderBadge]: TopReaderBadgeModal,
+  [LazyModal.AdvancedCustomFeedSoon]: AdvancedCustomFeedSoonModal,
+  [LazyModal.BookmarkFolderSoon]: BookmarkFolderSoonModal,
 };
 
 type GetComponentProps<T> = T extends

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -61,6 +61,8 @@ export enum LazyModal {
   PostModeration = 'postModeration',
   NewSquad = 'newSquad',
   TopReaderBadge = 'topReaderBadge',
+  AdvancedCustomFeedSoon = 'advancedCustomFeedSoon',
+  BookmarkFolderSoon = 'bookmarkFolderSoon',
 }
 
 export type ModalTabItem = {

--- a/packages/shared/src/components/modals/soon/AdvancedCustomFeedSoonModal.tsx
+++ b/packages/shared/src/components/modals/soon/AdvancedCustomFeedSoonModal.tsx
@@ -19,7 +19,7 @@ export type SlackIntegrationModalProps = Omit<ModalProps, 'children'>;
 const AdvancedCustomFeedSoonModal = ({
   ...props
 }: SlackIntegrationModalProps): ReactElement => {
-  const { logSubscriptionEvent } = usePlusSubscription();
+  const { logSubscriptionEvent, isPlus } = usePlusSubscription();
 
   return (
     <Modal
@@ -58,32 +58,34 @@ const AdvancedCustomFeedSoonModal = ({
           sorting options, block unwanted words, and customize your feed—your
           rules, your way.
         </Typography>
-        <div className="flex flex-col gap-4 rounded-10 border border-border-subtlest-tertiary bg-action-plus-float p-4">
-          <Typography
-            type={TypographyType.Body}
-            color={TypographyColor.Primary}
-          >
-            Upgrade to daily.dev Plus today, get an early adopter discount and
-            be among the first to experience it as soon as it launches!
-          </Typography>
-          <Button
-            className="w-full"
-            tag="a"
-            type="button"
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Medium}
-            href="/plus"
-            icon={<DevPlusIcon className="text-action-plus-default" />}
-            onClick={() => {
-              logSubscriptionEvent({
-                event_name: LogEvent.UpgradeSubscription,
-                target_id: TargetId.AdvancedCustomFeedSoonModal,
-              });
-            }}
-          >
-            Upgrade to Plus
-          </Button>
-        </div>
+        {!isPlus && (
+          <div className="flex flex-col items-center justify-center gap-4 rounded-10 border border-border-subtlest-tertiary bg-action-plus-float p-4">
+            <Typography
+              type={TypographyType.Body}
+              color={TypographyColor.Primary}
+            >
+              Upgrade to daily.dev Plus today, get an early adopter discount and
+              be among the first to experience it as soon as it launches!
+            </Typography>
+            <Button
+              className="w-full"
+              tag="a"
+              type="button"
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Medium}
+              href="/plus"
+              icon={<DevPlusIcon className="text-action-plus-default" />}
+              onClick={() => {
+                logSubscriptionEvent({
+                  event_name: LogEvent.UpgradeSubscription,
+                  target_id: TargetId.AdvancedCustomFeedSoonModal,
+                });
+              }}
+            >
+              Upgrade to Plus
+            </Button>
+          </div>
+        )}
       </Modal.Body>
     </Modal>
   );

--- a/packages/shared/src/components/modals/soon/AdvancedCustomFeedSoonModal.tsx
+++ b/packages/shared/src/components/modals/soon/AdvancedCustomFeedSoonModal.tsx
@@ -34,11 +34,18 @@ const AdvancedCustomFeedSoonModal = ({
         variant={ButtonVariant.Primary}
       />
       <Modal.Body className="flex flex-col items-center justify-center gap-4 text-center">
-        <Image
-          className="rounded-16"
-          src={advancedCustomFeedSoonImage}
-          alt="Advanced Custom Feeds coming soon"
-        />
+        <div className="relative overflow-hidden">
+          <Image
+            className="rounded-16"
+            src={advancedCustomFeedSoonImage}
+            alt="Advanced Custom Feeds coming soon"
+          />
+          <div className="absolute -right-14 top-8 w-52 rotate-45 bg-action-plus-default px-2 py-1 text-white">
+            <Typography type={TypographyType.Callout} bold>
+              Coming soon
+            </Typography>
+          </div>
+        </div>
         <Typography
           type={TypographyType.Title1}
           bold

--- a/packages/shared/src/components/modals/soon/AdvancedCustomFeedSoonModal.tsx
+++ b/packages/shared/src/components/modals/soon/AdvancedCustomFeedSoonModal.tsx
@@ -56,7 +56,7 @@ const AdvancedCustomFeedSoonModal = ({
         </Typography>
         <Typography type={TypographyType.Body} color={TypographyColor.Tertiary}>
           Choose your tags, sources, content types, and languages. Enjoy diverse
-          sorting options, block unwanted words, and customize your feed—your
+          sorting options, block unwanted words, and customize your feed, your
           rules, your way.
         </Typography>
         {!isPlus && (

--- a/packages/shared/src/components/modals/soon/AdvancedCustomFeedSoonModal.tsx
+++ b/packages/shared/src/components/modals/soon/AdvancedCustomFeedSoonModal.tsx
@@ -13,6 +13,7 @@ import { advancedCustomFeedSoonImage } from '../../../lib/image';
 import { DevPlusIcon } from '../../icons';
 import { usePlusSubscription } from '../../../hooks/usePlusSubscription';
 import { LogEvent, TargetId } from '../../../lib/log';
+import { webappUrl } from '../../../lib/constants';
 
 export type SlackIntegrationModalProps = Omit<ModalProps, 'children'>;
 
@@ -73,7 +74,7 @@ const AdvancedCustomFeedSoonModal = ({
               type="button"
               variant={ButtonVariant.Primary}
               size={ButtonSize.Medium}
-              href="/plus"
+              href={`${webappUrl}plus`}
               icon={<DevPlusIcon className="text-action-plus-default" />}
               onClick={() => {
                 logSubscriptionEvent({

--- a/packages/shared/src/components/modals/soon/AdvancedCustomFeedSoonModal.tsx
+++ b/packages/shared/src/components/modals/soon/AdvancedCustomFeedSoonModal.tsx
@@ -79,7 +79,7 @@ const AdvancedCustomFeedSoonModal = ({
               onClick={() => {
                 logSubscriptionEvent({
                   event_name: LogEvent.UpgradeSubscription,
-                  target_id: TargetId.AdvancedCustomFeedSoonModal,
+                  target_id: TargetId.CustomFeed,
                 });
               }}
             >

--- a/packages/shared/src/components/modals/soon/AdvancedCustomFeedSoonModal.tsx
+++ b/packages/shared/src/components/modals/soon/AdvancedCustomFeedSoonModal.tsx
@@ -1,0 +1,85 @@
+import React, { ReactElement } from 'react';
+import { Modal, ModalProps } from '../common/Modal';
+import { ModalClose } from '../common/ModalClose';
+import { ButtonSize, ButtonVariant } from '../../buttons/common';
+import { Image } from '../../image/Image';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../typography/Typography';
+import { Button } from '../../buttons/Button';
+import { advancedCustomFeedSoonImage } from '../../../lib/image';
+import { DevPlusIcon } from '../../icons';
+import { usePlusSubscription } from '../../../hooks/usePlusSubscription';
+import { LogEvent, TargetId } from '../../../lib/log';
+
+export type SlackIntegrationModalProps = Omit<ModalProps, 'children'>;
+
+const AdvancedCustomFeedSoonModal = ({
+  ...props
+}: SlackIntegrationModalProps): ReactElement => {
+  const { logSubscriptionEvent } = usePlusSubscription();
+
+  return (
+    <Modal
+      kind={Modal.Kind.FlexibleCenter}
+      size={Modal.Size.Small}
+      isDrawerOnMobile
+      {...props}
+    >
+      <ModalClose
+        className="right-4 top-4"
+        onClick={props.onRequestClose}
+        variant={ButtonVariant.Primary}
+      />
+      <Modal.Body className="flex flex-col items-center justify-center gap-4 text-center">
+        <Image
+          className="rounded-16"
+          src={advancedCustomFeedSoonImage}
+          alt="Advanced Custom Feeds coming soon"
+        />
+        <Typography
+          type={TypographyType.Title1}
+          bold
+          color={TypographyColor.Primary}
+        >
+          Advanced Custom Feeds
+        </Typography>
+        <Typography type={TypographyType.Body} color={TypographyColor.Tertiary}>
+          Choose your tags, sources, content types, and languages. Enjoy diverse
+          sorting options, block unwanted words, and customize your feed—your
+          rules, your way.
+        </Typography>
+        <div className="flex flex-col gap-4 rounded-10 border border-border-subtlest-tertiary bg-action-plus-float p-4">
+          <Typography
+            type={TypographyType.Body}
+            color={TypographyColor.Primary}
+          >
+            Upgrade to daily.dev Plus today, get an early adopter discount and
+            be among the first to experience it as soon as it launches!
+          </Typography>
+          <Button
+            className="w-full"
+            tag="a"
+            type="button"
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Medium}
+            href="/plus"
+            icon={<DevPlusIcon className="text-action-plus-default" />}
+            onClick={() => {
+              logSubscriptionEvent({
+                event_name: LogEvent.UpgradeSubscription,
+                target_id: TargetId.AdvancedCustomFeedSoonModal,
+              });
+            }}
+          >
+            Upgrade to Plus
+          </Button>
+        </div>
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+export default AdvancedCustomFeedSoonModal;

--- a/packages/shared/src/components/modals/soon/BookmarkFolderSoonModal.tsx
+++ b/packages/shared/src/components/modals/soon/BookmarkFolderSoonModal.tsx
@@ -19,7 +19,7 @@ export type SlackIntegrationModalProps = Omit<ModalProps, 'children'>;
 const BookmarkFolderSoonModal = ({
   ...props
 }: SlackIntegrationModalProps): ReactElement => {
-  const { logSubscriptionEvent } = usePlusSubscription();
+  const { logSubscriptionEvent, isPlus } = usePlusSubscription();
 
   return (
     <Modal
@@ -57,32 +57,34 @@ const BookmarkFolderSoonModal = ({
           Organize your bookmarked posts into folders so you always know where
           to find what you need.
         </Typography>
-        <div className="flex flex-col gap-4 rounded-10 border border-border-subtlest-tertiary bg-action-plus-float p-4">
-          <Typography
-            type={TypographyType.Body}
-            color={TypographyColor.Primary}
-          >
-            Upgrade to daily.dev Plus today, get an early adopter discount and
-            be among the first to experience it as soon as it launches!
-          </Typography>
-          <Button
-            className="w-full"
-            tag="a"
-            type="button"
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.Medium}
-            href="/plus"
-            icon={<DevPlusIcon className="text-action-plus-default" />}
-            onClick={() => {
-              logSubscriptionEvent({
-                event_name: LogEvent.UpgradeSubscription,
-                target_id: TargetId.BookmarkFolderSoonModal,
-              });
-            }}
-          >
-            Upgrade to Plus
-          </Button>
-        </div>
+        {!isPlus && (
+          <div className="flex flex-col items-center justify-center gap-4 rounded-10 border border-border-subtlest-tertiary bg-action-plus-float p-4">
+            <Typography
+              type={TypographyType.Body}
+              color={TypographyColor.Primary}
+            >
+              Upgrade to daily.dev Plus today, get an early adopter discount and
+              be among the first to experience it as soon as it launches!
+            </Typography>
+            <Button
+              className="w-full"
+              tag="a"
+              type="button"
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Medium}
+              href="/plus"
+              icon={<DevPlusIcon className="text-action-plus-default" />}
+              onClick={() => {
+                logSubscriptionEvent({
+                  event_name: LogEvent.UpgradeSubscription,
+                  target_id: TargetId.BookmarkFolderSoonModal,
+                });
+              }}
+            >
+              Upgrade to Plus
+            </Button>
+          </div>
+        )}
       </Modal.Body>
     </Modal>
   );

--- a/packages/shared/src/components/modals/soon/BookmarkFolderSoonModal.tsx
+++ b/packages/shared/src/components/modals/soon/BookmarkFolderSoonModal.tsx
@@ -13,6 +13,7 @@ import { Button } from '../../buttons/Button';
 import { DevPlusIcon } from '../../icons';
 import { LogEvent, TargetId } from '../../../lib/log';
 import { bookmarkFolderSoonImage } from '../../../lib/image';
+import { webappUrl } from '../../../lib/constants';
 
 export type SlackIntegrationModalProps = Omit<ModalProps, 'children'>;
 
@@ -72,7 +73,7 @@ const BookmarkFolderSoonModal = ({
               type="button"
               variant={ButtonVariant.Primary}
               size={ButtonSize.Medium}
-              href="/plus"
+              href={`${webappUrl}plus`}
               icon={<DevPlusIcon className="text-action-plus-default" />}
               onClick={() => {
                 logSubscriptionEvent({

--- a/packages/shared/src/components/modals/soon/BookmarkFolderSoonModal.tsx
+++ b/packages/shared/src/components/modals/soon/BookmarkFolderSoonModal.tsx
@@ -78,7 +78,7 @@ const BookmarkFolderSoonModal = ({
               onClick={() => {
                 logSubscriptionEvent({
                   event_name: LogEvent.UpgradeSubscription,
-                  target_id: TargetId.BookmarkFolderSoonModal,
+                  target_id: TargetId.BookmarkFolder,
                 });
               }}
             >

--- a/packages/shared/src/components/modals/soon/BookmarkFolderSoonModal.tsx
+++ b/packages/shared/src/components/modals/soon/BookmarkFolderSoonModal.tsx
@@ -34,11 +34,18 @@ const BookmarkFolderSoonModal = ({
         variant={ButtonVariant.Primary}
       />
       <Modal.Body className="flex flex-col items-center justify-center gap-4 text-center">
-        <Image
-          className="rounded-16"
-          src={bookmarkFolderSoonImage}
-          alt="Bookmark Folder coming soon"
-        />
+        <div className="relative overflow-hidden">
+          <Image
+            className="rounded-16"
+            src={bookmarkFolderSoonImage}
+            alt="Bookmark Folder coming soon"
+          />
+          <div className="absolute -right-14 top-8 w-52 rotate-45 bg-action-plus-default px-2 py-1 text-white">
+            <Typography type={TypographyType.Callout} bold>
+              Coming soon
+            </Typography>
+          </div>
+        </div>
         <Typography
           type={TypographyType.Title1}
           bold

--- a/packages/shared/src/components/modals/soon/BookmarkFolderSoonModal.tsx
+++ b/packages/shared/src/components/modals/soon/BookmarkFolderSoonModal.tsx
@@ -1,0 +1,84 @@
+import React, { ReactElement } from 'react';
+import { Modal, ModalProps } from '../common/Modal';
+import { usePlusSubscription } from '../../../hooks/usePlusSubscription';
+import { ModalClose } from '../common/ModalClose';
+import { ButtonSize, ButtonVariant } from '../../buttons/common';
+import { Image } from '../../image/Image';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../typography/Typography';
+import { Button } from '../../buttons/Button';
+import { DevPlusIcon } from '../../icons';
+import { LogEvent, TargetId } from '../../../lib/log';
+import { bookmarkFolderSoonImage } from '../../../lib/image';
+
+export type SlackIntegrationModalProps = Omit<ModalProps, 'children'>;
+
+const BookmarkFolderSoonModal = ({
+  ...props
+}: SlackIntegrationModalProps): ReactElement => {
+  const { logSubscriptionEvent } = usePlusSubscription();
+
+  return (
+    <Modal
+      kind={Modal.Kind.FlexibleCenter}
+      size={Modal.Size.Small}
+      isDrawerOnMobile
+      {...props}
+    >
+      <ModalClose
+        className="right-4 top-4"
+        onClick={props.onRequestClose}
+        variant={ButtonVariant.Primary}
+      />
+      <Modal.Body className="flex flex-col items-center justify-center gap-4 text-center">
+        <Image
+          className="rounded-16"
+          src={bookmarkFolderSoonImage}
+          alt="Bookmark Folder coming soon"
+        />
+        <Typography
+          type={TypographyType.Title1}
+          bold
+          color={TypographyColor.Primary}
+        >
+          Folders are coming soon...
+        </Typography>
+        <Typography type={TypographyType.Body} color={TypographyColor.Tertiary}>
+          Organize your bookmarked posts into folders so you always know where
+          to find what you need.
+        </Typography>
+        <div className="flex flex-col gap-4 rounded-10 border border-border-subtlest-tertiary bg-action-plus-float p-4">
+          <Typography
+            type={TypographyType.Body}
+            color={TypographyColor.Primary}
+          >
+            Upgrade to daily.dev Plus today, get an early adopter discount and
+            be among the first to experience it as soon as it launches!
+          </Typography>
+          <Button
+            className="w-full"
+            tag="a"
+            type="button"
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Medium}
+            href="/plus"
+            icon={<DevPlusIcon className="text-action-plus-default" />}
+            onClick={() => {
+              logSubscriptionEvent({
+                event_name: LogEvent.UpgradeSubscription,
+                target_id: TargetId.BookmarkFolderSoonModal,
+              });
+            }}
+          >
+            Upgrade to Plus
+          </Button>
+        </div>
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+export default BookmarkFolderSoonModal;

--- a/packages/shared/src/components/sidebar/ClickableNavItem.tsx
+++ b/packages/shared/src/components/sidebar/ClickableNavItem.tsx
@@ -30,7 +30,7 @@ export function ClickableNavItem({
         event.preventDefault();
         showLogin();
       } else {
-        item.action?.();
+        item.action?.(event);
       }
     },
     [showLogin, item],

--- a/packages/shared/src/components/sidebar/SidebarDesktop.tsx
+++ b/packages/shared/src/components/sidebar/SidebarDesktop.tsx
@@ -13,6 +13,8 @@ import { NetworkSection } from './sections/NetworkSection';
 import { CustomFeedSection } from './sections/CustomFeedSection';
 import { DiscoverSection } from './sections/DiscoverSection';
 import { ResourceSection } from './sections/ResourceSection';
+import { BookmarkSection } from './sections/BookmarkSection';
+import { usePlusSubscription } from '../../hooks';
 
 type SidebarDesktopProps = {
   featureTheme?: {
@@ -33,6 +35,7 @@ export const SidebarDesktop = ({
   const { isAvailable: isBannerAvailable } = useBanner();
   const { isLoggedIn } = useAuthContext();
   const activePage = router.asPath || router.pathname;
+  const { showPlusSubscription } = usePlusSubscription();
 
   const defaultRenderSectionProps = useMemo(
     () => ({
@@ -78,6 +81,13 @@ export const SidebarDesktop = ({
             title="Custom feeds"
             isItemsButton={false}
           />
+          {showPlusSubscription && (
+            <BookmarkSection
+              {...defaultRenderSectionProps}
+              title="Bookmarks"
+              isItemsButton={false}
+            />
+          )}
           <DiscoverSection
             {...defaultRenderSectionProps}
             title="Discover"

--- a/packages/shared/src/components/sidebar/common.tsx
+++ b/packages/shared/src/components/sidebar/common.tsx
@@ -37,7 +37,9 @@ export interface SidebarMenuItem {
   onClick?: () => unknown;
   target?: HTMLAttributeAnchorTarget | undefined;
   isForcedLink?: boolean;
-  action?: () => unknown;
+  action?: (
+    event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+  ) => unknown;
   alert?: ReactElement;
   active?: boolean;
   hideOnMobile?: boolean;

--- a/packages/shared/src/components/sidebar/sections/BookmarkSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/BookmarkSection.tsx
@@ -1,0 +1,46 @@
+import React, { ReactElement } from 'react';
+import { SidebarMenuItem } from '../common';
+import { PlusIcon } from '../../icons';
+import { Section } from '../Section';
+import { webappUrl } from '../../../lib/constants';
+import { SidebarSettingsFlags } from '../../../graphql/settings';
+import { SidebarSectionProps } from './common';
+import { useLazyModal } from '../../../hooks/useLazyModal';
+import { LazyModal } from '../../modals/common/types';
+
+export const BookmarkSection = ({
+  isItemsButton,
+  ...defaultRenderSectionProps
+}: SidebarSectionProps): ReactElement => {
+  const { openModal } = useLazyModal();
+
+  const menuItems: SidebarMenuItem[] = [
+    {
+      icon: () => (
+        <div className="rounded-6 bg-background-subtle">
+          <PlusIcon />
+        </div>
+      ),
+      title: 'New folder',
+      path: `${webappUrl}bookmarks/new`,
+      isForcedLink: true,
+      requiresLogin: true,
+      action: (
+        event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+      ) => {
+        event.preventDefault();
+
+        openModal({ type: LazyModal.BookmarkFolderSoon, props: {} });
+      },
+    },
+  ];
+
+  return (
+    <Section
+      {...defaultRenderSectionProps}
+      items={menuItems}
+      isItemsButton={isItemsButton}
+      flag={SidebarSettingsFlags.BookmarksExpanded}
+    />
+  );
+};

--- a/packages/shared/src/components/sidebar/sections/BookmarkSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/BookmarkSection.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
-import { SidebarMenuItem } from '../common';
-import { PlusIcon } from '../../icons';
+import { ListIcon, SidebarMenuItem } from '../common';
+import { BookmarkIcon, PlusIcon } from '../../icons';
 import { Section } from '../Section';
 import { webappUrl } from '../../../lib/constants';
 import { SidebarSettingsFlags } from '../../../graphql/settings';
@@ -15,6 +15,15 @@ export const BookmarkSection = ({
   const { openModal } = useLazyModal();
 
   const menuItems: SidebarMenuItem[] = [
+    {
+      icon: (active: boolean) => (
+        <ListIcon Icon={() => <BookmarkIcon secondary={active} />} />
+      ),
+      title: 'Bookmarks',
+      path: `${webappUrl}bookmarks`,
+      isForcedLink: true,
+      requiresLogin: true,
+    },
     {
       icon: () => (
         <div className="rounded-6 bg-background-subtle">

--- a/packages/shared/src/components/sidebar/sections/CustomFeedSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/CustomFeedSection.tsx
@@ -3,15 +3,19 @@ import { SidebarMenuItem } from '../common';
 import { HashtagIcon, PlusIcon } from '../../icons';
 import { Section } from '../Section';
 import { webappUrl } from '../../../lib/constants';
-import { useFeeds } from '../../../hooks';
+import { useFeeds, usePlusSubscription } from '../../../hooks';
 import { SidebarSettingsFlags } from '../../../graphql/settings';
 import { SidebarSectionProps } from './common';
+import { useLazyModal } from '../../../hooks/useLazyModal';
+import { LazyModal } from '../../modals/common/types';
 
 export const CustomFeedSection = ({
   isItemsButton,
   ...defaultRenderSectionProps
 }: SidebarSectionProps): ReactElement => {
   const { feeds } = useFeeds();
+  const { openModal } = useLazyModal();
+  const { showPlusSubscription } = usePlusSubscription();
 
   const menuItems: SidebarMenuItem[] = useMemo(() => {
     const customFeeds =
@@ -39,9 +43,24 @@ export const CustomFeedSection = ({
         title: 'Custom feed',
         path: `${webappUrl}feeds/new`,
         requiresLogin: true,
+        isForcedClickable: true,
+        action: (
+          event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>,
+        ) => {
+          if (showPlusSubscription) {
+            event.preventDefault();
+
+            openModal({ type: LazyModal.AdvancedCustomFeedSoon, props: {} });
+          }
+        },
       },
     ].filter(Boolean);
-  }, [defaultRenderSectionProps.activePage, feeds?.edges]);
+  }, [
+    defaultRenderSectionProps.activePage,
+    feeds?.edges,
+    showPlusSubscription,
+    openModal,
+  ]);
 
   return (
     <Section

--- a/packages/shared/src/components/sidebar/sections/MainSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/MainSection.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useCallback, useMemo } from 'react';
 import { Section } from '../Section';
 import { ListIcon, SidebarMenuItem } from '../common';
-import { DevPlusIcon, EyeIcon, HotIcon } from '../../icons';
+import { BookmarkIcon, DevPlusIcon, EyeIcon, HotIcon } from '../../icons';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { ProfileImageSize, ProfilePicture } from '../../ProfilePicture';
 import { OtherFeedPage } from '../../../lib/query';
@@ -16,7 +16,8 @@ export const MainSection = ({
   ...defaultRenderSectionProps
 }: SidebarSectionProps): ReactElement => {
   const { user, isLoggedIn } = useAuthContext();
-  const { isEnrolledNotPlus, logSubscriptionEvent } = usePlusSubscription();
+  const { showPlusSubscription, isEnrolledNotPlus, logSubscriptionEvent } =
+    usePlusSubscription();
 
   const onPlusClick = useCallback(() => {
     logSubscriptionEvent({
@@ -58,6 +59,15 @@ export const MainSection = ({
         path: '/posts',
         action: () => onNavTabClick?.(OtherFeedPage.Explore),
       },
+      !showPlusSubscription && {
+        icon: (active: boolean) => (
+          <ListIcon Icon={() => <BookmarkIcon secondary={active} />} />
+        ),
+        title: 'Bookmarks',
+        path: `${webappUrl}bookmarks`,
+        isForcedLink: true,
+        requiresLogin: true,
+      },
       {
         icon: (active: boolean) => (
           <ListIcon Icon={() => <EyeIcon secondary={active} />} />
@@ -69,7 +79,14 @@ export const MainSection = ({
       },
       plus,
     ].filter(Boolean);
-  }, [isLoggedIn, isEnrolledNotPlus, onNavTabClick, onPlusClick, user]);
+  }, [
+    isLoggedIn,
+    isEnrolledNotPlus,
+    onNavTabClick,
+    onPlusClick,
+    user,
+    showPlusSubscription,
+  ]);
 
   return (
     <Section

--- a/packages/shared/src/components/sidebar/sections/MainSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/MainSection.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useCallback, useMemo } from 'react';
 import { Section } from '../Section';
 import { ListIcon, SidebarMenuItem } from '../common';
-import { BookmarkIcon, DevPlusIcon, EyeIcon, HotIcon } from '../../icons';
+import { DevPlusIcon, EyeIcon, HotIcon } from '../../icons';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { ProfileImageSize, ProfilePicture } from '../../ProfilePicture';
 import { OtherFeedPage } from '../../../lib/query';
@@ -57,15 +57,6 @@ export const MainSection = ({
         title: 'Explore',
         path: '/posts',
         action: () => onNavTabClick?.(OtherFeedPage.Explore),
-      },
-      {
-        icon: (active: boolean) => (
-          <ListIcon Icon={() => <BookmarkIcon secondary={active} />} />
-        ),
-        title: 'Bookmarks',
-        path: `${webappUrl}bookmarks`,
-        isForcedLink: true,
-        requiresLogin: true,
       },
       {
         icon: (active: boolean) => (

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -125,6 +125,7 @@ const defaultSettings: RemoteSettings = {
     sidebarCustomFeedsExpanded: true,
     sidebarOtherExpanded: true,
     sidebarResourcesExpanded: true,
+    sidebarBookmarksExpanded: true,
   },
 };
 

--- a/packages/shared/src/graphql/settings.ts
+++ b/packages/shared/src/graphql/settings.ts
@@ -14,6 +14,7 @@ export type SettingsFlags = {
   sidebarCustomFeedsExpanded: boolean;
   sidebarOtherExpanded: boolean;
   sidebarResourcesExpanded: boolean;
+  sidebarBookmarksExpanded: boolean;
 };
 
 export enum SidebarSettingsFlags {
@@ -21,6 +22,7 @@ export enum SidebarSettingsFlags {
   CustomFeedsExpanded = 'sidebarCustomFeedsExpanded',
   OtherExpanded = 'sidebarOtherExpanded',
   ResourcesExpanded = 'sidebarResourcesExpanded',
+  BookmarksExpanded = 'sidebarBookmarksExpanded',
 }
 
 export type RemoteSettings = {

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -273,10 +273,10 @@ export const cloudinaryAndroidApp =
   'https://daily-now-res.cloudinary.com/image/upload/s--IEq-BTWL--/f_auto/v1733066824/dailydev_pwa_peqr8o';
 
 export const advancedCustomFeedSoonImage =
-  'https://daily-now-res.cloudinary.com/image/upload/s--Ls638OHs--/f_auto,q_auto/v1733124310/Custom_feeds_plus_khgqj6';
+  'https://daily-now-res.cloudinary.com/image/upload/s--1ITlYroY--/f_auto/v1733239487/Advanced_custom_feeds_mfimpv';
 
 export const bookmarkFolderSoonImage =
-  'https://daily-now-res.cloudinary.com/image/upload/s--9VOiZG0E--/f_auto,q_auto/v1733124591/Folders_are_coming_soon_unhesr';
+  'https://daily-now-res.cloudinary.com/image/upload/s--_jM3zDSE--/f_auto/v1733239852/daily_dev_bookmarks_folders_fsughm';
 
 export const smallPostImage = (url: string): string => {
   if (!url) {

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -272,6 +272,12 @@ export const cloudinaryAuthBannerBackground1440w =
 export const cloudinaryAndroidApp =
   'https://daily-now-res.cloudinary.com/image/upload/s--IEq-BTWL--/f_auto/v1733066824/dailydev_pwa_peqr8o';
 
+export const advancedCustomFeedSoonImage =
+  'https://daily-now-res.cloudinary.com/image/upload/s--Ls638OHs--/f_auto,q_auto/v1733124310/Custom_feeds_plus_khgqj6';
+
+export const bookmarkFolderSoonImage =
+  'https://daily-now-res.cloudinary.com/image/upload/s--9VOiZG0E--/f_auto,q_auto/v1733124591/Folders_are_coming_soon_unhesr';
+
 export const smallPostImage = (url: string): string => {
   if (!url) {
     return cloudinaryPostImageCoverPlaceholder;

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -287,6 +287,8 @@ export enum TargetId {
   PlusBadge = 'plus badge',
   Onboarding = 'onboarding',
   BlockedWords = 'block words',
+  AdvancedCustomFeedSoonModal = 'advanced custom feed soon modal',
+  BookmarkFolderSoonModal = 'bookmark folder soon modal',
 }
 
 export enum NotificationChannel {

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -287,8 +287,8 @@ export enum TargetId {
   PlusBadge = 'plus badge',
   Onboarding = 'onboarding',
   BlockedWords = 'block words',
-  AdvancedCustomFeedSoonModal = 'advanced custom feed soon modal',
-  BookmarkFolderSoonModal = 'bookmark folder soon modal',
+  CustomFeed = 'custom feed',
+  BookmarkFolder = 'bookmark folder',
   FeedSettings = 'feed settings',
 }
 

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -289,6 +289,7 @@ export enum TargetId {
   BlockedWords = 'block words',
   AdvancedCustomFeedSoonModal = 'advanced custom feed soon modal',
   BookmarkFolderSoonModal = 'bookmark folder soon modal',
+  FeedSettings = 'feed settings',
 }
 
 export enum NotificationChannel {

--- a/packages/webapp/pages/feeds/new.tsx
+++ b/packages/webapp/pages/feeds/new.tsx
@@ -18,6 +18,7 @@ import { formToJson } from '@dailydotdev/shared/src/lib/form';
 import {
   useActions,
   useFeeds,
+  usePlusSubscription,
   useProgressAnimation,
   useToastNotification,
 } from '@dailydotdev/shared/src/hooks';
@@ -72,6 +73,13 @@ const NewFeedPage = (): ReactElement => {
   const { showPrompt } = usePrompt();
   const { FeedPageLayoutComponent } = useFeedLayout();
   const { logEvent } = useLogContext();
+  const { isEnrolledNotPlus } = usePlusSubscription();
+
+  useEffect(() => {
+    if (isEnrolledNotPlus) {
+      router.replace(webappUrl);
+    }
+  }, [isEnrolledNotPlus, router]);
 
   const { user } = useAuthContext();
   const { feedSettings } = useFeedSettings({ feedId: newFeedId });
@@ -171,6 +179,10 @@ const NewFeedPage = (): ReactElement => {
       event_name: LogEvent.StartCustomFeed,
     });
   }, [logEvent]);
+
+  if (isEnrolledNotPlus) {
+    return null;
+  }
 
   if (finished) {
     return (

--- a/packages/webapp/pages/feeds/new.tsx
+++ b/packages/webapp/pages/feeds/new.tsx
@@ -73,13 +73,13 @@ const NewFeedPage = (): ReactElement => {
   const { showPrompt } = usePrompt();
   const { FeedPageLayoutComponent } = useFeedLayout();
   const { logEvent } = useLogContext();
-  const { isEnrolledNotPlus } = usePlusSubscription();
+  const { showPlusSubscription } = usePlusSubscription();
 
   useEffect(() => {
-    if (isEnrolledNotPlus) {
+    if (showPlusSubscription) {
       router.replace(webappUrl);
     }
-  }, [isEnrolledNotPlus, router]);
+  }, [showPlusSubscription, router]);
 
   const { user } = useAuthContext();
   const { feedSettings } = useFeedSettings({ feedId: newFeedId });
@@ -180,7 +180,7 @@ const NewFeedPage = (): ReactElement => {
     });
   }, [logEvent]);
 
-  if (isEnrolledNotPlus) {
+  if (showPlusSubscription) {
     return null;
   }
 


### PR DESCRIPTION
## Changes

- add new soon modals
- connect them to entry points
  - feed settings under content types & languages
  - custom feeds on click on "new feed"
  - bookmarks on click on new bookmark

Engineering decision, for each of these blocks:
<img width="289" alt="image" src="https://github.com/user-attachments/assets/e8bf7387-27a0-4a1a-953e-b03cf535b14e">

If you are a plus member I just hide them (because you still are waiting for the feature but you are already a plus member. 

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

| Type   | event_name  | value |
|--------|-------------|-------|
| Change| upgrade subscription | target_id: advanced custom feed soon modal |
| Change| upgrade subscription | target_id: bookmark folder soon modal |
| Change| upgrade subscription | target_id: feed settings |

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-793

### Preview domain
https://as-793-entry-points-plus.preview.app.daily.dev