### PR TITLE
fix: group hover state

### DIFF
--- a/packages/shared/src/components/cards/collection/CollectionCardHeader.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionCardHeader.tsx
@@ -47,7 +47,7 @@ export const CollectionCardHeader = ({
         <div className="flex-1" />
         <PostOptionButton
           post={post}
-          triggerClassName="group-hover:flex laptop:hidden"
+          triggerClassName="laptop:mouse:invisible laptop:mouse:group-hover:visible"
         />
       </CollectionPillSources>
     </>

--- a/packages/shared/src/components/cards/common/SquadPostCardHeader.tsx
+++ b/packages/shared/src/components/cards/common/SquadPostCardHeader.tsx
@@ -81,7 +81,7 @@ export const SquadPostCardHeader = ({
           <div className="flex flex-1" />
           <PostOptionButton
             post={post}
-            triggerClassName="group-hover:flex laptop:hidden"
+            triggerClassName="laptop:mouse:invisible laptop:mouse:group-hover:visible"
           />
         </div>
       </div>


### PR DESCRIPTION
## Changes

We did hard hidden/flex on the options-button resetting the radix element so it would flash top left corner.
Now it applies visible-state group hover which is more stable.

@sshanzel thanks for reporting this!

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://chore-fix-group-hover.preview.app.daily.dev