### PR TITLE
feat: store user location once-off for now

### DIFF
--- a/packages/extension/src/newtab/App.tsx
+++ b/packages/extension/src/newtab/App.tsx
@@ -32,6 +32,7 @@ import { structuredCloneJsonPolyfill } from '@dailydotdev/shared/src/lib/structu
 import { useOnboardingActions } from '@dailydotdev/shared/src/hooks/auth';
 import { useCheckCoresRole } from '@dailydotdev/shared/src/hooks/useCheckCoresRole';
 import { ShortcutsProvider } from '@dailydotdev/shared/src/features/shortcuts/contexts/ShortcutsProvider';
+import { useCheckLocation } from '@dailydotdev/shared/src/hooks/useCheckLocation';
 import { ExtensionContextProvider } from '../contexts/ExtensionContext';
 import CustomRouter from '../lib/CustomRouter';
 import { version } from '../../package.json';
@@ -68,6 +69,7 @@ function InternalApp(): ReactElement {
   const shouldRedirectOnboarding =
     isPageReady && (!user || !isOnboardingComplete) && !isTesting;
 
+  useCheckLocation();
   useCheckCoresRole();
 
   useEffect(() => {

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -26,6 +26,14 @@ export const USER_SHORT_BY_ID = `
   }
 `;
 
+export const CHECK_LOCATION_QUERY = gql`
+  query checkLocation {
+    checkLocation {
+      _
+    }
+  }
+`;
+
 export const USER_BY_ID_STATIC_FIELDS_QUERY = `
   query User($id: ID!) {
     user(id: $id) {

--- a/packages/shared/src/hooks/useCheckLocation.ts
+++ b/packages/shared/src/hooks/useCheckLocation.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { generateQueryKey, RequestKey } from '../lib/query';
+import type { LoggedUser } from '../lib/user';
+import { useAuthContext } from '../contexts/AuthContext';
+import { useRequestProtocol } from './useRequestProtocol';
+import { CHECK_LOCATION_QUERY } from '../graphql/users';
+
+export const useCheckLocation = (): void => {
+  const { user, isFetched, updateUser } = useAuthContext();
+  const { requestMethod } = useRequestProtocol();
+
+  useQuery({
+    queryKey: generateQueryKey(RequestKey.CheckLocation, user),
+    queryFn: async () => {
+      const result = await requestMethod<{
+        location: Pick<LoggedUser, 'hasLocationSet'>;
+      }>(CHECK_LOCATION_QUERY);
+      await updateUser({
+        ...user,
+        hasLocationSet: !!result,
+      });
+    },
+    staleTime: Infinity,
+    gcTime: Infinity,
+    enabled: !!user && isFetched && !user.hasLocationSet,
+  });
+};

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -213,6 +213,7 @@ export enum RequestKey {
   NotificationSettings = 'notification_settings',
   PostAnalytics = 'post_analytics',
   PostAnalyticsHistory = 'post_analytics_history',
+  CheckLocation = 'check_location',
 }
 
 export const getPostByIdKey = (id: string): QueryKey => [RequestKey.Post, id];

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -163,6 +163,7 @@ export interface LoggedUser extends UserProfile, AnonymousUser {
     amount: number;
   };
   clickbaitTries?: number;
+  hasLocationSet?: boolean;
 }
 
 export async function logout(reason: string): Promise<void> {

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -43,6 +43,7 @@ import {
   postWebKitMessage,
   WebKitMessageHandlers,
 } from '@dailydotdev/shared/src/lib/ios';
+import { useCheckLocation } from '@dailydotdev/shared/src/hooks/useCheckLocation';
 import Seo, { defaultSeo, defaultSeoTitle } from '../next-seo';
 import useWebappVersion from '../hooks/useWebappVersion';
 import { PixelsProvider } from '../context/PixelsContext';
@@ -87,6 +88,7 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
   useIOSError();
 
   useCheckCoresRole();
+  useCheckLocation();
 
   useEffect(() => {
     if (


### PR DESCRIPTION
## Changes

Thought I already opened this one 🤦 

Introduces the frontend call the set location once-off for now.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://feat-store-location.preview.app.daily.dev