### PR TITLE
feat: extension buy cores

### DIFF
--- a/packages/shared/src/lib/links.ts
+++ b/packages/shared/src/lib/links.ts
@@ -1,4 +1,5 @@
 import { webappUrl } from './constants';
+import { checkIsExtension } from './func';
 
 export const getTagPageLink = (tag: string): string =>
   `${process.env.NEXT_PUBLIC_WEBAPP_URL}tags/${encodeURIComponent(tag)}`;
@@ -96,4 +97,26 @@ export const withPrefix = (prefix: string, url?: string): string => {
 
 export const fromCDN = (path: string): string => {
   return `${process.env.NEXT_PUBLIC_CDN_ASSET_PREFIX || ''}${path}`;
+};
+
+export const getRedirectNextPath = (params: URLSearchParams): string => {
+  const next = params.get('next');
+
+  let nextPath = '/';
+
+  if (next) {
+    try {
+      const nextUrl = new URL(next, 'http://localhost');
+      // infinite redirect loop prevention
+      nextUrl.searchParams.delete('next');
+
+      // we ignore url origin since we don't allow cross-origin redirects
+      nextPath = getPathnameWithQuery(nextUrl.pathname, nextUrl.searchParams);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
+  }
+
+  return checkIsExtension() ? `${webappUrl}${nextPath}` : nextPath;
 };

--- a/packages/webapp/pages/cores/payment.tsx
+++ b/packages/webapp/pages/cores/payment.tsx
@@ -10,6 +10,10 @@ import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import { BuyCoresContextProvider } from '@dailydotdev/shared/src/contexts/BuyCoresContext';
 import { Origin } from '@dailydotdev/shared/src/lib/log';
 import { TransactionStatusListener } from '@dailydotdev/shared/src/components/modals/award/BuyCoresModal';
+import {
+  getPathnameWithQuery,
+  getRedirectNextPath,
+} from '@dailydotdev/shared/src/lib/links';
 import { getTemplatedTitle } from '../../components/layouts/utils';
 import { defaultOpenGraph } from '../../next-seo';
 import { getCoresLayout } from '../../components/layouts/CoresLayout';
@@ -32,7 +36,14 @@ const CoresPaymentPage = (): ReactElement => {
     }
 
     if (isLaptop || !pid) {
-      router?.replace(`${webappUrl}cores`);
+      const searchParams = new URLSearchParams(window.location.search);
+      const nextParams = new URLSearchParams();
+
+      if (searchParams.get('next')) {
+        nextParams.set('next', searchParams.get('next'));
+      }
+
+      router?.replace(getPathnameWithQuery(`${webappUrl}cores`, nextParams));
     }
   }, [pid, router, isLaptop]);
 
@@ -49,7 +60,9 @@ const CoresPaymentPage = (): ReactElement => {
     <BuyCoresContextProvider
       origin={Origin.EarningsPageCTA}
       onCompletion={() => {
-        router?.push(webappUrl);
+        router?.push(
+          getRedirectNextPath(new URLSearchParams(window.location.search)),
+        );
       }}
     >
       <TransactionStatusListener isOpen isDrawerOnMobile />


### PR DESCRIPTION
## Changes

- buy cores through cores page instead of modal in extension
- add support for `next` param to redirect back from cores pages

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

AS-1053
AS-1058


### Preview domain
https://buy-award-extension.preview.app.daily.dev