### PR TITLE
fix: post bookmark reminder

### DIFF
--- a/packages/shared/src/components/cards/Freeform/FreeformGrid.tsx
+++ b/packages/shared/src/components/cards/Freeform/FreeformGrid.tsx
@@ -57,11 +57,11 @@ export const FreeformGrid = forwardRef(function SharePostCard(
         onPostCardClick={onPostCardClick}
         onPostCardAuxClick={onPostCardAuxClick}
       />
-      <SquadPostCardHeader
-        post={post}
-        enableSourceHeader={enableSourceHeader}
-      />
       <CardTextContainer>
+        <SquadPostCardHeader
+          post={post}
+          enableSourceHeader={enableSourceHeader}
+        />
         <FreeformCardTitle
           className={classNames(
             generateTitleClamp({

--- a/packages/shared/src/components/cards/collection/CollectionCardHeader.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionCardHeader.tsx
@@ -29,11 +29,7 @@ export const CollectionCardHeader = ({
 
   return (
     <>
-      {highlightBookmarkedPost && (
-        <BookmakProviderHeader
-          className={classNames('relative my-1 flex h-10 py-2')}
-        />
-      )}
+      {highlightBookmarkedPost && <BookmakProviderHeader />}
       <CollectionPillSources
         className={{
           main: classNames(

--- a/packages/shared/src/components/cards/common/BookmarkProviderHeader.tsx
+++ b/packages/shared/src/components/cards/common/BookmarkProviderHeader.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import { CardHeader } from './Card';
 import { BookmarkIcon } from '../../icons';
+import type { WithClassNameProps } from '../../utilities';
 
 export const bookmarkProviderText = 'Revisit this post you saved earlier?';
 export const bookmarkProviderIcon = <BookmarkIcon secondary className="mx-1" />;
@@ -13,18 +14,11 @@ const bookmarkProviderMouseClassName =
 export const headerHiddenClassName =
   'laptop:mouse:invisible laptop:mouse:group-hover:visible';
 
-interface BookmakProviderHeaderProps {
-  className: string;
-  isArticleCard?: boolean;
-}
-
 export const BookmakProviderHeader = ({
   className,
-  isArticleCard = false,
-}: BookmakProviderHeaderProps): ReactElement => {
-  const Component = isArticleCard ? CardHeader : 'div';
+}: WithClassNameProps): ReactElement => {
   return (
-    <Component
+    <CardHeader
       className={classNames(
         className,
         bookmarkProviderMouseClassName,
@@ -33,6 +27,6 @@ export const BookmakProviderHeader = ({
     >
       {bookmarkProviderIcon}
       {bookmarkProviderText}
-    </Component>
+    </CardHeader>
   );
 };

--- a/packages/shared/src/components/cards/common/PostCardHeader.tsx
+++ b/packages/shared/src/components/cards/common/PostCardHeader.tsx
@@ -82,9 +82,7 @@ export const PostCardHeader = ({
 
   return (
     <>
-      {highlightBookmarkedPost && (
-        <BookmakProviderHeader className={className} isArticleCard />
-      )}
+      {highlightBookmarkedPost && <BookmakProviderHeader />}
       <CardHeader
         className={classNames(
           className,

--- a/packages/shared/src/components/cards/common/SquadPostCardHeader.tsx
+++ b/packages/shared/src/components/cards/common/SquadPostCardHeader.tsx
@@ -38,18 +38,10 @@ export const SquadPostCardHeader = ({
 
   return (
     <>
-      {highlightBookmarkedPost && (
-        <BookmakProviderHeader
-          className={classNames(
-            'relative my-2 flex py-2',
-            enableSourceHeader ? 'h-10' : 'h-12',
-          )}
-        />
-      )}
+      {highlightBookmarkedPost && <BookmakProviderHeader />}
       <div
         className={classNames(
-          'mx-4 mt-4',
-          'relative m-2 flex gap-2',
+          'mb-2 mt-4',
           highlightBookmarkedPost && headerHiddenClassName,
         )}
       >

--- a/packages/shared/src/components/cards/common/list/PostCardHeader.tsx
+++ b/packages/shared/src/components/cards/common/list/PostCardHeader.tsx
@@ -67,9 +67,7 @@ export const PostCardHeader = ({
 
   return (
     <>
-      {highlightBookmarkedPost && (
-        <BookmakProviderHeader className={classNames(className, 'mb-4')} />
-      )}
+      {highlightBookmarkedPost && <BookmakProviderHeader className="mb-4" />}
       <CardHeader className={className}>
         {children}
         {!!post?.author && (


### PR DESCRIPTION
## Changes

Fixes the post bookmark reminder. It was broken for freeform and collection posts.
Also cleaned up some redundant css classes.

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="1484" height="978" alt="image" src="https://github.com/user-attachments/assets/84114013-0881-494b-a1f9-1ecabc7db12c" />
    <td><img width="1484" height="948" alt="image" src="https://github.com/user-attachments/assets/cab49c1b-70e0-414c-8ffc-91cc09eade64" />
  </tr>
</table>

Closes https://github.com/dailydotdev/daily/issues/2042

### Preview domain
https://fix-bookmark-reminder-post.preview.app.daily.dev