### PR TITLE
fix: show correct source name in EnableNotification when source is user

### DIFF
--- a/packages/shared/src/components/modals/PollPostModal.tsx
+++ b/packages/shared/src/components/modals/PollPostModal.tsx
@@ -10,6 +10,7 @@ import type { Post } from '../../graphql/posts';
 import { PostType } from '../../graphql/posts';
 import EnableNotification from '../notifications/EnableNotification';
 import { PollPostContent } from '../post/poll/PollPostContent';
+import { isSourceUserSource } from '../../graphql/sources';
 
 interface PollPostModalProps extends ModalProps, PassedPostNavigationProps {
   id: string;
@@ -47,7 +48,11 @@ export default function PollPostModal({
     >
       <EnableNotification
         source={NotificationPromptSource.SquadPostModal}
-        label={post?.source?.handle}
+        label={
+          isSourceUserSource(post?.source)
+            ? post?.author?.username
+            : post?.source?.handle
+        }
       />
       <PollPostContent
         position={position}

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -10,6 +10,7 @@ import type { Post } from '../../graphql/posts';
 import { PostType } from '../../graphql/posts';
 import EnableNotification from '../notifications/EnableNotification';
 import { SquadPostContent } from '../post/SquadPostContent';
+import { isSourceUserSource } from '../../graphql/sources';
 
 interface PostModalProps extends ModalProps, PassedPostNavigationProps {
   id: string;
@@ -47,7 +48,11 @@ export default function PostModal({
     >
       <EnableNotification
         source={NotificationPromptSource.SquadPostModal}
-        label={post?.source?.handle}
+        label={
+          isSourceUserSource(post?.source)
+            ? post?.author?.username
+            : post?.source?.handle
+        }
       />
       <SquadPostContent
         position={position}


### PR DESCRIPTION
## Changes

Check if source is user source and use author username instead

### Preview domain
https://fix-enablenotification-user-sour.preview.app.daily.dev