### PR TITLE
refactor: reorganize settings navigation labels

### DIFF
--- a/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
+++ b/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
@@ -22,9 +22,9 @@ import {
   InviteIcon,
   MagicIcon,
   MailIcon,
+  EyeIcon,
   NewTabIcon,
   PhoneIcon,
-  PinIcon,
   ReputationLightningIcon,
   ExitIcon,
   OrganizationIcon,
@@ -33,7 +33,6 @@ import {
   TerminalIcon,
   TourIcon,
   FeatherIcon,
-  GiftIcon,
   JoystickIcon,
 } from '../icons';
 import { NavDrawer } from '../drawers/NavDrawer';
@@ -41,7 +40,6 @@ import {
   appsUrl,
   businessWebsiteUrl,
   docs,
-  feedback,
   reputation,
   settingsUrl,
   walletUrl,
@@ -71,14 +69,8 @@ import { VolunteeringIcon } from '../icons/Volunteering';
 import { GraduationIcon } from '../icons/Graduation';
 import { MedalBadgeIcon } from '../icons/MedalBadge';
 import { MedalIcon } from '../icons/Medal';
-import {
-  achievementTrackingWidgetFeature,
-  questsFeature,
-} from '../../lib/featureManagement';
+import { questsFeature } from '../../lib/featureManagement';
 import { useConditionalFeature } from '../../hooks/useConditionalFeature';
-import { useProfileAchievements } from '../../hooks/profile/useProfileAchievements';
-import { shouldShowAchievementTracker } from '../../lib/achievements';
-import { useTrackedAchievement } from '../../hooks/profile/useTrackedAchievement';
 
 type MenuItems = Record<
   string,
@@ -91,32 +83,14 @@ type MenuItems = Record<
 const defineMenuItems = <T extends MenuItems>(items: T): T => items;
 
 const useAccountPageItems = ({ onClose }: { onClose?: () => void } = {}) => {
-  const { openModal, closeModal } = useLazyModal();
+  const { openModal } = useLazyModal();
   const { logEvent } = useLogContext();
   const { user } = useAuthContext();
 
-  const { value: isAchievementTrackingWidgetEnabled } = useConditionalFeature({
-    feature: achievementTrackingWidgetFeature,
-    shouldEvaluate: !!user,
-  });
   const { value: isQuestsFeatureEnabled } = useConditionalFeature({
     feature: questsFeature,
     shouldEvaluate: !!user,
   });
-
-  const { achievements, unlockedCount, totalCount } = useProfileAchievements(
-    user,
-    isAchievementTrackingWidgetEnabled === true,
-  );
-
-  const showAchievementTracker = shouldShowAchievementTracker({
-    isExperimentEnabled: isAchievementTrackingWidgetEnabled === true,
-    unlockedCount,
-    totalCount,
-  });
-
-  const { trackedAchievement, trackAchievement, untrackAchievement } =
-    useTrackedAchievement(undefined, showAchievementTracker);
 
   const items = useMemo(
     () =>
@@ -130,9 +104,14 @@ const useAccountPageItems = ({ onClose }: { onClose?: () => void } = {}) => {
               href: `${settingsUrl}/profile`,
             },
             account: {
-              title: 'Account',
+              title: 'Account & Security',
               icon: MailIcon,
               href: `${settingsUrl}/security`,
+            },
+            notifications: {
+              title: 'Notifications',
+              icon: BellIcon,
+              href: `${settingsUrl}/notifications`,
             },
             'job-preferences': {
               title: 'Job preferences',
@@ -145,30 +124,15 @@ const useAccountPageItems = ({ onClose }: { onClose?: () => void } = {}) => {
                 });
               },
             },
-            achievements: {
-              title: 'Achievements',
-              icon: MedalBadgeIcon,
-              href: `${webappUrl}${user?.username}/achievements`,
-            },
             appearance: {
               title: 'Appearance',
               icon: NewTabIcon,
               href: `${settingsUrl}/appearance`,
             },
             composition: {
-              title: 'Composition',
+              title: 'Posting',
               icon: FeatherIcon,
               href: `${settingsUrl}/composition`,
-            },
-            notifications: {
-              title: 'Notifications',
-              icon: BellIcon,
-              href: `${settingsUrl}/notifications`,
-            },
-            feedback: {
-              title: 'Your Feedback',
-              icon: FeedbackIcon,
-              href: `${settingsUrl}/feedback`,
             },
             invite: {
               title: 'Invite Friends',
@@ -177,48 +141,39 @@ const useAccountPageItems = ({ onClose }: { onClose?: () => void } = {}) => {
             },
           },
         },
-        misc: {
-          title: 'Misc',
+        feed: {
+          title: 'Feed settings',
           items: {
-            hotTakes: {
-              title: 'Hot Takes',
-              icon: HotIcon,
-              href: `${webappUrl}?openModal=hottakes`,
-              onClick: () => {
-                logEvent({ event_name: LogEvent.OpenHotAndCold });
-                onClose?.();
-              },
+            general: {
+              title: 'General',
+              icon: EditIcon,
+              href: `${settingsUrl}/feed/general`,
             },
-            gameCenter: {
-              title: 'Game Center',
-              icon: JoystickIcon,
-              href: `${webappUrl}game-center`,
+            tags: {
+              title: 'Tags',
+              icon: HashtagIcon,
+              href: `${settingsUrl}/feed/tags`,
             },
-            trackAchievement: {
-              title: 'Track achievement',
-              icon: PinIcon,
-              onClick: () => {
-                logEvent({
-                  event_name: LogEvent.OpenAchievementPickerModal,
-                });
-                onClose?.();
-                openModal({
-                  type: LazyModal.AchievementPicker,
-                  props: {
-                    achievements: achievements ?? [],
-                    trackedAchievementId: trackedAchievement?.achievement.id,
-                    onTrack: async (achievementId: string) => {
-                      await trackAchievement(achievementId);
-                      closeModal();
-                    },
-                    onUntrack: async () => {
-                      await untrackAchievement();
-                      closeModal();
-                    },
-                  },
-                });
-              },
-            } as ProfileSectionItemPropsWithoutHref,
+            sources: {
+              title: 'Content sources',
+              icon: AddUserIcon,
+              href: `${settingsUrl}/feed/sources`,
+            },
+            preferences: {
+              title: 'Content preferences',
+              icon: AppIcon,
+              href: `${settingsUrl}/feed/preferences`,
+            },
+            ai: {
+              title: 'AI superpowers',
+              icon: MagicIcon,
+              href: `${settingsUrl}/feed/ai`,
+            },
+            blocked: {
+              title: 'Blocked content',
+              icon: BlockIcon,
+              href: `${settingsUrl}/feed/blocked`,
+            },
           },
         },
         career: {
@@ -256,6 +211,63 @@ const useAccountPageItems = ({ onClose }: { onClose?: () => void } = {}) => {
             },
           },
         },
+        playground: {
+          title: 'Gamification',
+          items: {
+            gameCenter: {
+              title: 'Game Center',
+              icon: JoystickIcon,
+              href: `${webappUrl}game-center`,
+              external: true,
+            },
+            gamification: {
+              title: 'Feature visibility',
+              icon: EyeIcon,
+              href: `${settingsUrl}/customization/gamification`,
+            },
+            streaks: {
+              title: 'Streaks',
+              icon: HotIcon,
+              href: `${settingsUrl}/customization/streaks`,
+            },
+            achievements: {
+              title: 'Achievements',
+              icon: MedalBadgeIcon,
+              href: `${webappUrl}${user?.username}/achievements`,
+              external: true,
+            },
+            hotTakes: {
+              title: 'Hot Takes',
+              icon: HotIcon,
+              href: `${webappUrl}?openModal=hottakes`,
+              external: true,
+              onClick: () => {
+                logEvent({ event_name: LogEvent.OpenHotAndCold });
+                onClose?.();
+              },
+            },
+            devcard: {
+              title: 'DevCard',
+              icon: DevCardIcon,
+              href: `${settingsUrl}/customization/devcard`,
+            },
+          },
+        },
+        customization: {
+          title: 'Developers',
+          items: {
+            api: {
+              title: 'API Access',
+              icon: TerminalIcon,
+              href: `${settingsUrl}/api`,
+            },
+            integrations: {
+              title: 'Integrations',
+              icon: EmbedIcon,
+              href: `${settingsUrl}/customization/integrations`,
+            },
+          },
+        },
         billing: {
           title: 'Billing and Monetization',
           items: {
@@ -282,74 +294,14 @@ const useAccountPageItems = ({ onClose }: { onClose?: () => void } = {}) => {
             } as ProfileSectionItemPropsWithoutHref,
           },
         },
-        feed: {
-          title: 'Feed Settings',
-          items: {
-            general: {
-              title: 'General',
-              icon: EditIcon,
-              href: `${settingsUrl}/feed/general`,
-            },
-            tags: {
-              title: 'Tags',
-              icon: HashtagIcon,
-              href: `${settingsUrl}/feed/tags`,
-            },
-            sources: {
-              title: 'Content sources',
-              icon: AddUserIcon,
-              href: `${settingsUrl}/feed/sources`,
-            },
-            preferences: {
-              title: 'Content preferences',
-              icon: AppIcon,
-              href: `${settingsUrl}/feed/preferences`,
-            },
-            ai: {
-              title: 'AI superpowers',
-              icon: MagicIcon,
-              href: `${settingsUrl}/feed/ai`,
-            },
-            blocked: {
-              title: 'Blocked content',
-              icon: BlockIcon,
-              href: `${settingsUrl}/feed/blocked`,
-            },
-          },
-        },
-        customization: {
-          title: 'Customization',
-          items: {
-            streaks: {
-              title: 'Streaks',
-              icon: HotIcon,
-              href: `${settingsUrl}/customization/streaks`,
-            },
-            gamification: {
-              title: 'Gamification',
-              icon: GiftIcon,
-              href: `${settingsUrl}/customization/gamification`,
-            },
-            devcard: {
-              title: 'DevCard',
-              icon: DevCardIcon,
-              href: `${settingsUrl}/customization/devcard`,
-            },
-            integrations: {
-              title: 'Integrations',
-              icon: EmbedIcon,
-              href: `${settingsUrl}/customization/integrations`,
-            },
-            api: {
-              title: 'API Access',
-              icon: TerminalIcon,
-              href: `${settingsUrl}/api`,
-            },
-          },
-        },
         help: {
           title: 'Help center',
           items: {
+            feedback: {
+              title: 'Your Feedback',
+              icon: FeedbackIcon,
+              href: `${settingsUrl}/feedback`,
+            },
             privacy: {
               title: 'Privacy',
               icon: PrivacyIcon,
@@ -379,12 +331,6 @@ const useAccountPageItems = ({ onClose }: { onClose?: () => void } = {}) => {
               href: docs,
               external: true,
             },
-            support: {
-              title: 'Support',
-              icon: FeedbackIcon,
-              href: feedback,
-              external: true,
-            },
           },
         },
         logout: {
@@ -398,20 +344,10 @@ const useAccountPageItems = ({ onClose }: { onClose?: () => void } = {}) => {
           },
         },
       }),
-    [
-      achievements,
-      closeModal,
-      logEvent,
-      onClose,
-      openModal,
-      trackAchievement,
-      untrackAchievement,
-      trackedAchievement?.achievement.id,
-      user?.username,
-    ],
+    [logEvent, onClose, openModal, user?.username],
   );
 
-  return { items, showAchievementTracker, isQuestsFeatureEnabled };
+  return { items, isQuestsFeatureEnabled };
 };
 
 interface ProfileSettingsMenuProps {
@@ -420,8 +356,6 @@ interface ProfileSettingsMenuProps {
   shouldKeepOpen?: boolean;
 }
 
-const TRACK_ACHIEVEMENT_KEY = 'trackAchievement';
-
 export const InnerProfileSettingsMenu = ({
   className,
   onClose,
@@ -429,11 +363,8 @@ export const InnerProfileSettingsMenu = ({
   const { asPath } = useRouter();
   const isMobile = useViewSize(ViewSize.MobileL);
   const hasAccessToCores = useHasAccessToCores();
-  const {
-    items: accountPageItems,
-    showAchievementTracker,
-    isQuestsFeatureEnabled,
-  } = useAccountPageItems({ onClose });
+  const { items: accountPageItems, isQuestsFeatureEnabled } =
+    useAccountPageItems({ onClose });
 
   return (
     <nav className={classNames('flex flex-col gap-2', className)}>
@@ -448,13 +379,6 @@ export const InnerProfileSettingsMenu = ({
             items={Object.entries(menuItem.items)
               .filter(([itemKey, item]) => {
                 if (item.href === walletUrl && !hasAccessToCores) {
-                  return false;
-                }
-
-                if (
-                  itemKey === TRACK_ACHIEVEMENT_KEY &&
-                  !showAchievementTracker
-                ) {
                   return false;
                 }
 

--- a/packages/webapp/components/layouts/SettingsLayout/Security/index.tsx
+++ b/packages/webapp/components/layouts/SettingsLayout/Security/index.tsx
@@ -151,7 +151,7 @@ function AccountSecurityDefault({
   };
 
   return (
-    <AccountPageContainer title="Account access">
+    <AccountPageContainer title="Account & Security">
       <AccountContentSection
         className={{ heading: 'mt-0' }}
         title="Email"

--- a/packages/webapp/pages/settings/composition.tsx
+++ b/packages/webapp/pages/settings/composition.tsx
@@ -19,16 +19,16 @@ import { getPageSeoTitles } from '../../components/layouts/utils';
 
 const defaultWriteTabs: RadioItemProps[] = Object.keys(WriteFormTab).map(
   (key) => ({
-    label: WriteFormTab[key],
+    label: WriteFormTab[key as keyof typeof WriteFormTab],
     value: key,
   }),
 );
 
-const AccountManageSubscriptionPage = (): ReactElement => {
+const PostingSettingsPage = (): ReactElement => {
   const { updateFlag, flags } = useSettingsContext();
 
   return (
-    <AccountPageContainer title="Composition">
+    <AccountPageContainer title="Posting">
       <div id="compose" aria-hidden />
       <FlexCol className="gap-2">
         <Typography bold type={TypographyType.Subhead}>
@@ -38,7 +38,7 @@ const AccountManageSubscriptionPage = (): ReactElement => {
         <Radio
           name="default-write-tab"
           options={defaultWriteTabs}
-          value={flags.defaultWriteTab}
+          value={flags?.defaultWriteTab}
           onChange={(value) => {
             updateFlag('defaultWriteTab', value);
           }}
@@ -56,10 +56,10 @@ const AccountManageSubscriptionPage = (): ReactElement => {
 
 const seo: NextSeoProps = {
   ...defaultSeo,
-  ...getPageSeoTitles('Appearance'),
+  ...getPageSeoTitles('Posting'),
 };
 
-AccountManageSubscriptionPage.getLayout = getSettingsLayout;
-AccountManageSubscriptionPage.layoutProps = { seo };
+PostingSettingsPage.getLayout = getSettingsLayout;
+PostingSettingsPage.layoutProps = { seo };
 
-export default AccountManageSubscriptionPage;
+export default PostingSettingsPage;

--- a/packages/webapp/pages/settings/customization/devcard.tsx
+++ b/packages/webapp/pages/settings/customization/devcard.tsx
@@ -26,7 +26,7 @@ const DevCardStep2 = dynamic(() =>
   ).then((mod) => mod.DevCardStep2),
 );
 
-const seoTitles = getPageSeoTitles('Grab your DevCard');
+const seoTitles = getPageSeoTitles('DevCard');
 const seo: NextSeoProps = {
   title: seoTitles.title,
   description:

--- a/packages/webapp/pages/settings/customization/gamification.tsx
+++ b/packages/webapp/pages/settings/customization/gamification.tsx
@@ -69,8 +69,7 @@ const GamificationSettingsPage = (): ReactElement | null => {
             checked={!optOutQuestSystem}
             onToggle={toggleOptOutQuestSystem}
           >
-            Turn quest UI on or off across the product. Toggle to display or
-            hide the quest system UI.
+            Toggle to display or hide the quest system UI across the product.
           </SettingsSwitch>
         </section>
       </div>

--- a/packages/webapp/pages/settings/customization/gamification.tsx
+++ b/packages/webapp/pages/settings/customization/gamification.tsx
@@ -7,7 +7,6 @@ import { useConditionalFeature } from '@dailydotdev/shared/src/hooks';
 import { questsFeature } from '@dailydotdev/shared/src/lib/featureManagement';
 import {
   Typography,
-  TypographyColor,
   TypographyType,
 } from '@dailydotdev/shared/src/components/typography/Typography';
 import { AccountPageContainer } from '../../../components/layouts/SettingsLayout/AccountPageContainer';
@@ -42,7 +41,7 @@ const GamificationSettingsPage = (): ReactElement | null => {
   }
 
   return (
-    <AccountPageContainer title="Gamification">
+    <AccountPageContainer title="Feature visibility">
       <div className="flex flex-col gap-6">
         <section className="flex flex-col gap-2">
           <Typography bold type={TypographyType.Subhead}>
@@ -61,25 +60,17 @@ const GamificationSettingsPage = (): ReactElement | null => {
         </section>
 
         <section className="flex flex-col gap-2">
-          <div className="flex flex-col gap-1">
-            <Typography bold type={TypographyType.Subhead}>
-              Show quests
-            </Typography>
-
-            <Typography
-              type={TypographyType.Callout}
-              color={TypographyColor.Tertiary}
-            >
-              Turn quest UI on or off across the product.
-            </Typography>
-          </div>
+          <Typography bold type={TypographyType.Subhead}>
+            Show quests
+          </Typography>
 
           <SettingsSwitch
             name="quest-system"
             checked={!optOutQuestSystem}
             onToggle={toggleOptOutQuestSystem}
           >
-            Toggle to display or hide the quest system UI.
+            Turn quest UI on or off across the product. Toggle to display or
+            hide the quest system UI.
           </SettingsSwitch>
         </section>
       </div>
@@ -89,7 +80,7 @@ const GamificationSettingsPage = (): ReactElement | null => {
 
 const seo: NextSeoProps = {
   ...defaultSeo,
-  title: getTemplatedTitle('Gamification'),
+  title: getTemplatedTitle('Feature visibility'),
 };
 
 GamificationSettingsPage.getLayout = getSettingsLayout;

--- a/packages/webapp/pages/settings/customization/integrations.tsx
+++ b/packages/webapp/pages/settings/customization/integrations.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import React, { useCallback, useState } from 'react';
+import type { NextSeoProps } from 'next-seo';
 
 import { useIntegrationsQuery } from '@dailydotdev/shared/src/hooks/integrations/useIntegrationsQuery';
 
@@ -16,6 +17,13 @@ import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
 import { LogEvent, Origin } from '@dailydotdev/shared/src/lib/log';
 import { getSettingsLayout } from '../../../components/layouts/SettingsLayout';
 import { AccountPageContainer } from '../../../components/layouts/SettingsLayout/AccountPageContainer';
+import { defaultSeo } from '../../../next-seo';
+import { getPageSeoTitles } from '../../../components/layouts/utils';
+
+const seo: NextSeoProps = {
+  ...defaultSeo,
+  ...getPageSeoTitles('Integrations'),
+};
 
 const AccountIntegrationsPage = (): ReactElement => {
   const [state, setState] = useState<{
@@ -84,5 +92,6 @@ const AccountIntegrationsPage = (): ReactElement => {
 };
 
 AccountIntegrationsPage.getLayout = getSettingsLayout;
+AccountIntegrationsPage.layoutProps = { seo };
 
 export default AccountIntegrationsPage;

--- a/packages/webapp/pages/settings/feed/ai.tsx
+++ b/packages/webapp/pages/settings/feed/ai.tsx
@@ -18,7 +18,7 @@ const AccountManageSubscriptionPage = (): ReactElement => {
   );
 };
 
-const seoTitles = getPageSeoTitles('Edit AI superpowers');
+const seoTitles = getPageSeoTitles('AI superpowers');
 const seo: NextSeoProps = {
   title: seoTitles.title,
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },

--- a/packages/webapp/pages/settings/feed/blocked.tsx
+++ b/packages/webapp/pages/settings/feed/blocked.tsx
@@ -18,7 +18,7 @@ const AccountManageSubscriptionPage = (): ReactElement => {
   );
 };
 
-const seoTitles = getPageSeoTitles('Edit blocked content');
+const seoTitles = getPageSeoTitles('Blocked content');
 const seo: NextSeoProps = {
   title: seoTitles.title,
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },

--- a/packages/webapp/pages/settings/feed/general.tsx
+++ b/packages/webapp/pages/settings/feed/general.tsx
@@ -18,7 +18,7 @@ const AccountManageSubscriptionPage = (): ReactElement => {
   );
 };
 
-const seoTitles = getPageSeoTitles('Edit feed');
+const seoTitles = getPageSeoTitles('General');
 const seo: NextSeoProps = {
   title: seoTitles.title,
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },

--- a/packages/webapp/pages/settings/feed/preferences.tsx
+++ b/packages/webapp/pages/settings/feed/preferences.tsx
@@ -18,7 +18,7 @@ const AccountManageSubscriptionPage = (): ReactElement => {
   );
 };
 
-const seoTitles = getPageSeoTitles('Edit content preferences');
+const seoTitles = getPageSeoTitles('Content preferences');
 const seo: NextSeoProps = {
   title: seoTitles.title,
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },

--- a/packages/webapp/pages/settings/feed/sources.tsx
+++ b/packages/webapp/pages/settings/feed/sources.tsx
@@ -18,7 +18,7 @@ const AccountManageSubscriptionPage = (): ReactElement => {
   );
 };
 
-const seoTitles = getPageSeoTitles('Edit content sources');
+const seoTitles = getPageSeoTitles('Content sources');
 const seo: NextSeoProps = {
   title: seoTitles.title,
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },

--- a/packages/webapp/pages/settings/feed/tags.tsx
+++ b/packages/webapp/pages/settings/feed/tags.tsx
@@ -18,7 +18,7 @@ const AccountManageSubscriptionPage = (): ReactElement => {
   );
 };
 
-const seoTitles = getPageSeoTitles('Edit tags');
+const seoTitles = getPageSeoTitles('Tags');
 const seo: NextSeoProps = {
   title: seoTitles.title,
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },

--- a/packages/webapp/pages/settings/invite.tsx
+++ b/packages/webapp/pages/settings/invite.tsx
@@ -55,7 +55,10 @@ import { getSettingsLayout } from '../../components/layouts/SettingsLayout';
 import { defaultSeo } from '../../next-seo';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 
-const seo: NextSeoProps = { ...defaultSeo, ...getPageSeoTitles('Invite') };
+const seo: NextSeoProps = {
+  ...defaultSeo,
+  ...getPageSeoTitles('Invite Friends'),
+};
 
 const AccountInvitePage = (): ReactElement => {
   const { openModal } = useLazyModal();
@@ -88,10 +91,10 @@ const AccountInvitePage = (): ReactElement => {
       getNextPageParam(referredUsers?.pageInfo),
   });
   const users: UserShortProfile[] = useMemo(() => {
-    const list = [];
+    const list: UserShortProfile[] = [];
     usersResult.data?.pages.forEach((page) => {
       page?.referredUsers.edges.forEach(({ node }) => {
-        list.push(node);
+        list.push(node as UserShortProfile);
       });
     }, []);
 

--- a/packages/webapp/pages/settings/job-preferences.tsx
+++ b/packages/webapp/pages/settings/job-preferences.tsx
@@ -61,7 +61,7 @@ import { AccountPageContainer } from '../../components/layouts/SettingsLayout/Ac
 
 const seo: NextSeoProps = {
   ...defaultSeo,
-  ...getPageSeoTitles('Manage job preferences'),
+  ...getPageSeoTitles('Job preferences'),
 };
 
 const options = [
@@ -84,9 +84,9 @@ const JobPreferencesPage = (): ReactElement => {
   const { user } = useAuthContext();
   const { displayToast } = useToastNotification();
   const { completeAction } = useActions();
-  const [option, setOption] = useState(null);
+  const [option, setOption] = useState<CandidateStatus | null>(null);
 
-  const opts = getCandidatePreferencesOptions(user?.id);
+  const opts = getCandidatePreferencesOptions(user?.id ?? '');
   const updateQuery = useUpdateQuery(opts);
 
   const { data: preferences, isPending } = useQuery(opts);
@@ -282,7 +282,7 @@ const JobPreferencesPage = (): ReactElement => {
 };
 
 export const getStaticProps: GetStaticProps<{
-  dehydratedState: DehydratedState;
+  dehydratedState: DehydratedState | null;
 }> = async () => {
   const queryClient = new QueryClient();
   try {

--- a/packages/webapp/pages/settings/notifications.tsx
+++ b/packages/webapp/pages/settings/notifications.tsx
@@ -16,7 +16,7 @@ import { AccountPageContent } from '../../components/layouts/SettingsLayout/comm
 
 const seo: NextSeoProps = {
   ...defaultSeo,
-  ...getPageSeoTitles('Manage account notifications'),
+  ...getPageSeoTitles('Notifications'),
 };
 
 const AccountNotificationsPage = (): ReactElement => {

--- a/packages/webapp/pages/settings/organization/[orgId]/billing.tsx
+++ b/packages/webapp/pages/settings/organization/[orgId]/billing.tsx
@@ -31,7 +31,7 @@ import { defaultSeo } from '../../../../next-seo';
 import { getPageSeoTitles } from '../../../../components/layouts/utils';
 import { getOrganizationLayout } from '../../../../components/layouts/OrganizationLayout';
 
-const Page = (): ReactElement => {
+const Page = (): ReactElement | null => {
   const router = useRouter();
   const { openModal } = useLazyModal();
   const organizationId = router.query.orgId as string;
@@ -56,7 +56,7 @@ const Page = (): ReactElement => {
     setData(origData);
   }, [origData, data]);
 
-  if (isFetching || !isAuthReady) {
+  if (isFetching || !isAuthReady || !organization) {
     return null;
   }
 
@@ -68,7 +68,7 @@ const Page = (): ReactElement => {
         section: 'flex-1 gap-6',
       }}
     >
-      {data && (
+      {data && pricing && data.total && pricing.price?.monthly && (
         <>
           <section>
             <Typography bold type={TypographyType.Body} className="pb-4">
@@ -158,7 +158,7 @@ const Page = (): ReactElement => {
                   {new Intl.NumberFormat(navigator.language, {
                     style: 'currency',
                     currency: pricing.currency.code,
-                  }).format(pricing.price?.monthly?.amount)}
+                  }).format(pricing.price.monthly.amount)}
                   /seat
                 </Typography>
               </div>
@@ -200,7 +200,7 @@ const Page = (): ReactElement => {
 
 const seo: NextSeoProps = {
   ...defaultSeo,
-  ...getPageSeoTitles('Organization'),
+  ...getPageSeoTitles('Billing'),
 };
 
 Page.getLayout = getOrganizationLayout;

--- a/packages/webapp/pages/settings/organization/[orgId]/general.tsx
+++ b/packages/webapp/pages/settings/organization/[orgId]/general.tsx
@@ -39,7 +39,7 @@ import { getPageSeoTitles } from '../../../../components/layouts/utils';
 import { defaultSeo } from '../../../../next-seo';
 import { AccountPageContainer } from '../../../../components/layouts/SettingsLayout/AccountPageContainer';
 
-const Page = (): ReactElement => {
+const Page = (): ReactElement | null => {
   const router = useRouter();
   const { showPrompt } = usePrompt();
   const {
@@ -72,10 +72,7 @@ const Page = (): ReactElement => {
       data.image = imageFile;
     }
 
-    await updateOrganization({
-      id: organization.id,
-      form: data,
-    });
+    await updateOrganization({ form: data });
 
     setImageChanged(false);
     return null;
@@ -98,14 +95,14 @@ const Page = (): ReactElement => {
     }
   };
 
+  if (isFetching || !organization) {
+    return null;
+  }
+
   const disableDeletion =
     !isOwner ||
     organization.status === SubscriptionStatus.Active ||
     seats.assigned > 0;
-
-  if (isFetching) {
-    return null;
-  }
 
   return (
     <AccountPageContainer
@@ -220,7 +217,7 @@ const Page = (): ReactElement => {
 
 const seo: NextSeoProps = {
   ...defaultSeo,
-  ...getPageSeoTitles('Organization'),
+  ...getPageSeoTitles('General'),
 };
 
 Page.getLayout = getOrganizationLayout;

--- a/packages/webapp/pages/settings/organization/[orgId]/members.tsx
+++ b/packages/webapp/pages/settings/organization/[orgId]/members.tsx
@@ -73,7 +73,7 @@ const OrganizationOptionsMenu = ({
   member,
 }: {
   member: Omit<OrganizationMember, 'lastActive'>;
-}) => {
+}): ReactElement | null => {
   const { user: currentUser } = useAuthContext();
   const router = useRouter();
   const {
@@ -84,7 +84,11 @@ const OrganizationOptionsMenu = ({
     includeMembers: true,
   });
 
-  const { user, role, seatType } = member || {};
+  const { user, role, seatType } = member;
+
+  if (!currentUser) {
+    return null;
+  }
 
   const isCurrentUser = currentUser.id === user.id;
 
@@ -312,7 +316,7 @@ const OrganizationMembersItem = ({
   );
 };
 
-const Page = (): ReactElement => {
+const Page = (): ReactElement | null => {
   const isMobile = useViewSize(ViewSize.MobileL);
   const { push, query } = useRouter();
   const { openModal } = useLazyModal();
@@ -344,11 +348,11 @@ const Page = (): ReactElement => {
     }
   };
 
-  const isRegularMember = !isPrivilegedOrganizationRole(role);
-
-  if (isFetching || !organization) {
+  if (isFetching || !organization || !user || !role || !seatType) {
     return null;
   }
+
+  const isRegularMember = !isPrivilegedOrganizationRole(role);
 
   const members = [
     { role, user, seatType, lastActive: new Date() },
@@ -473,7 +477,7 @@ const Page = (): ReactElement => {
 
 const seo: NextSeoProps = {
   ...defaultSeo,
-  ...getPageSeoTitles('Organization members'),
+  ...getPageSeoTitles('Members'),
 };
 
 Page.getLayout = getOrganizationLayout;

--- a/packages/webapp/pages/settings/profile.tsx
+++ b/packages/webapp/pages/settings/profile.tsx
@@ -9,7 +9,7 @@ import { getPageSeoTitles } from '../../components/layouts/utils';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
-  ...getPageSeoTitles('Manage account profile'),
+  ...getPageSeoTitles('Profile details'),
 };
 
 const AccountProfilePage = (): ReactElement => {

--- a/packages/webapp/pages/settings/profile/experience/opensource.tsx
+++ b/packages/webapp/pages/settings/profile/experience/opensource.tsx
@@ -18,7 +18,7 @@ import { AccountPageContainer } from '../../../../components/layouts/SettingsLay
 
 const seo: NextSeoProps = {
   ...defaultSeo,
-  ...getPageSeoTitles('Open source'),
+  ...getPageSeoTitles('Open Source'),
 };
 
 const OpenSourcePage = (): ReactElement => {

--- a/packages/webapp/pages/settings/security.tsx
+++ b/packages/webapp/pages/settings/security.tsx
@@ -37,7 +37,7 @@ import { getPageSeoTitles } from '../../components/layouts/utils';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
-  ...getPageSeoTitles('Manage account security'),
+  ...getPageSeoTitles('Account & Security'),
 };
 
 const BETTER_AUTH_CHANGE_EMAIL_MESSAGE =

--- a/packages/webapp/pages/settings/subscription.tsx
+++ b/packages/webapp/pages/settings/subscription.tsx
@@ -49,7 +49,7 @@ const PlusList = dynamic(() =>
 
 const seo: NextSeoProps = {
   ...defaultSeo,
-  ...getPageSeoTitles('Manage plus'),
+  ...getPageSeoTitles('Subscriptions'),
 };
 
 const PlusInfo = (): ReactElement => {


### PR DESCRIPTION
## Summary
- reorganize the settings sidebar so related items are grouped more clearly and the section order matches the new structure
- align renamed settings pages and sidebar entries so page titles and metadata match the visible navigation labels
- update the gamification/playground area with clearer labels, ordering, and external-link affordances for items that jump out to separate surfaces

## Test plan
- [x] Run `pnpm --filter @dailydotdev/shared lint`
- [x] Run `pnpm --filter webapp lint`
- [x] Run `node ./scripts/typecheck-strict-changed.js`

Made with [Cursor](https://cursor.com)

### Preview domain
https://feat-settings-navigation-refresh.preview.app.daily.dev