### PR TITLE
fix: only render notification link of it has targetUrl

### DIFF
--- a/packages/shared/src/components/notifications/NotificationItem.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.tsx
@@ -214,7 +214,7 @@ function NotificationItem(props: NotificationItemProps): ReactElement {
         isUnread && 'bg-surface-float',
       )}
     >
-      {renderLink && (
+      {renderLink && targetUrl && (
         <Link href={targetUrl} passHref>
           <a
             role="link"


### PR DESCRIPTION
## Changes

Fixed the squad member joined notification, so that when welcome post is deleted, we don't link to it. So this makes sure that it handles when a notification have no link.

### API PR
https://github.com/dailydotdev/daily-api/pull/3466

### Preview domain
https://fix-notification-link.preview.app.daily.dev