### PR TITLE
feat: button ping animation

### DIFF
--- a/packages/shared/src/features/onboarding/shared/FunnelStepCtaWrapper.tsx
+++ b/packages/shared/src/features/onboarding/shared/FunnelStepCtaWrapper.tsx
@@ -21,6 +21,7 @@ export type FunnelStepCtaWrapperProps = ButtonProps<'button'> & {
   cta?: {
     label?: string;
     note?: string;
+    animation?: string;
   };
   containerClassName?: string;
   skip?: ButtonProps<'button'> & {
@@ -59,7 +60,7 @@ export function FunnelStepCtaWrapper({
       <div className="sticky bottom-2 m-4 flex flex-col gap-4">
         {note}
         <Button
-          className={classNames(className, 'w-full')}
+          className={classNames(className, cta?.animation, 'w-full')}
           data-funnel-track={FunnelTargetId.StepCta}
           size={ButtonSize.XLarge}
           type="button"

--- a/packages/shared/src/features/onboarding/steps/FunnelFact/FunnelFactWrapper.tsx
+++ b/packages/shared/src/features/onboarding/steps/FunnelFact/FunnelFactWrapper.tsx
@@ -9,7 +9,7 @@ export const FunnelFactWrapper = ({
   ...props
 }: PropsWithChildren<FunnelStepFact>) => {
   const { parameters, onTransition, transitions } = props;
-  const { cta, ctaNote } = parameters;
+  const { cta, ctaNote, ctaAnimation } = parameters;
   const skip = useMemo(
     () => transitions.find((t) => t.on === FunnelStepTransitionType.Skip),
     [transitions],
@@ -26,7 +26,7 @@ export const FunnelFactWrapper = ({
   return (
     <FunnelStepCtaWrapper
       containerClassName="flex"
-      cta={{ label: cta ?? 'Next', note: ctaNote }}
+      cta={{ label: cta ?? 'Next', note: ctaNote, animation: ctaAnimation }}
       onClick={() =>
         onTransition({
           type: FunnelStepTransitionType.Complete,

--- a/packages/shared/src/features/onboarding/types/funnel.ts
+++ b/packages/shared/src/features/onboarding/types/funnel.ts
@@ -116,6 +116,7 @@ export interface FunnelStepFactParameters {
   headline: string;
   cta?: string;
   ctaNote?: string;
+  ctaAnimation?: string;
   reverse?: boolean;
   badge?: {
     placement?: 'bottom' | 'top';

--- a/packages/shared/src/styles/components/buttons.css
+++ b/packages/shared/src/styles/components/buttons.css
@@ -132,6 +132,20 @@
       --button-color: var(--button-hover-color);
       --button-box-shadow: var(--button-hover-box-shadow);
     }
+
+    &.ping {
+      position: relative;
+
+      &::before {
+        content: '';
+        z-index: -1;
+        position: absolute;
+        inset: -2px;
+        background: inherit;
+        border-radius: inherit;
+        animation: fast-ping 1s ease-in-out infinite;
+      }
+    }
   }
 
 
@@ -281,5 +295,30 @@
   &:is([aria-pressed="true"], [aria-checked="true"]) {
     @apply bg-brand-active;
     @apply border-brand-default;
+  }
+}
+
+@keyframes fast-ping {
+  0% {
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+  }
+
+  45% {
+    top: -0.125rem;
+    left: 0;
+    width: calc(100% + 0.25rem);
+    height: calc(100% + 0.25rem);
+
+    opacity: 1;
+  }
+
+  100% {
+    top: -0.75rem;
+    left: -0.75rem;
+    width: calc(100% + 1.5rem);
+    height: calc(100% + 1.5rem);
+    opacity: 0;
   }
 }


### PR DESCRIPTION
## Changes
- Button ping animation based on configuration.
- The animation should inherit the color we are currently using. So both theme should work as intended, even using specific colors we have for buttons.
- Since the animation was pretty simple, we didn't use Lottie as it would just add complexity for the simple animation.

Preview:


https://github.com/user-attachments/assets/fdbbd4ed-a89c-476d-8998-a4ec14ea0297



From the design team:


https://github.com/user-attachments/assets/8553b0e3-fa25-4d57-84ba-46447eae3abd



## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Jira ticket
MI-898

### Preview domain
https://mi-898-pulse.preview.app.daily.dev