### PR TITLE
feat: add protections against directly accessing accept/reject pages

### DIFF
--- a/packages/webapp/components/layouts/OpportunityProtectedLayout.tsx
+++ b/packages/webapp/components/layouts/OpportunityProtectedLayout.tsx
@@ -4,8 +4,7 @@ import type { PropsWithChildren, ReactNode } from 'react';
 import { useRouter } from 'next/router';
 
 import { opportunityUrl } from '@dailydotdev/shared/src/lib/constants';
-import { useQueryClient } from '@tanstack/react-query';
-import type { Opportunity } from '@dailydotdev/shared/src/features/opportunity/types';
+import { useQuery } from '@tanstack/react-query';
 import { opportunityByIdOptions } from '@dailydotdev/shared/src/features/opportunity/queries';
 import { getLayout as getNoSidebarLayout } from './NoSidebarLayout';
 
@@ -17,10 +16,10 @@ export const OpportunityProtectedLayout = ({
     push,
   } = useRouter();
   const opportunityId = id as string;
-  const queryClient = useQueryClient();
-  const opportunity = queryClient.getQueryData<Opportunity>(
-    opportunityByIdOptions({ id: opportunityId }).queryKey,
-  );
+  const { data: opportunity } = useQuery({
+    ...opportunityByIdOptions({ id: opportunityId }),
+    enabled: false,
+  });
 
   useEffect(() => {
     if (!opportunity) {

--- a/packages/webapp/components/layouts/OpportunityProtectedLayout.tsx
+++ b/packages/webapp/components/layouts/OpportunityProtectedLayout.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
+
+import { useRouter } from 'next/router';
+
+import { opportunityUrl } from '@dailydotdev/shared/src/lib/constants';
+import { useQueryClient } from '@tanstack/react-query';
+import type { Opportunity } from '@dailydotdev/shared/src/features/opportunity/types';
+import { opportunityByIdOptions } from '@dailydotdev/shared/src/features/opportunity/queries';
+import { getLayout as getNoSidebarLayout } from './NoSidebarLayout';
+
+export const OpportunityProtectedLayout = ({
+  children,
+}: PropsWithChildren): ReactNode => {
+  const {
+    query: { id },
+    push,
+  } = useRouter();
+  const opportunityId = id as string;
+  const queryClient = useQueryClient();
+  const opportunity = queryClient.getQueryData<Opportunity>(
+    opportunityByIdOptions({ id: opportunityId }).queryKey,
+  );
+
+  useEffect(() => {
+    if (!opportunity) {
+      push(`${opportunityUrl}/${opportunityId}`);
+    }
+  }, [opportunity, opportunityId, push]);
+
+  if (!opportunity) {
+    return null;
+  }
+
+  return children;
+};
+
+export const getOpportunityProtectedLayout: typeof getNoSidebarLayout = (
+  page,
+  ...props
+) =>
+  getNoSidebarLayout(
+    <OpportunityProtectedLayout>{page}</OpportunityProtectedLayout>,
+    ...props,
+  );

--- a/packages/webapp/pages/opportunity/[id]/decline.tsx
+++ b/packages/webapp/pages/opportunity/[id]/decline.tsx
@@ -26,13 +26,13 @@ import { useRouter } from 'next/router';
 import classNames from 'classnames';
 import { useActions } from '@dailydotdev/shared/src/hooks';
 import { ActionType } from '@dailydotdev/shared/src/graphql/actions';
-import { getLayout } from '../../../components/layouts/NoSidebarLayout';
 import {
   defaultOpenGraph,
   defaultSeo,
   defaultSeoTitle,
 } from '../../../next-seo';
 import { opportunityPageLayoutProps } from '../../../components/layouts/utils';
+import { getOpportunityProtectedLayout } from '../../../components/layouts/OpportunityProtectedLayout';
 
 const seo: NextSeoProps = {
   title: defaultSeoTitle,
@@ -174,9 +174,7 @@ const DeclinePage = (): ReactElement => {
   );
 };
 
-const getPageLayout: typeof getLayout = (...page) => getLayout(...page);
-
-DeclinePage.getLayout = getPageLayout;
+DeclinePage.getLayout = getOpportunityProtectedLayout;
 DeclinePage.layoutProps = {
   ...opportunityPageLayoutProps,
   seo,

--- a/packages/webapp/pages/opportunity/[id]/done.tsx
+++ b/packages/webapp/pages/opportunity/[id]/done.tsx
@@ -25,13 +25,13 @@ import { usePushNotificationContext } from '@dailydotdev/shared/src/contexts/Pus
 import { anchorDefaultRel } from '@dailydotdev/shared/src/lib/strings';
 import { settingsUrl, webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
-import { getLayout } from '../../../components/layouts/NoSidebarLayout';
 import {
   defaultOpenGraph,
   defaultSeo,
   defaultSeoTitle,
 } from '../../../next-seo';
 import { opportunityPageLayoutProps } from '../../../components/layouts/utils';
+import { getOpportunityProtectedLayout } from '../../../components/layouts/OpportunityProtectedLayout';
 
 const seo: NextSeoProps = {
   title: defaultSeoTitle,
@@ -205,9 +205,7 @@ const DonePage = (): ReactElement => {
   );
 };
 
-const getPageLayout: typeof getLayout = (...page) => getLayout(...page);
-
-DonePage.getLayout = getPageLayout;
+DonePage.getLayout = getOpportunityProtectedLayout;
 DonePage.layoutProps = {
   ...opportunityPageLayoutProps,
   hideBackButton: true,

--- a/packages/webapp/pages/opportunity/[id]/notify.tsx
+++ b/packages/webapp/pages/opportunity/[id]/notify.tsx
@@ -24,13 +24,13 @@ import { NotificationPromptSource } from '@dailydotdev/shared/src/lib/log';
 import { opportunityUrl } from '@dailydotdev/shared/src/lib/constants';
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
 import { useRouter } from 'next/router';
-import { getLayout } from '../../../components/layouts/NoSidebarLayout';
 import {
   defaultOpenGraph,
   defaultSeo,
   defaultSeoTitle,
 } from '../../../next-seo';
 import { opportunityPageLayoutProps } from '../../../components/layouts/utils';
+import { getOpportunityProtectedLayout } from '../../../components/layouts/OpportunityProtectedLayout';
 
 const seo: NextSeoProps = {
   title: defaultSeoTitle,
@@ -143,9 +143,7 @@ const NotifyPage = (): ReactElement => {
   );
 };
 
-const getPageLayout: typeof getLayout = (...page) => getLayout(...page);
-
-NotifyPage.getLayout = getPageLayout;
+NotifyPage.getLayout = getOpportunityProtectedLayout;
 NotifyPage.layoutProps = {
   ...opportunityPageLayoutProps,
   hideBackButton: true,

--- a/packages/webapp/pages/opportunity/[id]/passive-done.tsx
+++ b/packages/webapp/pages/opportunity/[id]/passive-done.tsx
@@ -19,13 +19,13 @@ import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import { anchorDefaultRel } from '@dailydotdev/shared/src/lib/strings';
 import { settingsUrl, webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
-import { getLayout } from '../../../components/layouts/NoSidebarLayout';
 import {
   defaultOpenGraph,
   defaultSeo,
   defaultSeoTitle,
 } from '../../../next-seo';
 import { opportunityPageLayoutProps } from '../../../components/layouts/utils';
+import { getOpportunityProtectedLayout } from '../../../components/layouts/OpportunityProtectedLayout';
 
 const seo: NextSeoProps = {
   title: defaultSeoTitle,
@@ -83,9 +83,7 @@ const PassiveDonePage = (): ReactElement => {
   );
 };
 
-const getPageLayout: typeof getLayout = (...page) => getLayout(...page);
-
-PassiveDonePage.getLayout = getPageLayout;
+PassiveDonePage.getLayout = getOpportunityProtectedLayout;
 PassiveDonePage.layoutProps = {
   ...opportunityPageLayoutProps,
   hideBackButton: true,

--- a/packages/webapp/pages/opportunity/[id]/preference-done.tsx
+++ b/packages/webapp/pages/opportunity/[id]/preference-done.tsx
@@ -20,13 +20,13 @@ import { anchorDefaultRel } from '@dailydotdev/shared/src/lib/strings';
 import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import { briefButtonBg } from '@dailydotdev/shared/src/styles/custom';
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
-import { getLayout } from '../../../components/layouts/NoSidebarLayout';
 import {
   defaultOpenGraph,
   defaultSeo,
   defaultSeoTitle,
 } from '../../../next-seo';
 import { opportunityPageLayoutProps } from '../../../components/layouts/utils';
+import { getOpportunityProtectedLayout } from '../../../components/layouts/OpportunityProtectedLayout';
 
 const seo: NextSeoProps = {
   title: defaultSeoTitle,
@@ -123,9 +123,7 @@ const PreferenceDonePage = (): ReactElement => {
   );
 };
 
-const getPageLayout: typeof getLayout = (...page) => getLayout(...page);
-
-PreferenceDonePage.getLayout = getPageLayout;
+PreferenceDonePage.getLayout = getOpportunityProtectedLayout;
 PreferenceDonePage.layoutProps = {
   ...opportunityPageLayoutProps,
   hideBackButton: true,

--- a/packages/webapp/pages/opportunity/[id]/preference.tsx
+++ b/packages/webapp/pages/opportunity/[id]/preference.tsx
@@ -20,13 +20,13 @@ import { PreferenceOptionsForm } from '@dailydotdev/shared/src/components/opport
 
 import { useRouter } from 'next/router';
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
-import { getLayout } from '../../../components/layouts/NoSidebarLayout';
 import {
   defaultOpenGraph,
   defaultSeo,
   defaultSeoTitle,
 } from '../../../next-seo';
 import { opportunityPageLayoutProps } from '../../../components/layouts/utils';
+import { getOpportunityProtectedLayout } from '../../../components/layouts/OpportunityProtectedLayout';
 
 const seo: NextSeoProps = {
   title: defaultSeoTitle,
@@ -107,9 +107,7 @@ const PreferencePage = (): ReactElement => {
   );
 };
 
-const getPageLayout: typeof getLayout = (...page) => getLayout(...page);
-
-PreferencePage.getLayout = getPageLayout;
+PreferencePage.getLayout = getOpportunityProtectedLayout;
 PreferencePage.layoutProps = {
   ...opportunityPageLayoutProps,
   seo,

--- a/packages/webapp/pages/opportunity/[id]/questions.tsx
+++ b/packages/webapp/pages/opportunity/[id]/questions.tsx
@@ -23,12 +23,9 @@ import {
   useToastNotification,
 } from '@dailydotdev/shared/src/hooks';
 import { ActionType } from '@dailydotdev/shared/src/graphql/actions';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { opportunityByIdOptions } from '@dailydotdev/shared/src/features/opportunity/queries';
-import type {
-  Opportunity,
-  OpportunityScreeningAnswer,
-} from '@dailydotdev/shared/src/features/opportunity/types';
+import type { OpportunityScreeningAnswer } from '@dailydotdev/shared/src/features/opportunity/types';
 import {
   acceptOpportunityMatchMutationOptions,
   saveOpportunityScreeningAnswersMutationOptions,
@@ -58,7 +55,6 @@ const AcceptPage = (): ReactElement => {
     back,
   } = useRouter();
   const opportunityId = id as string;
-  const queryClient = useQueryClient();
   const [activeQuestion, setActiveQuestion] = useState(0);
   const [activeAnswer, setActiveAnswer] = useState('');
   const [showPreferenceForm, setShowPreferenceForm] = useState(false);
@@ -72,9 +68,10 @@ const AcceptPage = (): ReactElement => {
     ActionType.UserCandidatePreferencesSaved,
   );
 
-  const opportunity = queryClient.getQueryData<Opportunity>(
-    opportunityByIdOptions({ id: opportunityId }).queryKey,
-  );
+  const { data: opportunity } = useQuery({
+    ...opportunityByIdOptions({ id: opportunityId }),
+    enabled: false,
+  });
 
   const { mutate: acceptOpportunity } = useMutation({
     ...acceptOpportunityMatchMutationOptions(opportunityId),

--- a/packages/webapp/pages/opportunity/[id]/questions.tsx
+++ b/packages/webapp/pages/opportunity/[id]/questions.tsx
@@ -23,15 +23,17 @@ import {
   useToastNotification,
 } from '@dailydotdev/shared/src/hooks';
 import { ActionType } from '@dailydotdev/shared/src/graphql/actions';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { opportunityByIdOptions } from '@dailydotdev/shared/src/features/opportunity/queries';
-import type { OpportunityScreeningAnswer } from '@dailydotdev/shared/src/features/opportunity/types';
+import type {
+  Opportunity,
+  OpportunityScreeningAnswer,
+} from '@dailydotdev/shared/src/features/opportunity/types';
 import {
   acceptOpportunityMatchMutationOptions,
   saveOpportunityScreeningAnswersMutationOptions,
 } from '@dailydotdev/shared/src/features/opportunity/mutations';
 import { opportunityUrl } from '@dailydotdev/shared/src/lib/constants';
-import { getLayout } from '../../../components/layouts/NoSidebarLayout';
 import {
   defaultOpenGraph,
   defaultSeo,
@@ -39,6 +41,7 @@ import {
 } from '../../../next-seo';
 import { opportunityPageLayoutProps } from '../../../components/layouts/utils';
 import { InnerPreferencePage } from './preference';
+import { getOpportunityProtectedLayout } from '../../../components/layouts/OpportunityProtectedLayout';
 
 const seo: NextSeoProps = {
   title: defaultSeoTitle,
@@ -55,6 +58,7 @@ const AcceptPage = (): ReactElement => {
     back,
   } = useRouter();
   const opportunityId = id as string;
+  const queryClient = useQueryClient();
   const [activeQuestion, setActiveQuestion] = useState(0);
   const [activeAnswer, setActiveAnswer] = useState('');
   const [showPreferenceForm, setShowPreferenceForm] = useState(false);
@@ -68,9 +72,9 @@ const AcceptPage = (): ReactElement => {
     ActionType.UserCandidatePreferencesSaved,
   );
 
-  const { data: opportunity, isPending } = useQuery({
-    ...opportunityByIdOptions({ id: opportunityId }),
-  });
+  const opportunity = queryClient.getQueryData<Opportunity>(
+    opportunityByIdOptions({ id: opportunityId }).queryKey,
+  );
 
   const { mutate: acceptOpportunity } = useMutation({
     ...acceptOpportunityMatchMutationOptions(opportunityId),
@@ -134,7 +138,7 @@ const AcceptPage = (): ReactElement => {
     completeAction(ActionType.OpportunityInitialView);
   }, [completeAction, isActionsFetched]);
 
-  if (!opportunity || isPending) {
+  if (!opportunity) {
     return null;
   }
 
@@ -241,9 +245,7 @@ const AcceptPage = (): ReactElement => {
   );
 };
 
-const getPageLayout: typeof getLayout = (...page) => getLayout(...page);
-
-AcceptPage.getLayout = getPageLayout;
+AcceptPage.getLayout = getOpportunityProtectedLayout;
 AcceptPage.layoutProps = {
   ...opportunityPageLayoutProps,
   seo,


### PR DESCRIPTION
## Changes

Add a layer of protection so that you cannot directly access the accept/decline pages of an opportunity, you must go via listing page

### Preview domain
https://fix-protect-accept-pages.preview.app.daily.dev