### PR TITLE
feat: add deleted render for shared posts

### DIFF
--- a/packages/shared/src/components/cards/common/PostCardHeader.tsx
+++ b/packages/shared/src/components/cards/common/PostCardHeader.tsx
@@ -23,6 +23,7 @@ import {
 import { ProfileTooltip } from '../../profile/ProfileTooltip';
 import { ProfileImageLink } from '../../profile/ProfileImageLink';
 import { ProfileImageSize } from '../../ProfilePicture';
+import { DeletedPostId } from '../../../lib/constants';
 
 interface CardHeaderProps {
   post: Post;
@@ -51,7 +52,7 @@ export const PostCardHeader = ({
   showFeedback,
 }: CardHeaderProps): ReactElement => {
   const isFeedPreview = useFeedPreviewMode();
-  const isSharedPostDeleted = post.sharedPost?.id === '404';
+  const isSharedPostDeleted = post.sharedPost?.id === DeletedPostId;
 
   const { highlightBookmarkedPost } = useBookmarkProvider({
     bookmarked: post.bookmarked && !showFeedback,

--- a/packages/shared/src/components/cards/common/PostCardHeader.tsx
+++ b/packages/shared/src/components/cards/common/PostCardHeader.tsx
@@ -51,6 +51,7 @@ export const PostCardHeader = ({
   showFeedback,
 }: CardHeaderProps): ReactElement => {
   const isFeedPreview = useFeedPreviewMode();
+  const isSharedPostDeleted = post.sharedPost?.id === '404';
 
   const { highlightBookmarkedPost } = useBookmarkProvider({
     bookmarked: post.bookmarked && !showFeedback,
@@ -96,14 +97,16 @@ export const PostCardHeader = ({
         >
           {!isFeedPreview && (
             <>
-              <ReadArticleButton
-                content={getReadPostButtonText(post)}
-                className="mr-2"
-                variant={ButtonVariant.Primary}
-                href={articleLink}
-                onClick={onReadArticleClick}
-                openNewTab={openNewTab}
-              />
+              {!isSharedPostDeleted && (
+                <ReadArticleButton
+                  content={getReadPostButtonText(post)}
+                  className="mr-2"
+                  variant={ButtonVariant.Primary}
+                  href={articleLink}
+                  onClick={onReadArticleClick}
+                  openNewTab={openNewTab}
+                />
+              )}
               <OptionsButton onClick={onMenuClick} tooltipPlacement="top" />
             </>
           )}

--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -25,6 +25,7 @@ import {
   TypographyColor,
   TypographyType,
 } from '../typography/Typography';
+import { DeletedPostId } from '../../lib/constants';
 
 export interface CommonSharePostContentProps {
   sharedPost: SharedPost;
@@ -65,7 +66,7 @@ export function CommonSharePostContent({
   const shouldUseInternalLink =
     isSharedPostSquadPost({ sharedPost }) || isInternalReadType(sharedPost);
 
-  const isDeleted = sharedPost.id === '404';
+  const isDeleted = sharedPost.id === DeletedPostId;
 
   if (isDeleted) {
     return (

--- a/packages/shared/src/components/post/SharePostContent.tsx
+++ b/packages/shared/src/components/post/SharePostContent.tsx
@@ -19,6 +19,12 @@ import { TruncateText } from '../utilities';
 import { LazyImage } from '../LazyImage';
 import { cloudinaryPostImageCoverPlaceholder } from '../../lib/image';
 import { SharePostTitle } from './share/SharePostTitle';
+import { BlockIcon } from '../icons';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../typography/Typography';
 
 export interface CommonSharePostContentProps {
   sharedPost: SharedPost;
@@ -58,6 +64,26 @@ export function CommonSharePostContent({
 
   const shouldUseInternalLink =
     isSharedPostSquadPost({ sharedPost }) || isInternalReadType(sharedPost);
+
+  const isDeleted = sharedPost.id === '404';
+
+  if (isDeleted) {
+    return (
+      <SharedLinkContainer summary={sharedPost.summary} className="mb-5 mt-8">
+        <div className="flex flex-row items-center gap-1 px-5 py-4">
+          <BlockIcon />
+          <Typography
+            className="flex-1"
+            type={TypographyType.Subhead}
+            color={TypographyColor.Secondary}
+          >
+            This post is no longer available. It might have been removed or the
+            link has expired.
+          </Typography>
+        </div>
+      </SharedLinkContainer>
+    );
+  }
 
   return (
     <SharedLinkContainer summary={sharedPost.summary} className="mb-5 mt-8">

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -139,3 +139,5 @@ export const invalidPlusRegions = [
   'ZW',
   'RU',
 ];
+
+export const DeletedPostId = '404';

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -12,6 +12,7 @@ import usePostById from '@dailydotdev/shared/src/hooks/usePostById';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
 import type { ApiErrorResult } from '@dailydotdev/shared/src/graphql/common';
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
 import { useDiscardPost } from '@dailydotdev/shared/src/hooks/input/useDiscardPost';
 import type { NextSeoProps } from 'next-seo';
 import { NextSeo } from 'next-seo';
@@ -31,6 +32,8 @@ import { getLayout as getMainLayout } from '../../../components/layouts/MainLayo
 import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
 
 function EditPost(): ReactElement {
+  gqlClient.unsetHeader('content-language');
+
   const { completeAction } = useActions();
   const { query, isReady, push } = useRouter();
   const idQuery = query.id as string;


### PR DESCRIPTION
## Changes

Adds a deleted render when shared posts get deleted.

On the card we no longer show the `Read post` button as it can't link anywhere.
On the modal/page we render as such:

![Screenshot 2025-01-29 at 10 24 04](https://github.com/user-attachments/assets/c92b2643-aa73-4470-a7d6-2d420984c464)

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://feat-deleted-render.preview.app.daily.dev