### PR TITLE
Fix: Added bottom margin to footer links for better spacing and consistent layout

### DIFF
--- a/packages/shared/src/components/footer/FooterLinks.tsx
+++ b/packages/shared/src/components/footer/FooterLinks.tsx
@@ -15,8 +15,7 @@ export const FooterLinks = ({ className }: FooterLinksProps): ReactElement => {
         <ul
           className={classNames(
             className,
-            'flex flex-row flex-wrap justify-center gap-3 text-text-tertiary typo-caption1',
-            'mb-4', // Ensure bottom margin is always present
+            'flex flex-row flex-wrap justify-center gap-3 mb-4 text-text-tertiary typo-caption1'
           )}
         >
           <li>&copy; {new Date().getFullYear()} Daily Dev Ltd.</li>

--- a/packages/shared/src/components/footer/FooterLinks.tsx
+++ b/packages/shared/src/components/footer/FooterLinks.tsx
@@ -15,7 +15,7 @@ export const FooterLinks = ({ className }: FooterLinksProps): ReactElement => {
         <ul
           className={classNames(
             className,
-            'flex flex-row flex-wrap justify-center gap-3 mb-4 text-text-tertiary typo-caption1'
+            'mb-4 flex flex-row flex-wrap justify-center gap-3 text-text-tertiary typo-caption1',
           )}
         >
           <li>&copy; {new Date().getFullYear()} Daily Dev Ltd.</li>

--- a/packages/shared/src/components/footer/FooterLinks.tsx
+++ b/packages/shared/src/components/footer/FooterLinks.tsx
@@ -10,12 +10,13 @@ export type FooterLinksProps = {
 
 export const FooterLinks = ({ className }: FooterLinksProps): ReactElement => {
   return (
-    <footer className="z-1">
+    <footer className="z-1 pb-4">
       <nav>
         <ul
           className={classNames(
             className,
             'flex flex-row flex-wrap justify-center gap-3 text-text-tertiary typo-caption1',
+            'mb-4', // Ensure bottom margin is always present
           )}
         >
           <li>&copy; {new Date().getFullYear()} Daily Dev Ltd.</li>


### PR DESCRIPTION
## Changes

### Describe what this PR does  
- Fixes the missing bottom margin in footer links when no comments are present.  
- Ensures consistent spacing regardless of whether comments exist.  
- Adjusts the footer layout to prevent it from appearing broken when no comments are available.  

#### **Before vs After Screenshots**  
#### Before:
![image](https://github.com/user-attachments/assets/8a17f542-8176-490b-a610-e6f8e4146400)

#### After: 
![image](https://github.com/user-attachments/assets/c530b4f1-c0ca-408f-a79c-763ec276dc37)

---

## Events  

Did you introduce any new tracking events?  
<!-- No new tracking events introduced for this PR. -->

---

## Experiment  

Did you introduce any new experiments?  
<!-- No new experiments introduced for this PR. -->

---

## Manual Testing  

> [!CAUTION]  
> Please make sure existing components are not breaking/affected by this PR.  

### On those affected packages:  
- [x] Have you done sanity checks in the webapp?  
- [x] Have you done sanity checks in the extension?  
- [x] Does this not break anything in companion?  

### Did you test the modified components media queries?  
- [x] MobileL (420px)  
- [x] Tablet (656px)  
- [x] Laptop (1020px)  

#### Did you test on actual mobile devices?  
- [x] iOS (Chrome and Safari)  
- [x] Android  

---

### **Issue Reference**  
Fixes #[1808](https://github.com/dailydotdev/daily/issues/1808)

---

This PR ensures a consistent UI experience by fixing an issue where the footer spacing was incorrect when no comments were present. 🚀
