### PR TITLE
fix: send target type with complete checkout

### DIFF
--- a/packages/shared/src/contexts/payment/Paddle.tsx
+++ b/packages/shared/src/contexts/payment/Paddle.tsx
@@ -4,6 +4,7 @@ import type { CheckoutEventNames, PaddleEventData } from '@paddle/paddle-js';
 import { usePaddlePayment } from '../../hooks/usePaddlePayment';
 import type { PaymentContextProviderProps } from './context';
 import { BasePaymentProvider } from './BasePaymentProvider';
+import { TargetType } from '../../lib/log';
 
 export type PaddleSubProviderProps = PaymentContextProviderProps<
   PaddleEventData,
@@ -16,6 +17,7 @@ export const PaddleSubProvider = ({
 }: PaymentContextProviderProps): ReactElement => {
   const { openCheckout, isPaddleReady } = usePaddlePayment({
     successCallback,
+    targetType: TargetType.Plus,
   });
 
   return (

--- a/packages/shared/src/hooks/usePaddlePayment.ts
+++ b/packages/shared/src/hooks/usePaddlePayment.ts
@@ -24,7 +24,7 @@ interface UsePaddlePaymentProps
     PaymentContextProviderProps<PaddleEventData, CheckoutEventNames>,
     'successCallback' | 'disabledEvents'
   > {
-  targetType?: TargetType;
+  targetType: TargetType;
   getProductQuantity?: (event: PaddleEventData) => number;
 }
 


### PR DESCRIPTION
The paddle refactor introduced an issue that caused `complete checkout` coming from Plus to not include the target type property. This is now fixed and I set target type as required field

### Preview domain
https://complete-checkout-fix.preview.app.daily.dev