### PR TITLE
fix(shared): respect safe area offsets in ipad pwa layout

### DIFF
--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -101,7 +101,7 @@ function MainLayoutHeader({
         'z-header',
         !isMobileSearchPage &&
           (isMobileProfile ? 'hidden laptop:flex' : 'flex'),
-        hasBanner && 'laptop:top-8',
+        hasBanner && 'laptop:[--safe-area-top-offset:2rem]',
         !isMobileSearchPage && isSearchPage && 'mb-16 laptop:mb-0',
         !isMobileSearchPage && scrollClassName,
       )}

--- a/packages/shared/src/components/layout/MainLayoutHeader.tsx
+++ b/packages/shared/src/components/layout/MainLayoutHeader.tsx
@@ -11,6 +11,7 @@ import { useScrollTopClassName } from '../../hooks/useScrollTopClassName';
 import { useSettingsContext } from '../../contexts/SettingsContext';
 import { useActiveFeedNameContext } from '../../contexts';
 import { useFeedName } from '../../hooks/feed/useFeedName';
+import { SharedFeedPage } from '../utilities';
 import FeedNav from '../feeds/FeedNav';
 import { MobileExploreHeader } from '../header/MobileExploreHeader';
 import useActiveNav from '../../hooks/useActiveNav';
@@ -43,16 +44,17 @@ function MainLayoutHeader({
   const { loadedSettings } = useSettingsContext();
   const [hasHydrated, setHasHydrated] = useState(false);
   const { streak, isStreaksEnabled } = useReadingStreak();
-  const isStreakLarge = streak?.current > 99; // if we exceed 100, we need to display it differently in the UI
+  const isStreakLarge = (streak?.current ?? 0) > 99; // if we exceed 100, we need to display it differently in the UI
   const { feedName } = useActiveFeedNameContext();
+  const activeFeedName = feedName ?? SharedFeedPage.Popular;
   const { isAnyExplore, isSearch } = useFeedName({
-    feedName,
+    feedName: activeFeedName,
   });
   const isLaptop = useViewSize(ViewSize.Laptop);
   const isSearchPage = isSearch || isAnyExplore;
   const featureTheme = useFeatureTheme();
   const scrollClassName = useScrollTopClassName({ enabled: !!featureTheme });
-  const { profile } = useActiveNav(feedName);
+  const { profile } = useActiveNav(activeFeedName);
   const shouldUseLoadedSettings = loadedSettings && hasHydrated;
   const isMobileProfile = profile && !isLaptop;
   const isMobile = !isLaptop;
@@ -110,7 +112,7 @@ function MainLayoutHeader({
       {isMobileSearchPage ? (
         <>
           {renderSearchPanel()}
-          {!isSearch && <MobileExploreHeader path={feedName as string} />}
+          {!isSearch && <MobileExploreHeader path={activeFeedName} />}
         </>
       ) : (
         sidebarRendered !== undefined && (

--- a/packages/shared/src/components/sidebar/SidebarDesktop.tsx
+++ b/packages/shared/src/components/sidebar/SidebarDesktop.tsx
@@ -50,8 +50,8 @@ export const SidebarDesktop = ({
       className={classNames(
         sidebarExpanded ? 'laptop:w-60' : 'laptop:w-11',
         isBannerAvailable
-          ? 'laptop:top-24 laptop:h-[calc(100vh-theme(space.24))]'
-          : 'laptop:top-16 laptop:h-[calc(100vh-theme(space.16))]',
+          ? 'laptop:[--safe-area-top-offset:6rem]'
+          : 'laptop:[--safe-area-top-offset:4rem]',
         featureTheme && 'bg-transparent',
       )}
     >

--- a/packages/shared/src/styles/safeArea.css
+++ b/packages/shared/src/styles/safeArea.css
@@ -28,10 +28,13 @@ body {
 }
 
 body .antialiased > .sticky.top-0,
-body .antialiased > .fixed.top-0,
-body .antialiased [data-testid="sidebar-aside"].fixed.top-0,
+body .fixed.top-0,
 body .fixed.inset-0 {
-  top: var(--safe-area-top);
+  top: calc(var(--safe-area-top) + var(--safe-area-top-offset, 0px));
+}
+
+body .fixed.top-0.h-full {
+  height: calc(100vh - var(--safe-area-top) - var(--safe-area-top-offset, 0px));
 }
 
 .min-h-dvh {

--- a/packages/shared/src/styles/safeArea.css
+++ b/packages/shared/src/styles/safeArea.css
@@ -13,7 +13,7 @@
 }
 
 body::before {
-  content: '';
+  content: "";
   position: fixed;
   top: 0;
   left: 0;
@@ -28,6 +28,8 @@ body {
 }
 
 body .antialiased > .sticky.top-0,
+body .antialiased > .fixed.top-0,
+body .antialiased [data-testid="sidebar-aside"].fixed.top-0,
 body .fixed.inset-0 {
   top: var(--safe-area-top);
 }

--- a/packages/shared/src/styles/safeArea.css
+++ b/packages/shared/src/styles/safeArea.css
@@ -13,7 +13,7 @@
 }
 
 body::before {
-  content: "";
+  content: '';
   position: fixed;
   top: 0;
   left: 0;


### PR DESCRIPTION
## Summary
- extend the shared safe-area handling so fixed top-aligned header and sidebar layouts respect the iPad PWA safe area
- switch the header and desktop sidebar to additive safe-area offset variables so existing banner offsets are preserved
- tighten MainLayoutHeader strict typing while verifying the branch for PR readiness

## Key Decisions
- kept the safe-area behavior centralized in `safeArea.css` instead of scattering device-specific fixes across components
- used additive `--safe-area-top-offset` values so existing layout offsets and safe-area insets compose cleanly
- fixed the changed-file strict type errors in `MainLayoutHeader.tsx` so the branch passes scoped verification

Closes ENG-1316

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1316-feedback-bug-report-dai.preview.app.daily.dev