### PR TITLE
fix: disable button and show error if Turnstile is not loaded

### DIFF
--- a/packages/shared/src/components/auth/RegistrationForm.tsx
+++ b/packages/shared/src/components/auth/RegistrationForm.tsx
@@ -83,6 +83,7 @@ const RegistrationForm = ({
   const router = useRouter();
   const { logEvent } = useContext(LogContext);
   const [turnstileError, setTurnstileError] = useState<boolean>(false);
+  const [turnstileLoaded, setTurnstileLoaded] = useState<boolean>(false);
   const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
   const [name, setName] = useState('');
   const isAuthorOnboarding = trigger === AuthTriggers.Author;
@@ -415,6 +416,7 @@ const RegistrationForm = ({
               theme: 'dark',
             }}
             className="mx-auto min-h-[4.5rem]"
+            onWidgetLoad={() => setTurnstileLoaded(true)}
           />
           {turnstileError ? (
             <Alert
@@ -424,7 +426,7 @@ const RegistrationForm = ({
           ) : undefined}
           <Button
             className="w-full"
-            disabled={isCheckPending}
+            disabled={isCheckPending || !turnstileLoaded}
             form="auth-form"
             type="submit"
             variant={ButtonVariant.Primary}

--- a/packages/shared/src/components/auth/RegistrationForm.tsx
+++ b/packages/shared/src/components/auth/RegistrationForm.tsx
@@ -88,7 +88,7 @@ const RegistrationForm = ({
   const [name, setName] = useState('');
   const isAuthorOnboarding = trigger === AuthTriggers.Author;
   const { username, setUsername } = useGenerateUsername(name);
-  const ref = useRef<TurnstileInstance>(null);
+  const turnstileRef = useRef<TurnstileInstance>(null);
   const isReorderExperiment = useFeature(featureOnboardingReorder);
   const isOnboardingExperiment = !!(
     router.pathname?.startsWith('/onboarding') && isReorderExperiment
@@ -111,7 +111,7 @@ const RegistrationForm = ({
       if (hints?.csrf_token) {
         setTurnstileError(true);
       }
-      ref?.current?.reset();
+      turnstileRef?.current?.reset();
     }
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -173,7 +173,7 @@ const RegistrationForm = ({
       return;
     }
 
-    if (!ref?.current?.getResponse()) {
+    if (!turnstileRef?.current?.getResponse()) {
       logEvent({
         event_name: AuthEventNames.SubmitSignUpFormError,
         extra: JSON.stringify({
@@ -213,7 +213,7 @@ const RegistrationForm = ({
       headers: {
         'True-Client-Ip': isDevelopment
           ? undefined
-          : ref?.current?.getResponse(),
+          : turnstileRef?.current?.getResponse(),
       },
     });
   };
@@ -410,7 +410,7 @@ const RegistrationForm = ({
           )}
         >
           <Turnstile
-            ref={ref}
+            ref={turnstileRef}
             siteKey={process.env.NEXT_PUBLIC_TURNSTILE_KEY}
             options={{
               theme: 'dark',

--- a/packages/shared/src/components/auth/RegistrationForm.tsx
+++ b/packages/shared/src/components/auth/RegistrationForm.tsx
@@ -119,6 +119,10 @@ const RegistrationForm = ({
   }, [hints]);
 
   useEffect(() => {
+    if (turnstileLoaded) {
+      return () => {};
+    }
+
     const turnstileLoadTimeout = setTimeout(() => {
       if (!turnstileLoaded) {
         logRef.current({

--- a/packages/shared/src/lib/auth.ts
+++ b/packages/shared/src/lib/auth.ts
@@ -34,6 +34,7 @@ export enum AuthEventNames {
   RegistrationError = 'registration error',
   RegistrationInitializationError = 'registration initialization error',
   VerifiedSuccessfully = 'verified successfully',
+  TurnstileLoadError = 'turnstile load error',
 }
 
 export enum AuthTriggers {


### PR DESCRIPTION
## Changes

- Disable the create account button while Cloudflare Turnstile has not loaded.
- Fix the eslint hook disable rule
- Show an error if Turnstile is not loaded after 5 seconds
  ![image](https://github.com/user-attachments/assets/f0db4f9e-50f1-4f6e-afac-652423fb79c4)


https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1745824704486649

### Preview domain
https://fix-turnstile-disable-create-acc.preview.app.daily.dev