### PR TITLE
feat(shared): implement shared element transition for post modal using framer-motion

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -128,6 +128,7 @@
     "@tiptap/starter-kit": "^3.14.0",
     "check-password-strength": "^2.0.10",
     "fetch-event-stream": "^0.1.5",
+    "framer-motion": "^12.23.25",
     "graphql-ws": "^5.5.5",
     "jotai": "^2.12.2",
     "lottie-react": "^2.4.1",
@@ -140,6 +141,7 @@
     "recharts": "^3.1.2",
     "remark-gfm": "^3.0.1",
     "uuid": "^8.3.2",
+    "vaul": "^1.1.2",
     "web-vitals": "^3.5.0",
     "webextension-polyfill": "^0.12.0",
     "zod": "4.1.8"

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -40,6 +40,8 @@ import {
   useFeedLayout,
   useFeedVotePost,
   useMutationSubscription,
+  useViewSize,
+  ViewSize,
 } from '../hooks';
 import { useProfileCompletionCard } from '../hooks/profile/useProfileCompletionCard';
 import type { AllFeedPages } from '../lib/query';
@@ -188,6 +190,8 @@ export default function Feed<T>({
   const { user } = useContext(AuthContext);
   const { isFallback, query: routerQuery } = useRouter();
   const { openNewTab, spaciness, loadedSettings } = useContext(SettingsContext);
+  const isLaptopView = useViewSize(ViewSize.Laptop);
+  const isLaptop = isNullOrUndefined(isLaptopView) || isLaptopView;
   const { isListMode } = useFeedLayout();
   const numCards = currentSettings.numCards[spaciness ?? 'eco'];
   const isSquadFeed = feedName === OtherFeedPage.Squad;
@@ -430,18 +434,6 @@ export default function Feed<T>({
     }
   }, [canFetchMore, isFetching, trackFinishFeed]);
 
-  useEffect(() => {
-    return () => {
-      document.body.classList.remove('hidden-scrollbar');
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!selectedPost) {
-      document.body.classList.remove('hidden-scrollbar');
-    }
-  }, [selectedPost]);
-
   const onShareClick = useCallback(
     (post: Post, row?: number, column?: number) =>
       openSharePost({ post, columns: virtualizedNumCards, column, row }),
@@ -463,7 +455,6 @@ export default function Feed<T>({
     row?: number;
     column?: number;
   }) => {
-    document.body.classList.add('hidden-scrollbar');
     callback?.();
     setPostModalIndex({ index, row, column });
     onOpenModal(index);
@@ -484,7 +475,7 @@ export default function Feed<T>({
     await onPostClick(post, index, row, column, {
       skipPostUpdate: true,
     });
-    if (!isAuxClick && !shouldUseListFeedLayout) {
+    if (!isAuxClick && (!shouldUseListFeedLayout || !isLaptop)) {
       onPostModalOpen({ index, row, column });
     }
   };
@@ -515,7 +506,7 @@ export default function Feed<T>({
         is_ad: isAd,
       }),
     );
-    if (!shouldUseListFeedLayout) {
+    if (!shouldUseListFeedLayout || !isLaptop) {
       onPostModalOpen({ index, row, column });
     }
   };
@@ -627,7 +618,7 @@ export default function Feed<T>({
             {!isFetching && !isInitialLoading && !isHorizontal && (
               <InfiniteScrollScreenOffset ref={infiniteScrollRef} />
             )}
-            {!shouldUseListFeedLayout && selectedPost && PostModal && (
+            {(!shouldUseListFeedLayout || !isLaptop) && selectedPost && PostModal && (
               <PostModal
                 isOpen={!!selectedPost}
                 id={selectedPost.id}

--- a/packages/shared/src/components/cards/article/ArticleList.tsx
+++ b/packages/shared/src/components/cards/article/ArticleList.tsx
@@ -28,6 +28,7 @@ import { HIGH_PRIORITY_IMAGE_PROPS } from '../../image/Image';
 import { ClickbaitShield } from '../common/ClickbaitShield';
 import { useSmartTitle } from '../../../hooks/post/useSmartTitle';
 import { isSourceUserSource } from '../../../graphql/sources';
+import { motion } from 'framer-motion';
 
 export const ArticleList = forwardRef(function ArticleList(
   {
@@ -103,7 +104,9 @@ export const ArticleList = forwardRef(function ArticleList(
         ...domProps,
         style,
         className,
-      }}
+        layoutId: `post-card-${post.id}`,
+        transition: { type: 'spring', stiffness: 400, damping: 35 },
+      } as any}
       ref={ref}
       flagProps={{ pinnedAt, trending, type }}
       linkProps={
@@ -144,6 +147,7 @@ export const ArticleList = forwardRef(function ArticleList(
             <CardContent>
               <div className="mr-4 flex flex-1 flex-col">
                 <CardTitle
+                  layoutId={`post-title-${post.id}`}
                   lineClamp={undefined}
                   className={!!post.read && 'text-text-tertiary'}
                 >
@@ -160,26 +164,28 @@ export const ArticleList = forwardRef(function ArticleList(
                 {!isMobile && actionButtons}
               </div>
 
-              <CardCoverList
-                data-testid="postImage"
-                isVideoType={isVideoType}
-                onShare={onShare}
-                post={post}
-                imageProps={{
-                  alt: 'Post Cover image',
-                  className: classNames(
-                    'mobileXXL:self-start',
-                    !isVideoType && 'mt-4',
-                  ),
-                  ...(eagerLoadImage
-                    ? HIGH_PRIORITY_IMAGE_PROPS
-                    : { loading: 'lazy' }),
-                  src: post.image,
-                }}
-                videoProps={{
-                  className: 'mt-4 mobileXL:w-40 mobileXXL:w-56 !h-fit',
-                }}
-              />
+              <motion.div layoutId={`post-cover-${post.id}`} transition={{ type: 'spring', stiffness: 400, damping: 35 }} className="w-full mobileXL:w-auto">
+                <CardCoverList
+                  data-testid="postImage"
+                  isVideoType={isVideoType}
+                  onShare={onShare}
+                  post={post}
+                  imageProps={{
+                    alt: 'Post Cover image',
+                    className: classNames(
+                      'mobileXXL:self-start',
+                      !isVideoType && 'mt-4',
+                    ),
+                    ...(eagerLoadImage
+                      ? HIGH_PRIORITY_IMAGE_PROPS
+                      : { loading: 'lazy' }),
+                    src: post.image,
+                  }}
+                  videoProps={{
+                    className: 'mt-4 mobileXL:w-40 mobileXXL:w-56 !h-fit',
+                  }}
+                />
+              </motion.div>
             </CardContent>
           </CardContainer>
           {isMobile && actionButtons}

--- a/packages/shared/src/components/cards/common/PostCardHeader.tsx
+++ b/packages/shared/src/components/cards/common/PostCardHeader.tsx
@@ -84,6 +84,8 @@ export const PostCardHeader = ({
     <>
       {highlightBookmarkedPost && <BookmakProviderHeader />}
       <CardHeader
+        layoutId={`post-author-${post.id}`}
+        transition={{ type: 'spring', stiffness: 400, damping: 35 }}
         className={classNames(
           className,
           highlightBookmarkedPost && headerHiddenClassName,

--- a/packages/shared/src/components/cards/common/list/FeedItemContainer.tsx
+++ b/packages/shared/src/components/cards/common/list/FeedItemContainer.tsx
@@ -72,6 +72,25 @@ function FeedItemContainer(
         <Link href={linkProps.href}>
           <CardLink
             {...linkProps}
+            onClick={(event) => {
+              if (
+                event.ctrlKey ||
+                event.metaKey ||
+                event.shiftKey ||
+                event.altKey
+              ) {
+                linkProps.onClick?.(event);
+                return;
+              }
+
+              event.preventDefault();
+
+              const card = (event.currentTarget as HTMLElement).closest(
+                'article',
+              );
+
+              linkProps.onClick?.(event);
+            }}
             onFocus={() => setFocus(true)}
             onBlur={() => setFocus(false)}
           />

--- a/packages/shared/src/components/cards/common/list/ListCard.tsx
+++ b/packages/shared/src/components/cards/common/list/ListCard.tsx
@@ -1,6 +1,7 @@
 import type { HTMLAttributes, ReactNode } from 'react';
 import React from 'react';
 import classNames from 'classnames';
+import { motion } from 'framer-motion';
 import type { ReactElement } from 'react-markdown/lib/react-markdown';
 import classed from '../../../../lib/classed';
 import { Image } from '../../../image/Image';
@@ -8,17 +9,23 @@ import { Image } from '../../../image/Image';
 type TitleProps = HTMLAttributes<HTMLHeadingElement> & {
   lineClamp?: `line-clamp-${number}`;
   children: ReactNode;
+  layoutId?: string;
 };
+
+const SHARED_TRANSITION = { type: 'spring', stiffness: 400, damping: 35 };
 
 const Title = ({
   className,
   lineClamp = 'line-clamp-3',
   children,
+  layoutId,
   ...rest
 }: TitleProps): ReactElement => {
   return (
-    <h3
+    <motion.h3
       {...rest}
+      transition={SHARED_TRANSITION}
+      layoutId={layoutId}
       className={classNames(
         'multi-truncate font-bold text-text-primary typo-title3',
         lineClamp,
@@ -26,7 +33,7 @@ const Title = ({
       )}
     >
       {children}
-    </h3>
+    </motion.h3>
   );
 };
 
@@ -37,7 +44,7 @@ export const CardContainer = classed('div', 'flex flex-col');
 export const CardContent = classed('div', 'flex flex-col mobileXL:flex-row');
 
 export const CardImage = classed(
-  Image,
+  motion(Image) as any,
   'rounded-12 min-h-[10rem] max-h-[12.5rem] object-cover w-full h-auto mobileXL:max-h-40 mobileXL:w-40 mobileXXL:max-h-56 mobileXXL:w-56',
 );
 
@@ -50,10 +57,10 @@ const clickableCardClasses = classNames(
 export const CardLink = classed('a', clickableCardClasses);
 
 export const ListCard = classed(
-  'article',
+  motion.article as any,
   `group relative w-full flex flex-col py-6 px-4 border-t border-border-subtlest-tertiary rounded-16
    hover:bg-surface-float
   `,
 );
 
-export const CardHeader = classed('div', 'flex flex-row items-center mb-2');
+export const CardHeader = classed(motion.div as any, 'flex flex-row items-center mb-2');

--- a/packages/shared/src/components/modals/BasePostModal.module.css
+++ b/packages/shared/src/components/modals/BasePostModal.module.css
@@ -9,5 +9,41 @@
     padding: 0;
     overflow-y: auto;
     z-index: 100;
+    opacity: 0;
+    transition: opacity 250ms ease-out;
+  }
+
+  & :global(.post-modal-overlay.ReactModal__Overlay--after-open) {
+    opacity: 1;
+  }
+
+  & :global(.post-modal-overlay.ReactModal__Overlay--before-close) {
+    opacity: 0;
+    transition: opacity 150ms ease-in;
+  }
+
+  & :global(.post-modal-overlay .modal) {
+    opacity: 1;
+  }
+
+  /* Laptop: subtle slide-up animation since there's no morph overlay */
+  @media (min-width: 64rem) {
+    & :global(.post-modal-overlay .modal) {
+      opacity: 0;
+      transform: translateY(0.75rem) scale(0.99);
+      transition:
+        transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+        opacity 260ms cubic-bezier(0.22, 1, 0.36, 1);
+    }
+
+    & :global(.post-modal-overlay.ReactModal__Overlay--after-open .modal) {
+      opacity: 1;
+      transform: none;
+    }
+
+    & :global(.post-modal-overlay.ReactModal__Overlay--before-close .modal) {
+      opacity: 0;
+      transform: translateY(0.75rem) scale(0.99);
+    }
   }
 }

--- a/packages/shared/src/components/modals/BasePostModal.tsx
+++ b/packages/shared/src/components/modals/BasePostModal.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import React, { useState, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import classNames from 'classnames';
 import type { ModalProps } from './common/Modal';
 import { Modal } from './common/Modal';
@@ -27,6 +28,8 @@ interface BasePostModalProps extends ModalProps {
   onNextPost?: () => void;
   post: Post;
 }
+
+const SHARED_TRANSITION = { type: 'spring', stiffness: 400, damping: 35 };
 
 function BasePostModal({
   className,
@@ -81,10 +84,20 @@ function BasePostModal({
         <Modal
           size={Modal.Size.XLarge}
           kind={Modal.Kind.FlexibleTop}
+          closeTimeoutMS={300}
           portalClassName={styles.postModal}
           id="post-modal"
           overlayRef={setScrollNode}
           {...props}
+          contentElement={(contentProps, contentChildren) => (
+            <AnimatePresence>
+              {props.isOpen && (
+                <motion.div {...contentProps as any} layoutId={`post-card-${post?.id}`} transition={SHARED_TRANSITION}>
+                  {contentChildren}
+                </motion.div>
+              )}
+            </AnimatePresence>
+          )}
           overlayClassName="post-modal-overlay bg-overlay-quaternary-onion"
           className={classNames(
             className,

--- a/packages/shared/src/components/post/BasePostContent.tsx
+++ b/packages/shared/src/components/post/BasePostContent.tsx
@@ -6,6 +6,7 @@ import PostEngagements from './PostEngagements';
 import type { BasePostContentProps } from './common';
 import { PostHeaderActions } from './PostHeaderActions';
 import { ButtonSize } from '../buttons/common';
+import { PostBottomAction } from './PostBottomAction';
 
 const Custom404 = dynamic(
   () => import(/* webpackChunkName: "custom404" */ '../Custom404'),
@@ -63,6 +64,9 @@ export function BasePostContent({
           logOrigin={origin}
           shouldOnboardAuthor={shouldOnboardAuthor}
         />
+      )}
+      {!isPostPage && !!navigationProps?.onClose && (
+        <PostBottomAction onAction={() => navigationProps.onClose?.(null as any)} />
       )}
     </>
   );

--- a/packages/shared/src/components/post/PostBottomAction.tsx
+++ b/packages/shared/src/components/post/PostBottomAction.tsx
@@ -1,0 +1,227 @@
+import type { ReactElement } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import classNames from 'classnames';
+import { ArrowIcon } from '../icons';
+import { useViewSize, ViewSize } from '../../hooks';
+
+interface PostBottomActionProps {
+  onAction: () => void;
+}
+
+const THRESHOLD = 120;
+const MAX_PULL = 200;
+const BOTTOM_TOLERANCE = 24;
+
+export function PostBottomAction({
+  onAction,
+}: PostBottomActionProps): ReactElement {
+  const isLaptop = useViewSize(ViewSize.Laptop);
+  const [pullDistance, setPullDistance] = useState(0);
+  const [atBottom, setAtBottom] = useState(false);
+  const [overlayFound, setOverlayFound] = useState(false);
+
+  const pullRef = useRef(0);
+  const touchStartY = useRef<number | null>(null);
+  const gestureActive = useRef(false);
+  const closingRef = useRef(false);
+  const overlayRef = useRef<HTMLElement | null>(null);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const findOverlay = useCallback((): HTMLElement | null => {
+    if (overlayRef.current && overlayRef.current.isConnected) {
+      return overlayRef.current;
+    }
+
+    const fromSentinel = sentinelRef.current?.closest(
+      '.post-modal-overlay',
+    ) as HTMLElement | null;
+    if (fromSentinel) {
+      overlayRef.current = fromSentinel;
+      return fromSentinel;
+    }
+
+    const fromDocument = document.querySelector(
+      '.post-modal-overlay',
+    ) as HTMLElement | null;
+    overlayRef.current = fromDocument;
+    return fromDocument;
+  }, []);
+
+  const isScrolledToBottom = useCallback(
+    (overlay: HTMLElement) => {
+      return (
+        overlay.scrollTop + overlay.clientHeight >=
+        overlay.scrollHeight - BOTTOM_TOLERANCE
+      );
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (isLaptop) return undefined;
+
+    let retryTimer: ReturnType<typeof setTimeout>;
+    let overlay = findOverlay();
+
+    if (!overlay) {
+      retryTimer = setTimeout(() => {
+        overlay = findOverlay();
+        if (overlay) setOverlayFound(true);
+      }, 300);
+      return () => clearTimeout(retryTimer);
+    }
+
+    setOverlayFound(true);
+
+    const onScroll = () => {
+      if (!gestureActive.current && overlay) {
+        setAtBottom(isScrolledToBottom(overlay));
+      }
+    };
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (!overlay || !isScrolledToBottom(overlay)) {
+        touchStartY.current = null;
+        gestureActive.current = false;
+        return;
+      }
+      touchStartY.current = e.touches[0].clientY;
+      gestureActive.current = false;
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (touchStartY.current === null) return;
+
+      const dy = touchStartY.current - e.touches[0].clientY;
+
+      if (dy > 8) {
+        gestureActive.current = true;
+        const damped = Math.min((dy - 8) * 0.55, MAX_PULL);
+        pullRef.current = damped;
+        setPullDistance(damped);
+      } else if (gestureActive.current && dy <= 0) {
+        pullRef.current = 0;
+        setPullDistance(0);
+      }
+    };
+
+    const onTouchEnd = () => {
+      if (gestureActive.current && pullRef.current >= THRESHOLD) {
+        if (!closingRef.current) {
+          closingRef.current = true;
+          onAction();
+          setTimeout(() => {
+            closingRef.current = false;
+          }, 400);
+        }
+      }
+      touchStartY.current = null;
+      gestureActive.current = false;
+      pullRef.current = 0;
+      setPullDistance(0);
+    };
+
+    overlay.addEventListener('scroll', onScroll, { passive: true });
+    overlay.addEventListener('touchstart', onTouchStart, { passive: true });
+    overlay.addEventListener('touchmove', onTouchMove, { passive: true });
+    overlay.addEventListener('touchend', onTouchEnd);
+    overlay.addEventListener('touchcancel', onTouchEnd);
+
+    onScroll();
+
+    return () => {
+      if (!overlay) return;
+      overlay.removeEventListener('scroll', onScroll);
+      overlay.removeEventListener('touchstart', onTouchStart);
+      overlay.removeEventListener('touchmove', onTouchMove);
+      overlay.removeEventListener('touchend', onTouchEnd);
+      overlay.removeEventListener('touchcancel', onTouchEnd);
+    };
+  }, [isLaptop, onAction, findOverlay, isScrolledToBottom, overlayFound]);
+
+  useEffect(() => {
+    if (pullDistance >= THRESHOLD && navigator.vibrate) {
+      navigator.vibrate(10);
+    }
+  }, [pullDistance >= THRESHOLD]);
+
+  if (isLaptop) return <span ref={sentinelRef} />;
+
+  const progress = Math.min(pullDistance / THRESHOLD, 1);
+  const isTriggered = pullDistance >= THRESHOLD;
+  const circumference = 2 * Math.PI * 18;
+  const dashOffset = circumference - progress * circumference;
+  const showPull = pullDistance > 0;
+  const showIdle = !showPull && atBottom;
+
+  const indicator = (showPull || showIdle) ? (
+    <div
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-[9999] flex justify-center pb-28 tablet:pb-20"
+      style={{ willChange: 'transform' }}
+    >
+      {showPull && (
+        <div
+          className={classNames(
+            'flex h-12 w-12 items-center justify-center rounded-full shadow-2xl backdrop-blur-md',
+            isTriggered
+              ? 'bg-text-primary text-background-default'
+              : 'border border-border-subtlest-tertiary bg-background-default text-text-primary',
+          )}
+          style={{
+            opacity: Math.min(pullDistance / 20, 1),
+            transform: `scale(${0.5 + progress * 0.5}) translateY(${-pullDistance * 0.3}px)`,
+            transition: 'background-color 150ms, border-color 150ms',
+          }}
+        >
+          <svg className="absolute inset-0 -rotate-90" viewBox="0 0 48 48">
+            <circle
+              cx="24"
+              cy="24"
+              r="20"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              opacity={0.15}
+            />
+            <circle
+              cx="24"
+              cy="24"
+              r="20"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeDasharray={2 * Math.PI * 20}
+              strokeDashoffset={
+                2 * Math.PI * 20 - progress * (2 * Math.PI * 20)
+              }
+              strokeLinecap="round"
+              style={{ transition: 'stroke-dashoffset 60ms linear' }}
+            />
+          </svg>
+          <ArrowIcon
+            className={classNames(
+              'h-5 w-5 rotate-180 transition-transform duration-150',
+              isTriggered && 'scale-125',
+            )}
+          />
+        </div>
+      )}
+      {showIdle && (
+        <div className="flex flex-col items-center">
+          <ArrowIcon className="h-5 w-5 rotate-180 animate-bounce text-text-tertiary" />
+          <ArrowIcon className="-mt-2 h-5 w-5 rotate-180 animate-bounce text-text-tertiary [animation-delay:100ms]" />
+        </div>
+      )}
+    </div>
+  ) : null;
+
+  return (
+    <>
+      <span ref={sentinelRef} className="invisible block h-0 w-0" />
+      {typeof document !== 'undefined' &&
+        indicator &&
+        createPortal(indicator, document.body)}
+    </>
+  );
+}

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -19,6 +19,7 @@ import { useViewPost } from '../../hooks/post';
 import { TruncateText } from '../utilities';
 import { useFeature } from '../GrowthBookProvider';
 import { feature } from '../../lib/featureManagement';
+import { motion } from 'framer-motion';
 import { LazyImage } from '../LazyImage';
 import { cloudinaryPostImageCoverPlaceholder } from '../../lib/image';
 import { withPostById } from './withPostById';
@@ -35,6 +36,8 @@ const PostCodeSnippets = dynamic(() =>
     (mod) => mod.PostCodeSnippets,
   ),
 );
+
+const SHARED_TRANSITION = { type: 'spring', stiffness: 400, damping: 35 };
 
 export function PostContentRaw({
   post,
@@ -162,18 +165,22 @@ export function PostContentRaw({
           post={post}
         >
           <div className={isCompactModalSpacing ? 'my-4' : 'my-6'}>
-            <PostSourceInfo
-              className="mb-3"
-              post={post}
-              onClose={onClose}
-              onReadArticle={onReadArticle}
-            />
-            <h1
+            <motion.div layoutId={`post-author-${post.id}`} transition={SHARED_TRANSITION}>
+              <PostSourceInfo
+                className="mb-3"
+                post={post}
+                onClose={onClose}
+                onReadArticle={onReadArticle}
+              />
+            </motion.div>
+            <motion.h1
+              layoutId={`post-title-${post.id}`}
+              transition={SHARED_TRANSITION}
               className="break-words font-bold typo-large-title"
               data-testid="post-modal-title"
             >
               <ArticleLink>{title}</ArticleLink>
-            </h1>
+            </motion.h1>
             {post.clickbaitTitleDetected && <PostClickbaitShield post={post} />}
           </div>
           {isVideoType && (
@@ -208,22 +215,24 @@ export function PostContentRaw({
             }
           />
           {!isVideoType && (
-            <ArticleLink
-              className={classNames(
-                'block cursor-pointer overflow-hidden rounded-16',
-                isCompactModalSpacing ? 'mb-4' : 'mb-10',
-              )}
-              style={{ maxWidth: '25.625rem' }}
-            >
-              <LazyImage
-                imgSrc={post.image}
-                imgAlt="Post cover image"
-                ratio="49%"
-                eager
-                fallbackSrc={cloudinaryPostImageCoverPlaceholder}
-                fetchPriority="high"
-              />
-            </ArticleLink>
+            <motion.div layoutId={`post-cover-${post.id}`} transition={SHARED_TRANSITION}>
+              <ArticleLink
+                className={classNames(
+                  'block cursor-pointer overflow-hidden rounded-16',
+                  isCompactModalSpacing ? 'mb-4' : 'mb-10',
+                )}
+                style={{ maxWidth: '25.625rem' }}
+              >
+                <LazyImage
+                  imgSrc={post.image}
+                  imgAlt="Post cover image"
+                  ratio="49%"
+                  eager
+                  fallbackSrc={cloudinaryPostImageCoverPlaceholder}
+                  fetchPriority="high"
+                />
+              </ArticleLink>
+            </motion.div>
           )}
           {post.toc?.length > 0 && (
             <PostToc

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,9 @@ importers:
       fetch-event-stream:
         specifier: ^0.1.5
         version: 0.1.5
+      framer-motion:
+        specifier: ^12.23.25
+        version: 12.23.25(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphql-ws:
         specifier: ^5.5.5
         version: 5.16.0(graphql@16.9.0)
@@ -513,6 +516,9 @@ importers:
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       web-vitals:
         specifier: ^3.5.0
         version: 3.5.2
@@ -2766,6 +2772,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-direction@1.1.1':
@@ -9750,6 +9769,12 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+
   vercel@21.3.3:
     resolution: {integrity: sha512-NhxhAmpUoymKQp2WT0PR+NgFPcoVRuhYJ7HSSPKP+S0UCQtZNhy9YCeMkbBzooAw9rrb8gEH+ODEbhK0u5YlFg==}
     engines: {node: '>= 10'}
@@ -11830,6 +11855,28 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.12
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.12)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.12)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.1(@types/react@18.3.12)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
 
   '@radix-ui/react-direction@1.1.1(@types/react@18.3.12)(react@18.3.1)':
     dependencies:
@@ -20064,6 +20111,15 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vaul@1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vercel@21.3.3:
     dependencies:


### PR DESCRIPTION
## Summary
- Add `framer-motion` dependency to `@dailydotdev/shared` package.
- Map `layoutId`s between feed cards (`ListCard`) and the opened modal (`BasePostModal` and `PostContent`) for seamless expansion and collapse.
- Remove old manual modal overlays and old pull-to-close calculations in favor of native Framer Motion layout morphing.
- Fix scrolling behaviors and layout shifts on open/close.

## Test plan
- Verify that clicking an article card smoothly morphs the card into the modal.
- Verify that closing the modal (via X or pull-to-close) smoothly morphs the modal back into the original card.
- Verify that `framer-motion` does not introduce unintended side effects in other layouts.

Made with [Cursor](https://cursor.com)

### Preview domain
https://fix-shared-element-transition.preview.app.daily.dev