### PR TITLE
feat: Remove default add btn in advanced settings, add block btn on u…

### DIFF
--- a/packages/shared/src/components/contentPreference/BlockButton.tsx
+++ b/packages/shared/src/components/contentPreference/BlockButton.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { ContentPreferenceType } from '../../graphql/contentPreference';
+import { ContentPreferenceStatus } from '../../graphql/contentPreference';
+import { Button } from '../buttons/Button';
+import { ButtonVariant, ButtonSize } from '../buttons/common';
+import { useContentPreference } from '../../hooks/contentPreference/useContentPreference';
+
+type BlockButtonProps = {
+  feedId: string;
+  entityId: string;
+  entityName: string;
+  status?: ContentPreferenceStatus;
+  entityType: ContentPreferenceType;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+};
+
+const BlockButton = ({
+  variant = ButtonVariant.Secondary,
+  size = ButtonSize.Small,
+  feedId,
+  entityId,
+  entityName,
+  entityType,
+  status,
+}: BlockButtonProps): ReactElement => {
+  const { block, unblock } = useContentPreference();
+
+  return (
+    <Button
+      onClick={(e) => {
+        e.preventDefault();
+        if (status === ContentPreferenceStatus.Blocked) {
+          unblock({
+            id: entityId,
+            entity: entityType,
+            entityName,
+            feedId,
+          });
+        } else {
+          block({
+            id: entityId,
+            entity: entityType,
+            entityName,
+            feedId,
+          });
+        }
+      }}
+      variant={variant}
+      size={size}
+    >
+      {status === ContentPreferenceStatus.Blocked ? 'Unblock' : 'Block'}
+    </Button>
+  );
+};
+
+export default BlockButton;

--- a/packages/shared/src/components/feeds/FeedSettings/components/BlockedSourceList.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/components/BlockedSourceList.tsx
@@ -58,6 +58,8 @@ export const BlockedSourceList = ({
         canFetchMore: checkFetchMore(queryResult),
         fetchNextPage,
       }}
+      showBlock
+      showFollow={false}
     />
   );
 };

--- a/packages/shared/src/components/feeds/FeedSettings/components/BlockedTagList.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/components/BlockedTagList.tsx
@@ -51,6 +51,8 @@ export const BlockedTagList = ({
         canFetchMore: checkFetchMore(queryResult),
         fetchNextPage,
       }}
+      showBlock
+      showFollow={false}
     />
   );
 };

--- a/packages/shared/src/components/feeds/FeedSettings/components/BlockedUserList.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/components/BlockedUserList.tsx
@@ -1,18 +1,14 @@
 import type { ReactElement } from 'react';
 import React, { useMemo } from 'react';
 import { useFeedSettingsEditContext } from '../FeedSettingsEditContext';
-import {
-  ContentPreferenceStatus,
-  ContentPreferenceType,
-} from '../../../../graphql/contentPreference';
+import { ContentPreferenceType } from '../../../../graphql/contentPreference';
 import UserList from '../../../profile/UserList';
 import { checkFetchMore } from '../../../containers/InfiniteScrolling';
 import { Origin } from '../../../../lib/log';
 import { CopyType } from '../../../sources/SourceActions/SourceActionsFollow';
 import { useBlockedQuery } from '../../../../hooks/contentPreference/useBlockedQuery';
 import { anchorDefaultRel } from '../../../../lib/strings';
-import { Button, ButtonSize, ButtonVariant } from '../../../buttons/Button';
-import { useContentPreference } from '../../../../hooks/contentPreference/useContentPreference';
+import BlockButton from '../../../contentPreference/BlockButton';
 
 type BlockedUserListProps = {
   searchQuery?: string;
@@ -21,7 +17,6 @@ type BlockedUserListProps = {
 export const BlockedUserList = ({
   searchQuery,
 }: BlockedUserListProps): ReactElement => {
-  const { block, unblock } = useContentPreference();
   const { feed } = useFeedSettingsEditContext();
 
   const queryResult = useBlockedQuery({
@@ -59,34 +54,13 @@ export const BlockedUserList = ({
         fetchNextPage,
       }}
       additionalContent={(user) => (
-        <Button
-          onClick={(e) => {
-            e.preventDefault();
-            if (
-              user.contentPreference.status === ContentPreferenceStatus.Blocked
-            ) {
-              unblock({
-                id: user.id,
-                entity: ContentPreferenceType.User,
-                entityName: user.name,
-                feedId: feed.id,
-              });
-            } else {
-              block({
-                id: user.id,
-                entity: ContentPreferenceType.User,
-                entityName: user.name,
-                feedId: feed.id,
-              });
-            }
-          }}
-          variant={ButtonVariant.Secondary}
-          size={ButtonSize.Small}
-        >
-          {user.contentPreference.status === ContentPreferenceStatus.Blocked
-            ? 'Unblock'
-            : 'Block'}
-        </Button>
+        <BlockButton
+          feedId={feed.id}
+          entityId={user.id}
+          entityName={user.name}
+          entityType={ContentPreferenceType.User}
+          status={user.contentPreference.status}
+        />
       )}
       userInfoProps={{
         origin: Origin.BlockedFilter,

--- a/packages/shared/src/components/feeds/FeedSettings/components/BlockedUserList.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/components/BlockedUserList.tsx
@@ -1,13 +1,18 @@
 import type { ReactElement } from 'react';
 import React, { useMemo } from 'react';
 import { useFeedSettingsEditContext } from '../FeedSettingsEditContext';
-import { ContentPreferenceType } from '../../../../graphql/contentPreference';
+import {
+  ContentPreferenceStatus,
+  ContentPreferenceType,
+} from '../../../../graphql/contentPreference';
 import UserList from '../../../profile/UserList';
 import { checkFetchMore } from '../../../containers/InfiniteScrolling';
 import { Origin } from '../../../../lib/log';
 import { CopyType } from '../../../sources/SourceActions/SourceActionsFollow';
 import { useBlockedQuery } from '../../../../hooks/contentPreference/useBlockedQuery';
 import { anchorDefaultRel } from '../../../../lib/strings';
+import { Button, ButtonSize, ButtonVariant } from '../../../buttons/Button';
+import { useContentPreference } from '../../../../hooks/contentPreference/useContentPreference';
 
 type BlockedUserListProps = {
   searchQuery?: string;
@@ -16,6 +21,7 @@ type BlockedUserListProps = {
 export const BlockedUserList = ({
   searchQuery,
 }: BlockedUserListProps): ReactElement => {
+  const { block, unblock } = useContentPreference();
   const { feed } = useFeedSettingsEditContext();
 
   const queryResult = useBlockedQuery({
@@ -52,9 +58,39 @@ export const BlockedUserList = ({
         canFetchMore: checkFetchMore(queryResult),
         fetchNextPage,
       }}
+      additionalContent={(user) => (
+        <Button
+          onClick={(e) => {
+            e.preventDefault();
+            if (
+              user.contentPreference.status === ContentPreferenceStatus.Blocked
+            ) {
+              unblock({
+                id: user.id,
+                entity: ContentPreferenceType.User,
+                entityName: user.name,
+                feedId: feed.id,
+              });
+            } else {
+              block({
+                id: user.id,
+                entity: ContentPreferenceType.User,
+                entityName: user.name,
+                feedId: feed.id,
+              });
+            }
+          }}
+          variant={ButtonVariant.Secondary}
+          size={ButtonSize.Small}
+        >
+          {user.contentPreference.status === ContentPreferenceStatus.Blocked
+            ? 'Unblock'
+            : 'Block'}
+        </Button>
+      )}
       userInfoProps={{
         origin: Origin.BlockedFilter,
-        showFollow: true,
+        showFollow: false,
         showSubscribe: false,
         copyType: CopyType.Custom,
         feedId: feed.id,

--- a/packages/shared/src/components/profile/SourceList.tsx
+++ b/packages/shared/src/components/profile/SourceList.tsx
@@ -20,6 +20,7 @@ import { SourceListPlaceholder } from './SourceListPlaceholder';
 import { webappUrl } from '../../lib/constants';
 import Link from '../utilities/Link';
 import { anchorDefaultRel } from '../../lib/strings';
+import BlockButton from '../contentPreference/BlockButton';
 
 export interface SourceListProps {
   scrollingProps: Omit<InfiniteScrollingProps, 'children'>;
@@ -27,6 +28,8 @@ export interface SourceListProps {
   placeholderAmount?: number;
   isLoading?: boolean;
   emptyPlaceholder?: JSX.Element;
+  showFollow?: boolean;
+  showBlock?: boolean;
 }
 
 export const SourceList = ({
@@ -35,6 +38,8 @@ export const SourceList = ({
   sources,
   isLoading,
   emptyPlaceholder,
+  showFollow = true,
+  showBlock,
 }: SourceListProps): ReactElement => {
   const feedSettingsEditContext = useFeedSettingsEditContext();
   const feed = feedSettingsEditContext?.feed;
@@ -107,15 +112,26 @@ export const SourceList = ({
                   {source.description}
                 </Typography>
               </div>
-              <FollowButton
-                feedId={feed?.id}
-                entityId={source.id}
-                type={ContentPreferenceType.Source}
-                status={source.contentPreference.status}
-                entityName={`@${source.handle}`}
-                showSubscribe={false}
-                copyType={CopyType.Custom}
-              />
+              {showBlock && (
+                <BlockButton
+                  feedId={feed?.id}
+                  entityId={source.id}
+                  entityName={`@${source.handle}`}
+                  entityType={ContentPreferenceType.Source}
+                  status={source.contentPreference.status}
+                />
+              )}
+              {showFollow && (
+                <FollowButton
+                  feedId={feed?.id}
+                  entityId={source.id}
+                  type={ContentPreferenceType.Source}
+                  status={source.contentPreference.status}
+                  entityName={`@${source.handle}`}
+                  showSubscribe={false}
+                  copyType={CopyType.Custom}
+                />
+              )}
             </a>
           </Link>
         ))}

--- a/packages/shared/src/components/profile/TagList.tsx
+++ b/packages/shared/src/components/profile/TagList.tsx
@@ -13,6 +13,7 @@ import { FollowButton } from '../contentPreference/FollowButton';
 import { useFeedSettingsEditContext } from '../feeds/FeedSettings/FeedSettingsEditContext';
 import { CopyType } from '../sources/SourceActions/SourceActionsFollow';
 import { TagListPlaceholder } from './TagListPlaceholder';
+import BlockButton from '../contentPreference/BlockButton';
 
 export interface TagListProps {
   scrollingProps: Omit<InfiniteScrollingProps, 'children'>;
@@ -20,6 +21,8 @@ export interface TagListProps {
   placeholderAmount?: number;
   isLoading?: boolean;
   emptyPlaceholder?: JSX.Element;
+  showBlock?: boolean;
+  showFollow?: boolean;
 }
 
 export const TagList = ({
@@ -28,6 +31,8 @@ export const TagList = ({
   tags,
   isLoading,
   emptyPlaceholder,
+  showBlock = false,
+  showFollow = true,
 }: TagListProps): ReactElement => {
   const feedSettingsEditContext = useFeedSettingsEditContext();
   const feed = feedSettingsEditContext?.feed;
@@ -51,15 +56,26 @@ export const TagList = ({
             >
               #{tag.referenceId}
             </Typography>
-            <FollowButton
-              feedId={feed?.id}
-              entityId={tag.referenceId}
-              type={ContentPreferenceType.Keyword}
-              status={tag.status}
-              entityName={`@${tag.referenceId}`}
-              showSubscribe={false}
-              copyType={CopyType.Custom}
-            />
+            {showBlock && (
+              <BlockButton
+                feedId={feed?.id}
+                entityId={tag.referenceId}
+                entityName={`@${tag.referenceId}`}
+                entityType={ContentPreferenceType.Keyword}
+                status={tag.status}
+              />
+            )}
+            {showFollow && (
+              <FollowButton
+                feedId={feed?.id}
+                entityId={tag.referenceId}
+                type={ContentPreferenceType.Keyword}
+                status={tag.status}
+                entityName={`@${tag.referenceId}`}
+                showSubscribe={false}
+                copyType={CopyType.Custom}
+              />
+            )}
           </div>
         ))}
       </InfiniteScrolling>


### PR DESCRIPTION
## Changes

Custom feed design has the unblock button:
![image](https://github.com/user-attachments/assets/d68df4cb-4f5a-4631-8c80-31a261628c13)


But currently, all tabs look like this:
![image](https://github.com/user-attachments/assets/3a09eda8-ea7f-4fb3-b0c6-03073e70c6af)
And they function as a follow button. So I updated it to be as in the design

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://mi-758.preview.app.daily.dev