### PR TITLE
fix: mobile user source issues solved

### DIFF
--- a/packages/shared/src/components/post/PostSourceInfo.tsx
+++ b/packages/shared/src/components/post/PostSourceInfo.tsx
@@ -81,7 +81,7 @@ function PostSourceInfo({
             {showActionBtn && (
               <>
                 {!isUserSource && <Separator className="flex tablet:hidden" />}
-                {source?.type !== SourceType.Squad && (
+                {source?.type !== SourceType.Squad && !isUserSource && (
                   <FollowButton
                     variant={ButtonVariant.Tertiary}
                     followedVariant={ButtonVariant.Tertiary}

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -119,7 +119,7 @@ function SquadPostContentRaw({
           <div
             className={
               isUserSource
-                ? 'flex flex-row-reverse items-center justify-between'
+                ? 'flex flex-row-reverse items-center justify-between truncate'
                 : undefined
             }
           >
@@ -133,7 +133,9 @@ function SquadPostContentRaw({
               author={post?.author}
               role={role}
               date={post.createdAt}
-              className={{ container: !isUserSource && 'mt-3' }}
+              className={{
+                container: !isUserSource ? 'mt-3' : 'shrink truncate',
+              }}
               isUserSource={isUserSource}
               size={ProfileImageSize.Large}
             />


### PR DESCRIPTION
## Changes

Issue with showing double follow button
(Basically if source is user type we shouldn't show the source one)
Also fixed minor truncate-overlap issue on mobile.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://fix-user-source-styling.preview.app.daily.dev