### PR TITLE
fix(shared): preserve spacing after reply mention prefill

### DIFF
--- a/packages/shared/src/hooks/post/useComments.spec.ts
+++ b/packages/shared/src/hooks/post/useComments.spec.ts
@@ -1,51 +1,11 @@
-import { act, renderHook } from '@testing-library/react';
-import { sharePost } from '../../../__tests__/fixture/post';
-import { useAuthContext } from '../../contexts/AuthContext';
-import { useLogContext } from '../../contexts/LogContext';
-import { useActiveFeedContext } from '../../contexts';
-import { useComments } from './useComments';
-
-jest.mock('../../contexts/AuthContext', () => ({
-  useAuthContext: jest.fn(),
-}));
-
-jest.mock('../../contexts/LogContext', () => ({
-  useLogContext: jest.fn(),
-}));
-
-jest.mock('../../contexts', () => ({
-  useActiveFeedContext: jest.fn(),
-}));
-
-const mockUseAuthContext = useAuthContext as jest.Mock;
-const mockUseLogContext = useLogContext as jest.Mock;
-const mockUseActiveFeedContext = useActiveFeedContext as jest.Mock;
+import { getReplyToInitialContent } from './useComments';
 
 describe('useComments', () => {
-  beforeEach(() => {
-    mockUseAuthContext.mockReturnValue({
-      user: { username: 'current-user' },
-      showLogin: jest.fn(),
-    });
-    mockUseLogContext.mockReturnValue({ logEvent: jest.fn() });
-    mockUseActiveFeedContext.mockReturnValue({ logOpts: null });
+  it('should include a non-breaking trailing space for a reply mention', () => {
+    expect(getReplyToInitialContent('target-user')).toBe('@target-user\u00a0');
   });
 
-  it('should prefill reply mention with a non-breaking trailing space', () => {
-    const { result } = renderHook(() => useComments(sharePost));
-
-    act(() => {
-      result.current.onReplyTo({
-        commentId: 'comment-id',
-        parentCommentId: 'parent-id',
-        username: 'target-user',
-      });
-    });
-
-    expect(result.current.inputProps).toMatchObject({
-      parentCommentId: 'parent-id',
-      replyTo: 'target-user',
-      initialContent: '@target-user\u00a0',
-    });
+  it('should return undefined when username is missing', () => {
+    expect(getReplyToInitialContent()).toBeUndefined();
   });
 });

--- a/packages/shared/src/hooks/post/useComments.ts
+++ b/packages/shared/src/hooks/post/useComments.ts
@@ -18,6 +18,10 @@ interface UseComments extends CommentWrite {
   onReplyTo: (params: ReplyTo) => void;
 }
 
+export const getReplyToInitialContent = (
+  username?: string,
+): string | undefined => (username ? `@${username}\u00a0` : undefined);
+
 export const useComments = (post: Post): UseComments => {
   const { logEvent } = useLogContext();
   const { logOpts } = useActiveFeedContext();
@@ -30,12 +34,11 @@ export const useComments = (post: Post): UseComments => {
     }
 
     const { username, parentCommentId } = replyTo ?? {};
-    const replyToContent = username ? `@${username}\u00a0` : undefined;
 
     return {
       parentCommentId,
       replyTo: username,
-      initialContent: replyToContent,
+      initialContent: getReplyToInitialContent(username),
     };
   }, [replyTo]);
 


### PR DESCRIPTION
## Summary
- preserve a visible trailing space after auto-prefilled `@username` in reply-to-comment flow
- extract `getReplyToInitialContent()` in `useComments` to keep the behavior explicit and simplify testing
- add focused unit coverage for the mention prefill formatting

## Key Decisions
- applied the fix at mention-prefill source (`useComments`) instead of editor initialization, so only reply mentions are affected
- used a non-breaking space (`\u00a0`) to survive HTML parsing/collapsing before Tiptap cursor placement
- kept tests scoped to impacted files and validated with targeted lint + jest

Closes ENG-782

---
Created by Huginn 🐦‍⬛