### PR TITLE
feat: recruiter dashboard view

### DIFF
--- a/packages/shared/src/components/modals/recruiter/RecruiterJobLinkModal.tsx
+++ b/packages/shared/src/components/modals/recruiter/RecruiterJobLinkModal.tsx
@@ -13,11 +13,13 @@ import { TextField } from '../../fields/TextField';
 import { MagicIcon, ShieldIcon } from '../../icons';
 import { DragDrop } from '../../fields/DragDrop';
 import type { PendingSubmission } from '../../../features/opportunity/context/PendingSubmissionContext';
+import { ModalClose } from '../common/ModalClose';
 
 const jobLinkSchema = z.url({ message: 'Please enter a valid URL' });
 
 export interface RecruiterJobLinkModalProps extends ModalProps {
   onSubmit: (submission: PendingSubmission) => void;
+  closeable?: boolean;
 }
 
 const fileValidation = {
@@ -32,6 +34,7 @@ const fileValidation = {
 export const RecruiterJobLinkModal = ({
   onSubmit,
   onRequestClose,
+  closeable = false,
   ...modalProps
 }: RecruiterJobLinkModalProps): ReactElement => {
   const [jobLink, setJobLink] = useState('');
@@ -92,9 +95,10 @@ export const RecruiterJobLinkModal = ({
       kind={Modal.Kind.FlexibleCenter}
       size={Modal.Size.Medium}
       onRequestClose={onRequestClose}
-      shouldCloseOnOverlayClick={false}
-      shouldCloseOnEsc={false}
+      shouldCloseOnOverlayClick={closeable}
+      shouldCloseOnEsc={closeable}
     >
+      {closeable && <ModalClose className="top-2" onClick={onRequestClose} />}
       <Modal.Body className="flex flex-col gap-6 p-6">
         <Typography type={TypographyType.Title1} bold center>
           Help us understand your role

--- a/packages/shared/src/features/recruiter/components/DashboardView.tsx
+++ b/packages/shared/src/features/recruiter/components/DashboardView.tsx
@@ -1,0 +1,62 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../components/buttons/Button';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { PlusIcon } from '../../../components/icons';
+import type { Opportunity } from '../../opportunity/types';
+import { OpportunityCard } from './OpportunityCard';
+
+export type DashboardViewProps = {
+  opportunities: Opportunity[];
+  onAddNew: () => void;
+};
+
+export const DashboardView = ({
+  opportunities,
+  onAddNew,
+}: DashboardViewProps): ReactElement => {
+  return (
+    <div className="relative mx-4 mt-10 max-w-[47.875rem] tablet:mx-auto">
+      <div className="flex flex-col gap-8 tablet:mx-4 laptop:mx-0">
+        <div className="flex flex-col gap-2 text-center">
+          <Typography type={TypographyType.Title1} bold>
+            Your Opportunities
+          </Typography>
+          <Typography color={TypographyColor.Tertiary}>
+            Manage your job opportunities and find top candidates
+          </Typography>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <Typography type={TypographyType.Title2} bold>
+              All Opportunities ({opportunities.length})
+            </Typography>
+            <Button
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Small}
+              icon={<PlusIcon />}
+              onClick={onAddNew}
+            >
+              Add New
+            </Button>
+          </div>
+
+          <div className="grid gap-4 tablet:grid-cols-2 laptop:grid-cols-3">
+            {opportunities.map((opportunity) => (
+              <OpportunityCard key={opportunity.id} opportunity={opportunity} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/shared/src/features/recruiter/components/OnboardingView.tsx
+++ b/packages/shared/src/features/recruiter/components/OnboardingView.tsx
@@ -1,0 +1,30 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { RecruiterHeader } from '../../../components/recruiter/Header';
+import {
+  RecruiterProgress,
+  RecruiterProgressStep,
+} from '../../../components/recruiter/Progress';
+import type { OpportunityPreviewContextType } from '../../opportunity/context/OpportunityPreviewContext';
+import { OpportunityPreviewProvider } from '../../opportunity/context/OpportunityPreviewContext';
+import { AnalyzeContent } from '../../opportunity/components/analyze/AnalyzeContent';
+
+export type OnboardingViewProps = {
+  mockData: OpportunityPreviewContextType;
+  loadingStep: number;
+};
+
+export const OnboardingView = ({
+  mockData,
+  loadingStep,
+}: OnboardingViewProps): ReactElement => {
+  return (
+    <OpportunityPreviewProvider mockData={mockData}>
+      <div className="pointer-events-none flex flex-1 flex-col blur-sm">
+        <RecruiterHeader />
+        <RecruiterProgress activeStep={RecruiterProgressStep.AnalyzeAndMatch} />
+        <AnalyzeContent loadingStep={loadingStep} />
+      </div>
+    </OpportunityPreviewProvider>
+  );
+};

--- a/packages/shared/src/features/recruiter/components/OpportunityCard.tsx
+++ b/packages/shared/src/features/recruiter/components/OpportunityCard.tsx
@@ -1,0 +1,108 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../components/buttons/Button';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { EditIcon, UserIcon } from '../../../components/icons';
+import { webappUrl } from '../../../lib/constants';
+import type { Opportunity } from '../../opportunity/types';
+import { OpportunityState } from '../../opportunity/protobuf/opportunity';
+
+const getStateLabel = (state: OpportunityState): string => {
+  switch (state) {
+    case OpportunityState.LIVE:
+      return 'Live';
+    case OpportunityState.DRAFT:
+      return 'Draft';
+    case OpportunityState.IN_REVIEW:
+      return 'In Review';
+    case OpportunityState.CLOSED:
+      return 'Closed';
+    default:
+      return 'Unknown';
+  }
+};
+
+const getStateColor = (state: OpportunityState): string => {
+  switch (state) {
+    case OpportunityState.LIVE:
+      return 'bg-accent-cabbage-default';
+    case OpportunityState.DRAFT:
+      return 'bg-surface-secondary';
+    case OpportunityState.IN_REVIEW:
+      return 'bg-accent-cheese-default';
+    case OpportunityState.CLOSED:
+      return 'bg-surface-tertiary';
+    default:
+      return 'bg-surface-secondary';
+  }
+};
+
+export type OpportunityCardProps = {
+  opportunity: Opportunity;
+};
+
+export const OpportunityCard = ({
+  opportunity,
+}: OpportunityCardProps): ReactElement => {
+  const { title, organization, id, state } = opportunity;
+
+  return (
+    <div className="flex flex-col gap-3 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-4">
+      {organization?.image && (
+        <img
+          src={organization.image}
+          alt={organization.name}
+          className="h-12 w-12 rounded-12 object-cover"
+        />
+      )}
+
+      <div className="flex flex-1 flex-col gap-1">
+        <Typography type={TypographyType.Title3} bold>
+          {title}
+        </Typography>
+        <Typography type={TypographyType.Body} color={TypographyColor.Tertiary}>
+          {organization?.name || 'Company'}
+        </Typography>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span
+          className={classNames(
+            'rounded-8 px-2 py-1 text-text-primary typo-caption1',
+            getStateColor(state),
+          )}
+        >
+          {getStateLabel(state)}
+        </span>
+
+        <div className="flex items-center gap-1">
+          <Button
+            tag="a"
+            href={`${webappUrl}recruiter/${id}/matches`}
+            variant={ButtonVariant.Tertiary}
+            size={ButtonSize.Small}
+            icon={<UserIcon />}
+            title="View matches"
+          />
+          <Button
+            tag="a"
+            href={`${webappUrl}recruiter/${id}/prepare`}
+            variant={ButtonVariant.Tertiary}
+            size={ButtonSize.Small}
+            icon={<EditIcon />}
+            title="Edit opportunity"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/webapp/pages/recruiter/index.tsx
+++ b/packages/webapp/pages/recruiter/index.tsx
@@ -2,21 +2,20 @@ import type { ReactElement } from 'react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useQuery } from '@tanstack/react-query';
-import { RecruiterHeader } from '@dailydotdev/shared/src/components/recruiter/Header';
-import {
-  RecruiterProgress,
-  RecruiterProgressStep,
-} from '@dailydotdev/shared/src/components/recruiter/Progress';
 import { useLazyModal } from '@dailydotdev/shared/src/hooks/useLazyModal';
 import { LazyModal } from '@dailydotdev/shared/src/components/modals/common/types';
-import { OpportunityPreviewProvider } from '@dailydotdev/shared/src/features/opportunity/context/OpportunityPreviewContext';
 import type { PendingSubmission } from '@dailydotdev/shared/src/features/opportunity/context/PendingSubmissionContext';
 import { usePendingSubmission } from '@dailydotdev/shared/src/features/opportunity/context/PendingSubmissionContext';
 import { mockOpportunityPreviewData } from '@dailydotdev/shared/src/features/opportunity/mockData';
 import type { OpportunityPreviewContextType } from '@dailydotdev/shared/src/features/opportunity/context/OpportunityPreviewContext';
-import { AnalyzeContent } from '@dailydotdev/shared/src/features/opportunity/components/analyze/AnalyzeContent';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import { getOpportunitiesOptions } from '@dailydotdev/shared/src/features/opportunity/queries';
+import {
+  Typography,
+  TypographyColor,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+import { DashboardView } from '@dailydotdev/shared/src/features/recruiter/components/DashboardView';
+import { OnboardingView } from '@dailydotdev/shared/src/features/recruiter/components/OnboardingView';
 import { getLayout } from '../../components/layouts/RecruiterSelfServeLayout';
 
 const useLoadingAnimation = (isActive: boolean) => {
@@ -86,20 +85,24 @@ function RecruiterPage(): ReactElement {
     }
   };
 
-  const openJobLinkModal = useCallback(() => {
-    openModal({
-      type: LazyModal.RecruiterJobLink,
-      props: {
-        onSubmit: (submission: PendingSubmission) =>
-          handleJobSubmitRef.current?.(submission),
-      },
-    });
-  }, [openModal]);
+  const openJobLinkModal = useCallback(
+    (closeable = false) => {
+      openModal({
+        type: LazyModal.RecruiterJobLink,
+        props: {
+          closeable,
+          onSubmit: (submission: PendingSubmission) =>
+            handleJobSubmitRef.current?.(submission),
+        },
+      });
+    },
+    [openModal],
+  );
 
   const hasExistingOpportunities =
     opportunitiesData?.edges && opportunitiesData.edges.length > 0;
 
-  // Open the appropriate modal when the page loads
+  // Open the onboarding modal flow for new users (no opportunities)
   useEffect(() => {
     const { openModal: openModalParam } = router.query;
     // If openModal=joblink query param is present, skip intro/trust modals
@@ -121,12 +124,12 @@ function RecruiterPage(): ReactElement {
 
     hasInitializedRef.current = true;
 
+    // Users with existing opportunities see the dashboard, no auto-modal
     if (hasExistingOpportunities) {
-      openJobLinkModal();
       return;
     }
 
-    // Default flow: start with intro modal
+    // Default flow for new users: start with intro modal
     openModal({
       type: LazyModal.RecruiterIntro,
       props: {
@@ -155,21 +158,36 @@ function RecruiterPage(): ReactElement {
     loadingUser,
   ]);
 
-  return (
-    <OpportunityPreviewProvider mockData={mockData}>
-      <div className="flex flex-1 flex-col">
-        <RecruiterHeader />
-        <RecruiterProgress activeStep={RecruiterProgressStep.AnalyzeAndMatch} />
-        <AnalyzeContent loadingStep={loadingStep} />
+  const opportunities = opportunitiesData?.edges.map((edge) => edge.node) || [];
+
+  // Loading state
+  if ((user && isLoadingOpportunities) || loadingUser) {
+    return (
+      <div className="relative mx-4 mt-10 max-w-[47.875rem] tablet:mx-auto">
+        <div className="flex flex-col items-center justify-center py-20">
+          <Typography color={TypographyColor.Tertiary}>
+            Loading your opportunities...
+          </Typography>
+        </div>
       </div>
-    </OpportunityPreviewProvider>
-  );
+    );
+  }
+
+  // Dashboard view for users with existing opportunities
+  if (hasExistingOpportunities) {
+    return (
+      <DashboardView
+        opportunities={opportunities}
+        onAddNew={() => openJobLinkModal(true)}
+      />
+    );
+  }
+
+  // Onboarding flow for new users (with blur effect)
+  return <OnboardingView mockData={mockData} loadingStep={loadingStep} />;
 }
 
 RecruiterPage.getLayout = getLayout;
-RecruiterPage.layoutProps = {
-  className: { main: 'pointer-events-none blur-sm' },
-};
 
 export async function getServerSideProps() {
   return { props: {} };


### PR DESCRIPTION
## Changes

New flow:
- No opps -> show 3 modals flow
- Has opps -> show dashboard

Dashboard can now show
- Matches - Edit opportunity (prepare)

Split to components for easer maintenance

### Preview domain
https://feat-recruiter-dashboard-view.preview.app.daily.dev