### PR TITLE
fix: displayed ui when gifted

### DIFF
--- a/packages/shared/src/components/plus/GiftReceivedPlusModal.tsx
+++ b/packages/shared/src/components/plus/GiftReceivedPlusModal.tsx
@@ -52,7 +52,7 @@ export function GiftReceivedPlusModal(props: ModalProps): ReactElement {
   const { onRequestClose } = props;
   const { user } = useAuthContext();
   const { data: gifter, isLoading } = useQuery({
-    queryKey: generateQueryKey(RequestKey.GifterUser),
+    queryKey: generateQueryKey(RequestKey.GifterUser, user),
     queryFn: getPlusGifterUser,
     enabled: Boolean(user?.isPlus),
   });

--- a/packages/shared/src/components/plus/PlusPlus.tsx
+++ b/packages/shared/src/components/plus/PlusPlus.tsx
@@ -26,14 +26,14 @@ const Container = classed(
 
 export const PlusPlus = ({ className }: PlusPlusProps): ReactElement => {
   const { user } = useAuthContext();
-  const { data: gifter, isLoading } = useQuery({
+  const { data: gifter, isPending } = useQuery({
     queryKey: generateQueryKey(RequestKey.GifterUser, user),
     queryFn: getPlusGifterUser,
     enabled: Boolean(user?.isPlus),
     staleTime: StaleTime.Default,
   });
 
-  if (isLoading) {
+  if (isPending) {
     return (
       <Container>
         <Loader />

--- a/packages/shared/src/components/plus/PlusPlus.tsx
+++ b/packages/shared/src/components/plus/PlusPlus.tsx
@@ -41,7 +41,7 @@ export const PlusPlus = ({ className }: PlusPlusProps): ReactElement => {
     );
   }
 
-  const additional = gifter
+  const manageCopy = gifter
     ? ''
     : ` Manage your subscription anytime to update your plan, payment details, or preferences.`;
 
@@ -64,7 +64,7 @@ export const PlusPlus = ({ className }: PlusPlusProps): ReactElement => {
           color={TypographyColor.Tertiary}
         >
           Thanks for supporting daily.dev and unlocking our most powerful
-          experience.{additional}.
+          experience.{manageCopy}.
         </Typography>
       </div>
       {!gifter && (


### PR DESCRIPTION
## Changes
- We should not show the button to manage subscription when user was just gifted. https://dailydotdev.slack.com/archives/C081Q26LZ3K/p1739196673669699?thread_ts=1739189289.357419&cid=C081Q26LZ3K

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://fix-gifted.preview.app.daily.dev