### PR TITLE
feat(funnels): add isActive prop to Loading Screen

### DIFF
--- a/packages/shared/src/features/onboarding/steps/FunnelLoading.tsx
+++ b/packages/shared/src/features/onboarding/steps/FunnelLoading.tsx
@@ -20,27 +20,26 @@ const animationDuration = 4500;
 const FunnelLoading = ({
   parameters,
   onTransition,
+  isActive = false,
 }: FunnelStepLoading): ReactElement => {
   const [percentage, setPercentage] = useState(0);
   const animationRef = useRef<number>();
   const pauseTimeoutRef = useRef<NodeJS.Timeout>();
+  const hasStarted = useRef(false);
 
   useEffect(() => {
     if (percentage >= 100) {
       onTransition({ type: FunnelStepTransitionType.Complete });
     }
-
-    return () => {
-      if (pauseTimeoutRef.current) {
-        clearTimeout(pauseTimeoutRef.current);
-      }
-      if (animationRef.current) {
-        cancelAnimationFrame(animationRef.current);
-      }
-    };
   }, [percentage, onTransition]);
 
   useEffect(() => {
+    if (!isActive || hasStarted.current) {
+      return;
+    }
+
+    hasStarted.current = true;
+
     const firstPhaseDuration = animationDuration * 0.4; // Time to reach 40%
     const secondPhaseDuration = animationDuration * 0.6; // Remaining time after 40%
 
@@ -104,6 +103,7 @@ const FunnelLoading = ({
     const animationStart = performance.now();
     animateFirstPhase(animationStart);
 
+    // eslint-disable-next-line consistent-return
     return () => {
       clearTimeout(forceCompletionTimeoutId);
       if (pauseTimeoutRef.current) {
@@ -113,7 +113,7 @@ const FunnelLoading = ({
         cancelAnimationFrame(animationRef.current);
       }
     };
-  }, []);
+  }, [isActive]);
 
   const getProgressArcPath = (percent: number): string => {
     const radius = 90;

--- a/packages/shared/src/features/onboarding/types/funnel.ts
+++ b/packages/shared/src/features/onboarding/types/funnel.ts
@@ -42,6 +42,7 @@ interface FunnelStepCommon {
   id: string;
   parameters: FunnelStepParameters;
   transitions: FunnelStepTransition[];
+  isActive?: boolean;
 }
 
 export interface FunnelStepChapter extends FunnelStepCommon {
@@ -55,7 +56,6 @@ export interface FunnelStepLandingPage extends FunnelStepCommon {
 export interface FunnelStepLoading
   extends Omit<FunnelStepCommon, 'transitions'> {
   type: FunnelStepType.Loading;
-  isActive?: boolean;
   onTransition: FunnelStepTransitionCallback<void>;
 }
 

--- a/packages/shared/src/features/onboarding/types/funnel.ts
+++ b/packages/shared/src/features/onboarding/types/funnel.ts
@@ -55,6 +55,7 @@ export interface FunnelStepLandingPage extends FunnelStepCommon {
 export interface FunnelStepLoading
   extends Omit<FunnelStepCommon, 'transitions'> {
   type: FunnelStepType.Loading;
+  isActive?: boolean;
   onTransition: FunnelStepTransitionCallback<void>;
 }
 


### PR DESCRIPTION
## Changes

Since we are now loading all the screens at the same time, we need a property to tell the loading screen when it should start loading.

Also removed the unnecessary cleanup from the second useEffect

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://update-loading-screen.preview.app.daily.dev