### PR TITLE
fix: use full-screen drawer for GIF picker on mobile

### DIFF
--- a/packages/shared/src/components/popover/GifPopover.tsx
+++ b/packages/shared/src/components/popover/GifPopover.tsx
@@ -70,7 +70,9 @@ const GifPickerContent = ({
         inputId="gifs"
         label="Search Tenor"
         placeholder={
-          searchSuggestions[Math.floor(Math.random() * searchSuggestions.length)]
+          searchSuggestions[
+            Math.floor(Math.random() * searchSuggestions.length)
+          ]
         }
       />
     </div>
@@ -101,7 +103,9 @@ const GifPickerContent = ({
                 <button
                   className="mb-auto"
                   type="button"
-                  onClick={() => handleGifClick({ url: gif.url, title: gif.title })}
+                  onClick={() =>
+                    handleGifClick({ url: gif.url, title: gif.title })
+                  }
                 >
                   <img
                     src={gif.preview}
@@ -222,10 +226,7 @@ const GifPopover = ({
   if (!isTablet) {
     return (
       <>
-        <Button
-          {...buttonProps}
-          onClick={() => handleOpenChange(true)}
-        />
+        <Button {...buttonProps} onClick={() => handleOpenChange(true)} />
         <Drawer
           isOpen={open}
           onClose={handleClose}


### PR DESCRIPTION
## Changes

- On mobile, switch GIF picker from Radix Popover to full-screen Drawer
- Fixes issue where mobile keyboard caused the popover to shift off-screen
- Desktop/tablet views continue using the existing popover behavior
- Extracted shared `GifPickerContent` component for code reuse

## Events

No new tracking events introduced.

## Experiment

No new experiments introduced.

## Manual Testing

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

### Preview domain
https://amardailydev-gif-popover-mobile.preview.app.daily.dev