### PR TITLE
fix: minor increase on max height of dropdown

### DIFF
--- a/packages/shared/src/components/dropdown/DropdownMenu.tsx
+++ b/packages/shared/src/components/dropdown/DropdownMenu.tsx
@@ -111,7 +111,7 @@ export const DropdownMenuContent = React.forwardRef<
         className={classNames('DropdownMenuContent overflow-hidden', className)}
         align={align}
       >
-        <div className="max-h-70 overflow-y-auto bg-inherit">{children}</div>
+        <div className="max-h-72 overflow-y-auto bg-inherit">{children}</div>
       </DropdownMenuContentRoot>
     </DropdownMenuPortal>
   );


### PR DESCRIPTION
## Changes

Minor increase in height to remove scrollbar

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="181" height="300" alt="image" src="https://github.com/user-attachments/assets/35e15a1f-117e-4cf8-be84-bedcfbb3d2e4" />
    <td><img width="174" height="311" alt="image" src="https://github.com/user-attachments/assets/02db2bb6-db94-4cc2-a21f-a7904079617a" />
  </tr>
</table>

### Preview domain
https://minor-bump-dropdown.preview.app.daily.dev