### PR TITLE
fix: overflow gradient background on award modal

### DIFF
--- a/packages/shared/src/components/modals/award/BuyCoresModal.tsx
+++ b/packages/shared/src/components/modals/award/BuyCoresModal.tsx
@@ -297,7 +297,7 @@ const BuyCoreDesktop = () => {
   return (
     <ModalBody
       className={classNames(
-        'bg-gradient-to-t from-theme-overlay-float-bun to-transparent !p-0',
+        'bg-gradient-to-t from-theme-overlay-float-bun to-transparent !p-0 tablet:rounded-b-16',
       )}
     >
       <div className="flex flex-1 flex-row">

--- a/packages/shared/src/components/modals/award/GiveAwardModal.tsx
+++ b/packages/shared/src/components/modals/award/GiveAwardModal.tsx
@@ -111,7 +111,7 @@ const IntroScreen = () => {
           </Button>
         ) : null}
       </Modal.Header>
-      <Modal.Body className="bg-gradient-to-t from-theme-overlay-to to-transparent">
+      <Modal.Body className="bg-gradient-to-t from-theme-overlay-to to-transparent tablet:rounded-b-16">
         <div className="flex flex-col items-center justify-center gap-2 p-4">
           <Image
             src={hasAwards ? cloudinaryAwardUnicorn : entity.receiver.image}


### PR DESCRIPTION
## Changes

Fixes overflow background on the award/ core modal.

![image](https://github.com/user-attachments/assets/d45ccb3c-44b2-4d84-b738-a0b9505ae68e)

Could also solve it by adding `overflow: hidden` on the Modal component, but it could cause unexpected errors.

### Preview domain
https://fix-bg-overflow.preview.app.daily.dev