### PR TITLE
Show rich text submit shortcut in composer

### DIFF
--- a/packages/shared/src/components/fields/RichTextInput.tsx
+++ b/packages/shared/src/components/fields/RichTextInput.tsx
@@ -56,6 +56,7 @@ import { useDraftStorage } from './RichTextEditor/useDraftStorage';
 import { useToastNotification } from '../../hooks/useToastNotification';
 import styles from './RichTextEditor/richtext.module.css';
 import type { UserShortProfile } from '../../lib/user';
+import { isAppleDevice } from '../../lib/func';
 
 const RecommendedEmojiTooltip = dynamic(
   () =>
@@ -196,6 +197,10 @@ function RichTextInput(
   const inputRef = useRef('');
   const [offset, setOffset] = useState([0, 0]);
   const [isMarkdownMode, setIsMarkdownMode] = useState(false);
+  const [submitShortcut, setSubmitShortcut] = useState('Ctrl + Enter');
+  useEffect(() => {
+    setSubmitShortcut(isAppleDevice() ? '⌘ + Enter' : 'Ctrl + Enter');
+  }, []);
 
   const isUploadEnabled = enabledCommand[MarkdownCommand.Upload];
   const isMentionEnabled = enabledCommand[MarkdownCommand.Mention];
@@ -640,7 +645,6 @@ function RichTextInput(
       : null;
 
   const hasToolbarActions = isUploadEnabled || isMentionEnabled || isGifEnabled;
-  const hasUploadHint = isUploadEnabled;
   const toolbarActions = (
     <>
       {isUploadEnabled && (
@@ -889,9 +893,9 @@ function RichTextInput(
       )}
       {footer ?? (
         <span className="flex flex-row items-center gap-3 border-border-subtlest-tertiary p-2 px-3 text-text-tertiary laptop:border-t">
-          {hasUploadHint && !isMarkdownMode && (
+          {shouldShowSubmit && !isMarkdownMode && (
             <span className="hidden text-text-quaternary typo-caption1 tablet:inline">
-              Drag and drop images to attach
+              Press {submitShortcut} to send
             </span>
           )}
           {maxLength && remainingCharacters !== null && (


### PR DESCRIPTION
## What changed
- updated `RichTextInput` footer copy to show the submit keyboard shortcut instead of the drag-and-drop hint when the submit action is visible
- detect Apple devices so the copy shows `⌘ + Enter` on macOS/iOS and `Ctrl + Enter` elsewhere

## Why this changed
The current footer hint is less useful in the send flow than the actual keyboard shortcut users can use to submit quickly.

## Impact
This makes the shared rich-text composer clearer for keyboard-driven submit flows without changing the submit behavior itself.

## Validation
- `node ./scripts/typecheck-strict-changed.js`
- `pnpm --filter shared exec eslint src/components/fields/RichTextInput.tsx`


### Preview domain
https://codex-richtext-submit-shortcut.preview.app.daily.dev