### PR TITLE
fix: wrap Wallet button in header in `Link` to prevent hard-navigate

### DIFF
--- a/packages/shared/src/components/profile/ProfileButton.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.tsx
@@ -16,6 +16,7 @@ import { walletUrl } from '../../lib/constants';
 import { largeNumberFormat } from '../../lib';
 import { formatCurrency } from '../../lib/utils';
 import { useHasAccessToCores } from '../../hooks/useCoresFeature';
+import Link from '../utilities/Link';
 
 const ProfileMenu = dynamic(
   () => import(/* webpackChunkName: "profileMenu" */ '../ProfileMenu'),
@@ -67,15 +68,16 @@ export default function ProfileButton({
                 </>
               }
             >
-              <Button
-                icon={<CoreIcon />}
-                tag="a"
-                href={walletUrl}
-                variant={ButtonVariant.Tertiary}
-                size={ButtonSize.Small}
-              >
-                {largeNumberFormat(user?.balance?.amount || 0)}
-              </Button>
+              <Link href={walletUrl} passHref>
+                <Button
+                  icon={<CoreIcon />}
+                  tag="a"
+                  variant={ButtonVariant.Tertiary}
+                  size={ButtonSize.Small}
+                >
+                  {largeNumberFormat(user?.balance?.amount || 0)}
+                </Button>
+              </Link>
             </SimpleTooltip>
           )}
           <SimpleTooltip placement="bottom" content="Profile settings">


### PR DESCRIPTION
## Changes

Wraps the Wallet button in the header in a Link to prevent hard navigate

### Preview domain
https://ux-wrap-wallet-button-in-link.preview.app.daily.dev