### PR TITLE
fix: make the user stack item spacing more visually even

### DIFF
--- a/packages/shared/src/features/profile/components/stack/UserStackItem.tsx
+++ b/packages/shared/src/features/profile/components/stack/UserStackItem.tsx
@@ -41,7 +41,7 @@ export function UserStackItem({
   return (
     <div
       className={classNames(
-        'group relative flex items-center justify-between gap-3 rounded-12 border border-border-subtlest-tertiary p-3',
+        'group relative flex items-center justify-between gap-3 rounded-12 border border-border-subtlest-tertiary px-3 pb-2.5 pt-2',
         'hover:border-border-subtlest-secondary',
       )}
     >


### PR DESCRIPTION
## Changes

Makes the user stack items vertical padding more visually even

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="473" height="170" alt="image" src="https://github.com/user-attachments/assets/d5ca0f35-4504-4f15-a4e7-54ae5feba733" />
    <td><img width="473" height="164" alt="image" src="https://github.com/user-attachments/assets/9156df42-def7-4f70-ac7e-7e9ee8c41f8c" />
  </tr>
</table>

### Preview domain
https://fix-stack-spacing.preview.app.daily.dev