### PR TITLE
feat: Display custom feed as default when set

### DIFF
--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -19,6 +19,7 @@ import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
 import { useFeedLayout } from '@dailydotdev/shared/src/hooks';
 import { useDndContext } from '@dailydotdev/shared/src/contexts/DndContext';
 import { FeedLayoutProvider } from '@dailydotdev/shared/src/contexts/FeedContext';
+import useCustomDefaultFeed from '@dailydotdev/shared/src/hooks/feed/useCustomDefaultFeed';
 import ShortcutLinks from './ShortcutLinks/ShortcutLinks';
 import DndBanner from './DndBanner';
 import { CompanionPopupButton } from '../companion/CompanionPopupButton';
@@ -51,6 +52,7 @@ export default function MainFeedPage({
   const { shouldUseListFeedLayout } = useFeedLayout({ feedRelated: false });
   useCompanionSettings();
   const { isActive: isDndActive, showDnd, setShowDnd } = useDndContext();
+  const { isCustomDefaultFeed } = useCustomDefaultFeed();
 
   const onNavTabClick = useCallback(
     (tab: string): void => {
@@ -71,6 +73,11 @@ export default function MainFeedPage({
   const activePage = useMemo(() => {
     if (isSearchOn) {
       return '/search';
+    }
+
+    // default page when user selected custom default feed
+    if (isCustomDefaultFeed && feedName === 'default') {
+      return '/';
     }
 
     const feed = getFeedName(feedName, {

--- a/packages/shared/src/components/CustomFeedEmptyScreen.tsx
+++ b/packages/shared/src/components/CustomFeedEmptyScreen.tsx
@@ -8,15 +8,12 @@ import {
   EmptyScreenTitle,
 } from './EmptyScreen';
 import { HashtagIcon } from './icons';
-import { PageContainer, SharedFeedPage } from './utilities';
+import { PageContainer } from './utilities';
 import { ButtonSize } from './buttons/common';
-import { getFeedName } from '../lib/feed';
 import { webappUrl } from '../lib/constants';
-import { useAuthContext } from '../contexts/AuthContext';
 
 export const CustomFeedEmptyScreen = (): ReactElement => {
   const router = useRouter();
-  const { user } = useAuthContext();
 
   return (
     <PageContainer className="mx-auto">
@@ -32,15 +29,7 @@ export const CustomFeedEmptyScreen = (): ReactElement => {
         </EmptyScreenDescription>
         <EmptyScreenButton
           onClick={() => {
-            const feedName = getFeedName(router.pathname);
-
-            router.push(
-              `${webappUrl}feeds/${
-                feedName === SharedFeedPage.Custom
-                  ? router.query.slugOrId
-                  : user.id
-              }/edit`,
-            );
+            router.push(`${webappUrl}feeds/${router.query.slugOrId}/edit`);
           }}
           size={ButtonSize.Large}
         >

--- a/packages/shared/src/components/FeedEmptyScreen.tsx
+++ b/packages/shared/src/components/FeedEmptyScreen.tsx
@@ -8,9 +8,8 @@ import {
   EmptyScreenTitle,
 } from './EmptyScreen';
 import { FilterIcon } from './icons';
-import { PageContainer, SharedFeedPage } from './utilities';
+import { PageContainer } from './utilities';
 import { ButtonSize } from './buttons/common';
-import { getFeedName } from '../lib/feed';
 import { webappUrl } from '../lib/constants';
 import { useAuthContext } from '../contexts/AuthContext';
 
@@ -32,15 +31,7 @@ function FeedEmptyScreen(): ReactElement {
         </EmptyScreenDescription>
         <EmptyScreenButton
           onClick={() => {
-            const feedName = getFeedName(router.pathname);
-
-            router.push(
-              `${webappUrl}feeds/${
-                feedName === SharedFeedPage.Custom
-                  ? router.query.slugOrId
-                  : user.id
-              }/edit`,
-            );
+            router.push(`${webappUrl}feeds/${user.id}/edit`);
           }}
           size={ButtonSize.Large}
         >

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -55,6 +55,7 @@ import { Origin } from '../lib/log';
 import { ExploreTabs, tabToUrl, urlToTab } from './header';
 import { QueryStateKeys, useQueryState } from '../hooks/utils/useQueryState';
 import { useSearchResultsLayout } from '../hooks/search/useSearchResultsLayout';
+import useCustomDefaultFeed from '../hooks/feed/useCustomDefaultFeed';
 
 const FeedExploreHeader = dynamic(
   () =>
@@ -190,6 +191,7 @@ export default function MainFeedLayout({
     hasFiltered: !alerts?.filter,
     hasUser: !!user,
   });
+  const { isCustomDefaultFeed } = useCustomDefaultFeed();
   const isLaptop = useViewSize(ViewSize.Laptop);
   const feedVersion = useFeature(feature.feedVersion);
   const {
@@ -272,14 +274,14 @@ export default function MainFeedLayout({
       return null;
     }
 
-    if (user?.defaultFeedId && user.defaultFeedId !== user.id) {
+    if (router?.pathname === '/' && isCustomDefaultFeed) {
       return {
-        feedName: SharedFeedPage.MyFeed,
-        feedQueryKey: generateQueryKey(SharedFeedPage.MyFeed, user),
+        feedName: SharedFeedPage.Custom,
+        feedQueryKey: generateQueryKey(SharedFeedPage.Custom, user),
         query: CUSTOM_FEED_QUERY,
         variables: {
           feedId: user.defaultFeedId,
-          feedName: SharedFeedPage.MyFeed,
+          feedName: SharedFeedPage.Custom,
         },
         emptyScreen: propsByFeed[feedName].emptyScreen || <FeedEmptyScreen />,
         actionButtons: feedWithActions && (
@@ -381,6 +383,7 @@ export default function MainFeedLayout({
     selectedPeriod,
     setSelectedAlgo,
     router.pathname,
+    isCustomDefaultFeed,
   ]);
 
   useEffect(() => {

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -274,7 +274,7 @@ export default function MainFeedLayout({
       return null;
     }
 
-    if (router?.pathname === '/' && isCustomDefaultFeed) {
+    if (feedNameProp === 'default' && isCustomDefaultFeed) {
       return {
         feedName: SharedFeedPage.Custom,
         feedQueryKey: generateQueryKey(SharedFeedPage.Custom, user),
@@ -384,6 +384,7 @@ export default function MainFeedLayout({
     setSelectedAlgo,
     router.pathname,
     isCustomDefaultFeed,
+    feedNameProp,
   ]);
 
   useEffect(() => {

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -275,7 +275,7 @@ export default function MainFeedLayout({
     if (user?.defaultFeedId && user.defaultFeedId !== user.id) {
       return {
         feedName: SharedFeedPage.MyFeed,
-        feedQueryKey: generateQueryKey(SharedFeedPage.Custom, user),
+        feedQueryKey: generateQueryKey(SharedFeedPage.MyFeed, user),
         query: CUSTOM_FEED_QUERY,
         variables: {
           feedId: user.defaultFeedId,

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -272,6 +272,25 @@ export default function MainFeedLayout({
       return null;
     }
 
+    if (user?.defaultFeedId && user.defaultFeedId !== user.id) {
+      return {
+        feedName: SharedFeedPage.MyFeed,
+        feedQueryKey: generateQueryKey(SharedFeedPage.Custom, user),
+        query: CUSTOM_FEED_QUERY,
+        variables: {
+          feedId: user.defaultFeedId,
+          feedName: SharedFeedPage.MyFeed,
+        },
+        emptyScreen: propsByFeed[feedName].emptyScreen || <FeedEmptyScreen />,
+        actionButtons: feedWithActions && (
+          <SearchControlHeader
+            algoState={[selectedAlgo, setSelectedAlgo]}
+            feedName={feedName}
+          />
+        ),
+      };
+    }
+
     if (isSearchOn && searchQuery) {
       const searchVersion = getFeatureValue(feature.searchVersion);
       return {

--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -33,6 +33,7 @@ import { OtherFeedPage } from '../../lib/query';
 import { ChecklistViewState } from '../../lib/checklist';
 import { LazyModal } from '../modals/common/types';
 import { useLazyModal } from '../../hooks/useLazyModal';
+import useCustomDefaultFeed from '../../hooks/feed/useCustomDefaultFeed';
 
 const OnboardingChecklistBar = dynamic(
   () =>
@@ -78,6 +79,7 @@ function FeedNav(): ReactElement {
   const scrollClassName = useScrollTopClassName({ enabled: !!featureTheme });
   const { feeds } = useFeeds();
   const { showPlusSubscription } = usePlusSubscription();
+  const { isCustomDefaultFeed, defaultFeedId } = useCustomDefaultFeed();
   const { openModal } = useLazyModal();
 
   const isHiddenOnboardingChecklistView =
@@ -85,9 +87,14 @@ function FeedNav(): ReactElement {
 
   const urlToTab: Record<string, FeedNavTab> = useMemo(() => {
     const customFeeds = feeds?.edges?.reduce((acc, { node: feed }) => {
-      const feedPath = `${webappUrl}feeds/${feed.id}`;
       const isEditingFeed =
         router.query.slugOrId === feed.id && router.pathname.endsWith('/edit');
+      let feedPath = `${webappUrl}feeds/${feed.id}`;
+
+      if (!isEditingFeed && isCustomDefaultFeed && feed.id === defaultFeedId) {
+        feedPath = `${webappUrl}`;
+      }
+
       const urlPath = `${feedPath}${isEditingFeed ? '/edit' : ''}`;
 
       acc[urlPath] = feed.flags?.name || `Feed ${feed.id}`;
@@ -95,9 +102,11 @@ function FeedNav(): ReactElement {
       return acc;
     }, {});
 
+    const forYouTab = isCustomDefaultFeed ? `${webappUrl}my-feed` : webappUrl;
+
     const urls = {
       [`${webappUrl}feeds/new`]: FeedNavTab.NewFeed,
-      [`${webappUrl}`]: FeedNavTab.ForYou,
+      [forYouTab]: FeedNavTab.ForYou,
       ...customFeeds,
     };
 
@@ -111,7 +120,13 @@ function FeedNav(): ReactElement {
       [`${webappUrl}bookmarks`]: FeedNavTab.Bookmarks,
       [`${webappUrl}history`]: FeedNavTab.History,
     };
-  }, [feeds?.edges, router.query.slugOrId, router.pathname]);
+  }, [
+    feeds?.edges,
+    router.query.slugOrId,
+    router.pathname,
+    defaultFeedId,
+    isCustomDefaultFeed,
+  ]);
 
   if (!shouldRenderNav || router?.pathname?.startsWith('/posts/[id]')) {
     return null;

--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -196,7 +196,7 @@ function FeedNav(): ReactElement {
           }}
         >
           {Object.entries(urlToTab).map(([url, label]) => (
-            <Tab key={label} label={label} url={url} />
+            <Tab key={`${label}-${url}`} label={label} url={url} />
           ))}
         </TabContainer>
 

--- a/packages/shared/src/components/feeds/FeedSettings/FeedSettingsEdit.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/FeedSettingsEdit.tsx
@@ -36,6 +36,7 @@ import {
 import { ButtonSize, ButtonVariant } from '../../buttons/common';
 import { LogEvent, TargetId } from '../../../lib/log';
 import { Button } from '../../buttons/Button';
+import useCustomDefaultFeed from '../../../hooks/feed/useCustomDefaultFeed';
 
 export type FeedSettingsEditProps = {
   feedSlugOrId: string;
@@ -50,6 +51,7 @@ export const FeedSettingsEdit = ({
   const { isPlus, showPlusSubscription, logSubscriptionEvent } =
     usePlusSubscription();
 
+  const { isCustomDefaultFeed, defaultFeedId } = useCustomDefaultFeed();
   const tabs = useMemo(() => {
     return [
       {
@@ -146,7 +148,10 @@ export const FeedSettingsEdit = ({
         size={Modal.Size.XLarge}
         tabs={tabs}
         onRequestClose={() => {
-          if (feed?.type === FeedType.Main) {
+          if (
+            feed?.type === FeedType.Main ||
+            (isCustomDefaultFeed && feedSlugOrId === defaultFeedId)
+          ) {
             router.replace(webappUrl);
           } else {
             router.replace(`${webappUrl}feeds/${feedSlugOrId}`);

--- a/packages/shared/src/components/feeds/FeedSettings/FeedSettingsEdit.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/FeedSettingsEdit.tsx
@@ -36,7 +36,6 @@ import {
 import { ButtonSize, ButtonVariant } from '../../buttons/common';
 import { LogEvent, TargetId } from '../../../lib/log';
 import { Button } from '../../buttons/Button';
-import useCustomDefaultFeed from '../../../hooks/feed/useCustomDefaultFeed';
 
 export type FeedSettingsEditProps = {
   feedSlugOrId: string;
@@ -47,11 +46,10 @@ export const FeedSettingsEdit = ({
 }: FeedSettingsEditProps): ReactElement => {
   const router = useRouter();
   const feedSettingsEditContext = useFeedSettingsEdit({ feedSlugOrId });
-  const { feed } = feedSettingsEditContext;
+  const { feed, onBackToFeed } = feedSettingsEditContext;
   const { isPlus, showPlusSubscription, logSubscriptionEvent } =
     usePlusSubscription();
 
-  const { isCustomDefaultFeed, defaultFeedId } = useCustomDefaultFeed();
   const tabs = useMemo(() => {
     return [
       {
@@ -147,16 +145,7 @@ export const FeedSettingsEdit = ({
         kind={Modal.Kind.FlexibleCenter}
         size={Modal.Size.XLarge}
         tabs={tabs}
-        onRequestClose={() => {
-          if (
-            feed?.type === FeedType.Main ||
-            (isCustomDefaultFeed && feedSlugOrId === defaultFeedId)
-          ) {
-            router.replace(webappUrl);
-          } else {
-            router.replace(`${webappUrl}feeds/${feedSlugOrId}`);
-          }
-        }}
+        onRequestClose={onBackToFeed}
         defaultView={defaultView}
       >
         <FeedSettingsEditHeader />

--- a/packages/shared/src/components/feeds/FeedSettings/FeedSettingsEditHeader.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/FeedSettingsEditHeader.tsx
@@ -1,8 +1,6 @@
-import { useRouter } from 'next/router';
 import React, { ReactElement, useContext } from 'react';
 import { FeedSettingsEditContext } from './FeedSettingsEditContext';
 import { useViewSizeClient, ViewSize } from '../../../hooks/useViewSize';
-import { webappUrl } from '../../../lib/constants';
 import { Button } from '../../buttons/Button';
 import { ButtonSize, ButtonVariant } from '../../buttons/common';
 import { Modal } from '../../modals/common/Modal';
@@ -18,10 +16,8 @@ const viewsWithSaveButton = new Set([
 ]);
 
 export const FeedSettingsEditHeader = (): ReactElement => {
-  const router = useRouter();
-  const { feed, onSubmit, onDiscard, isSubmitPending, isDirty } = useContext(
-    FeedSettingsEditContext,
-  );
+  const { onSubmit, onDiscard, isSubmitPending, isDirty, onBackToFeed } =
+    useContext(FeedSettingsEditContext);
   const { activeView, setActiveView } = useContext(ModalPropsContext);
   const isMobile = useViewSizeClient(ViewSize.MobileL);
 
@@ -54,7 +50,7 @@ export const FeedSettingsEditHeader = (): ReactElement => {
               if (isMobile) {
                 setActiveView(undefined);
               } else {
-                router.push(`${webappUrl}feeds/${feed.id}`);
+                onBackToFeed();
               }
             }}
           >

--- a/packages/shared/src/components/feeds/FeedSettings/types.ts
+++ b/packages/shared/src/components/feeds/FeedSettings/types.ts
@@ -24,6 +24,7 @@ export type FeedSettingsEditContextValue = {
   onTagClick: (props: OnSelectTagProps) => void;
   onDiscard: () => Promise<boolean>;
   isDirty: boolean;
+  onBackToFeed: () => void;
 };
 
 export enum FeedSettingsMenu {

--- a/packages/shared/src/components/feeds/MobileFeedActions.tsx
+++ b/packages/shared/src/components/feeds/MobileFeedActions.tsx
@@ -2,7 +2,7 @@ import React, { ReactElement } from 'react';
 import { useRouter } from 'next/router';
 import Link from '../utilities/Link';
 import { ReadingStreakButton } from '../streak/ReadingStreakButton';
-import { Divider } from '../utilities';
+import { Divider, SharedFeedPage } from '../utilities';
 import MyFeedHeading from '../filters/MyFeedHeading';
 import { useReadingStreak } from '../../hooks/streaks';
 import { ButtonIconPosition } from '../buttons/common';
@@ -11,11 +11,14 @@ import { ProfileImageSize, ProfilePicture } from '../ProfilePicture';
 import HeaderLogo from '../layout/HeaderLogo';
 import { LogoPosition } from '../Logo';
 import { webappUrl } from '../../lib/constants';
+import useCustomDefaultFeed from '../../hooks/feed/useCustomDefaultFeed';
+import { getFeedName } from '../../lib/feed';
 
 export function MobileFeedActions(): ReactElement {
   const router = useRouter();
   const { user } = useAuthContext();
   const { streak, isLoading, isStreaksEnabled } = useReadingStreak();
+  const { isCustomDefaultFeed, defaultFeedId } = useCustomDefaultFeed();
 
   return (
     <div className="flex flex-row justify-between px-4 py-1">
@@ -35,7 +38,19 @@ export function MobileFeedActions(): ReactElement {
         <Divider className="bg-border-subtlest-tertiary" vertical />
         <MyFeedHeading
           onOpenFeedFilters={() => {
-            router.push(`${webappUrl}feeds/${user.id}/edit`);
+            if (isCustomDefaultFeed && router.pathname === '/') {
+              router.push(`${webappUrl}feeds/${defaultFeedId}/edit`);
+            } else {
+              const feedName = getFeedName(router.pathname);
+
+              router.push(
+                `${webappUrl}feeds/${
+                  feedName === SharedFeedPage.Custom
+                    ? router.query.slugOrId
+                    : user.id
+                }/edit`,
+              );
+            }
           }}
         />
         {user && (

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -31,6 +31,7 @@ import {
 import { ToggleClickbaitShield } from '../buttons/ToggleClickbaitShield';
 import { Origin } from '../../lib/log';
 import { useAuthContext } from '../../contexts/AuthContext';
+import useCustomDefaultFeed from '../../hooks/feed/useCustomDefaultFeed';
 
 type State<T> = [T, Dispatch<SetStateAction<T>>];
 
@@ -75,6 +76,7 @@ export const SearchControlHeader = ({
   const { streak, isLoading, isStreaksEnabled } = useReadingStreak();
   const { showPlusSubscription } = usePlusSubscription();
   const { user } = useAuthContext();
+  const { isCustomDefaultFeed, defaultFeedId } = useCustomDefaultFeed();
 
   if (isMobile) {
     return null;
@@ -96,13 +98,17 @@ export const SearchControlHeader = ({
       <MyFeedHeading
         key="my-feed"
         onOpenFeedFilters={() => {
-          router.push(
-            `${webappUrl}feeds/${
-              feedName === SharedFeedPage.Custom
-                ? router.query.slugOrId
-                : user.id
-            }/edit`,
-          );
+          if (isCustomDefaultFeed && router.pathname === '/') {
+            router.push(`${webappUrl}feeds/${defaultFeedId}/edit`);
+          } else {
+            router.push(
+              `${webappUrl}feeds/${
+                feedName === SharedFeedPage.Custom
+                  ? router.query.slugOrId
+                  : user.id
+              }/edit`,
+            );
+          }
         }}
       />
     ) : null,

--- a/packages/shared/src/components/sidebar/Sidebar.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.tsx
@@ -2,6 +2,7 @@ import React, { ReactElement } from 'react';
 import dynamic from 'next/dynamic';
 import { useViewSize, ViewSize } from '../../hooks';
 import { useFeatureTheme } from '../../hooks/utils/useFeatureTheme';
+import { isExtension } from '../../lib/func';
 
 const SidebarTablet = dynamic(() =>
   import(/* webpackChunkName: "sidebarTablet" */ './SidebarTablet').then(
@@ -44,6 +45,9 @@ export const Sidebar = ({
   if (isLaptop) {
     return (
       <SidebarDesktop
+        // for extension we want to pass active page
+        // because router does not update there
+        activePage={isExtension ? activePage : undefined}
         featureTheme={featureTheme}
         isNavButtons={isNavButtons}
         onNavTabClick={onNavTabClick}

--- a/packages/shared/src/components/sidebar/SidebarDesktop.tsx
+++ b/packages/shared/src/components/sidebar/SidebarDesktop.tsx
@@ -17,6 +17,7 @@ import { usePlusSubscription } from '../../hooks';
 import { SidebarMenuIcon } from './SidebarMenuIcon';
 
 type SidebarDesktopProps = {
+  activePage?: string;
   featureTheme?: {
     logo?: string;
     logoText?: string;
@@ -25,6 +26,7 @@ type SidebarDesktopProps = {
   onNavTabClick?: (tab: string) => void;
 };
 export const SidebarDesktop = ({
+  activePage: activePageProp,
   featureTheme,
   isNavButtons,
   onNavTabClick,
@@ -33,7 +35,7 @@ export const SidebarDesktop = ({
   const { sidebarExpanded, onboardingChecklistView } = useSettingsContext();
   const { isAvailable: isBannerAvailable } = useBanner();
   const { isLoggedIn } = useAuthContext();
-  const activePage = router.asPath || router.pathname;
+  const activePage = activePageProp || router.asPath || router.pathname;
   const { showPlusSubscription } = usePlusSubscription();
 
   const defaultRenderSectionProps = useMemo(
@@ -74,6 +76,7 @@ export const SidebarDesktop = ({
           />
           <CustomFeedSection
             {...defaultRenderSectionProps}
+            onNavTabClick={onNavTabClick}
             title="Custom feeds"
             isItemsButton={false}
           />

--- a/packages/shared/src/components/sidebar/sections/CustomFeedSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/CustomFeedSection.tsx
@@ -9,23 +9,44 @@ import { SidebarSectionProps } from './common';
 import { useLazyModal } from '../../../hooks/useLazyModal';
 import { LazyModal } from '../../modals/common/types';
 import useCustomDefaultFeed from '../../../hooks/feed/useCustomDefaultFeed';
+import { isExtension } from '../../../lib/func';
 
 export const CustomFeedSection = ({
   isItemsButton,
+  onNavTabClick,
   ...defaultRenderSectionProps
 }: SidebarSectionProps): ReactElement => {
   const { feeds } = useFeeds();
   const { openModal } = useLazyModal();
   const { showPlusSubscription, isPlus } = usePlusSubscription();
-  const { isCustomDefaultFeed, defaultFeedId } = useCustomDefaultFeed();
+  const { defaultFeedId } = useCustomDefaultFeed();
 
   const menuItems: SidebarMenuItem[] = useMemo(() => {
     const customFeeds =
       feeds?.edges?.map((feed) => {
-        const feedPath =
-          isCustomDefaultFeed && defaultFeedId === feed.node.id
-            ? '/'
-            : `${webappUrl}feeds/${feed.node.id}`;
+        const isDefaultFeed = defaultFeedId === feed.node.id;
+
+        if (isDefaultFeed) {
+          const isCustomFeedPageActive = [
+            `${webappUrl}feeds/${feed.node.id}`,
+            '/',
+          ].includes(defaultRenderSectionProps.activePage);
+
+          return {
+            title: feed.node.flags.name || `Feed ${feed.node.id}`,
+            // on extension we don't use router so no need for a path
+            // onNavTabClick takes care of the navigation
+            path: isExtension ? undefined : '/',
+            action: isExtension ? () => onNavTabClick?.('default') : undefined,
+            icon: feed.node.flags.icon || (
+              <HashtagIcon secondary={isCustomFeedPageActive} />
+            ),
+            active: isCustomFeedPageActive,
+          };
+        }
+
+        const feedPath = `${webappUrl}feeds/${feed.node.id}`;
+
         return {
           title: feed.node.flags.name || `Feed ${feed.node.id}`,
           path: feedPath,
@@ -66,8 +87,8 @@ export const CustomFeedSection = ({
     showPlusSubscription,
     openModal,
     isPlus,
-    isCustomDefaultFeed,
     defaultFeedId,
+    onNavTabClick,
   ]);
 
   return (

--- a/packages/shared/src/components/sidebar/sections/CustomFeedSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/CustomFeedSection.tsx
@@ -8,6 +8,7 @@ import { SidebarSettingsFlags } from '../../../graphql/settings';
 import { SidebarSectionProps } from './common';
 import { useLazyModal } from '../../../hooks/useLazyModal';
 import { LazyModal } from '../../modals/common/types';
+import useCustomDefaultFeed from '../../../hooks/feed/useCustomDefaultFeed';
 
 export const CustomFeedSection = ({
   isItemsButton,
@@ -16,11 +17,15 @@ export const CustomFeedSection = ({
   const { feeds } = useFeeds();
   const { openModal } = useLazyModal();
   const { showPlusSubscription, isPlus } = usePlusSubscription();
+  const { isCustomDefaultFeed, defaultFeedId } = useCustomDefaultFeed();
 
   const menuItems: SidebarMenuItem[] = useMemo(() => {
     const customFeeds =
       feeds?.edges?.map((feed) => {
-        const feedPath = `${webappUrl}feeds/${feed.node.id}`;
+        const feedPath =
+          isCustomDefaultFeed && defaultFeedId === feed.node.id
+            ? '/'
+            : `${webappUrl}feeds/${feed.node.id}`;
         return {
           title: feed.node.flags.name || `Feed ${feed.node.id}`,
           path: feedPath,
@@ -61,6 +66,8 @@ export const CustomFeedSection = ({
     showPlusSubscription,
     openModal,
     isPlus,
+    isCustomDefaultFeed,
+    defaultFeedId,
   ]);
 
   return (

--- a/packages/shared/src/components/sidebar/sections/MainSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/MainSection.tsx
@@ -104,6 +104,7 @@ export const MainSection = ({
     onPlusClick,
     onNavTabClick,
     showPlusSubscription,
+    isCustomDefaultFeed,
   ]);
 
   return (

--- a/packages/shared/src/components/sidebar/sections/MainSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/MainSection.tsx
@@ -15,7 +15,7 @@ import { SidebarSectionProps } from './common';
 import { webappUrl } from '../../../lib/constants';
 import { usePlusSubscription } from '../../../hooks/usePlusSubscription';
 import { LogEvent, TargetId } from '../../../lib/log';
-import useCustomDefaultFeed from '../../../hooks/feed/useCustomDefaultFeed';
+import { SharedFeedPage } from '../../utilities';
 
 export const MainSection = ({
   isItemsButton,
@@ -23,7 +23,6 @@ export const MainSection = ({
   ...defaultRenderSectionProps
 }: SidebarSectionProps): ReactElement => {
   const { user, isLoggedIn } = useAuthContext();
-  const { isCustomDefaultFeed } = useCustomDefaultFeed();
   const { showPlusSubscription, isEnrolledNotPlus, logSubscriptionEvent } =
     usePlusSubscription();
 
@@ -35,12 +34,11 @@ export const MainSection = ({
   }, [logSubscriptionEvent]);
 
   const menuItems: SidebarMenuItem[] = useMemo(() => {
-    const myFeedPath = isCustomDefaultFeed ? '/my-feed' : '/';
     const myFeed = isLoggedIn
       ? {
           title: 'My feed',
-          path: myFeedPath,
-          action: () => onNavTabClick?.(myFeedPath),
+          path: '/',
+          action: () => onNavTabClick?.(SharedFeedPage.MyFeed),
           icon: <ProfilePicture size={ProfileImageSize.XSmall} user={user} />,
         }
       : undefined;
@@ -103,7 +101,6 @@ export const MainSection = ({
     onPlusClick,
     onNavTabClick,
     showPlusSubscription,
-    isCustomDefaultFeed,
   ]);
 
   return (

--- a/packages/shared/src/components/sidebar/sections/MainSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/MainSection.tsx
@@ -16,6 +16,7 @@ import { webappUrl } from '../../../lib/constants';
 import { usePlusSubscription } from '../../../hooks/usePlusSubscription';
 import { LogEvent, TargetId } from '../../../lib/log';
 import { SharedFeedPage } from '../../utilities';
+import useCustomDefaultFeed from '../../../hooks/feed/useCustomDefaultFeed';
 
 export const MainSection = ({
   isItemsButton,
@@ -23,6 +24,7 @@ export const MainSection = ({
   ...defaultRenderSectionProps
 }: SidebarSectionProps): ReactElement => {
   const { user, isLoggedIn } = useAuthContext();
+  const { isCustomDefaultFeed } = useCustomDefaultFeed();
   const { showPlusSubscription, isEnrolledNotPlus, logSubscriptionEvent } =
     usePlusSubscription();
 
@@ -34,10 +36,11 @@ export const MainSection = ({
   }, [logSubscriptionEvent]);
 
   const menuItems: SidebarMenuItem[] = useMemo(() => {
+    const myFeedPath = isCustomDefaultFeed ? `${webappUrl}my-feed` : '/';
     const myFeed = isLoggedIn
       ? {
           title: 'My feed',
-          path: '/',
+          path: myFeedPath,
           action: () => onNavTabClick?.(SharedFeedPage.MyFeed),
           icon: <ProfilePicture size={ProfileImageSize.XSmall} user={user} />,
         }

--- a/packages/shared/src/components/sidebar/sections/MainSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/MainSection.tsx
@@ -103,6 +103,7 @@ export const MainSection = ({
     onPlusClick,
     onNavTabClick,
     showPlusSubscription,
+    isCustomDefaultFeed,
   ]);
 
   return (

--- a/packages/shared/src/components/sidebar/sections/MainSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/MainSection.tsx
@@ -15,6 +15,7 @@ import { SidebarSectionProps } from './common';
 import { webappUrl } from '../../../lib/constants';
 import { usePlusSubscription } from '../../../hooks/usePlusSubscription';
 import { LogEvent, TargetId } from '../../../lib/log';
+import useCustomDefaultFeed from '../../../hooks/feed/useCustomDefaultFeed';
 
 export const MainSection = ({
   isItemsButton,
@@ -22,6 +23,7 @@ export const MainSection = ({
   ...defaultRenderSectionProps
 }: SidebarSectionProps): ReactElement => {
   const { user, isLoggedIn } = useAuthContext();
+  const { isCustomDefaultFeed } = useCustomDefaultFeed();
   const { showPlusSubscription, isEnrolledNotPlus, logSubscriptionEvent } =
     usePlusSubscription();
 
@@ -33,11 +35,12 @@ export const MainSection = ({
   }, [logSubscriptionEvent]);
 
   const menuItems: SidebarMenuItem[] = useMemo(() => {
+    const myFeedPath = isCustomDefaultFeed ? '/my-feed' : '/';
     const myFeed = isLoggedIn
       ? {
           title: 'My feed',
-          path: '/',
-          action: () => onNavTabClick?.('/'),
+          path: myFeedPath,
+          action: () => onNavTabClick?.(myFeedPath),
           icon: <ProfilePicture size={ProfileImageSize.XSmall} user={user} />,
         }
       : undefined;

--- a/packages/shared/src/components/sidebar/sections/MainSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/MainSection.tsx
@@ -15,8 +15,8 @@ import { SidebarSectionProps } from './common';
 import { webappUrl } from '../../../lib/constants';
 import { usePlusSubscription } from '../../../hooks/usePlusSubscription';
 import { LogEvent, TargetId } from '../../../lib/log';
-import { SharedFeedPage } from '../../utilities';
 import useCustomDefaultFeed from '../../../hooks/feed/useCustomDefaultFeed';
+import { SharedFeedPage } from '../../utilities';
 
 export const MainSection = ({
   isItemsButton,
@@ -36,12 +36,14 @@ export const MainSection = ({
   }, [logSubscriptionEvent]);
 
   const menuItems: SidebarMenuItem[] = useMemo(() => {
-    const myFeedPath = isCustomDefaultFeed ? `${webappUrl}my-feed` : '/';
+    const myFeedPath = isCustomDefaultFeed ? '/my-feed' : '/';
+
     const myFeed = isLoggedIn
       ? {
           title: 'My feed',
           path: myFeedPath,
-          action: () => onNavTabClick?.(SharedFeedPage.MyFeed),
+          action: () =>
+            onNavTabClick?.(isCustomDefaultFeed ? SharedFeedPage.MyFeed : '/'),
           icon: <ProfilePicture size={ProfileImageSize.XSmall} user={user} />,
         }
       : undefined;

--- a/packages/shared/src/components/sidebar/sections/MainSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/MainSection.tsx
@@ -36,6 +36,8 @@ export const MainSection = ({
   }, [logSubscriptionEvent]);
 
   const menuItems: SidebarMenuItem[] = useMemo(() => {
+    // this path can be opened on extension so it purposly
+    // is not using webappUrl so it gets selected
     const myFeedPath = isCustomDefaultFeed ? '/my-feed' : '/';
 
     const myFeed = isLoggedIn
@@ -65,7 +67,9 @@ export const MainSection = ({
       myFeed,
       {
         title: 'Following',
-        path: `${webappUrl}following`,
+        // this path can be opened on extension so it purposly
+        // is not using webappUrl so it gets selected
+        path: '/following',
         action: () => onNavTabClick?.(OtherFeedPage.Following),
         icon: (active: boolean) => (
           <ListIcon Icon={() => <SquadIcon secondary={active} />} />

--- a/packages/shared/src/components/tabs/TabContainer.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.tsx
@@ -134,7 +134,7 @@ export function TabContainer<T extends string = string>({
     : children.map((child, i) =>
         createElement<TabProps<T>>(child.type, {
           ...child.props,
-          key: child.props.label || i,
+          key: child.key || child.props.label || i,
           style: isTabActive(child)
             ? child.props.style
             : { ...child.props.style, display: 'none' },

--- a/packages/shared/src/components/tabs/TabList.tsx
+++ b/packages/shared/src/components/tabs/TabList.tsx
@@ -130,7 +130,7 @@ function TabList<T extends string = string>({
 
         return (
           <Tag
-            key={label}
+            key={`${label}-${href}`}
             ref={(el) => {
               if (!el || !isActive) {
                 return;

--- a/packages/shared/src/hooks/feed/useCustomDefaultFeed.ts
+++ b/packages/shared/src/hooks/feed/useCustomDefaultFeed.ts
@@ -1,0 +1,17 @@
+import { useAuthContext } from '../../contexts/AuthContext';
+
+type UseCustomDefaultFeed = {
+  isCustomDefaultFeed: boolean;
+  defaultFeedId: string;
+};
+
+const useCustomDefaultFeed = (): UseCustomDefaultFeed => {
+  const { user } = useAuthContext();
+
+  return {
+    isCustomDefaultFeed: user?.defaultFeedId && user.defaultFeedId !== user?.id,
+    defaultFeedId: user?.defaultFeedId ?? user?.id,
+  };
+};
+
+export default useCustomDefaultFeed;


### PR DESCRIPTION
## Changes
If the user has selected a custom feed as main, it will be shown as the main feed on the base path "/"

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->
AS-858 #done

### Preview domain
https://as-858.preview.app.daily.dev