### PR TITLE
feat: post messages for log events so that Fylla Devtools can use it

### DIFF
--- a/packages/shared/src/hooks/log/useLogQueue.ts
+++ b/packages/shared/src/hooks/log/useLogQueue.ts
@@ -4,7 +4,7 @@ import { useMemo, useRef } from 'react';
 import { apiUrl } from '../../lib/config';
 import useDebounceFn from '../useDebounceFn';
 import { ExtensionMessageType } from '../../lib/extension';
-import { isTesting } from '../../lib/constants';
+import { isDevelopment } from '../../lib/constants';
 
 export interface LogEvent extends Record<string, unknown> {
   visit_id?: string;
@@ -80,7 +80,7 @@ export default function useLogQueue({
           const blob = new Blob([JSON.stringify({ events })], {
             type: 'application/json',
           });
-          if (!isTesting && window) {
+          if (!isDevelopment) {
             window.postMessage({
               type: 'FYLLA_LOG_DO_NOT_USE_OR_YOU_WILL_BE_FIRED',
               events,

--- a/packages/shared/src/hooks/log/useLogQueue.ts
+++ b/packages/shared/src/hooks/log/useLogQueue.ts
@@ -79,6 +79,10 @@ export default function useLogQueue({
           const blob = new Blob([JSON.stringify({ events })], {
             type: 'application/json',
           });
+          window.postMessage({
+            type: 'FYLLA_LOG_DO_NOT_USE_OR_YOU_WILL_BE_FIRED',
+            events,
+          });
           if (backgroundMethod) {
             backgroundMethod?.({
               url: LOG_ENDPOINT,

--- a/packages/shared/src/hooks/log/useLogQueue.ts
+++ b/packages/shared/src/hooks/log/useLogQueue.ts
@@ -80,7 +80,7 @@ export default function useLogQueue({
           const blob = new Blob([JSON.stringify({ events })], {
             type: 'application/json',
           });
-          if (!isDevelopment) {
+          if (isDevelopment && window) {
             window.postMessage({
               type: 'FYLLA_LOG_DO_NOT_USE_OR_YOU_WILL_BE_FIRED',
               events,

--- a/packages/shared/src/hooks/log/useLogQueue.ts
+++ b/packages/shared/src/hooks/log/useLogQueue.ts
@@ -4,6 +4,7 @@ import { useMemo, useRef } from 'react';
 import { apiUrl } from '../../lib/config';
 import useDebounceFn from '../useDebounceFn';
 import { ExtensionMessageType } from '../../lib/extension';
+import { isTesting } from '../../lib/constants';
 
 export interface LogEvent extends Record<string, unknown> {
   visit_id?: string;
@@ -79,10 +80,12 @@ export default function useLogQueue({
           const blob = new Blob([JSON.stringify({ events })], {
             type: 'application/json',
           });
-          window.postMessage({
-            type: 'FYLLA_LOG_DO_NOT_USE_OR_YOU_WILL_BE_FIRED',
-            events,
-          });
+          if (!isTesting && window) {
+            window.postMessage({
+              type: 'FYLLA_LOG_DO_NOT_USE_OR_YOU_WILL_BE_FIRED',
+              events,
+            });
+          }
           if (backgroundMethod) {
             backgroundMethod?.({
               url: LOG_ENDPOINT,


### PR DESCRIPTION
## Changes

The Fylla Devtools can natively listen for web traffic, but for sendBeacon we need to send messages to the extension.

### Preview domain
https://fylla-devtools.preview.app.daily.dev