### PR TITLE
fix(dropdown): add scrollable wrapper to support long menus

### DIFF
--- a/packages/shared/src/components/dropdown/DropdownMenu.tsx
+++ b/packages/shared/src/components/dropdown/DropdownMenu.tsx
@@ -111,7 +111,9 @@ export const DropdownMenuContent = React.forwardRef<
         className={classNames('DropdownMenuContent', className)}
         align={align}
       >
-        {children}
+        <div className='DropdownScrollView'>
+          {children}
+        </div>
       </DropdownMenuContentRoot>
     </DropdownMenuPortal>
   );

--- a/packages/shared/src/components/dropdown/style.css
+++ b/packages/shared/src/components/dropdown/style.css
@@ -95,3 +95,11 @@
     transform: translateX(0);
   }
 }
+
+.DropdownMenuContent .DropdownScrollView {
+  max-height: 15rem;
+  overflow-y: auto;
+  background: inherit;
+  border-radius: inherit;
+}
+


### PR DESCRIPTION
### **Description:**

Time Preference dropdown menu with many items previously overflowed the viewport without a scroll option. This adds a scrollable wrapper with max-height and auto overflow to improve usability.

Fixes [https://github.com/dailydotdev/daily/issues/1931](https://github.com/dailydotdev/daily/issues/1931)

> **Note:** I was able to verify this fix in the Gitpod environment. However, I encountered a persistent caching issue with the local development server (`pnpm --filter extension dev:chrome`) where changes were not reflected in the browser, even after clearing all caches and using a new browser profile. The code has been confirmed to be correct and properly compiled in the build output.

## Changes

-   Wrapped the children of the generic `DropdownMenuContent` component in a new `<div className="DropdownScrollView">`. This provides a dedicated container for scrolling that is compatible with the project's version of Radix UI.
-   Added a new CSS rule to apply `max-height` and `overflow-y: auto` to the DropdownScrollView.

-   **Demo:**
    

https://github.com/user-attachments/assets/8724ce92-93e4-4bf8-ac25-588a8092a0bb



## Events

N/A

## Experiment

N/A

## Manual Testing

*Testing was performed in the Gitpod environment.*

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android