### PR TITLE
fix: revert to using initialData again

### DIFF
--- a/packages/shared/src/hooks/post/useSmartTitle.ts
+++ b/packages/shared/src/hooks/post/useSmartTitle.ts
@@ -40,7 +40,7 @@ export const useSmartTitle = (post: Post): UseSmartTitle => {
     ...getPostByIdKey(post?.id),
   );
 
-  const { data: title, refetch } = useQuery({
+  const { data: smartTitle, refetch } = useQuery({
     queryKey: key,
     queryFn: async () => {
       // Enusre that we don't accidentally fetch the smart title for users outside of the feature flag
@@ -61,7 +61,7 @@ export const useSmartTitle = (post: Post): UseSmartTitle => {
       return data.fetchSmartTitle.title;
     },
     enabled: false,
-    initialData: post?.title || post?.sharedPost?.title,
+    staleTime: Infinity,
     ...disabledRefetch,
   });
 
@@ -96,6 +96,10 @@ export const useSmartTitle = (post: Post): UseSmartTitle => {
     refetch,
     key,
   ]);
+
+  const title = useMemo(() => {
+    return fetchedSmartTitle ? smartTitle : post?.title;
+  }, [fetchedSmartTitle, smartTitle, post]);
 
   return {
     fetchSmartTitle,

--- a/packages/shared/src/hooks/usePostById.ts
+++ b/packages/shared/src/hooks/usePostById.ts
@@ -28,7 +28,6 @@ import {
   mutationKeyToContentPreferenceStatusMap,
 } from './contentPreference/types';
 import { PropsParameters } from '../types';
-import { usePlusSubscription } from './usePlusSubscription';
 
 interface UsePostByIdProps {
   id: string;
@@ -118,7 +117,6 @@ export const removePostComments = (
 const usePostById = ({ id, options = {} }: UsePostByIdProps): UsePostById => {
   const { initialData, ...restOptions } = options;
   const { tokenRefreshed } = useAuthContext();
-  const { isPlus } = usePlusSubscription();
   const key = getPostByIdKey(id);
   const {
     data: postById,
@@ -131,9 +129,7 @@ const usePostById = ({ id, options = {} }: UsePostByIdProps): UsePostById => {
     staleTime: StaleTime.Default,
     enabled: !!id && tokenRefreshed,
   });
-  const post = isPlus
-    ? postById
-    : postById || (options?.initialData as PostData);
+  const post = postById || (options?.initialData as PostData);
 
   useMutationSubscription({
     matcher: contentPreferenceMutationMatcher,


### PR DESCRIPTION
## Changes
Reverts to use initialData again, but use memoization of title

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://as-788-revert-initaldata.preview.app.daily.dev