### PR TITLE
fix(notifications): truncate X post attachment titles in notification list

### DIFF
--- a/packages/shared/src/components/notifications/NotificationItem.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.tsx
@@ -281,6 +281,7 @@ function NotificationItem(props: NotificationItemProps): ReactElement {
           <NotificationItemAttachment
             key={attachment}
             title={attachment}
+            notificationType={type}
             {...restAttachmentProps}
           />
         ))}

--- a/packages/shared/src/components/notifications/NotificationItem.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.tsx
@@ -90,7 +90,7 @@ const NotificationOptionsButton = ({
     });
   };
 
-  const Icon = (): ReactElement => {
+  const Icon = (): ReactElement | null => {
     if (!notification) {
       return null;
     }
@@ -109,7 +109,7 @@ const NotificationOptionsButton = ({
 
   const label = useMemo((): string => {
     if (!notification) {
-      return null;
+      return '';
     }
 
     if (isFetching) {
@@ -119,6 +119,10 @@ const NotificationOptionsButton = ({
     const isMuted =
       preferences[0]?.status === NotificationPreferenceStatus.Muted;
     const copy = notificationMutingCopy[notification?.type];
+
+    if (!copy) {
+      return '';
+    }
 
     return isMuted ? copy.unmute : copy.mute;
   }, [notification, preferences, isFetching]);
@@ -145,7 +149,7 @@ const NotificationOptionsButton = ({
   );
 };
 
-function NotificationItem(props: NotificationItemProps): ReactElement {
+function NotificationItem(props: NotificationItemProps): ReactElement | null {
   const {
     icon,
     type,
@@ -165,7 +169,7 @@ function NotificationItem(props: NotificationItemProps): ReactElement {
     isReady,
     title: memoizedTitle,
     description: memoizedDescription,
-  } = useObjectPurify({ title, description });
+  } = useObjectPurify({ title, description: description ?? '' });
   const router = useRouter();
   const isClickable = !notificationTypeNotClickable[type];
 

--- a/packages/shared/src/components/notifications/NotificationItemAttachment.tsx
+++ b/packages/shared/src/components/notifications/NotificationItemAttachment.tsx
@@ -1,15 +1,28 @@
 import type { ReactElement } from 'react';
 import React from 'react';
+import classNames from 'classnames';
 import type { NotificationAttachment } from '../../graphql/notifications';
 import { NotificationAttachmentType } from '../../graphql/notifications';
 import { IconSize } from '../Icon';
 import { CardCover } from '../cards/common/CardCover';
+import { NotificationType } from './utils';
+
+interface NotificationItemAttachmentProps extends NotificationAttachment {
+  notificationType?: NotificationType;
+}
+
+const truncatedNotificationTypes = new Set([
+  NotificationType.SourcePostAdded,
+  NotificationType.UserPostAdded,
+  NotificationType.SquadPostAdded,
+]);
 
 function NotificationItemAttachment({
   image,
   title,
   type,
-}: NotificationAttachment): ReactElement {
+  notificationType,
+}: NotificationItemAttachmentProps): ReactElement {
   return (
     <div className="mt-2 flex flex-row items-center rounded-16 border border-border-subtlest-tertiary p-4">
       <div>
@@ -25,7 +38,16 @@ function NotificationItemAttachment({
           videoProps={{ size: IconSize.XLarge }}
         />
       </div>
-      <span className="ml-4 flex-1 break-words typo-callout">{title}</span>
+      <span
+        className={classNames(
+          'ml-4 flex-1 break-words typo-callout',
+          notificationType &&
+            truncatedNotificationTypes.has(notificationType) &&
+            'multi-truncate line-clamp-3',
+        )}
+      >
+        {title}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Apply CSS `line-clamp-3` truncation to notification attachment titles for `SourcePostAdded`, `UserPostAdded`, and `SquadPostAdded` notification types
- Thread `notificationType` prop from `NotificationItem` down to `NotificationItemAttachment` to enable conditional styling
- Uses the existing `multi-truncate line-clamp-3` pattern already established in `InAppNotificationItem` and social card components

## Key decisions
- **Scoped by notification type, not post type**: The notification attachment model doesn't carry `PostType`, so we scope by the three notification types that can produce X post attachments. For non-X posts under these types, article titles are naturally short and won't hit the 3-line clamp.
- **CSS-only approach**: Retroactively fixes all existing notifications. Full text preserved in DOM for accessibility. No backend/schema changes needed.
- **`line-clamp-3`**: Matches the existing `InAppNotificationItem` pattern (~3 visible lines).

## Test plan
- [x] All 14 existing `NotificationItem.spec.tsx` tests pass
- [ ] Manual QA: verify X post notification attachments truncate to ~3 lines with ellipsis
- [ ] Manual QA: verify other notification type attachments are unaffected

Closes ENG-1258

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1258-truncate-x-notification.preview.app.daily.dev