### PR TITLE
fix: dropdown menu pixel sticking out 🤗 

### DIFF
--- a/packages/shared/src/components/dropdown/DropdownMenu.tsx
+++ b/packages/shared/src/components/dropdown/DropdownMenu.tsx
@@ -108,7 +108,7 @@ export const DropdownMenuContent = React.forwardRef<
       <DropdownMenuContentRoot
         {...props}
         ref={forwardedRef}
-        className={classNames('DropdownMenuContent', className)}
+        className={classNames('DropdownMenuContent overflow-hidden', className)}
         align={align}
       >
         <div className="max-h-70 overflow-y-auto bg-inherit">{children}</div>


### PR DESCRIPTION
## Changes

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="280" height="291" alt="image" src="https://github.com/user-attachments/assets/99c56422-ea25-44a3-b2e0-83dc405d7ded" />
    <td><img width="279" height="290" alt="image" src="https://github.com/user-attachments/assets/30ab8da8-57e4-46a7-85af-7dd1a43a3207" />
  </tr>
  <tr>
    <td><img width="165" height="74" alt="image" src="https://github.com/user-attachments/assets/dfa56e8c-7a88-40b0-9aab-d3f872776d49" />
    <td><img width="165" height="74" alt="image" src="https://github.com/user-attachments/assets/10d07ac4-6734-4231-a354-5873e49f167b" />
  </tr>
</table>

### Preview domain
https://hug-a-pixel.preview.app.daily.dev