### PR TITLE
fix: stabilize highlight modal mobile scroll and tailwind scan

### DIFF
--- a/packages/shared/src/components/modals/HighlightPostModal.tsx
+++ b/packages/shared/src/components/modals/HighlightPostModal.tsx
@@ -688,7 +688,7 @@ export function HighlightPostModal({
         </h2>
       }
     >
-      <div className="relative flex min-h-0 max-w-full flex-col laptop:h-full">
+      <div className="relative flex min-h-0 min-w-0 max-w-full flex-1 flex-col overflow-hidden laptop:h-full">
         {!shouldUseMobileLayout && (
           <HighlightDesktopRail
             activeIndex={activeIndex}
@@ -717,7 +717,7 @@ export function HighlightPostModal({
         )}
         <div
           ref={setArticleViewportRef}
-          className="min-h-0 min-w-0 flex-1 overflow-y-auto [scrollbar-gutter:stable]"
+          className="min-h-0 min-w-0 flex-1 overflow-y-auto overscroll-y-contain [scrollbar-gutter:stable]"
           {...swipeHandlers}
         >
           <div className="relative overflow-hidden">

--- a/packages/webapp/tailwind.config.ts
+++ b/packages/webapp/tailwind.config.ts
@@ -4,16 +4,18 @@ import config from '@dailydotdev/shared/tailwind.config';
 import path from 'path';
 import * as fs from 'fs';
 
+const sharedSrcPath = fs.realpathSync('./node_modules/@dailydotdev/shared/src');
+
 export default {
   ...config,
   content: [
     './app/**/*.{js,ts,jsx,tsx}',
     './pages/**/*.{js,ts,jsx,tsx}',
     './components/**/*.{js,ts,jsx,tsx}',
-    path.join(
-      fs.realpathSync('./node_modules/@dailydotdev/shared/src'),
-      '**/*.{js,ts,jsx,tsx}',
-    ),
+    path.join(sharedSrcPath, '**/*.{js,ts,jsx,tsx}'),
+    `!${path.join(sharedSrcPath, '**/*.spec.{js,ts,jsx,tsx}')}`,
+    `!${path.join(sharedSrcPath, '**/*.test.{js,ts,jsx,tsx}')}`,
+    `!${path.join(sharedSrcPath, '**/__tests__/**/*.{js,ts,jsx,tsx}')}`,
   ],
   // eslint-disable-next-line
 } satisfies Config;


### PR DESCRIPTION
## Summary
- constrain the Happening Now modal mobile layout so the inner article viewport owns scrolling on iOS
- exclude shared spec/test files from the webapp Tailwind content scan to avoid stale deleted-file lookups in dev

## Testing
- node ./scripts/typecheck-strict-changed.js

### Preview domain
https://codex-fix-highlight-modal-ios-he.preview.app.daily.dev