### PR TITLE
fix: hide cores settings ui if user has no access

### DIFF
--- a/packages/shared/src/components/ProfileMenu/sections/MainSection.tsx
+++ b/packages/shared/src/components/ProfileMenu/sections/MainSection.tsx
@@ -5,8 +5,10 @@ import { ProfileSection } from '../ProfileSection';
 import { CoinIcon, DevCardIcon, UserIcon } from '../../icons';
 import { walletUrl, webappUrl } from '../../../lib/constants';
 import { useAuthContext } from '../../../contexts/AuthContext';
+import { useHasAccessToCores } from '../../../hooks/useCoresFeature';
 
 export const MainSection = (): ReactElement => {
+  const hasAccessToCores = useHasAccessToCores();
   const { user } = useAuthContext();
 
   return (
@@ -17,13 +19,17 @@ export const MainSection = (): ReactElement => {
           href: `${webappUrl}${user.username}`,
           icon: UserIcon,
         },
-        { title: 'Core wallet', href: walletUrl, icon: CoinIcon },
+        hasAccessToCores && {
+          title: 'Core wallet',
+          href: walletUrl,
+          icon: CoinIcon,
+        },
         {
           title: 'DevCard',
           href: `${webappUrl}account/customization/devcard`,
           icon: DevCardIcon,
         },
-      ]}
+      ].filter(Boolean)}
     />
   );
 };

--- a/packages/shared/src/components/credit/BuyCreditsButton.tsx
+++ b/packages/shared/src/components/credit/BuyCreditsButton.tsx
@@ -12,6 +12,7 @@ import { largeNumberFormat } from '../../lib';
 import { LogEvent, Origin } from '../../lib/log';
 import { useLogContext } from '../../contexts/LogContext';
 import { useModalContext } from '../modals/common/types';
+import { useHasAccessToCores } from '../../hooks/useCoresFeature';
 
 type BuyCreditsButtonProps = {
   className?: string;
@@ -23,6 +24,7 @@ export const BuyCreditsButton = ({
   onPlusClick,
   hideBuyButton,
 }: BuyCreditsButtonProps): ReactElement => {
+  const hasCoresAccess = useHasAccessToCores();
   const isInsideModal = useModalContext().onRequestClose !== null;
   const { user } = useAuthContext();
 
@@ -35,6 +37,10 @@ export const BuyCreditsButton = ({
     });
     onPlusClick?.();
   };
+
+  if (!hasCoresAccess) {
+    return null;
+  }
 
   return (
     <div

--- a/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
+++ b/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
@@ -49,6 +49,7 @@ import { ProfileMenuHeader } from '../ProfileMenu/ProfileMenuHeader';
 import { ProfileImageSize } from '../ProfilePicture';
 import { useViewSize, ViewSize } from '../../hooks';
 import { TypographyColor, TypographyType } from '../typography/Typography';
+import { useHasAccessToCores } from '../../hooks/useCoresFeature';
 
 type MenuItems = Record<
   string,
@@ -216,6 +217,7 @@ export const InnerProfileSettingsMenu = ({ className }: WithClassNameProps) => {
   const { asPath } = useRouter();
   const { logout } = useAuthContext();
   const isMobile = useViewSize(ViewSize.MobileL);
+  const hasAccessToCores = useHasAccessToCores();
 
   return (
     <nav className={classNames('flex flex-col gap-2', className)}>
@@ -224,8 +226,15 @@ export const InnerProfileSettingsMenu = ({ className }: WithClassNameProps) => {
           key={key}
           withSeparator
           title={menuItem.title}
-          items={Object.entries(menuItem.items).map(
-            ([, item]: [string, ProfileSectionItemProps]) => {
+          items={Object.entries(menuItem.items)
+            .filter(([, item]) => {
+              if (item.href === walletUrl && !hasAccessToCores) {
+                return false;
+              }
+
+              return true;
+            })
+            .map(([, item]: [string, ProfileSectionItemProps]) => {
               return {
                 ...item,
                 isActive: asPath === item.href,
@@ -236,8 +245,7 @@ export const InnerProfileSettingsMenu = ({ className }: WithClassNameProps) => {
                   },
                 }),
               };
-            },
-          )}
+            })}
         />
       ))}
 


### PR DESCRIPTION
## Changes

Noticed that new settings did not have cores check for cores UI.

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://fix-cores-settings.preview.app.daily.dev