### PR TITLE
feat: ISR fetch the initial keyword autocomplete

### DIFF
--- a/packages/shared/src/features/opportunity/queries.ts
+++ b/packages/shared/src/features/opportunity/queries.ts
@@ -105,7 +105,7 @@ export const getKeywordAutocompleteOptions = (
 
       return res.autocompleteKeywords;
     },
-    staleTime: StaleTime.Default,
+    staleTime: query.length === 0 ? StaleTime.OneHour : StaleTime.Default,
     enabled: query.length === 0 || query.length >= 2,
     placeholderData: keepPreviousData,
   };

--- a/packages/webapp/components/layouts/hydrationLayout.tsx
+++ b/packages/webapp/components/layouts/hydrationLayout.tsx
@@ -1,0 +1,8 @@
+import { HydrationBoundary } from '@tanstack/react-query';
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+
+export const getHydrationLayout = (page: ReactNode) => {
+  const { dehydratedState } = (page as ReactElement)?.props || {};
+  return <HydrationBoundary state={dehydratedState}>{page}</HydrationBoundary>;
+};

--- a/packages/webapp/components/layouts/hydrationLayout.tsx
+++ b/packages/webapp/components/layouts/hydrationLayout.tsx
@@ -1,8 +1,0 @@
-import { HydrationBoundary } from '@tanstack/react-query';
-import type { ReactElement, ReactNode } from 'react';
-import React from 'react';
-
-export const getHydrationLayout = (page: ReactNode) => {
-  const { dehydratedState } = (page as ReactElement)?.props || {};
-  return <HydrationBoundary state={dehydratedState}>{page}</HydrationBoundary>;
-};

--- a/packages/webapp/pages/settings/job-preferences.tsx
+++ b/packages/webapp/pages/settings/job-preferences.tsx
@@ -54,7 +54,6 @@ import { getSettingsLayout } from '../../components/layouts/SettingsLayout';
 import { defaultSeo } from '../../next-seo';
 import { getTemplatedTitle } from '../../components/layouts/utils';
 import { AccountPageContainer } from '../../components/layouts/SettingsLayout/AccountPageContainer';
-import { getHydrationLayout } from '../../components/layouts/hydrationLayout';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
@@ -308,8 +307,7 @@ export const getStaticProps: GetStaticProps<{
   }
 };
 
-JobPreferencesPage.getLayout = (page: ReactElement) =>
-  getSettingsLayout(getHydrationLayout(page));
+JobPreferencesPage.getLayout = getSettingsLayout;
 JobPreferencesPage.layoutProps = { seo };
 
 export default JobPreferencesPage;


### PR DESCRIPTION
## Changes

Use ISR for fetching the initial autocomplete results. These keywords won't change often, so we can set high stale time and cache too.

### Jira ticket
AS-1209

### Preview domain
https://as-1209-isr-initial-keywords.preview.app.daily.dev