### PR TITLE
fix: Display correct folder name in toast

### DIFF
--- a/packages/shared/src/components/modals/bookmark/MoveBookmarkModal.tsx
+++ b/packages/shared/src/components/modals/bookmark/MoveBookmarkModal.tsx
@@ -32,26 +32,24 @@ const MoveBookmarkModal = ({
   const { moveBookmarkToFolder, isPending: isMoving } =
     useMoveBookmarkToFolder();
 
-  const handleMoveBookmark = async (targetList?: string) => {
+  const handleMoveBookmark = async (folder?: {
+    id?: string;
+    name?: string;
+  }) => {
     if (isMoving) {
       return;
     }
-    await moveBookmarkToFolder({ postId, listId: targetList });
-    displayToast(
-      `✅ Moved to ${
-        folders?.find((f) => f.id === targetList)?.name || 'Quick saves'
-      }`,
-      {
-        onUndo: () => handleMoveBookmark(listId),
-      },
-    );
-    onMoveBookmark?.(targetList);
+    await moveBookmarkToFolder({ postId, listId: folder?.id });
+    displayToast(`✅ Moved to ${folder?.name}`, {
+      onUndo: () => handleMoveBookmark({ id: listId }),
+    });
+    onMoveBookmark?.(folder?.id);
     closeModal();
   };
 
   const onCreateNewFolder = async (folder: BookmarkFolder) => {
     const newFolder = await createFolder(folder);
-    handleMoveBookmark(newFolder.id);
+    handleMoveBookmark(newFolder);
     closeModal();
   };
 
@@ -88,7 +86,7 @@ const MoveBookmarkModal = ({
           New folder
         </Button>
         <Button
-          onClick={() => handleMoveBookmark()}
+          onClick={() => handleMoveBookmark({ name: 'Quick saves' })}
           icon={<BookmarkIcon />}
           variant={ButtonVariant.Option}
           role="radio"
@@ -106,7 +104,7 @@ const MoveBookmarkModal = ({
             <Button
               loading={isPending}
               key={folder.id}
-              onClick={() => handleMoveBookmark(folder.id)}
+              onClick={() => handleMoveBookmark(folder)}
               variant={ButtonVariant.Option}
               icon={folder?.icon ? <span>{folder.icon}</span> : <FolderIcon />}
               role="radio"


### PR DESCRIPTION
## Changes

Changed it so we pass the name of the folder, so we don't have to *guess* if it was moved to Quick Saves or not.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://mi-678.preview.app.daily.dev