### PR TITLE
fix(shared): align list action icon size with card mode

### DIFF
--- a/packages/shared/src/components/cards/common/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/common/ActionButtons.tsx
@@ -44,8 +44,8 @@ const variantConfig = {
     useCommentLink: false,
   },
   list: {
-    buttonSize: undefined, // Default size
-    iconSize: IconSize.Medium,
+    buttonSize: ButtonSize.Small,
+    iconSize: IconSize.XSmall,
     containerClassName: '',
     showTagsPanel: true,
     useCommentLink: true,


### PR DESCRIPTION
## Summary
- update `ActionButtons` list variant to use explicit sizing so list-mode action icons match card mode
- set list buttons to `ButtonSize.Small` and icons to `IconSize.XSmall` in `packages/shared/src/components/cards/common/ActionButtons.tsx`

## Key decisions
- used existing shared button/icon size tokens instead of adding list-specific style overrides
- limited the change to the `list` variant config to avoid impacting card/compact behavior

Closes ENG-722

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-722-list-mode-action-icons-a.preview.app.daily.dev