### PR TITLE
fix: prevent multiple logEvent calls in useEnableNotification hook

### DIFF
--- a/packages/shared/src/hooks/notifications/useEnableNotification.ts
+++ b/packages/shared/src/hooks/notifications/useEnableNotification.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useLogContext } from '../../contexts/LogContext';
 import usePersistentContext from '../usePersistentContext';
 import { LogEvent, NotificationPromptSource, TargetType } from '../../lib/log';
@@ -24,6 +24,7 @@ export const useEnableNotification = ({
 }: UseEnableNotificationProps): UseEnableNotification => {
   const isExtension = checkIsExtension();
   const { logEvent } = useLogContext();
+  const hasLoggedImpression = useRef(false);
   const { isInitialized, isPushSupported, isSubscribed, shouldOpenPopup } =
     usePushNotificationContext();
   const { hasPermissionCache, acceptedJustNow, onEnablePush } =
@@ -61,7 +62,7 @@ export const useEnableNotification = ({
     !isDismissed;
 
   useEffect(() => {
-    if (!shouldShowCta) {
+    if (!shouldShowCta || hasLoggedImpression.current) {
       return;
     }
 
@@ -70,6 +71,7 @@ export const useEnableNotification = ({
       target_type: TargetType.EnableNotifications,
       extra: JSON.stringify({ origin: source }),
     });
+    hasLoggedImpression.current = true;
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shouldShowCta]);


### PR DESCRIPTION
Fixes # 4698

Added useRef to track if impression event has been logged to prevent multiple firing per component mount. This ensures the enable_notification_impression event is only logged once per component lifecycle.

Generated with [Claude Code](https://claude.ai/code)

### Preview domain
https://claude-issue-4698-20250716-1354.preview.app.daily.dev