### PR TITLE
fix(shared): polish repost modal row interactions

### DIFF
--- a/packages/shared/src/components/modals/RepostListItem.tsx
+++ b/packages/shared/src/components/modals/RepostListItem.tsx
@@ -75,7 +75,7 @@ export function RepostListItem({
           />
           {post.source.permalink ? (
             <Link href={post.source.permalink}>
-              <a className="truncate text-text-secondary typo-callout !no-underline hover:!no-underline">
+              <a className="truncate text-text-secondary !no-underline typo-callout hover:!no-underline">
                 {post.source.name}
               </a>
             </Link>
@@ -108,7 +108,7 @@ export function RepostListItem({
       {!!post.title &&
         (post.commentsPermalink ? (
           <Link href={post.commentsPermalink}>
-            <a className="mt-3 line-clamp-3 block text-text-primary typo-body !no-underline hover:!no-underline">
+            <a className="mt-3 line-clamp-3 block text-text-primary !no-underline typo-body hover:!no-underline">
               {post.title}
             </a>
           </Link>

--- a/packages/shared/src/components/modals/RepostsModal.tsx
+++ b/packages/shared/src/components/modals/RepostsModal.tsx
@@ -54,7 +54,7 @@ export function RepostsModal({
     >
       <Modal.Header title="Reposts" />
       <Modal.Body
-        className="!p-0 [&_a]:!no-underline [&_a:hover]:!no-underline"
+        className="!p-0 [&_a:hover]:!no-underline [&_a]:!no-underline"
         ref={container}
       >
         <InfiniteScrolling


### PR DESCRIPTION
## Summary
- remove underline styling from repost modal row links, including hover state
- disable profile tooltip popovers in repost modal rows to reduce hover noise
- add row-level hover background (`bg-surface-hover`) for clearer interaction feedback

## Test plan
- [x] verify repost modal links never underline on hover
- [x] verify hovering author row no longer opens user tooltip
- [x] verify repost row gets hover background like other interactive modal rows

Made with [Cursor](https://cursor.com)

### Preview domain
https://fix-repost-fix-ui.preview.app.daily.dev