### PR TITLE
fix: show award modal on comments

### DIFF
--- a/packages/shared/src/components/comments/CommentActionButtons.tsx
+++ b/packages/shared/src/components/comments/CommentActionButtons.tsx
@@ -361,7 +361,7 @@ export default function CommentActionButtons({
           color={ButtonColor.BlueCheese}
         />
       </SimpleTooltip>
-      <SimpleTooltip content="Award tihs user" appendTo={appendTo}>
+      <SimpleTooltip content="Award this user" appendTo={appendTo}>
         <Button
           size={ButtonSize.Small}
           icon={<MedalBadgeIcon secondary />}

--- a/packages/shared/src/components/comments/CommentActionButtons.tsx
+++ b/packages/shared/src/components/comments/CommentActionButtons.tsx
@@ -13,6 +13,7 @@ import {
   DownvoteIcon,
   AddUserIcon,
   BlockIcon,
+  MedalBadgeIcon,
 } from '../icons';
 import type { Comment } from '../../graphql/comments';
 import type { UserShortProfile } from '../../lib/user';
@@ -160,6 +161,16 @@ export default function CommentActionButtons({
         comment,
         post,
       },
+    });
+  };
+
+  const openGiveAwardModal = () => {
+    if (!user) {
+      return showLogin({ trigger: AuthTriggers.GiveAward });
+    }
+
+    return openModal({
+      type: LazyModal.GiveAward,
     });
   };
 
@@ -348,6 +359,16 @@ export default function CommentActionButtons({
           className="mr-3"
           variant={ButtonVariant.Tertiary}
           color={ButtonColor.BlueCheese}
+        />
+      </SimpleTooltip>
+      <SimpleTooltip content="Award tihs user" appendTo={appendTo}>
+        <Button
+          size={ButtonSize.Small}
+          icon={<MedalBadgeIcon secondary />}
+          className="mr-3"
+          variant={ButtonVariant.Tertiary}
+          color={ButtonColor.Bun}
+          onClick={openGiveAwardModal}
         />
       </SimpleTooltip>
       <SimpleTooltip content="Share comment" appendTo={appendTo}>

--- a/packages/shared/src/components/modals/award/GiveAwardModal.tsx
+++ b/packages/shared/src/components/modals/award/GiveAwardModal.tsx
@@ -1,0 +1,21 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+
+import type { ModalProps } from '../common/Modal';
+import { Modal } from '../common/Modal';
+import { Typography, TypographyType } from '../../typography/Typography';
+
+const GiveAwardModal = ({ ...props }: ModalProps): ReactElement => {
+  return (
+    <Modal kind={Modal.Kind.FlexibleCenter} size={Modal.Size.Small} {...props}>
+      <Modal.Header title="Give an Award" />
+      <Modal.Body>
+        <Typography type={TypographyType.Callout}>
+          Show your appreciation! Pick an Award to send to John doe!
+        </Typography>
+      </Modal.Body>
+    </Modal>
+  );
+};
+
+export default GiveAwardModal;

--- a/packages/shared/src/components/modals/common.tsx
+++ b/packages/shared/src/components/modals/common.tsx
@@ -258,6 +258,11 @@ const GiftReceivedPlusModal = dynamic(
     ),
 );
 
+const GiveAwardModal = dynamic(
+  () =>
+    import(/* webpackChunkName: "giveAwardModal" */ './award/GiveAwardModal'),
+);
+
 export const modals = {
   [LazyModal.SquadMember]: SquadMemberModal,
   [LazyModal.UpvotedPopup]: UpvotedPopupModal,
@@ -301,6 +306,7 @@ export const modals = {
   [LazyModal.PlusMarketing]: PlusMarketingModal,
   [LazyModal.GiftPlus]: GiftPlusModal,
   [LazyModal.GiftPlusReceived]: GiftReceivedPlusModal,
+  [LazyModal.GiveAward]: GiveAwardModal,
 };
 
 type GetComponentProps<T> = T extends

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -67,6 +67,7 @@ export enum LazyModal {
   SmartPrompt = 'smartPrompt',
   PlusMarketing = 'plusMarketing',
   MobileSmartPrompts = 'mobileSmartPrompts',
+  GiveAward = 'giveAward',
 }
 
 export type ModalTabItem = {

--- a/packages/shared/src/lib/auth.ts
+++ b/packages/shared/src/lib/auth.ts
@@ -68,6 +68,7 @@ export enum AuthTriggers {
   FromNotification = 'from notification',
   Follow = 'follow',
   Plus = 'plus',
+  GiveAward = 'give award',
 }
 
 export type AuthTriggersType =


### PR DESCRIPTION
## Changes

Added simple award from comment option
Added empty placeholder modal for award system

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

AS-995 #done 

### Preview domain
https://as-995-gift-comment.preview.app.daily.dev