### PR TITLE
fix: remove double scroller from language dropdown

### DIFF
--- a/packages/shared/src/components/profile/LanguageDropdown.tsx
+++ b/packages/shared/src/components/profile/LanguageDropdown.tsx
@@ -80,10 +80,7 @@ export const LanguageDropdown = ({
               '!shadow-[inset_0.125rem_0_0_var(--status-error)]',
             selectedIndex > 0 && '!text-text-primary',
           ),
-          menu: classNames(
-            menuClassName,
-            'menu-primary max-h-[15.375rem] overflow-y-auto p-1',
-          ), // fit 6 items
+          menu: menuClassName,
           item: classNames(itemClassName, '*:min-h-10 *:!typo-callout'),
           container: dropdownClassName,
         }}


### PR DESCRIPTION
## Changes

Fixes the double scrollbar on language dropdown.

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="353" height="389" alt="image" src="https://github.com/user-attachments/assets/d0b6b693-02cf-4f03-b3a8-1075eb91e54f" />
    <td><img width="358" height="437" alt="image" src="https://github.com/user-attachments/assets/7d0b8f3f-a49d-4585-baa6-7d1da221c789" />
  </tr>
</table>

### Preview domain
https://fix-double-language-scroller.preview.app.daily.dev