### PR TITLE
fix(auth): prevent duplicate input in CodeField on mobile

### DIFF
--- a/packages/shared/src/components/fields/CodeField.tsx
+++ b/packages/shared/src/components/fields/CodeField.tsx
@@ -102,6 +102,7 @@ export function CodeField({
     if (!isNumbersOnly) {
       e.preventDefault();
     } else if (key.length === 1) {
+      e.preventDefault();
       updateCode(key, index);
 
       if (index < length - 1) {


### PR DESCRIPTION
## Summary
- Add `e.preventDefault()` when handling valid numeric key input in the `CodeField` component
- This prevents the browser's native input event from also processing the keystroke
- Fixes a race condition on mobile where typing a digit would populate the value in multiple input fields

## Test plan
- [ ] Test code verification flow on mobile device
- [ ] Verify single digit entry populates only one field
- [ ] Confirm cursor advances correctly to next field

Closes ENG-229
---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-229-code-verification-field.preview.app.daily.dev