### PR TITLE
fix: add extra padding on mobile

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -96,6 +96,7 @@
     "react-modal": "^3.14.3",
     "react-swipeable": "^7.0.1",
     "tailwindcss": "^3.4.14",
+    "tailwindcss-safe-area": "0.8.0",
     "ts-jest": "^26.5.4",
     "typescript": "5.6.3"
   },

--- a/packages/shared/src/features/onboarding/shared/FunnelStepCtaWrapper.tsx
+++ b/packages/shared/src/features/onboarding/shared/FunnelStepCtaWrapper.tsx
@@ -57,12 +57,7 @@ export function FunnelStepCtaWrapper({
   return (
     <div className="relative flex flex-1 flex-col gap-4">
       <div className={classNames('flex-1', containerClassName)}>{children}</div>
-      <div
-        className="sticky mx-auto my-4 flex w-full max-w-md flex-col gap-4 px-4"
-        style={{
-          bottom: `max(env(safe-area-inset-bottom, 0), .5rem)`,
-        }}
-      >
+      <div className="sticky mx-auto my-4 flex w-full max-w-md flex-col gap-4 px-4 bottom-safe-or-2">
         {note}
         <Button
           className={classNames(className, cta?.animation, 'w-full')}

--- a/packages/shared/tailwind.config.ts
+++ b/packages/shared/tailwind.config.ts
@@ -1,5 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { type Config } from 'tailwindcss';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import safeArea from 'tailwindcss-safe-area';
 import colors from './tailwind/colors';
 import boxShadow from './tailwind/boxShadow';
 import caret from './tailwind/caret';
@@ -252,7 +254,7 @@ export default {
     },
   },
   // eslint-disable-next-line global-require
-  plugins: [caret, typography, buttons],
+  plugins: [caret, typography, buttons, safeArea],
   corePlugins: {
     invert: false,
   },

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -98,6 +98,7 @@
     "prettier": "^2.6.2",
     "serwist": "^9.0.9",
     "tailwindcss": "^3.4.14",
+    "tailwindcss-safe-area": "0.8.0",
     "ts-jest": "^26.5.4",
     "typescript": "5.6.3",
     "vercel": "^21.3.3"

--- a/packages/webapp/pages/opportunity/[id]/index.tsx
+++ b/packages/webapp/pages/opportunity/[id]/index.tsx
@@ -330,12 +330,12 @@ const JobPage = (): ReactElement => {
           className={{
             buttons: 'flex-1',
             container:
-              'fixed bottom-0 z-header flex min-h-14 w-full items-center gap-4 border-t border-border-subtlest-tertiary bg-background-default px-4 tablet:hidden',
+              'fixed bottom-0 z-header flex h-14 w-full items-center gap-4 border-t border-border-subtlest-tertiary bg-background-default px-4 tablet:hidden',
           }}
           size={ButtonSize.Medium}
         />
       )}
-      <div className="mx-auto flex w-full max-w-[69.25rem] flex-col gap-4 laptop:flex-row">
+      <div className="mx-auto flex w-full max-w-[69.25rem] flex-col gap-4 pb-14 laptop:flex-row laptop:pb-0">
         <div className="h-full min-w-0 max-w-full flex-1 flex-shrink-0 rounded-16 border border-border-subtlest-tertiary">
           {/* Header */}
           <div className="flex min-h-14 items-center gap-4 border-b border-border-subtlest-tertiary p-3">

--- a/packages/webapp/pages/opportunity/[id]/index.tsx
+++ b/packages/webapp/pages/opportunity/[id]/index.tsx
@@ -330,7 +330,7 @@ const JobPage = (): ReactElement => {
           className={{
             buttons: 'flex-1',
             container:
-              'fixed bottom-0 z-header flex h-14 w-full items-center gap-4 border-t border-border-subtlest-tertiary bg-background-default px-4 tablet:hidden',
+              'fixed bottom-0 z-header flex min-h-14 w-full items-center gap-4 border-t border-border-subtlest-tertiary bg-background-default px-4 pt-2 pb-safe-or-2 tablet:hidden',
           }}
           size={ButtonSize.Medium}
         />

--- a/packages/webapp/pages/opportunity/[id]/index.tsx
+++ b/packages/webapp/pages/opportunity/[id]/index.tsx
@@ -335,7 +335,7 @@ const JobPage = (): ReactElement => {
           size={ButtonSize.Medium}
         />
       )}
-      <div className="mx-auto flex w-full max-w-[69.25rem] flex-col gap-4 pb-14 laptop:flex-row laptop:pb-0">
+      <div className="z-0 mx-auto flex w-full max-w-[69.25rem] flex-col gap-4 pb-14 laptop:flex-row laptop:pb-0">
         <div className="h-full min-w-0 max-w-full flex-1 flex-shrink-0 rounded-16 border border-border-subtlest-tertiary">
           {/* Header */}
           <div className="flex min-h-14 items-center gap-4 border-b border-border-subtlest-tertiary p-3">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -690,6 +690,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.14
         version: 3.4.16
+      tailwindcss-safe-area:
+        specifier: 0.8.0
+        version: 0.8.0(tailwindcss@3.4.16)
       ts-jest:
         specifier: ^26.5.4
         version: 26.5.6(jest@26.6.3)(typescript@5.6.3)
@@ -1070,6 +1073,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.14
         version: 3.4.16
+      tailwindcss-safe-area:
+        specifier: 0.8.0
+        version: 0.8.0(tailwindcss@3.4.16)
       ts-jest:
         specifier: ^26.5.4
         version: 26.5.6(jest@26.6.3)(typescript@5.6.3)
@@ -8712,6 +8718,12 @@ packages:
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
+
+  tailwindcss-safe-area@0.8.0:
+    resolution: {integrity: sha512-OIKZfSvinI9kZ3hduoSxqP8EfW2rXoKvHnNyTDY2zwem06IIRtLcKdMe0nF98o+Xluk5Fy7mmesr1rSXg/wkhA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      tailwindcss: ^2.0.0 || >=3.0.0
 
   tailwindcss@3.4.16:
     resolution: {integrity: sha512-TI4Cyx7gDiZ6r44ewaJmt0o6BrMCT5aK5e0rmJ/G9Xq3w7CX/5VXl/zIPEJZFUK5VEqwByyhqNPycPlvcK4ZNw==}
@@ -18150,6 +18162,10 @@ snapshots:
       slice-ansi: 4.0.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  tailwindcss-safe-area@0.8.0(tailwindcss@3.4.16):
+    dependencies:
+      tailwindcss: 3.4.16
 
   tailwindcss@3.4.16:
     dependencies:


### PR DESCRIPTION
## Changes

(Reminds me of my first PR #587)

Adds a new tailwind util plugin for easily accessing the safe-area- env variables so that we don't need to do raw `style` props.

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="446" height="991" alt="image" src="https://github.com/user-attachments/assets/112dd7c3-f073-4ec3-a544-2930e268564e" />
    <td><img width="446" height="991" alt="image" src="https://github.com/user-attachments/assets/50c4be95-956c-4365-9899-09b6695b46f9" />
  </tr>
</table>

Additionally it fixes z issues on response buttons when being recruiter (edge-case)
<img width="463" height="127" alt="image" src="https://github.com/user-attachments/assets/07c8ffcb-6813-4bb6-aba3-673ebda6514e" />

### Preview domain
https://fix-footer-on-mobile.preview.app.daily.dev