### PR TITLE
fix(link-preview): resolve container overflow in post modal

### DIFF
--- a/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
+++ b/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
@@ -138,6 +138,7 @@ export function CreateSharedPostModal({
                 preview={updatedPreview ?? preview}
                 link={link}
                 onLinkChange={onInput}
+                variant="modal"
               />
             )
           }

--- a/packages/shared/src/components/post/write/WriteLinkPreview.tsx
+++ b/packages/shared/src/components/post/write/WriteLinkPreview.tsx
@@ -1,5 +1,6 @@
 import type { FormEventHandler, ReactElement } from 'react';
 import React from 'react';
+import classNames from 'classnames';
 import { TextField } from '../../fields/TextField';
 import { LinkIcon, OpenLinkIcon } from '../../icons';
 import { SourceAvatar } from '../../profile/source';
@@ -31,6 +32,7 @@ interface WriteLinkPreviewProps {
   className?: string;
   showPreviewLink?: boolean;
   isMinimized?: boolean;
+  variant?: 'default' | 'modal';
 }
 
 export function WriteLinkPreview({
@@ -40,6 +42,7 @@ export function WriteLinkPreview({
   className,
   isMinimized,
   showPreviewLink = true,
+  variant = 'default',
 }: WriteLinkPreviewProps): ReactElement {
   return (
     <>
@@ -106,7 +109,12 @@ export function WriteLinkPreview({
             This link has already been shared here:
           </Typography>
 
-          <div className="flex max-h-52 flex-col gap-2 overflow-x-hidden overflow-y-scroll px-4 tablet:max-h-28">
+          <div
+            className={classNames(
+              'flex flex-col gap-2 overflow-x-hidden overflow-y-scroll px-4',
+              variant === 'modal' ? 'max-h-52 tablet:max-h-28' : 'max-h-52',
+            )}
+          >
             {preview.relatedPublicPosts.map((post) => {
               const isUserSource = isSourceUserSource(post.source);
 


### PR DESCRIPTION
## Changes

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

This PR fixes a UI bug where the list of previously shared links overflows the 'New Post' modal on larger screens.

- The list now has a smaller maximum height (max-h-28) on tablet and desktop viewports to ensure it fits within the modal, while retaining its original height (max-h-52) on mobile.

Fixes : https://github.com/dailydotdev/daily/issues/1942

Before:

<img width="1521" height="867" alt="ISSUE" src="https://github.com/user-attachments/assets/1b4c6969-c24d-4e61-b8f8-986ebdde4bb4" />


After:

<img width="1409" height="770" alt="Screenshot from 2025-09-04 14-32-24" src="https://github.com/user-attachments/assets/f7912ceb-93b0-4ad6-a9ab-3d6436c80043" />

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x ] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [x ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->
