### PR TITLE
fix: huge squad post moderation image

### DIFF
--- a/packages/shared/src/components/squads/moderation/SquadModerationItem.tsx
+++ b/packages/shared/src/components/squads/moderation/SquadModerationItem.tsx
@@ -99,7 +99,9 @@ export function SquadModerationItem(
           </Typography>
           <PostTags className="!mx-0 min-w-full" tags={post?.tags} />
         </div>
-        <CardImage src={image || post?.image} />
+        <div className="flex-1">
+          <CardImage src={image || post?.image} />
+        </div>
       </div>
       {status === SourcePostModerationStatus.Rejected && !user.isModerator && (
         <AlertPointerMessage color={AlertColor.Bun}>

--- a/packages/shared/src/components/squads/moderation/SquadModerationItem.tsx
+++ b/packages/shared/src/components/squads/moderation/SquadModerationItem.tsx
@@ -100,7 +100,7 @@ export function SquadModerationItem(
           <PostTags className="!mx-0 min-w-full" tags={post?.tags} />
         </div>
         <div className="flex-1">
-          <CardImage src={image || post?.image} />
+          <CardImage className="mx-auto" src={image || post?.image} />
         </div>
       </div>
       {status === SourcePostModerationStatus.Rejected && !user.isModerator && (


### PR DESCRIPTION
## Changes

* Added flex-1 to image so that it lines up with the buttons below 
![Screenshot 2024-12-06 at 00 53 37](https://github.com/user-attachments/assets/cad890c9-a237-41c9-88c8-8d7d1fb8f0e0)



## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->

MI-673 #done

### Preview domain
https://mi-673.preview.app.daily.dev