### PR TITLE
fix: style ordered lists properly

### DIFF
--- a/packages/webapp/pages/opportunity/[id]/index.tsx
+++ b/packages/webapp/pages/opportunity/[id]/index.tsx
@@ -555,14 +555,12 @@ const JobPage = (): ReactElement => {
                 >
                   {!!contentHtml && (
                     <div
-                      className="pb-4 [&>ul]:list-inside [&>ul]:list-disc"
+                      className="[&>ul,&>ol]:list-inside pb-4 [&>ol]:list-decimal [&>ul]:list-disc"
                       dangerouslySetInnerHTML={{
                         __html: contentHtml,
                       }}
                     />
                   )}
-                  {/* TODO: this is a hack so that numeric lists are styled correctly */}
-                  <span className="hidden list-decimal" />
                 </Accordion>
               </div>
             );


### PR DESCRIPTION
## Changes

Apply styling to ordered lists that might appear too.

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="781" height="379" alt="image" src="https://github.com/user-attachments/assets/c2e3836e-4674-4d3d-8cec-b22fc8931a11" />
    <td><img src="">
  </tr>
</table>