### PR TITLE
fix: handle `/` in branch names for preview domains

### DIFF
--- a/.github/workflows/add-preview-domain.yml
+++ b/.github/workflows/add-preview-domain.yml
@@ -65,10 +65,10 @@ jobs:
           script: |
             const subdomain = `${{ github.head_ref }}`
               .toLowerCase()
+              .slice(0, 32)
               .replace(/[^a-z0-9-]/g, '-')
               .replace(/^-+|-+$/g, '')
               .replace(/-{2,}/g, '-')
-              .slice(0, 32)
 
             const domain = `${subdomain}.${{ vars.PREVIEW_DOMAIN }}`
               .toLowerCase()

--- a/.github/workflows/remove-preview-domain.yml
+++ b/.github/workflows/remove-preview-domain.yml
@@ -18,10 +18,10 @@ jobs:
           script: |
             const subdomain = `${{ github.head_ref }}`
               .toLowerCase()
+              .slice(0, 32)
               .replace(/[^a-z0-9-]/g, '-')
               .replace(/^-+|-+$/g, '')
               .replace(/-{2,}/g, '-')
-              .slice(0, 32)
 
             const domain = `${subdomain}.${{ vars.PREVIEW_DOMAIN }}`
               .toLowerCase()


### PR DESCRIPTION
## Changes

Cursor background agent uses `cursor/` prefix in branch names, breaking preview domain

### Preview domain
https://fix-preview-with-slash.preview.app.daily.dev