### PR TITLE
feat: support clicking post boost notification

### DIFF
--- a/packages/shared/src/hooks/notifications/index.ts
+++ b/packages/shared/src/hooks/notifications/index.ts
@@ -4,3 +4,4 @@ export * from './usePushNotificationMutation';
 export * from './useEnableNotification';
 export * from './useNotificationPreferenceToggle';
 export * from './useBookmarkReminder';
+export * from './useCampaignByIdModal';

--- a/packages/shared/src/hooks/notifications/useCampaignByIdModal.ts
+++ b/packages/shared/src/hooks/notifications/useCampaignByIdModal.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useLazyModal } from '../useLazyModal';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { LazyModal } from '../../components/modals/common/types';
+
+export const useCampaignByIdModal = (): void => {
+  const { user } = useAuthContext();
+  const { openModal } = useLazyModal();
+  const {
+    query: { post_boost: postBoost, c_id: campaignId },
+    replace,
+    pathname,
+  } = useRouter();
+
+  useEffect(() => {
+    if (!user || !postBoost || !campaignId) {
+      return;
+    }
+    openModal({
+      type: LazyModal.FetchBoostedPostView,
+      props: {
+        campaignId: campaignId as string,
+        onAfterClose: () => replace(pathname),
+      },
+    });
+  }, [openModal, pathname, replace, postBoost, user, campaignId]);
+};

--- a/packages/webapp/pages/notifications.tsx
+++ b/packages/webapp/pages/notifications.tsx
@@ -32,6 +32,7 @@ import { usePushNotificationContext } from '@dailydotdev/shared/src/contexts/Pus
 import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
 import { useStreakRecoverModal } from '@dailydotdev/shared/src/hooks/notifications/useStreakRecoverModal';
 import { getNextPageParam } from '@dailydotdev/shared/src/lib/query';
+import { useCampaignByIdModal } from '@dailydotdev/shared/src/hooks/notifications';
 import { getLayout as getFooterNavBarLayout } from '../components/layouts/FooterNavBarLayout';
 import { getLayout } from '../components/layouts/MainLayout';
 import ProtectedPage from '../components/ProtectedPage';
@@ -96,6 +97,7 @@ const Notifications = (): ReactElement => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isFetchedAfterMount]);
 
+  useCampaignByIdModal();
   usePromotionModal();
   useStreakRecoverModal();
   useTopReaderModal();


### PR DESCRIPTION
## Changes
- When a campaign is finished, we send a notification, we should support clicking it and opening the modal.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->
