### PR TITLE
fix: image leakage under overlay

### DIFF
--- a/packages/shared/src/components/cards/share/SharedPostPreview.tsx
+++ b/packages/shared/src/components/cards/share/SharedPostPreview.tsx
@@ -67,7 +67,7 @@ export function SharedPostPreview({
             type={ImageType.Post}
             src={image}
             alt={title || 'Shared post cover image'}
-            className="size-full object-cover"
+            className="size-full overflow-hidden rounded-12 object-cover"
           />
           <div className="absolute inset-x-0 top-0 ">
             <div className="flex flex-col gap-2 rounded-t-8 bg-background-subtle p-2">


### PR DESCRIPTION
## Changes

Fixes the image leaking out from underneath the shared post image overlay

<table>
  <tr>
    <td>Before
    <td>After
  </tr>
  <tr>
    <td><img width="358" height="444" alt="image" src="https://github.com/user-attachments/assets/c192fd1d-f072-4197-b0cf-3e87b1220492" />
    <td><img width="358" height="444" alt="image" src="https://github.com/user-attachments/assets/783377d3-e52a-4ccf-a406-f6769649a511" />
  </tr>
</table>


### Preview domain
https://fix-image-leakage.preview.app.daily.dev