### PR TITLE
fix: correct timezone offset formatting

### DIFF
--- a/packages/shared/src/graphql/highlights.ts
+++ b/packages/shared/src/graphql/highlights.ts
@@ -1,6 +1,7 @@
 import { gql } from 'graphql-request';
 import { gqlClient } from './common';
 import type { Connection } from './common';
+import { ONE_MINUTE } from '../lib/time';
 
 export interface PostHighlight {
   id: string;
@@ -35,7 +36,6 @@ export interface MajorHeadlinesData {
   majorHeadlines: Connection<PostHighlight>;
 }
 
-const ONE_MINUTE = 60 * 1000;
 export const HIGHLIGHTS_PAGE_QUERY_KEY = ['highlights-page'];
 
 type HighlightIdentity = Pick<PostHighlight, 'id'>;

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -32,6 +32,7 @@ import type {
   ContentPreferenceType,
 } from '../graphql/contentPreference';
 import { PostType } from '../types';
+import { FIVE_MINUTES, ONE_HOUR, ONE_MINUTE, THIRTY_MINUTES } from './time';
 
 export enum OtherFeedPage {
   Tag = 'tag',
@@ -73,10 +74,6 @@ export enum OtherFeedPage {
   AgentsVibes = 'agents-vibes',
 }
 
-const ONE_MINUTE = 60 * 1000;
-const THIRTY_MINUTES = ONE_MINUTE * 30;
-const FIVE_MINUTES = ONE_MINUTE * 5;
-const ONE_HOUR = ONE_MINUTE * 60;
 export const STALE_TIME = 30 * 1000;
 
 export enum StaleTime {

--- a/packages/shared/src/lib/time.ts
+++ b/packages/shared/src/lib/time.ts
@@ -1,0 +1,6 @@
+export const MINUTES_IN_HOUR = 60;
+export const MILLISECONDS_IN_MINUTE = 60 * 1000;
+export const ONE_MINUTE = MILLISECONDS_IN_MINUTE;
+export const FIVE_MINUTES = ONE_MINUTE * 5;
+export const THIRTY_MINUTES = ONE_MINUTE * 30;
+export const ONE_HOUR = ONE_MINUTE * MINUTES_IN_HOUR;

--- a/packages/shared/src/lib/timezones.spec.ts
+++ b/packages/shared/src/lib/timezones.spec.ts
@@ -1,0 +1,31 @@
+import { getTimeZoneOptions, getTimezoneOffsetLabel } from './timezones';
+
+describe('timezones', () => {
+  it('formats quarter-hour offsets using minutes', () => {
+    expect(getTimeZoneOptions()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          value: 'Asia/Katmandu',
+          label: '(UTC +5:45) Kathmandu',
+        }),
+      ]),
+    );
+  });
+
+  it('formats half-hour offsets using minutes', () => {
+    expect(getTimeZoneOptions()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          value: 'Pacific/Marquesas',
+          label: '(UTC -9:30) Marquesas Islands',
+        }),
+      ]),
+    );
+  });
+
+  it('formats timezone labels without decimal hours', () => {
+    expect(getTimezoneOffsetLabel('Asia/Katmandu')).toBe(
+      '(UTC +5:45) Asia/Katmandu',
+    );
+  });
+});

--- a/packages/shared/src/lib/timezones.ts
+++ b/packages/shared/src/lib/timezones.ts
@@ -3,6 +3,7 @@ import type { FC } from 'react';
 import formatInTimeZone from 'date-fns-tz/formatInTimeZone';
 import { DaytimeIcon, NighttimeIcon } from '../components/icons/TimeZone';
 import type { IconProps } from '../components/Icon';
+import { MILLISECONDS_IN_MINUTE, MINUTES_IN_HOUR } from './time';
 
 interface TimeZoneItem {
   value: string;
@@ -10,8 +11,6 @@ interface TimeZoneItem {
   offset?: number;
 }
 
-const MINUTES_IN_HOUR = 60;
-const MILLISECONDS_IN_MINUTE = 60 * 1000;
 export const DEFAULT_TIMEZONE = 'Etc/UTC';
 
 const getTimezoneOffsetInMinutes = (
@@ -28,7 +27,13 @@ const formatTimezoneOffset = (offsetInMinutes: number): string => {
   const absoluteOffset = Math.abs(offsetInMinutes);
   const hours = Math.floor(absoluteOffset / MINUTES_IN_HOUR);
   const minutes = absoluteOffset % MINUTES_IN_HOUR;
-  const sign = offsetInMinutes > 0 ? '+' : offsetInMinutes < 0 ? '-' : '';
+  let sign = '';
+
+  if (offsetInMinutes > 0) {
+    sign = '+';
+  } else if (offsetInMinutes < 0) {
+    sign = '-';
+  }
 
   if (!minutes) {
     return `${sign}${hours}`;

--- a/packages/shared/src/lib/timezones.ts
+++ b/packages/shared/src/lib/timezones.ts
@@ -1,4 +1,4 @@
-import { getTimezoneOffset, utcToZonedTime } from 'date-fns-tz';
+import { getTimezoneOffset } from 'date-fns-tz';
 import type { FC } from 'react';
 import formatInTimeZone from 'date-fns-tz/formatInTimeZone';
 import { DaytimeIcon, NighttimeIcon } from '../components/icons/TimeZone';
@@ -9,6 +9,33 @@ interface TimeZoneItem {
   label: string;
   offset?: number;
 }
+
+const MINUTES_IN_HOUR = 60;
+const MILLISECONDS_IN_MINUTE = 60 * 1000;
+export const DEFAULT_TIMEZONE = 'Etc/UTC';
+
+const getTimezoneOffsetInMinutes = (
+  timezone: string,
+  date = new Date(),
+): number => {
+  return Math.round(
+    getTimezoneOffset(timezone || DEFAULT_TIMEZONE, date) /
+      MILLISECONDS_IN_MINUTE,
+  );
+};
+
+const formatTimezoneOffset = (offsetInMinutes: number): string => {
+  const absoluteOffset = Math.abs(offsetInMinutes);
+  const hours = Math.floor(absoluteOffset / MINUTES_IN_HOUR);
+  const minutes = absoluteOffset % MINUTES_IN_HOUR;
+  const sign = offsetInMinutes > 0 ? '+' : offsetInMinutes < 0 ? '-' : '';
+
+  if (!minutes) {
+    return `${sign}${hours}`;
+  }
+
+  return `${sign}${hours}:${minutes.toString().padStart(2, '0')}`;
+};
 
 const TIME_ZONES: TimeZoneItem[] = [
   {
@@ -510,19 +537,10 @@ const TIME_ZONES: TimeZoneItem[] = [
 ];
 
 const timeZoneCurrentOffsetLabel = (timeZone: TimeZoneItem) => {
-  const date = new Date();
-  date.setMilliseconds(0);
-  const userOffset = (date.getTimezoneOffset() / 60) * -1;
+  const offset = getTimezoneOffsetInMinutes(timeZone.value);
 
-  const timeZoneDate = utcToZonedTime(date, timeZone.value);
-  const localTimeZoneDate = new Date(timeZoneDate.toLocaleString('en-US'));
-
-  const diffHrs =
-    (localTimeZoneDate.getTime() - date.getTime()) / 1000 / 60 / 60;
-  const timeZoneOffset = userOffset + diffHrs;
-  const offset = timeZoneOffset >= 24 ? timeZoneOffset - 24 : timeZoneOffset;
   return {
-    label: `(UTC ${timeZoneOffset > 0 ? '+' : ''}${offset}) ${timeZone.label}`,
+    label: `(UTC ${formatTimezoneOffset(offset)}) ${timeZone.label}`,
     offset,
   };
 };
@@ -536,11 +554,9 @@ export const getTimeZoneOptions = (): TimeZoneItem[] => {
 
 export const getUserDefaultTimezone = (): string => {
   const timeZoneOptions = getTimeZoneOptions();
-  const timeZoneOffset = (new Date().getTimezoneOffset() / 60) * -1;
+  const timeZoneOffset = formatTimezoneOffset(-new Date().getTimezoneOffset());
   const timezoneGuess = timeZoneOptions.find((timezone) =>
-    timezone.label.startsWith(
-      `(UTC ${timeZoneOffset > 0 ? '+' : ''}${timeZoneOffset})`,
-    ),
+    timezone.label.startsWith(`(UTC ${timeZoneOffset})`),
   );
 
   if (timezoneGuess) {
@@ -589,8 +605,6 @@ export const getTimeZoneIcon = (timezone: string): FC<IconProps> => {
   return hour >= 6 && hour < 18 ? DaytimeIcon : NighttimeIcon;
 };
 
-export const DEFAULT_TIMEZONE = 'Etc/UTC';
-
 export const dateFormatInTimezone = (
   date: Date,
   format: string,
@@ -617,9 +631,8 @@ export const isSameDayInTimezone = (
 };
 
 export const getTimezoneOffsetLabel = (timezone: string): string => {
-  // from ms to hours
-  const timezoneOffset =
-    getTimezoneOffset(timezone || DEFAULT_TIMEZONE) / (60 * 60 * 1000);
+  const resolvedTimezone = timezone || DEFAULT_TIMEZONE;
+  const timezoneOffset = getTimezoneOffsetInMinutes(resolvedTimezone);
 
-  return `(UTC ${timezoneOffset > 0 ? '+' : ''}${timezoneOffset}) ${timezone}`;
+  return `(UTC ${formatTimezoneOffset(timezoneOffset)}) ${resolvedTimezone}`;
 };


### PR DESCRIPTION
## Summary
- Fix timezone offset labels to format minute-based offsets like +5:45 instead of +5:75
- Reuse the same formatter for dropdown labels, default-timezone matching, and mismatch prompts
- Add regression coverage for quarter-hour and half-hour offsets

## Testing
- Tests not run successfully in this worktree: local Jest/Babel environment is missing required packages such as jest-environment-jsdom and @babel/preset-env
- Strict TypeScript check in this checkout also fails before reaching this change because dependencies and types are unavailable

### Preview domain
https://codex-fix-timezone-offset-format.preview.app.daily.dev