### PR TITLE
feat(theme): update default background colors

### DIFF
--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -44,7 +44,7 @@ body {
 
 @define-mixin dark-mode {
   /* Background colors */
-  --theme-background-default: theme('colors.raw.pepper.90');
+  --theme-background-default: theme('colors.raw.pepper.80');
   --theme-background-subtle: theme('colors.raw.pepper.70');
   --theme-background-popover: theme('colors.raw.pepper.70');
   --theme-background-post-post: theme('colors.raw.pepper.70');
@@ -331,7 +331,7 @@ body {
 
 @define-mixin light-mode {
   /* Background colors */
-  --theme-background-default: theme('colors.raw.salt.0');
+  --theme-background-default: theme('colors.raw.salt.10');
   --theme-background-subtle: theme('colors.raw.salt.10');
   --theme-background-popover: theme('colors.raw.salt.0');
   --theme-background-post-post: theme('colors.raw.salt.10');


### PR DESCRIPTION
## Summary
Updates the default background colors for both dark and light modes to improve visual hierarchy and contrast.

## Changes
- **Dark mode**: Changed default background from `pepper.90` to `pepper.80` (lighter)
- **Light mode**: Changed default background from `salt.0` to `salt.10` (slightly darker)

Closes ENG-447

### Preview domain
https://eng-447-change-home-page-backgro.preview.app.daily.dev