### PR TITLE
fix: apply `hidden-scrollbar` to body when opening briefing modal

### DIFF
--- a/packages/webapp/pages/briefing/index.tsx
+++ b/packages/webapp/pages/briefing/index.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent, ReactElement } from 'react';
-import React from 'react';
+import React, { useEffect } from 'react';
 import type { NextSeoProps } from 'next-seo';
 
 import {
@@ -114,6 +114,8 @@ const Page = (): ReactElement => {
       return;
     }
 
+    document.body.classList.add('hidden-scrollbar');
+
     event.preventDefault();
 
     onOpenModal(briefIndex);
@@ -129,6 +131,18 @@ const Page = (): ReactElement => {
     firstBrief &&
     'post' in firstBrief &&
     new Date(firstBrief.post.createdAt) >= todayTime;
+
+  useEffect(() => {
+    return () => {
+      document.body.classList.remove('hidden-scrollbar');
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedPost) {
+      document.body.classList.remove('hidden-scrollbar');
+    }
+  }, [selectedPost]);
 
   if (!isActionsFetched) {
     return null;


### PR DESCRIPTION
## Changes

Because of #5326 double scrollbars now appeared

This mimicks post modal on feed, where it does the exact same thing.

### Preview domain
https://fix-briefing-modal-double-scroll.preview.app.daily.dev