### PR TITLE
fix: show squad member options for system moderators

### DIFF
--- a/packages/shared/src/components/modals/SquadMemberModal.tsx
+++ b/packages/shared/src/components/modals/SquadMemberModal.tsx
@@ -4,6 +4,8 @@ import type { ModalProps } from './common/Modal';
 import { Modal } from './common/Modal';
 import type { Squad } from '../../graphql/sources';
 import { SourceMemberRole, SourcePermissions } from '../../graphql/sources';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { isSystemModerator } from '../../lib/user';
 import UserListModal from './UserListModal';
 import { checkFetchMore } from '../containers/InfiniteScrolling';
 import { Origin } from '../../lib/log';
@@ -61,6 +63,7 @@ export function SquadMemberModal({
   squad,
   ...props
 }: SquadMemberModalProps): ReactElement {
+  const { user: loggedUser } = useAuthContext();
   const [roleFilter, setRoleFilter] = useState<SourceMemberRole>(null);
   const [query, setQuery] = useState('');
   const [handleSearchDebounce] = useDebounceFn(
@@ -85,10 +88,9 @@ export function SquadMemberModal({
     queryProp: 'sourceMembers',
   });
 
-  const hasPermission = verifyPermission(
-    squad,
-    SourcePermissions.ViewBlockedMembers,
-  );
+  const hasPermission =
+    isSystemModerator(loggedUser) ||
+    verifyPermission(squad, SourcePermissions.ViewBlockedMembers);
 
   const onTabClick = (tab: SquadMemberTab) => {
     switch (tab) {

--- a/packages/shared/src/components/squads/SquadMemberMenu.tsx
+++ b/packages/shared/src/components/squads/SquadMemberMenu.tsx
@@ -28,7 +28,7 @@ import {
 import { LazyModal } from '../modals/common/types';
 import { useLazyModal } from '../../hooks/useLazyModal';
 import { LogEvent, TargetId } from '../../lib/log';
-import { Roles } from '../../lib/user';
+import { isSystemModerator } from '../../lib/user';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -194,9 +194,8 @@ export default function SquadMemberMenu({
       (role: SourceMemberRole, title: MenuItemTitle) => () =>
         onUpdateMember(role, title);
     const menu: MenuItemProps[] = [];
-    const isSystemModerator = user?.roles?.includes(Roles.Moderator);
     const canUpdateRole =
-      isSystemModerator ||
+      isSystemModerator(user) ||
       verifyPermission(squad, SourcePermissions.MemberRoleUpdate);
 
     if (canUpdateRole) {

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -17,6 +17,10 @@ export enum Roles {
   Moderator = 'moderator',
 }
 
+export const isSystemModerator = (user?: { roles?: Roles[] }): boolean => {
+  return user?.roles?.includes(Roles.Moderator) ?? false;
+};
+
 export interface UserSocialLink {
   platform: string;
   url: string;


### PR DESCRIPTION
## Problem

The three-dots options button in the squad members modal was not showing for system moderators who are not members of the squad.

## Root Cause

In `SquadMemberModal.tsx`, the `hasPermission` variable that controls whether the options button renders was only checking for `ViewBlockedMembers` squad permission. System moderators don't have this squad-specific permission unless they're members.

## Solution

1. **Added `isSystemModerator()` helper** in `lib/user.ts`:
```typescript
export const isSystemModerator = (user?: {
  roles?: Roles[];
}): boolean => {
  return user?.roles?.includes(Roles.Moderator) ?? false;
};
```

2. **Updated `SquadMemberModal.tsx`** to use the helper for showing the options button

3. **Refactored `SquadMemberMenu.tsx`** to use the same helper (was previously using inline check from #5372)

## Testing

1. Log in as a system moderator who is not a member of a squad
2. Navigate to the squad page
3. Open the members panel
4. Verify the three-dots options button now appears for each member
5. Verify promote/demote actions work correctly

### Preview domain
https://fix-system-mod-squad-member-opti.preview.app.daily.dev