### PR TITLE
fix: return to my-feed instead of popular feed when clicking logo in extension

### DIFF
--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -88,7 +88,7 @@ export default function MainFeedPage({
   const onLogoClick = (e: React.MouseEvent): void => {
     e.preventDefault();
     e.stopPropagation();
-    setFeedName('popular');
+    setFeedName('my-feed');
     setIsSearchOn(false);
     setSearchQuery(undefined);
   };


### PR DESCRIPTION
## Changes

Set feed name to my-feed instead of popular when clicking on logo in extension.

https://dailydotdev.slack.com/archives/C01L0QXQJNB/p1760101538144169

### Preview domain
https://fix-extension-logo-click.preview.app.daily.dev