### PR TITLE
fix: add missing updateSquads to companion

### DIFF
--- a/packages/extension/src/companion/App.tsx
+++ b/packages/extension/src/companion/App.tsx
@@ -108,6 +108,7 @@ export default function App({
               getRedirectUri={() => browser.runtime.getURL('index.html')}
               updateUser={() => null}
               squads={squads}
+              updateSquads={() => null}
             >
               <SettingsContextProvider settings={settings}>
                 <AlertContextProvider alerts={alerts}>


### PR DESCRIPTION
## Changes

Missed a `updateSquads` in the App.tsx for the companion.

### Preview domain
https://fix-missing-updatesquads.preview.app.daily.dev