### PR TITLE
feat(shared): humanize feedback widget with team avatars

### DIFF
--- a/packages/shared/src/components/ScrollToTopButton.tsx
+++ b/packages/shared/src/components/ScrollToTopButton.tsx
@@ -41,7 +41,7 @@ export default function ScrollToTopButton(): ReactElement {
   }, []);
 
   if (!hasShown) {
-    return <></>;
+    return null;
   }
 
   const props: ButtonProps<'button'> = {

--- a/packages/shared/src/components/ScrollToTopButton.tsx
+++ b/packages/shared/src/components/ScrollToTopButton.tsx
@@ -8,32 +8,39 @@ import { useViewSize, ViewSize } from '../hooks';
 import { useSettingsContext } from '../contexts/SettingsContext';
 
 const baseStyle: CSSProperties = {
-  transition: 'transform 0.1s ease-out, opacity 0.1s ease-out',
+  transition: 'transform 0.25s ease-out, opacity 0.25s ease-out',
   willChange: 'transform, opacity',
 };
 
 export default function ScrollToTopButton(): ReactElement {
   const [show, setShow] = useState(false);
+  const [hasShown, setHasShown] = useState(false);
   const isLaptop = useViewSize(ViewSize.Laptop);
   const isTablet = useViewSize(ViewSize.Tablet);
   const { showFeedbackButton } = useSettingsContext();
   const size = (() => {
     if (isLaptop) {
-      return ButtonSize.XLarge;
+      return ButtonSize.Large;
     }
 
-    return isTablet ? ButtonSize.Large : ButtonSize.Small;
+    return isTablet ? ButtonSize.Medium : ButtonSize.Small;
   })();
 
   useEffect(() => {
     const callback = () => {
-      setShow(document.documentElement.scrollTop >= window.innerHeight / 2);
+      const shouldShow =
+        document.documentElement.scrollTop >= window.innerHeight / 2;
+      setShow(shouldShow);
+      if (shouldShow) {
+        setHasShown(true);
+      }
     };
+    callback();
     window.addEventListener('scroll', callback, { passive: true });
     return () => window.removeEventListener('scroll', callback);
   }, []);
 
-  if (!show) {
+  if (!hasShown) {
     return <></>;
   }
 
@@ -46,16 +53,19 @@ export default function ScrollToTopButton(): ReactElement {
     ...baseStyle,
     transform: show ? undefined : 'translateY(1rem)',
     opacity: show ? undefined : 0,
+    pointerEvents: show ? undefined : 'none',
   };
 
   return (
     <Button
       aria-label="scroll to top"
+      aria-hidden={!show}
+      tabIndex={show ? 0 : -1}
       {...props}
       className={classNames(
         'absolute right-4 z-2',
         showFeedbackButton
-          ? '-top-26 tablet:-top-28 laptop:-top-32'
+          ? '-top-26 tablet:-top-32'
           : '-top-12 tablet:-top-18 laptop:-top-24',
       )}
       variant={ButtonVariant.Primary}

--- a/packages/shared/src/components/ScrollToTopButton.tsx
+++ b/packages/shared/src/components/ScrollToTopButton.tsx
@@ -12,7 +12,7 @@ const baseStyle: CSSProperties = {
   willChange: 'transform, opacity',
 };
 
-export default function ScrollToTopButton(): ReactElement {
+export default function ScrollToTopButton(): ReactElement | null {
   const [show, setShow] = useState(false);
   const [hasShown, setHasShown] = useState(false);
   const isLaptop = useViewSize(ViewSize.Laptop);

--- a/packages/shared/src/components/feedback/FeedbackWidget.tsx
+++ b/packages/shared/src/components/feedback/FeedbackWidget.tsx
@@ -1,21 +1,94 @@
 import type { ReactElement } from 'react';
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import classNames from 'classnames';
 import { Button, ButtonVariant, ButtonSize } from '../buttons/Button';
-import { FeedbackIcon } from '../icons';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useSettingsContext } from '../../contexts/SettingsContext';
 import { useViewSize, ViewSize } from '../../hooks/useViewSize';
 import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
+import { ProfilePicture, ProfileImageSize } from '../ProfilePicture';
+
+const TEAM_MEMBERS = [
+  {
+    username: 'idoshamun',
+    name: 'Ido Shamun',
+    image:
+      'https://media.daily.dev/image/upload/s---xy_OAwk--/f_auto,q_auto/v1703781380/avatars/avatar_28849d86070e4c099c877ab6837c61f0',
+  },
+  {
+    username: 'kramer',
+    name: 'Nimrod Kramer',
+    image:
+      'https://media.daily.dev/image/upload/v1682322243/avatars/avatar_1d339aa5b85c4e0ba85fdedb523c48d4.jpg',
+  },
+  {
+    username: 'amar',
+    name: 'Amar',
+    image:
+      'https://media.daily.dev/image/upload/s--W1oZyHsz--/f_auto/v1719829173/avatars/avatar_0pjeBcFKQqsnU97ZOj9EW',
+  },
+  {
+    username: 'capjavert',
+    name: 'Ante Barić',
+    image:
+      'https://media.daily.dev/image/upload/v1679300599/avatars/avatar_LJSkpBexOSCWc8INyu3Eu.jpg',
+  },
+  {
+    username: 'dailydevtips',
+    name: 'Chris Bongers',
+    image:
+      'https://media.daily.dev/image/upload/s--9gxFz1e7--/f_auto/v1705902590/avatars/avatar_JUNiIGCV-?_a=BAMAMiZW0',
+  },
+  {
+    username: 'tsahimatsliah',
+    name: 'Tsahi Matsliah',
+    image:
+      'https://media.daily.dev/image/upload/s--k80T3WJe--/f_auto,q_auto/v1703793130/avatars/avatar_5e0af68445e04c02b0656c3530664aff',
+  },
+  {
+    username: 'dave28',
+    name: 'Dave',
+    image:
+      'https://media.daily.dev/image/upload/s--C7nUVtfM--/f_auto,q_auto/v1/avatars/avatar_14yFjmSDxLUrr05G27mp6',
+  },
+  {
+    username: 'vasn',
+    name: 'Vas N',
+    image:
+      'https://lh3.googleusercontent.com/a-/AOh14GhZpI6rlti8BFP-fzWGDxrFlAmSfb72Vd6u7XS5=s100',
+  },
+] as const;
+
+const MS_PER_DAY = 86_400_000;
+
+const getDailyTrio = (): ReadonlyArray<(typeof TEAM_MEMBERS)[number]> => {
+  const now = new Date();
+  const startOfYear = Date.UTC(now.getUTCFullYear(), 0, 0);
+  const dayOfYear = Math.floor((now.getTime() - startOfYear) / MS_PER_DAY);
+  const len = TEAM_MEMBERS.length;
+  return [0, 1, 2].map((i) => TEAM_MEMBERS[(dayOfYear + i) % len]);
+};
 
 export function FeedbackWidget(): ReactElement | null {
   const { user } = useAuthContext();
   const { showFeedbackButton } = useSettingsContext();
   const isMobile = useViewSize(ViewSize.MobileL);
   const { openModal } = useLazyModal();
+  const dailyTrio = useMemo(getDailyTrio, []);
+  const [isCompact, setIsCompact] = useState(false);
 
-  // Only show for authenticated users on desktop when setting is enabled
-  // Mobile feedback is handled by FooterPlusButton
+  useEffect(() => {
+    const callback = () => {
+      setIsCompact(
+        document.documentElement.scrollTop >= window.innerHeight / 2,
+      );
+    };
+    callback();
+    window.addEventListener('scroll', callback, { passive: true });
+    return () => window.removeEventListener('scroll', callback);
+  }, []);
+
   if (!user || isMobile || !showFeedbackButton) {
     return null;
   }
@@ -24,12 +97,38 @@ export function FeedbackWidget(): ReactElement | null {
     <Button
       variant={ButtonVariant.Primary}
       size={ButtonSize.Medium}
-      icon={<FeedbackIcon />}
-      className="fixed bottom-4 right-4 z-max shadow-2"
+      className="group fixed bottom-4 right-4 z-max !h-auto !gap-0 !px-3 py-1.5 shadow-2"
       onClick={() => openModal({ type: LazyModal.Feedback })}
-      aria-label="Send feedback"
+      aria-label="Send feedback. Humans reply."
     >
-      Feedback
+      <span
+        aria-hidden={isCompact}
+        className={classNames(
+          'flex flex-col items-start overflow-hidden whitespace-nowrap leading-tight transition-all duration-300 ease-out',
+          isCompact
+            ? 'max-w-0 opacity-0 group-hover:mr-3 group-hover:max-w-40 group-hover:opacity-100'
+            : 'mr-3 max-w-40 opacity-100',
+        )}
+      >
+        <span>Feedback</span>
+        <span className="opacity-80 font-normal typo-caption2">
+          Humans reply
+        </span>
+      </span>
+      <span className="flex">
+        {dailyTrio.map((member, index) => (
+          <ProfilePicture
+            key={member.username}
+            user={member}
+            size={ProfileImageSize.Medium}
+            rounded="full"
+            className={classNames(
+              'border-2 border-text-primary',
+              index !== 0 && '-ml-4',
+            )}
+          />
+        ))}
+      </span>
     </Button>
   );
 }

--- a/packages/shared/src/components/feedback/FeedbackWidget.tsx
+++ b/packages/shared/src/components/feedback/FeedbackWidget.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
 import { getDayOfYear } from 'date-fns';
 import { Button, ButtonVariant, ButtonSize } from '../buttons/Button';
@@ -73,8 +73,25 @@ export function FeedbackWidget(): ReactElement | null {
   const isMobile = useViewSize(ViewSize.MobileL);
   const { openModal } = useLazyModal();
   const dailyTrio = useMemo(getDailyTrio, []);
+  const [isCompact, setIsCompact] = useState(false);
 
-  if (!user || isMobile || !showFeedbackButton) {
+  const isVisible = !!user && !isMobile && showFeedbackButton;
+
+  useEffect(() => {
+    if (!isVisible) {
+      return undefined;
+    }
+    const callback = () => {
+      setIsCompact(
+        document.documentElement.scrollTop >= window.innerHeight / 2,
+      );
+    };
+    callback();
+    window.addEventListener('scroll', callback, { passive: true });
+    return () => window.removeEventListener('scroll', callback);
+  }, [isVisible]);
+
+  if (!isVisible) {
     return null;
   }
 
@@ -82,11 +99,19 @@ export function FeedbackWidget(): ReactElement | null {
     <Button
       variant={ButtonVariant.Primary}
       size={ButtonSize.Medium}
-      className="fixed bottom-4 right-4 z-max !h-auto !gap-0 !px-3 py-1.5 shadow-2"
+      className="group fixed bottom-4 right-4 z-max !h-auto !gap-0 !px-3 py-1.5 shadow-2"
       onClick={() => openModal({ type: LazyModal.Feedback })}
       aria-label="Send feedback. Real people reply."
     >
-      <span className="mr-3 flex flex-col items-start whitespace-nowrap leading-tight">
+      <span
+        aria-hidden={isCompact}
+        className={classNames(
+          'flex flex-col items-start overflow-hidden whitespace-nowrap leading-tight transition-all duration-300 ease-out',
+          isCompact
+            ? 'max-w-0 opacity-0 group-hover:mr-3 group-hover:max-w-40 group-hover:opacity-100'
+            : 'mr-3 max-w-40 opacity-100',
+        )}
+      >
         <span>Feedback</span>
         <span className="opacity-80 font-normal typo-caption2">
           Real people reply

--- a/packages/shared/src/components/feedback/FeedbackWidget.tsx
+++ b/packages/shared/src/components/feedback/FeedbackWidget.tsx
@@ -84,12 +84,12 @@ export function FeedbackWidget(): ReactElement | null {
       size={ButtonSize.Medium}
       className="fixed bottom-4 right-4 z-max !h-auto !gap-0 !px-3 py-1.5 shadow-2"
       onClick={() => openModal({ type: LazyModal.Feedback })}
-      aria-label="Send feedback. Humans reply."
+      aria-label="Send feedback. Real people reply."
     >
       <span className="mr-3 flex flex-col items-start whitespace-nowrap leading-tight">
         <span>Feedback</span>
         <span className="opacity-80 font-normal typo-caption2">
-          Humans reply
+          Real people reply
         </span>
       </span>
       <span className="flex">

--- a/packages/shared/src/components/feedback/FeedbackWidget.tsx
+++ b/packages/shared/src/components/feedback/FeedbackWidget.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import classNames from 'classnames';
+import { getDayOfYear } from 'date-fns';
 import { Button, ButtonVariant, ButtonSize } from '../buttons/Button';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useSettingsContext } from '../../contexts/SettingsContext';
@@ -60,12 +61,8 @@ const TEAM_MEMBERS = [
   },
 ] as const;
 
-const MS_PER_DAY = 86_400_000;
-
 const getDailyTrio = (): ReadonlyArray<(typeof TEAM_MEMBERS)[number]> => {
-  const now = new Date();
-  const startOfYear = Date.UTC(now.getUTCFullYear(), 0, 0);
-  const dayOfYear = Math.floor((now.getTime() - startOfYear) / MS_PER_DAY);
+  const dayOfYear = getDayOfYear(new Date());
   const len = TEAM_MEMBERS.length;
   return [0, 1, 2].map((i) => TEAM_MEMBERS[(dayOfYear + i) % len]);
 };
@@ -76,18 +73,6 @@ export function FeedbackWidget(): ReactElement | null {
   const isMobile = useViewSize(ViewSize.MobileL);
   const { openModal } = useLazyModal();
   const dailyTrio = useMemo(getDailyTrio, []);
-  const [isCompact, setIsCompact] = useState(false);
-
-  useEffect(() => {
-    const callback = () => {
-      setIsCompact(
-        document.documentElement.scrollTop >= window.innerHeight / 2,
-      );
-    };
-    callback();
-    window.addEventListener('scroll', callback, { passive: true });
-    return () => window.removeEventListener('scroll', callback);
-  }, []);
 
   if (!user || isMobile || !showFeedbackButton) {
     return null;
@@ -97,19 +82,11 @@ export function FeedbackWidget(): ReactElement | null {
     <Button
       variant={ButtonVariant.Primary}
       size={ButtonSize.Medium}
-      className="group fixed bottom-4 right-4 z-max !h-auto !gap-0 !px-3 py-1.5 shadow-2"
+      className="fixed bottom-4 right-4 z-max !h-auto !gap-0 !px-3 py-1.5 shadow-2"
       onClick={() => openModal({ type: LazyModal.Feedback })}
       aria-label="Send feedback. Humans reply."
     >
-      <span
-        aria-hidden={isCompact}
-        className={classNames(
-          'flex flex-col items-start overflow-hidden whitespace-nowrap leading-tight transition-all duration-300 ease-out',
-          isCompact
-            ? 'max-w-0 opacity-0 group-hover:mr-3 group-hover:max-w-40 group-hover:opacity-100'
-            : 'mr-3 max-w-40 opacity-100',
-        )}
-      >
+      <span className="mr-3 flex flex-col items-start whitespace-nowrap leading-tight">
         <span>Feedback</span>
         <span className="opacity-80 font-normal typo-caption2">
           Humans reply


### PR DESCRIPTION
## Summary
- Replace the static feedback icon with a daily-rotating trio of team avatars and add a "Humans reply" subline so users see there are real people behind the button.
- Compact behavior: when the user scrolls past half the viewport the text collapses; hovering re-expands it. Avatar stack stays visible.
- Fix back-to-top button rendering at the wrong (Small) size on laptop viewports — a regression introduced when removing its early-return for the fade-in transition. The Button was being committed to the DOM before `useViewSize` settled. Reintroduce a `hasShown` latch so the Button only mounts after the first scroll past threshold (when viewport hooks are stable), then stays mounted with the existing CSS-driven fade-in/out.

## Test plan
- [ ] Logged in on desktop: feedback widget shows three overlapping circular avatars (rotates daily) with "Feedback" + "Humans reply" copy.
- [ ] Scroll past half-viewport: text collapses to icon-only, height stays the same; hover re-expands smoothly.
- [ ] Mobile (< MobileL): widget hidden as before.
- [ ] Back-to-top button renders at the correct size per breakpoint (Small / Medium / Large for mobile / tablet / laptop) and fades in/out smoothly when crossing the half-viewport scroll threshold.
- [ ] Settings toggle off `showFeedbackButton`: feedback widget hidden, back-to-top still positioned correctly.


Made with [Cursor](https://cursor.com)

### Preview domain
https://feat-feedback-widget-humans-repl.preview.app.daily.dev