### PR TITLE
feat: replace mobile post comment bar with X-style action bar

### DIFF
--- a/packages/shared/src/components/post/MobilePostFloatingBar.tsx
+++ b/packages/shared/src/components/post/MobilePostFloatingBar.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React from 'react';
+import React, { useCallback } from 'react';
 import classNames from 'classnames';
 import {
   DiscussIcon as CommentIcon,
@@ -17,10 +17,14 @@ import InteractionCounter from '../InteractionCounter';
 import { useVotePost } from '../../hooks/vote/useVotePost';
 import { useBookmarkPost } from '../../hooks/useBookmarkPost';
 import { useBlockPostPanel } from '../../hooks/post/useBlockPostPanel';
-import { useLoggedCopyPostLink } from '../../hooks/post/useLoggedCopyPostLink';
+import { useCopyPostLink } from '../../hooks/useCopyPostLink';
+import { useGetShortUrl } from '../../hooks/utils/useGetShortUrl';
+import { useLogContext } from '../../contexts/LogContext';
+import { ReferralCampaignKey } from '../../lib';
 import { ShareProvider } from '../../lib/share';
+import { postLogEvent } from '../../lib/feed';
 import type { Origin } from '../../lib/log';
-import { Origin as LogOrigin } from '../../lib/log';
+import { LogEvent, Origin as LogOrigin } from '../../lib/log';
 
 export interface MobilePostFloatingBarProps {
   post: Post;
@@ -28,12 +32,12 @@ export interface MobilePostFloatingBarProps {
   className?: string;
 }
 
-// Mirrors the floating "Share your thoughts" container that this bar replaces.
-// `bg-surface-float` is the gray translucent tint the old bar effectively rendered
-// (it was the surviving class once Tailwind layered `bg-blur-baseline` underneath),
-// paired with the same backdrop blur and shadow used by the mobile footer chrome.
-// Buttons use `justify-between` so they span the full bar width edge-to-edge, with a
-// small horizontal pad so the outermost icons don't kiss the rounded corner.
+// Mirrors the floating "Share your thoughts" container that this bar replaces:
+// `bg-surface-float` is the gray translucent tint that bar effectively rendered
+// once Tailwind layered `bg-blur-baseline` underneath, paired with the same
+// backdrop blur and shadow used by the mobile footer chrome. `justify-between`
+// + `px-2` spreads the icons edge-to-edge with a small pad so the outermost
+// icons don't kiss the rounded corner.
 const containerClasses = classNames(
   'flex w-full items-center justify-between rounded-16 border border-border-subtlest-tertiary px-2 py-1',
   'bg-surface-float backdrop-blur-[2.5rem]',
@@ -49,7 +53,12 @@ export function MobilePostFloatingBar({
   const { onClose, onShowPanel } = useBlockPostPanel(post);
   const { toggleUpvote, toggleDownvote } = useVotePost();
   const { toggleBookmark } = useBookmarkPost();
-  const { onCopyLink } = useLoggedCopyPostLink(post, origin);
+
+  // Match the desktop `PostActions` copy flow: fetch the short URL imperatively
+  // on click so anonymous users still get a usable (long) link instead of a no-op.
+  const { getShortUrl } = useGetShortUrl();
+  const [, copyLink] = useCopyPostLink();
+  const { logEvent } = useLogContext();
 
   const isUpvoteActive = post?.userState?.vote === UserVote.Up;
   const isDownvoteActive = post?.userState?.vote === UserVote.Down;
@@ -78,10 +87,23 @@ export function MobilePostFloatingBar({
     await toggleBookmark({ post, origin });
   };
 
+  const onCopyLink = useCallback(async () => {
+    const shortLink = await getShortUrl(
+      post.commentsPermalink,
+      ReferralCampaignKey.SharePost,
+    );
+    copyLink({ link: shortLink });
+    logEvent(
+      postLogEvent(LogEvent.SharePost, post, {
+        extra: { provider: ShareProvider.CopyLink, origin },
+      }),
+    );
+  }, [copyLink, getShortUrl, logEvent, origin, post]);
+
   return (
     <div className={classNames(containerClasses, className)}>
       <QuaternaryButton
-        id="upvote-post-btn"
+        id="mobile-upvote-post-btn"
         aria-label={isUpvoteActive ? 'Remove upvote' : 'Upvote'}
         pressed={isUpvoteActive}
         onClick={onToggleUpvote}
@@ -89,14 +111,13 @@ export function MobilePostFloatingBar({
         variant={ButtonVariant.Tertiary}
         color={ButtonColor.Avocado}
         size={ButtonSize.Medium}
-        className="btn-tertiary-avocado"
       >
         {upvoteCount > 0 && (
           <InteractionCounter className="tabular-nums" value={upvoteCount} />
         )}
       </QuaternaryButton>
       <QuaternaryButton
-        id="downvote-post-btn"
+        id="mobile-downvote-post-btn"
         aria-label={isDownvoteActive ? 'Remove downvote' : 'Downvote'}
         pressed={isDownvoteActive}
         onClick={onToggleDownvote}
@@ -106,13 +127,11 @@ export function MobilePostFloatingBar({
         size={ButtonSize.Medium}
       />
       <QuaternaryButton
-        id="comment-post-btn"
+        id="mobile-comment-post-btn"
         aria-label="Comment"
         pressed={post.commented}
         onClick={() => onCommentClick(LogOrigin.PostCommentButton)}
         icon={<CommentIcon secondary={post.commented} />}
-        variant={ButtonVariant.Tertiary}
-        color={ButtonColor.BlueCheese}
         size={ButtonSize.Medium}
         className="btn-tertiary-blueCheese"
       >
@@ -124,7 +143,7 @@ export function MobilePostFloatingBar({
         post={post}
         iconSize={IconSize.Medium}
         buttonProps={{
-          id: 'bookmark-post-btn',
+          id: 'mobile-bookmark-post-btn',
           pressed: post.bookmarked,
           onClick: onToggleBookmark,
           size: ButtonSize.Medium,
@@ -132,9 +151,9 @@ export function MobilePostFloatingBar({
         }}
       />
       <QuaternaryButton
-        id="copy-post-btn"
+        id="mobile-copy-post-btn"
         aria-label="Copy link"
-        onClick={() => onCopyLink(ShareProvider.CopyLink)}
+        onClick={onCopyLink}
         icon={<LinkIcon />}
         variant={ButtonVariant.Tertiary}
         color={ButtonColor.Cabbage}

--- a/packages/shared/src/components/post/MobilePostFloatingBar.tsx
+++ b/packages/shared/src/components/post/MobilePostFloatingBar.tsx
@@ -1,0 +1,145 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import {
+  DiscussIcon as CommentIcon,
+  DownvoteIcon,
+  LinkIcon,
+  UpvoteIcon,
+} from '../icons';
+import type { Post } from '../../graphql/posts';
+import { UserVote } from '../../graphql/posts';
+import { QuaternaryButton } from '../buttons/QuaternaryButton';
+import { BookmarkButton } from '../buttons';
+import { ButtonColor, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { IconSize } from '../Icon';
+import InteractionCounter from '../InteractionCounter';
+import { useVotePost } from '../../hooks/vote/useVotePost';
+import { useBookmarkPost } from '../../hooks/useBookmarkPost';
+import { useBlockPostPanel } from '../../hooks/post/useBlockPostPanel';
+import { useLoggedCopyPostLink } from '../../hooks/post/useLoggedCopyPostLink';
+import { ShareProvider } from '../../lib/share';
+import type { Origin } from '../../lib/log';
+import { Origin as LogOrigin } from '../../lib/log';
+
+export interface MobilePostFloatingBarProps {
+  post: Post;
+  onCommentClick: (origin: Origin) => void;
+  className?: string;
+}
+
+// Mirrors the floating "Share your thoughts" container that this bar replaces.
+// `bg-surface-float` is the gray translucent tint the old bar effectively rendered
+// (it was the surviving class once Tailwind layered `bg-blur-baseline` underneath),
+// paired with the same backdrop blur and shadow used by the mobile footer chrome.
+// Buttons use `justify-between` so they span the full bar width edge-to-edge, with a
+// small horizontal pad so the outermost icons don't kiss the rounded corner.
+const containerClasses = classNames(
+  'flex w-full items-center justify-between rounded-16 border border-border-subtlest-tertiary px-2 py-1',
+  'bg-surface-float backdrop-blur-[2.5rem]',
+  'shadow-[0_0.25rem_1.5rem_0_var(--theme-shadow-shadow1)]',
+);
+
+export function MobilePostFloatingBar({
+  post,
+  onCommentClick,
+  className,
+}: MobilePostFloatingBarProps): ReactElement {
+  const origin = LogOrigin.ArticlePage;
+  const { onClose, onShowPanel } = useBlockPostPanel(post);
+  const { toggleUpvote, toggleDownvote } = useVotePost();
+  const { toggleBookmark } = useBookmarkPost();
+  const { onCopyLink } = useLoggedCopyPostLink(post, origin);
+
+  const isUpvoteActive = post?.userState?.vote === UserVote.Up;
+  const isDownvoteActive = post?.userState?.vote === UserVote.Down;
+  const upvoteCount = post.numUpvotes ?? 0;
+  const commentCount = post.numComments ?? 0;
+
+  const onToggleUpvote = async () => {
+    if (post?.userState?.vote === UserVote.None) {
+      onClose(true);
+    }
+
+    await toggleUpvote({ payload: post, origin });
+  };
+
+  const onToggleDownvote = async () => {
+    if (post.userState?.vote !== UserVote.Down) {
+      onShowPanel();
+    } else {
+      onClose(true);
+    }
+
+    await toggleDownvote({ payload: post, origin });
+  };
+
+  const onToggleBookmark = async () => {
+    await toggleBookmark({ post, origin });
+  };
+
+  return (
+    <div className={classNames(containerClasses, className)}>
+      <QuaternaryButton
+        id="upvote-post-btn"
+        aria-label={isUpvoteActive ? 'Remove upvote' : 'Upvote'}
+        pressed={isUpvoteActive}
+        onClick={onToggleUpvote}
+        icon={<UpvoteIcon secondary={isUpvoteActive} />}
+        variant={ButtonVariant.Tertiary}
+        color={ButtonColor.Avocado}
+        size={ButtonSize.Medium}
+        className="btn-tertiary-avocado"
+      >
+        {upvoteCount > 0 && (
+          <InteractionCounter className="tabular-nums" value={upvoteCount} />
+        )}
+      </QuaternaryButton>
+      <QuaternaryButton
+        id="downvote-post-btn"
+        aria-label={isDownvoteActive ? 'Remove downvote' : 'Downvote'}
+        pressed={isDownvoteActive}
+        onClick={onToggleDownvote}
+        icon={<DownvoteIcon secondary={isDownvoteActive} />}
+        variant={ButtonVariant.Tertiary}
+        color={ButtonColor.Ketchup}
+        size={ButtonSize.Medium}
+      />
+      <QuaternaryButton
+        id="comment-post-btn"
+        aria-label="Comment"
+        pressed={post.commented}
+        onClick={() => onCommentClick(LogOrigin.PostCommentButton)}
+        icon={<CommentIcon secondary={post.commented} />}
+        variant={ButtonVariant.Tertiary}
+        color={ButtonColor.BlueCheese}
+        size={ButtonSize.Medium}
+        className="btn-tertiary-blueCheese"
+      >
+        {commentCount > 0 && (
+          <InteractionCounter className="tabular-nums" value={commentCount} />
+        )}
+      </QuaternaryButton>
+      <BookmarkButton
+        post={post}
+        iconSize={IconSize.Medium}
+        buttonProps={{
+          id: 'bookmark-post-btn',
+          pressed: post.bookmarked,
+          onClick: onToggleBookmark,
+          size: ButtonSize.Medium,
+          className: 'btn-tertiary-bun',
+        }}
+      />
+      <QuaternaryButton
+        id="copy-post-btn"
+        aria-label="Copy link"
+        onClick={() => onCopyLink(ShareProvider.CopyLink)}
+        icon={<LinkIcon />}
+        variant={ButtonVariant.Tertiary}
+        color={ButtonColor.Cabbage}
+        size={ButtonSize.Medium}
+      />
+    </div>
+  );
+}

--- a/packages/shared/src/components/post/NewComment.tsx
+++ b/packages/shared/src/components/post/NewComment.tsx
@@ -1,4 +1,4 @@
-import type { MutableRefObject, ReactElement } from 'react';
+import type { ForwardedRef, ReactElement } from 'react';
 import React, {
   forwardRef,
   useCallback,
@@ -24,12 +24,19 @@ import { postLogEvent } from '../../lib/feed';
 import { LogEvent, Origin } from '../../lib/log';
 import { PostType } from '../../graphql/posts';
 import { AuthTriggers } from '../../lib/auth';
+import type { LoggedUser } from '../../lib/user';
+
+export interface NewCommentTriggerRenderProps {
+  user: LoggedUser | null;
+  onCommentClick: (origin: Origin) => void;
+}
 
 interface NewCommentProps extends CommentMarkdownInputProps {
   size?: ProfileImageSize;
   shouldHandleCommentQuery?: boolean;
   CommentInputOrModal: React.ElementType;
   onComposerOpenChange?: (isOpen: boolean) => void;
+  renderTrigger?: (props: NewCommentTriggerRenderProps) => ReactElement;
 }
 
 const buttonSize: Partial<Record<ProfileImageSize, ButtonSize>> = {
@@ -50,15 +57,18 @@ function NewCommentComponent(
     shouldHandleCommentQuery = false,
     CommentInputOrModal,
     onComposerOpenChange,
+    renderTrigger,
     ...props
   }: NewCommentProps,
-  ref: MutableRefObject<NewCommentRef>,
+  ref: ForwardedRef<NewCommentRef>,
 ): ReactElement {
   const router = useRouter();
   const { logEvent } = useLogContext();
   const { logOpts } = useActiveFeedContext();
   const { user, showLogin } = useAuthContext();
-  const [inputContent, setInputContent] = useState<string>(undefined);
+  const [inputContent, setInputContent] = useState<string | undefined>(
+    undefined,
+  );
 
   const onSuccess: typeof onCommented = (comment, isNew) => {
     setInputContent(undefined);
@@ -131,6 +141,10 @@ function NewCommentComponent(
         onClose={() => setInputContent(undefined)}
       />
     );
+  }
+
+  if (renderTrigger) {
+    return renderTrigger({ user: user ?? null, onCommentClick });
   }
 
   const pictureClasses = 'hidden tablet:flex';

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -361,7 +361,7 @@ it('should show post image', async () => {
 
 it('should show login on upvote click', async () => {
   renderPost({}, [createPostMock(), createCommentsMock()], undefined);
-  const el = await screen.findByLabelText('Upvote');
+  const [el] = await screen.findAllByLabelText('Upvote');
   fireEvent.click(el);
   expect(showLogin).toBeCalledTimes(1);
 });
@@ -482,7 +482,7 @@ it('should send upvote mutation', async () => {
   mockCompleteActionMutation(ActionType.VotePost);
 
   renderPost({}, [createPostMock(), createCommentsMock()]);
-  const el = await screen.findByLabelText('Upvote');
+  const [el] = await screen.findAllByLabelText('Upvote');
   fireEvent.click(el);
   await waitFor(() => expect(mutationCalled).toBeTruthy());
 });
@@ -766,7 +766,7 @@ it('should not cut summary when there is a summary without reaching threshold', 
 it('should show login on downvote click', async () => {
   renderPost({}, [createPostMock(), createCommentsMock()], undefined);
 
-  const el = await screen.findByLabelText('Downvote');
+  const [el] = await screen.findAllByLabelText('Downvote');
   fireEvent.click(el);
   expect(showLogin).toBeCalledTimes(1);
 });
@@ -783,7 +783,7 @@ it('should send downvote mutation', async () => {
 
   renderPost({}, [createPostMock(), createCommentsMock()]);
 
-  const el = await screen.findByLabelText('Downvote');
+  const [el] = await screen.findAllByLabelText('Downvote');
   fireEvent.click(el);
   await waitFor(() => expect(mutationCalled).toBeTruthy());
 });
@@ -832,7 +832,7 @@ it('should decrement number of upvotes if downvoting post that was upvoted', asy
     createCommentsMock(),
   ]);
 
-  const downvote = await screen.findByLabelText('Downvote');
+  const [downvote] = await screen.findAllByLabelText('Downvote');
   fireEvent.click(downvote);
   await new Promise(process.nextTick);
   await waitFor(() => expect(mutationCalled).toBeTruthy());
@@ -881,7 +881,7 @@ describe('downvote flow', () => {
       }),
       createCommentsMock(),
     ]);
-    const downvote = await screen.findByLabelText('Downvote');
+    const [downvote] = await screen.findAllByLabelText('Downvote');
     fireEvent.click(downvote);
     await new Promise(process.nextTick);
     await act(async () => {

--- a/packages/webapp/components/footer/FooterWrapper.tsx
+++ b/packages/webapp/components/footer/FooterWrapper.tsx
@@ -6,12 +6,17 @@ import { PostType } from '@dailydotdev/shared/src/graphql/posts';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import ScrollToTopButton from '@dailydotdev/shared/src/components/ScrollToTopButton';
-import { blurClasses } from './common';
 
 const NewComment = dynamic(() =>
   import(
     /* webpackChunkName: "newComment" */ '@dailydotdev/shared/src/components/post/NewComment'
   ).then((mod) => mod.NewComment),
+);
+
+const MobilePostFloatingBar = dynamic(() =>
+  import(
+    /* webpackChunkName: "mobilePostFloatingBar" */ '@dailydotdev/shared/src/components/post/MobilePostFloatingBar'
+  ).then((mod) => mod.MobilePostFloatingBar),
 );
 
 const FooterPlusButton = dynamic(() =>
@@ -62,14 +67,14 @@ export default function FooterWrapper({
         <div className="my-2 w-full px-2 tablet:hidden">
           <NewComment
             post={post}
-            className={{
-              container: classNames(
-                blurClasses,
-                'h-12 shadow-[0_0.25rem_1.5rem_0_var(--theme-shadow-shadow1)]',
-              ),
-            }}
             shouldHandleCommentQuery
             CommentInputOrModal={CommentInputOrModal}
+            renderTrigger={({ onCommentClick }) => (
+              <MobilePostFloatingBar
+                post={post}
+                onCommentClick={onCommentClick}
+              />
+            )}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- Replace the mobile "Share your thoughts" floating bar on post pages with a sticky X-style action bar (Upvote, Downvote, Comment, Bookmark, Share) so engagement actions are reachable without scrolling.
- Add a `renderTrigger` render-prop to `NewComment` so callers can swap the default trigger UI while preserving composer state and `?comment=` deep-link handling.
- New `MobilePostFloatingBar` reuses existing engagement hooks (`useVotePost`, `useBookmarkPost`, `useBlockPostPanel`, `useCopyPostLink`, `useGetShortUrl`) so behavior matches the desktop `PostActions`.

## Notes for reviewer
- **Button ids** are prefixed with `mobile-` (`mobile-upvote-post-btn`, etc.) to avoid colliding with the desktop `PostActions` ids — both render in the DOM at mobile width.
- **Award button** is intentionally omitted: the spec was Upvote / Downvote / Comment / Bookmark / Share. Happy to add a 6th if we want full desktop parity.
- **Block-tags panel placement** is a known follow-up: tapping Downvote on the floating bar flips `useBlockPostPanel`'s shared flag, which surfaces the panel in the inline desktop `PostActions` further up the page. Functional today but mobile users may have to scroll to find it; can be addressed in a separate PR with a contextual mobile sheet/popover.
- **PostPage tests** were updated to use `findAllByLabelText(...)[0]` for Upvote/Downvote (matches the existing bookmark test pattern) since both bars render in jsdom.

## Test plan
- [ ] On `/posts/[id]` at mobile width, the new bar renders with 5 buttons distributed edge-to-edge inside the floating container; tablet+ shows the desktop `PostActions` only.
- [ ] Tapping Comment opens the inline composer (parity with the previous bar).
- [ ] `?comment=...` deep links still expand the composer.
- [ ] Upvote / Downvote / Bookmark trigger their existing toasts and post-cache updates.
- [ ] Share copies the short URL when logged in (and the long URL when anonymous), and logs `LogEvent.SharePost` with `provider: copy`.
- [ ] Brief posts continue to hide the bar (existing `PostType.Brief` exclusion).