### PR TITLE
feat: enable shared web credentials on iOS

### DIFF
--- a/packages/webapp/public/.well-known/apple-app-site-association
+++ b/packages/webapp/public/.well-known/apple-app-site-association
@@ -22,5 +22,8 @@
                 ]
             }
         ]
-    }
+    },
+    "webcredentials": {
+        "apps": [ "C97TTQ7W57.dev.daily.app" ]
+    },
 }


### PR DESCRIPTION
## Changes

Enables [Shared Web Credentials](https://developer.apple.com/documentation/security/shared-web-credentials). It is already enabled in the app, just need to add it to our manifest.