### PR TITLE
fix: add ProfileImageLink back to SquadPostAuthor

### DIFF
--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -1,11 +1,7 @@
 import type { ReactElement } from 'react';
 import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
-import {
-  getProfilePictureClasses,
-  ProfileImageSize,
-  ProfilePicture,
-} from '../ProfilePicture';
+import { getProfilePictureClasses, ProfileImageSize } from '../ProfilePicture';
 import type { Author } from '../../graphql/comments';
 import type { SourceMemberRole } from '../../graphql/sources';
 import { ReputationUserBadge } from '../ReputationUserBadge';
@@ -25,6 +21,7 @@ import {
 import { useContentPreferenceStatusQuery } from '../../hooks/contentPreference/useContentPreferenceStatusQuery';
 import { useViewSize, ViewSize } from '../../hooks/useViewSize';
 import { ButtonVariant } from '../buttons/Button';
+import { ProfileImageLink } from '../profile/ProfileImageLink';
 
 interface SquadPostAuthorProps {
   className?: Partial<{
@@ -94,12 +91,14 @@ function SquadPostAuthor({
     <span
       className={classNames('flex flex-row items-center', className?.container)}
     >
-      <ProfilePicture
+      <ProfileImageLink
+        picture={{
+          size,
+          nativeLazyLoading: true,
+          eager: true,
+          fetchPriority: 'high',
+        }}
         user={author}
-        size={size}
-        nativeLazyLoading
-        eager
-        fetchPriority="high"
       />
       <a
         href={author.permalink}


### PR DESCRIPTION
## Changes
Was accidentally removed in an earlier updaate. Readding 
<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Jira ticket
MI-934

### Preview domain
https://mi-934.preview.app.daily.dev