### PR TITLE
feat: increase streak check timeout

### DIFF
--- a/packages/shared/src/hooks/streaks/useReadingStreak.ts
+++ b/packages/shared/src/hooks/streaks/useReadingStreak.ts
@@ -76,7 +76,7 @@ export const useReadingStreak = (): UserReadingStreak => {
         queryKey,
       });
     }
-  }, 100);
+  }, 1000);
 
   const isStreaksEnabled = loadedSettings && !optOutReadingStreak;
 


### PR DESCRIPTION
## Changes

I see we actually to refetch streak when post is not read (so that should get correct data), but the issue is redirector fires only after that so sometimes streak is still not updated (its async).

```js
if (!post.read) {
  checkReadingStreak(); // but redirect happens in parallel + cdc is async
}
```

In this PR I increase the timeout until we refetch streak on article click. Usually when all systems are nominal streak update happens in 400-600ms, so 1000ms should catch most of those cases and webapp should show correct state after refetch. 

This is a patch and long term fix should be done on API, see [thread](https://dailydotdev.slack.com/archives/C02E2C3C13R/p1733322909829059?thread_ts=1732891413.168089&cid=C02E2C3C13R) for more info on that. 

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-808

### Preview domain
https://streak-refetch-timeout.preview.app.daily.dev