### PR TITLE
fix: remove if not enrolled

### DIFF
--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -91,7 +91,10 @@ export const SearchControlHeader = ({
     buttonVariant: isLaptop ? ButtonVariant.Float : ButtonVariant.Tertiary,
   };
 
-  const feedsWithActions = [SharedFeedPage.MyFeed, SharedFeedPage.Custom];
+  const feedsWithActions = [SharedFeedPage.MyFeed];
+  if (showPlusSubscription) {
+    feedsWithActions.push(SharedFeedPage.Custom);
+  }
 
   const actionButtons = [
     feedsWithActions.includes(feedName as SharedFeedPage) ? (

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -93,7 +93,7 @@ export const SearchControlHeader = ({
 
   const feedsWithActions = [SharedFeedPage.MyFeed];
   if (showPlusSubscription) {
-    feedsWithActions.push(SharedFeedPage.Custom);
+    feedsWithActions.push(SharedFeedPage.Custom, SharedFeedPage.CustomForm);
   }
 
   const actionButtons = [

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -90,7 +90,7 @@ export const SearchControlHeader = ({
     iconOnly: true,
     buttonVariant: isLaptop ? ButtonVariant.Float : ButtonVariant.Tertiary,
   };
-  
+
   const feedsWithActions = [SharedFeedPage.MyFeed];
   if (showPlusSubscription) {
     feedsWithActions.push(SharedFeedPage.Custom, SharedFeedPage.CustomForm);


### PR DESCRIPTION
## Changes

@capJavert This should only not render if not in experiment right?
So enrolled - not plus will see it, but it will redirect to homepage...?

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://as-883-remove-button.preview.app.daily.dev