### PR TITLE
fix: gitpod env on server-side pages and improved experience

### DIFF
--- a/packages/shared/src/lib/config.ts
+++ b/packages/shared/src/lib/config.ts
@@ -1,13 +1,12 @@
 export const isLocalhost = process.env.NEXT_PUBLIC_DOMAIN === 'localhost';
 
-// For server-side requests, use direct API URL to bypass Next.js rewrites
-// For client-side requests, use /api which gets rewritten by Next.js
 const getApiUrl = () => {
-  if (typeof window === 'undefined') {
-    return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000'; // Server-side: direct API
+  if (isLocalhost) {
+    // For GitPod server-side requests, use direct API URL to bypass Next.js rewrites
+    return typeof window === 'undefined' ? 'http://localhost:5000' : '/api';
   }
 
-  return isLocalhost ? '/api' : process.env.NEXT_PUBLIC_API_URL; // Client-side: proxy
+  return process.env.NEXT_PUBLIC_API_URL;
 };
 
 export const apiUrl = getApiUrl();

--- a/packages/shared/src/lib/config.ts
+++ b/packages/shared/src/lib/config.ts
@@ -1,15 +1,14 @@
 export const isLocalhost = process.env.NEXT_PUBLIC_DOMAIN === 'localhost';
 
-const getApiUrl = () => {
-  if (isLocalhost) {
-    // For GitPod server-side requests, use direct API URL to bypass Next.js rewrites
-    return typeof window === 'undefined' ? 'http://localhost:5000' : '/api';
-  }
+// in gitpod, we need to call the API through the proxy rewrite to avoid CORS issues
+// but when window is undefined, it means server-side request so we need to call api directly
+const shouldCallProxyRewrite =
+  process.env.NEXT_PUBLIC_DOMAIN === 'localhost' &&
+  typeof window !== 'undefined';
 
-  return process.env.NEXT_PUBLIC_API_URL;
-};
-
-export const apiUrl = getApiUrl();
+export const apiUrl = shouldCallProxyRewrite
+  ? '/api'
+  : process.env.NEXT_PUBLIC_API_URL;
 
 export const graphqlUrl = `${apiUrl}/graphql`;
 

--- a/packages/shared/src/lib/config.ts
+++ b/packages/shared/src/lib/config.ts
@@ -1,7 +1,16 @@
-export const apiUrl =
-  process.env.NEXT_PUBLIC_DOMAIN === 'localhost'
-    ? '/api'
-    : process.env.NEXT_PUBLIC_API_URL;
+export const isLocalhost = process.env.NEXT_PUBLIC_DOMAIN === 'localhost';
+
+// For server-side requests, use direct API URL to bypass Next.js rewrites
+// For client-side requests, use /api which gets rewritten by Next.js
+const getApiUrl = () => {
+  if (typeof window === 'undefined') {
+    return process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000'; // Server-side: direct API
+  }
+
+  return isLocalhost ? '/api' : process.env.NEXT_PUBLIC_API_URL; // Client-side: proxy
+};
+
+export const apiUrl = getApiUrl();
 
 export const graphqlUrl = `${apiUrl}/graphql`;
 

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -64,6 +64,7 @@ import { OnboardingHeader } from '@dailydotdev/shared/src/components/onboarding'
 import { FunnelStepper } from '@dailydotdev/shared/src/features/onboarding/shared/FunnelStepper';
 import { useOnboardingActions } from '@dailydotdev/shared/src/hooks/auth';
 import { ActionType } from '@dailydotdev/shared/src/graphql/actions';
+import { isLocalhost } from '@dailydotdev/shared/src/lib/config';
 import { getTemplatedTitle } from '../components/layouts/utils';
 import { defaultOpenGraph, defaultSeo } from '../next-seo';
 
@@ -84,6 +85,10 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
   req,
   res,
 }) => {
+  if (isLocalhost) {
+    return { redirect: { destination: '/', permanent: false } };
+  }
+
   const { id, version } = query;
   const { cookies, forwardedHeaders } = getCookiesAndHeadersFromRequest(req);
 


### PR DESCRIPTION
## Changes
- There are two changes here:
  - First, when using GitPod, we bypass auth and set a test user. This means onboarding should never be hit. It would just confuse GitPod users.
  - Second is the long standing issue that server-side requests were not working due to CORS. We should call API directly to avoid CORS issues in these situations.
  - Verified the changes and worked as intended.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://chore-gitpod-env.preview.app.daily.dev