### PR TITLE
fix: pasting link to markdown

### DIFF
--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -33,6 +33,7 @@ import {
   getLinkReplacement,
   getMentionReplacement,
   getStyleReplacement,
+  isSelectionInMarkdownLink,
 } from '../../lib/markdown';
 import { handleRegex } from '../../graphql/users';
 import { UploadState, useSyncUploader } from './useSyncUploader';
@@ -354,9 +355,17 @@ export const useMarkdownInput = ({
       const cursor = getCursorType(textarea);
 
       if (cursor === CursorType.Highlighted) {
-        e.preventDefault();
-        await onLinkPaste(pastedText);
-        return;
+        const isInMarkdownLink = isSelectionInMarkdownLink(
+          textarea,
+          textarea.selectionStart,
+          textarea.selectionEnd,
+        );
+
+        if (!isInMarkdownLink) {
+          e.preventDefault();
+          await onLinkPaste(pastedText);
+          return;
+        }
       }
     }
 

--- a/packages/shared/src/lib/__tests__/markdown.test.ts
+++ b/packages/shared/src/lib/__tests__/markdown.test.ts
@@ -1,0 +1,84 @@
+import { isSelectionInMarkdownLink } from '../markdown';
+
+// Mock HTMLTextAreaElement
+const createMockTextarea = (
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+) => {
+  return {
+    value,
+    selectionStart,
+    selectionEnd,
+  } as HTMLTextAreaElement;
+};
+
+describe('isSelectionInMarkdownLink', () => {
+  test('should return true when selection is inside markdown link text', () => {
+    const textarea = createMockTextarea(
+      '[click here](https://example.com)',
+      1,
+      10,
+    );
+    const result = isSelectionInMarkdownLink(textarea, 1, 10);
+    expect(result).toBe(true);
+  });
+
+  test('should return true when selection is inside markdown link URL', () => {
+    const textarea = createMockTextarea(
+      '[click here](https://example.com)',
+      13,
+      32,
+    );
+    const result = isSelectionInMarkdownLink(textarea, 13, 32);
+    expect(result).toBe(true);
+  });
+
+  test('should return true when selection is in empty markdown link', () => {
+    const textarea = createMockTextarea('[](url)', 1, 1);
+    const result = isSelectionInMarkdownLink(textarea, 1, 1);
+    expect(result).toBe(true);
+  });
+
+  test('should return false when selection is not in markdown link', () => {
+    const textarea = createMockTextarea('This is regular text', 5, 10);
+    const result = isSelectionInMarkdownLink(textarea, 5, 10);
+    expect(result).toBe(false);
+  });
+
+  test('should return false when selection spans beyond markdown link', () => {
+    const textarea = createMockTextarea(
+      'Before [click here](https://example.com) after',
+      0,
+      20,
+    );
+    const result = isSelectionInMarkdownLink(textarea, 0, 20);
+    expect(result).toBe(false);
+  });
+
+  test('should return false when markdown link is incomplete', () => {
+    const textarea = createMockTextarea('[click here](', 1, 10);
+    const result = isSelectionInMarkdownLink(textarea, 1, 10);
+    expect(result).toBe(false);
+  });
+
+  test('should return false when there are newlines in between', () => {
+    const textarea = createMockTextarea(
+      '[click here\n](https://example.com)',
+      1,
+      10,
+    );
+    const result = isSelectionInMarkdownLink(textarea, 1, 10);
+    expect(result).toBe(false);
+  });
+
+  test('should handle multiple markdown links on same line', () => {
+    const textarea = createMockTextarea(
+      '[first](url1) [second](url2)',
+      15,
+      21,
+    );
+    const result = isSelectionInMarkdownLink(textarea, 15, 21);
+    expect(result).toBe(true);
+  });
+});

--- a/packages/shared/src/lib/__tests__/markdown.test.ts
+++ b/packages/shared/src/lib/__tests__/markdown.test.ts
@@ -73,11 +73,7 @@ describe('isSelectionInMarkdownLink', () => {
   });
 
   test('should handle multiple markdown links on same line', () => {
-    const textarea = createMockTextarea(
-      '[first](url1) [second](url2)',
-      15,
-      21,
-    );
+    const textarea = createMockTextarea('[first](url1) [second](url2)', 15, 21);
     const result = isSelectionInMarkdownLink(textarea, 15, 21);
     expect(result).toBe(true);
   });

--- a/packages/shared/src/lib/markdown.ts
+++ b/packages/shared/src/lib/markdown.ts
@@ -31,7 +31,7 @@ export const isSelectionInMarkdownLink = (
     }
     // If we hit a newline, stop looking
     if (text[i] === '\n') {
-      break;
+      return false;
     }
   }
 
@@ -55,7 +55,7 @@ export const isSelectionInMarkdownLink = (
     }
     // If we hit a newline, stop looking
     if (text[i] === '\n') {
-      break;
+      return false;
     }
   }
 


### PR DESCRIPTION
**Before the fix:**
Paste URL into `[](url)` selection → Results in `[]([url](https://example.com))`

**After the fix:**
Paste URL into `[](url)` selection → Results in normal paste behavior (no markdown link creation)

### Preview domain
https://markdown-link-fix.preview.app.daily.dev