### PR TITLE
fix(profile): invalidate profile cache when experience is saved/deleted

### DIFF
--- a/packages/shared/src/hooks/useRemoveExperience.ts
+++ b/packages/shared/src/hooks/useRemoveExperience.ts
@@ -6,6 +6,7 @@ import { useToastNotification } from './useToastNotification';
 import { labels } from '../lib/labels';
 import { webappUrl } from '../lib/constants';
 import { useUserExperiencesByType } from '../features/profile/hooks/useUserExperiencesByType';
+import { generateQueryKey, RequestKey } from '../lib/query';
 import { useAuthContext } from '../contexts/AuthContext';
 import { useLogContext } from '../contexts/LogContext';
 import { LogEvent } from '../lib/log';
@@ -30,6 +31,10 @@ const useRemoveExperience = ({ type }: { type: UserExperienceType }) => {
       });
       router.push(`${webappUrl}settings/profile/experience/${type}`);
       qc.invalidateQueries({ queryKey: experienceQueryKey });
+      qc.invalidateQueries({
+        queryKey: generateQueryKey(RequestKey.UserExperience, user, 'profile'),
+        exact: false,
+      });
     },
     onError: () => {
       displayToast(labels.error.generic || 'Failed to delete experience');

--- a/packages/shared/src/hooks/useUserExperienceForm.ts
+++ b/packages/shared/src/hooks/useUserExperienceForm.ts
@@ -14,6 +14,7 @@ import {
   UserExperienceType,
 } from '../graphql/user/profile';
 import { useDirtyForm } from './useDirtyForm';
+import { generateQueryKey, RequestKey } from '../lib/query';
 import { ApiError } from '../graphql/common';
 import type { ApiErrorResult } from '../graphql/common';
 import { labels } from '../lib/labels';
@@ -142,6 +143,10 @@ const useUserExperienceForm = ({
       methods.reset(vars);
       dirtyFormRef.current?.allowNavigation();
       qc.invalidateQueries({ queryKey: experienceQueryKey });
+      qc.invalidateQueries({
+        queryKey: generateQueryKey(RequestKey.UserExperience, user, 'profile'),
+        exact: false,
+      });
       router.push(`${webappUrl}settings/profile/experience/${type}`);
     },
     onError: (error: ApiErrorResult) => {


### PR DESCRIPTION
## Summary
- Adds invalidation of profile experiences query key when work experience is saved or deleted in settings
- Fixes stale data being displayed on the profile page after editing experiences in settings

The issue occurred because the settings page and profile page use different query keys for experiences. When saving/deleting in settings, only the settings query key was invalidated, but the profile page was still using its cached (now stale) data.

## Test plan
- [ ] Edit work experience in settings, save, navigate to profile - changes should be reflected
- [ ] Delete work experience in settings, navigate to profile - deletion should be reflected

Closes ENG-84
---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-84-work-experience-not-inval.preview.app.daily.dev