### PR TITLE
feat: additional tracking

### DIFF
--- a/packages/shared/src/components/accordion/index.tsx
+++ b/packages/shared/src/components/accordion/index.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { MouseEventHandler, ReactElement, ReactNode } from 'react';
 import React, { useId, useState } from 'react';
 import classNames from 'classnames';
 import { Button } from '../buttons/Button';
@@ -7,12 +7,25 @@ import { ArrowIcon } from '../icons';
 interface AccordionProps {
   title: ReactNode;
   children: ReactNode;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
 }
 
-export function Accordion({ title, children }: AccordionProps): ReactElement {
+export function Accordion({
+  title,
+  children,
+  onClick,
+}: AccordionProps): ReactElement {
   const [isOpen, setIsOpen] = useState(false);
   const id = useId();
   const contentId = `accordion-content-${id}`;
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (e) => {
+    if (onClick) {
+      onClick(e);
+    }
+
+    setIsOpen((prev) => !prev);
+  };
 
   return (
     <div className="flex w-full flex-col">
@@ -21,7 +34,7 @@ export function Accordion({ title, children }: AccordionProps): ReactElement {
         aria-expanded={isOpen}
         className="flex w-full flex-row gap-4 !px-0 text-left"
         type="button"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={handleClick}
       >
         <div className="min-w-0 flex-1">{title}</div>
         <ArrowIcon

--- a/packages/shared/src/components/plus/PlusCheckoutContainer.tsx
+++ b/packages/shared/src/components/plus/PlusCheckoutContainer.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import type { MouseEventHandler, ReactElement } from 'react';
 import React, { useMemo } from 'react';
 
 import classNames from 'classnames';
@@ -8,6 +8,8 @@ import { PlusUnavailable } from './PlusUnavailable';
 import { PlusPlus } from './PlusPlus';
 import { useGiftUserContext } from './GiftUserContext';
 import { Checkbox } from '../fields/Checkbox';
+import { useLogContext } from '../../contexts/LogContext';
+import { LogEvent } from '../../lib/log';
 
 export type PlusCheckoutContainerProps = {
   checkoutRef?: React.LegacyRef<HTMLDivElement>;
@@ -21,6 +23,7 @@ export const PlusCheckoutContainer = ({
   checkoutRef,
   className,
 }: PlusCheckoutContainerProps): ReactElement => {
+  const { logEvent } = useLogContext();
   const { giftToUser } = useGiftUserContext();
   const { isPlusAvailable, isFreeTrialExperiment, isPricesPending } =
     usePaymentContext();
@@ -47,9 +50,14 @@ export const PlusCheckoutContainer = ({
     !isPricesPending &&
     shouldRenderCheckout;
 
+  const handleHover: MouseEventHandler = (e) => {
+    logEvent({ event_name: LogEvent.HoverCheckoutWidget });
+  };
+
   return (
     <div className={className?.container}>
       <div
+        onMouseEnter={handleHover}
         ref={shouldRenderCheckout ? checkoutRef : undefined}
         className={classNames(shouldRenderCheckout && 'checkout-container')}
       />

--- a/packages/shared/src/components/plus/PlusFAQ.tsx
+++ b/packages/shared/src/components/plus/PlusFAQ.tsx
@@ -11,29 +11,42 @@ import { anchorDefaultRel } from '../../lib/strings';
 import { feedback } from '../../lib/constants';
 import { plusFAQItems, plusFAQTrialItem } from './common';
 import { usePaymentContext } from '../../contexts/payment/context';
+import { useLogContext } from '../../contexts/LogContext';
+import { LogEvent } from '../../lib/log';
 
 interface FAQ {
   question: string;
   answer: ReactNode;
 }
 
-const FAQItem = ({ item }: { item: FAQ }): ReactElement => (
-  <div className="rounded-10 bg-surface-float px-6 py-4">
-    <Accordion
-      title={
-        <Typography
-          bold
-          color={TypographyColor.Primary}
-          tag={TypographyTag.Span}
-        >
-          {item.question}
-        </Typography>
-      }
-    >
-      <div className="text-text-tertiary typo-callout">{item.answer}</div>
-    </Accordion>
-  </div>
-);
+const FAQItem = ({ item }: { item: FAQ }): ReactElement => {
+  const { logEvent } = useLogContext();
+  const handleClick = () => {
+    logEvent({
+      event_name: LogEvent.ClickPlusFaq,
+      target_id: item.question,
+    });
+  };
+
+  return (
+    <div className="rounded-10 bg-surface-float px-6 py-4">
+      <Accordion
+        onClick={handleClick}
+        title={
+          <Typography
+            bold
+            color={TypographyColor.Primary}
+            tag={TypographyTag.Span}
+          >
+            {item.question}
+          </Typography>
+        }
+      >
+        <div className="text-text-tertiary typo-callout">{item.answer}</div>
+      </Accordion>
+    </div>
+  );
+};
 
 export const PlusFAQ = (): ReactElement => {
   const { isFreeTrialExperiment } = usePaymentContext();

--- a/packages/shared/src/components/plus/PlusListItem.tsx
+++ b/packages/shared/src/components/plus/PlusListItem.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactElement } from 'react';
+import type { FC, MouseEventHandler, ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import ConditionalWrapper from '../ConditionalWrapper';
@@ -13,6 +13,8 @@ import {
   TypographyTag,
   TypographyType,
 } from '../typography/Typography';
+import { useLogContext } from '../../contexts/LogContext';
+import { LogEvent, TargetType } from '../../lib/log';
 
 export enum PlusItemStatus {
   Ready = 'done',
@@ -53,6 +55,19 @@ export const PlusListItem = ({
   typographyProps,
   onHover,
 }: PlusListItemProps): ReactElement => {
+  const { logEvent } = useLogContext();
+  const handleHover: MouseEventHandler = (e) => {
+    logEvent({
+      event_name: LogEvent.HoverPlusFeature,
+      target_type: TargetType.List,
+      target_id: item.id,
+    });
+
+    if (onHover) {
+      onHover();
+    }
+  };
+
   return (
     <ConditionalWrapper
       condition={!!item.tooltip}
@@ -74,7 +89,7 @@ export const PlusListItem = ({
           '-mx-1 flex gap-1 rounded-6 p-1',
           !!item.tooltip && 'hover:bg-surface-float',
         )}
-        onMouseEnter={onHover}
+        onMouseEnter={handleHover}
       >
         {Icon && (
           <Icon

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -244,6 +244,9 @@ export enum LogEvent {
   OnboardingUpgradePlus = 'upgrade subscription',
   GiftSubscription = 'gift subscription',
   CompleteGiftCheckout = 'complete gift checkout',
+  ClickPlusFaq = 'click plus faq',
+  HoverCheckoutWidget = 'hover checkout widget',
+  PageScroll = 'page scroll',
   // End Plus subscription
   // Clickbait Shield
   ToggleClickbaitShield = 'toggle clickbait shield',

--- a/packages/webapp/pages/plus/index.tsx
+++ b/packages/webapp/pages/plus/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import dynamic from 'next/dynamic';
 import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
@@ -9,6 +9,8 @@ import type { GiftUserContextData } from '@dailydotdev/shared/src/components/plu
 import { GiftUserContext } from '@dailydotdev/shared/src/components/plus/GiftUserContext';
 import type { CommonPlusPageProps } from '@dailydotdev/shared/src/components/plus/common';
 import { isIOSNative } from '@dailydotdev/shared/src/lib/func';
+import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
+import { LogEvent } from '@dailydotdev/shared/src/lib/log';
 import { getPlusLayout } from '../../components/layouts/PlusLayout/PlusLayout';
 import { getTemplatedTitle } from '../../components/layouts/utils';
 import { defaultOpenGraph } from '../../next-seo';
@@ -45,8 +47,26 @@ const PlusPage = ({
   giftToUser,
   shouldShowPlusHeader,
 }: PlusPageProps): ReactElement => {
+  const { logEvent } = useLogContext();
   const { isReady } = useRouter();
   const isLaptop = useViewSize(ViewSize.Laptop);
+
+  useEffect(() => {
+    const onScroll = () => {
+      logEvent({
+        event_name: LogEvent.PageScroll,
+        extra: JSON.stringify({
+          scrollTop: window.scrollY,
+        }),
+      });
+    };
+
+    globalThis?.window?.addEventListener('scrollend', onScroll);
+
+    return () => {
+      globalThis?.window?.removeEventListener('scrollend', onScroll);
+    };
+  }, [logEvent]);
 
   if (!isReady) {
     return null;


### PR DESCRIPTION
## Changes
- Additional analytics events:
  - Scroll event for the Plus page. 
  - Hover plus feature. This means, wherever we use the component, the analytics events are sent even when not in Plus page.
  - Click plus FAQ. Same as above on when the event can be triggered.
  - Hover checkout widget. Same as above on when the event can be triggered.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

MI-863 #done
