### PR TITLE
fix: allow native share only on mobile

### DIFF
--- a/packages/shared/src/hooks/useShareComment.ts
+++ b/packages/shared/src/hooks/useShareComment.ts
@@ -8,6 +8,7 @@ import { Comment, getCommentHash } from '../graphql/comments';
 import { useGetShortUrl } from './utils/useGetShortUrl';
 import { ReferralCampaignKey } from '../lib';
 import { useSharePost } from './useSharePost';
+import { shouldUseNativeShare } from '../lib/func';
 
 interface UseShareComment {
   openShareComment: (comment: Comment, post: Post) => void;
@@ -20,7 +21,7 @@ export function useShareComment(origin: Origin): UseShareComment {
 
   const openShareComment = useCallback(
     async (comment, post) => {
-      if ('share' in globalThis?.navigator) {
+      if (shouldUseNativeShare()) {
         try {
           const shortUrl = await getShortUrl(
             `${post.commentsPermalink}${getCommentHash(comment.id)}`,

--- a/packages/shared/src/hooks/useShareOrCopyLink.ts
+++ b/packages/shared/src/hooks/useShareOrCopyLink.ts
@@ -5,6 +5,7 @@ import { ShareProvider } from '../lib/share';
 import { LogEvent } from './log/useLogQueue';
 import { useGetShortUrl } from './utils/useGetShortUrl';
 import { ReferralCampaignKey } from '../lib';
+import { shouldUseNativeShare } from '../lib/func';
 
 interface UseShareOrCopyLinkProps {
   link: string;
@@ -26,7 +27,7 @@ export function useShareOrCopyLink({
   const onShareOrCopy: CopyNotifyFunction = async () => {
     const shortLink = cid ? await getShortUrl(link, cid) : link;
 
-    if ('share' in globalThis?.navigator) {
+    if (shouldUseNativeShare()) {
       try {
         await navigator.share({
           text: `${text}\n${shortLink}`,

--- a/packages/shared/src/lib/func.ts
+++ b/packages/shared/src/lib/func.ts
@@ -172,3 +172,9 @@ export const initApp = (): void => {
     globalThis.isAndroidApp = true;
   }
 };
+
+export const isMobile = (): boolean =>
+  globalThis?.localStorage.mobile || globalThis?.navigator.maxTouchPoints > 1;
+
+export const shouldUseNativeShare = (): boolean =>
+  'share' in globalThis?.navigator && isMobile();


### PR DESCRIPTION
Use native share only on mobile. Us boomers can't copy link with the shitty apple native share on Mac

### Preview domain
https://allow-native-share-mobile.preview.app.daily.dev