### PR TITLE
feat: set light mode by default for recruiter

### DIFF
--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -146,13 +146,17 @@ export const BootDataProvider = ({
     }
 
     if (boot?.settings?.theme) {
-      applyTheme(themeModes[boot.settings.theme]);
+      if (boot.settings?.recruiterTheme && getPage().startsWith('/recruiter')) {
+        applyTheme(themeModes[boot.settings?.recruiterTheme]);
+      } else {
+        applyTheme(themeModes[boot.settings.theme]);
+      }
     }
 
     preloadFeedsRef.current({ feeds: boot.feeds, user: boot.user });
 
     setCachedBootData(boot);
-  }, [localBootData]);
+  }, [getPage, localBootData]);
 
   const { hostGranted } = useHostStatus();
   const isExtension = checkIsExtension();

--- a/packages/shared/src/contexts/SettingsContext.tsx
+++ b/packages/shared/src/contexts/SettingsContext.tsx
@@ -41,8 +41,10 @@ export const themes: ThemeOption[] = Object.values(ThemeMode).map((theme) => ({
   value: theme,
 }));
 
-export interface SettingsContextData extends Omit<RemoteSettings, 'theme'> {
+export interface SettingsContextData
+  extends Omit<RemoteSettings, 'theme' | 'recruiterTheme'> {
   themeMode: ThemeMode;
+  recruiterTheme?: ThemeMode;
   setTheme: (theme: ThemeMode) => Promise<void>;
   toggleOpenNewTab: () => Promise<void>;
   setSpaciness: (density: Spaciness) => Promise<void>;
@@ -223,6 +225,7 @@ export const SettingsContextProvider = ({
       ...settings,
       syncSettings,
       themeMode: themeModes[settings.theme],
+      recruiterTheme: themeModes[settings?.recruiterTheme],
       setTheme: (theme: ThemeMode) =>
         setSettings({ ...settings, theme: remoteThemes[theme] }),
       toggleOpenNewTab: () =>

--- a/packages/shared/src/graphql/settings.ts
+++ b/packages/shared/src/graphql/settings.ts
@@ -33,6 +33,7 @@ export enum SidebarSettingsFlags {
 export type RemoteSettings = {
   openNewTab: boolean;
   theme: RemoteTheme;
+  recruiterTheme?: RemoteTheme;
   spaciness: Spaciness;
   insaneMode: boolean;
   showTopSites: boolean;

--- a/packages/webapp/components/layouts/RecruiterSelfServeLayout.tsx
+++ b/packages/webapp/components/layouts/RecruiterSelfServeLayout.tsx
@@ -1,13 +1,30 @@
 import type { ReactNode } from 'react';
-import React from 'react';
+import React, { useEffect } from 'react';
 import type { RecruiterSelfServeLayoutProps } from '@dailydotdev/shared/src/components/recruiter/layout/RecruiterLayout';
 import { RecruiterLayout } from '@dailydotdev/shared/src/components/recruiter/layout/RecruiterLayout';
+import { useSettingsContext } from '@dailydotdev/shared/src/contexts/SettingsContext';
 
 const GetLayout = (
   page: ReactNode,
   pageProps: Record<string, unknown>,
   layoutProps?: RecruiterSelfServeLayoutProps,
 ): ReactNode => {
+  const { applyThemeMode, recruiterTheme, loadedSettings } =
+    useSettingsContext();
+
+  useEffect(() => {
+    if (loadedSettings) {
+      applyThemeMode(recruiterTheme);
+    }
+  }, [applyThemeMode, recruiterTheme, loadedSettings]);
+
+  // Cleanup only on unmount
+  useEffect(() => {
+    return () => {
+      applyThemeMode();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   return <RecruiterLayout {...layoutProps}>{page}</RecruiterLayout>;
 };
 


### PR DESCRIPTION
## Changes

Little bit messy, but it's due to manual overwrites and defaults.

Idea is:
- SETTINGS_DEFAULT on API will get recruiterTheme: light 
- - This means if they have settings it will be null :) and they get whatever they set.
- If user claims opportunity on signup we assign light mode.

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://feat-default-light.preview.app.daily.dev