### PR TITLE
fix: show highlighted custom default feed on extension

### DIFF
--- a/packages/shared/src/components/feeds/CustomFeedSlider.tsx
+++ b/packages/shared/src/components/feeds/CustomFeedSlider.tsx
@@ -19,7 +19,7 @@ import useCustomDefaultFeed from '../../hooks/feed/useCustomDefaultFeed';
 const CustomFeedSlider = (): ReactElement => {
   const { feeds } = useFeeds();
   const { isPlus } = usePlusSubscription();
-  const { isCustomDefaultFeed } = useCustomDefaultFeed();
+  const { isCustomDefaultFeed, defaultFeedId } = useCustomDefaultFeed();
   const sortedFeeds = useSortedFeeds({ edges: feeds?.edges });
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const activeButtonRef = useRef<HTMLAnchorElement>(null);
@@ -30,13 +30,13 @@ const CustomFeedSlider = (): ReactElement => {
     return {
       [myFeedPath]: 'For you',
       ...sortedFeeds.reduce((acc, { node: feed }) => {
-        const feedPath = `/feeds/${feed.id}`;
+        const feedPath = defaultFeedId === feed.id ? '/' : `/feeds/${feed.id}`;
         acc[feedPath] = feed.flags?.name || `Feed ${feed.id}`;
         return acc;
       }, {}),
       '/feeds/new': 'New feed',
     };
-  }, [sortedFeeds, isCustomDefaultFeed]);
+  }, [sortedFeeds, isCustomDefaultFeed, defaultFeedId]);
 
   const scroll = (direction: 'left' | 'right') => {
     if (!scrollContainerRef.current) {


### PR DESCRIPTION
## Changes

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://mi-823.preview.app.daily.dev