### PR TITLE
fix: prevent empty image object from being sent in freeform post creation

### DIFF
--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -960,12 +960,17 @@ export type CreatePostInMultipleSourcesResponse = Array<{
 export const createPostInMultipleSources = async (
   variables: CreatePostInMultipleSourcesArgs,
 ) => {
+  const { image, ...rest } = variables;
+  const sanitized = {
+    ...rest,
+    ...(image instanceof File && image.size > 0 ? { image } : {}),
+  };
   const res = await gqlClient.request<
     {
       createPostInMultipleSources: CreatePostInMultipleSourcesResponse;
     },
     CreatePostInMultipleSourcesArgs
-  >(CREATE_POST_IN_MULTIPLE_SOURCES, variables);
+  >(CREATE_POST_IN_MULTIPLE_SOURCES, sanitized);
   return res.createPostInMultipleSources;
 };
 

--- a/packages/webapp/pages/squads/create.tsx
+++ b/packages/webapp/pages/squads/create.tsx
@@ -182,10 +182,11 @@ function CreatePost(): ReactElement {
       return;
     }
 
-    const { options, ...args } = params;
+    const { options, image, ...args } = params;
 
     await onCreate({
       ...args,
+      ...(image instanceof File && image.size > 0 && { image }),
       ...(options?.length && {
         options: options.map((text, order) => ({
           text,


### PR DESCRIPTION
## Problem

When creating a freeform post without a thumbnail image, the `image` field is sent as an empty object `{}` in the GraphQL variables. `graphql-request` v3 serializes `File` objects as `{}` in JSON since `File` has no enumerable own properties. The API receives this `{}`, enters the Cloudinary upload path (because `{}` is truthy), tries to call `createReadStream()` on it, and crashes with **"Unexpected error"**.

Reported in dailydotdev/daily#2095.

## Fix

Strip the `image` field from the mutation variables unless it is a valid `File` instance with non-zero size:

1. **`packages/webapp/pages/squads/create.tsx`** — destructure `image` out of params and only spread it back when valid
2. **`packages/shared/src/graphql/posts.ts`** — defensive sanitization in `createPostInMultipleSources()` before sending the request

## Testing

- Create a freeform post without selecting a thumbnail → should succeed (no Unexpected error)
- Create a freeform post with a thumbnail image → should still upload correctly

### Preview domain
https://fix-empty-image-object-freeform.preview.app.daily.dev