### PR TITLE
feat(notifications): add new follower setting toggle

### DIFF
--- a/packages/shared/src/components/notifications/utils.ts
+++ b/packages/shared/src/components/notifications/utils.ts
@@ -413,6 +413,11 @@ export const ACTIVITY_NOTIFICATIONS: NotificationItem[] = [
     label: 'Report updates',
     group: false,
   },
+  {
+    id: NotificationType.UserFollow,
+    label: 'New followers',
+    group: false,
+  },
 ];
 
 export const FOLLOWING_NOTIFICATIONS: NotificationItem[] = [


### PR DESCRIPTION
## Summary
- add a `New followers` notification setting to the shared activity notifications list
- expose the existing `user_follow` preference on both In-App and Email settings tabs through the existing shared rendering path

## Key Decisions
- placed the toggle in the Activity section because follower notifications are direct actions on the user
- reused the existing shared `ACTIVITY_NOTIFICATIONS` configuration so one additive change covers both channels without new rendering logic

Closes ENG-1283

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1283-feedback-feature-reques.preview.app.daily.dev