### PR TITLE
fix: block custom feeds for now (edit/creation)

### DIFF
--- a/packages/webapp/pages/feeds/[slugOrId]/edit.tsx
+++ b/packages/webapp/pages/feeds/[slugOrId]/edit.tsx
@@ -75,6 +75,10 @@ const EditFeedPage = (): ReactElement => {
   const { FeedPageLayoutComponent } = useFeedLayout();
   const { logEvent } = useLogContext();
 
+  useEffect(() => {
+    router.replace(webappUrl);
+  }, [router]);
+
   const feedSlugOrId = router.query.slugOrId as string;
   const feed = useMemo(() => {
     return feeds?.edges.find(

--- a/packages/webapp/pages/feeds/[slugOrId]/edit.tsx
+++ b/packages/webapp/pages/feeds/[slugOrId]/edit.tsx
@@ -79,6 +79,9 @@ const EditFeedPage = (): ReactElement => {
     router.replace(webappUrl);
   }, [router]);
 
+  // TODO: Remove once the new page is implemented
+  return null;
+
   const feedSlugOrId = router.query.slugOrId as string;
   const feed = useMemo(() => {
     return feeds?.edges.find(

--- a/packages/webapp/pages/feeds/new.tsx
+++ b/packages/webapp/pages/feeds/new.tsx
@@ -77,6 +77,9 @@ const NewFeedPage = (): ReactElement => {
     router.replace(webappUrl);
   }, [router]);
 
+  // TODO: Remove once the new page is implemented
+  return null;
+
   const { user } = useAuthContext();
   const { feedSettings } = useFeedSettings({ feedId: newFeedId });
   const [isPreviewFeedVisible, setPreviewFeedVisible] = useState(false);

--- a/packages/webapp/pages/feeds/new.tsx
+++ b/packages/webapp/pages/feeds/new.tsx
@@ -18,7 +18,6 @@ import { formToJson } from '@dailydotdev/shared/src/lib/form';
 import {
   useActions,
   useFeeds,
-  usePlusSubscription,
   useProgressAnimation,
   useToastNotification,
 } from '@dailydotdev/shared/src/hooks';
@@ -73,13 +72,10 @@ const NewFeedPage = (): ReactElement => {
   const { showPrompt } = usePrompt();
   const { FeedPageLayoutComponent } = useFeedLayout();
   const { logEvent } = useLogContext();
-  const { showPlusSubscription } = usePlusSubscription();
 
   useEffect(() => {
-    if (showPlusSubscription) {
-      router.replace(webappUrl);
-    }
-  }, [showPlusSubscription, router]);
+    router.replace(webappUrl);
+  }, [router]);
 
   const { user } = useAuthContext();
   const { feedSettings } = useFeedSettings({ feedId: newFeedId });
@@ -179,10 +175,6 @@ const NewFeedPage = (): ReactElement => {
       event_name: LogEvent.StartCustomFeed,
     });
   }, [logEvent]);
-
-  if (showPlusSubscription) {
-    return null;
-  }
 
   if (finished) {
     return (


### PR DESCRIPTION
## Changes

Edit/creation blocked for now.
Only weird for non enrolled members as we simply redirect without notion.

But since we plan to ship fast it should be fine.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-859 #done

### Preview domain
https://as-859-block-custom-feeds.preview.app.daily.dev