### PR TITLE
fix: min width on input field wrapper

### DIFF
--- a/packages/shared/src/components/plus/PlusAdjustQuantity.tsx
+++ b/packages/shared/src/components/plus/PlusAdjustQuantity.tsx
@@ -85,7 +85,7 @@ export const PlusAdjustQuantity = ({
           value={itemQuantity}
           type="number"
           className={{
-            container: 'flex-1 tablet:max-w-60',
+            container: 'min-w-0 flex-1 tablet:max-w-60',
           }}
           focused
           onChange={({ target }) => onQuantityChange(Number(target.value))}


### PR DESCRIPTION
## Changes

- Adds min-w-0 to the input wrapper
- Fix overflow on organization invite page

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/3fa7f95a-cc58-45ef-a2e4-17578096ae7d">
    <td><img src="https://github.com/user-attachments/assets/6f32f43c-af71-414c-9013-8abef145cf5b">
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/0403086c-435e-42cc-b0d6-ac036fc509f5">
    <td><img src="https://github.com/user-attachments/assets/566d118e-4722-46cf-8499-f00f2c673c31">
</tr>
</table>

### Preview domain
https://fix-org-team-size-adjuster-input.preview.app.daily.dev