### PR TITLE
fix: reverse functionality for the unsubscribe all emails button

### DIFF
--- a/packages/shared/src/components/notifications/EmailNotificationsTab.tsx
+++ b/packages/shared/src/components/notifications/EmailNotificationsTab.tsx
@@ -21,7 +21,7 @@ const EmailNotificationsTab = (): ReactElement => {
     toggleGroup,
     getGroupStatus,
     unsubscribeAllEmail,
-    emailsEnabled,
+    emailsDisabled,
   } = useNotificationSettings();
 
   return (
@@ -260,7 +260,8 @@ const EmailNotificationsTab = (): ReactElement => {
         <NotificationSwitch
           id="unsubscribe_all"
           label="Unsubscribe from all email notifications"
-          checked={emailsEnabled}
+          disabled={emailsDisabled}
+          checked={emailsDisabled}
           onToggle={unsubscribeAllEmail}
         />
       </NotificationSection>

--- a/packages/shared/src/components/notifications/NotificationSwitch.tsx
+++ b/packages/shared/src/components/notifications/NotificationSwitch.tsx
@@ -12,6 +12,7 @@ interface NotificationSwitchProps {
   description?: string;
   checked: boolean;
   onToggle: () => void;
+  disabled?: boolean;
 }
 
 const NotificationSwitch = ({
@@ -20,6 +21,7 @@ const NotificationSwitch = ({
   description,
   checked,
   onToggle,
+  disabled,
 }: NotificationSwitchProps) => {
   return (
     <div className="flex flex-row justify-between gap-1">
@@ -40,6 +42,7 @@ const NotificationSwitch = ({
         checked={checked}
         onToggle={onToggle}
         compact={false}
+        disabled={disabled}
       />
     </div>
   );

--- a/packages/shared/src/hooks/notifications/useNotificationSettings.ts
+++ b/packages/shared/src/hooks/notifications/useNotificationSettings.ts
@@ -145,18 +145,18 @@ const useNotificationSettings = () => {
     mutate(updatedSettings);
   };
 
-  const emailsEnabled = notificationSettings
-    ? Object.values(notificationSettings).some(
+  const emailsDisabled = notificationSettings
+    ? !Object.values(notificationSettings).some(
         (setting) => setting.email === NotificationPreferenceStatus.Subscribed,
       )
-    : false;
+    : true;
 
   return {
     toggleSetting,
     toggleGroup,
     getGroupStatus,
     unsubscribeAllEmail,
-    emailsEnabled,
+    emailsDisabled,
     notificationSettings,
     isLoadingPreferences,
   };


### PR DESCRIPTION
## Changes

The logic for the "unsubscribe all emails" button at the bottom of the email tab was reversed. it should be toggled ON when everything is unsubscribed, and OFF when one or more email notification types are subscribed.

I also disable it when its toggled on, since as far as I understand from the copy, toggling it off is not supposed to subscribe you to everything.

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Jira ticket
MI-972

### Preview domain
https://mi-972.preview.app.daily.dev