### PR TITLE
fix: fix typo in checkout completed event `localCurrenct` -> `localCurrency`

### DIFF
--- a/packages/shared/src/contexts/PaymentContext.tsx
+++ b/packages/shared/src/contexts/PaymentContext.tsx
@@ -125,7 +125,7 @@ export const PaymentContextProvider = ({
                 cycle:
                   event?.data.items?.[0]?.billing_cycle?.interval ?? 'one-off',
                 localCost: event?.data.totals.total,
-                localCurrenct: event?.data.currency_code,
+                localCurrency: event?.data.currency_code,
                 payment: event?.data.payment.method_details.type,
               },
             });


### PR DESCRIPTION
## Changes

Fixes a small typo in the `CHECKOUT_COMPLETED` event for paddle. `localCurrenct` -> `localCurrency`

### Preview domain
https://paddle-payment-event-fix-localcu.preview.app.daily.dev