### PR TITLE
fix: trigger turnstile reset on error

### DIFF
--- a/packages/shared/src/components/auth/RegistrationForm.tsx
+++ b/packages/shared/src/components/auth/RegistrationForm.tsx
@@ -109,6 +109,7 @@ const RegistrationForm = ({
       });
       if (hints?.csrf_token) {
         setTurnstileError(true);
+        ref?.current?.reset();
       }
     }
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM


### PR DESCRIPTION
## Changes

Trigger a reset of turnstile so that it gets a new valid token.

Closes https://github.com/dailydotdev/daily/issues/1824