### PR TITLE
feat(companion): add browsing context consent prompt

### DIFF
--- a/packages/extension/src/companion/App.tsx
+++ b/packages/extension/src/companion/App.tsx
@@ -24,6 +24,7 @@ import { GrowthBookProvider } from '@dailydotdev/shared/src/components/GrowthBoo
 import { NotificationsContextProvider } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import { useEventListener } from '@dailydotdev/shared/src/hooks';
 import { structuredCloneJsonPolyfill } from '@dailydotdev/shared/src/lib/structuredClone';
+import type { RemoteSettings } from '@dailydotdev/shared/src/graphql/settings';
 import Companion from './Companion';
 import CustomRouter from '../lib/CustomRouter';
 import { companionFetch } from './companionFetch';
@@ -62,6 +63,9 @@ export default function App({
 }: CompanionData): ReactElement | null {
   useError();
   const [token, setToken] = useState(accessToken);
+  const [currentSettings, setCurrentSettings] = useState(settings);
+  const updateSettings = (newSettings: RemoteSettings) =>
+    setCurrentSettings(newSettings);
   const [isOptOutCompanion, setIsOptOutCompanion] = useState<boolean>(
     settings?.optOutCompanion ?? false,
   );
@@ -109,7 +113,11 @@ export default function App({
               updateUser={async () => undefined}
               squads={squads}
             >
-              <SettingsContextProvider settings={settings}>
+              <SettingsContextProvider
+                settings={currentSettings}
+                updateSettings={updateSettings}
+                loadedSettings={!!currentSettings}
+              >
                 <AlertContextProvider alerts={alerts}>
                   <LogContextProvider
                     app={app}
@@ -126,7 +134,9 @@ export default function App({
                       <Companion
                         postData={postData}
                         companionHelper={alerts?.companionHelper ?? false}
-                        companionExpanded={settings?.companionExpanded ?? false}
+                        companionExpanded={
+                          currentSettings?.companionExpanded ?? false
+                        }
                         onOptOut={() => setIsOptOutCompanion(true)}
                         onUpdateToken={setToken}
                       />
@@ -138,7 +148,7 @@ export default function App({
                     />
                     <Toast
                       autoDismissNotifications={
-                        settings?.autoDismissNotifications
+                        currentSettings?.autoDismissNotifications
                       }
                     />
                   </LogContextProvider>

--- a/packages/extension/src/companion/Companion.tsx
+++ b/packages/extension/src/companion/Companion.tsx
@@ -19,6 +19,7 @@ import {
   updatePostCache,
 } from '@dailydotdev/shared/src/lib/query';
 import { getCompanionWrapper } from '@dailydotdev/shared/src/lib/extension';
+import { useCompanionBrowsingConsent } from '@dailydotdev/shared/src/hooks/useCompanionBrowsingConsent';
 import CompanionMenu from './CompanionMenu';
 import CompanionContent from './CompanionContent';
 import { companionRequest } from './companionRequest';
@@ -87,6 +88,8 @@ export default function Companion({
   });
   const containerRef = useRef<HTMLDivElement>();
   const [assetsLoaded, setAssetsLoaded] = useState(isTesting);
+  const { shouldShowBanner, onAccept, onDismiss } =
+    useCompanionBrowsingConsent();
   usePopupSelector({ parentSelector: getCompanionWrapper });
   const client = useQueryClient();
   const { data: post } = useQuery({
@@ -164,8 +167,14 @@ export default function Companion({
         setVerticalPosition={setVerticalPosition}
         isDragging={isDragging}
         setIsDragging={setIsDragging}
+        showConsentNotification={shouldShowBanner}
       />
-      <CompanionContent post={post} />
+      <CompanionContent
+        post={post}
+        shouldShowBanner={shouldShowBanner}
+        onAccept={onAccept}
+        onDismiss={onDismiss}
+      />
     </Container>
   );
 }

--- a/packages/extension/src/companion/Companion.tsx
+++ b/packages/extension/src/companion/Companion.tsx
@@ -12,6 +12,7 @@ import type {
 } from '@dailydotdev/shared/src/lib/boot';
 import useLogPageView from '@dailydotdev/shared/src/hooks/log/useLogPageView';
 import useDebounceFn from '@dailydotdev/shared/src/hooks/useDebounceFn';
+import { useCompanionBrowsingConsent } from '@dailydotdev/shared/src/hooks/useCompanionBrowsingConsent';
 import { usePopupSelector } from '@dailydotdev/shared/src/hooks/usePopupSelector';
 import { useBackgroundRequest } from '@dailydotdev/shared/src/hooks/companion';
 import {
@@ -85,6 +86,7 @@ export default function Companion({
   useBackgroundRequest(refreshTokenKey, {
     callback: ({ res }) => onUpdateToken(res.accessToken),
   });
+  useCompanionBrowsingConsent();
   const containerRef = useRef<HTMLDivElement>();
   const [assetsLoaded, setAssetsLoaded] = useState(isTesting);
   usePopupSelector({ parentSelector: getCompanionWrapper });

--- a/packages/extension/src/companion/Companion.tsx
+++ b/packages/extension/src/companion/Companion.tsx
@@ -12,7 +12,6 @@ import type {
 } from '@dailydotdev/shared/src/lib/boot';
 import useLogPageView from '@dailydotdev/shared/src/hooks/log/useLogPageView';
 import useDebounceFn from '@dailydotdev/shared/src/hooks/useDebounceFn';
-import { useCompanionBrowsingConsent } from '@dailydotdev/shared/src/hooks/useCompanionBrowsingConsent';
 import { usePopupSelector } from '@dailydotdev/shared/src/hooks/usePopupSelector';
 import { useBackgroundRequest } from '@dailydotdev/shared/src/hooks/companion';
 import {
@@ -86,7 +85,6 @@ export default function Companion({
   useBackgroundRequest(refreshTokenKey, {
     callback: ({ res }) => onUpdateToken(res.accessToken),
   });
-  useCompanionBrowsingConsent();
   const containerRef = useRef<HTMLDivElement>();
   const [assetsLoaded, setAssetsLoaded] = useState(isTesting);
   usePopupSelector({ parentSelector: getCompanionWrapper });

--- a/packages/extension/src/companion/CompanionBrowsingConsentBanner.tsx
+++ b/packages/extension/src/companion/CompanionBrowsingConsentBanner.tsx
@@ -1,0 +1,52 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import CloseButton from '@dailydotdev/shared/src/components/CloseButton';
+import type { UseCompanionBrowsingConsentReturn } from '@dailydotdev/shared/src/hooks/useCompanionBrowsingConsent';
+
+type CompanionBrowsingConsentBannerProps = Pick<
+  UseCompanionBrowsingConsentReturn,
+  'onAccept' | 'onDismiss'
+>;
+
+export function CompanionBrowsingConsentBanner({
+  onAccept,
+  onDismiss,
+}: CompanionBrowsingConsentBannerProps): ReactElement {
+  return (
+    <div className="relative mb-4 rounded-12 border border-border-subtlest-tertiary bg-surface-float p-4">
+      <CloseButton
+        size={ButtonSize.XSmall}
+        className="absolute right-1 top-1"
+        onClick={onDismiss}
+      />
+      <p className="pr-6 font-bold typo-callout">
+        Personalize with browsing context?
+      </p>
+      <p className="mt-1 text-text-tertiary typo-footnote">
+        Allow daily.dev to use your browsing context for more relevant
+        recommendations. Change anytime in settings.
+      </p>
+      <div className="mt-3 flex gap-3">
+        <Button
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Primary}
+          onClick={onAccept}
+        >
+          Allow
+        </Button>
+        <Button
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Float}
+          onClick={onDismiss}
+        >
+          No thanks
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/extension/src/companion/CompanionContent.tsx
+++ b/packages/extension/src/companion/CompanionContent.tsx
@@ -21,8 +21,10 @@ import { Origin } from '@dailydotdev/shared/src/lib/log';
 
 import { Tooltip } from '@dailydotdev/shared/src/components/tooltip/Tooltip';
 import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
+import { useCompanionBrowsingConsent } from '@dailydotdev/shared/src/hooks/useCompanionBrowsingConsent';
 import { CompanionEngagements } from './CompanionEngagements';
 import { CompanionDiscussion } from './CompanionDiscussion';
+import { CompanionBrowsingConsentBanner } from './CompanionBrowsingConsentBanner';
 import { useBackgroundPaginatedRequest } from './useBackgroundPaginatedRequest';
 
 type CompanionContentProps = {
@@ -35,6 +37,8 @@ export default function CompanionContent({
   post,
 }: CompanionContentProps): ReactElement {
   const { logEvent } = useLogContext();
+  const { shouldShowBanner, onAccept, onDismiss } =
+    useCompanionBrowsingConsent();
   const [copying, copyLink] = useCopyLink(() => post.commentsPermalink);
   const [heightPx, setHeightPx] = useState('0');
   const { queryKey, onShowUpvoted } = useUpvoteQuery();
@@ -83,6 +87,12 @@ export default function CompanionContent({
           />
         </Tooltip>
       </div>
+      {shouldShowBanner && (
+        <CompanionBrowsingConsentBanner
+          onAccept={onAccept}
+          onDismiss={onDismiss}
+        />
+      )}
       <p className="my-4 flex-1 break-words typo-callout">
         <TLDRText>TLDR -</TLDRText>
         <span>

--- a/packages/extension/src/companion/CompanionContent.tsx
+++ b/packages/extension/src/companion/CompanionContent.tsx
@@ -21,7 +21,7 @@ import { Origin } from '@dailydotdev/shared/src/lib/log';
 
 import { Tooltip } from '@dailydotdev/shared/src/components/tooltip/Tooltip';
 import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
-import { useCompanionBrowsingConsent } from '@dailydotdev/shared/src/hooks/useCompanionBrowsingConsent';
+import type { UseCompanionBrowsingConsentReturn } from '@dailydotdev/shared/src/hooks/useCompanionBrowsingConsent';
 import { CompanionEngagements } from './CompanionEngagements';
 import { CompanionDiscussion } from './CompanionDiscussion';
 import { CompanionBrowsingConsentBanner } from './CompanionBrowsingConsentBanner';
@@ -29,16 +29,17 @@ import { useBackgroundPaginatedRequest } from './useBackgroundPaginatedRequest';
 
 type CompanionContentProps = {
   post: PostBootData;
-};
+} & UseCompanionBrowsingConsentReturn;
 
 const COMPANION_TOP_OFFSET_PX = 120;
 
 export default function CompanionContent({
   post,
+  shouldShowBanner,
+  onAccept,
+  onDismiss,
 }: CompanionContentProps): ReactElement {
   const { logEvent } = useLogContext();
-  const { shouldShowBanner, onAccept, onDismiss } =
-    useCompanionBrowsingConsent();
   const [copying, copyLink] = useCopyLink(() => post.commentsPermalink);
   const [heightPx, setHeightPx] = useState('0');
   const { queryKey, onShowUpvoted } = useUpvoteQuery();

--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -74,6 +74,7 @@ type CompanionMenuProps = {
   isDragging: boolean;
   setIsDragging: (dragging: boolean) => void;
   onOpenComments?: () => void;
+  showConsentNotification?: boolean;
 };
 
 export default function CompanionMenu({
@@ -87,6 +88,7 @@ export default function CompanionMenu({
   setVerticalPosition,
   isDragging,
   setIsDragging,
+  showConsentNotification,
 }: CompanionMenuProps): ReactElement {
   const { modal, closeModal } = useLazyModal();
   const { logEvent } = useLogContext();
@@ -355,6 +357,7 @@ export default function CompanionMenu({
           isAlertDisabled={!showCompanionHelper}
           tooltipContainerClassName={tooltipContainerClassName}
           onToggleCompanion={toggleCompanion}
+          showNotification={showConsentNotification && !companionState}
         />
         <Tooltip
           side="left"

--- a/packages/extension/src/companion/CompanionToggle.tsx
+++ b/packages/extension/src/companion/CompanionToggle.tsx
@@ -18,6 +18,7 @@ interface CompanionToggleProps {
   isAlertDisabled: boolean;
   onToggleCompanion: () => void;
   tooltipContainerClassName?: string;
+  showNotification?: boolean;
 }
 
 function CompanionToggle({
@@ -25,6 +26,7 @@ function CompanionToggle({
   isAlertDisabled,
   tooltipContainerClassName,
   onToggleCompanion,
+  showNotification,
 }: CompanionToggleProps): ReactElement {
   return (
     <AlertPointer
@@ -47,7 +49,7 @@ function CompanionToggle({
             'group-hover:btn-secondary': !companionState,
           })}
           icon={
-            <>
+            <span className="relative">
               <LogoIcon
                 className={{
                   container: classNames(
@@ -64,7 +66,10 @@ function CompanionToggle({
                     : 'hidden -rotate-90 group-hover:block',
                 )}
               />
-            </>
+              {!!showNotification && (
+                <span className="absolute -right-0.5 -top-0.5 h-3 w-3 rounded-full border-2 border-background-default bg-accent-cabbage-default group-hover:hidden" />
+              )}
+            </span>
           }
           onClick={onToggleCompanion}
         />

--- a/packages/shared/src/graphql/settings.ts
+++ b/packages/shared/src/graphql/settings.ts
@@ -18,6 +18,7 @@ export type SettingsFlags = {
   sidebarBookmarksExpanded: boolean;
   clickbaitShieldEnabled: boolean;
   noAiFeedEnabled?: boolean;
+  browsingContextEnabled?: boolean;
   timezoneMismatchIgnore?: string;
   prompt?: Record<string, boolean>;
   lastPrompt?: string;
@@ -32,6 +33,7 @@ export enum SidebarSettingsFlags {
   BookmarksExpanded = 'sidebarBookmarksExpanded',
   ClickbaitShieldEnabled = 'clickbaitShieldEnabled',
   NoAiFeedEnabled = 'noAiFeedEnabled',
+  BrowsingContextEnabled = 'browsingContextEnabled',
 }
 
 export type RemoteSettings = {

--- a/packages/shared/src/hooks/useCompanionBrowsingConsent.spec.ts
+++ b/packages/shared/src/hooks/useCompanionBrowsingConsent.spec.ts
@@ -2,7 +2,6 @@ import { renderHook, act } from '@testing-library/react';
 import { useCompanionBrowsingConsent } from './useCompanionBrowsingConsent';
 import { useConditionalFeature } from './useConditionalFeature';
 import { useSettingsContext } from '../contexts/SettingsContext';
-import { usePrompt } from './usePrompt';
 import { useLogContext } from '../contexts/LogContext';
 import { LogEvent, Origin } from '../lib/log';
 import { SidebarSettingsFlags } from '../graphql/settings';
@@ -15,23 +14,17 @@ jest.mock('../contexts/SettingsContext', () => ({
   useSettingsContext: jest.fn(),
 }));
 
-jest.mock('./usePrompt', () => ({
-  usePrompt: jest.fn(),
-}));
-
 jest.mock('../contexts/LogContext', () => ({
   useLogContext: jest.fn(),
 }));
 
 const mockUseConditionalFeature = useConditionalFeature as jest.Mock;
 const mockUseSettingsContext = useSettingsContext as jest.Mock;
-const mockUsePrompt = usePrompt as jest.Mock;
 const mockUseLogContext = useLogContext as jest.Mock;
 
 describe('useCompanionBrowsingConsent', () => {
   const updateFlag = jest.fn().mockResolvedValue(undefined);
   const updatePromptFlag = jest.fn().mockResolvedValue(undefined);
-  const showPrompt = jest.fn();
   const logEvent = jest.fn();
 
   beforeEach(() => {
@@ -50,24 +43,13 @@ describe('useCompanionBrowsingConsent', () => {
       updateFlag,
       updatePromptFlag,
     });
-    mockUsePrompt.mockReturnValue({ showPrompt });
     mockUseLogContext.mockReturnValue({ logEvent });
   });
 
-  it('shows the consent prompt when feature is enabled and user has not seen it', async () => {
-    showPrompt.mockResolvedValue(true);
+  it('shows the banner when feature is enabled and user has not seen it', () => {
+    const { result } = renderHook(() => useCompanionBrowsingConsent());
 
-    await act(async () => {
-      renderHook(() => useCompanionBrowsingConsent());
-    });
-
-    expect(showPrompt).toHaveBeenCalledWith(
-      expect.objectContaining({
-        title: 'Personalize your feed with browsing context?',
-        okButton: { title: 'Allow' },
-        cancelButton: { title: 'No thanks' },
-      }),
-    );
+    expect(result.current.shouldShowBanner).toBe(true);
     expect(logEvent).toHaveBeenCalledWith({
       event_name: LogEvent.BrowsingConsentPromptShow,
       extra: JSON.stringify({ origin: Origin.Companion }),
@@ -75,58 +57,56 @@ describe('useCompanionBrowsingConsent', () => {
   });
 
   it('saves browsingContextEnabled flag when user accepts', async () => {
-    showPrompt.mockResolvedValue(true);
+    const { result } = renderHook(() => useCompanionBrowsingConsent());
 
     await act(async () => {
-      renderHook(() => useCompanionBrowsingConsent());
+      await result.current.onAccept();
     });
 
     expect(updateFlag).toHaveBeenCalledWith(
       SidebarSettingsFlags.BrowsingContextEnabled,
       true,
     );
+    expect(updatePromptFlag).toHaveBeenCalledWith(
+      'browsing_context_consent_prompt',
+      true,
+    );
     expect(logEvent).toHaveBeenCalledWith({
       event_name: LogEvent.BrowsingConsentPromptAccept,
       extra: JSON.stringify({ origin: Origin.Companion }),
     });
+  });
+
+  it('does not save browsingContextEnabled when user dismisses', async () => {
+    const { result } = renderHook(() => useCompanionBrowsingConsent());
+
+    await act(async () => {
+      await result.current.onDismiss();
+    });
+
+    expect(updateFlag).not.toHaveBeenCalled();
     expect(updatePromptFlag).toHaveBeenCalledWith(
       'browsing_context_consent_prompt',
       true,
     );
-  });
-
-  it('does not save browsingContextEnabled when user declines', async () => {
-    showPrompt.mockResolvedValue(false);
-
-    await act(async () => {
-      renderHook(() => useCompanionBrowsingConsent());
-    });
-
-    expect(updateFlag).not.toHaveBeenCalled();
     expect(logEvent).toHaveBeenCalledWith({
       event_name: LogEvent.BrowsingConsentPromptDecline,
       extra: JSON.stringify({ origin: Origin.Companion }),
     });
-    expect(updatePromptFlag).toHaveBeenCalledWith(
-      'browsing_context_consent_prompt',
-      true,
-    );
   });
 
-  it('does not show prompt when feature is disabled', async () => {
+  it('does not show banner when feature is disabled', () => {
     mockUseConditionalFeature.mockReturnValue({
       value: false,
       isLoading: false,
     });
 
-    await act(async () => {
-      renderHook(() => useCompanionBrowsingConsent());
-    });
+    const { result } = renderHook(() => useCompanionBrowsingConsent());
 
-    expect(showPrompt).not.toHaveBeenCalled();
+    expect(result.current.shouldShowBanner).toBe(false);
   });
 
-  it('does not show prompt when user already consented', async () => {
+  it('does not show banner when user already consented', () => {
     mockUseSettingsContext.mockReturnValue({
       flags: {
         browsingContextEnabled: true,
@@ -137,14 +117,12 @@ describe('useCompanionBrowsingConsent', () => {
       updatePromptFlag,
     });
 
-    await act(async () => {
-      renderHook(() => useCompanionBrowsingConsent());
-    });
+    const { result } = renderHook(() => useCompanionBrowsingConsent());
 
-    expect(showPrompt).not.toHaveBeenCalled();
+    expect(result.current.shouldShowBanner).toBe(false);
   });
 
-  it('does not show prompt when user already dismissed it', async () => {
+  it('does not show banner when user already dismissed it', () => {
     mockUseSettingsContext.mockReturnValue({
       flags: {
         browsingContextEnabled: false,
@@ -155,14 +133,12 @@ describe('useCompanionBrowsingConsent', () => {
       updatePromptFlag,
     });
 
-    await act(async () => {
-      renderHook(() => useCompanionBrowsingConsent());
-    });
+    const { result } = renderHook(() => useCompanionBrowsingConsent());
 
-    expect(showPrompt).not.toHaveBeenCalled();
+    expect(result.current.shouldShowBanner).toBe(false);
   });
 
-  it('does not show prompt when settings are not loaded', async () => {
+  it('does not show banner when settings are not loaded', () => {
     mockUseSettingsContext.mockReturnValue({
       flags: {
         browsingContextEnabled: false,
@@ -173,10 +149,8 @@ describe('useCompanionBrowsingConsent', () => {
       updatePromptFlag,
     });
 
-    await act(async () => {
-      renderHook(() => useCompanionBrowsingConsent());
-    });
+    const { result } = renderHook(() => useCompanionBrowsingConsent());
 
-    expect(showPrompt).not.toHaveBeenCalled();
+    expect(result.current.shouldShowBanner).toBe(false);
   });
 });

--- a/packages/shared/src/hooks/useCompanionBrowsingConsent.spec.ts
+++ b/packages/shared/src/hooks/useCompanionBrowsingConsent.spec.ts
@@ -1,0 +1,182 @@
+import { renderHook, act } from '@testing-library/react';
+import { useCompanionBrowsingConsent } from './useCompanionBrowsingConsent';
+import { useConditionalFeature } from './useConditionalFeature';
+import { useSettingsContext } from '../contexts/SettingsContext';
+import { usePrompt } from './usePrompt';
+import { useLogContext } from '../contexts/LogContext';
+import { LogEvent, Origin } from '../lib/log';
+import { SidebarSettingsFlags } from '../graphql/settings';
+
+jest.mock('./useConditionalFeature', () => ({
+  useConditionalFeature: jest.fn(),
+}));
+
+jest.mock('../contexts/SettingsContext', () => ({
+  useSettingsContext: jest.fn(),
+}));
+
+jest.mock('./usePrompt', () => ({
+  usePrompt: jest.fn(),
+}));
+
+jest.mock('../contexts/LogContext', () => ({
+  useLogContext: jest.fn(),
+}));
+
+const mockUseConditionalFeature = useConditionalFeature as jest.Mock;
+const mockUseSettingsContext = useSettingsContext as jest.Mock;
+const mockUsePrompt = usePrompt as jest.Mock;
+const mockUseLogContext = useLogContext as jest.Mock;
+
+describe('useCompanionBrowsingConsent', () => {
+  const updateFlag = jest.fn().mockResolvedValue(undefined);
+  const updatePromptFlag = jest.fn().mockResolvedValue(undefined);
+  const showPrompt = jest.fn();
+  const logEvent = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseConditionalFeature.mockReturnValue({
+      value: true,
+      isLoading: false,
+    });
+    mockUseSettingsContext.mockReturnValue({
+      flags: {
+        browsingContextEnabled: false,
+        prompt: {},
+      },
+      loadedSettings: true,
+      updateFlag,
+      updatePromptFlag,
+    });
+    mockUsePrompt.mockReturnValue({ showPrompt });
+    mockUseLogContext.mockReturnValue({ logEvent });
+  });
+
+  it('shows the consent prompt when feature is enabled and user has not seen it', async () => {
+    showPrompt.mockResolvedValue(true);
+
+    await act(async () => {
+      renderHook(() => useCompanionBrowsingConsent());
+    });
+
+    expect(showPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Personalize your feed with browsing context?',
+        okButton: { title: 'Allow' },
+        cancelButton: { title: 'No thanks' },
+      }),
+    );
+    expect(logEvent).toHaveBeenCalledWith({
+      event_name: LogEvent.BrowsingConsentPromptShow,
+      extra: JSON.stringify({ origin: Origin.Companion }),
+    });
+  });
+
+  it('saves browsingContextEnabled flag when user accepts', async () => {
+    showPrompt.mockResolvedValue(true);
+
+    await act(async () => {
+      renderHook(() => useCompanionBrowsingConsent());
+    });
+
+    expect(updateFlag).toHaveBeenCalledWith(
+      SidebarSettingsFlags.BrowsingContextEnabled,
+      true,
+    );
+    expect(logEvent).toHaveBeenCalledWith({
+      event_name: LogEvent.BrowsingConsentPromptAccept,
+      extra: JSON.stringify({ origin: Origin.Companion }),
+    });
+    expect(updatePromptFlag).toHaveBeenCalledWith(
+      'browsing_context_consent_prompt',
+      true,
+    );
+  });
+
+  it('does not save browsingContextEnabled when user declines', async () => {
+    showPrompt.mockResolvedValue(false);
+
+    await act(async () => {
+      renderHook(() => useCompanionBrowsingConsent());
+    });
+
+    expect(updateFlag).not.toHaveBeenCalled();
+    expect(logEvent).toHaveBeenCalledWith({
+      event_name: LogEvent.BrowsingConsentPromptDecline,
+      extra: JSON.stringify({ origin: Origin.Companion }),
+    });
+    expect(updatePromptFlag).toHaveBeenCalledWith(
+      'browsing_context_consent_prompt',
+      true,
+    );
+  });
+
+  it('does not show prompt when feature is disabled', async () => {
+    mockUseConditionalFeature.mockReturnValue({
+      value: false,
+      isLoading: false,
+    });
+
+    await act(async () => {
+      renderHook(() => useCompanionBrowsingConsent());
+    });
+
+    expect(showPrompt).not.toHaveBeenCalled();
+  });
+
+  it('does not show prompt when user already consented', async () => {
+    mockUseSettingsContext.mockReturnValue({
+      flags: {
+        browsingContextEnabled: true,
+        prompt: {},
+      },
+      loadedSettings: true,
+      updateFlag,
+      updatePromptFlag,
+    });
+
+    await act(async () => {
+      renderHook(() => useCompanionBrowsingConsent());
+    });
+
+    expect(showPrompt).not.toHaveBeenCalled();
+  });
+
+  it('does not show prompt when user already dismissed it', async () => {
+    mockUseSettingsContext.mockReturnValue({
+      flags: {
+        browsingContextEnabled: false,
+        prompt: { browsing_context_consent_prompt: true },
+      },
+      loadedSettings: true,
+      updateFlag,
+      updatePromptFlag,
+    });
+
+    await act(async () => {
+      renderHook(() => useCompanionBrowsingConsent());
+    });
+
+    expect(showPrompt).not.toHaveBeenCalled();
+  });
+
+  it('does not show prompt when settings are not loaded', async () => {
+    mockUseSettingsContext.mockReturnValue({
+      flags: {
+        browsingContextEnabled: false,
+        prompt: {},
+      },
+      loadedSettings: false,
+      updateFlag,
+      updatePromptFlag,
+    });
+
+    await act(async () => {
+      renderHook(() => useCompanionBrowsingConsent());
+    });
+
+    expect(showPrompt).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/hooks/useCompanionBrowsingConsent.ts
+++ b/packages/shared/src/hooks/useCompanionBrowsingConsent.ts
@@ -2,79 +2,61 @@ import { useCallback, useEffect, useRef } from 'react';
 import { useSettingsContext } from '../contexts/SettingsContext';
 import { useConditionalFeature } from './useConditionalFeature';
 import { featureCompanionBrowsingConsent } from '../lib/featureManagement';
-import { usePrompt } from './usePrompt';
 import { useLogContext } from '../contexts/LogContext';
 import { LogEvent, Origin } from '../lib/log';
 import { SidebarSettingsFlags } from '../graphql/settings';
 
 const BROWSING_CONSENT_PROMPT_FLAG = 'browsing_context_consent_prompt';
 
-export const useCompanionBrowsingConsent = (): void => {
-  const { value: featureEnabled } = useConditionalFeature({
-    feature: featureCompanionBrowsingConsent,
-    shouldEvaluate: true,
-  });
-  const { flags, loadedSettings, updateFlag, updatePromptFlag } =
-    useSettingsContext();
-  const { showPrompt } = usePrompt();
-  const { logEvent } = useLogContext();
-  const promptShownRef = useRef(false);
+export type UseCompanionBrowsingConsentReturn = {
+  shouldShowBanner: boolean;
+  onAccept: () => Promise<void>;
+  onDismiss: () => Promise<void>;
+};
 
-  const hasConsented = !!flags?.browsingContextEnabled;
-  const hasDismissedPrompt = !!flags?.prompt?.[BROWSING_CONSENT_PROMPT_FLAG];
-
-  const showConsentPrompt = useCallback(async () => {
-    if (promptShownRef.current) {
-      return;
-    }
-
-    promptShownRef.current = true;
-
-    logEvent({
-      event_name: LogEvent.BrowsingConsentPromptShow,
-      extra: JSON.stringify({ origin: Origin.Companion }),
+export const useCompanionBrowsingConsent =
+  (): UseCompanionBrowsingConsentReturn => {
+    const { value: featureEnabled } = useConditionalFeature({
+      feature: featureCompanionBrowsingConsent,
+      shouldEvaluate: true,
     });
+    const { flags, loadedSettings, updateFlag, updatePromptFlag } =
+      useSettingsContext();
+    const { logEvent } = useLogContext();
+    const impressionLoggedRef = useRef(false);
 
-    const accepted = await showPrompt({
-      title: 'Personalize your feed with browsing context?',
-      description:
-        'Allow daily.dev to use your browsing context to recommend more relevant content. You can change this anytime in settings.',
-      okButton: { title: 'Allow' },
-      cancelButton: { title: 'No thanks' },
-    });
+    const hasConsented = !!flags?.browsingContextEnabled;
+    const hasDismissedPrompt = !!flags?.prompt?.[BROWSING_CONSENT_PROMPT_FLAG];
 
-    if (accepted) {
+    const shouldShowBanner =
+      featureEnabled && loadedSettings && !hasConsented && !hasDismissedPrompt;
+
+    useEffect(() => {
+      if (shouldShowBanner && !impressionLoggedRef.current) {
+        impressionLoggedRef.current = true;
+        logEvent({
+          event_name: LogEvent.BrowsingConsentPromptShow,
+          extra: JSON.stringify({ origin: Origin.Companion }),
+        });
+      }
+    }, [shouldShowBanner, logEvent]);
+
+    const onAccept = useCallback(async () => {
       await updateFlag(SidebarSettingsFlags.BrowsingContextEnabled, true);
+      await updatePromptFlag(BROWSING_CONSENT_PROMPT_FLAG, true);
       logEvent({
         event_name: LogEvent.BrowsingConsentPromptAccept,
         extra: JSON.stringify({ origin: Origin.Companion }),
       });
-    } else {
+    }, [updateFlag, updatePromptFlag, logEvent]);
+
+    const onDismiss = useCallback(async () => {
+      await updatePromptFlag(BROWSING_CONSENT_PROMPT_FLAG, true);
       logEvent({
         event_name: LogEvent.BrowsingConsentPromptDecline,
         extra: JSON.stringify({ origin: Origin.Companion }),
       });
-    }
+    }, [updatePromptFlag, logEvent]);
 
-    await updatePromptFlag(BROWSING_CONSENT_PROMPT_FLAG, true);
-  }, [logEvent, showPrompt, updateFlag, updatePromptFlag]);
-
-  useEffect(() => {
-    if (
-      !featureEnabled ||
-      !loadedSettings ||
-      hasConsented ||
-      hasDismissedPrompt
-    ) {
-      return;
-    }
-
-    showConsentPrompt();
-  }, [
-    featureEnabled,
-    loadedSettings,
-    hasConsented,
-    hasDismissedPrompt,
-    showConsentPrompt,
-  ]);
-};
+    return { shouldShowBanner, onAccept, onDismiss };
+  };

--- a/packages/shared/src/hooks/useCompanionBrowsingConsent.ts
+++ b/packages/shared/src/hooks/useCompanionBrowsingConsent.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useSettingsContext } from '../contexts/SettingsContext';
+import { useConditionalFeature } from './useConditionalFeature';
+import { featureCompanionBrowsingConsent } from '../lib/featureManagement';
+import { usePrompt } from './usePrompt';
+import { useLogContext } from '../contexts/LogContext';
+import { LogEvent, Origin } from '../lib/log';
+import { SidebarSettingsFlags } from '../graphql/settings';
+
+const BROWSING_CONSENT_PROMPT_FLAG = 'browsing_context_consent_prompt';
+
+export const useCompanionBrowsingConsent = (): void => {
+  const { value: featureEnabled } = useConditionalFeature({
+    feature: featureCompanionBrowsingConsent,
+    shouldEvaluate: true,
+  });
+  const { flags, loadedSettings, updateFlag, updatePromptFlag } =
+    useSettingsContext();
+  const { showPrompt } = usePrompt();
+  const { logEvent } = useLogContext();
+  const promptShownRef = useRef(false);
+
+  const hasConsented = !!flags?.browsingContextEnabled;
+  const hasDismissedPrompt = !!flags?.prompt?.[BROWSING_CONSENT_PROMPT_FLAG];
+
+  const showConsentPrompt = useCallback(async () => {
+    if (promptShownRef.current) {
+      return;
+    }
+
+    promptShownRef.current = true;
+
+    logEvent({
+      event_name: LogEvent.BrowsingConsentPromptShow,
+      extra: JSON.stringify({ origin: Origin.Companion }),
+    });
+
+    const accepted = await showPrompt({
+      title: 'Personalize your feed with browsing context?',
+      description:
+        'Allow daily.dev to use your browsing context to recommend more relevant content. You can change this anytime in settings.',
+      okButton: { title: 'Allow' },
+      cancelButton: { title: 'No thanks' },
+    });
+
+    if (accepted) {
+      await updateFlag(SidebarSettingsFlags.BrowsingContextEnabled, true);
+      logEvent({
+        event_name: LogEvent.BrowsingConsentPromptAccept,
+        extra: JSON.stringify({ origin: Origin.Companion }),
+      });
+    } else {
+      logEvent({
+        event_name: LogEvent.BrowsingConsentPromptDecline,
+        extra: JSON.stringify({ origin: Origin.Companion }),
+      });
+    }
+
+    await updatePromptFlag(BROWSING_CONSENT_PROMPT_FLAG, true);
+  }, [logEvent, showPrompt, updateFlag, updatePromptFlag]);
+
+  useEffect(() => {
+    if (
+      !featureEnabled ||
+      !loadedSettings ||
+      hasConsented ||
+      hasDismissedPrompt
+    ) {
+      return;
+    }
+
+    showConsentPrompt();
+  }, [
+    featureEnabled,
+    loadedSettings,
+    hasConsented,
+    hasDismissedPrompt,
+    showConsentPrompt,
+  ]);
+};

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -33,6 +33,10 @@ export const discussedFeedVersion = new Feature('discussed_feed_version', 2);
 export const latestFeedVersion = new Feature('latest_feed_version', 2);
 export const customFeedVersion = new Feature('custom_feed_version', 2);
 export const featureNoAiFeed = new Feature('no_ai_feed', false);
+export const featureCompanionBrowsingConsent = new Feature(
+  'companion_browsing_consent',
+  false,
+);
 export const featureFeedV2Highlights = new Feature('feed_v2_highlights', false);
 
 // @ts-expect-error stale feature without default

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -280,6 +280,11 @@ export enum LogEvent {
   // End Clickbait Shield
   ToggleNoAiFeed = 'toggle no ai feed',
   SaveNoAiFeedPreference = 'save no ai feed preference',
+  // Browsing Context Consent
+  BrowsingConsentPromptShow = 'browsing consent prompt show',
+  BrowsingConsentPromptAccept = 'browsing consent prompt accept',
+  BrowsingConsentPromptDecline = 'browsing consent prompt decline',
+  // End Browsing Context Consent
   InstallPWA = 'install pwa',
   // Start Share
   ShareProfile = 'share profile',


### PR DESCRIPTION
## Summary
- Add `browsingContextEnabled` to frontend `SettingsFlags` type and `SidebarSettingsFlags` enum
- Add `companion_browsing_consent` GrowthBook feature flag for A/B testing
- Add analytics events: `browsing consent prompt show`, `accept`, `decline`
- Create `useCompanionBrowsingConsent` hook (follows `useNoAiFeed` pattern) that shows a one-time `showPrompt()` modal in the companion widget
- Integrate the hook into the `Companion` component

Basically collect permission for now, collection implemented later if enough users are interested. (API side flag merged already)

## Key decisions
- **Opt-in only**: absence of `browsingContextEnabled` flag = no consent; declining does not write `false`
- **One-time prompt**: dismiss state persisted in `flags.prompt.browsing_context_consent_prompt`, never re-triggers
- **Zero migration**: stored in existing JSONB `flags` column
- **Instant rollback**: GrowthBook flag can disable without deploy

## Test plan
- [x] Unit tests for all hook branches (accept, decline, feature-off, already-consented, already-dismissed, settings-not-loaded) — 7/7 pass
- [x] Manual: enable `companion_browsing_consent` in GrowthBook, open companion on any page, verify prompt appears once
- [x] Manual: accept → verify `browsingContextEnabled: true` in settings flags
- [x] Manual: decline → verify flag absent, prompt never re-appears

<img width="897" height="578" alt="image" src="https://github.com/user-attachments/assets/9fe355bf-ebb3-4c63-9047-18846d112577" />

<img width="976" height="515" alt="image" src="https://github.com/user-attachments/assets/c4ad39ba-d894-418e-9631-7849a2ed4a60" />


Closes ENG-1231

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1231-add-companion-consent-p.preview.app.daily.dev