### PR TITLE
fix: hide source role when user source

### DIFF
--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -34,6 +34,7 @@ interface SquadPostAuthorProps {
   role?: SourceMemberRole;
   size?: ProfileImageSize;
   date?: string;
+  isUserSource?: boolean;
 }
 
 const SquadPostAuthorSkeleton = ({
@@ -59,6 +60,7 @@ function SquadPostAuthor({
   role,
   size = ProfileImageSize.XXXLarge,
   date,
+  isUserSource = false,
 }: SquadPostAuthorProps): ReactElement {
   const isMobile = useViewSize(ViewSize.MobileXL);
   const { data, status } = useContentPreferenceStatusQuery({
@@ -134,7 +136,9 @@ function SquadPostAuthor({
             {author?.companies?.length > 0 && (
               <VerifiedCompanyUserBadge user={author} />
             )}
-            <UserBadge role={role}>{getRoleName(role)}</UserBadge>
+            {!isUserSource && (
+              <UserBadge role={role}>{getRoleName(role)}</UserBadge>
+            )}
           </div>
         </div>
       </a>

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -58,6 +58,7 @@ function SquadPostContentRaw({
     onClose,
     inlineActions,
   };
+  const isUserSource = isSourceUserSource(post.source);
 
   useEffect(() => {
     if (!post?.id || !user?.id) {
@@ -114,7 +115,7 @@ function SquadPostContentRaw({
           origin={origin}
           post={post}
         >
-          {!isSourceUserSource(post?.source) && (
+          {!isUserSource && (
             <PostSourceInfo
               post={post}
               onClose={onClose}
@@ -127,6 +128,7 @@ function SquadPostContentRaw({
             role={role}
             date={post.createdAt}
             className={{ container: 'mt-3' }}
+            isUserSource={isUserSource}
           />
           <Content post={post} onReadArticle={onReadArticle} />
         </BasePostContent>

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -58,7 +58,7 @@ function SquadPostContentRaw({
     onClose,
     inlineActions,
   };
-  const isUserSource = isSourceUserSource(post.source);
+  const isUserSource = isSourceUserSource(post?.source);
 
   useEffect(() => {
     if (!post?.id || !user?.id) {


### PR DESCRIPTION
## Changes

When post is from user source, we hade user role badge.

https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1752069987089189

### Preview domain
https://fix-hide-admin-user-source.preview.app.daily.dev