### PR TITLE
chore: remove unused sso preconnect

### DIFF
--- a/packages/extension/views/companion.html
+++ b/packages/extension/views/companion.html
@@ -7,7 +7,6 @@
     <link rel="icon" href="/icons/action_32.png" />
     <title>Companion</title>
     <link rel="preconnect" href="https://api.daily.dev" />
-    <link rel="preconnect" href="https://sso.daily.dev" />
     <link rel="preconnect" href="https://media.daily.dev" />
   </head>
   <body class='companion'>

--- a/packages/extension/views/newtab.html
+++ b/packages/extension/views/newtab.html
@@ -7,7 +7,6 @@
   <link rel='icon' href='/icons/action_32.png'>
   <title>New Tab</title>
   <link rel="preconnect" href="https://api.daily.dev" />
-  <link rel="preconnect" href="https://sso.daily.dev" />
   <link rel="preconnect" href="https://media.daily.dev" />
 </head>
 <body class="font-sans">

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -328,7 +328,6 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
           />
 
           <link rel="preconnect" href="https://api.daily.dev" />
-          <link rel="preconnect" href="https://sso.daily.dev" />
           <link rel="preconnect" href="https://media.daily.dev" />
         </Head>
         <DefaultSeo


### PR DESCRIPTION
## Summary
- remove the unused sso.daily.dev preconnect from the webapp head
- remove the same unused preconnect from the extension newtab and companion shells

## Testing
- node ./scripts/typecheck-strict-changed.js

### Preview domain
https://codex-remove-sso-preconnect.preview.app.daily.dev