### PR TITLE
fix(a11y): prevent profile tooltip from opening on keyboard focus

### DIFF
--- a/packages/shared/src/components/profile/ProfileTooltip.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltip.spec.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ProfileTooltip } from './ProfileTooltip';
+import { AuthContextProvider } from '../../contexts/AuthContext';
+import loggedUser from '../../../__tests__/fixture/loggedUser';
+
+const createWrapper = () => {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <AuthContextProvider
+          user={loggedUser}
+          updateUser={jest.fn()}
+          getRedirectUri={jest.fn()}
+          tokenRefreshed
+        >
+          {children}
+        </AuthContextProvider>
+      </QueryClientProvider>
+    );
+  };
+};
+
+describe('ProfileTooltip', () => {
+  describe('Accessibility', () => {
+    it('should not open tooltip on keyboard focus (WCAG 3.2.1)', async () => {
+      const user = userEvent.setup();
+      
+      render(
+        <ProfileTooltip userId="user-123">
+          <button data-testid="trigger-button">User Profile</button>
+        </ProfileTooltip>,
+        { wrapper: createWrapper() },
+      );
+
+      const triggerButton = screen.getByTestId('trigger-button');
+      
+      // Focus the button via keyboard (Tab)
+      await user.tab();
+      
+      // The button should be focused
+      expect(triggerButton).toHaveFocus();
+      
+      // But the tooltip should NOT be visible
+      // Tippy creates tooltip content in a separate portal
+      // If tooltip opened, it would contain UserEntityCard content
+      expect(screen.queryByTestId('user-entity-card')).not.toBeInTheDocument();
+    });
+
+    it('should render children correctly', () => {
+      render(
+        <ProfileTooltip userId="user-123">
+          <button>User Profile</button>
+        </ProfileTooltip>,
+        { wrapper: createWrapper() },
+      );
+
+      expect(screen.getByRole('button', { name: 'User Profile' })).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/shared/src/components/profile/ProfileTooltip.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltip.tsx
@@ -122,6 +122,9 @@ export function ProfileTooltip({
     content: !isLoading && data ? <UserEntityCard user={data} /> : null,
     plugins:
       onTooltipMouseEnter || onTooltipMouseLeave ? [hoverPlugin] : undefined,
+    // Only trigger on mouseenter, not focus - fixes WCAG 2.1 On Focus (3.2.1)
+    // Focus should highlight the element, not open a popup
+    trigger: 'mouseenter',
     ...tooltip,
     onShow: (instance) => {
       if (id !== userId) {


### PR DESCRIPTION
## Summary
The profile card popup was opening automatically when navigating with keyboard (Tab), which violates **WCAG 2.1 On Focus (3.2.1)** guideline.

> Elements should not trigger context changes on focus.

## Changes
- Added `trigger='mouseenter'` to ProfileTooltip props
- This ensures the tooltip only opens on mouse hover, not keyboard focus
- Focus now correctly highlights the element without opening the popup

## Before
Tab to profile card → popup opens automatically ❌

## After
Tab to profile card → element is focused/highlighted, popup stays closed ✅
Hover over profile card → popup opens as expected ✅

## Test
Added unit test to verify tooltip doesn't open on keyboard focus.

## References
- [WCAG 2.1 – On Focus (3.2.1)](https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html)

Fixes dailydotdev/daily#1949

### Preview domain
https://fix-a11y-profile-card-focus-1949.preview.app.daily.dev