### PR TITLE
fix: hot label positioning

### DIFF
--- a/packages/shared/src/components/HorizontalScroll/HorizontalScrollHeader.tsx
+++ b/packages/shared/src/components/HorizontalScroll/HorizontalScrollHeader.tsx
@@ -52,7 +52,7 @@ export function HorizontalScrollHeader({
   canScroll,
 }: HorizontalScrollHeaderProps): ReactElement {
   return (
-    <div className="mx-4 mb-4 flex min-h-10 w-auto flex-row items-center justify-between laptop:mx-0 laptop:w-full">
+    <div className="mx-4 flex min-h-10 w-auto flex-row items-center justify-between laptop:mx-0 laptop:w-full">
       <HorizontalScrollTitle {...title} />
       {canScroll && (
         <div className="hidden flex-row items-center gap-3 tablet:flex">

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -318,7 +318,7 @@ export const FeedContainer = ({
                 !isLaptop && (isExplorePopular || isExploreLatest) && 'mt-4',
                 isSearch && !shouldUseListFeedLayout && !isAnyExplore && 'mt-8',
                 isHorizontal &&
-                  'no-scrollbar snap-x snap-mandatory grid-flow-col overflow-x-scroll scroll-smooth py-2',
+                  'no-scrollbar snap-x snap-mandatory grid-flow-col overflow-x-scroll scroll-smooth py-2 pt-5',
                 gapClass({
                   isList,
                   isFeedLayoutList: shouldUseListFeedLayout,


### PR DESCRIPTION
## Changes

Moved around the padding so if there's flag label it can show correctly.

After:
<img width="1086" height="666" alt="Screenshot 2025-10-31 at 13 21 18" src="https://github.com/user-attachments/assets/623ed572-bbba-46b8-9c68-ed2cd242c86f" />

Solves:
https://github.com/dailydotdev/daily/issues/1983

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://chore-hot-label.preview.app.daily.dev