### PR TITLE
fix: add substack.com to known platform domains to prevent mastodon misdetection

### DIFF
--- a/packages/shared/src/lib/platforms.spec.ts
+++ b/packages/shared/src/lib/platforms.spec.ts
@@ -25,6 +25,15 @@ describe('detectPlatformFromUrl', () => {
     ).toBe('mastodon');
   });
 
+  it('should detect substack.com as substack, not mastodon', () => {
+    expect(
+      detectPlatformFromUrl('https://substack.com/@devnp2007', USER_PLATFORMS),
+    ).toBe('substack');
+    expect(
+      detectPlatformFromUrl('https://www.substack.com/@user', USER_PLATFORMS),
+    ).toBe('substack');
+  });
+
   it('should return null for unknown URLs', () => {
     expect(
       detectPlatformFromUrl('https://example.com/profile', USER_PLATFORMS),

--- a/packages/shared/src/lib/platforms.tsx
+++ b/packages/shared/src/lib/platforms.tsx
@@ -169,6 +169,13 @@ export const CORE_PLATFORMS = {
     icon: LinkIcon,
     urlBuilder: (u: string) => `https://medium.com/@${u}`,
   },
+  substack: {
+    id: 'substack',
+    label: 'Substack',
+    domains: ['substack.com'],
+    icon: LinkIcon,
+    urlBuilder: (u: string) => `https://substack.com/@${u}`,
+  },
 } satisfies Record<string, PlatformConfig>;
 
 /**


### PR DESCRIPTION
## Summary
- Added `substack` to `CORE_PLATFORMS` with domain `substack.com`, `LinkIcon`, and URL builder so Substack profile URLs (e.g. `https://substack.com/@devnp2007`) are correctly identified instead of triggering the Mastodon `/@` heuristic
- Added test confirming Substack URLs are detected as `substack`, not `mastodon`

## Test plan
- [x] `detectPlatformFromUrl('https://substack.com/@devnp2007', USER_PLATFORMS)` returns `'substack'`
- [x] `detectPlatformFromUrl('https://www.substack.com/@user', USER_PLATFORMS)` returns `'substack'`
- [x] All 5 platform detection tests pass

Closes ENG-1361

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1361-fix-substack-profile-li.preview.app.daily.dev