### PR TITLE
fix: noticed we showed a double plus badge

### DIFF
--- a/packages/shared/src/components/onboarding/OnboardingHeader.tsx
+++ b/packages/shared/src/components/onboarding/OnboardingHeader.tsx
@@ -11,9 +11,6 @@ import Logo, { LogoPosition, LogoWithPlus } from '../Logo';
 import { Button, ButtonVariant } from '../buttons/Button';
 import { CreateFeedButton } from './CreateFeedButton';
 import { OnboardingStep, wrapperMaxWidth } from './common';
-import ConditionalWrapper from '../ConditionalWrapper';
-import { PlusUser } from '../PlusUser';
-import { IconSize } from '../Icon';
 import {
   Typography,
   TypographyColor,
@@ -35,7 +32,6 @@ type OnboardingHeaderProps = {
   onClick: () => void;
   activeScreen: OnboardingStep;
   customActionName?: string;
-  showPlusIcon?: boolean;
 };
 
 export const OnboardingHeader = ({
@@ -44,7 +40,6 @@ export const OnboardingHeader = ({
   setAuth,
   onClick,
   customActionName,
-  showPlusIcon,
 }: OnboardingHeaderProps): ReactElement => {
   const { user } = useAuthContext();
   const { isFreeTrialExperiment } = usePaymentContext();
@@ -113,45 +108,32 @@ export const OnboardingHeader = ({
               !fullWidth && ' max-w-4xl ',
             )}
           >
-            <ConditionalWrapper
-              condition={showPlusIcon}
-              wrapper={(component) => (
-                <div className="flex flex-row items-center gap-1">
-                  {component}
-                  <PlusUser
-                    iconSize={IconSize.Small}
-                    typographyType={TypographyType.Title3}
-                  />
-                </div>
-              )}
-            >
-              {!isPlusStep ? (
-                <Logo
-                  logoClassName={{ container: 'h-6' }}
-                  position={LogoPosition.Relative}
-                  linkDisabled
-                />
-              ) : (
-                <LogoWithPlus />
-              )}
-              {activeScreen === OnboardingStep.InteractiveFeed && (
-                <div className="z-0 flex flex-col text-center">
-                  <Typography
-                    color={TypographyColor.Primary}
-                    bold
-                    type={TypographyType.Callout}
-                  >
-                    Let&apos;s make your feed work for you
-                  </Typography>
-                  <Typography
-                    type={TypographyType.Body}
-                    className={getCompletionColor()}
-                  >
-                    {completion}% optimized
-                  </Typography>
-                </div>
-              )}
-            </ConditionalWrapper>
+            {!isPlusStep ? (
+              <Logo
+                logoClassName={{ container: 'h-6' }}
+                position={LogoPosition.Relative}
+                linkDisabled
+              />
+            ) : (
+              <LogoWithPlus />
+            )}
+            {activeScreen === OnboardingStep.InteractiveFeed && (
+              <div className="z-0 flex flex-col text-center">
+                <Typography
+                  color={TypographyColor.Primary}
+                  bold
+                  type={TypographyType.Callout}
+                >
+                  Let&apos;s make your feed work for you
+                </Typography>
+                <Typography
+                  type={TypographyType.Body}
+                  className={getCompletionColor()}
+                >
+                  {completion}% optimized
+                </Typography>
+              </div>
+            )}
             {showCreateFeedButton.includes(activeScreen) && (
               <CreateFeedButton
                 onClick={onClick}

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -474,7 +474,6 @@ export function OnboardPage(): ReactElement {
           customActionName={customActionName}
           onClick={onClickCreateFeed}
           activeScreen={activeScreen}
-          showPlusIcon={isPlusCheckout && activeScreen === OnboardingStep.Plus}
         />
         <div
           className={classNames(


### PR DESCRIPTION
## Changes

I noticed on the one step checkout in onboarding we showed a double plus badge.
https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1743752915105479

Not sure why it was introduced as there's already one.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://fix-double-plus-badge.preview.app.daily.dev