### PR TITLE
fix: in-app redirect existing email

### DIFF
--- a/packages/shared/src/features/onboarding/shared/utils.ts
+++ b/packages/shared/src/features/onboarding/shared/utils.ts
@@ -30,3 +30,5 @@ export function shouldRedirectAuth(): boolean {
 
   return brokenWebviewPatterns.some((pattern) => pattern.test(ua));
 }
+
+export const AUTH_REDIRECT_KEY = 'auth_redirect';

--- a/packages/shared/src/features/onboarding/steps/FunnelRegistration.tsx
+++ b/packages/shared/src/features/onboarding/steps/FunnelRegistration.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useRouter } from 'next/router';
 import classNames from 'classnames';
 import {
@@ -29,7 +29,11 @@ import { broadcastChannel } from '../../../lib/constants';
 import Logo, { LogoPosition } from '../../../components/Logo';
 import type { LoggedUser } from '../../../lib/user';
 import { FunnelStepTransitionType } from '../types/funnel';
-import { sanitizeMessage, shouldRedirectAuth } from '../shared';
+import {
+  AUTH_REDIRECT_KEY,
+  sanitizeMessage,
+  shouldRedirectAuth,
+} from '../shared';
 import type { FunnelStepSignup } from '../types/funnel';
 import { useConsentCookie } from '../../../hooks/useCookieConsent';
 import { GdprConsentKey } from '../../../hooks/useCookieBanner';
@@ -50,15 +54,9 @@ const useRegistrationListeners = (
   const { logEvent } = useLogContext();
   const router = useRouter();
 
-  const onProviderMessage = async (e: MessageEvent) => {
-    const isEventSupported = supportedEvents.includes(e.data?.eventKey);
-
-    if (!isEventSupported) {
-      return undefined;
-    }
-
-    if (e.data?.flow) {
-      const connected = await getKratosFlow(AuthFlow.Registration, e.data.flow);
+  const handleExistingFlow = useCallback(
+    async (flow: string) => {
+      const connected = await getKratosFlow(AuthFlow.Registration, flow);
 
       logEvent({
         event_name: AuthEventNames.RegistrationError,
@@ -78,6 +76,19 @@ const useRegistrationListeners = (
       }
 
       return displayToast(`${labels.auth.error.generic} Code: ${code}`);
+    },
+    [displayToast, logEvent],
+  );
+
+  const onProviderMessage = async (e: MessageEvent) => {
+    const isEventSupported = supportedEvents.includes(e.data?.eventKey);
+
+    if (!isEventSupported) {
+      return undefined;
+    }
+
+    if (e.data?.flow) {
+      return handleExistingFlow(e.data.flow);
     }
 
     const bootResponse = await refetchBoot();
@@ -100,6 +111,23 @@ const useRegistrationListeners = (
   useEventListener(broadcastChannel, 'message', onProviderMessage);
 
   useEventListener(globalThis, 'message', onProviderMessage);
+
+  useEffect(() => {
+    if (!router?.isReady || !router?.query?.flow) {
+      return;
+    }
+
+    const flowFn = async () => {
+      await handleExistingFlow(router.query.flow as string);
+      const url = new URL(window.location.href);
+      const fullPath = url.origin + url.pathname;
+      const { flow, ...rest } = router.query;
+      const params = new URLSearchParams(rest as Record<string, string>);
+      router.replace(`${fullPath}?${params}`);
+    };
+
+    flowFn();
+  }, [handleExistingFlow, router]);
 };
 
 function InnerFunnelRegistration({
@@ -123,6 +151,7 @@ function InnerFunnelRegistration({
     },
     onRedirect: (redirect) => {
       if (shouldRedirect) {
+        window.sessionStorage.setItem(AUTH_REDIRECT_KEY, window.location.href);
         window.location.href = redirect;
       } else {
         windowPopup.current.location.href = redirect;
@@ -141,6 +170,14 @@ function InnerFunnelRegistration({
   useRegistrationListeners(onTransition);
 
   const sanitizedHeading = useMemo(() => sanitizeMessage(headline), [headline]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !shouldRedirect) {
+      return;
+    }
+
+    window.sessionStorage.removeItem(AUTH_REDIRECT_KEY);
+  }, [shouldRedirect]);
 
   return (
     <div className="relative flex w-full flex-1 flex-col items-center justify-center overflow-hidden">

--- a/packages/webapp/pages/callback.tsx
+++ b/packages/webapp/pages/callback.tsx
@@ -6,6 +6,10 @@ import { AuthEvent } from '@dailydotdev/shared/src/lib/kratos';
 import type { ReactElement } from 'react';
 import { useContext, useEffect } from 'react';
 import LogContext from '@dailydotdev/shared/src/contexts/LogContext';
+import {
+  AUTH_REDIRECT_KEY,
+  shouldRedirectAuth,
+} from '@dailydotdev/shared/src/features/onboarding/shared';
 
 const checkShouldSendBroadcast = () => {
   const ua = navigator.userAgent;
@@ -15,6 +19,21 @@ const checkShouldSendBroadcast = () => {
   const conditions = [isFromFacebook, isInstagramWebview, postMessageUndefined];
 
   return conditions.some(Boolean);
+};
+
+const handleRedirectAuth = (params: URLSearchParams) => {
+  const href = window.sessionStorage.getItem(AUTH_REDIRECT_KEY);
+
+  if (href) {
+    const [redirect, hrefParams] = href.split('?');
+    const redirectParams = new URLSearchParams(hrefParams);
+
+    Object.entries(redirectParams).forEach(([key, value]) =>
+      params.set(key, value),
+    );
+
+    window.location.replace(`${redirect}?${params}`);
+  }
 };
 
 function CallbackPage(): ReactElement {
@@ -33,6 +52,11 @@ function CallbackPage(): ReactElement {
     try {
       if (!window.opener && params.flow && params.settings) {
         window.location.replace(`/reset-password?${search}`);
+        return;
+      }
+
+      if (shouldRedirectAuth()) {
+        handleRedirectAuth(urlSearchParams);
         return;
       }
 


### PR DESCRIPTION
## Changes
- Same issue fixed here: https://github.com/dailydotdev/apps/commit/bbeafdaf720db4309d298b7a65061fe0fa0dfc68
  - Where the user is trying to login with an email that is already associated with another account.
- The only difference here, this is to fix the redirect flow because we now have to support auth for both redirect and callback postMessage :hide_the_pain:
- Context: when a user from Facebook in-app browser tries to login, and the case above happened, the user should be redirected to the params we sent (`redirect_to` or `return_to`) - those params when initializing a flow will only be utilized when the flow was successful. With the edge case above, it is considered a failed flow so the redirection falls back to our callback page instead of the redirect params we sent.
- Using session storage is ideal since the data goes away after closing the browser which is basically the same as closing the in-app browser.
- We also added a process to utilize the flow sent by the failing attempt so we can display the error message.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://fix-facebook-redirect-fail.preview.app.daily.dev