### PR TITLE
fix: prevent regex injection in blocked content filters

### DIFF
--- a/packages/shared/src/components/feeds/FeedSettings/components/BlockedSourceList.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/components/BlockedSourceList.tsx
@@ -6,6 +6,7 @@ import { checkFetchMore } from '../../../containers/InfiniteScrolling';
 import { SourceList } from '../../../profile/SourceList';
 import { SourceType } from '../../../../graphql/sources';
 import { useBlockedQuery } from '../../../../hooks/contentPreference/useBlockedQuery';
+import { escapeRegexCharacters } from '../../../../lib/strings';
 
 type BlockedSourceListProps = {
   type?: SourceType;
@@ -25,7 +26,8 @@ export const BlockedSourceList = ({
   const { data, isFetchingNextPage, fetchNextPage } = queryResult;
   const sources = useMemo(() => {
     // If search query provided, filter sources by search query
-    const regex = new RegExp(searchQuery, 'i');
+    const escapedSearchQuery = searchQuery ? escapeRegexCharacters(searchQuery) : '';
+    const regex = new RegExp(escapedSearchQuery, 'i');
     return data?.pages.reduce((acc, p) => {
       p?.edges.forEach(({ node }) => {
         if (type && node.source.type === type) {

--- a/packages/shared/src/components/feeds/FeedSettings/components/BlockedSourceList.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/components/BlockedSourceList.tsx
@@ -26,7 +26,9 @@ export const BlockedSourceList = ({
   const { data, isFetchingNextPage, fetchNextPage } = queryResult;
   const sources = useMemo(() => {
     // If search query provided, filter sources by search query
-    const escapedSearchQuery = searchQuery ? escapeRegexCharacters(searchQuery) : '';
+    const escapedSearchQuery = searchQuery
+      ? escapeRegexCharacters(searchQuery)
+      : '';
     const regex = new RegExp(escapedSearchQuery, 'i');
     return data?.pages.reduce((acc, p) => {
       p?.edges.forEach(({ node }) => {

--- a/packages/shared/src/components/feeds/FeedSettings/components/BlockedTagList.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/components/BlockedTagList.tsx
@@ -5,6 +5,7 @@ import { ContentPreferenceType } from '../../../../graphql/contentPreference';
 import { checkFetchMore } from '../../../containers/InfiniteScrolling';
 import { useBlockedQuery } from '../../../../hooks/contentPreference/useBlockedQuery';
 import { TagList } from '../../../profile/TagList';
+import { escapeRegexCharacters } from '../../../../lib/strings';
 
 type BlockedTagListProps = {
   searchQuery?: string;
@@ -23,7 +24,8 @@ export const BlockedTagList = ({
   const { data, isFetchingNextPage, fetchNextPage } = queryResult;
   const tags = useMemo(() => {
     // If search query provided, filter sources by search query
-    const regex = new RegExp(searchQuery, 'i');
+    const escapedSearchQuery = searchQuery ? escapeRegexCharacters(searchQuery) : '';
+    const regex = new RegExp(escapedSearchQuery, 'i');
     return data?.pages.reduce((acc, p) => {
       p?.edges.forEach(({ node }) => {
         if (regex && !regex.test(node.referenceId)) {

--- a/packages/shared/src/components/feeds/FeedSettings/components/BlockedTagList.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/components/BlockedTagList.tsx
@@ -24,7 +24,9 @@ export const BlockedTagList = ({
   const { data, isFetchingNextPage, fetchNextPage } = queryResult;
   const tags = useMemo(() => {
     // If search query provided, filter sources by search query
-    const escapedSearchQuery = searchQuery ? escapeRegexCharacters(searchQuery) : '';
+    const escapedSearchQuery = searchQuery
+      ? escapeRegexCharacters(searchQuery)
+      : '';
     const regex = new RegExp(escapedSearchQuery, 'i');
     return data?.pages.reduce((acc, p) => {
       p?.edges.forEach(({ node }) => {

--- a/packages/shared/src/components/feeds/FeedSettings/components/BlockedUserList.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/components/BlockedUserList.tsx
@@ -8,6 +8,7 @@ import { Origin } from '../../../../lib/log';
 import { CopyType } from '../../../sources/SourceActions/SourceActionsFollow';
 import { useBlockedQuery } from '../../../../hooks/contentPreference/useBlockedQuery';
 import BlockButton from '../../../contentPreference/BlockButton';
+import { escapeRegexCharacters } from '../../../../lib/strings';
 
 type BlockedUserListProps = {
   searchQuery?: string;
@@ -26,7 +27,8 @@ export const BlockedUserList = ({
   const { data, isFetchingNextPage, fetchNextPage } = queryResult;
   const users = useMemo(() => {
     // If search query provided, filter sources by search query
-    const regex = new RegExp(searchQuery, 'i');
+    const escapedSearchQuery = searchQuery ? escapeRegexCharacters(searchQuery) : '';
+    const regex = new RegExp(escapedSearchQuery, 'i');
     return data?.pages.reduce((acc, p) => {
       p?.edges.forEach(({ node }) => {
         if (searchQuery?.length > 0 && !regex.test(node.referenceUser.name)) {

--- a/packages/shared/src/components/feeds/FeedSettings/components/BlockedUserList.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/components/BlockedUserList.tsx
@@ -27,7 +27,9 @@ export const BlockedUserList = ({
   const { data, isFetchingNextPage, fetchNextPage } = queryResult;
   const users = useMemo(() => {
     // If search query provided, filter sources by search query
-    const escapedSearchQuery = searchQuery ? escapeRegexCharacters(searchQuery) : '';
+    const escapedSearchQuery = searchQuery
+      ? escapeRegexCharacters(searchQuery)
+      : '';
     const regex = new RegExp(escapedSearchQuery, 'i');
     return data?.pages.reduce((acc, p) => {
       p?.edges.forEach(({ node }) => {

--- a/packages/shared/src/lib/strings.ts
+++ b/packages/shared/src/lib/strings.ts
@@ -13,3 +13,13 @@ export const checkLowercaseEquality = (
   value1: string,
   value2: string,
 ): boolean => value1?.toLowerCase() === value2?.toLowerCase();
+
+/**
+ * Escapes special regex characters in a string to make it safe for use in RegExp constructor.
+ * This prevents regex injection attacks when user input is used in regex patterns.
+ * @param str - The string to escape
+ * @returns The escaped string safe for use in RegExp
+ */
+export const escapeRegexCharacters = (str: string): string => {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+};


### PR DESCRIPTION
This PR fixes the issue where entering special regex characters in blocked content filters caused crashes.

## Changes
- Created `escapeRegexCharacters()` utility function in `packages/shared/src/lib/strings.ts`
- Updated BlockedSourceList, BlockedTagList, and BlockedUserList to use the new utility
- Prevents regex injection attacks by escaping special characters before RegExp creation

## Testing
Users can now safely enter characters like ()*? in search fields without crashes.

Resolves #4705

Generated with [Claude Code](https://claude.ai/code)

### Preview domain
https://claude-issue-4705-20250717-0716.preview.app.daily.dev