### PR TITLE
fix: modal header button to wallet

### DIFF
--- a/packages/shared/src/components/modals/post/boost/BoostPostModal.tsx
+++ b/packages/shared/src/components/modals/post/boost/BoostPostModal.tsx
@@ -22,6 +22,7 @@ import { BoostPostSuccessModal } from './BoostPostSuccessModal';
 import { usePostBoostMutation } from '../../../../hooks/post/usePostBoostMutations';
 import { useLazyModal } from '../../../../hooks/useLazyModal';
 import { LazyModal } from '../../common/types';
+import { walletUrl } from '../../../../lib/constants';
 
 const Slider = dynamic(
   () => import('../../../fields/Slider').then((mod) => mod.Slider),
@@ -130,18 +131,25 @@ export function BoostPostModal({
         <Typography type={TypographyType.Title3} bold>
           Boost your post
         </Typography>
-        <Button
-          className="ml-4"
-          icon={<CoreIcon />}
-          size={ButtonSize.Small}
-          variant={ButtonVariant.Float}
-          onClick={() => setActiveScreen('BUY_CORES')}
-        >
-          {largeNumberFormat(user.balance.amount)}
-          <span className="ml-2 border-l border-border-subtlest-tertiary pl-2">
-            <PlusIcon />
-          </span>
-        </Button>
+        <div className="ml-4 flex flex-row rounded-10 bg-surface-float">
+          <Button
+            icon={<CoreIcon />}
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Tertiary}
+            target="_blank"
+            href={walletUrl}
+            tag="a"
+          >
+            {largeNumberFormat(user.balance.amount)}
+          </Button>
+          <div className="my-1 border-l border-border-subtlest-tertiary" />
+          <Button
+            icon={<PlusIcon />}
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Tertiary}
+            onClick={() => setActiveScreen('BUY_CORES')}
+          />
+        </div>
       </Modal.Header>
       <Modal.Body className="flex flex-col !gap-6">
         <Typography


### PR DESCRIPTION
## Changes
- This thing should be two separate buttons.
- One points to the wallet, one opens the Cores Modal.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://fix-wallet-button.preview.app.daily.dev