### PR TITLE
feat: add standup chat reaction controls

### DIFF
--- a/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
@@ -155,6 +155,8 @@ const createContextValue = (
   sendReaction: jest.fn(),
   sendChatMessage: jest.fn(),
   deleteChatMessage: jest.fn(),
+  sendChatMessageReaction: jest.fn(),
+  removeChatMessageReaction: jest.fn(),
   grantCoHost: jest.fn(),
   revokeCoHost: jest.fn(),
   setParticipantChatEnabled: jest.fn(),
@@ -485,6 +487,152 @@ describe('LiveRoom', () => {
     expect(screen.getByText('# heading')).toBeInTheDocument();
     expect(screen.getByText('hello')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument();
+  });
+
+  it('limits chat reaction shortcuts to the remaining slots when active reactions exist', async () => {
+    const sendChatMessageReaction = jest.fn().mockResolvedValue(undefined);
+    const removeChatMessageReaction = jest.fn().mockResolvedValue(undefined);
+    mockUseLiveRoomConnection.mockReturnValue(
+      createContextValue({
+        sendChatMessageReaction,
+        removeChatMessageReaction,
+        chatMessages: [
+          {
+            messageId: 'message-1',
+            participantId: 'speaker1',
+            body: 'hello',
+            createdAt: '2026-04-27T09:04:00.000Z',
+            reactions: [
+              {
+                messageId: 'message-1',
+                participantId: 'host',
+                key: '🔥',
+                createdAt: '2026-04-27T09:05:00.000Z',
+              },
+              {
+                messageId: 'message-1',
+                participantId: 'speaker2',
+                key: '🔥',
+                createdAt: '2026-04-27T09:05:01.000Z',
+              },
+              {
+                messageId: 'message-1',
+                participantId: 'speaker2',
+                key: '💡',
+                createdAt: '2026-04-27T09:05:02.000Z',
+              },
+              {
+                messageId: 'message-1',
+                participantId: 'speaker2',
+                key: '😂',
+                createdAt: '2026-04-27T09:05:03.000Z',
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    renderLiveRoom();
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Remove 🔥 reaction from message from @speaker1',
+      }),
+    ).toHaveTextContent('2');
+    expect(
+      screen.getAllByRole('button', {
+        name: /(?:React|Remove) .* (?:to|reaction from) message from @speaker1/,
+      }),
+    ).toHaveLength(5);
+    expect(
+      screen.getByRole('button', {
+        name: 'React 👏 to message from @speaker1',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'React 🤯 to message from @speaker1',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Custom reaction to message from @speaker1',
+      }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Remove 🔥 reaction from message from @speaker1',
+      }),
+    );
+
+    await waitFor(() =>
+      expect(removeChatMessageReaction).toHaveBeenCalledWith('message-1', '🔥'),
+    );
+    expect(sendChatMessageReaction).not.toHaveBeenCalledWith('message-1', '🔥');
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: 'remove standup chat reaction',
+        target_id: 'message-1',
+        extra: expect.stringContaining('"source":"active_chip"'),
+      }),
+    );
+  });
+
+  it('sends quick and custom chat reactions for messages without active reactions', async () => {
+    const sendChatMessageReaction = jest.fn().mockResolvedValue(undefined);
+    mockUseLiveRoomConnection.mockReturnValue(
+      createContextValue({
+        sendChatMessageReaction,
+        chatMessages: [
+          {
+            messageId: 'message-1',
+            participantId: 'speaker1',
+            body: 'hello',
+            createdAt: '2026-04-27T09:04:00.000Z',
+          },
+        ],
+      }),
+    );
+
+    renderLiveRoom();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'React 👏 to message from @speaker1',
+      }),
+    );
+
+    await waitFor(() =>
+      expect(sendChatMessageReaction).toHaveBeenCalledWith('message-1', '👏'),
+    );
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: 'send standup chat reaction',
+        target_id: 'message-1',
+        extra: expect.stringContaining('"source":"quick_shortcut"'),
+      }),
+    );
+
+    const customReactionButton = screen.getByRole('button', {
+      name: 'Custom reaction to message from @speaker1',
+    });
+    await waitFor(() => expect(customReactionButton).toBeEnabled());
+
+    fireEvent.click(customReactionButton);
+    fireEvent.click(screen.getByText('⭐'));
+
+    await waitFor(() =>
+      expect(sendChatMessageReaction).toHaveBeenCalledWith('message-1', '⭐'),
+    );
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: 'send standup chat reaction',
+        target_id: 'message-1',
+        extra: expect.stringContaining('"source":"custom_picker"'),
+      }),
+    );
   });
 
   it('shows host moderation controls for chat rows', async () => {

--- a/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
@@ -547,12 +547,12 @@ describe('LiveRoom', () => {
     ).toHaveLength(5);
     expect(
       screen.getByRole('button', {
-        name: 'React 👏 to message from @speaker1',
+        name: 'React 👀 to message from @speaker1',
       }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('button', {
-        name: 'React 🤯 to message from @speaker1',
+        name: 'React 🚀 to message from @speaker1',
       }),
     ).toBeInTheDocument();
     expect(
@@ -600,12 +600,12 @@ describe('LiveRoom', () => {
 
     fireEvent.click(
       screen.getByRole('button', {
-        name: 'React 👏 to message from @speaker1',
+        name: 'React 🔥 to message from @speaker1',
       }),
     );
 
     await waitFor(() =>
-      expect(sendChatMessageReaction).toHaveBeenCalledWith('message-1', '👏'),
+      expect(sendChatMessageReaction).toHaveBeenCalledWith('message-1', '🔥'),
     );
     expect(mockLogEvent).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/shared/src/components/liveRooms/LiveRoom.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.tsx
@@ -18,7 +18,10 @@ import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { Loader } from '../Loader';
 import { LiveRoomVideoTile } from './LiveRoomVideoTile';
 import { LiveRoomControls } from './LiveRoomControls';
-import { LiveRoomChatPanel } from './LiveRoomChatPanel';
+import {
+  LiveRoomChatPanel,
+  type ChatReactionAnalytics,
+} from './LiveRoomChatPanel';
 import { LiveRoomQueuePanel } from './LiveRoomQueuePanel';
 import {
   LiveRoomProvider,
@@ -28,6 +31,7 @@ import {
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useLogContext } from '../../contexts/LogContext';
 import { AuthTriggers } from '../../lib/auth';
+import { isDevelopment } from '../../lib/constants';
 import { buildStandupAnalyticsExtra } from '../../lib/liveRoom/analytics';
 import { getLiveRoomPrivilegeState } from '../../lib/liveRoom/privileges';
 import { LogEvent } from '../../lib/log';
@@ -157,6 +161,8 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     participantId,
     sendChatMessage,
     deleteChatMessage,
+    sendChatMessageReaction,
+    removeChatMessageReaction,
     grantCoHost,
     revokeCoHost,
     setParticipantChatEnabled,
@@ -184,6 +190,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
 
   const { onAskConfirmation } = useExitConfirmation({
     message: 'Leave the standup? You will disconnect from the stream.',
+    enabled: !isDevelopment,
     onValidateAction: () => status !== 'connected',
   });
 
@@ -292,6 +299,44 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     } catch (error) {
       displayToast(
         error instanceof Error ? error.message : 'Could not delete message',
+      );
+    }
+  };
+
+  const handleSendChatMessageReaction = async (
+    messageId: string,
+    key: string,
+    analytics: ChatReactionAnalytics,
+  ): Promise<void> => {
+    try {
+      await sendChatMessageReaction(messageId, key);
+      logStandupAction(LogEvent.SendStandupChatReaction, messageId, {
+        surface: 'chat',
+        reaction: key,
+        ...analytics,
+      });
+    } catch (error) {
+      displayToast(
+        error instanceof Error ? error.message : 'Could not react to message',
+      );
+    }
+  };
+
+  const handleRemoveChatMessageReaction = async (
+    messageId: string,
+    key: string,
+    analytics: ChatReactionAnalytics,
+  ): Promise<void> => {
+    try {
+      await removeChatMessageReaction(messageId, key);
+      logStandupAction(LogEvent.RemoveStandupChatReaction, messageId, {
+        surface: 'chat',
+        reaction: key,
+        ...analytics,
+      });
+    } catch (error) {
+      displayToast(
+        error instanceof Error ? error.message : 'Could not remove reaction',
       );
     }
   };
@@ -892,6 +937,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
                 participantProfilesById={participantProfilesById}
                 mentionSuggestions={mentionSuggestions}
                 participantChatPermissions={roomState?.chatPermissions ?? {}}
+                currentParticipantId={participantId}
                 hostParticipantId={room.host.id}
                 coHostParticipantIds={coHostParticipantIds}
                 canChat={canChat}
@@ -901,6 +947,8 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
                 hasHostPrivileges={hasHostPrivileges}
                 onSendMessage={handleSendChatMessage}
                 onDeleteMessage={handleDeleteChatMessage}
+                onSendMessageReaction={handleSendChatMessageReaction}
+                onRemoveMessageReaction={handleRemoveChatMessageReaction}
                 onKickParticipant={handleKickChatParticipant}
                 onSetParticipantChatEnabled={handleSetParticipantChatEnabled}
                 onRequestLogin={handleChatLogin}

--- a/packages/shared/src/components/liveRooms/LiveRoom.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.tsx
@@ -18,10 +18,8 @@ import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { Loader } from '../Loader';
 import { LiveRoomVideoTile } from './LiveRoomVideoTile';
 import { LiveRoomControls } from './LiveRoomControls';
-import {
-  LiveRoomChatPanel,
-  type ChatReactionAnalytics,
-} from './LiveRoomChatPanel';
+import { LiveRoomChatPanel } from './LiveRoomChatPanel';
+import type { ChatReactionAnalytics } from './LiveRoomChatReactions';
 import { LiveRoomQueuePanel } from './LiveRoomQueuePanel';
 import {
   LiveRoomProvider,

--- a/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
 import {
   DropdownMenu,
@@ -76,6 +76,129 @@ const getChatReactionGroups = (
   });
 
   return [...groups.values()];
+};
+
+const reactionPopKeyframes: Keyframe[] = [
+  { transform: 'scale(1)' },
+  { transform: 'scale(1.18)' },
+  { transform: 'scale(1)' },
+];
+
+const reactionPopOptions: KeyframeAnimationOptions = {
+  duration: 260,
+  easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
+};
+
+const FIRST_REACTION_PARTICLE_COUNT = 6;
+const FIRST_REACTION_BURST_DURATION_MS = 720;
+const FIRST_REACTION_PARTICLE_MAX_DELAY_MS = 90;
+const FIRST_REACTION_BURST_CLEAR_DELAY_MS =
+  FIRST_REACTION_BURST_DURATION_MS + FIRST_REACTION_PARTICLE_MAX_DELAY_MS;
+
+interface FirstReactionBurstProps {
+  emoji: string;
+  signal: number;
+}
+
+const FirstReactionBurst = ({
+  emoji,
+  signal,
+}: FirstReactionBurstProps): ReactElement | null => {
+  const particles = useMemo(() => {
+    if (!signal) {
+      return [];
+    }
+
+    const arcSpan = Math.PI * 0.9;
+    const baseAngle = -Math.PI / 2 - arcSpan / 2;
+    const step = arcSpan / Math.max(1, FIRST_REACTION_PARTICLE_COUNT - 1);
+
+    return Array.from({ length: FIRST_REACTION_PARTICLE_COUNT }, (_, index) => {
+      const angle = baseAngle + step * index + (Math.random() - 0.5) * 0.25;
+      const distance = 26 + Math.random() * 18;
+      return {
+        tx: Math.round(Math.cos(angle) * distance),
+        ty: Math.round(Math.sin(angle) * distance),
+        delay: Math.round(Math.random() * FIRST_REACTION_PARTICLE_MAX_DELAY_MS),
+      };
+    });
+  }, [signal]);
+
+  if (!signal) {
+    return null;
+  }
+
+  return (
+    <span
+      key={signal}
+      aria-hidden
+      className="z-10 pointer-events-none absolute left-2 top-0 block size-0"
+    >
+      {particles.map((particle, index) => (
+        <span
+          // eslint-disable-next-line react/no-array-index-key
+          key={index}
+          className="absolute left-0 top-0 block animate-reaction-burst text-sm leading-none opacity-0"
+          style={
+            {
+              '--burst-tx': `${particle.tx}px`,
+              '--burst-ty': `${particle.ty}px`,
+              animationDelay: `${particle.delay}ms`,
+            } as React.CSSProperties
+          }
+        >
+          {emoji}
+        </span>
+      ))}
+    </span>
+  );
+};
+
+interface ChatReactionChipProps {
+  emoji: string;
+  count: number;
+  ariaLabel: string;
+  disabled: boolean;
+  isSending: boolean;
+  pulseSignal: number;
+  onClick: () => void;
+}
+
+const ChatReactionChip = ({
+  emoji,
+  count,
+  ariaLabel,
+  disabled,
+  isSending,
+  pulseSignal,
+  onClick,
+}: ChatReactionChipProps): ReactElement => {
+  const ref = useRef<HTMLButtonElement>(null);
+  const lastPulseRef = useRef(pulseSignal);
+
+  useEffect(() => {
+    if (pulseSignal === lastPulseRef.current) {
+      return;
+    }
+
+    lastPulseRef.current = pulseSignal;
+    ref.current?.animate?.(reactionPopKeyframes, reactionPopOptions);
+  }, [pulseSignal]);
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      className="flex h-6 items-center gap-1 rounded-8 border border-border-subtlest-tertiary bg-surface-float px-1.5 text-xs leading-none text-text-secondary hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50"
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      <span>{emoji}</span>
+      <span>{count}</span>
+      {isSending ? <span className="sr-only">Sending</span> : null}
+    </button>
+  );
 };
 
 interface LiveRoomChatComposerProps {
@@ -253,6 +376,117 @@ export const LiveRoomChatPanel = ({
   const [moderationBusy, setModerationBusy] = useState<string | null>(null);
   const [reactionBusy, setReactionBusy] = useState<string | null>(null);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const [reactionPulseSignals, setReactionPulseSignals] = useState<
+    Map<string, number>
+  >(() => new Map());
+  const [firstReactionBursts, setFirstReactionBursts] = useState<
+    Map<string, { emoji: string; signal: number }>
+  >(() => new Map());
+  const previousReactionCountsRef = useRef<Map<string, number>>(new Map());
+  const previousMessagesWithReactionsRef = useRef<Set<string>>(new Set());
+  const hasInitializedReactionsRef = useRef(false);
+  const firstReactionBurstTimeoutsRef = useRef<
+    Map<string, ReturnType<typeof setTimeout>>
+  >(new Map());
+
+  useEffect(() => {
+    const firstReactionBurstTimeouts = firstReactionBurstTimeoutsRef.current;
+
+    return () => {
+      firstReactionBurstTimeouts.forEach(clearTimeout);
+      firstReactionBurstTimeouts.clear();
+    };
+  }, []);
+
+  useEffect(() => {
+    const nextCounts = new Map<string, number>();
+    const messagesWithReactions = new Set<string>();
+    const firstReactionEmojiByMessage = new Map<string, string>();
+
+    chatMessages.forEach((message) => {
+      message.reactions?.forEach((reaction) => {
+        const key = `${message.messageId}-${reaction.key}`;
+        nextCounts.set(key, (nextCounts.get(key) ?? 0) + 1);
+        messagesWithReactions.add(message.messageId);
+        if (!firstReactionEmojiByMessage.has(message.messageId)) {
+          firstReactionEmojiByMessage.set(message.messageId, reaction.key);
+        }
+      });
+    });
+
+    if (hasInitializedReactionsRef.current) {
+      const newlyIncreased: string[] = [];
+      nextCounts.forEach((count, key) => {
+        const previousCount = previousReactionCountsRef.current.get(key) ?? 0;
+        if (count > previousCount) {
+          newlyIncreased.push(key);
+        }
+      });
+
+      if (newlyIncreased.length > 0) {
+        setReactionPulseSignals((current) => {
+          const next = new Map(current);
+          newlyIncreased.forEach((key) => {
+            next.set(key, (next.get(key) ?? 0) + 1);
+          });
+          return next;
+        });
+      }
+
+      const newlyReactedMessageIds: { messageId: string; emoji: string }[] = [];
+      messagesWithReactions.forEach((messageId) => {
+        if (previousMessagesWithReactionsRef.current.has(messageId)) {
+          return;
+        }
+        const emoji = firstReactionEmojiByMessage.get(messageId);
+        if (!emoji) {
+          return;
+        }
+        newlyReactedMessageIds.push({ messageId, emoji });
+      });
+
+      if (newlyReactedMessageIds.length > 0) {
+        setFirstReactionBursts((current) => {
+          const next = new Map(current);
+          newlyReactedMessageIds.forEach(({ messageId, emoji }) => {
+            const previous = next.get(messageId);
+            next.set(messageId, {
+              emoji,
+              signal: (previous?.signal ?? 0) + 1,
+            });
+          });
+          return next;
+        });
+
+        newlyReactedMessageIds.forEach(({ messageId }) => {
+          const currentTimeout =
+            firstReactionBurstTimeoutsRef.current.get(messageId);
+          if (currentTimeout) {
+            clearTimeout(currentTimeout);
+          }
+
+          const timeout = setTimeout(() => {
+            setFirstReactionBursts((activeBursts) => {
+              const activeBurst = activeBursts.get(messageId);
+              if (!activeBurst) {
+                return activeBursts;
+              }
+
+              const remainingBursts = new Map(activeBursts);
+              remainingBursts.delete(messageId);
+              return remainingBursts;
+            });
+            firstReactionBurstTimeoutsRef.current.delete(messageId);
+          }, FIRST_REACTION_BURST_CLEAR_DELAY_MS);
+          firstReactionBurstTimeoutsRef.current.set(messageId, timeout);
+        });
+      }
+    }
+
+    previousReactionCountsRef.current = nextCounts;
+    previousMessagesWithReactionsRef.current = messagesWithReactions;
+    hasInitializedReactionsRef.current = true;
+  }, [chatMessages]);
 
   useEffect(() => {
     const scrollContainer = scrollRef.current;
@@ -369,6 +603,9 @@ export const LiveRoomChatPanel = ({
               activeReactionCount: reactionGroups.length,
               quickReactionCount: quickReactionKeys.length,
             };
+            const firstReactionBurst = firstReactionBursts.get(
+              message.messageId,
+            );
 
             return (
               <article
@@ -399,21 +636,27 @@ export const LiveRoomChatPanel = ({
                   {showReactionRow ? (
                     <div
                       className={classNames(
-                        'mt-1 flex flex-wrap items-center gap-1 transition-opacity',
+                        'relative mt-1 flex flex-wrap items-center gap-1 transition-opacity',
                         reactionGroups.length === 0
                           ? 'opacity-100 tablet:opacity-0 tablet:group-focus-within:opacity-100 tablet:group-hover:opacity-100'
                           : 'opacity-100',
                       )}
                     >
+                      {firstReactionBurst ? (
+                        <FirstReactionBurst
+                          emoji={firstReactionBurst.emoji}
+                          signal={firstReactionBurst.signal}
+                        />
+                      ) : null}
                       {reactionGroups.map((reaction) => {
-                        const busyKey = `${message.messageId}-${reaction.key}`;
+                        const reactionKey = `${message.messageId}-${reaction.key}`;
 
                         return (
-                          <button
+                          <ChatReactionChip
                             key={reaction.key}
-                            type="button"
-                            className="flex h-6 items-center gap-1 rounded-8 border border-border-subtlest-tertiary bg-surface-float px-1.5 text-xs leading-none text-text-secondary hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50"
-                            aria-label={`${
+                            emoji={reaction.key}
+                            count={reaction.count}
+                            ariaLabel={`${
                               reaction.isReactedByCurrentParticipant
                                 ? 'Remove'
                                 : 'React'
@@ -423,6 +666,10 @@ export const LiveRoomChatPanel = ({
                                 : 'to'
                             } message from ${senderName}`}
                             disabled={!canChat || !!reactionBusy}
+                            isSending={reactionBusy === reactionKey}
+                            pulseSignal={
+                              reactionPulseSignals.get(reactionKey) ?? 0
+                            }
                             onClick={() =>
                               runReactionAction(
                                 message.messageId,
@@ -434,13 +681,7 @@ export const LiveRoomChatPanel = ({
                                 reaction.isReactedByCurrentParticipant,
                               )
                             }
-                          >
-                            <span>{reaction.key}</span>
-                            <span>{reaction.count}</span>
-                            {reactionBusy === busyKey ? (
-                              <span className="sr-only">Sending</span>
-                            ) : null}
-                          </button>
+                          />
                         );
                       })}
                       {showQuickReactions || canChat ? (

--- a/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuTrigger,
 } from '../dropdown/DropdownMenu';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { EmojiPicker } from '../fields/EmojiPicker';
 import { ProfilePicture, ProfileImageSize } from '../ProfilePicture';
 import Markdown from '../Markdown';
 import RichTextInput, { type RichTextInputRef } from '../fields/RichTextInput';
@@ -21,17 +22,61 @@ import {
   DiscussIcon,
   LockIcon,
   MenuIcon,
+  PlusIcon,
   TrashIcon,
 } from '../icons';
 import { IconSize } from '../Icon';
 import type { LiveRoomChatEntry } from '../../contexts/LiveRoomContext';
 import { MarkdownCommand } from '../../hooks/input/useMarkdownInput';
 import { chatMarkdownToHtml } from '../../lib/liveRoom/chatMarkdown';
+import { LIVE_ROOM_QUICK_REACTION_EMOJIS } from '../../lib/liveRoom/reactions';
 import type { UserShortProfile } from '../../lib/user';
 import {
   buildParticipantProfile,
   userDisplayName,
 } from './liveRoomParticipants';
+
+export type ChatReactionSource =
+  | 'active_chip'
+  | 'quick_shortcut'
+  | 'custom_picker';
+
+export interface ChatReactionAnalytics {
+  source: ChatReactionSource;
+  activeReactionCount: number;
+  quickReactionCount: number;
+}
+
+interface ChatReactionGroup {
+  key: string;
+  count: number;
+  isReactedByCurrentParticipant: boolean;
+}
+
+const getChatReactionGroups = (
+  message: LiveRoomChatEntry,
+  currentParticipantId: string | null,
+): ChatReactionGroup[] => {
+  const groups = new Map<string, ChatReactionGroup>();
+
+  message.reactions?.forEach((reaction) => {
+    const group = groups.get(reaction.key) ?? {
+      key: reaction.key,
+      count: 0,
+      isReactedByCurrentParticipant: false,
+    };
+
+    groups.set(reaction.key, {
+      ...group,
+      count: group.count + 1,
+      isReactedByCurrentParticipant:
+        group.isReactedByCurrentParticipant ||
+        reaction.participantId === currentParticipantId,
+    });
+  });
+
+  return [...groups.values()];
+};
 
 interface LiveRoomChatComposerProps {
   canChat: boolean;
@@ -154,6 +199,7 @@ interface LiveRoomChatPanelProps {
   participantProfilesById: Map<string, UserShortProfile>;
   mentionSuggestions: UserShortProfile[];
   participantChatPermissions: Record<string, boolean>;
+  currentParticipantId: string | null;
   hostParticipantId: string;
   coHostParticipantIds: string[];
   canChat: boolean;
@@ -163,6 +209,16 @@ interface LiveRoomChatPanelProps {
   hasHostPrivileges: boolean;
   onSendMessage: (body: string) => Promise<void>;
   onDeleteMessage: (messageId: string) => Promise<void>;
+  onSendMessageReaction: (
+    messageId: string,
+    key: string,
+    analytics: ChatReactionAnalytics,
+  ) => Promise<void>;
+  onRemoveMessageReaction: (
+    messageId: string,
+    key: string,
+    analytics: ChatReactionAnalytics,
+  ) => Promise<void>;
   onKickParticipant: (participantId: string) => Promise<void>;
   onSetParticipantChatEnabled: (
     targetParticipantId: string,
@@ -176,6 +232,7 @@ export const LiveRoomChatPanel = ({
   participantProfilesById,
   mentionSuggestions,
   participantChatPermissions,
+  currentParticipantId,
   hostParticipantId,
   coHostParticipantIds,
   canChat,
@@ -185,6 +242,8 @@ export const LiveRoomChatPanel = ({
   hasHostPrivileges,
   onSendMessage,
   onDeleteMessage,
+  onSendMessageReaction,
+  onRemoveMessageReaction,
   onKickParticipant,
   onSetParticipantChatEnabled,
   onRequestLogin,
@@ -192,6 +251,7 @@ export const LiveRoomChatPanel = ({
   const scrollRef = useRef<HTMLDivElement>(null);
   const shouldAutoScrollRef = useRef(true);
   const [moderationBusy, setModerationBusy] = useState<string | null>(null);
+  const [reactionBusy, setReactionBusy] = useState<string | null>(null);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -233,6 +293,26 @@ export const LiveRoomChatPanel = ({
       });
   };
 
+  const runReactionAction = (
+    messageId: string,
+    reactionKey: string,
+    analytics: ChatReactionAnalytics,
+    shouldRemove = false,
+  ): void => {
+    const key = `${messageId}-${reactionKey}`;
+    if (reactionBusy || !canChat) {
+      return;
+    }
+
+    setReactionBusy(key);
+    const action = shouldRemove
+      ? onRemoveMessageReaction
+      : onSendMessageReaction;
+    action(messageId, reactionKey, analytics)
+      .catch(() => undefined)
+      .finally(() => setReactionBusy(null));
+  };
+
   return (
     <div className="flex h-full flex-col">
       <div
@@ -271,6 +351,24 @@ export const LiveRoomChatPanel = ({
               hasHostPrivileges &&
               message.participantId !== hostParticipantId &&
               message.participantId !== '';
+            const reactionGroups = getChatReactionGroups(
+              message,
+              currentParticipantId,
+            );
+            const reactionKeys = new Set(
+              reactionGroups.map((reaction) => reaction.key),
+            );
+            const quickReactionKeys = LIVE_ROOM_QUICK_REACTION_EMOJIS.filter(
+              (reactionKey) => !reactionKeys.has(reactionKey),
+            ).slice(0, Math.max(0, 5 - reactionGroups.length));
+            const showQuickReactions = canChat && quickReactionKeys.length > 0;
+            const showReactionRow =
+              canChat || showQuickReactions || reactionGroups.length > 0;
+            const senderName = userDisplayName(sender);
+            const baseReactionAnalytics = {
+              activeReactionCount: reactionGroups.length,
+              quickReactionCount: quickReactionKeys.length,
+            };
 
             return (
               <article
@@ -280,9 +378,7 @@ export const LiveRoomChatPanel = ({
                 <ProfilePicture user={sender} size={ProfileImageSize.Small} />
                 <div className="min-w-0 flex-1">
                   <div className="min-w-0 text-[0.9375rem] leading-[1.5]">
-                    <span className="mr-2 inline font-bold">
-                      {userDisplayName(sender)}
-                    </span>
+                    <span className="mr-2 inline font-bold">{senderName}</span>
                     {isSenderHost ? (
                       <span className="mr-2 inline rounded-6 bg-surface-float px-1.5 py-0.5 text-[0.6875rem] font-bold uppercase tracking-wide text-accent-bun-default">
                         Host
@@ -300,6 +396,131 @@ export const LiveRoomChatPanel = ({
                       })}
                     />
                   </div>
+                  {showReactionRow ? (
+                    <div
+                      className={classNames(
+                        'mt-1 flex flex-wrap items-center gap-1 transition-opacity',
+                        reactionGroups.length === 0
+                          ? 'opacity-100 tablet:opacity-0 tablet:group-focus-within:opacity-100 tablet:group-hover:opacity-100'
+                          : 'opacity-100',
+                      )}
+                    >
+                      {reactionGroups.map((reaction) => {
+                        const busyKey = `${message.messageId}-${reaction.key}`;
+
+                        return (
+                          <button
+                            key={reaction.key}
+                            type="button"
+                            className="flex h-6 items-center gap-1 rounded-8 border border-border-subtlest-tertiary bg-surface-float px-1.5 text-xs leading-none text-text-secondary hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50"
+                            aria-label={`${
+                              reaction.isReactedByCurrentParticipant
+                                ? 'Remove'
+                                : 'React'
+                            } ${reaction.key} ${
+                              reaction.isReactedByCurrentParticipant
+                                ? 'reaction from'
+                                : 'to'
+                            } message from ${senderName}`}
+                            disabled={!canChat || !!reactionBusy}
+                            onClick={() =>
+                              runReactionAction(
+                                message.messageId,
+                                reaction.key,
+                                {
+                                  ...baseReactionAnalytics,
+                                  source: 'active_chip',
+                                },
+                                reaction.isReactedByCurrentParticipant,
+                              )
+                            }
+                          >
+                            <span>{reaction.key}</span>
+                            <span>{reaction.count}</span>
+                            {reactionBusy === busyKey ? (
+                              <span className="sr-only">Sending</span>
+                            ) : null}
+                          </button>
+                        );
+                      })}
+                      {showQuickReactions || canChat ? (
+                        <div
+                          className={classNames(
+                            'flex flex-wrap items-center gap-1 transition-opacity',
+                            reactionGroups.length > 0 &&
+                              'opacity-100 tablet:opacity-0 tablet:group-focus-within:opacity-100 tablet:group-hover:opacity-100',
+                          )}
+                        >
+                          {showQuickReactions
+                            ? quickReactionKeys.map((reactionKey) => {
+                                const busyKey = `${message.messageId}-${reactionKey}`;
+
+                                return (
+                                  <button
+                                    key={reactionKey}
+                                    type="button"
+                                    className="flex size-6 items-center justify-center rounded-8 border border-border-subtlest-tertiary bg-surface-float text-sm leading-none text-text-secondary hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50"
+                                    aria-label={`React ${reactionKey} to message from ${senderName}`}
+                                    disabled={!!reactionBusy}
+                                    onClick={() =>
+                                      runReactionAction(
+                                        message.messageId,
+                                        reactionKey,
+                                        {
+                                          ...baseReactionAnalytics,
+                                          source: 'quick_shortcut',
+                                        },
+                                      )
+                                    }
+                                  >
+                                    <span>{reactionKey}</span>
+                                    {reactionBusy === busyKey ? (
+                                      <span className="sr-only">Sending</span>
+                                    ) : null}
+                                  </button>
+                                );
+                              })
+                            : null}
+                          <EmojiPicker
+                            value=""
+                            label={null}
+                            className="shrink-0"
+                            onChange={(reactionKey) => {
+                              if (!reactionKey) {
+                                return;
+                              }
+
+                              runReactionAction(
+                                message.messageId,
+                                reactionKey,
+                                {
+                                  ...baseReactionAnalytics,
+                                  source: 'custom_picker',
+                                },
+                              );
+                            }}
+                            renderTrigger={({ isOpen, toggleOpen }) => (
+                              <Button
+                                type="button"
+                                size={ButtonSize.XSmall}
+                                variant={
+                                  isOpen
+                                    ? ButtonVariant.Primary
+                                    : ButtonVariant.Float
+                                }
+                                className="!size-6 shrink-0"
+                                icon={<PlusIcon size={IconSize.Size16} />}
+                                aria-label={`Custom reaction to message from ${senderName}`}
+                                aria-expanded={isOpen}
+                                disabled={!!reactionBusy}
+                                onClick={toggleOpen}
+                              />
+                            )}
+                          />
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
                 </div>
                 {hasHostPrivileges ? (
                   <div

--- a/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import {
   DropdownMenu,
@@ -8,7 +8,6 @@ import {
   DropdownMenuTrigger,
 } from '../dropdown/DropdownMenu';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
-import { EmojiPicker } from '../fields/EmojiPicker';
 import { ProfilePicture, ProfileImageSize } from '../ProfilePicture';
 import Markdown from '../Markdown';
 import RichTextInput, { type RichTextInputRef } from '../fields/RichTextInput';
@@ -22,184 +21,21 @@ import {
   DiscussIcon,
   LockIcon,
   MenuIcon,
-  PlusIcon,
   TrashIcon,
 } from '../icons';
 import { IconSize } from '../Icon';
 import type { LiveRoomChatEntry } from '../../contexts/LiveRoomContext';
 import { MarkdownCommand } from '../../hooks/input/useMarkdownInput';
 import { chatMarkdownToHtml } from '../../lib/liveRoom/chatMarkdown';
-import { LIVE_ROOM_QUICK_REACTION_EMOJIS } from '../../lib/liveRoom/reactions';
 import type { UserShortProfile } from '../../lib/user';
 import {
   buildParticipantProfile,
   userDisplayName,
 } from './liveRoomParticipants';
-
-export type ChatReactionSource =
-  | 'active_chip'
-  | 'quick_shortcut'
-  | 'custom_picker';
-
-export interface ChatReactionAnalytics {
-  source: ChatReactionSource;
-  activeReactionCount: number;
-  quickReactionCount: number;
-}
-
-interface ChatReactionGroup {
-  key: string;
-  count: number;
-  isReactedByCurrentParticipant: boolean;
-}
-
-const getChatReactionGroups = (
-  message: LiveRoomChatEntry,
-  currentParticipantId: string | null,
-): ChatReactionGroup[] => {
-  const groups = new Map<string, ChatReactionGroup>();
-
-  message.reactions?.forEach((reaction) => {
-    const group = groups.get(reaction.key) ?? {
-      key: reaction.key,
-      count: 0,
-      isReactedByCurrentParticipant: false,
-    };
-
-    groups.set(reaction.key, {
-      ...group,
-      count: group.count + 1,
-      isReactedByCurrentParticipant:
-        group.isReactedByCurrentParticipant ||
-        reaction.participantId === currentParticipantId,
-    });
-  });
-
-  return [...groups.values()];
-};
-
-const reactionPopKeyframes: Keyframe[] = [
-  { transform: 'scale(1)' },
-  { transform: 'scale(1.18)' },
-  { transform: 'scale(1)' },
-];
-
-const reactionPopOptions: KeyframeAnimationOptions = {
-  duration: 260,
-  easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
-};
-
-const FIRST_REACTION_PARTICLE_COUNT = 6;
-const FIRST_REACTION_BURST_DURATION_MS = 720;
-const FIRST_REACTION_PARTICLE_MAX_DELAY_MS = 90;
-const FIRST_REACTION_BURST_CLEAR_DELAY_MS =
-  FIRST_REACTION_BURST_DURATION_MS + FIRST_REACTION_PARTICLE_MAX_DELAY_MS;
-
-interface FirstReactionBurstProps {
-  emoji: string;
-  signal: number;
-}
-
-const FirstReactionBurst = ({
-  emoji,
-  signal,
-}: FirstReactionBurstProps): ReactElement | null => {
-  const particles = useMemo(() => {
-    if (!signal) {
-      return [];
-    }
-
-    const arcSpan = Math.PI * 0.9;
-    const baseAngle = -Math.PI / 2 - arcSpan / 2;
-    const step = arcSpan / Math.max(1, FIRST_REACTION_PARTICLE_COUNT - 1);
-
-    return Array.from({ length: FIRST_REACTION_PARTICLE_COUNT }, (_, index) => {
-      const angle = baseAngle + step * index + (Math.random() - 0.5) * 0.25;
-      const distance = 26 + Math.random() * 18;
-      return {
-        tx: Math.round(Math.cos(angle) * distance),
-        ty: Math.round(Math.sin(angle) * distance),
-        delay: Math.round(Math.random() * FIRST_REACTION_PARTICLE_MAX_DELAY_MS),
-      };
-    });
-  }, [signal]);
-
-  if (!signal) {
-    return null;
-  }
-
-  return (
-    <span
-      key={signal}
-      aria-hidden
-      className="z-10 pointer-events-none absolute left-2 top-0 block size-0"
-    >
-      {particles.map((particle, index) => (
-        <span
-          // eslint-disable-next-line react/no-array-index-key
-          key={index}
-          className="absolute left-0 top-0 block animate-reaction-burst text-sm leading-none opacity-0"
-          style={
-            {
-              '--burst-tx': `${particle.tx}px`,
-              '--burst-ty': `${particle.ty}px`,
-              animationDelay: `${particle.delay}ms`,
-            } as React.CSSProperties
-          }
-        >
-          {emoji}
-        </span>
-      ))}
-    </span>
-  );
-};
-
-interface ChatReactionChipProps {
-  emoji: string;
-  count: number;
-  ariaLabel: string;
-  disabled: boolean;
-  isSending: boolean;
-  pulseSignal: number;
-  onClick: () => void;
-}
-
-const ChatReactionChip = ({
-  emoji,
-  count,
-  ariaLabel,
-  disabled,
-  isSending,
-  pulseSignal,
-  onClick,
-}: ChatReactionChipProps): ReactElement => {
-  const ref = useRef<HTMLButtonElement>(null);
-  const lastPulseRef = useRef(pulseSignal);
-
-  useEffect(() => {
-    if (pulseSignal === lastPulseRef.current) {
-      return;
-    }
-
-    lastPulseRef.current = pulseSignal;
-    ref.current?.animate?.(reactionPopKeyframes, reactionPopOptions);
-  }, [pulseSignal]);
-
-  return (
-    <button
-      ref={ref}
-      type="button"
-      className="flex h-6 items-center gap-1 rounded-8 border border-border-subtlest-tertiary bg-surface-float px-1.5 text-xs leading-none text-text-secondary hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50"
-      aria-label={ariaLabel}
-      disabled={disabled}
-      onClick={onClick}
-    >
-      <span>{emoji}</span>
-      <span>{count}</span>
-      {isSending ? <span className="sr-only">Sending</span> : null}
-    </button>
-  );
-};
+import {
+  LiveRoomChatReactions,
+  type ChatReactionAnalytics,
+} from './LiveRoomChatReactions';
 
 interface LiveRoomChatComposerProps {
   canChat: boolean;
@@ -376,117 +212,6 @@ export const LiveRoomChatPanel = ({
   const [moderationBusy, setModerationBusy] = useState<string | null>(null);
   const [reactionBusy, setReactionBusy] = useState<string | null>(null);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
-  const [reactionPulseSignals, setReactionPulseSignals] = useState<
-    Map<string, number>
-  >(() => new Map());
-  const [firstReactionBursts, setFirstReactionBursts] = useState<
-    Map<string, { emoji: string; signal: number }>
-  >(() => new Map());
-  const previousReactionCountsRef = useRef<Map<string, number>>(new Map());
-  const previousMessagesWithReactionsRef = useRef<Set<string>>(new Set());
-  const hasInitializedReactionsRef = useRef(false);
-  const firstReactionBurstTimeoutsRef = useRef<
-    Map<string, ReturnType<typeof setTimeout>>
-  >(new Map());
-
-  useEffect(() => {
-    const firstReactionBurstTimeouts = firstReactionBurstTimeoutsRef.current;
-
-    return () => {
-      firstReactionBurstTimeouts.forEach(clearTimeout);
-      firstReactionBurstTimeouts.clear();
-    };
-  }, []);
-
-  useEffect(() => {
-    const nextCounts = new Map<string, number>();
-    const messagesWithReactions = new Set<string>();
-    const firstReactionEmojiByMessage = new Map<string, string>();
-
-    chatMessages.forEach((message) => {
-      message.reactions?.forEach((reaction) => {
-        const key = `${message.messageId}-${reaction.key}`;
-        nextCounts.set(key, (nextCounts.get(key) ?? 0) + 1);
-        messagesWithReactions.add(message.messageId);
-        if (!firstReactionEmojiByMessage.has(message.messageId)) {
-          firstReactionEmojiByMessage.set(message.messageId, reaction.key);
-        }
-      });
-    });
-
-    if (hasInitializedReactionsRef.current) {
-      const newlyIncreased: string[] = [];
-      nextCounts.forEach((count, key) => {
-        const previousCount = previousReactionCountsRef.current.get(key) ?? 0;
-        if (count > previousCount) {
-          newlyIncreased.push(key);
-        }
-      });
-
-      if (newlyIncreased.length > 0) {
-        setReactionPulseSignals((current) => {
-          const next = new Map(current);
-          newlyIncreased.forEach((key) => {
-            next.set(key, (next.get(key) ?? 0) + 1);
-          });
-          return next;
-        });
-      }
-
-      const newlyReactedMessageIds: { messageId: string; emoji: string }[] = [];
-      messagesWithReactions.forEach((messageId) => {
-        if (previousMessagesWithReactionsRef.current.has(messageId)) {
-          return;
-        }
-        const emoji = firstReactionEmojiByMessage.get(messageId);
-        if (!emoji) {
-          return;
-        }
-        newlyReactedMessageIds.push({ messageId, emoji });
-      });
-
-      if (newlyReactedMessageIds.length > 0) {
-        setFirstReactionBursts((current) => {
-          const next = new Map(current);
-          newlyReactedMessageIds.forEach(({ messageId, emoji }) => {
-            const previous = next.get(messageId);
-            next.set(messageId, {
-              emoji,
-              signal: (previous?.signal ?? 0) + 1,
-            });
-          });
-          return next;
-        });
-
-        newlyReactedMessageIds.forEach(({ messageId }) => {
-          const currentTimeout =
-            firstReactionBurstTimeoutsRef.current.get(messageId);
-          if (currentTimeout) {
-            clearTimeout(currentTimeout);
-          }
-
-          const timeout = setTimeout(() => {
-            setFirstReactionBursts((activeBursts) => {
-              const activeBurst = activeBursts.get(messageId);
-              if (!activeBurst) {
-                return activeBursts;
-              }
-
-              const remainingBursts = new Map(activeBursts);
-              remainingBursts.delete(messageId);
-              return remainingBursts;
-            });
-            firstReactionBurstTimeoutsRef.current.delete(messageId);
-          }, FIRST_REACTION_BURST_CLEAR_DELAY_MS);
-          firstReactionBurstTimeoutsRef.current.set(messageId, timeout);
-        });
-      }
-    }
-
-    previousReactionCountsRef.current = nextCounts;
-    previousMessagesWithReactionsRef.current = messagesWithReactions;
-    hasInitializedReactionsRef.current = true;
-  }, [chatMessages]);
 
   useEffect(() => {
     const scrollContainer = scrollRef.current;
@@ -585,27 +310,7 @@ export const LiveRoomChatPanel = ({
               hasHostPrivileges &&
               message.participantId !== hostParticipantId &&
               message.participantId !== '';
-            const reactionGroups = getChatReactionGroups(
-              message,
-              currentParticipantId,
-            );
-            const reactionKeys = new Set(
-              reactionGroups.map((reaction) => reaction.key),
-            );
-            const quickReactionKeys = LIVE_ROOM_QUICK_REACTION_EMOJIS.filter(
-              (reactionKey) => !reactionKeys.has(reactionKey),
-            ).slice(0, Math.max(0, 5 - reactionGroups.length));
-            const showQuickReactions = canChat && quickReactionKeys.length > 0;
-            const showReactionRow =
-              canChat || showQuickReactions || reactionGroups.length > 0;
             const senderName = userDisplayName(sender);
-            const baseReactionAnalytics = {
-              activeReactionCount: reactionGroups.length,
-              quickReactionCount: quickReactionKeys.length,
-            };
-            const firstReactionBurst = firstReactionBursts.get(
-              message.messageId,
-            );
 
             return (
               <article
@@ -633,135 +338,14 @@ export const LiveRoomChatPanel = ({
                       })}
                     />
                   </div>
-                  {showReactionRow ? (
-                    <div
-                      className={classNames(
-                        'relative mt-1 flex flex-wrap items-center gap-1 transition-opacity',
-                        reactionGroups.length === 0
-                          ? 'opacity-100 tablet:opacity-0 tablet:group-focus-within:opacity-100 tablet:group-hover:opacity-100'
-                          : 'opacity-100',
-                      )}
-                    >
-                      {firstReactionBurst ? (
-                        <FirstReactionBurst
-                          emoji={firstReactionBurst.emoji}
-                          signal={firstReactionBurst.signal}
-                        />
-                      ) : null}
-                      {reactionGroups.map((reaction) => {
-                        const reactionKey = `${message.messageId}-${reaction.key}`;
-
-                        return (
-                          <ChatReactionChip
-                            key={reaction.key}
-                            emoji={reaction.key}
-                            count={reaction.count}
-                            ariaLabel={`${
-                              reaction.isReactedByCurrentParticipant
-                                ? 'Remove'
-                                : 'React'
-                            } ${reaction.key} ${
-                              reaction.isReactedByCurrentParticipant
-                                ? 'reaction from'
-                                : 'to'
-                            } message from ${senderName}`}
-                            disabled={!canChat || !!reactionBusy}
-                            isSending={reactionBusy === reactionKey}
-                            pulseSignal={
-                              reactionPulseSignals.get(reactionKey) ?? 0
-                            }
-                            onClick={() =>
-                              runReactionAction(
-                                message.messageId,
-                                reaction.key,
-                                {
-                                  ...baseReactionAnalytics,
-                                  source: 'active_chip',
-                                },
-                                reaction.isReactedByCurrentParticipant,
-                              )
-                            }
-                          />
-                        );
-                      })}
-                      {showQuickReactions || canChat ? (
-                        <div
-                          className={classNames(
-                            'flex flex-wrap items-center gap-1 transition-opacity',
-                            reactionGroups.length > 0 &&
-                              'opacity-100 tablet:opacity-0 tablet:group-focus-within:opacity-100 tablet:group-hover:opacity-100',
-                          )}
-                        >
-                          {showQuickReactions
-                            ? quickReactionKeys.map((reactionKey) => {
-                                const busyKey = `${message.messageId}-${reactionKey}`;
-
-                                return (
-                                  <button
-                                    key={reactionKey}
-                                    type="button"
-                                    className="flex size-6 items-center justify-center rounded-8 border border-border-subtlest-tertiary bg-surface-float text-sm leading-none text-text-secondary hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50"
-                                    aria-label={`React ${reactionKey} to message from ${senderName}`}
-                                    disabled={!!reactionBusy}
-                                    onClick={() =>
-                                      runReactionAction(
-                                        message.messageId,
-                                        reactionKey,
-                                        {
-                                          ...baseReactionAnalytics,
-                                          source: 'quick_shortcut',
-                                        },
-                                      )
-                                    }
-                                  >
-                                    <span>{reactionKey}</span>
-                                    {reactionBusy === busyKey ? (
-                                      <span className="sr-only">Sending</span>
-                                    ) : null}
-                                  </button>
-                                );
-                              })
-                            : null}
-                          <EmojiPicker
-                            value=""
-                            label={null}
-                            className="shrink-0"
-                            onChange={(reactionKey) => {
-                              if (!reactionKey) {
-                                return;
-                              }
-
-                              runReactionAction(
-                                message.messageId,
-                                reactionKey,
-                                {
-                                  ...baseReactionAnalytics,
-                                  source: 'custom_picker',
-                                },
-                              );
-                            }}
-                            renderTrigger={({ isOpen, toggleOpen }) => (
-                              <Button
-                                type="button"
-                                size={ButtonSize.XSmall}
-                                variant={
-                                  isOpen
-                                    ? ButtonVariant.Primary
-                                    : ButtonVariant.Float
-                                }
-                                className="!size-6 shrink-0"
-                                icon={<PlusIcon size={IconSize.Size16} />}
-                                aria-label={`Custom reaction to message from ${senderName}`}
-                                aria-expanded={isOpen}
-                                disabled={!!reactionBusy}
-                                onClick={toggleOpen}
-                              />
-                            )}
-                          />
-                        </div>
-                      ) : null}
-                    </div>
-                  ) : null}
+                  <LiveRoomChatReactions
+                    message={message}
+                    currentParticipantId={currentParticipantId}
+                    canChat={canChat}
+                    senderName={senderName}
+                    reactionBusy={reactionBusy}
+                    onReactionAction={runReactionAction}
+                  />
                 </div>
                 {hasHostPrivileges ? (
                   <div

--- a/packages/shared/src/components/liveRooms/LiveRoomChatReactions.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatReactions.tsx
@@ -1,0 +1,437 @@
+import type { ReactElement } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import classNames from 'classnames';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { EmojiPicker } from '../fields/EmojiPicker';
+import { IconSize } from '../Icon';
+import { PlusIcon } from '../icons';
+import type { LiveRoomChatEntry } from '../../contexts/LiveRoomContext';
+import { LIVE_ROOM_QUICK_REACTION_EMOJIS } from '../../lib/liveRoom/reactions';
+
+export type ChatReactionSource =
+  | 'active_chip'
+  | 'quick_shortcut'
+  | 'custom_picker';
+
+export interface ChatReactionAnalytics {
+  source: ChatReactionSource;
+  activeReactionCount: number;
+  quickReactionCount: number;
+}
+
+interface ChatReactionGroup {
+  key: string;
+  count: number;
+  isReactedByCurrentParticipant: boolean;
+}
+
+interface FirstReactionBurstState {
+  emoji: string;
+  signal: number;
+}
+
+interface ChatReactionAnimationState {
+  firstReactionBurst: FirstReactionBurstState | null;
+  getPulseSignal: (reactionKey: string) => number;
+}
+
+const reactionPopKeyframes: Keyframe[] = [
+  { transform: 'scale(1)' },
+  { transform: 'scale(1.18)' },
+  { transform: 'scale(1)' },
+];
+
+const reactionPopOptions: KeyframeAnimationOptions = {
+  duration: 260,
+  easing: 'cubic-bezier(0.34, 1.56, 0.64, 1)',
+};
+
+const FIRST_REACTION_PARTICLE_COUNT = 6;
+const FIRST_REACTION_BURST_DURATION_MS = 720;
+const FIRST_REACTION_PARTICLE_MAX_DELAY_MS = 90;
+const FIRST_REACTION_BURST_CLEAR_DELAY_MS =
+  FIRST_REACTION_BURST_DURATION_MS + FIRST_REACTION_PARTICLE_MAX_DELAY_MS;
+const MAX_REACTION_SLOTS = 5;
+
+const getChatReactionGroups = (
+  message: LiveRoomChatEntry,
+  currentParticipantId: string | null,
+): ChatReactionGroup[] => {
+  const groups = new Map<string, ChatReactionGroup>();
+
+  message.reactions?.forEach((reaction) => {
+    const group = groups.get(reaction.key) ?? {
+      key: reaction.key,
+      count: 0,
+      isReactedByCurrentParticipant: false,
+    };
+
+    groups.set(reaction.key, {
+      ...group,
+      count: group.count + 1,
+      isReactedByCurrentParticipant:
+        group.isReactedByCurrentParticipant ||
+        reaction.participantId === currentParticipantId,
+    });
+  });
+
+  return [...groups.values()];
+};
+
+const getReactionCounts = (
+  message: LiveRoomChatEntry,
+): {
+  counts: Map<string, number>;
+  firstReactionEmoji: string | null;
+  hasReactions: boolean;
+} => {
+  const counts = new Map<string, number>();
+  let firstReactionEmoji: string | null = null;
+
+  message.reactions?.forEach((reaction) => {
+    counts.set(reaction.key, (counts.get(reaction.key) ?? 0) + 1);
+    firstReactionEmoji ??= reaction.key;
+  });
+
+  return {
+    counts,
+    firstReactionEmoji,
+    hasReactions: counts.size > 0,
+  };
+};
+
+const useChatReactionAnimations = (
+  message: LiveRoomChatEntry,
+): ChatReactionAnimationState => {
+  const [reactionPulseSignals, setReactionPulseSignals] = useState<
+    Map<string, number>
+  >(() => new Map());
+  const [firstReactionBurst, setFirstReactionBurst] =
+    useState<FirstReactionBurstState | null>(null);
+  const previousReactionCountsRef = useRef<Map<string, number>>(new Map());
+  const previousHadReactionsRef = useRef(false);
+  const hasInitializedReactionsRef = useRef(false);
+  const firstReactionBurstTimeoutRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (firstReactionBurstTimeoutRef.current) {
+        clearTimeout(firstReactionBurstTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const { counts, firstReactionEmoji, hasReactions } =
+      getReactionCounts(message);
+
+    if (hasInitializedReactionsRef.current) {
+      const newlyIncreased: string[] = [];
+      counts.forEach((count, key) => {
+        const previousCount = previousReactionCountsRef.current.get(key) ?? 0;
+        if (count > previousCount) {
+          newlyIncreased.push(key);
+        }
+      });
+
+      if (newlyIncreased.length > 0) {
+        setReactionPulseSignals((current) => {
+          const next = new Map(current);
+          newlyIncreased.forEach((key) => {
+            next.set(key, (next.get(key) ?? 0) + 1);
+          });
+          return next;
+        });
+      }
+
+      if (
+        hasReactions &&
+        !previousHadReactionsRef.current &&
+        firstReactionEmoji
+      ) {
+        setFirstReactionBurst((current) => ({
+          emoji: firstReactionEmoji,
+          signal: (current?.signal ?? 0) + 1,
+        }));
+
+        if (firstReactionBurstTimeoutRef.current) {
+          clearTimeout(firstReactionBurstTimeoutRef.current);
+        }
+
+        firstReactionBurstTimeoutRef.current = setTimeout(() => {
+          setFirstReactionBurst(null);
+          firstReactionBurstTimeoutRef.current = null;
+        }, FIRST_REACTION_BURST_CLEAR_DELAY_MS);
+      }
+    }
+
+    previousReactionCountsRef.current = counts;
+    previousHadReactionsRef.current = hasReactions;
+    hasInitializedReactionsRef.current = true;
+  }, [message]);
+
+  return {
+    firstReactionBurst,
+    getPulseSignal: (reactionKey) => reactionPulseSignals.get(reactionKey) ?? 0,
+  };
+};
+
+interface FirstReactionBurstProps {
+  emoji: string;
+  signal: number;
+}
+
+const FirstReactionBurst = ({
+  emoji,
+  signal,
+}: FirstReactionBurstProps): ReactElement | null => {
+  const particles = useMemo(() => {
+    if (!signal) {
+      return [];
+    }
+
+    const arcSpan = Math.PI * 0.9;
+    const baseAngle = -Math.PI / 2 - arcSpan / 2;
+    const step = arcSpan / Math.max(1, FIRST_REACTION_PARTICLE_COUNT - 1);
+
+    return Array.from({ length: FIRST_REACTION_PARTICLE_COUNT }, (_, index) => {
+      const angle = baseAngle + step * index + (Math.random() - 0.5) * 0.25;
+      const distance = 26 + Math.random() * 18;
+      return {
+        tx: Math.round(Math.cos(angle) * distance),
+        ty: Math.round(Math.sin(angle) * distance),
+        delay: Math.round(Math.random() * FIRST_REACTION_PARTICLE_MAX_DELAY_MS),
+      };
+    });
+  }, [signal]);
+
+  if (!signal) {
+    return null;
+  }
+
+  return (
+    <span
+      key={signal}
+      aria-hidden
+      className="z-10 pointer-events-none absolute left-2 top-0 block size-0"
+    >
+      {particles.map((particle, index) => (
+        <span
+          // eslint-disable-next-line react/no-array-index-key
+          key={index}
+          className="absolute left-0 top-0 block animate-reaction-burst text-sm leading-none opacity-0"
+          style={
+            {
+              '--burst-tx': `${particle.tx}px`,
+              '--burst-ty': `${particle.ty}px`,
+              animationDelay: `${particle.delay}ms`,
+            } as React.CSSProperties
+          }
+        >
+          {emoji}
+        </span>
+      ))}
+    </span>
+  );
+};
+
+interface ChatReactionChipProps {
+  emoji: string;
+  count: number;
+  ariaLabel: string;
+  disabled: boolean;
+  isSending: boolean;
+  pulseSignal: number;
+  onClick: () => void;
+}
+
+const ChatReactionChip = ({
+  emoji,
+  count,
+  ariaLabel,
+  disabled,
+  isSending,
+  pulseSignal,
+  onClick,
+}: ChatReactionChipProps): ReactElement => {
+  const ref = useRef<HTMLButtonElement>(null);
+  const lastPulseRef = useRef(pulseSignal);
+
+  useEffect(() => {
+    if (pulseSignal === lastPulseRef.current) {
+      return;
+    }
+
+    lastPulseRef.current = pulseSignal;
+    ref.current?.animate?.(reactionPopKeyframes, reactionPopOptions);
+  }, [pulseSignal]);
+
+  return (
+    <button
+      ref={ref}
+      type="button"
+      className="flex h-6 items-center gap-1 rounded-8 border border-border-subtlest-tertiary bg-surface-float px-1.5 text-xs leading-none text-text-secondary hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50"
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      <span>{emoji}</span>
+      <span>{count}</span>
+      {isSending ? <span className="sr-only">Sending</span> : null}
+    </button>
+  );
+};
+
+interface LiveRoomChatReactionsProps {
+  message: LiveRoomChatEntry;
+  currentParticipantId: string | null;
+  canChat: boolean;
+  senderName: string;
+  reactionBusy: string | null;
+  onReactionAction: (
+    messageId: string,
+    reactionKey: string,
+    analytics: ChatReactionAnalytics,
+    shouldRemove?: boolean,
+  ) => void;
+}
+
+export const LiveRoomChatReactions = ({
+  message,
+  currentParticipantId,
+  canChat,
+  senderName,
+  reactionBusy,
+  onReactionAction,
+}: LiveRoomChatReactionsProps): ReactElement | null => {
+  const { firstReactionBurst, getPulseSignal } =
+    useChatReactionAnimations(message);
+  const reactionGroups = getChatReactionGroups(message, currentParticipantId);
+  const reactionKeys = new Set(reactionGroups.map((reaction) => reaction.key));
+  const quickReactionKeys = LIVE_ROOM_QUICK_REACTION_EMOJIS.filter(
+    (reactionKey) => !reactionKeys.has(reactionKey),
+  ).slice(0, Math.max(0, MAX_REACTION_SLOTS - reactionGroups.length));
+  const showQuickReactions = canChat && quickReactionKeys.length > 0;
+  const baseReactionAnalytics = {
+    activeReactionCount: reactionGroups.length,
+    quickReactionCount: quickReactionKeys.length,
+  };
+
+  if (!canChat && reactionGroups.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={classNames(
+        'relative mt-1 flex flex-wrap items-center gap-1 transition-opacity',
+        reactionGroups.length === 0
+          ? 'opacity-100 tablet:opacity-0 tablet:group-focus-within:opacity-100 tablet:group-hover:opacity-100'
+          : 'opacity-100',
+      )}
+    >
+      {firstReactionBurst ? (
+        <FirstReactionBurst
+          emoji={firstReactionBurst.emoji}
+          signal={firstReactionBurst.signal}
+        />
+      ) : null}
+      {reactionGroups.map((reaction) => {
+        const reactionKey = `${message.messageId}-${reaction.key}`;
+
+        return (
+          <ChatReactionChip
+            key={reaction.key}
+            emoji={reaction.key}
+            count={reaction.count}
+            ariaLabel={`${
+              reaction.isReactedByCurrentParticipant ? 'Remove' : 'React'
+            } ${reaction.key} ${
+              reaction.isReactedByCurrentParticipant ? 'reaction from' : 'to'
+            } message from ${senderName}`}
+            disabled={!canChat || !!reactionBusy}
+            isSending={reactionBusy === reactionKey}
+            pulseSignal={getPulseSignal(reaction.key)}
+            onClick={() =>
+              onReactionAction(
+                message.messageId,
+                reaction.key,
+                {
+                  ...baseReactionAnalytics,
+                  source: 'active_chip',
+                },
+                reaction.isReactedByCurrentParticipant,
+              )
+            }
+          />
+        );
+      })}
+      {showQuickReactions || canChat ? (
+        <div
+          className={classNames(
+            'flex flex-wrap items-center gap-1 transition-opacity',
+            reactionGroups.length > 0 &&
+              'opacity-100 tablet:opacity-0 tablet:group-focus-within:opacity-100 tablet:group-hover:opacity-100',
+          )}
+        >
+          {showQuickReactions
+            ? quickReactionKeys.map((reactionKey) => {
+                const busyKey = `${message.messageId}-${reactionKey}`;
+
+                return (
+                  <button
+                    key={reactionKey}
+                    type="button"
+                    className="flex size-6 items-center justify-center rounded-8 border border-border-subtlest-tertiary bg-surface-float text-sm leading-none text-text-secondary hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label={`React ${reactionKey} to message from ${senderName}`}
+                    disabled={!!reactionBusy}
+                    onClick={() =>
+                      onReactionAction(message.messageId, reactionKey, {
+                        ...baseReactionAnalytics,
+                        source: 'quick_shortcut',
+                      })
+                    }
+                  >
+                    <span>{reactionKey}</span>
+                    {reactionBusy === busyKey ? (
+                      <span className="sr-only">Sending</span>
+                    ) : null}
+                  </button>
+                );
+              })
+            : null}
+          <EmojiPicker
+            value=""
+            label={null}
+            className="shrink-0"
+            onChange={(reactionKey) => {
+              if (!reactionKey) {
+                return;
+              }
+
+              onReactionAction(message.messageId, reactionKey, {
+                ...baseReactionAnalytics,
+                source: 'custom_picker',
+              });
+            }}
+            renderTrigger={({ isOpen, toggleOpen }) => (
+              <Button
+                type="button"
+                size={ButtonSize.XSmall}
+                variant={isOpen ? ButtonVariant.Primary : ButtonVariant.Float}
+                className="!size-6 shrink-0"
+                icon={<PlusIcon size={IconSize.Size16} />}
+                aria-label={`Custom reaction to message from ${senderName}`}
+                aria-expanded={isOpen}
+                disabled={!!reactionBusy}
+                onClick={toggleOpen}
+              />
+            )}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/shared/src/components/liveRooms/LiveRoomChatReactions.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatReactions.tsx
@@ -314,6 +314,7 @@ export const LiveRoomChatReactions = ({
     (reactionKey) => !reactionKeys.has(reactionKey),
   ).slice(0, Math.max(0, MAX_REACTION_SLOTS - reactionGroups.length));
   const showQuickReactions = canChat && quickReactionKeys.length > 0;
+  const hasActiveReactions = reactionGroups.length > 0;
   const baseReactionAnalytics = {
     activeReactionCount: reactionGroups.length,
     quickReactionCount: quickReactionKeys.length,
@@ -327,7 +328,7 @@ export const LiveRoomChatReactions = ({
     <div
       className={classNames(
         'relative mt-1 flex flex-wrap items-center gap-1 transition-opacity',
-        reactionGroups.length === 0
+        !hasActiveReactions
           ? 'opacity-100 tablet:opacity-0 tablet:group-focus-within:opacity-100 tablet:group-hover:opacity-100'
           : 'opacity-100',
       )}
@@ -370,9 +371,10 @@ export const LiveRoomChatReactions = ({
       })}
       {showQuickReactions || canChat ? (
         <div
+          key={hasActiveReactions ? 'active-reactions' : 'empty-reactions'}
           className={classNames(
             'flex flex-wrap items-center gap-1 transition-opacity',
-            reactionGroups.length > 0 &&
+            hasActiveReactions &&
               'opacity-100 tablet:opacity-0 tablet:group-focus-within:opacity-100 tablet:group-hover:opacity-100',
           )}
         >

--- a/packages/shared/src/components/liveRooms/LiveRoomControls.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControls.spec.tsx
@@ -154,6 +154,8 @@ const createContextValue = (
   sendReaction: jest.fn(),
   sendChatMessage: jest.fn(),
   deleteChatMessage: jest.fn(),
+  sendChatMessageReaction: jest.fn(),
+  removeChatMessageReaction: jest.fn(),
   grantCoHost: jest.fn(),
   revokeCoHost: jest.fn(),
   setParticipantChatEnabled: jest.fn(),

--- a/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
@@ -23,6 +23,7 @@ import { useAuthContext } from '../../contexts/AuthContext';
 import { AuthTriggers } from '../../lib/auth';
 import { buildStandupAnalyticsExtra } from '../../lib/liveRoom/analytics';
 import { getLiveRoomPrivilegeState } from '../../lib/liveRoom/privileges';
+import { LIVE_ROOM_QUICK_REACTION_EMOJIS } from '../../lib/liveRoom/reactions';
 import { LogEvent } from '../../lib/log';
 import { Modal } from '../modals/common/Modal';
 import {
@@ -38,8 +39,6 @@ import {
   VIDEO_QUALITY_ITEMS,
   VIDEO_QUALITY_LABEL,
 } from './LiveRoomControlPrimitives';
-
-const REACTION_EMOJIS = ['👏', '🔥', '💡', '😂', '🤯'];
 
 interface LiveRoomControlsProps {
   roomId: string;
@@ -227,7 +226,7 @@ export const LiveRoomControls = ({
       <div className="pointer-events-auto relative flex w-full max-w-[42rem] flex-col items-center gap-2">
         {reactionsOpen ? (
           <div className="flex items-center gap-1 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-1.5 shadow-2">
-            {REACTION_EMOJIS.map((emoji) => (
+            {LIVE_ROOM_QUICK_REACTION_EMOJIS.map((emoji) => (
               <Button
                 key={emoji}
                 type="button"

--- a/packages/shared/src/contexts/LiveRoomContext.tsx
+++ b/packages/shared/src/contexts/LiveRoomContext.tsx
@@ -42,9 +42,12 @@ import {
 import { storageWrapper } from '../lib/storageWrapper';
 import type {
   ChatMessageDeletedEvent,
+  ChatMessageReactionRemovedEvent,
+  ChatMessageReactionSentEvent,
   ChatMessageSentEvent,
   LiveRoomCommand,
   LiveRoomChatMessage,
+  LiveRoomChatMessageReaction,
   LiveRoomParticipantRoleValue,
   LiveRoomState,
   MediaCapabilitiesPayload,
@@ -102,7 +105,9 @@ export interface LiveRoomReaction {
   lane: number;
 }
 
-export type LiveRoomChatEntry = LiveRoomChatMessage;
+export type LiveRoomChatEntry = LiveRoomChatMessage & {
+  reactions?: LiveRoomChatMessageReaction[];
+};
 
 interface RemoteSubscriptionHandle {
   kind: 'audio' | 'video';
@@ -132,6 +137,8 @@ export interface LiveRoomContextValue {
   sendReaction: (emoji: string) => Promise<void>;
   sendChatMessage: (body: string) => Promise<void>;
   deleteChatMessage: (messageId: string) => Promise<void>;
+  sendChatMessageReaction: (messageId: string, key: string) => Promise<void>;
+  removeChatMessageReaction: (messageId: string, key: string) => Promise<void>;
   grantCoHost: (targetParticipantId: string) => Promise<void>;
   revokeCoHost: (targetParticipantId: string) => Promise<void>;
   setParticipantChatEnabled: (
@@ -555,7 +562,7 @@ export const LiveRoomProvider = ({
 
   const pushChatMessage = useCallback((event: ChatMessageSentEvent) => {
     setChatMessages((current) => {
-      const next = [...current, event.message];
+      const next = [...current, { ...event.message, reactions: [] }];
 
       if (next.length <= CHAT_HISTORY_LIMIT) {
         return next;
@@ -570,6 +577,47 @@ export const LiveRoomProvider = ({
       current.filter((message) => message.messageId !== event.messageId),
     );
   }, []);
+
+  const pushChatMessageReaction = useCallback(
+    (event: ChatMessageReactionSentEvent) => {
+      setChatMessages((current) =>
+        current.map((message) => {
+          if (message.messageId !== event.messageReaction.messageId) {
+            return message;
+          }
+
+          return {
+            ...message,
+            reactions: [...(message.reactions ?? []), event.messageReaction],
+          };
+        }),
+      );
+    },
+    [],
+  );
+
+  const removeChatMessageReactionFromState = useCallback(
+    (event: ChatMessageReactionRemovedEvent) => {
+      setChatMessages((current) =>
+        current.map((message) => {
+          if (message.messageId !== event.messageReaction.messageId) {
+            return message;
+          }
+
+          return {
+            ...message,
+            reactions: (message.reactions ?? []).filter(
+              (reaction) =>
+                reaction.participantId !==
+                  event.messageReaction.participantId ||
+                reaction.key !== event.messageReaction.key,
+            ),
+          };
+        }),
+      );
+    },
+    [],
+  );
 
   useEffect(() => {
     setChatMessages([]);
@@ -961,6 +1009,14 @@ export const LiveRoomProvider = ({
     const offChatDeleted = connection.onChatMessageDeleted((event) => {
       removeChatMessage(event);
     });
+    const offChatReaction = connection.onChatMessageReaction((event) => {
+      pushChatMessageReaction(event);
+    });
+    const offChatReactionRemoved = connection.onChatMessageReactionRemoved(
+      (event) => {
+        removeChatMessageReactionFromState(event);
+      },
+    );
     const offClose = connection.onClose(({ reason }) => {
       if (openingWithResume && !sessionReady) {
         clearStoredLiveRoomResumeSession(roomId);
@@ -992,6 +1048,8 @@ export const LiveRoomProvider = ({
       offReaction();
       offChatMessage();
       offChatDeleted();
+      offChatReaction();
+      offChatReactionRemoved();
       offClose();
       offError();
       connection.close();
@@ -1000,8 +1058,10 @@ export const LiveRoomProvider = ({
   }, [
     joinToken,
     pushChatMessage,
+    pushChatMessageReaction,
     pushReaction,
     removeChatMessage,
+    removeChatMessageReactionFromState,
     roomId,
     storedResumeSession,
   ]);
@@ -1736,6 +1796,28 @@ export const LiveRoomProvider = ({
     [sendConnectionCommand],
   );
 
+  const sendChatMessageReaction = useCallback(
+    async (messageId: string, key: string) => {
+      await sendConnectionCommand(
+        'send chat message reaction',
+        { type: 'chat.message.reaction.send', messageId, key },
+        { messageId, key },
+      );
+    },
+    [sendConnectionCommand],
+  );
+
+  const removeChatMessageReaction = useCallback(
+    async (messageId: string, key: string) => {
+      await sendConnectionCommand(
+        'remove chat message reaction',
+        { type: 'chat.message.reaction.remove', messageId, key },
+        { messageId, key },
+      );
+    },
+    [sendConnectionCommand],
+  );
+
   const setParticipantChatEnabled = useCallback(
     async (targetParticipantId: string, nextCanChat: boolean) => {
       await sendConnectionCommand(
@@ -1836,6 +1918,8 @@ export const LiveRoomProvider = ({
       sendReaction,
       sendChatMessage,
       deleteChatMessage,
+      sendChatMessageReaction,
+      removeChatMessageReaction,
       grantCoHost,
       revokeCoHost,
       setParticipantChatEnabled,
@@ -1880,6 +1964,8 @@ export const LiveRoomProvider = ({
       sendReaction,
       sendChatMessage,
       deleteChatMessage,
+      sendChatMessageReaction,
+      removeChatMessageReaction,
       grantCoHost,
       revokeCoHost,
       setParticipantChatEnabled,

--- a/packages/shared/src/hooks/useExitConfirmation.spec.tsx
+++ b/packages/shared/src/hooks/useExitConfirmation.spec.tsx
@@ -1,0 +1,109 @@
+import { act, renderHook } from '@testing-library/react';
+import type { NextRouter } from 'next/router';
+import { useRouter } from 'next/router';
+import { useExitConfirmation } from './useExitConfirmation';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+describe('useExitConfirmation', () => {
+  let mockRouter: NextRouter;
+  let routerEventHandlers: Record<string, () => void>;
+  let windowEventHandlers: Map<string, EventListener>;
+
+  beforeEach(() => {
+    routerEventHandlers = {};
+    windowEventHandlers = new Map();
+
+    jest.spyOn(window, 'addEventListener').mockImplementation(((
+      event: string,
+      handler: EventListenerOrEventListenerObject,
+    ) => {
+      if (typeof handler === 'function') {
+        windowEventHandlers.set(event, handler);
+      }
+    }) as typeof window.addEventListener);
+
+    jest.spyOn(window, 'removeEventListener').mockImplementation(((
+      event: string,
+    ) => {
+      windowEventHandlers.delete(event);
+    }) as typeof window.removeEventListener);
+
+    mockRouter = {
+      isReady: true,
+      events: {
+        on: jest.fn((event: string, handler: () => void) => {
+          routerEventHandlers[event] = handler;
+        }),
+        off: jest.fn((event: string) => {
+          delete routerEventHandlers[event];
+        }),
+        emit: jest.fn(),
+      },
+    } as unknown as NextRouter;
+
+    jest.mocked(useRouter).mockReturnValue(mockRouter);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('does not register confirmation handlers when disabled', () => {
+    renderHook(() =>
+      useExitConfirmation({
+        enabled: false,
+        onValidateAction: () => false,
+      }),
+    );
+
+    expect(window.addEventListener).not.toHaveBeenCalled();
+    expect(mockRouter.events.on).not.toHaveBeenCalled();
+  });
+
+  it('prevents page unload when confirmation is enabled and validation fails', () => {
+    renderHook(() =>
+      useExitConfirmation({
+        onValidateAction: () => false,
+      }),
+    );
+
+    const event = {
+      preventDefault: jest.fn(),
+      returnValue: undefined as string | undefined,
+    } as unknown as BeforeUnloadEvent;
+
+    act(() => {
+      windowEventHandlers.get('beforeunload')?.(event);
+    });
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.returnValue).toBe(
+      'You have unsaved changes that will be lost if you leave the page',
+    );
+  });
+
+  it('aborts route navigation when the user rejects confirmation', () => {
+    jest.spyOn(window, 'confirm').mockReturnValue(false);
+
+    renderHook(() =>
+      useExitConfirmation({
+        message: 'Leave the page?',
+        onValidateAction: () => false,
+      }),
+    );
+
+    expect(() => {
+      act(() => {
+        routerEventHandlers.routeChangeStart();
+      });
+    }).toThrow(
+      'Route change aborted by useExitConfirmation. Please ignore this error.',
+    );
+
+    expect(window.confirm).toHaveBeenCalledWith('Leave the page?');
+    expect(mockRouter.events.emit).toHaveBeenCalledWith('routeChangeError');
+  });
+});

--- a/packages/shared/src/hooks/useExitConfirmation.ts
+++ b/packages/shared/src/hooks/useExitConfirmation.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef } from 'react';
 interface ExitProps {
   message?: string;
   onValidateAction: () => boolean;
+  enabled?: boolean;
 }
 
 export interface UseExitConfirmation {
@@ -13,6 +14,7 @@ export interface UseExitConfirmation {
 export function useExitConfirmation({
   message = 'You have unsaved changes that will be lost if you leave the page',
   onValidateAction,
+  enabled = true,
 }: ExitProps): UseExitConfirmation {
   const confirmRef = useRef(true);
   const router = useRouter();
@@ -23,7 +25,7 @@ export function useExitConfirmation({
   );
 
   useEffect(() => {
-    if (!router.isReady) {
+    if (!enabled || !router.isReady) {
       return undefined;
     }
 
@@ -60,7 +62,7 @@ export function useExitConfirmation({
       window.removeEventListener('beforeunload', closeHandler);
       router.events.off('routeChangeStart', routeHandler);
     };
-  }, [checkShouldAskConfirmation, message, router]);
+  }, [checkShouldAskConfirmation, enabled, message, router]);
 
   return {
     onAskConfirmation: (value) => {

--- a/packages/shared/src/lib/liveRoom/connection.ts
+++ b/packages/shared/src/lib/liveRoom/connection.ts
@@ -1,5 +1,7 @@
 import type {
   ChatMessageDeletedEvent,
+  ChatMessageReactionRemovedEvent,
+  ChatMessageReactionSentEvent,
   ChatMessageSentEvent,
   LiveRoomCommand,
   LiveRoomServerEvent,
@@ -66,6 +68,14 @@ export class LiveRoomConnection {
 
   private readonly chatDeletedListeners = new Set<
     Listener<ChatMessageDeletedEvent>
+  >();
+
+  private readonly chatReactionListeners = new Set<
+    Listener<ChatMessageReactionSentEvent>
+  >();
+
+  private readonly chatReactionRemovedListeners = new Set<
+    Listener<ChatMessageReactionRemovedEvent>
   >();
 
   private readonly closeListeners = new Set<
@@ -214,6 +224,20 @@ export class LiveRoomConnection {
     return () => this.chatDeletedListeners.delete(listener);
   }
 
+  onChatMessageReaction(
+    listener: Listener<ChatMessageReactionSentEvent>,
+  ): () => void {
+    this.chatReactionListeners.add(listener);
+    return () => this.chatReactionListeners.delete(listener);
+  }
+
+  onChatMessageReactionRemoved(
+    listener: Listener<ChatMessageReactionRemovedEvent>,
+  ): () => void {
+    this.chatReactionRemovedListeners.add(listener);
+    return () => this.chatReactionRemovedListeners.delete(listener);
+  }
+
   onClose(listener: Listener<{ code: number; reason: string }>): () => void {
     this.closeListeners.add(listener);
     return () => this.closeListeners.delete(listener);
@@ -259,6 +283,16 @@ export class LiveRoomConnection {
       }
       case 'chat.message.deleted': {
         this.chatDeletedListeners.forEach((listener) => listener(parsed));
+        return;
+      }
+      case 'chat.message.reaction.sent': {
+        this.chatReactionListeners.forEach((listener) => listener(parsed));
+        return;
+      }
+      case 'chat.message.reaction.removed': {
+        this.chatReactionRemovedListeners.forEach((listener) =>
+          listener(parsed),
+        );
         return;
       }
       case 'command.succeeded': {

--- a/packages/shared/src/lib/liveRoom/protocol.ts
+++ b/packages/shared/src/lib/liveRoom/protocol.ts
@@ -67,6 +67,20 @@ export interface LiveRoomChatMessage {
   createdAt: string;
 }
 
+export interface LiveRoomChatMessageReaction {
+  messageId: string;
+  participantId: string;
+  key: string;
+  createdAt: string;
+}
+
+export interface LiveRoomRemovedChatMessageReaction {
+  messageId: string;
+  participantId: string;
+  key: string;
+  removedAt: string;
+}
+
 export interface SessionReadyEvent {
   type: 'session.ready';
   roomId: string;
@@ -110,6 +124,18 @@ export interface ChatMessageDeletedEvent {
   deletedAt: string;
 }
 
+export interface ChatMessageReactionSentEvent {
+  type: 'chat.message.reaction.sent';
+  roomId: string;
+  messageReaction: LiveRoomChatMessageReaction;
+}
+
+export interface ChatMessageReactionRemovedEvent {
+  type: 'chat.message.reaction.removed';
+  roomId: string;
+  messageReaction: LiveRoomRemovedChatMessageReaction;
+}
+
 export interface CommandSucceededEvent {
   type: 'command.succeeded';
   requestId: string;
@@ -129,6 +155,8 @@ export type LiveRoomServerEvent =
   | ReactionSentEvent
   | ChatMessageSentEvent
   | ChatMessageDeletedEvent
+  | ChatMessageReactionSentEvent
+  | ChatMessageReactionRemovedEvent
   | CommandSucceededEvent
   | CommandFailedEvent;
 
@@ -166,6 +194,8 @@ export type LiveRoomCommand =
   | { type: 'room.cohost.revoke'; targetParticipantId: string }
   | { type: 'chat.message.send'; body: string }
   | { type: 'chat.message.delete'; messageId: string }
+  | { type: 'chat.message.reaction.send'; messageId: string; key: string }
+  | { type: 'chat.message.reaction.remove'; messageId: string; key: string }
   | {
       type: 'chat.privilege.set';
       targetParticipantId: string;

--- a/packages/shared/src/lib/liveRoom/reactions.ts
+++ b/packages/shared/src/lib/liveRoom/reactions.ts
@@ -1,0 +1,1 @@
+export const LIVE_ROOM_QUICK_REACTION_EMOJIS = ['👏', '🔥', '💡', '😂', '🤯'];

--- a/packages/shared/src/lib/liveRoom/reactions.ts
+++ b/packages/shared/src/lib/liveRoom/reactions.ts
@@ -1,1 +1,1 @@
-export const LIVE_ROOM_QUICK_REACTION_EMOJIS = ['👏', '🔥', '💡', '😂', '🤯'];
+export const LIVE_ROOM_QUICK_REACTION_EMOJIS = ['🔥', '👀', '🚀', '💀', '😬'];

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -269,6 +269,8 @@ export enum LogEvent {
   OpenStandupReactions = 'open standup reactions',
   SwitchStandupPanelTab = 'switch standup panel tab',
   SendStandupReaction = 'send standup reaction',
+  SendStandupChatReaction = 'send standup chat reaction',
+  RemoveStandupChatReaction = 'remove standup chat reaction',
   SendStandupChatMessage = 'send standup chat message',
   DeleteStandupChatMessage = 'delete standup chat message',
   UpdateStandupChatAccess = 'update standup chat access',

--- a/packages/shared/tailwind.config.ts
+++ b/packages/shared/tailwind.config.ts
@@ -252,12 +252,27 @@ export default {
             backgroundColor: 'transparent',
           },
         },
+        'reaction-burst': {
+          '0%': {
+            transform: 'translate(0, 0) scale(0.4)',
+            opacity: '0',
+          },
+          '15%': {
+            opacity: '1',
+          },
+          '100%': {
+            transform: 'translate(var(--burst-tx), var(--burst-ty)) scale(1)',
+            opacity: '0',
+          },
+        },
       },
       animation: {
         'scale-down-pulse':
           'scale-down-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
         'fade-slide-up': 'fade-slide-up 0.5s ease-out 1s both',
         'highlight-fade': 'highlight-fade 2.5s ease-out forwards',
+        'reaction-burst':
+          'reaction-burst 720ms cubic-bezier(0.2, 0.7, 0.4, 1) forwards',
       },
     },
     lineClamp: {


### PR DESCRIPTION
## What changed
- Add client support for Flyting chat message reaction send/remove events and commands.
- Render chat reaction chips, quick reaction shortcuts, and custom emoji picker in standup chat.
- Toggle the current user's active reaction through the new remove command instead of sending duplicates.
- Share the standup quick reaction emoji list between stage controls and chat.
- Disable the standup leave confirmation in development via the existing exit-confirmation hook option.

## Why
Flyting now exposes chat message reactions, including a remove command. The standup client needs to mirror that realtime contract and keep reaction UI behavior consistent with the existing stage reaction controls.

## Validation
- `node ./scripts/typecheck-strict-changed.js`
- focused ESLint for touched shared files
- `NODE_ENV=test pnpm --filter shared exec jest src/components/liveRooms/LiveRoom.spec.tsx --runInBand`
- `NODE_ENV=test pnpm --filter shared exec jest src/hooks/useExitConfirmation.spec.tsx --runInBand`


### Preview domain
https://codex-standup-chat-reactions.preview.app.daily.dev