### PR TITLE
fix: overflow on organization invite page

### DIFF
--- a/packages/webapp/pages/join/organization.tsx
+++ b/packages/webapp/pages/join/organization.tsx
@@ -148,7 +148,7 @@ const Page = ({
               type={ImageType.Organization}
             />
 
-            <div className="flex flex-col">
+            <div className="flex flex-1 flex-col">
               <Typography
                 bold
                 type={TypographyType.Title3}


### PR DESCRIPTION
## Changes

Forgot to actually commit this change in #4547 🙈 

- Fix overflow on organization invite page

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/0403086c-435e-42cc-b0d6-ac036fc509f5">
    <td><img src="https://github.com/user-attachments/assets/566d118e-4722-46cf-8499-f00f2c673c31">
</tr>
</table>


### Preview domain
https://fix-org-team-size-adjuster-input.preview.app.daily.dev