### PR TITLE
Add standup analytics and error telemetry

### DIFF
--- a/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
@@ -281,7 +281,15 @@ describe('LiveRoom', () => {
       expect(promoteSpeaker).toHaveBeenCalledWith('queued1');
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Remove @speaker1' }));
+    const removeSpeakerButton = screen.getByRole('button', {
+      name: 'Remove @speaker1',
+    });
+
+    await waitFor(() => {
+      expect(removeSpeakerButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(removeSpeakerButton);
 
     await waitFor(() => {
       expect(removeSpeaker).toHaveBeenCalledWith('speaker1');

--- a/packages/shared/src/components/liveRooms/LiveRoom.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import classNames from 'classnames';
 import {
@@ -20,11 +20,15 @@ import {
   type LiveRoomReaction,
 } from '../../contexts/LiveRoomContext';
 import { useAuthContext } from '../../contexts/AuthContext';
+import { useLogContext } from '../../contexts/LogContext';
 import { AuthTriggers } from '../../lib/auth';
+import { buildStandupAnalyticsExtra } from '../../lib/liveRoom/analytics';
+import { LogEvent } from '../../lib/log';
 import { useLiveRoom as useLiveRoomQuery } from '../../hooks/liveRooms/useLiveRoom';
 import { useLiveRoomParticipantProfiles } from '../../hooks/liveRooms/useLiveRoomParticipantProfiles';
 import { useLiveRoomParticipantStreams } from '../../hooks/liveRooms/useLiveRoomParticipantStreams';
 import { useStreamDuration } from '../../hooks/liveRooms/useStreamDuration';
+import useLogEventOnce from '../../hooks/log/useLogEventOnce';
 import { useToastNotification } from '../../hooks/useToastNotification';
 import { useExitConfirmation } from '../../hooks/useExitConfirmation';
 import { clearStoredLiveRoomResumeSession } from '../../lib/liveRoom/resumeSessionStorage';
@@ -137,12 +141,14 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   const router = useRouter();
   const { displayToast } = useToastNotification();
   const { isAuthReady, showLogin, user } = useAuthContext();
+  const { logEvent } = useLogContext();
   const {
     status,
     errorMessage,
     roomState,
     role,
     participantId,
+    canPublish,
     sendChatMessage,
     deleteChatMessage,
     setParticipantChatEnabled,
@@ -152,6 +158,8 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     canChat,
     localStream,
     remoteStreams,
+    selectedCameraId,
+    selectedMicId,
     videoSettings,
     reactions,
     chatMessages,
@@ -171,11 +179,70 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   const [moderationBusy, setModerationBusy] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<LiveRoomSidePanelTab>('chat');
   const [stagePage, setStagePage] = useState(0);
+  const buildStandupExtra = useCallback(
+    (extra: Record<string, unknown> = {}) =>
+      buildStandupAnalyticsExtra(
+        {
+          roomId,
+          authKind: user ? 'authenticated' : 'anonymous',
+          role,
+          roomStatus: roomState?.status ?? room?.status ?? null,
+          roomMode: roomState?.mode ?? room?.mode ?? null,
+          connectionStatus: status,
+          canPublish,
+          participantId,
+          selectedMicId,
+          selectedCameraId,
+          hasLocalAudioTrack: !!localStream?.getAudioTracks()[0],
+          hasLocalVideoTrack: !!localStream?.getVideoTracks()[0],
+          videoQuality: videoSettings.quality,
+          audioOnly: videoSettings.audioOnly,
+          hideSelfView: videoSettings.hideSelfView,
+        },
+        extra,
+      ),
+    [
+      roomId,
+      user,
+      role,
+      roomState?.status,
+      roomState?.mode,
+      room?.status,
+      room?.mode,
+      status,
+      canPublish,
+      participantId,
+      selectedMicId,
+      selectedCameraId,
+      localStream,
+      videoSettings.quality,
+      videoSettings.audioOnly,
+      videoSettings.hideSelfView,
+    ],
+  );
+  const logStandupAction = useCallback(
+    (
+      eventName: LogEvent,
+      targetId: string,
+      extra: Record<string, unknown> = {},
+    ) => {
+      logEvent({
+        event_name: eventName,
+        target_id: targetId,
+        extra: buildStandupExtra(extra),
+      });
+    },
+    [buildStandupExtra, logEvent],
+  );
 
   const handleLeave = (): void => {
     onAskConfirmation(false);
     clearStoredLiveRoomResumeSession(roomId);
     router.push('/standups');
+  };
+  const handleNavigateBack = (surface: string): void => {
+    logStandupAction(LogEvent.LeaveStandup, roomId, { surface });
+    handleLeave();
   };
 
   const guardedModerationAction = async (
@@ -199,6 +266,10 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   const handleSendChatMessage = async (body: string): Promise<void> => {
     try {
       await sendChatMessage(body);
+      logStandupAction(LogEvent.SendStandupChatMessage, roomId, {
+        surface: 'chat',
+        messageLength: body.length,
+      });
     } catch (error) {
       displayToast(error instanceof Error ? error.message : 'Message failed');
     }
@@ -207,6 +278,9 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   const handleDeleteChatMessage = async (messageId: string): Promise<void> => {
     try {
       await deleteChatMessage(messageId);
+      logStandupAction(LogEvent.DeleteStandupChatMessage, messageId, {
+        surface: 'chat',
+      });
     } catch (error) {
       displayToast(
         error instanceof Error ? error.message : 'Could not delete message',
@@ -220,6 +294,10 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   ): Promise<void> => {
     try {
       await setParticipantChatEnabled(targetParticipantId, nextCanChat);
+      logStandupAction(LogEvent.UpdateStandupChatAccess, targetParticipantId, {
+        surface: 'chat',
+        nextCanChat,
+      });
     } catch (error) {
       displayToast(
         error instanceof Error ? error.message : 'Could not update chat access',
@@ -232,6 +310,9 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   ): Promise<void> => {
     try {
       await kickParticipant(targetParticipantId);
+      logStandupAction(LogEvent.KickStandupParticipant, targetParticipantId, {
+        surface: 'chat',
+      });
     } catch (error) {
       displayToast(
         error instanceof Error ? error.message : 'Could not kick user',
@@ -242,6 +323,53 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   const handleChatLogin = (): void => {
     showLogin({ trigger: AuthTriggers.MainButton });
   };
+  const handlePromoteSpeaker = useCallback(
+    async (targetParticipantId: string, surface: string): Promise<void> => {
+      await promoteSpeaker(targetParticipantId);
+      logStandupAction(LogEvent.PromoteStandupSpeaker, targetParticipantId, {
+        surface,
+      });
+    },
+    [logStandupAction, promoteSpeaker],
+  );
+  const handleRemoveSpeaker = useCallback(
+    async (targetParticipantId: string, surface: string): Promise<void> => {
+      await removeSpeaker(targetParticipantId);
+      logStandupAction(LogEvent.RemoveStandupSpeaker, targetParticipantId, {
+        surface,
+      });
+    },
+    [logStandupAction, removeSpeaker],
+  );
+  const handleKickParticipant = useCallback(
+    async (targetParticipantId: string, surface: string): Promise<void> => {
+      await kickParticipant(targetParticipantId);
+      logStandupAction(LogEvent.KickStandupParticipant, targetParticipantId, {
+        surface,
+      });
+    },
+    [kickParticipant, logStandupAction],
+  );
+  const handleTabChange = (tab: LiveRoomSidePanelTab): void => {
+    if (tab === activeTab) {
+      return;
+    }
+
+    logStandupAction(LogEvent.SwitchStandupPanelTab, tab, {
+      surface: 'side_panel',
+      previousTab: activeTab,
+    });
+    setActiveTab(tab);
+  };
+
+  useLogEventOnce(
+    () => ({
+      event_name: LogEvent.ViewStandup,
+      target_id: roomId,
+      extra: buildStandupExtra({ surface: 'page' }),
+    }),
+    { condition: !!room && !roomError && !isRoomLoading && isAuthReady },
+  );
 
   const participantIds = useMemo(() => {
     const ids = new Set<string>();
@@ -407,6 +535,22 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     setStagePage((currentPage) => Math.min(currentPage, stagePageCount - 1));
   }, [stagePageCount]);
 
+  useEffect(() => {
+    if (!roomError) {
+      return;
+    }
+
+    logEvent({
+      event_name: LogEvent.StandupError,
+      target_id: 'room query',
+      extra: buildStandupExtra({
+        surface: 'page',
+        source: 'room_query',
+        message: roomError.message,
+      }),
+    });
+  }, [buildStandupExtra, logEvent, roomError]);
+
   if (!isAuthReady || isRoomLoading) {
     return (
       <div className="flex flex-1 items-center justify-center py-10">
@@ -430,7 +574,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
         <Button
           className="mt-2"
           variant={ButtonVariant.Primary}
-          onClick={handleLeave}
+          onClick={() => handleNavigateBack('load_error')}
         >
           Back to standups
         </Button>
@@ -457,7 +601,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
         <Button
           className="mt-2"
           variant={ButtonVariant.Primary}
-          onClick={handleLeave}
+          onClick={() => handleNavigateBack('connection_error')}
         >
           Back to standups
         </Button>
@@ -569,7 +713,8 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
                           ? () =>
                               guardedModerationAction(
                                 `tile-remove-${speaker.id}`,
-                                () => removeSpeaker(speaker.id),
+                                () =>
+                                  handleRemoveSpeaker(speaker.id, 'stage_tile'),
                               )
                           : undefined
                       }
@@ -578,7 +723,11 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
                           ? () =>
                               guardedModerationAction(
                                 `tile-kick-${speaker.id}`,
-                                () => kickParticipant(speaker.id),
+                                () =>
+                                  handleKickParticipant(
+                                    speaker.id,
+                                    'stage_tile',
+                                  ),
                               )
                           : undefined
                       }
@@ -632,7 +781,10 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
                 <Typography type={TypographyType.Title3} bold>
                   This standup has ended
                 </Typography>
-                <Button variant={ButtonVariant.Primary} onClick={handleLeave}>
+                <Button
+                  variant={ButtonVariant.Primary}
+                  onClick={() => handleNavigateBack('ended_state')}
+                >
                   Back to standups
                 </Button>
               </div>
@@ -640,7 +792,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
           ) : null}
 
           {roomState && !isEnded ? (
-            <LiveRoomControls onLeave={handleLeave} />
+            <LiveRoomControls roomId={roomId} onLeave={handleLeave} />
           ) : null}
         </section>
 
@@ -667,7 +819,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
                 count: audienceParticipantIds.length,
               },
             ]}
-            onChange={setActiveTab}
+            onChange={handleTabChange}
           />
           <div className="min-h-0 flex-1">
             {activeTab === 'chat' ? (
@@ -701,9 +853,15 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
                 stageLimit={stageLimit}
                 moderationBusy={moderationBusy}
                 guardedModerationAction={guardedModerationAction}
-                promoteSpeaker={promoteSpeaker}
-                removeSpeaker={removeSpeaker}
-                kickParticipant={kickParticipant}
+                promoteSpeaker={(targetParticipantId) =>
+                  handlePromoteSpeaker(targetParticipantId, 'queue_panel')
+                }
+                removeSpeaker={(targetParticipantId) =>
+                  handleRemoveSpeaker(targetParticipantId, 'queue_panel')
+                }
+                kickParticipant={(targetParticipantId) =>
+                  handleKickParticipant(targetParticipantId, 'queue_panel')
+                }
               />
             )}
           </div>

--- a/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
@@ -11,6 +11,7 @@ import {
 } from '../icons';
 import { IconSize } from '../Icon';
 import { useLiveRoom } from '../../contexts/LiveRoomContext';
+import { useLogContext } from '../../contexts/LogContext';
 import { useToastNotification } from '../../hooks/useToastNotification';
 import { LiveRoomMicLevel } from './LiveRoomMicLevel';
 import {
@@ -20,6 +21,8 @@ import {
 } from '../typography/Typography';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { AuthTriggers } from '../../lib/auth';
+import { buildStandupAnalyticsExtra } from '../../lib/liveRoom/analytics';
+import { LogEvent } from '../../lib/log';
 import { Modal } from '../modals/common/Modal';
 import {
   AUDIO_ONLY_LABEL,
@@ -38,14 +41,18 @@ import {
 const REACTION_EMOJIS = ['👏', '🔥', '💡', '😂', '🤯'];
 
 interface LiveRoomControlsProps {
+  roomId: string;
   onLeave: () => void;
 }
 
 export const LiveRoomControls = ({
+  roomId,
   onLeave,
 }: LiveRoomControlsProps): ReactElement => {
   const { user, showLogin } = useAuthContext();
+  const { logEvent } = useLogContext();
   const {
+    status,
     canPublish,
     isCameraOn,
     isMicOn,
@@ -85,6 +92,38 @@ export const LiveRoomControls = ({
     () => (localAudioTrack ? new MediaStream([localAudioTrack]) : null),
     [localAudioTrack],
   );
+  const buildStandupExtra = (extra: Record<string, unknown> = {}): string =>
+    buildStandupAnalyticsExtra(
+      {
+        roomId,
+        authKind: user ? 'authenticated' : 'anonymous',
+        role,
+        roomStatus: roomState?.status ?? null,
+        roomMode: roomState?.mode ?? null,
+        connectionStatus: status,
+        canPublish,
+        participantId,
+        selectedMicId,
+        selectedCameraId,
+        hasLocalAudioTrack: !!localStream?.getAudioTracks()[0],
+        hasLocalVideoTrack: !!localStream?.getVideoTracks()[0],
+        videoQuality: videoSettings.quality,
+        audioOnly: videoSettings.audioOnly,
+        hideSelfView: videoSettings.hideSelfView,
+      },
+      extra,
+    );
+  const logStandupAction = (
+    eventName: LogEvent,
+    targetId: string,
+    extra: Record<string, unknown> = {},
+  ): void => {
+    logEvent({
+      event_name: eventName,
+      target_id: targetId,
+      extra: buildStandupExtra(extra),
+    });
+  };
 
   const isBusy = (key: string): boolean => busyKeys.includes(key);
 
@@ -123,19 +162,33 @@ export const LiveRoomControls = ({
   };
 
   const switchCamera = (deviceId: string): void => {
-    selectCamera(deviceId).catch((error: unknown) =>
-      displayToast(
-        error instanceof Error ? error.message : 'Failed to switch camera',
-      ),
-    );
+    selectCamera(deviceId)
+      .then(() => {
+        logStandupAction(LogEvent.ChangeStandupSettings, 'selected_camera', {
+          surface: 'controls',
+          value: deviceId,
+        });
+      })
+      .catch((error: unknown) =>
+        displayToast(
+          error instanceof Error ? error.message : 'Failed to switch camera',
+        ),
+      );
   };
 
   const switchMicrophone = (deviceId: string): void => {
-    selectMic(deviceId).catch((error: unknown) =>
-      displayToast(
-        error instanceof Error ? error.message : 'Failed to switch mic',
-      ),
-    );
+    selectMic(deviceId)
+      .then(() => {
+        logStandupAction(LogEvent.ChangeStandupSettings, 'selected_mic', {
+          surface: 'controls',
+          value: deviceId,
+        });
+      })
+      .catch((error: unknown) =>
+        displayToast(
+          error instanceof Error ? error.message : 'Failed to switch mic',
+        ),
+      );
   };
 
   const isHost = role === 'host';
@@ -179,9 +232,12 @@ export const LiveRoomControls = ({
                 loading={isBusy(`reaction-${emoji}`)}
                 aria-label={`React ${emoji}`}
                 onClick={() =>
-                  runAuthenticatedAction(`reaction-${emoji}`, () =>
-                    sendReaction(emoji),
-                  )
+                  runAuthenticatedAction(`reaction-${emoji}`, async () => {
+                    await sendReaction(emoji);
+                    logStandupAction(LogEvent.SendStandupReaction, emoji, {
+                      surface: 'controls',
+                    });
+                  })
                 }
               >
                 <span className="text-lg leading-none">{emoji}</span>
@@ -195,9 +251,12 @@ export const LiveRoomControls = ({
                   return;
                 }
 
-                runAuthenticatedAction('reaction-custom', () =>
-                  sendReaction(emoji),
-                );
+                runAuthenticatedAction('reaction-custom', async () => {
+                  await sendReaction(emoji);
+                  logStandupAction(LogEvent.SendStandupReaction, emoji, {
+                    surface: 'controls',
+                  });
+                });
               }}
               renderTrigger={({ isOpen, toggleOpen }) => (
                 <Button
@@ -238,7 +297,15 @@ export const LiveRoomControls = ({
                 toggleIcon={
                   <SlashedIcon icon={<MegaphoneIcon />} slashed={!isMicOn} />
                 }
-                onToggle={() => guarded('mic', toggleMic)}
+                onToggle={() =>
+                  guarded('mic', async () => {
+                    await toggleMic();
+                    logStandupAction(LogEvent.ChangeStandupSettings, 'mic', {
+                      surface: 'controls',
+                      value: !isMicOn,
+                    });
+                  })
+                }
                 devices={microphones}
                 selectedId={selectedMicId}
                 onSelect={switchMicrophone}
@@ -273,9 +340,18 @@ export const LiveRoomControls = ({
                             isBusy(`mic-setting-${item.key}`)
                           }
                           onToggle={() => {
-                            guarded(`mic-setting-${item.key}`, () =>
-                              setMicSetting(item.key, !micSettings[item.key]),
-                            );
+                            guarded(`mic-setting-${item.key}`, async () => {
+                              const nextValue = !micSettings[item.key];
+                              await setMicSetting(item.key, nextValue);
+                              logStandupAction(
+                                LogEvent.ChangeStandupSettings,
+                                item.key,
+                                {
+                                  surface: 'controls',
+                                  value: nextValue,
+                                },
+                              );
+                            });
                           }}
                         />
                       ))}
@@ -297,7 +373,15 @@ export const LiveRoomControls = ({
                     slashed={!isCameraOn}
                   />
                 }
-                onToggle={() => guarded('camera', toggleCamera)}
+                onToggle={() =>
+                  guarded('camera', async () => {
+                    await toggleCamera();
+                    logStandupAction(LogEvent.ChangeStandupSettings, 'camera', {
+                      surface: 'controls',
+                      value: !isCameraOn,
+                    });
+                  })
+                }
                 devices={cameras}
                 selectedId={selectedCameraId}
                 onSelect={switchCamera}
@@ -311,9 +395,15 @@ export const LiveRoomControls = ({
                     disabled={isBusy('hide-self-view')}
                     onToggle={() =>
                       guarded('hide-self-view', async () => {
-                        setVideoSetting(
-                          'hideSelfView',
-                          !videoSettings.hideSelfView,
+                        const nextValue = !videoSettings.hideSelfView;
+                        setVideoSetting('hideSelfView', nextValue);
+                        logStandupAction(
+                          LogEvent.ChangeStandupSettings,
+                          'hide_self_view',
+                          {
+                            surface: 'controls',
+                            value: nextValue,
+                          },
                         );
                       })
                     }
@@ -340,7 +430,17 @@ export const LiveRoomControls = ({
                   return;
                 }
 
-                setReactionsOpen((open) => !open);
+                setReactionsOpen((open) => {
+                  const nextOpen = !open;
+                  if (nextOpen) {
+                    logStandupAction(
+                      LogEvent.OpenStandupReactions,
+                      'reactions',
+                      { surface: 'controls' },
+                    );
+                  }
+                  return nextOpen;
+                });
               }}
             >
               <span className="text-base leading-none">😀</span>
@@ -354,7 +454,12 @@ export const LiveRoomControls = ({
               icon={<SettingsIcon />}
               aria-label="Standup settings"
               aria-expanded={isSettingsOpen}
-              onClick={() => setIsSettingsOpen(true)}
+              onClick={() => {
+                logStandupAction(LogEvent.OpenStandupSettings, 'settings', {
+                  surface: 'controls',
+                });
+                setIsSettingsOpen(true);
+              }}
             />
             {isModerated && isAudience ? (
               <Button
@@ -367,7 +472,12 @@ export const LiveRoomControls = ({
                 loading={isBusy('queue')}
                 disabled={!canJoinQueue || isBusy('queue')}
                 onClick={() =>
-                  runAuthenticatedAction('queue', joinSpeakerQueue)
+                  runAuthenticatedAction('queue', async () => {
+                    await joinSpeakerQueue();
+                    logStandupAction(LogEvent.JoinStandupQueue, roomId, {
+                      surface: 'controls',
+                    });
+                  })
                 }
               >
                 {isQueued ? 'Queued' : 'Join queue'}
@@ -383,7 +493,14 @@ export const LiveRoomControls = ({
                 icon={<MegaphoneIcon />}
                 loading={isBusy('join-stage')}
                 disabled={!canJoinStage || isBusy('join-stage')}
-                onClick={() => runAuthenticatedAction('join-stage', joinStage)}
+                onClick={() =>
+                  runAuthenticatedAction('join-stage', async () => {
+                    await joinStage();
+                    logStandupAction(LogEvent.JoinStandupStage, roomId, {
+                      surface: 'controls',
+                    });
+                  })
+                }
               >
                 {isStageFull ? 'Stage full' : 'Join stage'}
               </Button>
@@ -395,7 +512,14 @@ export const LiveRoomControls = ({
                 variant={ButtonVariant.Secondary}
                 icon={<PhoneIcon />}
                 loading={isBusy('leave-stage')}
-                onClick={() => guarded('leave-stage', leaveStage)}
+                onClick={() =>
+                  guarded('leave-stage', async () => {
+                    await leaveStage();
+                    logStandupAction(LogEvent.LeaveStandupStage, roomId, {
+                      surface: 'controls',
+                    });
+                  })
+                }
               >
                 Leave stage
               </Button>
@@ -412,7 +536,14 @@ export const LiveRoomControls = ({
                 variant={ButtonVariant.Primary}
                 className="live-room-go-live-button !border-transparent"
                 loading={isBusy('go-live')}
-                onClick={() => guarded('go-live', startRoom)}
+                onClick={() =>
+                  guarded('go-live', async () => {
+                    await startRoom();
+                    logStandupAction(LogEvent.StartStandup, roomId, {
+                      surface: 'controls',
+                    });
+                  })
+                }
               >
                 Go live
               </Button>
@@ -426,6 +557,9 @@ export const LiveRoomControls = ({
                 onClick={() =>
                   guarded('end', async () => {
                     await endRoom();
+                    logStandupAction(LogEvent.EndStandup, roomId, {
+                      surface: 'controls',
+                    });
                     onLeave();
                   })
                 }
@@ -439,7 +573,12 @@ export const LiveRoomControls = ({
                 variant={ButtonVariant.Primary}
                 icon={<PhoneIcon />}
                 aria-label="Leave"
-                onClick={onLeave}
+                onClick={() => {
+                  logStandupAction(LogEvent.LeaveStandup, roomId, {
+                    surface: 'controls',
+                  });
+                  onLeave();
+                }}
               >
                 Leave
               </Button>
@@ -465,16 +604,31 @@ export const LiveRoomControls = ({
                 value: item.value,
                 label: item.label,
               }))}
-              onSelect={(quality) => setVideoSetting('quality', quality)}
+              onSelect={(quality) => {
+                setVideoSetting('quality', quality);
+                logStandupAction(
+                  LogEvent.ChangeStandupSettings,
+                  'video_quality',
+                  {
+                    surface: 'settings_modal',
+                    value: quality,
+                  },
+                );
+              }}
             />
             <MicSettingRow
               id="live-room-video-setting-audio-only"
               label={AUDIO_ONLY_LABEL}
               description="Hide remote video and keep the standup playing through audio."
               checked={videoSettings.audioOnly}
-              onToggle={() =>
-                setVideoSetting('audioOnly', !videoSettings.audioOnly)
-              }
+              onToggle={() => {
+                const nextValue = !videoSettings.audioOnly;
+                setVideoSetting('audioOnly', nextValue);
+                logStandupAction(LogEvent.ChangeStandupSettings, 'audio_only', {
+                  surface: 'settings_modal',
+                  value: nextValue,
+                });
+              }}
             />
           </Modal.Body>
         </Modal>

--- a/packages/shared/src/contexts/LiveRoomContext.tsx
+++ b/packages/shared/src/contexts/LiveRoomContext.tsx
@@ -23,10 +23,13 @@ import {
 } from '../graphql/liveRooms';
 import { generateQueryKey, RequestKey } from '../lib/query';
 import { useAuthContext } from './AuthContext';
+import { useLogContext } from './LogContext';
 import {
   buildLiveRoomWsUrl,
   LiveRoomConnection,
 } from '../lib/liveRoom/connection';
+import { buildStandupAnalyticsExtra } from '../lib/liveRoom/analytics';
+import { LogEvent } from '../lib/log';
 import {
   clearStoredLiveRoomResumeSession,
   readStoredLiveRoomResumeSession,
@@ -38,6 +41,7 @@ import { storageWrapper } from '../lib/storageWrapper';
 import type {
   ChatMessageDeletedEvent,
   ChatMessageSentEvent,
+  LiveRoomCommand,
   LiveRoomChatMessage,
   LiveRoomParticipantRoleValue,
   LiveRoomState,
@@ -344,11 +348,15 @@ const videoQualityOutgoingBitrateLimit: Record<LiveRoomVideoQuality, number> = {
   high: 2_500_000,
 };
 
+const getErrorMessage = (error: unknown, fallback: string): string =>
+  error instanceof Error ? error.message : fallback;
+
 export const LiveRoomProvider = ({
   roomId,
   children,
 }: LiveRoomProviderProps): ReactElement => {
   const { user, isAuthReady } = useAuthContext();
+  const { logEvent } = useLogContext();
   const [status, setStatus] = useState<LiveRoomConnectionStatus>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [roomState, setRoomState] = useState<LiveRoomState | null>(null);
@@ -414,6 +422,94 @@ export const LiveRoomProvider = ({
     roomState?.status === 'live' &&
     !!participantId &&
     (roomState.chatPermissions[participantId] ?? true);
+  const buildStandupExtra = useCallback(
+    (extra: Record<string, unknown> = {}) =>
+      buildStandupAnalyticsExtra(
+        {
+          roomId,
+          authKind: user ? 'authenticated' : 'anonymous',
+          role: currentRole,
+          roomStatus: roomState?.status ?? null,
+          roomMode: roomState?.mode ?? null,
+          connectionStatus: status,
+          canPublish,
+          participantId,
+          selectedMicId,
+          selectedCameraId,
+          hasLocalAudioTrack: !!localTracksRef.current.audio,
+          hasLocalVideoTrack: !!localTracksRef.current.video,
+          videoQuality: videoSettings.quality,
+          audioOnly: videoSettings.audioOnly,
+          hideSelfView: videoSettings.hideSelfView,
+          isResuming: !!storedResumeSession,
+        },
+        extra,
+      ),
+    [
+      roomId,
+      user,
+      currentRole,
+      roomState?.status,
+      roomState?.mode,
+      status,
+      canPublish,
+      participantId,
+      selectedMicId,
+      selectedCameraId,
+      videoSettings.quality,
+      videoSettings.audioOnly,
+      videoSettings.hideSelfView,
+      storedResumeSession,
+    ],
+  );
+  const logStandupError = useCallback(
+    (
+      targetId: string,
+      message: string,
+      extra: Record<string, unknown> = {},
+    ) => {
+      logEvent({
+        event_name: LogEvent.StandupError,
+        target_id: targetId,
+        extra: buildStandupExtra({
+          message,
+          ...extra,
+        }),
+      });
+    },
+    [buildStandupExtra, logEvent],
+  );
+  const sendConnectionCommand = useCallback(
+    async <T,>(
+      operation: string,
+      payload: LiveRoomCommand,
+      extra: Record<string, unknown> = {},
+    ): Promise<T> => {
+      const connection = connectionRef.current;
+      if (!connection) {
+        const error = new Error('Not connected');
+        logStandupError('websocket command', error.message, {
+          source: 'command',
+          operation,
+          ...extra,
+        });
+        throw error;
+      }
+
+      try {
+        return await connection.send<T>(payload);
+      } catch (error) {
+        const message = getErrorMessage(error, `Failed to ${operation}`);
+        logStandupError('websocket command', message, {
+          source: 'command',
+          operation,
+          ...extra,
+        });
+        throw error instanceof Error ? error : new Error(message);
+      }
+    },
+    [logStandupError],
+  );
 
   const pushReaction = useCallback((event: ReactionSentEvent) => {
     const createdAtMs = new Date(event.reaction.createdAt).getTime();
@@ -672,8 +768,11 @@ export const LiveRoomProvider = ({
     if (joinError) {
       setStatus('error');
       setErrorMessage(joinError.message);
+      logStandupError('join token fetch', joinError.message, {
+        source: 'join_token',
+      });
     }
-  }, [joinError]);
+  }, [joinError, logStandupError]);
 
   useEffect(() => {
     setStoredResumeSession(readStoredLiveRoomResumeSession(roomId));
@@ -716,10 +815,14 @@ export const LiveRoomProvider = ({
         }
         return nextMics[0]?.deviceId ?? null;
       });
-    } catch {
-      // ignore
+    } catch (error) {
+      logStandupError(
+        'device enumerate',
+        getErrorMessage(error, 'Failed to enumerate devices'),
+        { source: 'device_list' },
+      );
     }
-  }, []);
+  }, [logStandupError]);
 
   // Enumerate devices on mount and when device list changes (plug/unplug).
   useEffect(() => {
@@ -783,6 +886,11 @@ export const LiveRoomProvider = ({
     if (!wsUrl) {
       setStatus('error');
       setErrorMessage('Standup websocket URL is not configured');
+      logStandupError(
+        'websocket config',
+        'Standup websocket URL is not configured',
+        { source: 'connection_config' },
+      );
       return undefined;
     }
 
@@ -846,6 +954,9 @@ export const LiveRoomProvider = ({
       }
       setStatus('error');
       setErrorMessage(error.message);
+      logStandupError('websocket error', error.message, {
+        source: 'connection',
+      });
     });
 
     connection.open();
@@ -864,6 +975,7 @@ export const LiveRoomProvider = ({
     };
   }, [
     joinToken,
+    logStandupError,
     pushChatMessage,
     pushReaction,
     removeChatMessage,
@@ -1031,6 +1143,12 @@ export const LiveRoomProvider = ({
       ) {
         return;
       }
+      logStandupError('media init', err.message, {
+        source: 'media_init',
+        connectionGeneration,
+        recvTransportReady,
+        sendTransportReady,
+      });
       setStatus('error');
       setErrorMessage(err.message);
     });
@@ -1044,6 +1162,9 @@ export const LiveRoomProvider = ({
     canPublish,
     closeMediaSession,
     connectionGeneration,
+    logStandupError,
+    recvTransportReady,
+    sendTransportReady,
     status,
   ]);
 
@@ -1178,13 +1299,18 @@ export const LiveRoomProvider = ({
         } catch (err) {
           closeConsumer?.();
           subscriptionsRef.current.delete(publication.publicationId);
-          setErrorMessage(
-            err instanceof Error ? err.message : 'Failed to subscribe to media',
-          );
+          const message = getErrorMessage(err, 'Failed to subscribe to media');
+          logStandupError('media subscribe', message, {
+            source: 'subscription_create',
+            kind: publication.kind,
+            publicationId: publication.publicationId,
+            targetParticipantId: publication.participantId,
+          });
+          setErrorMessage(message);
         }
       })();
     });
-  }, [roomState, participantId, recvTransportReady]);
+  }, [logStandupError, roomState, participantId, recvTransportReady]);
 
   useEffect(() => {
     const syncRemoteVideoSubscriptions = async () => {
@@ -1209,13 +1335,17 @@ export const LiveRoomProvider = ({
     };
 
     syncRemoteVideoSubscriptions().catch((err) => {
-      setErrorMessage(
-        err instanceof Error
-          ? err.message
-          : 'Failed to update remote video subscriptions',
+      const message = getErrorMessage(
+        err,
+        'Failed to update remote video subscriptions',
       );
+      logStandupError('media settings sync', message, {
+        source: 'remote_video_subscriptions',
+      });
+      setErrorMessage(message);
     });
   }, [
+    logStandupError,
     recvTransportReady,
     setRemoteSubscriptionPaused,
     setRemoteSubscriptionPreferredSpatialLayer,
@@ -1227,13 +1357,17 @@ export const LiveRoomProvider = ({
     setRecvTransportOutgoingBitrateLimit(
       videoQualityOutgoingBitrateLimit[videoSettings.quality],
     ).catch((err) => {
-      setErrorMessage(
-        err instanceof Error
-          ? err.message
-          : 'Failed to update remote video quality',
+      const message = getErrorMessage(
+        err,
+        'Failed to update remote video quality',
       );
+      logStandupError('media settings sync', message, {
+        source: 'remote_video_quality',
+      });
+      setErrorMessage(message);
     });
   }, [
+    logStandupError,
     recvTransportReady,
     setRecvTransportOutgoingBitrateLimit,
     videoSettings.quality,
@@ -1277,12 +1411,15 @@ export const LiveRoomProvider = ({
           setPublishingFlag(kind, false);
         });
       } catch (err) {
-        setErrorMessage(
-          err instanceof Error ? err.message : `Failed to publish ${kind}`,
-        );
+        const message = getErrorMessage(err, `Failed to publish ${kind}`);
+        logStandupError(`media publish ${kind}`, message, {
+          source: 'publish_local_track',
+          kind,
+        });
+        setErrorMessage(message);
       }
     },
-    [setPublishingFlag],
+    [logStandupError, setPublishingFlag],
   );
 
   const unpublishKind = useCallback(
@@ -1335,62 +1472,77 @@ export const LiveRoomProvider = ({
       deviceId: string | null,
       nextMicSettings: LiveRoomMicSettings = micSettings,
     ) => {
-      if (typeof navigator === 'undefined' || !navigator.mediaDevices) {
-        throw new Error('Media devices are not available');
-      }
-      const stream = await navigator.mediaDevices.getUserMedia(
-        buildConstraints(kind, deviceId, nextMicSettings, micSettingSupport),
-      );
-      const track =
-        kind === 'video'
-          ? stream.getVideoTracks()[0]
-          : stream.getAudioTracks()[0];
-      if (!track) {
-        throw new Error(`No ${kind} track available`);
-      }
-      const previous = localTracksRef.current[kind];
-      const producer = producersRef.current.get(kind);
-      if (producer) {
-        try {
-          await producer.replaceTrack({ track });
-        } catch (err) {
-          track.stop();
-          setErrorMessage(
-            err instanceof Error
-              ? err.message
-              : `Failed to update ${kind} track`,
-          );
-          return;
+      try {
+        if (typeof navigator === 'undefined' || !navigator.mediaDevices) {
+          throw new Error('Media devices are not available');
         }
-      }
-      localTracksRef.current[kind] = track;
-      track.addEventListener('ended', () => {
-        if (localTracksRef.current[kind] !== track) {
-          return;
+        const stream = await navigator.mediaDevices.getUserMedia(
+          buildConstraints(kind, deviceId, nextMicSettings, micSettingSupport),
+        );
+        const track =
+          kind === 'video'
+            ? stream.getVideoTracks()[0]
+            : stream.getAudioTracks()[0];
+        if (!track) {
+          throw new Error(`No ${kind} track available`);
         }
-        localTracksRef.current[kind] = null;
+        const previous = localTracksRef.current[kind];
+        const producer = producersRef.current.get(kind);
+        if (producer) {
+          try {
+            await producer.replaceTrack({ track });
+          } catch (err) {
+            track.stop();
+            const message = getErrorMessage(
+              err,
+              `Failed to update ${kind} track`,
+            );
+            logStandupError(`media replace ${kind}`, message, {
+              source: 'capture_replace',
+              kind,
+              requestedDeviceId: deviceId,
+            });
+            setErrorMessage(message);
+            return;
+          }
+        }
+        localTracksRef.current[kind] = track;
+        track.addEventListener('ended', () => {
+          if (localTracksRef.current[kind] !== track) {
+            return;
+          }
+          localTracksRef.current[kind] = null;
+          refreshLocalStream();
+          if (kind === 'video') {
+            setIsCameraOn(false);
+          } else {
+            setIsMicOn(false);
+          }
+          unpublishKind(kind).catch(() => undefined);
+        });
+        previous?.stop();
         refreshLocalStream();
-        if (kind === 'video') {
-          setIsCameraOn(false);
-        } else {
-          setIsMicOn(false);
+        // Refresh device list to capture labels now that we have permission.
+        refreshDeviceList();
+        if (producer) {
+          return;
         }
-        unpublishKind(kind).catch(() => undefined);
-      });
-      previous?.stop();
-      refreshLocalStream();
-      // Refresh device list to capture labels now that we have permission.
-      refreshDeviceList();
-      if (producer) {
-        return;
-      }
-      // Otherwise, publish if room is live and transport is ready.
-      if (
-        sendTransportRef.current &&
-        roomState?.status === 'live' &&
-        canPublish
-      ) {
-        await publishLocalTrack(kind);
+        // Otherwise, publish if room is live and transport is ready.
+        if (
+          sendTransportRef.current &&
+          roomState?.status === 'live' &&
+          canPublish
+        ) {
+          await publishLocalTrack(kind);
+        }
+      } catch (error) {
+        const message = getErrorMessage(error, `Failed to capture ${kind}`);
+        logStandupError(`media capture ${kind}`, message, {
+          source: 'capture',
+          kind,
+          requestedDeviceId: deviceId,
+        });
+        throw error instanceof Error ? error : new Error(message);
       }
     },
     [
@@ -1399,6 +1551,7 @@ export const LiveRoomProvider = ({
       publishLocalTrack,
       unpublishKind,
       canPublish,
+      logStandupError,
       roomState?.status,
       micSettings,
       micSettingSupport,
@@ -1505,116 +1658,116 @@ export const LiveRoomProvider = ({
   );
 
   const startRoom = useCallback(async () => {
-    const connection = connectionRef.current;
-    if (!connection) {
-      throw new Error('Not connected');
-    }
-    await connection.send({ type: 'room.start' });
-  }, []);
+    await sendConnectionCommand('start room', { type: 'room.start' });
+  }, [sendConnectionCommand]);
 
   const endRoom = useCallback(async () => {
-    const connection = connectionRef.current;
-    if (!connection) {
-      throw new Error('Not connected');
-    }
-    await connection.send({ type: 'room.end' });
-  }, []);
+    await sendConnectionCommand('end room', { type: 'room.end' });
+  }, [sendConnectionCommand]);
 
   const joinSpeakerQueue = useCallback(async () => {
-    const connection = connectionRef.current;
-    if (!connection) {
-      throw new Error('Not connected');
-    }
-    await connection.send({ type: 'stage.queue.join' });
-  }, []);
+    await sendConnectionCommand('join speaker queue', {
+      type: 'stage.queue.join',
+    });
+  }, [sendConnectionCommand]);
 
   const joinStage = useCallback(async () => {
-    const connection = connectionRef.current;
-    if (!connection) {
-      throw new Error('Not connected');
-    }
-    await connection.send({ type: 'stage.speaker.join' });
-  }, []);
+    await sendConnectionCommand('join stage', { type: 'stage.speaker.join' });
+  }, [sendConnectionCommand]);
 
   const leaveStage = useCallback(async () => {
-    const connection = connectionRef.current;
-    if (!connection) {
-      throw new Error('Not connected');
-    }
-    await connection.send({ type: 'stage.speaker.leave' });
-  }, []);
+    await sendConnectionCommand('leave stage', { type: 'stage.speaker.leave' });
+  }, [sendConnectionCommand]);
 
-  const sendReaction = useCallback(async (emoji: string) => {
-    const connection = connectionRef.current;
-    if (!connection) {
-      throw new Error('Not connected');
-    }
-    await connection.send({ type: 'stage.reaction.send', key: emoji });
-  }, []);
+  const sendReaction = useCallback(
+    async (emoji: string) => {
+      await sendConnectionCommand(
+        'send reaction',
+        { type: 'stage.reaction.send', key: emoji },
+        { emoji },
+      );
+    },
+    [sendConnectionCommand],
+  );
 
-  const sendChatMessage = useCallback(async (body: string) => {
-    const connection = connectionRef.current;
-    if (!connection) {
-      throw new Error('Not connected');
-    }
-    await connection.send({ type: 'chat.message.send', body });
-  }, []);
+  const sendChatMessage = useCallback(
+    async (body: string) => {
+      await sendConnectionCommand(
+        'send chat message',
+        { type: 'chat.message.send', body },
+        { messageLength: body.length },
+      );
+    },
+    [sendConnectionCommand],
+  );
 
-  const deleteChatMessage = useCallback(async (messageId: string) => {
-    const connection = connectionRef.current;
-    if (!connection) {
-      throw new Error('Not connected');
-    }
-    await connection.send({ type: 'chat.message.delete', messageId });
-  }, []);
+  const deleteChatMessage = useCallback(
+    async (messageId: string) => {
+      await sendConnectionCommand(
+        'delete chat message',
+        { type: 'chat.message.delete', messageId },
+        { messageId },
+      );
+    },
+    [sendConnectionCommand],
+  );
 
   const setParticipantChatEnabled = useCallback(
     async (targetParticipantId: string, nextCanChat: boolean) => {
-      const connection = connectionRef.current;
-      if (!connection) {
-        throw new Error('Not connected');
-      }
-      await connection.send({
-        type: 'chat.privilege.set',
-        targetParticipantId,
-        canChat: nextCanChat,
-      });
+      await sendConnectionCommand(
+        'set participant chat access',
+        {
+          type: 'chat.privilege.set',
+          targetParticipantId,
+          canChat: nextCanChat,
+        },
+        { targetParticipantId, nextCanChat },
+      );
     },
-    [],
+    [sendConnectionCommand],
   );
 
-  const promoteSpeaker = useCallback(async (targetParticipantId: string) => {
-    const connection = connectionRef.current;
-    if (!connection) {
-      throw new Error('Not connected');
-    }
-    await connection.send({
-      type: 'stage.speaker.promote',
-      targetParticipantId,
-    });
-  }, []);
+  const promoteSpeaker = useCallback(
+    async (targetParticipantId: string) => {
+      await sendConnectionCommand(
+        'promote speaker',
+        {
+          type: 'stage.speaker.promote',
+          targetParticipantId,
+        },
+        { targetParticipantId },
+      );
+    },
+    [sendConnectionCommand],
+  );
 
-  const removeSpeaker = useCallback(async (targetParticipantId: string) => {
-    const connection = connectionRef.current;
-    if (!connection) {
-      throw new Error('Not connected');
-    }
-    await connection.send({
-      type: 'stage.speaker.remove',
-      targetParticipantId,
-    });
-  }, []);
+  const removeSpeaker = useCallback(
+    async (targetParticipantId: string) => {
+      await sendConnectionCommand(
+        'remove speaker',
+        {
+          type: 'stage.speaker.remove',
+          targetParticipantId,
+        },
+        { targetParticipantId },
+      );
+    },
+    [sendConnectionCommand],
+  );
 
-  const kickParticipant = useCallback(async (targetParticipantId: string) => {
-    const connection = connectionRef.current;
-    if (!connection) {
-      throw new Error('Not connected');
-    }
-    await connection.send({
-      type: 'stage.kick',
-      targetParticipantId,
-    });
-  }, []);
+  const kickParticipant = useCallback(
+    async (targetParticipantId: string) => {
+      await sendConnectionCommand(
+        'kick participant',
+        {
+          type: 'stage.kick',
+          targetParticipantId,
+        },
+        { targetParticipantId },
+      );
+    },
+    [sendConnectionCommand],
+  );
 
   const value = useMemo<LiveRoomContextValue>(
     () => ({

--- a/packages/shared/src/lib/liveRoom/analytics.ts
+++ b/packages/shared/src/lib/liveRoom/analytics.ts
@@ -1,0 +1,42 @@
+export interface StandupAnalyticsContext {
+  roomId: string;
+  authKind: 'anonymous' | 'authenticated';
+  role?: string | null;
+  roomStatus?: string | null;
+  roomMode?: string | null;
+  connectionStatus?: string | null;
+  canPublish?: boolean;
+  participantId?: string | null;
+  selectedMicId?: string | null;
+  selectedCameraId?: string | null;
+  hasLocalAudioTrack?: boolean;
+  hasLocalVideoTrack?: boolean;
+  videoQuality?: string | null;
+  audioOnly?: boolean;
+  hideSelfView?: boolean;
+  isResuming?: boolean;
+}
+
+export const buildStandupAnalyticsExtra = (
+  context: StandupAnalyticsContext,
+  extra: Record<string, unknown> = {},
+): string =>
+  JSON.stringify({
+    roomId: context.roomId,
+    authKind: context.authKind,
+    role: context.role,
+    roomStatus: context.roomStatus,
+    roomMode: context.roomMode,
+    connectionStatus: context.connectionStatus,
+    canPublish: context.canPublish,
+    participantId: context.participantId,
+    selectedMicId: context.selectedMicId,
+    selectedCameraId: context.selectedCameraId,
+    hasLocalAudioTrack: context.hasLocalAudioTrack,
+    hasLocalVideoTrack: context.hasLocalVideoTrack,
+    videoQuality: context.videoQuality,
+    audioOnly: context.audioOnly,
+    hideSelfView: context.hideSelfView,
+    isResuming: context.isResuming,
+    ...extra,
+  });

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -257,6 +257,27 @@ export enum LogEvent {
   // Settings
   ChangeSettings = 'change settings',
   // End settings
+  // Standups
+  ViewStandup = 'view standup',
+  LeaveStandup = 'leave standup',
+  StartStandup = 'start standup',
+  EndStandup = 'end standup',
+  JoinStandupQueue = 'join standup queue',
+  JoinStandupStage = 'join standup stage',
+  LeaveStandupStage = 'leave standup stage',
+  OpenStandupSettings = 'open standup settings',
+  OpenStandupReactions = 'open standup reactions',
+  SwitchStandupPanelTab = 'switch standup panel tab',
+  SendStandupReaction = 'send standup reaction',
+  SendStandupChatMessage = 'send standup chat message',
+  DeleteStandupChatMessage = 'delete standup chat message',
+  UpdateStandupChatAccess = 'update standup chat access',
+  PromoteStandupSpeaker = 'promote standup speaker',
+  RemoveStandupSpeaker = 'remove standup speaker',
+  KickStandupParticipant = 'kick standup participant',
+  ChangeStandupSettings = 'change standup settings',
+  StandupError = 'standup error',
+  // End standups
   // Integrations
   StartAddingWorkspace = 'start adding workspace',
   StartAddingIntegration = 'start adding integration',


### PR DESCRIPTION
## What changed
- added dedicated standup analytics events for the `/standups/[id]` surface
- wired action analytics for room entry/exit, stage controls, reactions, chat moderation, and standup settings changes
- added centralized `standup error` logging in the live-room context so websocket, join-token, media init, subscription, capture, and command failures carry enough runtime state to debug production issues
- introduced a shared standup analytics payload helper to keep action and error events consistent

## Why this changed
The standup page had no analytics coverage, which made it hard to understand both user flows and technical failures. Most operational failures were only surfaced as toasts or local error state, so they were difficult to diagnose after the fact.

## Impact
This gives us actionable telemetry for the standup experience, especially around media and connection failures, without logging sensitive content like chat bodies, room topics, device labels, or display names.

## Root cause
The standup/live-room surface was shipped without domain-specific analytics instrumentation and without structured handled-error logging for the websocket and media stack.

## Validation
- `node ./scripts/typecheck-strict-changed.js`
- `pnpm --filter shared exec eslint src/contexts/LiveRoomContext.tsx src/components/liveRooms/LiveRoom.tsx src/components/liveRooms/LiveRoomControls.tsx src/lib/liveRoom/analytics.ts src/lib/log.ts`


### Preview domain
https://codex-standup-analytics.preview.app.daily.dev