### PR TITLE
feat: boost newly created post banner and modal adjustments

### DIFF
--- a/packages/shared/src/components/modals/post/boost/AdsDashboardModal.tsx
+++ b/packages/shared/src/components/modals/post/boost/AdsDashboardModal.tsx
@@ -75,22 +75,24 @@ export function AdsDashboardModal({
           users={stats.users}
         />
         <Modal.Subtitle>Active ads</Modal.Subtitle>
-        <div className="flex flex-col gap-1">
-          <Typography
-            type={TypographyType.Callout}
-            color={TypographyColor.Secondary}
-          >
-            Learn how boosting works and launch your first campaign to get
-            discovered by more developers.
-          </Typography>
-          <a
-            href={boostPostDocsLink}
-            className="text-text-link typo-callout"
-            target="_blank"
-          >
-            Learn more about boosting
-          </a>
-        </div>
+        {!isLoading && !!list?.length && (
+          <div className="flex flex-col gap-1">
+            <Typography
+              type={TypographyType.Callout}
+              color={TypographyColor.Secondary}
+            >
+              Learn how boosting works and launch your first campaign to get
+              discovered by more developers.
+            </Typography>
+            <a
+              href={boostPostDocsLink}
+              className="text-text-link typo-callout"
+              target="_blank"
+            >
+              Learn more about boosting
+            </a>
+          </div>
+        )}
         {isLoading ? (
           <BoostHistoryLoading />
         ) : (

--- a/packages/shared/src/components/modals/post/boost/AdsDashboardModal.tsx
+++ b/packages/shared/src/components/modals/post/boost/AdsDashboardModal.tsx
@@ -2,10 +2,7 @@ import type { ReactElement } from 'react';
 import React, { useEffect, useMemo, useState } from 'react';
 import { Modal } from '../../common/Modal';
 import type { ModalProps } from '../../common/Modal';
-import { CoreIcon } from '../../../icons';
-import { IconSize } from '../../../Icon';
 import { usePostBoost } from '../../../../hooks/post/usePostBoost';
-import { DataTile } from '../../../../features/boost/DataTile';
 import { BoostHistoryLoading } from '../../../../features/boost/BoostHistoryLoading';
 import type { BoostedPostData } from '../../../../graphql/post/boost';
 import { BoostedPostViewModal } from './BoostedPostViewModal';
@@ -13,8 +10,14 @@ import { usePostById } from '../../../../hooks';
 import type { Post } from '../../../../graphql/posts';
 import { useLazyModal } from '../../../../hooks/useLazyModal';
 import { LazyModal } from '../../common/types';
-import { boostDashboardInfo } from './common';
 import { CampaignList } from '../../../../features/boost/CampaignList';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../../typography/Typography';
+import { boostPostDocsLink } from '../../../../lib/constants';
+import { CampaignStatsGrid } from '../../../../features/boost/CampaignListView';
 
 interface AdsDashboardModalProps extends ModalProps {
   initialBoostedPost?: BoostedPostData;
@@ -66,30 +69,28 @@ export function AdsDashboardModal({
       <Modal.Header title="Ads dashboard" showCloseButton />
       <Modal.Body className="flex flex-col gap-4 overflow-x-hidden">
         <Modal.Subtitle>Overview all time</Modal.Subtitle>
-        <div className="grid grid-cols-2 gap-4">
-          <DataTile
-            label="Spend"
-            value={stats.totalSpend}
-            icon={<CoreIcon size={IconSize.XSmall} />}
-            info={boostDashboardInfo.spend}
-          />
-          <DataTile
-            label="Impressions"
-            value={stats.impressions}
-            info={boostDashboardInfo.impressions}
-          />
-          <DataTile
-            label="Clicks"
-            value={stats.clicks}
-            info={boostDashboardInfo.clicks}
-          />
-          <DataTile
-            label="Engagement"
-            value={stats.engagements}
-            info={boostDashboardInfo.engagement}
-          />
-        </div>
+        <CampaignStatsGrid
+          spend={stats.totalSpend}
+          impressions={stats.impressions}
+          users={stats.users}
+        />
         <Modal.Subtitle>Active ads</Modal.Subtitle>
+        <div className="flex flex-col gap-1">
+          <Typography
+            type={TypographyType.Callout}
+            color={TypographyColor.Secondary}
+          >
+            Learn how boosting works and launch your first campaign to get
+            discovered by more developers.
+          </Typography>
+          <a
+            href={boostPostDocsLink}
+            className="text-text-link typo-callout"
+            target="_blank"
+          >
+            Learn more about boosting
+          </a>
+        </div>
         {isLoading ? (
           <BoostHistoryLoading />
         ) : (

--- a/packages/shared/src/components/modals/post/boost/BoostPostModal.tsx
+++ b/packages/shared/src/components/modals/post/boost/BoostPostModal.tsx
@@ -27,7 +27,7 @@ import { useLazyModal } from '../../../../hooks/useLazyModal';
 import { LazyModal } from '../../common/types';
 import { ActionSuccessModal } from '../../utils/ActionSuccessModal';
 import { postBoostSuccessCover } from '../../../../lib/image';
-import { walletUrl } from '../../../../lib/constants';
+import { boostPostDocsLink, walletUrl } from '../../../../lib/constants';
 import useDebounceFn from '../../../../hooks/useDebounceFn';
 import { Loader } from '../../../Loader';
 import { usePostById } from '../../../../hooks';
@@ -160,6 +160,12 @@ export function BoostPostModal({
           copy: 'Ads dashboard',
           onClick: () => openModal({ type: LazyModal.AdsDashboard }),
         }}
+        secondaryCta={{
+          copy: 'Learn more about boosting',
+          tag: 'a',
+          href: boostPostDocsLink,
+          target: '_blank',
+        }}
         content={{
           title: 'Post boosted successfully!',
           description:
@@ -223,6 +229,13 @@ export function BoostPostModal({
         >
           Give your content the spotlight it deserves. Our auto-targeting engine
           ensures your post gets shown to the developers most likely to care.
+          <a
+            href={boostPostDocsLink}
+            className="text-text-link"
+            target="_blank"
+          >
+            Learn more
+          </a>
         </Typography>
         <div className="rounded-16 bg-surface-float">
           <div className="flex flex-row items-center gap-5 p-2">

--- a/packages/shared/src/components/modals/post/boost/BoostedPostViewModal.tsx
+++ b/packages/shared/src/components/modals/post/boost/BoostedPostViewModal.tsx
@@ -128,12 +128,7 @@ export function FetchBoostedViewModal({
           <span className="text-text-quaternary typo-caption1">
             Fetching data, please hold...
           </span>
-          <CampaignStatsGrid
-            clicks={0}
-            cores={0}
-            engagements={0}
-            impressions={0}
-          />
+          <CampaignStatsGrid users={0} spend={0} impressions={0} />
         </div>
       </Modal>
     );
@@ -152,12 +147,7 @@ export function FetchBoostedViewModal({
           <span className="text-text-quaternary typo-caption1">
             No campaign found
           </span>
-          <CampaignStatsGrid
-            clicks={0}
-            cores={0}
-            engagements={0}
-            impressions={0}
-          />
+          <CampaignStatsGrid users={0} spend={0} impressions={0} />
         </div>
       </Modal>
     );

--- a/packages/shared/src/components/modals/post/boost/common.ts
+++ b/packages/shared/src/components/modals/post/boost/common.ts
@@ -1,8 +1,6 @@
 export const boostDashboardInfo = {
-  engagement:
-    'The combined total of upvotes, comments, and other interactions with your boosted posts',
   impressions:
     'The total number of times your boosted posts were shown to users',
-  clicks: 'The number of times users clicked on your boosted posts',
+  users: 'The total number of unique users that has seen your boosted post',
   spend: 'The total number of cores spent so far',
 };

--- a/packages/shared/src/components/modals/utils/ActionSuccessModal.tsx
+++ b/packages/shared/src/components/modals/utils/ActionSuccessModal.tsx
@@ -16,6 +16,7 @@ import { Image } from '../../image/Image';
 
 interface ActionSuccessModalProps<T extends AllowedTags> extends ModalProps {
   cta?: ButtonProps<T> & { copy: string };
+  secondaryCta?: ButtonProps<T> & { copy: string };
   content: {
     title: string;
     description: string;
@@ -27,6 +28,7 @@ interface ActionSuccessModalProps<T extends AllowedTags> extends ModalProps {
 
 export function ActionSuccessModal<T extends AllowedTags>({
   cta,
+  secondaryCta,
   content,
   ...props
 }: ActionSuccessModalProps<T>): React.ReactElement {
@@ -82,6 +84,16 @@ export function ActionSuccessModal<T extends AllowedTags>({
             {...cta}
           >
             {cta.copy}
+          </Button>
+        )}
+        {secondaryCta && (
+          <Button
+            variant={ButtonVariant.Float}
+            className="w-full"
+            type="button"
+            {...secondaryCta}
+          >
+            {secondaryCta.copy}
           </Button>
         )}
         <Button

--- a/packages/shared/src/components/post/FixedPostNavigation.tsx
+++ b/packages/shared/src/components/post/FixedPostNavigation.tsx
@@ -23,7 +23,7 @@ function FixedPostNavigation({
       contextMenuId="fixed-post-navigation-context"
       className={{
         container: classNames(
-          'fixed z-postNavigation ml-0 w-full border border-border-subtlest-tertiary bg-background-subtle px-4 py-1 laptop:px-6',
+          'fixed z-postNavigation ml-0 w-full border-b border-border-subtlest-tertiary bg-background-subtle px-4 py-1 laptop:border laptop:px-6',
           'max-w-full laptop:left-[unset]',
           isBannerVisible ? 'top-14' : 'top-0',
           className?.container,

--- a/packages/shared/src/components/post/FixedPostNavigation.tsx
+++ b/packages/shared/src/components/post/FixedPostNavigation.tsx
@@ -23,7 +23,7 @@ function FixedPostNavigation({
       contextMenuId="fixed-post-navigation-context"
       className={{
         container: classNames(
-          'fixed z-postNavigation ml-0 w-full border border-border-subtlest-tertiary bg-background-subtle px-6 py-1',
+          'fixed z-postNavigation ml-0 w-full border border-border-subtlest-tertiary bg-background-subtle px-4 py-1 laptop:px-6',
           'max-w-full laptop:left-[unset]',
           isBannerVisible ? 'top-14' : 'top-0',
           className?.container,

--- a/packages/shared/src/components/post/GoBackHeaderMobile.tsx
+++ b/packages/shared/src/components/post/GoBackHeaderMobile.tsx
@@ -75,7 +75,7 @@ export function GoBackHeaderMobile({
   return (
     <span
       className={classNames(
-        'sticky top-0 z-postNavigation flex flex-row items-center border-b border-border-subtlest-tertiary px-4 py-2 laptop:hidden',
+        'sticky top-0 z-postNavigation flex flex-row items-center border-b border-border-subtlest-tertiary px-4 py-2 tablet:-mx-6 laptop:hidden',
         scrollClassName,
         className,
       )}

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -114,7 +114,13 @@ export function PostContentRaw({
           ? {
               ...navigationProps,
               isBannerVisible,
-              className: className?.fixedNavigation,
+              className: {
+                ...className?.fixedNavigation,
+                container: classNames(
+                  className?.fixedNavigation?.container,
+                  'tablet:max-w-[calc(100%-4rem)]',
+                ),
+              },
             }
           : null
       }

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -118,7 +118,7 @@ export function PostContentRaw({
                 ...className?.fixedNavigation,
                 container: classNames(
                   className?.fixedNavigation?.container,
-                  'tablet:max-w-[calc(100%-4rem)]',
+                  isPostPage && 'tablet:max-w-[calc(100%-4rem)]',
                 ),
               },
             }

--- a/packages/shared/src/components/post/PostHeaderActions.tsx
+++ b/packages/shared/src/components/post/PostHeaderActions.tsx
@@ -1,14 +1,11 @@
 import type { ReactElement } from 'react';
 import React, { useContext } from 'react';
 import classNames from 'classnames';
-import { useQueryClient } from '@tanstack/react-query';
 import { OpenLinkIcon } from '../icons';
-import type { PostData } from '../../graphql/posts';
 import {
   getReadPostButtonText,
   isInternalReadType,
   PostType,
-  useCanBoostPost,
 } from '../../graphql/posts';
 import classed from '../../lib/classed';
 import { Button, ButtonVariant } from '../buttons/Button';
@@ -20,7 +17,7 @@ import { CollectionSubscribeButton } from './collection/CollectionSubscribeButto
 import { useViewSizeClient, ViewSize } from '../../hooks';
 import { BoostPostButton } from '../../features/boost/BoostPostButton';
 import { Tooltip } from '../tooltip/Tooltip';
-import { getPostByIdKey } from '../../lib/query';
+import { useShowBoostButton } from '../../features/boost/useShowBoostButton';
 
 const Container = classed('div', 'flex flex-row items-center');
 
@@ -35,15 +32,12 @@ export function PostHeaderActions({
   buttonSize,
   ...props
 }: PostHeaderActionsProps): ReactElement {
-  const key = getPostByIdKey(post?.id);
-  const client = useQueryClient();
-  const postById = client.getQueryData<PostData>(key);
   const { openNewTab } = useContext(SettingsContext);
   const isMobile = useViewSizeClient(ViewSize.MobileXL);
   const readButtonText = getReadPostButtonText(post);
   const isCollection = post?.type === PostType.Collection;
-  const { canBoost } = useCanBoostPost(post);
   const isInternalReadTyped = isInternalReadType(post);
+  const isBoostButtonVisible = useShowBoostButton({ post });
 
   return (
     <Container {...props} className={classNames('gap-2', className)}>
@@ -71,7 +65,7 @@ export function PostHeaderActions({
           </Button>
         </Tooltip>
       )}
-      {canBoost && postById && !postById.post?.flags?.campaignId && (
+      {isBoostButtonVisible && (
         <BoostPostButton post={post} buttonProps={{ size: buttonSize }} />
       )}
       {isCollection && <CollectionSubscribeButton post={post} />}

--- a/packages/shared/src/components/post/PostMenuOptions.tsx
+++ b/packages/shared/src/components/post/PostMenuOptions.tsx
@@ -18,13 +18,11 @@ export function PostMenuOptions({
   buttonSize,
 }: PostMenuOptionsProps): ReactElement {
   return (
-    <>
-      <PostOptionButton
-        post={post}
-        size={buttonSize}
-        variant={ButtonVariant.Tertiary}
-        origin={origin}
-      />
-    </>
+    <PostOptionButton
+      post={post}
+      size={buttonSize}
+      variant={ButtonVariant.Tertiary}
+      origin={origin}
+    />
   );
 }

--- a/packages/shared/src/components/post/PostSourceInfo.tsx
+++ b/packages/shared/src/components/post/PostSourceInfo.tsx
@@ -122,7 +122,7 @@ function PostSourceInfo({
               post={post}
               onClose={onClose}
               onReadArticle={onReadArticle}
-              className="ml-auto hidden tablet:flex"
+              className="ml-auto hidden laptop:flex"
               contextMenuId="post-widgets-context"
               buttonSize={ButtonSize.Small}
             />

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -19,7 +19,7 @@ import PostSourceInfo from './PostSourceInfo';
 import { isSourceUserSource } from '../../graphql/sources';
 import { ProfileImageSize } from '../ProfilePicture';
 import { BoostNewPostStrip } from '../../features/boost/BoostNewPostStrip';
-import { useActions } from '../../hooks';
+import { useActions, useViewSize, ViewSize } from '../../hooks';
 import { ActionType } from '../../graphql/actions';
 import { useShowBoostButton } from '../../features/boost/useShowBoostButton';
 
@@ -54,6 +54,7 @@ function SquadPostContentRaw({
   );
   const shouldShowBanner =
     isActionsFetched && !hasClosedBanner && isPostPage && isBoostButtonVisible;
+  const isLaptop = useViewSize(ViewSize.Laptop);
   const onSendViewPost = useViewPost();
   const hasNavigation = !!onPreviousPost || !!onNextPost;
   const engagementActions = usePostContent({ origin, post });
@@ -127,6 +128,9 @@ function SquadPostContentRaw({
           origin={origin}
           post={post}
         >
+          {shouldShowBanner && !isLaptop && (
+            <BoostNewPostStrip className="-mt-2 mb-4" />
+          )}
           <div
             className={
               isUserSource
@@ -138,9 +142,14 @@ function SquadPostContentRaw({
               post={post}
               onClose={onClose}
               onReadArticle={onReadArticle}
-              className={!isUserSource && 'mb-6'}
+              className={
+                !isUserSource &&
+                (shouldShowBanner && isLaptop ? 'mb-4' : 'mb-6')
+              }
             />
-            {shouldShowBanner && !isUserSource && <BoostNewPostStrip />}
+            {shouldShowBanner && !isUserSource && isLaptop && (
+              <BoostNewPostStrip />
+            )}
             <SquadPostAuthor
               author={post?.author}
               role={role}
@@ -152,7 +161,7 @@ function SquadPostContentRaw({
               size={ProfileImageSize.Large}
             />
           </div>
-          {shouldShowBanner && isUserSource && (
+          {shouldShowBanner && isUserSource && isLaptop && (
             <BoostNewPostStrip className="mt-2" />
           )}
           <Content post={post} onReadArticle={onReadArticle} />

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -18,6 +18,10 @@ import { withPostById } from './withPostById';
 import PostSourceInfo from './PostSourceInfo';
 import { isSourceUserSource } from '../../graphql/sources';
 import { ProfileImageSize } from '../ProfilePicture';
+import { BoostNewPostStrip } from '../../features/boost/BoostNewPostStrip';
+import { useActions } from '../../hooks';
+import { ActionType } from '../../graphql/actions';
+import { useShowBoostButton } from '../../features/boost/useShowBoostButton';
 
 const ContentMap = {
   [PostType.Freeform]: MarkdownPostContent,
@@ -42,7 +46,14 @@ function SquadPostContentRaw({
   isBannerVisible,
   isPostPage,
 }: PostContentProps): ReactElement {
+  const isBoostButtonVisible = useShowBoostButton({ post });
   const { user } = useAuthContext();
+  const { checkHasCompleted, isActionsFetched } = useActions();
+  const hasClosedBanner = checkHasCompleted(
+    ActionType.ClosedNewPostBoostBanner,
+  );
+  const shouldShowBanner =
+    isActionsFetched && !hasClosedBanner && isPostPage && isBoostButtonVisible;
   const onSendViewPost = useViewPost();
   const hasNavigation = !!onPreviousPost || !!onNextPost;
   const engagementActions = usePostContent({ origin, post });
@@ -129,6 +140,7 @@ function SquadPostContentRaw({
               onReadArticle={onReadArticle}
               className={!isUserSource && 'mb-6'}
             />
+            {shouldShowBanner && !isUserSource && <BoostNewPostStrip />}
             <SquadPostAuthor
               author={post?.author}
               role={role}
@@ -140,6 +152,9 @@ function SquadPostContentRaw({
               size={ProfileImageSize.Large}
             />
           </div>
+          {shouldShowBanner && isUserSource && (
+            <BoostNewPostStrip className="mt-2" />
+          )}
           <Content post={post} onReadArticle={onReadArticle} />
         </BasePostContent>
       </div>

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -127,7 +127,7 @@ function SquadPostContentRaw({
               post={post}
               onClose={onClose}
               onReadArticle={onReadArticle}
-              className="mb-6"
+              className={!isUserSource && 'mb-6'}
             />
             <SquadPostAuthor
               author={post?.author}

--- a/packages/shared/src/components/post/collection/CollectionPostContent.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPostContent.tsx
@@ -90,7 +90,7 @@ const CollectionPostContentRaw = ({
                 ...className?.fixedNavigation,
                 container: classNames(
                   className?.fixedNavigation?.container,
-                  'tablet:max-w-[calc(100%-4rem)]',
+                  isPostPage && 'tablet:max-w-[calc(100%-4rem)]',
                 ),
               },
             }

--- a/packages/shared/src/components/post/collection/CollectionPostContent.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPostContent.tsx
@@ -86,7 +86,13 @@ const CollectionPostContentRaw = ({
           ? {
               ...navigationProps,
               isBannerVisible,
-              className: className?.fixedNavigation,
+              className: {
+                ...className?.fixedNavigation,
+                container: classNames(
+                  className?.fixedNavigation?.container,
+                  'tablet:max-w-[calc(100%-4rem)]',
+                ),
+              },
             }
           : null
       }

--- a/packages/shared/src/features/boost/BoostNewPostStrip.tsx
+++ b/packages/shared/src/features/boost/BoostNewPostStrip.tsx
@@ -19,14 +19,11 @@ import { useActions } from '../../hooks';
 import { ActionType } from '../../graphql/actions';
 import { TooltipArrow } from '../../svg/TooltipArrow';
 import { Image } from '../../components/image/Image';
-
-interface BoostNewPostStripProps {
-  className?: string;
-}
+import type { WithClassNameProps } from '../../components/utilities';
 
 export function BoostNewPostStrip({
   className,
-}: BoostNewPostStripProps): ReactElement {
+}: WithClassNameProps): ReactElement {
   const { completeAction } = useActions();
 
   return (

--- a/packages/shared/src/features/boost/BoostNewPostStrip.tsx
+++ b/packages/shared/src/features/boost/BoostNewPostStrip.tsx
@@ -1,0 +1,84 @@
+import type { PropsWithChildren, ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import { IconSize } from '../../components/Icon';
+import { ClearIcon, TrendingIcon } from '../../components/icons';
+import {
+  Typography,
+  TypographyTag,
+  TypographyType,
+} from '../../components/typography/Typography';
+import { boostNewPostBanner } from '../../lib/image';
+import {
+  DEFAULT_CORES_PER_DAY,
+  DEFAULT_DURATION_DAYS,
+} from '../../graphql/post/boost';
+import { usePostBoostEstimation } from '../../hooks/post/usePostBoostEstimation';
+import type { Post } from '../../graphql/posts';
+import { largeNumberFormat } from '../../lib';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../components/buttons/Button';
+import { Loader } from '../../components/Loader';
+
+interface BoostNewPostStripProps {
+  post: Post;
+  className?: string;
+}
+
+export function BoostNewPostStrip({
+  post,
+  className,
+}: BoostNewPostStripProps): ReactElement {
+  const { isLoading, estimatedReach } = usePostBoostEstimation({
+    post,
+    query: {
+      budget: DEFAULT_CORES_PER_DAY,
+      duration: DEFAULT_DURATION_DAYS,
+    },
+  });
+
+  const Container = ({ children }: PropsWithChildren) => (
+    <div
+      className={classNames(
+        'relative mt-4 flex h-10 w-full flex-row items-center justify-end gap-1 overflow-hidden rounded-8 border border-accent-blueCheese-default bg-cover p-2',
+        className,
+      )}
+      style={{ backgroundImage: `url('${boostNewPostBanner}')` }}
+    >
+      {children}
+    </div>
+  );
+
+  if (isLoading) {
+    return (
+      <Container>
+        <Loader className="mr-2" />
+      </Container>
+    );
+  }
+
+  const { min, max } = estimatedReach;
+  const median = (min + max) / 2;
+
+  return (
+    <Container>
+      <TrendingIcon size={IconSize.Medium} />
+      <Typography tag={TypographyTag.Span} type={TypographyType.Callout}>
+        <span>Boost to reach</span>
+        <strong className="mx-1">
+          {median === 0 ? '100k' : largeNumberFormat(median)} more users
+        </strong>
+        <span>now!</span>
+      </Typography>
+      <Button
+        className="ml-1"
+        variant={ButtonVariant.Tertiary}
+        size={ButtonSize.Small}
+        icon={<ClearIcon secondary />}
+      />
+    </Container>
+  );
+}

--- a/packages/shared/src/features/boost/BoostNewPostStrip.tsx
+++ b/packages/shared/src/features/boost/BoostNewPostStrip.tsx
@@ -38,7 +38,7 @@ export function BoostNewPostStrip({
         className="absolute inset-0 z-0 hidden h-full w-full tablet:flex"
       />
       <div className="z-1 flex w-full flex-row items-center gap-1 tablet:justify-end">
-        <TooltipArrow className="absolute -top-2 right-18 text-accent-blueCheese-default" />
+        <TooltipArrow className="absolute -top-2 right-18 fill-accent-blueCheese-default" />
         <TrendingIcon size={IconSize.Medium} />
         <Typography tag={TypographyTag.Span} type={TypographyType.Callout}>
           <span>Boost to reach</span>

--- a/packages/shared/src/features/boost/BoostNewPostStrip.tsx
+++ b/packages/shared/src/features/boost/BoostNewPostStrip.tsx
@@ -38,7 +38,7 @@ export function BoostNewPostStrip({
         className="absolute inset-0 z-0 hidden h-full w-full tablet:flex"
       />
       <div className="z-1 flex w-full flex-row items-center gap-1 tablet:justify-end">
-        <TooltipArrow className="absolute -top-2 right-18" />
+        <TooltipArrow className="absolute -top-2 right-18 text-accent-blueCheese-default" />
         <TrendingIcon size={IconSize.Medium} />
         <Typography tag={TypographyTag.Span} type={TypographyType.Callout}>
           <span>Boost to reach</span>

--- a/packages/shared/src/features/boost/BoostNewPostStrip.tsx
+++ b/packages/shared/src/features/boost/BoostNewPostStrip.tsx
@@ -18,6 +18,7 @@ import {
 import { useActions } from '../../hooks';
 import { ActionType } from '../../graphql/actions';
 import { TooltipArrow } from '../../svg/TooltipArrow';
+import { Image } from '../../components/image/Image';
 
 interface BoostNewPostStripProps {
   className?: string;
@@ -31,25 +32,30 @@ export function BoostNewPostStrip({
   return (
     <div
       className={classNames(
-        'relative flex h-10 w-full flex-row items-center justify-end gap-1 rounded-8 border border-accent-blueCheese-default bg-cover p-2',
+        'relative flex h-10 w-full flex-row rounded-8 border border-accent-blueCheese-default p-2',
         className,
       )}
-      style={{ backgroundImage: `url('${boostNewPostBanner}')` }}
     >
-      <TooltipArrow className="absolute -top-2 right-18" />
-      <TrendingIcon size={IconSize.Medium} />
-      <Typography tag={TypographyTag.Span} type={TypographyType.Callout}>
-        <span>Boost to reach</span>
-        <strong className="mx-1">10k</strong>
-        <span>now!</span>
-      </Typography>
-      <Button
-        className="ml-1"
-        variant={ButtonVariant.Tertiary}
-        size={ButtonSize.Small}
-        icon={<ClearIcon secondary />}
-        onClick={() => completeAction(ActionType.ClosedNewPostBoostBanner)}
+      <Image
+        src={boostNewPostBanner}
+        className="absolute inset-0 z-0 hidden h-full w-full tablet:flex"
       />
+      <div className="z-1 flex w-full flex-row items-center gap-1 tablet:justify-end">
+        <TooltipArrow className="absolute -top-2 right-18" />
+        <TrendingIcon size={IconSize.Medium} />
+        <Typography tag={TypographyTag.Span} type={TypographyType.Callout}>
+          <span>Boost to reach</span>
+          <strong className="mx-1">10k more devs</strong>
+          <span>now!</span>
+        </Typography>
+        <Button
+          className="ml-auto tablet:ml-1"
+          variant={ButtonVariant.Tertiary}
+          size={ButtonSize.Small}
+          icon={<ClearIcon secondary />}
+          onClick={() => completeAction(ActionType.ClosedNewPostBoostBanner)}
+        />
+      </div>
     </div>
   );
 }

--- a/packages/shared/src/features/boost/BoostNewPostStrip.tsx
+++ b/packages/shared/src/features/boost/BoostNewPostStrip.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithChildren, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import { IconSize } from '../../components/Icon';
@@ -9,68 +9,38 @@ import {
   TypographyType,
 } from '../../components/typography/Typography';
 import { boostNewPostBanner } from '../../lib/image';
-import {
-  DEFAULT_CORES_PER_DAY,
-  DEFAULT_DURATION_DAYS,
-} from '../../graphql/post/boost';
-import { usePostBoostEstimation } from '../../hooks/post/usePostBoostEstimation';
-import type { Post } from '../../graphql/posts';
-import { largeNumberFormat } from '../../lib';
+
 import {
   Button,
   ButtonSize,
   ButtonVariant,
 } from '../../components/buttons/Button';
-import { Loader } from '../../components/Loader';
+import { useActions } from '../../hooks';
+import { ActionType } from '../../graphql/actions';
+import { TooltipArrow } from '../../svg/TooltipArrow';
 
 interface BoostNewPostStripProps {
-  post: Post;
   className?: string;
 }
 
 export function BoostNewPostStrip({
-  post,
   className,
 }: BoostNewPostStripProps): ReactElement {
-  const { isLoading, estimatedReach } = usePostBoostEstimation({
-    post,
-    query: {
-      budget: DEFAULT_CORES_PER_DAY,
-      duration: DEFAULT_DURATION_DAYS,
-    },
-  });
+  const { completeAction } = useActions();
 
-  const Container = ({ children }: PropsWithChildren) => (
+  return (
     <div
       className={classNames(
-        'relative mt-4 flex h-10 w-full flex-row items-center justify-end gap-1 overflow-hidden rounded-8 border border-accent-blueCheese-default bg-cover p-2',
+        'relative flex h-10 w-full flex-row items-center justify-end gap-1 rounded-8 border border-accent-blueCheese-default bg-cover p-2',
         className,
       )}
       style={{ backgroundImage: `url('${boostNewPostBanner}')` }}
     >
-      {children}
-    </div>
-  );
-
-  if (isLoading) {
-    return (
-      <Container>
-        <Loader className="mr-2" />
-      </Container>
-    );
-  }
-
-  const { min, max } = estimatedReach;
-  const median = (min + max) / 2;
-
-  return (
-    <Container>
+      <TooltipArrow className="absolute -top-2 right-18" />
       <TrendingIcon size={IconSize.Medium} />
       <Typography tag={TypographyTag.Span} type={TypographyType.Callout}>
         <span>Boost to reach</span>
-        <strong className="mx-1">
-          {median === 0 ? '100k' : largeNumberFormat(median)} more users
-        </strong>
+        <strong className="mx-1">10k</strong>
         <span>now!</span>
       </Typography>
       <Button
@@ -78,7 +48,8 @@ export function BoostNewPostStrip({
         variant={ButtonVariant.Tertiary}
         size={ButtonSize.Small}
         icon={<ClearIcon secondary />}
+        onClick={() => completeAction(ActionType.ClosedNewPostBoostBanner)}
       />
-    </Container>
+    </div>
   );
 }

--- a/packages/shared/src/features/boost/BoostPostButton.tsx
+++ b/packages/shared/src/features/boost/BoostPostButton.tsx
@@ -2,12 +2,11 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import type { Post } from '../../graphql/posts';
 import type { ButtonProps } from '../../components/buttons/Button';
-import { Button } from '../../components/buttons/Button';
+import { Button, ButtonColor } from '../../components/buttons/Button';
 import { ButtonVariant } from '../../components/buttons/common';
 import { BoostIcon } from '../../components/icons/Boost';
 import { LazyModal } from '../../components/modals/common/types';
 import { useLazyModal } from '../../hooks/useLazyModal';
-import { boostPostButton } from '../../styles/custom';
 
 export function BoostPostButton({
   post,
@@ -23,7 +22,7 @@ export function BoostPostButton({
       variant={ButtonVariant.Primary}
       {...buttonProps}
       icon={<BoostIcon secondary />}
-      style={{ background: boostPostButton }}
+      color={ButtonColor.BlueCheese}
       onClick={() => {
         openModal({ type: LazyModal.BoostPost, props: { post } });
       }}

--- a/packages/shared/src/features/boost/CampaignList.tsx
+++ b/packages/shared/src/features/boost/CampaignList.tsx
@@ -12,6 +12,7 @@ import type { BoostedPostData } from '../../graphql/post/boost';
 import type { InfiniteScrollingQueryProps } from '../../components/containers/InfiniteScrolling';
 import InfiniteScrolling from '../../components/containers/InfiniteScrolling';
 import { BoostHistoryLoading } from './BoostHistoryLoading';
+import { boostPostDocsLink } from '../../lib/constants';
 
 interface CampaignListProps {
   list: BoostedPostData[];
@@ -33,16 +34,23 @@ export function CampaignList({
           size={IconSize.XXLarge}
         />
         <Typography type={TypographyType.Title2} bold>
-          Ads dashboard
+          No running ads yet
         </Typography>
         <Typography
           color={TypographyColor.Tertiary}
           type={TypographyType.Callout}
           className="text-center"
         >
-          Once you boost a post, you’ll see real-time insights here—like views,
-          clicks, and engagement metrics.
+          Learn how boosting works and launch your first campaign to get
+          discovered by more developers.
         </Typography>
+        <a
+          href={boostPostDocsLink}
+          className="mt-3 text-text-link typo-callout"
+          target="_blank"
+        >
+          Learn more about boosting
+        </a>
       </div>
     );
   }

--- a/packages/shared/src/features/boost/CampaignListView.tsx
+++ b/packages/shared/src/features/boost/CampaignListView.tsx
@@ -33,23 +33,21 @@ interface CampaignListViewProps {
 
 interface CampaignStatsGridProps {
   impressions: number;
-  engagements: number;
-  clicks: number;
-  cores: number;
+  users: number;
+  spend: number;
   className?: string;
 }
 
 export const CampaignStatsGrid = ({
   className,
-  cores,
-  clicks,
-  engagements,
+  spend,
+  users,
   impressions,
 }: CampaignStatsGridProps) => (
   <div className={classNames('grid grid-cols-2 gap-4', className)}>
     <DataTile
       label="Spend"
-      value={cores}
+      value={spend}
       info={boostDashboardInfo.spend}
       icon={<CoreIcon size={IconSize.XSmall} />}
     />
@@ -58,12 +56,7 @@ export const CampaignStatsGrid = ({
       value={impressions}
       info={boostDashboardInfo.impressions}
     />
-    <DataTile label="Clicks" value={clicks} info={boostDashboardInfo.clicks} />
-    <DataTile
-      label="Engagement"
-      value={engagements}
-      info={boostDashboardInfo.engagement}
-    />
+    <DataTile label="Clicks" value={users} info={boostDashboardInfo.users} />
   </div>
 );
 
@@ -147,10 +140,9 @@ export function CampaignListView({
         </span>
         <CampaignStatsGrid
           className="mt-3"
-          cores={campaign.spend}
-          clicks={campaign.clicks}
+          spend={campaign.spend}
+          users={campaign.users}
           impressions={campaign.impressions}
-          engagements={post.engagements}
         />
       </div>
       <div className="h-px w-full bg-border-subtlest-tertiary" />

--- a/packages/shared/src/features/boost/CampaignListView.tsx
+++ b/packages/shared/src/features/boost/CampaignListView.tsx
@@ -56,7 +56,7 @@ export const CampaignStatsGrid = ({
       value={impressions}
       info={boostDashboardInfo.impressions}
     />
-    <DataTile label="Clicks" value={users} info={boostDashboardInfo.users} />
+    <DataTile label="Users" value={users} info={boostDashboardInfo.users} />
   </div>
 );
 

--- a/packages/shared/src/features/boost/useShowBoostButton.ts
+++ b/packages/shared/src/features/boost/useShowBoostButton.ts
@@ -1,0 +1,19 @@
+import { useQueryClient } from '@tanstack/react-query';
+import type { Post, PostData } from '../../graphql/posts';
+import { useCanBoostPost } from '../../graphql/posts';
+import { getPostByIdKey } from '../../lib/query';
+
+interface UseShowBoostButtonProps {
+  post: Post;
+}
+
+export const useShowBoostButton = ({ post }: UseShowBoostButtonProps) => {
+  const client = useQueryClient();
+  const key = getPostByIdKey(post?.id);
+  // post props could be fetched from server side which lacks some info
+  // to ensure we have now all the data we need, we wait until postById is fetched
+  const postById = client.getQueryData<PostData>(key);
+  const { canBoost } = useCanBoostPost(post);
+
+  return canBoost && postById && !postById.post?.flags?.campaignId;
+};

--- a/packages/shared/src/graphql/actions.ts
+++ b/packages/shared/src/graphql/actions.ts
@@ -16,6 +16,7 @@ export enum ActionType {
   HideBlockPanel = 'hide_block_panel',
   ExistingAnonymousBanner = 'existingAnonymousBanner',
   AcceptedSearch = 'accepted_search',
+  ClosedNewPostBoostBanner = 'closed_new_post_boost_banner',
   UsedSearch = 'used_search',
   CollectionsIntro = 'collections_intro',
   DevCardGenerate = 'dev_card_generate',

--- a/packages/shared/src/graphql/post/boost.ts
+++ b/packages/shared/src/graphql/post/boost.ts
@@ -49,6 +49,7 @@ export const BOOSTED_POST_CAMPAIGNS = gql`
         clicks
         totalSpend
         engagements
+        users
       }
     }
   }

--- a/packages/shared/src/graphql/post/boost.ts
+++ b/packages/shared/src/graphql/post/boost.ts
@@ -23,6 +23,7 @@ const BOOSTED_POST_FRAGMENT = gql`
       budget
       impressions
       clicks
+      users
       startedAt
       endedAt
     }
@@ -64,18 +65,23 @@ export interface PromotedPost {
   endedAt: Date;
   impressions: number;
   clicks: number;
+  users: number;
 }
 
 export interface PromotedPostList {
   promotedPosts: PromotedPost[];
   impressions: number;
   clicks: number;
+  users: number;
   totalSpend: number;
   postIds: string[];
 }
 
 export interface BoostedPostStats
-  extends Pick<PromotedPostList, 'clicks' | 'impressions' | 'totalSpend'> {
+  extends Pick<
+    PromotedPostList,
+    'clicks' | 'users' | 'impressions' | 'totalSpend'
+  > {
   engagements: number;
 }
 

--- a/packages/shared/src/graphql/post/boost.ts
+++ b/packages/shared/src/graphql/post/boost.ts
@@ -240,3 +240,6 @@ export const cancelPostBoost = async (
 
   return result.cancelPostBoost;
 };
+
+export const DEFAULT_CORES_PER_DAY = 5000;
+export const DEFAULT_DURATION_DAYS = 7;

--- a/packages/shared/src/hooks/post/usePostBoost.ts
+++ b/packages/shared/src/hooks/post/usePostBoost.ts
@@ -28,6 +28,7 @@ const defaultStats = {
   clicks: 0,
   impressions: 0,
   engagements: 0,
+  users: 0,
 };
 
 export const usePostBoost = (): UsePostBoost => {

--- a/packages/shared/src/hooks/post/usePostBoostEstimation.ts
+++ b/packages/shared/src/hooks/post/usePostBoostEstimation.ts
@@ -1,0 +1,89 @@
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import user from '../../../__tests__/fixture/loggedUser';
+import type { EstimatedReachProps } from '../../graphql/post/boost';
+import {
+  getBoostEstimatedReachDaily,
+  getBoostEstimatedReach,
+} from '../../graphql/post/boost';
+import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
+import type { Post } from '../../graphql/posts';
+import { briefRefetchIntervalMs, defautRefetchMs } from '../../graphql/posts';
+import { oneMinute } from '../../lib/dateFormat';
+import { usePostById } from '../usePostById';
+
+interface UsePostBoostEstimationProps {
+  post: Post;
+  query?: Omit<EstimatedReachProps, 'id'>;
+}
+
+const placeholderData = { min: 0, max: 0 };
+
+export const usePostBoostEstimation = ({
+  post: postFromProps,
+  query,
+}: UsePostBoostEstimationProps) => {
+  const [post, setPost] = useState(postFromProps);
+  const hasTags = !!post.tags?.length || !!post.sharedPost?.tags?.length;
+  const canBoost = hasTags || post.yggdrasilId;
+  const {
+    data: estimatedReach,
+    isPending,
+    isRefetching,
+  } = useQuery({
+    queryKey: generateQueryKey(
+      RequestKey.PostCampaigns,
+      user,
+      'estimate',
+      post.id,
+      query && hasTags ? Object.values(query).join(':') : undefined,
+    ),
+    queryFn: () => {
+      if (query && hasTags) {
+        return getBoostEstimatedReachDaily({
+          id: post.id,
+          budget: query.budget,
+          duration: query.duration,
+        });
+      }
+
+      return getBoostEstimatedReach({ id: post.id });
+    },
+    enabled: !!canBoost,
+    placeholderData,
+    staleTime: StaleTime.Default,
+  });
+
+  usePostById({
+    id: post.id,
+    options: {
+      enabled: !canBoost,
+      refetchInterval: (cache) => {
+        const retries = Math.max(
+          cache.state.dataUpdateCount,
+          cache.state.fetchFailureCount,
+        );
+
+        // 30 seconds is an ample time to process yggdrasil
+        const oneMinuteMs = oneMinute * 1000;
+        const maxRetries = oneMinuteMs / 2 / defautRefetchMs;
+
+        if (retries > maxRetries) {
+          return false;
+        }
+
+        const { data } = cache.state;
+
+        // in case of query error keep refetching until maxRetries is reached
+        if (data?.post.yggdrasilId) {
+          setPost(data.post);
+          return false;
+        }
+
+        return briefRefetchIntervalMs;
+      },
+    },
+  });
+
+  return { estimatedReach, isLoading: isPending || isRefetching, canBoost };
+};

--- a/packages/shared/src/hooks/post/usePostBoostEstimation.ts
+++ b/packages/shared/src/hooks/post/usePostBoostEstimation.ts
@@ -25,7 +25,7 @@ export const usePostBoostEstimation = ({
 }: UsePostBoostEstimationProps) => {
   const [post, setPost] = useState(postFromProps);
   const hasTags = !!post.tags?.length || !!post.sharedPost?.tags?.length;
-  const canBoost = hasTags || post.yggdrasilId;
+  const canBoost = hasTags || !!post.yggdrasilId;
   const {
     data: estimatedReach,
     isPending,

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -166,3 +166,5 @@ export const coresDocsLink = 'https://r.daily.dev/cores';
 export const webFunnelPrefix = '/helloworld';
 
 export const creatorsTermsOfService = 'https://r.daily.dev/creators-terms';
+
+export const boostPostDocsLink = 'https://r.daily.dev/boost';

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -167,4 +167,4 @@ export const webFunnelPrefix = '/helloworld';
 
 export const creatorsTermsOfService = 'https://r.daily.dev/creators-terms';
 
-export const boostPostDocsLink = 'https://r.daily.dev/boost';
+export const boostPostDocsLink = 'https://r.daily.dev/monetization/boost';

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -325,7 +325,7 @@ export const plusShowcaseSquadImage =
   'https://media.daily.dev/image/upload/s--LKIr_f6r--/f_auto/v1741698925/public/Members-only Squad';
 
 export const postBoostSuccessCover =
-  'https://media.daily.dev/image/upload/s--8gl6WZL1--/f_auto/v1749032473/public/dailydev_post_boost';
+  'https://media.daily.dev/image/upload/s--i9EWmj0H--/f_auto/v1753620990/public/boost';
 
 export const plusShowcaseTranslateImage =
   'https://media.daily.dev/image/upload/s--eHjHLYpQ--/f_auto/v1748954125/public/auto-translate';

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -351,3 +351,6 @@ export const exportLinkedInMobile =
   'https://media.daily.dev/image/upload/s--PqONkeKS--/f_auto/v1752576240/public/linkedin_cv_mobile';
 export const exportLinkedIn =
   'https://media.daily.dev/image/upload/s--UpRCf8h5--/f_auto/v1753166816/public/Export%20from%20LinkedIn%20popover%20web';
+
+export const boostNewPostBanner =
+  'https://media.daily.dev/image/upload/s--_UEbmtDg--/f_auto/v1753703398/public/booststrip';

--- a/packages/shared/src/styles/custom.ts
+++ b/packages/shared/src/styles/custom.ts
@@ -14,9 +14,6 @@ export const briefCardBorder = '1px solid #EFD5C8';
 export const briefCardBg =
   'linear-gradient(180deg, rgba(239, 213, 200, 0.16) 0%, rgba(210, 233, 227, 0.16) 25.96%, rgba(198, 222, 250, 0.16) 53.37%, rgba(196, 199, 251, 0.16) 79.33%, rgba(199, 182, 250, 0.16) 100%)';
 
-export const boostPostButton =
-  'radial-gradient(1030.79% 132.35% at 50.01% 56.13%, var(--Colors-Accent-Blue-Cheese-subtlest, #6FF1F6) 0%, var(--theme-accent-cabbage-default) 100%)';
-
 export const briefButtonBg =
   'linear-gradient(270deg, #EFD5C8 0%, #D2E9E3 25.96%, #C6DEFA 53.37%, #C4C7FB 79.33%, #C7B6FA 100%)';
 

--- a/packages/shared/src/svg/TooltipArrow.tsx
+++ b/packages/shared/src/svg/TooltipArrow.tsx
@@ -1,0 +1,22 @@
+import type { HTMLAttributes, ReactElement } from 'react';
+import React from 'react';
+
+export function TooltipArrow({
+  className,
+}: HTMLAttributes<SVGElement>): ReactElement {
+  return (
+    <svg
+      className={className}
+      width="9"
+      height="7"
+      viewBox="0 0 9 7"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M3.62842 0.549469C4.01073 -0.130183 4.98927 -0.130184 5.37158 0.549468L9 7H0L3.62842 0.549469Z"
+        fill="#2CDCE6"
+      />
+    </svg>
+  );
+}

--- a/packages/shared/src/svg/TooltipArrow.tsx
+++ b/packages/shared/src/svg/TooltipArrow.tsx
@@ -10,13 +10,10 @@ export function TooltipArrow({
       width="9"
       height="7"
       viewBox="0 0 9 7"
-      fill="none"
+      fill="#ffffff"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <path
-        d="M3.62842 0.549469C4.01073 -0.130183 4.98927 -0.130184 5.37158 0.549468L9 7H0L3.62842 0.549469Z"
-        fill="#2CDCE6"
-      />
+      <path d="M3.62842 0.549469C4.01073 -0.130183 4.98927 -0.130184 5.37158 0.549468L9 7H0L3.62842 0.549469Z" />
     </svg>
   );
 }

--- a/packages/webapp/pages/squads/create.tsx
+++ b/packages/webapp/pages/squads/create.tsx
@@ -42,7 +42,6 @@ import {
   WriteFormTabToFormID,
 } from '@dailydotdev/shared/src/components/fields/form/common';
 import { useQueryClient } from '@tanstack/react-query';
-import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import { getLayout as getMainLayout } from '../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 import { getTemplatedTitle } from '../../components/layouts/utils';
@@ -113,11 +112,7 @@ function CreatePost(): ReactElement {
         });
       }
 
-      onPostSuccess(
-        isUserSource
-          ? `${webappUrl}${user.username}/posts`
-          : post.commentsPermalink,
-      );
+      onPostSuccess(post.commentsPermalink);
     },
     onSourcePostModerationSuccess: async (post) => {
       onPostSuccess(post.source.permalink);


### PR DESCRIPTION
## Changes
- I tried to separate the changes per commit, but the list below is the supposed changes.
- Flow change: creating a new post for "Everyone" should now redirect to the post page.
- Display the banner on **post page** (only) when the user has just posted something.
- Changed the color of the Boost button. Thankfully.
- BoostPostModal must have a link pointing to docs.
- After successfully boosting a post, we display a success state. The link to docs should be present there too as a secondary cta.
  - Also updated the cover image for this UI.
- AdsDashboard modal must have the link pointing to the docs page.
  - Removed engagements metric.
  - Replaced Clicks with Unique reach.
  - Changed copy of the title.
  - Changed copy of the description.
  - Must have a link pointing to the docs page.

## Previews (you might notice a bug on tablet, but not related to this task; it has been raised already):

Hopefully we get to fix it before shipping this. Otherwise, I will fix it myself, just waiting for a response from the design team.

<img width="865" height="326" alt="Screenshot 2025-07-31 at 10 07 53 PM" src="https://github.com/user-attachments/assets/89f49200-e755-4ad9-88a6-77dd299712e9" />
<img width="870" height="383" alt="Screenshot 2025-07-31 at 10 07 48 PM" src="https://github.com/user-attachments/assets/d1071be9-9dbb-4f06-b721-20d7f9d1bbbd" />
<img width="834" height="338" alt="Screenshot 2025-07-31 at 10 07 43 PM" src="https://github.com/user-attachments/assets/ccc226b4-a502-4c43-8321-facb5c7ce3f5" />

<img width="1039" height="465" alt="Screenshot 2025-07-31 at 10 06 05 PM" src="https://github.com/user-attachments/assets/f10ac736-5390-444b-a0ff-e87b76724e28" />
<img width="1006" height="509" alt="Screenshot 2025-07-31 at 10 05 58 PM" src="https://github.com/user-attachments/assets/a59dc5a7-61e2-42f3-803c-c11af3ca2c40" />
<img width="971" height="490" alt="Screenshot 2025-07-31 at 10 05 51 PM" src="https://github.com/user-attachments/assets/fdb8d696-30b2-4ce9-a3fd-3622a4ab5c6b" />
<img width="776" height="439" alt="Screenshot 2025-07-31 at 10 05 19 PM" src="https://github.com/user-attachments/assets/ceddc418-b3d2-4ebc-853b-436a09237709" />
<img width="714" height="401" alt="Screenshot 2025-07-31 at 10 05 17 PM" src="https://github.com/user-attachments/assets/69e01364-b4d7-40b6-80b5-e63970a4f055" />
<img width="684" height="349" alt="Screenshot 2025-07-31 at 10 05 02 PM" src="https://github.com/user-attachments/assets/d0da584c-b094-4a3b-bde2-06ee6d1e2d01" />

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Jira ticket
MI-961

### Preview domain
https://mi-961-banner.preview.app.daily.dev