### PR TITLE
fix: plus marketing cta modal crash on close

### DIFF
--- a/packages/shared/src/components/plus/PlusExtension.tsx
+++ b/packages/shared/src/components/plus/PlusExtension.tsx
@@ -18,7 +18,7 @@ import { plusTakeoverContent } from '../../lib/featureManagement';
 const PlusExtension = (): ReactElement => {
   const { getMarketingCta } = useBoot();
   const marketingCta = getMarketingCta(MarketingCtaVariant.Plus);
-  const { flags } = marketingCta;
+  const { flags } = marketingCta || {};
   const { logEvent } = useLogContext();
   const { data: productOptions } = useQuery({
     queryKey: generateQueryKey(RequestKey.PricePreview),
@@ -49,8 +49,8 @@ const PlusExtension = (): ReactElement => {
       <div className="flex flex-1 flex-col pr-10 pt-6">
         <PlusInfo
           productOptions={productOptions || []}
-          title={experiment?.title ?? flags.title}
-          description={experiment?.description ?? flags.description}
+          title={experiment?.title ?? flags?.title}
+          description={experiment?.description ?? flags?.description}
           selectedOption={selectedOption}
           onChange={({ priceId }) => {
             setSelectedOption(priceId);
@@ -68,7 +68,7 @@ const PlusExtension = (): ReactElement => {
           className="mt-8"
           onClick={handleClick}
         >
-          {experiment?.cta ?? flags.ctaText}
+          {experiment?.cta ?? flags?.ctaText}
         </Button>
       </div>
       <PlusListModalSection

--- a/packages/shared/src/components/plus/PlusMarketingModal.tsx
+++ b/packages/shared/src/components/plus/PlusMarketingModal.tsx
@@ -46,8 +46,8 @@ const PlusMarketingModal = (modalProps: ModalProps): ReactElement => {
       target_type: TargetType.MarketingCtaPlus,
       target_id: campaignId,
     });
-    clearMarketingCta(campaignId);
     closeModal();
+    clearMarketingCta(campaignId);
   };
 
   const plusComponent = useMemo(() => {

--- a/packages/shared/src/components/plus/PlusWebapp.tsx
+++ b/packages/shared/src/components/plus/PlusWebapp.tsx
@@ -11,8 +11,7 @@ import PlusListModalSection from './PlusListModalSection';
 const PlusWebapp = (): ReactElement => {
   const { getMarketingCta } = useBoot();
   const marketingCta = getMarketingCta(MarketingCtaVariant.Plus);
-  const { flags } = marketingCta;
-  const { title, description } = flags;
+  const { flags } = marketingCta || {};
   const { openCheckout, productOptions, isPricesPending } = usePaymentContext();
   const [selectedOption, setSelectedOption] = useState<string | null>();
   const checkoutRef = useRef();
@@ -37,8 +36,8 @@ const PlusWebapp = (): ReactElement => {
           showPlusList={false}
           showGiftButton={false}
           showDailyDevLogo
-          title={title}
-          description={description}
+          title={flags?.title}
+          description={flags?.description}
           showTrustReviews={false}
         />
         {!showCheckout && (
@@ -47,7 +46,7 @@ const PlusWebapp = (): ReactElement => {
             variant={ButtonVariant.Primary}
             className="mt-8"
           >
-            {flags.ctaText}
+            {flags?.ctaText}
           </Button>
         )}
       </div>


### PR DESCRIPTION
## Changes

Fixes the issue of the app crashing when closing the modal. Seems to have been caused by the boot data being cleared before a refresh happens, which causes the app to re-render once before actually closing it, at which point the data is null.

There's been some recent changes that introduce states, which may have caused this to start happening suddenly.
The fix was to call `closeModal` before `clearMarketingCta`, but I also added a few checks around the code, so that if there's another issue with the flags at some point, it won't crash the entire app.

References:
[REPORT 1](https://github.com/dailydotdev/daily/issues/1807)
[REPORT 2
](https://github.com/dailydotdev/daily/issues/1806)

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Jira ticket
MI-841

### Preview domain
https://mi-841.preview.app.daily.dev