### PR TITLE
fix(analytics): consistent layout between analytics pages

### DIFF
--- a/packages/webapp/pages/analytics/index.tsx
+++ b/packages/webapp/pages/analytics/index.tsx
@@ -357,6 +357,6 @@ const Analytics = (): ReactElement => {
 const seo: NextSeoProps = { title: 'Analytics', nofollow: true, noindex: true };
 
 Analytics.getLayout = getLayout;
-Analytics.layoutProps = { seo };
+Analytics.layoutProps = { seo, screenCentered: false };
 
 export default Analytics;


### PR DESCRIPTION
## Summary
- Set `screenCentered: false` on the general analytics page to match the post analytics page layout positioning
- Ensures visual consistency between the main analytics dashboard and individual post analytics pages

## Test plan
- [ ] Navigate to the analytics page and verify layout positioning
- [ ] Navigate to a post analytics page and confirm both pages have consistent layout

Closes ENG-563
---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-563-different-layouts-for-an.preview.app.daily.dev