### PR TITLE
fix: update analytics shared props on signup

### DIFF
--- a/packages/shared/src/hooks/log/useLogSharedProps.ts
+++ b/packages/shared/src/hooks/log/useLogSharedProps.ts
@@ -98,6 +98,7 @@ export default function useLogSharedProps(
     visit,
     visitId,
     deviceId,
+    user?.createdAt,
   ]);
 
   return [sharedPropsRef, sharedPropsSet];


### PR DESCRIPTION
On the first visit `user_registration_date` is not set properly

WT-2247 #done

### Preview domain
https://wt-2247.preview.app.daily.dev