### PR TITLE
fix(dropdown): add scrollable wrapper to support long menus

### DIFF
--- a/packages/shared/src/components/dropdown/DropdownMenu.tsx
+++ b/packages/shared/src/components/dropdown/DropdownMenu.tsx
@@ -111,7 +111,9 @@ export const DropdownMenuContent = React.forwardRef<
         className={classNames('DropdownMenuContent', className)}
         align={align}
       >
-        {children}
+        <div className="DropdownScrollView">
+          {children}
+        </div>
       </DropdownMenuContentRoot>
     </DropdownMenuPortal>
   );

--- a/packages/shared/src/components/dropdown/style.css
+++ b/packages/shared/src/components/dropdown/style.css
@@ -52,6 +52,14 @@
   @apply bg-surface-hover;
 }
 
+.DropdownMenuContent .DropdownScrollView {
+  max-height: 15rem;
+  overflow-y: auto;
+  background: inherit;
+  border-radius: inherit;
+}
+
+
 @keyframes slideUpAndFade {
   from {
     opacity: 0;
@@ -95,3 +103,6 @@
     transform: translateX(0);
   }
 }
+
+
+


### PR DESCRIPTION
## Changes
- Fixed dropdown scroll issue; dropdown now scrolls smoothly and allows access to all items.
- Verified functionality on Gitpod dev server (`localhost:5002`).

https://github.com/user-attachments/assets/9de9df92-3a38-4d2e-82f1-59ab001821ea

## Events
None

## Experiment
None

## Manual Testing
- ✅ Confirmed working on Gitpod dev server (`localhost:5002`).
- Not able to validate in the Chrome extension locally because changes in the `dist/` folder (e.g., `companion.bundle.js`, `newtab.bundle.js`) were not reflected when loading the extension, even after cache clearing and fresh profile testing.
- Verified by inspecting `dist/` files in VSCode to confirm the changes existed.

## Notes
- Related issue: #1931
