### PR TITLE
feat: improve percentile banner logic and support flexible podium sources

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -3,8 +3,6 @@
   <component name="CommitMessageInspectionProfile">
     <profile version="1.0">
       <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
       <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
     </profile>
   </component>

--- a/packages/webapp/components/log/CardFavoriteSources.tsx
+++ b/packages/webapp/components/log/CardFavoriteSources.tsx
@@ -7,7 +7,11 @@ import styles from './Log.module.css';
 import ShareStatButton from './ShareStatButton';
 import TopPercentileBanner from './TopPercentileBanner';
 import type { BaseCardProps } from './types';
-import { SimpleHeadline, Podium } from './primitives';
+import {
+  SimpleHeadline,
+  Podium,
+  shouldShowPercentileBanner,
+} from './primitives';
 
 export default function CardFavoriteSources({
   data,
@@ -31,10 +35,7 @@ export default function CardFavoriteSources({
         </SimpleHeadline>
 
         {/* Podium */}
-        <Podium
-          sources={[data.topSources[0], data.topSources[1], data.topSources[2]]}
-          animated
-        />
+        <Podium sources={data.topSources} animated />
 
         {/* Discovery stat */}
         <motion.div
@@ -53,16 +54,18 @@ export default function CardFavoriteSources({
         </motion.div>
 
         {/* Banner */}
-        <TopPercentileBanner
-          preText="TOP"
-          mainText={`${data.sourcePercentile}%`}
-          postText="EXPLORER"
-          delay={1.5}
-          motionProps={{
-            initial: { opacity: 0, x: 100 },
-            animate: { opacity: 1, x: 0 },
-          }}
-        />
+        {shouldShowPercentileBanner(data.sourcePercentile) && (
+          <TopPercentileBanner
+            preText="TOP"
+            mainText={`${data.sourcePercentile}%`}
+            postText="EXPLORER"
+            delay={1.5}
+            motionProps={{
+              initial: { opacity: 0, x: 100 },
+              animate: { opacity: 1, x: 0 },
+            }}
+          />
+        )}
       </div>
 
       {/* Share button - pushed to bottom with margin-top: auto */}

--- a/packages/webapp/components/log/CardShare.tsx
+++ b/packages/webapp/components/log/CardShare.tsx
@@ -192,10 +192,10 @@ export default function CardShare({
             <div className={styles.shareReceiptRow}>
               <span className={styles.shareReceiptLabel}>
                 {RECORDS[bestRecord.type].emoji}{' '}
-                {bestRecord.label.toUpperCase()}
+                {RECORDS[bestRecord.type].defaultLabel.toUpperCase()}
               </span>
               <span className={styles.shareReceiptValue}>
-                {bestRecord.value}
+                {bestRecord.label}
               </span>
             </div>
           )}

--- a/packages/webapp/components/log/CardTopicEvolution.tsx
+++ b/packages/webapp/components/log/CardTopicEvolution.tsx
@@ -6,6 +6,7 @@ import styles from './Log.module.css';
 import ShareStatButton from './ShareStatButton';
 import TopPercentileBanner from './TopPercentileBanner';
 import type { BaseCardProps } from './types';
+import { shouldShowPercentileBanner } from './primitives';
 
 const MEDAL_EMOJIS = ['🥇', '🥈', '🥉'];
 
@@ -245,21 +246,6 @@ export default function CardTopicEvolution({
               </span>
             </div>
             {/* Actual visible content stacked on same grid cell */}
-            {currentQuarter?.comment && (
-              <motion.div
-                className={styles.pivotBadge}
-                style={{ gridArea: '1 / 1', placeSelf: 'center' }}
-                initial={{ rotateX: -90, opacity: 0 }}
-                animate={{ rotateX: 0, opacity: 1 }}
-                transition={{
-                  delay: 0.3,
-                  duration: 0.3,
-                  ease: [0.4, 0, 0.2, 1],
-                }}
-              >
-                {currentQuarter.comment}
-              </motion.div>
-            )}
             {isLastQuarter && (
               <motion.div
                 className={styles.badge}
@@ -278,20 +264,22 @@ export default function CardTopicEvolution({
         </div>
 
         {/* Banner - reserve space always, animate visibility on last quarter */}
-        <TopPercentileBanner
-          preText="MORE CURIOUS THAN"
-          mainText={`${100 - data.evolutionPercentile}%`}
-          postText="OF DEVS"
-          delay={isLastQuarter ? 0.5 : 0}
-          motionProps={{
-            initial: false,
-            animate: {
-              opacity: isLastQuarter ? 1 : 0,
-              scaleX: isLastQuarter ? 1 : 0,
-            },
-            style: { visibility: isLastQuarter ? 'visible' : 'hidden' },
-          }}
-        />
+        {shouldShowPercentileBanner(data.evolutionPercentile) && (
+          <TopPercentileBanner
+            preText="MORE CURIOUS THAN"
+            mainText={`${100 - data.evolutionPercentile}%`}
+            postText="OF DEVS"
+            delay={isLastQuarter ? 0.5 : 0}
+            motionProps={{
+              initial: false,
+              animate: {
+                opacity: isLastQuarter ? 1 : 0,
+                scaleX: isLastQuarter ? 1 : 0,
+              },
+              style: { visibility: isLastQuarter ? 'visible' : 'hidden' },
+            }}
+          />
+        )}
       </div>
 
       {/* Share button - pushed to bottom, only active on last quarter */}

--- a/packages/webapp/components/log/CardTotalImpact.tsx
+++ b/packages/webapp/components/log/CardTotalImpact.tsx
@@ -5,7 +5,12 @@ import styles from './Log.module.css';
 import ShareStatButton from './ShareStatButton';
 import TopPercentileBanner from './TopPercentileBanner';
 import type { BaseCardProps } from './types';
-import { HeadlineStack, StatBadgeGroup, Divider } from './primitives';
+import {
+  HeadlineStack,
+  StatBadgeGroup,
+  Divider,
+  shouldShowPercentileBanner,
+} from './primitives';
 
 export default function CardTotalImpact({
   data,
@@ -60,12 +65,14 @@ export default function CardTotalImpact({
         />
 
         {/* Competitive stat banner with slide in */}
-        <TopPercentileBanner
-          preText="Top"
-          mainText={`${data.totalImpactPercentile}%`}
-          postText="of devs"
-          delay={1.8}
-        />
+        {shouldShowPercentileBanner(data.totalImpactPercentile) && (
+          <TopPercentileBanner
+            preText="Top"
+            mainText={`${data.totalImpactPercentile}%`}
+            postText="of devs"
+            delay={1.8}
+          />
+        )}
       </div>
 
       {/* Share button */}

--- a/packages/webapp/components/log/CardWhenYouRead.tsx
+++ b/packages/webapp/components/log/CardWhenYouRead.tsx
@@ -11,6 +11,7 @@ import {
   normalizeHourDistribution,
   formatHour,
   PATTERN_BANNER_TEXT,
+  shouldShowPercentileBanner,
 } from './primitives';
 import { usePeakReadingHour } from '../../hooks/log/useLogStats';
 
@@ -75,12 +76,14 @@ export default function CardWhenYouRead({
         </motion.div>
 
         {/* Pattern stat */}
-        <TopPercentileBanner
-          preText={PATTERN_BANNER_TEXT[data.readingPattern].preText}
-          mainText={`${data.patternPercentile}%`}
-          postText={PATTERN_BANNER_TEXT[data.readingPattern].postText}
-          delay={1.4}
-        />
+        {shouldShowPercentileBanner(data.patternPercentile) && (
+          <TopPercentileBanner
+            preText={PATTERN_BANNER_TEXT[data.readingPattern].preText}
+            mainText={`${data.patternPercentile}%`}
+            postText={PATTERN_BANNER_TEXT[data.readingPattern].postText}
+            delay={1.4}
+          />
+        )}
       </div>
 
       {/* Share button - pushed to bottom with margin-top: auto */}

--- a/packages/webapp/components/log/primitives/index.ts
+++ b/packages/webapp/components/log/primitives/index.ts
@@ -30,5 +30,6 @@ export {
   PODIUM_DELAYS,
   getPodiumRank,
   findBestEngagementStat,
+  shouldShowPercentileBanner,
 } from './utils';
 export type { EngagementStat } from './utils';

--- a/packages/webapp/components/log/primitives/utils.ts
+++ b/packages/webapp/components/log/primitives/utils.ts
@@ -48,11 +48,21 @@ export const PATTERN_BANNER_TEXT: Record<
     shareText: 'Only {percentile}% of devs start this early',
   },
   afternoon: {
-    preText: 'ONLY',
-    postText: 'AT PEAK HOURS',
-    shareText: 'Only {percentile}% read during peak hours',
+    preText: 'TOP',
+    postText: 'AFTERNOON READER',
+    shareText: 'Top {percentile}% afternoon reader',
   },
 };
+
+/**
+ * Check if percentile banner should be shown
+ * Only show for users in top 50% (lower percentile = better ranking)
+ */
+export function shouldShowPercentileBanner(
+  percentile: number | null | undefined,
+): boolean {
+  return percentile != null && percentile <= 50;
+}
 
 /**
  * Podium configuration constants

--- a/packages/webapp/components/log/static/StaticCardFavoriteSources.tsx
+++ b/packages/webapp/components/log/static/StaticCardFavoriteSources.tsx
@@ -3,7 +3,11 @@ import React from 'react';
 import { EarthIcon } from '@dailydotdev/shared/src/components/icons';
 import type { LogData } from '../../../types/log';
 import styles from './StaticCards.module.css';
-import { SimpleHeadline, Podium } from '../primitives';
+import {
+  SimpleHeadline,
+  Podium,
+  shouldShowPercentileBanner,
+} from '../primitives';
 import TopPercentileBanner from '../TopPercentileBanner';
 
 interface StaticCardProps {
@@ -30,7 +34,7 @@ export default function StaticCardFavoriteSources({
 
       {/* Podium */}
       <Podium
-        sources={[data.topSources[0], data.topSources[1], data.topSources[2]]}
+        sources={data.topSources}
         animated={false}
         customStyles={{
           podiumStage: styles.podiumStage,
@@ -58,20 +62,22 @@ export default function StaticCardFavoriteSources({
       </div>
 
       {/* Competitive stat banner */}
-      <TopPercentileBanner
-        preText="TOP"
-        mainText={`${data.sourcePercentile}%`}
-        postText="EXPLORER"
-        animated={false}
-        customStyles={{
-          celebrationBanner: styles.celebrationBanner,
-          bannerBg: styles.bannerBg,
-          bannerContent: styles.bannerContent,
-          bannerPre: styles.bannerPre,
-          bannerMain: styles.bannerMain,
-          bannerPost: styles.bannerPost,
-        }}
-      />
+      {shouldShowPercentileBanner(data.sourcePercentile) && (
+        <TopPercentileBanner
+          preText="TOP"
+          mainText={`${data.sourcePercentile}%`}
+          postText="EXPLORER"
+          animated={false}
+          customStyles={{
+            celebrationBanner: styles.celebrationBanner,
+            bannerBg: styles.bannerBg,
+            bannerContent: styles.bannerContent,
+            bannerPre: styles.bannerPre,
+            bannerMain: styles.bannerMain,
+            bannerPost: styles.bannerPost,
+          }}
+        />
+      )}
     </>
   );
 }

--- a/packages/webapp/components/log/static/StaticCardShare.tsx
+++ b/packages/webapp/components/log/static/StaticCardShare.tsx
@@ -134,9 +134,10 @@ export default function StaticCardShare({
         {bestRecord && (
           <div className={styles.shareReceiptRow}>
             <span className={styles.shareReceiptLabel}>
-              {RECORDS[bestRecord.type].emoji} {bestRecord.label.toUpperCase()}
+              {RECORDS[bestRecord.type].emoji}{' '}
+              {RECORDS[bestRecord.type].defaultLabel.toUpperCase()}
             </span>
-            <span className={styles.shareReceiptValue}>{bestRecord.value}</span>
+            <span className={styles.shareReceiptValue}>{bestRecord.label}</span>
           </div>
         )}
 

--- a/packages/webapp/components/log/static/StaticCardTopicEvolution.tsx
+++ b/packages/webapp/components/log/static/StaticCardTopicEvolution.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import type { LogData } from '../../../types/log';
 import styles from './StaticCards.module.css';
+import { shouldShowPercentileBanner } from '../primitives';
 
 interface StaticCardProps {
   data: Pick<LogData, 'topicJourney' | 'uniqueTopics' | 'evolutionPercentile'>;
@@ -100,16 +101,18 @@ export default function StaticCardTopicEvolution({
       </div>
 
       {/* Competitive stat banner */}
-      <div className={styles.celebrationBanner}>
-        <div className={styles.bannerBg} />
-        <div className={styles.bannerContent}>
-          <span className={styles.bannerPre}>MORE CURIOUS THAN</span>
-          <span className={styles.bannerMain}>
-            {100 - data.evolutionPercentile}%
-          </span>
-          <span className={styles.bannerPost}>OF DEVS</span>
+      {shouldShowPercentileBanner(data.evolutionPercentile) && (
+        <div className={styles.celebrationBanner}>
+          <div className={styles.bannerBg} />
+          <div className={styles.bannerContent}>
+            <span className={styles.bannerPre}>MORE CURIOUS THAN</span>
+            <span className={styles.bannerMain}>
+              {100 - data.evolutionPercentile}%
+            </span>
+            <span className={styles.bannerPost}>OF DEVS</span>
+          </div>
         </div>
-      </div>
+      )}
     </>
   );
 }

--- a/packages/webapp/components/log/static/StaticCardTotalImpact.tsx
+++ b/packages/webapp/components/log/static/StaticCardTotalImpact.tsx
@@ -2,7 +2,12 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import type { LogData } from '../../../types/log';
 import styles from './StaticCards.module.css';
-import { HeadlineStack, StatBadgeGroup, Divider } from '../primitives';
+import {
+  HeadlineStack,
+  StatBadgeGroup,
+  Divider,
+  shouldShowPercentileBanner,
+} from '../primitives';
 import TopPercentileBanner from '../TopPercentileBanner';
 
 interface StaticCardProps {
@@ -55,20 +60,22 @@ export default function StaticCardTotalImpact({
       />
 
       {/* Competitive stat banner */}
-      <TopPercentileBanner
-        preText="Top"
-        mainText={`${data.totalImpactPercentile}%`}
-        postText="of devs"
-        animated={false}
-        customStyles={{
-          celebrationBanner: styles.celebrationBanner,
-          bannerBg: styles.bannerBg,
-          bannerContent: styles.bannerContent,
-          bannerPre: styles.bannerPre,
-          bannerMain: styles.bannerMain,
-          bannerPost: styles.bannerPost,
-        }}
-      />
+      {shouldShowPercentileBanner(data.totalImpactPercentile) && (
+        <TopPercentileBanner
+          preText="Top"
+          mainText={`${data.totalImpactPercentile}%`}
+          postText="of devs"
+          animated={false}
+          customStyles={{
+            celebrationBanner: styles.celebrationBanner,
+            bannerBg: styles.bannerBg,
+            bannerContent: styles.bannerContent,
+            bannerPre: styles.bannerPre,
+            bannerMain: styles.bannerMain,
+            bannerPost: styles.bannerPost,
+          }}
+        />
+      )}
     </>
   );
 }

--- a/packages/webapp/components/log/static/StaticCardWhenYouRead.tsx
+++ b/packages/webapp/components/log/static/StaticCardWhenYouRead.tsx
@@ -7,6 +7,7 @@ import {
   SimpleHeadline,
   normalizeHourDistribution,
   PATTERN_BANNER_TEXT,
+  shouldShowPercentileBanner,
 } from '../primitives';
 import TopPercentileBanner from '../TopPercentileBanner';
 import { getPeakReadingHour } from '../../../hooks/log/useLogStats';
@@ -77,20 +78,22 @@ export default function StaticCardWhenYouRead({
       </div>
 
       {/* Competitive stat banner */}
-      <TopPercentileBanner
-        preText={PATTERN_BANNER_TEXT[data.readingPattern].preText}
-        mainText={`${data.patternPercentile}%`}
-        postText={PATTERN_BANNER_TEXT[data.readingPattern].postText}
-        animated={false}
-        customStyles={{
-          celebrationBanner: styles.celebrationBanner,
-          bannerBg: styles.bannerBg,
-          bannerContent: styles.bannerContent,
-          bannerPre: styles.bannerPre,
-          bannerMain: styles.bannerMain,
-          bannerPost: styles.bannerPost,
-        }}
-      />
+      {shouldShowPercentileBanner(data.patternPercentile) && (
+        <TopPercentileBanner
+          preText={PATTERN_BANNER_TEXT[data.readingPattern].preText}
+          mainText={`${data.patternPercentile}%`}
+          postText={PATTERN_BANNER_TEXT[data.readingPattern].postText}
+          animated={false}
+          customStyles={{
+            celebrationBanner: styles.celebrationBanner,
+            bannerBg: styles.bannerBg,
+            bannerContent: styles.bannerContent,
+            bannerPre: styles.bannerPre,
+            bannerMain: styles.bannerMain,
+            bannerPost: styles.bannerPost,
+          }}
+        />
+      )}
     </>
   );
 }

--- a/packages/webapp/pages/log/index.tsx
+++ b/packages/webapp/pages/log/index.tsx
@@ -128,8 +128,17 @@ export default function LogPage(): ReactElement {
         subcards: (data?.topicJourney?.length ?? 1) - 1,
       },
       { id: 'favorite-sources', component: CardFavoriteSources },
-      { id: 'community', component: CardCommunityEngagement },
     ];
+
+    // Only include community card if user has any interactions
+    const hasInteractions =
+      (data?.upvotesGiven ?? 0) +
+        (data?.commentsWritten ?? 0) +
+        (data?.postsBookmarked ?? 0) >
+      0;
+    if (hasInteractions) {
+      baseCards.push({ id: 'community', component: CardCommunityEngagement });
+    }
 
     if (data?.hasContributions) {
       baseCards.push({
@@ -145,7 +154,13 @@ export default function LogPage(): ReactElement {
     );
 
     return baseCards;
-  }, [data?.hasContributions, data?.topicJourney?.length]);
+  }, [
+    data?.hasContributions,
+    data?.topicJourney?.length,
+    data?.upvotesGiven,
+    data?.commentsWritten,
+    data?.postsBookmarked,
+  ]);
 
   // Ref for navigation callback to avoid circular dependency with useCardNavigation
   const onNavigateRef = useRef<(event: NavigationEvent) => void>(() => {});


### PR DESCRIPTION
- Added `shouldShowPercentileBanner` utility to conditionally render competitive stat banners based on percentile.
- Updated `Podium` component to support dynamic number of top sources (1-3 items).
- Refined percentile share text for clarity and alignment (`Top {percentile}%`).
- Applied condition-based rendering to multiple cards to improve UX.

### Preview domain
https://log-fixes.preview.app.daily.dev