### PR TITLE
fix: only include `Tiltfile` if it exists

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,9 +1,16 @@
 load('ext://uibutton', 'cmd_button', 'location')
 
-include('../daily-api/Tiltfile')
-include('../heimdall/Tiltfile')
-include('../post-scraper-one-ai/Tiltfile')
-include('../njord/Tiltfile')
+def include_if_exists(path):
+  if os.path.exists(path):
+    print("including %s", path)
+    include(path)
+  else:
+    print("skipping %s because it does not exist", path)
+
+include_if_exists('../daily-api/Tiltfile')
+include_if_exists('../heimdall/Tiltfile')
+include_if_exists('../post-scraper-one-ai/Tiltfile')
+include_if_exists('../njord/Tiltfile')
 
 def get_daily_dir(app=""):
   parent = os.path.dirname(os.getcwd())


### PR DESCRIPTION
## Changes

Add new function to only include `Tiltfile` if it exists, and don't throw an error.

https://dailydotdev.slack.com/archives/C02E2C3C13R/p1742369827333029

### Preview domain
https://fix-no-fail-if-not-exist.preview.app.daily.dev