### PR TITLE
fix: show manage subscription sheet on larger tablets

### DIFF
--- a/packages/shared/src/components/ProfileMenu.tsx
+++ b/packages/shared/src/components/ProfileMenu.tsx
@@ -26,7 +26,7 @@ import { HeroImage } from './profile/HeroImage';
 import { anchorDefaultRel } from '../lib/strings';
 import { LogoutReason } from '../lib/user';
 import { useLazyModal } from '../hooks/useLazyModal';
-import { checkIsExtension } from '../lib/func';
+import { checkIsExtension, isIOSNative } from '../lib/func';
 import { useDndContext } from '../contexts/DndContext';
 import { LazyModal } from './modals/common/types';
 import { usePlusSubscription } from '../hooks/usePlusSubscription';
@@ -35,6 +35,7 @@ import { featurePlusCtaCopy } from '../lib/featureManagement';
 import { GiftIcon } from './icons/gift';
 import { useConditionalFeature } from '../hooks';
 import { SubscriptionProvider } from '../lib/plus';
+import { postWebKitMessage, WebKitMessageHandlers } from '../lib/ios';
 
 interface ListItem {
   title: string;
@@ -85,6 +86,17 @@ export default function ProfileMenu({
             ? '_blank'
             : undefined,
         onClick: () => {
+          if (
+            isPlus &&
+            isIOSNative() &&
+            plusProvider === SubscriptionProvider.AppleStoreKit
+          ) {
+            postWebKitMessage(
+              WebKitMessageHandlers.IAPSubscriptionManage,
+              null,
+            );
+          }
+
           logSubscriptionEvent({
             event_name: isPlus
               ? LogEvent.ManageSubscription

--- a/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
+++ b/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
@@ -37,11 +37,7 @@ import {
   featurePlusCtaCopy,
 } from '../../lib/featureManagement';
 import { SubscriptionProvider } from '../../lib/plus';
-import {
-  iOSSupportsPlusPurchase,
-  postWebKitMessage,
-  WebKitMessageHandlers,
-} from '../../lib/ios';
+import { postWebKitMessage, WebKitMessageHandlers } from '../../lib/ios';
 
 const useMenuItems = (): NavItemProps[] => {
   const { logout, isAndroidApp } = useAuthContext();
@@ -91,37 +87,32 @@ const useMenuItems = (): NavItemProps[] => {
       { label: 'Edit profile', icon: <EditIcon />, href: '/account/profile' },
     ];
 
-    if (!isIOSNative() || iOSSupportsPlusPurchase()) {
-      items.push({
-        label: isPlus ? 'Manage plus' : plusCta,
-        icon: <DevPlusIcon />,
-        href: plusHref,
-        className: isPlus ? undefined : 'text-action-plus-default',
-        target:
-          isPlus && plusProvider === SubscriptionProvider.Paddle
-            ? '_blank'
-            : undefined,
-        onClick: () => {
-          if (
-            isPlus &&
-            isIOSNative() &&
-            plusProvider === SubscriptionProvider.AppleStoreKit
-          ) {
-            postWebKitMessage(
-              WebKitMessageHandlers.IAPSubscriptionManage,
-              null,
-            );
-          }
+    items.push({
+      label: isPlus ? 'Manage plus' : plusCta,
+      icon: <DevPlusIcon />,
+      href: plusHref,
+      className: isPlus ? undefined : 'text-action-plus-default',
+      target:
+        isPlus && plusProvider === SubscriptionProvider.Paddle
+          ? '_blank'
+          : undefined,
+      onClick: () => {
+        if (
+          isPlus &&
+          isIOSNative() &&
+          plusProvider === SubscriptionProvider.AppleStoreKit
+        ) {
+          postWebKitMessage(WebKitMessageHandlers.IAPSubscriptionManage, null);
+        }
 
-          logSubscriptionEvent({
-            event_name: isPlus
-              ? LogEvent.ManageSubscription
-              : LogEvent.UpgradeSubscription,
-            target_id: TargetId.ProfileDropdown,
-          });
-        },
-      });
-    }
+        logSubscriptionEvent({
+          event_name: isPlus
+            ? LogEvent.ManageSubscription
+            : LogEvent.UpgradeSubscription,
+          target_id: TargetId.ProfileDropdown,
+        });
+      },
+    });
 
     return [
       ...items,


### PR DESCRIPTION
## Changes

On larger iPads, it uses the desktop profile menu, so need to make it trigger the native modal.
![image](https://github.com/user-attachments/assets/dd39cdb6-47ae-47cd-9a61-5e3a597d2252)


### Preview domain
https://fix-manage-subscription-ios.preview.app.daily.dev