### PR TITLE
feat: ship full TLDR on post pages

### DIFF
--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -25,7 +25,6 @@ import { cloudinaryPostImageCoverPlaceholder } from '../../lib/image';
 import { withPostById } from './withPostById';
 import { PostClickbaitShield } from './common/PostClickbaitShield';
 import { useSmartTitle } from '../../hooks/post/useSmartTitle';
-import ShowMoreContent from '../cards/common/ShowMoreContent';
 import { PostTagList } from './tags/PostTagList';
 import PostSourceInfo from './PostSourceInfo';
 
@@ -193,16 +192,16 @@ export function PostContentRaw({
           {post.summary && (
             <div
               className={classNames(
-                'mb-6 text-text-secondary',
+                'mb-6 overflow-hidden text-text-secondary',
                 isCompactModalSpacing && 'mb-4',
               )}
             >
-              <ShowMoreContent
-                className={{ wrapper: 'overflow-hidden' }}
-                content={post.summary}
-                charactersLimit={330}
-                threshold={50}
-              />
+              <p
+                className="select-text break-words typo-markdown"
+                data-testid="tldr-container"
+              >
+                {post.summary}
+              </p>
             </div>
           )}
           <PostTagList post={post} />

--- a/packages/shared/src/components/post/common/SharedLinkContainer.tsx
+++ b/packages/shared/src/components/post/common/SharedLinkContainer.tsx
@@ -2,7 +2,6 @@ import type { ReactElement, ReactNode } from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import type { Post } from '../../../graphql/posts';
-import ShowMoreContent from '../../cards/common/ShowMoreContent';
 
 interface SharedLinkContainerProps {
   children: ReactNode;
@@ -20,13 +19,13 @@ export function SharedLinkContainer({
   Wrapper,
 }: SharedLinkContainerProps): ReactElement {
   const postSummary = post?.summary ? (
-    <div className="mb-4 px-4 text-text-secondary">
-      <ShowMoreContent
-        className={{ wrapper: 'overflow-hidden' }}
-        content={post.summary}
-        charactersLimit={330}
-        threshold={50}
-      />
+    <div className="mb-4 overflow-hidden px-4 text-text-secondary">
+      <p
+        className="select-text break-words typo-markdown"
+        data-testid="tldr-container"
+      >
+        {post.summary}
+      </p>
     </div>
   ) : null;
 

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -714,25 +714,22 @@ it('should show TLDR when there is a summary', async () => {
   expect(link).not.toBeInTheDocument();
 });
 
-it('should toggle TLDR on click', async () => {
+it('should show full TLDR for long summaries without a Show more toggle', async () => {
+  const summaryText =
+    "Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book type specimen book type specimen book type specimen book type.Ipsum is simply dummy text of the printing and typesetting industry. book type.Ipsum is simply dummy text of the printing and typesetting industry.";
   renderPost({}, [
-    createPostMock({
-      summary:
-        "Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book type specimen book type specimen book type specimen book type.Ipsum is simply dummy text of the printing and typesetting industry. book type.Ipsum is simply dummy text of the printing and typesetting industry.",
-    }),
+    createPostMock({ summary: summaryText }),
     completeActionMock({ action: ActionType.BookmarkPost }),
   ]);
   const el = await screen.findByTestId('tldr-container');
   expect(el).toBeInTheDocument();
+  expect(el).toHaveTextContent(summaryText);
   // eslint-disable-next-line testing-library/no-node-access, testing-library/prefer-screen-queries
   const showMoreLink = queryByText(
     getRequiredElement(el.parentElement, 'Expected TLDR container parent'),
     'Show more',
   );
-  expect(showMoreLink).toBeInTheDocument();
-  fireEvent.click(getRequiredElement(showMoreLink, 'Expected show more link'));
-  const showLessLink = await screen.findByText('Show less');
-  expect(showLessLink).toBeInTheDocument();
+  expect(showMoreLink).not.toBeInTheDocument();
 });
 
 it('should not show Show more link when there is a summary without reaching threshold', async () => {
@@ -899,7 +896,9 @@ describe('downvote flow', () => {
 
   it('should prevent user to click block if no tags are selected', async () => {
     await prepareDownvote();
-    const block = await screen.findByRole('button', { name: 'Block' });
+    const block = await screen.findByRole<HTMLButtonElement>('button', {
+      name: 'Block',
+    });
     expect(block.disabled).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- Drop the planned A/B test and ship the variant directly: post TLDRs now render the full summary on all post pages and post modals (article, squad-shared, YouTube-shared), across all viewport sizes.
- The Show more / Show less control is removed for post TLDRs.
- `ShowMoreContent` is unchanged in behavior for its remaining consumer (`UserExperienceItem`).

## Changes
- Render the TLDR directly in `PostContent.tsx` and `SharedLinkContainer.tsx`, preserving the existing `data-testid=\"tldr-container\"` and typography classes.
- No new feature flag.
- Replace the Show-more-toggle Jest test with one that asserts the full summary is rendered and no toggle is present for long summaries.

## Test plan
- [ ] Article post page and modal: TLDR renders fully, no Show more / Show less.
- [ ] Squad-shared post page and modal: same.
- [ ] YouTube-shared post page and modal: same.
- [ ] Verify on mobile, tablet, and desktop viewport sizes.
- [ ] Profile experience (`UserExperienceItem`) still uses the Show more / Show less behavior.

### Preview domain
https://experiment-tldr-full-content.preview.app.daily.dev