### PR TITLE
fix(analytics): show loading indicator before data is fetched

### DIFF
--- a/packages/webapp/pages/analytics/index.tsx
+++ b/packages/webapp/pages/analytics/index.tsx
@@ -319,11 +319,11 @@ const Analytics = (): ReactElement => {
                 </div>
               )}
             </div>
-            {isLoadingHistory ? (
-              <div className="h-40 w-full" />
-            ) : hasChartData ? (
+            {isLoadingHistory && <div className="h-40 w-full" />}
+            {!isLoadingHistory && hasChartData && (
               <CombinedImpressionsChart data={historyData} />
-            ) : (
+            )}
+            {!isLoadingHistory && !hasChartData && (
               <div className="flex h-40 items-center justify-center rounded-12 border border-border-subtlest-tertiary">
                 <Typography
                   type={TypographyType.Callout}


### PR DESCRIPTION
## Summary
- Fix premature empty state display on analytics page while waiting for user authentication
- Add `!!postsData` check to `hasNoPosts` condition to ensure the empty state only appears after the first fetch completes with no results

Closes ENG-569
---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-569-show-loading-indicator-w.preview.app.daily.dev