### PR TITLE
fix: ensure object fallback for deconstruct

### DIFF
--- a/packages/shared/src/components/plus/PlusIOS.tsx
+++ b/packages/shared/src/components/plus/PlusIOS.tsx
@@ -55,7 +55,7 @@ export const PlusIOS = ({
       return {};
     }
     const marketingCta = getMarketingCta(MarketingCtaVariant.Plus);
-    const { flags } = marketingCta;
+    const { flags } = marketingCta || {};
     return flags;
   }, [getMarketingCta, showModalSection]);
 

--- a/packages/shared/src/components/plus/PlusMarketingModal.tsx
+++ b/packages/shared/src/components/plus/PlusMarketingModal.tsx
@@ -34,7 +34,7 @@ const PlusIOS = dynamic(() =>
 const PlusMarketingModal = (modalProps: ModalProps): ReactElement => {
   const { getMarketingCta, clearMarketingCta } = useBoot();
   const marketingCta = getMarketingCta(MarketingCtaVariant.Plus);
-  const { campaignId } = marketingCta;
+  const { campaignId } = marketingCta || {};
   const { logEvent } = useLogContext();
   const { closeModal } = useLazyModal();
   const isExtension = checkIsExtension();

--- a/packages/shared/src/components/plus/PlusMobileDrawer.tsx
+++ b/packages/shared/src/components/plus/PlusMobileDrawer.tsx
@@ -24,7 +24,7 @@ const PlusMobileDrawer = ({ onClose }: PlusMobileDrawerProps): ReactElement => {
   const { logEvent } = useLogContext();
   const { getMarketingCta } = useBoot();
   const marketingCta = getMarketingCta(MarketingCtaVariant.Plus);
-  const { flags } = marketingCta;
+  const { flags } = marketingCta || {};
 
   const handleClick = () => {
     logEvent({


### PR DESCRIPTION
## Changes

Found some error logs where it for some reason couldn't deconstruct marketingCta when null. Not been able to reproduce it, so just taking a stab in the dark.

```
{"msg":"Right side of assignment cannot be destructured","url":"https://app.daily.dev/?ios=true&fb_anon_id=4DE50206-6838-4A2B-ABCC-3501DB15E9AE&aiid=C6E01887FA9A4F229DB77E5D94131C40","error":{},"stack":"\nk@https://cdn.daily.dev/_next/static/chunks/plusMarketingModal.9532f84792809f00.js:1:4098\nLoad...
```

### Preview domain
https://fix-marketingcta-deconstruct.preview.app.daily.dev