### PR TITLE
fix: unblock sitemap fetching in robots.txt

### DIFF
--- a/packages/webapp/public/robots.txt
+++ b/packages/webapp/public/robots.txt
@@ -58,17 +58,17 @@ Allow: /
 # All other crawlers
 User-agent: *
 Allow: /
-Allow: /api/sitemaps/
 Disallow: /join
 Disallow: /error
 Disallow: /callback
 Disallow: /helloworld
 Disallow: /helloworld/
 Disallow: /welcome
-Disallow: /api/
+Disallow: /api/r/
 
-# Sitemap index
+# Sitemap indexes
 Sitemap: https://app.daily.dev/sitemap.xml
+Sitemap: https://app.daily.dev/api/sitemaps/index.xml
 
 # LLM-friendly documentation
 # https://app.daily.dev/llms.txt


### PR DESCRIPTION
## Summary
- Replace broad `Disallow: /api/` with specific `Disallow: /api/r/` (redirector only)
- Add API sitemap index as second `Sitemap:` directive
- The broad `/api/` disallow was preventing Google from fetching sitemaps at `/api/sitemaps/`

## Context
All API sitemaps show "Couldn't fetch" in Google Search Console. The `Disallow: /api/` rule was originally added to prevent redirector pages from being indexed, but it also blocks sitemap fetching. Narrowing it to `/api/r/` keeps the redirector blocked while unblocking sitemaps.

Companion PR: dailydotdev/daily-api#3785

## Test plan
- [ ] Verify Google Search Console shows sitemaps as fetchable after deploy
- [ ] Verify `/api/r/` URLs are still blocked by robots.txt

### Preview domain
https://fix-robots-txt-sitemaps.preview.app.daily.dev