### PR TITLE
Revert "refactor: use timed animation to be non-blocking (#3671)"

### DIFF
--- a/packages/shared/src/hooks/useTimedAnimation.ts
+++ b/packages/shared/src/hooks/useTimedAnimation.ts
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useTransition,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { isNullOrUndefined } from '../lib/func';
 import useDebounceFn from './useDebounceFn';
 
@@ -31,13 +24,7 @@ export const useTimedAnimation = ({
   outAnimationDuration = OUT_ANIMATION_DURATION,
   onAnimationEnd,
 }: UseTimedAnimationProps): UseTimedAnimation => {
-  const [timer, setTimerBlocking] = useState(0);
-  const [, startTransition] = useTransition();
-  const setTimer: typeof setTimerBlocking = useCallback((value) => {
-    startTransition(() => {
-      setTimerBlocking(value);
-    });
-  }, []);
+  const [timer, setTimer] = useState(0);
   const interval = useRef<number>();
   const [animationEnd] = useDebounceFn(onAnimationEnd, outAnimationDuration);
 
@@ -56,7 +43,7 @@ export const useTimedAnimation = ({
     }
 
     setTimer(0);
-  }, [setTimer]);
+  }, []);
 
   const startAnimation = useCallback(
     (duration: number) => {
@@ -82,7 +69,7 @@ export const useTimedAnimation = ({
         PROGRESS_INTERVAL,
       );
     },
-    [autoEndAnimation, setTimer],
+    [autoEndAnimation],
   );
 
   useEffect(() => {


### PR DESCRIPTION
This reverts commit f17d1e0c017703d10c34b593a15ae8c3075abe46.

## Changes
- This reverts the usage of `useTransition` on toast notification that caused the laggy experience.
- Tested locally and worked as intended.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://mi-715.preview.app.daily.dev