### PR TITLE
feat: add live room co-host controls

### DIFF
--- a/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
@@ -10,6 +10,7 @@ import { LiveRoom } from './LiveRoom';
 
 const mockPush = jest.fn();
 const mockDisplayToast = jest.fn();
+const mockLogEvent = jest.fn();
 const mockUseLiveRoomConnection = jest.fn<LiveRoomContextValue, []>();
 const mockUseLiveRoomQuery = jest.fn();
 const mockUseAuthContext = jest.fn();
@@ -39,6 +40,10 @@ jest.mock('../../hooks/liveRooms/useLiveRoom', () => ({
 
 jest.mock('../../contexts/AuthContext', () => ({
   useAuthContext: () => mockUseAuthContext(),
+}));
+
+jest.mock('../../contexts/LogContext', () => ({
+  useLogContext: () => ({ logEvent: mockLogEvent }),
 }));
 
 jest.mock('../../hooks/liveRooms/useLiveRoomParticipantStreams', () => ({
@@ -128,6 +133,7 @@ const createContextValue = (
         updatedAt: '2026-04-27T09:03:00.000Z',
       },
     },
+    coHostParticipantIds: [],
     chatPermissions: {},
     sessions: {},
     stage: {
@@ -149,6 +155,8 @@ const createContextValue = (
   sendReaction: jest.fn(),
   sendChatMessage: jest.fn(),
   deleteChatMessage: jest.fn(),
+  grantCoHost: jest.fn(),
+  revokeCoHost: jest.fn(),
   setParticipantChatEnabled: jest.fn(),
   promoteSpeaker: jest.fn(),
   removeSpeaker: jest.fn(),
@@ -293,6 +301,24 @@ describe('LiveRoom', () => {
 
     await waitFor(() => {
       expect(removeSpeaker).toHaveBeenCalledWith('speaker1');
+    });
+  });
+
+  it('lets the original host grant co-host from the queue panel', async () => {
+    const grantCoHost = jest.fn().mockResolvedValue(undefined);
+    mockUseLiveRoomConnection.mockReturnValue(
+      createContextValue({ grantCoHost }),
+    );
+
+    renderLiveRoom();
+
+    fireEvent.click(screen.getByRole('tab', { name: /Queue/ }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Grant co-host to @queued1' }),
+    );
+
+    await waitFor(() => {
+      expect(grantCoHost).toHaveBeenCalledWith('queued1');
     });
   });
 
@@ -488,6 +514,39 @@ describe('LiveRoom', () => {
     ).toBeInTheDocument();
   });
 
+  it('lets a co-host access host-only chat moderation controls', () => {
+    mockUseLiveRoomConnection.mockReturnValue(
+      createContextValue({
+        role: 'audience',
+        participantId: 'queued1',
+        roomState: {
+          ...createContextValue().roomState!,
+          coHostParticipantIds: ['queued1'],
+        },
+        chatMessages: [
+          {
+            messageId: 'message-1',
+            participantId: 'speaker1',
+            body: 'hello',
+            createdAt: '2026-04-27T09:04:00.000Z',
+          },
+        ],
+      }),
+    );
+
+    renderLiveRoom();
+
+    expect(
+      screen.getByRole('button', { name: /Delete message/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Kick user/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Revoke chat access/i }),
+    ).toBeInTheDocument();
+  });
+
   it('paginates stage tiles after the first 12 visible speakers', () => {
     const activeSpeakerParticipantIds = Array.from(
       { length: 12 },
@@ -532,5 +591,41 @@ describe('LiveRoom', () => {
 
     expect(screen.getByText('Page 1 / 2')).toBeInTheDocument();
     expect(screen.getAllByTestId('live-room-tile')).toHaveLength(12);
+  });
+
+  it('logs a room query error only once for the same failure', () => {
+    let contextValue = createContextValue({ selectedMicId: 'mic-1' });
+
+    mockUseLiveRoomConnection.mockImplementation(() => contextValue);
+    mockUseLiveRoomQuery.mockReturnValue({
+      data: undefined,
+      error: new Error('Room fetch failed'),
+      isLoading: false,
+    });
+
+    const queryClient = new QueryClient();
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <LiveRoom roomId="room-1" />
+      </QueryClientProvider>,
+    );
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1);
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: 'standup error',
+        target_id: 'room query',
+      }),
+    );
+
+    contextValue = createContextValue({ selectedMicId: 'mic-2' });
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <LiveRoom roomId="room-1" />
+      </QueryClientProvider>,
+    );
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/shared/src/components/liveRooms/LiveRoom.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.tsx
@@ -1,5 +1,11 @@
 import type { ReactElement } from 'react';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useRouter } from 'next/router';
 import classNames from 'classnames';
 import {
@@ -23,6 +29,7 @@ import { useAuthContext } from '../../contexts/AuthContext';
 import { useLogContext } from '../../contexts/LogContext';
 import { AuthTriggers } from '../../lib/auth';
 import { buildStandupAnalyticsExtra } from '../../lib/liveRoom/analytics';
+import { getLiveRoomPrivilegeState } from '../../lib/liveRoom/privileges';
 import { LogEvent } from '../../lib/log';
 import { useLiveRoom as useLiveRoomQuery } from '../../hooks/liveRooms/useLiveRoom';
 import { useLiveRoomParticipantProfiles } from '../../hooks/liveRooms/useLiveRoomParticipantProfiles';
@@ -148,9 +155,10 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     roomState,
     role,
     participantId,
-    canPublish,
     sendChatMessage,
     deleteChatMessage,
+    grantCoHost,
+    revokeCoHost,
     setParticipantChatEnabled,
     promoteSpeaker,
     removeSpeaker,
@@ -158,13 +166,16 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     canChat,
     localStream,
     remoteStreams,
-    selectedCameraId,
-    selectedMicId,
     videoSettings,
     reactions,
     chatMessages,
     isMicOn,
   } = useLiveRoomConnection();
+  const privilegeState = getLiveRoomPrivilegeState(
+    roomState,
+    participantId,
+    role,
+  );
   const {
     data: room,
     error: roomError,
@@ -179,6 +190,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   const [moderationBusy, setModerationBusy] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<LiveRoomSidePanelTab>('chat');
   const [stagePage, setStagePage] = useState(0);
+  const lastLoggedRoomErrorRef = useRef<string | null>(null);
   const buildStandupExtra = useCallback(
     (extra: Record<string, unknown> = {}) =>
       buildStandupAnalyticsExtra(
@@ -189,10 +201,8 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
           roomStatus: roomState?.status ?? room?.status ?? null,
           roomMode: roomState?.mode ?? room?.mode ?? null,
           connectionStatus: status,
-          canPublish,
           participantId,
-          selectedMicId,
-          selectedCameraId,
+          isCoHost: privilegeState.isCoHost,
           hasLocalAudioTrack: !!localStream?.getAudioTracks()[0],
           hasLocalVideoTrack: !!localStream?.getVideoTracks()[0],
           videoQuality: videoSettings.quality,
@@ -210,10 +220,8 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
       room?.status,
       room?.mode,
       status,
-      canPublish,
       participantId,
-      selectedMicId,
-      selectedCameraId,
+      privilegeState.isCoHost,
       localStream,
       videoSettings.quality,
       videoSettings.audioOnly,
@@ -350,6 +358,24 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     },
     [kickParticipant, logStandupAction],
   );
+  const handleGrantCoHost = useCallback(
+    async (targetParticipantId: string, surface: string): Promise<void> => {
+      await grantCoHost(targetParticipantId);
+      logStandupAction(LogEvent.GrantStandupCoHost, targetParticipantId, {
+        surface,
+      });
+    },
+    [grantCoHost, logStandupAction],
+  );
+  const handleRevokeCoHost = useCallback(
+    async (targetParticipantId: string, surface: string): Promise<void> => {
+      await revokeCoHost(targetParticipantId);
+      logStandupAction(LogEvent.RevokeStandupCoHost, targetParticipantId, {
+        surface,
+      });
+    },
+    [logStandupAction, revokeCoHost],
+  );
   const handleTabChange = (tab: LiveRoomSidePanelTab): void => {
     if (tab === activeTab) {
       return;
@@ -402,7 +428,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     localStream,
     participantId,
   );
-  const isHost = role === 'host';
+  const { hasHostPrivileges, isHost } = privilegeState;
   const isCreated = roomState?.status === 'created';
   const isLive = roomState?.status === 'live';
   const isEnded = roomState?.status === 'ended' || room?.status === 'ended';
@@ -416,6 +442,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     ? Object.keys(roomState.participants).length
     : room?.participantCount ?? 0;
   const hostId = room?.host.id ?? '';
+  const coHostParticipantIds = roomState?.coHostParticipantIds ?? [];
   const activeSpeakerIds =
     roomState?.stage.activeSpeakerParticipantIds.filter(
       (id) => !!roomState.participants[id] && id !== hostId,
@@ -488,6 +515,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
           stream: participantStreamsById.get(room.host.id) ?? null,
           selfView: room.host.id === participantId,
           isHost: true,
+          isCoHost: false,
         },
         ...activeSpeakerIds.map((id) => ({
           id,
@@ -497,6 +525,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
           stream: participantStreamsById.get(id) ?? null,
           selfView: id === participantId,
           isHost: false,
+          isCoHost: coHostParticipantIds.includes(id),
         })),
       ].map((speaker) => ({
         ...speaker,
@@ -523,7 +552,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     1,
     Math.ceil(paginatedStageSpeakers.length / stageGridColumnCount),
   );
-  const showAudienceWaiting = isCreated && !isHost;
+  const showAudienceWaiting = isCreated && !hasHostPrivileges;
 
   useEffect(() => {
     if (isFreeForAll && activeTab === 'queue') {
@@ -537,8 +566,15 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
 
   useEffect(() => {
     if (!roomError) {
+      lastLoggedRoomErrorRef.current = null;
       return;
     }
+
+    const errorKey = `${roomId}:${roomError.message}`;
+    if (lastLoggedRoomErrorRef.current === errorKey) {
+      return;
+    }
+    lastLoggedRoomErrorRef.current = errorKey;
 
     logEvent({
       event_name: LogEvent.StandupError,
@@ -549,7 +585,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
         message: roomError.message,
       }),
     });
-  }, [buildStandupExtra, logEvent, roomError]);
+  }, [buildStandupExtra, logEvent, roomError, roomId]);
 
   if (!isAuthReady || isRoomLoading) {
     return (
@@ -695,7 +731,8 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
               }}
             >
               {paginatedStageSpeakers.map((speaker) => {
-                const canModerate = isHost && !speaker.isHost;
+                const canModerate = hasHostPrivileges && !speaker.isHost;
+                const canManageCoHosts = isHost && !speaker.isHost;
 
                 return (
                   <div
@@ -707,7 +744,28 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
                       user={speaker.profile}
                       selfView={speaker.selfView}
                       isHost={speaker.isHost}
+                      isCoHost={speaker.isCoHost}
                       isMuted={speaker.isMuted}
+                      onGrantCoHost={
+                        canManageCoHosts && !speaker.isCoHost
+                          ? () =>
+                              guardedModerationAction(
+                                `tile-grant-cohost-${speaker.id}`,
+                                () =>
+                                  handleGrantCoHost(speaker.id, 'stage_tile'),
+                              )
+                          : undefined
+                      }
+                      onRevokeCoHost={
+                        canManageCoHosts && speaker.isCoHost
+                          ? () =>
+                              guardedModerationAction(
+                                `tile-revoke-cohost-${speaker.id}`,
+                                () =>
+                                  handleRevokeCoHost(speaker.id, 'stage_tile'),
+                              )
+                          : undefined
+                      }
                       onRemoveSpeaker={
                         canModerate
                           ? () =>
@@ -733,6 +791,12 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
                       }
                       isRemoving={
                         moderationBusy === `tile-remove-${speaker.id}`
+                      }
+                      isGrantingCoHost={
+                        moderationBusy === `tile-grant-cohost-${speaker.id}`
+                      }
+                      isRevokingCoHost={
+                        moderationBusy === `tile-revoke-cohost-${speaker.id}`
                       }
                       isKicking={moderationBusy === `tile-kick-${speaker.id}`}
                       moderationDisabled={!!moderationBusy}
@@ -829,11 +893,12 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
                 mentionSuggestions={mentionSuggestions}
                 participantChatPermissions={roomState?.chatPermissions ?? {}}
                 hostParticipantId={room.host.id}
+                coHostParticipantIds={coHostParticipantIds}
                 canChat={canChat}
                 isLive={!!isLive}
                 isEnded={!!isEnded}
                 isLoggedIn={!!user}
-                isHost={isHost}
+                hasHostPrivileges={hasHostPrivileges}
                 onSendMessage={handleSendChatMessage}
                 onDeleteMessage={handleDeleteChatMessage}
                 onKickParticipant={handleKickChatParticipant}
@@ -849,10 +914,18 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
                 audienceParticipantIds={audienceParticipantIds}
                 participantsById={roomState?.participants ?? {}}
                 participantProfilesById={participantProfilesById}
-                isHost={isHost}
+                coHostParticipantIds={coHostParticipantIds}
+                canModerate={hasHostPrivileges}
+                canManageCoHosts={isHost}
                 stageLimit={stageLimit}
                 moderationBusy={moderationBusy}
                 guardedModerationAction={guardedModerationAction}
+                grantCoHost={(targetParticipantId) =>
+                  handleGrantCoHost(targetParticipantId, 'queue_panel')
+                }
+                revokeCoHost={(targetParticipantId) =>
+                  handleRevokeCoHost(targetParticipantId, 'queue_panel')
+                }
                 promoteSpeaker={(targetParticipantId) =>
                   handlePromoteSpeaker(targetParticipantId, 'queue_panel')
                 }

--- a/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
@@ -155,11 +155,12 @@ interface LiveRoomChatPanelProps {
   mentionSuggestions: UserShortProfile[];
   participantChatPermissions: Record<string, boolean>;
   hostParticipantId: string;
+  coHostParticipantIds: string[];
   canChat: boolean;
   isLive: boolean;
   isEnded: boolean;
   isLoggedIn: boolean;
-  isHost: boolean;
+  hasHostPrivileges: boolean;
   onSendMessage: (body: string) => Promise<void>;
   onDeleteMessage: (messageId: string) => Promise<void>;
   onKickParticipant: (participantId: string) => Promise<void>;
@@ -176,11 +177,12 @@ export const LiveRoomChatPanel = ({
   mentionSuggestions,
   participantChatPermissions,
   hostParticipantId,
+  coHostParticipantIds,
   canChat,
   isLive,
   isEnded,
   isLoggedIn,
-  isHost,
+  hasHostPrivileges,
   onSendMessage,
   onDeleteMessage,
   onKickParticipant,
@@ -261,8 +263,12 @@ export const LiveRoomChatPanel = ({
             const isSenderBlocked =
               (participantChatPermissions[message.participantId] ?? true) ===
               false;
+            const isSenderHost = message.participantId === hostParticipantId;
+            const isSenderCoHost =
+              !isSenderHost &&
+              coHostParticipantIds.includes(message.participantId);
             const canModerateParticipant =
-              isHost &&
+              hasHostPrivileges &&
               message.participantId !== hostParticipantId &&
               message.participantId !== '';
 
@@ -277,6 +283,16 @@ export const LiveRoomChatPanel = ({
                     <span className="mr-2 inline font-bold">
                       {userDisplayName(sender)}
                     </span>
+                    {isSenderHost ? (
+                      <span className="mr-2 inline rounded-6 bg-surface-float px-1.5 py-0.5 text-[0.6875rem] font-bold uppercase tracking-wide text-accent-bun-default">
+                        Host
+                      </span>
+                    ) : null}
+                    {isSenderCoHost ? (
+                      <span className="mr-2 inline rounded-6 bg-surface-float px-1.5 py-0.5 text-[0.6875rem] font-bold uppercase tracking-wide text-accent-water-bolder">
+                        Co-host
+                      </span>
+                    ) : null}
                     <Markdown
                       className="inline !text-[0.9375rem] [&_a]:!text-[0.9375rem] [&_code]:rounded-[0.375rem] [&_code]:bg-surface-hover [&_code]:px-1 [&_code]:py-0.5 [&_p]:inline [&_p]:!text-[0.9375rem] [&_p]:!leading-[1.5]"
                       content={chatMarkdownToHtml(message.body, {
@@ -285,7 +301,7 @@ export const LiveRoomChatPanel = ({
                     />
                   </div>
                 </div>
-                {isHost ? (
+                {hasHostPrivileges ? (
                   <div
                     className={classNames(
                       'ml-2 shrink-0 pt-0.5 transition-opacity',

--- a/packages/shared/src/components/liveRooms/LiveRoomControls.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControls.spec.tsx
@@ -132,6 +132,7 @@ const createContextValue = (
         updatedAt: '2026-04-27T09:01:00.000Z',
       },
     },
+    coHostParticipantIds: [],
     chatPermissions: {},
     sessions: {},
     stage: {
@@ -153,6 +154,8 @@ const createContextValue = (
   sendReaction: jest.fn(),
   sendChatMessage: jest.fn(),
   deleteChatMessage: jest.fn(),
+  grantCoHost: jest.fn(),
+  revokeCoHost: jest.fn(),
   setParticipantChatEnabled: jest.fn(),
   promoteSpeaker: jest.fn(),
   removeSpeaker: jest.fn(),
@@ -208,7 +211,7 @@ const renderLiveRoomControls = () => {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <LiveRoomControls onLeave={jest.fn()} />
+      <LiveRoomControls roomId="room-1" onLeave={jest.fn()} />
     </QueryClientProvider>,
   );
 };
@@ -499,6 +502,46 @@ describe('LiveRoomControls', () => {
     expect(
       screen.queryByRole('button', { name: 'Join queue' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('shows host-only room controls for a co-host audience participant', () => {
+    mockUseLiveRoom.mockReturnValue(
+      createContextValue({
+        role: 'audience',
+        participantId: 'audience',
+        roomState: {
+          ...createRoomState(),
+          coHostParticipantIds: ['audience'],
+        },
+      }),
+    );
+
+    renderLiveRoomControls();
+
+    expect(
+      screen.getByRole('button', { name: 'End standup' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Leave' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('lets a co-host start a room before it goes live', () => {
+    mockUseLiveRoom.mockReturnValue(
+      createContextValue({
+        role: 'audience',
+        participantId: 'audience',
+        roomState: {
+          ...createRoomState(),
+          status: 'created',
+          coHostParticipantIds: ['audience'],
+        },
+      }),
+    );
+
+    renderLiveRoomControls();
+
+    expect(screen.getByRole('button', { name: 'Go live' })).toBeInTheDocument();
   });
 
   it('shows media controls when the current participant becomes a speaker', () => {

--- a/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
@@ -22,6 +22,7 @@ import {
 import { useAuthContext } from '../../contexts/AuthContext';
 import { AuthTriggers } from '../../lib/auth';
 import { buildStandupAnalyticsExtra } from '../../lib/liveRoom/analytics';
+import { getLiveRoomPrivilegeState } from '../../lib/liveRoom/privileges';
 import { LogEvent } from '../../lib/log';
 import { Modal } from '../modals/common/Modal';
 import {
@@ -86,6 +87,11 @@ export const LiveRoomControls = ({
   const [busyKeys, setBusyKeys] = useState<string[]>([]);
   const [reactionsOpen, setReactionsOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const privilegeState = getLiveRoomPrivilegeState(
+    roomState,
+    participantId,
+    role,
+  );
 
   const localAudioTrack = localStream?.getAudioTracks()[0] ?? null;
   const localAudioStream = useMemo(
@@ -101,10 +107,8 @@ export const LiveRoomControls = ({
         roomStatus: roomState?.status ?? null,
         roomMode: roomState?.mode ?? null,
         connectionStatus: status,
-        canPublish,
         participantId,
-        selectedMicId,
-        selectedCameraId,
+        isCoHost: privilegeState.isCoHost,
         hasLocalAudioTrack: !!localStream?.getAudioTracks()[0],
         hasLocalVideoTrack: !!localStream?.getVideoTracks()[0],
         videoQuality: videoSettings.quality,
@@ -191,7 +195,6 @@ export const LiveRoomControls = ({
       );
   };
 
-  const isHost = role === 'host';
   const isAudience = role === 'audience';
   const isSpeaker = role === 'speaker';
   const isModerated = roomState?.mode === 'moderated';
@@ -213,7 +216,8 @@ export const LiveRoomControls = ({
     isFreeForAll && isAudience && roomState?.status === 'live' && !isStageFull;
   const canLeaveStage =
     isFreeForAll && isSpeaker && roomState?.status === 'live';
-  const showGoLive = isHost && roomState?.status === 'created';
+  const showGoLive =
+    privilegeState.hasHostPrivileges && roomState?.status === 'created';
 
   const previewSuffix = (active: boolean, publishing: boolean): string =>
     active && !publishing ? ' (preview)' : '';
@@ -548,7 +552,7 @@ export const LiveRoomControls = ({
                 Go live
               </Button>
             ) : null}
-            {isHost ? (
+            {privilegeState.hasHostPrivileges ? (
               <Button
                 type="button"
                 size={ButtonSize.Small}

--- a/packages/shared/src/components/liveRooms/LiveRoomQueuePanel.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomQueuePanel.tsx
@@ -7,7 +7,14 @@ import {
   TypographyColor,
   TypographyType,
 } from '../typography/Typography';
-import { BlockIcon, PlusUserIcon, RemoveUserIcon, UserIcon } from '../icons';
+import {
+  BlockIcon,
+  PlusUserIcon,
+  RemoveUserIcon,
+  ShieldCheckIcon as ShieldCheckActionIcon,
+  ShieldIcon as ShieldActionIcon,
+  UserIcon,
+} from '../icons';
 import { IconSize } from '../Icon';
 import { ProfilePicture, ProfileImageSize } from '../ProfilePicture';
 import type { LiveRoomParticipantRecord } from '../../lib/liveRoom/protocol';
@@ -22,6 +29,7 @@ interface StageParticipantItemProps {
   participantId: string;
   profile?: UserShortProfile;
   subtitle?: string;
+  badgeLabel?: string;
   leading?: ReactNode;
   actions?: ReactNode;
 }
@@ -30,6 +38,7 @@ const StageParticipantItem = ({
   participantId,
   profile,
   subtitle,
+  badgeLabel,
   leading,
   actions,
 }: StageParticipantItemProps): ReactElement => {
@@ -40,9 +49,21 @@ const StageParticipantItem = ({
       {leading}
       <ProfilePicture user={user} size={ProfileImageSize.Small} />
       <div className="min-w-0 flex-1">
-        <Typography type={TypographyType.Footnote} bold truncate>
-          {userDisplayName(user)}
-        </Typography>
+        <div className="flex min-w-0 items-center gap-2">
+          <Typography
+            type={TypographyType.Footnote}
+            bold
+            truncate
+            title={userDisplayName(user)}
+          >
+            {userDisplayName(user)}
+          </Typography>
+          {badgeLabel ? (
+            <span className="shrink-0 rounded-6 bg-surface-float px-1.5 py-0.5 text-[0.6875rem] font-bold uppercase tracking-wide text-accent-water-bolder">
+              {badgeLabel}
+            </span>
+          ) : null}
+        </div>
         {subtitle ? (
           <Typography
             type={TypographyType.Caption2}
@@ -66,13 +87,17 @@ interface LiveRoomQueuePanelProps {
   audienceParticipantIds: string[];
   participantsById: Record<string, LiveRoomParticipantRecord>;
   participantProfilesById: Map<string, UserShortProfile>;
-  isHost: boolean;
+  coHostParticipantIds: string[];
+  canModerate: boolean;
+  canManageCoHosts: boolean;
   stageLimit?: number | null;
   moderationBusy: string | null;
   guardedModerationAction: (
     key: string,
     fn: () => Promise<void>,
   ) => Promise<void>;
+  grantCoHost: (targetParticipantId: string) => Promise<void>;
+  revokeCoHost: (targetParticipantId: string) => Promise<void>;
   promoteSpeaker: (targetParticipantId: string) => Promise<void>;
   removeSpeaker: (targetParticipantId: string) => Promise<void>;
   kickParticipant: (targetParticipantId: string) => Promise<void>;
@@ -86,18 +111,18 @@ export const LiveRoomQueuePanel = ({
   audienceParticipantIds,
   participantsById,
   participantProfilesById,
-  isHost,
+  coHostParticipantIds,
+  canModerate,
+  canManageCoHosts,
   stageLimit,
   moderationBusy,
   guardedModerationAction,
+  grantCoHost,
+  revokeCoHost,
   promoteSpeaker,
   removeSpeaker,
   kickParticipant,
 }: LiveRoomQueuePanelProps): ReactElement => {
-  const getProfile = (participantId: string): UserShortProfile =>
-    participantProfilesById.get(participantId) ??
-    buildParticipantProfile(participantId);
-
   const activeSpeakers = activeSpeakerParticipantIds
     .map((participantId) => participantsById[participantId])
     .filter(
@@ -157,58 +182,113 @@ export const LiveRoomQueuePanel = ({
               <ul className="flex flex-col gap-2">
                 {activeSpeakers.map((participant) => {
                   const id = participant.participantId;
-                  const profile = getProfile(id);
+                  const profile = participantProfilesById.get(id);
+                  const displayProfile = profile ?? buildParticipantProfile(id);
+                  const isCoHost = coHostParticipantIds.includes(id);
 
                   return (
                     <StageParticipantItem
                       key={id}
                       participantId={id}
                       profile={profile}
+                      badgeLabel={isCoHost ? 'Co-host' : undefined}
                       actions={
-                        isHost ? (
+                        canModerate || canManageCoHosts ? (
                           <div className="flex shrink-0 items-center gap-1">
-                            <Tooltip
-                              content={`Remove ${userDisplayName(
-                                profile,
-                              )} from stage`}
-                            >
-                              <Button
-                                type="button"
-                                size={ButtonSize.XSmall}
-                                variant={ButtonVariant.Tertiary}
-                                icon={<RemoveUserIcon />}
-                                loading={moderationBusy === `remove-${id}`}
-                                disabled={!!moderationBusy}
-                                aria-label={`Remove ${userDisplayName(
-                                  profile,
-                                )}`}
-                                onClick={() =>
-                                  guardedModerationAction(`remove-${id}`, () =>
-                                    removeSpeaker(id),
-                                  )
-                                }
-                              />
-                            </Tooltip>
-                            <Tooltip
-                              content={`Kick ${userDisplayName(
-                                profile,
-                              )} from room`}
-                            >
-                              <Button
-                                type="button"
-                                size={ButtonSize.XSmall}
-                                variant={ButtonVariant.Tertiary}
-                                icon={<BlockIcon />}
-                                loading={moderationBusy === `kick-${id}`}
-                                disabled={!!moderationBusy}
-                                aria-label={`Kick ${userDisplayName(profile)}`}
-                                onClick={() =>
-                                  guardedModerationAction(`kick-${id}`, () =>
-                                    kickParticipant(id),
-                                  )
-                                }
-                              />
-                            </Tooltip>
+                            {canModerate ? (
+                              <Tooltip
+                                content={`Remove ${userDisplayName(
+                                  displayProfile,
+                                )} from stage`}
+                              >
+                                <Button
+                                  type="button"
+                                  size={ButtonSize.XSmall}
+                                  variant={ButtonVariant.Tertiary}
+                                  icon={<RemoveUserIcon />}
+                                  loading={moderationBusy === `remove-${id}`}
+                                  disabled={!!moderationBusy}
+                                  aria-label={`Remove ${userDisplayName(
+                                    displayProfile,
+                                  )}`}
+                                  onClick={() =>
+                                    guardedModerationAction(
+                                      `remove-${id}`,
+                                      () => removeSpeaker(id),
+                                    )
+                                  }
+                                />
+                              </Tooltip>
+                            ) : null}
+                            {canManageCoHosts ? (
+                              <Tooltip
+                                content={`${
+                                  isCoHost
+                                    ? 'Revoke co-host from'
+                                    : 'Grant co-host to'
+                                } ${userDisplayName(displayProfile)}`}
+                              >
+                                <Button
+                                  type="button"
+                                  size={ButtonSize.XSmall}
+                                  variant={ButtonVariant.Tertiary}
+                                  icon={
+                                    isCoHost ? (
+                                      <ShieldCheckActionIcon />
+                                    ) : (
+                                      <ShieldActionIcon />
+                                    )
+                                  }
+                                  loading={
+                                    moderationBusy ===
+                                    `${
+                                      isCoHost ? 'revoke' : 'grant'
+                                    }-cohost-${id}`
+                                  }
+                                  disabled={!!moderationBusy}
+                                  aria-label={`${
+                                    isCoHost
+                                      ? 'Revoke co-host from'
+                                      : 'Grant co-host to'
+                                  } ${userDisplayName(displayProfile)}`}
+                                  onClick={() =>
+                                    guardedModerationAction(
+                                      `${
+                                        isCoHost ? 'revoke' : 'grant'
+                                      }-cohost-${id}`,
+                                      () =>
+                                        isCoHost
+                                          ? revokeCoHost(id)
+                                          : grantCoHost(id),
+                                    )
+                                  }
+                                />
+                              </Tooltip>
+                            ) : null}
+                            {canModerate ? (
+                              <Tooltip
+                                content={`Kick ${userDisplayName(
+                                  displayProfile,
+                                )} from room`}
+                              >
+                                <Button
+                                  type="button"
+                                  size={ButtonSize.XSmall}
+                                  variant={ButtonVariant.Tertiary}
+                                  icon={<BlockIcon />}
+                                  loading={moderationBusy === `kick-${id}`}
+                                  disabled={!!moderationBusy}
+                                  aria-label={`Kick ${userDisplayName(
+                                    displayProfile,
+                                  )}`}
+                                  onClick={() =>
+                                    guardedModerationAction(`kick-${id}`, () =>
+                                      kickParticipant(id),
+                                    )
+                                  }
+                                />
+                              </Tooltip>
+                            ) : null}
                           </div>
                         ) : null
                       }
@@ -257,20 +337,26 @@ export const LiveRoomQueuePanel = ({
                   return null;
                 }
 
-                const profile = getProfile(participantId);
+                const profile = participantProfilesById.get(participantId);
+                const displayProfile =
+                  profile ?? buildParticipantProfile(participantId);
+                const isCoHost = coHostParticipantIds.includes(participantId);
 
                 return (
                   <StageParticipantItem
                     key={participantId}
                     participantId={participantId}
                     profile={profile}
+                    badgeLabel={isCoHost ? 'Co-host' : undefined}
                     actions={
-                      isHost ? (
+                      canModerate || canManageCoHosts ? (
                         <div className="flex shrink-0 items-center gap-1">
-                          {!isAudienceTab && mode === 'moderated' ? (
+                          {canModerate &&
+                          !isAudienceTab &&
+                          mode === 'moderated' ? (
                             <Tooltip
                               content={`Promote ${userDisplayName(
-                                profile,
+                                displayProfile,
                               )} to speaker`}
                             >
                               <Button
@@ -283,7 +369,7 @@ export const LiveRoomQueuePanel = ({
                                 }
                                 disabled={!!moderationBusy}
                                 aria-label={`Promote ${userDisplayName(
-                                  profile,
+                                  displayProfile,
                                 )}`}
                                 onClick={() =>
                                   guardedModerationAction(
@@ -294,29 +380,78 @@ export const LiveRoomQueuePanel = ({
                               />
                             </Tooltip>
                           ) : null}
-                          <Tooltip
-                            content={`Kick ${userDisplayName(
-                              profile,
-                            )} from room`}
-                          >
-                            <Button
-                              type="button"
-                              size={ButtonSize.XSmall}
-                              variant={ButtonVariant.Tertiary}
-                              icon={<BlockIcon />}
-                              loading={
-                                moderationBusy === `kick-${participantId}`
-                              }
-                              disabled={!!moderationBusy}
-                              aria-label={`Kick ${userDisplayName(profile)}`}
-                              onClick={() =>
-                                guardedModerationAction(
-                                  `kick-${participantId}`,
-                                  () => kickParticipant(participantId),
-                                )
-                              }
-                            />
-                          </Tooltip>
+                          {canManageCoHosts ? (
+                            <Tooltip
+                              content={`${
+                                isCoHost
+                                  ? 'Revoke co-host from'
+                                  : 'Grant co-host to'
+                              } ${userDisplayName(displayProfile)}`}
+                            >
+                              <Button
+                                type="button"
+                                size={ButtonSize.XSmall}
+                                variant={ButtonVariant.Tertiary}
+                                icon={
+                                  isCoHost ? (
+                                    <ShieldCheckActionIcon />
+                                  ) : (
+                                    <ShieldActionIcon />
+                                  )
+                                }
+                                loading={
+                                  moderationBusy ===
+                                  `${
+                                    isCoHost ? 'revoke' : 'grant'
+                                  }-cohost-${participantId}`
+                                }
+                                disabled={!!moderationBusy}
+                                aria-label={`${
+                                  isCoHost
+                                    ? 'Revoke co-host from'
+                                    : 'Grant co-host to'
+                                } ${userDisplayName(displayProfile)}`}
+                                onClick={() =>
+                                  guardedModerationAction(
+                                    `${
+                                      isCoHost ? 'revoke' : 'grant'
+                                    }-cohost-${participantId}`,
+                                    () =>
+                                      isCoHost
+                                        ? revokeCoHost(participantId)
+                                        : grantCoHost(participantId),
+                                  )
+                                }
+                              />
+                            </Tooltip>
+                          ) : null}
+                          {canModerate ? (
+                            <Tooltip
+                              content={`Kick ${userDisplayName(
+                                displayProfile,
+                              )} from room`}
+                            >
+                              <Button
+                                type="button"
+                                size={ButtonSize.XSmall}
+                                variant={ButtonVariant.Tertiary}
+                                icon={<BlockIcon />}
+                                loading={
+                                  moderationBusy === `kick-${participantId}`
+                                }
+                                disabled={!!moderationBusy}
+                                aria-label={`Kick ${userDisplayName(
+                                  displayProfile,
+                                )}`}
+                                onClick={() =>
+                                  guardedModerationAction(
+                                    `kick-${participantId}`,
+                                    () => kickParticipant(participantId),
+                                  )
+                                }
+                              />
+                            </Tooltip>
+                          ) : null}
                         </div>
                       ) : null
                     }

--- a/packages/shared/src/components/liveRooms/LiveRoomTileActions.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomTileActions.tsx
@@ -7,6 +7,8 @@ import {
   BlockIcon,
   MedalBadgeIcon,
   RemoveUserIcon,
+  ShieldCheckIcon,
+  ShieldIcon,
   VIcon,
 } from '../icons';
 import { Tooltip } from '../tooltip/Tooltip';
@@ -25,8 +27,12 @@ import type { UserShortProfile } from '../../lib/user';
 interface LiveRoomTileActionsProps {
   user: UserShortProfile;
   className?: string;
+  onGrantCoHost?: () => void;
+  onRevokeCoHost?: () => void;
   onRemoveSpeaker?: () => void;
   onKick?: () => void;
+  isGrantingCoHost?: boolean;
+  isRevokingCoHost?: boolean;
   isRemoving?: boolean;
   isKicking?: boolean;
   moderationDisabled?: boolean;
@@ -35,8 +41,12 @@ interface LiveRoomTileActionsProps {
 export const LiveRoomTileActions = ({
   user,
   className,
+  onGrantCoHost,
+  onRevokeCoHost,
   onRemoveSpeaker,
   onKick,
+  isGrantingCoHost = false,
+  isRevokingCoHost = false,
   isRemoving = false,
   isKicking = false,
   moderationDisabled = false,
@@ -55,9 +65,15 @@ export const LiveRoomTileActions = ({
     followPreference?.status === ContentPreferenceStatus.Follow ||
     followPreference?.status === ContentPreferenceStatus.Subscribed;
 
+  const showGrantCoHost = !!onGrantCoHost;
+  const showRevokeCoHost = !!onRevokeCoHost;
   const showRemove = !!onRemoveSpeaker;
   const showKick = !!onKick;
-  const moderationCount = (showRemove ? 1 : 0) + (showKick ? 1 : 0);
+  const moderationCount =
+    (showGrantCoHost ? 1 : 0) +
+    (showRevokeCoHost ? 1 : 0) +
+    (showRemove ? 1 : 0) +
+    (showKick ? 1 : 0);
 
   if (isSelf && moderationCount === 0) {
     return null;
@@ -114,7 +130,7 @@ export const LiveRoomTileActions = ({
   return (
     <div
       className={classNames(
-        'pointer-events-auto flex max-w-0 items-center gap-1 overflow-hidden opacity-0 transition-[max-width,opacity,transform] duration-200 ease-out group-hover:max-w-[7rem] group-hover:opacity-100',
+        'pointer-events-auto flex max-w-0 items-center gap-1 overflow-hidden opacity-0 transition-[max-width,opacity,transform] duration-200 ease-out group-hover:max-w-[14rem] group-hover:opacity-100',
         '-translate-x-1 group-hover:translate-x-0',
         className,
       )}
@@ -144,6 +160,36 @@ export const LiveRoomTileActions = ({
             icon={<MedalBadgeIcon secondary />}
             aria-label={`Award ${user.name}`}
             onClick={handleAward}
+          />
+        </Tooltip>
+      ) : null}
+      {showGrantCoHost ? (
+        <Tooltip content={`Grant co-host to ${user.name}`}>
+          <Button
+            type="button"
+            size={ButtonSize.XSmall}
+            variant={ButtonVariant.Tertiary}
+            className="!text-white"
+            icon={<ShieldIcon />}
+            loading={isGrantingCoHost}
+            disabled={moderationDisabled || isGrantingCoHost}
+            aria-label={`Grant co-host to ${user.name}`}
+            onClick={onGrantCoHost}
+          />
+        </Tooltip>
+      ) : null}
+      {showRevokeCoHost ? (
+        <Tooltip content={`Revoke co-host from ${user.name}`}>
+          <Button
+            type="button"
+            size={ButtonSize.XSmall}
+            variant={ButtonVariant.Tertiary}
+            className="!text-white"
+            icon={<ShieldCheckIcon />}
+            loading={isRevokingCoHost}
+            disabled={moderationDisabled || isRevokingCoHost}
+            aria-label={`Revoke co-host from ${user.name}`}
+            onClick={onRevokeCoHost}
           />
         </Tooltip>
       ) : null}

--- a/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
@@ -25,10 +25,15 @@ interface LiveRoomVideoTileProps {
   // When true, only video is shown (audio not rendered to avoid feedback for own preview).
   selfView?: boolean;
   isHost?: boolean;
+  isCoHost?: boolean;
   isMuted?: boolean;
   className?: string;
+  onGrantCoHost?: () => void;
+  onRevokeCoHost?: () => void;
   onRemoveSpeaker?: () => void;
   onKick?: () => void;
+  isGrantingCoHost?: boolean;
+  isRevokingCoHost?: boolean;
   isRemoving?: boolean;
   isKicking?: boolean;
   moderationDisabled?: boolean;
@@ -51,10 +56,15 @@ export const LiveRoomVideoTile = ({
   user,
   selfView = false,
   isHost = false,
+  isCoHost = false,
   isMuted = false,
   className,
+  onGrantCoHost,
+  onRevokeCoHost,
   onRemoveSpeaker,
   onKick,
+  isGrantingCoHost = false,
+  isRevokingCoHost = false,
   isRemoving = false,
   isKicking = false,
   moderationDisabled = false,
@@ -208,6 +218,15 @@ export const LiveRoomVideoTile = ({
               Host
             </Typography>
           ) : null}
+          {isCoHost ? (
+            <Typography
+              type={TypographyType.Caption2}
+              bold
+              className="shrink-0 uppercase tracking-wide !text-accent-water-bolder"
+            >
+              Co-host
+            </Typography>
+          ) : null}
           {isMuted ? (
             <VolumeOffIcon
               size={IconSize.XSmall}
@@ -224,8 +243,12 @@ export const LiveRoomVideoTile = ({
           )}
           <LiveRoomTileActions
             user={user}
+            onGrantCoHost={onGrantCoHost}
+            onRevokeCoHost={onRevokeCoHost}
             onRemoveSpeaker={onRemoveSpeaker}
             onKick={onKick}
+            isGrantingCoHost={isGrantingCoHost}
+            isRevokingCoHost={isRevokingCoHost}
             isRemoving={isRemoving}
             isKicking={isKicking}
             moderationDisabled={moderationDisabled}

--- a/packages/shared/src/contexts/LiveRoomContext.tsx
+++ b/packages/shared/src/contexts/LiveRoomContext.tsx
@@ -29,6 +29,7 @@ import {
   LiveRoomConnection,
 } from '../lib/liveRoom/connection';
 import { buildStandupAnalyticsExtra } from '../lib/liveRoom/analytics';
+import { getLiveRoomPrivilegeState } from '../lib/liveRoom/privileges';
 import { LogEvent } from '../lib/log';
 import {
   clearStoredLiveRoomResumeSession,
@@ -130,6 +131,8 @@ export interface LiveRoomContextValue {
   sendReaction: (emoji: string) => Promise<void>;
   sendChatMessage: (body: string) => Promise<void>;
   deleteChatMessage: (messageId: string) => Promise<void>;
+  grantCoHost: (targetParticipantId: string) => Promise<void>;
+  revokeCoHost: (targetParticipantId: string) => Promise<void>;
   setParticipantChatEnabled: (
     targetParticipantId: string,
     canChat: boolean,
@@ -416,6 +419,11 @@ export const LiveRoomProvider = ({
   const mediaRebuildQueuedRef = useRef(false);
   const currentRole =
     (participantId && roomState?.participants[participantId]?.role) || role;
+  const privilegeState = getLiveRoomPrivilegeState(
+    roomState,
+    participantId,
+    currentRole,
+  );
   const canPublish = !!currentRole && PUBLISH_ROLES.includes(currentRole);
   const canChat =
     !!user &&
@@ -432,10 +440,8 @@ export const LiveRoomProvider = ({
           roomStatus: roomState?.status ?? null,
           roomMode: roomState?.mode ?? null,
           connectionStatus: status,
-          canPublish,
           participantId,
-          selectedMicId,
-          selectedCameraId,
+          isCoHost: privilegeState.isCoHost,
           hasLocalAudioTrack: !!localTracksRef.current.audio,
           hasLocalVideoTrack: !!localTracksRef.current.video,
           videoQuality: videoSettings.quality,
@@ -452,10 +458,8 @@ export const LiveRoomProvider = ({
       roomState?.status,
       roomState?.mode,
       status,
-      canPublish,
       participantId,
-      selectedMicId,
-      selectedCameraId,
+      privilegeState.isCoHost,
       videoSettings.quality,
       videoSettings.audioOnly,
       videoSettings.hideSelfView,
@@ -479,6 +483,22 @@ export const LiveRoomProvider = ({
     },
     [buildStandupExtra, logEvent],
   );
+  const logStandupErrorRef = useRef(logStandupError);
+  const sendTransportReadyRef = useRef(sendTransportReady);
+  const recvTransportReadyRef = useRef(recvTransportReady);
+
+  useEffect(() => {
+    logStandupErrorRef.current = logStandupError;
+  }, [logStandupError]);
+
+  useEffect(() => {
+    sendTransportReadyRef.current = sendTransportReady;
+  }, [sendTransportReady]);
+
+  useEffect(() => {
+    recvTransportReadyRef.current = recvTransportReady;
+  }, [recvTransportReady]);
+
   const sendConnectionCommand = useCallback(
     async <T,>(
       operation: string,
@@ -488,7 +508,7 @@ export const LiveRoomProvider = ({
       const connection = connectionRef.current;
       if (!connection) {
         const error = new Error('Not connected');
-        logStandupError('websocket command', error.message, {
+        logStandupErrorRef.current('websocket command', error.message, {
           source: 'command',
           operation,
           ...extra,
@@ -500,7 +520,7 @@ export const LiveRoomProvider = ({
         return await connection.send<T>(payload);
       } catch (error) {
         const message = getErrorMessage(error, `Failed to ${operation}`);
-        logStandupError('websocket command', message, {
+        logStandupErrorRef.current('websocket command', message, {
           source: 'command',
           operation,
           ...extra,
@@ -508,7 +528,7 @@ export const LiveRoomProvider = ({
         throw error instanceof Error ? error : new Error(message);
       }
     },
-    [logStandupError],
+    [],
   );
 
   const pushReaction = useCallback((event: ReactionSentEvent) => {
@@ -768,11 +788,11 @@ export const LiveRoomProvider = ({
     if (joinError) {
       setStatus('error');
       setErrorMessage(joinError.message);
-      logStandupError('join token fetch', joinError.message, {
+      logStandupErrorRef.current('join token fetch', joinError.message, {
         source: 'join_token',
       });
     }
-  }, [joinError, logStandupError]);
+  }, [joinError]);
 
   useEffect(() => {
     setStoredResumeSession(readStoredLiveRoomResumeSession(roomId));
@@ -816,13 +836,13 @@ export const LiveRoomProvider = ({
         return nextMics[0]?.deviceId ?? null;
       });
     } catch (error) {
-      logStandupError(
+      logStandupErrorRef.current(
         'device enumerate',
         getErrorMessage(error, 'Failed to enumerate devices'),
         { source: 'device_list' },
       );
     }
-  }, [logStandupError]);
+  }, []);
 
   // Enumerate devices on mount and when device list changes (plug/unplug).
   useEffect(() => {
@@ -886,7 +906,7 @@ export const LiveRoomProvider = ({
     if (!wsUrl) {
       setStatus('error');
       setErrorMessage('Standup websocket URL is not configured');
-      logStandupError(
+      logStandupErrorRef.current(
         'websocket config',
         'Standup websocket URL is not configured',
         { source: 'connection_config' },
@@ -954,7 +974,7 @@ export const LiveRoomProvider = ({
       }
       setStatus('error');
       setErrorMessage(error.message);
-      logStandupError('websocket error', error.message, {
+      logStandupErrorRef.current('websocket error', error.message, {
         source: 'connection',
       });
     });
@@ -975,7 +995,6 @@ export const LiveRoomProvider = ({
     };
   }, [
     joinToken,
-    logStandupError,
     pushChatMessage,
     pushReaction,
     removeChatMessage,
@@ -1041,6 +1060,13 @@ export const LiveRoomProvider = ({
     }
     const connection = connectionRef.current;
     if (!connection) {
+      return undefined;
+    }
+    if (
+      deviceRef.current ||
+      recvTransportRef.current ||
+      sendTransportRef.current
+    ) {
       return undefined;
     }
 
@@ -1143,11 +1169,11 @@ export const LiveRoomProvider = ({
       ) {
         return;
       }
-      logStandupError('media init', err.message, {
+      logStandupErrorRef.current('media init', err.message, {
         source: 'media_init',
         connectionGeneration,
-        recvTransportReady,
-        sendTransportReady,
+        recvTransportReady: recvTransportReadyRef.current,
+        sendTransportReady: sendTransportReadyRef.current,
       });
       setStatus('error');
       setErrorMessage(err.message);
@@ -1162,9 +1188,6 @@ export const LiveRoomProvider = ({
     canPublish,
     closeMediaSession,
     connectionGeneration,
-    logStandupError,
-    recvTransportReady,
-    sendTransportReady,
     status,
   ]);
 
@@ -1300,7 +1323,7 @@ export const LiveRoomProvider = ({
           closeConsumer?.();
           subscriptionsRef.current.delete(publication.publicationId);
           const message = getErrorMessage(err, 'Failed to subscribe to media');
-          logStandupError('media subscribe', message, {
+          logStandupErrorRef.current('media subscribe', message, {
             source: 'subscription_create',
             kind: publication.kind,
             publicationId: publication.publicationId,
@@ -1310,7 +1333,7 @@ export const LiveRoomProvider = ({
         }
       })();
     });
-  }, [logStandupError, roomState, participantId, recvTransportReady]);
+  }, [roomState, participantId, recvTransportReady]);
 
   useEffect(() => {
     const syncRemoteVideoSubscriptions = async () => {
@@ -1339,13 +1362,12 @@ export const LiveRoomProvider = ({
         err,
         'Failed to update remote video subscriptions',
       );
-      logStandupError('media settings sync', message, {
+      logStandupErrorRef.current('media settings sync', message, {
         source: 'remote_video_subscriptions',
       });
       setErrorMessage(message);
     });
   }, [
-    logStandupError,
     recvTransportReady,
     setRemoteSubscriptionPaused,
     setRemoteSubscriptionPreferredSpatialLayer,
@@ -1361,13 +1383,12 @@ export const LiveRoomProvider = ({
         err,
         'Failed to update remote video quality',
       );
-      logStandupError('media settings sync', message, {
+      logStandupErrorRef.current('media settings sync', message, {
         source: 'remote_video_quality',
       });
       setErrorMessage(message);
     });
   }, [
-    logStandupError,
     recvTransportReady,
     setRecvTransportOutgoingBitrateLimit,
     videoSettings.quality,
@@ -1412,14 +1433,14 @@ export const LiveRoomProvider = ({
         });
       } catch (err) {
         const message = getErrorMessage(err, `Failed to publish ${kind}`);
-        logStandupError(`media publish ${kind}`, message, {
+        logStandupErrorRef.current(`media publish ${kind}`, message, {
           source: 'publish_local_track',
           kind,
         });
         setErrorMessage(message);
       }
     },
-    [logStandupError, setPublishingFlag],
+    [setPublishingFlag],
   );
 
   const unpublishKind = useCallback(
@@ -1497,7 +1518,7 @@ export const LiveRoomProvider = ({
               err,
               `Failed to update ${kind} track`,
             );
-            logStandupError(`media replace ${kind}`, message, {
+            logStandupErrorRef.current(`media replace ${kind}`, message, {
               source: 'capture_replace',
               kind,
               requestedDeviceId: deviceId,
@@ -1537,7 +1558,7 @@ export const LiveRoomProvider = ({
         }
       } catch (error) {
         const message = getErrorMessage(error, `Failed to capture ${kind}`);
-        logStandupError(`media capture ${kind}`, message, {
+        logStandupErrorRef.current(`media capture ${kind}`, message, {
           source: 'capture',
           kind,
           requestedDeviceId: deviceId,
@@ -1551,7 +1572,6 @@ export const LiveRoomProvider = ({
       publishLocalTrack,
       unpublishKind,
       canPublish,
-      logStandupError,
       roomState?.status,
       micSettings,
       micSettingSupport,
@@ -1727,6 +1747,34 @@ export const LiveRoomProvider = ({
     [sendConnectionCommand],
   );
 
+  const grantCoHost = useCallback(
+    async (targetParticipantId: string) => {
+      await sendConnectionCommand(
+        'grant co-host',
+        {
+          type: 'room.cohost.grant',
+          targetParticipantId,
+        },
+        { targetParticipantId },
+      );
+    },
+    [sendConnectionCommand],
+  );
+
+  const revokeCoHost = useCallback(
+    async (targetParticipantId: string) => {
+      await sendConnectionCommand(
+        'revoke co-host',
+        {
+          type: 'room.cohost.revoke',
+          targetParticipantId,
+        },
+        { targetParticipantId },
+      );
+    },
+    [sendConnectionCommand],
+  );
+
   const promoteSpeaker = useCallback(
     async (targetParticipantId: string) => {
       await sendConnectionCommand(
@@ -1784,6 +1832,8 @@ export const LiveRoomProvider = ({
       sendReaction,
       sendChatMessage,
       deleteChatMessage,
+      grantCoHost,
+      revokeCoHost,
       setParticipantChatEnabled,
       promoteSpeaker,
       removeSpeaker,
@@ -1826,6 +1876,8 @@ export const LiveRoomProvider = ({
       sendReaction,
       sendChatMessage,
       deleteChatMessage,
+      grantCoHost,
+      revokeCoHost,
       setParticipantChatEnabled,
       promoteSpeaker,
       removeSpeaker,

--- a/packages/shared/src/lib/liveRoom/analytics.spec.ts
+++ b/packages/shared/src/lib/liveRoom/analytics.spec.ts
@@ -1,0 +1,66 @@
+import { buildStandupAnalyticsExtra } from './analytics';
+
+describe('buildStandupAnalyticsExtra', () => {
+  it('serializes the standup analytics context with caller extras', () => {
+    const extra = buildStandupAnalyticsExtra(
+      {
+        roomId: 'room-1',
+        authKind: 'authenticated',
+        role: 'speaker',
+        roomStatus: 'live',
+        roomMode: 'moderated',
+        connectionStatus: 'connected',
+        participantId: 'participant-1',
+        isCoHost: false,
+        hasLocalAudioTrack: true,
+        hasLocalVideoTrack: false,
+        videoQuality: 'high',
+        audioOnly: false,
+        hideSelfView: true,
+        isResuming: true,
+      },
+      {
+        source: 'test',
+      },
+    );
+
+    expect(JSON.parse(extra)).toEqual({
+      roomId: 'room-1',
+      authKind: 'authenticated',
+      role: 'speaker',
+      roomStatus: 'live',
+      roomMode: 'moderated',
+      connectionStatus: 'connected',
+      participantId: 'participant-1',
+      isCoHost: false,
+      hasLocalAudioTrack: true,
+      hasLocalVideoTrack: false,
+      videoQuality: 'high',
+      audioOnly: false,
+      hideSelfView: true,
+      isResuming: true,
+      source: 'test',
+    });
+  });
+
+  it('omits null and undefined context fields', () => {
+    const extra = buildStandupAnalyticsExtra({
+      roomId: 'room-1',
+      authKind: 'anonymous',
+      role: null,
+      roomStatus: null,
+      roomMode: undefined,
+      connectionStatus: 'connecting',
+      participantId: undefined,
+      isCoHost: undefined,
+      hasLocalAudioTrack: false,
+    });
+
+    expect(JSON.parse(extra)).toEqual({
+      roomId: 'room-1',
+      authKind: 'anonymous',
+      connectionStatus: 'connecting',
+      hasLocalAudioTrack: false,
+    });
+  });
+});

--- a/packages/shared/src/lib/liveRoom/analytics.ts
+++ b/packages/shared/src/lib/liveRoom/analytics.ts
@@ -5,10 +5,8 @@ export interface StandupAnalyticsContext {
   roomStatus?: string | null;
   roomMode?: string | null;
   connectionStatus?: string | null;
-  canPublish?: boolean;
   participantId?: string | null;
-  selectedMicId?: string | null;
-  selectedCameraId?: string | null;
+  isCoHost?: boolean;
   hasLocalAudioTrack?: boolean;
   hasLocalVideoTrack?: boolean;
   videoQuality?: string | null;
@@ -17,26 +15,35 @@ export interface StandupAnalyticsContext {
   isResuming?: boolean;
 }
 
+const compactStandupExtra = (
+  payload: Record<string, unknown>,
+): Record<string, unknown> =>
+  Object.fromEntries(
+    Object.entries(payload).filter(
+      ([, value]) => value !== null && value !== undefined,
+    ),
+  );
+
 export const buildStandupAnalyticsExtra = (
   context: StandupAnalyticsContext,
   extra: Record<string, unknown> = {},
 ): string =>
-  JSON.stringify({
-    roomId: context.roomId,
-    authKind: context.authKind,
-    role: context.role,
-    roomStatus: context.roomStatus,
-    roomMode: context.roomMode,
-    connectionStatus: context.connectionStatus,
-    canPublish: context.canPublish,
-    participantId: context.participantId,
-    selectedMicId: context.selectedMicId,
-    selectedCameraId: context.selectedCameraId,
-    hasLocalAudioTrack: context.hasLocalAudioTrack,
-    hasLocalVideoTrack: context.hasLocalVideoTrack,
-    videoQuality: context.videoQuality,
-    audioOnly: context.audioOnly,
-    hideSelfView: context.hideSelfView,
-    isResuming: context.isResuming,
-    ...extra,
-  });
+  JSON.stringify(
+    compactStandupExtra({
+      roomId: context.roomId,
+      authKind: context.authKind,
+      role: context.role,
+      roomStatus: context.roomStatus,
+      roomMode: context.roomMode,
+      connectionStatus: context.connectionStatus,
+      participantId: context.participantId,
+      isCoHost: context.isCoHost,
+      hasLocalAudioTrack: context.hasLocalAudioTrack,
+      hasLocalVideoTrack: context.hasLocalVideoTrack,
+      videoQuality: context.videoQuality,
+      audioOnly: context.audioOnly,
+      hideSelfView: context.hideSelfView,
+      isResuming: context.isResuming,
+      ...extra,
+    }),
+  );

--- a/packages/shared/src/lib/liveRoom/privileges.ts
+++ b/packages/shared/src/lib/liveRoom/privileges.ts
@@ -1,0 +1,28 @@
+import type { LiveRoomParticipantRoleValue, LiveRoomState } from './protocol';
+
+export interface LiveRoomPrivilegeState {
+  isHost: boolean;
+  isCoHost: boolean;
+  hasHostPrivileges: boolean;
+}
+
+export const isCoHostParticipant = (
+  roomState: Pick<LiveRoomState, 'coHostParticipantIds'> | null | undefined,
+  participantId: string | null | undefined,
+): boolean =>
+  !!participantId && !!roomState?.coHostParticipantIds?.includes(participantId);
+
+export const getLiveRoomPrivilegeState = (
+  roomState: Pick<LiveRoomState, 'coHostParticipantIds'> | null | undefined,
+  participantId: string | null | undefined,
+  role: LiveRoomParticipantRoleValue | null | undefined,
+): LiveRoomPrivilegeState => {
+  const isHost = role === 'host';
+  const isCoHost = isCoHostParticipant(roomState, participantId);
+
+  return {
+    isHost,
+    isCoHost,
+    hasHostPrivileges: isHost || isCoHost,
+  };
+};

--- a/packages/shared/src/lib/liveRoom/protocol.ts
+++ b/packages/shared/src/lib/liveRoom/protocol.ts
@@ -50,6 +50,7 @@ export interface LiveRoomState {
   status: LiveRoomStatusValue;
   version: number;
   participants: Record<string, LiveRoomParticipantRecord>;
+  coHostParticipantIds: string[];
   chatPermissions: Record<string, boolean>;
   sessions: Record<string, LiveRoomSessionRecord>;
   stage: LiveRoomStageState;
@@ -161,6 +162,8 @@ export type LiveRoomCommand =
   | { type: 'connection.ping' }
   | { type: 'room.start' }
   | { type: 'room.end' }
+  | { type: 'room.cohost.grant'; targetParticipantId: string }
+  | { type: 'room.cohost.revoke'; targetParticipantId: string }
   | { type: 'chat.message.send'; body: string }
   | { type: 'chat.message.delete'; messageId: string }
   | {

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -272,6 +272,8 @@ export enum LogEvent {
   SendStandupChatMessage = 'send standup chat message',
   DeleteStandupChatMessage = 'delete standup chat message',
   UpdateStandupChatAccess = 'update standup chat access',
+  GrantStandupCoHost = 'grant standup co-host',
+  RevokeStandupCoHost = 'revoke standup co-host',
   PromoteStandupSpeaker = 'promote standup speaker',
   RemoveStandupSpeaker = 'remove standup speaker',
   KickStandupParticipant = 'kick standup participant',


### PR DESCRIPTION
## What changed

- Added live room co-host privilege support across the shared protocol, context, controls, stage tiles, and queue/audience panel.
- Added co-host grant/revoke analytics events and included co-host state in standup analytics context.
- Cleaned up standup analytics payloads by omitting nullish fields and removing device identifiers from the shared extra payload.
- Hardened live-room error/media flows by avoiding repeated room-query error logs, stabilizing error logging callbacks, and preventing duplicate media transport initialization.

## Validation

- `NODE_ENV=test pnpm --filter @dailydotdev/shared test -- LiveRoom.spec.tsx LiveRoomControls.spec.tsx analytics.spec.ts`
- `node ./scripts/typecheck-strict-changed.js`
- `git diff --check`

Note: the focused test run passes but still prints an existing React `act(...)` warning from `LiveRoomControls` async busy-state cleanup.


### Preview domain
https://codex-live-room-cohost-analytics.preview.app.daily.dev