### PR TITLE
feat: finish feed tracking

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -1,8 +1,9 @@
 import type { ReactElement, ReactNode } from 'react';
 import React, {
+  useRef,
+  useEffect,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -169,6 +170,7 @@ export default function Feed<T>({
   const numCards = currentSettings.numCards[spaciness ?? 'eco'];
   const isSquadFeed = feedName === OtherFeedPage.Squad;
   const { shouldUseListFeedLayout } = useFeedLayout();
+  const trackedFeedFinish = useRef(false);
   const isMyFeed = feedName === SharedFeedPage.MyFeed;
   const showAcquisitionForm =
     isMyFeed &&
@@ -374,7 +376,24 @@ export default function Feed<T>({
     'go to link',
   );
 
+  const trackFinishFeed = useCallback(() => {
+    if (!canFetchMore) {
+      logEvent({
+        event_name: LogEvent.FinishFeed,
+        extra: JSON.stringify(feedLogExtra(feedName, ranking).extra),
+        ...logOpts,
+      });
+    }
+  }, [canFetchMore, feedName, logEvent, logOpts, ranking]);
+
   const { openSharePost, copyLink } = useSharePost(origin);
+
+  useEffect(() => {
+    if (!canFetchMore && !isFetching && !trackedFeedFinish.current) {
+      trackFinishFeed();
+      trackedFeedFinish.current = true;
+    }
+  }, [canFetchMore, isFetching, trackFinishFeed]);
 
   useEffect(() => {
     return () => {

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -97,6 +97,7 @@ export enum LogEvent {
   ClickScrollBlock = 'click scroll block',
   KeyboardShortcutTriggered = 'keyboard shortcut triggered',
   FeedEmpty = 'feed empty',
+  FinishFeed = 'finish feed',
   // notifications - start
   ClickNotificationIcon = 'click notification icon',
   OpenNotificationList = 'open notification list',


### PR DESCRIPTION
## Changes

Add new tracking event for finish feed.

Example:
```
{
  "app_platform": "webapp",
  "app_theme": "dark",
  "feed_density": "eco",
  "feed_layout": "cards",
  "session_id": "45190257-2d8a-41b8-b299-a8383d50248b",
  "user_id": "3fjt9kZ8DSDWMTejhr7K9",
  "user_registration_date": "2025-03-25T09:12:34.851Z",
  "visit_id": "e9d4e132-0ff7-4c5c-8c29-571ef33097f9",
  "device_id": "0907d62e-cadc-4c2c-8de5-3f3f52ea06e1",
  "screen_height": 1440,
  "screen_width": 3440,
  "page_referrer": "https://app.local.fylla.dev:5002/",
  "window_height": 1247,
  "window_width": 1126,
  "page_state": "active",
  "event_timestamp": "2025-09-15T12:37:56.741Z",
  "event_id": "1757939877piudk",
  "event_page": "/",
  "event_name": "finish feed",
  "extra": "{\"origin\":\"feed\",\"feed\":\"my-feed\",\"ranking\":\"POPULARITY\"}",
  "columns": 2
}
```

## Events

Did you introduce any new tracking events?

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
|New | finish feed  | extra: { origin: string, feed: string, ranking: ENUM } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->
