### PR TITLE
refactor: split DragDrop into re-usable hooks

### DIFF
--- a/packages/shared/src/components/fields/DragDrop.tsx
+++ b/packages/shared/src/components/fields/DragDrop.tsx
@@ -406,7 +406,7 @@ export function DragDrop({
           className="text-text-primary"
           variant={ButtonVariant.Subtle}
           size={ButtonSize.Small}
-          onClick={() => inputRef.current.click()}
+          onClick={onClickCta}
           type="button"
         >
           {ctaLabelDesktop}

--- a/packages/shared/src/components/fields/DragDrop.tsx
+++ b/packages/shared/src/components/fields/DragDrop.tsx
@@ -66,6 +66,7 @@ export interface DragDropProps {
   dragDropDescription?: string;
   ctaLabelDesktop?: string;
   ctaLabelMobile?: string;
+  uploadIcon?: ReactNode;
   showRemove?: boolean;
 }
 
@@ -180,6 +181,7 @@ export function DragDrop({
   ctaLabelDesktop = 'Upload PDF',
   ctaLabelMobile = 'Upload PDF',
   showRemove,
+  uploadIcon,
 }: DragDropProps): ReactElement {
   const isLaptop = useViewSize(ViewSize.Laptop);
   const inputRef = useRef<HTMLInputElement>();
@@ -387,6 +389,8 @@ export function DragDrop({
     );
   }
 
+  const defaultIcon = <DocsIcon secondary />;
+
   const defaultContent = (
     <span className="flex flex-row items-center gap-1">
       <Typography
@@ -394,7 +398,7 @@ export function DragDrop({
         type={TypographyType.Footnote}
         bold={isCopyBold}
       >
-        <DocsIcon secondary />
+        {uploadIcon ?? defaultIcon}
         {dragDropDescription}
       </Typography>
       {renderCta?.(onClickCta) ?? (

--- a/packages/shared/src/components/fields/DragDrop.tsx
+++ b/packages/shared/src/components/fields/DragDrop.tsx
@@ -66,6 +66,7 @@ export interface DragDropProps {
   dragDropDescription?: string;
   ctaLabelDesktop?: string;
   ctaLabelMobile?: string;
+  showRemove?: boolean;
 }
 
 const BYTES_PER_MB = 1024 * 1024;
@@ -94,9 +95,17 @@ interface ItemProps {
   state: MutationStatus;
   uploadAt?: Date;
   className?: string;
+  showRemove?: boolean;
+  onRemove?: () => void;
 }
 
-const LargeItem = ({ name, state, uploadAt }: ItemProps) => (
+const LargeItem = ({
+  name,
+  state,
+  uploadAt,
+  showRemove,
+  onRemove,
+}: ItemProps) => (
   <div className="flex w-full items-center gap-1">
     <DocsIcon secondary size={IconSize.Size48} />
     <div className="flex min-w-0 flex-1 flex-col">
@@ -115,10 +124,24 @@ const LargeItem = ({ name, state, uploadAt }: ItemProps) => (
       )}
     </div>
     {getIcon(state)}
+    {showRemove && (
+      <Button
+        variant={ButtonVariant.Tertiary}
+        size={ButtonSize.XSmall}
+        onClick={onRemove}
+        icon={<ClearIcon />}
+      />
+    )}
   </div>
 );
 
-const CompactItem = ({ name, state, className }: ItemProps) => (
+const CompactItem = ({
+  name,
+  state,
+  className,
+  showRemove,
+  onRemove,
+}: ItemProps) => (
   <div className={classNames('flex w-full items-center gap-1', className)}>
     <DocsIcon secondary />
     <div className="min-w-0 flex-1 text-left">
@@ -127,6 +150,14 @@ const CompactItem = ({ name, state, className }: ItemProps) => (
       </Typography>
     </div>
     {getIcon(state)}
+    {showRemove && (
+      <Button
+        variant={ButtonVariant.Tertiary}
+        size={ButtonSize.XSmall}
+        onClick={onRemove}
+        icon={<ClearIcon />}
+      />
+    )}
   </div>
 );
 
@@ -407,8 +438,14 @@ export function DragDrop({
       >
         {shouldShowContent
           ? defaultContent
-          : filenames?.map((name) => (
-              <ListItem key={name} name={name} state={state} />
+          : filenames.map((name) => (
+              <ListItem
+                key={name}
+                name={name}
+                state={state}
+                showRemove={showRemove}
+                onRemove={() => removeFile(name)}
+              />
             ))}
       </div>
       {input}

--- a/packages/shared/src/components/fields/DragDrop.tsx
+++ b/packages/shared/src/components/fields/DragDrop.tsx
@@ -1,11 +1,6 @@
 import classNames from 'classnames';
-import type {
-  DragEvent,
-  MutableRefObject,
-  ReactElement,
-  ReactNode,
-} from 'react';
-import React, { useImperativeHandle, useRef, useState } from 'react';
+import type { ReactElement, ReactNode, MutableRefObject } from 'react';
+import React, { useState } from 'react';
 import type { MutationStatus } from '@tanstack/react-query';
 import { useToastNotification } from '../../hooks/useToastNotification';
 import {
@@ -13,33 +8,19 @@ import {
   TypographyColor,
   TypographyType,
 } from '../typography/Typography';
-import { ChecklistAIcon, DocsIcon } from '../icons';
+import { ChecklistAIcon, ClearIcon, DocsIcon } from '../icons';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { Loader } from '../Loader';
 import { IconSize } from '../Icon';
 import { useViewSize, ViewSize } from '../../hooks';
 import { UploadIcon } from '../icons/Upload';
-
-export interface DragDropValidation {
-  /** Maximum file size in bytes */
-  maxSize?: number;
-  /** Maximum file size in MB (convenience prop) */
-  maxSizeMB?: number;
-  /** Allowed file types (MIME types) */
-  acceptedTypes?: string[];
-  /** Allowed file extensions */
-  acceptedExtensions?: string[];
-  /** Maximum number of files allowed */
-  maxFiles?: number;
-  /** Whether to allow multiple files */
-  multiple?: boolean;
-}
-
-export interface DragDropError {
-  type: 'size' | 'format' | 'count' | 'unknown';
-  message: string;
-  file?: File;
-}
+import type {
+  DragDropError,
+  DragDropValidation,
+} from '../../features/fileUpload/hooks/useFileValidation';
+import { useFileValidation } from '../../features/fileUpload/hooks/useFileValidation';
+import { useFileInput } from '../../features/fileUpload/hooks/useFileInput';
+import { useDragAndDrop } from '../../features/fileUpload/hooks/useDragAndDrop';
 
 export interface DragDropProps {
   /** Callback when files are dropped/selected */
@@ -69,15 +50,6 @@ export interface DragDropProps {
   uploadIcon?: ReactNode;
   showRemove?: boolean;
 }
-
-const BYTES_PER_MB = 1024 * 1024;
-
-const defaultErrorMessages = {
-  size: 'File size exceeds the maximum allowed size',
-  format: 'File type is not supported',
-  count: 'Too many files selected',
-  unknown: 'An error occurred while processing the file',
-};
 
 const getIcon = (state: MutationStatus) => {
   if (state === 'pending') {
@@ -172,7 +144,7 @@ export function DragDrop({
   disabled = false,
   className,
   state,
-  inputRef: inputRefProps,
+  inputRef,
   isCompactList,
   ctaSize,
   renderCta,
@@ -183,122 +155,12 @@ export function DragDrop({
   showRemove,
   uploadIcon,
 }: DragDropProps): ReactElement {
-  const isLaptop = useViewSize(ViewSize.Laptop);
-  const inputRef = useRef<HTMLInputElement>();
-  useImperativeHandle(inputRefProps, () => inputRef.current);
   const [filenames, setFilenames] = useState<string[]>([]);
-  const [isDragOver, setIsDragOver] = useState(false);
-  const [isDragValid, setIsDragValid] = useState(true);
-  const toast = useToastNotification();
+  const isLaptop = useViewSize(ViewSize.Laptop);
+  const { displayToast } = useToastNotification();
   const isError = state === 'error';
 
-  const {
-    maxSize,
-    maxSizeMB = 10,
-    acceptedTypes = [],
-    acceptedExtensions = [],
-    maxFiles = 1,
-    multiple = false,
-  } = validation;
-
-  const finalMaxSize = maxSize || maxSizeMB * BYTES_PER_MB;
-  const finalErrorMessages = { ...defaultErrorMessages, ...errorMessages };
-
-  const validateFile = (file: File): DragDropError | null => {
-    // Check file size
-    if (file.size > finalMaxSize) {
-      return {
-        type: 'size',
-        message: finalErrorMessages.size,
-        file,
-      };
-    }
-
-    // Check file type
-    if (acceptedTypes.length > 0 && !acceptedTypes.includes(file.type)) {
-      return {
-        type: 'format',
-        message: finalErrorMessages.format,
-        file,
-      };
-    }
-
-    // Check file extension
-    if (acceptedExtensions.length > 0) {
-      const fileExtension = file.name.split('.').pop()?.toLowerCase();
-      if (!fileExtension || !acceptedExtensions.includes(fileExtension)) {
-        return {
-          type: 'format',
-          message: finalErrorMessages.format,
-          file,
-        };
-      }
-    }
-
-    return null;
-  };
-
-  const validateFiles = (
-    files: File[],
-  ): { validFiles: File[]; errors: DragDropError[] } => {
-    const validFiles: File[] = [];
-    const errors: DragDropError[] = [];
-
-    // Check file count
-    if (!multiple && files.length > 1) {
-      errors.push({
-        type: 'count',
-        message: finalErrorMessages.count,
-      });
-      return { validFiles, errors };
-    }
-
-    if (maxFiles > 0 && files.length > maxFiles) {
-      errors.push({
-        type: 'count',
-        message: finalErrorMessages.count,
-      });
-      return { validFiles, errors };
-    }
-
-    // Validate each file
-    files.forEach((file) => {
-      const error = validateFile(file);
-      if (error) {
-        errors.push(error);
-      } else {
-        validFiles.push(file);
-      }
-    });
-
-    return { validFiles, errors };
-  };
-
-  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-
-    if (disabled) {
-      return;
-    }
-
-    setIsDragOver(true);
-
-    // Check if drag contains files
-    const hasFiles = event.dataTransfer.types.includes('Files');
-    setIsDragValid(hasFiles);
-  };
-
-  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-
-    // Only set drag over to false if we're leaving the drop zone entirely
-    if (!event.currentTarget.contains(event.relatedTarget as Node)) {
-      setIsDragOver(false);
-      setIsDragValid(true);
-    }
-  };
+  const { validateFiles } = useFileValidation(validation, errorMessages);
 
   const handleFiles = (files: FileList | null) => {
     if (!files || files.length === 0) {
@@ -307,65 +169,50 @@ export function DragDrop({
 
     const fileArray = Array.from(files);
     const { validFiles, errors } = validateFiles(fileArray);
-    const [error] = errors ?? [];
 
-    if (error) {
-      const fileName = error.file ? ` (${error.file.name})` : '';
-      toast.displayToast(`${error.message}${fileName}`);
+    if (errors.length > 0) {
+      const first = errors[0];
+      const fileName = first.file ? ` (${first.file.name})` : '';
+      displayToast(`${first.message}${fileName}`);
       return;
     }
 
-    // Call callback with valid files and errors
-    setFilenames(validFiles.map(({ name }: File) => name));
+    setFilenames(validFiles.map((f) => f.name));
     onFilesDrop(validFiles, errors.length > 0 ? errors : undefined);
   };
 
-  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
+  const { input, openFileInput } = useFileInput({
+    inputRef,
+    onFiles: handleFiles,
+    accept: validation.acceptedTypes,
+    multiple: validation.multiple,
+    disabled,
+  });
 
-    if (disabled) {
-      return;
+  const {
+    isDragOver,
+    isDragValid,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+  } = useDragAndDrop({ disabled, onFiles: handleFiles });
+
+  const removeFile = (name: string) => {
+    const newFilenames = filenames.filter((n) => n !== name);
+    setFilenames(newFilenames);
+    if (newFilenames.length === 0) {
+      onFilesDrop([], []);
     }
-
-    setIsDragOver(false);
-    setIsDragValid(true);
-
-    handleFiles(event.dataTransfer.files);
   };
-
-  const handleFileInput = (event: React.ChangeEvent<HTMLInputElement>) => {
-    handleFiles(event.target.files);
-    // Reset the input value so the same file can be selected again
-    setTimeout(() => {
-      if (inputRef.current) {
-        inputRef.current.value = '';
-      }
-    }, 0);
-  };
-
-  const input = (
-    <input
-      type="file"
-      hidden
-      ref={inputRef}
-      onChange={handleFileInput}
-      accept={acceptedTypes.join(',')}
-      multiple={multiple}
-      disabled={disabled}
-    />
-  );
-
-  const onClickCta = () => inputRef.current.click();
 
   if (!isLaptop) {
     const isProcessed = !isError && filenames?.length;
-    const cta = renderCta?.(onClickCta) ?? (
+    const cta = renderCta?.(openFileInput) ?? (
       <Button
         type="button"
         className={classNames('w-fit', className)}
         variant={ButtonVariant.Primary}
-        onClick={onClickCta}
+        onClick={openFileInput}
         icon={<UploadIcon />}
         size={ctaSize}
       >
@@ -401,12 +248,12 @@ export function DragDrop({
         {uploadIcon ?? defaultIcon}
         {dragDropDescription}
       </Typography>
-      {renderCta?.(onClickCta) ?? (
+      {renderCta?.(openFileInput) ?? (
         <Button
           className="text-text-primary"
           variant={ButtonVariant.Subtle}
           size={ButtonSize.Small}
-          onClick={onClickCta}
+          onClick={openFileInput}
           type="button"
         >
           {ctaLabelDesktop}

--- a/packages/shared/src/components/fields/DragDrop.tsx
+++ b/packages/shared/src/components/fields/DragDrop.tsx
@@ -392,9 +392,9 @@ export function DragDrop({
   const defaultIcon = <DocsIcon secondary />;
 
   const defaultContent = (
-    <span className="flex flex-row items-center gap-1">
+    <span className="flex flex-row items-center gap-2">
       <Typography
-        className="flex flex-row items-center gap-1"
+        className="flex flex-row items-center gap-2"
         type={TypographyType.Footnote}
         bold={isCopyBold}
       >

--- a/packages/shared/src/components/fields/DragDrop.tsx
+++ b/packages/shared/src/components/fields/DragDrop.tsx
@@ -179,6 +179,7 @@ export function DragDrop({
   dragDropDescription = 'Drag & Drop your CV or',
   ctaLabelDesktop = 'Upload PDF',
   ctaLabelMobile = 'Upload PDF',
+  showRemove,
 }: DragDropProps): ReactElement {
   const isLaptop = useViewSize(ViewSize.Laptop);
   const inputRef = useRef<HTMLInputElement>();

--- a/packages/shared/src/features/fileUpload/hooks/useDragAndDrop.ts
+++ b/packages/shared/src/features/fileUpload/hooks/useDragAndDrop.ts
@@ -1,0 +1,65 @@
+// useDragAndDrop.ts
+import { useState, useCallback } from 'react';
+
+interface DragState {
+  isDragOver: boolean;
+  isDragValid: boolean;
+}
+
+interface Options {
+  disabled?: boolean;
+  onFiles: (files: FileList | null) => void;
+}
+
+export const useDragAndDrop = ({ disabled, onFiles }: Options) => {
+  const [state, setState] = useState<DragState>({
+    isDragOver: false,
+    isDragValid: true,
+  });
+
+  const handleDragOver = useCallback(
+    (event: React.DragEvent<HTMLElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (disabled) {
+        return;
+      }
+
+      const hasFiles = Array.from(event.dataTransfer.types).includes('Files');
+      setState({ isDragOver: true, isDragValid: hasFiles });
+    },
+    [disabled],
+  );
+
+  const handleDragLeave = useCallback((event: React.DragEvent<HTMLElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const target = event.currentTarget as HTMLElement;
+    const related = event.relatedTarget as Node | null;
+    if (!target.contains(related)) {
+      setState({ isDragOver: false, isDragValid: true });
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (event: React.DragEvent<HTMLElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (disabled) {
+        return;
+      }
+
+      setState({ isDragOver: false, isDragValid: true });
+      onFiles(event.dataTransfer.files);
+    },
+    [disabled, onFiles],
+  );
+
+  return {
+    isDragOver: state.isDragOver,
+    isDragValid: state.isDragValid,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+  };
+};

--- a/packages/shared/src/features/fileUpload/hooks/useFileInput.tsx
+++ b/packages/shared/src/features/fileUpload/hooks/useFileInput.tsx
@@ -1,0 +1,94 @@
+import React, {
+  useRef,
+  useCallback,
+  useMemo,
+  useImperativeHandle,
+} from 'react';
+import type { MutableRefObject } from 'react';
+
+type OnFiles = (files: FileList | null) => void;
+
+export type UseFileInputProps = {
+  onFiles: OnFiles;
+  accept?: string | string[];
+  multiple?: boolean;
+  disabled?: boolean;
+  name?: string;
+  id?: string;
+  capture?: boolean | 'user' | 'environment';
+  className?: string;
+  inputProps?: Record<string, unknown>;
+  inputRef?: MutableRefObject<HTMLInputElement>;
+};
+
+export const useFileInput = ({
+  onFiles,
+  inputRef: inputRefProp,
+  accept,
+  multiple,
+  disabled,
+  name,
+  id,
+  capture,
+  className,
+  inputProps,
+}: UseFileInputProps) => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  useImperativeHandle(inputRefProp, () => inputRef.current as HTMLInputElement);
+
+  const openFileInput = useCallback(() => {
+    inputRef.current?.click();
+  }, []);
+
+  const onChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onFiles(e.target.files);
+      // Allow selecting the same file again
+      setTimeout(() => {
+        if (inputRef.current) {
+          inputRef.current.value = '';
+        }
+      }, 0);
+    },
+    [onFiles],
+  );
+
+  const acceptStr = useMemo(() => {
+    if (!accept) {
+      return undefined;
+    }
+    return Array.isArray(accept) ? accept.join(',') : accept;
+  }, [accept]);
+
+  const input = useMemo(
+    () => (
+      <input
+        type="file"
+        hidden
+        ref={inputRef}
+        onChange={onChange}
+        accept={acceptStr}
+        multiple={multiple}
+        disabled={disabled}
+        name={name}
+        id={id}
+        capture={capture}
+        className={className}
+        {...inputProps}
+      />
+    ),
+    [
+      acceptStr,
+      capture,
+      className,
+      disabled,
+      id,
+      inputProps,
+      multiple,
+      name,
+      onChange,
+    ],
+  );
+
+  return { input, openFileInput, inputRef };
+};

--- a/packages/shared/src/features/fileUpload/hooks/useFileValidation.ts
+++ b/packages/shared/src/features/fileUpload/hooks/useFileValidation.ts
@@ -1,0 +1,95 @@
+import { useMemo } from 'react';
+
+export interface DragDropValidation {
+  maxSize?: number;
+  maxSizeMB?: number;
+  acceptedTypes?: string[];
+  acceptedExtensions?: string[];
+  maxFiles?: number;
+  multiple?: boolean;
+}
+
+export interface DragDropError {
+  type: 'size' | 'format' | 'count' | 'unknown';
+  message: string;
+  file?: File;
+}
+
+const BYTES_PER_MB = 1024 * 1024;
+
+const defaultErrorMessages = {
+  size: 'File size exceeds the maximum allowed size',
+  format: 'File type is not supported',
+  count: 'Too many files selected',
+  unknown: 'An error occurred while processing the file',
+};
+
+export const useFileValidation = (
+  validation: DragDropValidation = {},
+  errorMessages: Partial<typeof defaultErrorMessages> = {},
+) => {
+  const {
+    maxSize,
+    maxSizeMB = 10,
+    acceptedTypes = [],
+    acceptedExtensions = [],
+    maxFiles = 1,
+    multiple = false,
+  } = validation;
+
+  const finalMaxSize = maxSize ?? maxSizeMB * BYTES_PER_MB;
+  const messages = useMemo(
+    () => ({ ...defaultErrorMessages, ...errorMessages }),
+    [errorMessages],
+  );
+
+  const validateFile = (file: File): DragDropError | null => {
+    if (file.size > finalMaxSize) {
+      return { type: 'size', message: messages.size, file };
+    }
+
+    if (acceptedTypes.length > 0 && !acceptedTypes.includes(file.type)) {
+      return { type: 'format', message: messages.format, file };
+    }
+
+    if (acceptedExtensions.length > 0) {
+      const ext = file.name.split('.').pop()?.toLowerCase();
+      if (!ext || !acceptedExtensions.includes(ext)) {
+        return { type: 'format', message: messages.format, file };
+      }
+    }
+
+    return null;
+  };
+
+  const validateFiles = (
+    files: File[],
+  ): { validFiles: File[]; errors: DragDropError[] } => {
+    const validFiles: File[] = [];
+    const errors: DragDropError[] = [];
+
+    if (!multiple && files.length > 1) {
+      errors.push({ type: 'count', message: messages.count });
+      return { validFiles, errors };
+    }
+
+    if (maxFiles > 0 && files.length > maxFiles) {
+      errors.push({ type: 'count', message: messages.count });
+      return { validFiles, errors };
+    }
+
+    // Validate each file
+    files.forEach((file) => {
+      const error = validateFile(file);
+      if (error) {
+        errors.push(error);
+      } else {
+        validFiles.push(file);
+      }
+    });
+
+    return { validFiles, errors };
+  };
+
+  return { validateFiles, messages };
+};


### PR DESCRIPTION
## Changes

I need to create a upload component that is just a button, and to not duplicate the code, I've extracted the file validation and handling into re-usable hooks.
Also included some changes from #4778 like custom icon, remove file from list and spacing adjustments.

### Preview domain
https://reusable-file-upload.preview.app.daily.dev