### PR TITLE
refactor: disable tracking in ios native

### DIFF
--- a/packages/shared/src/contexts/AuthContext.tsx
+++ b/packages/shared/src/contexts/AuthContext.tsx
@@ -13,7 +13,7 @@ import { isCompanionActivated } from '../lib/element';
 import type { AuthTriggersType } from '../lib/auth';
 import { AuthTriggers } from '../lib/auth';
 import type { Squad } from '../graphql/sources';
-import { checkIsExtension, isNullOrUndefined } from '../lib/func';
+import { checkIsExtension, isIOSNative, isNullOrUndefined } from '../lib/func';
 import { AFTER_AUTH_PARAM } from '../components/auth/common';
 import { Continent, outsideGdpr } from '../lib/geo';
 
@@ -199,7 +199,8 @@ export const AuthContextProvider = ({
         isAndroidApp,
         isGdprCovered:
           geo?.continent === Continent.Europe ||
-          !outsideGdpr.includes(geo?.region),
+          !outsideGdpr.includes(geo?.region) ||
+          isIOSNative(),
       }}
     >
       {children}

--- a/packages/shared/src/hooks/useCookieBanner.ts
+++ b/packages/shared/src/hooks/useCookieBanner.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuthContext } from '../contexts/AuthContext';
 import type { AcceptCookiesCallback } from './useCookieConsent';
 import { useConsentCookie } from './useCookieConsent';
+import { isIOSNative } from '../lib/func';
 
 export const cookieAcknowledgedKey = 'cookie_acknowledged';
 
@@ -56,7 +57,7 @@ export function useCookieBanner(): UseCookieBanner {
   );
 
   useEffect(() => {
-    if (!isAuthReady || isOpen || isInitializedRef.current) {
+    if (!isAuthReady || isOpen || isInitializedRef.current || isIOSNative()) {
       return;
     }
 


### PR DESCRIPTION
Don't show cookie banner and disable third-party tracking in ios (for now)


### Preview domain
https://ios-tracking.preview.app.daily.dev