### PR TITLE
fix: onboarding language fix

### DIFF
--- a/packages/shared/src/components/auth/RegistrationForm.tsx
+++ b/packages/shared/src/components/auth/RegistrationForm.tsx
@@ -145,7 +145,6 @@ const RegistrationForm = ({
   const isUsernameValid = !hints?.['traits.username'] && isSubmitted;
   const isExperienceLevelValid =
     !isSubmitted || !hints?.['traits.experienceLevel'];
-  const isLanguageValid = !isSubmitted || !hints?.['traits.language'];
 
   const headingId = useId();
 
@@ -271,13 +270,6 @@ const RegistrationForm = ({
         <LanguageDropdown
           className={{ container: 'w-full' }}
           name="traits.language"
-          valid={isLanguageValid}
-          hint={hints?.['traits.language']}
-          onChange={() =>
-            hints?.['traits.language'] &&
-            onUpdateHints({ ...hints, 'traits.language': '' })
-          }
-          saveHintSpace
         />
         <span className="border-b border-border-subtlest-tertiary pb-4 text-text-secondary typo-subhead">
           Your email will be used to send you product and community updates

--- a/packages/shared/src/components/auth/SocialRegistrationForm.tsx
+++ b/packages/shared/src/components/auth/SocialRegistrationForm.tsx
@@ -64,7 +64,6 @@ export const SocialRegistrationForm = ({
   const [usernameHint, setUsernameHint] = useState<string>(null);
   const [twitterHint, setTwitterHint] = useState<string>(null);
   const [experienceLevelHint, setExperienceLevelHint] = useState<string>(null);
-  const [languageHint, setLanguageHint] = useState<string>(null);
   const [name, setName] = useState(user?.name);
   const isAuthorOnboarding = trigger === AuthTriggers.Author;
   const { username, setUsername } = useGenerateUsername(name);
@@ -259,18 +258,7 @@ export const SocialRegistrationForm = ({
           hint={experienceLevelHint}
           saveHintSpace
         />
-        <LanguageDropdown
-          className={{ container: 'w-full' }}
-          name="language"
-          onChange={() => {
-            if (languageHint) {
-              setLanguageHint(null);
-            }
-          }}
-          valid={languageHint === null}
-          hint={languageHint}
-          saveHintSpace
-        />
+        <LanguageDropdown className={{ container: 'w-full' }} name="language" />
         <span className="border-b border-border-subtlest-tertiary pb-4 text-text-secondary typo-subhead">
           Your email will be used to send you product and community updates
         </span>

--- a/packages/shared/src/components/profile/LanguageDropdown.tsx
+++ b/packages/shared/src/components/profile/LanguageDropdown.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import classNames from 'classnames';
 import type { DropdownClassName } from '../fields/Dropdown';
 import { Dropdown } from '../fields/Dropdown';
@@ -33,8 +33,13 @@ export const LanguageDropdown = ({
   icon = defaultIcon,
 }: Props): ReactElement => {
   const [open, setOpen] = useState(false);
+  const values = useMemo(() => {
+    const val = Object.values(ContentLanguage);
+    val.splice(1, 1);
+    return val;
+  }, []);
   const [selectedIndex, setSelectedIndex] = useState(
-    defaultValue ? Object.values(ContentLanguage).indexOf(defaultValue) : 0,
+    defaultValue ? values.indexOf(defaultValue) : 0,
   );
 
   const {
@@ -75,8 +80,7 @@ export const LanguageDropdown = ({
         selectedIndex={selectedIndex}
         options={Object.values(contentLanguageToLabelMap)}
         onChange={(_, index) => {
-          const val =
-            index === 0 ? null : Object.values(ContentLanguage)[index];
+          const val = values[index];
           onChange?.(val, index);
           setSelectedIndex(index);
         }}
@@ -89,7 +93,7 @@ export const LanguageDropdown = ({
           type="text"
           className="hidden"
           name={name}
-          value={Object.values(ContentLanguage)[selectedIndex]}
+          value={values[selectedIndex]}
           readOnly
         />
       )}

--- a/packages/shared/src/components/profile/LanguageDropdown.tsx
+++ b/packages/shared/src/components/profile/LanguageDropdown.tsx
@@ -80,7 +80,7 @@ export const LanguageDropdown = ({
         selectedIndex={selectedIndex}
         options={Object.values(contentLanguageToLabelMap)}
         onChange={(_, index) => {
-          const val = values[index];
+          const val = values[index] as ContentLanguage;
           onChange?.(val, index);
           setSelectedIndex(index);
         }}

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -231,7 +231,7 @@ export enum LogoutReason {
 }
 
 export enum ContentLanguage {
-  Disabled = 'disabled',
+  Disabled = null,
   English = 'en',
   Spanish = 'es',
   German = 'de',
@@ -245,7 +245,7 @@ export enum ContentLanguage {
 }
 
 export const contentLanguageToLabelMap = {
-  [ContentLanguage.Disabled]: 'Disabled',
+  [ContentLanguage.Disabled]: 'Original language',
   [ContentLanguage.English]: 'English',
   [ContentLanguage.Spanish]: 'Spanish',
   [ContentLanguage.German]: 'German',


### PR DESCRIPTION
## Changes

As @omBratteng mentioned before JS adds a empyt object when using `null` as enum value.
However decided to fix it inside the component by resetting index (1) (extra null)

This way it works for all users of this component

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://chore-onboarding-language.preview.app.daily.dev