### PR TITLE
fix: hydration issue on bookmarks list

### DIFF
--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren, ReactElement, ReactNode } from 'react';
-import React, { useContext, useMemo, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import classNames from 'classnames';
 import {
@@ -63,6 +63,7 @@ export default function BookmarkFeedLayout({
   title = 'Bookmarks',
   isReminderOnly,
 }: BookmarkFeedLayoutProps): ReactElement {
+  const [isHydrated, setIsHydrated] = useState(false);
   const {
     shouldUseListFeedLayout,
     FeedPageLayoutComponent,
@@ -123,6 +124,14 @@ export default function BookmarkFeedLayout({
       options: { refetchOnMount: true },
     };
   }, [searchQuery, feedQueryKey, listId, isReminderOnly, isFolderPage]);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  if (!isHydrated) {
+    return null;
+  }
 
   return (
     <FeedPageLayoutComponent>


### PR DESCRIPTION
## Changes
- The issue is, a Plus user for some reason is having UI rendered wrongly for bookmarks list. One thing is for sure, I notice the margins on the header are not right, and that only happens locally when there is a hydration issue. We are trying to pinpoint the root cause by fixing anything that could be affecting the result. The problem is, no one is able to replicate the issue.
- Previously, we tried using `useViewSizeClient` and it worked perfectly. The only issue is that, it produced a layout shift on the Feed on mobile.
- Due to the urgency of the issue at hand, I've decided to go for this at the moment rather than jumping in the `useFeedLayout` rabbit hole (where we previously applied the `useViewSizeClient`).

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->
