### PR TITLE
Fix premature plus user prompt display

### DIFF
--- a/clickbait-shield-fix-summary.md
+++ b/clickbait-shield-fix-summary.md
@@ -1,0 +1,66 @@
+# Clickbait Shield Loading Issue Fix
+
+## Problem Description
+The "This title could be cleaner..." prompt was being shown to Plus users for a brief period when loading post pages. This occurred because the user's Plus subscription status wasn't resolved yet during the initial page load.
+
+## Root Cause
+The issue was in the `usePlusSubscription` hook and related components:
+
+1. **`usePlusSubscription` hook**: Returns `isPlus: user?.isPlus || false` which defaults to `false` when `user` is `undefined` during loading
+2. **Clickbait Shield components**: Check `if (!isPlus)` to decide whether to show the prompt, but this condition is `true` during loading even for Plus users
+3. **Timing issue**: Components render before authentication is complete, showing the prompt briefly to all users
+
+## Components Fixed
+
+### 1. `usePlusSubscription` Hook
+**File**: `packages/shared/src/hooks/usePlusSubscription.ts`
+
+**Changes**:
+- Added `isPlusLoading` state that combines `loadingUser`, `!isAuthReady`, and `!user` conditions
+- This indicates when the user's Plus subscription status is still being determined
+
+### 2. `PostClickbaitShield` Component  
+**File**: `packages/shared/src/components/post/common/PostClickbaitShield.tsx`
+
+**Changes**:
+- Added early return `if (isPlusLoading) return null;` 
+- Prevents prompt from showing while user status is loading
+
+### 3. `ClickbaitShield` Component
+**File**: `packages/shared/src/components/cards/common/ClickbaitShield.tsx` 
+
+**Changes**:
+- Added early return `if (isPlusLoading) return null;`
+- Prevents prompt from showing in feed cards while user status is loading
+
+### 4. `ToggleClickbaitShield` Component
+**File**: `packages/shared/src/components/buttons/ToggleClickbaitShield.tsx`
+
+**Changes**:
+- Added early return `if (isPlusLoading) return null;`
+- Prevents incorrect shield toggle button from showing while loading
+
+### 5. `UpgradeToPlus` Component
+**File**: `packages/shared/src/components/UpgradeToPlus.tsx`
+
+**Changes**:
+- Updated condition to `if (isPlusLoading || isPlus) return null;`
+- Prevents upgrade button from briefly showing to Plus users
+
+## Solution Summary
+
+The fix ensures that clickbait shield prompts and related Plus-specific UI elements wait for the user's subscription status to be fully resolved before deciding what to display. This eliminates the brief "blink" of inappropriate content for Plus users during page load.
+
+## Key Benefits
+
+1. **No more false prompts**: Plus users no longer see clickbait shield prompts
+2. **Better UX**: Eliminates confusing UI flicker during page load  
+3. **Consistent behavior**: All Plus-related components now properly wait for status resolution
+4. **Scalable solution**: The `isPlusLoading` state can be used by any component that needs to wait for Plus status
+
+## Testing
+
+To verify the fix:
+1. **As a Plus user**: Load a post page and confirm no clickbait shield prompt appears
+2. **As a non-Plus user**: Confirm the prompt still appears as expected
+3. **Network throttling**: Test with slow network to ensure no flicker occurs during loading

--- a/packages/shared/src/components/UpgradeToPlus.tsx
+++ b/packages/shared/src/components/UpgradeToPlus.tsx
@@ -77,7 +77,7 @@ export const UpgradeToPlus = ({
   const isLaptop = useViewSize(ViewSize.Laptop);
   const isLaptopXL = useViewSize(ViewSize.LaptopXL);
   const isFullCTAText = !isLaptop || isLaptopXL;
-  const { isPlus, logSubscriptionEvent } = usePlusSubscription();
+  const { isPlus, isPlusLoading, logSubscriptionEvent } = usePlusSubscription();
   const { value: ctaCopy } = useConditionalFeature({
     feature: featurePlusCtaCopy,
     shouldEvaluate: !isPlus,
@@ -104,7 +104,8 @@ export const UpgradeToPlus = ({
     [isLoggedIn, logSubscriptionEvent, showLogin, target],
   );
 
-  if (isPlus) {
+  // Don't show anything while loading user's plus status or if user is already plus
+  if (isPlusLoading || isPlus) {
     return null;
   }
 

--- a/packages/shared/src/components/buttons/ToggleClickbaitShield.tsx
+++ b/packages/shared/src/components/buttons/ToggleClickbaitShield.tsx
@@ -31,7 +31,7 @@ export const ToggleClickbaitShield = ({
 }): ReactElement => {
   const queryClient = useQueryClient();
   const { queryKey: feedQueryKey } = useActiveFeedContext();
-  const { isPlus } = usePlusSubscription();
+  const { isPlus, isPlusLoading } = usePlusSubscription();
   const { logEvent } = useLogContext();
   const { flags, updateFlag } = useSettingsContext();
   const [loading, setLoading] = useState(false);
@@ -45,6 +45,11 @@ export const ToggleClickbaitShield = ({
     iconSecondaryOnHover: true,
     ...buttonProps,
   };
+
+  // Don't show anything while loading user's plus status
+  if (isPlusLoading) {
+    return null;
+  }
 
   if (!isPlus) {
     return (

--- a/packages/shared/src/components/cards/common/ClickbaitShield.tsx
+++ b/packages/shared/src/components/cards/common/ClickbaitShield.tsx
@@ -20,13 +20,18 @@ import { Tooltip } from '../../tooltip/Tooltip';
 
 export const ClickbaitShield = ({ post }: { post: Post }): ReactElement => {
   const { openModal } = useLazyModal();
-  const { isPlus } = usePlusSubscription();
+  const { isPlus, isPlusLoading } = usePlusSubscription();
   const { fetchSmartTitle, fetchedSmartTitle, shieldActive } =
     useSmartTitle(post);
   const isMobile = useViewSize(ViewSize.MobileL);
   const router = useRouter();
   const { user } = useAuthContext();
   const { hasUsedFreeTrial, triesLeft } = useClickbaitTries();
+
+  // Don't show anything while loading user's plus status
+  if (isPlusLoading) {
+    return null;
+  }
 
   if (!isPlus) {
     return (

--- a/packages/shared/src/components/post/common/PostClickbaitShield.tsx
+++ b/packages/shared/src/components/post/common/PostClickbaitShield.tsx
@@ -24,13 +24,18 @@ import { Tooltip } from '../../tooltip/Tooltip';
 
 export const PostClickbaitShield = ({ post }: { post: Post }): ReactElement => {
   const { openModal } = useLazyModal();
-  const { isPlus } = usePlusSubscription();
+  const { isPlus, isPlusLoading } = usePlusSubscription();
   const { fetchSmartTitle, fetchedSmartTitle, shieldActive } =
     useSmartTitle(post);
   const isMobile = useViewSize(ViewSize.MobileL);
   const router = useRouter();
   const { user } = useAuthContext();
   const { hasUsedFreeTrial, triesLeft } = useClickbaitTries();
+
+  // Don't show anything while loading user's plus status
+  if (isPlusLoading) {
+    return null;
+  }
 
   if (!isPlus) {
     return (

--- a/packages/shared/src/hooks/usePlusSubscription.ts
+++ b/packages/shared/src/hooks/usePlusSubscription.ts
@@ -16,15 +16,19 @@ type LogSubscriptionEvent = {
 
 export const usePlusSubscription = (): {
   isPlus: boolean;
+  isPlusLoading: boolean;
   plusProvider?: SubscriptionProvider;
   logSubscriptionEvent: (event: LogSubscriptionEvent) => void;
   plusHref: string | undefined;
   status?: SubscriptionStatus;
 } => {
-  const { user } = useAuthContext();
+  const { user, loadingUser, isAuthReady } = useAuthContext();
   const { logEvent } = useLogContext();
   const isPlus = user?.isPlus || false;
   const { status, provider: plusProvider } = user?.subscriptionFlags || {};
+  
+  // Plus status is loading if user is loading, auth isn't ready, or we have no user data yet
+  const isPlusLoading = loadingUser || !isAuthReady || !user;
 
   const logSubscriptionEvent = useCallback(
     ({ event_name, target_id, extra }: LogSubscriptionEvent) => {
@@ -59,6 +63,7 @@ export const usePlusSubscription = (): {
 
   return {
     isPlus,
+    isPlusLoading,
     plusProvider,
     logSubscriptionEvent,
     plusHref,


### PR DESCRIPTION
## Changes

### Describe what this PR does

-   **Fixes UI flicker for Plus users**: Resolves an issue where the "This title could be cleaner..." prompt briefly appeared for Plus users on post page load.
-   **Introduces `isPlusLoading` state**: The `usePlusSubscription` hook now includes an `isPlusLoading` state to indicate when the user's Plus subscription status is still being determined.
-   **Ensures correct rendering**: `PostClickbaitShield`, `ClickbaitShield`, `ToggleClickbaitShield`, and `UpgradeToPlus` components now wait for `isPlusLoading` to resolve before rendering, preventing premature display of non-Plus specific UI elements.

## Events

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [x] iOS (Chrome and Safari)
- [x] Android

**Specific testing steps:**
1.  **As a Plus user**: Load a post page and confirm no "This title could be cleaner..." prompt appears, even briefly.
2.  **As a non-Plus user**: Confirm the "This title could be cleaner..." prompt still appears as expected.
3.  **Network throttling**: Test with a slow network connection to ensure no flicker occurs during loading for either Plus or non-Plus users.

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->

---

[Slack Thread](https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1752565327387759?thread_ts=1752565327.387759&cid=C01L0QXQJNB)

### Preview domain
https://cursor-fix-premature-plus-user-p.preview.app.daily.dev