### PR TITLE
fix: refresh RelativeTime label when dateTime prop changes

### DIFF
--- a/packages/shared/src/components/utilities/RelativeTime.spec.tsx
+++ b/packages/shared/src/components/utilities/RelativeTime.spec.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { RelativeTime } from './RelativeTime';
+
+describe('RelativeTime', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-04-28T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders the relative label for the provided dateTime', () => {
+    const tenMinutesAgo = new Date('2026-04-28T11:50:00Z').toISOString();
+    render(<RelativeTime dateTime={tenMinutesAgo} />);
+    expect(screen.getByText('10m ago')).toBeInTheDocument();
+  });
+
+  it('updates the label immediately when the dateTime prop changes', () => {
+    const tenMinutesAgo = new Date('2026-04-28T11:50:00Z').toISOString();
+    const twoHoursAgo = new Date('2026-04-28T10:00:00Z').toISOString();
+
+    const { rerender } = render(<RelativeTime dateTime={tenMinutesAgo} />);
+    expect(screen.getByText('10m ago')).toBeInTheDocument();
+
+    rerender(<RelativeTime dateTime={twoHoursAgo} />);
+    expect(screen.getByText('2h ago')).toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/utilities/RelativeTime.tsx
+++ b/packages/shared/src/components/utilities/RelativeTime.tsx
@@ -20,6 +20,8 @@ export const RelativeTime = ({
   );
 
   useEffect(() => {
+    setLabel(getLastActivityDateFormat(dateTime, { maxHoursAgo }));
+
     const id = setInterval(() => {
       setLabel(getLastActivityDateFormat(dateTime, { maxHoursAgo }));
     }, REFRESH_INTERVAL_MS);


### PR DESCRIPTION
## Summary

The Happening Now sidebar widget added in #5919 rotates the displayed highlight every 6s, but in production every rotation showed the **same timestamp** as the first highlight. Root cause: `RelativeTime` only computed its label via the `useState` initializer (mount-only) and the 60s `setInterval` tick — so changing the `dateTime` prop did not refresh the visible label until the next minute boundary.

Fix: also recompute the label inside the `useEffect` so prop changes update it immediately.

Added a spec covering both the initial render and the prop-change case as a regression guard.

## Test plan

- `pnpm --filter @dailydotdev/shared exec jest RelativeTime` passes (CI).
- Manually: open a post page with the Happening Now widget — each rotated headline now shows its own correct relative timestamp instead of the first one.


Made with [Cursor](https://cursor.com)

### Preview domain
https://fix-relative-time-stale-on-prop.preview.app.daily.dev