### PR TITLE
feat: add global best-of archive pages and explore tab

### DIFF
--- a/packages/shared/src/components/archive/ArchiveEntryCard.tsx
+++ b/packages/shared/src/components/archive/ArchiveEntryCard.tsx
@@ -2,13 +2,12 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import { useQuery } from '@tanstack/react-query';
-import type { ArchiveIndexData } from '../../graphql/archive';
+import type { ArchiveIndexData, ArchiveScopeType } from '../../graphql/archive';
 import {
   ARCHIVE_INDEX_QUERY,
   ArchiveRankingType,
   ArchiveSubjectType,
 } from '../../graphql/archive';
-import type { ArchiveScopeInfo } from '../../lib/archive';
 import {
   getArchiveIndexUrl,
   getArchiveTitle,
@@ -20,7 +19,9 @@ import Link from '../utilities/Link';
 import { ArrowIcon } from '../icons';
 import { IconSize } from '../Icon';
 
-interface ArchiveEntryCardProps extends ArchiveScopeInfo {
+interface ArchiveEntryCardProps {
+  scopeType: ArchiveScopeType.Tag | ArchiveScopeType.Source;
+  scopeId: string;
   scopeName: string;
   className?: string;
 }

--- a/packages/shared/src/components/archive/ArchiveFeedPage.tsx
+++ b/packages/shared/src/components/archive/ArchiveFeedPage.tsx
@@ -12,7 +12,9 @@ import Link from '../utilities/Link';
 import { ArrowIcon } from '../icons';
 import { IconSize } from '../Icon';
 
-interface ArchiveFeedPageProps extends ArchiveScopeInfo {
+interface ArchiveFeedPageProps {
+  scopeType: ArchiveScopeInfo['scopeType'];
+  scopeId?: string;
   archive: Archive | null;
   scopeName: string;
   periodType: ArchivePeriodType;
@@ -88,7 +90,10 @@ export function ArchiveFeedPage({
         ? new Date(Date.UTC(year, month - 1, 1)).toISOString()
         : new Date(Date.UTC(year, 0, 1)).toISOString(),
   });
-  const indexUrl = getArchiveIndexUrl({ scopeType, scopeId });
+  const indexUrl = getArchiveIndexUrl({
+    scopeType,
+    scopeId,
+  } as ArchiveScopeInfo);
   const items = archive?.items ?? [];
 
   return (

--- a/packages/shared/src/components/archive/ArchiveIndexPage.tsx
+++ b/packages/shared/src/components/archive/ArchiveIndexPage.tsx
@@ -14,7 +14,9 @@ import { ArrowIcon } from '../icons';
 import { IconSize } from '../Icon';
 import { ElementPlaceholder } from '../ElementPlaceholder';
 
-interface ArchiveIndexPageProps extends ArchiveScopeInfo {
+interface ArchiveIndexPageProps {
+  scopeType: ArchiveScopeInfo['scopeType'];
+  scopeId?: string;
   archives: Archive[];
   scopeName: string;
   isLoading?: boolean;
@@ -28,10 +30,13 @@ function ArchiveMonthCard({
 }: {
   archive: Archive;
   scopeType: ArchiveScopeInfo['scopeType'];
-  scopeId: string;
+  scopeId?: string;
 }): ReactElement {
   const { month } = parseArchivePeriod(archive.periodStart);
-  const url = getArchiveUrlFromArchive({ scopeType, scopeId }, archive);
+  const url = getArchiveUrlFromArchive(
+    { scopeType, scopeId } as ArchiveScopeInfo,
+    archive,
+  );
   const itemCount = archive.items?.length;
 
   return (
@@ -57,9 +62,12 @@ function ArchiveYearLink({
 }: {
   archive: Archive;
   scopeType: ArchiveScopeInfo['scopeType'];
-  scopeId: string;
+  scopeId?: string;
 }): ReactElement {
-  const url = getArchiveUrlFromArchive({ scopeType, scopeId }, archive);
+  const url = getArchiveUrlFromArchive(
+    { scopeType, scopeId } as ArchiveScopeInfo,
+    archive,
+  );
 
   return (
     <Link href={url} prefetch={false}>
@@ -82,7 +90,7 @@ function ArchiveGrid({
 }: {
   groups: ArchivesByYear[];
   scopeType: ArchiveScopeInfo['scopeType'];
-  scopeId: string;
+  scopeId?: string;
   isLoading?: boolean;
 }): ReactElement {
   if (isLoading) {

--- a/packages/shared/src/components/archive/ArchiveNavigation.tsx
+++ b/packages/shared/src/components/archive/ArchiveNavigation.tsx
@@ -8,7 +8,9 @@ import type { Archive } from '../../graphql/archive';
 import type { ArchiveScopeInfo } from '../../lib/archive';
 import { getArchiveTitle, getArchiveUrlFromArchive } from '../../lib/archive';
 
-interface ArchiveNavigationProps extends ArchiveScopeInfo {
+interface ArchiveNavigationProps {
+  scopeType: ArchiveScopeInfo['scopeType'];
+  scopeId?: string;
   prev?: Archive | null;
   next?: Archive | null;
   className?: string;
@@ -25,7 +27,7 @@ export function ArchiveNavigation({
     return null;
   }
 
-  const scope = { scopeType, scopeId };
+  const scope = { scopeType, scopeId } as ArchiveScopeInfo;
 
   return (
     <nav

--- a/packages/shared/src/components/header/FeedExploreHeader.tsx
+++ b/packages/shared/src/components/header/FeedExploreHeader.tsx
@@ -20,6 +20,7 @@ export enum ExploreTabs {
   MostUpvoted = 'By upvotes',
   BestDiscussions = 'By comments',
   ByDate = 'By date',
+  BestOf = 'Best of',
 }
 
 export const tabsToFeedMap: Partial<Record<OtherFeedPage, ExploreTabs>> = {
@@ -34,6 +35,7 @@ export const urlToTab: Record<string, ExploreTabs> = {
   [`/${OtherFeedPage.Explore}/upvoted`]: ExploreTabs.MostUpvoted,
   [`/${OtherFeedPage.Explore}/discussed`]: ExploreTabs.BestDiscussions,
   [`/${OtherFeedPage.Explore}/latest`]: ExploreTabs.ByDate,
+  [`/${OtherFeedPage.Explore}/best-of`]: ExploreTabs.BestOf,
 };
 
 export const tabToUrl = Object.entries(urlToTab).reduce(

--- a/packages/shared/src/lib/archive.ts
+++ b/packages/shared/src/lib/archive.ts
@@ -2,10 +2,15 @@ import { format, getMonth, getYear } from 'date-fns';
 import type { Archive, ArchiveItem } from '../graphql/archive';
 import { ArchivePeriodType, ArchiveScopeType } from '../graphql/archive';
 
-export type ArchiveScopeInfo = {
-  scopeType: ArchiveScopeType.Tag | ArchiveScopeType.Source;
-  scopeId: string;
-};
+export type ArchiveScopeInfo =
+  | {
+      scopeType: ArchiveScopeType.Tag | ArchiveScopeType.Source;
+      scopeId: string;
+    }
+  | {
+      scopeType: ArchiveScopeType.Global;
+      scopeId?: undefined;
+    };
 
 export function getMonthName(month: number, short = false): string {
   return format(new Date(2000, month - 1, 1), short ? 'MMM' : 'MMMM');
@@ -40,6 +45,10 @@ export function getArchiveTitle(archive: {
 }
 
 function getScopeBasePath(scope: ArchiveScopeInfo): string {
+  if (scope.scopeType === ArchiveScopeType.Global) {
+    return '/posts/best-of';
+  }
+
   if (scope.scopeType === ArchiveScopeType.Tag) {
     return `/tags/${encodeURIComponent(scope.scopeId)}/best-of`;
   }

--- a/packages/webapp/pages/posts/best-of/[year].tsx
+++ b/packages/webapp/pages/posts/best-of/[year].tsx
@@ -1,0 +1,222 @@
+import type {
+  GetStaticPathsResult,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import Head from 'next/head';
+import type { ParsedUrlQuery } from 'querystring';
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { NextSeoProps } from 'next-seo/lib/types';
+import type {
+  Archive,
+  ArchiveData,
+  ArchiveIndexData,
+} from '@dailydotdev/shared/src/graphql/archive';
+import {
+  ARCHIVE_INDEX_QUERY,
+  ARCHIVE_QUERY,
+  ArchivePeriodType,
+  ArchiveRankingType,
+  ArchiveScopeType,
+  ArchiveSubjectType,
+} from '@dailydotdev/shared/src/graphql/archive';
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import { PageWrapperLayout } from '@dailydotdev/shared/src/components/layout/PageWrapperLayout';
+import { ArchiveFeedPage } from '@dailydotdev/shared/src/components/archive/ArchiveFeedPage';
+import { ArchiveBreadcrumbs } from '@dailydotdev/shared/src/components/archive/ArchiveBreadcrumbs';
+import {
+  buildArchiveItemListJsonLd,
+  buildBreadcrumbListJsonLd,
+  findAdjacentArchives,
+  getArchiveDescription,
+  getArchiveUrlFromArchive,
+} from '@dailydotdev/shared/src/lib/archive';
+import { getLayout as getFooterNavBarLayout } from '../../../components/layouts/FooterNavBarLayout';
+import { getLayout } from '../../../components/layouts/MainLayout';
+import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
+import { getPageSeoTitles } from '../../../components/layouts/utils';
+import { getAppOrigin } from '../../../lib/seo';
+
+const appOrigin = getAppOrigin();
+const scopeName = 'daily.dev';
+const scope = { scopeType: ArchiveScopeType.Global as const };
+
+interface PageProps {
+  year: number;
+  archive: Archive | null;
+  prev: Archive | null;
+  next: Archive | null;
+  seo: NextSeoProps;
+}
+
+interface PageParams extends ParsedUrlQuery {
+  year: string;
+}
+
+function getJsonLd({
+  year,
+  archive,
+}: Pick<PageProps, 'year' | 'archive'>): string {
+  const pageUrl = `${appOrigin}/posts/best-of/${year}`;
+
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'CollectionPage',
+        '@id': `${pageUrl}#page`,
+        url: pageUrl,
+        name: `Best Developer Posts of ${year}`,
+        description: getArchiveDescription(
+          scopeName,
+          ArchivePeriodType.Year,
+          year,
+        ),
+        isPartOf: { '@type': 'WebSite', url: appOrigin },
+      },
+      ...buildArchiveItemListJsonLd(pageUrl, archive?.items),
+      buildBreadcrumbListJsonLd([
+        { name: 'Home', item: appOrigin },
+        { name: 'Explore', item: `${appOrigin}/posts` },
+        { name: 'Best of', item: `${appOrigin}/posts/best-of` },
+        { name: String(year) },
+      ]),
+    ],
+  });
+}
+
+const GlobalYearlyArchivePage = ({
+  year,
+  archive,
+  prev,
+  next,
+}: PageProps): ReactElement => {
+  const jsonLd = getJsonLd({ year, archive });
+
+  return (
+    <PageWrapperLayout>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: jsonLd }}
+        />
+        {prev && (
+          <link
+            rel="prev"
+            href={`${appOrigin}${getArchiveUrlFromArchive(scope, prev)}`}
+          />
+        )}
+        {next && (
+          <link
+            rel="next"
+            href={`${appOrigin}${getArchiveUrlFromArchive(scope, next)}`}
+          />
+        )}
+      </Head>
+      <ArchiveBreadcrumbs
+        items={[
+          { label: 'Explore', href: '/posts' },
+          { label: 'Best of', href: '/posts/best-of' },
+          { label: String(year) },
+        ]}
+      />
+      <ArchiveFeedPage
+        archive={archive}
+        scopeType={ArchiveScopeType.Global}
+        scopeName={scopeName}
+        periodType={ArchivePeriodType.Year}
+        year={year}
+        prev={prev}
+        next={next}
+      />
+    </PageWrapperLayout>
+  );
+};
+
+const getPageLayout: typeof getLayout = (...props) =>
+  getFooterNavBarLayout(getLayout(...props));
+
+GlobalYearlyArchivePage.getLayout = getPageLayout;
+GlobalYearlyArchivePage.layoutProps = {
+  screenCentered: false,
+};
+
+export default GlobalYearlyArchivePage;
+
+export async function getStaticPaths(): Promise<GetStaticPathsResult> {
+  return { paths: [], fallback: 'blocking' };
+}
+
+export async function getStaticProps({
+  params,
+}: GetStaticPropsContext<PageParams>): Promise<
+  GetStaticPropsResult<PageProps>
+> {
+  const yearStr = params?.year;
+
+  if (!yearStr) {
+    return { notFound: true, revalidate: 3600 };
+  }
+
+  const year = parseInt(yearStr, 10);
+
+  if (Number.isNaN(year) || year < 2000 || year > 2100) {
+    return { notFound: true, revalidate: 3600 };
+  }
+
+  try {
+    const [archiveResult, indexResult] = await Promise.all([
+      gqlClient.request<ArchiveData>(ARCHIVE_QUERY, {
+        subjectType: ArchiveSubjectType.Post,
+        rankingType: ArchiveRankingType.Best,
+        scopeType: ArchiveScopeType.Global,
+        periodType: ArchivePeriodType.Year,
+        year,
+      }),
+      gqlClient.request<ArchiveIndexData>(ARCHIVE_INDEX_QUERY, {
+        subjectType: ArchiveSubjectType.Post,
+        rankingType: ArchiveRankingType.Best,
+        scopeType: ArchiveScopeType.Global,
+        periodType: ArchivePeriodType.Year,
+      }),
+    ]);
+
+    const archive = archiveResult?.archive ?? null;
+
+    if (!archive) {
+      return { notFound: true, revalidate: 3600 };
+    }
+
+    const { prev, next } = findAdjacentArchives(
+      indexResult?.archiveIndex ?? [],
+      archive.periodStart,
+      ArchivePeriodType.Year,
+    );
+
+    const seoTitles = getPageSeoTitles(`Best developer posts of ${year}`);
+    const seo: NextSeoProps = {
+      ...defaultSeo,
+      ...seoTitles,
+      openGraph: { ...defaultOpenGraph, ...seoTitles.openGraph },
+      description: getArchiveDescription(
+        scopeName,
+        ArchivePeriodType.Year,
+        year,
+      ),
+    };
+
+    return {
+      props: {
+        year,
+        archive,
+        prev: prev ?? null,
+        next: next ?? null,
+        seo,
+      },
+      revalidate: 3600,
+    };
+  } catch {
+    return { notFound: true, revalidate: 3600 };
+  }
+}

--- a/packages/webapp/pages/posts/best-of/[year]/[month].tsx
+++ b/packages/webapp/pages/posts/best-of/[year]/[month].tsx
@@ -1,0 +1,247 @@
+import type {
+  GetStaticPathsResult,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import Head from 'next/head';
+import type { ParsedUrlQuery } from 'querystring';
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { NextSeoProps } from 'next-seo/lib/types';
+import type {
+  Archive,
+  ArchiveData,
+  ArchiveIndexData,
+} from '@dailydotdev/shared/src/graphql/archive';
+import {
+  ARCHIVE_INDEX_QUERY,
+  ARCHIVE_QUERY,
+  ArchivePeriodType,
+  ArchiveRankingType,
+  ArchiveScopeType,
+  ArchiveSubjectType,
+} from '@dailydotdev/shared/src/graphql/archive';
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import { PageWrapperLayout } from '@dailydotdev/shared/src/components/layout/PageWrapperLayout';
+import { ArchiveFeedPage } from '@dailydotdev/shared/src/components/archive/ArchiveFeedPage';
+import { ArchiveBreadcrumbs } from '@dailydotdev/shared/src/components/archive/ArchiveBreadcrumbs';
+import {
+  buildArchiveItemListJsonLd,
+  buildBreadcrumbListJsonLd,
+  findAdjacentArchives,
+  getArchiveDescription,
+  getArchiveUrlFromArchive,
+  getMonthName,
+  padMonth,
+} from '@dailydotdev/shared/src/lib/archive';
+import { getLayout as getFooterNavBarLayout } from '../../../../components/layouts/FooterNavBarLayout';
+import { getLayout } from '../../../../components/layouts/MainLayout';
+import { defaultOpenGraph, defaultSeo } from '../../../../next-seo';
+import { getPageSeoTitles } from '../../../../components/layouts/utils';
+import { getAppOrigin } from '../../../../lib/seo';
+
+const appOrigin = getAppOrigin();
+const scopeName = 'daily.dev';
+const scope = { scopeType: ArchiveScopeType.Global as const };
+
+interface PageProps {
+  year: number;
+  month: number;
+  archive: Archive | null;
+  prev: Archive | null;
+  next: Archive | null;
+  seo: NextSeoProps;
+}
+
+interface PageParams extends ParsedUrlQuery {
+  year: string;
+  month: string;
+}
+
+function getJsonLd({
+  year,
+  month,
+  archive,
+}: Pick<PageProps, 'year' | 'month' | 'archive'>): string {
+  const monthName = getMonthName(month);
+  const pageUrl = `${appOrigin}/posts/best-of/${year}/${padMonth(month)}`;
+
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'CollectionPage',
+        '@id': `${pageUrl}#page`,
+        url: pageUrl,
+        name: `Best Developer Posts — ${monthName} ${year}`,
+        description: getArchiveDescription(
+          scopeName,
+          ArchivePeriodType.Month,
+          year,
+          month,
+        ),
+        isPartOf: { '@type': 'WebSite', url: appOrigin },
+      },
+      ...buildArchiveItemListJsonLd(pageUrl, archive?.items),
+      buildBreadcrumbListJsonLd([
+        { name: 'Home', item: appOrigin },
+        { name: 'Explore', item: `${appOrigin}/posts` },
+        { name: 'Best of', item: `${appOrigin}/posts/best-of` },
+        { name: `${monthName} ${year}` },
+      ]),
+    ],
+  });
+}
+
+const GlobalMonthlyArchivePage = ({
+  year,
+  month,
+  archive,
+  prev,
+  next,
+}: PageProps): ReactElement => {
+  const monthName = getMonthName(month);
+  const jsonLd = getJsonLd({ year, month, archive });
+
+  return (
+    <PageWrapperLayout>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: jsonLd }}
+        />
+        {prev && (
+          <link
+            rel="prev"
+            href={`${appOrigin}${getArchiveUrlFromArchive(scope, prev)}`}
+          />
+        )}
+        {next && (
+          <link
+            rel="next"
+            href={`${appOrigin}${getArchiveUrlFromArchive(scope, next)}`}
+          />
+        )}
+      </Head>
+      <ArchiveBreadcrumbs
+        items={[
+          { label: 'Explore', href: '/posts' },
+          { label: 'Best of', href: '/posts/best-of' },
+          { label: `${monthName} ${year}` },
+        ]}
+      />
+      <ArchiveFeedPage
+        archive={archive}
+        scopeType={ArchiveScopeType.Global}
+        scopeName={scopeName}
+        periodType={ArchivePeriodType.Month}
+        year={year}
+        month={month}
+        prev={prev}
+        next={next}
+      />
+    </PageWrapperLayout>
+  );
+};
+
+const getPageLayout: typeof getLayout = (...props) =>
+  getFooterNavBarLayout(getLayout(...props));
+
+GlobalMonthlyArchivePage.getLayout = getPageLayout;
+GlobalMonthlyArchivePage.layoutProps = {
+  screenCentered: false,
+};
+
+export default GlobalMonthlyArchivePage;
+
+export async function getStaticPaths(): Promise<GetStaticPathsResult> {
+  return { paths: [], fallback: 'blocking' };
+}
+
+export async function getStaticProps({
+  params,
+}: GetStaticPropsContext<PageParams>): Promise<
+  GetStaticPropsResult<PageProps>
+> {
+  const yearStr = params?.year;
+  const monthStr = params?.month;
+
+  if (!yearStr || !monthStr) {
+    return { notFound: true, revalidate: 3600 };
+  }
+
+  const year = parseInt(yearStr, 10);
+  const month = parseInt(monthStr, 10);
+
+  if (
+    Number.isNaN(year) ||
+    Number.isNaN(month) ||
+    month < 1 ||
+    month > 12 ||
+    year < 2000 ||
+    year > 2100
+  ) {
+    return { notFound: true, revalidate: 3600 };
+  }
+
+  try {
+    const [archiveResult, indexResult] = await Promise.all([
+      gqlClient.request<ArchiveData>(ARCHIVE_QUERY, {
+        subjectType: ArchiveSubjectType.Post,
+        rankingType: ArchiveRankingType.Best,
+        scopeType: ArchiveScopeType.Global,
+        periodType: ArchivePeriodType.Month,
+        year,
+        month,
+      }),
+      gqlClient.request<ArchiveIndexData>(ARCHIVE_INDEX_QUERY, {
+        subjectType: ArchiveSubjectType.Post,
+        rankingType: ArchiveRankingType.Best,
+        scopeType: ArchiveScopeType.Global,
+        periodType: ArchivePeriodType.Month,
+      }),
+    ]);
+
+    const archive = archiveResult?.archive ?? null;
+
+    if (!archive) {
+      return { notFound: true, revalidate: 3600 };
+    }
+
+    const { prev, next } = findAdjacentArchives(
+      indexResult?.archiveIndex ?? [],
+      archive.periodStart,
+      ArchivePeriodType.Month,
+    );
+
+    const monthName = getMonthName(month);
+    const seoTitles = getPageSeoTitles(
+      `Best developer posts — ${monthName} ${year}`,
+    );
+    const seo: NextSeoProps = {
+      ...defaultSeo,
+      ...seoTitles,
+      openGraph: { ...defaultOpenGraph, ...seoTitles.openGraph },
+      description: getArchiveDescription(
+        scopeName,
+        ArchivePeriodType.Month,
+        year,
+        month,
+      ),
+    };
+
+    return {
+      props: {
+        year,
+        month,
+        archive,
+        prev: prev ?? null,
+        next: next ?? null,
+        seo,
+      },
+      revalidate: 3600,
+    };
+  } catch {
+    return { notFound: true, revalidate: 3600 };
+  }
+}

--- a/packages/webapp/pages/posts/best-of/index.tsx
+++ b/packages/webapp/pages/posts/best-of/index.tsx
@@ -1,0 +1,124 @@
+import type { GetStaticPropsResult } from 'next';
+import Head from 'next/head';
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { NextSeoProps } from 'next-seo/lib/types';
+import type {
+  Archive,
+  ArchiveIndexData,
+} from '@dailydotdev/shared/src/graphql/archive';
+import {
+  ARCHIVE_INDEX_QUERY,
+  ArchiveRankingType,
+  ArchiveScopeType,
+  ArchiveSubjectType,
+} from '@dailydotdev/shared/src/graphql/archive';
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import { PageWrapperLayout } from '@dailydotdev/shared/src/components/layout/PageWrapperLayout';
+import { ArchiveIndexPage } from '@dailydotdev/shared/src/components/archive/ArchiveIndexPage';
+import { ArchiveBreadcrumbs } from '@dailydotdev/shared/src/components/archive/ArchiveBreadcrumbs';
+import { buildBreadcrumbListJsonLd } from '@dailydotdev/shared/src/lib/archive';
+import { getLayout as getFooterNavBarLayout } from '../../../components/layouts/FooterNavBarLayout';
+import { getLayout } from '../../../components/layouts/MainLayout';
+import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
+import { getPageSeoTitles } from '../../../components/layouts/utils';
+import { getAppOrigin } from '../../../lib/seo';
+
+const appOrigin = getAppOrigin();
+const scopeName = 'daily.dev';
+
+interface PageProps {
+  archives: Archive[];
+  seo: NextSeoProps;
+}
+
+function getJsonLd(): string {
+  const pageUrl = `${appOrigin}/posts/best-of`;
+
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'CollectionPage',
+        '@id': `${pageUrl}#page`,
+        url: pageUrl,
+        name: `Best of ${scopeName} — Archive`,
+        description: `Browse the best developer posts by month and year, curated by the ${scopeName} community.`,
+        isPartOf: { '@type': 'WebSite', url: appOrigin },
+      },
+      buildBreadcrumbListJsonLd([
+        { name: 'Home', item: appOrigin },
+        { name: 'Explore', item: `${appOrigin}/posts` },
+        { name: 'Best of' },
+      ]),
+    ],
+  });
+}
+
+const GlobalArchiveIndexPage = ({ archives }: PageProps): ReactElement => {
+  const jsonLd = getJsonLd();
+
+  return (
+    <PageWrapperLayout>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: jsonLd }}
+        />
+      </Head>
+      <ArchiveBreadcrumbs
+        items={[{ label: 'Explore', href: '/posts' }, { label: 'Best of' }]}
+      />
+      <ArchiveIndexPage
+        archives={archives}
+        scopeType={ArchiveScopeType.Global}
+        scopeName={scopeName}
+      />
+    </PageWrapperLayout>
+  );
+};
+
+const getPageLayout: typeof getLayout = (...props) =>
+  getFooterNavBarLayout(getLayout(...props));
+
+GlobalArchiveIndexPage.getLayout = getPageLayout;
+GlobalArchiveIndexPage.layoutProps = {
+  screenCentered: false,
+};
+
+export default GlobalArchiveIndexPage;
+
+export async function getStaticProps(): Promise<
+  GetStaticPropsResult<PageProps>
+> {
+  try {
+    const indexResult = await gqlClient.request<ArchiveIndexData>(
+      ARCHIVE_INDEX_QUERY,
+      {
+        subjectType: ArchiveSubjectType.Post,
+        rankingType: ArchiveRankingType.Best,
+        scopeType: ArchiveScopeType.Global,
+      },
+    );
+
+    const archives = indexResult?.archiveIndex ?? [];
+
+    const seoTitles = getPageSeoTitles(`Best of ${scopeName} — Archive`);
+    const seo: NextSeoProps = {
+      ...defaultSeo,
+      ...seoTitles,
+      openGraph: { ...defaultOpenGraph, ...seoTitles.openGraph },
+      description: `Browse the best developer posts by month and year, curated by the ${scopeName} community.`,
+    };
+
+    return {
+      props: {
+        archives,
+        seo,
+      },
+      revalidate: 3600,
+    };
+  } catch {
+    return { notFound: true, revalidate: 3600 };
+  }
+}


### PR DESCRIPTION
## Summary
- Add global best-of archive pages at `/posts/best-of` (index, yearly, monthly) using `ArchiveScopeType.Global`, with SSG, JSON-LD structured data, and prev/next navigation
- Add "Best of" tab to the explore header navigation, linking to the archive index
- Extend `ArchiveScopeInfo` union type to support `Global` scope (no `scopeId`)

## Test plan
- [ ] Visit `/posts` and verify "Best of" tab appears in explore navigation
- [ ] Click "Best of" tab and confirm it navigates to `/posts/best-of`
- [ ] Verify archive index shows year/month grid
- [ ] Click a year/month entry and verify the archive feed page renders
- [ ] Verify breadcrumbs show "Explore > Best of > ..." on all archive pages
- [ ] Confirm existing tag/source best-of pages still work

### Preview domain
https://feat-global-best-of-archive.preview.app.daily.dev