### PR TITLE
fix: show correct source avatar in reading history

### DIFF
--- a/packages/shared/src/components/post/PostItemCard.tsx
+++ b/packages/shared/src/components/post/PostItemCard.tsx
@@ -25,6 +25,7 @@ import {
   ButtonSize,
   ButtonVariant,
 } from '../buttons/Button';
+import { isSourceUserSource } from '../../graphql/sources';
 
 export interface PostItemCardProps {
   className?: string;
@@ -39,7 +40,7 @@ export interface PostItemCardProps {
 
 const SourceShadow = classed(
   'div',
-  'absolute left-5 -my-1 w-8 h-8 rounded-full bg-background-default',
+  'absolute left-5 -my-1 w-8 h-8 bg-background-default',
 );
 
 export default function PostItemCard({
@@ -59,6 +60,7 @@ export default function PostItemCard({
     onHide({ postId: post.id, timestamp: timestampDb });
   };
   const article = post?.sharedPost ?? post;
+  const isUserSource = isSourceUserSource(post.source);
 
   const { toggleUpvote, toggleDownvote } = useReadHistoryVotePost();
 
@@ -89,16 +91,21 @@ export default function PostItemCard({
             loading="lazy"
             fallbackSrc={cloudinaryPostImageCoverPlaceholder}
           />
-          <SourceShadow className={showVoteActions && 'top-8'} />
+          <SourceShadow
+            className={classNames(
+              showVoteActions && 'top-8',
+              isUserSource ? 'rounded-12' : 'rounded-full',
+            )}
+          />
           <ProfilePicture
             size={ProfileImageSize.Small}
-            rounded="full"
+            rounded={isUserSource ? ProfileImageSize.Small : 'full'}
             className={classNames(
               'absolute left-6',
               showVoteActions && 'top-8',
             )}
             user={{
-              image: post.source.image,
+              image: isUserSource ? post.author.image : post.source.image,
               username: `source of ${post.title}`,
             }}
             nativeLazyLoading

--- a/packages/shared/src/components/post/PostItemCard.tsx
+++ b/packages/shared/src/components/post/PostItemCard.tsx
@@ -71,6 +71,8 @@ export default function PostItemCard({
     className,
   );
 
+  const title = post?.title || post?.sharedPost?.title;
+
   return (
     <article className={classNames(!clickable && classes)}>
       <ConditionalWrapper
@@ -106,7 +108,7 @@ export default function PostItemCard({
             )}
             user={{
               image: isUserSource ? post.author.image : post.source.image,
-              username: `source of ${post.title}`,
+              username: `source of ${title}`,
             }}
             nativeLazyLoading
           />
@@ -118,7 +120,7 @@ export default function PostItemCard({
           >
             <div className="ml-4 flex flex-1 flex-col">
               <h3 className="mr-6 line-clamp-2 flex flex-1 break-words text-left typo-callout">
-                {post.title}
+                {title}
               </h3>
               <PostMetadata
                 readTime={post.readTime}


### PR DESCRIPTION
## Changes

Show the correct source image in reading history for when the source is user. And add fallback to sharedPostTitle when there's no title

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/0647bac7-590a-4cb5-94ed-bc50f7493a0e">
    <td><img src="https://github.com/user-attachments/assets/531ee803-5720-43a3-a1f3-2f1a14a407e7">
  </tr>
</table>

### Preview domain
https://fix-reading-history.preview.app.daily.dev