### PR TITLE
feat: add hover dismiss to feedback widget

### DIFF
--- a/packages/shared/src/components/feedback/FeedbackWidget.tsx
+++ b/packages/shared/src/components/feedback/FeedbackWidget.tsx
@@ -1,18 +1,31 @@
 import type { ReactElement } from 'react';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Button, ButtonVariant, ButtonSize } from '../buttons/Button';
-import { FeedbackIcon } from '../icons';
+import { FeedbackIcon, MiniCloseIcon } from '../icons';
+import { IconSize } from '../Icon';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useSettingsContext } from '../../contexts/SettingsContext';
 import { useViewSize, ViewSize } from '../../hooks/useViewSize';
 import { useLazyModal } from '../../hooks/useLazyModal';
+import { useLogContext } from '../../contexts/LogContext';
 import { LazyModal } from '../modals/common/types';
+import { LogEvent, TargetType } from '../../lib/log';
 
 export function FeedbackWidget(): ReactElement | null {
   const { user } = useAuthContext();
-  const { showFeedbackButton } = useSettingsContext();
+  const { showFeedbackButton, toggleShowFeedbackButton } = useSettingsContext();
   const isMobile = useViewSize(ViewSize.MobileL);
   const { openModal } = useLazyModal();
+  const { logEvent } = useLogContext();
+
+  const onHide = useCallback(() => {
+    logEvent({
+      event_name: LogEvent.ChangeSettings,
+      target_type: TargetType.FeedbackButton,
+      target_id: 'hide',
+    });
+    return toggleShowFeedbackButton();
+  }, [logEvent, toggleShowFeedbackButton]);
 
   // Only show for authenticated users on desktop when setting is enabled
   // Mobile feedback is handled by FooterPlusButton
@@ -21,16 +34,28 @@ export function FeedbackWidget(): ReactElement | null {
   }
 
   return (
-    <Button
-      variant={ButtonVariant.Primary}
-      size={ButtonSize.Medium}
-      icon={<FeedbackIcon />}
-      className="fixed bottom-4 right-4 z-max shadow-2"
-      onClick={() => openModal({ type: LazyModal.Feedback })}
-      aria-label="Send feedback"
-    >
-      Feedback
-    </Button>
+    <div className="group fixed bottom-4 right-4 z-max">
+      <Button
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Medium}
+        icon={<FeedbackIcon />}
+        className="shadow-2"
+        onClick={() => openModal({ type: LazyModal.Feedback })}
+        aria-label="Send feedback"
+      >
+        Feedback
+      </Button>
+      <Button
+        type="button"
+        size={ButtonSize.XSmall}
+        variant={ButtonVariant.Primary}
+        icon={<MiniCloseIcon size={IconSize.XXSmall} />}
+        onClick={onHide}
+        aria-label="Hide feedback button"
+        title="Hide feedback button"
+        className="invisible absolute -left-2 -top-2 !h-5 !w-5 !rounded-full shadow-2 group-focus-within:visible group-hover:visible"
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds a small circular × button that appears on hover/focus-within over the floating Feedback widget, letting users dismiss it in place.
- Dismiss reuses the existing \`toggleShowFeedbackButton\` setting and logs a matching \`ChangeSettings\` / \`FeedbackButton\` / \`hide\` event, so users can still re-enable the widget from the profile menu's existing toggle.

## Test plan

- [x] Desktop, signed-in user: Feedback button visible bottom-right, close button hidden.
- [x] Hover over Feedback pill: small circular × appears on top-left corner.
- [x] Click ×: widget disappears, profile menu toggle \"Feedback button\" flips off.
- [x] Re-enable from profile menu: widget reappears.
- [x] Keyboard: Tab reaches the × (focus-within keeps it visible).
- [x] Mobile: widget still not rendered (\`FooterPlusButton\` handles mobile).


Made with [Cursor](https://cursor.com)

### Preview domain
https://feat-feedback-widget-hover-dismi.preview.app.daily.dev