### PR TITLE
chore: cleanup `placeholder` from GQL

### DIFF
--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -105,7 +105,6 @@ export interface Post {
   author?: Author;
   scout?: Scout;
   views?: number;
-  placeholder?: string;
   read?: boolean;
   bookmarked?: boolean;
   trending?: number;
@@ -261,7 +260,6 @@ export const POST_BY_ID_STATIC_FIELDS_QUERY = gql`
       title
       permalink
       image
-      placeholder
       createdAt
       readTime
       tags


### PR DESCRIPTION
## Changes

Post `placeholder` has been deprecated for at least 3 years, and I don't see anywhere where it is used.
https://github.com/dailydotdev/daily-api/blame/ab1a21106e1cf6ab665f5e5a0348355f1eac17bf/src/schema/posts.ts#L478-L481


### Preview domain
https://cleanup-deprecated-gql.preview.app.daily.dev