### PR TITLE
fix: rebrandly link for boost docs

### DIFF
--- a/packages/shared/src/components/modals/post/boost/BoostPostModal.tsx
+++ b/packages/shared/src/components/modals/post/boost/BoostPostModal.tsx
@@ -188,7 +188,7 @@ export function BoostPostModal({
           ensures your post gets shown to the developers most likely to care.
           <a
             href={boostPostDocsLink}
-            className="text-text-link"
+            className="ml-1 text-text-link"
             target="_blank"
           >
             Learn more

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -167,4 +167,4 @@ export const webFunnelPrefix = '/helloworld';
 
 export const creatorsTermsOfService = 'https://r.daily.dev/creators-terms';
 
-export const boostPostDocsLink = 'https://r.daily.dev/monetization/boost';
+export const boostPostDocsLink = 'https://r.daily.dev/boost';


### PR DESCRIPTION
## Changes
- The new link does not yet point to anything. For now, we should use the initial rebrandly link until Sab fixes the new link. Basically they will point to the same thing.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://fix-rebrandly-link.preview.app.daily.dev