### PR TITLE
fix: ensure the adjustActions has the correct DOM when trying to calculate action width

### DIFF
--- a/packages/shared/src/components/post/PostActions.tsx
+++ b/packages/shared/src/components/post/PostActions.tsx
@@ -153,7 +153,10 @@ export function PostActions({
     return () => {
       resizeObserver.disconnect();
     };
-  }, []);
+
+    // It needs the post?.userState?.awarded dependency to ensure that the querySelector
+    // for labels is executed after the DOM is updated with the new state.
+  }, [post?.userState?.awarded]);
 
   return (
     <ConditionalWrapper


### PR DESCRIPTION
## Changes

The ConditionalWrapper with a SimpleTooltip causes the DOM to change and the list of actions to be refer to a non-existent node, causing the calculation to be wrong.

### Preview domain
https://fix-award-overflow.preview.app.daily.dev