### PR TITLE
test: cover Happening Now widget loop rotation

### DIFF
--- a/packages/shared/src/components/cards/highlight/HighlightPostSidebarWidget.spec.tsx
+++ b/packages/shared/src/components/cards/highlight/HighlightPostSidebarWidget.spec.tsx
@@ -170,6 +170,45 @@ describe('HighlightPostSidebarWidget', () => {
     expect(screen.queryByText('The first highlight')).not.toBeInTheDocument();
   });
 
+  it('loops back to the first highlight after the last one', async () => {
+    jest.useFakeTimers({ doNotFake: ['queueMicrotask'] });
+    mockGqlRequest.mockResolvedValue(
+      buildResponse([
+        buildHighlight('h1', 'The first highlight'),
+        buildHighlight('h2', 'The second highlight'),
+      ]),
+    );
+
+    renderWidget();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText('The first highlight')).toBeInTheDocument(),
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(6000);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByText('The second highlight')).toBeInTheDocument();
+
+    await act(async () => {
+      jest.advanceTimersByTime(6000);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(screen.getByText('The first highlight')).toBeInTheDocument();
+    expect(screen.queryByText('The second highlight')).not.toBeInTheDocument();
+  });
+
   it('pauses rotation while hovering and resumes after unhover', async () => {
     jest.useFakeTimers({ doNotFake: ['queueMicrotask'] });
     mockGqlRequest.mockResolvedValue(


### PR DESCRIPTION
## Summary

Adds a regression test for the post-page Happening Now sidebar widget verifying that, after rotating through the last highlight, the widget wraps back to the first (latest) one — locking in the existing modulo behavior so it doesn't silently regress.

No production code changes.

## Test plan

- `pnpm --filter @dailydotdev/shared exec jest HighlightPostSidebarWidget` passes (CI).


Made with [Cursor](https://cursor.com)

### Preview domain
https://test-highlight-widget-loop-rotat.preview.app.daily.dev