### PR TITLE
feat: move timezone ignore setting to api

### DIFF
--- a/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
+++ b/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
@@ -27,18 +27,15 @@ import {
 } from '../../../lib/timezones';
 import { SimpleTooltip } from '../../tooltips';
 import { isTesting } from '../../../lib/constants';
-import {
-  timezoneMismatchIgnoreKey,
-  useStreakTimezoneOk,
-} from '../../../hooks/streaks/useStreakTimezoneOk';
+import { useStreakTimezoneOk } from '../../../hooks/streaks/useStreakTimezoneOk';
 import { usePrompt } from '../../../hooks/usePrompt';
-import usePersistentContext from '../../../hooks/usePersistentContext';
 import { useLogContext } from '../../../contexts/LogContext';
 import {
   LogEvent,
   StreakTimezonePromptAction,
   TargetId,
 } from '../../../lib/log';
+import { useSettingsContext } from '../../../contexts/SettingsContext';
 
 const getStreak = ({
   value,
@@ -106,6 +103,7 @@ export function ReadingStreakPopup({
   fullWidth,
 }: ReadingStreakPopupProps): ReactElement {
   const router = useRouter();
+  const { flags, updateFlag } = useSettingsContext();
   const isMobile = useViewSize(ViewSize.MobileL);
   const { user } = useAuthContext();
   const { completeAction } = useActions();
@@ -117,8 +115,6 @@ export function ReadingStreakPopup({
   const [showStreakConfig, toggleShowStreakConfig] = useToggle(false);
   const isTimezoneOk = useStreakTimezoneOk();
   const { showPrompt } = usePrompt();
-  const [timezoneMismatchIgnore, setTimezoneMismatchIgnore] =
-    usePersistentContext(timezoneMismatchIgnoreKey, '');
   const { logEvent } = useLogContext();
 
   const streaks = useMemo(() => {
@@ -210,7 +206,7 @@ export function ReadingStreakPopup({
                         device_timezone: deviceTimezone,
                         user_timezone: user?.timezone,
                         timezone_ok: isTimezoneOk,
-                        timezone_ignore: timezoneMismatchIgnore,
+                        timezone_ignore: flags?.timezoneMismatchIgnore,
                       };
 
                       logEvent({
@@ -253,7 +249,7 @@ export function ReadingStreakPopup({
                       });
 
                       if (!promptResult) {
-                        setTimezoneMismatchIgnore(deviceTimezone);
+                        updateFlag('timezoneMismatchIgnore', deviceTimezone);
 
                         return;
                       }

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -55,7 +55,10 @@ export interface SettingsContextData extends Omit<RemoteSettings, 'theme'> {
   toggleAutoDismissNotifications: () => Promise<void>;
   loadedSettings: boolean;
   updateCustomLinks: (links: string[]) => Promise<unknown>;
-  updateFlag: (flag: keyof SettingsFlags, value: boolean) => Promise<unknown>;
+  updateFlag: (
+    flag: keyof SettingsFlags,
+    value: string | boolean,
+  ) => Promise<unknown>;
   syncSettings: (bootUserId?: string) => Promise<unknown>;
   onToggleHeaderPlacement(): Promise<unknown>;
   setOnboardingChecklistView: (value: ChecklistViewState) => Promise<unknown>;
@@ -267,7 +270,7 @@ export const SettingsContextProvider = ({
           ...settings,
           onboardingChecklistView: value,
         }),
-      updateFlag: (flag: keyof SettingsFlags, value: boolean) =>
+      updateFlag: (flag: keyof SettingsFlags, value: string | boolean) =>
         setSettings({
           ...settings,
           flags: {

--- a/packages/shared/src/graphql/settings.ts
+++ b/packages/shared/src/graphql/settings.ts
@@ -16,6 +16,7 @@ export type SettingsFlags = {
   sidebarResourcesExpanded: boolean;
   sidebarBookmarksExpanded: boolean;
   clickbaitShieldEnabled: boolean;
+  timezoneMismatchIgnore?: string;
 };
 
 export enum SidebarSettingsFlags {


### PR DESCRIPTION
## Changes

- moved to API so extension also has it when once set

https://github.com/dailydotdev/daily-api/pull/2600

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://as-914-reading-streak-setting-ap.preview.app.daily.dev