### PR TITLE
fix: lottie layout shift while lazy loading

### DIFF
--- a/packages/shared/src/components/LottieAnimation.tsx
+++ b/packages/shared/src/components/LottieAnimation.tsx
@@ -1,8 +1,7 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { LottieComponentProps } from 'lottie-react';
 import type { ReactElement } from 'react';
-import dynamic from 'next/dynamic';
 import { RequestKey } from '../lib/query';
 import { disabledRefetch } from '../lib/func';
 import { fromCDN } from '../lib';
@@ -11,9 +10,9 @@ export type LottieAnimationProps = {
   className?: string;
   src: string;
   basePath?: string;
-} & Omit<LottieComponentProps, 'animationData' | 'width' | 'height'>;
+} & Omit<LottieComponentProps, 'animationData' | 'width' | 'height' | 'ref'>;
 
-const Lottie = dynamic(
+const Lottie = lazy(
   () => import(/* webpackChunkName: "lottieReact" */ 'lottie-react'),
 );
 
@@ -51,12 +50,14 @@ export const LottieAnimation = ({
   });
 
   return (
-    <Lottie
-      {...lottieProps}
-      className={className}
-      loop={loop}
-      autoplay={autoplay}
-      animationData={animationData}
-    />
+    <Suspense fallback={<div className={className} />}>
+      <Lottie
+        {...lottieProps}
+        className={className}
+        loop={loop}
+        autoplay={autoplay}
+        animationData={animationData}
+      />
+    </Suspense>
   );
 };


### PR DESCRIPTION
## Changes

While lottie JS bundle is loading nothing would be rendered which would cause layout shift once JS loads and animation is shown:

before:
https://github.com/user-attachments/assets/7c000afe-de34-4752-a65e-01799d507224

after:
https://github.com/user-attachments/assets/46226634-714a-4756-a6ae-00afda4428d3

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->
