### PR TITLE
Fix strikethrough support in comment markdown

### DIFF
--- a/packages/shared/src/lib/__tests__/markdown.test.ts
+++ b/packages/shared/src/lib/__tests__/markdown.test.ts
@@ -1,4 +1,4 @@
-import { isSelectionInMarkdownLink } from '../markdown';
+import { isSelectionInMarkdownLink, looksLikeMarkdown } from '../markdown';
 
 // Mock HTMLTextAreaElement
 const createMockTextarea = (
@@ -76,5 +76,11 @@ describe('isSelectionInMarkdownLink', () => {
     const textarea = createMockTextarea('[first](url1) [second](url2)', 15, 21);
     const result = isSelectionInMarkdownLink(textarea, 15, 21);
     expect(result).toBe(true);
+  });
+});
+
+describe('looksLikeMarkdown', () => {
+  test('should detect strikethrough markdown', () => {
+    expect(looksLikeMarkdown('~~struck~~')).toBe(true);
   });
 });

--- a/packages/shared/src/lib/markdown.ts
+++ b/packages/shared/src/lib/markdown.ts
@@ -6,7 +6,7 @@ const getUrlText = (content = '', url = urlText) => `[${content}](${url})`;
 
 // Fast check used to detect whether plain text likely contains markdown syntax.
 const markdownSyntaxRegex =
-  /(^|\n)\s{0,3}(#{1,6}\s|[-*]\s|\d+\.\s|```)|\[[^\]]+\]\([^)]+\)|!\[[^\]]*]\([^)]+\)|`[^`]+`|\*\*[^*]+\*\*/;
+  /(^|\n)\s{0,3}(#{1,6}\s|[-*]\s|\d+\.\s|```)|\[[^\]]+\]\([^)]+\)|!\[[^\]]*]\([^)]+\)|`[^`]+`|\*\*[^*]+\*\*|~~[^~]+~~/;
 
 export const looksLikeMarkdown = (value: string): boolean =>
   markdownSyntaxRegex.test(value);

--- a/packages/shared/src/lib/markdownConversion.spec.ts
+++ b/packages/shared/src/lib/markdownConversion.spec.ts
@@ -9,6 +9,12 @@ describe('markdownConversion', () => {
     );
   });
 
+  it('should convert strikethrough markdown to html', () => {
+    const html = markdownToHtmlBasic('~~gone~~');
+
+    expect(html).toBe('<p><s>gone</s></p>');
+  });
+
   it('should convert fenced code blocks to html', () => {
     const html = markdownToHtmlBasic('```js\nconst a = 1;\n```');
 
@@ -29,6 +35,12 @@ describe('markdownConversion', () => {
     );
 
     expect(markdown).toBe('```\nconst a = 1;\n```');
+  });
+
+  it('should convert html strikethrough to markdown', () => {
+    const markdown = htmlToMarkdownBasic('<p><s>gone</s></p>');
+
+    expect(markdown).toBe('~~gone~~');
   });
 
   it('should preserve images while converting html and markdown', () => {
@@ -111,6 +123,14 @@ describe('markdownConversion', () => {
 
   it('should keep simple bold in markdown round-trip', () => {
     const initialMarkdown = '**bold**';
+    const html = markdownToHtmlBasic(initialMarkdown);
+    const markdown = htmlToMarkdownBasic(html);
+
+    expect(markdown).toBe(initialMarkdown);
+  });
+
+  it('should keep simple strikethrough in markdown round-trip', () => {
+    const initialMarkdown = '~~gone~~';
     const html = markdownToHtmlBasic(initialMarkdown);
     const markdown = htmlToMarkdownBasic(html);
 

--- a/packages/shared/src/lib/markdownConversion.ts
+++ b/packages/shared/src/lib/markdownConversion.ts
@@ -10,6 +10,7 @@ const applyInlineTextFormatting = (value: string): string => {
   let result = value;
 
   result = result.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  result = result.replace(/~~(.+?)~~/g, '<s>$1</s>');
   result = result.replace(/\*(?!\*)([^*]+)\*(?!\*)/g, '<em>$1</em>');
   result = result.replace(/_(.+?)_/g, '<em>$1</em>');
   result = result.replace(/`([^`]+)`/g, '<code>$1</code>');
@@ -204,7 +205,7 @@ function serializeInline(node: Node): string {
   }
 
   const tagName = node.tagName.toLowerCase();
-  const wrapLines = (value: string, marker: '**' | '_') => {
+  const wrapLines = (value: string, marker: '**' | '_' | '~~') => {
     if (!value.includes('\n')) {
       return `${marker}${value}${marker}`;
     }
@@ -222,6 +223,10 @@ function serializeInline(node: Node): string {
     case 'em':
     case 'i':
       return wrapLines(serializeChildren(node), '_');
+    case 's':
+    case 'del':
+    case 'strike':
+      return wrapLines(serializeChildren(node), '~~');
     case 'a': {
       const href = node.getAttribute('href') || '';
       const label = serializeChildren(node) || href;


### PR DESCRIPTION
## Summary
- Add `~~strikethrough~~` support to the shared markdown converter in both directions
- Update markdown detection so pasted strikethrough is recognized consistently
- Add regression tests for markdown-to-HTML, HTML-to-markdown, and round-trip behavior

## Testing
- Unit tests added for markdown conversion and markdown syntax detection
- `packages/shared` changed-file strict typecheck passed

### Preview domain
https://codex-investigate-issue-2099.preview.app.daily.dev