### PR TITLE
fix: `onAfterClose` in the right place for marketingCtaPlus

### DIFF
--- a/packages/shared/src/components/modals/BootPopups.tsx
+++ b/packages/shared/src/components/modals/BootPopups.tsx
@@ -105,9 +105,6 @@ export const BootPopups = (): ReactElement => {
     if (marketingCtaPlus && !isIOSNative() && isValidRegion && !user?.isPlus) {
       addBootPopup({
         type: LazyModal.PlusMarketing,
-        onAfterClose: () => {
-          updateLastBootPopup();
-        },
         props: {
           onAfterOpen: () => {
             logEvent({
@@ -115,6 +112,9 @@ export const BootPopups = (): ReactElement => {
               target_type: TargetType.MarketingCtaPlus,
               target_id: marketingCtaPlus.campaignId,
             });
+          },
+          onAfterClose: () => {
+            updateLastBootPopup();
           },
         },
       });


### PR DESCRIPTION
## Changes

`onAfterClose` was not set in the right place, so it could cause issues where you'd see a popup right after another popup.

### Preview domain
https://ombratteng-patch-1.preview.app.daily.dev