### PR TITLE
fix: re-allow plus pages to deep link into the app

### DIFF
--- a/packages/webapp/public/.well-known/apple-app-site-association
+++ b/packages/webapp/public/.well-known/apple-app-site-association
@@ -11,11 +11,6 @@
                         "comment": "Matches any OAuth callback URL"
                     },
                     {
-                        "/": "/plus*",
-                        "exclude": true,
-                        "comment": "Matches any plus URL"
-                    },
-                    {
                         "/": "/*",
                         "comment": "Matches any URL path under app.daily.dev"
                     }


### PR DESCRIPTION
## Changes

Once the app is approved and published, we can re-allow deep links into iOS

### Jira ticket
AS-1006

### Preview domain
https://as-1006-remove-plus-exclusion.preview.app.daily.dev