### PR TITLE
fix: use replace instead of push to not spam history when toggling profile preview

### DIFF
--- a/packages/shared/src/hooks/profile/useProfilePreview.ts
+++ b/packages/shared/src/hooks/profile/useProfilePreview.ts
@@ -35,7 +35,7 @@ export function useProfilePreview(
     } else {
       newQuery.preview = 'true';
     }
-    router.push(
+    router.replace(
       {
         pathname: router.pathname,
         query: newQuery,


### PR DESCRIPTION
## Changes

Use replace instead of push to prevent spamming history when toggling profile preview.

### Preview domain
https://fix-replace-not-push-preview.preview.app.daily.dev