### PR TITLE
feat: allow uploading webp and avif images 🫂 

### DIFF
--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -22,7 +22,7 @@ import { PostType } from '../types';
 import { FEED_POST_CONNECTION_FRAGMENT } from './feed';
 import { getPostByIdKey, RequestKey, StaleTime } from '../lib/query';
 
-export const ACCEPTED_TYPES = 'image/png,image/jpeg';
+export const ACCEPTED_TYPES = 'image/png,image/jpeg,image/webp,image/avif';
 export const acceptedTypesList = ACCEPTED_TYPES.split(',');
 export const MEGABYTE = 1024 * 1024;
 export type TocItem = { text: string; id?: string; children?: TocItem[] };


### PR DESCRIPTION
## Changes

Finally no more needing to convert webp/avif to jpeg or png before uploading them.

No changes needed on API, was this simple, it's already supported via image host.

### Preview domain
https://feat-webp-avif.preview.app.daily.dev