### PR TITLE
fix: lock background scroll when modals are open

### DIFF
--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -11,6 +11,10 @@ body {
   /* mobile viewport bug fix */
   min-height: stretch;
 
+  &.ReactModal__Body--open {
+    overflow: hidden;
+  }
+
   &.ReactModal__Body--open .ReactModal__Content,
   &.ReactModal__Body--open .ReactModal__Content > * {
     overscroll-behavior-y: none;


### PR DESCRIPTION
## Summary
- Add `overflow: hidden` to body when modals are open to prevent background page scrolling
- Uses the existing `ReactModal__Body--open` class that react-modal applies automatically

Closes ENG-459

Created by Huginn 🐦‍⬛

### Preview domain
https://eng-459-lock-scroll-when-profile.preview.app.daily.dev