### PR TITLE
fix(shared): align award modal button content on mobile

### DIFF
--- a/packages/shared/src/components/buttons/Button.tsx
+++ b/packages/shared/src/components/buttons/Button.tsx
@@ -128,7 +128,7 @@ function ButtonComponent<TagName extends AllowedTags>(
         ) &&
         getIconWithSize(icon, iconSecondaryOnHover ? isHovering : false)}
       {hasChildren && (
-        <span className={classNames('btn-label', loading && 'invisible')}>
+        <span className={classNames('btn-label flex items-center gap-1', loading && 'invisible')}>
           {children}
         </span>
       )}

--- a/packages/shared/src/components/buttons/Button.tsx
+++ b/packages/shared/src/components/buttons/Button.tsx
@@ -128,7 +128,12 @@ function ButtonComponent<TagName extends AllowedTags>(
         ) &&
         getIconWithSize(icon, iconSecondaryOnHover ? isHovering : false)}
       {hasChildren && (
-        <span className={classNames('btn-label flex items-center gap-1', loading && 'invisible')}>
+        <span
+          className={classNames(
+            'btn-label flex items-center gap-1',
+            loading && 'invisible',
+          )}
+        >
           {children}
         </span>
       )}

--- a/packages/shared/src/components/modals/award/GiveAwardModal.tsx
+++ b/packages/shared/src/components/modals/award/GiveAwardModal.tsx
@@ -241,11 +241,8 @@ const IntroScreen = () => {
           )}
           {!canPurchaseCores && (
             <Button className="w-full" variant={ButtonVariant.Primary} disabled>
-              <span className="inline-flex gap-1">
-                {' '}
-                Insufficient Cores
-                <CoreIcon secondary />{' '}
-              </span>
+              Insufficient Cores
+              <CoreIcon secondary />
               {product.value === 0
                 ? 'Free'
                 : formatCoresCurrency(product.value)}


### PR DESCRIPTION
## Summary
- Add `flex items-center gap-1` to the `btn-label` span in `Button.tsx` so mixed children (text + icons + price) align properly on mobile
- Remove the redundant `<span className="inline-flex gap-1">` workaround from the "Insufficient Cores" button in `GiveAwardModal.tsx`

## Key decisions
- Fixed at the `Button` component level rather than adding per-button overrides — the outer element is already `inline-flex items-center`, so making the inner label span flex is consistent and prevents this issue from recurring
- `gap-1` has no effect on buttons with a single text child, so existing buttons are unaffected

## Test plan
- [x] All 64 Button-related tests pass
- [x] ESLint clean
- [x] TypeScript clean (0 errors in changed files)
- [ ] Visual QA: award modal buttons on mobile viewport (< 480px) — "Buy Cores", "Insufficient Cores", and "Send Award for" should show text, icon, and price aligned on a single line

Closes ENG-1292

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1292-fix-award-button.preview.app.daily.dev