### PR TITLE
feat: add extra analytics for cv and employment agreement upload

### DIFF
--- a/packages/shared/src/features/opportunity/components/ClearEmploymentAgreementButton.tsx
+++ b/packages/shared/src/features/opportunity/components/ClearEmploymentAgreementButton.tsx
@@ -14,9 +14,12 @@ import { useUpdateQuery } from '../../../hooks/useUpdateQuery';
 import { clearEmploymentAgreementMutationOptions } from '../mutations';
 import { useActions, useToastNotification } from '../../../hooks';
 import { ActionType } from '../../../graphql/actions';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
 
 export const ClearEmploymentAgreementButton = (): ReactElement => {
   const { user } = useAuthContext();
+  const { logEvent } = useLogContext();
   const { displayToast } = useToastNotification();
   const { completeAction } = useActions();
   const opts = getCandidatePreferencesOptions(user?.id);
@@ -25,6 +28,9 @@ export const ClearEmploymentAgreementButton = (): ReactElement => {
   const { mutate: clearFile, isPending: isClearFilePending } = useMutation({
     ...clearEmploymentAgreementMutationOptions(updateQuery, () => {
       completeAction(ActionType.UserCandidatePreferencesSaved);
+      logEvent({
+        event_name: LogEvent.ClearEmploymentAgreement,
+      });
     }),
     onError: () => {
       displayToast(

--- a/packages/shared/src/features/opportunity/components/ClearResumeButton.tsx
+++ b/packages/shared/src/features/opportunity/components/ClearResumeButton.tsx
@@ -14,9 +14,12 @@ import { useUpdateQuery } from '../../../hooks/useUpdateQuery';
 import { clearResumeMutationOptions } from '../mutations';
 import { useActions, useToastNotification } from '../../../hooks';
 import { ActionType } from '../../../graphql/actions';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
 
 export const ClearResumeButton = (): ReactElement => {
   const { user } = useAuthContext();
+  const { logEvent } = useLogContext();
   const { displayToast } = useToastNotification();
   const { completeAction } = useActions();
   const opts = getCandidatePreferencesOptions(user?.id);
@@ -25,6 +28,9 @@ export const ClearResumeButton = (): ReactElement => {
   const { mutate: clearResume, isPending: isClearResumePending } = useMutation({
     ...clearResumeMutationOptions(updateQuery, () => {
       completeAction(ActionType.UserCandidatePreferencesSaved);
+      logEvent({
+        event_name: LogEvent.ClearCv,
+      });
     }),
     onError: () => {
       displayToast('Failed to remove uploaded CV. Please try again.');

--- a/packages/shared/src/features/opportunity/components/UploadEmploymentAgreementButton.tsx
+++ b/packages/shared/src/features/opportunity/components/UploadEmploymentAgreementButton.tsx
@@ -10,9 +10,12 @@ import { useToastNotification } from '../../../hooks';
 import { useUpdateQuery } from '../../../hooks/useUpdateQuery';
 import { getCandidatePreferencesOptions } from '../queries';
 import { uploadEmploymentAgreementMutationOptions } from '../mutations';
+import { LogEvent } from '../../../lib/log';
+import { useLogContext } from '../../../contexts/LogContext';
 
 export const UploadEmploymentAgreementButton = (): ReactElement => {
   const { user } = useAuthContext();
+  const { logEvent } = useLogContext();
   const { displayToast } = useToastNotification();
 
   const updateQuery = useUpdateQuery(getCandidatePreferencesOptions(user?.id));
@@ -21,6 +24,9 @@ export const UploadEmploymentAgreementButton = (): ReactElement => {
     useMutation({
       ...uploadEmploymentAgreementMutationOptions(updateQuery, () => {
         displayToast('Employment agreement uploaded successfully!');
+        logEvent({
+          event_name: LogEvent.UploadEmploymentAgreement,
+        });
       }),
       onError: () => {
         displayToast(

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -313,6 +313,7 @@ export enum LogEvent {
   // End Brief
   // CV Upload
   UploadCv = 'upload cv',
+  ClearCv = 'clear cv',
   // end CV Upload
   ImpressionComment = 'impression comment',
   // Opportunity
@@ -330,6 +331,8 @@ export enum LogEvent {
   UpdateCandidatePreferences = 'update candidate preferences',
   ClickCandidatePreferences = 'click candidate preferences',
   // End Opportunity
+  UploadEmploymentAgreement = 'upload employment agreement',
+  ClearEmploymentAgreement = 'clear employment agreement',
 }
 
 export enum TargetType {


### PR DESCRIPTION
## Changes

Some extra analytics events for uploading and clearing cv/ employment agreement. Not originally in taxonomy, but thought could be nice to have.

### Preview domain
https://extra-analytics.preview.app.daily.dev