### PR TITLE
fix: limit highest level leaderboard to top 10 on homepage

### DIFF
--- a/packages/webapp/pages/users.tsx
+++ b/packages/webapp/pages/users.tsx
@@ -201,7 +201,7 @@ export async function getStaticProps(): Promise<
     try {
       const levelRes = await gqlClient.request<{
         highestLevel: UserLeaderboard[];
-      }>(HIGHEST_LEVEL_QUERY);
+      }>(HIGHEST_LEVEL_QUERY, { limit: 10 });
       highestLevel = levelRes.highestLevel ?? [];
       isHighestLevelSupported = true;
     } catch (levelError: unknown) {


### PR DESCRIPTION
## Summary
- Pass `{ limit: 10 }` to `HIGHEST_LEVEL_QUERY` in the homepage `getStaticProps` so the "Highest level" card shows only 10 entries, consistent with all other leaderboard cards on `/users`
- The query already accepts a `$limit` variable (defaulting to 100 for the detail page), so this is a single-variable override at the call site — no query or backend changes needed
- The detail page (`/users/highestLevel`) is unaffected and continues to show up to 100 entries

## Test plan
- [ ] Load `/users` and confirm the "Highest level" card shows exactly 10 entries
- [ ] Load `/users/highestLevel` and confirm it still shows up to 100 entries

Closes ENG-1253

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1253-level-leaderboard-too-l.preview.app.daily.dev