### PR TITLE
fix: show tooltip on existing users only

### DIFF
--- a/packages/shared/src/components/post/write/CreatePostButton.tsx
+++ b/packages/shared/src/components/post/write/CreatePostButton.tsx
@@ -26,7 +26,7 @@ interface CreatePostButtonProps<Tag extends AllowedTags>
   footer?: boolean;
 }
 
-const SHOW_POLL_ACOUNTS_BEFORE = new Date(2025, 9, 22);
+const SHOW_POLL_ACOUNTS_BEFORE = new Date(2025, 9, 18);
 
 export function CreatePostButton<Tag extends AllowedTags>({
   className,

--- a/packages/shared/src/components/post/write/CreatePostButton.tsx
+++ b/packages/shared/src/components/post/write/CreatePostButton.tsx
@@ -59,7 +59,7 @@ export function CreatePostButton<Tag extends AllowedTags>({
     new Date(user.createdAt) < SHOW_POLL_TOOLTIP_ACOUNTS_BEFORE;
 
   useEffect(() => {
-    if (shouldShowPollCondition) {
+    if (!shouldShowPollCondition) {
       return;
     }
 

--- a/packages/shared/src/components/post/write/CreatePostButton.tsx
+++ b/packages/shared/src/components/post/write/CreatePostButton.tsx
@@ -26,7 +26,7 @@ interface CreatePostButtonProps<Tag extends AllowedTags>
   footer?: boolean;
 }
 
-const SHOW_POLL_TOOLTIP_ACOUNTS_BEFORE = new Date(2025, 9, 22);
+const SHOW_POLL_TOOLTIP_ACOUNTS_BEFORE = new Date(2025, 9, 18);
 
 export function CreatePostButton<Tag extends AllowedTags>({
   className,

--- a/packages/shared/src/components/post/write/CreatePostButton.tsx
+++ b/packages/shared/src/components/post/write/CreatePostButton.tsx
@@ -26,6 +26,8 @@ interface CreatePostButtonProps<Tag extends AllowedTags>
   footer?: boolean;
 }
 
+const SHOW_POLL_ACOUNTS_BEFORE = new Date(2025, 9, 22);
+
 export function CreatePostButton<Tag extends AllowedTags>({
   className,
   compact,
@@ -49,15 +51,21 @@ export function CreatePostButton<Tag extends AllowedTags>({
   const { isActionsFetched, checkHasCompleted, completeAction } = useActions();
   const completedPollType = checkHasCompleted(ActionType.SeenPostPollTooltip);
   const [shouldShowPollTooltip, setShouldShowPollTooltip] = useState(false);
+  const shouldShowPollCondition =
+    isActionsFetched &&
+    !completedPollType &&
+    isTablet &&
+    user?.createdAt &&
+    new Date(user.createdAt) < SHOW_POLL_ACOUNTS_BEFORE;
 
   useEffect(() => {
-    if (!isActionsFetched || completedPollType || !isTablet) {
+    if (shouldShowPollCondition) {
       return;
     }
 
     completeAction(ActionType.SeenPostPollTooltip);
     setShouldShowPollTooltip(true);
-  }, [completedPollType, isActionsFetched, isTablet, completeAction]);
+  }, [shouldShowPollCondition, completeAction]);
 
   if (!footer && !user) {
     return null;

--- a/packages/shared/src/components/post/write/CreatePostButton.tsx
+++ b/packages/shared/src/components/post/write/CreatePostButton.tsx
@@ -26,7 +26,7 @@ interface CreatePostButtonProps<Tag extends AllowedTags>
   footer?: boolean;
 }
 
-const SHOW_POLL_TOOLTIP_ACOUNTS_BEFORE = new Date(2025, 9, 18);
+const SHOW_POLL_TOOLTIP_ACOUNTS_BEFORE = new Date(2025, 9, 22);
 
 export function CreatePostButton<Tag extends AllowedTags>({
   className,

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -187,19 +187,7 @@ const renderPost = (
 
   client = new QueryClient();
 
-  // Add default mock for SeenPostPollTooltip action
-  const defaultMocks = [
-    ...mocks,
-    {
-      request: {
-        query: COMPLETE_ACTION_MUTATION,
-        variables: { type: ActionType.SeenPostPollTooltip },
-      },
-      result: () => ({ data: { _: true } }),
-    },
-  ];
-
-  defaultMocks.forEach(mockGraphQL);
+  mocks.forEach(mockGraphQL);
 
   return render(
     <TestBootProvider

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -187,19 +187,8 @@ const renderPost = (
 
   client = new QueryClient();
 
-  // Add default mock for SeenPostPollTooltip action
-  const defaultMocks = [
-    ...mocks,
-    {
-      request: {
-        query: COMPLETE_ACTION_MUTATION,
-        variables: { type: ActionType.SeenPostPollTooltip },
-      },
-      result: () => ({ data: { _: true } }),
-    },
-  ];
+  mocks.forEach(mockGraphQL);
 
-  defaultMocks.forEach(mockGraphQL);
   return render(
     <TestBootProvider
       client={client}

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -187,7 +187,19 @@ const renderPost = (
 
   client = new QueryClient();
 
-  mocks.forEach(mockGraphQL);
+  // Add default mock for SeenPostPollTooltip action
+  const defaultMocks = [
+    ...mocks,
+    {
+      request: {
+        query: COMPLETE_ACTION_MUTATION,
+        variables: { type: ActionType.SeenPostPollTooltip },
+      },
+      result: () => ({ data: { _: true } }),
+    },
+  ];
+
+  defaultMocks.forEach(mockGraphQL);
 
   return render(
     <TestBootProvider

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -187,8 +187,19 @@ const renderPost = (
 
   client = new QueryClient();
 
-  mocks.forEach(mockGraphQL);
+  // Add default mock for SeenPostPollTooltip action
+  const defaultMocks = [
+    ...mocks,
+    {
+      request: {
+        query: COMPLETE_ACTION_MUTATION,
+        variables: { type: ActionType.SeenPostPollTooltip },
+      },
+      result: () => ({ data: { _: true } }),
+    },
+  ];
 
+  defaultMocks.forEach(mockGraphQL);
   return render(
     <TestBootProvider
       client={client}


### PR DESCRIPTION
## Changes
- I think next week Monday should be an okay date to filter users created before that to participate.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Jira ticket
MI-1013

### Preview domain
https://mi-1013-user.preview.app.daily.dev