### PR TITLE
fix: opportuntity state

### DIFF
--- a/packages/shared/src/features/recruiter/hooks/useOpportunityAcceptanceHandlers.ts
+++ b/packages/shared/src/features/recruiter/hooks/useOpportunityAcceptanceHandlers.ts
@@ -19,6 +19,7 @@ export const useOpportunityAcceptanceHandlers = ({
   onSaveAnswers,
   onLogAnswer,
   onLogExperienceLevel,
+  onComplete,
   initialExperienceLevel,
   initialLocationId,
 }: {
@@ -37,6 +38,7 @@ export const useOpportunityAcceptanceHandlers = ({
   onLogExperienceLevel?: (
     experienceLevel: keyof typeof UserExperienceLevel,
   ) => void;
+  onComplete?: () => void;
   initialExperienceLevel?: keyof typeof UserExperienceLevel;
   initialLocationId?: string;
 }) => {
@@ -83,6 +85,7 @@ export const useOpportunityAcceptanceHandlers = ({
       case AcceptStep.CV:
         if (questions.length > 0) {
           goToLastQuestion();
+          setCurrentStep(AcceptStep.QUESTIONS);
         } else {
           setCurrentStep(AcceptStep.EXPERIENCE_LEVEL);
         }
@@ -130,6 +133,9 @@ export const useOpportunityAcceptanceHandlers = ({
           setCurrentStep(AcceptStep.QUESTIONS);
         } else if (!hasUploadedCV) {
           setCurrentStep(AcceptStep.CV);
+        } else {
+          // Experience level is the last step, complete the flow
+          onComplete?.();
         }
       },
     });
@@ -140,6 +146,7 @@ export const useOpportunityAcceptanceHandlers = ({
     questions.length,
     hasUploadedCV,
     setCurrentStep,
+    onComplete,
   ]);
 
   const handleNext = useCallback(() => {

--- a/packages/webapp/pages/jobs/[id]/questions.tsx
+++ b/packages/webapp/pages/jobs/[id]/questions.tsx
@@ -198,6 +198,7 @@ const AcceptPage = (): ReactElement => {
         }),
       });
     },
+    onComplete: acceptOpportunity,
     initialExperienceLevel: user?.experienceLevel,
     initialLocationId: candidatePreferences?.externalLocationId,
   });


### PR DESCRIPTION
## Changes

Several improvements to question flow.

New test:
<img width="1081" height="556" alt="Screenshot 2026-01-09 at 09 59 57" src="https://github.com/user-attachments/assets/f323df70-27f6-498f-bc3e-4a60f95cda8d" />


## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://fix-opportunity-state.preview.app.daily.dev