### PR TITLE
fix: remove flex from promoted text to fix scrambler concatenation

### DIFF
--- a/packages/shared/src/components/comments/AdAsComment.tsx
+++ b/packages/shared/src/components/comments/AdAsComment.tsx
@@ -99,7 +99,7 @@ export const AdAsComment = ({ postId }: AdAsCommentProps): ReactElement => {
         <TruncateText className="commentAuthor flex w-fit font-bold text-text-primary typo-callout">
           {company}
         </TruncateText>
-        <TruncateText className="flex w-fit text-text-quaternary typo-callout">
+        <TruncateText className="text-text-quaternary typo-callout">
           {promotedText}
         </TruncateText>
       </div>


### PR DESCRIPTION
The useScrambler hook returns an array of spans and strings for ad text obfuscation. When displayed in a flex container, each element became a separate flex item causing visual gaps between characters.

### Preview domain
https://claude-slack-fix-promoted-concat.preview.app.daily.dev