### PR TITLE
fix: bug with saving filters

### DIFF
--- a/packages/shared/src/components/feeds/FeedSettings/FeedSettingsEditHeader.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/FeedSettingsEditHeader.tsx
@@ -18,7 +18,7 @@ const SaveButton = ({ activeView }: { activeView: string }): ReactElement => {
     FeedSettingsEditContext,
   );
 
-  if (activeView !== 'General') {
+  if (activeView !== 'General' && activeView !== 'Filters') {
     return (
       <Button
         type="submit"


### PR DESCRIPTION
## Changes

We should call save function when on filter page as well as general.
Edge-case when you change something and toggle away it doesn't save, but we should address seperately.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-911 #done 


### Preview domain
https://as-911-saving-filter-bug.preview.app.daily.dev