### PR TITLE
feat: show more emoji results

### DIFF
--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -130,7 +130,8 @@ export const useMarkdownInput = ({
   const { displayToast } = useToastNotification();
 
   const emojiData = useMemo(
-    () => (emojiQuery ? emojiSearch(emojiQuery.toLowerCase()) : []),
+    () =>
+      emojiQuery ? emojiSearch(emojiQuery.toLowerCase()).slice(0, 20) : [],
     [emojiQuery],
   );
 

--- a/packages/shared/src/hooks/input/useMarkdownInput.ts
+++ b/packages/shared/src/hooks/input/useMarkdownInput.ts
@@ -130,7 +130,7 @@ export const useMarkdownInput = ({
   const { displayToast } = useToastNotification();
 
   const emojiData = useMemo(
-    () => (emojiQuery ? emojiSearch(emojiQuery.toLowerCase()).slice(0, 5) : []),
+    () => (emojiQuery ? emojiSearch(emojiQuery.toLowerCase()) : []),
     [emojiQuery],
   );
 


### PR DESCRIPTION
## Changes

Since sometimes when you type, the top 5 results don't give you what you want, I decided to add a scroll and show more results

For example; Before, when you would type :heart - there was still a chance you got 5 results that weren't the ❤️ , so now you're stuck not being able to get the emoji.

Also added some functionality to scroll the window with the user's selected emoji (for keyboard support)



https://github.com/user-attachments/assets/89383f3b-570a-4b15-8359-ea0b346c982d



<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->

### Preview domain
https://show-all-emoji-results.preview.app.daily.dev