### PR TITLE
fix: Should not show following when blocked

### DIFF
--- a/packages/shared/src/components/contentPreference/FollowButton.tsx
+++ b/packages/shared/src/components/contentPreference/FollowButton.tsx
@@ -95,10 +95,14 @@ export const FollowButton = ({
     return null;
   }
 
+  const isFollowing =
+    currentStatus === ContentPreferenceStatus.Subscribed ||
+    currentStatus === ContentPreferenceStatus.Follow;
+
   return (
     <div className={classNames('relative z-1 inline-flex gap-2', className)}>
       <SourceActionsFollow
-        isSubscribed={!!currentStatus}
+        isSubscribed={isFollowing}
         isFetching={isLoading}
         variant={variant}
         onClick={(e) => {
@@ -108,7 +112,7 @@ export const FollowButton = ({
         }}
         copyType={copyType}
       />
-      {!!currentStatus && showSubscribe && (
+      {isFollowing && showSubscribe && (
         <SourceActionsNotify
           haveNotificationsOn={
             currentStatus === ContentPreferenceStatus.Subscribed

--- a/packages/shared/src/components/contentPreference/FollowButton.tsx
+++ b/packages/shared/src/components/contentPreference/FollowButton.tsx
@@ -95,9 +95,10 @@ export const FollowButton = ({
     return null;
   }
 
-  const isFollowing =
-    currentStatus === ContentPreferenceStatus.Subscribed ||
-    currentStatus === ContentPreferenceStatus.Follow;
+  const isFollowing = [
+    ContentPreferenceStatus.Subscribed,
+    ContentPreferenceStatus.Follow,
+  ].includes(currentStatus);
 
   return (
     <div className={classNames('relative z-1 inline-flex gap-2', className)}>


### PR DESCRIPTION
## Changes

Currently this component is only looking for a current status, which means that if the entity is blocked by the current user, it will show as "following".

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://mi-747.preview.app.daily.dev