### PR TITLE
fix: align upvote icon with sibling action buttons

### DIFF
--- a/packages/shared/src/components/cards/common/UpvoteButtonIcon.tsx
+++ b/packages/shared/src/components/cards/common/UpvoteButtonIcon.tsx
@@ -9,8 +9,6 @@ import type { BrandColors, UpvoteAnimationConfig } from '../../../lib/brand';
 import styles from './UpvoteButtonIcon.module.css';
 
 interface UpvoteButtonIconProps extends IconProps {
-  /** Post tags to check for brand sponsorship */
-  postTags?: string[];
   /** Brand animation config (passed from parent) */
   brandAnimation?: {
     colors: BrandColors;

--- a/packages/shared/src/components/cards/common/UpvoteButtonIcon.tsx
+++ b/packages/shared/src/components/cards/common/UpvoteButtonIcon.tsx
@@ -80,7 +80,7 @@ export const UpvoteButtonIcon = React.memo(function UpvoteButtonIconComp(
   const hasBrandLogo = brandAnimation?.brandLogo;
 
   return (
-    <span className="pointer-events-none relative">
+    <span className="pointer-events-none relative inline-flex items-center justify-center">
       <span
         className={classNames(
           styles.iconWrapper,


### PR DESCRIPTION
## Summary
- Wrap the `UpvoteButtonIcon` outer span as `inline-flex items-center justify-center` so its height collapses to the 20×20 SVG instead of inheriting the button's `typo-callout` line-box. This restores vertical alignment with the comment, downvote, bookmark, and link icons in the action row (regression from #5720).
- Drop the unused `postTags` prop from `UpvoteButtonIconProps` — neither `ActionButtons` nor `PostActions` passes it.

## Test plan
- [x] `pnpm --filter @dailydotdev/shared exec eslint src/components/cards/common/UpvoteButtonIcon.tsx`
- [x] `node ./scripts/typecheck-strict-changed.js`
- [x] Jest: ArticleGrid / CollectionGrid / ShareGrid / BrandedUpvoteAnimation / BrandedTag specs (45 tests pass)
- [ ] Visual check on a feed grid card and a list card — upvote icon sits on the same baseline as the other actions

Made with [Cursor](https://cursor.com)

### Preview domain
https://upvote-button-align-fix.preview.app.daily.dev