### PR TITLE
fix: add fallback image to leaderboard lists

### DIFF
--- a/packages/shared/src/components/widgets/PostUsersHighlights.tsx
+++ b/packages/shared/src/components/widgets/PostUsersHighlights.tsx
@@ -92,7 +92,8 @@ const Image = (props: ImageProps) => {
       >
         <StyledImage
           className={classNames('cursor-pointer rounded-full', className)}
-          imgSrc={image || fallbackImages.avatar}
+          imgSrc={image}
+          fallbackSrc={fallbackImages.avatar}
           imgAlt={name}
           background="var(--theme-background-subtle)"
         />
@@ -107,6 +108,7 @@ const Image = (props: ImageProps) => {
       <StyledImage
         className="rounded-12"
         imgSrc={image}
+        fallbackSrc={fallbackImages.avatar}
         imgAlt={name}
         background="var(--theme-background-subtle)"
       />


### PR DESCRIPTION
## Changes

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="358" height="66" alt="image" src="https://github.com/user-attachments/assets/8de5f3ae-14da-4042-8c67-eceed08925dd" />
    <td><img width="339" height="63" alt="image" src="https://github.com/user-attachments/assets/1107874c-369d-4904-b4ca-02eb20ad091d" />
  </tr>
</table>

### Preview domain
https://fix-leaderboard-avatar-fallback.preview.app.daily.dev