### PR TITLE
feat: add featured archives widget to post page sidebar

### DIFF
--- a/packages/shared/src/components/post/PostWidgets.tsx
+++ b/packages/shared/src/components/post/PostWidgets.tsx
@@ -14,6 +14,7 @@ import type { SourceTooltip } from '../../graphql/sources';
 import { SourceType } from '../../graphql/sources';
 import EntityCardSkeleton from '../cards/entity/EntityCardSkeleton';
 import { PostSidebarAdWidget } from './PostSidebarAdWidget';
+import { FeaturedArchives } from '../widgets/FeaturedArchives';
 
 const UserEntityCard = dynamic(
   /* webpackChunkName: "userEntityCard" */ () =>
@@ -102,6 +103,7 @@ export function PostWidgets({
         onCopyPostLink={onCopyPostLink}
       />
       {tokenRefreshed && <FurtherReading currentPost={post} />}
+      <FeaturedArchives postId={post.id} />
       <FooterLinks />
     </PageWidgets>
   );

--- a/packages/shared/src/components/post/SquadPostWidgets.tsx
+++ b/packages/shared/src/components/post/SquadPostWidgets.tsx
@@ -15,6 +15,7 @@ import SourceEntityCard from '../cards/entity/SourceEntityCard';
 import UserEntityCard from '../cards/entity/UserEntityCard';
 import type { UserShortProfile } from '../../lib/user';
 import { PostSidebarAdWidget } from './PostSidebarAdWidget';
+import { FeaturedArchives } from '../widgets/FeaturedArchives';
 
 export function SquadPostWidgets({
   onCopyPostLink,
@@ -76,6 +77,7 @@ export function SquadPostWidgets({
         </>
       )}
       {tokenRefreshed && <FurtherReading currentPost={post} />}
+      <FeaturedArchives postId={post.id} />
       <FooterLinks />
     </PageWidgets>
   );

--- a/packages/shared/src/components/post/collection/CollectionPostWidgets.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPostWidgets.tsx
@@ -9,6 +9,7 @@ import { PostRelationType } from '../../../graphql/posts';
 import type { PostWidgetsProps } from '../PostWidgets';
 import { FooterLinks } from '../../footer';
 import { PostSidebarAdWidget } from '../PostSidebarAdWidget';
+import { FeaturedArchives } from '../../widgets/FeaturedArchives';
 
 export const CollectionPostWidgets = ({
   onCopyPostLink,
@@ -34,6 +35,7 @@ export const CollectionPostWidgets = ({
         onCopyPostLink={onCopyPostLink}
         link={post.commentsPermalink}
       />
+      <FeaturedArchives postId={post.id} />
       <FooterLinks />
     </PageWidgets>
   );

--- a/packages/shared/src/components/widgets/FeaturedArchives.tsx
+++ b/packages/shared/src/components/widgets/FeaturedArchives.tsx
@@ -1,0 +1,164 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { FeaturedArchivesData } from '../../graphql/archive';
+import {
+  ArchivePeriodType,
+  ArchiveScopeType,
+  ArchiveSubjectType,
+  FEATURED_ARCHIVES_QUERY,
+} from '../../graphql/archive';
+import type { ArchiveScopeInfo } from '../../lib/archive';
+import {
+  getArchivePeriodLabel,
+  getArchiveUrlFromArchive,
+  getArchiveIndexUrl,
+} from '../../lib/archive';
+import { gqlClient } from '../../graphql/common';
+import { RequestKey, StaleTime } from '../../lib/query';
+import Link from '../utilities/Link';
+import { ArrowIcon } from '../icons';
+import { MedalIcon } from '../icons/Medal';
+import { IconSize } from '../Icon';
+import { WidgetContainer } from './common';
+
+interface FeaturedArchivesProps {
+  postId: string;
+  className?: string;
+}
+
+const MAX_VISIBLE = 3;
+
+type FeaturedArchive = FeaturedArchivesData['featuredArchives'][number];
+
+function getScopeInfo(
+  scopeType: ArchiveScopeType,
+  scopeId: string | null,
+): ArchiveScopeInfo {
+  if (scopeType === ArchiveScopeType.Global) {
+    return { scopeType: ArchiveScopeType.Global };
+  }
+
+  return {
+    scopeType: scopeType as ArchiveScopeType.Tag | ArchiveScopeType.Source,
+    scopeId: scopeId!,
+  };
+}
+
+function getArchiveLabel(archive: FeaturedArchive): string {
+  if (archive.scopeType === ArchiveScopeType.Tag) {
+    return archive.keyword?.flags?.title || archive.keyword?.value || 'Tag';
+  }
+
+  if (archive.scopeType === ArchiveScopeType.Source) {
+    return archive.source?.name || 'Source';
+  }
+
+  return 'Global';
+}
+
+const SCOPE_PRIORITY: Record<ArchiveScopeType, number> = {
+  [ArchiveScopeType.Global]: 0,
+  [ArchiveScopeType.Tag]: 1,
+  [ArchiveScopeType.Source]: 2,
+};
+
+const PERIOD_PRIORITY: Record<ArchivePeriodType, number> = {
+  [ArchivePeriodType.Year]: 0,
+  [ArchivePeriodType.Month]: 1,
+};
+
+function sortArchives(archives: FeaturedArchive[]): FeaturedArchive[] {
+  return [...archives].sort((a, b) => {
+    const periodDiff =
+      PERIOD_PRIORITY[a.periodType] - PERIOD_PRIORITY[b.periodType];
+
+    if (periodDiff !== 0) {
+      return periodDiff;
+    }
+
+    return SCOPE_PRIORITY[a.scopeType] - SCOPE_PRIORITY[b.scopeType];
+  });
+}
+
+export function FeaturedArchives({
+  postId,
+  className,
+}: FeaturedArchivesProps): ReactElement | null {
+  const { data } = useQuery({
+    queryKey: [RequestKey.FeaturedArchives, postId],
+    queryFn: () =>
+      gqlClient.request<FeaturedArchivesData>(FEATURED_ARCHIVES_QUERY, {
+        subjectType: ArchiveSubjectType.Post,
+        subjectId: postId,
+      }),
+    staleTime: StaleTime.OneHour,
+  });
+
+  const archives = data?.featuredArchives;
+
+  if (!archives || archives.length === 0) {
+    return null;
+  }
+
+  const sorted = sortArchives(archives);
+  const visible = sorted.slice(0, MAX_VISIBLE);
+  const hidden = sorted.slice(MAX_VISIBLE);
+
+  return (
+    <WidgetContainer className={className}>
+      <div className="flex items-center gap-2 border-b border-border-subtlest-tertiary px-4 py-3">
+        <MedalIcon size={IconSize.Small} className="text-text-tertiary" />
+        <h4 className="font-bold text-text-primary typo-callout">Best of</h4>
+      </div>
+      <div className="flex flex-col">
+        {visible.map((archive) => {
+          const scope = getScopeInfo(archive.scopeType, archive.scopeId);
+          const url = getArchiveUrlFromArchive(scope, archive);
+          const label = getArchiveLabel(archive);
+          const date = getArchivePeriodLabel(archive);
+
+          return (
+            <Link key={archive.id} href={url} prefetch={false}>
+              <a className="flex items-center justify-between gap-2 px-4 py-3 transition-colors hover:bg-surface-hover">
+                <span className="break-words text-text-primary typo-callout">
+                  {label} - {date}
+                </span>
+                <ArrowIcon
+                  className="shrink-0 rotate-90 text-text-quaternary"
+                  size={IconSize.Small}
+                />
+              </a>
+            </Link>
+          );
+        })}
+      </div>
+      {hidden.length > 0 && (
+        <nav aria-label="More archive links" className="sr-only">
+          {hidden.map((archive) => {
+            const scope = getScopeInfo(archive.scopeType, archive.scopeId);
+            const url = getArchiveUrlFromArchive(scope, archive);
+            const label = getArchiveLabel(archive);
+            const date = getArchivePeriodLabel(archive);
+
+            return (
+              <Link key={archive.id} href={url} prefetch={false}>
+                <a>
+                  {label} - {date}
+                </a>
+              </Link>
+            );
+          })}
+        </nav>
+      )}
+      <Link
+        href={getArchiveIndexUrl({ scopeType: ArchiveScopeType.Global })}
+        prefetch={false}
+      >
+        <a className="flex items-center justify-center border-t border-border-subtlest-tertiary px-4 py-3 text-text-tertiary transition-colors typo-callout hover:text-text-primary">
+          Explore all archives
+        </a>
+      </Link>
+    </WidgetContainer>
+  );
+}

--- a/packages/shared/src/graphql/archive.ts
+++ b/packages/shared/src/graphql/archive.ts
@@ -48,6 +48,10 @@ export interface ArchiveIndexData {
   archiveIndex: Archive[];
 }
 
+export interface FeaturedArchivesData {
+  featuredArchives: Archive[];
+}
+
 export const ARCHIVE_QUERY = gql`
   query Archive(
     $subjectType: String!
@@ -116,6 +120,27 @@ export const ARCHIVE_QUERY = gql`
             permalink
           }
         }
+      }
+    }
+  }
+`;
+
+export const FEATURED_ARCHIVES_QUERY = gql`
+  query FeaturedArchives($subjectType: String!, $subjectId: String!) {
+    featuredArchives(subjectType: $subjectType, subjectId: $subjectId) {
+      id
+      scopeType
+      scopeId
+      periodType
+      periodStart
+      keyword {
+        value
+        flags {
+          title
+        }
+      }
+      source {
+        name
       }
     }
   }

--- a/packages/shared/src/lib/archive.ts
+++ b/packages/shared/src/lib/archive.ts
@@ -31,17 +31,24 @@ export function parseArchivePeriod(periodStart: string | Date): {
   };
 }
 
-export function getArchiveTitle(archive: {
+export function getArchivePeriodLabel(archive: {
   periodType: ArchivePeriodType;
   periodStart: string | Date;
 }): string {
   const { year, month } = parseArchivePeriod(archive.periodStart);
 
   if (archive.periodType === ArchivePeriodType.Month) {
-    return `Best of ${getMonthName(month)} ${year}`;
+    return `${getMonthName(month)} ${year}`;
   }
 
-  return `Best of ${year}`;
+  return `${year}`;
+}
+
+export function getArchiveTitle(archive: {
+  periodType: ArchivePeriodType;
+  periodStart: string | Date;
+}): string {
+  return `Best of ${getArchivePeriodLabel(archive)}`;
 }
 
 function getScopeBasePath(scope: ArchiveScopeInfo): string {

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -192,6 +192,7 @@ export enum RequestKey {
   TagsBestDiscussed = 'tagsBestDiscussed',
   Archive = 'archive',
   ArchiveIndex = 'archiveIndex',
+  FeaturedArchives = 'featuredArchives',
   UserCompanies = 'user_companies',
   PostCodeSnippets = 'post_code_snippets',
   ContentPreference = 'content_preference',


### PR DESCRIPTION
## Summary
- Add a **Featured Archives** sidebar widget to all post types (article, squad, collection, poll, social)
- Shows top 3 archives a post is featured in, prioritized: yearly > monthly, global > tags > sources
- Remaining archive links rendered as `sr-only` for SEO crawlability
- New `featuredArchives` GraphQL query and `getArchivePeriodLabel` utility

## Test plan
- [ ] Verify widget appears on article post pages with featured archives
- [ ] Verify widget does not render on posts without archives
- [ ] Verify widget appears on squad, collection, and poll post pages
- [ ] Verify archive links navigate to correct archive pages
- [ ] Verify hidden SEO links are present in DOM but not visible

### Preview domain
https://feat-featured-archives-post-widg.preview.app.daily.dev