### PR TITLE
Fix profile name update bug

### DIFF
--- a/packages/webapp/components/layouts/SettingsLayout/Profile/index.tsx
+++ b/packages/webapp/components/layouts/SettingsLayout/Profile/index.tsx
@@ -90,6 +90,10 @@ const ProfileIndex = ({
   const onSubmit = (e: React.MouseEvent) => {
     e.preventDefault();
     const values = formToJson<UpdateProfileParameters>(formRef.current);
+    const usernameForRedirect = values.username ?? user?.username;
+    const profileDestination = usernameForRedirect
+      ? `/${usernameForRedirect.toLowerCase()}`
+      : user?.permalink ?? '/';
     const params = {
       name: values.name,
       username: values.username,
@@ -110,7 +114,7 @@ const ProfileIndex = ({
       bluesky: values.bluesky,
       experienceLevel: values.experienceLevel,
       onUpdateSuccess: () =>
-        router.push(`/${values.username.toLowerCase()}`).then(() => {
+        router.push(profileDestination).then(() => {
           router.reload();
         }),
     };


### PR DESCRIPTION
## Changes

-   **Fixes profile update failure:** Prevents errors when `values.username` is `null` or `undefined` during profile name updates, which previously caused the update to fail.
-   **Ensures valid redirect after profile save:** Introduces a robust fallback for the post-update redirect path, prioritizing `values.username`, then `user?.username`, then `user?.permalink`, and finally `/`, to ensure users are always redirected to a valid page.

## Events

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
<!--
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android
-->

ENG-48

---
Linear Issue: [ENG-48](https://linear.app/dailydev/issue/ENG-48/cant-update-prfoile-name)

<a href="https://cursor.com/background-agent?bcId=bc-aaadc6f4-8f72-4f3f-b9b6-1ab2aa79295b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aaadc6f4-8f72-4f3f-b9b6-1ab2aa79295b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



### Preview domain
https://cursor-eng-48-fix-profile-name-u.preview.app.daily.dev