### PR TITLE
fix(funnels): remove dependency from useEffect

### DIFF
--- a/packages/shared/src/features/onboarding/steps/FunnelLoading.tsx
+++ b/packages/shared/src/features/onboarding/steps/FunnelLoading.tsx
@@ -28,7 +28,8 @@ const FunnelLoading = ({
     if (percentage >= 100) {
       onTransition({ type: FunnelStepTransitionType.Complete });
     }
-  }, [percentage, onTransition]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [percentage]);
 
   useEffect(() => {
     if (!isActive || hasStarted.current) {

--- a/packages/shared/src/features/onboarding/steps/FunnelLoading.tsx
+++ b/packages/shared/src/features/onboarding/steps/FunnelLoading.tsx
@@ -28,6 +28,7 @@ const FunnelLoading = ({
     if (percentage >= 100) {
       onTransition({ type: FunnelStepTransitionType.Complete });
     }
+    // Having onTransition as a dependency here causes an infinite re-render loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [percentage]);
 


### PR DESCRIPTION
## Changes

Having onTransition be a dependency in the useEffect that called it when the loading was finished caused an infinite re-render, which crashed the app.

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://fix-loading-screen-crash-after-c.preview.app.daily.dev