### PR TITLE
fix(shared): anchor toast to top + tint floating bar counters

### DIFF
--- a/packages/shared/src/components/AGENTS.md
+++ b/packages/shared/src/components/AGENTS.md
@@ -284,6 +284,17 @@ Some components use compound patterns for flexibility:
 ### Toolbar Actions
 When adding icon-only buttons in toolbars, keep any adjacent status labels inline and match the control height (e.g., `ButtonSize.XSmall` uses `h-6`). This avoids overlap and keeps action rows visually aligned.
 
+### Toasts (`useToastNotification` / `Toast`)
+
+There is one global toast renderer (`packages/shared/src/components/notifications/Toast.tsx`); call sites only push messages via `useToastNotification().displayToast(...)`. Keep these rules in mind:
+
+- **Position**: the toast is anchored to the **top** of the viewport on every breakpoint (`top: 1rem` on mobile, `top: 2rem` on tablet+) and slides down from above. This avoids collisions with bottom-anchored chrome (`MobilePostFloatingBar`, `MobileFooterNavbar`, future floating CTAs). Do not move the toast back to the bottom on a single surface — solve it with a top-anchored toast for everyone.
+- **Prefer inline confirmation over a toast** for instant, locally-scoped actions (copy link, copy code, save toggles). Inline feedback (icon swap to checkmark, brief label change) is faster, accessible at the point of interaction, and avoids the toast at all.
+- **One toast at a time**: `displayToast` overwrites the current toast. Don't fire toasts in rapid succession from the same flow — pick the most actionable message.
+- **Auto-dismiss vs persistent**: default `timer` is 5s. Use `persistent: true` only when an `action` button is present (e.g., undo) and the user must consciously dismiss; otherwise keep the timed default.
+- **Use `subject: ToastSubject.*`** when a toast should be scoped/cleared by a specific surface (e.g., `PostContent`, `Feed`). Don't introduce new subjects unless there is a real consumer that filters on them.
+- **Copy style**: short sentence, sentence case, no trailing period unless multi-sentence. The leading checkmark/❌ emoji pattern (see `useCopy.ts`) is reserved for clipboard feedback — don't extend it to other categories.
+
 ### classed() Utility
 For simple styled wrappers:
 ```typescript

--- a/packages/shared/src/components/notifications/Toast.module.css
+++ b/packages/shared/src/components/notifications/Toast.module.css
@@ -1,22 +1,23 @@
 .toastContainer {
   z-index: 1000;
-  transform: translate(-50%, 5rem);
+  /* Slides down from above on every breakpoint so the toast never overlaps
+     bottom-anchored chrome (mobile floating bars, footer nav). Mirrors the
+     existing tablet+ behaviour, just applied to mobile too. */
+  transform: translate(-50%, -5rem);
   transition: transform 0.14s ease-in-out;
   max-width: calc(100vw - 2rem);
   max-height: unset;
   min-height: unset;
   width: 100%;
-  bottom: 4rem;
+  top: 1rem;
 
   @screen tablet {
     top: 2rem;
-    bottom: unset;
     width: fit-content;
     min-width: 12.5rem;
     max-width: 80vw;
     min-height: 2.75rem;
     max-height: 4.125rem;
-    transform: translate(-50%, -5rem);
   }
 
   &:global(.slide-in) {

--- a/packages/shared/src/components/post/MobilePostFloatingBar.tsx
+++ b/packages/shared/src/components/post/MobilePostFloatingBar.tsx
@@ -44,6 +44,14 @@ const containerClasses = classNames(
   'shadow-[0_0.25rem_1.5rem_0_var(--theme-shadow-shadow1)]',
 );
 
+// `QuaternaryButton` renders its children inside a sibling `<label>`, so the
+// `btn-tertiary-*` text color set on the button itself doesn't reach the
+// `InteractionCounter`. We tint the counter explicitly with the tertiary
+// semantic token to match the design system; otherwise the label inherits
+// the page text color (white in dark mode) and stands out next to the
+// muted icons.
+const counterClasses = 'tabular-nums text-text-tertiary';
+
 export function MobilePostFloatingBar({
   post,
   onCommentClick,
@@ -113,7 +121,7 @@ export function MobilePostFloatingBar({
         size={ButtonSize.Medium}
       >
         {upvoteCount > 0 && (
-          <InteractionCounter className="tabular-nums" value={upvoteCount} />
+          <InteractionCounter className={counterClasses} value={upvoteCount} />
         )}
       </QuaternaryButton>
       <QuaternaryButton
@@ -136,7 +144,7 @@ export function MobilePostFloatingBar({
         className="btn-tertiary-blueCheese"
       >
         {commentCount > 0 && (
-          <InteractionCounter className="tabular-nums" value={commentCount} />
+          <InteractionCounter className={counterClasses} value={commentCount} />
         )}
       </QuaternaryButton>
       <BookmarkButton


### PR DESCRIPTION
## Summary

- Mobile toast was at `bottom: 4rem`, which collided with `MobilePostFloatingBar` on post pages — the share/copy confirmation visually hid the action bar. Anchored the toast to the top on every breakpoint (matching the existing tablet+ behaviour) so it never overlaps bottom chrome.
- Tinted the upvote/comment `InteractionCounter` in `MobilePostFloatingBar` with `text-text-tertiary`. `QuaternaryButton` renders children inside a sibling `<label>`, so the `btn-tertiary-*` text color never reached the counter and it inherited the page text color (white in dark mode) instead of the muted gray used elsewhere.
- Added a Toasts section to `packages/shared/src/components/AGENTS.md` documenting the new top-anchored position rule and reminding contributors to prefer inline confirmation for instant local actions.

## Test plan

- [ ] On mobile viewport, open a post detail page and confirm `MobilePostFloatingBar` is fully visible with no toast covering it.
- [ ] Tap the share/link icon — toast slides in from the top of the viewport with the "Copied link to clipboard" message.
- [ ] Trigger a bookmark on the same page — same top-anchored toast.
- [ ] Confirm upvote and comment counters in the floating bar render in muted gray (not white) in dark mode, and stay legible in light mode.
- [ ] Tablet+ unchanged: toast still slides in from the top at `top: 2rem`.

Made with [Cursor](https://cursor.com)

### Preview domain
https://fix-mobile-post-bar-share-toast.preview.app.daily.dev