### PR TITLE
fix: ensure same font in new tab as on webapp

### DIFF
--- a/packages/extension/views/newtab.html
+++ b/packages/extension/views/newtab.html
@@ -10,7 +10,7 @@
   <link rel="preconnect" href="https://sso.daily.dev" />
   <link rel="preconnect" href="https://media.daily.dev" />
 </head>
-<body>
+<body class="font-sans">
 <noscript>
   <strong>We're sorry but extension doesn't work properly without JavaScript
     enabled. Please enable it to


### PR DESCRIPTION
## Changes

Fixes the missing font on webapp. Basically the issue is that the root font is set via `html`, and there's a default injected font-family style on `body` which takes presidence over `html`. Easiest fix is to just add `font-sans` to `body` in newtab.html.

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="1280" height="705" alt="image" src="https://github.com/user-attachments/assets/46667b9c-1334-4c22-be0f-7205b42c9211" />
    <td><img width="1280" height="705" alt="image" src="https://github.com/user-attachments/assets/d45cf070-eb57-4c21-9570-9c84feac9c6e" />
  </tr>
</table>

### Preview domain
https://fix-font-extension.preview.app.daily.dev