### PR TITLE
fix: add Facebook to SoMe icon map

### DIFF
--- a/packages/webapp/pages/opportunity/[id]/index.tsx
+++ b/packages/webapp/pages/opportunity/[id]/index.tsx
@@ -135,7 +135,9 @@ const faq = [
   },
 ];
 
-const socialMediaIconMap: { [K in SocialMediaType]: ReactElement } = {
+type SocialMediaIconMap = { [Key in SocialMediaType]: ReactElement };
+
+const socialMediaIconMap: SocialMediaIconMap = {
   [SocialMediaType.Facebook]: <FacebookIcon />,
   [SocialMediaType.X]: <TwitterIcon />,
   [SocialMediaType.GitHub]: <GitHubIcon />,


### PR DESCRIPTION
## Changes

Just pre-emptively adding Facebook icon to the map, since it is an exisiting type already.

### Preview domain
https://fix-facebook-some-icon.preview.app.daily.dev