### PR TITLE
feat(mobile): add delightful loading screen for mobile users

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -167,7 +167,10 @@ function MainLayoutComponent({
     (!isPageReady && isPageApplicableForOnboarding) ||
     shouldRedirectOnboarding
   ) {
-    if (typeof window !== 'undefined' && (isPWA() || isIOSNative() || isAndroidApp)) {
+    if (
+      typeof window !== 'undefined' &&
+      (isPWA() || isIOSNative() || isAndroidApp)
+    ) {
       return <MobileAppLoader />;
     }
     return null;

--- a/packages/shared/src/components/MobileAppLoader.tsx
+++ b/packages/shared/src/components/MobileAppLoader.tsx
@@ -14,7 +14,7 @@ export function MobileAppLoader({
   return (
     <div
       className={classNames(
-        'fixed inset-0 z-50 flex flex-col items-center justify-center gap-6 bg-background-default',
+        'z-50 fixed inset-0 flex flex-col items-center justify-center gap-6 bg-background-default',
         className,
       )}
     >


### PR DESCRIPTION
## Summary
- Add `MobileAppLoader` component with floating logo animation and spinner for a polished loading experience
- Integrate into `MainLayout` to display during app initialization on mobile instead of a blank screen
- Uses existing design system tokens and `float-animation` utility class

Closes ENG-604

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-604-make-mobile-loading-scre.preview.app.daily.dev