### PR TITLE
refactor: move product meta into GB feature for more control

### DIFF
--- a/packages/shared/src/components/plus/PlusOptionRadio.tsx
+++ b/packages/shared/src/components/plus/PlusOptionRadio.tsx
@@ -95,7 +95,9 @@ export function PlusOptionRadio({
           color={TypographyColor.Primary}
           bold
         >
-          {isYearlyGift ? price.formatted : price.monthlyFormatted}
+          {isYearlyGift
+            ? price.formatted
+            : price.monthlyFormatted ?? price.formatted}
         </Typography>
         {currencyCode && (
           <Typography

--- a/packages/shared/src/contexts/payment/StoreKit.tsx
+++ b/packages/shared/src/contexts/payment/StoreKit.tsx
@@ -81,8 +81,6 @@ export const StoreKitSubProvider = ({
                 price: {
                   amount: parseFloat(product.attributes.offers[0].price),
                   formatted: product.attributes.offers[0].priceFormatted,
-                  monthlyAmount: parseFloat(product.attributes.offers[0].price),
-                  monthlyFormatted: product.attributes.offers[0].priceFormatted,
                 },
                 extraLabel,
                 appsId: appsId ?? PlusPriceTypeAppsId.Default,

--- a/packages/shared/src/contexts/payment/StoreKit.tsx
+++ b/packages/shared/src/contexts/payment/StoreKit.tsx
@@ -72,12 +72,11 @@ export const StoreKitSubProvider = ({
 
           return productsRaw
             ?.map((product: IAPProduct): ProductOption => {
-              const duration = productIds[
-                product.attributes.offerName
-              ] as PlusPriceType;
+              const { duration, label, extraLabel, appsId } =
+                productIds[product.attributes.offerName];
 
               return {
-                label: product.attributes.name,
+                label,
                 value: product.attributes.offerName,
                 price: {
                   amount: parseFloat(product.attributes.offers[0].price),
@@ -85,11 +84,8 @@ export const StoreKitSubProvider = ({
                   monthlyAmount: parseFloat(product.attributes.offers[0].price),
                   monthlyFormatted: product.attributes.offers[0].priceFormatted,
                 },
-                extraLabel: product.attributes?.description?.standard,
-                appsId:
-                  product.attributes.offerName === 'annualSpecial'
-                    ? PlusPriceTypeAppsId.EarlyAdopter
-                    : PlusPriceTypeAppsId.Default,
+                extraLabel,
+                appsId: appsId ?? PlusPriceTypeAppsId.Default,
                 duration,
                 durationLabel:
                   duration === PlusPriceType.Yearly ? 'year' : 'month',

--- a/packages/shared/src/contexts/payment/context.ts
+++ b/packages/shared/src/contexts/payment/context.ts
@@ -42,6 +42,13 @@ export interface PaymentContextData {
   isFreeTrialExperiment: boolean;
 }
 
+export type ProductMeta = {
+  label: string;
+  extraLabel?: string;
+  duration: PlusPriceType;
+  appsId?: PlusPriceTypeAppsId;
+};
+
 export const PaymentContext = createContext<PaymentContextData>(undefined);
 
 export const usePaymentContext = (): PaymentContextData => {

--- a/packages/shared/src/contexts/payment/context.ts
+++ b/packages/shared/src/contexts/payment/context.ts
@@ -12,8 +12,8 @@ export type ProductOption = {
   price: {
     amount: number;
     formatted: string;
-    monthlyAmount: number;
-    monthlyFormatted: string;
+    monthlyAmount?: number;
+    monthlyFormatted?: string;
   };
   currencyCode?: string;
   currencySymbol?: string;

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -5,7 +5,8 @@ import {
 } from './image';
 import type { FeedAdTemplate } from './feed';
 import type { FeedSettingsKeys } from '../contexts/FeedContext';
-import { PlusPriceType } from './featureValues';
+import { PlusPriceType, PlusPriceTypeAppsId } from './featureValues';
+import type { ProductMeta } from '../contexts/payment/context';
 
 export class Feature<T extends JSONValue> {
   readonly id: string;
@@ -41,11 +42,26 @@ const feature = {
   }),
 };
 
-export const featureIAPProducts = new Feature('iap_products', {
-  annualSpecial: PlusPriceType.Yearly,
-  annual: PlusPriceType.Yearly,
-  monthly: PlusPriceType.Monthly,
-});
+export const featureIAPProducts = new Feature<Record<string, ProductMeta>>(
+  'iap_products',
+  {
+    annualSpecial: {
+      label: 'Annual Special',
+      extraLabel: '💜 Early bird',
+      duration: PlusPriceType.Yearly,
+      appsId: PlusPriceTypeAppsId.EarlyAdopter,
+    },
+    annual: {
+      label: 'Annual',
+      extraLabel: 'Save 50%',
+      duration: PlusPriceType.Yearly,
+    },
+    monthly: {
+      label: 'Monthly',
+      duration: PlusPriceType.Monthly,
+    },
+  },
+);
 
 export const featurePostTagSorting = new Feature('post_tag_sorting', false);
 


### PR DESCRIPTION
## Changes

- Move some product meta data into GB feature as StoreKit doesn't really have the same options
- Make monthly price optional and fallback to yearly price (reduces duplication in StoreKit provider)