### PR TITLE
fix: pass the right entity name to content preference functions

### DIFF
--- a/packages/shared/src/hooks/contentPreference/useContentPreference.ts
+++ b/packages/shared/src/hooks/contentPreference/useContentPreference.ts
@@ -30,6 +30,9 @@ type UseContentPreferenceProps = {
   showToastOnSuccess?: boolean;
 };
 
+const getTargetType = (entity: ContentPreferenceType): string =>
+  entity === ContentPreferenceType.Keyword ? 'tag' : entity;
+
 export const useContentPreference = ({
   showToastOnSuccess,
 }: UseContentPreferenceProps = {}): UseContentPreference => {
@@ -59,7 +62,7 @@ export const useContentPreference = ({
       logEvent({
         event_name: LogEvent.Follow,
         target_id: id,
-        target_type: entityName,
+        target_type: getTargetType(entity),
         extra: extra || undefined,
       });
 
@@ -98,7 +101,7 @@ export const useContentPreference = ({
       logEvent({
         event_name: LogEvent.Unfollow,
         target_id: id,
-        target_type: entityName,
+        target_type: getTargetType(entity),
         extra: extra || undefined,
       });
 
@@ -134,7 +137,7 @@ export const useContentPreference = ({
       logEvent({
         event_name: LogEvent.Subscribe,
         target_id: id,
-        target_type: entityName,
+        target_type: getTargetType(entity),
         extra: extra || undefined,
       });
 
@@ -174,7 +177,7 @@ export const useContentPreference = ({
       logEvent({
         event_name: LogEvent.Unsubscribe,
         target_id: id,
-        target_type: entityName,
+        target_type: getTargetType(entity),
         extra: extra || undefined,
       });
 
@@ -211,7 +214,7 @@ export const useContentPreference = ({
       logEvent({
         event_name: LogEvent.Block,
         target_id: id,
-        target_type: entityName,
+        target_type: getTargetType(entity),
         extra: extra || undefined,
       });
 
@@ -255,7 +258,7 @@ export const useContentPreference = ({
       logEvent({
         event_name: LogEvent.Unblock,
         target_id: id,
-        target_type: entityName,
+        target_type: getTargetType(entity),
         extra: extra || undefined,
       });
 

--- a/packages/shared/src/hooks/contentPreference/useContentPreference.ts
+++ b/packages/shared/src/hooks/contentPreference/useContentPreference.ts
@@ -13,7 +13,7 @@ import type { PropsParameters } from '../../types';
 import { useToastNotification } from '../useToastNotification';
 import type { ContentPreferenceMutation } from './types';
 import { useLogContext } from '../../contexts/LogContext';
-import { LogEvent } from '../../lib/log';
+import { LogEvent, TargetType } from '../../lib/log';
 import { AuthTriggers } from '../../lib/auth';
 import { generateQueryKey, RequestKey } from '../../lib/query';
 
@@ -31,7 +31,7 @@ type UseContentPreferenceProps = {
 };
 
 const getTargetType = (entity: ContentPreferenceType): string =>
-  entity === ContentPreferenceType.Keyword ? 'tag' : entity;
+  entity === ContentPreferenceType.Keyword ? TargetType.Tag : entity;
 
 export const useContentPreference = ({
   showToastOnSuccess,

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -342,6 +342,7 @@ export enum TargetType {
   Comment = 'comment',
   ReadingReminder = 'reading reminder',
   Source = 'source',
+  Tag = 'tag',
   // Settings
   Layout = 'layout',
   Theme = 'theme',


### PR DESCRIPTION
Before the fix: we passed the username/source name/etc

After the fix: we pass the type of entity as we should (user/tag/source/etc)

### Preview domain
https://follow-events-fix.preview.app.daily.dev