### PR TITLE
fix: fallback to redirect in case of oauth popup failing

### DIFF
--- a/packages/shared/src/components/auth/AuthOptionsInner.tsx
+++ b/packages/shared/src/components/auth/AuthOptionsInner.tsx
@@ -21,14 +21,9 @@ import {
   betterAuthSendVerificationOTP,
   betterAuthVerifyEmailOTP,
 } from '../../lib/betterAuth';
-import {
-  webappUrl,
-  broadcastChannel,
-  isTesting,
-  isBrave,
-} from '../../lib/constants';
+import { webappUrl, broadcastChannel, isTesting } from '../../lib/constants';
 import { getUserDefaultTimezone } from '../../lib/timezones';
-import { isIOSNative, isMobile } from '../../lib/func';
+import { shouldUseSocialAuthPopup } from '../../lib/func';
 import { generateNameFromEmail } from '../../lib/strings';
 import { generateUsername, claimClaimableItem } from '../../graphql/users';
 import useRegistration from '../../hooks/useRegistration';
@@ -558,9 +553,9 @@ function AuthOptionsInner({
       await handleLoginMessage();
       return;
     }
-    const isIOSApp = isIOSNative();
+    const shouldUsePopup = shouldUseSocialAuthPopup();
     onAuthStateUpdate?.({ isLoading: true });
-    if (!isIOSApp) {
+    if (shouldUsePopup) {
       windowPopup.current = window.open();
     }
     const callbackURL = `${webappUrl}callback?login=true`;
@@ -585,21 +580,8 @@ function AuthOptionsInner({
       onAuthStateUpdate?.({ isLoading: false });
       return;
     }
-    if (isIOSApp || (isBrave() && isMobile())) {
-      window.location.href = socialUrl;
-      return;
-    }
     if (!windowPopup.current) {
-      logEvent({
-        event_name: authErrorEventName,
-        extra: JSON.stringify({
-          error: 'Failed to open social login window',
-          origin: 'betterauth social popup',
-        }),
-      });
-      setIsSocialAuthLoading(false);
-      displayToast(SOCIAL_AUTH_RETRY_MESSAGE);
-      onAuthStateUpdate?.({ isLoading: false });
+      window.location.href = socialUrl;
       return;
     }
     windowPopup.current.location.href = socialUrl;

--- a/packages/shared/src/hooks/useLogin.ts
+++ b/packages/shared/src/hooks/useLogin.ts
@@ -26,7 +26,7 @@ import { labels } from '../lib';
 import { Origin } from '../lib/log';
 import { useEventListener } from './useEventListener';
 import { broadcastChannel, webappUrl } from '../lib/constants';
-import { isIOSNative } from '../lib/func';
+import { shouldUseSocialAuthPopup } from '../lib/func';
 
 interface UseLogin {
   isPasswordLoginLoading?: boolean;
@@ -178,8 +178,8 @@ const useLogin = ({
         }
         return;
       }
-      const isIOSApp = isIOSNative();
-      const socialPopup = isIOSApp ? null : window.open();
+      const shouldUsePopup = shouldUseSocialAuthPopup();
+      const socialPopup = shouldUsePopup ? window.open() : null;
       const callbackURL = `${webappUrl}callback?login=true`;
       const { url: socialUrl, error } = await getBetterAuthSocialRedirectData(
         provider,
@@ -197,22 +197,11 @@ const useLogin = ({
         displayToast(labels.auth.error.generic);
         return;
       }
-      if (isIOSApp) {
-        window.location.href = socialUrl;
-        return;
-      }
       if (socialPopup) {
         socialPopup.location.href = socialUrl;
         return;
       }
-      logEvent({
-        event_name: AuthEventNames.LoginError,
-        extra: JSON.stringify({
-          error: 'Failed to open social login window',
-          origin: Origin.BetterAuthSocialPopup,
-        }),
-      });
-      displayToast(labels.auth.error.generic);
+      window.location.href = socialUrl;
     },
     [displayToast, logEvent, refetchBoot, onUpdateSignBack],
   );

--- a/packages/shared/src/lib/func.ts
+++ b/packages/shared/src/lib/func.ts
@@ -216,6 +216,18 @@ export const isMobile = (): boolean =>
 export const shouldUseNativeShare = (): boolean =>
   'share' in globalThis?.navigator && isMobile();
 
+export const shouldUseSocialAuthPopup = (): boolean => {
+  if (isIOSNative()) {
+    return false;
+  }
+
+  if (isBrave() && isMobile()) {
+    return false;
+  }
+
+  return true;
+};
+
 interface BroadcastMessage {
   eventKey: string;
   [key: string]: unknown;

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -91,7 +91,6 @@ export enum Origin {
   BetterAuthNativeIdToken = 'betterauth native id token',
   BetterAuthNativeIdTokenBoot = 'betterauth native id token boot',
   BetterAuthSocialUrl = 'betterauth social url',
-  BetterAuthSocialPopup = 'betterauth social popup',
   LoginTurnstile = 'login turnstile',
 }
 


### PR DESCRIPTION
## Changes

If oauth popup gets blocked by 3party webview, app or blocker/extension we use plain redirect.

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->
