### PR TITLE
feat: custom feed navigation adjustments

### DIFF
--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -28,6 +28,7 @@ import { useAuthContext } from '../../contexts/AuthContext';
 import { OtherFeedPage } from '../../lib/query';
 import { ChecklistViewState } from '../../lib/checklist';
 import useCustomDefaultFeed from '../../hooks/feed/useCustomDefaultFeed';
+import { useSortedFeeds } from '../../hooks/feed/useSortedFeeds';
 
 const OnboardingChecklistBar = dynamic(
   () =>
@@ -77,8 +78,10 @@ function FeedNav(): ReactElement {
   const isHiddenOnboardingChecklistView =
     onboardingChecklistView === ChecklistViewState.Hidden;
 
+  const sortedFeeds = useSortedFeeds({ edges: feeds?.edges });
+
   const urlToTab: Record<string, FeedNavTab> = useMemo(() => {
-    const customFeeds = feeds?.edges?.reduce((acc, { node: feed }) => {
+    const customFeeds = sortedFeeds.reduce((acc, { node: feed }) => {
       const isEditingFeed =
         router.query.slugOrId === feed.id && router.pathname.endsWith('/edit');
       let feedPath = `${webappUrl}feeds/${feed.id}`;
@@ -113,7 +116,7 @@ function FeedNav(): ReactElement {
       [`${webappUrl}history`]: FeedNavTab.History,
     };
   }, [
-    feeds?.edges,
+    sortedFeeds,
     router.query.slugOrId,
     router.pathname,
     defaultFeedId,

--- a/packages/shared/src/components/sidebar/SidebarDesktop.tsx
+++ b/packages/shared/src/components/sidebar/SidebarDesktop.tsx
@@ -79,16 +79,16 @@ export const SidebarDesktop = ({
             onNavTabClick={onNavTabClick}
             isItemsButton={isNavButtons}
           />
-          <NetworkSection
-            {...defaultRenderSectionProps}
-            title="Network"
-            isItemsButton={isNavButtons}
-          />
           <CustomFeedSection
             {...defaultRenderSectionProps}
             onNavTabClick={onNavTabClick}
             title="Custom feeds"
             isItemsButton={false}
+          />
+          <NetworkSection
+            {...defaultRenderSectionProps}
+            title="Network"
+            isItemsButton={isNavButtons}
           />
           <BookmarkSection
             {...defaultRenderSectionProps}

--- a/packages/shared/src/components/sidebar/sections/CustomFeedSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/CustomFeedSection.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import React, { useMemo } from 'react';
 import type { SidebarMenuItem } from '../common';
-import { HashtagIcon, PlusIcon } from '../../icons';
+import { HashtagIcon, PlusIcon, StarIcon } from '../../icons';
 import { Section } from '../Section';
 import { webappUrl } from '../../../lib/constants';
 import { useFeeds } from '../../../hooks';
@@ -9,6 +9,7 @@ import { SidebarSettingsFlags } from '../../../graphql/settings';
 import type { SidebarSectionProps } from './common';
 import useCustomDefaultFeed from '../../../hooks/feed/useCustomDefaultFeed';
 import { isExtension } from '../../../lib/func';
+import { useSortedFeeds } from '../../../hooks/feed/useSortedFeeds';
 
 export const CustomFeedSection = ({
   isItemsButton,
@@ -17,10 +18,11 @@ export const CustomFeedSection = ({
 }: SidebarSectionProps): ReactElement => {
   const { feeds } = useFeeds();
   const { defaultFeedId } = useCustomDefaultFeed();
+  const sortedFeeds = useSortedFeeds({ edges: feeds?.edges });
 
   const menuItems: SidebarMenuItem[] = useMemo(() => {
     const customFeeds =
-      feeds?.edges?.map((feed) => {
+      sortedFeeds.map((feed) => {
         const isDefaultFeed = defaultFeedId === feed.node.id;
 
         if (isDefaultFeed) {
@@ -37,6 +39,12 @@ export const CustomFeedSection = ({
             action: isExtension ? () => onNavTabClick?.('default') : undefined,
             icon: feed.node.flags.icon || (
               <HashtagIcon secondary={isCustomFeedPageActive} />
+            ),
+            rightIcon: () => (
+              <StarIcon
+                secondary
+                className="text-surface-disabled opacity-[0.8]"
+              />
             ),
             active: isCustomFeedPageActive,
           };
@@ -71,7 +79,7 @@ export const CustomFeedSection = ({
     ].filter(Boolean);
   }, [
     defaultRenderSectionProps.activePage,
-    feeds?.edges,
+    sortedFeeds,
     defaultFeedId,
     onNavTabClick,
   ]);

--- a/packages/shared/src/hooks/feed/useSortedFeeds.ts
+++ b/packages/shared/src/hooks/feed/useSortedFeeds.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import type { Edge } from '../../graphql/common';
+import type { Feed } from '../../graphql/feed';
+import useCustomDefaultFeed from './useCustomDefaultFeed';
+
+export type UseSortedFeedsProps = {
+  edges?: Edge<Feed>[];
+};
+
+export type UseSortedFeeds = Edge<Feed>[];
+
+export const useSortedFeeds = ({
+  edges,
+}: UseSortedFeedsProps): UseSortedFeeds => {
+  const { defaultFeedId } = useCustomDefaultFeed();
+
+  return useMemo(() => {
+    if (!edges) {
+      return [];
+    }
+
+    let sortedFeeds = [...edges];
+    const defaultFeed = sortedFeeds.findIndex(
+      (feed) => feed.node.id === defaultFeedId,
+    );
+
+    if (defaultFeed === -1) {
+      return sortedFeeds;
+    }
+
+    sortedFeeds = [...sortedFeeds.splice(defaultFeed, 1), ...sortedFeeds];
+
+    return sortedFeeds;
+  }, [edges, defaultFeedId]);
+};


### PR DESCRIPTION
## Changes

- custom feeds above network in sidebar
- always show default feed in the first place
  - on mobile tabs as well
- show star in sidebar for default feed to differentiate
  - no need for mobile

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->
