### PR TITLE
fix: name of notificationSettings query

### DIFF
--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -700,7 +700,7 @@ export const TOP_READER_BADGE_BY_ID = gql`
 `;
 
 export const GET_NOTIFICATION_SETTINGS = gql`
-  query User {
+  query NotificationSettings {
     notificationSettings
   }
 `;


### PR DESCRIPTION
## Changes

Was confused why I saw queries for User when on notification preferences

`User` -> `NotificationSettings`