### PR TITLE
feat(extension): add awards to companion menu

### DIFF
--- a/packages/extension/src/companion/CompanionMenu.spec.tsx
+++ b/packages/extension/src/companion/CompanionMenu.spec.tsx
@@ -1,0 +1,205 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { QueryClient } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import defaultUser from '@dailydotdev/shared/__tests__/fixture/loggedUser';
+import { TestBootProvider } from '@dailydotdev/shared/__tests__/helpers/boot';
+import { UserVote } from '@dailydotdev/shared/src/graphql/posts';
+import { SourceType } from '@dailydotdev/shared/src/graphql/sources';
+import { LazyModal } from '@dailydotdev/shared/src/components/modals/common/types';
+import type { PostBootData } from '@dailydotdev/shared/src/lib/boot';
+import { CoresRole } from '@dailydotdev/shared/src/lib/user';
+import { useLazyModal } from '@dailydotdev/shared/src/hooks/useLazyModal';
+import CompanionMenu from './CompanionMenu';
+
+jest.mock('react-modal', () => ({
+  setAppElement: jest.fn(),
+}));
+
+jest.mock('@dailydotdev/shared/src/hooks/usePrompt', () => ({
+  usePrompt: () => ({
+    showPrompt: jest.fn(),
+  }),
+}));
+
+jest.mock('./useCompanionActions', () => ({
+  __esModule: true,
+  default: () => ({
+    bookmark: jest.fn(),
+    removeBookmark: jest.fn(),
+    blockSource: jest.fn(),
+    disableCompanion: jest.fn(),
+    removeCompanionHelper: jest.fn(),
+    toggleCompanionExpanded: jest.fn(),
+  }),
+}));
+
+jest.mock('@dailydotdev/shared/src/hooks', () => ({
+  useToastNotification: () => ({
+    displayToast: jest.fn(),
+  }),
+  useVotePost: () => ({
+    toggleUpvote: jest.fn(),
+    toggleDownvote: jest.fn(),
+  }),
+}));
+
+jest.mock('@dailydotdev/shared/src/hooks/useSharePost', () => ({
+  useSharePost: () => ({
+    openSharePost: jest.fn(),
+  }),
+}));
+
+jest.mock('@dailydotdev/shared/src/hooks/useLazyModal', () => ({
+  useLazyModal: jest.fn(),
+}));
+
+const mockOpenModal = jest.fn();
+
+const defaultPost: PostBootData = {
+  id: 'post-1',
+  title: 'Test post',
+  commentsPermalink: 'https://app.daily.dev/posts/post-1',
+  trending: 1,
+  summary: 'summary',
+  numUpvotes: 3,
+  numComments: 2,
+  bookmarked: false,
+  source: {
+    id: 'source-1',
+    name: 'Test source',
+    image: 'https://daily.dev/source.png',
+    type: SourceType.Machine,
+  } as PostBootData['source'],
+  image: 'https://daily.dev/post.png',
+  createdAt: new Date().toISOString(),
+  readTime: 4,
+  tags: ['react'],
+  permalink: 'https://app.daily.dev/posts/post-1',
+  author: {
+    id: 'author-1',
+    username: 'author',
+    name: 'Author',
+    image: 'https://daily.dev/author.png',
+    permalink: 'https://app.daily.dev/author',
+    coresRole: CoresRole.Creator,
+  } as unknown as PostBootData['author'],
+  commented: false,
+  type: 'article' as PostBootData['type'],
+  flags: {
+    banned: false,
+    deleted: false,
+    private: false,
+    visible: true,
+    showOnFeed: true,
+    promoteToPublic: 0,
+    campaignId: null,
+    sentAnalyticsReport: false,
+  },
+  userState: {
+    vote: UserVote.None,
+    awarded: false,
+  },
+  numAwards: 0,
+  featuredAward: undefined,
+};
+
+const renderComponent = (
+  post: Partial<PostBootData> = {},
+  authUser = {
+    ...defaultUser,
+    coresRole: CoresRole.User,
+  },
+) => {
+  const client = new QueryClient();
+  jest.mocked(useLazyModal).mockReturnValue({
+    modal: null,
+    closeModal: jest.fn(),
+    openModal: mockOpenModal,
+  } as unknown as ReturnType<typeof useLazyModal>);
+
+  return render(
+    <TestBootProvider client={client} auth={{ user: authUser }}>
+      <CompanionMenu
+        post={{ ...defaultPost, ...post }}
+        companionHelper={false}
+        setPost={jest.fn()}
+        companionState={false}
+        onOptOut={jest.fn()}
+        setCompanionState={jest.fn()}
+        verticalPosition={0}
+        setVerticalPosition={jest.fn()}
+        isDragging={false}
+        setIsDragging={jest.fn()}
+      />
+    </TestBootProvider>,
+  );
+};
+
+describe('CompanionMenu', () => {
+  beforeEach(() => {
+    mockOpenModal.mockReset();
+  });
+
+  it('renders the award button when the viewer can award the author', async () => {
+    renderComponent();
+
+    expect(await screen.findByLabelText('Award this post')).toBeInTheDocument();
+  });
+
+  it('hides the award button when the viewer cannot award the author', () => {
+    renderComponent({}, { ...defaultUser, coresRole: CoresRole.None });
+
+    expect(screen.queryByLabelText('Award this post')).not.toBeInTheDocument();
+  });
+
+  it('opens the give award modal when clicking the award button', async () => {
+    renderComponent();
+
+    fireEvent.click(await screen.findByLabelText('Award this post'));
+
+    expect(mockOpenModal).toHaveBeenCalledWith({
+      type: LazyModal.GiveAward,
+      props: {
+        type: 'POST',
+        entity: {
+          id: defaultPost.id,
+          receiver: defaultPost.author,
+          numAwards: defaultPost.numAwards,
+        },
+        post: defaultPost,
+      },
+    });
+  });
+
+  it('opens the awards list when the post was already awarded', async () => {
+    renderComponent({
+      userState: {
+        vote: UserVote.None,
+        awarded: true,
+      },
+      numAwards: 1,
+      featuredAward: {
+        award: {
+          name: 'Gold',
+          image: 'https://daily.dev/gold.png',
+          value: 100,
+        },
+      },
+    });
+
+    fireEvent.click(
+      await screen.findByLabelText('You already awarded this post!'),
+    );
+
+    expect(mockOpenModal).toHaveBeenCalledWith({
+      type: LazyModal.ListAwards,
+      props: {
+        queryProps: {
+          id: defaultPost.id,
+          type: 'POST',
+        },
+      },
+    });
+  });
+});

--- a/packages/extension/src/companion/CompanionMenu.spec.tsx
+++ b/packages/extension/src/companion/CompanionMenu.spec.tsx
@@ -153,6 +153,19 @@ describe('CompanionMenu', () => {
     expect(screen.queryByLabelText('Award this post')).not.toBeInTheDocument();
   });
 
+  it('shows the award button for the post author', async () => {
+    renderComponent(
+      {},
+      {
+        ...defaultUser,
+        id: 'author-1',
+        coresRole: CoresRole.None,
+      },
+    );
+
+    expect(await screen.findByLabelText('Award this post')).toBeInTheDocument();
+  });
+
   it('opens the give award modal when clicking the award button', async () => {
     renderComponent();
 
@@ -191,6 +204,29 @@ describe('CompanionMenu', () => {
     fireEvent.click(
       await screen.findByLabelText('You already awarded this post!'),
     );
+
+    expect(mockOpenModal).toHaveBeenCalledWith({
+      type: LazyModal.ListAwards,
+      props: {
+        queryProps: {
+          id: defaultPost.id,
+          type: 'POST',
+        },
+      },
+    });
+  });
+
+  it('opens the awards list for the post author', async () => {
+    renderComponent(
+      {},
+      {
+        ...defaultUser,
+        id: 'author-1',
+        coresRole: CoresRole.None,
+      },
+    );
+
+    fireEvent.click(await screen.findByLabelText('Award this post'));
 
     expect(mockOpenModal).toHaveBeenCalledWith({
       type: LazyModal.ListAwards,

--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import type { Dispatch, ReactElement, SetStateAction } from 'react';
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import {
@@ -13,6 +13,7 @@ import {
   EyeIcon,
   FeedbackIcon,
   FlagIcon,
+  MedalBadgeIcon,
   MenuIcon,
   ShareIcon,
   UpvoteIcon,
@@ -55,6 +56,12 @@ import { usePrompt } from '@dailydotdev/shared/src/hooks/usePrompt';
 import type { ReportedCallback } from '@dailydotdev/shared/src/components/modals';
 import { ReportPostModal } from '@dailydotdev/shared/src/components/modals';
 import { labels } from '@dailydotdev/shared/src/lib';
+import { Image } from '@dailydotdev/shared/src/components/image/Image';
+import { useCanAwardUser } from '@dailydotdev/shared/src/hooks/useCoresFeature';
+import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
+import GiveAwardModal from '@dailydotdev/shared/src/components/modals/award/GiveAwardModal';
+import type { ListAwardsModalProps } from '@dailydotdev/shared/src/components/modals/award/ListAwardsModal';
+import { ListAwardsModal } from '@dailydotdev/shared/src/components/modals/award/ListAwardsModal';
 import useCompanionActions from './useCompanionActions';
 import CompanionToggle from './CompanionToggle';
 
@@ -65,16 +72,19 @@ if (!isTesting) {
 type CompanionMenuProps = {
   post: PostBootData;
   companionHelper: boolean;
-  setPost: (T) => void;
+  setPost: Dispatch<SetStateAction<PostBootData>>;
   companionState: boolean;
   onOptOut: () => void;
-  setCompanionState: (T) => void;
+  setCompanionState: Dispatch<SetStateAction<boolean>>;
   verticalPosition: number;
   setVerticalPosition: (position: number) => void;
   isDragging: boolean;
   setIsDragging: (dragging: boolean) => void;
   onOpenComments?: () => void;
 };
+
+const getCompanionModalParent = (): HTMLElement =>
+  getCompanionWrapper() ?? document.body;
 
 export default function CompanionMenu({
   post,
@@ -88,19 +98,30 @@ export default function CompanionMenu({
   isDragging,
   setIsDragging,
 }: CompanionMenuProps): ReactElement {
-  const { modal, closeModal } = useLazyModal();
+  const { modal, closeModal, openModal } = useLazyModal();
   const { logEvent } = useLogContext();
   const { user } = useContext(AuthContext);
   const { showPrompt } = usePrompt();
   const [reportModal, setReportModal] = useState<boolean>();
   const { displayToast } = useToastNotification();
   const dragStartRef = useRef({ y: 0, initialY: 0 });
+  const author = post.author as LoggedUser | undefined;
+  const canAward = useCanAwardUser({
+    sendingUser: user,
+    receivingUser: author,
+  });
 
   const [showCompanionHelper, setShowCompanionHelper] = usePersistentContext(
     'companion_helper',
     companionHelper,
   );
-  const updatePost = async ({ update, event }) => {
+  const updatePost = async ({
+    update,
+    event,
+  }: {
+    update: Partial<PostBootData>;
+    event: LogEvent;
+  }) => {
     const oldPost = post;
     setPost({
       ...post,
@@ -162,6 +183,35 @@ export default function CompanionMenu({
   };
 
   const onShare = () => openSharePost({ post });
+
+  const onAward = () => {
+    if (!author) {
+      return;
+    }
+
+    if (post.userState?.awarded) {
+      openModal({
+        type: LazyModal.ListAwards,
+        props: {
+          queryProps: { id: post.id, type: 'POST' },
+        },
+      });
+      return;
+    }
+
+    openModal({
+      type: LazyModal.GiveAward,
+      props: {
+        type: 'POST',
+        entity: {
+          id: post.id,
+          receiver: author,
+          numAwards: post.numAwards,
+        },
+        post,
+      },
+    });
+  };
 
   const optOut = async () => {
     const options: PromptOptions = {
@@ -254,8 +304,9 @@ export default function CompanionMenu({
         <WrapperMenuIcon
           Icon={DownvoteIcon}
           className={
-            post?.userState?.vote === UserVote.Down &&
-            'text-accent-ketchup-default'
+            post?.userState?.vote === UserVote.Down
+              ? 'text-accent-ketchup-default'
+              : undefined
           }
           secondary={post?.userState?.vote === UserVote.Down}
         />
@@ -422,6 +473,35 @@ export default function CompanionMenu({
             icon={<ShareIcon />}
           />
         </Tooltip>
+        {canAward && (
+          <Tooltip
+            side="left"
+            content={
+              post.userState?.awarded
+                ? 'You already awarded this post!'
+                : 'Award this post'
+            }
+            className={tooltipContainerClassName}
+          >
+            <Button
+              variant={ButtonVariant.Tertiary}
+              color={ButtonColor.Cabbage}
+              pressed={!!post.userState?.awarded}
+              onClick={onAward}
+              icon={
+                post.userState?.awarded && post.featuredAward?.award?.image ? (
+                  <Image
+                    src={post.featuredAward.award.image}
+                    alt={post.featuredAward.award.name}
+                    className="size-6 object-contain"
+                  />
+                ) : (
+                  <MedalBadgeIcon secondary={!!post.userState?.awarded} />
+                )
+              }
+            />
+          </Tooltip>
+        )}
         <DropdownMenu>
           <DropdownMenuTrigger
             tooltip={{ content: 'More options', side: 'left' }}
@@ -435,18 +515,34 @@ export default function CompanionMenu({
         </DropdownMenu>
         {modal?.type === LazyModal.Share && (
           <ShareModal
-            isOpen
-            parentSelector={getCompanionWrapper}
-            onRequestClose={closeModal}
             {...(modal.props as ShareProps)}
+            isOpen
+            parentSelector={getCompanionModalParent}
+            onRequestClose={closeModal}
           />
         )}
         {modal?.type === LazyModal.UpvotedPopup && (
           <UpvotedPopupModal
-            isOpen
-            parentSelector={getCompanionWrapper}
-            onRequestClose={closeModal}
             {...(modal.props as UpvotedPopupModalProps)}
+            isOpen
+            parentSelector={getCompanionModalParent}
+            onRequestClose={closeModal}
+          />
+        )}
+        {modal?.type === LazyModal.GiveAward && (
+          <GiveAwardModal
+            {...modal.props}
+            isOpen
+            parentSelector={getCompanionModalParent}
+            onRequestClose={closeModal}
+          />
+        )}
+        {modal?.type === LazyModal.ListAwards && (
+          <ListAwardsModal
+            {...(modal.props as ListAwardsModalProps)}
+            isOpen
+            parentSelector={getCompanionModalParent}
+            onRequestClose={closeModal}
           />
         )}
       </div>
@@ -454,12 +550,12 @@ export default function CompanionMenu({
         <ReportPostModal
           className="z-rank"
           post={post}
-          parentSelector={getCompanionWrapper}
+          parentSelector={getCompanionModalParent}
           isOpen={!!reportModal}
           index={1}
           origin={Origin.CompanionContextMenu}
           onReported={onReportPost}
-          onRequestClose={() => setReportModal(null)}
+          onRequestClose={() => setReportModal(false)}
         />
       )}
     </>

--- a/packages/extension/src/companion/CompanionMenu.tsx
+++ b/packages/extension/src/companion/CompanionMenu.tsx
@@ -106,10 +106,12 @@ export default function CompanionMenu({
   const { displayToast } = useToastNotification();
   const dragStartRef = useRef({ y: 0, initialY: 0 });
   const author = post.author as LoggedUser | undefined;
+  const isSameUser = user?.id === author?.id;
   const canAward = useCanAwardUser({
     sendingUser: user,
     receivingUser: author,
   });
+  const shouldShowAwardAction = !!author && (canAward || isSameUser);
 
   const [showCompanionHelper, setShowCompanionHelper] = usePersistentContext(
     'companion_helper',
@@ -189,7 +191,7 @@ export default function CompanionMenu({
       return;
     }
 
-    if (post.userState?.awarded) {
+    if (isSameUser || post.userState?.awarded) {
       openModal({
         type: LazyModal.ListAwards,
         props: {
@@ -473,7 +475,7 @@ export default function CompanionMenu({
             icon={<ShareIcon />}
           />
         </Tooltip>
-        {canAward && (
+        {shouldShowAwardAction && (
           <Tooltip
             side="left"
             content={

--- a/packages/shared/src/lib/boot.ts
+++ b/packages/shared/src/lib/boot.ts
@@ -40,6 +40,8 @@ export type PostBootData = Pick<
   | 'type'
   | 'flags'
   | 'userState'
+  | 'numAwards'
+  | 'featuredAward'
 >;
 
 export enum BootApp {


### PR DESCRIPTION
## Summary
- add the award action to the extension companion rail
- extend the companion post boot type with the award fields needed by the modal flow
- add focused companion menu coverage for eligible viewers, authors, and already-awarded posts

## Key decisions
- kept the award action inline in the rail rather than hiding it in the overflow menu
- mirrored the shared post action behavior so post authors can still open the awards list from the companion
- rendered award-related lazy modals inside the companion wrapper so they work correctly in the extension context

Closes ENG-1319

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1319-feedback-ux-issue-user.preview.app.daily.dev