### PR TITLE
fix(shared): show custom feed names in mobile nav

### DIFF
--- a/packages/shared/src/components/feeds/FeedNav.spec.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.spec.tsx
@@ -1,0 +1,140 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useRouter } from 'next/router';
+import FeedNav from './FeedNav';
+
+const mockTabContainer = jest.fn(
+  ({
+    children,
+    controlledActive,
+  }: {
+    children: ReactNode;
+    controlledActive?: string;
+  }): ReactElement => (
+    <div data-active-tab={controlledActive}>
+      <div>{children}</div>
+    </div>
+  ),
+);
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('../../contexts', () => ({
+  useActiveFeedNameContext: jest.fn(() => ({ feedName: 'custom' })),
+}));
+
+jest.mock('../../contexts/SettingsContext', () => ({
+  useSettingsContext: jest.fn(() => ({ sortingEnabled: false })),
+}));
+
+jest.mock('../../hooks', () => ({
+  useFeeds: jest.fn(() => ({
+    feeds: {
+      edges: [
+        {
+          node: {
+            id: 'feed-123',
+            slug: 'frontend-picks',
+            flags: undefined,
+          },
+        },
+      ],
+    },
+  })),
+  useViewSize: jest.fn(() => true),
+  ViewSize: { MobileL: 'MobileL' },
+}));
+
+jest.mock('../../hooks/feed/useFeedName', () => ({
+  useFeedName: jest.fn(() => ({ isSortableFeed: false })),
+}));
+
+jest.mock('../../hooks/feed/useSortedFeeds', () => ({
+  useSortedFeeds: jest.fn(({ edges }) => edges ?? []),
+}));
+
+jest.mock('../../hooks/feed/useCustomDefaultFeed', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    isCustomDefaultFeed: false,
+    defaultFeedId: undefined,
+  })),
+}));
+
+jest.mock('../../hooks/useActiveNav', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ home: true, bookmarks: false })),
+}));
+
+jest.mock('../../hooks/usePersistentContext', () => ({
+  __esModule: true,
+  default: jest.fn(() => [0, jest.fn()]),
+}));
+
+jest.mock('../../hooks/useScrollTopClassName', () => ({
+  useScrollTopClassName: jest.fn(() => ''),
+}));
+
+jest.mock('../../hooks/utils/useFeatureTheme', () => ({
+  useFeatureTheme: jest.fn(() => null),
+}));
+
+jest.mock('../../hooks/usePlusEntry', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ plusEntryForYou: null })),
+}));
+
+jest.mock('../tabs/TabContainer', () => ({
+  TabContainer: (props: {
+    children: ReactNode;
+    controlledActive?: string;
+  }): ReactElement => mockTabContainer(props),
+  Tab: ({ label }: { label: string }): ReactElement => <div>{label}</div>,
+}));
+
+jest.mock('./MobileFeedActions', () => ({
+  MobileFeedActions: (): ReactElement => (
+    <div data-testid="mobile-feed-actions" />
+  ),
+}));
+
+jest.mock('../filters/MyFeedHeading', () => ({
+  __esModule: true,
+  default: (): ReactElement => <div data-testid="my-feed-heading" />,
+}));
+
+jest.mock('../notifications/NotificationsBell', () => ({
+  __esModule: true,
+  default: (): ReactElement => <div data-testid="notifications-bell" />,
+}));
+
+jest.mock('../banners/PlusMobileEntryBanner', () => ({
+  __esModule: true,
+  default: (): ReactElement => <div data-testid="plus-entry-banner" />,
+}));
+
+const mockUseRouter = jest.mocked(useRouter);
+
+describe('FeedNav', () => {
+  beforeEach(() => {
+    mockTabContainer.mockClear();
+    mockUseRouter.mockReturnValue({
+      pathname: '/feeds/[slugOrId]',
+      asPath: '/feeds/frontend-picks',
+      query: { slugOrId: 'frontend-picks' },
+    } as unknown as ReturnType<typeof useRouter>);
+  });
+
+  it('should use a readable custom feed label when the feed name is missing', () => {
+    render(<FeedNav />);
+
+    expect(screen.getByText('Frontend Picks')).toBeInTheDocument();
+    expect(screen.queryByText('Feed feed-123')).not.toBeInTheDocument();
+    expect(mockTabContainer).toHaveBeenCalledWith(
+      expect.objectContaining({ controlledActive: 'Frontend Picks' }),
+    );
+  });
+});

--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -105,73 +105,17 @@ function FeedNav(): ReactElement | null {
     ((sortingEnabled && isSortableFeed) ||
       activeFeedName === SharedFeedPage.Custom);
 
-  const customFeedTabs = useMemo<FeedNavTabEntry[]>(() => {
-    return sortedFeeds.map(({ node: feed }) => {
-      const isMatchingRoute =
-        router.query.slugOrId === feed.id ||
-        router.query.slugOrId === feed.slug;
-      const isEditingFeed =
-        isMatchingRoute && router.pathname.endsWith('/edit');
-      const feedLabel = getCustomFeedTabLabel(feed);
-      let feedPath = `${webappUrl}feeds/${feed.id}`;
+  const activeCustomFeedLabel = useMemo(() => {
+    const activeCustomFeed = sortedFeeds.find(({ node: feed }) => {
+      return (
+        router.query.slugOrId === feed.id || router.query.slugOrId === feed.slug
+      );
+    })?.node;
 
-      if (!isEditingFeed && isCustomDefaultFeed && feed.id === defaultFeedId) {
-        feedPath = webappUrl;
-      }
-
-      return {
-        label: feedLabel,
-        url: `${feedPath}${isEditingFeed ? '/edit' : ''}`,
-      };
-    });
-  }, [
-    sortedFeeds,
-    router.query.slugOrId,
-    router.pathname,
-    defaultFeedId,
-    isCustomDefaultFeed,
-  ]);
-
-  const urlToTab: Record<string, string> = useMemo(() => {
-    const forYouTab = isCustomDefaultFeed ? `${webappUrl}my-feed` : webappUrl;
-    const customFeedAliases = sortedFeeds.reduce((acc, { node: feed }) => {
-      const feedLabel = getCustomFeedTabLabel(feed);
-      const isDefaultCustomFeed =
-        isCustomDefaultFeed && feed.id === defaultFeedId;
-      const canonicalPath = isDefaultCustomFeed
-        ? webappUrl
-        : `${webappUrl}feeds/${feed.id}`;
-      const slugPath =
-        feed.slug && feed.slug !== feed.id
-          ? `${webappUrl}feeds/${feed.slug}`
-          : undefined;
-
-      acc[canonicalPath] = feedLabel;
-      acc[`${canonicalPath}/edit`] = feedLabel;
-
-      if (slugPath) {
-        acc[slugPath] = feedLabel;
-        acc[`${slugPath}/edit`] = feedLabel;
-      }
-
-      return acc;
-    }, {} as Record<string, string>);
-
-    return {
-      [`${webappUrl}feeds/new`]: FeedNavTab.NewFeed,
-      [forYouTab]: FeedNavTab.ForYou,
-      [`${webappUrl}posts`]: FeedNavTab.Popular,
-      [`${webappUrl}agents`]: FeedNavTab.AgenticHub,
-      ...customFeedAliases,
-      [`${webappUrl}following`]: FeedNavTab.Following,
-      [`${webappUrl}${OtherFeedPage.Discussed}`]: FeedNavTab.Discussions,
-      [`${webappUrl}tags`]: FeedNavTab.Tags,
-      [`${webappUrl}sources`]: FeedNavTab.Sources,
-      [`${webappUrl}users`]: FeedNavTab.Leaderboard,
-      [`${webappUrl}bookmarks`]: FeedNavTab.Bookmarks,
-      [`${webappUrl}history`]: FeedNavTab.History,
-    };
-  }, [sortedFeeds, defaultFeedId, isCustomDefaultFeed]);
+    return activeCustomFeed
+      ? getCustomFeedTabLabel(activeCustomFeed)
+      : undefined;
+  }, [sortedFeeds, router.query.slugOrId]);
 
   const tabs = useMemo<FeedNavTabEntry[]>(
     () => [
@@ -182,7 +126,13 @@ function FeedNav(): ReactElement | null {
       },
       { label: FeedNavTab.Popular, url: `${webappUrl}posts` },
       { label: FeedNavTab.AgenticHub, url: `${webappUrl}agents` },
-      ...customFeedTabs,
+      ...sortedFeeds.map(({ node: feed }) => ({
+        label: getCustomFeedTabLabel(feed),
+        url:
+          isCustomDefaultFeed && feed.id === defaultFeedId
+            ? webappUrl
+            : `${webappUrl}feeds/${feed.id}`,
+      })),
       { label: FeedNavTab.Following, url: `${webappUrl}following` },
       {
         label: FeedNavTab.Discussions,
@@ -194,8 +144,31 @@ function FeedNav(): ReactElement | null {
       { label: FeedNavTab.Bookmarks, url: `${webappUrl}bookmarks` },
       { label: FeedNavTab.History, url: `${webappUrl}history` },
     ],
-    [customFeedTabs, isCustomDefaultFeed],
+    [sortedFeeds, defaultFeedId, isCustomDefaultFeed],
   );
+
+  const activeTab = useMemo(() => {
+    if (activeCustomFeedLabel) {
+      return activeCustomFeedLabel;
+    }
+
+    const staticTabs: Record<string, string> = {
+      [`${webappUrl}feeds/new`]: FeedNavTab.NewFeed,
+      [isCustomDefaultFeed ? `${webappUrl}my-feed` : webappUrl]:
+        FeedNavTab.ForYou,
+      [`${webappUrl}posts`]: FeedNavTab.Popular,
+      [`${webappUrl}agents`]: FeedNavTab.AgenticHub,
+      [`${webappUrl}following`]: FeedNavTab.Following,
+      [`${webappUrl}${OtherFeedPage.Discussed}`]: FeedNavTab.Discussions,
+      [`${webappUrl}tags`]: FeedNavTab.Tags,
+      [`${webappUrl}sources`]: FeedNavTab.Sources,
+      [`${webappUrl}users`]: FeedNavTab.Leaderboard,
+      [`${webappUrl}bookmarks`]: FeedNavTab.Bookmarks,
+      [`${webappUrl}history`]: FeedNavTab.History,
+    };
+
+    return staticTabs[router.asPath] ?? '';
+  }, [activeCustomFeedLabel, isCustomDefaultFeed, router.asPath]);
 
   const shouldRenderNav = home || (isMobile && bookmarks);
   if (!shouldRenderNav || router?.pathname?.startsWith('/posts/[id]')) {
@@ -212,7 +185,7 @@ function FeedNav(): ReactElement | null {
       {isMobile && <MobileFeedActions />}
       <div className="mb-4 h-[3.25rem] tablet:relative tablet:mb-0 tablet:h-auto tablet:min-h-[3.25rem]">
         <TabContainer
-          controlledActive={urlToTab[router.asPath] ?? ''}
+          controlledActive={activeTab}
           shouldMountInactive
           className={{
             header: classNames(

--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -21,6 +21,7 @@ import { ButtonSize, ButtonVariant } from '../buttons/common';
 import { useScrollTopClassName } from '../../hooks/useScrollTopClassName';
 import { useFeatureTheme } from '../../hooks/utils/useFeatureTheme';
 import { webappUrl } from '../../lib/constants';
+import { formatKeyword } from '../../lib/strings';
 import NotificationsBell from '../notifications/NotificationsBell';
 import classed from '../../lib/classed';
 import { OtherFeedPage } from '../../lib/query';
@@ -47,17 +48,43 @@ enum FeedNavTab {
   Following = 'Following',
 }
 
+type FeedNavTabEntry = {
+  label: string;
+  url: string;
+};
+
 const StickyNavIconWrapper = classed(
   'div',
   'sticky flex h-14 pt-1 -translate-y-16 items-center justify-end bg-gradient-to-r from-transparent via-background-default via-40% to-background-default pr-4',
 );
 
-function FeedNav(): ReactElement {
+const getCustomFeedTabLabel = ({
+  id,
+  slug,
+  flags,
+}: {
+  id: string;
+  slug?: string;
+  flags?: { name?: string };
+}): string => {
+  if (flags?.name) {
+    return flags.name;
+  }
+
+  if (slug && slug !== id) {
+    return formatKeyword(slug);
+  }
+
+  return `Feed ${id}`;
+};
+
+function FeedNav(): ReactElement | null {
   const router = useRouter();
   const { feedName } = useActiveFeedNameContext();
+  const activeFeedName = feedName ?? SharedFeedPage.MyFeed;
   const { sortingEnabled } = useSettingsContext();
-  const { isSortableFeed } = useFeedName({ feedName });
-  const { home, bookmarks } = useActiveNav(feedName);
+  const { isSortableFeed } = useFeedName({ feedName: activeFeedName });
+  const { home, bookmarks } = useActiveNav(activeFeedName);
   const isMobile = useViewSize(ViewSize.MobileL);
   const [selectedAlgo, setSelectedAlgo] = usePersistentContext(
     DEFAULT_ALGORITHM_KEY,
@@ -75,37 +102,67 @@ function FeedNav(): ReactElement {
   const { plusEntryForYou } = usePlusEntry();
   const showStickyButton =
     isMobile &&
-    ((sortingEnabled && isSortableFeed) || feedName === SharedFeedPage.Custom);
+    ((sortingEnabled && isSortableFeed) ||
+      activeFeedName === SharedFeedPage.Custom);
 
-  const urlToTab: Record<string, FeedNavTab> = useMemo(() => {
-    const customFeeds = sortedFeeds.reduce((acc, { node: feed }) => {
+  const customFeedTabs = useMemo<FeedNavTabEntry[]>(() => {
+    return sortedFeeds.map(({ node: feed }) => {
+      const isMatchingRoute =
+        router.query.slugOrId === feed.id ||
+        router.query.slugOrId === feed.slug;
       const isEditingFeed =
-        router.query.slugOrId === feed.id && router.pathname.endsWith('/edit');
+        isMatchingRoute && router.pathname.endsWith('/edit');
+      const feedLabel = getCustomFeedTabLabel(feed);
       let feedPath = `${webappUrl}feeds/${feed.id}`;
 
       if (!isEditingFeed && isCustomDefaultFeed && feed.id === defaultFeedId) {
-        feedPath = `${webappUrl}`;
+        feedPath = webappUrl;
       }
 
-      const urlPath = `${feedPath}${isEditingFeed ? '/edit' : ''}`;
+      return {
+        label: feedLabel,
+        url: `${feedPath}${isEditingFeed ? '/edit' : ''}`,
+      };
+    });
+  }, [
+    sortedFeeds,
+    router.query.slugOrId,
+    router.pathname,
+    defaultFeedId,
+    isCustomDefaultFeed,
+  ]);
 
-      acc[urlPath] = feed.flags?.name || `Feed ${feed.id}`;
+  const urlToTab: Record<string, string> = useMemo(() => {
+    const forYouTab = isCustomDefaultFeed ? `${webappUrl}my-feed` : webappUrl;
+    const customFeedAliases = sortedFeeds.reduce((acc, { node: feed }) => {
+      const feedLabel = getCustomFeedTabLabel(feed);
+      const isDefaultCustomFeed =
+        isCustomDefaultFeed && feed.id === defaultFeedId;
+      const canonicalPath = isDefaultCustomFeed
+        ? webappUrl
+        : `${webappUrl}feeds/${feed.id}`;
+      const slugPath =
+        feed.slug && feed.slug !== feed.id
+          ? `${webappUrl}feeds/${feed.slug}`
+          : undefined;
+
+      acc[canonicalPath] = feedLabel;
+      acc[`${canonicalPath}/edit`] = feedLabel;
+
+      if (slugPath) {
+        acc[slugPath] = feedLabel;
+        acc[`${slugPath}/edit`] = feedLabel;
+      }
 
       return acc;
-    }, {});
+    }, {} as Record<string, string>);
 
-    const forYouTab = isCustomDefaultFeed ? `${webappUrl}my-feed` : webappUrl;
-
-    const urls = {
+    return {
       [`${webappUrl}feeds/new`]: FeedNavTab.NewFeed,
       [forYouTab]: FeedNavTab.ForYou,
       [`${webappUrl}posts`]: FeedNavTab.Popular,
       [`${webappUrl}agents`]: FeedNavTab.AgenticHub,
-      ...customFeeds,
-    };
-
-    return {
-      ...urls,
+      ...customFeedAliases,
       [`${webappUrl}following`]: FeedNavTab.Following,
       [`${webappUrl}${OtherFeedPage.Discussed}`]: FeedNavTab.Discussions,
       [`${webappUrl}tags`]: FeedNavTab.Tags,
@@ -114,13 +171,31 @@ function FeedNav(): ReactElement {
       [`${webappUrl}bookmarks`]: FeedNavTab.Bookmarks,
       [`${webappUrl}history`]: FeedNavTab.History,
     };
-  }, [
-    sortedFeeds,
-    router.query.slugOrId,
-    router.pathname,
-    defaultFeedId,
-    isCustomDefaultFeed,
-  ]);
+  }, [sortedFeeds, defaultFeedId, isCustomDefaultFeed]);
+
+  const tabs = useMemo<FeedNavTabEntry[]>(
+    () => [
+      { label: FeedNavTab.NewFeed, url: `${webappUrl}feeds/new` },
+      {
+        label: FeedNavTab.ForYou,
+        url: isCustomDefaultFeed ? `${webappUrl}my-feed` : webappUrl,
+      },
+      { label: FeedNavTab.Popular, url: `${webappUrl}posts` },
+      { label: FeedNavTab.AgenticHub, url: `${webappUrl}agents` },
+      ...customFeedTabs,
+      { label: FeedNavTab.Following, url: `${webappUrl}following` },
+      {
+        label: FeedNavTab.Discussions,
+        url: `${webappUrl}${OtherFeedPage.Discussed}`,
+      },
+      { label: FeedNavTab.Tags, url: `${webappUrl}tags` },
+      { label: FeedNavTab.Sources, url: `${webappUrl}sources` },
+      { label: FeedNavTab.Leaderboard, url: `${webappUrl}users` },
+      { label: FeedNavTab.Bookmarks, url: `${webappUrl}bookmarks` },
+      { label: FeedNavTab.History, url: `${webappUrl}history` },
+    ],
+    [customFeedTabs, isCustomDefaultFeed],
+  );
 
   const shouldRenderNav = home || (isMobile && bookmarks);
   if (!shouldRenderNav || router?.pathname?.startsWith('/posts/[id]')) {
@@ -164,7 +239,7 @@ function FeedNav(): ReactElement {
             return null;
           }}
         >
-          {Object.entries(urlToTab).map(([url, label]) => (
+          {tabs.map(({ label, url }) => (
             <Tab key={`${label}-${url}`} label={label} url={url} />
           ))}
         </TabContainer>


### PR DESCRIPTION
## Summary
- fix the mobile feed navigation label so custom feeds show a readable name instead of `Feed <id>`
- add focused coverage for the mobile custom-feed tab label behavior

## Key Decisions
- derive the active custom-feed tab label from the current route and the cached feed list
- keep custom-feed tab URLs canonical to feed ids while still resolving labels from either id or slug routes
- fall back to a readable slug only when a custom feed name is unavailable

Closes ENG-1247

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1247-mobile-navigation-shows.preview.app.daily.dev