### PR TITLE
feat(funnels): add align to quiz and rating labels

### DIFF
--- a/packages/shared/src/features/common/components/FormInputRating.spec.tsx
+++ b/packages/shared/src/features/common/components/FormInputRating.spec.tsx
@@ -29,23 +29,6 @@ describe('FormInputRating', () => {
     }
   });
 
-  it('should render with custom options', () => {
-    const customOptions = Array.from({ length: 11 }, (_, i) => ({
-      label: i.toString(),
-      value: i.toString(),
-    }));
-    renderComponent({ options: customOptions });
-
-    // Should have 11 buttons for options 0-10
-    const buttons = screen.getAllByRole('radio');
-    expect(buttons).toHaveLength(11);
-
-    // Should have correct values
-    for (let i = 0; i <= 10; i += 1) {
-      expect(screen.getByText(i.toString())).toBeInTheDocument();
-    }
-  });
-
   it('should render with defaultValue', () => {
     renderComponent({ defaultValue: '3' });
 

--- a/packages/shared/src/features/common/components/FormInputRating.tsx
+++ b/packages/shared/src/features/common/components/FormInputRating.tsx
@@ -3,6 +3,11 @@ import React, { useState } from 'react';
 import classNames from 'classnames';
 import { Button, ButtonVariant } from '../../../components/buttons/Button';
 import { FunnelTargetId } from '../../onboarding/types/funnelEvents';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../../components/typography/Typography';
 
 type RatingValue = string;
 type OptionItem = {
@@ -66,10 +71,24 @@ export const FormInputRating = ({
               type="button"
               variant={ButtonVariant.Quiz}
             >
-              {item.label}
+              {index + 1}
             </Button>
           );
         })}
+      </div>
+      <div className="flex flex-row justify-between">
+        <Typography
+          type={TypographyType.Callout}
+          color={TypographyColor.Tertiary}
+        >
+          {options.at(0)?.label}
+        </Typography>
+        <Typography
+          type={TypographyType.Callout}
+          color={TypographyColor.Tertiary}
+        >
+          {options.at(-1)?.label}
+        </Typography>
       </div>
       {!!children && (
         <div className="flex flex-row justify-between gap-2">{children}</div>

--- a/packages/shared/src/features/onboarding/steps/FunnelQuiz.tsx
+++ b/packages/shared/src/features/onboarding/steps/FunnelQuiz.tsx
@@ -15,6 +15,7 @@ import {
   FormInputCheckboxGroup,
 } from '../../common/components/FormInputCheckboxGroup';
 import ConditionalWrapper from '../../../components/ConditionalWrapper';
+import type { StepHeadlineAlign } from '../shared';
 import { FunnelStepCtaWrapper, StepHeadline } from '../shared';
 import { Image } from '../../../components/image/Image';
 import { TypographyColor } from '../../../components/typography/Typography';
@@ -45,7 +46,7 @@ const checkIfCheckboxGroup = (
 export function FunnelQuiz({
   id,
   onTransition,
-  parameters: { question, explainer },
+  parameters: { question, explainer, align },
 }: FunnelStepQuiz): ReactElement {
   const { type, text, options, imageUrl } = question;
   const isSingleChoice = checkIfSingleChoice(type);
@@ -101,6 +102,7 @@ export function FunnelQuiz({
         <StepHeadline
           heading={text}
           description={explainer}
+          align={align as StepHeadlineAlign}
           descriptionProps={{ color: TypographyColor.Tertiary }}
         />
         {imageUrl && (


### PR DESCRIPTION
## Changes

Align dependent on this [PR](https://github.com/dailydotdev/freyja/pull/19) as props not in the schema get filtered out.

Also added label support for "rating" type quiz. I removed the "label" from the actual rating buttons and just added the index there. There's nothing in the spec about allowing labels there, and considering their sizes, its not intended, so we will use labels purely for the first and last inputs (as is in editor) to show a min/max label.

<img width="415" alt="Screenshot 2025-04-11 at 15 32 14" src="https://github.com/user-attachments/assets/21505cdf-a529-4a8f-a0f4-7884c0aeabc8" />


<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://quiz-fix.preview.app.daily.dev