### PR TITLE
feat(shared): onboarding personas quick-start with tag pop animation

### DIFF
--- a/packages/shared/src/components/onboarding/EditTag.tsx
+++ b/packages/shared/src/components/onboarding/EditTag.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import classNames from 'classnames';
 import { FeedPreviewControls } from '../feeds';
 import { REQUIRED_TAGS_THRESHOLD } from './common';
 import { Origin } from '../../lib/log';
@@ -14,6 +15,10 @@ import { useTagSearch } from '../../hooks/useTagSearch';
 import { useViewSize, ViewSize } from '../../hooks/useViewSize';
 import { SearchField } from '../fields/SearchField';
 import { FunnelTargetId } from '../../features/onboarding/types/funnelEvents';
+import { PersonaSelector } from './PersonaSelector';
+import { useConditionalFeature } from '../../hooks/useConditionalFeature';
+import { featureOnboardingPersonas } from '../../lib/featureManagement';
+import { subscribePersonaSelection } from './onboardingPopBus';
 
 interface EditTagProps {
   feedSettings: FeedSettings;
@@ -45,26 +50,65 @@ export const EditTag = ({
   });
   const searchTags = searchResult?.searchTags.tags || [];
 
+  const { value: showPersonas } = useConditionalFeature({
+    feature: featureOnboardingPersonas,
+    shouldEvaluate: !!feedSettings,
+  });
+
+  const tagsRef = useRef<HTMLDivElement>(null);
+  const hasScrolledToTagsRef = useRef(false);
+
+  useEffect(() => {
+    if (!isMobile || !showPersonas) {
+      return undefined;
+    }
+    return subscribePersonaSelection(() => {
+      if (hasScrolledToTagsRef.current) {
+        return;
+      }
+      hasScrolledToTagsRef.current = true;
+      tagsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  }, [isMobile, showPersonas]);
+
+  // When the persona feature is on, override any caller-supplied headline
+  // (Freyja funnel JSON or OnboardingV2 modal) with the persona-tuned copy.
+  // TODO: drop this override once Freyja's persona-experiment variant ships
+  // the new headline directly.
+  const resolvedHeadline = showPersonas
+    ? 'Tune your feed'
+    : headline || 'Pick tags that are relevant to you';
+
   return (
     <>
       <h2 className="text-center font-bold typo-large-title">
-        {headline || 'Pick tags that are relevant to you'}
+        {resolvedHeadline}
       </h2>
-      <TagSelection
-        className="mt-10 max-w-4xl"
-        searchElement={
-          <SearchField
-            aria-label="Pick tags that are relevant to you"
-            autoFocus={!isMobile}
-            className="mb-10 w-full tablet:max-w-xs"
-            inputId="search-filters"
-            placeholder="Search javascript, php, git, etc…"
-            valueChanged={onSearch}
-          />
-        }
-        searchQuery={searchQuery}
-        searchTags={searchTags}
-      />
+      {showPersonas && (
+        <>
+          <p className="mt-3 max-w-2xl text-center text-text-tertiary typo-callout">
+            Pick a role to start fast, then add tags you like.
+          </p>
+          <PersonaSelector className="mt-6" />
+        </>
+      )}
+      <div ref={tagsRef} className="flex w-full flex-col items-center">
+        <TagSelection
+          className={classNames('max-w-4xl', showPersonas ? 'mt-6' : 'mt-10')}
+          searchElement={
+            <SearchField
+              aria-label="Pick tags that are relevant to you"
+              autoFocus={!isMobile}
+              className="mb-10 w-full tablet:max-w-xs"
+              inputId="search-filters"
+              placeholder="Search javascript, php, git, etc…"
+              valueChanged={onSearch}
+            />
+          }
+          searchQuery={searchQuery}
+          searchTags={searchTags}
+        />
+      </div>
       {!hidePreview && (
         <FeedPreviewControls
           isOpen={isPreviewVisible}

--- a/packages/shared/src/components/onboarding/PersonaSelector.spec.tsx
+++ b/packages/shared/src/components/onboarding/PersonaSelector.spec.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PersonaSelector } from './PersonaSelector';
+import {
+  broadcastPersonaSelection,
+  broadcastRecommendRequest,
+} from './onboardingPopBus';
+
+jest.mock('./onboardingPopBus', () => {
+  const actual = jest.requireActual('./onboardingPopBus');
+  return {
+    ...actual,
+    broadcastPersonaSelection: jest.fn(actual.broadcastPersonaSelection),
+    broadcastRecommendRequest: jest.fn(actual.broadcastRecommendRequest),
+  };
+});
+
+const mockOnFollowTags = jest.fn().mockResolvedValue({ successful: true });
+const mockOnUnfollowTags = jest.fn().mockResolvedValue({ successful: true });
+const mockLogEvent = jest.fn();
+const mockRequest = jest.fn();
+
+jest.mock('../../graphql/common', () => ({
+  gqlClient: { request: (...args: unknown[]) => mockRequest(...args) },
+}));
+
+jest.mock('../../hooks/useTagAndSource', () => ({
+  __esModule: true,
+  default: () => ({
+    onFollowTags: mockOnFollowTags,
+    onUnfollowTags: mockOnUnfollowTags,
+  }),
+}));
+
+jest.mock('../../contexts/LogContext', () => ({
+  useLogContext: () => ({ logEvent: mockLogEvent }),
+}));
+
+const personas = [
+  { id: 'frontend', title: 'Frontend', emoji: '🌐', tags: ['react', 'css'] },
+  { id: 'backend', title: 'Backend', emoji: '🖥️', tags: ['node', 'sql'] },
+  { id: 'mobile', title: 'Mobile', emoji: '📱', tags: ['ios', 'android'] },
+  { id: 'devops', title: 'DevOps', emoji: '☁️', tags: ['docker', 'k8s'] },
+];
+
+const renderComponent = () => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <PersonaSelector />
+    </QueryClientProvider>,
+  );
+};
+
+describe('PersonaSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequest.mockResolvedValue({ onboardingPersonas: personas });
+  });
+
+  it('renders pills with emoji and title', async () => {
+    renderComponent();
+    expect(await screen.findByText('Frontend')).toBeInTheDocument();
+    expect(screen.getByText('Backend')).toBeInTheDocument();
+  });
+
+  it('follows tags and broadcasts pop + recommend on click', async () => {
+    renderComponent();
+    fireEvent.click(await screen.findByText('Frontend'));
+    await waitFor(() =>
+      expect(mockOnFollowTags).toHaveBeenCalledWith({
+        tags: ['react', 'css'],
+        requireLogin: true,
+      }),
+    );
+    expect(broadcastPersonaSelection).toHaveBeenCalledWith(['react', 'css']);
+    expect(broadcastRecommendRequest).toHaveBeenCalledWith(['react', 'css']);
+  });
+
+  it('allows multi-select without unfollowing previous persona', async () => {
+    renderComponent();
+    fireEvent.click(await screen.findByText('Frontend'));
+    await waitFor(() => expect(mockOnFollowTags).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByText('Backend'));
+    await waitFor(() => expect(mockOnFollowTags).toHaveBeenCalledTimes(2));
+
+    expect(mockOnFollowTags).toHaveBeenLastCalledWith({
+      tags: ['node', 'sql'],
+      requireLogin: true,
+    });
+    expect(mockOnUnfollowTags).not.toHaveBeenCalled();
+  });
+
+  it('disables additional personas after 3 are selected', async () => {
+    renderComponent();
+    fireEvent.click(await screen.findByText('Frontend'));
+    await waitFor(() => expect(mockOnFollowTags).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText('Backend'));
+    await waitFor(() => expect(mockOnFollowTags).toHaveBeenCalledTimes(2));
+    fireEvent.click(screen.getByText('Mobile'));
+    await waitFor(() => expect(mockOnFollowTags).toHaveBeenCalledTimes(3));
+
+    const devopsButton = screen.getByText('DevOps').closest('button');
+    expect(devopsButton).toBeDisabled();
+
+    fireEvent.click(screen.getByText('DevOps'));
+    expect(mockOnFollowTags).toHaveBeenCalledTimes(3);
+  });
+
+  it('deselects only the clicked persona', async () => {
+    renderComponent();
+    fireEvent.click(await screen.findByText('Frontend'));
+    await waitFor(() => expect(mockOnFollowTags).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByText('Backend'));
+    await waitFor(() => expect(mockOnFollowTags).toHaveBeenCalledTimes(2));
+
+    fireEvent.click(screen.getByText('Frontend'));
+    await waitFor(() =>
+      expect(mockOnUnfollowTags).toHaveBeenCalledWith({
+        tags: ['react', 'css'],
+      }),
+    );
+    expect(mockOnUnfollowTags).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/shared/src/components/onboarding/PersonaSelector.tsx
+++ b/packages/shared/src/components/onboarding/PersonaSelector.tsx
@@ -1,0 +1,161 @@
+import type { ReactElement } from 'react';
+import React, { useState } from 'react';
+import classNames from 'classnames';
+import { useQuery } from '@tanstack/react-query';
+import { gqlClient } from '../../graphql/common';
+import type { GQLPersona } from '../../graphql/feedSettings';
+import { GET_ONBOARDING_PERSONAS_QUERY } from '../../graphql/feedSettings';
+import useTagAndSource from '../../hooks/useTagAndSource';
+import { useLogContext } from '../../contexts/LogContext';
+import { LogEvent, Origin } from '../../lib/log';
+import { disabledRefetch } from '../../lib/func';
+import { RequestKey, StaleTime, generateQueryKey } from '../../lib/query';
+import { Button, ButtonColor } from '../buttons/Button';
+import { ButtonVariant } from '../buttons/common';
+import { ElementPlaceholder } from '../ElementPlaceholder';
+import {
+  broadcastPersonaSelection,
+  broadcastRecommendRequest,
+} from './onboardingPopBus';
+
+export const MAX_PERSONAS = 3;
+
+interface PersonaSelectorProps {
+  className?: string;
+  feedId?: string;
+}
+
+export function PersonaSelector({
+  className,
+  feedId,
+}: PersonaSelectorProps): ReactElement | null {
+  const { logEvent } = useLogContext();
+  const [activeIds, setActiveIds] = useState<Set<string>>(new Set());
+  const { onFollowTags, onUnfollowTags } = useTagAndSource({
+    origin: Origin.OnboardingPersona,
+    feedId,
+  });
+
+  const {
+    data: personas,
+    isPending,
+    isError,
+  } = useQuery<GQLPersona[]>({
+    queryKey: generateQueryKey(
+      RequestKey.Tags,
+      undefined,
+      'onboardingPersonas',
+    ),
+    queryFn: async () => {
+      const result = await gqlClient.request<{
+        onboardingPersonas: GQLPersona[];
+      }>(GET_ONBOARDING_PERSONAS_QUERY, {});
+      return result.onboardingPersonas;
+    },
+    ...disabledRefetch,
+    staleTime: StaleTime.OneHour,
+  });
+
+  const handleClick = async (persona: GQLPersona) => {
+    const isActive = activeIds.has(persona.id);
+    const isAtCap = !isActive && activeIds.size >= MAX_PERSONAS;
+    if (isAtCap) {
+      return;
+    }
+
+    logEvent({
+      event_name: LogEvent.SelectOnboardingPersona,
+      target_type: 'persona',
+      target_id: persona.id,
+      extra: JSON.stringify({
+        action: isActive ? 'deselect' : 'select',
+        tags_count: persona.tags.length,
+        active_count: isActive ? activeIds.size - 1 : activeIds.size + 1,
+      }),
+    });
+
+    if (isActive) {
+      await onUnfollowTags({ tags: persona.tags });
+      setActiveIds((prev) => {
+        const next = new Set(prev);
+        next.delete(persona.id);
+        return next;
+      });
+      return;
+    }
+
+    broadcastPersonaSelection(persona.tags);
+    await onFollowTags({ tags: persona.tags, requireLogin: true });
+    broadcastRecommendRequest(persona.tags);
+    setActiveIds((prev) => {
+      const next = new Set(prev);
+      next.add(persona.id);
+      return next;
+    });
+  };
+
+  if (isError) {
+    return null;
+  }
+
+  const isAtCap = activeIds.size >= MAX_PERSONAS;
+
+  return (
+    <div
+      role="group"
+      aria-label="Pick a role to follow related tags"
+      aria-busy={isPending}
+      className={classNames(
+        'flex w-full max-w-4xl flex-wrap justify-center gap-3',
+        className,
+      )}
+    >
+      {isPending &&
+        Array.from({ length: 10 }).map((_, i) => (
+          <ElementPlaceholder
+            // eslint-disable-next-line react/no-array-index-key
+            key={i}
+            className="h-9 w-32 rounded-12"
+          />
+        ))}
+      {!isPending &&
+        personas?.map((persona) => {
+          const isActive = activeIds.has(persona.id);
+          const isDisabled = !isActive && isAtCap;
+          const buttonContent = (
+            <>
+              <span aria-hidden className="mr-2">
+                {persona.emoji}
+              </span>
+              {persona.title}
+            </>
+          );
+
+          if (isActive) {
+            return (
+              <Button
+                key={persona.id}
+                pressed
+                variant={ButtonVariant.Primary}
+                color={ButtonColor.Cabbage}
+                onClick={() => handleClick(persona)}
+              >
+                {buttonContent}
+              </Button>
+            );
+          }
+
+          return (
+            <Button
+              key={persona.id}
+              variant={ButtonVariant.Float}
+              disabled={isDisabled}
+              onClick={() => handleClick(persona)}
+            >
+              {buttonContent}
+            </Button>
+          );
+        })}
+    </div>
+  );
+}

--- a/packages/shared/src/components/onboarding/onboardingPopBus.ts
+++ b/packages/shared/src/components/onboarding/onboardingPopBus.ts
@@ -1,0 +1,29 @@
+type PopListener = (tagNames: string[]) => void;
+type RecommendListener = (tags: string[]) => void;
+
+const popListeners = new Set<PopListener>();
+const recommendListeners = new Set<RecommendListener>();
+
+export function subscribePersonaSelection(listener: PopListener): () => void {
+  popListeners.add(listener);
+  return () => {
+    popListeners.delete(listener);
+  };
+}
+
+export function broadcastPersonaSelection(tagNames: string[]): void {
+  popListeners.forEach((listener) => listener(tagNames));
+}
+
+export function subscribeRecommendRequest(
+  listener: RecommendListener,
+): () => void {
+  recommendListeners.add(listener);
+  return () => {
+    recommendListeners.delete(listener);
+  };
+}
+
+export function broadcastRecommendRequest(tags: string[]): void {
+  recommendListeners.forEach((listener) => listener(tags));
+}

--- a/packages/shared/src/components/tags/TagElement.tsx
+++ b/packages/shared/src/components/tags/TagElement.tsx
@@ -1,17 +1,22 @@
 import classNames from 'classnames';
-import type { ReactElement } from 'react';
-import React from 'react';
+import type { AnimationEvent, ReactElement } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { AlertDot, AlertColor } from '../AlertDot';
 import { Button, ButtonColor } from '../buttons/Button';
 import { ButtonVariant } from '../buttons/common';
 import type { Tag } from '../../graphql/feedSettings';
 import type { OnSelectTagProps } from './common';
+import { subscribePersonaSelection } from '../onboarding/onboardingPopBus';
+
+const SPARK_COUNT = 5;
 
 export type OnboardingTagProps = {
   tag: Tag;
   onClick: (props: Pick<OnSelectTagProps, 'tag'>) => void;
   isSelected?: boolean;
   isHighlighted?: boolean;
+  isExiting?: boolean;
+  onExited?: (tagName: string) => void;
 };
 
 export const TagElement = ({
@@ -19,10 +24,63 @@ export const TagElement = ({
   onClick,
   isSelected = false,
   isHighlighted = false,
+  isExiting = false,
+  onExited,
   ...attrs
 }: OnboardingTagProps): ReactElement => {
-  const className = classNames({ 'btn-tag': !isSelected }, 'relative');
-  const handleClick = () => onClick({ tag });
+  const [popDelayMs, setPopDelayMs] = useState<number | null>(null);
+
+  useEffect(() => {
+    return subscribePersonaSelection((tagNames) => {
+      const idx = tagNames.indexOf(tag.name ?? '');
+      if (idx === -1) {
+        return;
+      }
+      setPopDelayMs(Math.min(idx, 9) * 60);
+    });
+  }, [tag.name]);
+
+  const isPopping = popDelayMs !== null && !isExiting;
+
+  const sparks = useMemo(() => {
+    if (!isPopping) {
+      return [];
+    }
+    return Array.from({ length: SPARK_COUNT }, (_, i) => {
+      const angle = (i / SPARK_COUNT) * Math.PI * 2 + Math.random() * 0.6;
+      const radius = 18 + Math.random() * 12;
+      return {
+        fx: `${Math.cos(angle) * radius}px`,
+        fy: `${Math.sin(angle) * radius}px`,
+      };
+    });
+  }, [isPopping]);
+
+  const className = classNames(
+    { 'btn-tag': !isSelected },
+    'relative',
+    isExiting && 'pointer-events-none animate-tag-fade-out',
+    !isExiting && isPopping && 'animate-tag-pop',
+  );
+  const style =
+    !isExiting && isPopping ? { animationDelay: `${popDelayMs}ms` } : undefined;
+  const handleAnimationEnd = (event: AnimationEvent<HTMLElement>) => {
+    if (event.animationName === 'tag-fade-out') {
+      if (tag.name) {
+        onExited?.(tag.name);
+      }
+      return;
+    }
+    if (event.animationName === 'tag-pop') {
+      setPopDelayMs(null);
+    }
+  };
+  const handleClick = () => {
+    if (isExiting) {
+      return;
+    }
+    onClick({ tag });
+  };
   const content = (
     <>
       {tag.name}
@@ -32,6 +90,25 @@ export const TagElement = ({
           color={AlertColor.Cabbage}
         />
       )}
+      {isPopping && (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute left-1/2 top-1/2"
+        >
+          {sparks.map((spark, i) => (
+            <span
+              // eslint-disable-next-line react/no-array-index-key
+              key={i}
+              className="tag-spark animate-tag-spark"
+              style={{
+                ['--spark-fx' as string]: spark.fx,
+                ['--spark-fy' as string]: spark.fy,
+                animationDelay: `${(popDelayMs ?? 0) + i * 30}ms`,
+              }}
+            />
+          ))}
+        </span>
+      )}
     </>
   );
 
@@ -39,6 +116,8 @@ export const TagElement = ({
     return (
       <Button
         className={className}
+        style={style}
+        onAnimationEnd={handleAnimationEnd}
         variant={ButtonVariant.Primary}
         color={ButtonColor.Cabbage}
         onClick={handleClick}
@@ -52,6 +131,8 @@ export const TagElement = ({
   return (
     <Button
       className={className}
+      style={style}
+      onAnimationEnd={handleAnimationEnd}
       variant={ButtonVariant.Float}
       onClick={handleClick}
       {...attrs}

--- a/packages/shared/src/components/tags/TagSelection.tsx
+++ b/packages/shared/src/components/tags/TagSelection.tsx
@@ -1,29 +1,28 @@
 import type { ReactElement, ReactNode } from 'react';
-import React, { useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import classNames from 'classnames';
 import type { QueryFilters } from '@tanstack/react-query';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import useFeedSettings, {
-  getFeedSettingsQueryKey,
-} from '../../hooks/useFeedSettings';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import useFeedSettings from '../../hooks/useFeedSettings';
 import { RequestKey, generateQueryKey } from '../../lib/query';
-import type {
-  AllTagCategoriesData,
-  TagsData,
-} from '../../graphql/feedSettings';
+import type { TagsData } from '../../graphql/feedSettings';
 import { useAuthContext } from '../../contexts/AuthContext';
-import {
-  GET_ONBOARDING_TAGS_QUERY,
-  GET_RECOMMENDED_TAGS_QUERY,
-  ONBOARDING_RECOMMEND_TAGS_MUTATION,
-} from '../../graphql/feedSettings';
+import { GET_ONBOARDING_TAGS_QUERY } from '../../graphql/feedSettings';
 import { useConditionalFeature } from '../../hooks/useConditionalFeature';
 import { featureOnboardingTagRecommender } from '../../lib/featureManagement';
 import { disabledRefetch, getRandomNumber } from '../../lib/func';
 import useDebounceFn from '../../hooks/useDebounceFn';
 import type { FilterOnboardingProps } from '../onboarding/FilterOnboarding';
 import useTagAndSource from '../../hooks/useTagAndSource';
+import { useRecommendedTags } from '../../hooks/useRecommendedTags';
 import { Origin } from '../../lib/log';
+import { REQUIRED_TAGS_THRESHOLD } from '../onboarding/common';
 import { ElementPlaceholder } from '../ElementPlaceholder';
 import type { OnboardingTagProps } from './TagElement';
 import { TagElement as TagElementDefault } from './TagElement';
@@ -35,6 +34,10 @@ import {
   TypographyType,
 } from '../typography/Typography';
 import { FunnelTargetId } from '../../features/onboarding/types/funnelEvents';
+import {
+  broadcastPersonaSelection,
+  subscribeRecommendRequest,
+} from '../onboarding/onboardingPopBus';
 
 const tagsSelector = (data: TagsData) => data?.tags || [];
 
@@ -141,83 +144,127 @@ export function TagSelection({
       return [];
     }
 
-    return [...onboardingTags.map((item) => item.name)];
+    return onboardingTags
+      .map((item) => item.name)
+      .filter((name): name is string => !!name);
   }, [onboardingTags]);
 
-  const { mutate: recommendTags, data: recommendedTags } = useMutation({
-    mutationFn: async ({ tag }: Pick<OnSelectTagProps, 'tag'>) => {
-      const tagName = tag.name;
-      if (!tagName) {
-        return new Set<string>();
-      }
+  const recommendedTagsRef = useRef<Set<string>>(new Set());
+  const [recommendedNames, setRecommendedNames] = useState<Set<string>>(
+    new Set(),
+  );
 
-      let recommended: TagsData['tags'];
+  const selectedTagsRef = useRef<Set<string>>(selectedTags);
+  useEffect(() => {
+    selectedTagsRef.current = selectedTags;
+  }, [selectedTags]);
 
-      if (isTagRecommenderEnabled) {
-        // Read the freshest selection from the cache rather than the closure-bound
-        // memo: collaborative-filtering quality depends on an accurate input set.
-        // onFollowTags runs after recommendTags, so the just-clicked tag isn't
-        // yet in the cache. Append it to satisfy the [String!]! min-1 constraint.
-        const cached = queryClient.getQueryData<AllTagCategoriesData>(
-          getFeedSettingsQueryKey(user, feedId),
-        );
-        const currentSelection = cached?.feedSettings?.includeTags ?? [];
-        const selectedForMutation = currentSelection.includes(tagName)
-          ? currentSelection
-          : [...currentSelection, tagName];
+  const manualClickCounterRef = useRef<number>(0);
+  const RECOMMEND_THROTTLE = 10;
 
-        const result = await gqlClient.request<{
-          onboardingRecommendTags: { tags: string[] };
-        }>(ONBOARDING_RECOMMEND_TAGS_MUTATION, {
-          selectedTags: selectedForMutation,
-          n: 10,
-        });
-
-        recommended = result.onboardingRecommendTags.tags.map((name) => ({
-          name,
-        }));
-      } else {
-        const result = await gqlClient.request<{
-          recommendedTags: TagsData;
-        }>(GET_RECOMMENDED_TAGS_QUERY, {
-          tags: [tagName],
-          excludedTags,
-        });
-        recommended = result.recommendedTags.tags;
-      }
-
-      const recommendedTagsSet = new Set(
-        recommended
-          .map((item) => item.name)
-          .filter((name): name is string => !!name),
-      );
-
-      queryClient.setQueryData<TagsData>(onboardingTagsQueryKey, (current) => {
-        if (!current) {
-          return current;
+  const curatedNamesRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (onboardingTagsRaw && curatedNamesRef.current.size === 0) {
+      onboardingTagsRaw.forEach((tag) => {
+        if (tag.name) {
+          curatedNamesRef.current.add(tag.name);
         }
-        const existingNames = new Set(current.tags.map((item) => item.name));
-        const newRecommended = recommended.filter(
-          (item) => item.name && !existingNames.has(item.name),
-        );
-
-        if (!newRecommended.length) {
-          return current;
-        }
-
-        const newTags = [...current.tags];
-        const insertIndex = newTags.findIndex((item) => item.name === tagName);
-
-        newTags.splice(insertIndex + 1, 0, ...newRecommended);
-
-        return {
-          tags: newTags,
-        };
       });
+    }
+  }, [onboardingTagsRaw]);
 
-      return recommendedTagsSet;
+  const [manualSelectCount, setManualSelectCount] = useState(0);
+  const [curatedHidden, setCuratedHidden] = useState(false);
+  useEffect(() => {
+    if (!curatedHidden && manualSelectCount >= REQUIRED_TAGS_THRESHOLD) {
+      setCuratedHidden(true);
+    }
+  }, [curatedHidden, manualSelectCount]);
+
+  const [exitingTags, setExitingTags] = useState<Set<string>>(new Set());
+  const [removedTags, setRemovedTags] = useState<Set<string>>(new Set());
+
+  // When the curated baseline crosses the threshold, mark unselected curated
+  // tags as exiting so they can play the fade-out animation.
+  useEffect(() => {
+    if (!curatedHidden) {
+      return;
+    }
+    setExitingTags((prev) => {
+      let next = prev;
+      curatedNamesRef.current.forEach((name) => {
+        if (
+          !selectedTags.has(name) &&
+          !removedTags.has(name) &&
+          !next.has(name)
+        ) {
+          if (next === prev) {
+            next = new Set(prev);
+          }
+          next.add(name);
+        }
+      });
+      return next;
+    });
+  }, [curatedHidden, selectedTags, removedTags]);
+
+  const handleTagExited = useCallback((tagName: string) => {
+    setExitingTags((prev) => {
+      if (!prev.has(tagName)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.delete(tagName);
+      return next;
+    });
+    setRemovedTags((prev) => {
+      if (prev.has(tagName)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.add(tagName);
+      return next;
+    });
+  }, []);
+
+  const { mutate: recommendTags } = useRecommendedTags({
+    onboardingTagsQueryKey,
+    excludedTags,
+    recommendedRef: recommendedTagsRef,
+    selectedRef: selectedTagsRef,
+    useTagRecommenderMutation: isTagRecommenderEnabled,
+    user,
+    feedId,
+    onRecommended: (names) => {
+      setRecommendedNames(new Set(names));
+    },
+    onFreshRecommendations: (names) => {
+      if (names.length) {
+        broadcastPersonaSelection(names);
+      }
+    },
+    onEvicting: (names) => {
+      setExitingTags((prev) => {
+        let next = prev;
+        names.forEach((name) => {
+          if (next.has(name)) {
+            return;
+          }
+          if (next === prev) {
+            next = new Set(prev);
+          }
+          next.add(name);
+        });
+        return next;
+      });
     },
   });
+
+  useEffect(() => {
+    return subscribeRecommendRequest((tags) => {
+      recommendTags({ seeds: tags });
+    });
+  }, [recommendTags]);
 
   const handleClickTag = async ({ tag }: Pick<OnSelectTagProps, 'tag'>) => {
     const tagName = tag.name;
@@ -247,7 +294,19 @@ export function TagSelection({
         );
       }
 
-      recommendTags({ tag });
+      setManualSelectCount((count) => count + 1);
+      const clickIndex = manualClickCounterRef.current;
+      manualClickCounterRef.current = clickIndex + 1;
+      // New recommendations always fetch and add to the screen. The
+      // eviction sweep — removing previously-shown recommendations the
+      // user didn't pick — only runs every Nth click.
+      const shouldEvict =
+        clickIndex > 0 && clickIndex % RECOMMEND_THROTTLE === 0;
+      recommendTags({
+        seeds: [tagName],
+        anchorTag: tagName,
+        evictPrevious: shouldEvict,
+      });
 
       await onFollowTags({ tags: [tagName] });
     } else {
@@ -299,7 +358,11 @@ export function TagSelection({
               return null;
             }
             const tagName = tag.name;
+            if (removedTags.has(tagName)) {
+              return null;
+            }
             const isSelected = selectedTags.has(tagName);
+            const isExiting = exitingTags.has(tagName);
             renderedTags[tagName] = true;
 
             return (
@@ -308,7 +371,9 @@ export function TagSelection({
                 tag={tag}
                 onClick={handleClickTag}
                 isSelected={isSelected}
-                isHighlighted={!searchQuery && !!recommendedTags?.has(tagName)}
+                isHighlighted={!searchQuery && recommendedNames.has(tagName)}
+                isExiting={isExiting}
+                onExited={handleTagExited}
                 data-funnel-track={FunnelTargetId.FeedTag}
               />
             );

--- a/packages/shared/src/components/tags/TagSelection.tsx
+++ b/packages/shared/src/components/tags/TagSelection.tsx
@@ -15,7 +15,10 @@ import type { TagsData } from '../../graphql/feedSettings';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { GET_ONBOARDING_TAGS_QUERY } from '../../graphql/feedSettings';
 import { useConditionalFeature } from '../../hooks/useConditionalFeature';
-import { featureOnboardingTagRecommender } from '../../lib/featureManagement';
+import {
+  featureOnboardingPersonas,
+  featureOnboardingTagRecommender,
+} from '../../lib/featureManagement';
 import { disabledRefetch, getRandomNumber } from '../../lib/func';
 import useDebounceFn from '../../hooks/useDebounceFn';
 import type { FilterOnboardingProps } from '../onboarding/FilterOnboarding';
@@ -85,6 +88,13 @@ export function TagSelection({
     feature: featureOnboardingTagRecommender,
     shouldEvaluate: origin === Origin.Onboarding,
   });
+  // Personas always use the recswipe-backed recommender; ops doesn't need
+  // to enroll users in both experiments.
+  const { value: isPersonasEnabled } = useConditionalFeature({
+    feature: featureOnboardingPersonas,
+    shouldEvaluate: origin === Origin.Onboarding,
+  });
+  const shouldUseTagRecommender = isTagRecommenderEnabled || isPersonasEnabled;
   const { onFollowTags, onUnfollowTags } = useTagAndSource({
     origin,
     shouldUpdateAlerts,
@@ -232,7 +242,7 @@ export function TagSelection({
     excludedTags,
     recommendedRef: recommendedTagsRef,
     selectedRef: selectedTagsRef,
-    useTagRecommenderMutation: isTagRecommenderEnabled,
+    useTagRecommenderMutation: shouldUseTagRecommender,
     user,
     feedId,
     onRecommended: (names) => {

--- a/packages/shared/src/graphql/feedSettings.ts
+++ b/packages/shared/src/graphql/feedSettings.ts
@@ -57,6 +57,13 @@ export interface TagCategory {
   emoji: string;
 }
 
+export interface GQLPersona {
+  id: string;
+  title: string;
+  emoji: string;
+  tags: string[];
+}
+
 export interface AllTagCategoriesData {
   feedSettings?: FeedSettings;
   loggedIn?: boolean;
@@ -194,6 +201,17 @@ export const GET_RECOMMENDED_TAGS_QUERY = gql`
 export const ONBOARDING_RECOMMEND_TAGS_MUTATION = gql`
   mutation OnboardingRecommendTags($selectedTags: [String!]!, $n: Int) {
     onboardingRecommendTags(selectedTags: $selectedTags, n: $n) {
+      tags
+    }
+  }
+`;
+
+export const GET_ONBOARDING_PERSONAS_QUERY = gql`
+  query OnboardingPersonas {
+    onboardingPersonas {
+      id
+      title
+      emoji
       tags
     }
   }

--- a/packages/shared/src/hooks/useRecommendedTags.ts
+++ b/packages/shared/src/hooks/useRecommendedTags.ts
@@ -1,0 +1,240 @@
+import type { MutableRefObject } from 'react';
+import type { QueryKey, UseMutationResult } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { gqlClient } from '../graphql/common';
+import type {
+  AllTagCategoriesData,
+  Tag,
+  TagsData,
+} from '../graphql/feedSettings';
+import {
+  GET_RECOMMENDED_TAGS_QUERY,
+  ONBOARDING_RECOMMEND_TAGS_MUTATION,
+} from '../graphql/feedSettings';
+import type { LoggedUser } from '../lib/user';
+import { getFeedSettingsQueryKey } from './useFeedSettings';
+
+export interface RecommendTagsArgs {
+  /**
+   * One or more seed tag names. Each seed triggers an independent
+   * `recommendedTags` query in parallel; results are deduped and merged.
+   */
+  seeds: string[];
+  /**
+   * If set and present in the cache, recommendations are spliced after
+   * this tag. Used by manual single-tag clicks. Persona fan-outs leave
+   * it undefined and the recommendations are appended.
+   */
+  anchorTag?: string;
+  /**
+   * When true, the previous recommendation batch (minus anything now
+   * selected) is evicted from the screen with a fade-out. When false
+   * (the default), new recommendations are added on top of the
+   * existing ones — adding is immediate, eviction is deferred.
+   */
+  evictPrevious?: boolean;
+}
+
+export interface UseRecommendedTagsArgs {
+  onboardingTagsQueryKey: QueryKey;
+  excludedTags: string[];
+  /** Cap on the visible recommendations after dedupe. Default: 8. */
+  limit?: number;
+  recommendedRef: MutableRefObject<Set<string>>;
+  /**
+   * Names that are currently selected by the user. Tags in this set are
+   * never evicted, even if a new recommendation batch supersedes them.
+   */
+  selectedRef?: MutableRefObject<Set<string>>;
+  /**
+   * When set, the hook routes through ONBOARDING_RECOMMEND_TAGS_MUTATION
+   * (sending the current selection as a single payload) instead of the
+   * per-tag fan-out against GET_RECOMMENDED_TAGS_QUERY. Used by the
+   * onboarding tag recommender experiment.
+   */
+  useTagRecommenderMutation?: boolean;
+  /** User + feedId for the cache lookup the recommender mutation needs. */
+  user?: LoggedUser;
+  feedId?: string;
+  /**
+   * Called with the full accumulated recommendation set after each
+   * mutation — drives `recommendedNames` state for highlighting.
+   */
+  onRecommended?: (tagNames: string[]) => void;
+  /**
+   * Called with only the freshly-fetched recommendation names (the
+   * additions in this mutation), not the accumulated set. Drives the
+   * pop/spark animation so previously-shown tags don't re-pop.
+   */
+  onFreshRecommendations?: (tagNames: string[]) => void;
+  /**
+   * Called before the new batch is committed, with the names from the
+   * previous batch that should now play their fade-out animation.
+   */
+  onEvicting?: (tagNames: string[]) => void;
+}
+
+export type UseRecommendedTagsResult = UseMutationResult<
+  Set<string>,
+  Error,
+  RecommendTagsArgs
+>;
+
+export function useRecommendedTags({
+  onboardingTagsQueryKey,
+  excludedTags,
+  limit = 12,
+  recommendedRef,
+  selectedRef,
+  useTagRecommenderMutation = false,
+  user,
+  feedId,
+  onRecommended,
+  onFreshRecommendations,
+  onEvicting,
+}: UseRecommendedTagsArgs): UseRecommendedTagsResult {
+  const queryClient = useQueryClient();
+
+  return useMutation<Set<string>, Error, RecommendTagsArgs>({
+    mutationFn: async ({ seeds, anchorTag, evictPrevious = false }) => {
+      const uniqueSeeds = Array.from(new Set(seeds.filter(Boolean)));
+      if (!uniqueSeeds.length) {
+        return new Set();
+      }
+
+      const excludedSet = new Set(excludedTags);
+      const dedupedNames = new Set<string>();
+      const dedupedTags: Tag[] = [];
+
+      if (useTagRecommenderMutation) {
+        // Onboarding tag recommender experiment: send the current
+        // selection as one payload and trust the backend's ranking.
+        const cached = queryClient.getQueryData<AllTagCategoriesData>(
+          getFeedSettingsQueryKey(user, feedId),
+        );
+        const currentSelection = cached?.feedSettings?.includeTags ?? [];
+        const seedNames = new Set(uniqueSeeds);
+        const selectedForMutation = new Set([
+          ...currentSelection,
+          ...uniqueSeeds,
+        ]);
+        const result = await gqlClient.request<{
+          onboardingRecommendTags: { tags: string[] };
+        }>(ONBOARDING_RECOMMEND_TAGS_MUTATION, {
+          selectedTags: Array.from(selectedForMutation),
+          n: limit,
+        });
+
+        result.onboardingRecommendTags.tags.forEach((name) => {
+          if (
+            name &&
+            !dedupedNames.has(name) &&
+            !excludedSet.has(name) &&
+            !seedNames.has(name) &&
+            !recommendedRef.current.has(name) &&
+            dedupedTags.length < limit
+          ) {
+            dedupedNames.add(name);
+            dedupedTags.push({ name });
+          }
+        });
+      } else {
+        const responses = await Promise.all(
+          uniqueSeeds.map((seed) =>
+            gqlClient.request<{ recommendedTags: TagsData }>(
+              GET_RECOMMENDED_TAGS_QUERY,
+              { tags: [seed], excludedTags },
+            ),
+          ),
+        );
+
+        // Round-robin across the per-seed responses so every seed
+        // contributes before any one seed's later results are picked up.
+        // This avoids a single sub-cluster dominating the recommendations
+        // for personas whose tags overlap heavily (e.g., AI/ML).
+        const responseTagLists = responses.map(
+          (response) => response.recommendedTags.tags,
+        );
+        const maxResultsPerSeed = responseTagLists.reduce(
+          (max, tags) => Math.max(max, tags.length),
+          0,
+        );
+        for (let rank = 0; rank < maxResultsPerSeed; rank += 1) {
+          for (
+            let seedIdx = 0;
+            seedIdx < responseTagLists.length;
+            seedIdx += 1
+          ) {
+            if (dedupedTags.length >= limit) {
+              break;
+            }
+            const tag = responseTagLists[seedIdx][rank];
+            if (
+              tag?.name &&
+              !dedupedNames.has(tag.name) &&
+              !excludedSet.has(tag.name) &&
+              !recommendedRef.current.has(tag.name)
+            ) {
+              dedupedNames.add(tag.name);
+              dedupedTags.push(tag);
+            }
+          }
+          if (dedupedTags.length >= limit) {
+            break;
+          }
+        }
+      }
+
+      if (evictPrevious) {
+        const previousRecommendations = Array.from(recommendedRef.current);
+        const selectedNow = selectedRef?.current ?? new Set<string>();
+        const evicting = previousRecommendations.filter(
+          (name) => !dedupedNames.has(name) && !selectedNow.has(name),
+        );
+        if (evicting.length) {
+          onEvicting?.(evicting);
+        }
+      }
+
+      queryClient.setQueryData<TagsData>(onboardingTagsQueryKey, (current) => {
+        if (!current) {
+          return current;
+        }
+
+        const freshTags = dedupedTags.filter(
+          (tag) =>
+            tag.name &&
+            !current.tags.some((existing) => existing.name === tag.name),
+        );
+
+        if (!freshTags.length) {
+          return current;
+        }
+
+        const insertIndex = anchorTag
+          ? current.tags.findIndex((tag) => tag.name === anchorTag)
+          : -1;
+
+        if (insertIndex >= 0) {
+          return {
+            tags: [
+              ...current.tags.slice(0, insertIndex + 1),
+              ...freshTags,
+              ...current.tags.slice(insertIndex + 1),
+            ],
+          };
+        }
+
+        return { tags: [...current.tags, ...freshTags] };
+      });
+
+      if (evictPrevious) {
+        recommendedRef.current.clear();
+      }
+      dedupedNames.forEach((name) => recommendedRef.current.add(name));
+      onRecommended?.(Array.from(recommendedRef.current));
+      onFreshRecommendations?.(Array.from(dedupedNames));
+      return dedupedNames;
+    },
+  });
+}

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -171,6 +171,11 @@ export const featureOnboardingTagRecommender = new Feature(
   false,
 );
 
+export const featureOnboardingPersonas = new Feature(
+  'onboarding_personas',
+  false,
+);
+
 export const featurePostSignupWidget = new Feature('post_signup_widget', false);
 
 export const featureReaderModal = new Feature('reader_modal', false);

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -54,6 +54,7 @@ export enum Origin {
   Onboarding = 'onboarding',
   ManageTag = 'manage_tag',
   EditTag = 'edit_tag',
+  OnboardingPersona = 'onboarding persona',
   // Collection
   CollectionModal = 'collection modal',
   Settings = 'settings',
@@ -470,6 +471,8 @@ export enum LogEvent {
   ReaderEmbedReady = 'reader embed ready',
   ReaderEmbedPermissionRequired = 'reader embed permission required',
   ReaderEmbedError = 'reader embed error',
+  // Onboarding personas
+  SelectOnboardingPersona = 'select onboarding persona',
 }
 
 export enum TargetType {

--- a/packages/shared/src/styles/utilities.css
+++ b/packages/shared/src/styles/utilities.css
@@ -298,6 +298,15 @@
   opacity: 0;
 }
 
+.tag-spark {
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  border-radius: 9999px;
+  background: var(--theme-accent-cabbage-default);
+  pointer-events: none;
+}
+
 @keyframes leaderboard-medal-spark {
   0% {
     transform: translate(-50%, -50%) scale(1);

--- a/packages/shared/tailwind.config.ts
+++ b/packages/shared/tailwind.config.ts
@@ -289,6 +289,45 @@ export default {
           '30%': { transform: 'rotate(14deg)' },
           '45%': { transform: 'rotate(-8deg)' },
         },
+        'tag-pop': {
+          '0%': {
+            transform: 'scale(0.92)',
+            boxShadow: '0 0 0 0 transparent',
+          },
+          '40%': {
+            transform: 'scale(1.08)',
+            boxShadow:
+              '0 0 0 4px color-mix(in srgb, var(--theme-accent-cabbage-default) 35%, transparent)',
+          },
+          '100%': {
+            transform: 'scale(1)',
+            boxShadow: '0 0 0 0 transparent',
+          },
+        },
+        'tag-spark': {
+          '0%': {
+            transform: 'translate(0, 0) scale(0.4)',
+            opacity: '0',
+          },
+          '20%': {
+            opacity: '1',
+          },
+          '100%': {
+            transform:
+              'translate(var(--spark-fx, 0px), var(--spark-fy, 0px)) scale(0)',
+            opacity: '0',
+          },
+        },
+        'tag-fade-out': {
+          '0%': {
+            transform: 'scale(1)',
+            opacity: '1',
+          },
+          '100%': {
+            transform: 'scale(0.6)',
+            opacity: '0',
+          },
+        },
       },
       animation: {
         'scale-down-pulse':
@@ -304,6 +343,9 @@ export default {
           'queue-attention 1.6s cubic-bezier(0.4, 0, 0.6, 1) infinite',
         'queue-attention-wave':
           'queue-attention-wave 1.6s ease-in-out infinite',
+        'tag-pop': 'tag-pop 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both',
+        'tag-spark': 'tag-spark 0.6s ease-out both',
+        'tag-fade-out': 'tag-fade-out 0.25s ease-in forwards',
       },
     },
     lineClamp: {


### PR DESCRIPTION
## Changes

Adds an A/B-gated **persona** picker (Frontend, Backend, AI/ML, DevOps, etc.) inside the onboarding tag step. Selecting a persona batch-follows ~10 curated tags via the existing `useTagAndSource().onFollowTags` path, and a small staggered pop animation runs across the matching tag chips so the selection reads as intentional.

- `PersonaSelector` renders the API-backed persona list using existing `Button` chip primitives (`Float` / `Primary+Cabbage`) so visual style stays consistent with the tag picker
- Multi-select up to 3 personas; the 4th persona pill goes disabled until one is deselected
- Per-persona-tag fan-out for recommendations: each persona-tag fires its own `recommendedTags` request in parallel, results dedupe and cap at 8 visible
- Soft pruning model: manual tag clicks always *add* fresh recommendations; the eviction sweep that fades out unselected recommendations only runs every 10th manual click
- Curated baseline tags fade out once the user has manually picked `REQUIRED_TAGS_THRESHOLD` (5) individual tags; persona clicks don't count toward the threshold
- New `tag-pop` keyframe + procedural spark burst lifted from the leaderboard `crown-spark` pattern
- New `tag-fade-out` keyframe for the eviction animation; `onAnimationEnd` is routed by `event.animationName` so pop, spark, and fade-out events don't conflict
- New `onboardingPopBus` module event bus lets `TagElement` react to persona clicks (and `TagSelection` react to recommend requests) without prop-drilling
- Mobile auto-scroll: the first persona click smooth-scrolls to the top of the tag area so users can see their selection take effect
- Headline copy override: when the persona flag is on, the headline shows **"Tune your feed"** with subtitle **"Pick a role to start fast, then add tags you like."** This currently overrides the funnel/modal-supplied headline in code; see "Pre-merge" below
- Backend (`onboardingPersonas` query) is already shipped in daily-api

## Pre-merge

> [!IMPORTANT]
> **Update Freyja funnel JSON** for the persona-experiment variant to set the EditTags step's `headline` parameter to `"Tune your feed"`. Once Freyja serves the new copy, the in-code override in `EditTag.tsx` (search for the `TODO: drop this override once Freyja's persona-experiment variant ships the new headline directly` comment) can be removed.

## Events

| Type | event_name | value |
|------|------------|-------|
| New | `select onboarding persona` | `target_type: 'persona'`, `target_id: <persona id>`, `extra: { action: 'select' \| 'deselect', tags_count, active_count }` |

## Experiment

Yes — gated behind the new `onboarding_personas` GrowthBook flag (`featureOnboardingPersonas`, default `false`). Slack `#experiments` enrolment to be posted before merge.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

## Manual Testing

### On those affected packages:
- [x] Sanity-checked the webapp onboarding flow
- [ ] Sanity-check in extension
- [ ] Sanity-check companion is unaffected

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://davidercruz-onboarding-personas.preview.app.daily.dev