### PR TITLE
fix: add fallback for breadcrumb name to fix SEO validation error

### DIFF
--- a/packages/webapp/components/PostSEOSchema.tsx
+++ b/packages/webapp/components/PostSEOSchema.tsx
@@ -149,8 +149,7 @@ export const getBreadcrumbJsonLd = (post: Post): string => {
       {
         '@type': 'ListItem',
         position: 3,
-        name: post.title,
-        item: post.commentsPermalink,
+        name: post.title || post.sharedPost?.title || 'Post',
       },
     ],
   });


### PR DESCRIPTION
## Summary
- Fixed Google Search Console error: "Either name or item.name should be specified (in itemListElement)"
- Added fallback chain for the breadcrumb name property when `post.title` is undefined
- Removed `item` property from last breadcrumb per Google's recommendation (not required for the final item)

## Test plan
- [x] Verify breadcrumb JSON-LD output includes `name` for all three items
- [x] Validate with Google's Rich Results Test tool

### Preview domain
https://fix-breadcrumb-seo-missing-name.preview.app.daily.dev