### PR TITLE
fix: hide comment input on brief posts on mobile

### DIFF
--- a/packages/webapp/components/footer/FooterWrapper.tsx
+++ b/packages/webapp/components/footer/FooterWrapper.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import type { Post } from '@dailydotdev/shared/src/graphql/posts';
+import { PostType } from '@dailydotdev/shared/src/graphql/posts';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { blurClasses } from './common';
@@ -53,7 +54,7 @@ export default function FooterWrapper({
           'footer-navbar bg-gradient-to-t from-background-subtle from-70% to-transparent px-2 pt-2',
       )}
     >
-      {post && (
+      {post && post.type !== PostType.Brief && (
         <div className="my-2 w-full px-2 tablet:hidden">
           <NewComment
             post={post}


### PR DESCRIPTION
## Changes

Remove the comment section on brief posts

https://dailydotdev.slack.com/archives/C08R2QZJBDK/p1754736886608409

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="430" height="932" alt="image" src="https://github.com/user-attachments/assets/4a1372ec-a4aa-48e9-ab04-1c4e5e10d982" />
    <td><img width="430" height="932" alt="image" src="https://github.com/user-attachments/assets/f113f1e0-e5f2-4c4e-92fe-26d1642181da" />
  </tr>
</table>

### Preview domain
https://fix-hide-comments-on-brief.preview.app.daily.dev