### PR TITLE
fix: buttons on cv overlay for opportunity on mobile

### DIFF
--- a/packages/shared/src/features/opportunity/components/CVOverlay.tsx
+++ b/packages/shared/src/features/opportunity/components/CVOverlay.tsx
@@ -130,7 +130,7 @@ export const CVOverlay = ({
             explicitly say yes to an opportunity.
           </Typography>
         </div>
-        <div className="flex justify-between">
+        <div className="flex flex-col justify-between gap-4 tablet:flex-row">
           {backButton}
           <Button
             variant={ButtonVariant.Primary}


### PR DESCRIPTION
## Changes

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="430" height="932" alt="image" src="https://github.com/user-attachments/assets/cc991c1f-0070-4613-8c61-43def57cb172" />
    <td><img width="430" height="932" alt="image" src="https://github.com/user-attachments/assets/68d6d445-43e3-472c-b491-e7bc907f2757" />
  </tr>
</table>

### Preview domain
https://fix-cv-overlay-buttons.preview.app.daily.dev