### PR TITLE
fix: restore justify-between spacing for list variant ActionButtons

### DIFF
--- a/packages/shared/src/components/cards/common/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/common/ActionButtons.tsx
@@ -147,12 +147,7 @@ const ActionButtons = ({
         className,
       )}
     >
-      <div
-        className={classNames(
-          'flex items-center',
-          variant === 'grid' && 'flex-1 justify-between',
-        )}
-      >
+      <div className="flex flex-1 items-center justify-between">
         <Tooltip
           content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
           side={variant === 'grid' ? 'bottom' : undefined}


### PR DESCRIPTION
The card refactor in commit 277364c consolidated grid and list ActionButtons into a single component but lost the justify-between class for the list variant, causing engagement buttons to be squeezed together on mobile (iOS) where list layout is used.

https://claude.ai/code/session_019itBL149wEbuFBkFK9vvvF

## Changes

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->


### Preview domain
https://claude-slack-find-regression-com.preview.app.daily.dev