### PR TITLE
fix: highlights page desktop tab dragging

### DIFF
--- a/packages/shared/src/components/highlights/HighlightsPage.tsx
+++ b/packages/shared/src/components/highlights/HighlightsPage.tsx
@@ -153,7 +153,7 @@ export const HighlightsPage = (): ReactElement => {
         showBorder={false}
         shallow
         swipeable
-        tabListProps={{ autoScrollActive: true }}
+        tabListProps={{ autoScrollActive: true, dragScroll: true }}
         tabTag="a"
         className={{
           header:

--- a/packages/shared/src/components/sidebar/Sidebar.spec.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.spec.tsx
@@ -38,13 +38,14 @@ const defaultAlerts: Alerts = { filter: true };
 const renderComponent = (
   alertsData = defaultAlerts,
   mocks: MockedGraphQLResponse[] = [createMockFeedSettings()],
-  user: LoggedUser | undefined = defaultUser,
+  user: LoggedUser | null = defaultUser,
   sidebarExpanded = true,
 ): RenderResult => {
   const settingsContext = createTestSettings({
     sidebarExpanded,
     toggleSidebarExpanded,
   });
+  const authUser = user ?? undefined;
   client = new QueryClient();
   client.setQueryData(TOAST_NOTIF_KEY, null);
   mocks.forEach(mockGraphQL);
@@ -58,10 +59,10 @@ const renderComponent = (
       >
         <AuthContext.Provider
           value={{
-            user,
+            user: authUser,
             isAuthReady: true,
             isFetched: true,
-            isLoggedIn: !!user?.id,
+            isLoggedIn: !!authUser?.id,
             shouldShowLogin: false,
             showLogin,
             logout: jest.fn(),
@@ -108,7 +109,7 @@ it('should toggle the sidebar on button click', async () => {
 });
 
 it('should show the sidebar as closed if user has this set', async () => {
-  renderComponent(defaultAlerts, [], undefined, false);
+  renderComponent(defaultAlerts, [], null, false);
   const trigger = await screen.findByLabelText('Open sidebar');
   expect(trigger).toBeInTheDocument();
 
@@ -134,7 +135,7 @@ it('should render Highlights item linking to highlights page', async () => {
 });
 
 it('should require login before opening following for anonymous users', async () => {
-  renderComponent(defaultAlerts, [createMockFeedSettings()], undefined);
+  renderComponent(defaultAlerts, [createMockFeedSettings()], null);
   const item = await screen.findByRole('link', { name: 'Following' });
 
   fireEvent.click(item);

--- a/packages/shared/src/components/sidebar/Sidebar.spec.tsx
+++ b/packages/shared/src/components/sidebar/Sidebar.spec.tsx
@@ -135,13 +135,15 @@ it('should render Highlights item linking to highlights page', async () => {
 
 it('should require login before opening following for anonymous users', async () => {
   renderComponent(defaultAlerts, [createMockFeedSettings()], undefined);
-  const item = await screen.findByText('Following');
+  const item = await screen.findByRole('link', { name: 'Following' });
 
   fireEvent.click(item);
 
-  expect(showLogin).toHaveBeenCalledWith({
-    trigger: 'Following',
-  });
+  await waitFor(() =>
+    expect(showLogin).toHaveBeenCalledWith({
+      trigger: 'Following',
+    }),
+  );
 });
 
 const sidebarItems = [

--- a/packages/shared/src/components/tabs/TabContainer.spec.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.spec.tsx
@@ -201,7 +201,7 @@ describe('tab container component', () => {
 
       const first = await screen.findByRole('link', { name: 'First' });
 
-      expect(first).toHaveAttribute('draggable', 'false');
+      expect(first.draggable).toBe(false);
     });
   });
 });

--- a/packages/shared/src/components/tabs/TabContainer.spec.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.spec.tsx
@@ -197,6 +197,7 @@ describe('tab container component', () => {
       renderUrlComponent({
         shouldMountInactive: true,
         tabListProps: { dragScroll: true },
+        tabTag: 'a',
       });
 
       const first = await screen.findByRole('link', { name: 'First' });

--- a/packages/shared/src/components/tabs/TabContainer.spec.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.spec.tsx
@@ -61,6 +61,43 @@ describe('tab container component', () => {
     await screen.findByText('Test');
   });
 
+  it('should drag-scroll the tab list on desktop when enabled', () => {
+    renderComponent({
+      className: { header: 'overflow-x-auto' },
+      tabListProps: { dragScroll: true },
+    });
+
+    const list = screen.getByRole('list');
+    const scrollableParent = list.parentElement as HTMLElement;
+
+    Object.defineProperty(scrollableParent, 'scrollWidth', {
+      configurable: true,
+      value: 400,
+    });
+    Object.defineProperty(scrollableParent, 'clientWidth', {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scrollableParent, 'scrollLeft', {
+      configurable: true,
+      value: 100,
+      writable: true,
+    });
+
+    fireEvent.mouseDown(list, {
+      button: 0,
+      clientX: 100,
+    });
+    fireEvent.mouseMove(window, {
+      clientX: 60,
+    });
+    fireEvent.mouseUp(window, {
+      clientX: 60,
+    });
+
+    expect(scrollableParent.scrollLeft).toBe(140);
+  });
+
   it('should mount tabs if shouldMountInactive is true but hidden', async () => {
     renderComponent({ shouldMountInactive: true });
     await screen.findByText('First');
@@ -112,6 +149,59 @@ describe('tab container component', () => {
       expect(routerPush).toHaveBeenCalledWith('/first', undefined, {
         shallow: false,
       });
+    });
+
+    it('should not redirect after a drag gesture', async () => {
+      renderUrlComponent({
+        className: { header: 'overflow-x-auto' },
+        shouldMountInactive: true,
+        tabListProps: { dragScroll: true },
+      });
+
+      const list = screen.getByRole('list');
+      const first = await screen.findByText('First');
+      const scrollableParent = list.parentElement as HTMLElement;
+
+      Object.defineProperty(scrollableParent, 'scrollWidth', {
+        configurable: true,
+        value: 400,
+      });
+      Object.defineProperty(scrollableParent, 'clientWidth', {
+        configurable: true,
+        value: 200,
+      });
+      Object.defineProperty(scrollableParent, 'scrollLeft', {
+        configurable: true,
+        value: 100,
+        writable: true,
+      });
+
+      fireEvent.mouseDown(list, {
+        button: 0,
+        clientX: 100,
+      });
+      fireEvent.mouseMove(window, {
+        clientX: 60,
+      });
+      fireEvent.mouseUp(window, {
+        clientX: 60,
+      });
+      fireEvent.click(first);
+
+      expect(routerPush).not.toHaveBeenCalledWith('/first', undefined, {
+        shallow: false,
+      });
+    });
+
+    it('should disable native anchor dragging when drag scroll is enabled', async () => {
+      renderUrlComponent({
+        shouldMountInactive: true,
+        tabListProps: { dragScroll: true },
+      });
+
+      const first = await screen.findByRole('link', { name: 'First' });
+
+      expect(first).toHaveAttribute('draggable', 'false');
     });
   });
 });

--- a/packages/shared/src/components/tabs/TabContainer.tsx
+++ b/packages/shared/src/components/tabs/TabContainer.tsx
@@ -59,7 +59,10 @@ export interface TabContainerProps<T extends string = string> {
   style?: CSSProperties;
   shallow?: boolean;
   swipeable?: boolean;
-  tabListProps?: Pick<TabListProps, 'className' | 'autoScrollActive'>;
+  tabListProps?: Pick<
+    TabListProps,
+    'className' | 'autoScrollActive' | 'dragScroll'
+  >;
   tabTag?: AllowedTabTags;
   extraHeaderContent?: ReactNode;
 }
@@ -236,6 +239,7 @@ export function TabContainer<T extends string = string>({
           active={currentActive}
           className={tabListProps?.className}
           autoScrollActive={tabListProps?.autoScrollActive}
+          dragScroll={tabListProps?.dragScroll}
           tag={tabTag}
         />
         {extraHeaderContent}

--- a/packages/shared/src/components/tabs/TabList.tsx
+++ b/packages/shared/src/components/tabs/TabList.tsx
@@ -1,6 +1,12 @@
 import classNames from 'classnames';
 import type { ReactElement } from 'react';
-import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import type { RenderTab } from './common';
 import type { TabProps } from './TabContainer';
 
@@ -16,6 +22,13 @@ interface DimensionProps {
   offset: number;
   indicatorOffset: number;
 }
+
+interface DragState {
+  startClientX: number;
+  startScrollLeft: number;
+  didDrag: boolean;
+}
+
 export interface TabListProps<T extends string = string> {
   items: Pick<TabProps<T>, 'label' | 'url' | 'hint'>[];
   active: T;
@@ -25,6 +38,7 @@ export interface TabListProps<T extends string = string> {
   ) => unknown;
   className?: ClassName;
   autoScrollActive?: boolean;
+  dragScroll?: boolean;
   renderTab?: RenderTab;
   tag?: AllowedTabTags;
 }
@@ -35,17 +49,25 @@ function TabList<T extends string = string>({
   onClick,
   className = {},
   autoScrollActive,
+  dragScroll = false,
   renderTab,
   tag: Tag = 'button',
 }: TabListProps<T>): ReactElement {
   const labels = items.map((item) => item.label);
   const hasActive = labels.includes(active);
   const currentActiveTab = useRef<HTMLElement | null>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const dragStateRef = useRef<DragState | null>(null);
+  const suppressClickRef = useRef(false);
   const [dimensions, setDimensions] = useState<DimensionProps>({
     offset: 0,
     indicatorOffset: 0,
   });
   const isAnchor = Tag === 'a';
+  const getScrollableParent = useCallback(
+    () => listRef.current?.parentElement,
+    [],
+  );
 
   const scrollIfNotInView = useCallback(() => {
     const { activeTabRect, offset } = dimensions;
@@ -109,10 +131,105 @@ function TabList<T extends string = string>({
     scrollIfNotInView();
   }, [scrollIfNotInView]);
 
+  const clearDragSuppression = useCallback(() => {
+    setTimeout(() => {
+      suppressClickRef.current = false;
+    }, 0);
+  }, []);
+
+  const finishDrag = useCallback(() => {
+    const dragState = dragStateRef.current;
+    if (!dragState) {
+      return;
+    }
+
+    dragStateRef.current = null;
+
+    if (!dragState.didDrag) {
+      return;
+    }
+
+    suppressClickRef.current = true;
+    clearDragSuppression();
+  }, [clearDragSuppression]);
+
+  useEffect(() => {
+    if (!dragScroll) {
+      return undefined;
+    }
+
+    const list = listRef.current;
+    if (!list) {
+      return undefined;
+    }
+
+    const onMouseDown = (event: MouseEvent) => {
+      if (event.button !== 0) {
+        return;
+      }
+
+      const scrollableParent = getScrollableParent();
+      if (!scrollableParent) {
+        return;
+      }
+
+      if (scrollableParent.scrollWidth <= scrollableParent.clientWidth) {
+        return;
+      }
+
+      dragStateRef.current = {
+        startClientX: event.clientX,
+        startScrollLeft: scrollableParent.scrollLeft,
+        didDrag: false,
+      };
+    };
+
+    const onMouseMove = (event: MouseEvent) => {
+      const dragState = dragStateRef.current;
+      if (!dragState) {
+        return;
+      }
+
+      const scrollableParent = getScrollableParent();
+      if (!scrollableParent) {
+        return;
+      }
+
+      const offsetX = event.clientX - dragState.startClientX;
+      if (!dragState.didDrag && Math.abs(offsetX) < 5) {
+        return;
+      }
+
+      dragState.didDrag = true;
+      scrollableParent.scrollLeft = dragState.startScrollLeft - offsetX;
+      event.preventDefault();
+    };
+
+    const onMouseUp = () => {
+      finishDrag();
+    };
+
+    list.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+
+    return () => {
+      list.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    };
+  }, [dragScroll, finishDrag, getScrollableParent]);
+
   const { indicatorOffset } = dimensions;
 
   return (
-    <ul className="relative flex flex-row">
+    <ul
+      ref={listRef}
+      className={classNames(
+        'relative flex flex-row',
+        dragScroll && 'cursor-grab select-none active:cursor-grabbing',
+      )}
+    >
       {items.map(({ label, url: href, hint }) => {
         const isActive = label === active;
         const renderedTab = renderTab?.({ label, isActive }) ?? (
@@ -144,14 +261,28 @@ function TabList<T extends string = string>({
               isAnchor && 'cursor-pointer',
             )}
             onClick={(event) => {
+              if (suppressClickRef.current) {
+                suppressClickRef.current = false;
+                event.preventDefault();
+                return;
+              }
+
               if (isAnchor) {
                 event.preventDefault();
               }
               onClick?.(label, event);
             }}
+            onDragStart={
+              dragScroll
+                ? (event) => {
+                    event.preventDefault();
+                  }
+                : undefined
+            }
             {...(isAnchor
               ? {
                   'aria-label': label,
+                  draggable: !dragScroll,
                   title: label,
                   ...(href ? { href } : {}),
                 }


### PR DESCRIPTION
## What changed
- added desktop drag-to-scroll support for the highlights page tab navigation
- disabled native anchor dragging on those tabs so the browser stops dragging the tab URL
- preserved normal tab clicks while suppressing accidental navigation immediately after a drag
- added regression coverage for drag scrolling, click suppression after drag, and native anchor dragging being disabled

## Why
The highlights navigation already supported touch swiping, but non-touch devices could not drag the overflowing tab row. The first pass at desktop dragging exposed the browser's native link-drag behavior and then interfered with regular tab clicks.

## Impact
Desktop users can now drag the highlights tab strip horizontally without triggering native URL dragging, and normal tab clicks still navigate as expected.

## Root cause
The tab items are rendered as anchors. Browsers treat those anchors as draggable by default, and the earlier pointer-capture approach was too aggressive for the native click flow.

## Validation
- `pnpm --filter shared exec eslint src/components/tabs/TabList.tsx src/components/tabs/TabContainer.spec.tsx --max-warnings 0`
- `node ./scripts/typecheck-strict-changed.js`
- Focused Jest verification is still blocked by the repo's existing jsdom/runtime issue: `Cannot read properties of undefined (reading 'testEnvironmentOptions')`


### Preview domain
https://codex-fix-highlights-desktop-tab.preview.app.daily.dev