### PR TITLE
fix: improve feed highlights card behavior

### DIFF
--- a/packages/shared/src/components/cards/highlight/HighlightCards.spec.tsx
+++ b/packages/shared/src/components/cards/highlight/HighlightCards.spec.tsx
@@ -46,6 +46,12 @@ describe('Highlight cards', () => {
       'href',
       '/highlights?highlight=highlight-1',
     );
+    expect(screen.getByText('The first highlight')).not.toHaveClass(
+      'line-clamp-2',
+    );
+    expect(
+      screen.getByRole('link', { name: /the first highlight/i }).parentElement,
+    ).toHaveClass('no-scrollbar', 'overflow-y-auto');
   });
 
   it('should render the list card with highlight links', () => {

--- a/packages/shared/src/components/cards/highlight/common.tsx
+++ b/packages/shared/src/components/cards/highlight/common.tsx
@@ -38,7 +38,7 @@ const HighlightRow = ({
         href={getHighlightUrl(highlight)}
         onClick={() => onHighlightClick?.(highlight, index + 1)}
       >
-        <span className="line-clamp-2 font-bold text-text-primary typo-callout">
+        <span className="break-words font-bold text-text-primary typo-callout">
           {highlight.headline}
         </span>
         <RelativeTime
@@ -63,8 +63,8 @@ export const HighlightCardContent = ({
       : 'flex items-center px-4 py-4';
   const contentClassName =
     variant === 'list'
-      ? 'flex flex-col gap-2'
-      : 'flex flex-1 flex-col gap-0 px-2.5 pb-1 pt-0';
+      ? 'no-scrollbar flex min-h-0 flex-col gap-2 overflow-y-auto'
+      : 'no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-y-auto px-2.5 pb-1 pt-0';
   const footerClassName = variant === 'list' ? 'pt-1.5' : 'px-1 pb-1';
   const firstHighlight = highlights[0];
 

--- a/packages/shared/src/graphql/feed.spec.ts
+++ b/packages/shared/src/graphql/feed.spec.ts
@@ -17,7 +17,7 @@ describe('normalizeFeedPage', () => {
     expect(FEED_V2_QUERY).toContain('highlightsLimit: $highlightsLimit');
     expect(FEED_V2_QUERY).toContain('... on FeedHighlightsItem');
     expect(FEED_V2_QUERY).toContain('...PostHighlightCard');
-    expect(FEED_V2_HIGHLIGHTS_LIMIT).toBe(4);
+    expect(FEED_V2_HIGHLIGHTS_LIMIT).toBe(5);
   });
 
   it('should add highlight to feedV2 supported types only when enabled', () => {

--- a/packages/shared/src/graphql/feed.ts
+++ b/packages/shared/src/graphql/feed.ts
@@ -33,7 +33,7 @@ export const supportedTypesForPrivateSources = [
 
 const joinedTypes = baseFeedSupportedTypes.join('","');
 export const SUPPORTED_TYPES = `$supportedTypes: [String!] = ["${joinedTypes}"]`;
-export const FEED_V2_HIGHLIGHTS_LIMIT = 4;
+export const FEED_V2_HIGHLIGHTS_LIMIT = 5;
 
 export const getFeedV2SupportedTypes = (
   shouldSupportHighlights: boolean,


### PR DESCRIPTION
## What changed
- remove headline clamping from the feed highlights card so long headlines can wrap naturally
- make the highlights list scroll vertically with an invisible scrollbar inside the card
- increase the feed v2 highlights query limit from 4 to 5
- update the related specs to lock in the new behavior and limit

## Why
The highlight card needed to show full headlines without truncation while keeping the card layout contained, and the feed query needed one additional highlight item.

## Validation
- node ./scripts/typecheck-strict-changed.js
- pnpm exec eslint packages/shared/src/components/cards/highlight/common.tsx packages/shared/src/components/cards/highlight/HighlightCards.spec.tsx packages/shared/src/graphql/feed.ts packages/shared/src/graphql/feed.spec.ts
- Jest could not be executed in this environment because the repo currently expects Node >= 24.14.0 while the local runtime here is Node v20.20.0, which causes jest-environment-jsdom to fail before the suite boots


### Preview domain
https://codex-highlights-card-scroll-lim.preview.app.daily.dev