### PR TITLE
fix: overscroll modal

### DIFF
--- a/packages/shared/src/components/modals/common/ModalSidebar.tsx
+++ b/packages/shared/src/components/modals/common/ModalSidebar.tsx
@@ -61,7 +61,12 @@ export function ModalSidebar({
   className,
 }: ModalSidebarProps): ReactElement {
   return (
-    <div className={classNames('flex w-full flex-1 flex-row', className)}>
+    <div
+      className={classNames(
+        'flex w-full flex-1 flex-row overflow-y-auto',
+        className,
+      )}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
## Changes

The feed setting modal (ModalSidebar) needs to scroll only the content section.

![Screenshot 2025-04-16 at 13 35 48](https://github.com/user-attachments/assets/d9b2ba85-c0fa-4855-b7f6-b9b620b61ad2)

Mentioned here:
https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1741507698404249

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://fix-overscroll-modal.preview.app.daily.dev