### PR TITLE
fix: emoji regex early return

### DIFF
--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -100,7 +100,7 @@ export const defaultMarkdownCommands = {
   emoji: true,
 };
 
-const specialCharsRegex = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~`]/;
+const specialCharsRegex = /[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~`]/;
 
 export const useMarkdownInput = ({
   textareaRef,

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -100,6 +100,8 @@ export const defaultMarkdownCommands = {
   emoji: true,
 };
 
+const specialCharsRegex = /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~`]/;
+
 export const useMarkdownInput = ({
   textareaRef,
   postId,
@@ -211,7 +213,11 @@ export const useMarkdownInput = ({
   };
 
   const updateEmojiQuery = (value: string) => {
-    if (!isEmojiEnabled || value === emojiQuery) {
+    if (
+      !isEmojiEnabled ||
+      value === emojiQuery ||
+      specialCharsRegex.test(value)
+    ) {
       return;
     }
 

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -100,7 +100,7 @@ export const defaultMarkdownCommands = {
   emoji: true,
 };
 
-const specialCharsRegex = /[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~`]/;
+const specialCharsRegex = new RegExp(/[^A-Za-z0-9_.]/);
 
 export const useMarkdownInput = ({
   textareaRef,


### PR DESCRIPTION
## Changes

We should early return if user is typing `:`+special character.
It basically means they not wanting the emoji completer.

See it in action:

https://github.com/user-attachments/assets/574c0d8e-c20a-4373-a32c-075b92fef7a1

Solves:
https://github.com/dailydotdev/daily/issues/1974

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://feat-emoji-regex-fix.preview.app.daily.dev