### PR TITLE
fix: reposition notification bell on tablet

### DIFF
--- a/packages/shared/src/components/buttons/BookmarkButton.tsx
+++ b/packages/shared/src/components/buttons/BookmarkButton.tsx
@@ -50,6 +50,8 @@ export function BookmarkButton({
   ];
 
   if (hasReminder) {
+    const { onClick, ...buttonPropsWithoutOnClick } = buttonProps;
+
     return (
       <DropdownMenu>
         <DropdownMenuTrigger
@@ -61,7 +63,7 @@ export function BookmarkButton({
           <QuaternaryButton
             color={ButtonColor.Bun}
             variant={ButtonVariant.Tertiary}
-            {...buttonProps}
+            {...buttonPropsWithoutOnClick}
             type="button"
             pressed={post.bookmarked}
             icon={<Icon secondary={post.bookmarked} />}

--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -225,9 +225,9 @@ function FeedNav(): ReactElement {
             <MyFeedHeading />
           </StickyNavIconWrapper>
         )}
-        <StickyNavIconWrapper className="hidden translate-x-[calc(100vw-180%)] tablet:flex laptop:hidden">
+        <div className="absolute right-0 top-0 hidden h-[3.25rem] items-center bg-background-default tablet:flex laptop:hidden">
           <NotificationsBell compact />
-        </StickyNavIconWrapper>
+        </div>
       </div>
       {isForYouTab && plusEntryForYou && (
         <PlusMobileEntryBanner

--- a/packages/shared/src/components/notifications/NotificationsBell.tsx
+++ b/packages/shared/src/components/notifications/NotificationsBell.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import type { ReactElement } from 'react';
 import React from 'react';
 import { useRouter } from 'next/router';
-import { Button, ButtonVariant } from '../buttons/Button';
+import { Button, ButtonIconPosition, ButtonVariant } from '../buttons/Button';
 import { BellIcon } from '../icons';
 import { Bubble } from '../tooltips/utils';
 import { getUnreadText, notificationsUrl } from './utils';
@@ -10,8 +10,8 @@ import { useNotificationContext } from '../../contexts/NotificationsContext';
 import { LogEvent, NotificationTarget } from '../../lib/log';
 import { useLogContext } from '../../contexts/LogContext';
 import { webappUrl } from '../../lib/constants';
-import { LinkWithTooltip } from '../tooltips/LinkWithTooltip';
 import { useViewSize, ViewSize } from '../../hooks';
+import { Tooltip } from '../tooltip/Tooltip';
 
 function NotificationsBell({ compact }: { compact?: boolean }): ReactElement {
   const router = useRouter();
@@ -31,17 +31,16 @@ function NotificationsBell({ compact }: { compact?: boolean }): ReactElement {
   const mobileVariant = atNotificationsPage ? undefined : ButtonVariant.Option;
 
   return (
-    <LinkWithTooltip
-      tooltip={{ placement: 'bottom', content: 'Notifications' }}
-      href={`${webappUrl}notifications`}
-    >
-      <a className="relative laptop:flex">
-        <Button
-          variant={isLaptop ? ButtonVariant.Float : mobileVariant}
-          className="justify-center"
-          onClick={onNavigateNotifications}
-          icon={<BellIcon secondary={atNotificationsPage} />}
-        />
+    <Tooltip side="bottom" content="Notifications">
+      <Button
+        variant={isLaptop ? ButtonVariant.Float : mobileVariant}
+        className="relative justify-center"
+        tag="a"
+        iconPosition={ButtonIconPosition.Top}
+        href={`${webappUrl}notifications`}
+        onClick={onNavigateNotifications}
+        icon={<BellIcon secondary={atNotificationsPage} />}
+      >
         {hasNotification && (
           <Bubble
             className={classNames(
@@ -52,8 +51,8 @@ function NotificationsBell({ compact }: { compact?: boolean }): ReactElement {
             {getUnreadText(unreadCount)}
           </Bubble>
         )}
-      </a>
-    </LinkWithTooltip>
+      </Button>
+    </Tooltip>
   );
 }
 

--- a/packages/shared/src/components/notifications/NotificationsBell.tsx
+++ b/packages/shared/src/components/notifications/NotificationsBell.tsx
@@ -12,6 +12,7 @@ import { useLogContext } from '../../contexts/LogContext';
 import { webappUrl } from '../../lib/constants';
 import { useViewSize, ViewSize } from '../../hooks';
 import { Tooltip } from '../tooltip/Tooltip';
+import Link from '../utilities/Link';
 
 function NotificationsBell({ compact }: { compact?: boolean }): ReactElement {
   const router = useRouter();
@@ -32,26 +33,27 @@ function NotificationsBell({ compact }: { compact?: boolean }): ReactElement {
 
   return (
     <Tooltip side="bottom" content="Notifications">
-      <Button
-        variant={isLaptop ? ButtonVariant.Float : mobileVariant}
-        className="relative w-10 justify-center"
-        tag="a"
-        iconPosition={ButtonIconPosition.Top}
-        href={`${webappUrl}notifications`}
-        onClick={onNavigateNotifications}
-        icon={<BellIcon secondary={atNotificationsPage} />}
-      >
-        {hasNotification && (
-          <Bubble
-            className={classNames(
-              '-right-1.5 -top-1.5 cursor-pointer px-1',
-              compact && 'right-0 top-0',
-            )}
-          >
-            {getUnreadText(unreadCount)}
-          </Bubble>
-        )}
-      </Button>
+      <Link href={`${webappUrl}notifications`} passHref>
+        <Button
+          variant={isLaptop ? ButtonVariant.Float : mobileVariant}
+          className="relative w-10 justify-center"
+          tag="a"
+          iconPosition={ButtonIconPosition.Top}
+          onClick={onNavigateNotifications}
+          icon={<BellIcon secondary={atNotificationsPage} />}
+        >
+          {hasNotification && (
+            <Bubble
+              className={classNames(
+                '-right-1.5 -top-1.5 cursor-pointer px-1',
+                compact && 'right-0 top-0',
+              )}
+            >
+              {getUnreadText(unreadCount)}
+            </Bubble>
+          )}
+        </Button>
+      </Link>
     </Tooltip>
   );
 }

--- a/packages/shared/src/components/notifications/NotificationsBell.tsx
+++ b/packages/shared/src/components/notifications/NotificationsBell.tsx
@@ -34,7 +34,7 @@ function NotificationsBell({ compact }: { compact?: boolean }): ReactElement {
     <Tooltip side="bottom" content="Notifications">
       <Button
         variant={isLaptop ? ButtonVariant.Float : mobileVariant}
-        className="relative justify-center"
+        className="relative w-10 justify-center"
         tag="a"
         iconPosition={ButtonIconPosition.Top}
         href={`${webappUrl}notifications`}


### PR DESCRIPTION
## Changes

Currently the notification bell on tablet is quite buggy:


https://github.com/user-attachments/assets/0bc7b03a-d83d-4773-aaab-641eb76fcec2

This change fixes it and positions it top right:



https://github.com/user-attachments/assets/b8a9532f-9697-4cd5-ab50-2609ebf2a7c7


<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Jira ticket
MI-931

### Preview domain
https://mi-931.preview.app.daily.dev