### PR TITLE
fix: temporarily add account details item

### DIFF
--- a/packages/shared/src/components/ProfileMenu/sections/AccountSection.tsx
+++ b/packages/shared/src/components/ProfileMenu/sections/AccountSection.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import type { ReactElement } from 'react';
 
 import { ProfileSection } from '../ProfileSection';
-import { CreditCardIcon, InviteIcon, SettingsIcon } from '../../icons';
+import {
+  CreditCardIcon,
+  EditIcon,
+  InviteIcon,
+  SettingsIcon,
+} from '../../icons';
 import { webappUrl } from '../../../lib/constants';
 import { useLazyModal } from '../../../hooks/useLazyModal';
 import { LazyModal } from '../../modals/common/types';
@@ -14,8 +19,12 @@ export const AccountSection = (): ReactElement => {
     <ProfileSection
       items={[
         {
-          title: 'Settings',
-          // href: `${webappUrl}account/profile`,
+          title: 'Account details',
+          href: `${webappUrl}account/profile`,
+          icon: <EditIcon />,
+        },
+        {
+          title: 'Customize',
           onClick: () => openModal({ type: LazyModal.UserSettings }),
           icon: <SettingsIcon />,
         },

--- a/packages/shared/src/components/profile/ProfileButton.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.spec.tsx
@@ -41,7 +41,7 @@ it('should show settings option that opens modal', async () => {
   });
 
   const settingsButton = await screen.findByRole('button', {
-    name: 'Settings',
+    name: 'Customize',
   });
   expect(settingsButton).toBeInTheDocument();
 });


### PR DESCRIPTION
## Changes

Temporarily re-adds account details icon to profile menu dropdown

### Preview domain
https://tmp-fix-profile-dropdown.preview.app.daily.dev