### PR TITLE
fix(funnels): missing data-funnel-track for social signup

### DIFF
--- a/packages/shared/src/features/onboarding/shared/SocialRegistration.tsx
+++ b/packages/shared/src/features/onboarding/shared/SocialRegistration.tsx
@@ -19,6 +19,7 @@ import {
 import { cookiePolicy, termsOfService } from '../../../lib/constants';
 import { anchorDefaultRel } from '../../../lib/strings';
 import { isWebView } from '../../../components/auth/OnboardingRegistrationForm';
+import { FunnelTargetId } from '../types/funnelEvents';
 
 interface MobileSocialRegistrationProps {
   onClick: (provider: SocialProvider) => void;
@@ -72,6 +73,7 @@ export function SocialRegistration({
         onClick={() => handleClick(firstProvider)}
         data-testid={`social-button-${firstProvider.toLowerCase()}`}
         icon={providerMap[firstProvider].icon}
+        data-funnel-track={FunnelTargetId.SignupProvider}
       >
         Sign up with {providerMap[firstProvider].label}
       </Button>
@@ -80,6 +82,7 @@ export function SocialRegistration({
         onClick={() => handleClick(SocialProvider.GitHub)}
         data-testid="social-button-github"
         icon={providerMap[SocialProvider.GitHub].icon}
+        data-funnel-track={FunnelTargetId.SignupProvider}
       >
         Sign up with {providerMap[SocialProvider.GitHub].label}
       </Button>

--- a/packages/shared/src/features/onboarding/types/funnelEvents.ts
+++ b/packages/shared/src/features/onboarding/types/funnelEvents.ts
@@ -21,6 +21,7 @@ export enum FunnelTargetId {
   StepSkip = 'step skip',
   StepBack = 'step back',
   SubPlan = 'subscription plan',
+  SignupProvider = 'signup provider',
 }
 
 export type FunnelEvent =


### PR DESCRIPTION
Add missing `data-funnel-track` property to social registration buttons so we can track them


### Preview domain
https://signup-funnel-track.preview.app.daily.dev