### PR TITLE
fix: onboarding ready condition and missing deps

### DIFF
--- a/packages/shared/src/hooks/auth/useOnboarding.tsx
+++ b/packages/shared/src/hooks/auth/useOnboarding.tsx
@@ -33,7 +33,7 @@ export const useOnboarding = (): UseOnboarding => {
 
   return {
     shouldShowAuthBanner,
-    isOnboardingReady: isActionsFetched && isAuthReady,
+    isOnboardingReady: isAuthReady && (isActionsFetched || !user),
     hasCompletedEditTags,
     hasCompletedContentTypes,
     completeStep: (action: ActionType) => completeAction(action),

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -449,8 +449,6 @@ export function OnboardPage(): ReactElement {
     activeScreen === OnboardingStep.Intro &&
     !isOnboardingReady;
 
-  console.log('is onboarding ready: ', isOnboardingReady);
-
   if (!isPageReady) {
     return null;
   }

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -150,7 +150,6 @@ const seo: NextSeoProps = {
 };
 
 export function OnboardPage(): ReactElement {
-  const params = new URLSearchParams(window.location.search);
   const { isAvailable: canUserInstallPWA } = useInstallPWA();
   const {
     isOnboardingReady,
@@ -225,31 +224,44 @@ export function OnboardPage(): ReactElement {
   ].includes(activeScreen);
 
   useEffect(() => {
-    if (!isPageReady || isLogged.current || !isOnboardingReady) {
-      return;
-    }
-
-    if (user?.infoConfirmed && !hasCompletedEditTags) {
-      setActiveScreen(OnboardingStep.EditTag);
-      return;
-    }
-
-    if (user?.infoConfirmed && !hasCompletedContentTypes) {
-      setActiveScreen(OnboardingStep.ContentTypes);
-      return;
-    }
-
-    if (user?.infoConfirmed && activeScreen === OnboardingStep.Intro) {
-      const afterAuth = params.get(AFTER_AUTH_PARAM);
-      params.delete(AFTER_AUTH_PARAM);
-      router.replace(getPathnameWithQuery(afterAuth || webappUrl, params));
+    if (
+      !isPageReady ||
+      isLogged.current ||
+      !isOnboardingReady ||
+      !user?.infoConfirmed
+    ) {
       return;
     }
 
     isLogged.current = true;
+
+    if (!hasCompletedEditTags) {
+      setActiveScreen(OnboardingStep.EditTag);
+      return;
+    }
+
+    if (!hasCompletedContentTypes) {
+      setActiveScreen(OnboardingStep.ContentTypes);
+      return;
+    }
+
+    if (activeScreen === OnboardingStep.Intro) {
+      const params = new URLSearchParams(window.location.search);
+      const afterAuth = params.get(AFTER_AUTH_PARAM);
+      params.delete(AFTER_AUTH_PARAM);
+      router.replace(getPathnameWithQuery(afterAuth || webappUrl, params));
+    }
+
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPageReady, user, isOnboardingReady]);
+  }, [
+    isPageReady,
+    user,
+    isOnboardingReady,
+    hasCompletedEditTags,
+    hasCompletedContentTypes,
+    activeScreen,
+  ]);
 
   const onClickNext: OnboardingOnClickNext = (options) => {
     logEvent({
@@ -346,6 +358,7 @@ export function OnboardPage(): ReactElement {
         : LogEvent.OnboardingSkip,
     });
 
+    const params = new URLSearchParams(window.location.search);
     const afterAuth = params.get(AFTER_AUTH_PARAM);
     return router.replace({
       pathname: afterAuth || '/',
@@ -435,6 +448,8 @@ export function OnboardPage(): ReactElement {
     isAuthLoading &&
     activeScreen === OnboardingStep.Intro &&
     !isOnboardingReady;
+
+  console.log('is onboarding ready: ', isOnboardingReady);
 
   if (!isPageReady) {
     return null;


### PR DESCRIPTION
## Changes
- Fixes the `isOnboardingReady` evaluation.
- Fixes the issue introduced by updating the props.
- Updated the deps cycle.
- Tested each login flows.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://revert-revert-condition.preview.app.daily.dev