### PR TITLE
fix: add cores as plus bonus

### DIFF
--- a/packages/shared/src/components/plus/PlusList.tsx
+++ b/packages/shared/src/components/plus/PlusList.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import type { WithClassNameProps } from '../utilities';
 import type { PlusItem, PlusListItemProps } from './PlusListItem';
 import { PlusItemStatus, PlusListItem } from './PlusListItem';
+import { CoinIcon } from '../icons';
 
 export const defaultFeatureList: Array<PlusItem> = [
   {
@@ -34,6 +35,15 @@ export const defaultFeatureList: Array<PlusItem> = [
 ];
 
 export const plusFeatureList: Array<PlusItem> = [
+  {
+    icon: CoinIcon,
+    typographyProps: {
+      bold: true,
+    },
+    label: 'Get {{x}} Cores every {{month/year}}',
+    status: PlusItemStatus.Ready,
+    tooltip: `Unlock {{x}} Cores every {{month/year}} to access exclusive content, features, and benefits.`,
+  },
   {
     label: 'Run prompts on any post',
     status: PlusItemStatus.Ready,
@@ -95,7 +105,13 @@ export const PlusList = ({
   return (
     <ul className={classNames('flex flex-col gap-0.5 py-6', className)}>
       {items.map((item) => (
-        <PlusListItem key={item.label} item={item} {...props} />
+        <PlusListItem
+          key={item.label}
+          item={item}
+          icon={item.icon}
+          typographyProps={item.typographyProps}
+          {...props}
+        />
       ))}
     </ul>
   );

--- a/packages/shared/src/components/plus/PlusListItem.tsx
+++ b/packages/shared/src/components/plus/PlusListItem.tsx
@@ -23,6 +23,8 @@ export interface PlusItem {
   label: string;
   status: PlusItemStatus;
   tooltip?: string;
+  icon?: FC<IconProps>;
+  typographyProps?: TypographyProps<TypographyTag.P>;
 }
 
 export interface PlusListItemProps {


### PR DESCRIPTION
## Changes

Bit tricky because it's the only one with different icon and typography options.
I saw it was kind of prepared but only on list level.

Note:
- Icon and copy still outdated

![Screenshot 2025-02-25 at 16 57 47](https://github.com/user-attachments/assets/18a5e7ac-bff8-4471-b47b-34f09579537a)


## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://as-984-core-plus-bonus.preview.app.daily.dev