### PR TITLE
fix(shared): align squad post author info row items

### DIFF
--- a/packages/shared/src/components/post/SquadPostAuthor.tsx
+++ b/packages/shared/src/components/post/SquadPostAuthor.tsx
@@ -118,7 +118,7 @@ function SquadPostAuthor({
       >
         <div
           className={classNames(
-            'flex gap-1 text-text-tertiary',
+            'flex items-center gap-1 text-text-tertiary',
             className?.handle,
           )}
         >


### PR DESCRIPTION
## Summary
- add `items-center` to the author metadata flex row in `SquadPostAuthor`
- resolve vertical misalignment between author name, Plus badge, separator dot, and date text on mobile

## Key Decisions
- keep scope to a single Tailwind class change in the shared component used by squad and poll post details
- avoid behavioral changes or additional refactors; this is a pure UI alignment fix

Closes ENG-778

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-778-alignment-issue-triggere.preview.app.daily.dev