### PR TITLE
chore(shared): remove ad referral cta feature flag

### DIFF
--- a/packages/shared/src/components/cards/ad/AdCard.spec.tsx
+++ b/packages/shared/src/components/cards/ad/AdCard.spec.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import type { RenderResult } from '@testing-library/react';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
-import { GrowthBook } from '@growthbook/growthbook-react';
 import ad from '../../../../__tests__/fixture/ad';
 import { AdGrid } from './AdGrid';
 import { AdList } from './AdList';
@@ -25,11 +24,10 @@ beforeEach(() => {
 
 const renderListComponent = (
   props: Partial<AdCardProps> = {},
-  gb = new GrowthBook(),
 ): RenderResult => {
   const client = new QueryClient();
   return render(
-    <TestBootProvider client={client} gb={gb}>
+    <TestBootProvider client={client}>
       <ActiveFeedContext.Provider value={{ items: [], queryKey: ['test'] }}>
         <AdList {...defaultProps} {...props} />
       </ActiveFeedContext.Provider>
@@ -50,29 +48,16 @@ const renderSignalListComponent = (
   );
 };
 
-const getGrowthBook = (isAdReferralCtaEnabled = false): GrowthBook => {
-  const gb = new GrowthBook();
-
-  gb.setFeatures({
-    ad_referral_cta: {
-      defaultValue: isAdReferralCtaEnabled,
-    },
-  });
-
-  return gb;
-};
-
 const getNormalizedText = (element?: Element | null): string =>
   element?.textContent?.replace(/\u200B/g, '').trim() ?? '';
 
 const renderGridComponent = (
   props: Partial<AdCardProps> = {},
-  gb = new GrowthBook(),
 ): RenderResult => {
   const client = new QueryClient();
 
   return render(
-    <TestBootProvider client={client} gb={gb}>
+    <TestBootProvider client={client}>
       <ActiveFeedContext.Provider value={{ items: [], queryKey: ['test'] }}>
         <AdGrid {...defaultProps} {...props} />
       </ActiveFeedContext.Provider>
@@ -122,16 +107,8 @@ it('should show pixel images', async () => {
   expect(el).toHaveAttribute('src', 'https://daily.dev/pixel');
 });
 
-it('should not render advertise link by default', () => {
+it('should render advertise link on grid ad', () => {
   renderGridComponent();
-
-  expect(
-    screen.queryByRole('link', { name: 'Advertise here' }),
-  ).not.toBeInTheDocument();
-});
-
-it('should render advertise link on grid ad when feature is enabled', () => {
-  renderGridComponent({}, getGrowthBook(true));
 
   expect(screen.getByRole('link', { name: 'Advertise here' })).toHaveAttribute(
     'href',
@@ -152,8 +129,8 @@ it('should render promoted attribution outside of list title clamp', async () =>
   expect(await screen.findByText(promotedMatcher)).toBeInTheDocument();
 });
 
-it('should render advertise link on list ad when feature is enabled', () => {
-  renderListComponent({}, getGrowthBook(true));
+it('should render advertise link on list ad', () => {
+  renderListComponent();
 
   expect(screen.getByRole('link', { name: 'Advertise here' })).toHaveAttribute(
     'href',

--- a/packages/shared/src/components/cards/ad/common/AdvertiseLink.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdvertiseLink.tsx
@@ -16,12 +16,14 @@ type AdvertiseLinkProps = {
   size?: ButtonSize;
 };
 
+const advertiseHereLabel = 'Advertise here';
+
 export const AdvertiseLink = ({
   targetId,
   className,
   buttonStyle = false,
   size = ButtonSize.Medium,
-}: AdvertiseLinkProps): ReactElement | null => {
+}: AdvertiseLinkProps): ReactElement => {
   const { logEvent } = useLogContext();
 
   useEffect(() => {
@@ -39,13 +41,17 @@ export const AdvertiseLink = ({
       target_id: targetId,
     });
 
+  const linkProps = {
+    href: businessWebsiteUrl,
+    target: '_blank',
+    rel: anchorDefaultRel,
+  };
+
   if (buttonStyle) {
     return (
       <Button
         tag="a"
-        href={businessWebsiteUrl}
-        target="_blank"
-        rel={anchorDefaultRel}
+        {...linkProps}
         variant={ButtonVariant.Float}
         size={size}
         className={classNames(
@@ -54,23 +60,21 @@ export const AdvertiseLink = ({
         )}
         onClick={onClick}
       >
-        Advertise here
+        {advertiseHereLabel}
       </Button>
     );
   }
 
   return (
     <a
-      href={businessWebsiteUrl}
-      target="_blank"
-      rel={anchorDefaultRel}
+      {...linkProps}
       className={classNames(
         'whitespace-nowrap text-text-quaternary no-underline typo-footnote',
         className,
       )}
       {...combinedClicks(onClick)}
     >
-      Advertise here
+      {advertiseHereLabel}
     </a>
   );
 };

--- a/packages/shared/src/components/cards/ad/common/AdvertiseLink.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdvertiseLink.tsx
@@ -2,10 +2,8 @@ import type { ReactElement } from 'react';
 import React, { useEffect } from 'react';
 import classNames from 'classnames';
 import { Button, ButtonSize, ButtonVariant } from '../../../buttons/Button';
-import { useFeature } from '../../../GrowthBookProvider';
 import { useLogContext } from '../../../../contexts/LogContext';
 import { combinedClicks } from '../../../../lib/click';
-import { featureAdReferralCta } from '../../../../lib/featureManagement';
 import { businessWebsiteUrl } from '../../../../lib/constants';
 import type { TargetId } from '../../../../lib/log';
 import { LogEvent, TargetType } from '../../../../lib/log';
@@ -24,20 +22,15 @@ export const AdvertiseLink = ({
   buttonStyle = false,
   size = ButtonSize.Medium,
 }: AdvertiseLinkProps): ReactElement | null => {
-  const isEnabled = useFeature(featureAdReferralCta);
   const { logEvent } = useLogContext();
 
   useEffect(() => {
-    if (!isEnabled) {
-      return;
-    }
-
     logEvent({
       event_name: LogEvent.Impression,
       target_type: TargetType.AdvertiseHereCta,
       target_id: targetId,
     });
-  }, [isEnabled, logEvent, targetId]);
+  }, [logEvent, targetId]);
 
   const onClick = () =>
     logEvent({
@@ -45,10 +38,6 @@ export const AdvertiseLink = ({
       target_type: TargetType.AdvertiseHereCta,
       target_id: targetId,
     });
-
-  if (!isEnabled) {
-    return null;
-  }
 
   if (buttonStyle) {
     return (

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -60,7 +60,6 @@ export const featurePlusCtaCopy = new Feature('plus_cta_copy', {
 export const featurePlusApiLanding = new Feature('plus_api_landing_v2', false);
 
 export const featureAutorotateAds = new Feature('autorotate_ads', 0);
-export const featureAdReferralCta = new Feature('ad_referral_cta', false);
 
 export const featureFeedAdTemplate = new Feature('feed_ad_template', {
   default: {


### PR DESCRIPTION
## Summary
- remove the `ad_referral_cta` feature export and all remaining references from the shared ad card flow
- keep the treatment behavior permanently by always rendering the "Advertise here" CTA on grid and list ad cards
- simplify the ad card spec and `AdvertiseLink` implementation now that GrowthBook gating is gone

## Key Decisions
- preserved the existing treatment-side impression and click logging behavior while deleting the control path
- verified only the impacted shared files with targeted Jest, ESLint, strict typecheck, and a repo-wide reference search

Closes ENG-1341

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1341-remove-ad-referral-cta.preview.app.daily.dev