### PR TITLE
feat: Reusable 3 dots for adding to custom feed

### DIFF
--- a/packages/shared/src/components/CustomFeedOptionsMenu.tsx
+++ b/packages/shared/src/components/CustomFeedOptionsMenu.tsx
@@ -1,0 +1,57 @@
+import React, { type ReactElement } from 'react';
+import { ContextMenuIds } from '../hooks/constants';
+import type { MenuItemProps } from './fields/ContextMenu';
+import ContextMenu from './fields/ContextMenu';
+import { HashtagIcon, MenuIcon as DotsIcon, ShareIcon } from './icons';
+import { MenuIcon } from './MenuIcon';
+import useContextMenu from '../hooks/useContextMenu';
+import { Button, ButtonSize } from './buttons/Button';
+import {
+  useShareOrCopyLink,
+  type UseShareOrCopyLinkProps,
+} from '../hooks/useShareOrCopyLink';
+
+type CustomFeedOptionsMenuProps = {
+  shareProps: UseShareOrCopyLinkProps;
+};
+
+const CustomFeedOptionsMenu = ({
+  shareProps,
+}: CustomFeedOptionsMenuProps): ReactElement => {
+  const [, onShareOrCopyLink] = useShareOrCopyLink(shareProps);
+  const { isOpen, onMenuClick } = useContextMenu({
+    id: ContextMenuIds.CustomFeedContext,
+  });
+
+  const options: MenuItemProps[] = [
+    {
+      icon: <MenuIcon Icon={ShareIcon} />,
+      label: 'Share',
+      action: () => onShareOrCopyLink(),
+    },
+    {
+      icon: <MenuIcon Icon={HashtagIcon} />,
+      label: 'Add to custom feed',
+      action: () => {
+        console.log('TODO: Implement modal || funnel to upgrade to plus');
+      },
+    },
+  ];
+
+  return (
+    <>
+      <Button onClick={onMenuClick} size={ButtonSize.XSmall}>
+        <DotsIcon />
+      </Button>
+      <ContextMenu
+        disableBoundariesCheck
+        id={ContextMenuIds.CustomFeedContext}
+        className="mt-2"
+        options={options}
+        isOpen={isOpen}
+      />
+    </>
+  );
+};
+
+export default CustomFeedOptionsMenu;

--- a/packages/shared/src/components/CustomFeedOptionsMenu.tsx
+++ b/packages/shared/src/components/CustomFeedOptionsMenu.tsx
@@ -1,21 +1,24 @@
 import React, { type ReactElement } from 'react';
+import classNames from 'classnames';
 import { ContextMenuIds } from '../hooks/constants';
 import type { MenuItemProps } from './fields/ContextMenu';
 import ContextMenu from './fields/ContextMenu';
 import { HashtagIcon, MenuIcon as DotsIcon, ShareIcon } from './icons';
 import { MenuIcon } from './MenuIcon';
 import useContextMenu from '../hooks/useContextMenu';
-import { Button, ButtonSize } from './buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from './buttons/Button';
 import {
   useShareOrCopyLink,
   type UseShareOrCopyLinkProps,
 } from '../hooks/useShareOrCopyLink';
 
 type CustomFeedOptionsMenuProps = {
+  className?: string;
   shareProps: UseShareOrCopyLinkProps;
 };
 
 const CustomFeedOptionsMenu = ({
+  className,
   shareProps,
 }: CustomFeedOptionsMenuProps): ReactElement => {
   const [, onShareOrCopyLink] = useShareOrCopyLink(shareProps);
@@ -33,20 +36,24 @@ const CustomFeedOptionsMenu = ({
       icon: <MenuIcon Icon={HashtagIcon} />,
       label: 'Add to custom feed',
       action: () => {
-        console.log('TODO: Implement modal || funnel to upgrade to plus');
+        // TODO: Implement modal || funnel to upgrade to plus
       },
     },
   ];
 
   return (
     <>
-      <Button onClick={onMenuClick} size={ButtonSize.XSmall}>
+      <Button
+        className={classNames('!border-none !px-1.5', className)}
+        onClick={onMenuClick}
+        size={ButtonSize.Small}
+        variant={ButtonVariant.Float}
+      >
         <DotsIcon />
       </Button>
       <ContextMenu
         disableBoundariesCheck
         id={ContextMenuIds.CustomFeedContext}
-        className="mt-2"
         options={options}
         isOpen={isOpen}
       />

--- a/packages/shared/src/components/CustomFeedOptionsMenu.tsx
+++ b/packages/shared/src/components/CustomFeedOptionsMenu.tsx
@@ -44,13 +44,12 @@ const CustomFeedOptionsMenu = ({
   return (
     <>
       <Button
-        className={classNames('!border-none !px-1.5', className)}
+        className={classNames('!px-1.5', className)}
         onClick={onMenuClick}
         size={ButtonSize.Small}
         variant={ButtonVariant.Float}
-      >
-        <DotsIcon />
-      </Button>
+        icon={<DotsIcon />}
+      />
       <ContextMenu
         disableBoundariesCheck
         id={ContextMenuIds.CustomFeedContext}

--- a/packages/shared/src/components/CustomFeedOptionsMenu.tsx
+++ b/packages/shared/src/components/CustomFeedOptionsMenu.tsx
@@ -11,6 +11,7 @@ import {
   useShareOrCopyLink,
   type UseShareOrCopyLinkProps,
 } from '../hooks/useShareOrCopyLink';
+import { usePlusSubscription } from '../hooks';
 
 type CustomFeedOptionsMenuProps = {
   className?: string;
@@ -21,6 +22,7 @@ const CustomFeedOptionsMenu = ({
   className,
   shareProps,
 }: CustomFeedOptionsMenuProps): ReactElement => {
+  const { showPlusSubscription } = usePlusSubscription();
   const [, onShareOrCopyLink] = useShareOrCopyLink(shareProps);
   const { isOpen, onMenuClick } = useContextMenu({
     id: ContextMenuIds.CustomFeedContext,
@@ -40,6 +42,17 @@ const CustomFeedOptionsMenu = ({
       },
     },
   ];
+
+  if (!showPlusSubscription) {
+    return (
+      <Button
+        variant={ButtonVariant.Float}
+        size={ButtonSize.Small}
+        icon={<ShareIcon />}
+        onClick={() => onShareOrCopyLink()}
+      />
+    );
+  }
 
   return (
     <>

--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -14,7 +14,7 @@ import { ContentPreferenceType } from '../../graphql/contentPreference';
 import { UpgradeToPlus } from '../UpgradeToPlus';
 import { useContentPreferenceStatusQuery } from '../../hooks/contentPreference/useContentPreferenceStatusQuery';
 import { usePlusSubscription } from '../../hooks/usePlusSubscription';
-import { TargetId } from '../../lib/log';
+import { LogEvent, TargetId } from '../../lib/log';
 import CustomFeedOptionsMenu from '../CustomFeedOptionsMenu';
 
 export interface HeaderProps {
@@ -102,7 +102,7 @@ export function Header({
             link: user.permalink,
             cid: ReferralCampaignKey.ShareProfile,
             logObject: () => ({
-              event_name: 'share profile',
+              event_name: LogEvent.ShareProfile,
               target_id: user.id,
             }),
           }}

--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -96,6 +96,7 @@ export function Header({
       />
       {!isSameUser && (
         <CustomFeedOptionsMenu
+          className="ml-2"
           shareProps={{
             text: `Check out ${user.name}'s profile on daily.dev`,
             link: user.permalink,

--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -69,45 +69,46 @@ export function Header({
           <h2 className="mr-auto font-bold typo-body">Profile</h2>
         )}
       </>
-      {isSameUser && (
-        <Button
-          className="mr-2 hidden laptop:flex"
-          variant={ButtonVariant.Float}
-          size={ButtonSize.Small}
-          tag="a"
-          href={`${process.env.NEXT_PUBLIC_WEBAPP_URL}account/profile`}
-        >
-          Edit profile
-        </Button>
-      )}
-      {isSameUser && !isPlus && (
-        <UpgradeToPlus
-          className="mr-2 max-w-fit laptop:hidden"
-          size={ButtonSize.Small}
-          target={TargetId.MyProfile}
+      <div className="flex flex-row gap-2">
+        {isSameUser && (
+          <Button
+            className="hidden laptop:flex"
+            variant={ButtonVariant.Float}
+            size={ButtonSize.Small}
+            tag="a"
+            href={`${process.env.NEXT_PUBLIC_WEBAPP_URL}account/profile`}
+          >
+            Edit profile
+          </Button>
+        )}
+        {isSameUser && !isPlus && (
+          <UpgradeToPlus
+            className="max-w-fit laptop:hidden"
+            size={ButtonSize.Small}
+            target={TargetId.MyProfile}
+          />
+        )}
+        <FollowButton
+          entityId={user.id}
+          type={ContentPreferenceType.User}
+          status={contentPreference?.status}
+          entityName={`@${user.username}`}
+          className="flex-row-reverse"
         />
-      )}
-      <FollowButton
-        entityId={user.id}
-        type={ContentPreferenceType.User}
-        status={contentPreference?.status}
-        entityName={`@${user.username}`}
-        className="ml-2 flex-row-reverse"
-      />
-      {!isSameUser && (
-        <CustomFeedOptionsMenu
-          className="ml-2"
-          shareProps={{
-            text: `Check out ${user.name}'s profile on daily.dev`,
-            link: user.permalink,
-            cid: ReferralCampaignKey.ShareProfile,
-            logObject: () => ({
-              event_name: LogEvent.ShareProfile,
-              target_id: user.id,
-            }),
-          }}
-        />
-      )}
+        {!isSameUser && (
+          <CustomFeedOptionsMenu
+            shareProps={{
+              text: `Check out ${user.name}'s profile on daily.dev`,
+              link: user.permalink,
+              cid: ReferralCampaignKey.ShareProfile,
+              logObject: () => ({
+                event_name: LogEvent.ShareProfile,
+                target_id: user.id,
+              }),
+            }}
+          />
+        )}
+      </div>
       {isSameUser && (
         <>
           <Button

--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -1,9 +1,8 @@
 import React, { CSSProperties, ReactElement, useState } from 'react';
 import classNames from 'classnames';
 import { PublicProfile } from '../../lib/user';
-import { SettingsIcon, ShareIcon } from '../icons';
+import { SettingsIcon } from '../icons';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
-import { useShareOrCopyLink } from '../../hooks/useShareOrCopyLink';
 import { ProfileImageSize, ProfilePicture } from '../ProfilePicture';
 import { largeNumberFormat, ReferralCampaignKey } from '../../lib';
 import { ProfileSettingsMenu } from './ProfileSettingsMenu';
@@ -16,6 +15,7 @@ import { UpgradeToPlus } from '../UpgradeToPlus';
 import { useContentPreferenceStatusQuery } from '../../hooks/contentPreference/useContentPreferenceStatusQuery';
 import { usePlusSubscription } from '../../hooks/usePlusSubscription';
 import { TargetId } from '../../lib/log';
+import CustomFeedOptionsMenu from '../CustomFeedOptionsMenu';
 
 export interface HeaderProps {
   user: PublicProfile;
@@ -33,12 +33,6 @@ export function Header({
   className,
   style,
 }: HeaderProps): ReactElement {
-  const [, onShareOrCopyLink] = useShareOrCopyLink({
-    text: `Check out ${user.name}'s profile on daily.dev`,
-    link: user.permalink,
-    cid: ReferralCampaignKey.ShareProfile,
-    logObject: () => ({ event_name: 'share profile', target_id: user.id }),
-  });
   const isMobile = useViewSize(ViewSize.MobileL);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { isPlus } = usePlusSubscription();
@@ -93,12 +87,6 @@ export function Header({
           target={TargetId.MyProfile}
         />
       )}
-      <Button
-        variant={ButtonVariant.Float}
-        size={ButtonSize.Small}
-        icon={<ShareIcon />}
-        onClick={() => onShareOrCopyLink()}
-      />
       <FollowButton
         userId={user.id}
         type={ContentPreferenceType.User}
@@ -106,6 +94,19 @@ export function Header({
         entityName={`@${user.username}`}
         className="ml-2 flex-row-reverse"
       />
+      {!isSameUser && (
+        <CustomFeedOptionsMenu
+          shareProps={{
+            text: `Check out ${user.name}'s profile on daily.dev`,
+            link: user.permalink,
+            cid: ReferralCampaignKey.ShareProfile,
+            logObject: () => ({
+              event_name: 'share profile',
+              target_id: user.id,
+            }),
+          }}
+        />
+      )}
       {isSameUser && (
         <>
           <Button

--- a/packages/shared/src/components/sources/SourceActions/index.tsx
+++ b/packages/shared/src/components/sources/SourceActions/index.tsx
@@ -1,10 +1,11 @@
 import React, { ReactElement } from 'react';
 import { ButtonVariant } from '../../buttons/common';
 import { Source } from '../../../graphql/sources';
-import { useSourceActions } from '../../../hooks';
+import { ReferralCampaignKey, useSourceActions } from '../../../hooks';
 import SourceActionsNotify from './SourceActionsNotify';
 import SourceActionsBlock from './SourceActionsBlock';
 import SourceActionsFollow from './SourceActionsFollow';
+import CustomFeedOptionsMenu from '../../CustomFeedOptionsMenu';
 
 interface SourceActionsButton {
   className?: string;
@@ -66,6 +67,17 @@ export const SourceActions = ({
           {...blockProps}
         />
       )}
+      <CustomFeedOptionsMenu
+        shareProps={{
+          text: `Check out ${source.handle} on daily.dev`,
+          link: source.permalink,
+          cid: ReferralCampaignKey.ShareSource,
+          logObject: () => ({
+            event_name: 'share source',
+            target_id: source.id,
+          }),
+        }}
+      />
     </div>
   );
 };

--- a/packages/shared/src/components/sources/SourceActions/index.tsx
+++ b/packages/shared/src/components/sources/SourceActions/index.tsx
@@ -6,6 +6,7 @@ import SourceActionsNotify from './SourceActionsNotify';
 import SourceActionsBlock from './SourceActionsBlock';
 import SourceActionsFollow from './SourceActionsFollow';
 import CustomFeedOptionsMenu from '../../CustomFeedOptionsMenu';
+import { LogEvent } from '../../../lib/log';
 
 interface SourceActionsButton {
   className?: string;
@@ -73,7 +74,7 @@ export const SourceActions = ({
           link: source.permalink,
           cid: ReferralCampaignKey.ShareSource,
           logObject: () => ({
-            event_name: 'share source',
+            event_name: LogEvent.ShareSource,
             target_id: source.id,
           }),
         }}

--- a/packages/shared/src/hooks/constants.ts
+++ b/packages/shared/src/hooks/constants.ts
@@ -9,6 +9,7 @@ export enum ContextMenu {
   ShortcutContext = 'shortcut-context',
   SidebarOnboardingChecklistCard = 'sidebar-onboarding-checklist-card-context',
   SourceIntegrationContext = 'source-integration-context',
+  CustomFeedContext = 'custom-feed-context',
 }
 
 export const ContextMenuIds = ContextMenu;

--- a/packages/shared/src/hooks/useShareOrCopyLink.ts
+++ b/packages/shared/src/hooks/useShareOrCopyLink.ts
@@ -6,7 +6,7 @@ import { LogEvent } from './log/useLogQueue';
 import { useGetShortUrl } from './utils/useGetShortUrl';
 import { ReferralCampaignKey } from '../lib';
 
-interface UseShareOrCopyLinkProps {
+export interface UseShareOrCopyLinkProps {
   link: string;
   text: string;
   logObject?: (provider: ShareProvider) => LogEvent;

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -229,6 +229,11 @@ export enum LogEvent {
   ToggleClickbaitShield = 'toggle clickbait shield',
   ClickbaitShieldTitle = 'clickbait shield title',
   // End Clickbait Shield
+  // Start Share
+  ShareProfile = 'share profile',
+  ShareSource = 'share source',
+  ShareTag = 'share tag',
+  // End Share
 }
 
 export enum FeedItemTitle {

--- a/packages/shared/src/lib/referral.ts
+++ b/packages/shared/src/lib/referral.ts
@@ -4,4 +4,6 @@ export enum ReferralCampaignKey {
   SharePost = 'share_post',
   ShareComment = 'share_comment',
   ShareProfile = 'share_profile',
+  ShareSource = 'share_source',
+  ShareTag = 'share_tag',
 }

--- a/packages/webapp/pages/join.tsx
+++ b/packages/webapp/pages/join.tsx
@@ -22,6 +22,8 @@ const componentsMap: ReferralRecord<FunctionComponent<JoinPageProps>> = {
   [ReferralCampaignKey.SharePost]: Referral,
   [ReferralCampaignKey.ShareComment]: Referral,
   [ReferralCampaignKey.ShareProfile]: Referral,
+  [ReferralCampaignKey.ShareSource]: Referral,
+  [ReferralCampaignKey.ShareTag]: Referral,
 };
 
 const Page = ({

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -49,7 +49,10 @@ import {
   GET_RECOMMENDED_TAGS_QUERY,
   TagsData,
 } from '@dailydotdev/shared/src/graphql/feedSettings';
-import { useFeedLayout } from '@dailydotdev/shared/src/hooks';
+import {
+  ReferralCampaignKey,
+  useFeedLayout,
+} from '@dailydotdev/shared/src/hooks';
 import { RecommendedTags } from '@dailydotdev/shared/src/components/RecommendedTags';
 import {
   SOURCES_BY_TAG_QUERY,
@@ -65,6 +68,8 @@ import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { cloudinarySourceRoadmap } from '@dailydotdev/shared/src/lib/image';
 import { anchorDefaultRel } from '@dailydotdev/shared/src/lib/strings';
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
+import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
+import CustomFeedOptionsMenu from '@dailydotdev/shared/src/components/CustomFeedOptionsMenu';
 import { getLayout } from '../../components/layouts/FeedLayout';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
 import { DynamicSeoProps } from '../../components/common';
@@ -234,6 +239,17 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
               {tagStatus === 'followed' ? 'Unfollow' : 'Follow'}
             </Button>
           )}
+          <CustomFeedOptionsMenu
+            shareProps={{
+              text: `Check out the ${tag} tag on daily.dev`,
+              link: `${webappUrl}tags/${tag}`,
+              cid: ReferralCampaignKey.ShareTag,
+              logObject: () => ({
+                event_name: 'share tag',
+                target_id: tag,
+              }),
+            }}
+          />
           {tagStatus !== 'followed' && (
             <Button
               variant={ButtonVariant.Float}

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -68,7 +68,6 @@ import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { cloudinarySourceRoadmap } from '@dailydotdev/shared/src/lib/image';
 import { anchorDefaultRel } from '@dailydotdev/shared/src/lib/strings';
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
-import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import CustomFeedOptionsMenu from '@dailydotdev/shared/src/components/CustomFeedOptionsMenu';
 import { getLayout } from '../../components/layouts/FeedLayout';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
@@ -242,7 +241,7 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
           <CustomFeedOptionsMenu
             shareProps={{
               text: `Check out the ${tag} tag on daily.dev`,
-              link: `${webappUrl}tags/${tag}`,
+              link: globalThis?.location?.href,
               cid: ReferralCampaignKey.ShareTag,
               logObject: () => ({
                 event_name: LogEvent.ShareTag,

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -238,6 +238,15 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
               {tagStatus === 'followed' ? 'Unfollow' : 'Follow'}
             </Button>
           )}
+          {tagStatus !== 'followed' && (
+            <Button
+              variant={ButtonVariant.Float}
+              {...blockButtonProps}
+              aria-label={tagStatus === 'blocked' ? 'Unblock' : 'Block'}
+            >
+              {tagStatus === 'blocked' ? 'Unblock' : 'Block'}
+            </Button>
+          )}
           <CustomFeedOptionsMenu
             shareProps={{
               text: `Check out the ${tag} tag on daily.dev`,
@@ -249,15 +258,6 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
               }),
             }}
           />
-          {tagStatus !== 'followed' && (
-            <Button
-              variant={ButtonVariant.Float}
-              {...blockButtonProps}
-              aria-label={tagStatus === 'blocked' ? 'Unblock' : 'Block'}
-            >
-              {tagStatus === 'blocked' ? 'Unblock' : 'Block'}
-            </Button>
-          )}
         </div>
         {initialData?.flags?.description && (
           <p className="typo-body">{initialData?.flags?.description}</p>

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -38,7 +38,7 @@ import {
   RequestKey,
   StaleTime,
 } from '@dailydotdev/shared/src/lib/query';
-import { Origin } from '@dailydotdev/shared/src/lib/log';
+import { LogEvent, Origin } from '@dailydotdev/shared/src/lib/log';
 import {
   KEYWORD_QUERY,
   Keyword,
@@ -245,7 +245,7 @@ const TagPage = ({ tag, initialData }: TagPageProps): ReactElement => {
               link: `${webappUrl}tags/${tag}`,
               cid: ReferralCampaignKey.ShareTag,
               logObject: () => ({
-                event_name: 'share tag',
+                event_name: LogEvent.ShareTag,
                 target_id: tag,
               }),
             }}


### PR DESCRIPTION
## Changes

Added the new CustomFeedOptionsMenu to profile, tag and source pages. Have not done anything to squad page yet, as that is a button in an already existing menu, and can be added with [AS-842](https://dailydotdev.atlassian.net/browse/AS-842)

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->

AS-853 #done
AS-854 #done
AS-855 #done
AS-856 #done


[AS-842]: https://dailydotdev.atlassian.net/browse/AS-842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Preview domain
https://as-853.preview.app.daily.dev