### PR TITLE
fix: unset content-language header on post edit

### DIFF
--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -12,6 +12,7 @@ import usePostById from '@dailydotdev/shared/src/hooks/usePostById';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
 import type { ApiErrorResult } from '@dailydotdev/shared/src/graphql/common';
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
 import { useDiscardPost } from '@dailydotdev/shared/src/hooks/input/useDiscardPost';
 import type { NextSeoProps } from 'next-seo';
 import { NextSeo } from 'next-seo';
@@ -31,6 +32,8 @@ import { getLayout as getMainLayout } from '../../../components/layouts/MainLayo
 import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
 
 function EditPost(): ReactElement {
+  gqlClient.unsetHeader('content-language');
+
   const { completeAction } = useActions();
   const { query, isReady, push } = useRouter();
   const idQuery = query.id as string;


### PR DESCRIPTION
## Changes

Encountered this during testing of real time translation, but it has been an issue since we introduced content-language header. Because we send the `content-language` header when you have a different content language set, we fetch the translated title and fill it into the edit form.

<table>
<tr>
<td>Before
<td>After
<tr>
<td>Content-language set to German (fetched German translation)
<img src=https://github.com/user-attachments/assets/caa6e1ff-ac81-46b0-9a27-686beb2602d5>

Content-language set default (fetched original title)
<img src=https://github.com/user-attachments/assets/a6b26d2a-35cc-4490-a0da-1956f52d92ef>
</td>
<td>Content-language set to German (fetched original title)
<img src=https://github.com/user-attachments/assets/04939417-614d-44f0-93e5-9d3b12596a13>

Content-language set default (fetched original title)
<img src=https://github.com/user-attachments/assets/f59669a3-fbd5-4cd7-80bd-f0d6260245a2>
</td>
<table>



### Preview domain
https://fix-original-title-in-post-edit.preview.app.daily.dev