### PR TITLE
fix: remove extra white space under pinned label in list view

### DIFF
--- a/packages/shared/src/components/cards/common/list/RaisedLabel.tsx
+++ b/packages/shared/src/components/cards/common/list/RaisedLabel.tsx
@@ -40,7 +40,7 @@ export function RaisedLabel({
       <Tooltip content={description}>
         <div
           className={classNames(
-            'relative -top-2 flex h-4 rounded-4 px-2 font-bold uppercase text-white typo-caption2',
+            'flex h-4 rounded-4 px-2 font-bold uppercase text-white typo-caption2',
             typeToClassName[type],
           )}
         >


### PR DESCRIPTION
Fixes #4713

Remove relative -top-2 positioning from RaisedLabel inner div that was causing unnecessary negative top margin and creating unwanted white space under pinned labels.

Generated with [Claude Code](https://claude.ai/code)