### PR TITLE
[codex] fix sidebar anonymous following test

### DIFF
--- a/packages/shared/src/components/sidebar/Sidebar.spec.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.spec.tsx
@@ -38,9 +38,10 @@ const defaultAlerts: Alerts = { filter: true };
 const renderComponent = (
   alertsData = defaultAlerts,
   mocks: MockedGraphQLResponse[] = [createMockFeedSettings()],
-  user: LoggedUser | undefined = defaultUser,
+  user: LoggedUser | null | undefined = defaultUser,
   sidebarExpanded = true,
 ): RenderResult => {
+  const resolvedUser = user === null ? undefined : user;
   const settingsContext = createTestSettings({
     sidebarExpanded,
     toggleSidebarExpanded,
@@ -58,10 +59,10 @@ const renderComponent = (
       >
         <AuthContext.Provider
           value={{
-            user,
+            user: resolvedUser,
             isAuthReady: true,
             isFetched: true,
-            isLoggedIn: !!user?.id,
+            isLoggedIn: !!resolvedUser?.id,
             shouldShowLogin: false,
             showLogin,
             logout: jest.fn(),
@@ -134,7 +135,7 @@ it('should render Highlights item linking to highlights page', async () => {
 });
 
 it('should require login before opening following for anonymous users', async () => {
-  renderComponent(defaultAlerts, [createMockFeedSettings()], undefined);
+  renderComponent(defaultAlerts, [createMockFeedSettings()], null);
   const item = await screen.findByText('Following');
 
   fireEvent.click(item);


### PR DESCRIPTION
## What changed
- restores the sidebar test helper's anonymous-user path by treating `null` as an explicit anonymous case instead of falling back to `defaultUser`
- updates the `Following` login-gate test to pass `null` again so it actually exercises the anonymous flow

## Why
A recent refactor changed the test helper signature to default `undefined` back to `defaultUser`. That made the spec render a logged-in user, so `showLogin` was never called and the assertion became invalid.

## Impact
The failing test now matches the intended product behavior again: anonymous users should be prompted to log in before opening `Following` from the sidebar.

## Validation
- `node ./scripts/typecheck-strict-changed.js`
- attempted to run the focused Jest spec, but the current workspace install crashes before loading tests because the installed Jest stack is skewed (`jest` 29 with `jest-cli` / `@jest/environment` 26)


### Preview domain
https://codex-fix-sidebar-anon-following.preview.app.daily.dev