### PR TITLE
fix: add truncate on long names

### DIFF
--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -149,7 +149,7 @@ function FeedNav(): ReactElement {
           tabListProps={{
             className: {
               indicator: '!w-6',
-              item: 'px-1 tablet:last-of-type:mr-12',
+              item: 'px-1 tablet:last-of-type:mr-12 max-w-60',
             },
             autoScrollActive: true,
           }}

--- a/packages/shared/src/components/tabs/TabContainer.spec.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.spec.tsx
@@ -51,9 +51,12 @@ describe('tab container component', () => {
     const inactive1 = await screen.findByText('Second');
     const inactive2 = await screen.findByText('Third');
 
-    expect(active).toHaveClass('bg-theme-active');
-    expect(inactive1).not.toHaveClass('bg-theme-active');
-    expect(inactive2).not.toHaveClass('bg-theme-active');
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(active.parentElement).toHaveClass('bg-theme-active');
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(inactive1.parentElement).not.toHaveClass('bg-theme-active');
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(inactive2.parentElement).not.toHaveClass('bg-theme-active');
   });
 
   it('should switch between tabs', async () => {
@@ -102,9 +105,12 @@ describe('tab container component', () => {
       const inactive1 = await screen.findByText('First');
       const inactive2 = await screen.findByText('Third');
 
-      expect(active).toHaveClass('bg-theme-active');
-      expect(inactive1).not.toHaveClass('bg-theme-active');
-      expect(inactive2).not.toHaveClass('bg-theme-active');
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(active.parentElement).toHaveClass('bg-theme-active');
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(inactive1.parentElement).not.toHaveClass('bg-theme-active');
+      // eslint-disable-next-line testing-library/no-node-access
+      expect(inactive2.parentElement).not.toHaveClass('bg-theme-active');
     });
 
     it('should redirect to the given URL on tab click', async () => {

--- a/packages/shared/src/components/tabs/TabList.tsx
+++ b/packages/shared/src/components/tabs/TabList.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import { RenderTab } from './common';
 import type { TabProps } from './TabContainer';
+import { TruncateText } from '../utilities';
 
 export type AllowedTabTags = keyof Pick<JSX.IntrinsicElements, 'a' | 'button'>;
 
@@ -119,11 +120,11 @@ function TabList<T extends string = string>({
         const renderedTab = renderTab?.({ label, isActive }) ?? (
           <span
             className={classNames(
-              'inline rounded-10 px-3 py-1.5',
+              'flex rounded-10 px-3 py-1.5',
               isActive && 'bg-theme-active',
             )}
           >
-            {label}
+            <TruncateText>{label}</TruncateText>
           </span>
         );
 


### PR DESCRIPTION
## Changes

Add truncating if long names are used.

![Screenshot 2024-12-13 at 15 54 37](https://github.com/user-attachments/assets/a83c49a0-94db-4b85-8a26-9c5eebcfae09)

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-814 #done 


### Preview domain
https://as-839-tab-bar-truncate.preview.app.daily.dev