### PR TITLE
fix: bg image overlay on header on iOS

### DIFF
--- a/packages/webapp/pages/opportunity/welcome.tsx
+++ b/packages/webapp/pages/opportunity/welcome.tsx
@@ -353,13 +353,13 @@ const FAQSection = (): ReactElement => (
   </FlexCol>
 );
 
-const BackgroundImage = (): ReactElement => {
+export const BackgroundImage = (): ReactElement => {
   const { jobsWelcome } = useThemedAsset();
   return (
     <img
       src={jobsWelcome}
       alt="Jobs welcome"
-      className="fixed left-1/2 top-12 z-0 max-w-[60rem] -translate-x-1/2 transform laptop:top-14"
+      className="fixed left-1/2 top-12 -z-1 max-w-[60rem] -translate-x-1/2 transform laptop:top-14"
     />
   );
 };

--- a/packages/webapp/pages/recruiter-spam-to-cores.tsx
+++ b/packages/webapp/pages/recruiter-spam-to-cores.tsx
@@ -17,7 +17,6 @@ import {
   recruiterSpamCampaign,
   recruiterSpamCampaignSEO,
 } from '@dailydotdev/shared/src/lib/image';
-import { useThemedAsset } from '@dailydotdev/shared/src/hooks/utils';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 
 import { Image } from '@dailydotdev/shared/src/components/image/Image';
@@ -35,6 +34,7 @@ import { anchorDefaultRel } from '@dailydotdev/shared/src/lib/strings';
 import { defaultSeo } from '../next-seo';
 import { getLayout } from '../components/layouts/NoSidebarLayout';
 import ProtectedPage from '../components/ProtectedPage';
+import { BackgroundImage } from './opportunity/welcome';
 
 const seo: NextSeoProps = {
   title: 'daily.dev | Convert Recruiter Spam to Cores',
@@ -275,17 +275,6 @@ const GetStartedSection = (): ReactElement => {
         I want my Cores
       </Button>
     </FlexCol>
-  );
-};
-
-const BackgroundImage = (): ReactElement => {
-  const { jobsWelcome } = useThemedAsset();
-  return (
-    <img
-      src={jobsWelcome}
-      alt="Jobs welcome"
-      className="fixed left-1/2 top-12 z-0 max-w-[60rem] -translate-x-1/2 transform laptop:top-14"
-    />
   );
 };
 


### PR DESCRIPTION
## Changes

Because some CSS inset applied on iOS app, the image was a bit further up and on top of the header

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/f59a7b3c-9086-4d84-9348-c9f0f5146719" />
    <td><img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/74ae9b22-d74d-435c-a318-31b103d64d43" />
  </tr>
  <tr>
    <td><img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/97e96d12-ae29-49c2-8232-599c0ebd05cf" />
    <td><img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/d2980d6c-e14f-4968-90bd-adb6704da20c" />
  </tr>
</table>