### PR TITLE
feat: allow system moderators to promote squad members

### DIFF
--- a/packages/shared/src/components/squads/SquadMemberMenu.tsx
+++ b/packages/shared/src/components/squads/SquadMemberMenu.tsx
@@ -28,6 +28,7 @@ import {
 import { LazyModal } from '../modals/common/types';
 import { useLazyModal } from '../../hooks/useLazyModal';
 import { LogEvent, TargetId } from '../../lib/log';
+import { Roles } from '../../lib/user';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -193,10 +194,10 @@ export default function SquadMemberMenu({
       (role: SourceMemberRole, title: MenuItemTitle) => () =>
         onUpdateMember(role, title);
     const menu: MenuItemProps[] = [];
-    const canUpdateRole = verifyPermission(
-      squad,
-      SourcePermissions.MemberRoleUpdate,
-    );
+    const isSystemModerator = user?.roles?.includes(Roles.Moderator);
+    const canUpdateRole =
+      isSystemModerator ||
+      verifyPermission(squad, SourcePermissions.MemberRoleUpdate);
 
     if (canUpdateRole) {
       const memberOptions = getUpdateRoleOptions(member, getUpdateRoleFn);


### PR DESCRIPTION
## Summary

Allow system moderators to update squad member roles, giving them the same role management capabilities as squad admins for member promotion/demotion.

## Changes

- Added check for system moderator role (`Roles.Moderator`) in `SquadMemberMenu`
- System moderators can now see and use role update options for squad members regardless of squad-level permissions

Closes ENG-454

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-454-allow-sys-admin-to-promo.preview.app.daily.dev