### PR TITLE
feat: add hydration boundary to _app

### DIFF
--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -6,7 +6,12 @@ import Head from 'next/head';
 import 'focus-visible';
 import { useConsoleLogo } from '@dailydotdev/shared/src/hooks/useConsoleLogo';
 import { DefaultSeo, NextSeo } from 'next-seo';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { DehydratedState } from '@tanstack/react-query';
+import {
+  HydrationBoundary,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import {
   useCookieBanner,
@@ -253,7 +258,9 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
   );
 }
 
-export default function App(props: AppProps): ReactElement {
+export default function App(
+  props: AppProps<{ dehydratedState: DehydratedState }>,
+): ReactElement {
   const [queryClient] = useState(
     () => new QueryClient(defaultQueryClientConfig),
   );
@@ -262,27 +269,33 @@ export default function App(props: AppProps): ReactElement {
   useError();
   useManualScrollRestoration();
 
+  const {
+    pageProps: { dehydratedState },
+  } = props;
+
   return (
     <ProgressiveEnhancementContextProvider>
       <QueryClientProvider client={queryClient}>
-        <BootDataProvider
-          app={BootApp.Webapp}
-          getRedirectUri={getRedirectUri}
-          getPage={getPage}
-          version={version}
-          deviceId={deviceId}
-        >
-          <PixelsProvider>
-            <PushNotificationContextProvider>
-              <SubscriptionContextProvider>
-                <PostReferrerContextProvider>
-                  <InternalApp {...props} />
-                </PostReferrerContextProvider>
-              </SubscriptionContextProvider>
-            </PushNotificationContextProvider>
-          </PixelsProvider>
-        </BootDataProvider>
-        <ReactQueryDevtools />
+        <HydrationBoundary state={dehydratedState}>
+          <BootDataProvider
+            app={BootApp.Webapp}
+            getRedirectUri={getRedirectUri}
+            getPage={getPage}
+            version={version}
+            deviceId={deviceId}
+          >
+            <PixelsProvider>
+              <PushNotificationContextProvider>
+                <SubscriptionContextProvider>
+                  <PostReferrerContextProvider>
+                    <InternalApp {...props} />
+                  </PostReferrerContextProvider>
+                </SubscriptionContextProvider>
+              </PushNotificationContextProvider>
+            </PixelsProvider>
+          </BootDataProvider>
+          <ReactQueryDevtools />
+        </HydrationBoundary>
       </QueryClientProvider>
     </ProgressiveEnhancementContextProvider>
   );

--- a/packages/webapp/pages/helloworld/index.tsx
+++ b/packages/webapp/pages/helloworld/index.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 import React, { useEffect, useCallback } from 'react';
 import type { GetServerSideProps } from 'next';
+import type { DehydratedState } from '@tanstack/react-query';
 import Head from 'next/head';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { BootApp } from '@dailydotdev/shared/src/lib/boot';
@@ -23,6 +24,7 @@ import {
 } from '@dailydotdev/shared/src/features/onboarding/lib/utils';
 
 type PageProps = {
+  dehydratedState: DehydratedState;
   initialStepId: string | null;
   showCookieBanner?: boolean;
 };

--- a/packages/webapp/pages/helloworld/index.tsx
+++ b/packages/webapp/pages/helloworld/index.tsx
@@ -1,13 +1,8 @@
 import type { ReactElement } from 'react';
 import React, { useEffect, useCallback } from 'react';
 import type { GetServerSideProps } from 'next';
-import type { DehydratedState } from '@tanstack/react-query';
 import Head from 'next/head';
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
+import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { BootApp } from '@dailydotdev/shared/src/lib/boot';
 import {
   FUNNEL_BOOT_QUERY_KEY,
@@ -28,7 +23,6 @@ import {
 } from '@dailydotdev/shared/src/features/onboarding/lib/utils';
 
 type PageProps = {
-  dehydratedState: DehydratedState;
   initialStepId: string | null;
   showCookieBanner?: boolean;
 };
@@ -79,7 +73,6 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
 };
 
 export default function HelloWorldPage({
-  dehydratedState,
   initialStepId,
   showCookieBanner,
 }: PageProps): ReactElement {
@@ -111,7 +104,7 @@ export default function HelloWorldPage({
   }
 
   return (
-    <HydrationBoundary state={dehydratedState}>
+    <>
       {/* <HotJarTracking hotjarId="6381877" /> */}
       <JotaiProvider>
         <Head>
@@ -129,6 +122,6 @@ export default function HelloWorldPage({
         )}
         <Toast autoDismissNotifications />
       </JotaiProvider>
-    </HydrationBoundary>
+    </>
   );
 }

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -36,12 +36,7 @@ import {
 } from '@dailydotdev/shared/src/components/auth/common';
 import Toast from '@dailydotdev/shared/src/components/notifications/Toast';
 import type { GetServerSideProps } from 'next';
-import type { DehydratedState } from '@tanstack/react-query';
-import {
-  dehydrate,
-  HydrationBoundary,
-  QueryClient,
-} from '@tanstack/react-query';
+import { dehydrate, QueryClient } from '@tanstack/react-query';
 import {
   FunnelBootFeatureKey,
   getFunnelBootData,
@@ -75,7 +70,6 @@ const seo: NextSeoProps = {
 };
 
 type PageProps = {
-  dehydratedState: DehydratedState;
   initialStepId: string | null;
   showCookieBanner?: boolean;
 };
@@ -360,15 +354,12 @@ function Onboarding({ initialStepId }: PageProps): ReactElement {
 }
 
 function Page(props: PageProps) {
-  const { dehydratedState } = props;
   const { autoDismissNotifications } = useSettingsContext();
   return (
-    <HydrationBoundary state={dehydratedState}>
-      <JotaiProvider>
-        <Onboarding {...props} />
-        <Toast autoDismissNotifications={autoDismissNotifications} />
-      </JotaiProvider>
-    </HydrationBoundary>
+    <JotaiProvider>
+      <Onboarding {...props} />
+      <Toast autoDismissNotifications={autoDismissNotifications} />
+    </JotaiProvider>
   );
 }
 

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -36,6 +36,7 @@ import {
 } from '@dailydotdev/shared/src/components/auth/common';
 import Toast from '@dailydotdev/shared/src/components/notifications/Toast';
 import type { GetServerSideProps } from 'next';
+import type { DehydratedState } from '@tanstack/react-query';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import {
   FunnelBootFeatureKey,
@@ -70,6 +71,7 @@ const seo: NextSeoProps = {
 };
 
 type PageProps = {
+  dehydratedState: DehydratedState;
   initialStepId: string | null;
   showCookieBanner?: boolean;
 };


### PR DESCRIPTION
## Changes

Adding `HydrationBoundary` to global app so we can [reduce boiler plate](https://tanstack.com/query/v5/docs/framework/react/guides/ssr#optional---remove-boilerplate), and automagically have option for hydration on a global level.

re disussion https://github.com/dailydotdev/apps/pull/4896#discussion_r2357870402

### Preview domain
https://feat-global-hydration-boundary.preview.app.daily.dev