### PR TITLE
fix: maintain feed meta in post modal

### DIFF
--- a/packages/shared/src/components/post/withPostById.tsx
+++ b/packages/shared/src/components/post/withPostById.tsx
@@ -30,6 +30,11 @@ export const withPostById = <Props, LayoutProps = unknown>(
       return null;
     }
 
+    // Important to maintain the feed meta if it exists
+    if (!post?.feedMeta && initialPost?.feedMeta) {
+      post.feedMeta = initialPost.feedMeta;
+    }
+
     return <WrappedComponent {...props} post={post} />;
   };
 


### PR DESCRIPTION
We found an issue that `feedMeta` is overridden in the post modal, which causes a mess 🙈 
This should fix it