### PR TITLE
fix: ensure blocked words work per feed

### DIFF
--- a/packages/shared/src/components/filters/BlockedWords.tsx
+++ b/packages/shared/src/components/filters/BlockedWords.tsx
@@ -2,6 +2,7 @@ import React, {
   KeyboardEvent,
   ReactElement,
   useCallback,
+  useContext,
   useState,
 } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -30,8 +31,10 @@ import { useAuthContext } from '../../contexts/AuthContext';
 import { useContentPreference } from '../../hooks/contentPreference/useContentPreference';
 import { usePlusSubscription } from '../../hooks';
 import { IconSize } from '../Icon';
+import { FeedSettingsEditContext } from '../feeds/FeedSettings/FeedSettingsEditContext';
 
 export const BlockedWords = (): ReactElement => {
+  const { feed } = useContext(FeedSettingsEditContext);
   const queryClient = useQueryClient();
   const { user } = useAuthContext();
   const { block, unblock } = useContentPreference();
@@ -52,6 +55,7 @@ export const BlockedWords = (): ReactElement => {
   }, [queryClient, user]);
   const queryResult = useBlockedQuery({
     entity: ContentPreferenceType.Word,
+    feedId: feed?.id,
   });
   const flatBlockedWords =
     queryResult?.data?.pages.flatMap(
@@ -64,6 +68,7 @@ export const BlockedWords = (): ReactElement => {
         id: words,
         entity: ContentPreferenceType.Word,
         entityName: 'words',
+        feedId: feed?.id,
       });
       invalidateBlockedWords();
       setWords('');
@@ -144,6 +149,7 @@ export const BlockedWords = (): ReactElement => {
                 id: word.referenceId,
                 entity: ContentPreferenceType.Word,
                 entityName: word.referenceId,
+                feedId: feed?.id,
               }).then(() => invalidateBlockedWords())
             }
             tagItem={word.referenceId}


### PR DESCRIPTION
## Changes

Ensure feed id's get passed correctly for blocked words

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-872 #done 


### Preview domain
https://as-872-blocked-words-per-feed.preview.app.daily.dev