### PR TITLE
feat: added new marketingCta brief card in myfeed

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -176,11 +176,18 @@ export default function Feed<T>({
     (routerQuery?.[acquisitionKey] as string)?.toLocaleLowerCase() === 'true' &&
     !user?.acquisitionChannel;
   const { getMarketingCta } = useBoot();
-  const marketingCta = getMarketingCta(MarketingCtaVariant.Card);
-  const { plusEntryFeed } = usePlusEntry();
-  const showMarketingCta = !!marketingCta;
-  const { isSearchPageLaptop } = useSearchResultsLayout();
   const { isActionsFetched, checkHasCompleted } = useActions();
+  const marketingCta =
+    getMarketingCta(MarketingCtaVariant.Card) ||
+    getMarketingCta(MarketingCtaVariant.BriefCard);
+  const { plusEntryFeed } = usePlusEntry();
+  const hasDismissBriefCta =
+    isActionsFetched && checkHasCompleted(ActionType.DisableBriefCardCta);
+  const showMarketingCta =
+    !!marketingCta &&
+    (marketingCta?.variant !== MarketingCtaVariant.BriefCard ||
+      !hasDismissBriefCta);
+  const { isSearchPageLaptop } = useSearchResultsLayout();
   const hasNoBriefAction =
     isActionsFetched && !checkHasCompleted(ActionType.GeneratedBrief);
   const { value: briefCardFeatureValue } = useConditionalFeature({

--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -42,6 +42,8 @@ import { SquadAdList } from './cards/ad/squad/SquadAdList';
 import { SquadAdGrid } from './cards/ad/squad/SquadAdGrid';
 import { adLogEvent, feedLogExtra } from '../lib/feed';
 import { useLogContext } from '../contexts/LogContext';
+import { MarketingCtaVariant } from './marketingCta/common';
+import { MarketingCtaBriefing } from './marketingCta/MarketingCtaBriefing';
 
 const CommentPopup = dynamic(
   () =>
@@ -388,6 +390,10 @@ function FeedItemComponent({
     case FeedItemType.UserAcquisition:
       return <AcquisitionFormTag key="user-acquisition-card" />;
     case FeedItemType.MarketingCta:
+      if (item.marketingCta.variant === MarketingCtaVariant.BriefCard) {
+        return <MarketingCtaBriefing {...item.marketingCta} />;
+      }
+
       return (
         <MarketingCtaTag
           key="marketing-cta-card"

--- a/packages/shared/src/components/marketingCta/MarketingCtaBriefing.tsx
+++ b/packages/shared/src/components/marketingCta/MarketingCtaBriefing.tsx
@@ -69,6 +69,15 @@ export const MarketingCtaBriefing = ({
     completeAction(ActionType.DisableBriefCardCta);
   }, [completeAction, hideCard]);
 
+  const onClickCta = useCallback(() => {
+    hideCard();
+    logEvent({
+      event_name: LogEvent.Click,
+      target_type: TargetType.MarketingCtaBrief,
+      target_id: campaignId,
+    });
+  }, [hideCard, logEvent, campaignId]);
+
   useEffect(() => {
     if (!hasSentImpression.current) {
       hasSentImpression.current = true;
@@ -165,6 +174,7 @@ export const MarketingCtaBriefing = ({
           href={ctaUrl}
           variant={ButtonVariant.Primary}
           size={ButtonSize.Medium}
+          onClick={onClickCta}
         >
           {ctaText}
         </Button>

--- a/packages/shared/src/components/marketingCta/MarketingCtaBriefing.tsx
+++ b/packages/shared/src/components/marketingCta/MarketingCtaBriefing.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import { format } from 'date-fns';
 import type { MarketingCta } from './common';
@@ -29,7 +29,7 @@ import {
 } from '../dropdown/DropdownMenu';
 import { useActions, useBoot } from '../../hooks';
 import { ActionType } from '../../graphql/actions';
-import { LogEvent, TargetId, TargetType } from '../../lib/log';
+import { LogEvent, TargetType } from '../../lib/log';
 import { useLogContext } from '../../contexts/LogContext';
 
 const stats = [
@@ -51,6 +51,7 @@ export const MarketingCtaBriefing = ({
   const isLightMode = useIsLightTheme();
   const { clearMarketingCta } = useBoot();
   const { logEvent } = useLogContext();
+  const hasSentImpression = useRef(false);
 
   const hideCard = useCallback(() => {
     // log dismiss event
@@ -69,12 +70,15 @@ export const MarketingCtaBriefing = ({
   }, [completeAction, hideCard]);
 
   useEffect(() => {
-    // log impression event
-    logEvent({
-      event_name: LogEvent.Impression,
-      target_type: TargetType.MarketingCtaBrief,
-      target_id: campaignId,
-    });
+    if (!hasSentImpression.current) {
+      hasSentImpression.current = true;
+      // log impression event
+      logEvent({
+        event_name: LogEvent.Impression,
+        target_type: TargetType.MarketingCtaBrief,
+        target_id: campaignId,
+      });
+    }
   }, [logEvent, campaignId]);
 
   return (

--- a/packages/shared/src/components/marketingCta/MarketingCtaBriefing.tsx
+++ b/packages/shared/src/components/marketingCta/MarketingCtaBriefing.tsx
@@ -31,6 +31,7 @@ import { useActions, useBoot } from '../../hooks';
 import { ActionType } from '../../graphql/actions';
 import { LogEvent, TargetType } from '../../lib/log';
 import { useLogContext } from '../../contexts/LogContext';
+import { anchorDefaultRel } from '../../lib/strings';
 
 const stats = [
   {
@@ -78,16 +79,18 @@ export const MarketingCtaBriefing = ({
     });
   }, [hideCard, logEvent, campaignId]);
 
+  // log impression event
   useEffect(() => {
-    if (!hasSentImpression.current) {
-      hasSentImpression.current = true;
-      // log impression event
-      logEvent({
-        event_name: LogEvent.Impression,
-        target_type: TargetType.MarketingCtaBrief,
-        target_id: campaignId,
-      });
+    if (hasSentImpression.current) {
+      return;
     }
+
+    hasSentImpression.current = true;
+    logEvent({
+      event_name: LogEvent.Impression,
+      target_type: TargetType.MarketingCtaBrief,
+      target_id: campaignId,
+    });
   }, [logEvent, campaignId]);
 
   return (
@@ -173,9 +176,11 @@ export const MarketingCtaBriefing = ({
           className="w-full"
           href={ctaUrl}
           onClick={onClickCta}
-          size={ButtonSize.Medium}
+          rel={anchorDefaultRel}
+          size={ButtonSize.Small}
           tag="a"
           variant={ButtonVariant.Primary}
+          target="_blank"
         >
           {ctaText}
         </Button>

--- a/packages/shared/src/components/marketingCta/MarketingCtaBriefing.tsx
+++ b/packages/shared/src/components/marketingCta/MarketingCtaBriefing.tsx
@@ -71,13 +71,13 @@ export const MarketingCtaBriefing = ({
   }, [completeAction, hideCard]);
 
   const onClickCta = useCallback(() => {
-    hideCard();
+    clearMarketingCta(campaignId);
     logEvent({
       event_name: LogEvent.Click,
       target_type: TargetType.MarketingCtaBrief,
       target_id: campaignId,
     });
-  }, [hideCard, logEvent, campaignId]);
+  }, [clearMarketingCta, campaignId, logEvent]);
 
   // log impression event
   useEffect(() => {

--- a/packages/shared/src/components/marketingCta/MarketingCtaBriefing.tsx
+++ b/packages/shared/src/components/marketingCta/MarketingCtaBriefing.tsx
@@ -73,9 +73,9 @@ export const MarketingCtaBriefing = ({
     logEvent({
       event_name: LogEvent.Impression,
       target_type: TargetType.MarketingCtaBrief,
-      target_id: TargetId.Feed,
+      target_id: campaignId,
     });
-  }, [logEvent]);
+  }, [logEvent, campaignId]);
 
   return (
     <ClickableCard

--- a/packages/shared/src/components/marketingCta/MarketingCtaBriefing.tsx
+++ b/packages/shared/src/components/marketingCta/MarketingCtaBriefing.tsx
@@ -1,0 +1,170 @@
+import React, { useCallback, useEffect } from 'react';
+import classNames from 'classnames';
+import { format } from 'date-fns';
+import type { MarketingCta } from './common';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../typography/Typography';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { briefButtonBg } from '../../styles/custom';
+import { ClickableCard } from '../cards/common/Card';
+import { useIsLightTheme } from '../../hooks/utils';
+import { IconSize } from '../Icon';
+import {
+  AnalyticsIcon,
+  BellDisabledIcon,
+  BriefIcon,
+  EyeIcon,
+  MenuIcon,
+  TimerIcon,
+} from '../icons';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuOptions,
+  DropdownMenuTrigger,
+} from '../dropdown/DropdownMenu';
+import { useActions, useBoot } from '../../hooks';
+import { ActionType } from '../../graphql/actions';
+import { LogEvent, TargetId, TargetType } from '../../lib/log';
+import { useLogContext } from '../../contexts/LogContext';
+
+const stats = [
+  {
+    Icon: TimerIcon,
+    label: 'Save 15-20 hours of reading',
+  },
+  {
+    Icon: AnalyticsIcon,
+    label: 'Analyzed 5,000+ posts and videos',
+  },
+];
+
+export const MarketingCtaBriefing = ({
+  campaignId,
+  flags: { title, description, ctaText, ctaUrl },
+}: MarketingCta) => {
+  const { completeAction } = useActions();
+  const isLightMode = useIsLightTheme();
+  const { clearMarketingCta } = useBoot();
+  const { logEvent } = useLogContext();
+
+  const hideCard = useCallback(() => {
+    // log dismiss event
+    logEvent({
+      event_name: LogEvent.MarketingCtaDismiss,
+      target_type: TargetType.MarketingCtaBrief,
+      target_id: campaignId,
+    });
+
+    clearMarketingCta(campaignId);
+  }, [campaignId, clearMarketingCta, logEvent]);
+
+  const onNeverShowAgain = useCallback(() => {
+    hideCard();
+    completeAction(ActionType.DisableBriefCardCta);
+  }, [completeAction, hideCard]);
+
+  useEffect(() => {
+    // log impression event
+    logEvent({
+      event_name: LogEvent.Impression,
+      target_type: TargetType.MarketingCtaBrief,
+      target_id: TargetId.Feed,
+    });
+  }, [logEvent]);
+
+  return (
+    <ClickableCard
+      className={classNames('flex flex-col gap-3 p-4', {
+        invert: !isLightMode,
+      })}
+      style={{
+        background: briefButtonBg,
+      }}
+    >
+      <div className="flex items-center justify-between gap-2 text-text-primary">
+        <div className="flex items-center gap-1">
+          <BriefIcon secondary size={IconSize.Large} aria-hidden />
+          <Typography type={TypographyType.Footnote}>
+            {format(new Date(), 'MMMM d, yyyy')}
+          </Typography>
+        </div>
+        <div className="relative">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant={ButtonVariant.Tertiary}
+                className="my-auto"
+                icon={<MenuIcon />}
+                size={ButtonSize.Small}
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuOptions
+                options={[
+                  {
+                    icon: <EyeIcon aria-hidden />,
+                    label: 'Hide',
+                    action: () => hideCard(),
+                  },
+                  {
+                    icon: <BellDisabledIcon aria-hidden />,
+                    label: `Don't show me again`,
+                    action: () => onNeverShowAgain(),
+                  },
+                ]}
+              />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+      <div className="flex flex-1 flex-col gap-2">
+        <Typography
+          bold
+          color={TypographyColor.Primary}
+          type={TypographyType.Title3}
+          tag={TypographyTag.H3}
+        >
+          {title}
+        </Typography>
+        <Typography
+          color={TypographyColor.Primary}
+          type={TypographyType.Footnote}
+          tag={TypographyTag.P}
+        >
+          {description}
+        </Typography>
+      </div>
+      <footer className="flex flex-col gap-4">
+        <Typography
+          className="flex flex-col gap-2"
+          color={TypographyColor.Primary}
+          type={TypographyType.Footnote}
+          tag={TypographyTag.P}
+        >
+          {stats.map(({ Icon, label }) => (
+            <span
+              className="flex items-center gap-1 whitespace-nowrap"
+              key={label}
+            >
+              <Icon size={IconSize.Size16} aria-hidden /> {label}
+            </span>
+          ))}
+        </Typography>
+        <Button
+          className="w-full"
+          tag="a"
+          href={ctaUrl}
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Medium}
+        >
+          {ctaText}
+        </Button>
+      </footer>
+    </ClickableCard>
+  );
+};

--- a/packages/shared/src/components/marketingCta/MarketingCtaBriefing.tsx
+++ b/packages/shared/src/components/marketingCta/MarketingCtaBriefing.tsx
@@ -110,10 +110,11 @@ export const MarketingCtaBriefing = ({
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
-                variant={ButtonVariant.Tertiary}
+                aria-label="Show options menu"
                 className="my-auto"
                 icon={<MenuIcon />}
                 size={ButtonSize.Small}
+                variant={ButtonVariant.Tertiary}
               />
             </DropdownMenuTrigger>
             <DropdownMenuContent>
@@ -139,15 +140,15 @@ export const MarketingCtaBriefing = ({
         <Typography
           bold
           color={TypographyColor.Primary}
-          type={TypographyType.Title3}
           tag={TypographyTag.H3}
+          type={TypographyType.Title3}
         >
           {title}
         </Typography>
         <Typography
           color={TypographyColor.Primary}
-          type={TypographyType.Footnote}
           tag={TypographyTag.P}
+          type={TypographyType.Footnote}
         >
           {description}
         </Typography>
@@ -156,8 +157,8 @@ export const MarketingCtaBriefing = ({
         <Typography
           className="flex flex-col gap-2"
           color={TypographyColor.Primary}
-          type={TypographyType.Footnote}
           tag={TypographyTag.P}
+          type={TypographyType.Footnote}
         >
           {stats.map(({ Icon, label }) => (
             <span
@@ -170,11 +171,11 @@ export const MarketingCtaBriefing = ({
         </Typography>
         <Button
           className="w-full"
-          tag="a"
           href={ctaUrl}
-          variant={ButtonVariant.Primary}
-          size={ButtonSize.Medium}
           onClick={onClickCta}
+          size={ButtonSize.Medium}
+          tag="a"
+          variant={ButtonVariant.Primary}
         >
           {ctaText}
         </Button>

--- a/packages/shared/src/components/marketingCta/common.tsx
+++ b/packages/shared/src/components/marketingCta/common.tsx
@@ -27,6 +27,7 @@ export enum MarketingCtaVariant {
   PlusBookmarkTab = 'plus_bookmark_tab',
   PlusAnnouncementBar = 'plus_announcement_bar',
   FeedBanner = 'feed_banner',
+  BriefCard = 'brief_card',
 }
 
 export interface MarketingCta {

--- a/packages/shared/src/graphql/actions.ts
+++ b/packages/shared/src/graphql/actions.ts
@@ -46,6 +46,7 @@ export enum ActionType {
   GeneratedBrief = 'generated_brief',
   ClosedProfileBanner = 'closed_profile_banner',
   UploadedCV = 'uploaded_cv',
+  DisableBriefCardCta = 'disable_brief_card_cta',
 }
 
 export const cvActions = [

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -341,6 +341,7 @@ export enum TargetType {
   MarketingCtaPopover = 'promotion_popover',
   MarketingCtaPopoverSmall = 'promotion_popover_small',
   MarketingCtaPlus = 'promotion_plus',
+  MarketingCtaBrief = 'promotion_briefing',
   PlusEntryCard = 'plus_entry_card',
   PlusEntryForYouTab = 'plus_entry_for_you_tab',
   PlusEntryBookmarkTab = 'plus_entry_bookmark_tab',


### PR DESCRIPTION
## Changes

- Added new marketing CTA component for briefing;
- Added log events for impression/dismiss card;

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Jira ticket
MI-969

### Preview domain
https://mi-969-brief-retool-card.preview.app.daily.dev