### PR TITLE
fix: correct link for linkedin SoMe link on profile

### DIFF
--- a/packages/shared/src/features/profile/components/AboutMe.tsx
+++ b/packages/shared/src/features/profile/components/AboutMe.tsx
@@ -70,7 +70,7 @@ export function AboutMe({
       },
       user.linkedin && {
         id: 'linkedin',
-        url: user.linkedin,
+        url: `https://linkedin.com/in/${user.linkedin}`,
         icon: <LinkedInIcon size={IconSize.XSmall} />,
         label: 'LinkedIn',
       },


### PR DESCRIPTION
## Changes

API only returns username for linkedin profile, so we need to properly set the URL on link.

### Preview domain
https://fix-profile-some-linkedin.preview.app.daily.dev