### PR TITLE
feat: remove redirect when creating custom feed from sidebar

### DIFF
--- a/packages/shared/src/components/feeds/FeedSettings/FeedSettingsCreate.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/FeedSettingsCreate.tsx
@@ -80,6 +80,7 @@ export const FeedSettingsCreate = (): ReactElement => {
         });
 
         if (isNewFeedPage) {
+          // go back to entity page that was followed
           router.back();
         }
 

--- a/packages/shared/src/components/feeds/FeedSettings/FeedSettingsCreate.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/FeedSettingsCreate.tsx
@@ -34,8 +34,10 @@ import { ModalClose } from '../../modals/common/ModalClose';
 import { ActionType } from '../../../graphql/actions';
 import { useContentPreference } from '../../../hooks/contentPreference/useContentPreference';
 import type { ContentPreferenceType } from '../../../graphql/contentPreference';
+import { useLazyModal } from '../../../hooks/useLazyModal';
 
 export const FeedSettingsCreate = (): ReactElement => {
+  const { closeModal } = useLazyModal();
   const [newFeedId] = useState(() => Date.now().toString());
   const { completeAction } = useActions();
   const { user } = useAuthContext();
@@ -75,9 +77,6 @@ export const FeedSettingsCreate = (): ReactElement => {
           entityName: entityId,
           feedId: newFeed.id,
         });
-
-        // go back to entity page that was followed
-        router.back();
 
         return;
       }
@@ -135,7 +134,7 @@ export const FeedSettingsCreate = (): ReactElement => {
   }, [logEvent]);
 
   const onRequestClose = () => {
-    router.replace(webappUrl);
+    closeModal();
   };
 
   return (

--- a/packages/shared/src/components/feeds/FeedSettings/FeedSettingsCreate.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/FeedSettingsCreate.tsx
@@ -42,6 +42,7 @@ export const FeedSettingsCreate = (): ReactElement => {
   const { completeAction } = useActions();
   const { user } = useAuthContext();
   const router = useRouter();
+  const isNewFeedPage = router.pathname.includes('/feeds/new');
   const queryClient = useQueryClient();
   const { displayToast } = useToastNotification();
   const { logEvent } = useLogContext();
@@ -77,6 +78,10 @@ export const FeedSettingsCreate = (): ReactElement => {
           entityName: entityId,
           feedId: newFeed.id,
         });
+
+        if (isNewFeedPage) {
+          router.back();
+        }
 
         return;
       }
@@ -134,7 +139,11 @@ export const FeedSettingsCreate = (): ReactElement => {
   }, [logEvent]);
 
   const onRequestClose = () => {
-    closeModal();
+    if (isNewFeedPage) {
+      return router.replace(webappUrl);
+    }
+
+    return closeModal();
   };
 
   return (

--- a/packages/shared/src/components/modals/common.tsx
+++ b/packages/shared/src/components/modals/common.tsx
@@ -228,6 +228,12 @@ const ReportUserModal = dynamic(
     ),
 );
 
+const CreateCustomFeedModal = dynamic(() =>
+  import(
+    /* webpackChunkName: "createCustomFeedModal" */ '../feeds/FeedSettings/FeedSettingsCreate'
+  ).then((mod) => mod.FeedSettingsCreate),
+);
+
 export const modals = {
   [LazyModal.SquadMember]: SquadMemberModal,
   [LazyModal.UpvotedPopup]: UpvotedPopupModal,
@@ -266,6 +272,7 @@ export const modals = {
   [LazyModal.AddToCustomFeed]: AddToCustomFeedModal,
   [LazyModal.CookieConsent]: CookieConsentModal,
   [LazyModal.ReportUser]: ReportUserModal,
+  [LazyModal.CreateCustomFeed]: CreateCustomFeedModal,
 };
 
 type GetComponentProps<T> = T extends

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -62,6 +62,7 @@ export enum LazyModal {
   AddToCustomFeed = 'addToCustomFeed',
   CookieConsent = 'cookieConsent',
   ReportUser = 'reportUser',
+  CreateCustomFeed = 'createCustomFeed',
 }
 
 export type ModalTabItem = {

--- a/packages/shared/src/components/sidebar/sections/CustomFeedSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/CustomFeedSection.tsx
@@ -9,12 +9,15 @@ import { SidebarSettingsFlags } from '../../../graphql/settings';
 import type { SidebarSectionProps } from './common';
 import useCustomDefaultFeed from '../../../hooks/feed/useCustomDefaultFeed';
 import { isExtension } from '../../../lib/func';
+import { useLazyModal } from '../../../hooks/useLazyModal';
+import { LazyModal } from '../../modals/common/types';
 
 export const CustomFeedSection = ({
   isItemsButton,
   onNavTabClick,
   ...defaultRenderSectionProps
 }: SidebarSectionProps): ReactElement => {
+  const { openModal } = useLazyModal();
   const { feeds } = useFeeds();
   const { defaultFeedId } = useCustomDefaultFeed();
 
@@ -64,7 +67,10 @@ export const CustomFeedSection = ({
           </div>
         ),
         title: 'Custom feed',
-        path: `${webappUrl}feeds/new`,
+        action: () =>
+          openModal({
+            type: LazyModal.CreateCustomFeed,
+          }),
         requiresLogin: true,
         isForcedClickable: true,
       },
@@ -74,6 +80,7 @@ export const CustomFeedSection = ({
     feeds?.edges,
     defaultFeedId,
     onNavTabClick,
+    openModal,
   ]);
 
   return (


### PR DESCRIPTION
## Changes

Currently when clicking the create custom feed modal it redirects you to /feeds/new. This has no real effect, but can seem a bit jarring to the user. This change opens the modal on the page where it was clicked.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://mi-773.preview.app.daily.dev