### PR TITLE
Change boosted to promoted copy

### DIFF
--- a/packages/shared/src/components/cards/ad/squad/SquadAdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/squad/SquadAdGrid.tsx
@@ -65,13 +65,13 @@ export function SquadAdGrid({
           type={TypographyType.Footnote}
           color={TypographyColor.Tertiary}
         >
-          <Tooltip content={`Boosted by ${campaign?.user?.username}`}>
+          <Tooltip content={`Promoted by @${campaign?.user?.username}`}>
             <button
               type="button"
               disabled
               className="relative text-action-comment-default"
             >
-              <strong>Boosted</strong>
+              <strong>Promoted</strong>
             </button>
           </Tooltip>
           <Separator />@{source.handle}

--- a/packages/shared/src/components/cards/ad/squad/SquadAdList.tsx
+++ b/packages/shared/src/components/cards/ad/squad/SquadAdList.tsx
@@ -62,13 +62,13 @@ export function SquadAdList({
             type={TypographyType.Footnote}
             color={TypographyColor.Tertiary}
           >
-            <Tooltip content={`Boosted by ${campaign?.user?.username}`}>
+            <Tooltip content={`Promoted by @${campaign?.user?.username}`}>
               <button
                 type="button"
                 disabled
                 className="relative text-action-comment-default"
               >
-                <strong>Boosted</strong>
+                <strong>Promoted</strong>
               </button>
             </Tooltip>
             <Separator />@{source.handle}

--- a/packages/shared/src/components/cards/common/PostMetadata.tsx
+++ b/packages/shared/src/components/cards/common/PostMetadata.tsx
@@ -45,8 +45,8 @@ export default function PostMetadata({
     >
       <TruncateText>
         {boostedBy && (
-          <Tooltip content={`Boosted by @${boostedBy.username}`}>
-            <strong>Boosted</strong>
+          <Tooltip content={`Promoted by @${boostedBy.username}`}>
+            <strong>Promoted</strong>
           </Tooltip>
         )}
         {boostedBy && (!!description || !!createdAt || showReadTime) && (

--- a/packages/shared/src/components/cards/common/list/PostMetadata.tsx
+++ b/packages/shared/src/components/cards/common/list/PostMetadata.tsx
@@ -39,7 +39,7 @@ export default function PostMetadata({
             color={TypographyColor.Tertiary}
             bold
           >
-            Boosted by @{boostedBy.username}
+            Promoted by @{boostedBy.username}
           </Typography>
         )}
         {!!boostedBy && !!bottomLabel && <Separator />}

--- a/packages/shared/src/components/cards/squad/SquadGrid.tsx
+++ b/packages/shared/src/components/cards/squad/SquadGrid.tsx
@@ -132,13 +132,13 @@ export const SquadGrid = ({
               color={TypographyColor.Secondary}
             >
               {campaign && (
-                <Tooltip content={`Boosted by @${campaign.user.username}`}>
+                <Tooltip content={`Promoted by @${campaign.user.username}`}>
                   <button
                     type="button"
                     disabled
                     className="relative text-action-comment-default"
                   >
-                    <strong>Boosted</strong>
+                    <strong>Promoted</strong>
                   </button>
                 </Tooltip>
               )}

--- a/packages/shared/src/components/cards/squad/SquadList.tsx
+++ b/packages/shared/src/components/cards/squad/SquadList.tsx
@@ -65,7 +65,7 @@ export const SquadList = ({
         >
           {campaignId && (
             <strong>
-              Boosted <Separator />
+              Promoted <Separator />
             </strong>
           )}
           @{squad.handle}

--- a/packages/shared/src/features/boost/BoostSourceButton.tsx
+++ b/packages/shared/src/features/boost/BoostSourceButton.tsx
@@ -130,7 +130,7 @@ export function BoostSourceButton({
       wrapper={(component) => (
         <Tooltip
           className="max-w-64"
-          content={`The Squad is currently being boosted by ${
+          content={`The Squad is currently being promoted by ${
             campaign.user.name
           }. You can start a new boost once this one ends on ${campaign.endedAt.toLocaleString()}`}
         >

--- a/packages/webapp/pages/posts/[id]/analytics/index.tsx
+++ b/packages/webapp/pages/posts/[id]/analytics/index.tsx
@@ -517,7 +517,7 @@ const PostAnalyticsPage = ({
               </div>
               <div className="flex items-center gap-1">
                 <div className="size-2 rounded-full bg-accent-blueCheese-default" />{' '}
-                <Typography type={TypographyType.Footnote}>Boosted</Typography>
+                <Typography type={TypographyType.Footnote}>Promoted</Typography>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Changes

-   Updated all instances of "Boosted" to "Promoted" in user-facing copy for boosted posts (e.g., "Boosted by @username" is now "Promoted by @username").
-   Ensured consistency across labels, tooltips, and the analytics chart legend.
-   Added the `@` symbol to tooltips in `SquadAdList.tsx` and `SquadAdGrid.tsx` for uniform "Promoted by @username" formatting.

## Events

No

## Experiment

No

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

ENG-24

---
Linear Issue: [ENG-24](https://linear.app/dailydev/issue/ENG-24/change-boosted-to-promoted)

<a href="https://cursor.com/background-agent?bcId=bc-0dab0346-0ae3-48f5-bbbc-9a5f0ec28a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0dab0346-0ae3-48f5-bbbc-9a5f0ec28a13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



### Preview domain
https://cursor-eng-24-change-boosted-to.preview.app.daily.dev