### PR TITLE
fix: shared post grid render

### DIFF
--- a/packages/shared/src/components/cards/share/ShareGrid.tsx
+++ b/packages/shared/src/components/cards/share/ShareGrid.tsx
@@ -25,6 +25,11 @@ import { BlockIcon, EarthIcon } from '../../icons';
 import { Typography, TypographyType } from '../../typography/Typography';
 import { IconSize } from '../../Icon';
 
+const EmptyStateContainer = classed(
+  'div',
+  'h-40 my-2 flex-col text-center flex items-center justify-center p-4 rounded-12 border border-border-subtlest-tertiary gap-2 text-text-tertiary',
+);
+
 export const ShareGrid = forwardRef(function ShareGrid(
   {
     post,
@@ -59,11 +64,6 @@ export const ShareGrid = forwardRef(function ShareGrid(
     ...post,
     image: post.sharedPost.image,
   };
-
-  const EmptyStateContainer = classed(
-    'div',
-    'h-40 my-2 flex-col text-center flex items-center justify-center p-4 rounded-8 border border-border-subtlest-tertiary gap-2 text-text-tertiary',
-  );
 
   const Footer = () => {
     if (isDeleted) {

--- a/packages/shared/src/components/cards/share/ShareGrid.tsx
+++ b/packages/shared/src/components/cards/share/ShareGrid.tsx
@@ -18,6 +18,12 @@ import { PostCardFooter } from '../common/PostCardFooter';
 import ActionButtons from '../ActionsButtons';
 import { ClickbaitShield } from '../common/ClickbaitShield';
 import { useSmartTitle } from '../../../hooks/post/useSmartTitle';
+import { DeletedPostId } from '../../../lib/constants';
+import { SourceType } from '../../../graphql/sources';
+import classed from '../../../lib/classed';
+import { BlockIcon, EarthIcon } from '../../icons';
+import { Typography, TypographyType } from '../../typography/Typography';
+import { IconSize } from '../../Icon';
 
 export const ShareGrid = forwardRef(function ShareGrid(
   {
@@ -42,12 +48,54 @@ export const ShareGrid = forwardRef(function ShareGrid(
   const onPostCardAuxClick = () => onPostAuxClick(post);
   const containerRef = useRef<HTMLDivElement>();
   const { title } = useSmartTitle(post);
-
+  const isDeleted = post?.sharedPost?.id === DeletedPostId;
+  const { private: sharedPostPrivate, source: sharedPostSource } =
+    post?.sharedPost;
+  const isPrivate =
+    sharedPostPrivate && sharedPostSource?.type === SourceType.Squad;
   const isVideoType = isVideoPost(post);
 
   const footerPost = {
     ...post,
     image: post.sharedPost.image,
+  };
+
+  const EmptyStateContainer = classed(
+    'div',
+    'h-40 my-2 flex-col text-center flex items-center justify-center p-4 rounded-8 border border-border-subtlest-tertiary gap-2 text-text-tertiary',
+  );
+
+  const Footer = () => {
+    if (isDeleted) {
+      return (
+        <EmptyStateContainer>
+          <BlockIcon size={IconSize.Size16} />
+          <Typography type={TypographyType.Footnote}>
+            This post is no longer available. It might have been removed or the
+            link has expired.
+          </Typography>
+        </EmptyStateContainer>
+      );
+    }
+    if (isPrivate) {
+      return (
+        <EmptyStateContainer>
+          <div className="flex size-6 items-center justify-center rounded-full bg-surface-secondary text-surface-primary">
+            <EarthIcon size={IconSize.Size16} />
+          </div>
+          <Typography type={TypographyType.Footnote}>
+            This post is in a private squad.
+          </Typography>
+        </EmptyStateContainer>
+      );
+    }
+    return (
+      <PostCardFooter
+        openNewTab={openNewTab}
+        post={footerPost}
+        className={{}}
+      />
+    );
   };
 
   return (
@@ -100,11 +148,7 @@ export const ShareGrid = forwardRef(function ShareGrid(
         </Container>
       </>
       <Container ref={containerRef}>
-        <PostCardFooter
-          openNewTab={openNewTab}
-          post={footerPost}
-          className={{}}
-        />
+        <Footer />
         <ActionButtons
           post={post}
           onUpvoteClick={onUpvoteClick}

--- a/packages/shared/src/graphql/feed.ts
+++ b/packages/shared/src/graphql/feed.ts
@@ -71,11 +71,13 @@ export const FEED_POST_FRAGMENT = gql`
       createdAt
       type
       tags
+      private
       source {
         id
         handle
         permalink
         image
+        type
       }
       slug
       clickbaitTitleDetected


### PR DESCRIPTION
## Changes

Fix to render state of deleted/private posts.
As it only targets squad feeds we only need to worry about grid view. (there's no list view in squads)

![image](https://github.com/user-attachments/assets/cd20b2d2-6092-476f-b9b5-9e2f4adfea40)

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-1005 #done 


### Preview domain
https://as-1005-shared-post-grid.preview.app.daily.dev