### PR TITLE
refactor: move pixels to _app

### DIFF
--- a/packages/webapp/components/layouts/PlusLayout/PlusLayout.tsx
+++ b/packages/webapp/components/layouts/PlusLayout/PlusLayout.tsx
@@ -6,7 +6,6 @@ import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import { onboardingUrl } from '@dailydotdev/shared/src/lib/constants';
 import { useRouter } from 'next/router';
 import { useGrowthBookContext } from '@dailydotdev/shared/src/components/GrowthBookProvider';
-import { Pixels } from '@dailydotdev/shared/src/components/Pixels';
 import {
   ThemeMode,
   useSettingsContext,
@@ -62,7 +61,6 @@ export default function PlusLayout({
 export function getPlusLayout(page: ReactNode): ReactNode {
   return (
     <PaymentContextProvider>
-      <Pixels hotjarId="5215055" />
       <PlusLayout>{page}</PlusLayout>
     </PaymentContextProvider>
   );

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -35,6 +35,7 @@ import { DndContextProvider } from '@dailydotdev/shared/src/contexts/DndContext'
 import { structuredCloneJsonPolyfill } from '@dailydotdev/shared/src/lib/structuredClone';
 import { fromCDN } from '@dailydotdev/shared/src/lib';
 import { useOnboarding } from '@dailydotdev/shared/src/hooks/auth';
+import { Pixels } from '@dailydotdev/shared/src/components/Pixels';
 import Seo, { defaultSeo, defaultSeoTitle } from '../next-seo';
 import useWebappVersion from '../hooks/useWebappVersion';
 
@@ -218,6 +219,7 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
           }}
         />
       )}
+      <Pixels />
     </>
   );
 }

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -40,10 +40,7 @@ import {
   withFeaturesBoundary,
 } from '@dailydotdev/shared/src/components';
 import useFeedSettings from '@dailydotdev/shared/src/hooks/useFeedSettings';
-import {
-  logPixelSignUp,
-  Pixels,
-} from '@dailydotdev/shared/src/components/Pixels';
+import { logPixelSignUp } from '@dailydotdev/shared/src/components/Pixels';
 import {
   feature,
   featureOnboardingDesktopPWA,
@@ -462,7 +459,6 @@ export function OnboardPage(): ReactElement {
         />
       )}
       <Toast autoDismissNotifications={autoDismissNotifications} />
-      <Pixels />
       {showGenerigLoader && <GenericLoader />}
       <OnboardingHeader
         showOnboardingPage={showOnboardingPage}

--- a/packages/webapp/pages/welcome/index.tsx
+++ b/packages/webapp/pages/welcome/index.tsx
@@ -37,7 +37,6 @@ import classNames from 'classnames';
 import type { NextSeoProps } from 'next-seo';
 import { useQueryClient } from '@tanstack/react-query';
 import { getPathnameWithQuery } from '@dailydotdev/shared/src/lib';
-import { Pixels } from '@dailydotdev/shared/src/components/Pixels';
 import { useFeaturesReadyContext } from '@dailydotdev/shared/src/components/GrowthBookProvider';
 import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { authGradientBg } from '@dailydotdev/shared/src/components/banners';
@@ -108,7 +107,6 @@ const DemoPage = (): ReactElement => {
 
   return (
     <>
-      <Pixels />
       <div
         className={classNames(
           'sticky top-0 z-header flex h-12 w-full justify-between border-b border-accent-cabbage-default px-4 py-2',


### PR DESCRIPTION
Instead of adding them to specific pages, I rather have them everywhere in the webapp. We have some concerns about attribution so I'd like to see if this improves the situation.

The only caveat is hotjar. This means it will record all the sessions if we enable it. We should consider moving hotjar out and put it only where we need it. Right now it's disabled anyway

### Preview domain
https://global-pixels.preview.app.daily.dev