### PR TITLE
fix: prevent position flash of buy cores modal

### DIFF
--- a/packages/shared/src/components/modals/award/BuyCoresModal.tsx
+++ b/packages/shared/src/components/modals/award/BuyCoresModal.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { ModalKind } from '../common/types';
 import type { ModalProps } from '../common/Modal';
 import { Modal } from '../common/Modal';
-import { useViewSizeClient, ViewSize } from '../../../hooks';
+import { useViewSize, ViewSize } from '../../../hooks';
 import { ModalBody } from '../common/ModalBody';
 import {
   BuyCoresContextProvider,
@@ -323,7 +323,7 @@ const BuyCoreDesktop = () => {
 
 const BuyFlow = ({ ...props }: ModalProps): ReactElement => {
   const { setActiveModal } = useGiveAwardModalContext();
-  const isMobile = useViewSizeClient(ViewSize.MobileL);
+  const isMobile = useViewSize(ViewSize.MobileL);
 
   return (
     <Modal

--- a/packages/shared/src/components/modals/award/GiveAwardModal.tsx
+++ b/packages/shared/src/components/modals/award/GiveAwardModal.tsx
@@ -401,6 +401,10 @@ const ModalRender = ({ ...props }: ModalProps) => {
     setActiveModal('AWARD');
   }, [setActiveModal]);
 
+  const onRequestClose = useCallback(() => {
+    setActiveModal('AWARD');
+  }, [setActiveModal]);
+
   return (
     <>
       {activeModal === 'AWARD' ? (
@@ -423,6 +427,7 @@ const ModalRender = ({ ...props }: ModalProps) => {
         <BuyCoresModal
           {...props}
           onCompletion={onCompletion}
+          onRequestClose={onRequestClose}
           product={product}
           origin={Origin.Award}
         />


### PR DESCRIPTION
## Changes

- Use `useViewSize` to prevent flash of buy cores modal at top of page
- Show award modal when closing buy cores modal


----

Started with adding a state to track when to go back to award, but if I'm not wrong, all cases should lead back to award modal.