### PR TITLE
feat: limit Happening Now sidebar widget to last 24 hours

### DIFF
--- a/packages/shared/src/components/cards/highlight/HighlightPostSidebarWidget.spec.tsx
+++ b/packages/shared/src/components/cards/highlight/HighlightPostSidebarWidget.spec.tsx
@@ -12,6 +12,7 @@ import { useAuthContext } from '../../../contexts/AuthContext';
 import { useConditionalFeature } from '../../../hooks/useConditionalFeature';
 import { useLogContext } from '../../../contexts/LogContext';
 import { gqlClient } from '../../../graphql/common';
+import { ONE_HOUR } from '../../../lib/time';
 
 jest.mock('../../../lib/constants', () => ({
   webappUrl: '/',
@@ -32,13 +33,11 @@ const mockUseConditionalFeature = jest.mocked(useConditionalFeature);
 const mockUseLogContext = jest.mocked(useLogContext);
 const mockGqlRequest = jest.mocked(gqlClient.request);
 
-const ONE_HOUR_MS = 60 * 60 * 1000;
-
 const buildHighlight = (id: string, headline: string, hoursAgo = 1) => ({
   id,
   channel: 'agents',
   headline,
-  highlightedAt: new Date(Date.now() - hoursAgo * ONE_HOUR_MS).toISOString(),
+  highlightedAt: new Date(Date.now() - hoursAgo * ONE_HOUR).toISOString(),
   post: {
     id: `post-${id}`,
     commentsPermalink: `/posts/post-${id}`,

--- a/packages/shared/src/components/cards/highlight/HighlightPostSidebarWidget.spec.tsx
+++ b/packages/shared/src/components/cards/highlight/HighlightPostSidebarWidget.spec.tsx
@@ -34,11 +34,7 @@ const mockGqlRequest = jest.mocked(gqlClient.request);
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
-const buildHighlight = (
-  id: string,
-  headline: string,
-  hoursAgo = 1,
-) => ({
+const buildHighlight = (id: string, headline: string, hoursAgo = 1) => ({
   id,
   channel: 'agents',
   headline,

--- a/packages/shared/src/components/cards/highlight/HighlightPostSidebarWidget.spec.tsx
+++ b/packages/shared/src/components/cards/highlight/HighlightPostSidebarWidget.spec.tsx
@@ -32,11 +32,17 @@ const mockUseConditionalFeature = jest.mocked(useConditionalFeature);
 const mockUseLogContext = jest.mocked(useLogContext);
 const mockGqlRequest = jest.mocked(gqlClient.request);
 
-const buildHighlight = (id: string, headline: string) => ({
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+const buildHighlight = (
+  id: string,
+  headline: string,
+  hoursAgo = 1,
+) => ({
   id,
   channel: 'agents',
   headline,
-  highlightedAt: '2026-04-05T09:00:00.000Z',
+  highlightedAt: new Date(Date.now() - hoursAgo * ONE_HOUR_MS).toISOString(),
   post: {
     id: `post-${id}`,
     commentsPermalink: `/posts/post-${id}`,
@@ -102,6 +108,37 @@ describe('HighlightPostSidebarWidget', () => {
 
   it('returns null when no highlights are returned', async () => {
     mockGqlRequest.mockResolvedValue(buildResponse([]));
+
+    renderWidget();
+
+    await waitFor(() => expect(mockGqlRequest).toHaveBeenCalled());
+    expect(screen.queryByText('Happening Now')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('postPageHighlightWidget'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('filters out highlights older than 24 hours', async () => {
+    mockGqlRequest.mockResolvedValue(
+      buildResponse([
+        buildHighlight('fresh', 'Fresh headline', 2),
+        buildHighlight('stale', 'Stale headline', 30),
+      ]),
+    );
+
+    renderWidget();
+
+    expect(await screen.findByText('Fresh headline')).toBeInTheDocument();
+    expect(screen.queryByText('Stale headline')).not.toBeInTheDocument();
+  });
+
+  it('hides the widget when all highlights are older than 24 hours', async () => {
+    mockGqlRequest.mockResolvedValue(
+      buildResponse([
+        buildHighlight('stale1', 'Stale one', 25),
+        buildHighlight('stale2', 'Stale two', 48),
+      ]),
+    );
 
     renderWidget();
 

--- a/packages/shared/src/components/cards/highlight/HighlightPostSidebarWidget.tsx
+++ b/packages/shared/src/components/cards/highlight/HighlightPostSidebarWidget.tsx
@@ -17,7 +17,7 @@ import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent, Origin } from '../../../lib/log';
 import { feedHighlightsLogEvent } from '../../../lib/feed';
 import useLogEventOnce from '../../../hooks/log/useLogEventOnce';
-import { ONE_HOUR } from '../../../lib/time';
+import { ONE_HOUR, ONE_MINUTE } from '../../../lib/time';
 
 const HIGHLIGHTS_LIMIT = 10;
 const ROTATION_INTERVAL_MS = 6000;
@@ -43,6 +43,7 @@ export const HighlightPostSidebarWidget = (): ReactElement | null => {
   const { data } = useQuery({
     ...majorHeadlinesQueryOptions({ first: HIGHLIGHTS_LIMIT }),
     enabled: isEnabled && !!user,
+    refetchInterval: ONE_MINUTE,
   });
 
   const cutoff = Date.now() - MAX_HIGHLIGHT_AGE_MS;

--- a/packages/shared/src/components/cards/highlight/HighlightPostSidebarWidget.tsx
+++ b/packages/shared/src/components/cards/highlight/HighlightPostSidebarWidget.tsx
@@ -17,11 +17,13 @@ import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent, Origin } from '../../../lib/log';
 import { feedHighlightsLogEvent } from '../../../lib/feed';
 import useLogEventOnce from '../../../hooks/log/useLogEventOnce';
+import { ONE_HOUR } from '../../../lib/time';
 
 const HIGHLIGHTS_LIMIT = 10;
 const ROTATION_INTERVAL_MS = 6000;
 const FADE_DURATION_MS = 500;
 const FEED_NAME = 'post-page-highlights';
+const MAX_HIGHLIGHT_AGE_MS = 24 * ONE_HOUR;
 
 const prefersReducedMotion = (): boolean => {
   if (typeof window === 'undefined' || !window.matchMedia) {
@@ -43,8 +45,10 @@ export const HighlightPostSidebarWidget = (): ReactElement | null => {
     enabled: isEnabled && !!user,
   });
 
-  const highlights: PostHighlight[] =
-    data?.majorHeadlines?.edges?.map((edge) => edge.node) ?? [];
+  const cutoff = Date.now() - MAX_HIGHLIGHT_AGE_MS;
+  const highlights: PostHighlight[] = (
+    data?.majorHeadlines?.edges?.map((edge) => edge.node) ?? []
+  ).filter((h) => new Date(h.highlightedAt).getTime() >= cutoff);
 
   const [index, setIndex] = useState(0);
   const [isVisible, setIsVisible] = useState(true);
@@ -175,7 +179,7 @@ export const HighlightPostSidebarWidget = (): ReactElement | null => {
             </span>
             <RelativeTime
               dateTime={current.highlightedAt}
-              maxHoursAgo={72}
+              maxHoursAgo={24}
               className="text-text-tertiary typo-footnote"
             />
           </a>


### PR DESCRIPTION
## Summary

Restricts the post-page Happening Now sidebar widget to highlights from the last 24 hours. Older highlights returned by `majorHeadlines` are filtered out client-side; if none qualify, the widget hides entirely. Tightened `RelativeTime`'s `maxHoursAgo` to match the new window.

The `majorHeadlines` GraphQL query has no time-window argument, so the filter has to live on the client. The widget refetches every minute (existing `staleTime`) and the cutoff is recomputed on each render, so the displayed list naturally rolls forward as time passes.

## Test plan

- New unit tests cover the in-window/out-of-window cases and the all-stale hide case.
- Manually: post page sidebar shows only fresh highlights; widget disappears once everything is stale.


Made with [Cursor](https://cursor.com)

### Preview domain
https://feat-post-page-highlights-24h-wi.preview.app.daily.dev