### PR TITLE
fix(profile): align cores header counter with compact indicators

### DIFF
--- a/packages/shared/src/components/profile/ProfileButton.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.spec.tsx
@@ -192,5 +192,4 @@ it('should keep the cores counter styling aligned with the compact header indica
   renderComponent(user);
 
   expect(screen.getByText('100').closest('a')).toHaveClass('!typo-subhead');
-  expect(screen.getByText('100').closest('div')).toHaveClass('h-8');
 });

--- a/packages/shared/src/components/profile/ProfileButton.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.spec.tsx
@@ -179,3 +179,18 @@ it('should increment reward counters and animate impact on each hit', async () =
     }
   }
 });
+
+it('should keep the cores counter styling aligned with the compact header indicators', () => {
+  const user = {
+    ...defaultUser,
+    coresRole: CoresRole.User,
+    balance: {
+      amount: 100,
+    },
+  };
+
+  renderComponent(user);
+
+  expect(screen.getByText('100').closest('a')).toHaveClass('!typo-subhead');
+  expect(screen.getByText('100').closest('div')).toHaveClass('h-8');
+});

--- a/packages/shared/src/components/profile/ProfileButton.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.tsx
@@ -227,7 +227,7 @@ export default function ProfileButton({
             >
               <div
                 ref={coresCounterRef}
-                className="origin-center will-change-transform"
+                className="flex h-8 origin-center items-center will-change-transform"
               >
                 <Link href={walletUrl} passHref>
                   <Button
@@ -236,6 +236,7 @@ export default function ProfileButton({
                     tag="a"
                     variant={ButtonVariant.Tertiary}
                     size={ButtonSize.Small}
+                    className="!typo-subhead"
                   >
                     {largeNumberFormat(displayedBalance)}
                   </Button>

--- a/packages/shared/src/components/profile/ProfileButton.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.tsx
@@ -227,7 +227,7 @@ export default function ProfileButton({
             >
               <div
                 ref={coresCounterRef}
-                className="flex h-8 origin-center items-center will-change-transform"
+                className="origin-center will-change-transform"
               >
                 <Link href={walletUrl} passHref>
                   <Button


### PR DESCRIPTION
## Summary
- align the cores counter in the profile header with the daily streak and reputation indicators
- keep the implementation scoped to the compact header button styling
- add a regression test covering the compact cores counter presentation

## Key Decisions
- used a minimal typography override on the existing cores button instead of adding more layout wrappers
- kept verification focused on the impacted shared profile files

Closes ENG-1209

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1209-feedback-ux-issue-cores.preview.app.daily.dev