### PR TITLE
fix: show shared post TLDR for share-type highlights

### DIFF
--- a/packages/shared/src/components/highlights/HighlightItem.spec.tsx
+++ b/packages/shared/src/components/highlights/HighlightItem.spec.tsx
@@ -13,6 +13,7 @@ const highlight: PostHighlightFeed = {
   highlightedAt: '2026-04-05T09:00:00.000Z',
   post: {
     id: 'post-1',
+    type: 'article',
     commentsPermalink: '/posts/post-1',
     summary,
   },

--- a/packages/shared/src/components/highlights/HighlightItem.tsx
+++ b/packages/shared/src/components/highlights/HighlightItem.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
 import type { PostHighlightFeed } from '../../graphql/highlights';
 import { stripHtmlTags } from '../../lib/strings';
+import { PostType } from '../../graphql/posts';
 import { ArrowIcon } from '../icons/Arrow';
 import { IconSize } from '../Icon';
 import Link from '../utilities/Link';
@@ -33,18 +34,23 @@ export const HighlightItem = ({
   }, [defaultExpanded]);
 
   const tldr = useMemo(() => {
-    const summary = highlight.post.summary?.trim();
+    const post =
+      highlight.post.type === PostType.Share && highlight.post.sharedPost
+        ? highlight.post.sharedPost
+        : highlight.post;
+
+    const summary = post.summary?.trim();
     if (summary) {
       return summary;
     }
 
-    const html = highlight.post.contentHtml?.trim();
+    const html = post.contentHtml?.trim();
     if (html) {
       return stripHtmlTags(html).slice(0, 300);
     }
 
     return '';
-  }, [highlight.post.summary, highlight.post.contentHtml]);
+  }, [highlight.post]);
 
   return (
     <article ref={ref}>

--- a/packages/shared/src/graphql/highlights.ts
+++ b/packages/shared/src/graphql/highlights.ts
@@ -20,9 +20,14 @@ export interface PostHighlightFeed {
   highlightedAt: string;
   post: {
     id: string;
+    type: string;
     commentsPermalink: string;
     summary?: string;
     contentHtml?: string;
+    sharedPost?: {
+      summary?: string;
+      contentHtml?: string;
+    };
   };
 }
 
@@ -106,9 +111,14 @@ export const POST_HIGHLIGHT_FEED_FRAGMENT = gql`
     highlightedAt
     post {
       id
+      type
       commentsPermalink
       summary
       contentHtml
+      sharedPost {
+        summary
+        contentHtml
+      }
     }
   }
 `;


### PR DESCRIPTION
## Summary
- When a highlight refers to a share post, the TLDR was empty because we only fetched `summary`/`contentHtml` from the main post
- Updated the GraphQL fragment to also fetch `type` and `sharedPost { summary, contentHtml }`
- Updated `HighlightItem` to prefer the shared post's summary for share-type posts

## Test plan
- [ ] Open highlights page with a highlight that references a share post — TLDR should now display
- [ ] Highlights referencing regular posts should continue working as before

### Preview domain
https://fix-highlight-share-post-tldr.preview.app.daily.dev