### PR TITLE
fix: invalidate content preference from tag and source

### DIFF
--- a/packages/shared/src/hooks/useTagAndSource.ts
+++ b/packages/shared/src/hooks/useTagAndSource.ts
@@ -6,12 +6,13 @@ import useMutateFilters from './useMutateFilters';
 import type { Source } from '../graphql/sources';
 import AlertContext from '../contexts/AlertContext';
 import type { BooleanPromise } from '../components/filters/common';
-import { generateQueryKey } from '../lib/query';
+import { generateQueryKey, RequestKey } from '../lib/query';
 import useDebounceFn from './useDebounceFn';
 import { SharedFeedPage } from '../components/utilities';
 import type { Origin } from '../lib/log';
 import { LogEvent } from '../lib/log';
 import type { AuthTriggersType } from '../lib/auth';
+import { ContentPreferenceType } from '../graphql/contentPreference';
 
 export interface TagActionArguments {
   tags: Array<string>;
@@ -82,6 +83,29 @@ export default function useTagAndSource({
     });
   }, 100);
 
+  const invalidateContentPreferences = useCallback(
+    ({
+      entity,
+      subQuery,
+    }: {
+      entity: ContentPreferenceType;
+      subQuery: RequestKey;
+    }) => {
+      queryClient.invalidateQueries({
+        queryKey: generateQueryKey(
+          RequestKey.ContentPreference,
+          user,
+          subQuery,
+          {
+            feedId: feedId || user?.id,
+            entity,
+          },
+        ),
+      });
+    },
+    [queryClient, user, feedId],
+  );
+
   const onFollowTags = useCallback(
     async ({ tags, category, requireLogin }: TagActionArguments) => {
       if (shouldShowLogin(requireLogin)) {
@@ -101,6 +125,11 @@ export default function useTagAndSource({
 
       invalidateQueries();
 
+      invalidateContentPreferences({
+        entity: ContentPreferenceType.Keyword,
+        subQuery: RequestKey.UserFollowing,
+      });
+
       return { successful: true };
     },
     [
@@ -115,6 +144,7 @@ export default function useTagAndSource({
       alerts?.filter,
       invalidateQueries,
       shouldUpdateAlerts,
+      invalidateContentPreferences,
     ],
   );
 
@@ -134,6 +164,11 @@ export default function useTagAndSource({
 
       invalidateQueries();
 
+      invalidateContentPreferences({
+        entity: ContentPreferenceType.Keyword,
+        subQuery: RequestKey.UserFollowing,
+      });
+
       return { successful: true };
     },
     [
@@ -144,6 +179,7 @@ export default function useTagAndSource({
       showLogin,
       unfollowTags,
       invalidateQueries,
+      invalidateContentPreferences,
     ],
   );
 
@@ -164,6 +200,11 @@ export default function useTagAndSource({
 
       invalidateQueries();
 
+      invalidateContentPreferences({
+        entity: ContentPreferenceType.Keyword,
+        subQuery: RequestKey.UserBlocked,
+      });
+
       return { successful: true };
     },
     [
@@ -175,6 +216,7 @@ export default function useTagAndSource({
       blockTag,
       postId,
       invalidateQueries,
+      invalidateContentPreferences,
     ],
   );
 
@@ -194,6 +236,11 @@ export default function useTagAndSource({
 
       invalidateQueries();
 
+      invalidateContentPreferences({
+        entity: ContentPreferenceType.Keyword,
+        subQuery: RequestKey.UserBlocked,
+      });
+
       return { successful: true };
     },
     [
@@ -205,6 +252,7 @@ export default function useTagAndSource({
       unblockTag,
       postId,
       invalidateQueries,
+      invalidateContentPreferences,
     ],
   );
 
@@ -225,6 +273,11 @@ export default function useTagAndSource({
 
       invalidateQueries();
 
+      invalidateContentPreferences({
+        entity: ContentPreferenceType.Source,
+        subQuery: RequestKey.UserBlocked,
+      });
+
       return { successful: true };
     },
     [
@@ -236,6 +289,7 @@ export default function useTagAndSource({
       unblockSource,
       postId,
       invalidateQueries,
+      invalidateContentPreferences,
     ],
   );
 
@@ -256,6 +310,11 @@ export default function useTagAndSource({
 
       invalidateQueries();
 
+      invalidateContentPreferences({
+        entity: ContentPreferenceType.Source,
+        subQuery: RequestKey.UserBlocked,
+      });
+
       return { successful: true };
     },
     [
@@ -267,6 +326,7 @@ export default function useTagAndSource({
       blockSource,
       postId,
       invalidateQueries,
+      invalidateContentPreferences,
     ],
   );
 
@@ -288,6 +348,11 @@ export default function useTagAndSource({
 
       invalidateQueries();
 
+      invalidateContentPreferences({
+        entity: ContentPreferenceType.Source,
+        subQuery: RequestKey.UserFollowing,
+      });
+
       return { successful: true };
     },
     [
@@ -299,6 +364,7 @@ export default function useTagAndSource({
       followSource,
       postId,
       invalidateQueries,
+      invalidateContentPreferences,
     ],
   );
 
@@ -320,6 +386,11 @@ export default function useTagAndSource({
 
       invalidateQueries();
 
+      invalidateContentPreferences({
+        entity: ContentPreferenceType.Source,
+        subQuery: RequestKey.UserFollowing,
+      });
+
       return { successful: true };
     },
     [
@@ -331,6 +402,7 @@ export default function useTagAndSource({
       unfollowSource,
       invalidateQueries,
       showLogin,
+      invalidateContentPreferences,
     ],
   );
 


### PR DESCRIPTION
## Changes

Since new feed settings are using content preference queries we want to invalidate specific queries for source/tag block/follow so visiting feed settings correctly refetches data. 

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->
