### PR TITLE
fix: add missing bottom padding on iOS

### DIFF
--- a/packages/webapp/pages/opportunity/[id]/index.tsx
+++ b/packages/webapp/pages/opportunity/[id]/index.tsx
@@ -344,7 +344,7 @@ const JobPage = (): ReactElement => {
           size={ButtonSize.Medium}
         />
       )}
-      <div className="z-0 mx-auto flex w-full max-w-[69.25rem] flex-col gap-4 pb-14 laptop:flex-row laptop:pb-0">
+      <div className="z-0 mx-auto flex w-full max-w-[69.25rem] flex-col gap-4 pb-safe-offset-14 laptop:flex-row laptop:pb-0">
         <div className="h-full min-w-0 max-w-full flex-1 flex-shrink-0 rounded-16 border border-border-subtlest-tertiary">
           {/* Header */}
           <div className="flex min-h-14 items-center gap-4 border-b border-border-subtlest-tertiary p-3">


### PR DESCRIPTION
## Changes

Since I made response buttons have safe area inset, it came up higher, which I forgot to account for in #4959.

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="446" height="991" alt="image" src="https://github.com/user-attachments/assets/7fb2b96a-35fa-40bb-83a6-4750bd79a721" />
    <td><img width="446" height="991" alt="image" src="https://github.com/user-attachments/assets/2658ee88-b73e-4e67-972d-cb4bf167bd00" />
  </tr>
</table>