### PR TITLE
fix: disable account deletion button when user has active storekit subscription

### DIFF
--- a/packages/shared/src/components/profile/AccountDangerZone.tsx
+++ b/packages/shared/src/components/profile/AccountDangerZone.tsx
@@ -27,6 +27,24 @@ const Important = () => (
   </>
 );
 
+const ImportantActiveAppleSubscription = () => {
+  return (
+    <>
+      You have an active subscription. To proceed with account deletion,
+      you&apos;ll need to cancel your subscription first (via Apple). Contact{' '}
+      <a
+        className="text-text-link"
+        href="mailto:support@daily.dev?subject=I have a question about deleting my account"
+        target="_blank"
+        rel={anchorDefaultRel}
+      >
+        support@daily.dev
+      </a>{' '}
+      with any questions.
+    </>
+  );
+};
+
 function AccountDangerZone({
   onDelete,
   className,
@@ -49,7 +67,9 @@ function AccountDangerZone({
         'Permanently delete all your content, including your posts, bookmarks, comments, upvotes, etc.',
         'Allow your username to become available to anyone.',
       ]}
-      important={<Important />}
+      important={
+        disableDeletion ? <ImportantActiveAppleSubscription /> : <Important />
+      }
       buttonDisabled={disableDeletion}
     />
   );

--- a/packages/shared/src/components/profile/AccountDangerZone.tsx
+++ b/packages/shared/src/components/profile/AccountDangerZone.tsx
@@ -2,6 +2,8 @@ import type { ReactElement, ReactNode } from 'react';
 import React from 'react';
 import { DangerZone } from '../widgets/DangerZone';
 import { anchorDefaultRel } from '../../lib/strings';
+import { usePlusSubscription } from '../../hooks';
+import { SubscriptionProvider, UserSubscriptionStatus } from '../../lib/plus';
 
 interface AccountDangerZoneProps {
   onDelete: () => void;
@@ -29,6 +31,13 @@ function AccountDangerZone({
   onDelete,
   className,
 }: AccountDangerZoneProps): ReactElement {
+  const { isPlus, status, plusProvider } = usePlusSubscription();
+
+  const disableDeletion =
+    isPlus &&
+    status === UserSubscriptionStatus.Active &&
+    plusProvider === SubscriptionProvider.AppleStoreKit;
+
   return (
     <DangerZone
       onClick={onDelete}
@@ -41,6 +50,7 @@ function AccountDangerZone({
         'Allow your username to become available to anyone.',
       ]}
       important={<Important />}
+      buttonDisabled={disableDeletion}
     />
   );
 }

--- a/packages/shared/src/components/widgets/DangerZone.tsx
+++ b/packages/shared/src/components/widgets/DangerZone.tsx
@@ -17,6 +17,7 @@ interface DangerZoneProps {
   cta: string;
   onClick: () => void;
   className?: string;
+  buttonDisabled?: boolean;
 }
 
 export function DangerZone({
@@ -27,6 +28,7 @@ export function DangerZone({
   className,
   onClick,
   children,
+  buttonDisabled = false,
 }: DangerZoneProps): ReactElement {
   return (
     <section
@@ -56,6 +58,7 @@ export function DangerZone({
         color={ButtonColor.Ketchup}
         className="mt-6 self-start"
         type="button"
+        disabled={buttonDisabled}
       >
         {cta}
       </Button>

--- a/packages/shared/src/hooks/usePlusSubscription.ts
+++ b/packages/shared/src/hooks/usePlusSubscription.ts
@@ -3,6 +3,7 @@ import { useAuthContext } from '../contexts/AuthContext';
 import { TargetType } from '../lib/log';
 import type { LogEvent, TargetId } from '../lib/log';
 import { useLogContext } from '../contexts/LogContext';
+import type { UserSubscriptionStatus } from '../lib/plus';
 import { SubscriptionProvider } from '../lib/plus';
 import { managePlusUrl, plusUrl, webappUrl } from '../lib/constants';
 import { isIOSNative } from '../lib/func';
@@ -18,11 +19,13 @@ export const usePlusSubscription = (): {
   plusProvider: SubscriptionProvider | null;
   logSubscriptionEvent: (event: LogSubscriptionEvent) => void;
   plusHref: string | undefined;
+  status: UserSubscriptionStatus;
 } => {
   const { user } = useAuthContext();
+  const { logEvent } = useLogContext();
   const isPlus = user?.isPlus || false;
   const plusProvider = user?.subscriptionFlags?.provider || null;
-  const { logEvent } = useLogContext();
+  const { status } = user.subscriptionFlags;
 
   const logSubscriptionEvent = useCallback(
     ({ event_name, target_id, extra }: LogSubscriptionEvent) => {
@@ -60,5 +63,6 @@ export const usePlusSubscription = (): {
     plusProvider,
     logSubscriptionEvent,
     plusHref,
+    status,
   };
 };

--- a/packages/shared/src/hooks/usePlusSubscription.ts
+++ b/packages/shared/src/hooks/usePlusSubscription.ts
@@ -16,16 +16,15 @@ type LogSubscriptionEvent = {
 
 export const usePlusSubscription = (): {
   isPlus: boolean;
-  plusProvider: SubscriptionProvider | null;
+  plusProvider?: SubscriptionProvider;
   logSubscriptionEvent: (event: LogSubscriptionEvent) => void;
   plusHref: string | undefined;
-  status: UserSubscriptionStatus;
+  status?: UserSubscriptionStatus;
 } => {
   const { user } = useAuthContext();
   const { logEvent } = useLogContext();
   const isPlus = user?.isPlus || false;
-  const plusProvider = user?.subscriptionFlags?.provider || null;
-  const { status } = user.subscriptionFlags;
+  const { status, provider: plusProvider } = user?.subscriptionFlags || {};
 
   const logSubscriptionEvent = useCallback(
     ({ event_name, target_id, extra }: LogSubscriptionEvent) => {

--- a/packages/shared/src/lib/plus.ts
+++ b/packages/shared/src/lib/plus.ts
@@ -2,3 +2,9 @@ export enum SubscriptionProvider {
   Paddle = 'paddle',
   AppleStoreKit = 'storekit',
 }
+
+export enum UserSubscriptionStatus {
+  Active = 'active',
+  Expired = 'expired',
+  Cancelled = 'cancelled',
+}

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -175,10 +175,14 @@ export async function logout(reason: string): Promise<void> {
 }
 
 export async function deleteAccount(): Promise<void> {
-  await fetch(`${apiUrl}/v1/users/me`, {
+  const res = await fetch(`${apiUrl}/v1/users/me`, {
     method: 'DELETE',
     credentials: 'include',
   });
+
+  if (!res.ok) {
+    throw new Error('Failed to delete account');
+  }
 }
 
 const getProfileRequest = async (id: string) => {

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -7,7 +7,7 @@ import {
 import type { Company } from './userCompany';
 import type { ContentPreference } from '../graphql/contentPreference';
 import type { TopReader } from '../components/badges/TopReaderBadge';
-import type { SubscriptionProvider } from './plus';
+import type { SubscriptionProvider, UserSubscriptionStatus } from './plus';
 
 export enum Roles {
   Moderator = 'moderator',
@@ -122,6 +122,7 @@ export type UserFlagsPublic = Partial<{
 
 export type UserSubscriptionFlags = Partial<{
   provider: SubscriptionProvider;
+  status: UserSubscriptionStatus;
 
   // StoreKit flags
   appAccountToken?: string; // StoreKit app account token (UUID)

--- a/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
+++ b/packages/webapp/components/layouts/AccountLayout/Security/index.tsx
@@ -26,9 +26,13 @@ import SimpleTooltip from '@dailydotdev/shared/src/components/tooltips/SimpleToo
 import type { PromptOptions } from '@dailydotdev/shared/src/hooks/usePrompt';
 import { usePrompt } from '@dailydotdev/shared/src/hooks/usePrompt';
 import { useSignBack } from '@dailydotdev/shared/src/hooks/auth/useSignBack';
-import { useEventListener } from '@dailydotdev/shared/src/hooks';
+import {
+  useEventListener,
+  useToastNotification,
+} from '@dailydotdev/shared/src/hooks';
 import { capitalize } from '@dailydotdev/shared/src/lib/strings';
 import { BOOT_LOCAL_KEY } from '@dailydotdev/shared/src/contexts/common';
+import { DEFAULT_ERROR } from '@dailydotdev/shared/src/graphql/common';
 import AccountContentSection from '../AccountContentSection';
 import { AccountPageContainer } from '../AccountPageContainer';
 import type { ManageSocialProvidersProps } from '../common';
@@ -115,6 +119,7 @@ function AccountSecurityDefault({
   onUpdateProviders,
 }: AccountSecurityDefaultProps): ReactElement {
   const { deleteAccount } = useContext(AuthContext);
+  const { displayToast } = useToastNotification();
   const { onUpdateSignBack } = useSignBack();
   const [linkProvider, setLinkProvider] = useState(null);
   const hasPassword = userProviders?.result?.includes('password');
@@ -149,7 +154,12 @@ function AccountSecurityDefault({
   };
   const deleteAccountPrompt = async () => {
     if (await showPrompt(deleteAccountPromptOptions)) {
-      await deleteAccount();
+      try {
+        await deleteAccount();
+      } catch (error) {
+        displayToast(DEFAULT_ERROR);
+        return;
+      }
       await onUpdateSignBack(null, null);
       globalThis?.localStorage.removeItem(BOOT_LOCAL_KEY);
       window.location.replace('/');


### PR DESCRIPTION
## Changes

Because we can't cancel a subscription on behalf of a user, we can't let the user delete their account until they have cancelled their subscription

<table>
 <tr>
  <td>Can delete
  <td>Prevented from deletion
 <tr>
  <td><img src="https://github.com/user-attachments/assets/403ae99e-d381-49e9-b420-2ab3e77f7865">
  <td><img src="https://github.com/user-attachments/assets/da9ea42b-aa0c-49cd-a15f-bfab300a4f88">
</table>

### Preview domain
https://fix-disable-deletion-when-active.preview.app.daily.dev