### PR TITLE
feat(shared): a/b test recswipe tag recommender on onboarding

### DIFF
--- a/packages/shared/src/components/tags/TagSelection.tsx
+++ b/packages/shared/src/components/tags/TagSelection.tsx
@@ -3,9 +3,15 @@ import React, { useMemo, useState } from 'react';
 import classNames from 'classnames';
 import type { QueryFilters } from '@tanstack/react-query';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import useFeedSettings from '../../hooks/useFeedSettings';
+import useFeedSettings, {
+  getFeedSettingsQueryKey,
+} from '../../hooks/useFeedSettings';
 import { RequestKey, generateQueryKey } from '../../lib/query';
-import type { TagsData } from '../../graphql/feedSettings';
+import type {
+  AllTagCategoriesData,
+  TagsData,
+} from '../../graphql/feedSettings';
+import { useAuthContext } from '../../contexts/AuthContext';
 import {
   GET_ONBOARDING_TAGS_QUERY,
   GET_RECOMMENDED_TAGS_QUERY,
@@ -67,6 +73,7 @@ export function TagSelection({
 }: TagSelectionProps): ReactElement {
   const [isShuffled, setIsShuffled] = useState(false);
   const queryClient = useQueryClient();
+  const { user } = useAuthContext();
   const { feedSettings } = useFeedSettings({ feedId });
   const selectedTags = useMemo(() => {
     return new Set(feedSettings?.includeTags || []);
@@ -147,9 +154,14 @@ export function TagSelection({
       let recommended: TagsData['tags'];
 
       if (isTagRecommenderEnabled) {
+        // Read the freshest selection from the cache rather than the closure-bound
+        // memo: collaborative-filtering quality depends on an accurate input set.
         // onFollowTags runs after recommendTags, so the just-clicked tag isn't
-        // yet in selectedTags. Append it to satisfy the [String!]! min-1 constraint.
-        const currentSelection = Array.from(selectedTags);
+        // yet in the cache. Append it to satisfy the [String!]! min-1 constraint.
+        const cached = queryClient.getQueryData<AllTagCategoriesData>(
+          getFeedSettingsQueryKey(user, feedId),
+        );
+        const currentSelection = cached?.feedSettings?.includeTags ?? [];
         const selectedForMutation = currentSelection.includes(tagName)
           ? currentSelection
           : [...currentSelection, tagName];
@@ -184,10 +196,19 @@ export function TagSelection({
         if (!current) {
           return current;
         }
+        const existingNames = new Set(current.tags.map((item) => item.name));
+        const newRecommended = recommended.filter(
+          (item) => item.name && !existingNames.has(item.name),
+        );
+
+        if (!newRecommended.length) {
+          return current;
+        }
+
         const newTags = [...current.tags];
         const insertIndex = newTags.findIndex((item) => item.name === tagName);
 
-        newTags.splice(insertIndex + 1, 0, ...recommended);
+        newTags.splice(insertIndex + 1, 0, ...newRecommended);
 
         return {
           tags: newTags,

--- a/packages/shared/src/components/tags/TagSelection.tsx
+++ b/packages/shared/src/components/tags/TagSelection.tsx
@@ -170,7 +170,7 @@ export function TagSelection({
           onboardingRecommendTags: { tags: string[] };
         }>(ONBOARDING_RECOMMEND_TAGS_MUTATION, {
           selectedTags: selectedForMutation,
-          n: 5,
+          n: 10,
         });
 
         recommended = result.onboardingRecommendTags.tags.map((name) => ({

--- a/packages/shared/src/components/tags/TagSelection.tsx
+++ b/packages/shared/src/components/tags/TagSelection.tsx
@@ -9,7 +9,10 @@ import type { TagsData } from '../../graphql/feedSettings';
 import {
   GET_ONBOARDING_TAGS_QUERY,
   GET_RECOMMENDED_TAGS_QUERY,
+  ONBOARDING_RECOMMEND_TAGS_MUTATION,
 } from '../../graphql/feedSettings';
+import { useConditionalFeature } from '../../hooks/useConditionalFeature';
+import { featureOnboardingTagRecommender } from '../../lib/featureManagement';
 import { disabledRefetch, getRandomNumber } from '../../lib/func';
 import useDebounceFn from '../../hooks/useDebounceFn';
 import type { FilterOnboardingProps } from '../onboarding/FilterOnboarding';
@@ -68,6 +71,10 @@ export function TagSelection({
   const selectedTags = useMemo(() => {
     return new Set(feedSettings?.includeTags || []);
   }, [feedSettings?.includeTags]);
+  const { value: isTagRecommenderEnabled } = useConditionalFeature({
+    feature: featureOnboardingTagRecommender,
+    shouldEvaluate: origin === Origin.Onboarding,
+  });
   const { onFollowTags, onUnfollowTags } = useTagAndSource({
     origin,
     shouldUpdateAlerts,
@@ -132,22 +139,55 @@ export function TagSelection({
 
   const { mutate: recommendTags, data: recommendedTags } = useMutation({
     mutationFn: async ({ tag }: Pick<OnSelectTagProps, 'tag'>) => {
-      const result = await gqlClient.request<{
-        recommendedTags: TagsData;
-      }>(GET_RECOMMENDED_TAGS_QUERY, {
-        tags: [tag.name],
-        excludedTags,
-      });
+      const tagName = tag.name;
+      if (!tagName) {
+        return new Set<string>();
+      }
+
+      let recommended: TagsData['tags'];
+
+      if (isTagRecommenderEnabled) {
+        // onFollowTags runs after recommendTags, so the just-clicked tag isn't
+        // yet in selectedTags. Append it to satisfy the [String!]! min-1 constraint.
+        const currentSelection = Array.from(selectedTags);
+        const selectedForMutation = currentSelection.includes(tagName)
+          ? currentSelection
+          : [...currentSelection, tagName];
+
+        const result = await gqlClient.request<{
+          onboardingRecommendTags: { tags: string[] };
+        }>(ONBOARDING_RECOMMEND_TAGS_MUTATION, {
+          selectedTags: selectedForMutation,
+          n: 5,
+        });
+
+        recommended = result.onboardingRecommendTags.tags.map((name) => ({
+          name,
+        }));
+      } else {
+        const result = await gqlClient.request<{
+          recommendedTags: TagsData;
+        }>(GET_RECOMMENDED_TAGS_QUERY, {
+          tags: [tagName],
+          excludedTags,
+        });
+        recommended = result.recommendedTags.tags;
+      }
 
       const recommendedTagsSet = new Set(
-        result.recommendedTags.tags.map((item) => item.name),
+        recommended
+          .map((item) => item.name)
+          .filter((name): name is string => !!name),
       );
 
       queryClient.setQueryData<TagsData>(onboardingTagsQueryKey, (current) => {
+        if (!current) {
+          return current;
+        }
         const newTags = [...current.tags];
-        const insertIndex = newTags.findIndex((item) => item.name === tag.name);
+        const insertIndex = newTags.findIndex((item) => item.name === tagName);
 
-        newTags.splice(insertIndex + 1, 0, ...result.recommendedTags.tags);
+        newTags.splice(insertIndex + 1, 0, ...recommended);
 
         return {
           tags: newTags,
@@ -159,15 +199,22 @@ export function TagSelection({
   });
 
   const handleClickTag = async ({ tag }: Pick<OnSelectTagProps, 'tag'>) => {
+    const tagName = tag.name;
+    if (!tagName) {
+      return;
+    }
     const isSearchMode = !!searchQuery;
-    const isSelected = selectedTags.has(tag.name);
+    const isSelected = selectedTags.has(tagName);
 
     if (!isSelected) {
       if (isSearchMode) {
         queryClient.setQueryData<TagsData>(
           onboardingTagsQueryKey,
           (current) => {
-            if (!excludedTags.includes(tag.name)) {
+            if (!current) {
+              return current;
+            }
+            if (!excludedTags.includes(tagName)) {
               return {
                 ...current,
                 tags: [...current.tags, tag],
@@ -181,9 +228,9 @@ export function TagSelection({
 
       recommendTags({ tag });
 
-      await onFollowTags({ tags: [tag.name] });
+      await onFollowTags({ tags: [tagName] });
     } else {
-      await onUnfollowTags({ tags: [tag.name] });
+      await onUnfollowTags({ tags: [tagName] });
     }
 
     if (onClickTag) {
@@ -194,7 +241,7 @@ export function TagSelection({
   };
 
   const tags = searchQuery ? searchTags : onboardingTags;
-  const renderedTags = {};
+  const renderedTags: Record<string, boolean> = {};
 
   return (
     <div className={classNames(className, 'flex w-full flex-col items-center')}>
@@ -227,16 +274,20 @@ export function TagSelection({
         )}
         {!isPending &&
           tags?.map((tag) => {
-            const isSelected = selectedTags.has(tag.name);
-            renderedTags[tag.name] = true;
+            if (!tag.name) {
+              return null;
+            }
+            const tagName = tag.name;
+            const isSelected = selectedTags.has(tagName);
+            renderedTags[tagName] = true;
 
             return (
               <TagElement
-                key={`tag-${tag.name}`}
+                key={`tag-${tagName}`}
                 tag={tag}
                 onClick={handleClickTag}
                 isSelected={isSelected}
-                isHighlighted={!searchQuery && !!recommendedTags?.has(tag.name)}
+                isHighlighted={!searchQuery && !!recommendedTags?.has(tagName)}
                 data-funnel-track={FunnelTargetId.FeedTag}
               />
             );

--- a/packages/shared/src/graphql/feedSettings.ts
+++ b/packages/shared/src/graphql/feedSettings.ts
@@ -190,3 +190,11 @@ export const GET_RECOMMENDED_TAGS_QUERY = gql`
     }
   }
 `;
+
+export const ONBOARDING_RECOMMEND_TAGS_MUTATION = gql`
+  mutation OnboardingRecommendTags($selectedTags: [String!]!, $n: Int) {
+    onboardingRecommendTags(selectedTags: $selectedTags, n: $n) {
+      tags
+    }
+  }
+`;

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -157,6 +157,11 @@ export const sharedPostPreviewFeature = new Feature(
 
 export const featureOnboardingV2 = new Feature('onboarding_v2', false);
 
+export const featureOnboardingTagRecommender = new Feature(
+  'onboarding_tag_recommender',
+  false,
+);
+
 export const featurePostSignupWidget = new Feature('post_signup_widget', false);
 
 export const featureReaderModal = new Feature('reader_modal', false);


### PR DESCRIPTION
## Changes

- Add `featureOnboardingTagRecommender` flag (`onboarding_tag_recommender`, default `false`) to gate the new recswipe-backed tag recommender on the onboarding tag-selection step.
- Add the `ONBOARDING_RECOMMEND_TAGS_MUTATION` GraphQL constant matching the new daily-api proxy (`onboardingRecommendTags(selectedTags: [String!]!, n: Int)`).
- In `TagSelection`, branch the per-click `recommendTags` mutation behind the flag — when ON, call the new mutation with the user's full current selection (plus the just-clicked tag, to satisfy the `[String!]!` non-empty constraint on first click) and `n: 5`. Initial mount still uses `onboardingTags` in both arms.
- Flag exposure is scoped to `Origin.Onboarding` via `useConditionalFeature` so the experiment doesn't fire in the feed-settings tag editor.
- Drive-by: clean up pre-existing strict-mode `tag.name` violations in `TagSelection.tsx` so the changed file passes the strict-typecheck guard.

## Events

Did you introduce any new tracking events?

## Experiment

Did you introduce any new experiments?

Yes — `onboarding_tag_recommender` (boolean, default off). Experiment enrolment to be set up in GrowthBook before merge; will link the #experiments Slack message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Preview domain
https://davidercruz-tag-rec-flag.preview.app.daily.dev