### PR TITLE
fix: register noop event listener for `unload`

### DIFF
--- a/packages/shared/src/lib/lifecycle.ts
+++ b/packages/shared/src/lib/lifecycle.ts
@@ -216,6 +216,8 @@ export default function listenToLifecycleEvents(): void {
     }),
   );
 
+  window.addEventListener('unload', () => {}, true);
+
   // Safari does not reliably fire the `pagehide` or `visibilitychange`
   // events when closing a tab, so we have to use `beforeunload` with a
   // timeout to check whether the default action was prevented.


### PR DESCRIPTION
## Changes

- Adds a no-op event listener to `unload`, so that the `pagehide` event triggers properly.

------

While investigating the issue [Dave reported about missing events](https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1744172476038589), I started looking into the code that triggers the sendBeacon, and saw that we're using `pagehide` event listener.

And just doing some testing, I added the following code to the page cansole, and tried to hard navigate.

```js
window.addEventListener('pagehide', () => {console.log("pagehide")}, true)
```

Nothing showed up.

Then I tried this code, and did the same, and i logged as expected.

```js
window.addEventListener('unload', () => {console.log("unload")}, true)
```

I then went back and tried the first code, but instead of hard navigate, I reloaded the page (not hard navigate). It logged the line correct 😬 :thisisfine:

To make sure that I didn't mess anything up, I added both of them at the same time, and hard navigate

```js
window.addEventListener('pagehide', () => {console.log("pagehide")}, true);window.addEventListener('unload', () => {console.log("unload")}, true)
```

And :fml: it works. Something, somewhere, somehow, the `pagehide` event is reliant on `unload` being registered in the window.

------

But important to note, this might only be a temporary fix, as [`unload` is deprecated](https://developer.chrome.com/docs/web-platform/deprecating-unload) and will be removed in June from Chrome.