### PR TITLE
fix: add note post award

### DIFF
--- a/packages/shared/src/components/comments/CommentContainer.tsx
+++ b/packages/shared/src/components/comments/CommentContainer.tsx
@@ -68,7 +68,7 @@ export default function CommentContainer({
     <article
       ref={isCommentReferenced ? commentRef : null}
       className={classNames(
-        'flex flex-col rounded-16 p-4 hover:bg-surface-hover focus:outline',
+        'relative flex flex-col rounded-16 p-4 hover:bg-surface-hover focus:outline',
         comment.userState?.awarded && 'bg-overlay-float-onion',
         isCommentReferenced
           ? 'border border-accent-cabbage-default'

--- a/packages/shared/src/components/post/PostActions.tsx
+++ b/packages/shared/src/components/post/PostActions.tsx
@@ -89,7 +89,7 @@ export function PostActions({
       variables: mutationVariables,
       queryClient: mutationQueryClient,
     }) => {
-      const { entityId, type } = mutationVariables as AwardProps;
+      const { entityId, type, note } = mutationVariables as AwardProps;
 
       mutationQueryClient.invalidateQueries({
         queryKey: generateQueryKey(RequestKey.Transactions, user),
@@ -108,11 +108,9 @@ export function PostActions({
           },
           numAwards: (post.numAwards || 0) + 1,
         });
-
-        return;
       }
 
-      if (type === 'COMMENT') {
+      if (note) {
         mutationQueryClient.invalidateQueries({
           queryKey: generateQueryKey(RequestKey.PostComments, undefined, {
             postId: post.id,


### PR DESCRIPTION
## Changes

Show the comment remark properly and invalidate comments if note is present.
(needed to make parent relative, not sure why we didn't always do it already.. (seems to not break anything)

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Jira ticket
AS-1065

### Preview domain
https://as-1065-note-post-award.preview.app.daily.dev