### PR TITLE
fix: gifting while user is a Plus member already

### DIFF
--- a/packages/shared/src/components/plus/PlusCheckoutContainer.tsx
+++ b/packages/shared/src/components/plus/PlusCheckoutContainer.tsx
@@ -6,6 +6,7 @@ import { usePaymentContext } from '../../contexts/PaymentContext';
 import { usePlusSubscription } from '../../hooks';
 import { PlusUnavailable } from './PlusUnavailable';
 import { PlusPlus } from './PlusPlus';
+import { useGiftUserContext } from './GiftUserContext';
 
 export type PlusCheckoutContainerProps = {
   checkoutRef?: React.LegacyRef<HTMLDivElement>;
@@ -19,6 +20,7 @@ export const PlusCheckoutContainer = ({
   checkoutRef,
   className,
 }: PlusCheckoutContainerProps): ReactElement => {
+  const { giftToUser } = useGiftUserContext();
   const { isPlusAvailable } = usePaymentContext();
   const { isPlus } = usePlusSubscription();
 
@@ -27,7 +29,7 @@ export const PlusCheckoutContainer = ({
       return PlusUnavailable;
     }
 
-    if (isPlus) {
+    if (isPlus && !giftToUser) {
       return PlusPlus;
     }
 

--- a/packages/shared/src/components/plus/PlusCheckoutContainer.tsx
+++ b/packages/shared/src/components/plus/PlusCheckoutContainer.tsx
@@ -25,11 +25,15 @@ export const PlusCheckoutContainer = ({
   const { isPlus } = usePlusSubscription();
 
   const getContainerElement = () => {
+    if (giftToUser) {
+      return null;
+    }
+
     if (!isPlusAvailable) {
       return PlusUnavailable;
     }
 
-    if (isPlus && !giftToUser) {
+    if (isPlus) {
       return PlusPlus;
     }
 

--- a/packages/shared/src/components/plus/PlusCheckoutContainer.tsx
+++ b/packages/shared/src/components/plus/PlusCheckoutContainer.tsx
@@ -25,12 +25,12 @@ export const PlusCheckoutContainer = ({
   const { isPlus } = usePlusSubscription();
 
   const getContainerElement = () => {
-    if (giftToUser) {
-      return null;
-    }
-
     if (!isPlusAvailable) {
       return PlusUnavailable;
+    }
+
+    if (giftToUser) {
+      return null;
     }
 
     if (isPlus) {

--- a/packages/shared/src/components/plus/PlusDesktop.tsx
+++ b/packages/shared/src/components/plus/PlusDesktop.tsx
@@ -49,10 +49,6 @@ export const PlusDesktop = (): ReactElement => {
     if (option && !selectedOption) {
       setSelectedOption(option);
       openCheckout({ priceId: option });
-    } else if (giftToUser && giftOneYear) {
-      const { value } = giftOneYear;
-      setSelectedOption(value);
-      openCheckout({ priceId: value });
     }
   }, [
     giftOneYear,

--- a/packages/shared/src/components/plus/PlusDesktop.tsx
+++ b/packages/shared/src/components/plus/PlusDesktop.tsx
@@ -5,9 +5,12 @@ import { usePaymentContext } from '../../contexts/PaymentContext';
 
 import { PlusInfo } from './PlusInfo';
 import { PlusCheckoutContainer } from './PlusCheckoutContainer';
+import { useGiftUserContext } from './GiftUserContext';
 
 export const PlusDesktop = (): ReactElement => {
-  const { openCheckout, paddle, productOptions } = usePaymentContext();
+  const { openCheckout, paddle, productOptions, giftOneYear } =
+    usePaymentContext();
+  const { giftToUser } = useGiftUserContext();
   const {
     query: { selectedPlan },
   } = useRouter();
@@ -28,12 +31,32 @@ export const PlusDesktop = (): ReactElement => {
       return;
     }
 
+    if (giftToUser) {
+      if (!giftOneYear) {
+        return;
+      }
+
+      if (!selectedOption) {
+        const { value } = giftOneYear;
+        setSelectedOption(value);
+        openCheckout({ priceId: value });
+      }
+
+      return;
+    }
+
     const option = initialPaymentOption || productOptions?.[0]?.value;
     if (option && !selectedOption) {
       setSelectedOption(option);
       openCheckout({ priceId: option });
+    } else if (giftToUser && giftOneYear) {
+      const { value } = giftOneYear;
+      setSelectedOption(value);
+      openCheckout({ priceId: value });
     }
   }, [
+    giftOneYear,
+    giftToUser,
     initialPaymentOption,
     openCheckout,
     paddle,

--- a/packages/shared/src/components/plus/PlusDesktop.tsx
+++ b/packages/shared/src/components/plus/PlusDesktop.tsx
@@ -32,15 +32,13 @@ export const PlusDesktop = (): ReactElement => {
     }
 
     if (giftToUser) {
-      if (!giftOneYear) {
+      if (!giftOneYear || selectedOption) {
         return;
       }
 
-      if (!selectedOption) {
-        const { value } = giftOneYear;
-        setSelectedOption(value);
-        openCheckout({ priceId: value });
-      }
+      const { value } = giftOneYear;
+      setSelectedOption(value);
+      openCheckout({ priceId: value });
 
       return;
     }

--- a/packages/shared/src/contexts/PaymentContext.tsx
+++ b/packages/shared/src/contexts/PaymentContext.tsx
@@ -124,38 +124,6 @@ export const PaymentContextProvider = ({
     });
   }, [router]);
 
-  const openCheckout = useCallback(
-    ({ priceId }: { priceId: string }) => {
-      if (isPlus) {
-        return;
-      }
-
-      if (!isPlusAvailable) {
-        return;
-      }
-
-      paddle?.Checkout.open({
-        items: [{ priceId, quantity: 1 }],
-        customer: {
-          email: user?.email,
-        },
-        customData: {
-          user_id: user?.id,
-        },
-        settings: {
-          displayMode: 'inline',
-          frameTarget: 'checkout-container',
-          frameInitialHeight: 500,
-          frameStyle:
-            'width: 100%; background-color: transparent; border: none;',
-          theme: 'dark',
-          showAddDiscounts: false,
-        },
-      });
-    },
-    [paddle, user, isPlusAvailable, isPlus],
-  );
-
   const getPrices = useCallback(async () => {
     return paddle?.PricePreview({
       items: Object.keys(planTypes).map((priceId) => ({
@@ -217,6 +185,38 @@ export const PaymentContextProvider = ({
         ({ appsId }) => appsId === PlusPriceTypeAppsId.GiftOneYear,
       ),
     [productOptions],
+  );
+
+  const openCheckout = useCallback(
+    ({ priceId }: { priceId: string }) => {
+      if (isPlus && priceId !== giftOneYear?.value) {
+        return;
+      }
+
+      if (!isPlusAvailable) {
+        return;
+      }
+
+      paddle?.Checkout.open({
+        items: [{ priceId, quantity: 1 }],
+        customer: {
+          email: user?.email,
+        },
+        customData: {
+          user_id: user?.id,
+        },
+        settings: {
+          displayMode: 'inline',
+          frameTarget: 'checkout-container',
+          frameInitialHeight: 500,
+          frameStyle:
+            'width: 100%; background-color: transparent; border: none;',
+          theme: 'dark',
+          showAddDiscounts: false,
+        },
+      });
+    },
+    [paddle, user, giftOneYear, isPlusAvailable, isPlus],
   );
 
   const contextData = useMemo<PaymentContextData>(

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -34,7 +34,7 @@ const feature = {
   onboardingChecklist: new Feature('onboarding_checklist', true),
   showCodeSnippets: new Feature('show_code_snippets', false),
   pricingIds: new Feature('pricing_ids', {
-    pri_01jjbwd5j7k0nm45k8e07yfmwr: PlusPriceType.Yearly, // TODO: this value is from test env and needs to be updated
+    pri_01jjvm32ygwb1ja7w52e668fr2: PlusPriceType.Yearly,
     pri_01jbsccbdbcwyhdy8hy3c2etyn: PlusPriceType.Monthly,
     pri_01jbscda57910yvwjtyapnrrzc: PlusPriceType.Yearly,
   }),


### PR DESCRIPTION
## Changes
- Fix to display that checkout is available when user is a Plus member and wants to gift a user.
- Updated the right id for the gifting price id.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://fix-availability.preview.app.daily.dev