### PR TITLE
feat: `/.well-known/change-password`

### DIFF
--- a/packages/webapp/next.config.ts
+++ b/packages/webapp/next.config.ts
@@ -203,6 +203,12 @@ const nextConfig: NextConfig = {
             destination: '/plus',
             permanent: false,
           },
+          // well-known redirect for change password
+          {
+            source: '/.well-known/change-password',
+            destination: '/account/security',
+            permanent: false,
+          },
         ];
       },
       headers: async () => {


### PR DESCRIPTION
## Changes

Adds a well-known URL redirect that is often used by password managers to link directly to the change password page of a website. It's just a simple redirect to whatever page we set.

### Preview domain
https://well-known/change-password.preview.app.daily.dev