### PR TITLE
feat: learn-to-code SEO hub

### DIFF
--- a/docs/prd-learn-to-code.md
+++ b/docs/prd-learn-to-code.md
@@ -1,0 +1,192 @@
+# PRD: Learn to Code Hub
+
+## Overview
+
+Build `/learn-to-code` as daily.dev's answer to "I want to learn to code — where do I start?" A hub page aggregating hundreds of programmatic SEO leaf pages, each curated by an AI agent with AI-native content (prompts-as-tutorials) and live daily.dev feed data. Captures high-impression "learn to code" head terms at the hub and long-tail beginner intent queries at the leaf level.
+
+---
+
+## User Stories
+
+### Must-have
+
+- As a career changer landing from Google, I want to immediately see paths relevant to my situation ("coding for marketers", "learn to code to get a job") so I don't bounce trying to figure out where to start.
+- As a beginner on a leaf page (e.g. `/learn-to-code/python`), I want ready-to-paste prompts for Cursor/Claude Code so I can start building something real in 10 minutes, not finish a 20-hour course first.
+- As someone who just vibe-coded something, I want to understand what the AI actually built so I'm learning concepts, not just copy-pasting forever.
+- As a user exploring the hub, I want to see what's trending in the beginner community right now (live daily.dev content) so the page feels like a living resource, not a static blog post from 2024.
+- As a search engine, I want well-structured JSON-LD, internal links between related leaf pages, and fresh content signals so the hub and leaves rank for their target queries.
+
+### Nice-to-have
+
+- As a returning user, I want to pick up where I left off (last visited leaf page surfaced on the hub).
+- As a user finishing a beginner leaf page, I want a "what's next" recommendation linking to adjacent leaf pages.
+
+---
+
+## Architecture
+
+### URL Structure
+
+```
+/learn-to-code                          ← The hub (aggregates everything below)
+├── /learn-to-code/build/todo-app       ← Use case pages
+├── /learn-to-code/build/portfolio-site
+├── /learn-to-code/automate/email
+├── /learn-to-code/automate/spreadsheets
+├── /learn-to-code/python               ← Language/tool pages
+├── /learn-to-code/javascript
+├── /learn-to-code/cursor
+├── /learn-to-code/vibe-coding          ← Technique pages
+├── /learn-to-code/for/designers        ← Audience pages
+├── /learn-to-code/for/marketers
+└── ...hundreds more
+```
+
+### pSEO Dimensions
+
+| Dimension | Examples | Long-tail queries captured |
+|-----------|----------|---------------------------|
+| **Use case** | build a todo app, automate tasks, make a website | "how to build a todo app" |
+| **Language/tool** | Python, JavaScript, Cursor, Claude Code | "learn python for beginners" |
+| **Audience** | designers, marketers, students, career changers | "coding for marketers" |
+| **Technique** | vibe coding, pair programming with AI, test-driven | "vibe coding for beginners" |
+| **Goal** | get a job, freelance, build a startup, automate work | "learn to code to get a job" |
+
+---
+
+## Hub Page (`/learn-to-code`)
+
+Four sections:
+
+1. **What do you want to build?** — use case cards linking to leaf pages
+2. **Popular paths** — top-visited leaves, ranked by traffic (hardcoded initially, analytics-driven later)
+3. **Fresh picks** — recently agent-updated pages, sorted by `lastUpdated`
+4. **Trending on daily.dev** — dynamic feed data filtered by beginner/programming-basics tags
+
+All sections render server-side at build time. "Trending on daily.dev" hydrates client-side via TanStack Query against existing feed API.
+
+---
+
+## Leaf Pages (`/learn-to-code/[...slug]`)
+
+Dynamic catch-all route. Each leaf page renders:
+
+1. **What & why** — one paragraph, agent-written, no fluff
+2. **Start building** — progressive prompt sequence (3–7 prompts), labeled by tool (Cursor / Claude Code / Replit / generic). Prompts are first-class content — the new tutorials.
+3. **Understand what you built** — key concepts the AI used, explained in plain language. Turns vibe-coding into actual learning.
+4. **Go deeper** — curated external resources (tutorials, courses, videos, docs). Agent-curated, refreshed for dead links.
+5. **Tools** — 2–4 AI coding tools recommended for this use case
+6. **Communities** — daily.dev squads + relevant subreddits/discords
+7. **Related daily.dev content** — dynamic feed filtered by leaf page's tags
+8. **Related pages** — internal links to adjacent leaf pages (powers the pSEO linking mesh)
+
+---
+
+## Data Model
+
+Each leaf page consumes a JSON file at `data/learn-to-code/{slug}.json`:
+
+```ts
+type LeafPageData = {
+  slug: string;           // e.g. "python" or "build/todo-app"
+  title: string;
+  description: string;    // one paragraph — SEO meta + page intro
+  dimension: 'language' | 'usecase' | 'audience' | 'technique' | 'goal';
+  tags: string[];         // daily.dev tag slugs for feed + related content
+  prompts: Prompt[];
+  concepts: Concept[];    // "understand what you built"
+  resources: Resource[];
+  tools: Tool[];
+  communities: Community[];
+  relatedSlugs: string[]; // internal linking mesh
+  lastUpdated: string;    // ISO date, agent stamps on refresh
+};
+
+type Prompt = {
+  step: number;
+  title: string;
+  body: string;           // the actual prompt text
+  tools: ('cursor' | 'claude-code' | 'replit' | 'generic')[];
+};
+
+type Concept = {
+  name: string;
+  explanation: string;    // plain language, 2-3 sentences
+};
+
+type Resource = {
+  title: string;
+  url: string;
+  type: 'video' | 'article' | 'course' | 'docs';
+  free: boolean;
+};
+
+type Tool = {
+  name: string;
+  url: string;
+  description: string;   // one-line rationale
+};
+
+type Community = {
+  name: string;
+  url: string;
+  platform: 'dailydev' | 'reddit' | 'discord' | 'other';
+};
+```
+
+A manifest file (`data/learn-to-code/manifest.json`) lists all slugs, titles, dimensions, and `lastUpdated`. Used by `getStaticPaths` and the hub page.
+
+---
+
+## The Curation Agent
+
+Separate system that outputs JSON files. Responsibilities:
+
+- Discover and curate quality resources across the web per page
+- Generate/curate starter prompts per use case, versioned for different tools
+- Write "understand what you built" concept explainers
+- Refresh existing recommendations (dead links, outdated content)
+- Identify new leaf pages worth creating (trending queries, emerging tools)
+- Pull relevant daily.dev content per topic
+- Stamp `lastUpdated` on each refresh
+
+---
+
+## Rendering & Performance
+
+- `getStaticProps` + ISR with `revalidate: 3600` for leaf pages
+- `fallback: 'blocking'` — pages generate on first request
+- Pre-generate top ~50 leaf pages at build time once data is seeded
+- Hub: ISR with `revalidate: 300` (5 min)
+
+---
+
+## SEO
+
+- **Leaf JSON-LD**: `HowTo` schema for prompt sequence (each prompt = `HowToStep`), `CollectionPage` for resources, `BreadcrumbList`
+- **Hub JSON-LD**: `CollectionPage` of featured leaf pages + `FAQPage` for common questions
+- **Title pattern**: `"Learn [Topic] — Prompts, Resources & Community | daily.dev"`
+- Canonical URLs enforced, no duplicate content across dimension combos
+- `sr-only` anchor links to related leaf pages for link equity
+
+---
+
+## Technical Details
+
+- **Routing**: `pages/learn-to-code/index.tsx` (hub) + `pages/learn-to-code/[...slug].tsx` (all leaves)
+- **Feed integration**: Existing `HorizontalFeed` + `TAG_FEED_QUERY` filtered by leaf's tags
+- **Squads integration**: Existing Squads API filtered by tags
+- **Layout**: `PageWrapperLayout`, `getFooterNavBarLayout(getLayout(...))`, `max-w-6xl`
+- **No new GraphQL**: All dynamic data uses existing queries. Leaf content is file-based.
+
+---
+
+## Out of Scope
+
+- User accounts / personalization / progress tracking
+- Generating leaf page JSON files (agent's job)
+- A/B testing hub layout variants
+- Mobile app surfaces
+- User-submitted resources or community curation
+- Search/filter UI within the hub
+- Localization / non-English pages

--- a/packages/webapp/data/learn-to-code/automate-your-workflow.json
+++ b/packages/webapp/data/learn-to-code/automate-your-workflow.json
@@ -22,7 +22,7 @@
       "step": 1,
       "title": "Automate file organization",
       "body": "Write a Python script that watches my Downloads folder and automatically organizes files into subfolders by type: Images (jpg, png, gif, svg), Documents (pdf, docx, xlsx), Videos (mp4, mov), Code (py, js, html, css), and Archives (zip, tar, gz). Move each file to the right folder as soon as it appears.",
-      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "beginner",
       "timeEstimate": "~30 min",
       "stuckTip": "If the file watcher doesn't trigger, ask the AI to show you how to test the script manually first by passing a folder path as a command-line argument."
@@ -31,7 +31,7 @@
       "step": 2,
       "title": "Batch rename files",
       "body": "Create a Python script that batch renames files in a folder. It should support: adding a prefix or suffix, replacing text in filenames, converting to lowercase, adding sequential numbers, and inserting the date. Show a preview of changes before applying them. Add an undo feature that can reverse the last rename operation.",
-      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "beginner",
       "timeEstimate": "~30 min",
       "stuckTip": "If the undo feature is confusing to implement, ask the AI to save a rename log as a JSON file that can be replayed in reverse."
@@ -123,11 +123,6 @@
       "name": "Zapier",
       "url": "https://zapier.com",
       "description": "No-code automation for connecting apps — good starting point before Python"
-    },
-    {
-      "name": "Replit",
-      "url": "https://replit.com",
-      "description": "Run Python scripts in the browser and schedule them to run automatically"
     }
   ],
   "communities": [

--- a/packages/webapp/data/learn-to-code/automate-your-workflow.json
+++ b/packages/webapp/data/learn-to-code/automate-your-workflow.json
@@ -1,0 +1,152 @@
+{
+  "slug": "automate-your-workflow",
+  "title": "Automate Your Workflow",
+  "description": "You don't need to be a programmer to automate repetitive tasks. If you can describe what you do manually, AI can help you write a script to do it automatically. Reclaim hours every week by automating the boring stuff.",
+  "dimension": "goal",
+  "tags": ["python", "automation", "scripting", "productivity"],
+  "projectDescription": "You'll build scripts that do your boring work for you — organizing messy downloads folders, batch renaming files, sending automated email reports, and monitoring websites for changes. Each script saves you real time every week.",
+  "outcomes": [
+    "Write Python scripts that automate repetitive file and folder tasks",
+    "Schedule scripts to run automatically without any manual trigger",
+    "Pull data from external services like Google Sheets and send formatted reports",
+    "Build a personal dashboard to monitor and manage all your automations"
+  ],
+  "aiTips": [
+    "Describe your manual workflow step by step before asking for a script — the more precise the input, the more useful the output",
+    "Always ask the AI to add logging to scripts that will run unattended so you can debug failures later",
+    "Test scripts on a small sample of real data before pointing them at your full Downloads folder or live spreadsheet",
+    "Ask the AI to add a dry-run mode that prints what the script would do without actually doing it"
+  ],
+  "prompts": [
+    {
+      "step": 1,
+      "title": "Automate file organization",
+      "body": "Write a Python script that watches my Downloads folder and automatically organizes files into subfolders by type: Images (jpg, png, gif, svg), Documents (pdf, docx, xlsx), Videos (mp4, mov), Code (py, js, html, css), and Archives (zip, tar, gz). Move each file to the right folder as soon as it appears.",
+      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "difficulty": "beginner",
+      "timeEstimate": "~30 min",
+      "stuckTip": "If the file watcher doesn't trigger, ask the AI to show you how to test the script manually first by passing a folder path as a command-line argument."
+    },
+    {
+      "step": 2,
+      "title": "Batch rename files",
+      "body": "Create a Python script that batch renames files in a folder. It should support: adding a prefix or suffix, replacing text in filenames, converting to lowercase, adding sequential numbers, and inserting the date. Show a preview of changes before applying them. Add an undo feature that can reverse the last rename operation.",
+      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "difficulty": "beginner",
+      "timeEstimate": "~30 min",
+      "stuckTip": "If the undo feature is confusing to implement, ask the AI to save a rename log as a JSON file that can be replayed in reverse."
+    },
+    {
+      "step": 3,
+      "title": "Automate email reports",
+      "body": "Write a Python script that reads data from a Google Sheet (using the gspread library), generates a summary report with key metrics and a chart, and sends it as a formatted HTML email using smtplib. Set it up to run automatically every Monday at 9am using a cron job or schedule library.",
+      "tools": ["cursor", "claude-code"],
+      "difficulty": "intermediate",
+      "timeEstimate": "~60 min",
+      "stuckTip": "If Google Sheets authentication fails, ask the AI to walk you through creating a service account and sharing the sheet with it."
+    },
+    {
+      "step": 4,
+      "title": "Build a web scraper",
+      "body": "Create a Python script that monitors a webpage for changes. It should: fetch the page at regular intervals, compare with the previous version, and send me a notification (desktop notification or email) when something changes. Add support for monitoring multiple URLs from a config file.",
+      "tools": ["cursor", "claude-code"],
+      "difficulty": "stretch",
+      "timeEstimate": "~60 min",
+      "stuckTip": "If the comparison produces false positives (timestamps changing), ask the AI to extract only the relevant content section rather than comparing the full HTML."
+    },
+    {
+      "step": 5,
+      "title": "Create a personal automation dashboard",
+      "body": "Build a web-based dashboard that shows all my automations: which ones are running, their last execution time, success/failure status, and logs. Add buttons to run each automation manually. Include a simple form to add new scheduled tasks. Use Flask for the backend and store automation status in SQLite.",
+      "tools": ["cursor", "claude-code"],
+      "difficulty": "stretch",
+      "timeEstimate": "~90 min",
+      "stuckTip": "Start with a static dashboard that reads from a hardcoded SQLite file before wiring up live automation status — get the UI right first."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "File System Operations",
+      "explanation": "Python's os and pathlib modules let you create, move, rename, and delete files and folders programmatically. Every automation starts with understanding how to interact with the file system."
+    },
+    {
+      "name": "Scheduling and Cron Jobs",
+      "explanation": "Cron (Linux/Mac) and Task Scheduler (Windows) run scripts automatically at set times. This is how you make automation truly hands-free — your script runs while you sleep."
+    },
+    {
+      "name": "APIs and Web Requests",
+      "explanation": "The requests library lets Python talk to any web service. Read data from Google Sheets, send Slack messages, check the weather — if a service has an API, you can automate it."
+    },
+    {
+      "name": "Error Handling and Logging",
+      "explanation": "Automations run unattended, so they need to handle errors gracefully. Logging records what happened so you can debug failures. Try/except blocks prevent one error from crashing everything."
+    }
+  ],
+  "resources": [
+    {
+      "title": "Automate the Boring Stuff with Python",
+      "url": "https://automatetheboringstuff.com/",
+      "type": "article",
+      "free": true
+    },
+    {
+      "title": "Python Automation Tutorial — freeCodeCamp",
+      "url": "https://www.freecodecamp.org/news/python-automation-scripts/",
+      "type": "article",
+      "free": true
+    },
+    {
+      "title": "Real Python — Task Automation",
+      "url": "https://realpython.com/tutorials/automation/",
+      "type": "article",
+      "free": true
+    },
+    {
+      "title": "Zapier — No-Code Automation",
+      "url": "https://zapier.com/",
+      "type": "docs",
+      "free": false
+    }
+  ],
+  "tools": [
+    {
+      "name": "Claude Code",
+      "url": "https://docs.anthropic.com/en/docs/claude-code",
+      "description": "Describe your manual workflow and let AI write the automation script"
+    },
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "AI code editor — great for building and testing automation scripts"
+    },
+    {
+      "name": "Zapier",
+      "url": "https://zapier.com",
+      "description": "No-code automation for connecting apps — good starting point before Python"
+    },
+    {
+      "name": "Replit",
+      "url": "https://replit.com",
+      "description": "Run Python scripts in the browser and schedule them to run automatically"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/automate",
+      "url": "https://reddit.com/r/automate",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/learnpython",
+      "url": "https://reddit.com/r/learnpython",
+      "platform": "reddit"
+    },
+    {
+      "name": "Indie Hackers",
+      "url": "https://indiehackers.com",
+      "platform": "other"
+    }
+  ],
+  "relatedSlugs": ["python", "for/marketers", "for/data-analysts"],
+  "lastUpdated": "2026-03-10"
+}

--- a/packages/webapp/data/learn-to-code/automate.json
+++ b/packages/webapp/data/learn-to-code/automate.json
@@ -1,0 +1,79 @@
+{
+  "slug": "automate",
+  "title": "Automate Your Life",
+  "description": "If you do the same task more than twice, a script can do it for you. Organize files, generate reports, send emails on a schedule — AI writes the code, you describe what you want automated.",
+  "dimension": "category",
+  "tags": ["python", "automation", "scripting", "productivity"],
+  "outcomes": [
+    "Write scripts that handle repetitive tasks so you never do them manually again",
+    "Schedule automations to run on their own — no clicking required",
+    "Connect tools and services together with APIs",
+    "Build personal dashboards and reports that update themselves"
+  ],
+  "recommendedPaths": [
+    {
+      "slug": "automate-your-workflow",
+      "title": "Automate Your Workflow",
+      "reason": "Start here. Organize messy folders, batch rename files, and build scripts that save you hours every week."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "Scripting",
+      "explanation": "A script is a small program that runs a sequence of steps automatically. Instead of clicking through 10 steps manually, you run one command and it does everything."
+    },
+    {
+      "name": "APIs",
+      "explanation": "APIs let your scripts talk to services like Google Sheets, Slack, and email. Instead of copying data between tools, your script pulls it directly."
+    },
+    {
+      "name": "Scheduling",
+      "explanation": "Cron jobs and task schedulers run your scripts on a timer — every hour, every morning, every Monday. Set it up once and forget about it."
+    }
+  ],
+  "resources": [
+    {
+      "title": "Automate the Boring Stuff with Python",
+      "url": "https://automatetheboringstuff.com/",
+      "type": "article",
+      "free": true
+    },
+    {
+      "title": "Python for Everybody",
+      "url": "https://www.py4e.com/",
+      "type": "course",
+      "free": true
+    }
+  ],
+  "tools": [
+    {
+      "name": "Claude Code",
+      "url": "https://docs.anthropic.com/en/docs/claude-code",
+      "description": "Describe what you want automated in plain English and it builds the script"
+    },
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "AI code editor — great for writing and debugging automation scripts"
+    },
+    {
+      "name": "Google Apps Script",
+      "url": "https://script.google.com",
+      "description": "Automate Google Sheets, Docs, and Gmail — no setup required"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/learnpython",
+      "url": "https://reddit.com/r/learnpython",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/automation",
+      "url": "https://reddit.com/r/automation",
+      "platform": "reddit"
+    }
+  ],
+  "relatedSlugs": ["python", "build", "skills"],
+  "lastUpdated": "2026-03-11"
+}

--- a/packages/webapp/data/learn-to-code/build.json
+++ b/packages/webapp/data/learn-to-code/build.json
@@ -1,0 +1,100 @@
+{
+  "slug": "build",
+  "title": "Build Something",
+  "description": "The fastest way to learn is to build. Pick a project below, paste the prompts into your AI coding tool, and ship something real this weekend. No experience required — each guide walks you through it step by step.",
+  "dimension": "category",
+  "tags": ["programming", "webdev", "beginners"],
+  "outcomes": [
+    "Go from zero to a working app you can share with a link",
+    "Understand the basics of how web apps, bots, and extensions work",
+    "Learn to iterate on AI-generated code — add features, fix bugs, make it yours",
+    "Deploy a real project to the internet"
+  ],
+  "recommendedPaths": [
+    {
+      "slug": "build/todo-app",
+      "title": "Build a Todo App",
+      "reason": "The classic first project. Simple enough to finish in an hour, complex enough to learn real concepts like state, storage, and UI."
+    },
+    {
+      "slug": "build/personal-website",
+      "title": "Build a Personal Website",
+      "reason": "Create a portfolio site you actually own. Great for anyone who wants a web presence — students, freelancers, job seekers."
+    },
+    {
+      "slug": "build/chrome-extension",
+      "title": "Build a Chrome Extension",
+      "reason": "Customize your browser with a tool you'll actually use every day. A satisfying project that feels immediately useful."
+    },
+    {
+      "slug": "build/discord-bot",
+      "title": "Build a Discord Bot",
+      "reason": "Build a bot for your server — moderator, game, or utility. Fun to build, fun to show friends, and teaches real API concepts."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "Frontend vs Backend",
+      "explanation": "Frontend is what users see (HTML, CSS, JavaScript in the browser). Backend is the server-side logic — databases, APIs, authentication. Most projects touch both."
+    },
+    {
+      "name": "State Management",
+      "explanation": "State is the data your app holds in memory — the list of todos, whether a toggle is on or off. Understanding state is the key to understanding how apps behave."
+    },
+    {
+      "name": "Deployment",
+      "explanation": "Deployment means putting your app on the internet so anyone can use it. Services like Vercel, Railway, and Netlify make this free and simple for small projects."
+    }
+  ],
+  "resources": [
+    {
+      "title": "freeCodeCamp - Responsive Web Design",
+      "url": "https://www.freecodecamp.org/learn/2022/responsive-web-design/",
+      "type": "course",
+      "free": true
+    },
+    {
+      "title": "The Odin Project",
+      "url": "https://www.theodinproject.com/",
+      "type": "course",
+      "free": true
+    },
+    {
+      "title": "JavaScript.info",
+      "url": "https://javascript.info/",
+      "type": "docs",
+      "free": true
+    }
+  ],
+  "tools": [
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "AI-first code editor — the fastest way to build projects with AI assistance"
+    },
+    {
+      "name": "Claude Code",
+      "url": "https://docs.anthropic.com/en/docs/claude-code",
+      "description": "Agentic coding in your terminal — describe what you want and it builds it"
+    },
+    {
+      "name": "Vercel",
+      "url": "https://vercel.com",
+      "description": "Free hosting for web apps — deploy with one command"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/learnprogramming",
+      "url": "https://reddit.com/r/learnprogramming",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/webdev",
+      "url": "https://reddit.com/r/webdev",
+      "platform": "reddit"
+    }
+  ],
+  "relatedSlugs": ["vibe-coding", "languages", "automate"],
+  "lastUpdated": "2026-03-11"
+}

--- a/packages/webapp/data/learn-to-code/debugging.json
+++ b/packages/webapp/data/learn-to-code/debugging.json
@@ -1,0 +1,152 @@
+{
+  "slug": "debugging",
+  "title": "Debugging with AI",
+  "description": "Bugs are inevitable — even AI-generated code has them. The good news is that AI is also incredible at finding and fixing bugs. Learning to debug effectively is the difference between giving up in frustration and actually shipping your project.",
+  "dimension": "technique",
+  "tags": ["debugging", "programming", "beginners"],
+  "projectDescription": "You'll work through increasingly tricky bugs — from simple typos to logic errors to mysterious crashes. Each prompt gives you a broken piece of code and guides you through fixing it with AI. By the end, you'll have a repeatable system for solving any bug.",
+  "outcomes": [
+    "Decode any error message and trace it back to the root cause",
+    "Use browser DevTools and VS Code debugger to step through code",
+    "Apply a systematic reproduce-isolate-fix workflow to any bug",
+    "Add TypeScript, validation, and tests to prevent bugs proactively"
+  ],
+  "aiTips": [
+    "Always paste the full error message and stack trace — the AI needs the exact text, not a paraphrase",
+    "If the AI's fix introduces a new bug, describe both the original error and the new one together",
+    "Ask the AI to explain why a bug happened, not just how to fix it — the explanation is the real learning",
+    "Use AI as a rubber duck: describe what your code should do line by line and it will often spot the issue before you finish"
+  ],
+  "prompts": [
+    {
+      "step": 1,
+      "title": "Learn to read error messages",
+      "body": "I'm going to paste error messages I encounter while coding. For each one, explain: what the error means in plain English, what likely caused it, and how to fix it. Start with these common ones: TypeError, ReferenceError, SyntaxError, and ModuleNotFoundError. Give me a real code example for each that triggers the error.",
+      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "difficulty": "beginner",
+      "timeEstimate": "~20 min",
+      "stuckTip": "If an error type is confusing, ask the AI to show you three different real-world examples of what triggers it."
+    },
+    {
+      "step": 2,
+      "title": "Debug a broken app",
+      "body": "Create a simple todo app in JavaScript that has 5 intentional bugs: a logic error, an off-by-one error, a missing null check, a scope issue, and a race condition. Show me the buggy code first. Then walk me through finding each bug using console.log, the browser debugger, and logical reasoning.",
+      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "difficulty": "beginner",
+      "timeEstimate": "~40 min",
+      "stuckTip": "If you can't find a bug after 10 minutes, ask the AI to give you a single hint about which line range to look at — not the answer."
+    },
+    {
+      "step": 3,
+      "title": "Set up proper debugging tools",
+      "body": "Show me how to set up debugging for a Node.js project in VS Code: breakpoints, watch variables, step through code, and the debug console. Then do the same for a React app in Chrome DevTools: component inspector, network tab, and console filtering. Create a sample project to practice with.",
+      "tools": ["cursor", "claude-code"],
+      "difficulty": "intermediate",
+      "timeEstimate": "~45 min",
+      "stuckTip": "If the VS Code debugger won't attach, ask the AI to walk you through the launch.json configuration for your specific project type."
+    },
+    {
+      "step": 4,
+      "title": "Debug someone else's code",
+      "body": "Generate a 100-line Python script that processes a CSV file but has 3 subtle bugs that only appear with certain data. Give me the script without telling me what the bugs are. Guide me through a systematic debugging approach: reproduce, isolate, identify, fix, verify.",
+      "tools": ["cursor", "claude-code", "generic"],
+      "difficulty": "stretch",
+      "timeEstimate": "~60 min",
+      "stuckTip": "Create a minimal test CSV with only a few rows that triggers the bug — smaller inputs make issues much easier to isolate."
+    },
+    {
+      "step": 5,
+      "title": "Prevent bugs before they happen",
+      "body": "Take the todo app from step 2 and add: TypeScript for type safety, input validation for all user inputs, error boundaries for the React components, and 5 unit tests for the most critical functions. Explain how each prevention measure would have caught the original bugs.",
+      "tools": ["cursor", "claude-code"],
+      "difficulty": "stretch",
+      "timeEstimate": "~60 min",
+      "stuckTip": "If TypeScript migration feels overwhelming, ask the AI to convert one file at a time and explain each type annotation it adds."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "Error Messages Are Your Friend",
+      "explanation": "Error messages tell you exactly what went wrong and where. The stack trace shows the chain of function calls that led to the error. Learning to read them is the single biggest debugging skill you can develop."
+    },
+    {
+      "name": "Reproduce, Isolate, Fix",
+      "explanation": "The debugging process: first make the bug happen reliably, then narrow down where it occurs (binary search by commenting out code), then fix it and verify the fix didn't break anything else."
+    },
+    {
+      "name": "Rubber Duck Debugging",
+      "explanation": "Explaining your code line by line — to an AI, a colleague, or even a rubber duck — often reveals the bug. The act of verbalizing your assumptions forces you to check each one. AI assistants are the ultimate rubber duck."
+    },
+    {
+      "name": "Defensive Programming",
+      "explanation": "Check for problems before they crash your app. Validate inputs, handle null values, add type checks. It's easier to prevent bugs than to find them after they happen."
+    }
+  ],
+  "resources": [
+    {
+      "title": "Chrome DevTools Debugging Guide",
+      "url": "https://developer.chrome.com/docs/devtools/javascript/",
+      "type": "docs",
+      "free": true
+    },
+    {
+      "title": "VS Code Debugging Documentation",
+      "url": "https://code.visualstudio.com/docs/editor/debugging",
+      "type": "docs",
+      "free": true
+    },
+    {
+      "title": "Fireship — Debugging Tips",
+      "url": "https://www.youtube.com/@Fireship",
+      "type": "video",
+      "free": true
+    },
+    {
+      "title": "Python Debugging with pdb",
+      "url": "https://docs.python.org/3/library/pdb.html",
+      "type": "docs",
+      "free": true
+    }
+  ],
+  "tools": [
+    {
+      "name": "Chrome DevTools",
+      "url": "https://developer.chrome.com/docs/devtools/",
+      "description": "Built-in browser debugger — breakpoints, network inspector, console, and more"
+    },
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "Paste your error into the AI chat and get an explanation and fix instantly"
+    },
+    {
+      "name": "Claude Code",
+      "url": "https://docs.anthropic.com/en/docs/claude-code",
+      "description": "Describe your bug in plain English and let AI find and fix it in your codebase"
+    },
+    {
+      "name": "VS Code Debugger",
+      "url": "https://code.visualstudio.com/docs/editor/debugging",
+      "description": "Step through code line by line, inspect variables, and set breakpoints"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/learnprogramming",
+      "url": "https://reddit.com/r/learnprogramming",
+      "platform": "reddit"
+    },
+    {
+      "name": "Stack Overflow",
+      "url": "https://stackoverflow.com/",
+      "platform": "other"
+    },
+    {
+      "name": "r/webdev",
+      "url": "https://reddit.com/r/webdev",
+      "platform": "reddit"
+    }
+  ],
+  "relatedSlugs": ["vibe-coding", "python", "javascript"],
+  "lastUpdated": "2026-03-10"
+}

--- a/packages/webapp/data/learn-to-code/debugging.json
+++ b/packages/webapp/data/learn-to-code/debugging.json
@@ -22,7 +22,7 @@
       "step": 1,
       "title": "Learn to read error messages",
       "body": "I'm going to paste error messages I encounter while coding. For each one, explain: what the error means in plain English, what likely caused it, and how to fix it. Start with these common ones: TypeError, ReferenceError, SyntaxError, and ModuleNotFoundError. Give me a real code example for each that triggers the error.",
-      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "beginner",
       "timeEstimate": "~20 min",
       "stuckTip": "If an error type is confusing, ask the AI to show you three different real-world examples of what triggers it."
@@ -31,7 +31,7 @@
       "step": 2,
       "title": "Debug a broken app",
       "body": "Create a simple todo app in JavaScript that has 5 intentional bugs: a logic error, an off-by-one error, a missing null check, a scope issue, and a race condition. Show me the buggy code first. Then walk me through finding each bug using console.log, the browser debugger, and logical reasoning.",
-      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "beginner",
       "timeEstimate": "~40 min",
       "stuckTip": "If you can't find a bug after 10 minutes, ask the AI to give you a single hint about which line range to look at — not the answer."

--- a/packages/webapp/data/learn-to-code/for/data-analysts.json
+++ b/packages/webapp/data/learn-to-code/for/data-analysts.json
@@ -1,0 +1,132 @@
+{
+  "slug": "for/data-analysts",
+  "title": "Coding for Data Analysts",
+  "description": "You already think in data — coding just gives you superpowers. Stop clicking through Excel menus and start writing scripts that clean, analyze, and visualize data in seconds. Python + AI tools = the end of repetitive data work.",
+  "dimension": "audience",
+  "tags": ["python", "data-science", "pandas", "automation"],
+  "outcomes": [
+    "Replace repetitive Excel workflows with Python scripts that process data in seconds",
+    "Generate professional charts and multi-page PDF reports automatically from any dataset",
+    "Build interactive dashboards stakeholders can explore without emailing you for filters",
+    "Connect directly to databases with SQL and schedule automated data refreshes"
+  ],
+  "aiTips": [
+    "Paste a few rows of your actual data as context — AI writes much better pandas code when it can see your real column names and data types",
+    "Ask the AI to add print statements at each step so you can see what the data looks like as it transforms — this makes debugging much faster",
+    "When a chart doesn't look right, describe the visual problem specifically: 'the x-axis labels are overlapping' is more useful than 'it looks bad'",
+    "Ask the AI to write modular functions rather than one big script — it's easier to reuse and adapt pieces for your next analysis"
+  ],
+  "recommendedPaths": [
+    {
+      "slug": "python",
+      "title": "Learn Python",
+      "reason": "Python + pandas is how analysts replace Excel. Write scripts that clean, transform, and analyze data in seconds instead of clicking through menus."
+    },
+    {
+      "slug": "automate-your-workflow",
+      "title": "Automate Your Workflow",
+      "reason": "Stop manually pulling reports every Monday. Build scripts that fetch data, generate charts, and email summaries on a schedule."
+    },
+    {
+      "slug": "debugging",
+      "title": "Debugging with AI",
+      "reason": "When your data pipeline breaks at 2am, you need to fix it fast. Learn to diagnose and fix errors systematically with AI help."
+    },
+    {
+      "slug": "vibe-coding",
+      "title": "Try Vibe Coding",
+      "reason": "Describe your analysis in plain English — 'group by region, calculate monthly growth rate, make a heatmap' — and watch AI write the pandas code."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "DataFrames",
+      "explanation": "A DataFrame is a table in code — rows and columns you can filter, sort, and aggregate programmatically. pandas DataFrames are like Excel spreadsheets that can process millions of rows in seconds."
+    },
+    {
+      "name": "Data Cleaning",
+      "explanation": "Real data is messy — missing values, duplicates, inconsistent formats. Data cleaning is usually 80% of the work. Python scripts make this repeatable — clean once, run the same steps on every new data drop."
+    },
+    {
+      "name": "Visualization Libraries",
+      "explanation": "matplotlib creates any chart you can imagine. seaborn makes statistical charts beautiful with minimal code. Plotly adds interactivity. Together they replace Tableau for most reporting needs."
+    },
+    {
+      "name": "SQL Fundamentals",
+      "explanation": "SQL is the language of databases. SELECT, WHERE, GROUP BY, and JOIN let you pull exactly the data you need from any database. Every analyst job expects SQL proficiency."
+    }
+  ],
+  "resources": [
+    {
+      "title": "Python for Data Analysis (Wes McKinney)",
+      "url": "https://wesmckinney.com/book/",
+      "type": "article",
+      "free": true
+    },
+    {
+      "title": "Kaggle Learn — Pandas",
+      "url": "https://www.kaggle.com/learn/pandas",
+      "type": "course",
+      "free": true
+    },
+    {
+      "title": "Mode Analytics — SQL Tutorial",
+      "url": "https://mode.com/sql-tutorial",
+      "type": "course",
+      "free": true
+    },
+    {
+      "title": "Streamlit Documentation",
+      "url": "https://docs.streamlit.io/",
+      "type": "docs",
+      "free": true
+    },
+    {
+      "title": "Corey Schafer — Pandas Tutorials",
+      "url": "https://www.youtube.com/playlist?list=PL-osiE80TeTsWmV9i9c58mdDCSskIFdDS",
+      "type": "video",
+      "free": true
+    }
+  ],
+  "tools": [
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "AI code editor — describe your analysis and it writes the pandas code"
+    },
+    {
+      "name": "Claude Code",
+      "url": "https://docs.anthropic.com/en/docs/claude-code",
+      "description": "Build data pipelines and dashboards from plain English descriptions"
+    },
+    {
+      "name": "Jupyter Notebooks",
+      "url": "https://jupyter.org/",
+      "description": "Mix code, charts, and notes in one document — the standard for data analysis"
+    },
+    {
+      "name": "Streamlit",
+      "url": "https://streamlit.io",
+      "description": "Turn Python scripts into interactive web dashboards in minutes"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/dataanalysis",
+      "url": "https://reddit.com/r/dataanalysis",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/learnpython",
+      "url": "https://reddit.com/r/learnpython",
+      "platform": "reddit"
+    },
+    {
+      "name": "Kaggle Community",
+      "url": "https://www.kaggle.com/discussions",
+      "platform": "other"
+    }
+  ],
+  "relatedSlugs": ["python", "automate-your-workflow", "for/marketers"],
+  "lastUpdated": "2026-03-10"
+}

--- a/packages/webapp/data/learn-to-code/for/designers.json
+++ b/packages/webapp/data/learn-to-code/for/designers.json
@@ -1,0 +1,132 @@
+{
+  "slug": "for/designers",
+  "title": "Coding for Designers",
+  "description": "You already think in layout, color, and interaction — coding just gives you the tools to build what you design. With AI writing the syntax for you, the gap between a Figma mockup and a live website has never been smaller.",
+  "dimension": "audience",
+  "tags": ["css", "html", "webdev", "design"],
+  "outcomes": [
+    "Translate Figma mockups into working HTML and CSS without relying on a developer",
+    "Build a reusable component library with consistent design tokens you control",
+    "Create polished micro-interactions and animations that match your design intent",
+    "Ship a live portfolio site and React component library you can show in interviews"
+  ],
+  "aiTips": [
+    "Share your Figma specs or screenshots directly — AI understands design language like spacing, type scale, and color values",
+    "Describe interactions the way you'd write a design note: 'button scales to 1.05 on hover with a 150ms ease-out transition'",
+    "Ask the AI to use CSS custom properties for all colors so you can swap themes without hunting through the code",
+    "When the output doesn't match your vision, annotate a screenshot and describe exactly what looks off rather than re-explaining from scratch"
+  ],
+  "recommendedPaths": [
+    {
+      "slug": "html-css",
+      "title": "Learn HTML & CSS",
+      "reason": "You already think in layout and color — HTML and CSS are the code equivalent of your design tools. See your designs come alive in the browser."
+    },
+    {
+      "slug": "build/personal-website",
+      "title": "Build a Personal Website",
+      "reason": "Turn your portfolio into a real website. Build it yourself, deploy it, and show it off with a custom domain."
+    },
+    {
+      "slug": "javascript",
+      "title": "Learn JavaScript",
+      "reason": "Add interactivity to your designs — hover animations, scroll effects, dynamic content. JavaScript makes static pages feel alive."
+    },
+    {
+      "slug": "vibe-coding",
+      "title": "Try Vibe Coding",
+      "reason": "Describe your Figma mockup in words and watch AI write the code. The fastest way to prototype in code instead of static screens."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "CSS Custom Properties (Design Tokens)",
+      "explanation": "Design tokens in code. Define your colors, spacing, and typography as CSS variables once, then reference them everywhere. Change the primary color in one line and the entire site updates — just like Figma styles."
+    },
+    {
+      "name": "CSS Transforms and Transitions",
+      "explanation": "Transforms move, rotate, and scale elements. Transitions animate between states smoothly. Together they create the micro-interactions that make interfaces feel polished — hover effects, button animations, loading states."
+    },
+    {
+      "name": "Component-Based Architecture",
+      "explanation": "Just like Figma components with variants, code components are reusable pieces with configurable properties. Build a Button component once, use it everywhere with different styles. Changes propagate automatically."
+    },
+    {
+      "name": "Responsive Units",
+      "explanation": "rem, em, vw, vh, and % let your designs adapt to any screen size. Combined with media queries, you can create layouts that flow naturally from phone to desktop — no fixed pixel values needed."
+    }
+  ],
+  "resources": [
+    {
+      "title": "CSS-Tricks — A Complete Guide to CSS Grid",
+      "url": "https://css-tricks.com/snippets/css/complete-guide-grid/",
+      "type": "article",
+      "free": true
+    },
+    {
+      "title": "Refactoring UI",
+      "url": "https://www.refactoringui.com/",
+      "type": "article",
+      "free": false
+    },
+    {
+      "title": "Kevin Powell — CSS for Designers",
+      "url": "https://www.youtube.com/@KevinPowell",
+      "type": "video",
+      "free": true
+    },
+    {
+      "title": "Tailwind CSS Documentation",
+      "url": "https://tailwindcss.com/docs",
+      "type": "docs",
+      "free": true
+    },
+    {
+      "title": "Storybook — UI Component Workshop",
+      "url": "https://storybook.js.org/docs",
+      "type": "docs",
+      "free": true
+    }
+  ],
+  "tools": [
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "Describe your design in words and AI writes the HTML and CSS"
+    },
+    {
+      "name": "Claude Code",
+      "url": "https://docs.anthropic.com/en/docs/claude-code",
+      "description": "Convert design specs into working code from your terminal"
+    },
+    {
+      "name": "CodePen",
+      "url": "https://codepen.io",
+      "description": "Live playground to experiment with CSS animations and layouts"
+    },
+    {
+      "name": "Tailwind CSS",
+      "url": "https://tailwindcss.com",
+      "description": "Utility-first CSS framework — design directly in your HTML with readable classes"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/web_design",
+      "url": "https://reddit.com/r/web_design",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/Frontend",
+      "url": "https://reddit.com/r/Frontend",
+      "platform": "reddit"
+    },
+    {
+      "name": "Designership Slack",
+      "url": "https://designership.com/",
+      "platform": "other"
+    }
+  ],
+  "relatedSlugs": ["html-css", "build/personal-website", "javascript"],
+  "lastUpdated": "2026-03-10"
+}

--- a/packages/webapp/data/learn-to-code/for/marketers.json
+++ b/packages/webapp/data/learn-to-code/for/marketers.json
@@ -84,11 +84,6 @@
   ],
   "tools": [
     {
-      "name": "Replit",
-      "url": "https://replit.com",
-      "description": "Write and run code in your browser — no setup, no terminal, just start"
-    },
-    {
       "name": "Claude Code",
       "url": "https://docs.anthropic.com/en/docs/claude-code",
       "description": "Describe what you want automated in plain English and it builds it"

--- a/packages/webapp/data/learn-to-code/for/marketers.json
+++ b/packages/webapp/data/learn-to-code/for/marketers.json
@@ -1,0 +1,126 @@
+{
+  "slug": "for/marketers",
+  "title": "Coding for Marketers",
+  "description": "You don't need to become a developer — you need to automate the repetitive parts of your job, build internal tools your team actually needs, and stop waiting on engineering for simple changes. AI makes this realistic for the first time.",
+  "dimension": "audience",
+  "tags": ["javascript", "python", "automation", "beginners"],
+  "outcomes": [
+    "Automate repetitive reporting tasks with Python scripts that run on a schedule",
+    "Build internal tools like UTM generators and content calendars without a developer",
+    "Make basic edits to landing pages and web copy without touching engineering",
+    "Connect marketing platforms to scripts via APIs to eliminate manual data exports"
+  ],
+  "aiTips": [
+    "Start by describing your existing manual process — AI works best when you tell it what you're already doing step by step",
+    "Paste in a sample of your real data (a few rows of CSV) so the AI can write code that matches your exact column names",
+    "When something breaks, copy the full error message into the chat — AI can fix most errors immediately if you share the exact text",
+    "Ask the AI to explain each section after it writes code, so you understand what to change next time"
+  ],
+  "recommendedPaths": [
+    {
+      "slug": "automate-your-workflow",
+      "title": "Automate Your Workflow",
+      "reason": "Stop manually pulling campaign reports and copying data between spreadsheets. Build scripts that do it for you on a schedule."
+    },
+    {
+      "slug": "python",
+      "title": "Learn Python",
+      "reason": "Python is the fastest way to automate spreadsheet tasks, analyze campaign data, and generate reports — no computer science needed."
+    },
+    {
+      "slug": "build/personal-website",
+      "title": "Build a Personal Website",
+      "reason": "Stop waiting on engineering for landing pages. Build and deploy pages yourself with HTML, CSS, and a free hosting tool."
+    },
+    {
+      "slug": "vibe-coding",
+      "title": "Try Vibe Coding",
+      "reason": "Describe what you want in plain English and watch AI build it. The fastest way to create internal tools without learning syntax."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "Data Processing with Python",
+      "explanation": "Python is a marketer's best friend for data work. Reading CSVs, calculating metrics, generating reports — these are things you currently do in Excel that Python can automate and run on a schedule."
+    },
+    {
+      "name": "HTML/CSS Basics",
+      "explanation": "Every web page is HTML (structure) and CSS (styling). Understanding this lets you tweak landing pages, fix formatting issues, and build simple tools without waiting for a developer."
+    },
+    {
+      "name": "APIs and Automation",
+      "explanation": "APIs let your scripts talk to services like Google Ads, HubSpot, and Slack. Instead of manually exporting data and building reports, you can automate the entire pipeline."
+    },
+    {
+      "name": "localStorage and Client-Side Apps",
+      "explanation": "You can build genuinely useful internal tools that run entirely in the browser with no server needed. localStorage keeps the data on your machine — perfect for personal productivity tools."
+    }
+  ],
+  "resources": [
+    {
+      "title": "Automate the Boring Stuff with Python",
+      "url": "https://automatetheboringstuff.com/",
+      "type": "article",
+      "free": true
+    },
+    {
+      "title": "freeCodeCamp - Responsive Web Design",
+      "url": "https://www.freecodecamp.org/learn/2022/responsive-web-design/",
+      "type": "course",
+      "free": true
+    },
+    {
+      "title": "Google Apps Script Tutorial",
+      "url": "https://developers.google.com/apps-script/overview",
+      "type": "docs",
+      "free": true
+    },
+    {
+      "title": "Zapier - Intro to APIs",
+      "url": "https://zapier.com/resources/guides/apis",
+      "type": "article",
+      "free": true
+    }
+  ],
+  "tools": [
+    {
+      "name": "Replit",
+      "url": "https://replit.com",
+      "description": "Write and run code in your browser — no setup, no terminal, just start"
+    },
+    {
+      "name": "Claude Code",
+      "url": "https://docs.anthropic.com/en/docs/claude-code",
+      "description": "Describe what you want automated in plain English and it builds it"
+    },
+    {
+      "name": "Google Apps Script",
+      "url": "https://script.google.com",
+      "description": "Automate Google Sheets, Docs, and Gmail — the easiest entry point for marketers"
+    },
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "AI code editor for building web pages and tools visually"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/learnprogramming",
+      "url": "https://reddit.com/r/learnprogramming",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/nocode",
+      "url": "https://reddit.com/r/nocode",
+      "platform": "reddit"
+    },
+    {
+      "name": "Indie Hackers",
+      "url": "https://indiehackers.com",
+      "platform": "other"
+    }
+  ],
+  "relatedSlugs": ["python", "vibe-coding", "build/todo-app"],
+  "lastUpdated": "2026-03-06"
+}

--- a/packages/webapp/data/learn-to-code/for/students.json
+++ b/packages/webapp/data/learn-to-code/for/students.json
@@ -1,0 +1,132 @@
+{
+  "slug": "for/students",
+  "title": "Coding for Students",
+  "description": "Whether you're studying CS or something completely different, coding is the most useful skill you can learn in school. It's not just for tech jobs — it helps you analyze data, automate homework, build side projects, and stand out in any career.",
+  "dimension": "audience",
+  "tags": ["python", "programming", "beginners", "career"],
+  "outcomes": [
+    "Automate repetitive study tasks like summarizing notes and generating flashcards",
+    "Build web apps with real data persistence that you can add to your portfolio",
+    "Analyze and visualize datasets for class assignments using Python and pandas",
+    "Deploy a full-stack project to the web using modern tools like React, Firebase, and Vercel"
+  ],
+  "aiTips": [
+    "Use AI as a study partner — ask it to explain why the code works, not just to write it for you",
+    "When debugging, describe what you expected vs what actually happened — that context helps AI find the real issue faster",
+    "Ask the AI to suggest what to learn next after each project so you build skills in the right order",
+    "If you're short on time before a deadline, tell the AI your constraints upfront so it scopes the solution appropriately"
+  ],
+  "recommendedPaths": [
+    {
+      "slug": "python",
+      "title": "Learn Python",
+      "reason": "The most beginner-friendly language — great for automating study tasks, analyzing data for class projects, and building scripts that save you hours."
+    },
+    {
+      "slug": "build/todo-app",
+      "title": "Build a Todo App",
+      "reason": "Your first real project that teaches web development fundamentals. Simple enough to finish in an afternoon, impressive enough to show friends."
+    },
+    {
+      "slug": "build/discord-bot",
+      "title": "Build a Discord Bot",
+      "reason": "Build something your friend group will actually use. Learn APIs, event handling, and deployment while making your server more fun."
+    },
+    {
+      "slug": "get-a-dev-job",
+      "title": "Get Your First Dev Job",
+      "reason": "Turn your coding skills into a career. Build a portfolio, nail interviews, and land your first developer role after graduation."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "Text Processing",
+      "explanation": "Splitting text into chunks, finding patterns, and generating structured output from unstructured input. This is how chatbots, search engines, and autocomplete work under the hood."
+    },
+    {
+      "name": "State Management",
+      "explanation": "Keeping track of data that changes over time — your GPA as you add courses, your timer as it counts down. Understanding state is the key to building any interactive application."
+    },
+    {
+      "name": "Data Visualization",
+      "explanation": "Charts and graphs turn raw numbers into insights you can actually see. Libraries like matplotlib (Python) and Chart.js (JavaScript) make it easy to create professional visualizations from any dataset."
+    },
+    {
+      "name": "Full-Stack Development",
+      "explanation": "Frontend (what users see) + Backend (data storage, authentication) = a full-stack app. Firebase handles the backend so you can focus on the user experience without managing servers."
+    }
+  ],
+  "resources": [
+    {
+      "title": "CS50 — Harvard's Intro to Computer Science",
+      "url": "https://cs50.harvard.edu/x/",
+      "type": "course",
+      "free": true
+    },
+    {
+      "title": "The Odin Project",
+      "url": "https://www.theodinproject.com/",
+      "type": "course",
+      "free": true
+    },
+    {
+      "title": "freeCodeCamp",
+      "url": "https://www.freecodecamp.org/",
+      "type": "course",
+      "free": true
+    },
+    {
+      "title": "GitHub Student Developer Pack",
+      "url": "https://education.github.com/pack",
+      "type": "docs",
+      "free": true
+    },
+    {
+      "title": "Codecademy",
+      "url": "https://www.codecademy.com/",
+      "type": "course",
+      "free": false
+    }
+  ],
+  "tools": [
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "AI code editor — build projects for class or side projects faster"
+    },
+    {
+      "name": "Replit",
+      "url": "https://replit.com",
+      "description": "Code from any computer — no installation needed, works on school laptops"
+    },
+    {
+      "name": "GitHub",
+      "url": "https://github.com",
+      "description": "Store your code, collaborate on group projects, and build your portfolio"
+    },
+    {
+      "name": "Claude Code",
+      "url": "https://docs.anthropic.com/en/docs/claude-code",
+      "description": "Get AI help while learning — explain code, debug errors, build features"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/learnprogramming",
+      "url": "https://reddit.com/r/learnprogramming",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/csMajors",
+      "url": "https://reddit.com/r/csMajors",
+      "platform": "reddit"
+    },
+    {
+      "name": "CS50 Discord",
+      "url": "https://discord.gg/cs50",
+      "platform": "discord"
+    }
+  ],
+  "relatedSlugs": ["python", "javascript", "get-a-dev-job"],
+  "lastUpdated": "2026-03-10"
+}

--- a/packages/webapp/data/learn-to-code/for/students.json
+++ b/packages/webapp/data/learn-to-code/for/students.json
@@ -95,11 +95,6 @@
       "description": "AI code editor — build projects for class or side projects faster"
     },
     {
-      "name": "Replit",
-      "url": "https://replit.com",
-      "description": "Code from any computer — no installation needed, works on school laptops"
-    },
-    {
       "name": "GitHub",
       "url": "https://github.com",
       "description": "Store your code, collaborate on group projects, and build your portfolio"

--- a/packages/webapp/data/learn-to-code/get-a-dev-job.json
+++ b/packages/webapp/data/learn-to-code/get-a-dev-job.json
@@ -1,0 +1,158 @@
+{
+  "slug": "get-a-dev-job",
+  "title": "Get Your First Dev Job",
+  "description": "Breaking into tech is more realistic than ever. Companies need developers, and AI tools mean you can build production-quality projects faster than previous generations of developers. Here's a practical path from zero to employed.",
+  "dimension": "goal",
+  "tags": ["career", "programming", "webdev", "interview"],
+  "projectDescription": "You'll build a portfolio that actually gets interviews — a deployed full-stack project, a polished GitHub profile, and practice solving the coding challenges companies ask. Each step is designed around what hiring managers and recruiters actually look for.",
+  "outcomes": [
+    "Ship a deployed full-stack portfolio project employers can click and use",
+    "Write a resume and GitHub profile that pass ATS filters and impress recruiters",
+    "Solve common interview coding challenges with explained, optimal solutions",
+    "Perform confidently in a simulated junior developer technical interview"
+  ],
+  "aiTips": [
+    "Describe your target role when asking for help — 'junior frontend at a startup' gets more relevant advice than 'developer job'",
+    "Use AI to critique your resume and GitHub README as if it were a skeptical hiring manager",
+    "For coding challenges, attempt the problem yourself first before asking the AI for the solution — the struggle is the practice",
+    "Run mock interviews repeatedly with different questions until answers feel natural, not rehearsed"
+  ],
+  "prompts": [
+    {
+      "step": 1,
+      "title": "Build a portfolio project",
+      "body": "Build a full-stack task management app with: user authentication (email/password), create/edit/delete tasks with due dates and priority levels, drag-and-drop to reorder tasks, and a dashboard showing task completion stats. Use React, Node.js, and PostgreSQL. Deploy to Vercel + Railway.",
+      "tools": ["cursor", "claude-code"],
+      "difficulty": "beginner",
+      "timeEstimate": "~2 hrs",
+      "stuckTip": "If the database connection fails, ask the AI to walk you through the Railway environment variables step by step."
+    },
+    {
+      "step": 2,
+      "title": "Create your developer resume",
+      "body": "Generate a one-page developer resume in HTML/CSS that I can also export to PDF. Include sections for: technical skills, projects (with links to live demos and GitHub), education, and a brief professional summary. Use a clean, ATS-friendly design. Make it responsive so it also works as a web page.",
+      "tools": ["cursor", "claude-code", "generic"],
+      "difficulty": "beginner",
+      "timeEstimate": "~45 min",
+      "stuckTip": "If PDF export looks off, ask the AI to add print-specific CSS that hides nav elements and fixes page breaks."
+    },
+    {
+      "step": 3,
+      "title": "Practice coding challenges",
+      "body": "Give me 5 coding challenges that commonly appear in junior developer interviews. For each one: state the problem clearly, let me attempt it, then show the optimal solution with a step-by-step explanation. Cover: array manipulation, string processing, basic algorithms, object transformation, and async/promises.",
+      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "difficulty": "intermediate",
+      "timeEstimate": "~90 min",
+      "stuckTip": "If you're completely blocked on a challenge, ask the AI for just the algorithm approach (not the code) so you can implement it yourself."
+    },
+    {
+      "step": 4,
+      "title": "Set up a GitHub profile",
+      "body": "Help me create a standout GitHub profile README with: a brief intro, my tech stack with badges, links to my best projects with descriptions, contribution stats, and a 'currently learning' section. Also help me write good README files for my top 3 repositories with screenshots, setup instructions, and tech stack details.",
+      "tools": ["cursor", "claude-code", "generic"],
+      "difficulty": "stretch",
+      "timeEstimate": "~60 min",
+      "stuckTip": "Ask the AI to review your README from the perspective of a hiring manager who has 30 seconds to decide whether to look at your code."
+    },
+    {
+      "step": 5,
+      "title": "Prepare for the interview",
+      "body": "Simulate a technical interview for a junior frontend developer position. Ask me: 2 behavioral questions about my projects, 3 technical questions about React and JavaScript, 1 system design question about building a simple feature, and 1 live coding exercise. After each answer, give me feedback and a better answer.",
+      "tools": ["claude-code", "generic"],
+      "difficulty": "stretch",
+      "timeEstimate": "~60 min",
+      "stuckTip": "If your answers feel thin, ask the AI to help you build a story around a specific project using the STAR format (Situation, Task, Action, Result)."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "The Portfolio Over the Resume",
+      "explanation": "For junior developers, your projects speak louder than credentials. A deployed app that solves a real problem is more impressive than any certificate. Hiring managers want to see you can build things."
+    },
+    {
+      "name": "Full-Stack Basics",
+      "explanation": "Most junior roles expect you to work across the stack — frontend (React, HTML/CSS), backend (Node.js, Python), and database (SQL). You don't need to be an expert in all of them, but you need to be comfortable navigating each layer."
+    },
+    {
+      "name": "Git and Collaboration",
+      "explanation": "Every development team uses Git. Understanding branches, pull requests, and code reviews is essential. Contributing to open source is the best way to practice collaboration before your first job."
+    },
+    {
+      "name": "Technical Communication",
+      "explanation": "Explaining your code and decisions clearly matters as much as the code itself. Write good READMEs, comment your thought process, and practice talking through your approach to problems."
+    }
+  ],
+  "resources": [
+    {
+      "title": "The Odin Project — Full Stack Path",
+      "url": "https://www.theodinproject.com/",
+      "type": "course",
+      "free": true
+    },
+    {
+      "title": "LeetCode — Interview Prep",
+      "url": "https://leetcode.com/",
+      "type": "course",
+      "free": false
+    },
+    {
+      "title": "Tech Interview Handbook",
+      "url": "https://www.techinterviewhandbook.org/",
+      "type": "article",
+      "free": true
+    },
+    {
+      "title": "Neetcode — Algorithm Patterns",
+      "url": "https://neetcode.io/",
+      "type": "video",
+      "free": true
+    },
+    {
+      "title": "daily.dev — Developer News Feed",
+      "url": "https://app.daily.dev",
+      "type": "article",
+      "free": true
+    }
+  ],
+  "tools": [
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "Build portfolio projects fast with AI assistance"
+    },
+    {
+      "name": "Claude Code",
+      "url": "https://docs.anthropic.com/en/docs/claude-code",
+      "description": "Practice coding challenges and get instant feedback"
+    },
+    {
+      "name": "GitHub",
+      "url": "https://github.com",
+      "description": "Your developer portfolio — employers will check your GitHub profile"
+    },
+    {
+      "name": "Vercel",
+      "url": "https://vercel.com",
+      "description": "Deploy your portfolio projects for free so employers can see live demos"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/cscareerquestions",
+      "url": "https://reddit.com/r/cscareerquestions",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/learnprogramming",
+      "url": "https://reddit.com/r/learnprogramming",
+      "platform": "reddit"
+    },
+    {
+      "name": "daily.dev",
+      "url": "https://app.daily.dev",
+      "platform": "dailydev"
+    }
+  ],
+  "relatedSlugs": ["javascript", "build/personal-website", "for/students"],
+  "lastUpdated": "2026-03-10"
+}

--- a/packages/webapp/data/learn-to-code/get-a-dev-job.json
+++ b/packages/webapp/data/learn-to-code/get-a-dev-job.json
@@ -40,7 +40,7 @@
       "step": 3,
       "title": "Practice coding challenges",
       "body": "Give me 5 coding challenges that commonly appear in junior developer interviews. For each one: state the problem clearly, let me attempt it, then show the optimal solution with a step-by-step explanation. Cover: array manipulation, string processing, basic algorithms, object transformation, and async/promises.",
-      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "intermediate",
       "timeEstimate": "~90 min",
       "stuckTip": "If you're completely blocked on a challenge, ask the AI for just the algorithm approach (not the code) so you can implement it yourself."

--- a/packages/webapp/data/learn-to-code/html-css.json
+++ b/packages/webapp/data/learn-to-code/html-css.json
@@ -22,7 +22,7 @@
       "step": 1,
       "title": "Your first web page",
       "body": "Create a personal homepage about me. Include a heading with my name, a short bio paragraph, a profile photo placeholder, and a list of 3 hobbies. Use semantic HTML (header, main, section, footer). Add basic CSS to center everything and use a nice font.",
-      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "beginner",
       "timeEstimate": "~30 min",
       "stuckTip": "Open the page in Chrome, right-click any element, and choose 'Inspect' to see exactly what styles are being applied and why."
@@ -31,7 +31,7 @@
       "step": 2,
       "title": "Make it responsive",
       "body": "Update the homepage to look great on both phones and desktops. Add a navigation bar that collapses into a hamburger menu on mobile. Use CSS Grid for the layout and Flexbox for the nav. Add a dark color scheme with good contrast.",
-      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "beginner",
       "timeEstimate": "~45 min",
       "stuckTip": "Toggle Chrome DevTools into mobile view (Ctrl+Shift+M) and shrink the viewport width slowly to pinpoint exactly where the layout breaks."
@@ -40,7 +40,7 @@
       "step": 3,
       "title": "Add a project showcase",
       "body": "Add a 'Projects' section with 4 cards in a responsive grid. Each card should have an image, title, description, and a 'View project' link. Cards should have a subtle shadow and a hover effect that lifts them up slightly.",
-      "tools": ["cursor", "claude-code", "replit"],
+      "tools": ["cursor", "claude-code"],
       "difficulty": "intermediate",
       "timeEstimate": "~1 hr",
       "stuckTip": "If the grid isn't behaving, paste your CSS into the AI and ask it to explain what each grid property does — understanding grid-template-columns will unblock most issues."
@@ -49,7 +49,7 @@
       "step": 4,
       "title": "Build a contact form",
       "body": "Add a contact section with a form that has name, email, and message fields. Style the inputs to match the page design. Add CSS-only validation styles — green border for valid fields, red for invalid. The submit button should have a gradient background.",
-      "tools": ["cursor", "claude-code", "replit"],
+      "tools": ["cursor", "claude-code"],
       "difficulty": "stretch",
       "timeEstimate": "~1 hr",
       "stuckTip": "CSS validation styles rely on :valid and :invalid pseudo-classes — ask the AI to explain how browsers decide when an input is valid, and make sure your inputs have the correct type attribute."
@@ -124,11 +124,6 @@
       "name": "CodePen",
       "url": "https://codepen.io",
       "description": "Live HTML/CSS playground — see your changes instantly in the browser"
-    },
-    {
-      "name": "Replit",
-      "url": "https://replit.com",
-      "description": "Full web development environment in your browser, no setup needed"
     },
     {
       "name": "Chrome DevTools",

--- a/packages/webapp/data/learn-to-code/html-css.json
+++ b/packages/webapp/data/learn-to-code/html-css.json
@@ -1,0 +1,158 @@
+{
+  "slug": "html-css",
+  "title": "Learn HTML & CSS",
+  "description": "HTML and CSS are the foundation of every website. HTML structures the content, CSS makes it look good. These are the easiest coding skills to learn — you'll see results in your browser within minutes.",
+  "dimension": "language",
+  "tags": ["html", "css", "webdev", "beginners"],
+  "projectDescription": "You'll build a real personal portfolio website from scratch — starting with text and images, then adding layout, colors, and responsive design. By the end, it'll be live on the internet with your own URL that you can share with anyone.",
+  "outcomes": [
+    "Build and publish a complete personal portfolio site from scratch",
+    "Write semantic HTML that is accessible and SEO-friendly",
+    "Create responsive layouts using Flexbox and CSS Grid that work on any device",
+    "Add polished animations and interactions using pure CSS and the Intersection Observer API"
+  ],
+  "aiTips": [
+    "Paste your full HTML into the chat and ask the AI to explain what each tag does — reading AI explanations of your own code is one of the fastest ways to learn",
+    "When a layout breaks, describe what you see vs. what you expect and ask the AI to diagnose it; this trains you to spot box-model and specificity issues yourself over time",
+    "Ask the AI to generate two or three alternative CSS approaches for the same layout so you can compare trade-offs between Flexbox, Grid, and older techniques",
+    "Use AI to review your finished page for accessibility issues — ask it to check color contrast, missing alt text, and keyboard navigation before you publish"
+  ],
+  "prompts": [
+    {
+      "step": 1,
+      "title": "Your first web page",
+      "body": "Create a personal homepage about me. Include a heading with my name, a short bio paragraph, a profile photo placeholder, and a list of 3 hobbies. Use semantic HTML (header, main, section, footer). Add basic CSS to center everything and use a nice font.",
+      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "difficulty": "beginner",
+      "timeEstimate": "~30 min",
+      "stuckTip": "Open the page in Chrome, right-click any element, and choose 'Inspect' to see exactly what styles are being applied and why."
+    },
+    {
+      "step": 2,
+      "title": "Make it responsive",
+      "body": "Update the homepage to look great on both phones and desktops. Add a navigation bar that collapses into a hamburger menu on mobile. Use CSS Grid for the layout and Flexbox for the nav. Add a dark color scheme with good contrast.",
+      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "difficulty": "beginner",
+      "timeEstimate": "~45 min",
+      "stuckTip": "Toggle Chrome DevTools into mobile view (Ctrl+Shift+M) and shrink the viewport width slowly to pinpoint exactly where the layout breaks."
+    },
+    {
+      "step": 3,
+      "title": "Add a project showcase",
+      "body": "Add a 'Projects' section with 4 cards in a responsive grid. Each card should have an image, title, description, and a 'View project' link. Cards should have a subtle shadow and a hover effect that lifts them up slightly.",
+      "tools": ["cursor", "claude-code", "replit"],
+      "difficulty": "intermediate",
+      "timeEstimate": "~1 hr",
+      "stuckTip": "If the grid isn't behaving, paste your CSS into the AI and ask it to explain what each grid property does — understanding grid-template-columns will unblock most issues."
+    },
+    {
+      "step": 4,
+      "title": "Build a contact form",
+      "body": "Add a contact section with a form that has name, email, and message fields. Style the inputs to match the page design. Add CSS-only validation styles — green border for valid fields, red for invalid. The submit button should have a gradient background.",
+      "tools": ["cursor", "claude-code", "replit"],
+      "difficulty": "stretch",
+      "timeEstimate": "~1 hr",
+      "stuckTip": "CSS validation styles rely on :valid and :invalid pseudo-classes — ask the AI to explain how browsers decide when an input is valid, and make sure your inputs have the correct type attribute."
+    },
+    {
+      "step": 5,
+      "title": "Add animations and polish",
+      "body": "Add CSS animations: fade-in sections as you scroll down (using @keyframes and Intersection Observer), smooth transitions on all hover states, and a subtle parallax effect on the hero section. Add a custom favicon and Open Graph meta tags for social sharing.",
+      "tools": ["cursor", "claude-code"],
+      "difficulty": "stretch",
+      "timeEstimate": "~1.5 hrs",
+      "stuckTip": "If Intersection Observer isn't firing, add a console.log inside the callback to confirm the observer is attached, then ask the AI why the threshold or root margin might be causing it to miss your elements."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "Semantic HTML",
+      "explanation": "Tags like <header>, <nav>, <main>, and <footer> tell browsers and screen readers what each part of the page means. This improves accessibility and SEO — Google understands your page structure better."
+    },
+    {
+      "name": "CSS Box Model",
+      "explanation": "Every HTML element is a box with content, padding, border, and margin. Understanding this model is the key to controlling spacing and layout. Once it clicks, CSS stops feeling random."
+    },
+    {
+      "name": "Flexbox and Grid",
+      "explanation": "Flexbox handles one-dimensional layouts (rows or columns). Grid handles two-dimensional layouts (rows AND columns). Together they solve 99% of layout challenges without any hacks."
+    },
+    {
+      "name": "Responsive Design",
+      "explanation": "Media queries let you apply different CSS at different screen sizes. Combined with relative units (%, rem, vw) and fluid layouts, your page adapts automatically from phone to desktop."
+    }
+  ],
+  "resources": [
+    {
+      "title": "freeCodeCamp — Responsive Web Design",
+      "url": "https://www.freecodecamp.org/learn/2022/responsive-web-design/",
+      "type": "course",
+      "free": true
+    },
+    {
+      "title": "CSS-Tricks — A Complete Guide to Flexbox",
+      "url": "https://css-tricks.com/snippets/css/a-guide-to-flexbox/",
+      "type": "article",
+      "free": true
+    },
+    {
+      "title": "MDN — Getting Started with the Web",
+      "url": "https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web",
+      "type": "docs",
+      "free": true
+    },
+    {
+      "title": "Kevin Powell — CSS tutorials",
+      "url": "https://www.youtube.com/@KevinPowell",
+      "type": "video",
+      "free": true
+    },
+    {
+      "title": "Flexbox Froggy",
+      "url": "https://flexboxfroggy.com/",
+      "type": "course",
+      "free": true
+    }
+  ],
+  "tools": [
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "AI code editor — describe a layout and it writes the HTML and CSS for you"
+    },
+    {
+      "name": "CodePen",
+      "url": "https://codepen.io",
+      "description": "Live HTML/CSS playground — see your changes instantly in the browser"
+    },
+    {
+      "name": "Replit",
+      "url": "https://replit.com",
+      "description": "Full web development environment in your browser, no setup needed"
+    },
+    {
+      "name": "Chrome DevTools",
+      "url": "https://developer.chrome.com/docs/devtools/",
+      "description": "Built into Chrome — inspect any website's HTML and CSS to learn how it works"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/webdev",
+      "url": "https://reddit.com/r/webdev",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/css",
+      "url": "https://reddit.com/r/css",
+      "platform": "reddit"
+    },
+    {
+      "name": "Frontend Mentor",
+      "url": "https://www.frontendmentor.io/",
+      "platform": "other"
+    }
+  ],
+  "relatedSlugs": ["javascript", "build/personal-website", "for/designers"],
+  "lastUpdated": "2026-03-10"
+}

--- a/packages/webapp/data/learn-to-code/hub.json
+++ b/packages/webapp/data/learn-to-code/hub.json
@@ -1,0 +1,83 @@
+{
+  "seo": {
+    "title": "Learn to Code with AI — Free Prompts, Build Real Projects in 30 Min",
+    "description": "Copy a prompt into Cursor or Claude Code, watch AI build your first project, then learn what it did. No experience needed. Start building in minutes — free prompts, real projects, zero setup."
+  },
+  "hero": {
+    "heading": "Build anything you can describe",
+    "subtitle": "Copy a prompt into your AI coding tool, watch it build your project, then learn what it did and why. No experience needed — start building in minutes."
+  },
+  "popularPaths": [
+    {
+      "title": "I have an app idea",
+      "slug": "vibe-coding",
+      "subtitle": "Describe what you want, AI builds it. Go from idea to deployed app in an afternoon.",
+      "gradient": "from-accent-onion-default/20 to-accent-bacon-default/10",
+      "accentColor": "accent-onion-default",
+      "iconKey": "sparkle"
+    },
+    {
+      "title": "I want to automate boring work",
+      "slug": "automate-your-workflow",
+      "subtitle": "Annoyed by repetitive tasks? Build scripts that handle the boring parts for you.",
+      "gradient": "from-accent-water-default/20 to-accent-blueCheese-default/10",
+      "accentColor": "accent-water-default",
+      "iconKey": "magic"
+    },
+    {
+      "title": "I want to understand what AI writes",
+      "slug": "python",
+      "subtitle": "Learn the fundamentals so you can read, modify, and debug AI-generated code.",
+      "gradient": "from-accent-cheese-default/20 to-accent-avocado-default/10",
+      "accentColor": "accent-cheese-default",
+      "iconKey": "graduation"
+    },
+    {
+      "title": "I want to build something fun",
+      "slug": "build/discord-bot",
+      "subtitle": "Build a Discord bot, a web game, or a personal tool this weekend — no experience needed.",
+      "gradient": "from-accent-cabbage-default/20 to-accent-onion-default/10",
+      "accentColor": "accent-cabbage-default",
+      "iconKey": "hammer"
+    }
+  ],
+  "dimensions": {
+    "order": ["language", "usecase", "audience", "technique", "goal"],
+    "titles": {
+      "language": "By language",
+      "usecase": "By project",
+      "audience": "By audience",
+      "technique": "By technique",
+      "goal": "By goal"
+    },
+    "icons": {
+      "language": "graduation",
+      "usecase": "hammer",
+      "audience": "magic",
+      "technique": "sparkle",
+      "goal": "star"
+    }
+  },
+  "faq": [
+    {
+      "question": "Is it too late to learn to code in 2026?",
+      "answer": "No — it's actually the best time. AI coding tools have dramatically lowered the barrier to entry. You can build real applications by describing what you want in plain English, and learn the underlying concepts as you go."
+    },
+    {
+      "question": "Should I learn to code or just use AI?",
+      "answer": "Both. Use AI to build things fast, then learn the concepts behind what it built. Understanding code gives you a lasting edge — you can debug problems, make better architectural decisions, and push AI tools further."
+    },
+    {
+      "question": "What programming language should I learn first?",
+      "answer": "Python if you want to automate tasks and work with data. JavaScript if you want to build websites and web apps. Both are beginner-friendly and have massive communities. Don't overthink it — the concepts transfer between languages."
+    },
+    {
+      "question": "Can I learn to code for free?",
+      "answer": "Yes. freeCodeCamp, The Odin Project, Python.org, and JavaScript.info are all free and excellent. Pair them with an AI coding tool like Cursor or Claude Code and you have everything you need."
+    },
+    {
+      "question": "What is vibe coding?",
+      "answer": "Vibe coding means building software by describing what you want in natural language and letting AI write the code. Coined by Andrej Karpathy, it's become a popular way for beginners and non-developers to build real applications."
+    }
+  ]
+}

--- a/packages/webapp/data/learn-to-code/hub.json
+++ b/packages/webapp/data/learn-to-code/hub.json
@@ -7,57 +7,58 @@
     "heading": "Build anything you can describe",
     "subtitle": "Copy a prompt into your AI coding tool, watch it build your project, then learn what it did and why. No experience needed — start building in minutes."
   },
-  "popularPaths": [
+  "categories": [
     {
-      "title": "I have an app idea",
-      "slug": "vibe-coding",
-      "subtitle": "Describe what you want, AI builds it. Go from idea to deployed app in an afternoon.",
-      "gradient": "from-accent-onion-default/20 to-accent-bacon-default/10",
-      "accentColor": "accent-onion-default",
-      "iconKey": "sparkle"
+      "title": "Build something",
+      "slug": "build",
+      "subtitle": "Pick a project, paste a prompt, and watch AI build it. Todo apps, websites, bots — no experience needed.",
+      "gradient": "from-accent-cabbage-default/20 to-accent-onion-default/10",
+      "accentColor": "accent-cabbage-default",
+      "iconKey": "hammer"
     },
     {
-      "title": "I want to automate boring work",
-      "slug": "automate-your-workflow",
-      "subtitle": "Annoyed by repetitive tasks? Build scripts that handle the boring parts for you.",
+      "title": "Automate your life",
+      "slug": "automate",
+      "subtitle": "Stop doing boring tasks manually. Build scripts that organize files, send reports, and run on autopilot.",
       "gradient": "from-accent-water-default/20 to-accent-blueCheese-default/10",
       "accentColor": "accent-water-default",
       "iconKey": "magic"
     },
     {
-      "title": "I want to understand what AI writes",
-      "slug": "python",
-      "subtitle": "Learn the fundamentals so you can read, modify, and debug AI-generated code.",
+      "title": "Learn a language",
+      "slug": "languages",
+      "subtitle": "Pick a language, learn the fundamentals, and understand what AI is actually writing for you.",
       "gradient": "from-accent-cheese-default/20 to-accent-avocado-default/10",
       "accentColor": "accent-cheese-default",
       "iconKey": "graduation"
     },
     {
-      "title": "I want to build something fun",
-      "slug": "build/discord-bot",
-      "subtitle": "Build a Discord bot, a web game, or a personal tool this weekend — no experience needed.",
-      "gradient": "from-accent-cabbage-default/20 to-accent-onion-default/10",
-      "accentColor": "accent-cabbage-default",
-      "iconKey": "hammer"
+      "title": "Acquire new skills",
+      "slug": "skills",
+      "subtitle": "Level up with vibe coding, debugging techniques, and career skills that make you stand out.",
+      "gradient": "from-accent-onion-default/20 to-accent-bacon-default/10",
+      "accentColor": "accent-onion-default",
+      "iconKey": "sparkle"
     }
   ],
-  "dimensions": {
-    "order": ["language", "usecase", "audience", "technique", "goal"],
-    "titles": {
-      "language": "By language",
-      "usecase": "By project",
-      "audience": "By audience",
-      "technique": "By technique",
-      "goal": "By goal"
+  "audiencePaths": [
+    {
+      "slug": "for/marketers",
+      "title": "Marketers"
     },
-    "icons": {
-      "language": "graduation",
-      "usecase": "hammer",
-      "audience": "magic",
-      "technique": "sparkle",
-      "goal": "star"
+    {
+      "slug": "for/designers",
+      "title": "Designers"
+    },
+    {
+      "slug": "for/students",
+      "title": "Students"
+    },
+    {
+      "slug": "for/data-analysts",
+      "title": "Data Analysts"
     }
-  },
+  ],
   "faq": [
     {
       "question": "Is it too late to learn to code in 2026?",

--- a/packages/webapp/data/learn-to-code/javascript.json
+++ b/packages/webapp/data/learn-to-code/javascript.json
@@ -1,0 +1,158 @@
+{
+  "slug": "javascript",
+  "title": "Learn JavaScript",
+  "description": "JavaScript is the language of the web — every website you've ever visited runs it. It's the easiest path to building interactive websites, browser extensions, and full-stack apps. With AI tools, you can start building real things today.",
+  "dimension": "language",
+  "tags": ["javascript", "webdev", "programming"],
+  "projectDescription": "You'll build interactive web pages that respond to clicks and typing, then level up to fetching real data from the internet. By the end, you'll have a full web app with user accounts and a database — the kind of project you can show employers or friends.",
+  "outcomes": [
+    "Build interactive web pages that respond to user input without reloading",
+    "Store and retrieve data in the browser using localStorage",
+    "Fetch data from external APIs and handle loading and error states",
+    "Refactor vanilla JavaScript into a component-based React app"
+  ],
+  "aiTips": [
+    "Paste error messages directly into the chat — AI is excellent at reading stack traces and pinpointing the exact line causing the issue",
+    "Ask the AI to explain each line it generates before moving on; understanding the code now prevents confusion in later steps",
+    "When a feature works but looks rough, prompt 'make this look polished with clean CSS' as a separate follow-up rather than cramming it into the first request",
+    "If you're stuck on a concept like closures or async/await, ask for a 5-line example using your current project's code rather than a generic tutorial snippet"
+  ],
+  "prompts": [
+    {
+      "step": 1,
+      "title": "Your first interactive page",
+      "body": "Create an HTML page with a button that counts how many times I've clicked it. Show the count in big text on the page. Add a reset button that sets it back to zero. Use vanilla JavaScript — no frameworks.",
+      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "difficulty": "beginner",
+      "timeEstimate": "~20 min",
+      "stuckTip": "Ask the AI to walk you through what `addEventListener` does and show you a minimal working example with just one button."
+    },
+    {
+      "step": 2,
+      "title": "Build a color palette generator",
+      "body": "Create a web page that generates random color palettes. Show 5 colors side by side with their hex codes. Clicking a color copies its hex code to the clipboard. Add a 'Generate new palette' button. Make it look good with clean CSS.",
+      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "difficulty": "beginner",
+      "timeEstimate": "~30 min",
+      "stuckTip": "If the clipboard copy isn't working, ask the AI specifically about the Clipboard API and why it requires a secure context (HTTPS or localhost)."
+    },
+    {
+      "step": 3,
+      "title": "Add localStorage persistence",
+      "body": "Add a 'Save palette' feature that stores favorite palettes in localStorage. Show saved palettes below the generator. Each saved palette should have a name field and a delete button. The saved palettes should persist when I refresh the page.",
+      "tools": ["cursor", "claude-code", "replit"],
+      "difficulty": "intermediate",
+      "timeEstimate": "~40 min",
+      "stuckTip": "Open your browser's DevTools, go to the Application tab, and inspect the localStorage entries — then share what you see with the AI to debug serialization issues."
+    },
+    {
+      "step": 4,
+      "title": "Make it a single-page app",
+      "body": "Refactor the color palette tool into a React app using Vite. Keep all the same features but organize the code into components: PaletteGenerator, ColorSwatch, SavedPalettes, and PaletteCard. Add smooth animations when generating new palettes.",
+      "tools": ["cursor", "claude-code"],
+      "difficulty": "stretch",
+      "timeEstimate": "~60 min",
+      "stuckTip": "If state isn't updating as expected, ask the AI to add a `console.log` inside each component's render to trace where the data flow breaks down."
+    },
+    {
+      "step": 5,
+      "title": "Add an API integration",
+      "body": "Use the Colormind API (http://colormind.io/api/) to generate AI-powered color palettes instead of random ones. Add a loading state while the API responds. Keep the random generator as a fallback if the API is down.",
+      "tools": ["cursor", "claude-code"],
+      "difficulty": "stretch",
+      "timeEstimate": "~45 min",
+      "stuckTip": "If the API call fails, ask the AI to show you how to inspect the network request in DevTools and what CORS errors look like versus a server error."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "DOM Manipulation",
+      "explanation": "The DOM is the browser's representation of your HTML page. JavaScript can change any element — update text, add buttons, change styles. Every interactive website works by manipulating the DOM."
+    },
+    {
+      "name": "Event Handling",
+      "explanation": "Events are things that happen on a page — clicks, key presses, form submissions. Event listeners let your code respond to these actions. This is how buttons, forms, and interactive features work."
+    },
+    {
+      "name": "localStorage",
+      "explanation": "localStorage lets you save data in the user's browser that persists between page refreshes. It's perfect for small apps that don't need a server — think settings, saved preferences, or bookmarks."
+    },
+    {
+      "name": "Components and State",
+      "explanation": "React breaks UIs into reusable components, each managing their own state. When state changes, React automatically updates the page. This pattern is how modern web apps like Twitter, Netflix, and daily.dev are built."
+    }
+  ],
+  "resources": [
+    {
+      "title": "JavaScript.info — The Modern JavaScript Tutorial",
+      "url": "https://javascript.info/",
+      "type": "article",
+      "free": true
+    },
+    {
+      "title": "freeCodeCamp — JavaScript Algorithms and Data Structures",
+      "url": "https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures-v8/",
+      "type": "course",
+      "free": true
+    },
+    {
+      "title": "MDN Web Docs — JavaScript",
+      "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide",
+      "type": "docs",
+      "free": true
+    },
+    {
+      "title": "Fireship — JavaScript in 100 Seconds",
+      "url": "https://www.youtube.com/watch?v=DHjqpvDnNGE",
+      "type": "video",
+      "free": true
+    },
+    {
+      "title": "Eloquent JavaScript",
+      "url": "https://eloquentjavascript.net/",
+      "type": "article",
+      "free": true
+    }
+  ],
+  "tools": [
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "AI code editor with built-in chat — the fastest way to build web projects"
+    },
+    {
+      "name": "Claude Code",
+      "url": "https://docs.anthropic.com/en/docs/claude-code",
+      "description": "Build entire web apps from your terminal with natural language"
+    },
+    {
+      "name": "Replit",
+      "url": "https://replit.com",
+      "description": "Write and run JavaScript in your browser — zero setup required"
+    },
+    {
+      "name": "CodePen",
+      "url": "https://codepen.io",
+      "description": "Live playground for HTML, CSS, and JavaScript — see results instantly"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/learnjavascript",
+      "url": "https://reddit.com/r/learnjavascript",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/webdev",
+      "url": "https://reddit.com/r/webdev",
+      "platform": "reddit"
+    },
+    {
+      "name": "Reactiflux Discord",
+      "url": "https://discord.gg/reactiflux",
+      "platform": "discord"
+    }
+  ],
+  "relatedSlugs": ["html-css", "build/personal-website", "python"],
+  "lastUpdated": "2026-03-10"
+}

--- a/packages/webapp/data/learn-to-code/javascript.json
+++ b/packages/webapp/data/learn-to-code/javascript.json
@@ -21,46 +21,58 @@
     {
       "step": 1,
       "title": "Your first interactive page",
-      "body": "Create an HTML page with a button that counts how many times I've clicked it. Show the count in big text on the page. Add a reset button that sets it back to zero. Use vanilla JavaScript — no frameworks.",
-      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "body": "Create an HTML page with a button that counts how many times I've clicked it. Show the count in big text on the page. Add a reset button that sets it back to zero. Use vanilla JavaScript — no frameworks. Add a comment above each section explaining what it does. Handle the edge case where someone double-clicks really fast. Add a fun animation when the count changes.",
+      "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "beginner",
       "timeEstimate": "~20 min",
+      "expectedOutput": "You should see a page with a large number (starting at 0), a 'Click me' button, and a 'Reset' button. Each click makes the number jump up with a brief scale animation. The reset button smoothly returns it to 0.",
+      "comprehensionPrompt": "Ask AI: 'Explain what addEventListener does — how does the browser know which function to call when I click? What's the difference between innerHTML and textContent? Why did you use let instead of const for the counter variable?'",
+      "challenge": "Change the background color to shift slightly with each click (getting darker or changing hue). Do this yourself without asking AI.",
       "stuckTip": "Ask the AI to walk you through what `addEventListener` does and show you a minimal working example with just one button."
     },
     {
       "step": 2,
       "title": "Build a color palette generator",
-      "body": "Create a web page that generates random color palettes. Show 5 colors side by side with their hex codes. Clicking a color copies its hex code to the clipboard. Add a 'Generate new palette' button. Make it look good with clean CSS.",
-      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "body": "Create a web page that generates random color palettes. Show 5 colors side by side with their hex codes. Clicking a color copies its hex code to the clipboard and shows a brief 'Copied!' confirmation. Add a 'Generate new palette' button. Style it with clean CSS — centered layout, rounded corners, subtle shadows, and a smooth transition when new colors appear.",
+      "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "beginner",
       "timeEstimate": "~30 min",
+      "expectedOutput": "A clean page with 5 vertical color bars side by side, each showing its hex code (like #3B82F6). Clicking a color briefly shows 'Copied!' and the hex code is in your clipboard. The 'Generate' button smoothly transitions to new colors.",
+      "comprehensionPrompt": "Ask AI: 'How do hex color codes work — what do the 6 characters represent? How does the Clipboard API work and why does it need a secure context? What's the difference between CSS transitions and CSS animations?'",
+      "challenge": "Add a 'lock' toggle on each color so locked colors stay the same when you generate a new palette. Implement this yourself first.",
       "stuckTip": "If the clipboard copy isn't working, ask the AI specifically about the Clipboard API and why it requires a secure context (HTTPS or localhost)."
     },
     {
       "step": 3,
       "title": "Add localStorage persistence",
-      "body": "Add a 'Save palette' feature that stores favorite palettes in localStorage. Show saved palettes below the generator. Each saved palette should have a name field and a delete button. The saved palettes should persist when I refresh the page.",
-      "tools": ["cursor", "claude-code", "replit"],
+      "body": "Add a 'Save palette' feature that stores favorite palettes in localStorage. Show saved palettes below the generator in a grid layout. Each saved palette should have a name field and a delete button with a confirmation. The saved palettes should persist when I refresh the page. Add an undo feature for accidentally deleted palettes.",
+      "tools": ["cursor", "claude-code"],
       "difficulty": "intermediate",
       "timeEstimate": "~40 min",
+      "expectedOutput": "Below the generator, you should see a 'Saved Palettes' section. After saving a few palettes with custom names, refreshing the page shows them all still there. Deleting one shows a brief 'Undo' toast. Clicking Undo restores it.",
+      "comprehensionPrompt": "Ask AI: 'How does localStorage differ from cookies? What's JSON.stringify and JSON.parse — why can't localStorage store objects directly? How does the undo feature work — where is the deleted palette temporarily stored?'",
       "stuckTip": "Open your browser's DevTools, go to the Application tab, and inspect the localStorage entries — then share what you see with the AI to debug serialization issues."
     },
     {
       "step": 4,
       "title": "Make it a single-page app",
-      "body": "Refactor the color palette tool into a React app using Vite. Keep all the same features but organize the code into components: PaletteGenerator, ColorSwatch, SavedPalettes, and PaletteCard. Add smooth animations when generating new palettes.",
+      "body": "Refactor the color palette tool into a React app using Vite. Keep all the same features but organize the code into components: PaletteGenerator, ColorSwatch, SavedPalettes, and PaletteCard. Add smooth animations when generating new palettes. Use proper React state management — no direct DOM manipulation.",
       "tools": ["cursor", "claude-code"],
       "difficulty": "stretch",
       "timeEstimate": "~60 min",
+      "expectedOutput": "The app should look and behave identically to the vanilla JS version, but the code is now organized into separate component files. The React DevTools browser extension should show your component tree: App > PaletteGenerator > ColorSwatch (×5).",
+      "comprehensionPrompt": "Ask AI: 'What's the difference between vanilla JS DOM manipulation and React's approach? Why do we use useState instead of regular variables? What does the Virtual DOM do and why is it faster?'",
       "stuckTip": "If state isn't updating as expected, ask the AI to add a `console.log` inside each component's render to trace where the data flow breaks down."
     },
     {
       "step": 5,
       "title": "Add an API integration",
-      "body": "Use the Colormind API (http://colormind.io/api/) to generate AI-powered color palettes instead of random ones. Add a loading state while the API responds. Keep the random generator as a fallback if the API is down.",
+      "body": "Use the Colormind API (http://colormind.io/api/) to generate AI-powered color palettes instead of random ones. Add a loading spinner while the API responds. Keep the random generator as a fallback if the API is down. Handle network errors gracefully with a user-friendly message.",
       "tools": ["cursor", "claude-code"],
       "difficulty": "stretch",
       "timeEstimate": "~45 min",
+      "expectedOutput": "Clicking 'Generate' shows a brief loading spinner, then the colors update from the Colormind API. If you disconnect your wifi and click 'Generate', it should show a friendly error and fall back to random generation.",
+      "comprehensionPrompt": "Ask AI: 'What is an API and how does fetch() work under the hood? What's the difference between a GET and POST request? What are CORS errors and why do they happen? How does async/await relate to Promises?'",
       "stuckTip": "If the API call fails, ask the AI to show you how to inspect the network request in DevTools and what CORS errors look like versus a server error."
     }
   ],
@@ -124,11 +136,6 @@
       "name": "Claude Code",
       "url": "https://docs.anthropic.com/en/docs/claude-code",
       "description": "Build entire web apps from your terminal with natural language"
-    },
-    {
-      "name": "Replit",
-      "url": "https://replit.com",
-      "description": "Write and run JavaScript in your browser — zero setup required"
     },
     {
       "name": "CodePen",

--- a/packages/webapp/data/learn-to-code/languages.json
+++ b/packages/webapp/data/learn-to-code/languages.json
@@ -1,0 +1,100 @@
+{
+  "slug": "languages",
+  "title": "Learn a Language",
+  "description": "AI writes code for you — but understanding what it wrote is what makes you dangerous. Pick a language, learn the fundamentals, and go from copying prompts to actually knowing what's happening.",
+  "dimension": "category",
+  "tags": ["programming", "beginners", "python", "javascript"],
+  "outcomes": [
+    "Read and understand code that AI generates for you",
+    "Modify AI-generated code confidently — add features, fix bugs, change behavior",
+    "Write simple programs from scratch when AI isn't available",
+    "Know which language to pick for different types of projects"
+  ],
+  "recommendedPaths": [
+    {
+      "slug": "python",
+      "title": "Learn Python",
+      "reason": "The most beginner-friendly language. Perfect for automation, data work, and AI. If you're not sure where to start, start here."
+    },
+    {
+      "slug": "javascript",
+      "title": "Learn JavaScript",
+      "reason": "The language of the web. If you want to build websites, web apps, or anything that runs in a browser, this is your language."
+    },
+    {
+      "slug": "html-css",
+      "title": "Learn HTML & CSS",
+      "reason": "Not programming languages, but the foundation of every website. Learn these first if you want to build anything visual on the web."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "Variables and Types",
+      "explanation": "Variables are named containers that hold data — a number, some text, a list. Types tell the language what kind of data it is, which determines what you can do with it."
+    },
+    {
+      "name": "Functions",
+      "explanation": "Functions are reusable blocks of code. Instead of writing the same logic over and over, you write it once as a function and call it whenever you need it."
+    },
+    {
+      "name": "Control Flow",
+      "explanation": "If/else statements and loops let your code make decisions and repeat actions. This is how programs handle different situations — 'if the user is logged in, show the dashboard; otherwise, show the login page.'"
+    }
+  ],
+  "resources": [
+    {
+      "title": "freeCodeCamp",
+      "url": "https://www.freecodecamp.org/",
+      "type": "course",
+      "free": true
+    },
+    {
+      "title": "The Odin Project",
+      "url": "https://www.theodinproject.com/",
+      "type": "course",
+      "free": true
+    },
+    {
+      "title": "Exercism",
+      "url": "https://exercism.org/",
+      "type": "course",
+      "free": true
+    }
+  ],
+  "tools": [
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "AI-first code editor — learn by building with AI assistance"
+    },
+    {
+      "name": "Claude Code",
+      "url": "https://docs.anthropic.com/en/docs/claude-code",
+      "description": "Terminal-based AI coding — great for learning how programs work"
+    },
+    {
+      "name": "VS Code",
+      "url": "https://code.visualstudio.com/",
+      "description": "The standard free code editor — works with every language"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/learnprogramming",
+      "url": "https://reddit.com/r/learnprogramming",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/learnpython",
+      "url": "https://reddit.com/r/learnpython",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/learnjavascript",
+      "url": "https://reddit.com/r/learnjavascript",
+      "platform": "reddit"
+    }
+  ],
+  "relatedSlugs": ["build", "vibe-coding", "skills"],
+  "lastUpdated": "2026-03-11"
+}

--- a/packages/webapp/data/learn-to-code/manifest.json
+++ b/packages/webapp/data/learn-to-code/manifest.json
@@ -1,0 +1,94 @@
+{
+  "pages": [
+    {
+      "slug": "python",
+      "title": "Learn Python",
+      "dimension": "language",
+      "lastUpdated": "2026-03-08"
+    },
+    {
+      "slug": "javascript",
+      "title": "Learn JavaScript",
+      "dimension": "language",
+      "lastUpdated": "2026-03-10"
+    },
+    {
+      "slug": "html-css",
+      "title": "Learn HTML & CSS",
+      "dimension": "language",
+      "lastUpdated": "2026-03-10"
+    },
+    {
+      "slug": "build/todo-app",
+      "title": "Build a Todo App",
+      "dimension": "usecase",
+      "lastUpdated": "2026-03-07"
+    },
+    {
+      "slug": "build/personal-website",
+      "title": "Build a Personal Website",
+      "dimension": "usecase",
+      "lastUpdated": "2026-03-10"
+    },
+    {
+      "slug": "build/chrome-extension",
+      "title": "Build a Chrome Extension",
+      "dimension": "usecase",
+      "lastUpdated": "2026-03-10"
+    },
+    {
+      "slug": "build/discord-bot",
+      "title": "Build a Discord Bot",
+      "dimension": "usecase",
+      "lastUpdated": "2026-03-10"
+    },
+    {
+      "slug": "vibe-coding",
+      "title": "Vibe Coding",
+      "dimension": "technique",
+      "lastUpdated": "2026-03-10"
+    },
+    {
+      "slug": "debugging",
+      "title": "Debugging with AI",
+      "dimension": "technique",
+      "lastUpdated": "2026-03-10"
+    },
+    {
+      "slug": "for/marketers",
+      "title": "Coding for Marketers",
+      "dimension": "audience",
+      "lastUpdated": "2026-03-06"
+    },
+    {
+      "slug": "for/designers",
+      "title": "Coding for Designers",
+      "dimension": "audience",
+      "lastUpdated": "2026-03-10"
+    },
+    {
+      "slug": "for/students",
+      "title": "Coding for Students",
+      "dimension": "audience",
+      "lastUpdated": "2026-03-10"
+    },
+    {
+      "slug": "for/data-analysts",
+      "title": "Coding for Data Analysts",
+      "dimension": "audience",
+      "lastUpdated": "2026-03-10"
+    },
+    {
+      "slug": "get-a-dev-job",
+      "title": "Get Your First Dev Job",
+      "dimension": "goal",
+      "lastUpdated": "2026-03-10"
+    },
+    {
+      "slug": "automate-your-workflow",
+      "title": "Automate Your Workflow",
+      "dimension": "goal",
+      "lastUpdated": "2026-03-10"
+    }
+  ]
+}

--- a/packages/webapp/data/learn-to-code/manifest.json
+++ b/packages/webapp/data/learn-to-code/manifest.json
@@ -1,6 +1,30 @@
 {
   "pages": [
     {
+      "slug": "build",
+      "title": "Build Something",
+      "dimension": "category",
+      "lastUpdated": "2026-03-11"
+    },
+    {
+      "slug": "automate",
+      "title": "Automate Your Life",
+      "dimension": "category",
+      "lastUpdated": "2026-03-11"
+    },
+    {
+      "slug": "languages",
+      "title": "Learn a Language",
+      "dimension": "category",
+      "lastUpdated": "2026-03-11"
+    },
+    {
+      "slug": "skills",
+      "title": "Acquire New Skills",
+      "dimension": "category",
+      "lastUpdated": "2026-03-11"
+    },
+    {
       "slug": "python",
       "title": "Learn Python",
       "dimension": "language",

--- a/packages/webapp/data/learn-to-code/python.json
+++ b/packages/webapp/data/learn-to-code/python.json
@@ -1,0 +1,168 @@
+{
+  "slug": "python",
+  "title": "Learn Python",
+  "description": "Python is the most beginner-friendly programming language and the #1 choice for data science, automation, and AI. With AI coding assistants, you can start building real Python projects in minutes — not months.",
+  "dimension": "language",
+  "tags": ["python", "python3", "programming"],
+  "projectDescription": "You'll start by writing simple scripts that do real things — a number guessing game, a file organizer, a CLI tool. By the end, you'll have built a working API with a database. Each step builds on the last, and AI handles the syntax so you can focus on learning how programs think.",
+  "outcomes": [
+    "Write Python scripts that accept user input, do calculations, and produce useful output",
+    "Read and write files and JSON data so your programs remember things between runs",
+    "Build a real CLI tool with subcommands, just like git or npm",
+    "Deploy a working web app that anyone can access from a browser"
+  ],
+  "aiTips": [
+    "Paste error messages directly into the chat — AI is exceptionally good at explaining what went wrong and why",
+    "Ask the AI to explain each code block it generates before moving on; understanding beats copy-pasting",
+    "When you're stuck, describe what you *want* to happen in plain English rather than asking how to fix specific code",
+    "Use AI to generate a second, simpler version of any concept you don't understand — ask it to 'explain this like I've never coded before'"
+  ],
+  "prompts": [
+    {
+      "step": 1,
+      "title": "Your first Python script",
+      "body": "Create a Python script that asks for my name and age, then tells me what year I was born and how many days I've been alive. Make it friendly and conversational.",
+      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "difficulty": "beginner",
+      "timeEstimate": "~20 min",
+      "stuckTip": "If the math feels confusing, ask the AI to break the calculation into smaller steps and explain each one."
+    },
+    {
+      "step": 2,
+      "title": "Add file handling",
+      "body": "Modify the script to save each person's info to a JSON file called 'people.json'. If the file already exists, add to it instead of overwriting. Show me how to read back all the entries.",
+      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "difficulty": "beginner",
+      "timeEstimate": "~30 min",
+      "stuckTip": "If you get a file-not-found or JSON decode error, paste the exact error into the AI chat and ask what's causing it."
+    },
+    {
+      "step": 3,
+      "title": "Build a CLI tool",
+      "body": "Turn this into a proper command-line tool using argparse with three commands: 'add' to add a person, 'list' to show all people, and 'stats' to show the average age and oldest/youngest person.",
+      "tools": ["cursor", "claude-code", "generic"],
+      "difficulty": "intermediate",
+      "timeEstimate": "~45 min",
+      "stuckTip": "Run `python tool.py --help` to see how argparse is wiring up your commands, and ask the AI to explain any flag that looks wrong."
+    },
+    {
+      "step": 4,
+      "title": "Add a web interface",
+      "body": "Create a simple Flask web app that does the same thing but in a browser. It should have a form to add people and a page that shows the list. Use a SQLite database instead of JSON.",
+      "tools": ["cursor", "claude-code", "generic"],
+      "difficulty": "stretch",
+      "timeEstimate": "~60 min",
+      "stuckTip": "If the app won't start, check that Flask is installed (`pip install flask`) and ask the AI to walk through the startup error line by line."
+    },
+    {
+      "step": 5,
+      "title": "Deploy it",
+      "body": "Help me deploy this Flask app to Railway or Render for free. Walk me through the steps and create the necessary configuration files (requirements.txt, Procfile, etc).",
+      "tools": ["cursor", "claude-code", "generic"],
+      "difficulty": "stretch",
+      "timeEstimate": "~45 min",
+      "stuckTip": "Deployment errors are almost always environment or config issues — paste the deploy log into the AI and ask it to pinpoint the first failure."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "Variables and Types",
+      "explanation": "When you stored someone's name and age, Python created variables — named containers that hold data. Python figures out the type (text vs number) automatically, unlike many other languages."
+    },
+    {
+      "name": "File I/O and JSON",
+      "explanation": "Reading and writing files is how programs persist data between runs. JSON is a universal format for structured data — almost every API and config file uses it."
+    },
+    {
+      "name": "Command-line Arguments",
+      "explanation": "argparse turns your script into a real tool with subcommands and flags. This is how most developer tools work under the hood — git, npm, and pip all work this way."
+    },
+    {
+      "name": "Web Frameworks and HTTP",
+      "explanation": "Flask handles the HTTP request/response cycle — when someone visits a URL, Flask routes it to your Python function and sends back HTML. This is the foundation of every web application."
+    },
+    {
+      "name": "Databases and SQL",
+      "explanation": "SQLite gives you a real database in a single file. SQL is the language for querying data — SELECT, INSERT, UPDATE. Every web app uses a database, and the concepts transfer to PostgreSQL, MySQL, and others."
+    }
+  ],
+  "resources": [
+    {
+      "title": "Python for Everybody (Dr. Chuck)",
+      "url": "https://www.py4e.com/",
+      "type": "course",
+      "free": true
+    },
+    {
+      "title": "Automate the Boring Stuff with Python",
+      "url": "https://automatetheboringstuff.com/",
+      "type": "article",
+      "free": true
+    },
+    {
+      "title": "Official Python Tutorial",
+      "url": "https://docs.python.org/3/tutorial/",
+      "type": "docs",
+      "free": true
+    },
+    {
+      "title": "Corey Schafer's Python Tutorials",
+      "url": "https://www.youtube.com/user/schaaborern",
+      "type": "video",
+      "free": true
+    },
+    {
+      "title": "Real Python",
+      "url": "https://realpython.com/",
+      "type": "article",
+      "free": false
+    },
+    {
+      "title": "Exercism Python Track",
+      "url": "https://exercism.org/tracks/python",
+      "type": "course",
+      "free": true
+    }
+  ],
+  "tools": [
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "AI-first code editor — the fastest way to write Python with AI assistance built in"
+    },
+    {
+      "name": "Claude Code",
+      "url": "https://docs.anthropic.com/en/docs/claude-code",
+      "description": "Terminal-based AI coding — great for Python scripts and CLI tools"
+    },
+    {
+      "name": "Replit",
+      "url": "https://replit.com",
+      "description": "Code in your browser with zero setup — perfect for beginners who don't want to install anything"
+    },
+    {
+      "name": "VS Code + Python Extension",
+      "url": "https://code.visualstudio.com/docs/python/python-tutorial",
+      "description": "The standard free editor with excellent Python support"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/learnpython",
+      "url": "https://reddit.com/r/learnpython",
+      "platform": "reddit"
+    },
+    {
+      "name": "Python Discord",
+      "url": "https://discord.gg/python",
+      "platform": "discord"
+    },
+    {
+      "name": "r/Python",
+      "url": "https://reddit.com/r/Python",
+      "platform": "reddit"
+    }
+  ],
+  "relatedSlugs": ["build/todo-app", "vibe-coding", "javascript"],
+  "lastUpdated": "2026-03-08"
+}

--- a/packages/webapp/data/learn-to-code/python.json
+++ b/packages/webapp/data/learn-to-code/python.json
@@ -21,46 +21,58 @@
     {
       "step": 1,
       "title": "Your first Python script",
-      "body": "Create a Python script that asks for my name and age, then tells me what year I was born and how many days I've been alive. Make it friendly and conversational.",
-      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "body": "Create a Python script that asks for my name and age, then tells me what year I was born and how many days I've been alive. Use f-strings for output. Add emoji to make it fun. Handle the case where someone types a non-number for age — show a helpful error instead of crashing. Add a comment above each section explaining what it does.",
+      "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "beginner",
       "timeEstimate": "~20 min",
+      "expectedOutput": "You should see a terminal asking for your name. After typing it, it asks for age. If you type '25', it prints something like 'Hey Sarah! You were born in 2001 and you've been alive for approximately 9,131 days 🎉'. If you type 'abc' for age, it should say something like 'Oops, that's not a number — try again!'",
+      "comprehensionPrompt": "Now paste this into AI: 'Explain what f-strings are and why you used them instead of string concatenation. Then explain the try/except block — what would happen if we removed it?'",
+      "challenge": "Before moving to Step 2: Change the emoji. Then add one more calculation — how many weeks old the person is. Do this yourself without asking the AI.",
       "stuckTip": "If the math feels confusing, ask the AI to break the calculation into smaller steps and explain each one."
     },
     {
       "step": 2,
       "title": "Add file handling",
-      "body": "Modify the script to save each person's info to a JSON file called 'people.json'. If the file already exists, add to it instead of overwriting. Show me how to read back all the entries.",
-      "tools": ["cursor", "claude-code", "replit", "generic"],
+      "body": "Modify the script to save each person's info to a JSON file called 'people.json'. If the file already exists, add to it instead of overwriting. Add a timestamp to each entry. Show me how to read back all the entries and display them in a formatted table. Handle the edge case where the JSON file exists but is empty or corrupted.",
+      "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "beginner",
       "timeEstimate": "~30 min",
+      "expectedOutput": "After running the script twice with different names, you should see a 'people.json' file with two entries. Running 'list' mode should show a clean table like: 'Name: Sarah | Age: 25 | Added: 2026-03-10'.",
+      "comprehensionPrompt": "Ask AI: 'Explain the difference between read mode and write mode when opening files. What does json.dump() do vs json.dumps()? Why do we need to handle the case where the file doesn't exist yet?'",
+      "challenge": "Add a 'delete' option that removes a person by name from the JSON file. Do this yourself first, then ask AI to review your attempt.",
       "stuckTip": "If you get a file-not-found or JSON decode error, paste the exact error into the AI chat and ask what's causing it."
     },
     {
       "step": 3,
       "title": "Build a CLI tool",
-      "body": "Turn this into a proper command-line tool using argparse with three commands: 'add' to add a person, 'list' to show all people, and 'stats' to show the average age and oldest/youngest person.",
+      "body": "Turn this into a proper command-line tool using argparse with three commands: 'add' to add a person interactively, 'list' to show all people in a formatted table with colors using the 'rich' library, and 'stats' to show the average age, oldest/youngest person, and a simple bar chart of age distribution. Add a '--format' flag to 'list' that switches between 'table' and 'json' output.",
       "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "intermediate",
       "timeEstimate": "~45 min",
+      "expectedOutput": "Running 'python tool.py --help' shows your three commands. 'python tool.py list' shows a colorful table. 'python tool.py list --format json' outputs raw JSON. 'python tool.py stats' shows averages and a simple text-based bar chart.",
+      "comprehensionPrompt": "Ask AI: 'Walk me through how argparse routes commands to functions. What's the difference between a positional argument and an optional flag? How does the rich library format the table?'",
       "stuckTip": "Run `python tool.py --help` to see how argparse is wiring up your commands, and ask the AI to explain any flag that looks wrong."
     },
     {
       "step": 4,
       "title": "Add a web interface",
-      "body": "Create a simple Flask web app that does the same thing but in a browser. It should have a form to add people and a page that shows the list. Use a SQLite database instead of JSON.",
+      "body": "Create a simple Flask web app that does the same thing but in a browser. It should have a form to add people and a page that shows the list with sorting options. Use a SQLite database instead of JSON. Add basic input validation — reject empty names and ages below 0 or above 150. Style it with a simple CSS file so it doesn't look like raw HTML.",
       "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "stretch",
       "timeEstimate": "~60 min",
+      "expectedOutput": "Open http://localhost:5000 in your browser. You should see a form at the top to add a person and a styled list below. Submitting an empty name should show an error message. The list should be sortable by name or age.",
+      "comprehensionPrompt": "Ask AI: 'Explain the request-response cycle — when I submit the form, what happens step by step from the browser to Flask and back? What's the difference between GET and POST? Why did you use SQLite instead of just a JSON file?'",
       "stuckTip": "If the app won't start, check that Flask is installed (`pip install flask`) and ask the AI to walk through the startup error line by line."
     },
     {
       "step": 5,
       "title": "Deploy it",
-      "body": "Help me deploy this Flask app to Railway or Render for free. Walk me through the steps and create the necessary configuration files (requirements.txt, Procfile, etc).",
+      "body": "Help me deploy this Flask app to Railway or Render for free. Walk me through the steps and create the necessary configuration files (requirements.txt, Procfile, etc). Add proper environment variable handling so secrets aren't hardcoded. Set up a production-ready WSGI server (gunicorn) instead of Flask's development server.",
       "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "stretch",
       "timeEstimate": "~45 min",
+      "expectedOutput": "After deployment, you should have a public URL like 'your-app.railway.app' that anyone can visit. The app should work exactly like it did locally. Visiting the URL on your phone should also work.",
+      "comprehensionPrompt": "Ask AI: 'What's the difference between a development server and a production server like gunicorn? Why do we use environment variables for configuration? What does the Procfile tell the hosting platform?'",
       "stuckTip": "Deployment errors are almost always environment or config issues — paste the deploy log into the AI and ask it to pinpoint the first failure."
     }
   ],
@@ -134,11 +146,6 @@
       "name": "Claude Code",
       "url": "https://docs.anthropic.com/en/docs/claude-code",
       "description": "Terminal-based AI coding — great for Python scripts and CLI tools"
-    },
-    {
-      "name": "Replit",
-      "url": "https://replit.com",
-      "description": "Code in your browser with zero setup — perfect for beginners who don't want to install anything"
     },
     {
       "name": "VS Code + Python Extension",

--- a/packages/webapp/data/learn-to-code/python.json
+++ b/packages/webapp/data/learn-to-code/python.json
@@ -21,6 +21,7 @@
     {
       "step": 1,
       "title": "Your first Python script",
+      "subtitle": "Ask your name, calculate your age, handle errors gracefully",
       "body": "Create a Python script that asks for my name and age, then tells me what year I was born and how many days I've been alive. Use f-strings for output. Add emoji to make it fun. Handle the case where someone types a non-number for age — show a helpful error instead of crashing. Add a comment above each section explaining what it does.",
       "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "beginner",
@@ -33,6 +34,7 @@
     {
       "step": 2,
       "title": "Add file handling",
+      "subtitle": "Save data to JSON files and read it back in formatted tables",
       "body": "Modify the script to save each person's info to a JSON file called 'people.json'. If the file already exists, add to it instead of overwriting. Add a timestamp to each entry. Show me how to read back all the entries and display them in a formatted table. Handle the edge case where the JSON file exists but is empty or corrupted.",
       "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "beginner",
@@ -45,6 +47,7 @@
     {
       "step": 3,
       "title": "Build a CLI tool",
+      "subtitle": "Turn your script into a real tool with subcommands and flags",
       "body": "Turn this into a proper command-line tool using argparse with three commands: 'add' to add a person interactively, 'list' to show all people in a formatted table with colors using the 'rich' library, and 'stats' to show the average age, oldest/youngest person, and a simple bar chart of age distribution. Add a '--format' flag to 'list' that switches between 'table' and 'json' output.",
       "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "intermediate",
@@ -56,6 +59,7 @@
     {
       "step": 4,
       "title": "Add a web interface",
+      "subtitle": "Build a browser-based app with Flask and SQLite",
       "body": "Create a simple Flask web app that does the same thing but in a browser. It should have a form to add people and a page that shows the list with sorting options. Use a SQLite database instead of JSON. Add basic input validation — reject empty names and ages below 0 or above 150. Style it with a simple CSS file so it doesn't look like raw HTML.",
       "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "stretch",
@@ -67,6 +71,7 @@
     {
       "step": 5,
       "title": "Deploy it",
+      "subtitle": "Deploy your Flask app to Railway or Render for free",
       "body": "Help me deploy this Flask app to Railway or Render for free. Walk me through the steps and create the necessary configuration files (requirements.txt, Procfile, etc). Add proper environment variable handling so secrets aren't hardcoded. Set up a production-ready WSGI server (gunicorn) instead of Flask's development server.",
       "tools": ["cursor", "claude-code", "generic"],
       "difficulty": "stretch",

--- a/packages/webapp/data/learn-to-code/skills.json
+++ b/packages/webapp/data/learn-to-code/skills.json
@@ -1,0 +1,100 @@
+{
+  "slug": "skills",
+  "title": "Acquire New Skills",
+  "description": "Go beyond the basics. Learn techniques that make you more effective — from vibe coding entire apps with AI to debugging like a pro and landing your first dev job.",
+  "dimension": "category",
+  "tags": ["programming", "ai-tools", "career", "beginners"],
+  "outcomes": [
+    "Build complete apps by describing them in plain English (vibe coding)",
+    "Debug errors systematically instead of guessing",
+    "Build a portfolio and skills that get you hired",
+    "Use AI tools effectively as a coding partner, not a crutch"
+  ],
+  "recommendedPaths": [
+    {
+      "slug": "vibe-coding",
+      "title": "Vibe Coding",
+      "reason": "Build software by describing what you want. The fastest way to go from idea to working app — no syntax required."
+    },
+    {
+      "slug": "debugging",
+      "title": "Debugging with AI",
+      "reason": "Things will break. Learn how to find and fix bugs systematically using AI as your debugging partner."
+    },
+    {
+      "slug": "get-a-dev-job",
+      "title": "Get Your First Dev Job",
+      "reason": "Turn your coding skills into a career. Portfolio building, interview prep, and what hiring managers actually look for."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "Prompt Engineering for Code",
+      "explanation": "The quality of AI-generated code depends on how you describe what you want. Being specific about behavior, edge cases, and tech stack produces dramatically better results."
+    },
+    {
+      "name": "Debugging Mindset",
+      "explanation": "Debugging isn't guessing — it's systematically narrowing down where things went wrong. Read the error, form a hypothesis, test it. AI accelerates every step."
+    },
+    {
+      "name": "Iterative Development",
+      "explanation": "Build in layers — get the core working first, then add features one at a time. Trying to build everything at once produces worse results with both AI and manual coding."
+    }
+  ],
+  "resources": [
+    {
+      "title": "Cursor Documentation",
+      "url": "https://docs.cursor.com",
+      "type": "docs",
+      "free": true
+    },
+    {
+      "title": "Claude Code Getting Started",
+      "url": "https://docs.anthropic.com/en/docs/claude-code/overview",
+      "type": "docs",
+      "free": true
+    },
+    {
+      "title": "Roadmap.sh",
+      "url": "https://roadmap.sh/",
+      "type": "article",
+      "free": true
+    }
+  ],
+  "tools": [
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "The most popular AI code editor — built for vibe coding workflows"
+    },
+    {
+      "name": "Claude Code",
+      "url": "https://docs.anthropic.com/en/docs/claude-code",
+      "description": "Agentic coding in your terminal — great for building full projects from a description"
+    },
+    {
+      "name": "Lovable",
+      "url": "https://lovable.dev",
+      "description": "AI full-stack engineer — generates complete apps from a single prompt"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/vibecoding",
+      "url": "https://reddit.com/r/vibecoding",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/cscareerquestions",
+      "url": "https://reddit.com/r/cscareerquestions",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/learnprogramming",
+      "url": "https://reddit.com/r/learnprogramming",
+      "platform": "reddit"
+    }
+  ],
+  "relatedSlugs": ["build", "languages", "automate"],
+  "lastUpdated": "2026-03-11"
+}

--- a/packages/webapp/data/learn-to-code/types.ts
+++ b/packages/webapp/data/learn-to-code/types.ts
@@ -5,11 +5,7 @@ export type LeafPageDimension =
   | 'technique'
   | 'goal';
 
-export type PromptTool =
-  | 'cursor'
-  | 'claude-code'
-  | 'replit'
-  | 'generic';
+export type PromptTool = 'cursor' | 'claude-code' | 'replit' | 'generic';
 
 export type ResourceType = 'video' | 'article' | 'course' | 'docs';
 

--- a/packages/webapp/data/learn-to-code/types.ts
+++ b/packages/webapp/data/learn-to-code/types.ts
@@ -1,0 +1,88 @@
+export type LeafPageDimension =
+  | 'language'
+  | 'usecase'
+  | 'audience'
+  | 'technique'
+  | 'goal';
+
+export type PromptTool =
+  | 'cursor'
+  | 'claude-code'
+  | 'replit'
+  | 'generic';
+
+export type ResourceType = 'video' | 'article' | 'course' | 'docs';
+
+export type CommunityPlatform = 'dailydev' | 'reddit' | 'discord' | 'other';
+
+export type PromptDifficulty = 'beginner' | 'intermediate' | 'stretch';
+
+export interface Prompt {
+  step: number;
+  title: string;
+  body: string;
+  tools: PromptTool[];
+  difficulty?: PromptDifficulty;
+  timeEstimate?: string;
+  stuckTip?: string;
+}
+
+export interface Concept {
+  name: string;
+  explanation: string;
+}
+
+export interface Resource {
+  title: string;
+  url: string;
+  type: ResourceType;
+  free: boolean;
+}
+
+export interface Tool {
+  name: string;
+  url: string;
+  description: string;
+}
+
+export interface Community {
+  name: string;
+  url: string;
+  platform: CommunityPlatform;
+}
+
+export interface RecommendedPath {
+  slug: string;
+  title: string;
+  reason: string;
+}
+
+export interface LeafPageData {
+  slug: string;
+  title: string;
+  description: string;
+  dimension: LeafPageDimension;
+  tags: string[];
+  outcomes?: string[];
+  aiTips?: string[];
+  projectDescription?: string;
+  recommendedPaths?: RecommendedPath[];
+  prompts?: Prompt[];
+  concepts: Concept[];
+  resources: Resource[];
+  tools: Tool[];
+  communities: Community[];
+  relatedSlugs: string[];
+  lastUpdated: string;
+}
+
+export interface ManifestEntry {
+  slug: string;
+  title: string;
+  dimension: LeafPageDimension;
+  lastUpdated: string;
+}
+
+export interface Manifest {
+  pages: ManifestEntry[];
+}

--- a/packages/webapp/data/learn-to-code/types.ts
+++ b/packages/webapp/data/learn-to-code/types.ts
@@ -5,13 +5,25 @@ export type LeafPageDimension =
   | 'technique'
   | 'goal';
 
-export type PromptTool = 'cursor' | 'claude-code' | 'replit' | 'generic';
+export type PromptTool = 'cursor' | 'claude-code' | 'generic';
 
 export type ResourceType = 'video' | 'article' | 'course' | 'docs';
 
 export type CommunityPlatform = 'dailydev' | 'reddit' | 'discord' | 'other';
 
 export type PromptDifficulty = 'beginner' | 'intermediate' | 'stretch';
+
+export type IconKey =
+  | 'sparkle'
+  | 'magic'
+  | 'graduation'
+  | 'hammer'
+  | 'star'
+  | 'trending'
+  | 'terminal'
+  | 'alert'
+  | 'share'
+  | 'upvote';
 
 export interface Prompt {
   step: number;
@@ -21,6 +33,9 @@ export interface Prompt {
   difficulty?: PromptDifficulty;
   timeEstimate?: string;
   stuckTip?: string;
+  expectedOutput?: string;
+  comprehensionPrompt?: string;
+  challenge?: string;
 }
 
 export interface Concept {
@@ -53,6 +68,16 @@ export interface RecommendedPath {
   reason: string;
 }
 
+export interface HowItWorksStep {
+  title: string;
+  subtitle: string;
+}
+
+export interface TroubleshootingItem {
+  problem: string;
+  fix: string;
+}
+
 export interface LeafPageData {
   slug: string;
   title: string;
@@ -70,6 +95,14 @@ export interface LeafPageData {
   communities: Community[];
   relatedSlugs: string[];
   lastUpdated: string;
+  howItWorks?: HowItWorksStep[];
+  prerequisites?: string[];
+  troubleshooting?: TroubleshootingItem[];
+  learningRule?: string;
+  shipCta?: {
+    title: string;
+    body: string;
+  };
 }
 
 export interface ManifestEntry {
@@ -81,4 +114,36 @@ export interface ManifestEntry {
 
 export interface Manifest {
   pages: ManifestEntry[];
+}
+
+export interface FaqItem {
+  question: string;
+  answer: string;
+}
+
+export interface PopularPath {
+  title: string;
+  slug: string;
+  subtitle: string;
+  gradient: string;
+  accentColor: string;
+  iconKey: IconKey;
+}
+
+export interface HubData {
+  seo: {
+    title: string;
+    description: string;
+  };
+  hero: {
+    heading: string;
+    subtitle: string;
+  };
+  popularPaths: PopularPath[];
+  dimensions: {
+    order: LeafPageDimension[];
+    titles: Record<string, string>;
+    icons: Record<string, IconKey>;
+  };
+  faq: FaqItem[];
 }

--- a/packages/webapp/data/learn-to-code/types.ts
+++ b/packages/webapp/data/learn-to-code/types.ts
@@ -3,7 +3,8 @@ export type LeafPageDimension =
   | 'usecase'
   | 'audience'
   | 'technique'
-  | 'goal';
+  | 'goal'
+  | 'category';
 
 export type PromptTool = 'cursor' | 'claude-code' | 'generic';
 
@@ -130,6 +131,11 @@ export interface PopularPath {
   iconKey: IconKey;
 }
 
+export interface AudiencePath {
+  slug: string;
+  title: string;
+}
+
 export interface HubData {
   seo: {
     title: string;
@@ -139,11 +145,7 @@ export interface HubData {
     heading: string;
     subtitle: string;
   };
-  popularPaths: PopularPath[];
-  dimensions: {
-    order: LeafPageDimension[];
-    titles: Record<string, string>;
-    icons: Record<string, IconKey>;
-  };
+  categories: PopularPath[];
+  audiencePaths: AudiencePath[];
   faq: FaqItem[];
 }

--- a/packages/webapp/data/learn-to-code/types.ts
+++ b/packages/webapp/data/learn-to-code/types.ts
@@ -37,6 +37,7 @@ export interface Prompt {
   expectedOutput?: string;
   comprehensionPrompt?: string;
   challenge?: string;
+  subtitle?: string;
 }
 
 export interface Concept {

--- a/packages/webapp/data/learn-to-code/vibe-coding.json
+++ b/packages/webapp/data/learn-to-code/vibe-coding.json
@@ -21,46 +21,58 @@
     {
       "step": 1,
       "title": "Your first vibe-coded app",
-      "body": "Build me a personal bookmark manager. I want to paste a URL, and it should automatically fetch the page title, save it with tags I can add, and let me search through my saved bookmarks. Use React, TypeScript, and Tailwind. Store everything in localStorage.",
-      "tools": ["cursor", "claude-code", "replit"],
+      "body": "Build me a personal bookmark manager. I want to paste a URL, and it should automatically fetch the page title, save it with tags I can add, and let me search through my saved bookmarks. Use React, TypeScript, and Tailwind. Store everything in localStorage. Add a clean, modern UI with a dark mode toggle. Handle the edge case where the URL is invalid — show a friendly error.",
+      "tools": ["cursor", "claude-code"],
       "difficulty": "beginner",
       "timeEstimate": "~30 min",
+      "expectedOutput": "You should see a web app with an input field at the top for pasting URLs. After pasting a URL and clicking 'Save', the bookmark appears in a list below with its title and any tags you added. A search bar filters bookmarks as you type. The dark mode toggle switches the entire UI.",
+      "comprehensionPrompt": "Ask AI: 'Walk me through how localStorage works — where is the data actually stored? What happens if the user clears their browser data? Why did you use React state for the UI but localStorage for persistence?'",
+      "challenge": "Change the color scheme of the dark mode. Then add a counter that shows the total number of bookmarks. Do both without asking AI.",
       "stuckTip": "If the app won't run, paste the exact error message into the AI chat and ask it to explain and fix it."
     },
     {
       "step": 2,
       "title": "Make it smarter",
-      "body": "When I save a bookmark, auto-suggest 3 tags based on the URL and title. Group bookmarks by tag in the sidebar. Add a 'read later' queue that shows bookmarks I haven't opened yet.",
-      "tools": ["cursor", "claude-code", "replit"],
+      "body": "When I save a bookmark, auto-suggest 3 tags based on the URL and title. Group bookmarks by tag in the sidebar with a count badge showing how many bookmarks each tag has. Add a 'read later' queue that shows bookmarks I haven't opened yet, sorted by when they were saved.",
+      "tools": ["cursor", "claude-code"],
       "difficulty": "beginner",
       "timeEstimate": "~30 min",
+      "expectedOutput": "When you save a bookmark for 'github.com/facebook/react', you should see suggested tags like 'github', 'programming', 'react'. The sidebar shows tags with counts like 'programming (5)'. The 'Read Later' tab shows unread bookmarks with the oldest at the top.",
+      "comprehensionPrompt": "Ask AI: 'How does the tag suggestion algorithm work? How would you make it smarter over time? What's the difference between filtering in the component vs filtering in a separate function?'",
+      "challenge": "Add a 'favorite' button (heart/star) to each bookmark so you can mark your most important ones. Implement this yourself before checking with AI.",
       "stuckTip": "If the tag suggestions feel off, ask the AI to explain the logic it used and suggest a better approach."
     },
     {
       "step": 3,
       "title": "Add a feature you didn't plan",
-      "body": "Add a daily digest view that shows me 3 random unread bookmarks each morning. Also add import/export so I can backup my bookmarks as a JSON file and restore them on another device.",
+      "body": "Add a daily digest view that shows me 3 random unread bookmarks each morning — it should only refresh once per day (use the date as a seed). Also add import/export so I can backup my bookmarks as a JSON file and restore them on another device. Validate the imported JSON and show clear errors if the format is wrong.",
       "tools": ["cursor", "claude-code"],
       "difficulty": "intermediate",
       "timeEstimate": "~45 min",
+      "expectedOutput": "A 'Daily Digest' tab shows exactly 3 random unread bookmarks. Refreshing the page shows the same 3 (until tomorrow). The Export button downloads a .json file. Importing that file on a fresh browser restores all bookmarks. Importing a corrupted file shows a clear error.",
+      "comprehensionPrompt": "Ask AI: 'How does using the date as a random seed give us the same results all day? What's the difference between Math.random() and a seeded random? How does file download work in the browser without a server?'",
       "stuckTip": "Break the feature into two separate prompts — daily digest first, then import/export — if the combined prompt produces messy results."
     },
     {
       "step": 4,
       "title": "Fix what broke",
-      "body": "Review the entire codebase and identify any bugs, performance issues, or edge cases I should fix. Then fix them. Explain each issue you found and why it matters.",
+      "body": "Review the entire codebase and identify any bugs, performance issues, or edge cases I should fix. Then fix them. Explain each issue you found and why it matters. Specifically check: What happens with 1000+ bookmarks? What happens if localStorage is full? Are there any XSS vulnerabilities from pasting URLs?",
       "tools": ["cursor", "claude-code"],
       "difficulty": "stretch",
       "timeEstimate": "~60 min",
+      "expectedOutput": "AI should identify 3-8 issues. After fixes, the app should handle large datasets smoothly, show a warning when storage is nearly full, and sanitize any HTML in bookmark titles to prevent XSS.",
+      "comprehensionPrompt": "Ask AI: 'Explain each bug you found — how could a real user trigger it? What's XSS and why is it dangerous? How would you test for these issues systematically?'",
       "stuckTip": "Ask the AI to focus on one category at a time (bugs, then performance, then edge cases) if the full review is overwhelming."
     },
     {
       "step": 5,
       "title": "Ship it",
-      "body": "Set up this project for deployment to Vercel. Add a nice README, proper meta tags for social sharing, and make sure it works well on mobile. Add a PWA manifest so I can install it as an app on my phone.",
+      "body": "Set up this project for deployment to Vercel. Add a nice README with screenshots, proper Open Graph meta tags for social sharing (so it looks good when shared on Twitter/Slack), and make sure it works well on mobile. Add a PWA manifest so I can install it as an app on my phone.",
       "tools": ["cursor", "claude-code"],
       "difficulty": "stretch",
       "timeEstimate": "~60 min",
+      "expectedOutput": "After deployment, you should have a URL like 'your-app.vercel.app'. Sharing that URL on Twitter/Slack shows a nice preview card with your app's title and description. On mobile, you can 'Add to Home Screen' and it opens like a native app.",
+      "comprehensionPrompt": "Ask AI: 'What are Open Graph tags and why do they matter? What does a PWA manifest do — how does the browser know it's installable? What's the difference between Vercel's free tier and a paid plan?'",
       "stuckTip": "If Vercel deployment fails, share the build error with the AI and ask it to fix the configuration — most issues are environment or build settings."
     }
   ],
@@ -124,11 +136,6 @@
       "name": "Claude Code",
       "url": "https://docs.anthropic.com/en/docs/claude-code",
       "description": "Agentic coding in your terminal — great for building full projects from a description"
-    },
-    {
-      "name": "Replit Agent",
-      "url": "https://replit.com",
-      "description": "Describe your app, Replit builds and deploys it — the most beginner-friendly option"
     },
     {
       "name": "Lovable",

--- a/packages/webapp/data/learn-to-code/vibe-coding.json
+++ b/packages/webapp/data/learn-to-code/vibe-coding.json
@@ -1,0 +1,158 @@
+{
+  "slug": "vibe-coding",
+  "title": "Vibe Coding",
+  "description": "Vibe coding is building software by describing what you want in plain English and letting AI write the code. It's the fastest way to go from idea to working app — no syntax memorization required. The key skill isn't writing code, it's knowing what to ask for.",
+  "dimension": "technique",
+  "tags": ["ai", "ai-tools", "cursor", "programming"],
+  "projectDescription": "You'll go from describing an idea in plain English to deploying a working web app — no coding experience needed. You'll learn how to talk to AI effectively, iterate on what it builds, and ship a real project you can share with a link.",
+  "outcomes": [
+    "Build and deploy a working web app using only natural language prompts",
+    "Iterate on AI-generated code to add features and fix edge cases",
+    "Review and understand code you didn't write yourself",
+    "Ship a mobile-friendly PWA to a real URL"
+  ],
+  "aiTips": [
+    "Be specific about your tech stack upfront — 'React, TypeScript, Tailwind, localStorage' beats 'make a web app'",
+    "When output isn't right, tell the AI what's wrong rather than re-prompting from scratch",
+    "Use AI to explain generated code line by line so you understand what you own",
+    "Ask AI to review its own output for bugs before you run it — it often catches obvious issues"
+  ],
+  "prompts": [
+    {
+      "step": 1,
+      "title": "Your first vibe-coded app",
+      "body": "Build me a personal bookmark manager. I want to paste a URL, and it should automatically fetch the page title, save it with tags I can add, and let me search through my saved bookmarks. Use React, TypeScript, and Tailwind. Store everything in localStorage.",
+      "tools": ["cursor", "claude-code", "replit"],
+      "difficulty": "beginner",
+      "timeEstimate": "~30 min",
+      "stuckTip": "If the app won't run, paste the exact error message into the AI chat and ask it to explain and fix it."
+    },
+    {
+      "step": 2,
+      "title": "Make it smarter",
+      "body": "When I save a bookmark, auto-suggest 3 tags based on the URL and title. Group bookmarks by tag in the sidebar. Add a 'read later' queue that shows bookmarks I haven't opened yet.",
+      "tools": ["cursor", "claude-code", "replit"],
+      "difficulty": "beginner",
+      "timeEstimate": "~30 min",
+      "stuckTip": "If the tag suggestions feel off, ask the AI to explain the logic it used and suggest a better approach."
+    },
+    {
+      "step": 3,
+      "title": "Add a feature you didn't plan",
+      "body": "Add a daily digest view that shows me 3 random unread bookmarks each morning. Also add import/export so I can backup my bookmarks as a JSON file and restore them on another device.",
+      "tools": ["cursor", "claude-code"],
+      "difficulty": "intermediate",
+      "timeEstimate": "~45 min",
+      "stuckTip": "Break the feature into two separate prompts — daily digest first, then import/export — if the combined prompt produces messy results."
+    },
+    {
+      "step": 4,
+      "title": "Fix what broke",
+      "body": "Review the entire codebase and identify any bugs, performance issues, or edge cases I should fix. Then fix them. Explain each issue you found and why it matters.",
+      "tools": ["cursor", "claude-code"],
+      "difficulty": "stretch",
+      "timeEstimate": "~60 min",
+      "stuckTip": "Ask the AI to focus on one category at a time (bugs, then performance, then edge cases) if the full review is overwhelming."
+    },
+    {
+      "step": 5,
+      "title": "Ship it",
+      "body": "Set up this project for deployment to Vercel. Add a nice README, proper meta tags for social sharing, and make sure it works well on mobile. Add a PWA manifest so I can install it as an app on my phone.",
+      "tools": ["cursor", "claude-code"],
+      "difficulty": "stretch",
+      "timeEstimate": "~60 min",
+      "stuckTip": "If Vercel deployment fails, share the build error with the AI and ask it to fix the configuration — most issues are environment or build settings."
+    }
+  ],
+  "concepts": [
+    {
+      "name": "Prompt Engineering for Code",
+      "explanation": "The quality of AI-generated code depends entirely on how you describe what you want. Being specific about tech stack, behavior, and edge cases produces dramatically better results than vague requests."
+    },
+    {
+      "name": "Iterative Development",
+      "explanation": "Vibe coding works best in layers — get the core working first, then add features one at a time. Each prompt builds on the last. Trying to describe everything at once usually produces worse results."
+    },
+    {
+      "name": "Code Review as a Skill",
+      "explanation": "When AI writes your code, your job shifts to reviewing it. Can you spot a bug? Does the approach make sense? Understanding code you didn't write is arguably more important than writing it yourself."
+    },
+    {
+      "name": "The 80/20 of Vibe Coding",
+      "explanation": "AI gets you to 80% fast. The last 20% — edge cases, polish, performance — is where you'll learn the most. This is where you start understanding what the code actually does."
+    }
+  ],
+  "resources": [
+    {
+      "title": "Andrej Karpathy on Vibe Coding",
+      "url": "https://x.com/karpathy/status/1886192184808149383",
+      "type": "article",
+      "free": true
+    },
+    {
+      "title": "Cursor Documentation",
+      "url": "https://docs.cursor.com",
+      "type": "docs",
+      "free": true
+    },
+    {
+      "title": "Claude Code Getting Started",
+      "url": "https://docs.anthropic.com/en/docs/claude-code/overview",
+      "type": "docs",
+      "free": true
+    },
+    {
+      "title": "The Uncomfortable Truth About Vibe Coding",
+      "url": "https://developers.redhat.com/articles/2026/02/17/uncomfortable-truth-about-vibe-coding",
+      "type": "article",
+      "free": true
+    },
+    {
+      "title": "Fireship - Vibe Coding Explained",
+      "url": "https://www.youtube.com/fireship",
+      "type": "video",
+      "free": true
+    }
+  ],
+  "tools": [
+    {
+      "name": "Cursor",
+      "url": "https://cursor.sh",
+      "description": "The most popular AI code editor — built specifically for vibe coding workflows"
+    },
+    {
+      "name": "Claude Code",
+      "url": "https://docs.anthropic.com/en/docs/claude-code",
+      "description": "Agentic coding in your terminal — great for building full projects from a description"
+    },
+    {
+      "name": "Replit Agent",
+      "url": "https://replit.com",
+      "description": "Describe your app, Replit builds and deploys it — the most beginner-friendly option"
+    },
+    {
+      "name": "Lovable",
+      "url": "https://lovable.dev",
+      "description": "AI full-stack engineer — generates complete apps from a single prompt"
+    }
+  ],
+  "communities": [
+    {
+      "name": "r/vibecoding",
+      "url": "https://reddit.com/r/vibecoding",
+      "platform": "reddit"
+    },
+    {
+      "name": "r/ChatGPTCoding",
+      "url": "https://reddit.com/r/ChatGPTCoding",
+      "platform": "reddit"
+    },
+    {
+      "name": "Cursor Community Discord",
+      "url": "https://discord.gg/cursor",
+      "platform": "discord"
+    }
+  ],
+  "relatedSlugs": ["python", "build/todo-app", "for/marketers"],
+  "lastUpdated": "2026-03-10"
+}

--- a/packages/webapp/pages/learn-to-code/[...slug].tsx
+++ b/packages/webapp/pages/learn-to-code/[...slug].tsx
@@ -337,8 +337,7 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
   const { user } = useContext(AuthContext);
 
   const feedTag = pageData?.tags?.[0];
-  const isSubHub =
-    pageData?.dimension === 'audience' && !!pageData?.recommendedPaths?.length;
+  const isSubHub = !!pageData?.recommendedPaths?.length;
 
   const feedVariables = useMemo(
     () => ({

--- a/packages/webapp/pages/learn-to-code/[...slug].tsx
+++ b/packages/webapp/pages/learn-to-code/[...slug].tsx
@@ -37,6 +37,8 @@ import SettingsContext from '@dailydotdev/shared/src/contexts/SettingsContext';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { PostType } from '@dailydotdev/shared/src/graphql/posts';
 import { UpvoteIcon } from '@dailydotdev/shared/src/components/icons';
+import { AlertIcon } from '@dailydotdev/shared/src/components/icons/Alert';
+import { ShareIcon } from '@dailydotdev/shared/src/components/icons/Share';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
 import type { NextSeoProps } from 'next-seo/lib/types';
 import { getLayout } from '../../components/layouts/MainLayout';
@@ -44,10 +46,12 @@ import { getLayout as getFooterNavBarLayout } from '../../components/layouts/Foo
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 import type {
+  HowItWorksStep,
   LeafPageData,
   Manifest,
   Prompt,
   RecommendedPath,
+  TroubleshootingItem,
 } from '../../data/learn-to-code/types';
 import type { DynamicSeoProps } from '../../components/common';
 import manifest from '../../data/learn-to-code/manifest.json';
@@ -65,7 +69,6 @@ function ForceListMode({ children }: { children: ReactNode }): ReactElement {
 const TOOL_LABELS: Record<string, string> = {
   cursor: 'Cursor',
   'claude-code': 'Claude Code',
-  replit: 'Replit',
   generic: 'Any AI Tool',
 };
 
@@ -73,6 +76,12 @@ const DIFFICULTY_LABELS: Record<string, string> = {
   beginner: 'Beginner',
   intermediate: 'Intermediate',
   stretch: 'Stretch',
+};
+
+const DIFFICULTY_COLORS: Record<string, string> = {
+  beginner: 'bg-accent-avocado-default',
+  intermediate: 'bg-accent-cheese-default',
+  stretch: 'bg-accent-onion-default',
 };
 
 const RESOURCE_TYPE_ICONS: Record<string, ReactElement> = {
@@ -105,6 +114,61 @@ const PLATFORM_LABELS: Record<string, string> = {
   reddit: 'Reddit',
   discord: 'Discord',
   other: 'Web',
+};
+
+const DEFAULT_HOW_IT_WORKS: HowItWorksStep[] = [
+  {
+    title: 'Pick a free AI tool',
+    subtitle: 'Cursor, Claude Code, or any tool you like — all work great',
+  },
+  {
+    title: 'Copy a prompt below',
+    subtitle:
+      "Each prompt tells the AI exactly what to build — you don't need to know the syntax",
+  },
+  {
+    title: 'Paste and watch it build',
+    subtitle:
+      'The AI writes the code, you see real results — then learn what it did and why',
+  },
+];
+
+const DEFAULT_PREREQUISITES: string[] = [
+  'A laptop or desktop computer',
+  'About 30 minutes of free time',
+  'One free AI tool (see recommendations below)',
+  'Zero coding experience required',
+];
+
+const DEFAULT_TROUBLESHOOTING: TroubleshootingItem[] = [
+  {
+    problem: "It broke and I don't know why",
+    fix: 'Paste the full error into AI chat. Copy the exact error text, not a paraphrase. AI is exceptionally good at explaining what went wrong.',
+  },
+  {
+    problem: "The code doesn't do what I expected",
+    fix: 'Describe what you want vs what happened. Be specific: "I expected X but got Y" gets better results than "it\'s wrong."',
+  },
+  {
+    problem: "I feel like I'm not actually learning",
+    fix: "That's normal. Modify one thing in the AI-generated code yourself. Then another. Understanding comes from changing code, not just reading it.",
+  },
+  {
+    problem: 'The AI keeps going in circles',
+    fix: "Start fresh. Delete the broken code and re-prompt from scratch with a clearer description. Don't try to fix bad code forever.",
+  },
+  {
+    problem: "I can't deploy it",
+    fix: 'This is the hardest step for everyone. Follow the deployment prompt step by step and paste every error into AI chat.',
+  },
+];
+
+const DEFAULT_LEARNING_RULE =
+  'AI gets you to code faster. But understanding what it built is what makes you a developer. After each prompt, ask: "Explain this code to me line by line." That single habit is the difference between vibe coding and actually learning.';
+
+const DEFAULT_SHIP_CTA = {
+  title: 'You built it — now ship it',
+  body: 'Deploy your project and share the link. Post what you built on daily.dev and tag it #LearnToCode — other beginners seeing "someone like me built this" is the most powerful motivation there is.',
 };
 
 interface LeafPageParams extends ParsedUrlQuery {
@@ -175,12 +239,48 @@ function PromptCard({ prompt }: { prompt: Prompt }): ReactElement {
           </Button>
         </div>
 
-        {/* The prompt text — styled like a friendly message, not a code block */}
+        {/* The prompt text */}
         <div className="rounded-16 border border-border-subtlest-tertiary bg-surface-float p-5">
           <p className="whitespace-pre-wrap text-text-secondary typo-body">
             {prompt.body}
           </p>
         </div>
+
+        {/* Expected output */}
+        {prompt.expectedOutput && (
+          <div className="border-l-2 border-accent-avocado-default pl-4">
+            <p className="text-text-tertiary typo-footnote">
+              <span className="font-bold text-text-secondary">
+                What you should see:
+              </span>{' '}
+              {prompt.expectedOutput}
+            </p>
+          </div>
+        )}
+
+        {/* Comprehension prompt */}
+        {prompt.comprehensionPrompt && (
+          <div className="border-l-2 border-accent-water-default pl-4">
+            <p className="text-text-tertiary typo-footnote">
+              <span className="font-bold text-text-secondary">
+                Now understand it:
+              </span>{' '}
+              {prompt.comprehensionPrompt}
+            </p>
+          </div>
+        )}
+
+        {/* Challenge */}
+        {prompt.challenge && (
+          <div className="border-l-2 border-accent-onion-default pl-4">
+            <p className="text-text-tertiary typo-footnote">
+              <span className="font-bold text-text-secondary">
+                Try it yourself:
+              </span>{' '}
+              {prompt.challenge}
+            </p>
+          </div>
+        )}
 
         {/* Stuck tip */}
         {prompt.stuckTip && (
@@ -262,7 +362,38 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
     .map((slug) => pages.find((p) => p.slug === slug))
     .filter(Boolean);
 
-  const jsonLd = isSubHub
+  const howItWorks = pageData.howItWorks ?? DEFAULT_HOW_IT_WORKS;
+  const prerequisites = pageData.prerequisites ?? DEFAULT_PREREQUISITES;
+  const troubleshooting = pageData.troubleshooting ?? DEFAULT_TROUBLESHOOTING;
+  const learningRule = pageData.learningRule ?? DEFAULT_LEARNING_RULE;
+  const shipCta = pageData.shipCta ?? DEFAULT_SHIP_CTA;
+
+  const breadcrumbLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: 'Home',
+        item: 'https://app.daily.dev',
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Learn to Code',
+        item: 'https://app.daily.dev/learn-to-code',
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: pageData.title,
+        item: `https://app.daily.dev/learn-to-code/${pageData.slug}`,
+      },
+    ],
+  };
+
+  const pageLd = isSubHub
     ? {
         '@context': 'https://schema.org',
         '@type': 'CollectionPage',
@@ -293,6 +424,8 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
         })),
       };
 
+  const jsonLd = [pageLd, breadcrumbLd];
+
   return (
     <div className="relative mx-auto flex w-full max-w-[69.25rem] flex-col">
       <Head>
@@ -311,7 +444,7 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
           </Link>
         </BreadCrumbs>
 
-        {/* Hero — full width above the two columns */}
+        {/* Hero */}
         <header className="mb-8 mt-8 flex flex-col gap-4 laptop:mt-10">
           <h1 className="font-bold text-text-primary typo-title1 laptop:typo-mega2">
             {pageData.title}
@@ -349,49 +482,21 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
                 How this works
               </h2>
               <div className="grid grid-cols-1 gap-4 tablet:grid-cols-3">
-                <div className="flex items-start gap-3">
-                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent-cabbage-subtlest font-bold text-accent-cabbage-default typo-callout">
-                    1
-                  </span>
-                  <div className="flex flex-1 flex-col gap-1">
-                    <span className="font-bold text-text-primary typo-callout">
-                      Pick a free AI tool
+                {howItWorks.map((step, index) => (
+                  <div key={step.title} className="flex items-start gap-3">
+                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent-cabbage-subtlest font-bold text-accent-cabbage-default typo-callout">
+                      {index + 1}
                     </span>
-                    <span className="text-text-quaternary typo-footnote">
-                      {pageData.tools[0]?.name || 'Cursor'},{' '}
-                      {pageData.tools[1]?.name || 'Replit'}, or any tool you
-                      like — all work great
-                    </span>
+                    <div className="flex flex-1 flex-col gap-1">
+                      <span className="font-bold text-text-primary typo-callout">
+                        {step.title}
+                      </span>
+                      <span className="text-text-quaternary typo-footnote">
+                        {step.subtitle}
+                      </span>
+                    </div>
                   </div>
-                </div>
-                <div className="flex items-start gap-3">
-                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent-cabbage-subtlest font-bold text-accent-cabbage-default typo-callout">
-                    2
-                  </span>
-                  <div className="flex flex-1 flex-col gap-1">
-                    <span className="font-bold text-text-primary typo-callout">
-                      Copy a prompt below
-                    </span>
-                    <span className="text-text-quaternary typo-footnote">
-                      Each prompt tells the AI exactly what to build — you
-                      don&apos;t need to know the syntax
-                    </span>
-                  </div>
-                </div>
-                <div className="flex items-start gap-3">
-                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent-cabbage-subtlest font-bold text-accent-cabbage-default typo-callout">
-                    3
-                  </span>
-                  <div className="flex flex-1 flex-col gap-1">
-                    <span className="font-bold text-text-primary typo-callout">
-                      Paste and watch it build
-                    </span>
-                    <span className="text-text-quaternary typo-footnote">
-                      The AI writes the code, you see real results — then learn
-                      what it did and why
-                    </span>
-                  </div>
-                </div>
+                ))}
               </div>
             </section>
 
@@ -401,30 +506,17 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
                   What you need to start
                 </h3>
                 <ul className="flex flex-col gap-3">
-                  <li className="flex items-center gap-3 text-text-secondary typo-body">
-                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-avocado-subtlest text-accent-avocado-default typo-caption2">
-                      ✓
-                    </span>
-                    A laptop or desktop computer
-                  </li>
-                  <li className="flex items-center gap-3 text-text-secondary typo-body">
-                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-avocado-subtlest text-accent-avocado-default typo-caption2">
-                      ✓
-                    </span>
-                    About 30 minutes of free time
-                  </li>
-                  <li className="flex items-center gap-3 text-text-secondary typo-body">
-                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-avocado-subtlest text-accent-avocado-default typo-caption2">
-                      ✓
-                    </span>
-                    One free AI tool (see recommendations below)
-                  </li>
-                  <li className="flex items-center gap-3 text-text-secondary typo-body">
-                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-avocado-subtlest text-accent-avocado-default typo-caption2">
-                      ✓
-                    </span>
-                    Zero coding experience required
-                  </li>
+                  {prerequisites.map((item) => (
+                    <li
+                      key={item}
+                      className="flex items-center gap-3 text-text-secondary typo-body"
+                    >
+                      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-avocado-subtlest text-accent-avocado-default typo-caption2">
+                        ✓
+                      </span>
+                      {item}
+                    </li>
+                  ))}
                 </ul>
               </div>
 
@@ -472,6 +564,18 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
               </section>
             )}
 
+            {/* AI Learning Rule */}
+            {!isSubHub && pageData.prompts && pageData.prompts.length > 0 && (
+              <div className="mb-8 rounded-16 border border-border-subtlest-tertiary bg-background-subtle p-6">
+                <p className="text-text-secondary typo-callout">
+                  <span className="font-bold text-text-primary">
+                    The #1 rule for learning with AI:
+                  </span>{' '}
+                  {learningRule}
+                </p>
+              </div>
+            )}
+
             {/* Leaf page: Start Building — prompts */}
             {!isSubHub && pageData.prompts && pageData.prompts.length > 0 && (
               <section>
@@ -492,9 +596,91 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
                     </p>
                   </div>
                 </div>
+
+                {/* Difficulty progression bar */}
+                <div
+                  className="mb-6 flex items-center gap-1"
+                  role="list"
+                  aria-label="Step difficulty progression"
+                >
+                  {(pageData.prompts || []).map((prompt) => {
+                    const difficulty = prompt.difficulty || 'beginner';
+
+                    return (
+                      <div
+                        key={prompt.step}
+                        role="listitem"
+                        className="flex flex-1 flex-col items-center gap-1.5"
+                        aria-label={`Step ${prompt.step}: ${DIFFICULTY_LABELS[difficulty]}`}
+                      >
+                        <div
+                          className={`h-1 w-full rounded-full ${DIFFICULTY_COLORS[difficulty]}`}
+                        />
+                        <span className="text-text-quaternary typo-caption2">
+                          {prompt.step}. {DIFFICULTY_LABELS[difficulty]}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+
                 <div className="flex flex-col gap-5">
                   {pageData.prompts.map((prompt) => (
                     <PromptCard key={prompt.step} prompt={prompt} />
+                  ))}
+                </div>
+
+                {/* Ship & Share CTA */}
+                <div className="mt-8 rounded-24 border border-border-subtlest-tertiary bg-background-subtle p-6">
+                  <div className="flex items-start gap-3">
+                    <ShareIcon
+                      size={IconSize.Medium}
+                      className="shrink-0 text-text-tertiary"
+                    />
+                    <div className="flex flex-col gap-1">
+                      <span className="font-bold text-text-primary typo-callout">
+                        {shipCta.title}
+                      </span>
+                      <p className="text-text-tertiary typo-footnote">
+                        {shipCta.body}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </section>
+            )}
+
+            {/* When things go wrong */}
+            {!isSubHub && (
+              <section className="mt-14">
+                <div className="mb-6 flex items-start gap-3">
+                  <AlertIcon
+                    size={IconSize.Medium}
+                    className="shrink-0 text-text-tertiary"
+                  />
+                  <div className="flex-1">
+                    <h2 className="font-bold text-text-primary typo-title2">
+                      When things go wrong
+                    </h2>
+                    <p className="text-text-tertiary typo-footnote">
+                      Getting stuck is normal — every developer does.
+                      Here&apos;s how to get unstuck fast.
+                    </p>
+                  </div>
+                </div>
+                <div className="flex flex-col gap-4">
+                  {troubleshooting.map((item) => (
+                    <div
+                      key={item.problem}
+                      className="rounded-16 border border-border-subtlest-tertiary bg-background-subtle p-5 transition-all duration-200 hover:border-border-subtlest-secondary"
+                    >
+                      <h3 className="font-bold text-text-primary typo-callout">
+                        &ldquo;{item.problem}&rdquo;
+                      </h3>
+                      <p className="mt-2 text-text-secondary typo-body">
+                        {item.fix}
+                      </p>
+                    </div>
                   ))}
                 </div>
               </section>
@@ -607,7 +793,7 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
             )}
           </div>
 
-          {/* Sidebar — sticky widgets */}
+          {/* Sidebar */}
           <aside className="flex w-full flex-col gap-6 px-0 pt-8 laptop:w-[21.25rem] laptop:max-w-[21.25rem] laptop:px-4 laptop:pt-0">
             {/* Tools widget */}
             <div className="flex flex-col gap-3">
@@ -772,7 +958,7 @@ export async function getStaticProps({
     const pageData = dataModule.default as LeafPageData;
 
     const seoTitles = getPageSeoTitles(
-      `Learn ${pageData.title} — Prompts, Resources & Community`,
+      `Learn ${pageData.title} with AI — Copy-Paste Prompts, Build Real Projects`,
     );
 
     return {

--- a/packages/webapp/pages/learn-to-code/[...slug].tsx
+++ b/packages/webapp/pages/learn-to-code/[...slug].tsx
@@ -1,0 +1,796 @@
+import type {
+  GetStaticPathsResult,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import Head from 'next/head';
+import type { ParsedUrlQuery } from 'querystring';
+import type { ReactElement, ReactNode } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import Link from '@dailydotdev/shared/src/components/utilities/Link';
+import { BreadCrumbs } from '@dailydotdev/shared/src/components/header/BreadCrumbs';
+import { PageWrapperLayout } from '@dailydotdev/shared/src/components/layout/PageWrapperLayout';
+import { GraduationIcon } from '@dailydotdev/shared/src/components/icons/Graduation';
+import { TerminalIcon } from '@dailydotdev/shared/src/components/icons/Terminal';
+import { OpenLinkIcon } from '@dailydotdev/shared/src/components/icons/OpenLink';
+import { CopyIcon } from '@dailydotdev/shared/src/components/icons/Copy';
+import { DiscordIcon } from '@dailydotdev/shared/src/components/icons/Discord';
+import { RedditIcon } from '@dailydotdev/shared/src/components/icons/Reddit';
+import { EarthIcon } from '@dailydotdev/shared/src/components/icons/Earth';
+import { PlayIcon } from '@dailydotdev/shared/src/components/icons/Play';
+import { DocsIcon } from '@dailydotdev/shared/src/components/icons/Docs';
+import { BookmarkIcon } from '@dailydotdev/shared/src/components/icons/Bookmark';
+import { ArrowIcon } from '@dailydotdev/shared/src/components/icons/Arrow';
+import { SparkleIcon } from '@dailydotdev/shared/src/components/icons/Sparkle';
+import { IconSize } from '@dailydotdev/shared/src/components/Icon';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import Feed from '@dailydotdev/shared/src/components/Feed';
+import { MOST_UPVOTED_FEED_QUERY } from '@dailydotdev/shared/src/graphql/feed';
+import { OtherFeedPage } from '@dailydotdev/shared/src/lib/query';
+import { ActiveFeedNameContext } from '@dailydotdev/shared/src/contexts';
+import SettingsContext from '@dailydotdev/shared/src/contexts/SettingsContext';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import { PostType } from '@dailydotdev/shared/src/graphql/posts';
+import { UpvoteIcon } from '@dailydotdev/shared/src/components/icons';
+import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
+import type { NextSeoProps } from 'next-seo/lib/types';
+import { getLayout } from '../../components/layouts/MainLayout';
+import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
+import { defaultOpenGraph, defaultSeo } from '../../next-seo';
+import { getPageSeoTitles } from '../../components/layouts/utils';
+import type {
+  LeafPageData,
+  Manifest,
+  Prompt,
+  RecommendedPath,
+} from '../../data/learn-to-code/types';
+import type { DynamicSeoProps } from '../../components/common';
+import manifest from '../../data/learn-to-code/manifest.json';
+
+function ForceListMode({ children }: { children: ReactNode }): ReactElement {
+  const settings = useContext(SettingsContext);
+
+  return (
+    <SettingsContext.Provider value={{ ...settings, insaneMode: true }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+const TOOL_LABELS: Record<string, string> = {
+  cursor: 'Cursor',
+  'claude-code': 'Claude Code',
+  replit: 'Replit',
+  generic: 'Any AI Tool',
+};
+
+const DIFFICULTY_LABELS: Record<string, string> = {
+  beginner: 'Beginner',
+  intermediate: 'Intermediate',
+  stretch: 'Stretch',
+};
+
+const RESOURCE_TYPE_ICONS: Record<string, ReactElement> = {
+  video: <PlayIcon size={IconSize.Small} className="text-text-tertiary" />,
+  article: <DocsIcon size={IconSize.Small} className="text-text-tertiary" />,
+  course: (
+    <GraduationIcon size={IconSize.Small} className="text-text-tertiary" />
+  ),
+  docs: <BookmarkIcon size={IconSize.Small} className="text-text-tertiary" />,
+};
+
+const RESOURCE_TYPE_LABELS: Record<string, string> = {
+  video: 'Video',
+  article: 'Article',
+  course: 'Course',
+  docs: 'Docs',
+};
+
+const PLATFORM_ICONS: Record<string, ReactElement> = {
+  reddit: <RedditIcon size={IconSize.Small} className="text-text-tertiary" />,
+  discord: <DiscordIcon size={IconSize.Small} className="text-text-tertiary" />,
+  dailydev: (
+    <GraduationIcon size={IconSize.Small} className="text-text-tertiary" />
+  ),
+  other: <EarthIcon size={IconSize.Small} className="text-text-tertiary" />,
+};
+
+const PLATFORM_LABELS: Record<string, string> = {
+  dailydev: 'daily.dev',
+  reddit: 'Reddit',
+  discord: 'Discord',
+  other: 'Web',
+};
+
+interface LeafPageParams extends ParsedUrlQuery {
+  slug: string[];
+}
+
+type LearnToCodeLeafProps = DynamicSeoProps & {
+  pageData: LeafPageData;
+};
+
+function PromptCard({ prompt }: { prompt: Prompt }): ReactElement {
+  const { displayToast } = useToastNotification();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(prompt.body);
+    setCopied(true);
+    displayToast('Prompt copied to clipboard');
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="group/card rounded-24 border border-border-subtlest-tertiary bg-background-subtle transition-all duration-200 hover:border-border-subtlest-secondary hover:shadow-2">
+      <div className="flex flex-col gap-4 p-6">
+        {/* Header with step number and copy button */}
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-float font-bold text-text-tertiary typo-callout">
+              {prompt.step}
+            </span>
+            <div className="flex min-w-0 flex-col">
+              <span className="truncate font-bold text-text-primary typo-title3">
+                {prompt.title}
+              </span>
+              {(prompt.difficulty || prompt.timeEstimate) && (
+                <div className="flex items-center gap-2">
+                  {prompt.difficulty && (
+                    <span className="text-text-quaternary typo-caption1">
+                      {DIFFICULTY_LABELS[prompt.difficulty]}
+                    </span>
+                  )}
+                  {prompt.difficulty && prompt.timeEstimate && (
+                    <span className="text-text-quaternary typo-caption1">
+                      ·
+                    </span>
+                  )}
+                  {prompt.timeEstimate && (
+                    <span className="text-text-quaternary typo-caption1">
+                      {prompt.timeEstimate}
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+          <Button
+            variant={copied ? ButtonVariant.Primary : ButtonVariant.Float}
+            size={ButtonSize.Small}
+            icon={<CopyIcon />}
+            onClick={handleCopy}
+            className={`shrink-0 ${
+              copied
+                ? 'bg-accent-avocado-default'
+                : 'hover:shadow-1 transition-all duration-200'
+            }`}
+          >
+            {copied ? 'Copied!' : 'Copy prompt'}
+          </Button>
+        </div>
+
+        {/* The prompt text — styled like a friendly message, not a code block */}
+        <div className="rounded-16 border border-border-subtlest-tertiary bg-surface-float p-5">
+          <p className="whitespace-pre-wrap text-text-secondary typo-body">
+            {prompt.body}
+          </p>
+        </div>
+
+        {/* Stuck tip */}
+        {prompt.stuckTip && (
+          <p className="text-text-quaternary typo-footnote">
+            <span className="font-bold text-text-tertiary">Stuck?</span>{' '}
+            {prompt.stuckTip}
+          </p>
+        )}
+
+        {/* Tool compatibility tags */}
+        <div className="flex flex-wrap gap-2">
+          <span className="text-text-quaternary typo-caption1">
+            Works with:
+          </span>
+          {prompt.tools.map((tool) => (
+            <span
+              key={tool}
+              className="rounded-10 bg-surface-float px-2.5 py-1 text-text-quaternary typo-caption1"
+            >
+              {TOOL_LABELS[tool]}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RecommendedPathCard({
+  path,
+}: {
+  path: RecommendedPath;
+}): ReactElement {
+  return (
+    <Link href={`/learn-to-code/${path.slug}`}>
+      <a className="group flex flex-col gap-2 rounded-24 border border-border-subtlest-tertiary bg-background-subtle p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-border-subtlest-secondary hover:shadow-2">
+        <div className="flex items-center justify-between">
+          <span className="font-bold text-text-primary typo-title3 group-hover:text-text-link">
+            {path.title}
+          </span>
+          <ArrowIcon
+            size={IconSize.Small}
+            className="rotate-90 text-text-quaternary transition-transform duration-200 group-hover:translate-x-0.5 group-hover:text-text-link"
+          />
+        </div>
+        <p className="text-text-tertiary typo-body">{path.reason}</p>
+      </a>
+    </Link>
+  );
+}
+
+const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
+  const { isFallback: isLoading } = useRouter();
+  const { user } = useContext(AuthContext);
+
+  const feedTag = pageData?.tags?.[0];
+  const isSubHub =
+    pageData?.dimension === 'audience' && !!pageData?.recommendedPaths?.length;
+
+  const feedVariables = useMemo(
+    () => ({
+      tag: feedTag,
+      supportedTypes: [
+        PostType.Article,
+        PostType.VideoYouTube,
+        PostType.Collection,
+      ],
+      period: 30,
+    }),
+    [feedTag],
+  );
+
+  if (isLoading || !pageData) {
+    return <></>;
+  }
+
+  const { pages } = manifest as Manifest;
+  const relatedPages = pageData.relatedSlugs
+    .map((slug) => pages.find((p) => p.slug === slug))
+    .filter(Boolean);
+
+  const jsonLd = isSubHub
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: pageData.title,
+        description: pageData.description,
+        url: `https://app.daily.dev/learn-to-code/${pageData.slug}`,
+        mainEntity: {
+          '@type': 'ItemList',
+          itemListElement: pageData.recommendedPaths.map((path, index) => ({
+            '@type': 'ListItem',
+            position: index + 1,
+            name: path.title,
+            url: `https://app.daily.dev/learn-to-code/${path.slug}`,
+          })),
+        },
+      }
+    : {
+        '@context': 'https://schema.org',
+        '@type': 'HowTo',
+        name: `Learn ${pageData.title}`,
+        description: pageData.description,
+        url: `https://app.daily.dev/learn-to-code/${pageData.slug}`,
+        step: (pageData.prompts || []).map((prompt) => ({
+          '@type': 'HowToStep',
+          position: prompt.step,
+          name: prompt.title,
+          text: prompt.body,
+        })),
+      };
+
+  return (
+    <div className="relative mx-auto flex w-full max-w-[69.25rem] flex-col">
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </Head>
+
+      <PageWrapperLayout className="py-6">
+        <BreadCrumbs>
+          <Link href="/learn-to-code">
+            <a>
+              <GraduationIcon size={IconSize.XSmall} secondary /> Learn to Code
+            </a>
+          </Link>
+        </BreadCrumbs>
+
+        {/* Hero — full width above the two columns */}
+        <header className="mb-8 mt-8 flex flex-col gap-4 laptop:mt-10">
+          <h1 className="font-bold text-text-primary typo-title1 laptop:typo-mega2">
+            {pageData.title}
+          </h1>
+          <p className="max-w-2xl text-text-secondary typo-body laptop:typo-title3">
+            {pageData.description}
+          </p>
+          {pageData.outcomes && pageData.outcomes.length > 0 && (
+            <div className="mt-2 flex flex-col gap-2">
+              <span className="font-bold text-text-tertiary typo-footnote">
+                After this path, you&apos;ll be able to:
+              </span>
+              <ul className="flex flex-col gap-1.5">
+                {pageData.outcomes.map((outcome) => (
+                  <li
+                    key={outcome}
+                    className="flex items-start gap-2 text-text-secondary typo-callout"
+                  >
+                    <span className="mt-0.5 shrink-0 text-text-quaternary">
+                      ✓
+                    </span>
+                    {outcome}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </header>
+
+        {/* Leaf-page-only sections: How this works + What you need */}
+        {!isSubHub && (
+          <>
+            <section className="mb-10 rounded-24 border border-border-subtlest-tertiary bg-background-subtle p-6 laptop:p-8">
+              <h2 className="mb-6 font-bold text-text-primary typo-title3">
+                How this works
+              </h2>
+              <div className="grid grid-cols-1 gap-4 tablet:grid-cols-3">
+                <div className="flex items-start gap-3">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent-cabbage-subtlest font-bold text-accent-cabbage-default typo-callout">
+                    1
+                  </span>
+                  <div className="flex flex-1 flex-col gap-1">
+                    <span className="font-bold text-text-primary typo-callout">
+                      Pick a free AI tool
+                    </span>
+                    <span className="text-text-quaternary typo-footnote">
+                      {pageData.tools[0]?.name || 'Cursor'},{' '}
+                      {pageData.tools[1]?.name || 'Replit'}, or any tool you
+                      like — all work great
+                    </span>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent-cabbage-subtlest font-bold text-accent-cabbage-default typo-callout">
+                    2
+                  </span>
+                  <div className="flex flex-1 flex-col gap-1">
+                    <span className="font-bold text-text-primary typo-callout">
+                      Copy a prompt below
+                    </span>
+                    <span className="text-text-quaternary typo-footnote">
+                      Each prompt tells the AI exactly what to build — you
+                      don&apos;t need to know the syntax
+                    </span>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent-cabbage-subtlest font-bold text-accent-cabbage-default typo-callout">
+                    3
+                  </span>
+                  <div className="flex flex-1 flex-col gap-1">
+                    <span className="font-bold text-text-primary typo-callout">
+                      Paste and watch it build
+                    </span>
+                    <span className="text-text-quaternary typo-footnote">
+                      The AI writes the code, you see real results — then learn
+                      what it did and why
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </section>
+
+            <div className="mb-10 grid grid-cols-1 gap-4 tablet:grid-cols-2">
+              <div className="rounded-24 border border-border-subtlest-tertiary bg-background-subtle p-6">
+                <h3 className="mb-4 font-bold text-text-primary typo-callout">
+                  What you need to start
+                </h3>
+                <ul className="flex flex-col gap-3">
+                  <li className="flex items-center gap-3 text-text-secondary typo-body">
+                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-avocado-subtlest text-accent-avocado-default typo-caption2">
+                      ✓
+                    </span>
+                    A laptop or desktop computer
+                  </li>
+                  <li className="flex items-center gap-3 text-text-secondary typo-body">
+                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-avocado-subtlest text-accent-avocado-default typo-caption2">
+                      ✓
+                    </span>
+                    About 30 minutes of free time
+                  </li>
+                  <li className="flex items-center gap-3 text-text-secondary typo-body">
+                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-avocado-subtlest text-accent-avocado-default typo-caption2">
+                      ✓
+                    </span>
+                    One free AI tool (see recommendations below)
+                  </li>
+                  <li className="flex items-center gap-3 text-text-secondary typo-body">
+                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-avocado-subtlest text-accent-avocado-default typo-caption2">
+                      ✓
+                    </span>
+                    Zero coding experience required
+                  </li>
+                </ul>
+              </div>
+
+              {pageData.projectDescription && (
+                <div className="rounded-24 border border-border-subtlest-tertiary bg-background-subtle p-6">
+                  <h3 className="mb-4 font-bold text-text-primary typo-callout">
+                    What you&apos;ll build
+                  </h3>
+                  <p className="text-text-secondary typo-body">
+                    {pageData.projectDescription}
+                  </p>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+
+        {/* Two-column layout: primary + sidebar */}
+        <div className="flex flex-1 flex-col laptop:flex-row">
+          {/* Primary column */}
+          <div className="flex w-full min-w-0 flex-1 flex-col laptop:w-0 laptop:border-r laptop:border-border-subtlest-tertiary laptop:pr-8">
+            {/* Sub-hub: Recommended paths */}
+            {isSubHub && (
+              <section>
+                <div className="mb-6 flex items-start gap-3">
+                  <ArrowIcon
+                    size={IconSize.Medium}
+                    className="shrink-0 rotate-90 text-text-tertiary"
+                  />
+                  <div className="flex-1">
+                    <h2 className="font-bold text-text-primary typo-title2">
+                      Recommended paths
+                    </h2>
+                    <p className="text-text-tertiary typo-footnote">
+                      Curated learning paths that match your background. Pick
+                      one and start building today.
+                    </p>
+                  </div>
+                </div>
+                <div className="flex flex-col gap-4">
+                  {pageData.recommendedPaths.map((path) => (
+                    <RecommendedPathCard key={path.slug} path={path} />
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {/* Leaf page: Start Building — prompts */}
+            {!isSubHub && pageData.prompts && pageData.prompts.length > 0 && (
+              <section>
+                <div className="mb-6 flex items-start gap-3">
+                  <TerminalIcon
+                    size={IconSize.Medium}
+                    className="shrink-0 text-text-tertiary"
+                  />
+                  <div className="flex-1">
+                    <h2 className="font-bold text-text-primary typo-title2">
+                      Start building
+                    </h2>
+                    <p className="text-text-tertiary typo-footnote">
+                      Copy these prompts into your AI coding tool — each step
+                      builds on the last. Steps 1–2 are easy wins. Steps 3–5
+                      will stretch you — that&apos;s where the real learning
+                      happens.
+                    </p>
+                  </div>
+                </div>
+                <div className="flex flex-col gap-5">
+                  {pageData.prompts.map((prompt) => (
+                    <PromptCard key={prompt.step} prompt={prompt} />
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {/* AI tips */}
+            {pageData.aiTips && pageData.aiTips.length > 0 && (
+              <section className="mt-14">
+                <div className="mb-6 flex items-start gap-3">
+                  <SparkleIcon
+                    size={IconSize.Medium}
+                    className="shrink-0 text-text-tertiary"
+                  />
+                  <div className="flex-1">
+                    <h2 className="font-bold text-text-primary typo-title2">
+                      How to use AI effectively
+                    </h2>
+                    <p className="text-text-tertiary typo-footnote">
+                      AI is a tutor, not a crutch — these tips help you actually
+                      learn
+                    </p>
+                  </div>
+                </div>
+                <div className="flex flex-col gap-3">
+                  {pageData.aiTips.map((tip) => (
+                    <div
+                      key={tip}
+                      className="rounded-16 border border-border-subtlest-tertiary bg-background-subtle p-5"
+                    >
+                      <p className="text-text-secondary typo-body">{tip}</p>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {/* Understand What You Built — concepts */}
+            <section className="mt-14">
+              <div className="mb-6 flex items-start gap-3">
+                <GraduationIcon
+                  size={IconSize.Medium}
+                  className="shrink-0 text-text-tertiary"
+                />
+                <div className="flex-1">
+                  <h2 className="font-bold text-text-primary typo-title2">
+                    Understand what you built
+                  </h2>
+                  <p className="text-text-tertiary typo-footnote">
+                    Key concepts behind the code — this turns copy-pasting into
+                    real learning
+                  </p>
+                </div>
+              </div>
+              <div className="flex flex-col gap-4">
+                {pageData.concepts.map((concept, index) => (
+                  <div
+                    key={concept.name}
+                    className="rounded-16 border border-border-subtlest-tertiary bg-background-subtle p-5 transition-all duration-200 hover:border-border-subtlest-secondary"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-surface-float font-bold text-text-tertiary typo-caption1">
+                        {index + 1}
+                      </span>
+                      <h3 className="font-bold text-text-primary typo-callout">
+                        {concept.name}
+                      </h3>
+                    </div>
+                    <p className="mt-2 pl-9 text-text-secondary typo-body">
+                      {concept.explanation}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </section>
+
+            {/* Trending feed */}
+            {feedTag && (
+              <section className="mt-14 pb-6">
+                <div className="mb-6 flex items-center gap-3">
+                  <UpvoteIcon
+                    size={IconSize.Medium}
+                    className="text-text-tertiary"
+                  />
+                  <h2 className="font-bold text-text-primary typo-title2">
+                    Trending in {feedTag}
+                  </h2>
+                </div>
+                <ForceListMode>
+                  <ActiveFeedNameContext.Provider
+                    value={{ feedName: OtherFeedPage.TagsMostUpvoted }}
+                  >
+                    <Feed
+                      feedName={OtherFeedPage.TagsMostUpvoted}
+                      feedQueryKey={[
+                        'learnToCodeRelated',
+                        user?.id ?? 'anonymous',
+                        Object.values(feedVariables),
+                      ]}
+                      query={MOST_UPVOTED_FEED_QUERY}
+                      variables={feedVariables}
+                      className="!mx-0 !w-auto"
+                      disableAds
+                      disableListFrame
+                      allowFetchMore={false}
+                      pageSize={5}
+                    />
+                  </ActiveFeedNameContext.Provider>
+                </ForceListMode>
+              </section>
+            )}
+          </div>
+
+          {/* Sidebar — sticky widgets */}
+          <aside className="flex w-full flex-col gap-6 px-0 pt-8 laptop:w-[21.25rem] laptop:max-w-[21.25rem] laptop:px-4 laptop:pt-0">
+            {/* Tools widget */}
+            <div className="flex flex-col gap-3">
+              <h3 className="flex items-center gap-2 font-bold text-text-primary typo-callout">
+                <TerminalIcon
+                  size={IconSize.Small}
+                  className="text-text-tertiary"
+                />
+                Recommended tools
+              </h3>
+              {pageData.tools.map((tool) => (
+                <a
+                  key={tool.url}
+                  href={tool.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group flex flex-col gap-1 rounded-12 border border-border-subtlest-tertiary bg-background-subtle p-4 transition-colors hover:border-border-subtlest-secondary hover:bg-surface-hover"
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="font-bold text-text-primary typo-footnote group-hover:text-text-link">
+                      {tool.name}
+                    </span>
+                    <OpenLinkIcon
+                      size={IconSize.XSmall}
+                      className="text-text-quaternary"
+                    />
+                  </div>
+                  <p className="text-text-tertiary typo-caption1">
+                    {tool.description}
+                  </p>
+                </a>
+              ))}
+            </div>
+
+            {/* Resources widget */}
+            <div className="flex flex-col gap-3">
+              <h3 className="flex items-center gap-2 font-bold text-text-primary typo-callout">
+                <DocsIcon
+                  size={IconSize.Small}
+                  className="text-text-tertiary"
+                />
+                Go deeper
+              </h3>
+              {pageData.resources.map((resource) => (
+                <a
+                  key={resource.url}
+                  href={resource.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group flex items-center gap-3 rounded-12 border border-border-subtlest-tertiary bg-background-subtle p-4 transition-colors hover:border-border-subtlest-secondary hover:bg-surface-hover"
+                >
+                  {RESOURCE_TYPE_ICONS[resource.type]}
+                  <div className="flex flex-1 flex-col">
+                    <span className="font-bold text-text-primary typo-footnote group-hover:text-text-link">
+                      {resource.title}
+                    </span>
+                    <div className="flex items-center gap-1">
+                      <span className="text-text-quaternary typo-caption2">
+                        {RESOURCE_TYPE_LABELS[resource.type]}
+                      </span>
+                      {resource.free && (
+                        <span className="text-text-quaternary typo-caption2">
+                          · Free
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </a>
+              ))}
+            </div>
+
+            {/* Communities widget */}
+            <div className="flex flex-col gap-3">
+              <h3 className="flex items-center gap-2 font-bold text-text-primary typo-callout">
+                <EarthIcon
+                  size={IconSize.Small}
+                  className="text-text-tertiary"
+                />
+                Community
+              </h3>
+              {pageData.communities.map((community) => (
+                <a
+                  key={community.url}
+                  href={community.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group flex items-center gap-3 rounded-12 border border-border-subtlest-tertiary bg-background-subtle p-4 transition-colors hover:border-border-subtlest-secondary hover:bg-surface-hover"
+                >
+                  {PLATFORM_ICONS[community.platform]}
+                  <div className="flex flex-col">
+                    <span className="font-bold text-text-primary typo-footnote group-hover:text-text-link">
+                      {community.name}
+                    </span>
+                    <span className="text-text-quaternary typo-caption2">
+                      {PLATFORM_LABELS[community.platform]}
+                    </span>
+                  </div>
+                </a>
+              ))}
+            </div>
+
+            {/* Related pages widget */}
+            {relatedPages.length > 0 && (
+              <div className="flex flex-col gap-3">
+                <h3 className="font-bold text-text-primary typo-callout">
+                  Continue learning
+                </h3>
+                {relatedPages.map((page) => (
+                  <Link key={page.slug} href={`/learn-to-code/${page.slug}`}>
+                    <a className="group flex items-center justify-between rounded-12 border border-border-subtlest-tertiary bg-background-subtle p-4 transition-colors hover:border-border-subtlest-secondary hover:bg-surface-hover">
+                      <span className="font-bold text-text-primary typo-footnote group-hover:text-text-link">
+                        {page.title}
+                      </span>
+                      <ArrowIcon
+                        size={IconSize.XSmall}
+                        className="rotate-90 text-text-quaternary"
+                      />
+                    </a>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </aside>
+        </div>
+      </PageWrapperLayout>
+    </div>
+  );
+};
+
+const getLeafPageLayout: typeof getLayout = (...props) =>
+  getFooterNavBarLayout(getLayout(...props));
+
+LearnToCodeLeaf.getLayout = getLeafPageLayout;
+LearnToCodeLeaf.layoutProps = {
+  screenCentered: false,
+};
+export default LearnToCodeLeaf;
+
+export async function getStaticPaths(): Promise<GetStaticPathsResult> {
+  const { pages } = manifest as Manifest;
+  const paths = pages.map((page) => ({
+    params: { slug: page.slug.split('/') },
+  }));
+
+  return { paths, fallback: 'blocking' };
+}
+
+export async function getStaticProps({
+  params,
+}: GetStaticPropsContext<LeafPageParams>): Promise<
+  GetStaticPropsResult<LearnToCodeLeafProps>
+> {
+  const slugParts = params?.slug;
+  if (!slugParts || slugParts.length === 0) {
+    return { notFound: true, revalidate: 3600 };
+  }
+
+  const slug = slugParts.join('/');
+
+  try {
+    const dataModule = await import(`../../data/learn-to-code/${slug}.json`);
+    const pageData = dataModule.default as LeafPageData;
+
+    const seoTitles = getPageSeoTitles(
+      `Learn ${pageData.title} — Prompts, Resources & Community`,
+    );
+
+    return {
+      props: {
+        pageData,
+        seo: {
+          ...defaultSeo,
+          ...seoTitles,
+          openGraph: {
+            ...defaultOpenGraph,
+            ...seoTitles.openGraph,
+          },
+          description: pageData.description,
+        } as NextSeoProps,
+      },
+      revalidate: 3600,
+    };
+  } catch {
+    return { notFound: true, revalidate: 3600 };
+  }
+}

--- a/packages/webapp/pages/learn-to-code/[...slug].tsx
+++ b/packages/webapp/pages/learn-to-code/[...slug].tsx
@@ -6,8 +6,16 @@ import type {
 import Head from 'next/head';
 import type { ParsedUrlQuery } from 'querystring';
 import type { ReactElement, ReactNode } from 'react';
-import React, { useContext, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useRouter } from 'next/router';
+import classNames from 'classnames';
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
 import { BreadCrumbs } from '@dailydotdev/shared/src/components/header/BreadCrumbs';
 import { PageWrapperLayout } from '@dailydotdev/shared/src/components/layout/PageWrapperLayout';
@@ -23,6 +31,12 @@ import { DocsIcon } from '@dailydotdev/shared/src/components/icons/Docs';
 import { BookmarkIcon } from '@dailydotdev/shared/src/components/icons/Bookmark';
 import { ArrowIcon } from '@dailydotdev/shared/src/components/icons/Arrow';
 import { SparkleIcon } from '@dailydotdev/shared/src/components/icons/Sparkle';
+import { TimerIcon } from '@dailydotdev/shared/src/components/icons/Timer';
+import { DownloadIcon } from '@dailydotdev/shared/src/components/icons/Download';
+import { MagicIcon } from '@dailydotdev/shared/src/components/icons/Magic';
+import { SearchIcon } from '@dailydotdev/shared/src/components/icons/Search';
+import { MiniCloseIcon } from '@dailydotdev/shared/src/components/icons/MiniClose';
+import { ShareIcon } from '@dailydotdev/shared/src/components/icons/Share';
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import {
   Button,
@@ -38,7 +52,8 @@ import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import { PostType } from '@dailydotdev/shared/src/graphql/posts';
 import { UpvoteIcon } from '@dailydotdev/shared/src/components/icons';
 import { AlertIcon } from '@dailydotdev/shared/src/components/icons/Alert';
-import { ShareIcon } from '@dailydotdev/shared/src/components/icons/Share';
+import { StarIcon } from '@dailydotdev/shared/src/components/icons/Star';
+import { VIcon } from '@dailydotdev/shared/src/components/icons/V';
 import { useToastNotification } from '@dailydotdev/shared/src/hooks/useToastNotification';
 import type { NextSeoProps } from 'next-seo/lib/types';
 import { getLayout } from '../../components/layouts/MainLayout';
@@ -46,19 +61,19 @@ import { getLayout as getFooterNavBarLayout } from '../../components/layouts/Foo
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 import type {
-  HowItWorksStep,
   LeafPageData,
   Manifest,
+  ManifestEntry,
   Prompt,
   RecommendedPath,
-  TroubleshootingItem,
 } from '../../data/learn-to-code/types';
 import type { DynamicSeoProps } from '../../components/common';
 import manifest from '../../data/learn-to-code/manifest.json';
 
+/* ═══ Helpers ═══ */
+
 function ForceListMode({ children }: { children: ReactNode }): ReactElement {
   const settings = useContext(SettingsContext);
-
   return (
     <SettingsContext.Provider value={{ ...settings, insaneMode: true }}>
       {children}
@@ -71,35 +86,39 @@ const TOOL_LABELS: Record<string, string> = {
   'claude-code': 'Claude Code',
   generic: 'Any AI Tool',
 };
-
 const DIFFICULTY_LABELS: Record<string, string> = {
   beginner: 'Beginner',
   intermediate: 'Intermediate',
   stretch: 'Stretch',
 };
-
-const DIFFICULTY_COLORS: Record<string, string> = {
-  beginner: 'bg-accent-avocado-default',
-  intermediate: 'bg-accent-cheese-default',
-  stretch: 'bg-accent-onion-default',
+const DIFFICULTY_COLORS: Record<
+  string,
+  { bg: string; text: string; left: string }
+> = {
+  beginner: {
+    bg: 'bg-accent-avocado-subtlest',
+    text: 'text-accent-avocado-default',
+    left: 'border-l-accent-avocado-default',
+  },
+  intermediate: {
+    bg: 'bg-accent-cheese-subtlest',
+    text: 'text-accent-cheese-default',
+    left: 'border-l-accent-cheese-default',
+  },
+  stretch: {
+    bg: 'bg-accent-onion-subtlest',
+    text: 'text-accent-onion-default',
+    left: 'border-l-accent-onion-default',
+  },
 };
-
 const RESOURCE_TYPE_ICONS: Record<string, ReactElement> = {
-  video: <PlayIcon size={IconSize.Small} className="text-text-tertiary" />,
-  article: <DocsIcon size={IconSize.Small} className="text-text-tertiary" />,
+  video: <PlayIcon size={IconSize.XSmall} className="text-text-tertiary" />,
+  article: <DocsIcon size={IconSize.XSmall} className="text-text-tertiary" />,
   course: (
-    <GraduationIcon size={IconSize.Small} className="text-text-tertiary" />
+    <GraduationIcon size={IconSize.XSmall} className="text-text-tertiary" />
   ),
-  docs: <BookmarkIcon size={IconSize.Small} className="text-text-tertiary" />,
+  docs: <BookmarkIcon size={IconSize.XSmall} className="text-text-tertiary" />,
 };
-
-const RESOURCE_TYPE_LABELS: Record<string, string> = {
-  video: 'Video',
-  article: 'Article',
-  course: 'Course',
-  docs: 'Docs',
-};
-
 const PLATFORM_ICONS: Record<string, ReactElement> = {
   reddit: <RedditIcon size={IconSize.Small} className="text-text-tertiary" />,
   discord: <DiscordIcon size={IconSize.Small} className="text-text-tertiary" />,
@@ -109,202 +128,727 @@ const PLATFORM_ICONS: Record<string, ReactElement> = {
   other: <EarthIcon size={IconSize.Small} className="text-text-tertiary" />,
 };
 
-const PLATFORM_LABELS: Record<string, string> = {
-  dailydev: 'daily.dev',
-  reddit: 'Reddit',
-  discord: 'Discord',
-  other: 'Web',
-};
-
-const DEFAULT_HOW_IT_WORKS: HowItWorksStep[] = [
-  {
-    title: 'Pick a free AI tool',
-    subtitle: 'Cursor, Claude Code, or any tool you like — all work great',
-  },
-  {
-    title: 'Copy a prompt below',
-    subtitle:
-      "Each prompt tells the AI exactly what to build — you don't need to know the syntax",
-  },
-  {
-    title: 'Paste and watch it build',
-    subtitle:
-      'The AI writes the code, you see real results — then learn what it did and why',
-  },
-];
-
 const DEFAULT_PREREQUISITES: string[] = [
   'A laptop or desktop computer',
   'About 30 minutes of free time',
-  'One free AI tool (see recommendations below)',
+  'One free AI tool (Cursor or Claude Code)',
   'Zero coding experience required',
 ];
-
-const DEFAULT_TROUBLESHOOTING: TroubleshootingItem[] = [
+const DEFAULT_TROUBLESHOOTING = [
   {
     problem: "It broke and I don't know why",
-    fix: 'Paste the full error into AI chat. Copy the exact error text, not a paraphrase. AI is exceptionally good at explaining what went wrong.',
+    fix: 'Paste the full error into your AI tool and ask: "What does this error mean and how do I fix it?"',
   },
   {
-    problem: "The code doesn't do what I expected",
-    fix: 'Describe what you want vs what happened. Be specific: "I expected X but got Y" gets better results than "it\'s wrong."',
+    problem: "Code doesn't do what I expected",
+    fix: 'Tell AI: "I expected X but got Y. Here\'s my code." — be specific about the mismatch.',
   },
   {
-    problem: "I feel like I'm not actually learning",
-    fix: "That's normal. Modify one thing in the AI-generated code yourself. Then another. Understanding comes from changing code, not just reading it.",
+    problem: "I'm not actually learning, just copy-pasting",
+    fix: 'After every AI response, change one thing yourself. Understanding comes from modifying code.',
   },
   {
-    problem: 'The AI keeps going in circles',
-    fix: "Start fresh. Delete the broken code and re-prompt from scratch with a clearer description. Don't try to fix bad code forever.",
-  },
-  {
-    problem: "I can't deploy it",
-    fix: 'This is the hardest step for everyone. Follow the deployment prompt step by step and paste every error into AI chat.',
+    problem: 'AI keeps going in circles',
+    fix: 'Start a new chat with a clearer description of what you want. Short, concrete prompts work best.',
   },
 ];
 
-const DEFAULT_LEARNING_RULE =
-  'AI gets you to code faster. But understanding what it built is what makes you a developer. After each prompt, ask: "Explain this code to me line by line." That single habit is the difference between vibe coding and actually learning.';
+const SKILL_CATEGORIES = [
+  { id: 'all', label: 'All' },
+  { id: 'setup', label: 'Setup' },
+  { id: 'debug', label: 'Debugging' },
+  { id: 'build', label: 'Building' },
+  { id: 'learn', label: 'Learning' },
+  { id: 'quality', label: 'Code quality' },
+];
 
-const DEFAULT_SHIP_CTA = {
-  title: 'You built it — now ship it',
-  body: 'Deploy your project and share the link. Post what you built on daily.dev and tag it #LearnToCode — other beginners seeing "someone like me built this" is the most powerful motivation there is.',
-};
+const AGENT_SKILLS = [
+  {
+    title: 'Python Project Starter',
+    description:
+      'Virtual envs, requirements, .gitignore — the right foundation',
+    category: 'setup',
+    content:
+      '# Python Project Starter\n\nWhen starting a new Python project:\n- Create a virtual environment with `python -m venv .venv`\n- Add a `requirements.txt` with pinned versions\n- Include a `.gitignore` for Python (include .venv/, __pycache__/, .env)\n- Use f-strings for string formatting, type hints on all function signatures\n- Wrap risky operations in try/except with specific exception types\n- Add docstrings to every function explaining what it does, its params, and return value\n- Structure: main.py at root, modules in src/, tests in tests/',
+  },
+  {
+    title: 'Debug Detective',
+    description: 'Find and fix bugs by analyzing errors step by step',
+    category: 'debug',
+    content:
+      '# Debug Detective\n\nWhen I share an error or unexpected behavior:\n1. Read the full traceback bottom-to-top and identify the exact line that failed\n2. Explain what the error type means (TypeError, ValueError, KeyError, etc.) in plain English\n3. Show me the broken code and the fixed version side by side\n4. Explain WHY the fix works, not just what changed\n5. Suggest a defensive check I can add to prevent this error in the future\n6. If the error is in a library, explain what my code did wrong when calling it',
+  },
+  {
+    title: 'Error Translator',
+    description: 'Turn cryptic Python errors into plain English',
+    category: 'debug',
+    content:
+      "# Error Translator\n\nWhen I paste a Python error message:\n- Translate the error into a single sentence a beginner would understand\n- Point to the exact line and variable causing it\n- Give the one-line fix\n- Show a 'before and after' of the code\n- Explain what to Google if this happens again\n- Common errors to recognize: IndentationError (wrong spacing), NameError (typo or undefined variable), TypeError (wrong data type), ImportError (missing pip install)",
+  },
+  {
+    title: 'Backend Engineer',
+    description: 'Build APIs, databases, and server-side code the right way',
+    category: 'build',
+    content:
+      '# Backend Engineer\n\nWhen building backend Python code:\n- Use FastAPI for new APIs (or Flask for simpler projects)\n- Always validate input with Pydantic models\n- Use SQLAlchemy or raw SQL with parameterized queries (never string concatenation)\n- Return proper HTTP status codes (201 for created, 404 for not found, 422 for validation error)\n- Add error handling middleware that returns JSON error responses\n- Use environment variables for secrets (never hardcode API keys, DB passwords)\n- Structure: routes/ for endpoints, models/ for data, services/ for business logic',
+  },
+  {
+    title: 'Script Builder',
+    description: 'Automate tasks with clean, reusable Python scripts',
+    category: 'build',
+    content:
+      '# Script Builder\n\nWhen writing automation scripts:\n- Accept input via command-line arguments (argparse) not hardcoded values\n- Add a --dry-run flag that shows what would happen without doing it\n- Log progress with print() or logging module so the user knows it is working\n- Handle file-not-found, permission errors, and network timeouts gracefully\n- Add a if __name__ == "__main__": guard\n- Include a --help description for every argument\n- If processing files: show a progress count (Processing 3/50...)',
+  },
+  {
+    title: 'Data Wrangler',
+    description: 'Clean, transform, and analyze data with pandas',
+    category: 'build',
+    content:
+      '# Data Wrangler\n\nWhen working with data in Python:\n- Use pandas for tabular data, json module for JSON, csv module for simple CSVs\n- Always inspect data first: df.head(), df.info(), df.describe()\n- Handle missing values explicitly (dropna or fillna with a sensible default)\n- When merging datasets, specify the join type and check for duplicates after\n- Name variables descriptively: raw_df, cleaned_df, summary_df\n- Save intermediate results so you can debug each step\n- Add comments explaining WHY you filtered or transformed, not just what',
+  },
+  {
+    title: "Explain Like I'm New",
+    description: 'Plain-language explanations with real-world analogies',
+    category: 'learn',
+    content:
+      "# Explain Like I'm New\n\nAfter writing code:\n- Explain each section in plain English using real-world analogies\n- Variables are like labeled boxes, functions are like recipes, loops are like assembly lines\n- Highlight which parts are boilerplate (safe to ignore) vs which parts to modify\n- After explaining, suggest ONE small change I can make myself to test understanding\n- If I ask 'why', never say 'because that's how it works' — explain the actual reason\n- Use analogies from cooking, building, or everyday life — not other programming concepts",
+  },
+  {
+    title: 'Code Reviewer',
+    description: 'Catch beginner mistakes and suggest improvements',
+    category: 'quality',
+    content:
+      '# Code Reviewer\n\nBefore I run my Python code, review it for:\n- Missing error handling (bare try/except, no handling for file or network operations)\n- Hardcoded values that should be variables or config\n- Functions doing more than one thing (should be split)\n- Missing type hints on function parameters and return values\n- print() used for debugging (should use logging)\n- Security issues: SQL injection, hardcoded secrets, unsafe file paths\n- Give feedback as: [Issue] what is wrong → [Fix] specific code change → [Why] one sentence explanation',
+  },
+  {
+    title: 'Testing Coach',
+    description: 'Write tests that actually catch bugs',
+    category: 'quality',
+    content:
+      '# Testing Coach\n\nWhen writing or reviewing Python code:\n- Suggest 3 test cases for every function: happy path, edge case, error case\n- Use pytest (not unittest) with descriptive test names: test_add_person_with_empty_name_raises_error\n- Show how to run tests: pytest -v\n- Mock external dependencies (API calls, file system, databases)\n- Test behavior, not implementation — test what the function returns, not how it works inside\n- If I am new to testing, start with the simplest assertion: assert function(input) == expected_output',
+  },
+  {
+    title: 'Refactoring Guide',
+    description: 'Improve existing code without breaking it',
+    category: 'quality',
+    content:
+      '# Refactoring Guide\n\nWhen I share code that works but looks messy:\n- First acknowledge what works well (positive reinforcement)\n- Identify the biggest readability issue and fix that first\n- Rename variables to be descriptive (x → user_age, d → response_data)\n- Extract repeated logic into named functions\n- Replace nested if/else with early returns\n- Show the refactored version and explain each change\n- Never change behavior — the output should be identical before and after',
+  },
+  {
+    title: 'Design Patterns',
+    description: 'When and how to structure Python code for real projects',
+    category: 'learn',
+    content:
+      '# Design Patterns for Python\n\nWhen my project grows beyond a single file:\n- Separate concerns: data access, business logic, and presentation in different files\n- Use classes when you have data + behavior together (e.g., a User that can authenticate)\n- Use plain functions when you just transform data in → data out\n- Configuration goes in .env files, loaded with python-dotenv\n- For CLI tools: one file per command, shared utils in a helpers module\n- Common pattern: main.py imports from modules, modules never import from main\n- Explain each pattern with a concrete example from my project, not abstract theory',
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    q: 'Do I need coding experience?',
+    a: 'No. AI writes the code; you learn by reading and modifying it.',
+  },
+  {
+    q: 'How long does it take?',
+    a: '30 min/day — real projects in 2-4 weeks.',
+  },
+  {
+    q: 'Which AI tool should I use?',
+    a: 'Cursor (free) or Claude Code — both work great for beginners.',
+  },
+  {
+    q: "I don't understand the code AI writes",
+    a: 'Ask AI: "Explain this code to me line by line." Every time.',
+  },
+  {
+    q: 'What can I actually build with Python?',
+    a: 'Web apps, scripts, dashboards, CLIs, APIs, chatbots, automations.',
+  },
+];
+
+const USE_CASES = [
+  {
+    title: 'Automate repetitive tasks',
+    description:
+      'Rename files, process CSVs, send emails, scrape data — scripts that save hours of manual work.',
+    tags: ['automation', 'scripts'],
+  },
+  {
+    title: 'Build a personal dashboard',
+    description:
+      'Track habits, finances, or fitness with a web app built on Flask or Streamlit.',
+    tags: ['web app', 'data'],
+  },
+  {
+    title: 'Create a Discord / Slack bot',
+    description:
+      'Build a bot that responds to commands, posts updates, or integrates with APIs.',
+    tags: ['bot', 'API'],
+  },
+  {
+    title: 'Analyze data and make charts',
+    description:
+      'Load a dataset, clean it, find insights, and visualize results with matplotlib or plotly.',
+    tags: ['data science', 'visualization'],
+  },
+  {
+    title: 'Build a CLI tool',
+    description:
+      'Create your own command-line utility with subcommands, flags, and colored output.',
+    tags: ['CLI', 'developer tools'],
+  },
+  {
+    title: 'Deploy an API',
+    description:
+      'Build a REST API with FastAPI or Flask that other apps can call.',
+    tags: ['API', 'backend'],
+  },
+];
+
+/* ═══ Intent definitions ═══ */
+
+interface Intent {
+  id: string;
+  label: string;
+  shortLabel: string;
+  icon: ReactElement;
+  description: string;
+}
+
+function buildIntents(pageData: LeafPageData): Intent[] {
+  return [
+    {
+      id: 'start',
+      label: 'Get started',
+      shortLabel: 'Start',
+      icon: <SparkleIcon size={IconSize.Small} />,
+      description: 'Setup checklist and your first prompt',
+    },
+    {
+      id: 'ai',
+      label: 'AI skills',
+      shortLabel: 'AI',
+      icon: <MagicIcon size={IconSize.Small} />,
+      description: `${AGENT_SKILLS.length} prompt templates for every scenario`,
+    },
+    {
+      id: 'build',
+      label: 'Projects',
+      shortLabel: 'Build',
+      icon: <TerminalIcon size={IconSize.Small} />,
+      description: `${
+        pageData.prompts?.length ?? 0
+      } step-by-step prompts to copy & run`,
+    },
+    {
+      id: 'understand',
+      label: 'Concepts',
+      shortLabel: 'Learn',
+      icon: <GraduationIcon size={IconSize.Small} />,
+      description: `${pageData.concepts.length} key topics explained simply`,
+    },
+    {
+      id: 'inspiration',
+      label: 'Inspiration',
+      shortLabel: 'Ideas',
+      icon: <StarIcon size={IconSize.Small} />,
+      description: `Use cases, community projects & trending posts`,
+    },
+  ];
+}
+
+/* ═══ Search index ═══ */
+
+interface SearchEntry {
+  text: string;
+  label: string;
+  intentId: string;
+  category: string;
+}
+
+function buildSearchIndex(pageData: LeafPageData): SearchEntry[] {
+  const entries: SearchEntry[] = [];
+  (pageData.prompts ?? []).forEach((p) => {
+    entries.push({
+      text: `${p.title} ${p.subtitle ?? ''} ${p.body}`.toLowerCase(),
+      label: `Project ${p.step}: ${p.title}`,
+      intentId: 'build',
+      category: 'Project',
+    });
+  });
+  pageData.concepts.forEach((c) => {
+    entries.push({
+      text: `${c.name} ${c.explanation}`.toLowerCase(),
+      label: c.name,
+      intentId: 'understand',
+      category: 'Concept',
+    });
+  });
+  FAQ_ITEMS.forEach((f) => {
+    entries.push({
+      text: `${f.q} ${f.a}`.toLowerCase(),
+      label: f.q,
+      intentId: 'start',
+      category: 'FAQ',
+    });
+  });
+  (pageData.troubleshooting ?? DEFAULT_TROUBLESHOOTING).forEach((t) => {
+    entries.push({
+      text: `${t.problem} ${t.fix}`.toLowerCase(),
+      label: t.problem,
+      intentId: 'start',
+      category: 'Help',
+    });
+  });
+  USE_CASES.forEach((u) => {
+    entries.push({
+      text: `${u.title} ${u.description} ${u.tags.join(' ')}`.toLowerCase(),
+      label: u.title,
+      intentId: 'inspiration',
+      category: 'Use case',
+    });
+  });
+  pageData.tools.forEach((t) => {
+    entries.push({
+      text: `${t.name} ${t.description}`.toLowerCase(),
+      label: t.name,
+      intentId: 'start',
+      category: 'Tool',
+    });
+  });
+  pageData.resources.forEach((r) => {
+    entries.push({
+      text: `${r.title}`.toLowerCase(),
+      label: r.title,
+      intentId: 'start',
+      category: 'Resource',
+    });
+  });
+  AGENT_SKILLS.forEach((s) => {
+    entries.push({
+      text: `${s.title} ${s.description} ${s.content}`.toLowerCase(),
+      label: s.title,
+      intentId: 'ai',
+      category: 'AI Skill',
+    });
+  });
+  return entries;
+}
+
+/* ═══ Types ═══ */
 
 interface LeafPageParams extends ParsedUrlQuery {
   slug: string[];
 }
+type LearnToCodeLeafProps = DynamicSeoProps & { pageData: LeafPageData };
 
-type LearnToCodeLeafProps = DynamicSeoProps & {
-  pageData: LeafPageData;
-};
+/* ═══ Spotlight ═══ */
+
+interface IntentChip {
+  label: string;
+  intentId: string;
+}
+
+function buildIntentChips(pageData: LeafPageData): IntentChip[] {
+  const topic = pageData.title.replace(/^Learn\s+/i, '');
+  return [
+    { label: `I want to start learning ${topic}`, intentId: 'start' },
+    { label: 'Help me set up my tools', intentId: 'start' },
+    { label: 'Give me a project to build', intentId: 'build' },
+    { label: `What can I build with ${topic}?`, intentId: 'inspiration' },
+    { label: `Supercharge my AI for ${topic}`, intentId: 'ai' },
+    { label: 'Explain a concept to me', intentId: 'understand' },
+  ];
+}
+
+function Spotlight({
+  searchIndex,
+  onNavigate,
+  intentChips,
+}: {
+  searchIndex: SearchEntry[];
+  onNavigate: (id: string) => void;
+  intentChips: IntentChip[];
+}): ReactElement {
+  const [query, setQuery] = useState('');
+  const [focused, setFocused] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const results = useMemo(() => {
+    if (query.length < 2) {
+      return [];
+    }
+    const words = query.toLowerCase().split(/\s+/).filter(Boolean);
+    return searchIndex
+      .filter((e) => words.every((w) => e.text.includes(w)))
+      .slice(0, 6);
+  }, [query, searchIndex]);
+  const showDropdown = focused && query.length >= 2;
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setFocused(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === '/' && !focused) {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+      if (e.key === 'Escape') {
+        setFocused(false);
+        inputRef.current?.blur();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [focused]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div
+        className={classNames(
+          'flex items-center gap-3 rounded-14 border bg-surface-float px-4 py-2.5 transition-all duration-200',
+          focused
+            ? 'border-accent-cabbage-default shadow-2'
+            : 'border-border-subtlest-tertiary',
+        )}
+      >
+        <SearchIcon
+          size={IconSize.Small}
+          className={classNames(
+            'shrink-0 transition-colors',
+            focused ? 'text-accent-cabbage-default' : 'text-text-quaternary',
+          )}
+        />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => setFocused(true)}
+          placeholder="What do you need help with?"
+          className="min-w-0 flex-1 bg-transparent text-text-primary outline-none typo-callout placeholder:text-text-quaternary"
+        />
+        {query && (
+          <button
+            type="button"
+            onClick={() => {
+              setQuery('');
+              inputRef.current?.focus();
+            }}
+            className="shrink-0 text-text-quaternary transition-colors hover:text-text-secondary"
+          >
+            <MiniCloseIcon size={IconSize.Small} />
+          </button>
+        )}
+        {!focused && (
+          <kbd className="hidden shrink-0 rounded-8 border border-border-subtlest-tertiary bg-background-default px-1.5 py-0.5 font-mono text-text-quaternary typo-caption2 tablet:block">
+            /
+          </kbd>
+        )}
+      </div>
+
+      {/* Intent chips */}
+      {!showDropdown && (
+        <div className="scrollbar-hide mt-2 flex gap-2 overflow-x-auto">
+          {intentChips.map((chip) => (
+            <button
+              type="button"
+              key={chip.label}
+              onClick={() => onNavigate(chip.intentId)}
+              className="hover:border-accent-cabbage-default/40 hover:bg-accent-cabbage-subtlest/10 shrink-0 rounded-10 border border-border-subtlest-tertiary bg-background-default px-3 py-1 text-text-tertiary transition-colors typo-caption1 hover:text-text-secondary"
+            >
+              {chip.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {showDropdown && (
+        <div className="z-50 absolute left-0 right-0 top-full mt-2 overflow-hidden rounded-16 border border-border-subtlest-secondary bg-background-default shadow-3">
+          {results.length === 0 ? (
+            <div className="px-4 py-6 text-center text-text-quaternary typo-callout">
+              No results for &ldquo;{query}&rdquo;
+            </div>
+          ) : (
+            <div className="flex flex-col py-1">
+              {results.map((r) => (
+                <button
+                  type="button"
+                  key={`${r.intentId}-${r.label}`}
+                  onClick={() => {
+                    onNavigate(r.intentId);
+                    setFocused(false);
+                    setQuery('');
+                  }}
+                  className="flex items-center gap-3 px-4 py-2 text-left transition-colors hover:bg-surface-hover"
+                >
+                  <span className="shrink-0 rounded-8 bg-surface-float px-2 py-0.5 font-bold text-text-quaternary typo-caption2">
+                    {r.category}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-text-primary typo-callout">
+                    {r.label}
+                  </span>
+                  <ArrowIcon
+                    size={IconSize.XSmall}
+                    className="shrink-0 rotate-90 text-text-quaternary"
+                  />
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ═══ Sub-components ═══ */
 
 function PromptCard({ prompt }: { prompt: Prompt }): ReactElement {
   const { displayToast } = useToastNotification();
   const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
+  const [expanded, setExpanded] = useState(false);
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation();
     await navigator.clipboard.writeText(prompt.body);
     setCopied(true);
-    displayToast('Prompt copied to clipboard');
+    displayToast('Prompt copied');
     setTimeout(() => setCopied(false), 2000);
   };
-
+  const d = prompt.difficulty ?? 'beginner';
+  const c = DIFFICULTY_COLORS[d];
   return (
-    <div className="group/card rounded-24 border border-border-subtlest-tertiary bg-background-subtle transition-all duration-200 hover:border-border-subtlest-secondary hover:shadow-2">
-      <div className="flex flex-col gap-4 p-6">
-        {/* Header with step number and copy button */}
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex min-w-0 items-center gap-3">
-            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-float font-bold text-text-tertiary typo-callout">
-              {prompt.step}
+    <div
+      className={classNames(
+        'overflow-hidden rounded-16 border-y border-l-4 border-r transition-all duration-200',
+        expanded
+          ? 'border-y-border-subtlest-secondary border-r-border-subtlest-secondary bg-surface-float'
+          : 'border-y-border-subtlest-tertiary border-r-border-subtlest-tertiary hover:bg-surface-float',
+        c.left,
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((p) => !p)}
+        className="flex w-full items-center gap-3 p-3 text-left"
+      >
+        <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-10 bg-surface-float font-bold text-text-tertiary typo-footnote">
+          {prompt.step}
+        </span>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="font-bold text-text-primary typo-callout">
+            {prompt.title}
+          </span>
+          {prompt.subtitle && !expanded && (
+            <span className="truncate text-text-quaternary typo-footnote">
+              {prompt.subtitle}
             </span>
-            <div className="flex min-w-0 flex-col">
-              <span className="truncate font-bold text-text-primary typo-title3">
-                {prompt.title}
+          )}
+        </div>
+        <span
+          className={classNames(
+            'shrink-0 rounded-8 px-2 py-0.5 font-bold typo-caption1',
+            c.bg,
+            c.text,
+          )}
+        >
+          {DIFFICULTY_LABELS[d]}
+        </span>
+        {prompt.timeEstimate && (
+          <span className="hidden items-center gap-1 text-text-quaternary typo-caption1 tablet:flex">
+            <TimerIcon size={IconSize.XXSmall} />
+            {prompt.timeEstimate}
+          </span>
+        )}
+        <ArrowIcon
+          size={IconSize.XSmall}
+          className={classNames(
+            'shrink-0 text-text-quaternary transition-transform',
+            expanded ? '-rotate-90' : 'rotate-90',
+          )}
+        />
+      </button>
+      {expanded && (
+        <div className="flex flex-col gap-3 border-t border-border-subtlest-tertiary p-4">
+          <div className="overflow-hidden rounded-12 border border-border-subtlest-tertiary bg-background-default">
+            <div className="flex items-center justify-between border-b border-border-subtlest-tertiary px-3 py-2">
+              <span className="flex items-center gap-1.5 text-text-quaternary typo-footnote">
+                <TerminalIcon size={IconSize.XSmall} />
+                {prompt.tools.map((t) => TOOL_LABELS[t]).join(' · ')}
               </span>
-              {(prompt.difficulty || prompt.timeEstimate) && (
-                <div className="flex items-center gap-2">
-                  {prompt.difficulty && (
-                    <span className="text-text-quaternary typo-caption1">
-                      {DIFFICULTY_LABELS[prompt.difficulty]}
-                    </span>
-                  )}
-                  {prompt.difficulty && prompt.timeEstimate && (
-                    <span className="text-text-quaternary typo-caption1">
-                      ·
-                    </span>
-                  )}
-                  {prompt.timeEstimate && (
-                    <span className="text-text-quaternary typo-caption1">
-                      {prompt.timeEstimate}
-                    </span>
-                  )}
-                </div>
-              )}
+              <Button
+                variant={
+                  copied ? ButtonVariant.Primary : ButtonVariant.Tertiary
+                }
+                size={ButtonSize.Small}
+                icon={copied ? <VIcon /> : <CopyIcon />}
+                onClick={handleCopy}
+                className={classNames(copied && 'bg-accent-avocado-default')}
+              >
+                {copied ? 'Copied!' : 'Copy prompt'}
+              </Button>
+            </div>
+            <div className="p-4">
+              <p className="whitespace-pre-wrap font-mono leading-relaxed text-text-secondary typo-footnote">
+                {prompt.body}
+              </p>
             </div>
           </div>
-          <Button
-            variant={copied ? ButtonVariant.Primary : ButtonVariant.Float}
-            size={ButtonSize.Small}
-            icon={<CopyIcon />}
-            onClick={handleCopy}
-            className={`shrink-0 ${
-              copied
-                ? 'bg-accent-avocado-default'
-                : 'hover:shadow-1 transition-all duration-200'
-            }`}
+          <div className="grid grid-cols-1 gap-3 tablet:grid-cols-2">
+            {prompt.expectedOutput && (
+              <div className="bg-accent-avocado-subtlest/20 rounded-12 p-3">
+                <span className="flex items-center gap-1.5 font-bold text-accent-avocado-default typo-footnote">
+                  <VIcon size={IconSize.XSmall} />
+                  Expected output
+                </span>
+                <p className="mt-1.5 text-text-secondary typo-footnote">
+                  {prompt.expectedOutput}
+                </p>
+              </div>
+            )}
+            {prompt.comprehensionPrompt && (
+              <div className="bg-accent-water-subtlest/20 rounded-12 p-3">
+                <span className="flex items-center gap-1.5 font-bold text-accent-water-default typo-footnote">
+                  <GraduationIcon size={IconSize.XSmall} />
+                  Understand it
+                </span>
+                <p className="mt-1.5 text-text-secondary typo-footnote">
+                  {prompt.comprehensionPrompt}
+                </p>
+              </div>
+            )}
+            {prompt.challenge && (
+              <div className="bg-accent-onion-subtlest/20 rounded-12 p-3">
+                <span className="flex items-center gap-1.5 font-bold text-accent-onion-default typo-footnote">
+                  <SparkleIcon size={IconSize.XSmall} />
+                  Challenge
+                </span>
+                <p className="mt-1.5 text-text-secondary typo-footnote">
+                  {prompt.challenge}
+                </p>
+              </div>
+            )}
+            {prompt.stuckTip && (
+              <div className="bg-accent-cheese-subtlest/20 rounded-12 p-3">
+                <span className="flex items-center gap-1.5 font-bold text-accent-cheese-default typo-footnote">
+                  <AlertIcon size={IconSize.XSmall} />
+                  Stuck?
+                </span>
+                <p className="mt-1.5 text-text-secondary typo-footnote">
+                  {prompt.stuckTip}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AgentSkillCard({
+  skill,
+}: {
+  skill: (typeof AGENT_SKILLS)[number];
+}): ReactElement {
+  const { displayToast } = useToastNotification();
+  const [copied, setCopied] = useState(false);
+  const [showContent, setShowContent] = useState(false);
+
+  return (
+    <div className="group rounded-14 border border-border-subtlest-tertiary transition-colors hover:border-border-subtlest-secondary hover:bg-surface-float">
+      <div className="flex items-start gap-2.5 p-3">
+        <div className="min-w-0 flex-1">
+          <button
+            type="button"
+            onClick={() => setShowContent((p) => !p)}
+            className="flex items-center gap-1.5 text-left"
           >
-            {copied ? 'Copied!' : 'Copy prompt'}
-          </Button>
-        </div>
-
-        {/* The prompt text */}
-        <div className="rounded-16 border border-border-subtlest-tertiary bg-surface-float p-5">
-          <p className="whitespace-pre-wrap text-text-secondary typo-body">
-            {prompt.body}
-          </p>
-        </div>
-
-        {/* Expected output */}
-        {prompt.expectedOutput && (
-          <div className="border-l-2 border-accent-avocado-default pl-4">
-            <p className="text-text-tertiary typo-footnote">
-              <span className="font-bold text-text-secondary">
-                What you should see:
-              </span>{' '}
-              {prompt.expectedOutput}
-            </p>
-          </div>
-        )}
-
-        {/* Comprehension prompt */}
-        {prompt.comprehensionPrompt && (
-          <div className="border-l-2 border-accent-water-default pl-4">
-            <p className="text-text-tertiary typo-footnote">
-              <span className="font-bold text-text-secondary">
-                Now understand it:
-              </span>{' '}
-              {prompt.comprehensionPrompt}
-            </p>
-          </div>
-        )}
-
-        {/* Challenge */}
-        {prompt.challenge && (
-          <div className="border-l-2 border-accent-onion-default pl-4">
-            <p className="text-text-tertiary typo-footnote">
-              <span className="font-bold text-text-secondary">
-                Try it yourself:
-              </span>{' '}
-              {prompt.challenge}
-            </p>
-          </div>
-        )}
-
-        {/* Stuck tip */}
-        {prompt.stuckTip && (
-          <p className="text-text-quaternary typo-footnote">
-            <span className="font-bold text-text-tertiary">Stuck?</span>{' '}
-            {prompt.stuckTip}
-          </p>
-        )}
-
-        {/* Tool compatibility tags */}
-        <div className="flex flex-wrap gap-2">
-          <span className="text-text-quaternary typo-caption1">
-            Works with:
-          </span>
-          {prompt.tools.map((tool) => (
-            <span
-              key={tool}
-              className="rounded-10 bg-surface-float px-2.5 py-1 text-text-quaternary typo-caption1"
-            >
-              {TOOL_LABELS[tool]}
+            <span className="font-bold text-text-primary typo-footnote">
+              {skill.title}
             </span>
-          ))}
+            <ArrowIcon
+              size={IconSize.XXSmall}
+              className={classNames(
+                'shrink-0 text-text-quaternary transition-transform',
+                showContent ? '-rotate-90' : 'rotate-90',
+              )}
+            />
+          </button>
+          <p className="mt-0.5 text-text-tertiary typo-caption1">
+            {skill.description}
+          </p>
         </div>
+        <Button
+          variant={copied ? ButtonVariant.Primary : ButtonVariant.Tertiary}
+          size={ButtonSize.XSmall}
+          icon={copied ? <VIcon /> : <CopyIcon />}
+          className={classNames(
+            'shrink-0 opacity-0 transition-opacity group-hover:opacity-100',
+            copied && 'bg-accent-avocado-default !opacity-100',
+          )}
+          onClick={async () => {
+            await navigator.clipboard.writeText(skill.content);
+            setCopied(true);
+            displayToast('Copied — paste into your AI tool');
+            setTimeout(() => setCopied(false), 2000);
+          }}
+        />
       </div>
+      {showContent && (
+        <div className="border-t border-border-subtlest-tertiary px-3 pb-3 pt-2">
+          <pre className="max-h-40 overflow-auto whitespace-pre-wrap rounded-10 bg-background-default p-2.5 font-mono text-text-secondary typo-caption1">
+            {skill.content}
+          </pre>
+          <div className="mt-2 flex gap-2">
+            <Button
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.XSmall}
+              icon={<CopyIcon />}
+              onClick={async () => {
+                await navigator.clipboard.writeText(skill.content);
+                setCopied(true);
+                displayToast('Copied — paste into your AI tool');
+                setTimeout(() => setCopied(false), 2000);
+              }}
+            >
+              {copied ? 'Copied!' : 'Copy'}
+            </Button>
+            <Button
+              variant={ButtonVariant.Tertiary}
+              size={ButtonSize.XSmall}
+              icon={<DownloadIcon />}
+              onClick={() => {
+                const b = new Blob([skill.content], {
+                  type: 'text/markdown',
+                });
+                const u = URL.createObjectURL(b);
+                const a = document.createElement('a');
+                a.href = u;
+                a.download = `${skill.title
+                  .toLowerCase()
+                  .replace(/\s+/g, '-')}.md`;
+                a.click();
+                URL.revokeObjectURL(u);
+                displayToast('Downloaded');
+              }}
+            >
+              Download
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
@@ -316,29 +860,747 @@ function RecommendedPathCard({
 }): ReactElement {
   return (
     <Link href={`/learn-to-code/${path.slug}`}>
-      <a className="group flex flex-col gap-2 rounded-24 border border-border-subtlest-tertiary bg-background-subtle p-6 transition-all duration-200 hover:-translate-y-0.5 hover:border-border-subtlest-secondary hover:shadow-2">
-        <div className="flex items-center justify-between">
-          <span className="font-bold text-text-primary typo-title3 group-hover:text-text-link">
+      <a className="group flex items-center justify-between rounded-16 border border-border-subtlest-tertiary bg-background-subtle p-5 transition-all hover:-translate-y-0.5 hover:border-border-subtlest-secondary hover:shadow-2">
+        <div className="flex flex-col gap-1">
+          <span className="font-bold text-text-primary typo-callout group-hover:text-text-link">
             {path.title}
           </span>
-          <ArrowIcon
-            size={IconSize.Small}
-            className="rotate-90 text-text-quaternary transition-transform duration-200 group-hover:translate-x-0.5 group-hover:text-text-link"
-          />
+          <span className="text-text-tertiary typo-footnote">
+            {path.reason}
+          </span>
         </div>
-        <p className="text-text-tertiary typo-body">{path.reason}</p>
+        <ArrowIcon
+          size={IconSize.Small}
+          className="rotate-90 text-text-quaternary"
+        />
       </a>
     </Link>
   );
 }
 
+/* ═══ Intent panels ═══ */
+
+function SectionPreview({
+  intent,
+  onNavigate,
+  children,
+}: {
+  intent: Intent;
+  onNavigate: (id: string) => void;
+  children: ReactNode;
+}): ReactElement {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="overflow-hidden rounded-14 border border-border-subtlest-tertiary transition-colors hover:border-border-subtlest-secondary">
+      <button
+        type="button"
+        onClick={() => setOpen((p) => !p)}
+        className="flex w-full items-center gap-3 p-3 text-left transition-colors hover:bg-surface-float"
+      >
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-10 bg-surface-float text-text-tertiary">
+          {intent.icon}
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="font-bold text-text-primary typo-footnote">
+            {intent.label}
+          </span>
+          <span className="text-text-quaternary typo-caption1">
+            {intent.description}
+          </span>
+        </div>
+        <ArrowIcon
+          size={IconSize.XSmall}
+          className={classNames(
+            'shrink-0 text-text-quaternary transition-transform duration-200',
+            open ? 'rotate-0' : 'rotate-90',
+          )}
+        />
+      </button>
+      {open && (
+        <div className="border-t border-border-subtlest-tertiary bg-surface-float px-4 pb-3 pt-3">
+          {children}
+          <button
+            type="button"
+            onClick={() => onNavigate(intent.id)}
+            className="mt-3 flex items-center gap-1.5 font-bold text-accent-cabbage-default typo-footnote hover:underline"
+          >
+            View all
+            <ArrowIcon size={IconSize.XSmall} className="rotate-90" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IntentStart({
+  pageData,
+  intents,
+  onNavigate,
+}: {
+  pageData: LeafPageData;
+  intents: Intent[];
+  onNavigate: (id: string) => void;
+}): ReactElement {
+  const { displayToast } = useToastNotification();
+  const [copied, setCopied] = useState(false);
+  const [checked, setChecked] = useState<Record<number, boolean>>({});
+  const prerequisites = pageData.prerequisites ?? DEFAULT_PREREQUISITES;
+  const checkedCount = Object.values(checked).filter(Boolean).length;
+  const firstPrompt = pageData.prompts?.[0];
+  const intentMap = useMemo(() => {
+    const m: Record<string, Intent> = {};
+    intents.forEach((i) => {
+      m[i.id] = i;
+    });
+    return m;
+  }, [intents]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* ── Quick context ── */}
+      <p className="text-text-secondary typo-body">{pageData.description}</p>
+
+      {/* ── Common questions ── */}
+      <div className="grid grid-cols-1 gap-2 tablet:grid-cols-2">
+        {FAQ_ITEMS.slice(0, 4).map((faq) => (
+          <div
+            key={faq.q}
+            className="rounded-12 border border-border-subtlest-tertiary p-3"
+          >
+            <span className="font-bold text-text-primary typo-footnote">
+              {faq.q}
+            </span>
+            <p className="mt-1 text-text-quaternary typo-caption1">{faq.a}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* ── Setup checklist ── */}
+      <div className="rounded-16 border border-border-subtlest-tertiary p-4">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="font-bold text-text-primary typo-callout">
+            Setup checklist
+          </span>
+          <span className="rounded-10 bg-accent-cabbage-subtlest px-2 py-0.5 font-bold text-accent-cabbage-default typo-caption1">
+            {checkedCount}/{prerequisites.length}
+          </span>
+        </div>
+        <div className="mb-2 h-1 overflow-hidden rounded-full bg-surface-float">
+          <div
+            className="h-full rounded-full bg-accent-avocado-default transition-all duration-500"
+            style={{
+              width: `${(checkedCount / prerequisites.length) * 100}%`,
+            }}
+          />
+        </div>
+        <div className="flex flex-col gap-1">
+          {prerequisites.map((item, idx) => (
+            <button
+              type="button"
+              key={item}
+              onClick={() =>
+                setChecked((prev) => ({ ...prev, [idx]: !prev[idx] }))
+              }
+              className="flex items-center gap-2.5 rounded-10 px-2 py-1.5 text-left transition-colors hover:bg-surface-float"
+            >
+              <span
+                className={classNames(
+                  'h-4.5 w-4.5 flex shrink-0 items-center justify-center rounded-6 border-2 transition-all',
+                  checked[idx]
+                    ? 'border-accent-avocado-default bg-accent-avocado-default'
+                    : 'border-border-subtlest-secondary',
+                )}
+              >
+                {checked[idx] && (
+                  <VIcon size={IconSize.XXSmall} className="text-white" />
+                )}
+              </span>
+              <span
+                className={classNames(
+                  'typo-footnote',
+                  checked[idx]
+                    ? 'text-text-quaternary line-through'
+                    : 'text-text-secondary',
+                )}
+              >
+                {item}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* ── First prompt ── */}
+      {firstPrompt && (
+        <div className="border-accent-cabbage-default/25 bg-accent-cabbage-subtlest/8 rounded-16 border p-4">
+          <div className="mb-2 flex items-center gap-2">
+            <SparkleIcon
+              size={IconSize.Small}
+              className="text-accent-cabbage-default"
+            />
+            <span className="font-bold text-text-primary typo-callout">
+              Your first prompt
+            </span>
+          </div>
+          <div className="overflow-hidden rounded-12 border border-border-subtlest-tertiary bg-background-default p-3">
+            <span className="block font-bold text-text-secondary typo-footnote">
+              {firstPrompt.title}
+            </span>
+            <p className="mt-1 truncate font-mono text-text-quaternary typo-caption1">
+              {firstPrompt.body}
+            </p>
+          </div>
+          <div className="mt-3 flex items-center gap-2">
+            <Button
+              variant={copied ? ButtonVariant.Primary : ButtonVariant.Secondary}
+              size={ButtonSize.Small}
+              icon={copied ? <VIcon /> : <CopyIcon />}
+              className={classNames(copied && 'bg-accent-avocado-default')}
+              onClick={async () => {
+                await navigator.clipboard.writeText(firstPrompt.body);
+                setCopied(true);
+                displayToast('Prompt copied');
+                setTimeout(() => setCopied(false), 2000);
+              }}
+            >
+              {copied ? 'Copied!' : 'Copy prompt'}
+            </Button>
+            <span className="text-text-quaternary typo-caption1">
+              Paste into Cursor or Claude Code and hit enter
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* ── What you'll build ── */}
+      {pageData.outcomes && pageData.outcomes.length > 0 && (
+        <div>
+          <h3 className="mb-2 font-bold text-text-primary typo-callout">
+            What you&apos;ll build
+          </h3>
+          <div className="grid grid-cols-1 gap-2 tablet:grid-cols-2">
+            {pageData.outcomes.map((o) => (
+              <div
+                key={o}
+                className="flex items-start gap-2 rounded-12 border border-border-subtlest-tertiary p-3"
+              >
+                <VIcon
+                  size={IconSize.XSmall}
+                  className="mt-0.5 shrink-0 text-accent-avocado-default"
+                />
+                <span className="text-text-secondary typo-footnote">{o}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* ── AI tips ── */}
+      {pageData.aiTips && pageData.aiTips.length > 0 && (
+        <div className="rounded-16 border border-border-subtlest-tertiary p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <MagicIcon
+              size={IconSize.Small}
+              className="text-accent-cabbage-default"
+            />
+            <span className="font-bold text-text-primary typo-callout">
+              Tips for working with AI
+            </span>
+          </div>
+          <ul className="flex flex-col gap-2">
+            {pageData.aiTips.map((tip) => (
+              <li
+                key={tip}
+                className="flex items-start gap-2 text-text-secondary typo-footnote"
+              >
+                <span className="mt-1.5 block h-1.5 w-1.5 shrink-0 rounded-full bg-accent-cabbage-default" />
+                {tip}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* ── Help & troubleshooting ── */}
+      <div>
+        <h3 className="mb-3 font-bold text-text-primary typo-callout">
+          Stuck? Try this
+        </h3>
+        <div className="border-accent-cheese-default/25 bg-accent-cheese-subtlest/8 mb-3 rounded-12 border p-3">
+          <p className="text-text-secondary typo-footnote">
+            <strong className="text-accent-cheese-default">Quick fix:</strong>{' '}
+            Paste the full error message into your AI tool and ask: &quot;What
+            does this mean and how do I fix it?&quot;
+          </p>
+        </div>
+        <div className="grid grid-cols-1 gap-2 tablet:grid-cols-2">
+          {(pageData.troubleshooting ?? DEFAULT_TROUBLESHOOTING)
+            .slice(0, 4)
+            .map((t) => (
+              <div
+                key={t.problem}
+                className="rounded-12 border border-border-subtlest-tertiary p-3"
+              >
+                <span className="font-bold text-text-primary typo-footnote">
+                  &ldquo;{t.problem}&rdquo;
+                </span>
+                <p className="mt-1 text-text-quaternary typo-caption1">
+                  {t.fix}
+                </p>
+              </div>
+            ))}
+        </div>
+      </div>
+
+      {/* ── Explore sections (expandable previews) ── */}
+      <div>
+        <h3 className="mb-3 font-bold text-text-primary typo-callout">
+          Explore this page
+        </h3>
+        <div className="flex flex-col gap-2">
+          {/* AI Skills preview */}
+          {intentMap.ai && (
+            <SectionPreview intent={intentMap.ai} onNavigate={onNavigate}>
+              <div className="flex flex-wrap gap-1.5">
+                {SKILL_CATEGORIES.filter((c) => c.id !== 'all').map((cat) => {
+                  const count = AGENT_SKILLS.filter(
+                    (s) => s.category === cat.id,
+                  ).length;
+                  return (
+                    <span
+                      key={cat.id}
+                      className="rounded-8 bg-background-default px-2.5 py-1 text-text-secondary typo-caption1"
+                    >
+                      {cat.label}{' '}
+                      <span className="text-text-quaternary">({count})</span>
+                    </span>
+                  );
+                })}
+              </div>
+            </SectionPreview>
+          )}
+
+          {/* Projects preview */}
+          {intentMap.build && (
+            <SectionPreview intent={intentMap.build} onNavigate={onNavigate}>
+              <div className="flex flex-col gap-2">
+                {(pageData.prompts ?? []).slice(0, 3).map((p) => (
+                  <div
+                    key={p.step}
+                    className="flex items-center gap-2 rounded-10 bg-background-default p-2"
+                  >
+                    <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-6 bg-surface-float font-bold text-text-tertiary typo-caption2">
+                      {p.step}
+                    </span>
+                    <span className="font-bold text-text-secondary typo-caption1">
+                      {p.title}
+                    </span>
+                    {p.difficulty && (
+                      <span
+                        className={classNames(
+                          'ml-auto shrink-0 rounded-6 px-1.5 py-0.5 font-bold typo-caption2',
+                          DIFFICULTY_COLORS[p.difficulty]?.bg,
+                          DIFFICULTY_COLORS[p.difficulty]?.text,
+                        )}
+                      >
+                        {DIFFICULTY_LABELS[p.difficulty] ?? p.difficulty}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </SectionPreview>
+          )}
+
+          {/* Concepts preview */}
+          {intentMap.understand && (
+            <SectionPreview
+              intent={intentMap.understand}
+              onNavigate={onNavigate}
+            >
+              <div className="flex flex-wrap gap-2">
+                {pageData.concepts.slice(0, 5).map((c) => (
+                  <span
+                    key={c.name}
+                    className="rounded-8 bg-background-default px-2.5 py-1 font-bold text-text-secondary typo-caption1"
+                  >
+                    {c.name}
+                  </span>
+                ))}
+              </div>
+            </SectionPreview>
+          )}
+
+          {/* Inspiration preview */}
+          {intentMap.inspiration && (
+            <SectionPreview
+              intent={intentMap.inspiration}
+              onNavigate={onNavigate}
+            >
+              <div className="flex flex-col gap-2">
+                {USE_CASES.slice(0, 2).map((u) => (
+                  <div
+                    key={u.title}
+                    className="rounded-10 bg-background-default p-2"
+                  >
+                    <span className="font-bold text-text-secondary typo-caption1">
+                      {u.title}
+                    </span>
+                    <p className="mt-0.5 text-text-quaternary typo-caption2">
+                      {u.description}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </SectionPreview>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IntentBuild({ pageData }: { pageData: LeafPageData }): ReactElement {
+  const prompts = pageData.prompts ?? [];
+  const totalTime = prompts.reduce((sum, p) => {
+    const m = p.timeEstimate?.match(/(\d+)/);
+    return sum + (m ? parseInt(m[1], 10) : 30);
+  }, 0);
+  return (
+    <div className="flex flex-col gap-4">
+      {pageData.projectDescription && (
+        <p className="text-text-secondary typo-body">
+          {pageData.projectDescription}
+        </p>
+      )}
+      <div className="flex flex-wrap items-center gap-3 rounded-12 border border-border-subtlest-tertiary bg-surface-float px-4 py-2.5">
+        <span className="flex items-center gap-1.5 text-text-tertiary typo-footnote">
+          <TerminalIcon size={IconSize.XSmall} />
+          {prompts.length} projects
+        </span>
+        <span className="h-3 w-px bg-border-subtlest-secondary" />
+        <span className="flex items-center gap-1.5 text-text-tertiary typo-footnote">
+          <TimerIcon size={IconSize.XSmall} />~{totalTime} min total
+        </span>
+        <span className="h-3 w-px bg-border-subtlest-secondary" />
+        <span className="text-text-quaternary typo-footnote">
+          Copy each prompt into your AI tool and follow along
+        </span>
+      </div>
+      {prompts.map((prompt) => (
+        <PromptCard key={prompt.step} prompt={prompt} />
+      ))}
+    </div>
+  );
+}
+
+function IntentUnderstand({
+  pageData,
+}: {
+  pageData: LeafPageData;
+}): ReactElement {
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-text-secondary typo-body">
+        These are the core concepts you&apos;ll encounter while building
+        projects. You don&apos;t need to memorize them — reference them when you
+        need clarity.
+      </p>
+      <div className="grid grid-cols-1 gap-3 tablet:grid-cols-2">
+        {pageData.concepts.map((concept) => (
+          <div
+            key={concept.name}
+            className="rounded-16 border border-border-subtlest-tertiary p-4 transition-colors hover:bg-surface-float"
+          >
+            <span className="font-bold text-text-primary typo-callout">
+              {concept.name}
+            </span>
+            <p className="mt-2 text-text-tertiary typo-footnote">
+              {concept.explanation}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IntentAI({ pageData }: { pageData: LeafPageData }): ReactElement {
+  const grouped = useMemo(() => {
+    const cats = SKILL_CATEGORIES.filter((c) => c.id !== 'all');
+    return cats
+      .map((cat) => ({
+        ...cat,
+        skills: AGENT_SKILLS.filter((s) => s.category === cat.id),
+      }))
+      .filter((g) => g.skills.length > 0);
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-text-secondary typo-body">
+        Prompt templates that teach your AI tool how to help you better. Copy
+        any skill and paste it at the start of a chat session.
+      </p>
+
+      {grouped.map((group) => (
+        <div key={group.id}>
+          <h3 className="mb-2 font-bold text-text-primary typo-callout">
+            {group.label}
+          </h3>
+          <div className="grid grid-cols-1 gap-2 tablet:grid-cols-2">
+            {group.skills.map((skill) => (
+              <AgentSkillCard key={skill.title} skill={skill} />
+            ))}
+          </div>
+        </div>
+      ))}
+
+      {(pageData.aiTips ?? []).length > 0 && (
+        <div className="bg-accent-cabbage-subtlest/10 rounded-16 p-4">
+          <span className="mb-2 flex items-center gap-2 font-bold text-accent-cabbage-default typo-footnote">
+            <SparkleIcon size={IconSize.XSmall} /> Tips for working with AI
+          </span>
+          <ul className="mt-2 flex flex-col gap-1.5">
+            {(pageData.aiTips ?? []).map((tip) => (
+              <li
+                key={tip}
+                className="flex items-start gap-2 text-text-secondary typo-footnote"
+              >
+                <span className="mt-1 shrink-0 text-accent-cabbage-default">
+                  &bull;
+                </span>
+                {tip}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IntentInspiration({
+  feedTag,
+  feedVariables,
+  userId,
+}: {
+  feedTag: string;
+  feedVariables: Record<string, unknown>;
+  userId: string;
+}): ReactElement {
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-text-secondary typo-body">
+        Not sure what to build? Browse real-world use cases, see what the
+        community is working on, and find your next project idea.
+      </p>
+
+      {/* Use cases */}
+      <div>
+        <h3 className="mb-3 font-bold text-text-primary typo-callout">
+          What people build
+        </h3>
+        <div className="grid grid-cols-1 gap-3 tablet:grid-cols-2">
+          {USE_CASES.map((uc) => (
+            <div
+              key={uc.title}
+              className="group rounded-16 border border-border-subtlest-tertiary p-4 transition-colors hover:bg-surface-float"
+            >
+              <span className="font-bold text-text-primary typo-callout">
+                {uc.title}
+              </span>
+              <p className="mt-1.5 text-text-tertiary typo-footnote">
+                {uc.description}
+              </p>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {uc.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-6 bg-surface-float px-2 py-0.5 text-text-quaternary typo-caption2 group-hover:bg-surface-hover"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Trending from daily.dev */}
+      <div>
+        <div className="mb-3 flex items-center gap-2">
+          <UpvoteIcon
+            size={IconSize.Small}
+            className="text-accent-cabbage-default"
+          />
+          <h3 className="font-bold text-text-primary typo-callout">
+            Trending in {feedTag}
+          </h3>
+          <span className="text-text-quaternary typo-caption1">
+            from daily.dev
+          </span>
+        </div>
+        <ForceListMode>
+          <ActiveFeedNameContext.Provider
+            value={{ feedName: OtherFeedPage.TagsMostUpvoted }}
+          >
+            <Feed
+              feedName={OtherFeedPage.TagsMostUpvoted}
+              feedQueryKey={[
+                'learnToCodeRelated',
+                userId,
+                Object.values(feedVariables),
+              ]}
+              query={MOST_UPVOTED_FEED_QUERY}
+              variables={feedVariables}
+              className="!mx-0 !w-auto"
+              disableAds
+              disableListFrame
+              allowFetchMore={false}
+              pageSize={5}
+            />
+          </ActiveFeedNameContext.Provider>
+        </ForceListMode>
+      </div>
+    </div>
+  );
+}
+
+/* ═══ Right sidebar ═══ */
+
+function RightSidebar({
+  pageData,
+  relatedPages,
+}: {
+  pageData: LeafPageData;
+  relatedPages: ManifestEntry[];
+}): ReactElement {
+  return (
+    <aside className="flex flex-col gap-4 overflow-hidden">
+      <div className="flex flex-col gap-1">
+        <span className="px-1 font-bold uppercase tracking-wider text-text-tertiary typo-caption1">
+          Tools
+        </span>
+        {pageData.tools.map((tool) => (
+          <a
+            key={tool.url}
+            href={tool.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group flex items-center gap-2 rounded-10 px-2 py-1.5 transition-colors hover:bg-surface-float"
+          >
+            <OpenLinkIcon
+              size={IconSize.XSmall}
+              className="shrink-0 text-text-quaternary"
+            />
+            <span className="truncate font-bold text-text-primary typo-caption1 group-hover:text-text-link">
+              {tool.name}
+            </span>
+          </a>
+        ))}
+      </div>
+      <hr className="border-border-subtlest-tertiary" />
+      <div className="flex flex-col gap-1">
+        <span className="px-1 font-bold uppercase tracking-wider text-text-tertiary typo-caption1">
+          Resources
+        </span>
+        {pageData.resources.map((r) => (
+          <a
+            key={r.url}
+            href={r.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group flex items-center gap-2 rounded-10 px-2 py-1.5 transition-colors hover:bg-surface-float"
+          >
+            {RESOURCE_TYPE_ICONS[r.type]}
+            <span className="min-w-0 flex-1 truncate text-text-primary typo-caption1 group-hover:text-text-link">
+              {r.title}
+            </span>
+            {r.free && (
+              <span className="shrink-0 rounded-6 bg-accent-avocado-subtlest px-1 py-0.5 font-bold text-accent-avocado-default typo-caption2">
+                Free
+              </span>
+            )}
+          </a>
+        ))}
+      </div>
+      <hr className="border-border-subtlest-tertiary" />
+      <div className="flex flex-col gap-1">
+        <span className="px-1 font-bold uppercase tracking-wider text-text-tertiary typo-caption1">
+          Community
+        </span>
+        {pageData.communities.map((c) => (
+          <a
+            key={c.url}
+            href={c.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group flex items-center gap-2 rounded-10 px-2 py-1.5 transition-colors hover:bg-surface-float"
+          >
+            {PLATFORM_ICONS[c.platform]}
+            <span className="truncate text-text-primary typo-caption1 group-hover:text-text-link">
+              {c.name}
+            </span>
+          </a>
+        ))}
+      </div>
+      {relatedPages.length > 0 && (
+        <>
+          <hr className="border-border-subtlest-tertiary" />
+          <div className="flex flex-col gap-1">
+            <span className="px-1 font-bold uppercase tracking-wider text-text-tertiary typo-caption1">
+              Related
+            </span>
+            {relatedPages.map((p) => (
+              <Link key={p.slug} href={`/learn-to-code/${p.slug}`}>
+                <a className="group flex items-center gap-2 rounded-10 px-2 py-1.5 transition-colors hover:bg-surface-float">
+                  <ArrowIcon
+                    size={IconSize.XSmall}
+                    className="rotate-90 text-text-quaternary"
+                  />
+                  <span className="truncate text-text-primary typo-caption1 group-hover:text-text-link">
+                    {p.title}
+                  </span>
+                </a>
+              </Link>
+            ))}
+          </div>
+        </>
+      )}
+    </aside>
+  );
+}
+
+/* ═══ Main component ═══ */
+
 const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
   const { isFallback: isLoading } = useRouter();
   const { user } = useContext(AuthContext);
+  const { displayToast } = useToastNotification();
 
   const feedTag = pageData?.tags?.[0];
   const isSubHub = !!pageData?.recommendedPaths?.length;
+  const hasPrompts = !!pageData?.prompts?.length;
+  const isHub = !isSubHub && hasPrompts;
 
+  const [activeIntent, setActiveIntent] = useState('start');
+  const navRef = useRef<HTMLElement>(null);
+
+  const intents = useMemo(
+    () => (pageData ? buildIntents(pageData) : []),
+    [pageData],
+  );
+  const searchIndex = useMemo(
+    () => (pageData ? buildSearchIndex(pageData) : []),
+    [pageData],
+  );
+  const intentChips = useMemo(
+    () => (pageData ? buildIntentChips(pageData) : []),
+    [pageData],
+  );
   const feedVariables = useMemo(
     () => ({
       tag: feedTag,
@@ -352,20 +1614,40 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
     [feedTag],
   );
 
+  const handleIntentClick = useCallback((id: string) => {
+    setActiveIntent(id);
+  }, []);
+
+  const handleShare = useCallback(async () => {
+    const url = window.location.href;
+    if (navigator.share) {
+      await navigator.share({ title: pageData?.title, url });
+    } else {
+      await navigator.clipboard.writeText(url);
+      displayToast('Link copied to clipboard');
+    }
+  }, [pageData?.title, displayToast]);
+
+  const handleDownloadAllSkills = useCallback(() => {
+    const allContent = AGENT_SKILLS.map((s) => s.content).join('\n\n---\n\n');
+    const blob = new Blob([allContent], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${pageData?.slug ?? 'python'}-ai-skills.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+    displayToast('All skills downloaded');
+  }, [pageData?.slug, displayToast]);
+
   if (isLoading || !pageData) {
     return <></>;
   }
 
   const { pages } = manifest as Manifest;
   const relatedPages = pageData.relatedSlugs
-    .map((slug) => pages.find((p) => p.slug === slug))
-    .filter(Boolean);
-
-  const howItWorks = pageData.howItWorks ?? DEFAULT_HOW_IT_WORKS;
-  const prerequisites = pageData.prerequisites ?? DEFAULT_PREREQUISITES;
-  const troubleshooting = pageData.troubleshooting ?? DEFAULT_TROUBLESHOOTING;
-  const learningRule = pageData.learningRule ?? DEFAULT_LEARNING_RULE;
-  const shipCta = pageData.shipCta ?? DEFAULT_SHIP_CTA;
+    .map((s) => pages.find((p) => p.slug === s))
+    .filter((p): p is ManifestEntry => !!p);
 
   const breadcrumbLd = {
     '@context': 'https://schema.org',
@@ -391,7 +1673,6 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
       },
     ],
   };
-
   const pageLd = isSubHub
     ? {
         '@context': 'https://schema.org',
@@ -401,9 +1682,9 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
         url: `https://app.daily.dev/learn-to-code/${pageData.slug}`,
         mainEntity: {
           '@type': 'ItemList',
-          itemListElement: pageData.recommendedPaths.map((path, index) => ({
+          itemListElement: (pageData.recommendedPaths ?? []).map((path, i) => ({
             '@type': 'ListItem',
-            position: index + 1,
+            position: i + 1,
             name: path.title,
             url: `https://app.daily.dev/learn-to-code/${path.slug}`,
           })),
@@ -415,349 +1696,215 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
         name: `Learn ${pageData.title}`,
         description: pageData.description,
         url: `https://app.daily.dev/learn-to-code/${pageData.slug}`,
-        step: (pageData.prompts || []).map((prompt) => ({
+        step: (pageData.prompts ?? []).map((p) => ({
           '@type': 'HowToStep',
-          position: prompt.step,
-          name: prompt.title,
-          text: prompt.body,
+          position: p.step,
+          name: p.title,
+          text: p.body,
         })),
       };
 
-  const jsonLd = [pageLd, breadcrumbLd];
-
   return (
-    <div className="relative mx-auto flex w-full max-w-[69.25rem] flex-col">
+    <div className="relative mx-auto flex w-full max-w-[72rem] flex-col">
       <Head>
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify([pageLd, breadcrumbLd]),
+          }}
         />
       </Head>
-
       <PageWrapperLayout className="py-6">
         <BreadCrumbs>
           <Link href="/learn-to-code">
-            <a>
+            <a className="flex items-center gap-1">
               <GraduationIcon size={IconSize.XSmall} secondary /> Learn to Code
             </a>
           </Link>
         </BreadCrumbs>
 
-        {/* Hero */}
-        <header className="mb-8 mt-8 flex flex-col gap-4 laptop:mt-10">
-          <h1 className="font-bold text-text-primary typo-title1 laptop:typo-mega2">
-            {pageData.title}
-          </h1>
-          <p className="max-w-2xl text-text-secondary typo-body laptop:typo-title3">
-            {pageData.description}
-          </p>
-          {pageData.outcomes && pageData.outcomes.length > 0 && (
-            <div className="mt-2 flex flex-col gap-2">
-              <span className="font-bold text-text-tertiary typo-footnote">
-                After this path, you&apos;ll be able to:
-              </span>
-              <ul className="flex flex-col gap-1.5">
-                {pageData.outcomes.map((outcome) => (
-                  <li
-                    key={outcome}
-                    className="flex items-start gap-2 text-text-secondary typo-callout"
-                  >
-                    <span className="mt-0.5 shrink-0 text-text-quaternary">
-                      ✓
-                    </span>
-                    {outcome}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </header>
-
-        {/* Leaf-page-only sections: How this works + What you need */}
-        {!isSubHub && (
+        {isSubHub && (
           <>
-            <section className="mb-10 rounded-24 border border-border-subtlest-tertiary bg-background-subtle p-6 laptop:p-8">
-              <h2 className="mb-6 font-bold text-text-primary typo-title3">
-                How this works
+            <header className="mb-8 mt-8 flex flex-col gap-4 laptop:mt-10">
+              <h1 className="font-bold text-text-primary typo-title1 laptop:typo-mega2">
+                {pageData.title}
+              </h1>
+              <p className="max-w-2xl text-text-secondary typo-body laptop:typo-title3">
+                {pageData.description}
+              </p>
+            </header>
+            <section className="mb-12">
+              <h2 className="mb-6 font-bold text-text-primary typo-title2">
+                Recommended paths
               </h2>
-              <div className="grid grid-cols-1 gap-4 tablet:grid-cols-3">
-                {howItWorks.map((step, index) => (
-                  <div key={step.title} className="flex items-start gap-3">
-                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-accent-cabbage-subtlest font-bold text-accent-cabbage-default typo-callout">
-                      {index + 1}
-                    </span>
-                    <div className="flex flex-1 flex-col gap-1">
-                      <span className="font-bold text-text-primary typo-callout">
-                        {step.title}
-                      </span>
-                      <span className="text-text-quaternary typo-footnote">
-                        {step.subtitle}
-                      </span>
-                    </div>
-                  </div>
+              <div className="flex flex-col gap-4">
+                {(pageData.recommendedPaths ?? []).map((path) => (
+                  <RecommendedPathCard key={path.slug} path={path} />
                 ))}
               </div>
             </section>
-
-            <div className="mb-10 grid grid-cols-1 gap-4 tablet:grid-cols-2">
-              <div className="rounded-24 border border-border-subtlest-tertiary bg-background-subtle p-6">
-                <h3 className="mb-4 font-bold text-text-primary typo-callout">
-                  What you need to start
-                </h3>
-                <ul className="flex flex-col gap-3">
-                  {prerequisites.map((item) => (
-                    <li
-                      key={item}
-                      className="flex items-center gap-3 text-text-secondary typo-body"
-                    >
-                      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-accent-avocado-subtlest text-accent-avocado-default typo-caption2">
-                        ✓
-                      </span>
-                      {item}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-
-              {pageData.projectDescription && (
-                <div className="rounded-24 border border-border-subtlest-tertiary bg-background-subtle p-6">
-                  <h3 className="mb-4 font-bold text-text-primary typo-callout">
-                    What you&apos;ll build
-                  </h3>
-                  <p className="text-text-secondary typo-body">
-                    {pageData.projectDescription}
-                  </p>
-                </div>
-              )}
-            </div>
           </>
         )}
 
-        {/* Two-column layout: primary + sidebar */}
-        <div className="flex flex-1 flex-col laptop:flex-row">
-          {/* Primary column */}
-          <div className="flex w-full min-w-0 flex-1 flex-col laptop:w-0 laptop:border-r laptop:border-border-subtlest-tertiary laptop:pr-8">
-            {/* Sub-hub: Recommended paths */}
-            {isSubHub && (
-              <section>
-                <div className="mb-6 flex items-start gap-3">
-                  <ArrowIcon
-                    size={IconSize.Medium}
-                    className="shrink-0 rotate-90 text-text-tertiary"
-                  />
-                  <div className="flex-1">
-                    <h2 className="font-bold text-text-primary typo-title2">
-                      Recommended paths
-                    </h2>
-                    <p className="text-text-tertiary typo-footnote">
-                      Curated learning paths that match your background. Pick
-                      one and start building today.
-                    </p>
-                  </div>
-                </div>
-                <div className="flex flex-col gap-4">
-                  {pageData.recommendedPaths.map((path) => (
-                    <RecommendedPathCard key={path.slug} path={path} />
-                  ))}
-                </div>
-              </section>
-            )}
-
-            {/* AI Learning Rule */}
-            {!isSubHub && pageData.prompts && pageData.prompts.length > 0 && (
-              <div className="mb-8 rounded-16 border border-border-subtlest-tertiary bg-background-subtle p-6">
-                <p className="text-text-secondary typo-callout">
-                  <span className="font-bold text-text-primary">
-                    The #1 rule for learning with AI:
-                  </span>{' '}
-                  {learningRule}
+        {isHub && (
+          <div className="mt-6 flex flex-col laptop:mt-8">
+            {/* Header */}
+            <header className="mb-4 flex items-start justify-between gap-4">
+              <div className="flex flex-col gap-1">
+                <h1 className="font-bold text-text-primary typo-title1 laptop:typo-mega2">
+                  {pageData.title}
+                </h1>
+                <p className="max-w-3xl text-text-secondary typo-body">
+                  {pageData.description}
                 </p>
               </div>
-            )}
-
-            {/* Leaf page: Start Building — prompts */}
-            {!isSubHub && pageData.prompts && pageData.prompts.length > 0 && (
-              <section>
-                <div className="mb-6 flex items-start gap-3">
-                  <TerminalIcon
-                    size={IconSize.Medium}
-                    className="shrink-0 text-text-tertiary"
-                  />
-                  <div className="flex-1">
-                    <h2 className="font-bold text-text-primary typo-title2">
-                      Start building
-                    </h2>
-                    <p className="text-text-tertiary typo-footnote">
-                      Copy these prompts into your AI coding tool — each step
-                      builds on the last. Steps 1–2 are easy wins. Steps 3–5
-                      will stretch you — that&apos;s where the real learning
-                      happens.
-                    </p>
-                  </div>
-                </div>
-
-                {/* Difficulty progression bar */}
-                <div
-                  className="mb-6 flex items-center gap-1"
-                  role="list"
-                  aria-label="Step difficulty progression"
+              <div className="flex shrink-0 items-center gap-1">
+                <Button
+                  variant={ButtonVariant.Tertiary}
+                  size={ButtonSize.Small}
+                  icon={<DownloadIcon />}
+                  onClick={handleDownloadAllSkills}
+                  aria-label="Download all AI skills"
                 >
-                  {(pageData.prompts || []).map((prompt) => {
-                    const difficulty = prompt.difficulty || 'beginner';
+                  <span className="hidden tablet:inline">Skills</span>
+                </Button>
+                <Button
+                  variant={ButtonVariant.Tertiary}
+                  size={ButtonSize.Small}
+                  icon={<ShareIcon />}
+                  onClick={handleShare}
+                  aria-label="Share"
+                >
+                  <span className="hidden tablet:inline">Share</span>
+                </Button>
+              </div>
+            </header>
 
+            {/* Spotlight */}
+            <div className="mb-4">
+              <Spotlight
+                searchIndex={searchIndex}
+                onNavigate={handleIntentClick}
+                intentChips={intentChips}
+              />
+            </div>
+
+            {/* 2-column layout */}
+            <div className="flex gap-8">
+              <div className="min-w-0 flex-1">
+                {/* Compact tab bar: icon + short label, no badges */}
+                <nav
+                  ref={navRef}
+                  className="scrollbar-hide z-40 sticky top-0 -mx-4 flex border-b border-border-subtlest-tertiary bg-background-default px-4 laptop:mx-0 laptop:px-0"
+                  aria-label="Navigation"
+                >
+                  {intents.map((intent) => {
+                    const isActive = activeIntent === intent.id;
                     return (
-                      <div
-                        key={prompt.step}
-                        role="listitem"
-                        className="flex flex-1 flex-col items-center gap-1.5"
-                        aria-label={`Step ${prompt.step}: ${DIFFICULTY_LABELS[difficulty]}`}
+                      <button
+                        type="button"
+                        key={intent.id}
+                        onClick={() => handleIntentClick(intent.id)}
+                        className={classNames(
+                          'relative flex shrink-0 items-center gap-1.5 px-3 pb-2.5 pt-2 transition-colors duration-150',
+                          isActive
+                            ? 'text-text-primary'
+                            : 'text-text-quaternary hover:text-text-secondary',
+                        )}
                       >
-                        <div
-                          className={`h-1 w-full rounded-full ${DIFFICULTY_COLORS[difficulty]}`}
-                        />
-                        <span className="text-text-quaternary typo-caption2">
-                          {prompt.step}. {DIFFICULTY_LABELS[difficulty]}
+                        {intent.icon}
+                        <span className="hidden whitespace-nowrap font-bold typo-footnote tablet:inline">
+                          {intent.label}
                         </span>
-                      </div>
+                        <span className="whitespace-nowrap font-bold typo-footnote tablet:hidden">
+                          {intent.shortLabel}
+                        </span>
+                        {isActive && (
+                          <span className="absolute bottom-0 left-1 right-1 h-0.5 rounded-full bg-accent-cabbage-default" />
+                        )}
+                      </button>
                     );
                   })}
-                </div>
+                </nav>
 
-                <div className="flex flex-col gap-5">
-                  {pageData.prompts.map((prompt) => (
-                    <PromptCard key={prompt.step} prompt={prompt} />
-                  ))}
-                </div>
-
-                {/* Ship & Share CTA */}
-                <div className="mt-8 rounded-24 border border-border-subtlest-tertiary bg-background-subtle p-6">
-                  <div className="flex items-start gap-3">
-                    <ShareIcon
-                      size={IconSize.Medium}
-                      className="shrink-0 text-text-tertiary"
+                {/* Content */}
+                <div className="pb-8 pt-5">
+                  {activeIntent === 'start' && (
+                    <IntentStart
+                      pageData={pageData}
+                      intents={intents}
+                      onNavigate={handleIntentClick}
                     />
-                    <div className="flex flex-col gap-1">
-                      <span className="font-bold text-text-primary typo-callout">
-                        {shipCta.title}
-                      </span>
-                      <p className="text-text-tertiary typo-footnote">
-                        {shipCta.body}
-                      </p>
-                    </div>
-                  </div>
+                  )}
+                  {activeIntent === 'build' && (
+                    <IntentBuild pageData={pageData} />
+                  )}
+                  {activeIntent === 'understand' && (
+                    <IntentUnderstand pageData={pageData} />
+                  )}
+                  {activeIntent === 'ai' && <IntentAI pageData={pageData} />}
+                  {activeIntent === 'inspiration' && feedTag && (
+                    <IntentInspiration
+                      feedTag={feedTag}
+                      feedVariables={feedVariables}
+                      userId={user?.id ?? 'anonymous'}
+                    />
+                  )}
                 </div>
-              </section>
-            )}
+              </div>
 
-            {/* When things go wrong */}
-            {!isSubHub && (
-              <section className="mt-14">
-                <div className="mb-6 flex items-start gap-3">
-                  <AlertIcon
-                    size={IconSize.Medium}
-                    className="shrink-0 text-text-tertiary"
+              {/* Sidebar */}
+              <div className="hidden w-56 shrink-0 laptop:block">
+                <div className="sticky top-12 pt-2">
+                  <RightSidebar
+                    pageData={pageData}
+                    relatedPages={relatedPages}
                   />
-                  <div className="flex-1">
-                    <h2 className="font-bold text-text-primary typo-title2">
-                      When things go wrong
-                    </h2>
-                    <p className="text-text-tertiary typo-footnote">
-                      Getting stuck is normal — every developer does.
-                      Here&apos;s how to get unstuck fast.
-                    </p>
-                  </div>
                 </div>
+              </div>
+            </div>
+
+            {/* Mobile sidebar */}
+            <div className="border-t border-border-subtlest-tertiary pt-6 laptop:hidden">
+              <RightSidebar pageData={pageData} relatedPages={relatedPages} />
+            </div>
+          </div>
+        )}
+
+        {!isSubHub && !hasPrompts && (
+          <>
+            <header className="mb-8 mt-8 flex flex-col gap-4 laptop:mt-10">
+              <h1 className="font-bold text-text-primary typo-title1 laptop:typo-mega2">
+                {pageData.title}
+              </h1>
+              <p className="max-w-2xl text-text-secondary typo-body laptop:typo-title3">
+                {pageData.description}
+              </p>
+            </header>
+            {pageData.concepts.length > 0 && (
+              <section className="mb-12">
+                <h2 className="mb-6 font-bold text-text-primary typo-title2">
+                  Key concepts
+                </h2>
                 <div className="flex flex-col gap-4">
-                  {troubleshooting.map((item) => (
+                  {pageData.concepts.map((c) => (
                     <div
-                      key={item.problem}
-                      className="rounded-16 border border-border-subtlest-tertiary bg-background-subtle p-5 transition-all duration-200 hover:border-border-subtlest-secondary"
-                    >
-                      <h3 className="font-bold text-text-primary typo-callout">
-                        &ldquo;{item.problem}&rdquo;
-                      </h3>
-                      <p className="mt-2 text-text-secondary typo-body">
-                        {item.fix}
-                      </p>
-                    </div>
-                  ))}
-                </div>
-              </section>
-            )}
-
-            {/* AI tips */}
-            {pageData.aiTips && pageData.aiTips.length > 0 && (
-              <section className="mt-14">
-                <div className="mb-6 flex items-start gap-3">
-                  <SparkleIcon
-                    size={IconSize.Medium}
-                    className="shrink-0 text-text-tertiary"
-                  />
-                  <div className="flex-1">
-                    <h2 className="font-bold text-text-primary typo-title2">
-                      How to use AI effectively
-                    </h2>
-                    <p className="text-text-tertiary typo-footnote">
-                      AI is a tutor, not a crutch — these tips help you actually
-                      learn
-                    </p>
-                  </div>
-                </div>
-                <div className="flex flex-col gap-3">
-                  {pageData.aiTips.map((tip) => (
-                    <div
-                      key={tip}
+                      key={c.name}
                       className="rounded-16 border border-border-subtlest-tertiary bg-background-subtle p-5"
                     >
-                      <p className="text-text-secondary typo-body">{tip}</p>
+                      <h3 className="font-bold text-text-primary typo-callout">
+                        {c.name}
+                      </h3>
+                      <p className="mt-2 text-text-secondary typo-body">
+                        {c.explanation}
+                      </p>
                     </div>
                   ))}
                 </div>
               </section>
             )}
-
-            {/* Understand What You Built — concepts */}
-            <section className="mt-14">
-              <div className="mb-6 flex items-start gap-3">
-                <GraduationIcon
-                  size={IconSize.Medium}
-                  className="shrink-0 text-text-tertiary"
-                />
-                <div className="flex-1">
-                  <h2 className="font-bold text-text-primary typo-title2">
-                    Understand what you built
-                  </h2>
-                  <p className="text-text-tertiary typo-footnote">
-                    Key concepts behind the code — this turns copy-pasting into
-                    real learning
-                  </p>
-                </div>
-              </div>
-              <div className="flex flex-col gap-4">
-                {pageData.concepts.map((concept, index) => (
-                  <div
-                    key={concept.name}
-                    className="rounded-16 border border-border-subtlest-tertiary bg-background-subtle p-5 transition-all duration-200 hover:border-border-subtlest-secondary"
-                  >
-                    <div className="flex items-center gap-3">
-                      <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-surface-float font-bold text-text-tertiary typo-caption1">
-                        {index + 1}
-                      </span>
-                      <h3 className="font-bold text-text-primary typo-callout">
-                        {concept.name}
-                      </h3>
-                    </div>
-                    <p className="mt-2 pl-9 text-text-secondary typo-body">
-                      {concept.explanation}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            </section>
-
-            {/* Trending feed */}
             {feedTag && (
-              <section className="mt-14 pb-6">
+              <section className="pb-6">
                 <div className="mb-6 flex items-center gap-3">
                   <UpvoteIcon
                     size={IconSize.Medium}
@@ -790,133 +1937,8 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
                 </ForceListMode>
               </section>
             )}
-          </div>
-
-          {/* Sidebar */}
-          <aside className="flex w-full flex-col gap-6 px-0 pt-8 laptop:w-[21.25rem] laptop:max-w-[21.25rem] laptop:px-4 laptop:pt-0">
-            {/* Tools widget */}
-            <div className="flex flex-col gap-3">
-              <h3 className="flex items-center gap-2 font-bold text-text-primary typo-callout">
-                <TerminalIcon
-                  size={IconSize.Small}
-                  className="text-text-tertiary"
-                />
-                Recommended tools
-              </h3>
-              {pageData.tools.map((tool) => (
-                <a
-                  key={tool.url}
-                  href={tool.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group flex flex-col gap-1 rounded-12 border border-border-subtlest-tertiary bg-background-subtle p-4 transition-colors hover:border-border-subtlest-secondary hover:bg-surface-hover"
-                >
-                  <div className="flex items-center justify-between">
-                    <span className="font-bold text-text-primary typo-footnote group-hover:text-text-link">
-                      {tool.name}
-                    </span>
-                    <OpenLinkIcon
-                      size={IconSize.XSmall}
-                      className="text-text-quaternary"
-                    />
-                  </div>
-                  <p className="text-text-tertiary typo-caption1">
-                    {tool.description}
-                  </p>
-                </a>
-              ))}
-            </div>
-
-            {/* Resources widget */}
-            <div className="flex flex-col gap-3">
-              <h3 className="flex items-center gap-2 font-bold text-text-primary typo-callout">
-                <DocsIcon
-                  size={IconSize.Small}
-                  className="text-text-tertiary"
-                />
-                Go deeper
-              </h3>
-              {pageData.resources.map((resource) => (
-                <a
-                  key={resource.url}
-                  href={resource.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group flex items-center gap-3 rounded-12 border border-border-subtlest-tertiary bg-background-subtle p-4 transition-colors hover:border-border-subtlest-secondary hover:bg-surface-hover"
-                >
-                  {RESOURCE_TYPE_ICONS[resource.type]}
-                  <div className="flex flex-1 flex-col">
-                    <span className="font-bold text-text-primary typo-footnote group-hover:text-text-link">
-                      {resource.title}
-                    </span>
-                    <div className="flex items-center gap-1">
-                      <span className="text-text-quaternary typo-caption2">
-                        {RESOURCE_TYPE_LABELS[resource.type]}
-                      </span>
-                      {resource.free && (
-                        <span className="text-text-quaternary typo-caption2">
-                          · Free
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                </a>
-              ))}
-            </div>
-
-            {/* Communities widget */}
-            <div className="flex flex-col gap-3">
-              <h3 className="flex items-center gap-2 font-bold text-text-primary typo-callout">
-                <EarthIcon
-                  size={IconSize.Small}
-                  className="text-text-tertiary"
-                />
-                Community
-              </h3>
-              {pageData.communities.map((community) => (
-                <a
-                  key={community.url}
-                  href={community.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="group flex items-center gap-3 rounded-12 border border-border-subtlest-tertiary bg-background-subtle p-4 transition-colors hover:border-border-subtlest-secondary hover:bg-surface-hover"
-                >
-                  {PLATFORM_ICONS[community.platform]}
-                  <div className="flex flex-col">
-                    <span className="font-bold text-text-primary typo-footnote group-hover:text-text-link">
-                      {community.name}
-                    </span>
-                    <span className="text-text-quaternary typo-caption2">
-                      {PLATFORM_LABELS[community.platform]}
-                    </span>
-                  </div>
-                </a>
-              ))}
-            </div>
-
-            {/* Related pages widget */}
-            {relatedPages.length > 0 && (
-              <div className="flex flex-col gap-3">
-                <h3 className="font-bold text-text-primary typo-callout">
-                  Continue learning
-                </h3>
-                {relatedPages.map((page) => (
-                  <Link key={page.slug} href={`/learn-to-code/${page.slug}`}>
-                    <a className="group flex items-center justify-between rounded-12 border border-border-subtlest-tertiary bg-background-subtle p-4 transition-colors hover:border-border-subtlest-secondary hover:bg-surface-hover">
-                      <span className="font-bold text-text-primary typo-footnote group-hover:text-text-link">
-                        {page.title}
-                      </span>
-                      <ArrowIcon
-                        size={IconSize.XSmall}
-                        className="rotate-90 text-text-quaternary"
-                      />
-                    </a>
-                  </Link>
-                ))}
-              </div>
-            )}
-          </aside>
-        </div>
+          </>
+        )}
       </PageWrapperLayout>
     </div>
   );
@@ -924,20 +1946,16 @@ const LearnToCodeLeaf = ({ pageData }: LearnToCodeLeafProps): ReactElement => {
 
 const getLeafPageLayout: typeof getLayout = (...props) =>
   getFooterNavBarLayout(getLayout(...props));
-
 LearnToCodeLeaf.getLayout = getLeafPageLayout;
-LearnToCodeLeaf.layoutProps = {
-  screenCentered: false,
-};
+LearnToCodeLeaf.layoutProps = { screenCentered: false };
 export default LearnToCodeLeaf;
 
 export async function getStaticPaths(): Promise<GetStaticPathsResult> {
   const { pages } = manifest as Manifest;
-  const paths = pages.map((page) => ({
-    params: { slug: page.slug.split('/') },
-  }));
-
-  return { paths, fallback: 'blocking' };
+  return {
+    paths: pages.map((p) => ({ params: { slug: p.slug.split('/') } })),
+    fallback: 'blocking',
+  };
 }
 
 export async function getStaticProps({
@@ -949,27 +1967,20 @@ export async function getStaticProps({
   if (!slugParts || slugParts.length === 0) {
     return { notFound: true, revalidate: 3600 };
   }
-
   const slug = slugParts.join('/');
-
   try {
     const dataModule = await import(`../../data/learn-to-code/${slug}.json`);
     const pageData = dataModule.default as LeafPageData;
-
     const seoTitles = getPageSeoTitles(
       `Learn ${pageData.title} with AI — Copy-Paste Prompts, Build Real Projects`,
     );
-
     return {
       props: {
         pageData,
         seo: {
           ...defaultSeo,
           ...seoTitles,
-          openGraph: {
-            ...defaultOpenGraph,
-            ...seoTitles.openGraph,
-          },
+          openGraph: { ...defaultOpenGraph, ...seoTitles.openGraph },
           description: pageData.description,
         } as NextSeoProps,
       },

--- a/packages/webapp/pages/learn-to-code/index.tsx
+++ b/packages/webapp/pages/learn-to-code/index.tsx
@@ -182,13 +182,13 @@ const LearnToCodeHub = ({ pages }: LearnToCodeHubProps): ReactElement => {
           </p>
         </header>
 
-        {/* Popular paths */}
+        {/* Categories */}
         <section>
           <h2 className="mb-6 font-bold text-text-primary typo-title2">
-            Popular paths
+            What do you want to do?
           </h2>
           <div className="grid grid-cols-1 gap-5 tablet:grid-cols-2">
-            {hub.popularPaths.map((item) => (
+            {hub.categories.map((item) => (
               <Link key={item.slug} href={`/learn-to-code/${item.slug}`}>
                 <a className="group relative flex flex-col gap-3 overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-background-subtle p-6 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:border-border-subtlest-secondary hover:shadow-2">
                   <div
@@ -221,44 +221,34 @@ const LearnToCodeHub = ({ pages }: LearnToCodeHubProps): ReactElement => {
           </div>
         </section>
 
-        {/* All paths grouped by dimension */}
-        {hub.dimensions.order.map((dimension) => {
-          const dimensionPages = pages.filter((p) => p.dimension === dimension);
-          if (dimensionPages.length === 0) {
-            return null;
-          }
-
-          const iconKey = hub.dimensions.icons[dimension];
-
-          return (
-            <section key={dimension} className="mt-14">
-              <div className="mb-4 flex items-center gap-2">
-                {iconKey &&
-                  ICON_MAP[iconKey]?.(IconSize.Small, 'text-text-tertiary')}
-                <h2 className="font-bold text-text-primary typo-title2">
-                  {hub.dimensions.titles[dimension]}
-                </h2>
-              </div>
-              <div className="grid grid-cols-1 gap-0 tablet:grid-cols-2 tablet:gap-4 laptopXL:grid-cols-3">
-                {dimensionPages.map((page) => (
-                  <Link key={page.slug} href={`/learn-to-code/${page.slug}`}>
-                    <a className="group flex items-center gap-3 border-b border-border-subtlest-tertiary p-4 transition-colors hover:bg-surface-hover tablet:rounded-12 tablet:border tablet:bg-surface-float">
-                      <div className="flex flex-1 flex-col">
-                        <span className="font-bold text-text-primary typo-callout group-hover:text-text-link">
-                          {page.title}
-                        </span>
-                      </div>
-                      <ArrowIcon
-                        size={IconSize.XSmall}
-                        className="rotate-90 text-text-quaternary transition-colors group-hover:text-text-link"
-                      />
-                    </a>
-                  </Link>
-                ))}
-              </div>
-            </section>
-          );
-        })}
+        {/* For your role */}
+        {hub.audiencePaths.length > 0 && (
+          <section className="mt-14">
+            <div className="mb-4 flex items-center gap-2">
+              {ICON_MAP.magic(IconSize.Small, 'text-text-tertiary')}
+              <h2 className="font-bold text-text-primary typo-title2">
+                Coding for your role
+              </h2>
+            </div>
+            <div className="grid grid-cols-1 gap-0 tablet:grid-cols-2 tablet:gap-4 laptopXL:grid-cols-4">
+              {hub.audiencePaths.map((item) => (
+                <Link key={item.slug} href={`/learn-to-code/${item.slug}`}>
+                  <a className="group flex items-center gap-3 border-b border-border-subtlest-tertiary p-4 transition-colors hover:bg-surface-hover tablet:rounded-12 tablet:border tablet:bg-surface-float">
+                    <div className="flex flex-1 flex-col">
+                      <span className="font-bold text-text-primary typo-callout group-hover:text-text-link">
+                        {item.title}
+                      </span>
+                    </div>
+                    <ArrowIcon
+                      size={IconSize.XSmall}
+                      className="rotate-90 text-text-quaternary transition-colors group-hover:text-text-link"
+                    />
+                  </a>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
 
         {/* Trending on daily.dev */}
         <section className="mt-14">

--- a/packages/webapp/pages/learn-to-code/index.tsx
+++ b/packages/webapp/pages/learn-to-code/index.tsx
@@ -27,8 +27,14 @@ import { getLayout } from '../../components/layouts/MainLayout';
 import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
 import { defaultOpenGraph } from '../../next-seo';
 import { getPageSeoTitles } from '../../components/layouts/utils';
-import type { Manifest, ManifestEntry } from '../../data/learn-to-code/types';
+import type {
+  HubData,
+  IconKey,
+  Manifest,
+  ManifestEntry,
+} from '../../data/learn-to-code/types';
 import manifest from '../../data/learn-to-code/manifest.json';
+import hubData from '../../data/learn-to-code/hub.json';
 
 function ForceListMode({ children }: { children: ReactNode }): ReactElement {
   const settings = useContext(SettingsContext);
@@ -40,101 +46,36 @@ function ForceListMode({ children }: { children: ReactNode }): ReactElement {
   );
 }
 
-const seoDescription =
-  'Learn to code in the AI era. Curated resources, ready-to-use prompts for AI coding tools, and real developer community — everything you need to start building.';
+const ICON_MAP: Record<
+  IconKey,
+  (size: IconSize, className: string) => ReactElement
+> = {
+  sparkle: (size, className) => (
+    <SparkleIcon size={size} className={className} />
+  ),
+  magic: (size, className) => <MagicIcon size={size} className={className} />,
+  graduation: (size, className) => (
+    <GraduationIcon size={size} className={className} />
+  ),
+  hammer: (size, className) => <HammerIcon size={size} className={className} />,
+  star: (size, className) => <StarIcon size={size} className={className} />,
+  trending: (size, className) => (
+    <TrendingIcon size={size} className={className} />
+  ),
+  terminal: () => <></>,
+  alert: () => <></>,
+  share: () => <></>,
+  upvote: (size, className) => <UpvoteIcon size={size} className={className} />,
+};
 
-const seoTitles = getPageSeoTitles(
-  'Learn to Code — Prompts, Resources & Community',
-);
+const hub = hubData as HubData;
+
+const seoTitles = getPageSeoTitles(hub.seo.title);
 const seo: NextSeoProps = {
   title: seoTitles.title,
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },
-  description: seoDescription,
+  description: hub.seo.description,
 };
-
-const DIMENSION_ICONS: Record<string, ReactElement> = {
-  usecase: <HammerIcon size={IconSize.Small} className="text-text-tertiary" />,
-  language: (
-    <GraduationIcon size={IconSize.Small} className="text-text-tertiary" />
-  ),
-  technique: (
-    <SparkleIcon size={IconSize.Small} className="text-text-tertiary" />
-  ),
-  audience: <MagicIcon size={IconSize.Small} className="text-text-tertiary" />,
-  goal: <StarIcon size={IconSize.Small} className="text-text-tertiary" />,
-};
-
-const DIMENSION_ORDER: string[] = [
-  'language',
-  'usecase',
-  'audience',
-  'technique',
-  'goal',
-];
-
-const DIMENSION_SECTION_TITLES: Record<string, string> = {
-  language: 'By language',
-  usecase: 'By project',
-  audience: 'By audience',
-  technique: 'By technique',
-  goal: 'By goal',
-};
-
-const USE_CASES = [
-  {
-    title: 'Build a Todo App',
-    slug: 'build/todo-app',
-    subtitle:
-      'A classic first project — simple enough to finish today, real enough to learn from.',
-    gradient: 'from-accent-cabbage-default/20 to-accent-onion-default/10',
-    iconColor: 'text-accent-cabbage-default',
-    icon: (
-      <HammerIcon
-        size={IconSize.Large}
-        className="text-accent-cabbage-default"
-      />
-    ),
-  },
-  {
-    title: 'Automate Your Tasks',
-    slug: 'automate-your-workflow',
-    subtitle:
-      'Stop doing repetitive work manually. Let code handle the boring parts.',
-    gradient: 'from-accent-water-default/20 to-accent-blueCheese-default/10',
-    iconColor: 'text-accent-water-default',
-    icon: (
-      <MagicIcon size={IconSize.Large} className="text-accent-water-default" />
-    ),
-  },
-  {
-    title: 'Learn Python',
-    slug: 'python',
-    subtitle:
-      'The most beginner-friendly language. Great for data, automation, and AI.',
-    gradient: 'from-accent-cheese-default/20 to-accent-avocado-default/10',
-    iconColor: 'text-accent-cheese-default',
-    icon: (
-      <GraduationIcon
-        size={IconSize.Large}
-        className="text-accent-cheese-default"
-      />
-    ),
-  },
-  {
-    title: 'Try Vibe Coding',
-    slug: 'vibe-coding',
-    subtitle:
-      'Describe what you want, AI builds it. The fastest path from idea to app.',
-    gradient: 'from-accent-onion-default/20 to-accent-bacon-default/10',
-    iconColor: 'text-accent-onion-default',
-    icon: (
-      <SparkleIcon
-        size={IconSize.Large}
-        className="text-accent-onion-default"
-      />
-    ),
-  },
-];
 
 type LearnToCodeHubProps = {
   pages: ManifestEntry[];
@@ -161,22 +102,54 @@ const LearnToCodeHub = ({ pages }: LearnToCodeHubProps): ReactElement => {
     return <></>;
   }
 
-  const jsonLd = {
-    '@context': 'https://schema.org',
-    '@type': 'CollectionPage',
-    name: 'Learn to Code',
-    description: seoDescription,
-    url: 'https://app.daily.dev/learn-to-code',
-    mainEntity: {
-      '@type': 'ItemList',
-      itemListElement: pages.map((page, index) => ({
-        '@type': 'ListItem',
-        position: index + 1,
-        name: page.title,
-        url: `https://app.daily.dev/learn-to-code/${page.slug}`,
+  const jsonLd = [
+    {
+      '@context': 'https://schema.org',
+      '@type': 'CollectionPage',
+      name: 'Learn to Code with AI',
+      description: hub.seo.description,
+      url: 'https://app.daily.dev/learn-to-code',
+      mainEntity: {
+        '@type': 'ItemList',
+        itemListElement: pages.map((page, index) => ({
+          '@type': 'ListItem',
+          position: index + 1,
+          name: page.title,
+          url: `https://app.daily.dev/learn-to-code/${page.slug}`,
+        })),
+      },
+    },
+    {
+      '@context': 'https://schema.org',
+      '@type': 'FAQPage',
+      mainEntity: hub.faq.map((faq) => ({
+        '@type': 'Question',
+        name: faq.question,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: faq.answer,
+        },
       })),
     },
-  };
+    {
+      '@context': 'https://schema.org',
+      '@type': 'BreadcrumbList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Home',
+          item: 'https://app.daily.dev',
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Learn to Code',
+          item: 'https://app.daily.dev/learn-to-code',
+        },
+      ],
+    },
+  ];
 
   return (
     <div className="relative mx-auto flex w-full max-w-6xl flex-col">
@@ -199,34 +172,34 @@ const LearnToCodeHub = ({ pages }: LearnToCodeHubProps): ReactElement => {
           <GraduationIcon size={IconSize.XSmall} secondary /> Learn to Code
         </BreadCrumbs>
 
-        {/* Hero — warm, inviting, big text */}
+        {/* Hero */}
         <header className="mb-14 mt-8 flex flex-col gap-4 laptop:mt-10">
           <h1 className="bg-gradient-to-r from-text-primary via-accent-cabbage-bolder to-accent-onion-default bg-clip-text font-bold text-transparent typo-title1 laptop:typo-mega2">
-            Learn to code in the AI era
+            {hub.hero.heading}
           </h1>
           <p className="max-w-2xl text-text-secondary typo-body laptop:typo-title3">
-            Curated resources, ready-to-use prompts, and a real developer
-            community. Pick what you want to build and start coding in minutes —
-            no experience needed.
+            {hub.hero.subtitle}
           </p>
         </header>
 
-        {/* Popular paths — large, visual cards */}
+        {/* Popular paths */}
         <section>
           <h2 className="mb-6 font-bold text-text-primary typo-title2">
             Popular paths
           </h2>
           <div className="grid grid-cols-1 gap-5 tablet:grid-cols-2">
-            {USE_CASES.map((item) => (
+            {hub.popularPaths.map((item) => (
               <Link key={item.slug} href={`/learn-to-code/${item.slug}`}>
                 <a className="group relative flex flex-col gap-3 overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-background-subtle p-6 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:border-border-subtlest-secondary hover:shadow-2">
-                  {/* Gradient glow on hover */}
                   <div
                     className={`pointer-events-none absolute inset-0 rounded-24 bg-gradient-to-br ${item.gradient} opacity-0 transition-opacity duration-200 group-hover:opacity-100`}
                   />
                   <div className="relative flex items-center gap-3">
                     <div className="flex h-10 w-10 items-center justify-center rounded-14 bg-surface-float">
-                      {item.icon}
+                      {ICON_MAP[item.iconKey]?.(
+                        IconSize.Large,
+                        `text-${item.accentColor}`,
+                      )}
                     </div>
                     <span className="font-bold text-text-primary typo-title3 group-hover:text-text-link">
                       {item.title}
@@ -249,18 +222,21 @@ const LearnToCodeHub = ({ pages }: LearnToCodeHubProps): ReactElement => {
         </section>
 
         {/* All paths grouped by dimension */}
-        {DIMENSION_ORDER.map((dimension) => {
+        {hub.dimensions.order.map((dimension) => {
           const dimensionPages = pages.filter((p) => p.dimension === dimension);
           if (dimensionPages.length === 0) {
             return null;
           }
 
+          const iconKey = hub.dimensions.icons[dimension];
+
           return (
             <section key={dimension} className="mt-14">
               <div className="mb-4 flex items-center gap-2">
-                {DIMENSION_ICONS[dimension]}
+                {iconKey &&
+                  ICON_MAP[iconKey]?.(IconSize.Small, 'text-text-tertiary')}
                 <h2 className="font-bold text-text-primary typo-title2">
-                  {DIMENSION_SECTION_TITLES[dimension]}
+                  {hub.dimensions.titles[dimension]}
                 </h2>
               </div>
               <div className="grid grid-cols-1 gap-0 tablet:grid-cols-2 tablet:gap-4 laptopXL:grid-cols-3">
@@ -358,43 +334,22 @@ const LearnToCodeHub = ({ pages }: LearnToCodeHubProps): ReactElement => {
           </ForceListMode>
         </section>
 
-        {/* FAQ — approachable, expandable cards */}
+        {/* FAQ */}
         <section className="mt-14 pb-6">
           <h2 className="mb-6 font-bold text-text-primary typo-title2">
             Common questions
           </h2>
           <div className="flex flex-col gap-3">
-            {[
-              {
-                q: 'Is it too late to learn to code in 2026?',
-                a: "No — it's actually the best time. AI coding tools have dramatically lowered the barrier to entry. You can build real applications by describing what you want in plain English, and learn the underlying concepts as you go.",
-              },
-              {
-                q: 'Should I learn to code or just use AI?',
-                a: 'Both. Use AI to build things fast, then learn the concepts behind what it built. Understanding code gives you a lasting edge — you can debug problems, make better architectural decisions, and push AI tools further.',
-              },
-              {
-                q: 'What programming language should I learn first?',
-                a: "Python if you want to automate tasks and work with data. JavaScript if you want to build websites and web apps. Both are beginner-friendly and have massive communities. Don't overthink it — the concepts transfer between languages.",
-              },
-              {
-                q: 'Can I learn to code for free?',
-                a: 'Yes. freeCodeCamp, The Odin Project, Python.org, and JavaScript.info are all free and excellent. Pair them with a free tier of an AI coding tool like Cursor or Replit and you have everything you need.',
-              },
-              {
-                q: 'What is vibe coding?',
-                a: "Vibe coding means building software by describing what you want in natural language and letting AI write the code. Coined by Andrej Karpathy, it's become a popular way for beginners and non-developers to build real applications.",
-              },
-            ].map((faq) => (
+            {hub.faq.map((faq) => (
               <details
-                key={faq.q}
+                key={faq.question}
                 className="[&[open]]:shadow-1 group rounded-16 border border-border-subtlest-tertiary bg-background-subtle transition-all duration-200 hover:border-border-subtlest-secondary"
               >
                 <summary className="cursor-pointer select-none px-6 py-5 font-bold text-text-primary typo-callout">
-                  {faq.q}
+                  {faq.question}
                 </summary>
                 <p className="px-6 pb-5 text-text-secondary typo-body">
-                  {faq.a}
+                  {faq.answer}
                 </p>
               </details>
             ))}

--- a/packages/webapp/pages/learn-to-code/index.tsx
+++ b/packages/webapp/pages/learn-to-code/index.tsx
@@ -1,0 +1,427 @@
+import type { ReactElement, ReactNode } from 'react';
+import React, { useContext, useMemo } from 'react';
+import type { GetStaticPropsResult } from 'next';
+import type { NextSeoProps } from 'next-seo/lib/types';
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import Link from '@dailydotdev/shared/src/components/utilities/Link';
+import { BreadCrumbs } from '@dailydotdev/shared/src/components/header/BreadCrumbs';
+import { PageWrapperLayout } from '@dailydotdev/shared/src/components/layout/PageWrapperLayout';
+import { GraduationIcon } from '@dailydotdev/shared/src/components/icons/Graduation';
+import { HammerIcon } from '@dailydotdev/shared/src/components/icons/Hammer';
+import { SparkleIcon } from '@dailydotdev/shared/src/components/icons/Sparkle';
+import { MagicIcon } from '@dailydotdev/shared/src/components/icons/Magic';
+import { TrendingIcon } from '@dailydotdev/shared/src/components/icons/Trending';
+import { StarIcon } from '@dailydotdev/shared/src/components/icons/Star';
+import { ArrowIcon } from '@dailydotdev/shared/src/components/icons/Arrow';
+import { IconSize } from '@dailydotdev/shared/src/components/Icon';
+import Feed from '@dailydotdev/shared/src/components/Feed';
+import { MOST_UPVOTED_FEED_QUERY } from '@dailydotdev/shared/src/graphql/feed';
+import { OtherFeedPage } from '@dailydotdev/shared/src/lib/query';
+import { ActiveFeedNameContext } from '@dailydotdev/shared/src/contexts';
+import SettingsContext from '@dailydotdev/shared/src/contexts/SettingsContext';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import { PostType } from '@dailydotdev/shared/src/graphql/posts';
+import { UpvoteIcon } from '@dailydotdev/shared/src/components/icons';
+import { getLayout } from '../../components/layouts/MainLayout';
+import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
+import { defaultOpenGraph } from '../../next-seo';
+import { getPageSeoTitles } from '../../components/layouts/utils';
+import type { Manifest, ManifestEntry } from '../../data/learn-to-code/types';
+import manifest from '../../data/learn-to-code/manifest.json';
+
+function ForceListMode({ children }: { children: ReactNode }): ReactElement {
+  const settings = useContext(SettingsContext);
+
+  return (
+    <SettingsContext.Provider value={{ ...settings, insaneMode: true }}>
+      {children}
+    </SettingsContext.Provider>
+  );
+}
+
+const seoDescription =
+  'Learn to code in the AI era. Curated resources, ready-to-use prompts for AI coding tools, and real developer community — everything you need to start building.';
+
+const seoTitles = getPageSeoTitles(
+  'Learn to Code — Prompts, Resources & Community',
+);
+const seo: NextSeoProps = {
+  title: seoTitles.title,
+  openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },
+  description: seoDescription,
+};
+
+const DIMENSION_ICONS: Record<string, ReactElement> = {
+  usecase: <HammerIcon size={IconSize.Small} className="text-text-tertiary" />,
+  language: (
+    <GraduationIcon size={IconSize.Small} className="text-text-tertiary" />
+  ),
+  technique: (
+    <SparkleIcon size={IconSize.Small} className="text-text-tertiary" />
+  ),
+  audience: <MagicIcon size={IconSize.Small} className="text-text-tertiary" />,
+  goal: <StarIcon size={IconSize.Small} className="text-text-tertiary" />,
+};
+
+const DIMENSION_ORDER: string[] = [
+  'language',
+  'usecase',
+  'audience',
+  'technique',
+  'goal',
+];
+
+const DIMENSION_SECTION_TITLES: Record<string, string> = {
+  language: 'By language',
+  usecase: 'By project',
+  audience: 'By audience',
+  technique: 'By technique',
+  goal: 'By goal',
+};
+
+const USE_CASES = [
+  {
+    title: 'Build a Todo App',
+    slug: 'build/todo-app',
+    subtitle:
+      'A classic first project — simple enough to finish today, real enough to learn from.',
+    gradient: 'from-accent-cabbage-default/20 to-accent-onion-default/10',
+    iconColor: 'text-accent-cabbage-default',
+    icon: (
+      <HammerIcon
+        size={IconSize.Large}
+        className="text-accent-cabbage-default"
+      />
+    ),
+  },
+  {
+    title: 'Automate Your Tasks',
+    slug: 'automate-your-workflow',
+    subtitle:
+      'Stop doing repetitive work manually. Let code handle the boring parts.',
+    gradient: 'from-accent-water-default/20 to-accent-blueCheese-default/10',
+    iconColor: 'text-accent-water-default',
+    icon: (
+      <MagicIcon size={IconSize.Large} className="text-accent-water-default" />
+    ),
+  },
+  {
+    title: 'Learn Python',
+    slug: 'python',
+    subtitle:
+      'The most beginner-friendly language. Great for data, automation, and AI.',
+    gradient: 'from-accent-cheese-default/20 to-accent-avocado-default/10',
+    iconColor: 'text-accent-cheese-default',
+    icon: (
+      <GraduationIcon
+        size={IconSize.Large}
+        className="text-accent-cheese-default"
+      />
+    ),
+  },
+  {
+    title: 'Try Vibe Coding',
+    slug: 'vibe-coding',
+    subtitle:
+      'Describe what you want, AI builds it. The fastest path from idea to app.',
+    gradient: 'from-accent-onion-default/20 to-accent-bacon-default/10',
+    iconColor: 'text-accent-onion-default',
+    icon: (
+      <SparkleIcon
+        size={IconSize.Large}
+        className="text-accent-onion-default"
+      />
+    ),
+  },
+];
+
+type LearnToCodeHubProps = {
+  pages: ManifestEntry[];
+};
+
+const LearnToCodeHub = ({ pages }: LearnToCodeHubProps): ReactElement => {
+  const { isFallback: isLoading } = useRouter();
+  const { user } = useContext(AuthContext);
+
+  const feedVariables = useMemo(
+    () => ({
+      tag: 'beginners',
+      supportedTypes: [
+        PostType.Article,
+        PostType.VideoYouTube,
+        PostType.Collection,
+      ],
+      period: 30,
+    }),
+    [],
+  );
+
+  if (isLoading) {
+    return <></>;
+  }
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: 'Learn to Code',
+    description: seoDescription,
+    url: 'https://app.daily.dev/learn-to-code',
+    mainEntity: {
+      '@type': 'ItemList',
+      itemListElement: pages.map((page, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        name: page.title,
+        url: `https://app.daily.dev/learn-to-code/${page.slug}`,
+      })),
+    },
+  };
+
+  return (
+    <div className="relative mx-auto flex w-full max-w-6xl flex-col">
+      {/* Ambient gradient glows */}
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="animate-float-slow bg-accent-cabbage-default/[0.07] absolute -left-40 -top-40 h-[500px] w-[500px] rounded-full blur-3xl" />
+        <div className="animate-float-slow-reverse bg-accent-onion-default/[0.06] absolute -right-32 top-20 h-80 w-80 rounded-full blur-3xl" />
+        <div className="animate-float-slow-delayed bg-accent-water-default/[0.05] absolute -bottom-20 left-1/4 h-64 w-64 rounded-full blur-3xl" />
+      </div>
+
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      </Head>
+
+      <PageWrapperLayout className="py-6">
+        <BreadCrumbs>
+          <GraduationIcon size={IconSize.XSmall} secondary /> Learn to Code
+        </BreadCrumbs>
+
+        {/* Hero — warm, inviting, big text */}
+        <header className="mb-14 mt-8 flex flex-col gap-4 laptop:mt-10">
+          <h1 className="bg-gradient-to-r from-text-primary via-accent-cabbage-bolder to-accent-onion-default bg-clip-text font-bold text-transparent typo-title1 laptop:typo-mega2">
+            Learn to code in the AI era
+          </h1>
+          <p className="max-w-2xl text-text-secondary typo-body laptop:typo-title3">
+            Curated resources, ready-to-use prompts, and a real developer
+            community. Pick what you want to build and start coding in minutes —
+            no experience needed.
+          </p>
+        </header>
+
+        {/* Popular paths — large, visual cards */}
+        <section>
+          <h2 className="mb-6 font-bold text-text-primary typo-title2">
+            Popular paths
+          </h2>
+          <div className="grid grid-cols-1 gap-5 tablet:grid-cols-2">
+            {USE_CASES.map((item) => (
+              <Link key={item.slug} href={`/learn-to-code/${item.slug}`}>
+                <a className="group relative flex flex-col gap-3 overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-background-subtle p-6 transition-all duration-200 ease-out hover:-translate-y-0.5 hover:border-border-subtlest-secondary hover:shadow-2">
+                  {/* Gradient glow on hover */}
+                  <div
+                    className={`pointer-events-none absolute inset-0 rounded-24 bg-gradient-to-br ${item.gradient} opacity-0 transition-opacity duration-200 group-hover:opacity-100`}
+                  />
+                  <div className="relative flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-14 bg-surface-float">
+                      {item.icon}
+                    </div>
+                    <span className="font-bold text-text-primary typo-title3 group-hover:text-text-link">
+                      {item.title}
+                    </span>
+                  </div>
+                  <p className="relative text-text-tertiary typo-body">
+                    {item.subtitle}
+                  </p>
+                  <div className="relative mt-1 flex items-center gap-1 text-text-quaternary transition-colors group-hover:text-text-link">
+                    <span className="typo-callout">Get started</span>
+                    <ArrowIcon
+                      size={IconSize.XSmall}
+                      className="rotate-90 transition-transform duration-200 group-hover:translate-x-0.5"
+                    />
+                  </div>
+                </a>
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        {/* All paths grouped by dimension */}
+        {DIMENSION_ORDER.map((dimension) => {
+          const dimensionPages = pages.filter((p) => p.dimension === dimension);
+          if (dimensionPages.length === 0) {
+            return null;
+          }
+
+          return (
+            <section key={dimension} className="mt-14">
+              <div className="mb-4 flex items-center gap-2">
+                {DIMENSION_ICONS[dimension]}
+                <h2 className="font-bold text-text-primary typo-title2">
+                  {DIMENSION_SECTION_TITLES[dimension]}
+                </h2>
+              </div>
+              <div className="grid grid-cols-1 gap-0 tablet:grid-cols-2 tablet:gap-4 laptopXL:grid-cols-3">
+                {dimensionPages.map((page) => (
+                  <Link key={page.slug} href={`/learn-to-code/${page.slug}`}>
+                    <a className="group flex items-center gap-3 border-b border-border-subtlest-tertiary p-4 transition-colors hover:bg-surface-hover tablet:rounded-12 tablet:border tablet:bg-surface-float">
+                      <div className="flex flex-1 flex-col">
+                        <span className="font-bold text-text-primary typo-callout group-hover:text-text-link">
+                          {page.title}
+                        </span>
+                      </div>
+                      <ArrowIcon
+                        size={IconSize.XSmall}
+                        className="rotate-90 text-text-quaternary transition-colors group-hover:text-text-link"
+                      />
+                    </a>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          );
+        })}
+
+        {/* Trending on daily.dev */}
+        <section className="mt-14">
+          <div className="mb-6 flex items-center gap-2">
+            <TrendingIcon
+              size={IconSize.Medium}
+              className="text-text-tertiary"
+            />
+            <h2 className="font-bold text-text-primary typo-title2">
+              Trending for beginners
+            </h2>
+          </div>
+          <ForceListMode>
+            <ActiveFeedNameContext.Provider
+              value={{ feedName: OtherFeedPage.ExploreUpvoted }}
+            >
+              <Feed
+                feedName={OtherFeedPage.ExploreUpvoted}
+                feedQueryKey={[
+                  'learnToCodeTrending',
+                  user?.id ?? 'anonymous',
+                  Object.values(feedVariables),
+                ]}
+                query={MOST_UPVOTED_FEED_QUERY}
+                variables={feedVariables}
+                className="!mx-0 !w-auto"
+                disableAds
+                disableListFrame
+                allowFetchMore={false}
+                pageSize={5}
+              />
+            </ActiveFeedNameContext.Provider>
+          </ForceListMode>
+        </section>
+
+        {/* Most upvoted programming content */}
+        <section className="mt-14">
+          <div className="mb-6 flex items-center gap-2">
+            <UpvoteIcon size={IconSize.Medium} className="text-text-tertiary" />
+            <h2 className="font-bold text-text-primary typo-title2">
+              Most upvoted programming posts
+            </h2>
+          </div>
+          <ForceListMode>
+            <ActiveFeedNameContext.Provider
+              value={{ feedName: OtherFeedPage.ExploreUpvoted }}
+            >
+              <Feed
+                feedName={OtherFeedPage.ExploreUpvoted}
+                feedQueryKey={[
+                  'learnToCodeUpvoted',
+                  user?.id ?? 'anonymous',
+                  'programming',
+                  30,
+                ]}
+                query={MOST_UPVOTED_FEED_QUERY}
+                variables={{
+                  tag: 'programming',
+                  supportedTypes: [
+                    PostType.Article,
+                    PostType.VideoYouTube,
+                    PostType.Collection,
+                  ],
+                  period: 30,
+                }}
+                className="!mx-0 !w-auto"
+                disableAds
+                disableListFrame
+                allowFetchMore={false}
+                pageSize={5}
+              />
+            </ActiveFeedNameContext.Provider>
+          </ForceListMode>
+        </section>
+
+        {/* FAQ — approachable, expandable cards */}
+        <section className="mt-14 pb-6">
+          <h2 className="mb-6 font-bold text-text-primary typo-title2">
+            Common questions
+          </h2>
+          <div className="flex flex-col gap-3">
+            {[
+              {
+                q: 'Is it too late to learn to code in 2026?',
+                a: "No — it's actually the best time. AI coding tools have dramatically lowered the barrier to entry. You can build real applications by describing what you want in plain English, and learn the underlying concepts as you go.",
+              },
+              {
+                q: 'Should I learn to code or just use AI?',
+                a: 'Both. Use AI to build things fast, then learn the concepts behind what it built. Understanding code gives you a lasting edge — you can debug problems, make better architectural decisions, and push AI tools further.',
+              },
+              {
+                q: 'What programming language should I learn first?',
+                a: "Python if you want to automate tasks and work with data. JavaScript if you want to build websites and web apps. Both are beginner-friendly and have massive communities. Don't overthink it — the concepts transfer between languages.",
+              },
+              {
+                q: 'Can I learn to code for free?',
+                a: 'Yes. freeCodeCamp, The Odin Project, Python.org, and JavaScript.info are all free and excellent. Pair them with a free tier of an AI coding tool like Cursor or Replit and you have everything you need.',
+              },
+              {
+                q: 'What is vibe coding?',
+                a: "Vibe coding means building software by describing what you want in natural language and letting AI write the code. Coined by Andrej Karpathy, it's become a popular way for beginners and non-developers to build real applications.",
+              },
+            ].map((faq) => (
+              <details
+                key={faq.q}
+                className="[&[open]]:shadow-1 group rounded-16 border border-border-subtlest-tertiary bg-background-subtle transition-all duration-200 hover:border-border-subtlest-secondary"
+              >
+                <summary className="cursor-pointer select-none px-6 py-5 font-bold text-text-primary typo-callout">
+                  {faq.q}
+                </summary>
+                <p className="px-6 pb-5 text-text-secondary typo-body">
+                  {faq.a}
+                </p>
+              </details>
+            ))}
+          </div>
+        </section>
+      </PageWrapperLayout>
+    </div>
+  );
+};
+
+const getLearnToCodeLayout: typeof getLayout = (...props) =>
+  getFooterNavBarLayout(getLayout(...props));
+
+LearnToCodeHub.getLayout = getLearnToCodeLayout;
+LearnToCodeHub.layoutProps = {
+  screenCentered: false,
+  seo,
+};
+export default LearnToCodeHub;
+
+export async function getStaticProps(): Promise<
+  GetStaticPropsResult<LearnToCodeHubProps>
+> {
+  const { pages } = manifest as Manifest;
+
+  return {
+    props: { pages },
+    revalidate: 300,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `/learn-to-code` hub page with popular paths, dimension-grouped navigation, FAQ, and trending feeds
- 11 leaf pages with step-by-step AI prompts, outcomes, AI tips, concepts, tools, resources, communities, and trending feed
- 4 audience sub-hub pages (marketers, designers, students, data analysts) that curate recommended leaf paths instead of prompts
- Two-column layout (primary + sidebar) matching the post page pattern
- Beginner-friendly onboarding sections: "How this works" 3-step explainer, "What you need" checklist, project descriptions
- HowTo and CollectionPage JSON-LD structured data for SEO

## Test plan
- [ ] Visit `/learn-to-code` — verify hub page renders with popular paths, dimension groups, FAQ, and feeds
- [ ] Visit a leaf page (e.g. `/learn-to-code/python`) — verify two-column layout, "How this works", "What you need", prompt cards with copy, AI tips, concepts, sidebar widgets
- [ ] Visit an audience sub-hub (e.g. `/learn-to-code/for/marketers`) — verify recommended path cards render instead of prompts, no "How this works" section
- [ ] Test prompt copy button works and shows toast
- [ ] Verify responsive layout on mobile and tablet breakpoints
- [ ] Check JSON-LD in page source for leaf and sub-hub pages

### Preview domain
https://learn-how-to-code.preview.app.daily.dev