### PR TITLE
chore: webpack build

### DIFF
--- a/packages/shared/src/components/modals/common.tsx
+++ b/packages/shared/src/components/modals/common.tsx
@@ -328,17 +328,24 @@ const SquadNotificationSettingsModal = dynamic(
     ),
 );
 
-const OpportunityEditModal = dynamic(() =>
-  import(
-    /* webpackChunkName: "opportunityEditModal" */ '../opportunity/OpportunityEditModal/OpportunityEditModal'
-  ).then((mod) => mod.OpportunityEditModal),
-);
+// Opportunity modals are webapp-only and import lib/schema/opportunity.ts
+// which triggers Next.js 15.4.10 Babel bug ("Invalid array length") in extension builds
+// Must use process.env directly (not isExtension) for webpack compile-time exclusion
+const OpportunityEditModal = process.env.TARGET_BROWSER
+  ? null
+  : dynamic(() =>
+      import(
+        /* webpackChunkName: "opportunityEditModal" */ '../opportunity/OpportunityEditModal/OpportunityEditModal'
+      ).then((mod) => mod.OpportunityEditModal),
+    );
 
-const OpportunityEditRecruiterModal = dynamic(() =>
-  import(
-    /* webpackChunkName: "opportunityEditRecruiterModal" */ '../opportunity/OpportunityEditModal/OpportunityEditRecruiterModal'
-  ).then((mod) => mod.OpportunityEditRecruiterModal),
-);
+const OpportunityEditRecruiterModal = process.env.TARGET_BROWSER
+  ? null
+  : dynamic(() =>
+      import(
+        /* webpackChunkName: "opportunityEditRecruiterModal" */ '../opportunity/OpportunityEditModal/OpportunityEditRecruiterModal'
+      ).then((mod) => mod.OpportunityEditRecruiterModal),
+    );
 
 const DirtyFormModal = dynamic(
   () => import(/* webpackChunkName: "dirtyFormModal" */ './DirtyFormModal'),


### PR DESCRIPTION
### Problem
  Extension builds were failing with `ERROR in [entry] [initial] js/newtab.bundle.js Invalid array length` after commit 4d36738 which added `OpportunityEditRecruiterModal`.

  ### Root Cause
  The modal imports from `lib/schema/opportunity.ts`, which contains complex zod validation schemas. When webpack processes this file during extension builds, Next.js 15.4.10's Babel plugin attempts to optimize/rewrite code patterns and hits a bug when processing:

  - Large numeric literals with underscores (`100_000_000`, `1_000_000`)
  - Complex nested zod schemas with refinements
  - Dynamic array patterns like `[0, 0.5, 1].map(item => z.literal(item, {...}))`

  The Babel regex rewriting plugin creates an invalid internal array structure, causing the "Invalid array length" error.

  ### Solution
  Conditionally exclude opportunity-related modals from extension builds by checking `process.env.TARGET_BROWSER` at compile time. These modals are webapp-only features (job posting management) and should never be loaded in the extension anyway.

  **Why this approach:**
  - ✅ Webpack performs compile-time replacement of `process.env.*`, enabling proper tree-shaking
  - ✅ The problematic imports are never processed during extension builds
  - ✅ No impact on webapp functionality
  - ✅ Cleaner than trying to rewrite complex zod schemas or webpack exclusions

  ### Changes
  - `packages/shared/src/components/modals/common.tsx`: Wrapped `OpportunityEditModal` and `OpportunityEditRecruiterModal` in conditional checks
  - `packages/shared/src/lib/schema/opportunity.ts`: Minor optimization of `roleType` union (changed from `.map()` to explicit literals)

  ### Testing
  - ✅ Extension build completes successfully
  - ✅ Webapp build unaffected (modals load normally)
  - ✅ Extension doesn't include unnecessary opportunity modal code

  ### Notes
  This is a workaround for a Next.js 15.4.10 Babel bug. The issue may be resolved in future Next.js versions, but this approach has the added benefit of reducing extension bundle size by excluding webapp-only features.


### Preview domain
https://hotfix-webpack-build.preview.app.daily.dev