### PR TITLE
fix: profile settings menu not fully visible on small screens

### DIFF
--- a/packages/shared/src/components/ProfileMenu/ProfileMenu.tsx
+++ b/packages/shared/src/components/ProfileMenu/ProfileMenu.tsx
@@ -61,7 +61,7 @@ export default function ProfileMenu({
       onClose={onClose}
       closeOutsideClick
       position={InteractivePopupPosition.ProfileMenu}
-      className="flex w-full max-w-80 flex-col gap-3 !rounded-10 border border-border-subtlest-tertiary !bg-accent-pepper-subtlest p-3"
+      className="flex max-h-[calc(100vh-4rem)] w-full max-w-80 flex-col gap-3 overflow-y-auto !rounded-10 border border-border-subtlest-tertiary !bg-accent-pepper-subtlest p-3"
     >
       {showProfileCompletion && <ProfileCompletion />}
       <ProfileMenuHeader />


### PR DESCRIPTION
## Summary
- Added `max-h-[calc(100vh-4rem)]` and `overflow-y-auto` to ProfileMenu popup to ensure menu items remain accessible on small viewport heights

The fix constrains the menu height to viewport minus header space and enables scrolling when content overflows.

Closes ENG-571
---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-571-bug-profile-settings-men.preview.app.daily.dev