### PR TITLE
fix: disable retry on checkLinkPreview mutation to prevent rate limiting

### DIFF
--- a/packages/shared/src/hooks/squads/usePostToSquad.tsx
+++ b/packages/shared/src/hooks/squads/usePostToSquad.tsx
@@ -185,6 +185,7 @@ export const usePostToSquad = ({
   const { mutateAsync: getLinkPreview, isPending: isLoadingPreview } =
     useMutation({
       mutationFn: (url: string) => getExternalLinkPreview(url, requestMethod),
+      retry: false,
       onSuccess: (data, url) => {
         const newPreview = { ...data, finalUrl: data.url, url };
         setPreview(newPreview);


### PR DESCRIPTION
## Summary
- Added explicit `retry: false` to the `getLinkPreview` `useMutation` config in `usePostToSquad` hook
- While TanStack Query v5 mutations default to `retry: 0`, this makes the intent explicit and prevents preview failures (e.g., rate limit errors) from ever being retried, avoiding cascading API rate limit exhaustion during debounced `checkLinkPreview` calls

## Test plan
- [ ] Submit a link in a squad and verify preview loads normally
- [ ] Simulate a rate limit error and confirm the toast appears only once (no retries)

Closes ENG-1342

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1342-link-submit-polling-can.preview.app.daily.dev