### PR TITLE
feat: store last prompt

### DIFF
--- a/packages/shared/src/components/post/smartPrompts/PromptButtons.tsx
+++ b/packages/shared/src/components/post/smartPrompts/PromptButtons.tsx
@@ -73,9 +73,21 @@ export const PromptButtons = ({
   const { data, isLoading } = usePromptsQuery();
   const { flags: settingFlags } = useSettingsContext();
   const { prompt: promptFlags } = settingFlags || {};
+  const lastPrompt = settingFlags?.lastPrompt;
   const prompts = useMemo(() => {
-    return data?.filter((prompt) => promptFlags?.[prompt.id] !== false);
-  }, [data, promptFlags]);
+    const filteredPrompts = data?.filter(
+      (prompt) => promptFlags?.[prompt.id] !== false,
+    );
+    if (lastPrompt) {
+      filteredPrompts?.unshift(
+        filteredPrompts?.splice(
+          filteredPrompts.findIndex((item) => item.id === lastPrompt),
+          1,
+        )[0],
+      );
+    }
+    return filteredPrompts;
+  }, [data, lastPrompt, promptFlags]);
 
   const { isPlus } = usePlusSubscription();
   const promptList = usePromptButtons({

--- a/packages/shared/src/components/post/smartPrompts/PromptButtons.tsx
+++ b/packages/shared/src/components/post/smartPrompts/PromptButtons.tsx
@@ -78,13 +78,12 @@ export const PromptButtons = ({
     const filteredPrompts = data?.filter(
       (prompt) => promptFlags?.[prompt.id] !== false,
     );
-    if (lastPrompt) {
-      filteredPrompts?.unshift(
-        filteredPrompts?.splice(
-          filteredPrompts.findIndex((item) => item.id === lastPrompt),
-          1,
-        )[0],
+    if (filteredPrompts && lastPrompt) {
+      const latPromptIndex = filteredPrompts.findIndex(
+        (item) => item.id === lastPrompt,
       );
+      const [lastPromptItem] = filteredPrompts.splice(latPromptIndex, 1);
+      filteredPrompts.unshift(lastPromptItem);
     }
     return filteredPrompts;
   }, [data, lastPrompt, promptFlags]);

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -59,6 +59,10 @@ export interface SettingsContextData extends Omit<RemoteSettings, 'theme'> {
     flag: keyof SettingsFlags,
     value: string | boolean,
   ) => Promise<unknown>;
+  updateFlagRemote: (
+    flag: keyof SettingsFlags,
+    value: string | boolean,
+  ) => Promise<unknown>;
   updatePromptFlag: (flag: string, value: boolean) => Promise<unknown>;
   syncSettings: (bootUserId?: string) => Promise<unknown>;
   onToggleHeaderPlacement(): Promise<unknown>;
@@ -273,6 +277,14 @@ export const SettingsContextProvider = ({
         }),
       updateFlag: (flag: keyof SettingsFlags, value: string | boolean) =>
         setSettings({
+          ...settings,
+          flags: {
+            ...settings.flags,
+            [flag]: value,
+          },
+        }),
+      updateFlagRemote: (flag: keyof SettingsFlags, value: string | boolean) =>
+        updateRemoteSettingsFn({
           ...settings,
           flags: {
             ...settings.flags,

--- a/packages/shared/src/graphql/settings.ts
+++ b/packages/shared/src/graphql/settings.ts
@@ -18,6 +18,7 @@ export type SettingsFlags = {
   clickbaitShieldEnabled: boolean;
   timezoneMismatchIgnore?: string;
   prompt?: Record<string, boolean>;
+  lastPrompt?: string;
 };
 
 export enum SidebarSettingsFlags {

--- a/packages/shared/src/hooks/prompt/useSmartPrompt.ts
+++ b/packages/shared/src/hooks/prompt/useSmartPrompt.ts
@@ -132,7 +132,15 @@ export const useSmartPrompt = ({
       source.addEventListener('message', onMessage);
       sourceRef.current = source;
     },
-    [accessToken?.token, client, post, queryKey],
+    [
+      accessToken?.token,
+      client,
+      lastPrompt,
+      post,
+      prompt.id,
+      queryKey,
+      updateFlag,
+    ],
   );
 
   useEffect(() => {

--- a/packages/shared/src/hooks/prompt/useSmartPrompt.ts
+++ b/packages/shared/src/hooks/prompt/useSmartPrompt.ts
@@ -17,6 +17,7 @@ import {
 } from '../../graphql/search';
 import type { CreatePayload, TokenPayload, UseChatMessage } from '../chat';
 import { UseChatMessageType } from '../chat';
+import { useSettingsContext } from '../../contexts/SettingsContext';
 
 export const useSmartPrompt = ({
   post,
@@ -30,6 +31,8 @@ export const useSmartPrompt = ({
   isPending: boolean;
 } => {
   const { user, accessToken } = useAuthContext();
+  const { flags, updateFlag } = useSettingsContext();
+  const lastPrompt = flags?.lastPrompt;
   const client = useQueryClient();
   const sourceRef = useRef<EventSource>();
 
@@ -43,6 +46,12 @@ export const useSmartPrompt = ({
     enabled: !!prompt.prompt,
     staleTime: StaleTime.OneHour,
   });
+
+  console.log('made it here?');
+  if (lastPrompt !== prompt.id) {
+    console.log('doing update?');
+    updateFlag('lastPrompt', prompt.id);
+  }
 
   const executePrompt = useCallback(
     async (value: string) => {
@@ -93,6 +102,10 @@ export const useSmartPrompt = ({
           case UseChatMessageType.Completed: {
             setSearchQuery({ completedAt: new Date() });
             sourceRef.current?.close();
+            console.log('made it here?');
+            if (lastPrompt !== prompt.id) {
+              updateFlag('lastPrompt', prompt.id);
+            }
             break;
           }
           case UseChatMessageType.Error: {

--- a/packages/shared/src/hooks/prompt/useSmartPrompt.ts
+++ b/packages/shared/src/hooks/prompt/useSmartPrompt.ts
@@ -31,7 +31,7 @@ export const useSmartPrompt = ({
   isPending: boolean;
 } => {
   const { user, accessToken } = useAuthContext();
-  const { flags, updateFlag } = useSettingsContext();
+  const { flags, updateFlagRemote } = useSettingsContext();
   const lastPrompt = flags?.lastPrompt;
   const client = useQueryClient();
   const sourceRef = useRef<EventSource>();
@@ -97,7 +97,7 @@ export const useSmartPrompt = ({
             setSearchQuery({ completedAt: new Date() });
             sourceRef.current?.close();
             if (lastPrompt !== prompt.id) {
-              updateFlag('lastPrompt', prompt.id);
+              updateFlagRemote('lastPrompt', prompt.id);
             }
             break;
           }
@@ -139,7 +139,7 @@ export const useSmartPrompt = ({
       post,
       prompt.id,
       queryKey,
-      updateFlag,
+      updateFlagRemote,
     ],
   );
 

--- a/packages/shared/src/hooks/prompt/useSmartPrompt.ts
+++ b/packages/shared/src/hooks/prompt/useSmartPrompt.ts
@@ -47,12 +47,6 @@ export const useSmartPrompt = ({
     staleTime: StaleTime.OneHour,
   });
 
-  console.log('made it here?');
-  if (lastPrompt !== prompt.id) {
-    console.log('doing update?');
-    updateFlag('lastPrompt', prompt.id);
-  }
-
   const executePrompt = useCallback(
     async (value: string) => {
       if (!value) {
@@ -102,7 +96,6 @@ export const useSmartPrompt = ({
           case UseChatMessageType.Completed: {
             setSearchQuery({ completedAt: new Date() });
             sourceRef.current?.close();
-            console.log('made it here?');
             if (lastPrompt !== prompt.id) {
               updateFlag('lastPrompt', prompt.id);
             }


### PR DESCRIPTION
## Changes

Storing the last prompt and swapping that one to the first spot.
I'm not 100% sure on the realtime swap that happens now. Going to check with product.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://as-976-store-last-prompt.preview.app.daily.dev