### PR TITLE
fix: show award icon as secondary when I have not gifted

### DIFF
--- a/packages/shared/src/components/post/PostActions.tsx
+++ b/packages/shared/src/components/post/PostActions.tsx
@@ -246,7 +246,7 @@ export function PostActions({
                     },
                   });
                 }}
-                icon={<MedalBadgeIcon />}
+                icon={<MedalBadgeIcon secondary={!post?.userState?.awarded} />}
                 className={classNames(
                   'btn-tertiary-cabbage',
                   post?.userState?.awarded && 'pointer-events-none',


### PR DESCRIPTION
## Changes

- Show award icon as secondary when I have not gifted

<table>
<tr>
<td>Before
<td>After
<tr>
<td><img src=https://github.com/user-attachments/assets/33bbc1e5-c83b-4710-bd23-015b6b7ba6de>
<td><img src=https://github.com/user-attachments/assets/5839e276-2c58-4ae4-b41a-0c02be1f83f9>

</table>

### Jira ticket
AS-1074

### Preview domain
https://as-1074-fix-award-icon-post-acti.preview.app.daily.dev