### PR TITLE
fix: padding with transparent background

### DIFF
--- a/packages/webapp/components/footer/FooterWrapper.tsx
+++ b/packages/webapp/components/footer/FooterWrapper.tsx
@@ -51,7 +51,7 @@ export default function FooterWrapper({
       className={classNames(
         'fixed !bottom-0 left-0 z-3 w-full',
         showNav &&
-          'footer-navbar bg-gradient-to-t from-background-subtle from-70% to-transparent px-2 pt-2',
+          'bg-gradient-to-t from-background-subtle from-70% to-transparent px-2 pt-2',
       )}
     >
       {post && post.type !== PostType.Brief && (

--- a/packages/webapp/components/footer/MobileFooterNavbar.tsx
+++ b/packages/webapp/components/footer/MobileFooterNavbar.tsx
@@ -148,7 +148,7 @@ const MobileFooterNavbar = (): ReactElement => {
       className={classNames(
         'grid w-full select-none auto-cols-fr grid-flow-col items-center justify-between rounded-16',
         activeClasses,
-        'border-t border-border-subtlest-tertiary',
+        'footer-navbar border-t border-border-subtlest-tertiary',
       )}
     >
       <FooterNavBarTabs activeTab={activeTab} tabs={tabs} />


### PR DESCRIPTION
## Changes
- added footer-navbar to the inner container, so the padding generated from safe-area-inset would actually be the same background as the navbar itself.

### Describe what this PR does

safe-area-inset-bottom which was added for iOS to add padding on the navbar, but this space it creates as padding does not inherit the container properties (background). Instead it will show the background of the parent.
You can see the issue in the image below.

<img width="1179" height="2556" alt="File" src="https://github.com/user-attachments/assets/8caedcad-ab99-49d0-80b9-eaa8bf49e8b9" />

Now this doesn't entirely fixes this issue mentioned here: https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1758791736286129

but I can't seem to replicate that issue anymore in webapp.


## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->
