### PR TITLE
chore: disable extension to load paddle sdk

### DIFF
--- a/packages/extension/src/newtab/ShortcutLinks/ShortcutLinks.spec.tsx
+++ b/packages/extension/src/newtab/ShortcutLinks/ShortcutLinks.spec.tsx
@@ -30,6 +30,7 @@ import { ChecklistViewState } from '@dailydotdev/shared/src/lib/checklist';
 import * as actionHook from '@dailydotdev/shared/src/hooks/useActions';
 import loggedUser from '@dailydotdev/shared/__tests__/fixture/loggedUser';
 import * as libFuncs from '@dailydotdev/shared/src/lib/func';
+import { SortCommentsBy } from '@dailydotdev/shared/src/graphql/comments';
 import ShortcutLinks from './ShortcutLinks';
 
 jest.mock('@dailydotdev/shared/src/lib/boot', () => ({
@@ -87,6 +88,7 @@ const defaultSettings: RemoteSettings = {
   optOutReadingStreak: true,
   optOutCompanion: true,
   autoDismissNotifications: true,
+  sortCommentsBy: SortCommentsBy.NewestFirst,
   customLinks: [
     'http://custom1.com',
     'http://custom2.com',

--- a/packages/extension/webpack.config.js
+++ b/packages/extension/webpack.config.js
@@ -54,6 +54,7 @@ const baseConfig = {
     alias: {
       'react-onesignal': false,
       '@marsidev/react-turnstile': false,
+      '@paddle/paddle-js': false,
     },
     fallback: {
       fs: false,

--- a/packages/shared/src/contexts/PaymentContext.tsx
+++ b/packages/shared/src/contexts/PaymentContext.tsx
@@ -157,7 +157,7 @@ export const PaymentContextProvider = ({
         setPaddle(paddleInstance);
       }
     });
-  }, [router, trackPayment]);
+  }, [isExtension, router, trackPayment]);
 
   const getPrices = useCallback(async () => {
     return paddle?.PricePreview({

--- a/packages/shared/src/contexts/PaymentContext.tsx
+++ b/packages/shared/src/contexts/PaymentContext.tsx
@@ -83,12 +83,11 @@ export const PaymentContextProvider = ({
   const [paddle, setPaddle] = useState<Paddle>();
   const { logSubscriptionEvent, isPlus } = usePlusSubscription();
   const logRef = useRef<typeof logSubscriptionEvent>();
-  const isExtension = checkIsExtension();
 
   logRef.current = logSubscriptionEvent;
   // Download and initialize Paddle instance from CDN
   useEffect(() => {
-    if (isExtension) {
+    if (checkIsExtension()) {
       // Payment not available on extension
       return;
     }
@@ -157,7 +156,7 @@ export const PaymentContextProvider = ({
         setPaddle(paddleInstance);
       }
     });
-  }, [isExtension, router, trackPayment]);
+  }, [router, trackPayment]);
 
   const getPrices = useCallback(async () => {
     return paddle?.PricePreview({

--- a/packages/shared/src/contexts/PaymentContext.tsx
+++ b/packages/shared/src/contexts/PaymentContext.tsx
@@ -28,6 +28,7 @@ import { feature } from '../lib/featureManagement';
 import { PlusPriceType, PlusPriceTypeAppsId } from '../lib/featureValues';
 import { getPrice } from '../lib';
 import { useFeature } from '../components/GrowthBookProvider';
+import { checkIsExtension } from '../lib/func';
 import { usePixelsContext } from './PixelsContext';
 
 export type ProductOption = {
@@ -82,10 +83,15 @@ export const PaymentContextProvider = ({
   const [paddle, setPaddle] = useState<Paddle>();
   const { logSubscriptionEvent, isPlus } = usePlusSubscription();
   const logRef = useRef<typeof logSubscriptionEvent>();
-  logRef.current = logSubscriptionEvent;
+  const isExtension = checkIsExtension();
 
+  logRef.current = logSubscriptionEvent;
   // Download and initialize Paddle instance from CDN
   useEffect(() => {
+    if (isExtension) {
+      // Payment not available on extension
+      return;
+    }
     const existingPaddleInstance = getPaddleInstance();
     if (existingPaddleInstance) {
       setPaddle(existingPaddleInstance);


### PR DESCRIPTION
## Changes

Ideally it shouldn't show the whole context, but I don't want to block long.
@sshanzel is going to re-evaluate anyway.

This will simply not init paddle (As it's empty) on extension.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
Copy and paste the below line outside the HTML comment tags to link this PR to the ticket in Jira

AS-{number} #done
or
MI-{number} #done
-->


### Preview domain
https://chore-disable-paddle-extension.preview.app.daily.dev