### PR TITLE
fix: correct read state on card title

### DIFF
--- a/packages/shared/src/components/cards/common/Card.tsx
+++ b/packages/shared/src/components/cards/common/Card.tsx
@@ -33,10 +33,7 @@ const Title = ({
   );
 };
 
-export const FreeformCardTitle = classed(
-  'h3',
-  'mt-2 break-words multi-truncate font-bold typo-title3',
-);
+export const FreeformCardTitle = classed(Title, 'mt-2 break-words');
 
 export const CardTitle = classed(Title, 'mt-2 break-words');
 


### PR DESCRIPTION
## Changes

Fixes the card title for freeform and collection cards so that they have the proper read state.

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="1442" height="910" alt="image" src="https://github.com/user-attachments/assets/5bc10d01-0aac-41e9-a1be-c30ed1ae4dc5" />
    <td><img width="1442" height="910" alt="image" src="https://github.com/user-attachments/assets/5ee1ad8a-9a35-4c1c-b64d-6d1ccda81eb5" />
  </tr>
</table>

### Preview domain
https://fix-card-read.preview.app.daily.dev