### PR TITLE
feat(recruiter): support url query param for analyze page

### DIFF
--- a/packages/webapp/pages/recruiter/[opportunityId]/analyze.tsx
+++ b/packages/webapp/pages/recruiter/[opportunityId]/analyze.tsx
@@ -47,6 +47,7 @@ const useNewOpportunityParser = (): UseNewOpportunityParserResult => {
   const [parsingComplete, setParsingComplete] = useState(false);
 
   const opportunityId = router.query.opportunityId as string;
+  const urlQueryParam = router.query.url as string | undefined;
   const isNewSubmission = opportunityId === 'new';
 
   const { mutate: parseOpportunity, isPending } = useMutation({
@@ -90,6 +91,14 @@ const useNewOpportunityParser = (): UseNewOpportunityParserResult => {
       return;
     }
 
+    // Support URL from query param (e.g., /recruiter/new/analyze?url=https://...)
+    if (urlQueryParam) {
+      hasStartedParsing.current = true;
+      parseOpportunity({ url: urlQueryParam });
+      return;
+    }
+
+    // Fall back to pending submission from context
     if (!pendingSubmission) {
       router.push(`/recruiter?openModal=joblink`);
       return;
@@ -102,7 +111,13 @@ const useNewOpportunityParser = (): UseNewOpportunityParserResult => {
     } else {
       parseOpportunity({ file: pendingSubmission.file });
     }
-  }, [isNewSubmission, pendingSubmission, parseOpportunity, router]);
+  }, [
+    isNewSubmission,
+    urlQueryParam,
+    pendingSubmission,
+    parseOpportunity,
+    router,
+  ]);
 
   // Consider parsing in progress if:
   // 1. The mutation is currently pending, OR


### PR DESCRIPTION
## Summary
- Support passing a job URL directly via query parameter when `opportunityId` is "new"
- Allows direct linking to analyze page, e.g., `/recruiter/new/analyze?url=https://example.com/job`
- Falls back to existing pending submission context behavior when no URL query param is provided

## Test plan
- [ ] Navigate to `/recruiter/new/analyze?url=<valid-job-url>` and verify the URL is parsed
- [ ] Navigate to `/recruiter/new/analyze` without query param and verify it uses pending submission context
- [ ] Navigate to `/recruiter/new/analyze` without query param or context and verify redirect to `/recruiter?openModal=joblink`

### Preview domain
https://analyze-url.preview.app.daily.dev