### PR TITLE
fix(shared): auto-focus comment editor when opened on mobile

### DIFF
--- a/packages/shared/src/components/fields/RichTextInput.tsx
+++ b/packages/shared/src/components/fields/RichTextInput.tsx
@@ -587,8 +587,7 @@ function RichTextInput(
   }));
 
   useEffect(() => {
-    const content = inputRef.current;
-    if (!content || !editor) {
+    if (!editor) {
       return;
     }
 


### PR DESCRIPTION
## Summary
- Auto-focus the rich text comment editor when the editor instance initializes.
- Ensure mobile comment box focus is not gated by `inputRef.current`, which can lag behind editor readiness.

## Key decisions
- Keep focus logic in the existing `editor`-dependent effect to target the exact initialization timing.
- Use `editor.commands.focus('end')` directly to place the caret at the end consistently.

Issue: https://linear.app/dailydev/issue/ENG-713/when-opening-the-comment-box-in-mobile-it-should-be-auto-focused

Closes ENG-713

---
Created by Huginn 🐦‍⬛


### Preview domain
https://eng-713-when-opening-the-comment.preview.app.daily.dev