### PR TITLE
fix: add custom feed form same feed

### DIFF
--- a/packages/shared/src/lib/feed.ts
+++ b/packages/shared/src/lib/feed.ts
@@ -201,9 +201,7 @@ export const getFeedName = (
     return OtherFeedPage.UserPosts;
   }
   if (feed.startsWith('feeds')) {
-    const isForm = ['new', 'edit'].some((item) => feed.endsWith(item));
-
-    return isForm ? SharedFeedPage.CustomForm : SharedFeedPage.Custom;
+    return SharedFeedPage.Custom;
   }
 
   const [page] = feed.split('?');


### PR DESCRIPTION
## Changes

I'm really not sure why Ante made it render a different feed on new/edit pages.
But this should work.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-890 #done 


### Preview domain
https://as-890-custom-feed-form.preview.app.daily.dev