### PR TITLE
fix(shared): resolve strict type errors in test fixtures

### DIFF
--- a/packages/shared/__tests__/fixture/auth.ts
+++ b/packages/shared/__tests__/fixture/auth.ts
@@ -1307,7 +1307,7 @@ export const verifiedLoginData = {
 
 export const mockVerificationValidation = (
   params: Partial<EmptyObjectLiteral>,
-  result: unknown = successfulSettingsFlowData,
+  result: nock.ReplyBody = successfulSettingsFlowData,
   code = 200,
 ): void => {
   nock(authUrl)
@@ -1320,16 +1320,20 @@ export const mockVerificationValidation = (
 
 export const mockSettingsValidation = (
   params: Partial<EmptyObjectLiteral>,
-  result: unknown = successfulSettingsFlowData,
+  result: nock.ReplyBody = successfulSettingsFlowData,
   code = 200,
 ): nock.Scope => {
   const url = new URL(settingsFlowMockData.ui.action);
+  const reqheaders: Record<string, nock.RequestHeaderMatcher> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+  if (params.csrf_token) {
+    reqheaders['X-CSRF-Token'] = params.csrf_token;
+  }
+
   return nock(authUrl, {
-    reqheaders: {
-      'Content-Type': 'application/json',
-      'X-CSRF-Token': params.csrf_token,
-      Accept: 'application/json',
-    },
+    reqheaders,
   })
     .post(url.pathname + url.search, params)
     .reply(code, result);
@@ -1337,16 +1341,20 @@ export const mockSettingsValidation = (
 
 export const mockKratosPost = <T = EmptyObjectLiteral>(
   { params, action }: KratosFormParams<Partial<T> & { csrf_token: string }>,
-  result: unknown,
+  result: nock.ReplyBody,
   code = 200,
 ): void => {
   const url = new URL(action);
+  const reqheaders: Record<string, nock.RequestHeaderMatcher> = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+  if (params.csrf_token) {
+    reqheaders['X-CSRF-Token'] = params.csrf_token;
+  }
+
   nock(authUrl, {
-    reqheaders: {
-      'Content-Type': 'application/json',
-      'X-CSRF-Token': params.csrf_token,
-      Accept: 'application/json',
-    },
+    reqheaders,
   })
     .post(url.pathname + url.search, params)
     .reply(code, result);

--- a/packages/shared/__tests__/fixture/feed.ts
+++ b/packages/shared/__tests__/fixture/feed.ts
@@ -138,7 +138,7 @@ const feed: Connection<Post> = {
         title: 'Star night',
         createdAt: '2020-05-16T14:23:10.000Z',
         image: 'https://media.daily.dev/image/upload/f_auto/v1/placeholders/7',
-        readTime: null,
+        readTime: 0,
         source: {
           id: 'codepen',
           handle: 'codepen',
@@ -168,7 +168,7 @@ const feed: Connection<Post> = {
         createdAt: '2020-05-16T14:18:17.000Z',
         image:
           'https://media.daily.dev/image/upload/f_auto,q_auto/v1/posts/7bd48c25940a571c7f7af6089795fac3',
-        readTime: null,
+        readTime: 0,
         source: {
           id: 'andpol',
           handle: 'andpol',

--- a/packages/shared/__tests__/fixture/pollPost.ts
+++ b/packages/shared/__tests__/fixture/pollPost.ts
@@ -19,10 +19,9 @@ export const pollPost: Post = {
     type: SourceType.Machine,
     public: true,
   },
-  readTime: null,
+  readTime: 0,
   image:
     'https://media.daily.dev/image/upload/f_auto,q_auto/v1/posts/poll-image',
-  placeholder: 'data:image/jpeg;base64,test-placeholder',
   commentsPermalink: 'https://daily.dev/poll-test-id',
   author,
   tags: ['poll', 'programming'],
@@ -67,7 +66,8 @@ export const pollPostWithUserVote: Post = {
   ...pollPost,
   id: 'poll-with-vote-id',
   userState: {
-    ...pollPost.userState,
+    vote: pollPost.userState?.vote ?? UserVote.None,
+    flags: pollPost.userState?.flags,
     pollOption: { id: 'option-1' },
   },
 };

--- a/packages/shared/__tests__/fixture/post.ts
+++ b/packages/shared/__tests__/fixture/post.ts
@@ -30,7 +30,7 @@ export const sharePost: Post = {
   title: 'Good read about react-query',
   createdAt: '2023-02-09T03:35:33.898Z',
   image: 'https://media.daily.dev/image/upload/f_auto/v1/placeholders/6',
-  readTime: null,
+  readTime: 0,
   source: {
     id: 'c0457b66-e89b-4fc0-b06d-48f920c7caa2',
     handle: 'avengers',
@@ -60,7 +60,6 @@ export const sharePost: Post = {
       'The level of type-safety can drastically vary from project to project. Every valid JavaScript code can be valid TypeScript code - depending on the TS settings. To truly leverage the power of TypeScript, there is one thing that you need above all: Trust our type definitions.',
     createdAt: '2023-01-07T19:26:43.146Z',
     private: false,
-    scout: null,
     author: {
       id: 'oHt34Q_Zn',
       name: 'TkDodo',
@@ -76,7 +75,6 @@ export const sharePost: Post = {
       handle: 'tkdodo',
       name: 'TkDodo',
       permalink: 'https://app.daily.dev/sources/tkdodo',
-      description: null,
       image:
         'https://media.daily.dev/image/upload/t_logo,f_auto/v1656338366/logos/tkdodo',
       type: SourceType.Machine,
@@ -87,7 +85,6 @@ export const sharePost: Post = {
   numComments: 0,
   numUpvotes: 1,
   commentsPermalink: 'https://app.daily.dev/posts/5nLQHVNHi',
-  scout: null,
   author: {
     id: 'ab02e61b958d49d88c8420b431a4d91c',
     name: 'Lee Hansel Solevilla Jr',
@@ -97,7 +94,6 @@ export const sharePost: Post = {
     username: 'sshanzel',
     bio: 'Software Engineer @daily.dev 👨‍💻  yes! here! 🥳',
   },
-  trending: null,
   tags: [],
   type: PostType.Share,
   private: true,

--- a/packages/shared/__tests__/fixture/squads.ts
+++ b/packages/shared/__tests__/fixture/squads.ts
@@ -242,7 +242,7 @@ export const generateTestMember = (
     source: null,
     referralToken: `${token}${i}`,
     role: SourceMemberRole.Member,
-  } as SourceMember);
+  } as unknown as SourceMember);
 
 export const generateTestSquad = (props: Partial<Squad> = {}): Squad => {
   const squad = {
@@ -262,8 +262,17 @@ export const generateTestSquad = (props: Partial<Squad> = {}): Squad => {
       referralToken: '3ZvloDmEbgiCKLF_eDg72JKLRPgp6MOpGDkh6qTRFr8',
       user: {
         id: 'u1',
+        name: 'Test member',
+        image: 'https://media.daily.dev/image/upload/f_auto/v1/placeholders/1',
+        permalink: 'https://app.daily.dev/test-member',
+        username: 'test-member',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        reputation: 0,
       },
-      permissions: ['post'],
+      source: {
+        id: '343f82f0-85f0-4f10-a666-aa331d8d7a1b',
+      } as Squad,
+      permissions: [SourcePermissions.Post],
     },
     ...props,
   };
@@ -276,11 +285,11 @@ export const generateTestSquad = (props: Partial<Squad> = {}): Squad => {
     }
   }
 
-  return squad;
+  return squad as Squad;
 };
 
 export const generateForbiddenSquadResult = (): GraphQLResult<SquadData> => ({
-  data: { source: null },
+  data: { source: null as unknown as Squad },
   errors: [
     {
       message: 'Access denied!',
@@ -292,7 +301,7 @@ export const generateForbiddenSquadResult = (): GraphQLResult<SquadData> => ({
 });
 
 export const generateNotFoundSquadResult = (): GraphQLResult<SquadData> => ({
-  data: { source: null },
+  data: { source: null as unknown as Squad },
   errors: [
     {
       message: 'Entity not found',

--- a/packages/shared/__tests__/helpers/boot.tsx
+++ b/packages/shared/__tests__/helpers/boot.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import type { QueryClient } from '@tanstack/react-query';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { GrowthBook, GrowthBookProvider } from '@growthbook/growthbook-react';
-import type { WidenPrimitives } from '@growthbook/growthbook';
+import type { JSONValue, WidenPrimitives } from '@growthbook/growthbook';
 import type { AuthContextData } from '../../src/contexts/AuthContext';
 import AuthContext from '../../src/contexts/AuthContext';
 import type { NotificationsContextProviderProps } from '../../src/contexts/NotificationsContext';
@@ -20,6 +20,7 @@ import { LazyModalElement } from '../../src/components/modals/LazyModalElement';
 import type { LogContextData } from '../../src/hooks/log/useLogContextData';
 import { PaymentContextProvider } from '../../src/contexts/payment';
 import { getLogContextStatic } from '../../src/contexts/LogContext';
+import type { Feature } from '../../src/lib/featureManagement';
 
 const LogContext = getLogContextStatic();
 
@@ -110,7 +111,7 @@ export const TestBootProvider = ({
             <FeaturesReadyContext.Provider
               value={{
                 ready: true,
-                getFeatureValue<T>(feature) {
+                getFeatureValue<T extends JSONValue>(feature: Feature<T>) {
                   return feature.defaultValue as WidenPrimitives<T>;
                 },
               }}


### PR DESCRIPTION
## Summary
- fix strict typing mismatches in shared test fixtures and test boot helper
- replace invalid nullable fixture values with type-safe values
- tighten nock helper argument/header typing in auth fixtures
- align squad fixture typing for SourceMember/Squad expectations

## Validation
- ran: pnpm --filter @dailydotdev/shared typecheck:strict
- strict issue count decreased from 3467 to 3449


### Preview domain
https://codex-ts-strict-shared-batch-2.preview.app.daily.dev