### PR TITLE
fix: disable refetchOnWindowFocus for recruiter matches page queries

### DIFF
--- a/packages/webapp/pages/recruiter/opportunities/[id].tsx
+++ b/packages/webapp/pages/recruiter/opportunities/[id].tsx
@@ -12,6 +12,7 @@ import {
   recruiterRejectOpportunityMatchMutationOptions,
 } from '@dailydotdev/shared/src/features/opportunity/mutations';
 import { RequestKey } from '@dailydotdev/shared/src/lib/query';
+import { disabledRefetch } from '@dailydotdev/shared/src/lib/func';
 import type { OpportunityMatch } from '@dailydotdev/shared/src/features/opportunity/types';
 import { OpportunityMatchStatus } from '@dailydotdev/shared/src/features/opportunity/types';
 import { OpportunityState } from '@dailydotdev/shared/src/features/opportunity/protobuf/opportunity';
@@ -311,7 +312,7 @@ const OpportunityDetailPage = (): ReactElement => {
   // Fetch opportunity details
   const { data: opportunity, isLoading: isLoadingOpportunity } = useQuery({
     ...opportunityByIdOptions({ id: id as string }),
-    refetchOnWindowFocus: false,
+    ...disabledRefetch,
   });
 
   // Require payment to view this page
@@ -325,7 +326,7 @@ const OpportunityDetailPage = (): ReactElement => {
   // Fetch opportunity matches
   const { data: matchesData, isLoading: isLoadingMatches } = useQuery({
     ...getOpportunityMatchesOptions({ opportunityId: id as string }),
-    refetchOnWindowFocus: false,
+    ...disabledRefetch,
   });
 
   const matches = matchesData?.edges.map((edge) => edge.node) || [];


### PR DESCRIPTION
## Summary
Fixes an issue where the recruiter job page would lose context when a tab was left open and the user returned to it. The page was refetching data on window focus, causing the UI state to reset unexpectedly.

## Changes
- Disabled `refetchOnWindowFocus` for the opportunity details query on the recruiter opportunities page
- Disabled `refetchOnWindowFocus` for the opportunity matches query on the recruiter opportunities page

This prevents TanStack Query from automatically refetching data when the browser tab regains focus, preserving the user's current context and UI state.

Closes ENG-461

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-461-recruiter-job-page-loses.preview.app.daily.dev