### PR TITLE
fix: correct highlights agentic route

### DIFF
--- a/packages/shared/src/components/highlights/HighlightsPage.spec.tsx
+++ b/packages/shared/src/components/highlights/HighlightsPage.spec.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { HighlightsPage } from './HighlightsPage';
+
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQuery: jest.fn(),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+const mockUseQuery = useQuery as jest.Mock;
+const mockUseRouter = useRouter as jest.Mock;
+
+describe('HighlightsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseRouter.mockReturnValue({
+      pathname: '/highlights',
+      query: {},
+      push: jest.fn(),
+    });
+  });
+
+  it('should use the agentic alias for the vibes channel tab URL', () => {
+    mockUseQuery.mockReturnValue({
+      data: {
+        majorHeadlines: {
+          edges: [],
+        },
+        channelConfigurations: [
+          {
+            channel: 'vibes',
+            displayName: 'Agentic',
+          },
+        ],
+      },
+      isFetching: false,
+    });
+
+    render(<HighlightsPage />);
+
+    expect(screen.getByRole('link', { name: 'Agentic' })).toHaveAttribute(
+      'href',
+      '/highlights/agentic',
+    );
+  });
+});

--- a/packages/shared/src/components/highlights/HighlightsPage.spec.tsx
+++ b/packages/shared/src/components/highlights/HighlightsPage.spec.tsx
@@ -17,6 +17,18 @@ const mockUseQuery = useQuery as jest.Mock;
 const mockUseRouter = useRouter as jest.Mock;
 
 describe('HighlightsPage', () => {
+  const highlightsPageData = {
+    majorHeadlines: {
+      edges: [],
+    },
+    channelConfigurations: [
+      {
+        channel: 'vibes',
+        displayName: 'Agentic',
+      },
+    ],
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseRouter.mockReturnValue({
@@ -28,17 +40,7 @@ describe('HighlightsPage', () => {
 
   it('should use the agentic alias for the vibes channel tab URL', () => {
     mockUseQuery.mockReturnValue({
-      data: {
-        majorHeadlines: {
-          edges: [],
-        },
-        channelConfigurations: [
-          {
-            channel: 'vibes',
-            displayName: 'Agentic',
-          },
-        ],
-      },
+      data: highlightsPageData,
       isFetching: false,
     });
 
@@ -48,5 +50,21 @@ describe('HighlightsPage', () => {
       'href',
       '/highlights/agentic',
     );
+  });
+
+  it('should keep the agentic tab selected for the alias route', () => {
+    mockUseRouter.mockReturnValue({
+      pathname: '/highlights/[channel]',
+      query: { channel: 'agentic' },
+      push: jest.fn(),
+    });
+    mockUseQuery.mockReturnValue({
+      data: highlightsPageData,
+      isFetching: false,
+    });
+
+    render(<HighlightsPage />);
+
+    expect(screen.getByText('Agentic')).toHaveClass('bg-theme-active');
   });
 });

--- a/packages/shared/src/components/highlights/HighlightsPage.tsx
+++ b/packages/shared/src/components/highlights/HighlightsPage.tsx
@@ -8,7 +8,9 @@ import type {
 } from '../../graphql/highlights';
 import {
   channelHighlightsFeedQueryOptions,
+  getHighlightsChannelSlug,
   highlightsPageQueryOptions,
+  resolveHighlightsChannelSlug,
 } from '../../graphql/highlights';
 import { Tab, TabContainer } from '../tabs/TabContainer';
 import { DigestCTA } from './DigestCTA';
@@ -127,6 +129,9 @@ const ChannelTab = ({
 export const HighlightsPage = (): ReactElement => {
   const router = useRouter();
   const channel = getSingleQueryParam(router.query.channel);
+  const resolvedChannel = channel
+    ? resolveHighlightsChannelSlug(channel)
+    : undefined;
   const expandedId = getSingleQueryParam(router.query.highlight);
   const { data, isFetching } = useQuery(highlightsPageQueryOptions());
 
@@ -138,7 +143,7 @@ export const HighlightsPage = (): ReactElement => {
   const majorLoading = isFetching && !data;
 
   const activeTab =
-    channels.find((c) => c.channel === channel)?.displayName ??
+    channels.find((c) => c.channel === resolvedChannel)?.displayName ??
     MAJOR_HEADLINES_LABEL;
 
   return (
@@ -176,7 +181,9 @@ export const HighlightsPage = (): ReactElement => {
             <Tab
               key={ch.channel}
               label={ch.displayName}
-              url={`${HIGHLIGHTS_BASE_URL}/${ch.channel}`}
+              url={`${HIGHLIGHTS_BASE_URL}/${getHighlightsChannelSlug(
+                ch.channel,
+              )}`}
             >
               <ChannelTab channel={ch} expandedId={expandedId} />
             </Tab>

--- a/packages/shared/src/components/highlights/HighlightsPage.tsx
+++ b/packages/shared/src/components/highlights/HighlightsPage.tsx
@@ -8,10 +8,12 @@ import type {
 } from '../../graphql/highlights';
 import {
   channelHighlightsFeedQueryOptions,
-  getHighlightsChannelSlug,
   highlightsPageQueryOptions,
-  resolveHighlightsChannelSlug,
 } from '../../graphql/highlights';
+import {
+  getHighlightsChannelSlug,
+  resolveHighlightsChannelSlug,
+} from '../../lib/highlights';
 import { Tab, TabContainer } from '../tabs/TabContainer';
 import { DigestCTA } from './DigestCTA';
 import { HighlightItem } from './HighlightItem';

--- a/packages/shared/src/graphql/highlights.ts
+++ b/packages/shared/src/graphql/highlights.ts
@@ -163,23 +163,6 @@ export interface HighlightsPageData {
   channelConfigurations: ChannelConfiguration[];
 }
 
-const HIGHLIGHTS_CHANNEL_TO_SLUG: Record<string, string> = {
-  vibes: 'agentic',
-};
-
-const HIGHLIGHTS_SLUG_TO_CHANNEL = Object.fromEntries(
-  Object.entries(HIGHLIGHTS_CHANNEL_TO_SLUG).map(([channel, slug]) => [
-    slug,
-    channel,
-  ]),
-);
-
-export const getHighlightsChannelSlug = (channel: string): string =>
-  HIGHLIGHTS_CHANNEL_TO_SLUG[channel] ?? channel;
-
-export const resolveHighlightsChannelSlug = (slug: string): string =>
-  HIGHLIGHTS_SLUG_TO_CHANNEL[slug] ?? slug;
-
 export const HIGHLIGHTS_PAGE_QUERY = gql`
   query HighlightsPage($first: Int, $after: String) {
     majorHeadlines(first: $first, after: $after) {

--- a/packages/shared/src/graphql/highlights.ts
+++ b/packages/shared/src/graphql/highlights.ts
@@ -163,6 +163,23 @@ export interface HighlightsPageData {
   channelConfigurations: ChannelConfiguration[];
 }
 
+const HIGHLIGHTS_CHANNEL_TO_SLUG: Record<string, string> = {
+  vibes: 'agentic',
+};
+
+const HIGHLIGHTS_SLUG_TO_CHANNEL = Object.fromEntries(
+  Object.entries(HIGHLIGHTS_CHANNEL_TO_SLUG).map(([channel, slug]) => [
+    slug,
+    channel,
+  ]),
+);
+
+export const getHighlightsChannelSlug = (channel: string): string =>
+  HIGHLIGHTS_CHANNEL_TO_SLUG[channel] ?? channel;
+
+export const resolveHighlightsChannelSlug = (slug: string): string =>
+  HIGHLIGHTS_SLUG_TO_CHANNEL[slug] ?? slug;
+
 export const HIGHLIGHTS_PAGE_QUERY = gql`
   query HighlightsPage($first: Int, $after: String) {
     majorHeadlines(first: $first, after: $after) {

--- a/packages/shared/src/lib/highlights.ts
+++ b/packages/shared/src/lib/highlights.ts
@@ -1,0 +1,8 @@
+const AGENTIC_HIGHLIGHTS_CHANNEL = 'vibes';
+const AGENTIC_HIGHLIGHTS_SLUG = 'agentic';
+
+export const getHighlightsChannelSlug = (channel: string): string =>
+  channel === AGENTIC_HIGHLIGHTS_CHANNEL ? AGENTIC_HIGHLIGHTS_SLUG : channel;
+
+export const resolveHighlightsChannelSlug = (slug: string): string =>
+  slug === AGENTIC_HIGHLIGHTS_SLUG ? AGENTIC_HIGHLIGHTS_CHANNEL : slug;

--- a/packages/webapp/__tests__/HighlightsChannelStaticProps.spec.ts
+++ b/packages/webapp/__tests__/HighlightsChannelStaticProps.spec.ts
@@ -1,0 +1,68 @@
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import {
+  HIGHLIGHTS_PAGE_QUERY,
+  POST_HIGHLIGHTS_FEED_QUERY,
+} from '@dailydotdev/shared/src/graphql/highlights';
+import { getStaticProps } from '../pages/highlights/[channel]';
+
+jest.mock('@dailydotdev/shared/src/graphql/common', () => {
+  const actual = jest.requireActual('@dailydotdev/shared/src/graphql/common');
+
+  return {
+    ...actual,
+    gqlClient: {
+      request: jest.fn(),
+    },
+  };
+});
+
+const mockRequest = gqlClient.request as jest.Mock;
+
+describe('highlights channel static props', () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  it('should resolve the agentic route alias to the vibes channel', async () => {
+    mockRequest.mockImplementation((query: string, variables?: object) => {
+      if (query === HIGHLIGHTS_PAGE_QUERY) {
+        return Promise.resolve({
+          majorHeadlines: {
+            edges: [],
+            pageInfo: {
+              endCursor: null,
+              hasNextPage: false,
+            },
+          },
+          channelConfigurations: [
+            {
+              channel: 'vibes',
+              displayName: 'Agentic',
+            },
+          ],
+        });
+      }
+
+      if (query === POST_HIGHLIGHTS_FEED_QUERY) {
+        expect(variables).toEqual({ channel: 'vibes' });
+
+        return Promise.resolve({
+          postHighlights: [],
+        });
+      }
+
+      return Promise.reject(new Error('Unexpected query'));
+    });
+
+    const result = await getStaticProps({
+      params: { channel: 'agentic' },
+    } as never);
+
+    expect(result).toMatchObject({
+      props: {
+        dehydratedState: expect.any(Object),
+      },
+      revalidate: 60,
+    });
+  });
+});

--- a/packages/webapp/pages/highlights/[channel].tsx
+++ b/packages/webapp/pages/highlights/[channel].tsx
@@ -11,6 +11,7 @@ import { dehydrate, QueryClient } from '@tanstack/react-query';
 import {
   channelHighlightsFeedQueryOptions,
   highlightsPageQueryOptions,
+  resolveHighlightsChannelSlug,
 } from '@dailydotdev/shared/src/graphql/highlights';
 import { HighlightsPage } from '@dailydotdev/shared/src/components/highlights/HighlightsPage';
 import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
@@ -64,7 +65,10 @@ export async function getStaticProps({
 }: GetStaticPropsContext<HighlightsChannelPageParams>): Promise<
   GetStaticPropsResult<HighlightsChannelPageProps>
 > {
-  const channel = params?.channel;
+  const channelSlug = params?.channel;
+  const channel = channelSlug
+    ? resolveHighlightsChannelSlug(channelSlug)
+    : undefined;
 
   if (!channel) {
     return {

--- a/packages/webapp/pages/highlights/[channel].tsx
+++ b/packages/webapp/pages/highlights/[channel].tsx
@@ -11,9 +11,9 @@ import { dehydrate, QueryClient } from '@tanstack/react-query';
 import {
   channelHighlightsFeedQueryOptions,
   highlightsPageQueryOptions,
-  resolveHighlightsChannelSlug,
 } from '@dailydotdev/shared/src/graphql/highlights';
 import { HighlightsPage } from '@dailydotdev/shared/src/components/highlights/HighlightsPage';
+import { resolveHighlightsChannelSlug } from '@dailydotdev/shared/src/lib/highlights';
 import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
 import { getLayout } from '../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';


### PR DESCRIPTION
## What changed
- update the Happening Now highlights tab to use `/highlights/agentic` for Agentic
- resolve the `agentic` slug back to the existing `vibes` channel for static props and data fetching
- add targeted regression coverage for the tab URL and alias route selection

## Key decisions
- kept the backend/content channel as `vibes` to avoid widening the change beyond routing
- moved the alias mapping into a small shared helper instead of leaving routing logic in the GraphQL module

Closes ENG-1273

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1273-feedback-bug-report-the.preview.app.daily.dev