### PR TITLE
refactor: condition whether to send broadcast message

### DIFF
--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -690,9 +690,9 @@ describe('Feed logged in', () => {
       expect(data).toBeTruthy();
     });
     const contextBtn = await screen.findByText('Unblock Echo JS');
+    fireEvent.click(contextBtn);
 
     await waitFor(async () => {
-      fireEvent.click(contextBtn);
       const alert = screen.getByRole('alert');
       expect(alert).toBeInTheDocument();
       const feed = screen.getByTestId('posts-feed');

--- a/packages/webapp/pages/callback.tsx
+++ b/packages/webapp/pages/callback.tsx
@@ -7,6 +7,16 @@ import type { ReactElement } from 'react';
 import { useContext, useEffect } from 'react';
 import LogContext from '@dailydotdev/shared/src/contexts/LogContext';
 
+const checkShouldSendBroadcast = () => {
+  const ua = navigator.userAgent;
+  const isFromFacebook = document.referrer === 'https://www.facebook.com/';
+  const isInstagramWebview = /Instagram/i.test(ua);
+  const postMessageUndefined = !window.opener?.postMessage;
+  const conditions = [isFromFacebook, isInstagramWebview, postMessageUndefined];
+
+  return conditions.some(Boolean);
+};
+
 function CallbackPage(): ReactElement {
   const { logEvent } = useContext(LogContext);
   useEffect(() => {
@@ -26,10 +36,7 @@ function CallbackPage(): ReactElement {
         return;
       }
 
-      if (
-        !window.opener?.postMessage ||
-        document.referrer === 'https://www.facebook.com/'
-      ) {
+      if (checkShouldSendBroadcast()) {
         broadcastMessage({ ...params, eventKey });
       } else {
         postWindowMessage(eventKey, params);


### PR DESCRIPTION
## Changes
- What I observed from the recording that Denis sent, the auth is pushing through and the callback page is functioning. However, the listeners are not executing accordingly.
- I think the issue is something similar to the past issues where post message is not working as intended.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://callback-webview-ig.preview.app.daily.dev