### PR TITLE
fix: add missing analytics events

### DIFF
--- a/packages/shared/src/components/plus/PlusAdjustQuantity.tsx
+++ b/packages/shared/src/components/plus/PlusAdjustQuantity.tsx
@@ -11,6 +11,8 @@ import { TextField } from '../fields/TextField';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { MinusIcon, PlusIcon } from '../icons';
 import type { WithClassNameProps } from '../utilities';
+import { usePlusSubscription } from '../../hooks';
+import { LogEvent } from '../../lib/log';
 
 type Props = {
   itemQuantity: number;
@@ -19,6 +21,7 @@ type Props = {
   setItemQuantity: Dispatch<SetStateAction<number>>;
   onChange?: (data: { priceId: string; quantity: number }) => void;
   label?: ReactNode;
+  existingSubscription?: boolean;
 } & WithClassNameProps;
 
 const minQuantity = 1;
@@ -31,7 +34,10 @@ export const PlusAdjustQuantity = ({
   setItemQuantity,
   onChange,
   label,
+  existingSubscription = false,
 }: Props): ReactElement => {
+  const { logSubscriptionEvent } = usePlusSubscription();
+
   const onQuantityChange = useCallback(
     (value: number) => {
       const newQuantity = Math.max(value, minQuantity);
@@ -40,9 +46,23 @@ export const PlusAdjustQuantity = ({
       if (newQuantity !== itemQuantity) {
         setItemQuantity(newQuantity);
         onChange?.({ priceId: selectedOption, quantity: newQuantity });
+        logSubscriptionEvent({
+          event_name: LogEvent.SetOrgSize,
+          target_id: newQuantity.toString(),
+          extra: {
+            existing: existingSubscription,
+          },
+        });
       }
     },
-    [itemQuantity, setItemQuantity, onChange, selectedOption],
+    [
+      itemQuantity,
+      setItemQuantity,
+      onChange,
+      selectedOption,
+      logSubscriptionEvent,
+      existingSubscription,
+    ],
   );
 
   return (

--- a/packages/shared/src/components/plus/PlusAdjustQuantity.tsx
+++ b/packages/shared/src/components/plus/PlusAdjustQuantity.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react'; // Import useCallback
 import type { Dispatch, ReactElement, ReactNode, SetStateAction } from 'react';
 import classNames from 'classnames';
 import {
@@ -21,6 +21,8 @@ type Props = {
   label?: ReactNode;
 } & WithClassNameProps;
 
+const minQuantity = 1;
+
 export const PlusAdjustQuantity = ({
   className,
   itemQuantity,
@@ -30,6 +32,19 @@ export const PlusAdjustQuantity = ({
   onChange,
   label,
 }: Props): ReactElement => {
+  const onQuantityChange = useCallback(
+    (value: number) => {
+      const newQuantity = Math.max(value, minQuantity);
+
+      // Only update state if the quantity has actually changed
+      if (newQuantity !== itemQuantity) {
+        setItemQuantity(newQuantity);
+        onChange?.({ priceId: selectedOption, quantity: newQuantity });
+      }
+    },
+    [itemQuantity, setItemQuantity, onChange, selectedOption],
+  );
+
   return (
     <div className={classNames('flex flex-col gap-4', className)}>
       {label && (
@@ -53,41 +68,22 @@ export const PlusAdjustQuantity = ({
             container: 'flex-1 tablet:max-w-60',
           }}
           focused
-          onChange={({ target }) => {
-            const newValue = Math.max(Number(target.value), 1);
-            if (newValue === itemQuantity) {
-              return;
-            }
-            setItemQuantity(newValue);
-            onChange?.({ priceId: selectedOption, quantity: newValue });
-          }}
+          onChange={({ target }) => onQuantityChange(Number(target.value))}
         />
         <Button
           size={ButtonSize.Large}
           variant={ButtonVariant.Secondary}
           icon={<MinusIcon />}
-          disabled={itemQuantity <= 1}
+          disabled={itemQuantity <= minQuantity} // Use minQuantity here
           loading={checkoutItemsLoading}
-          onClick={() => {
-            setItemQuantity((prev: number) => {
-              const newValue = Math.max(prev - 1, 1);
-              onChange?.({ priceId: selectedOption, quantity: newValue });
-              return newValue;
-            });
-          }}
+          onClick={() => onQuantityChange(itemQuantity - 1)}
         />
         <Button
           size={ButtonSize.Large}
           variant={ButtonVariant.Secondary}
           icon={<PlusIcon />}
           loading={checkoutItemsLoading}
-          onClick={() => {
-            setItemQuantity((prev: number) => {
-              const newValue = prev + 1;
-              onChange?.({ priceId: selectedOption, quantity: newValue });
-              return newValue;
-            });
-          }}
+          onClick={() => onQuantityChange(itemQuantity + 1)}
         />
       </div>
     </div>

--- a/packages/shared/src/components/plus/PlusInfo.tsx
+++ b/packages/shared/src/components/plus/PlusInfo.tsx
@@ -278,7 +278,7 @@ export const PlusInfo = ({
                     target_id: option.metadata.title.toLowerCase(),
                     extra: {
                       plan_type: isOrganization
-                        ? PlusPlanType.Team
+                        ? PlusPlanType.Organization
                         : PlusPlanType.Personal,
                       team_size: isOrganization ? itemQuantity : undefined,
                     },

--- a/packages/shared/src/components/plus/PlusInfo.tsx
+++ b/packages/shared/src/components/plus/PlusInfo.tsx
@@ -25,6 +25,7 @@ import Logo from '../Logo';
 import { ElementPlaceholder } from '../ElementPlaceholder';
 import { PlusTrustReviews } from './PlusTrustReviews';
 import type { ProductPricingPreview } from '../../graphql/paddle';
+import { PlusPlanType } from '../../graphql/paddle';
 import { isIOSNative } from '../../lib/func';
 import { PlusPriceType } from '../../lib/featureValues';
 import { PlusAdjustQuantity } from './PlusAdjustQuantity';
@@ -275,6 +276,12 @@ export const PlusInfo = ({
                   logSubscriptionEvent({
                     event_name: LogEvent.SelectBillingCycle,
                     target_id: option.metadata.title.toLowerCase(),
+                    extra: {
+                      plan_type: isOrganization
+                        ? PlusPlanType.Team
+                        : PlusPlanType.Personal,
+                      team_size: isOrganization ? itemQuantity : undefined,
+                    },
                   });
                 }}
               />

--- a/packages/shared/src/components/plus/PlusProductToggle.tsx
+++ b/packages/shared/src/components/plus/PlusProductToggle.tsx
@@ -2,13 +2,14 @@ import React, { useEffect, useRef } from 'react';
 import type { ReactElement } from 'react';
 import classNames from 'classnames';
 import { useRouter } from 'next/router';
+import { useAtom } from 'jotai';
 import {
   Button,
   ButtonGroup,
   ButtonSize,
   ButtonVariant,
 } from '../buttons/Button';
-import { usePaymentContext } from '../../contexts/payment/context';
+import { priceTypeAtom } from '../../contexts/payment/context';
 import type { PurchaseType } from '../../graphql/paddle';
 import type { WithClassNameProps } from '../utilities';
 import { usePlusSubscription } from '../../hooks';
@@ -32,7 +33,7 @@ export const PlusProductToggle = ({
   onSelect,
 }: Props): ReactElement => {
   const { query, replace } = useRouter();
-  const { priceType, setPriceType } = usePaymentContext();
+  const [priceType, setPriceType] = useAtom(priceTypeAtom);
   const { logSubscriptionEvent } = usePlusSubscription();
   const initialLoaded = useRef(false);
 

--- a/packages/shared/src/contexts/BuyCoresContext.tsx
+++ b/packages/shared/src/contexts/BuyCoresContext.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from 'react';
-import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useContext, useMemo, useRef, useState } from 'react';
 import type { Paddle } from '@paddle/paddle-js';
 import { useRouter } from 'next/router';
 import { useSetAtom } from 'jotai';
@@ -72,6 +72,8 @@ export const BuyCoresContextProvider = ({
 }: BuyCoresContextProviderProps): ReactElement => {
   const { logEvent } = useLogContext();
   const setPriceType = useSetAtom(priceTypeAtom);
+  setPriceType(PurchaseType.Cores);
+
   const [activeStep, setActiveStep] = useState<{
     step: Screens;
     providerTransactionId?: string;
@@ -134,10 +136,6 @@ export const BuyCoresContextProvider = ({
       selectedProduct,
     ],
   );
-
-  useEffect(() => {
-    setPriceType(PurchaseType.Cores);
-  }, [setPriceType]);
 
   return (
     <BuyCoresContext.Provider value={contextData}>

--- a/packages/shared/src/contexts/BuyCoresContext.tsx
+++ b/packages/shared/src/contexts/BuyCoresContext.tsx
@@ -1,8 +1,10 @@
 import type { ReactElement, ReactNode } from 'react';
-import React, { useContext, useMemo, useRef, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { Paddle } from '@paddle/paddle-js';
 import { useRouter } from 'next/router';
+import { useSetAtom } from 'jotai';
 import type { OpenCheckoutFn } from './payment/context';
+import { priceTypeAtom } from './payment/context';
 import type { Origin } from '../lib/log';
 import { TargetType } from '../lib/log';
 import { getQuantityForPrice } from '../graphql/njord';
@@ -69,6 +71,7 @@ export const BuyCoresContextProvider = ({
   children,
 }: BuyCoresContextProviderProps): ReactElement => {
   const { logEvent } = useLogContext();
+  const setPriceType = useSetAtom(priceTypeAtom);
   const [activeStep, setActiveStep] = useState<{
     step: Screens;
     providerTransactionId?: string;
@@ -131,6 +134,10 @@ export const BuyCoresContextProvider = ({
       selectedProduct,
     ],
   );
+
+  useEffect(() => {
+    setPriceType(PurchaseType.Cores);
+  }, [setPriceType]);
 
   return (
     <BuyCoresContext.Provider value={contextData}>

--- a/packages/shared/src/contexts/payment/BasePaymentProvider.tsx
+++ b/packages/shared/src/contexts/payment/BasePaymentProvider.tsx
@@ -1,7 +1,12 @@
 import type { PropsWithChildren, ReactElement } from 'react';
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
+import { useAtomValue } from 'jotai';
 import type { OpenCheckoutProps, PaymentContextData } from './context';
-import { PaymentContext, useFunnelPaymentPricingContext } from './context';
+import {
+  PaymentContext,
+  priceTypeAtom,
+  useFunnelPaymentPricingContext,
+} from './context';
 import { PurchaseType } from '../../graphql/paddle';
 import { PlusPriceTypeAppsId } from '../../lib/featureValues';
 import { useProductPricing } from '../../hooks/useProductPricing';
@@ -19,9 +24,8 @@ export const BasePaymentProvider = ({
   openCheckout,
   isPaddleReady,
   checkoutItemsLoading,
-  initialPriceType = PurchaseType.Plus,
 }: PropsWithChildren<BasePaymentProviderProps>): ReactElement => {
-  const [priceType, setPriceType] = useState<PurchaseType>(initialPriceType);
+  const priceType = useAtomValue(priceTypeAtom);
   const { isValidRegion: isPlusAvailable } = useAuthContext();
   const { pricing: funnelPricing } = useFunnelPaymentPricingContext() ?? {};
   const { data: plusPricing, isPending: isPricesPending } = useProductPricing({
@@ -50,8 +54,6 @@ export const BasePaymentProvider = ({
       isPricesPending,
       isPaddleReady,
       isOrganization,
-      priceType,
-      setPriceType,
       checkoutItemsLoading,
     }),
     [
@@ -62,7 +64,6 @@ export const BasePaymentProvider = ({
       isPricesPending,
       isPaddleReady,
       isOrganization,
-      priceType,
       checkoutItemsLoading,
     ],
   );

--- a/packages/shared/src/contexts/payment/StoreKit.tsx
+++ b/packages/shared/src/contexts/payment/StoreKit.tsx
@@ -235,8 +235,6 @@ export const StoreKitSubProvider = ({
       isPlusAvailable,
       giftOneYear: undefined,
       isPricesPending: false,
-      priceType: PurchaseType.Plus,
-      setPriceType: () => {},
     }),
     [isPlusAvailable, openCheckout, products],
   );

--- a/packages/shared/src/contexts/payment/context.ts
+++ b/packages/shared/src/contexts/payment/context.ts
@@ -20,7 +20,6 @@ export interface PaymentContextData {
   isPricesPending: boolean;
   isPaddleReady?: boolean;
   isOrganization?: boolean;
-  toggleOrganization?: () => void;
   priceType: PurchaseType;
   setPriceType: Dispatch<SetStateAction<PurchaseType>>;
   itemQuantity?: number;

--- a/packages/shared/src/contexts/payment/context.ts
+++ b/packages/shared/src/contexts/payment/context.ts
@@ -1,6 +1,8 @@
 import type { Dispatch, ReactNode, SetStateAction } from 'react';
 import { createContext, useContext } from 'react';
-import type { ProductPricingPreview, PurchaseType } from '../../graphql/paddle';
+import { atom } from 'jotai';
+import type { ProductPricingPreview } from '../../graphql/paddle';
+import { PurchaseType } from '../../graphql/paddle';
 
 export interface OpenCheckoutProps {
   priceId: string;
@@ -20,8 +22,6 @@ export interface PaymentContextData {
   isPricesPending: boolean;
   isPaddleReady?: boolean;
   isOrganization?: boolean;
-  priceType: PurchaseType;
-  setPriceType: Dispatch<SetStateAction<PurchaseType>>;
   itemQuantity?: number;
   setItemQuantity?: Dispatch<SetStateAction<number>>;
   checkoutItemsLoading?: boolean;
@@ -52,3 +52,5 @@ export const FunnelPaymentPricingContext = createContext<{
 
 export const useFunnelPaymentPricingContext = () =>
   useContext(FunnelPaymentPricingContext);
+
+export const priceTypeAtom = atom<PurchaseType>(PurchaseType.Plus);

--- a/packages/shared/src/features/organizations/components/manageSeats/PreviewChanges.tsx
+++ b/packages/shared/src/features/organizations/components/manageSeats/PreviewChanges.tsx
@@ -87,6 +87,7 @@ export const PreviewChanges = ({
           selectedOption="organization.plan"
           checkoutItemsLoading={isLoading || isRefetching}
           setItemQuantity={setQuantity}
+          existingSubscription
         />
 
         <Typography bold type={TypographyType.Body}>

--- a/packages/shared/src/graphql/paddle.ts
+++ b/packages/shared/src/graphql/paddle.ts
@@ -50,6 +50,11 @@ export enum PurchaseType {
   Cores = 'cores',
 }
 
+export enum PlusPlanType {
+  Team = 'team',
+  Personal = 'personal',
+}
+
 export const PRICING_METADATA_FRAGMENT = gql`
   fragment PricingMetadataFragment on ProductPricingMetadata {
     appsId

--- a/packages/shared/src/graphql/paddle.ts
+++ b/packages/shared/src/graphql/paddle.ts
@@ -51,7 +51,7 @@ export enum PurchaseType {
 }
 
 export enum PlusPlanType {
-  Team = 'team',
+  Organization = 'organization',
   Personal = 'personal',
 }
 

--- a/packages/shared/src/graphql/paddle.ts
+++ b/packages/shared/src/graphql/paddle.ts
@@ -1,7 +1,7 @@
 import { gql } from 'graphql-request';
 import type { PricePreviewResponse } from '@paddle/paddle-js/types/price-preview/price-preview';
 import { gqlClient } from './common';
-import type { PlusPriceType, PlusPriceTypeAppsId } from '../lib/featureValues';
+import type { PlusPriceTypeAppsId, PlusPriceType } from '../lib/featureValues';
 
 export type PaddleProductLineItem =
   PricePreviewResponse['data']['details']['lineItems'][0];
@@ -117,9 +117,20 @@ export const fetchPricingPreview = async (
 };
 
 const PRICING_PREVIEW_BY_IDS_QUERY = gql`
-  query PricingPreviewByIds($ids: [String]!, $locale: String) {
-    pricingPreviewByIds(ids: $ids, locale: $locale) {
+  query PricingPreviewByIds(
+    $ids: [String]!
+    $locale: String
+    $loadMetadata: Boolean
+  ) {
+    pricingPreviewByIds(
+      ids: $ids
+      locale: $locale
+      loadMetadata: $loadMetadata
+    ) {
       priceId
+      metadata {
+        ...PricingMetadataFragment
+      }
       price {
         amount
         formatted
@@ -143,15 +154,17 @@ const PRICING_PREVIEW_BY_IDS_QUERY = gql`
       }
     }
   }
+  ${PRICING_METADATA_FRAGMENT}
 `;
 
 export const fetchPricingPreviewByIds = async (
   ids: string[],
   locale = globalThis?.navigator?.language ?? 'en-US',
-): Promise<BaseProductPricingPreview[]> => {
+  loadMetadata = false,
+): Promise<ProductPricingPreview[]> => {
   const { pricingPreviewByIds } = await gqlClient.request<{
-    pricingPreviewByIds: BaseProductPricingPreview[];
-  }>(PRICING_PREVIEW_BY_IDS_QUERY, { ids, locale });
+    pricingPreviewByIds: ProductPricingPreview[];
+  }>(PRICING_PREVIEW_BY_IDS_QUERY, { ids, locale, loadMetadata });
 
   return pricingPreviewByIds;
 };

--- a/packages/shared/src/hooks/usePaddlePayment.ts
+++ b/packages/shared/src/hooks/usePaddlePayment.ts
@@ -8,6 +8,7 @@ import type {
 } from '@paddle/paddle-js';
 import { CheckoutEventNames, initializePaddle } from '@paddle/paddle-js';
 import { useRouter } from 'next/router';
+import { useAtomValue } from 'jotai';
 import { useAuthContext } from '../contexts/AuthContext';
 import { useLogContext } from '../contexts/LogContext';
 import type { TargetType } from '../lib/log';
@@ -18,6 +19,8 @@ import type {
   OpenCheckoutProps,
   PaymentContextProviderProps,
 } from '../contexts/payment/context';
+import { priceTypeAtom } from '../contexts/payment/context';
+import { PlusPlanType, PurchaseType } from '../graphql/paddle';
 
 interface UsePaddlePaymentProps
   extends Pick<
@@ -37,6 +40,7 @@ export const usePaddlePayment = ({
   const router = useRouter();
   const { logEvent } = useLogContext();
   const { user, geo, trackingId } = useAuthContext();
+  // const { isOrganization } = usePaymentContext();
   const [paddle, setPaddle] = useState<Paddle>();
   const isCheckoutOpenRef = useRef(false);
   const [checkoutItemsLoading, setCheckoutItemsLoading] = useState(false);
@@ -46,6 +50,11 @@ export const usePaddlePayment = ({
   successCallbackRef.current = successCallback;
   const getProductQuantityRef = useRef(getProductQuantity);
   getProductQuantityRef.current = getProductQuantity;
+
+  const priceType = useAtomValue(priceTypeAtom);
+
+  const isOrganization = priceType === PurchaseType.Organization;
+  const isPlusPlan = priceType === PurchaseType.Plus || isOrganization;
 
   useEffect(() => {
     if (checkIsExtension()) {
@@ -68,12 +77,24 @@ export const usePaddlePayment = ({
         const customData =
           event?.data?.custom_data || ({} as Record<string, unknown>);
 
+        const plusPlanExtra = isPlusPlan
+          ? {
+              plan_type: isOrganization
+                ? PlusPlanType.Organization
+                : PlusPlanType.Personal,
+              team_size: event?.data?.items?.[0]?.quantity,
+            }
+          : undefined;
+
         switch (event?.name) {
           case CheckoutEventNames.CHECKOUT_PAYMENT_INITIATED:
             logRef.current({
               target_type: targetType,
               event_name: LogEvent.InitiatePayment,
               target_id: event?.data?.payment.method_details.type,
+              extra: JSON.stringify({
+                ...plusPlanExtra,
+              }),
             });
             break;
           case CheckoutEventNames.CHECKOUT_LOADED:
@@ -82,6 +103,9 @@ export const usePaddlePayment = ({
               target_type: targetType,
               event_name: LogEvent.InitiateCheckout,
               target_id: event?.data?.payment.method_details.type,
+              extra: JSON.stringify({
+                ...plusPlanExtra,
+              }),
             });
             break;
           case CheckoutEventNames.CHECKOUT_PAYMENT_SELECTED:
@@ -89,6 +113,9 @@ export const usePaddlePayment = ({
               target_type: targetType,
               event_name: LogEvent.SelectCheckoutPayment,
               target_id: event?.data?.payment.method_details.type,
+              extra: JSON.stringify({
+                ...plusPlanExtra,
+              }),
             });
             break;
           case CheckoutEventNames.CHECKOUT_COMPLETED:
@@ -107,6 +134,7 @@ export const usePaddlePayment = ({
                 payment: event?.data.payment.method_details.type,
                 cycle:
                   event?.data.items?.[0]?.billing_cycle?.interval ?? 'one-off',
+                ...plusPlanExtra,
               }),
             });
 
@@ -155,7 +183,7 @@ export const usePaddlePayment = ({
         setPaddle(paddleInstance);
       }
     });
-  }, [router, disabledEvents, targetType]);
+  }, [router, disabledEvents, targetType, isOrganization, isPlusPlan]);
 
   const openCheckout = useCallback(
     ({

--- a/packages/shared/src/hooks/usePaddlePayment.ts
+++ b/packages/shared/src/hooks/usePaddlePayment.ts
@@ -40,7 +40,6 @@ export const usePaddlePayment = ({
   const router = useRouter();
   const { logEvent } = useLogContext();
   const { user, geo, trackingId } = useAuthContext();
-  // const { isOrganization } = usePaymentContext();
   const [paddle, setPaddle] = useState<Paddle>();
   const isCheckoutOpenRef = useRef(false);
   const [checkoutItemsLoading, setCheckoutItemsLoading] = useState(false);

--- a/packages/shared/src/hooks/useProductPricing.ts
+++ b/packages/shared/src/hooks/useProductPricing.ts
@@ -31,17 +31,19 @@ export const useProductPricing = ({
 export interface ProductPricingByIdsConfig {
   ids: string[];
   locale?: string;
+  loadMetadata?: boolean;
 }
 
 export const useProductPricingByIds = ({
   ids,
   locale,
+  loadMetadata = false,
 }: ProductPricingByIdsConfig) => {
   const { user, isValidRegion } = useAuthContext();
 
   return useQuery({
     queryKey: generateQueryKey(RequestKey.PricePreview, user, ids, locale),
-    queryFn: () => fetchPricingPreviewByIds(ids, locale),
+    queryFn: () => fetchPricingPreviewByIds(ids, locale, loadMetadata),
     enabled: isValidRegion && ids.length > 0,
     staleTime: StaleTime.Default,
   });

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -251,6 +251,7 @@ export enum LogEvent {
   HoverCheckoutWidget = 'hover checkout widget',
   PageScroll = 'page scroll',
   SelectSubscriptionType = 'select subscription type',
+  SetOrgSize = 'set org size',
   // End Plus subscription
   // Clickbait Shield
   ToggleClickbaitShield = 'toggle clickbait shield',

--- a/packages/webapp/pages/plus/payment.tsx
+++ b/packages/webapp/pages/plus/payment.tsx
@@ -6,14 +6,14 @@ import { useRouter } from 'next/router';
 import { plusUrl } from '@dailydotdev/shared/src/lib/constants';
 import { NextSeo } from 'next-seo';
 
-import { PlusCheckoutContainer } from '@dailydotdev/shared/src/components/plus/PlusCheckoutContainer';
-
 import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
 import {
   Typography,
   TypographyType,
 } from '@dailydotdev/shared/src/components/typography/Typography';
 import dynamic from 'next/dynamic';
+import { useProductPricingByIds } from '@dailydotdev/shared/src/hooks/useProductPricing';
+import { PlusCheckoutContainer } from '@dailydotdev/shared/src/components/plus/PlusCheckoutContainer';
 import { getPlusLayout } from '../../components/layouts/PlusLayout/PlusLayout';
 
 const PlusProductList = dynamic(
@@ -26,9 +26,13 @@ const PlusProductList = dynamic(
 
 const PlusPaymentPage = (): ReactElement => {
   const isLaptop = useViewSize(ViewSize.Laptop);
-  const { openCheckout, productOptions } = usePaymentContext();
+  const { openCheckout } = usePaymentContext();
   const router = useRouter();
   const { pid, gift } = router.query;
+  const { data: productPricing } = useProductPricingByIds({
+    ids: [pid as string],
+    loadMetadata: true,
+  });
 
   useEffect(() => {
     if (!router.isReady) {
@@ -39,13 +43,15 @@ const PlusPaymentPage = (): ReactElement => {
     }
   }, [pid, router]);
 
-  const selectedProduct = productOptions.find(({ priceId }) => priceId === pid);
+  const selectedProduct = productPricing?.find(
+    ({ priceId }) => priceId === pid,
+  );
 
   return (
     <>
       <NextSeo nofollow noindex />
       <div className="m-auto flex h-full w-full flex-col gap-6 laptop:h-fit laptop:w-[34.875rem]">
-        {isLaptop && selectedProduct && (
+        {isLaptop && productPricing && (
           <div className="flex flex-col items-center gap-4">
             <Typography type={TypographyType.Title2} bold>
               Plan details
@@ -53,7 +59,7 @@ const PlusPaymentPage = (): ReactElement => {
             <PlusProductList
               className="w-full"
               productList={[selectedProduct]}
-              selected={selectedProduct?.priceId}
+              selected={selectedProduct.priceId}
             />
           </div>
         )}

--- a/packages/webapp/pages/plus/payment.tsx
+++ b/packages/webapp/pages/plus/payment.tsx
@@ -51,7 +51,7 @@ const PlusPaymentPage = (): ReactElement => {
     <>
       <NextSeo nofollow noindex />
       <div className="m-auto flex h-full w-full flex-col gap-6 laptop:h-fit laptop:w-[34.875rem]">
-        {isLaptop && productPricing && (
+        {isLaptop && selectedProduct && (
           <div className="flex flex-col items-center gap-4">
             <Typography type={TypographyType.Title2} bold>
               Plan details


### PR DESCRIPTION
## Changes

- Adds tracking events to seat quantity component
- Add `plan_type` and `team_size` in extra for paddle events
- Refactor `plus/payment` page to use the `useProductPricingByIds` hook instead
- Refactor `PlusAdjustQuantity` to only have one on change definition


### Jira ticket
AS-1132

### Preview domain
https://as-1132-analytics.preview.app.daily.dev