### PR TITLE
fix: always add close to marketing CTA

### DIFF
--- a/packages/shared/src/components/marketingCta/MarketingCtaModal.tsx
+++ b/packages/shared/src/components/marketingCta/MarketingCtaModal.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import type { ModalProps } from '../modals/common/Modal';
 import { Modal } from '../modals/common/Modal';
-import { ButtonSize } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { CardCover } from '../cards/common/CardCover';
 import type { MarketingCta } from './common';
 import { CTAButton, Description, Header, Title } from './common';
@@ -10,6 +10,7 @@ import { useBoot } from '../../hooks';
 import { useLogContext } from '../../contexts/LogContext';
 import { LogEvent, TargetType } from '../../lib/log';
 import { promotion } from '../modals/generic';
+import { MiniCloseIcon } from '../icons';
 
 export interface MarketingCtaModalProps extends ModalProps {
   marketingCta: MarketingCta;
@@ -55,8 +56,8 @@ export const MarketingCtaModal = ({
         onModalClose(event, LogEvent.MarketingCtaDismiss)
       }
     >
-      <div className="p-6 !pt-4">
-        {tagColor && tagText && (
+      <div className="relative p-6 !pt-4">
+        {tagColor && tagText ? (
           <Header
             onClose={(event) =>
               onModalClose(event, LogEvent.MarketingCtaDismiss)
@@ -64,6 +65,17 @@ export const MarketingCtaModal = ({
             tagColor={tagColor}
             tagText={tagText}
             buttonSize={ButtonSize.Medium}
+          />
+        ) : (
+          <Button
+            className="absolute right-2 top-2"
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Tertiary}
+            icon={<MiniCloseIcon />}
+            aria-label="Close post"
+            onClick={(event) =>
+              onModalClose(event, LogEvent.MarketingCtaDismiss)
+            }
           />
         )}
         <Title className="!typo-large-title">{title}</Title>


### PR DESCRIPTION
## Changes

If no tag is set we should still render a close button.
It will just be asbolute to not add more height above the text.

<img width="498" height="579" alt="image" src="https://github.com/user-attachments/assets/a7142960-7b07-40a2-ba3d-cd4628efb2fe" />

(Small overlap on really long words)

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://feat-marketing-cta-close.preview.app.daily.dev