### PR TITLE
feat: experiment hiding non-Plus clickbait warning shield on feed

### DIFF
--- a/packages/shared/src/components/cards/common/ClickbaitShield.tsx
+++ b/packages/shared/src/components/cards/common/ClickbaitShield.tsx
@@ -17,8 +17,14 @@ import { FeedSettingsMenu } from '../../feeds/FeedSettings/types';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { webappUrl } from '../../../lib/constants';
 import { Tooltip } from '../../tooltip/Tooltip';
+import { useFeature } from '../../GrowthBookProvider';
+import { featureFeedClickbaitShieldWarning } from '../../../lib/featureManagement';
 
-export const ClickbaitShield = ({ post }: { post: Post }): ReactElement => {
+export const ClickbaitShield = ({
+  post,
+}: {
+  post: Post;
+}): ReactElement | null => {
   const { openModal } = useLazyModal();
   const { isPlus } = usePlusSubscription();
   const { fetchSmartTitle, fetchedSmartTitle, shieldActive } =
@@ -27,8 +33,13 @@ export const ClickbaitShield = ({ post }: { post: Post }): ReactElement => {
   const router = useRouter();
   const { user } = useAuthContext();
   const { hasUsedFreeTrial, triesLeft } = useClickbaitTries();
+  const showWarningShield = useFeature(featureFeedClickbaitShieldWarning);
 
   if (!isPlus) {
+    if (!fetchedSmartTitle && !showWarningShield) {
+      return null;
+    }
+
     return (
       <Tooltip
         className="max-w-70 text-center !typo-subhead"

--- a/packages/shared/src/components/cards/common/ClickbaitShield.tsx
+++ b/packages/shared/src/components/cards/common/ClickbaitShield.tsx
@@ -8,6 +8,7 @@ import {
   useViewSize,
   ViewSize,
   useClickbaitTries,
+  useConditionalFeature,
 } from '../../../hooks';
 import { useLazyModal } from '../../../hooks/useLazyModal';
 import { LazyModal } from '../../modals/common/types';
@@ -17,7 +18,6 @@ import { FeedSettingsMenu } from '../../feeds/FeedSettings/types';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { webappUrl } from '../../../lib/constants';
 import { Tooltip } from '../../tooltip/Tooltip';
-import { useFeature } from '../../GrowthBookProvider';
 import { featureFeedClickbaitShieldWarning } from '../../../lib/featureManagement';
 
 export const ClickbaitShield = ({
@@ -33,7 +33,10 @@ export const ClickbaitShield = ({
   const router = useRouter();
   const { user } = useAuthContext();
   const { hasUsedFreeTrial, triesLeft } = useClickbaitTries();
-  const showWarningShield = useFeature(featureFeedClickbaitShieldWarning);
+  const { value: showWarningShield } = useConditionalFeature({
+    feature: featureFeedClickbaitShieldWarning,
+    shouldEvaluate: !isPlus,
+  });
 
   if (!isPlus) {
     if (!fetchedSmartTitle && !showWarningShield) {

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -89,6 +89,11 @@ export const featureReadingReminderHeroCopy = new Feature(
 
 export const clickbaitTriesMax = new Feature('clickbait_tries_max', 5);
 
+export const featureFeedClickbaitShieldWarning = new Feature(
+  'feed_clickbait_shield_warning',
+  true,
+);
+
 export { feature };
 
 export const featureCores = new Feature('cores', isDevelopment);


### PR DESCRIPTION
## Summary

Runs a GrowthBook experiment to hide the yellow/red warning `ClickbaitShield` badge from non-Plus users on feed cards, without touching the rest of the feature.

- Adds boolean feature `feed_clickbait_shield_warning` (default `true`) in `packages/shared/src/lib/featureManagement.ts`.
- In `packages/shared/src/components/cards/common/ClickbaitShield.tsx`, when non-Plus and the user has not fetched the smart title for this post, returns `null` if the flag is `false`.

## Behavior

- Plus users: unchanged (`ShieldIcon` / `ShieldCheckIcon`).
- Non-Plus after a free try (`fetchedSmartTitle = true`): unchanged — still shows the green `ShieldCheckIcon` as proof of value.
- Non-Plus, warning state (`fetchedSmartTitle = false`): hidden when the flag is `false`; unchanged when `true` (default/control).
- Post detail `PostClickbaitShield`: unchanged.
- Feed header `ToggleClickbaitShield`: unchanged.

## Rollout

1. Land with the flag defaulting to `true` (no user impact).
2. Configure a 50/50 GrowthBook experiment on non-Plus users.
3. Watch feed engagement and Plus conversion; flip default or clean up based on results.

## Test plan

- [ ] Plus account: card shield renders as before (toggles original/optimized).
- [ ] Non-Plus, flag on (default): yellow/red warning shield renders as before.
- [ ] Non-Plus, flag off via GrowthBook override: no shield on cards for unfetched posts.
- [ ] Non-Plus, flag off, after using a free try on a post: green `ShieldCheckIcon` still renders on that card.
- [ ] Post detail pages and the feed header `ToggleClickbaitShield` are unaffected under both variants.

Made with [Cursor](https://cursor.com)

### Preview domain
https://feat-clickbait-shield-warning-ex.preview.app.daily.dev