### PR TITLE
chore: fix tag rendering

### DIFF
--- a/packages/shared/src/components/TagLinks.tsx
+++ b/packages/shared/src/components/TagLinks.tsx
@@ -27,7 +27,7 @@ export function TagLink({
     <Link href={getTagPageLink(tag)} passHref key={tag} prefetch={false}>
       <Button
         tag="a"
-        size={ButtonSize.Small}
+        size={ButtonSize.XSmall}
         variant={ButtonVariant.Float}
         className={classNames('relative', className)}
         {...buttonProps}

--- a/packages/webapp/pages/tags/index.tsx
+++ b/packages/webapp/pages/tags/index.tsx
@@ -15,6 +15,7 @@ import type { GraphQLError } from '@dailydotdev/shared/src/lib/errors';
 import { PageWrapperLayout } from '@dailydotdev/shared/src/components/layout/PageWrapperLayout';
 import { TagTopList } from '@dailydotdev/shared/src/components/cards/Leaderboard';
 import useFeedSettings from '@dailydotdev/shared/src/hooks/useFeedSettings';
+import { ButtonSize } from '@dailydotdev/shared/src/components/buttons/common';
 import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
 import { getLayout } from '../../components/layouts/MainLayout';
 import { defaultOpenGraph } from '../../next-seo';
@@ -130,6 +131,7 @@ const TagsPage = ({
                     tag={tag.value}
                     className="!line-clamp-2 !h-auto py-1.5"
                     isSelected={selectedTags.includes(tag.value)}
+                    buttonProps={{ size: ButtonSize.Small }}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Changes

Because of the `!line-clamp-2` which is needed we need to do some special magic.
The initial fix was to set all cases of TagLinks to be different size, but this affected other areas of the code.

This new one only affects the tag overview page to be bigger (for rendering the purple dot)

Solves.
https://github.com/dailydotdev/apps/pull/3907

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://chore-fix-tag-render.preview.app.daily.dev