### PR TITLE
fix: spacing between post title and clickbait shield

### DIFF
--- a/packages/shared/src/components/post/common/PostClickbaitShield.tsx
+++ b/packages/shared/src/components/post/common/PostClickbaitShield.tsx
@@ -38,7 +38,7 @@ export const PostClickbaitShield = ({ post }: { post: Post }): ReactElement => {
       <>
         <div
           className={classNames(
-            'mt-6 flex flex-wrap items-center text-text-tertiary typo-callout tablet:mt-1',
+            'mt-4 flex flex-wrap items-center text-text-tertiary typo-callout',
             !fetchedSmartTitle &&
               'rounded-12 border border-border-subtlest-tertiary px-3 py-2',
           )}
@@ -135,7 +135,7 @@ export const PostClickbaitShield = ({ post }: { post: Post }): ReactElement => {
       }
     >
       <Button
-        className="relative mr-2 mt-1 font-normal"
+        className="relative mr-2 mt-4 font-normal"
         size={ButtonSize.XSmall}
         icon={
           shieldActive ? (


### PR DESCRIPTION
## Summary

- Restored breathing room between the post page `<h1>` and the clickbait shield widget. The non-Plus banner was collapsing to `mt-1` (4px) on tablet/desktop via `tablet:mt-1`, leaving the bordered card glued to the title.
- Both branches of `PostClickbaitShield` (non-Plus banner and Plus pill button) now use a consistent `mt-4` (16px) so the gap is the same across viewports and subscription states.

## Test plan

- [ ] Open a post with `clickbaitTitleDetected` as a non-Plus user on desktop — verify the bordered "Try out Clickbait Shield" banner has 16px above it.
- [ ] Same post on mobile — gap stays consistent (no responsive jump).
- [ ] Open a post as a Plus user — "Optimized title" / "Clickbait Shield disabled" pill sits 16px below the title.

Made with [Cursor](https://cursor.com)

### Preview domain
https://fix-clickbait-shield-title-spaci.preview.app.daily.dev