### PR TITLE
feat: tier HOT pill tooltip copy by trending count

### DIFF
--- a/packages/shared/src/components/cards/article/ArticleGrid.spec.tsx
+++ b/packages/shared/src/components/cards/article/ArticleGrid.spec.tsx
@@ -141,9 +141,7 @@ it('should show author image when available', async () => {
 it('should show trending flag', async () => {
   const usePost = { ...post, trending: 20 };
   renderComponent({ post: usePost });
-  expect(
-    await screen.findByText('20 devs read it last hour'),
-  ).toBeInTheDocument();
+  expect(await screen.findByText('Trending now')).toBeInTheDocument();
 });
 
 it('should open the article when clicking the read post button', async () => {

--- a/packages/shared/src/components/cards/common/FeedItemContainer.tsx
+++ b/packages/shared/src/components/cards/common/FeedItemContainer.tsx
@@ -10,6 +10,7 @@ import {
 } from './RaisedLabel';
 import ConditionalWrapper from '../../ConditionalWrapper';
 import { useBookmarkProvider, useFeedPreviewMode } from '../../../hooks';
+import { getTrendingDescription } from './getTrendingDescription';
 
 export interface FlagProps extends Pick<Post, 'trending' | 'pinnedAt'> {
   listMode?: boolean;
@@ -32,9 +33,7 @@ function FeedItemContainer(
   const { listMode, pinnedAt, trending } = flagProps;
   const type = pinnedAt ? RaisedLabelType.Pinned : RaisedLabelType.Hot;
   const description =
-    type === RaisedLabelType.Hot
-      ? `${trending} devs read it last hour`
-      : undefined;
+    type === RaisedLabelType.Hot ? getTrendingDescription(trending) : undefined;
   const isFeedPreview = useFeedPreviewMode();
 
   return (

--- a/packages/shared/src/components/cards/common/getTrendingDescription.ts
+++ b/packages/shared/src/components/cards/common/getTrendingDescription.ts
@@ -1,0 +1,13 @@
+export const HOT_DESCRIPTION_THRESHOLD = 30;
+
+export const getTrendingDescription = (
+  trending?: number,
+): string | undefined => {
+  if (!trending || trending <= 0) {
+    return undefined;
+  }
+  if (trending >= HOT_DESCRIPTION_THRESHOLD) {
+    return `${trending} devs read it last hour`;
+  }
+  return 'Trending now';
+};

--- a/packages/shared/src/components/cards/common/list/FeedItemContainer.tsx
+++ b/packages/shared/src/components/cards/common/list/FeedItemContainer.tsx
@@ -14,6 +14,7 @@ import { RaisedLabel, RaisedLabelType } from '../RaisedLabel';
 import { useFeedPreviewMode, useBookmarkProvider } from '../../../../hooks';
 import { TypeLabel } from './TypeLabel';
 import { bookmarkProviderListBg } from '../../../../styles/custom';
+import { getTrendingDescription } from '../getTrendingDescription';
 
 interface FeedItemContainerProps {
   flagProps?: FlagProps;
@@ -47,8 +48,8 @@ function FeedItemContainer(
     ? RaisedLabelType.Pinned
     : RaisedLabelType.Hot;
   const description =
-    raisedLabelType === RaisedLabelType.Hot && trending && trending > 0
-      ? `${trending} devs read it last hour`
+    raisedLabelType === RaisedLabelType.Hot
+      ? getTrendingDescription(trending)
       : undefined;
   const isFeedPreview = useFeedPreviewMode();
   const showFlag = (!!pinnedAt || !!trending) && !isFeedPreview;

--- a/packages/shared/src/components/widgets/SimilarPosts.tsx
+++ b/packages/shared/src/components/widgets/SimilarPosts.tsx
@@ -23,6 +23,7 @@ import {
 import { PostEngagementCounts } from '../cards/SimilarPosts';
 import { LogEvent } from '../../lib/log';
 import { WidgetContainer } from './common';
+import { getTrendingDescription } from '../cards/common/getTrendingDescription';
 
 export type SimilarPostsProps = {
   posts: Post[] | null;
@@ -46,47 +47,50 @@ type PostProps = {
 const imageClassName = 'w-7 h-7 rounded-full mt-1';
 const textContainerClassName = 'flex flex-col ml-3 mr-2 flex-1';
 
-const DefaultListItem = ({ post, onLinkClick }: PostProps): ReactElement => (
-  <article
-    className={classNames(
-      'group relative -mx-4 flex items-start px-4 py-3 hover:bg-surface-hover',
-      styles.card,
-    )}
-  >
-    <CardLink
-      href={post.commentsPermalink}
-      title={post.title}
-      {...combinedClicks(onLinkClick)}
-    />
-    <LazyImage
-      imgSrc={post.source?.image ?? ''}
-      imgAlt={post.source?.name ?? ''}
-      className={imageClassName}
-    />
-    <div className={textContainerClassName}>
-      <h5
-        className={classNames(
-          'multi-truncate mb-0.5 text-ellipsis break-words text-text-primary typo-callout',
-          styles.title,
-        )}
-      >
-        {post.title}
-      </h5>
-      {post.trending ? (
-        <div className="flex items-center text-text-tertiary typo-footnote">
-          <HotLabel />
-          <div className="ml-2">{post.trending} devs read it last hour</div>
-        </div>
-      ) : (
-        <PostEngagementCounts
-          upvotes={post.numUpvotes ?? 0}
-          comments={post.numComments ?? 0}
-          className="text-text-tertiary"
-        />
+const DefaultListItem = ({ post, onLinkClick }: PostProps): ReactElement => {
+  const trendingDescription = getTrendingDescription(post.trending);
+  return (
+    <article
+      className={classNames(
+        'group relative -mx-4 flex items-start px-4 py-3 hover:bg-surface-hover',
+        styles.card,
       )}
-    </div>
-  </article>
-);
+    >
+      <CardLink
+        href={post.commentsPermalink}
+        title={post.title}
+        {...combinedClicks(onLinkClick)}
+      />
+      <LazyImage
+        imgSrc={post.source?.image ?? ''}
+        imgAlt={post.source?.name ?? ''}
+        className={imageClassName}
+      />
+      <div className={textContainerClassName}>
+        <h5
+          className={classNames(
+            'multi-truncate mb-0.5 text-ellipsis break-words text-text-primary typo-callout',
+            styles.title,
+          )}
+        >
+          {post.title}
+        </h5>
+        {trendingDescription ? (
+          <div className="flex items-center text-text-tertiary typo-footnote">
+            <HotLabel />
+            <div className="ml-2">{trendingDescription}</div>
+          </div>
+        ) : (
+          <PostEngagementCounts
+            upvotes={post.numUpvotes ?? 0}
+            comments={post.numComments ?? 0}
+            className="text-text-tertiary"
+          />
+        )}
+      </div>
+    </article>
+  );
+};
 
 const TextPlaceholder = classed(ElementPlaceholder, 'h-3 rounded-12 my-0.5');
 


### PR DESCRIPTION
## Summary
- Tier HOT pill tooltip copy: show `${trending} devs read it last hour` for `trending >= 30`, `Trending now` for lower counts.
- Extract shared `getTrendingDescription` helper used by both `FeedItemContainer` variants and the `SimilarPosts` widget.

Pairs with the daily-api PR lowering the trending threshold from 30 to 15 and raising the top-N from 3 to 25. Ship together.

## Test plan
- [x] `pnpm --filter shared lint`
- [x] Strict typecheck on changed files
- [x] Affected jest specs (`ArticleGrid`, `SimilarPosts`, `FurtherReading`)

Made with [Cursor](https://cursor.com)

### Preview domain
https://feat-hot-pill-copy-tier.preview.app.daily.dev