### PR TITLE
fix: add step to `isIOSNative` and render `UpgradeToPlus` btn on iOS

### DIFF
--- a/packages/shared/src/components/UpgradeToPlus.tsx
+++ b/packages/shared/src/components/UpgradeToPlus.tsx
@@ -13,7 +13,6 @@ import { LogEvent } from '../lib/log';
 import { useAuthContext } from '../contexts/AuthContext';
 import { AuthTriggers } from '../lib/auth';
 import type { WithClassNameProps } from './utilities';
-import { isIOSNative } from '../lib/func';
 import {
   featurePlusButtonColors,
   featurePlusCtaCopy,
@@ -105,7 +104,7 @@ export const UpgradeToPlus = ({
     [isLoggedIn, logSubscriptionEvent, showLogin, target],
   );
 
-  if (isPlus || isIOSNative()) {
+  if (isPlus) {
     return null;
   }
 

--- a/packages/shared/src/lib/func.ts
+++ b/packages/shared/src/lib/func.ts
@@ -73,7 +73,9 @@ export const isIOS = (): boolean =>
   /iPhone|iPad/i.test(globalThis?.navigator.userAgent);
 
 export const isIOSNative = (): boolean =>
-  globalThis.webkit && !!globalThis.webkit.messageHandlers;
+  globalThis.webkit &&
+  !!globalThis.webkit.messageHandlers &&
+  document.documentElement.classList.contains('ios');
 
 export enum ArrowKeyEnum {
   Up = 'ArrowUp',


### PR DESCRIPTION
## Changes

- Add a check if `ios` exists in document class list
- Render the `UpgradeToPlus` button on iOS native

### Preview domain
https://fix-detect-ios.preview.app.daily.dev