### PR TITLE
fix: hide boost button on brief

### DIFF
--- a/packages/shared/src/features/boost/useShowBoostButton.ts
+++ b/packages/shared/src/features/boost/useShowBoostButton.ts
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import type { Post, PostData } from '../../graphql/posts';
-import { useCanBoostPost } from '../../graphql/posts';
+import { PostType, useCanBoostPost } from '../../graphql/posts';
 import { getPostByIdKey } from '../../lib/query';
 
 interface UseShowBoostButtonProps {
@@ -15,5 +15,10 @@ export const useShowBoostButton = ({ post }: UseShowBoostButtonProps) => {
   const postById = client.getQueryData<PostData>(key);
   const { canBoost } = useCanBoostPost(post);
 
-  return canBoost && postById && !postById.post?.flags?.campaignId;
+  return (
+    canBoost &&
+    postById &&
+    !postById.post?.flags?.campaignId &&
+    postById.post?.type !== PostType.Brief
+  );
 };


### PR DESCRIPTION
## Changes

Hide the post boost button on brief posts.

https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1754737093684189

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="430" height="932" alt="image" src="https://github.com/user-attachments/assets/4a1372ec-a4aa-48e9-ab04-1c4e5e10d982" />
    <td><img width="430" height="932" alt="image" src="https://github.com/user-attachments/assets/5dc400f6-031a-460f-9684-3ee2c11f46e0" />
  </tr>
  <tr>
    <td><img width="762" height="200" alt="image" src="https://github.com/user-attachments/assets/f346b68c-1032-4c1d-987e-69628a0b811c" />
    <td><img width="762" height="200" alt="image" src="https://github.com/user-attachments/assets/c3d3b197-f33b-4dc5-89bb-50587c4c5b47" />
  </tr>
</table>

### Preview domain
https://fix-hide-boost-button-on-brief.preview.app.daily.dev