### PR TITLE
chore: remove questsFeature feature flag

### DIFF
--- a/packages/shared/src/components/feeds/MobileFeedActions.spec.tsx
+++ b/packages/shared/src/components/feeds/MobileFeedActions.spec.tsx
@@ -1,16 +1,15 @@
 import type { ReactElement } from 'react';
 import React from 'react';
 import { QueryClient } from '@tanstack/react-query';
-import { GrowthBook } from '@growthbook/growthbook';
 import { render, screen } from '@testing-library/react';
 import loggedUser from '../../../__tests__/fixture/loggedUser';
 import { TestBootProvider } from '../../../__tests__/helpers/boot';
 import { useReadingStreak } from '../../hooks/streaks';
 import { MobileFeedActions } from './MobileFeedActions';
 
-const mockQuestButton = jest.fn(
-  (): ReactElement => <div data-testid="quest-button">Quest button</div>,
-);
+const mockQuestButton = jest.fn<ReactElement, [{ compact?: boolean }]>(() => (
+  <div data-testid="quest-button">Quest button</div>
+));
 
 jest.mock('next/dynamic', () => () => {
   return function MockDynamicComponent() {
@@ -58,31 +57,16 @@ jest.mock('../quest/QuestButton', () => ({
 
 const mockUseReadingStreak = useReadingStreak as jest.Mock;
 
-const getGrowthBook = (isQuestsFeatureEnabled = true): GrowthBook => {
-  const gb = new GrowthBook();
-
-  gb.setFeatures({
-    quests: {
-      defaultValue: isQuestsFeatureEnabled,
-    },
-  });
-
-  return gb;
-};
-
 const renderComponent = ({
   optOutQuestSystem = false,
-  isQuestsFeatureEnabled = true,
 }: {
   optOutQuestSystem?: boolean;
-  isQuestsFeatureEnabled?: boolean;
 } = {}) =>
   render(
     <TestBootProvider
       client={new QueryClient()}
       auth={{ user: loggedUser }}
       settings={{ optOutQuestSystem }}
-      gb={getGrowthBook(isQuestsFeatureEnabled)}
     >
       <MobileFeedActions />
     </TestBootProvider>,
@@ -99,7 +83,7 @@ describe('MobileFeedActions', () => {
   });
 
   it('should render the quest entry next to the streak button', () => {
-    renderComponent({ optOutQuestSystem: false, isQuestsFeatureEnabled: true });
+    renderComponent({ optOutQuestSystem: false });
 
     const actionButtons = screen.getAllByTestId(/^(streak|quest)-button$/);
 
@@ -112,7 +96,7 @@ describe('MobileFeedActions', () => {
   });
 
   it('should hide the quest entry when opted out from quests', () => {
-    renderComponent({ optOutQuestSystem: true, isQuestsFeatureEnabled: true });
+    renderComponent({ optOutQuestSystem: true });
 
     expect(screen.queryByTestId('quest-button')).not.toBeInTheDocument();
   });

--- a/packages/shared/src/components/header/QuestHeaderButton.tsx
+++ b/packages/shared/src/components/header/QuestHeaderButton.tsx
@@ -2,8 +2,6 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useSettingsContext } from '../../contexts/SettingsContext';
-import { useConditionalFeature } from '../../hooks/useConditionalFeature';
-import { questsFeature } from '../../lib/featureManagement';
 import { QuestButton } from '../quest/QuestButton';
 
 interface QuestHeaderButtonProps {
@@ -15,18 +13,8 @@ export function QuestHeaderButton({
 }: QuestHeaderButtonProps): ReactElement | null {
   const { isLoggedIn, isAuthReady } = useAuthContext();
   const { loadedSettings, optOutQuestSystem } = useSettingsContext();
-  const { value: isQuestsFeatureEnabled } = useConditionalFeature({
-    feature: questsFeature,
-    shouldEvaluate: isLoggedIn,
-  });
 
-  if (
-    !isAuthReady ||
-    !loadedSettings ||
-    !isLoggedIn ||
-    isQuestsFeatureEnabled !== true ||
-    optOutQuestSystem
-  ) {
+  if (!isAuthReady || !loadedSettings || !isLoggedIn || optOutQuestSystem) {
     return null;
   }
 

--- a/packages/shared/src/components/layout/HeaderButtons.spec.tsx
+++ b/packages/shared/src/components/layout/HeaderButtons.spec.tsx
@@ -2,7 +2,6 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import { QueryClient } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import { GrowthBook } from '@growthbook/growthbook-react';
 import { TestBootProvider } from '../../../__tests__/helpers/boot';
 import { HeaderButtons } from './HeaderButtons';
 
@@ -34,53 +33,29 @@ jest.mock('../quest/QuestButton', () => ({
   QuestButton: (): ReactElement => <div>Quest button</div>,
 }));
 
-const getGrowthBook = (isQuestsFeatureEnabled = true): GrowthBook => {
-  const gb = new GrowthBook();
-
-  gb.setFeatures({
-    quests: {
-      defaultValue: isQuestsFeatureEnabled,
-    },
-  });
-
-  return gb;
-};
-
 const renderComponent = ({
   optOutQuestSystem = false,
-  isQuestsFeatureEnabled = true,
 }: {
   optOutQuestSystem?: boolean;
-  isQuestsFeatureEnabled?: boolean;
 } = {}) =>
   render(
     <TestBootProvider
       client={new QueryClient()}
       settings={{ optOutQuestSystem }}
-      gb={getGrowthBook(isQuestsFeatureEnabled)}
     >
       <HeaderButtons />
     </TestBootProvider>,
   );
 
 describe('HeaderButtons', () => {
-  it('should render the quest entry when quest experiment is enabled', () => {
-    renderComponent({ optOutQuestSystem: false, isQuestsFeatureEnabled: true });
+  it('should render the quest entry for logged-in users', () => {
+    renderComponent({ optOutQuestSystem: false });
 
     expect(screen.getByText('Quest button')).toBeInTheDocument();
   });
 
   it('should hide the quest entry when opted out from quests', () => {
-    renderComponent({ optOutQuestSystem: true, isQuestsFeatureEnabled: true });
-
-    expect(screen.queryByText('Quest button')).not.toBeInTheDocument();
-  });
-
-  it('should hide the quest entry when quest experiment is disabled', () => {
-    renderComponent({
-      optOutQuestSystem: false,
-      isQuestsFeatureEnabled: false,
-    });
+    renderComponent({ optOutQuestSystem: true });
 
     expect(screen.queryByText('Quest button')).not.toBeInTheDocument();
   });

--- a/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
+++ b/packages/shared/src/components/profile/ProfileSettingsMenu.tsx
@@ -69,8 +69,6 @@ import { VolunteeringIcon } from '../icons/Volunteering';
 import { GraduationIcon } from '../icons/Graduation';
 import { MedalBadgeIcon } from '../icons/MedalBadge';
 import { MedalIcon } from '../icons/Medal';
-import { questsFeature } from '../../lib/featureManagement';
-import { useConditionalFeature } from '../../hooks/useConditionalFeature';
 
 type MenuItems = Record<
   string,
@@ -86,11 +84,6 @@ const useAccountPageItems = ({ onClose }: { onClose?: () => void } = {}) => {
   const { openModal } = useLazyModal();
   const { logEvent } = useLogContext();
   const { user } = useAuthContext();
-
-  const { value: isQuestsFeatureEnabled } = useConditionalFeature({
-    feature: questsFeature,
-    shouldEvaluate: !!user,
-  });
 
   const items = useMemo(
     () =>
@@ -347,7 +340,7 @@ const useAccountPageItems = ({ onClose }: { onClose?: () => void } = {}) => {
     [logEvent, onClose, openModal, user?.username],
   );
 
-  return { items, isQuestsFeatureEnabled };
+  return { items };
 };
 
 interface ProfileSettingsMenuProps {
@@ -363,8 +356,7 @@ export const InnerProfileSettingsMenu = ({
   const { asPath } = useRouter();
   const isMobile = useViewSize(ViewSize.MobileL);
   const hasAccessToCores = useHasAccessToCores();
-  const { items: accountPageItems, isQuestsFeatureEnabled } =
-    useAccountPageItems({ onClose });
+  const { items: accountPageItems } = useAccountPageItems({ onClose });
 
   return (
     <nav className={classNames('flex flex-col gap-2', className)}>
@@ -377,22 +369,8 @@ export const InnerProfileSettingsMenu = ({
             withSeparator={!lastItem}
             title={menuItem.title ?? undefined}
             items={Object.entries(menuItem.items)
-              .filter(([itemKey, item]) => {
+              .filter(([, item]) => {
                 if (item.href === walletUrl && !hasAccessToCores) {
-                  return false;
-                }
-
-                if (
-                  itemKey === 'gamification' &&
-                  isQuestsFeatureEnabled !== true
-                ) {
-                  return false;
-                }
-
-                if (
-                  itemKey === 'gameCenter' &&
-                  isQuestsFeatureEnabled !== true
-                ) {
                   return false;
                 }
 

--- a/packages/shared/src/components/sidebar/sections/MainSection.spec.tsx
+++ b/packages/shared/src/components/sidebar/sections/MainSection.spec.tsx
@@ -5,7 +5,6 @@ import {
   gameCenterMilestoneSectionId,
   webappUrl,
 } from '../../../lib/constants';
-import { questsFeature } from '../../../lib/featureManagement';
 import { useConditionalFeature } from '../../../hooks';
 import useCustomDefaultFeed from '../../../hooks/feed/useCustomDefaultFeed';
 import { useQuestDashboard } from '../../../hooks/useQuestDashboard';
@@ -64,10 +63,10 @@ describe('MainSection', () => {
       },
       isLoggedIn: true,
     });
-    mockUseConditionalFeature.mockImplementation(({ feature }) => ({
-      value: feature === questsFeature,
+    mockUseConditionalFeature.mockReturnValue({
+      value: false,
       isLoading: false,
-    }));
+    });
     mockUseCustomDefaultFeed.mockReturnValue({
       isCustomDefaultFeed: false,
     });

--- a/packages/shared/src/components/sidebar/sections/MainSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/MainSection.tsx
@@ -29,7 +29,6 @@ import { useConditionalFeature } from '../../../hooks';
 import {
   featurePlusApiLanding,
   featureYearInReview,
-  questsFeature,
 } from '../../../lib/featureManagement';
 import { useQuestDashboard } from '../../../hooks/useQuestDashboard';
 import { Typography, TypographyColor } from '../../typography/Typography';
@@ -51,10 +50,6 @@ export const MainSection = ({
     : { full: 'Level Up with Plus', short: 'Upgrade' };
   const { value: showYearInReview } = useConditionalFeature({
     feature: featureYearInReview,
-    shouldEvaluate: isLoggedIn,
-  });
-  const { value: showGameCenter } = useConditionalFeature({
-    feature: questsFeature,
     shouldEvaluate: isLoggedIn,
   });
   const { data: questDashboard } = useQuestDashboard();
@@ -115,7 +110,7 @@ export const MainSection = ({
       claimableMilestoneCount > 0 ? `#${gameCenterMilestoneSectionId}` : ''
     }`;
 
-    const gameCenter = showGameCenter
+    const gameCenter = isLoggedIn
       ? {
           icon: (active: boolean) => (
             <ListIcon Icon={() => <JoystickIcon secondary={active} />} />
@@ -202,7 +197,6 @@ export const MainSection = ({
     isLoggedIn,
     isPlus,
     onNavTabClick,
-    showGameCenter,
     showYearInReview,
     user,
   ]);

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -138,8 +138,6 @@ export const featureProfileCompletionIndicator = new Feature(
   0,
 );
 
-export const questsFeature = new Feature('quests', false);
-
 export const achievementTrackingWidgetFeature = new Feature(
   'achievement_tracking_widget',
   false,

--- a/packages/webapp/__tests__/GameCenterStaticProps.spec.ts
+++ b/packages/webapp/__tests__/GameCenterStaticProps.spec.ts
@@ -20,7 +20,6 @@ import { useConditionalFeature } from '@dailydotdev/shared/src/hooks/useConditio
 import { useHasAccessToCores } from '@dailydotdev/shared/src/hooks/useCoresFeature';
 import { useQuestDashboard } from '@dailydotdev/shared/src/hooks/useQuestDashboard';
 import { gameCenterMilestoneSectionId } from '@dailydotdev/shared/src/lib/constants';
-import { questsFeature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { QuestStatus, QuestType } from '@dailydotdev/shared/src/graphql/quests';
 import GameCenterPage, {
   getStaticProps as getGameCenterStaticProps,
@@ -113,11 +112,6 @@ jest.mock('../components/ProtectedPage', () => ({
     fallback?: React.ReactNode;
     shouldFallback?: boolean;
   }) => (shouldFallback ? fallback : children),
-}));
-
-jest.mock('../pages/404', () => ({
-  __esModule: true,
-  default: () => '404 page',
 }));
 
 const mockRequest = gqlClient.request as jest.Mock;
@@ -304,38 +298,11 @@ describe('game center client gating', () => {
     });
   });
 
-  it('should render the 404 page when the quest feature is disabled', () => {
-    mockUseConditionalFeature
-      .mockReturnValueOnce({
-        value: false,
-        isLoading: false,
-      })
-      .mockReturnValueOnce({
-        value: false,
-        isLoading: false,
-      });
-
-    render(
-      React.createElement(GameCenterPage, {
-        highestReputation: [],
-        mostQuestsCompleted: [],
-        questCompletionStats: null,
-      }),
-    );
-
-    expect(screen.getByText('404 page')).toBeInTheDocument();
-  });
-
   it('should render the milestone quests section even when there are no milestone quests yet', () => {
-    mockUseConditionalFeature
-      .mockReturnValueOnce({
-        value: true,
-        isLoading: false,
-      })
-      .mockReturnValueOnce({
-        value: false,
-        isLoading: false,
-      });
+    mockUseConditionalFeature.mockReturnValue({
+      value: false,
+      isLoading: false,
+    });
     mockUseQuestDashboard.mockReturnValue({
       data: {
         level: {
@@ -374,15 +341,10 @@ describe('game center client gating', () => {
   it('should render milestone quest cards with claim actions on the game center page', async () => {
     const mutate = jest.fn();
 
-    mockUseConditionalFeature
-      .mockReturnValueOnce({
-        value: true,
-        isLoading: false,
-      })
-      .mockReturnValueOnce({
-        value: false,
-        isLoading: false,
-      });
+    mockUseConditionalFeature.mockReturnValue({
+      value: false,
+      isLoading: false,
+    });
     mockUseQuestDashboard.mockReturnValue({
       data: {
         level: {
@@ -453,10 +415,10 @@ describe('game center client gating', () => {
   });
 
   it('should scroll to the milestone quest section when claimable milestone quests are linked from the sidebar', async () => {
-    mockUseConditionalFeature.mockImplementation(({ feature }) => ({
-      value: feature === questsFeature,
+    mockUseConditionalFeature.mockReturnValue({
+      value: false,
       isLoading: false,
-    }));
+    });
     mockUseQuestDashboard.mockReturnValue({
       data: {
         level: {
@@ -526,10 +488,10 @@ describe('game center client gating', () => {
   });
 
   it('should highlight the most progressed milestone in the progress snapshot card', () => {
-    mockUseConditionalFeature.mockImplementation(({ feature }) => ({
-      value: feature === questsFeature,
+    mockUseConditionalFeature.mockReturnValue({
+      value: false,
       isLoading: false,
-    }));
+    });
     mockUseQuestDashboard.mockReturnValue({
       data: {
         level: {
@@ -636,10 +598,10 @@ describe('game center client gating', () => {
   });
 
   it('should skip claimable milestones in the progress snapshot card and show the next upcoming one', () => {
-    mockUseConditionalFeature.mockImplementation(({ feature }) => ({
-      value: feature === questsFeature,
+    mockUseConditionalFeature.mockReturnValue({
+      value: false,
       isLoading: false,
-    }));
+    });
     mockUseQuestDashboard.mockReturnValue({
       data: {
         level: {
@@ -731,15 +693,10 @@ describe('game center client gating', () => {
   });
 
   it('should render all milestone quests in a two-column grid without a show more toggle', () => {
-    mockUseConditionalFeature
-      .mockReturnValueOnce({
-        value: true,
-        isLoading: false,
-      })
-      .mockReturnValueOnce({
-        value: false,
-        isLoading: false,
-      });
+    mockUseConditionalFeature.mockReturnValue({
+      value: false,
+      isLoading: false,
+    });
     mockUseQuestDashboard.mockReturnValue({
       data: {
         level: {

--- a/packages/webapp/pages/game-center/index.tsx
+++ b/packages/webapp/pages/game-center/index.tsx
@@ -35,10 +35,7 @@ import {
 } from '@dailydotdev/shared/src/lib/dateFormat';
 import type { GraphQLError } from '@dailydotdev/shared/src/lib/errors';
 import { featuredAwardImage } from '@dailydotdev/shared/src/lib/image';
-import {
-  achievementTrackingWidgetFeature,
-  questsFeature,
-} from '@dailydotdev/shared/src/lib/featureManagement';
+import { achievementTrackingWidgetFeature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { fetchTopReaders } from '@dailydotdev/shared/src/lib/topReader';
 import { getFirstName } from '@dailydotdev/shared/src/lib/user';
 import {
@@ -90,7 +87,6 @@ import { getLayout as getFooterNavBarLayout } from '../../components/layouts/Foo
 import { getLayout } from '../../components/layouts/MainLayout';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 import ProtectedPage from '../../components/ProtectedPage';
-import Custom404Seo from '../404';
 import { defaultOpenGraph } from '../../next-seo';
 import {
   getAchievementSummary,
@@ -242,11 +238,6 @@ function GameCenterPage({
   const router = useRouter();
   const { user } = useAuthContext();
   const { optOutLevelSystem } = useSettingsContext();
-  const { value: isQuestsFeatureEnabled, isLoading: isQuestsFeatureLoading } =
-    useConditionalFeature({
-      feature: questsFeature,
-      shouldEvaluate: !!user,
-    });
   const { value: isAchievementTrackingEnabled } = useConditionalFeature({
     feature: achievementTrackingWidgetFeature,
     shouldEvaluate: !!user,
@@ -712,10 +703,7 @@ function GameCenterPage({
   }
 
   return (
-    <ProtectedPage
-      shouldFallback={isQuestsFeatureLoading || isQuestsFeatureEnabled !== true}
-      fallback={isQuestsFeatureLoading ? <></> : <Custom404Seo />}
-    >
+    <ProtectedPage>
       <div className="mx-auto w-full max-w-[72rem]">
         <LayoutHeader
           className={classNames('!mb-0 gap-2 border-b px-4', pageBorders)}
@@ -902,7 +890,7 @@ function GameCenterPage({
               </div>
 
               <div className="bg-background-default/70 flex min-w-[14rem] flex-col items-start justify-center gap-4 rounded-20 border border-border-subtlest-tertiary p-5 backdrop-blur-sm">
-                {isQuestsFeatureEnabled === true && questDashboard ? (
+                {questDashboard ? (
                   <>
                     <div className="flex items-center gap-4">
                       <QuestLevelProgressCircle

--- a/packages/webapp/pages/settings/customization/gamification.tsx
+++ b/packages/webapp/pages/settings/customization/gamification.tsx
@@ -1,10 +1,7 @@
 import type { ReactElement } from 'react';
-import React, { useEffect } from 'react';
+import React from 'react';
 import type { NextSeoProps } from 'next-seo';
-import { useRouter } from 'next/router';
 import { useSettingsContext } from '@dailydotdev/shared/src/contexts/SettingsContext';
-import { useConditionalFeature } from '@dailydotdev/shared/src/hooks';
-import { questsFeature } from '@dailydotdev/shared/src/lib/featureManagement';
 import {
   Typography,
   TypographyType,
@@ -15,30 +12,13 @@ import { defaultSeo } from '../../../next-seo';
 import { getTemplatedTitle } from '../../../components/layouts/utils';
 import { SettingsSwitch } from '../../../components/layouts/SettingsLayout/common';
 
-const GamificationSettingsPage = (): ReactElement | null => {
-  const router = useRouter();
+const GamificationSettingsPage = (): ReactElement => {
   const {
     optOutLevelSystem,
     optOutQuestSystem,
     toggleOptOutLevelSystem,
     toggleOptOutQuestSystem,
   } = useSettingsContext();
-  const { value: isQuestsFeatureEnabled, isLoading: isQuestsFeatureLoading } =
-    useConditionalFeature({
-      feature: questsFeature,
-    });
-
-  useEffect(() => {
-    if (isQuestsFeatureLoading || isQuestsFeatureEnabled === true) {
-      return;
-    }
-
-    router.replace('/settings/customization/streaks');
-  }, [isQuestsFeatureEnabled, isQuestsFeatureLoading, router]);
-
-  if (isQuestsFeatureLoading || isQuestsFeatureEnabled !== true) {
-    return null;
-  }
 
   return (
     <AccountPageContainer title="Feature visibility">

--- a/packages/webapp/pages/users.tsx
+++ b/packages/webapp/pages/users.tsx
@@ -12,9 +12,7 @@ import { useRouter } from 'next/router';
 import { BreadCrumbs } from '@dailydotdev/shared/src/components/header';
 import { SquadIcon } from '@dailydotdev/shared/src/components/icons';
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
-import { useConditionalFeature } from '@dailydotdev/shared/src/hooks';
 import type { GraphQLError } from '@dailydotdev/shared/src/lib/errors';
-import { questsFeature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { PageWrapperLayout } from '@dailydotdev/shared/src/components/layout/PageWrapperLayout';
 import type { UserLeaderboard } from '@dailydotdev/shared/src/components/cards/Leaderboard';
 import { UserTopList } from '@dailydotdev/shared/src/components/cards/Leaderboard';
@@ -73,9 +71,6 @@ const LeaderboardPage = ({
   popularHotTakes,
 }: PageProps): ReactElement => {
   const { isFallback: isLoading } = useRouter();
-  const { value: isQuestsFeatureEnabled } = useConditionalFeature({
-    feature: questsFeature,
-  });
 
   if (isLoading) {
     return <></>;
@@ -89,7 +84,7 @@ const LeaderboardPage = ({
         </BreadCrumbs>
       </div>
       <div className="grid grid-cols-1 gap-6 tablet:grid-cols-2 laptopXL:grid-cols-3">
-        {isQuestsFeatureEnabled === true && isHighestLevelSupported && (
+        {isHighestLevelSupported && (
           <UserTopList
             containerProps={{
               title: 'Highest level',

--- a/packages/webapp/pages/users/[id].tsx
+++ b/packages/webapp/pages/users/[id].tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useEffect } from 'react';
+import React from 'react';
 import type {
   GetStaticPathsResult,
   GetStaticPropsContext,
@@ -18,8 +18,6 @@ import { BreadCrumbs } from '@dailydotdev/shared/src/components/header';
 import { SquadIcon } from '@dailydotdev/shared/src/components/icons';
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import type { GraphQLError } from '@dailydotdev/shared/src/lib/errors';
-import { useConditionalFeature } from '@dailydotdev/shared/src/hooks';
-import { questsFeature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { PageWrapperLayout } from '@dailydotdev/shared/src/components/layout/PageWrapperLayout';
 import type { UserLeaderboard } from '@dailydotdev/shared/src/components/cards/Leaderboard';
 import { UserTopList } from '@dailydotdev/shared/src/components/cards/Leaderboard';
@@ -60,40 +58,13 @@ const LeaderboardDetailPage = ({
   userItems,
   companyItems,
 }: PageProps): ReactElement => {
-  const router = useRouter();
-  const { isFallback: isLoading } = router;
-  const { value: isQuestsFeatureEnabled, isLoading: isQuestsFeatureLoading } =
-    useConditionalFeature({
-      feature: questsFeature,
-    });
+  const { isFallback: isLoading } = useRouter();
 
   const isCompany = isCompanyLeaderboard(leaderboardType);
   const isLevelLeaderboard = leaderboardType === LeaderboardType.HighestLevel;
   const concatScore = leaderboardType !== LeaderboardType.LongestStreak;
 
-  useEffect(() => {
-    if (
-      !isLevelLeaderboard ||
-      isQuestsFeatureLoading ||
-      isQuestsFeatureEnabled === true
-    ) {
-      return;
-    }
-
-    router.replace('/users');
-  }, [
-    isLevelLeaderboard,
-    isQuestsFeatureEnabled,
-    isQuestsFeatureLoading,
-    router,
-  ]);
-
-  if (
-    isLoading ||
-    !title ||
-    (isLevelLeaderboard &&
-      (isQuestsFeatureLoading || isQuestsFeatureEnabled !== true))
-  ) {
+  if (isLoading || !title) {
     return <></>;
   }
 


### PR DESCRIPTION
## Summary
- Delete the `questsFeature` GrowthBook feature flag definition and all `useConditionalFeature` checks that referenced it across 8 component/page files
- Quest UI now renders unconditionally for logged-in users (auth checks and `optOutQuestSystem` user setting remain unchanged)
- Remove dead test branches that asserted feature-off behavior; simplify remaining test mocks

## Key decisions
- **Deleted the export entirely** rather than changing the default to `true` — cleaner since there are no backend consumers
- **Kept `ProtectedPage` wrapper** on game-center for auth protection, just removed the quest-feature fallback/404 gating
- **No backend changes needed** — daily-api already serves quest data unconditionally

Closes ENG-1315

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1315-remove-quest-feature.preview.app.daily.dev