### PR TITLE
fix: close profile menu on route change

### DIFF
--- a/packages/shared/src/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/shared/src/components/ProfileMenu/ProfileMenu.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
-import React from 'react';
+import React, { useEffect } from 'react';
 import dynamic from 'next/dynamic';
+import { useRouter } from 'next/router';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { ExitIcon } from '../icons';
 import InteractivePopup, {
@@ -35,7 +36,16 @@ interface ProfileMenuProps {
 export default function ProfileMenu({
   onClose,
 }: ProfileMenuProps): ReactElement {
+  const { events } = useRouter();
   const { user, logout } = useAuthContext();
+
+  useEffect(() => {
+    events.on('routeChangeStart', onClose);
+
+    return () => {
+      events.off('routeChangeStart', onClose);
+    };
+  }, [events, onClose]);
 
   if (!user) {
     return null;

--- a/packages/shared/src/components/ProfileMenu/sections/AccountSection.tsx
+++ b/packages/shared/src/components/ProfileMenu/sections/AccountSection.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from 'react';
 
 import { ProfileSection } from '../ProfileSection';
 import { CreditCardIcon, InviteIcon, SettingsIcon } from '../../icons';
-import { webappUrl } from '../../../lib/constants';
+import { settingsUrl } from '../../../lib/constants';
 
 export const AccountSection = (): ReactElement => {
   return (
@@ -11,17 +11,17 @@ export const AccountSection = (): ReactElement => {
       items={[
         {
           title: 'Settings',
-          href: `${webappUrl}account/profile`,
+          href: `${settingsUrl}/profile`,
           icon: SettingsIcon,
         },
         {
           title: 'Subscriptions',
-          href: `${webappUrl}account/subscription`,
+          href: `${settingsUrl}/subscription`,
           icon: CreditCardIcon,
         },
         {
           title: 'Invite friends',
-          href: `${webappUrl}account/invite`,
+          href: `${settingsUrl}/invite`,
           icon: InviteIcon,
         },
       ]}

--- a/packages/shared/src/components/ProfileMenu/sections/MainSection.tsx
+++ b/packages/shared/src/components/ProfileMenu/sections/MainSection.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from 'react';
 
 import { ProfileSection } from '../ProfileSection';
 import { CoinIcon, DevCardIcon, UserIcon } from '../../icons';
-import { walletUrl, webappUrl } from '../../../lib/constants';
+import { settingsUrl, walletUrl, webappUrl } from '../../../lib/constants';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { useHasAccessToCores } from '../../../hooks/useCoresFeature';
 
@@ -26,7 +26,7 @@ export const MainSection = (): ReactElement => {
         },
         {
           title: 'DevCard',
-          href: `${webappUrl}account/customization/devcard`,
+          href: `${settingsUrl}/customization/devcard`,
           icon: DevCardIcon,
         },
       ].filter(Boolean)}

--- a/packages/shared/src/components/profile/ProfileButton.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.spec.tsx
@@ -6,6 +6,17 @@ import ProfileButton from './ProfileButton';
 import defaultUser from '../../../__tests__/fixture/loggedUser';
 import { TestBootProvider } from '../../../__tests__/helpers/boot';
 
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    events: {
+      on: jest.fn(),
+      off: jest.fn(),
+    },
+    pathname: '/',
+    query: {},
+  }),
+}));
+
 const logout = jest.fn();
 
 const renderComponent = (): RenderResult => {

--- a/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
+++ b/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
@@ -41,7 +41,7 @@ import {
 import type { ProfileSectionItemProps } from '../ProfileMenu/ProfileSectionItem';
 import { ProfileSection } from '../ProfileMenu/ProfileSection';
 import { LogoutReason } from '../../lib/user';
-import { useAuthContext } from '../../contexts/AuthContext';
+import { logout, useAuthContext } from '../../contexts/AuthContext';
 import type { WithClassNameProps } from '../utilities';
 import { HorizontalSeparator } from '../utilities';
 import { useFeatureTheme } from '../../hooks/utils/useFeatureTheme';
@@ -203,6 +203,16 @@ export const accountPageItems = defineMenuItems({
       },
     },
   },
+  logout: {
+    title: null,
+    items: {
+      logout: {
+        title: 'Log out',
+        icon: ExitIcon,
+        onClick: () => logout(LogoutReason.ManualLogout),
+      },
+    },
+  },
 });
 
 export type AccountPageItemsType = typeof accountPageItems;
@@ -215,55 +225,42 @@ interface ProfileSettingsMenuProps {
 
 export const InnerProfileSettingsMenu = ({ className }: WithClassNameProps) => {
   const { asPath } = useRouter();
-  const { logout } = useAuthContext();
   const isMobile = useViewSize(ViewSize.MobileL);
   const hasAccessToCores = useHasAccessToCores();
 
   return (
     <nav className={classNames('flex flex-col gap-2', className)}>
-      {Object.entries(accountPageItems).map(([key, menuItem]) => (
-        <ProfileSection
-          key={key}
-          withSeparator
-          title={menuItem.title}
-          items={Object.entries(menuItem.items)
-            .filter(([, item]) => {
-              if (item.href === walletUrl && !hasAccessToCores) {
-                return false;
-              }
+      {Object.entries(accountPageItems).map(([key, menuItem], index, arr) => {
+        const lastItem = index === arr.length - 1;
 
-              return true;
-            })
-            .map(([, item]: [string, ProfileSectionItemProps]) => {
-              return {
-                ...item,
-                isActive: asPath === item.href,
-                ...(isMobile && {
-                  typography: {
-                    type: TypographyType.Body,
-                    color: TypographyColor.Primary,
-                  },
-                }),
-              };
-            })}
-        />
-      ))}
+        return (
+          <ProfileSection
+            key={key}
+            withSeparator={!lastItem}
+            title={menuItem.title}
+            items={Object.entries(menuItem.items)
+              .filter(([, item]) => {
+                if (item.href === walletUrl && !hasAccessToCores) {
+                  return false;
+                }
 
-      <ProfileSection
-        items={[
-          {
-            title: 'Log out',
-            icon: ExitIcon,
-            onClick: () => logout(LogoutReason.ManualLogout),
-            ...(isMobile && {
-              typography: {
-                type: TypographyType.Body,
-                color: TypographyColor.Primary,
-              },
-            }),
-          },
-        ]}
-      />
+                return true;
+              })
+              .map(([, item]: [string, ProfileSectionItemProps]) => {
+                return {
+                  ...item,
+                  isActive: asPath === item.href,
+                  ...(isMobile && {
+                    typography: {
+                      type: TypographyType.Body,
+                      color: TypographyColor.Primary,
+                    },
+                  }),
+                };
+              })}
+          />
+        );
+      })}
     </nav>
   );
 };


### PR DESCRIPTION
## Changes

- Add route change event listener to close profile menu on route change
- Moves the logout section into `accountPageItems` and reduce code duplication
- Use the correct URLs for settings pages

### Preview domain
https://fix-close-profile-menu.preview.app.daily.dev