### PR TITLE
feat: render content embeds

### DIFF
--- a/packages/shared/src/components/comments/CommentContainer.tsx
+++ b/packages/shared/src/components/comments/CommentContainer.tsx
@@ -24,6 +24,7 @@ import { ProfileImageSize, ProfilePicture } from '../ProfilePicture';
 import { useHasAccessToCores } from '../../hooks/useCoresFeature';
 import { AnimatedAwardImage } from '../AnimatedAward';
 import { isSourceUserSource } from '../../graphql/sources';
+import { ContentEmbeds } from '../contentEmbeds/ContentEmbeds';
 
 interface ClassName extends CommentClassName {
   content?: string;
@@ -178,6 +179,7 @@ export default function CommentContainer({
           content={comment.contentHtml}
           appendTooltipTo={appendTooltipTo}
         />
+        <ContentEmbeds embeds={comment.contentEmbeds} variant="comment" />
         {actions}
       </div>
     </article>

--- a/packages/shared/src/components/contentEmbeds/ContentEmbeds.spec.tsx
+++ b/packages/shared/src/components/contentEmbeds/ContentEmbeds.spec.tsx
@@ -1,0 +1,103 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { ContentEmbed, ContentEmbedPost } from '../../graphql/posts';
+import { PostType } from '../../graphql/posts';
+import { ContentEmbeds } from './ContentEmbeds';
+
+const createPost = (
+  overrides: Partial<ContentEmbedPost> = {},
+): ContentEmbedPost => ({
+  title: 'Embedded post',
+  image: 'https://daily.dev/image.jpg',
+  createdAt: new Date().toISOString(),
+  readTime: 4,
+  numUpvotes: 1200,
+  numComments: 3,
+  numReposts: 5,
+  numAwards: 2,
+  analytics: {
+    impressions: 10,
+  },
+  type: PostType.Freeform,
+  commentsPermalink: '/posts/p1',
+  ...overrides,
+});
+
+const createEmbed = (post: ContentEmbedPost = createPost()): ContentEmbed => ({
+  id: 'embed-1',
+  referenceType: 'post',
+  url: '/posts/p1',
+  sortOrder: 0,
+  post,
+});
+
+const renderComponent = (
+  props: Partial<Parameters<typeof ContentEmbeds>[0]> = {},
+): ReactElement => (
+  <ContentEmbeds embeds={[createEmbed()]} variant="post" {...props} />
+);
+
+it('should render post metadata and engagement stats as passive metadata', () => {
+  render(renderComponent());
+
+  expect(screen.getByText('Now')).toBeInTheDocument();
+  expect(screen.getByText('4m read time')).toBeInTheDocument();
+  expect(screen.getByText('10 Impressions')).toBeInTheDocument();
+  expect(screen.getByText('1.2K Upvotes')).toBeInTheDocument();
+  expect(screen.getByText('3 Comments')).toBeInTheDocument();
+  expect(screen.getByText('5 Reposts')).toBeInTheDocument();
+  expect(screen.getByText('2 Awards')).toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: /upvotes/i }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: /comments/i }),
+  ).not.toBeInTheDocument();
+});
+
+it('should keep comment embeds compact while showing engagement stats', () => {
+  render(renderComponent({ variant: 'comment' }));
+
+  expect(screen.getByText('Now')).toBeInTheDocument();
+  expect(screen.getByText('4m read time')).toBeInTheDocument();
+  expect(screen.getByText('1.2K Upvotes')).toBeInTheDocument();
+  expect(screen.getByText('3 Comments')).toBeInTheDocument();
+});
+
+it('should reuse collection metadata for source count', () => {
+  render(
+    renderComponent({
+      embeds: [
+        createEmbed(
+          createPost({
+            type: PostType.Collection,
+            numCollectionSources: 12,
+          }),
+        ),
+      ],
+    }),
+  );
+
+  expect(screen.getByText('12 sources')).toBeInTheDocument();
+});
+
+it('should reuse poll metadata for vote count', () => {
+  render(
+    renderComponent({
+      embeds: [
+        createEmbed(
+          createPost({
+            type: PostType.Poll,
+            readTime: undefined,
+            numPollVotes: 15,
+          }),
+        ),
+      ],
+    }),
+  );
+
+  expect(screen.getByText('Voting open')).toBeInTheDocument();
+  expect(screen.getByText('15 votes')).toBeInTheDocument();
+  expect(screen.queryByText('4m read time')).not.toBeInTheDocument();
+});

--- a/packages/shared/src/components/contentEmbeds/ContentEmbeds.tsx
+++ b/packages/shared/src/components/contentEmbeds/ContentEmbeds.tsx
@@ -1,0 +1,170 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import type { ContentEmbed, ContentEmbedPost } from '../../graphql/posts';
+import { PostType } from '../../graphql/posts';
+import Link from '../utilities/Link';
+import { Image, ImageType } from '../image/Image';
+import { SourceAvatar } from '../profile/source/SourceAvatar';
+import { ProfileImageSize } from '../ProfilePicture';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../typography/Typography';
+import PostMetadata from '../cards/common/PostMetadata';
+import { Separator } from '../cards/common/common';
+import { PostUpvotesCommentsCount } from '../post/PostUpvotesCommentsCount';
+import { useAuthContext } from '../../contexts/AuthContext';
+
+type ContentEmbedVariant = 'post' | 'comment';
+
+type ContentEmbedsProps = {
+  embeds?: ContentEmbed[] | null;
+  variant?: ContentEmbedVariant;
+  className?: string;
+};
+
+type DailyPostEmbedProps = {
+  post: ContentEmbedPost;
+  url: string;
+  variant: ContentEmbedVariant;
+};
+
+const getPostHref = (post: ContentEmbedPost, fallbackUrl: string): string =>
+  post.commentsPermalink || fallbackUrl;
+
+const isPostEmbed = (
+  embed: ContentEmbed,
+): embed is ContentEmbed & { post: ContentEmbedPost } =>
+  embed.referenceType === 'post' && !!embed.post;
+
+const isEmbedVideoPost = (post: ContentEmbedPost): boolean =>
+  post.type === PostType.VideoYouTube ||
+  (post.type === PostType.Share &&
+    post.sharedPost?.type === PostType.VideoYouTube);
+
+const DailyPostEmbed = ({
+  post,
+  url,
+  variant,
+}: DailyPostEmbedProps): ReactElement => {
+  const href = getPostHref(post, url);
+  const isCommentVariant = variant === 'comment';
+  const { source } = post;
+  const sourceLabel = source?.name || source?.handle;
+  const { user } = useAuthContext() ?? {};
+  const pollMetadata =
+    post.type === PostType.Poll
+      ? {
+          endsAt: post.endsAt,
+          isAuthor: user?.id === post.author?.id,
+          numPollVotes: post.numPollVotes,
+        }
+      : undefined;
+  const hasPostMetadata =
+    !!post.createdAt ||
+    post.readTime !== undefined ||
+    !!post.numCollectionSources ||
+    !!pollMetadata;
+
+  return (
+    <Link href={href} passHref>
+      <a
+        className={classNames(
+          'flex min-w-0 items-center gap-3 rounded-12 border border-border-subtlest-tertiary bg-background-subtle p-3 hover:border-border-subtlest-secondary',
+          isCommentVariant ? 'mt-3' : 'mt-4',
+        )}
+      >
+        <Image
+          src={post.image}
+          alt={post.title || 'Embedded post cover image'}
+          type={ImageType.Post}
+          loading="lazy"
+          className={classNames(
+            'shrink-0 rounded-10 object-cover',
+            isCommentVariant ? 'size-16' : 'size-24',
+          )}
+        />
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          {(source || hasPostMetadata) && (
+            <div className="flex min-w-0 items-center overflow-hidden text-text-tertiary typo-caption1">
+              {source && (
+                <>
+                  <SourceAvatar
+                    source={source}
+                    size={ProfileImageSize.Size16}
+                    className="mr-1 shrink-0"
+                  />
+                  <Typography
+                    type={TypographyType.Caption1}
+                    color={TypographyColor.Secondary}
+                    className="min-w-0 shrink truncate leading-4"
+                  >
+                    {sourceLabel}
+                  </Typography>
+                </>
+              )}
+              {source && hasPostMetadata && <Separator className="shrink-0" />}
+              {hasPostMetadata && (
+                <PostMetadata
+                  createdAt={post.createdAt}
+                  readTime={post.readTime}
+                  isVideoType={isEmbedVideoPost(post)}
+                  numSources={post.numCollectionSources}
+                  pollMetadata={pollMetadata}
+                  className="!typo-caption1"
+                />
+              )}
+            </div>
+          )}
+          <Typography
+            type={
+              isCommentVariant ? TypographyType.Footnote : TypographyType.Body
+            }
+            color={TypographyColor.Primary}
+            className={classNames(
+              'line-clamp-2 break-words font-bold',
+              isCommentVariant && 'leading-5',
+            )}
+          >
+            {post.title}
+          </Typography>
+          <PostUpvotesCommentsCount
+            post={post}
+            passive
+            compact
+            className="!typo-caption1"
+          />
+        </div>
+      </a>
+    </Link>
+  );
+};
+
+export const ContentEmbeds = ({
+  embeds,
+  variant = 'post',
+  className,
+}: ContentEmbedsProps): ReactElement | null => {
+  const postEmbeds = (embeds ?? [])
+    .filter(isPostEmbed)
+    .sort((a, b) => a.sortOrder - b.sortOrder);
+
+  if (!postEmbeds.length) {
+    return null;
+  }
+
+  return (
+    <div className={classNames('flex flex-col', className)}>
+      {postEmbeds.map((embed) => (
+        <DailyPostEmbed
+          key={embed.id}
+          post={embed.post}
+          url={embed.url}
+          variant={variant}
+        />
+      ))}
+    </div>
+  );
+};

--- a/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
@@ -256,9 +256,7 @@ export const LiveRoomControls = ({
   const previewSuffix = (active: boolean, publishing: boolean): string =>
     active && !publishing ? ' (preview)' : '';
   const reactionTooltip = reactionsOpen ? 'Close reactions' : 'Reactions';
-  const settingsTooltip = isSettingsOpen
-    ? 'Standup settings open'
-    : 'Standup settings';
+  const settingsTooltip = 'Settings';
   const queueTooltip = isQueued ? 'Queued' : 'Join queue';
   const joinStageTooltip = isStageFull ? 'Stage full' : 'Join stage';
 
@@ -565,31 +563,26 @@ export const LiveRoomControls = ({
               />
             </TooltipButton>
             {isModerated && isAudience ? (
-              <TooltipButton
-                tooltip={queueTooltip}
-                wrapDisabled={!canJoinQueue || isBusy('queue')}
+              <Button
+                type="button"
+                size={ButtonSize.Small}
+                variant={
+                  isQueued ? ButtonVariant.Secondary : ButtonVariant.Primary
+                }
+                icon={<MegaphoneIcon />}
+                loading={isBusy('queue')}
+                disabled={!canJoinQueue || isBusy('queue')}
+                onClick={() =>
+                  runAuthenticatedAction('queue', async () => {
+                    await joinSpeakerQueue();
+                    logStandupAction(LogEvent.JoinStandupQueue, roomId, {
+                      surface: 'controls',
+                    });
+                  })
+                }
               >
-                <Button
-                  type="button"
-                  size={ButtonSize.Small}
-                  variant={
-                    isQueued ? ButtonVariant.Secondary : ButtonVariant.Primary
-                  }
-                  icon={<MegaphoneIcon />}
-                  loading={isBusy('queue')}
-                  disabled={!canJoinQueue || isBusy('queue')}
-                  onClick={() =>
-                    runAuthenticatedAction('queue', async () => {
-                      await joinSpeakerQueue();
-                      logStandupAction(LogEvent.JoinStandupQueue, roomId, {
-                        surface: 'controls',
-                      });
-                    })
-                  }
-                >
-                  {queueTooltip}
-                </Button>
-              </TooltipButton>
+                {queueTooltip}
+              </Button>
             ) : null}
             {isFreeForAll && isAudience ? (
               <TooltipButton
@@ -671,43 +664,39 @@ export const LiveRoomControls = ({
               </TooltipButton>
             ) : null}
             {privilegeState.hasHostPrivileges ? (
-              <TooltipButton tooltip="End standup" wrapDisabled={isBusy('end')}>
-                <Button
-                  type="button"
-                  size={ButtonSize.Small}
-                  variant={ButtonVariant.Secondary}
-                  loading={isBusy('end')}
-                  onClick={() =>
-                    guarded('end', async () => {
-                      await endRoom();
-                      logStandupAction(LogEvent.EndStandup, roomId, {
-                        surface: 'controls',
-                      });
-                      onLeave();
-                    })
-                  }
-                >
-                  End standup
-                </Button>
-              </TooltipButton>
-            ) : (
-              <TooltipButton tooltip="Leave">
-                <Button
-                  type="button"
-                  size={ButtonSize.Small}
-                  variant={ButtonVariant.Primary}
-                  icon={<PhoneIcon />}
-                  aria-label="Leave"
-                  onClick={() => {
-                    logStandupAction(LogEvent.LeaveStandup, roomId, {
+              <Button
+                type="button"
+                size={ButtonSize.Small}
+                variant={ButtonVariant.Secondary}
+                loading={isBusy('end')}
+                onClick={() =>
+                  guarded('end', async () => {
+                    await endRoom();
+                    logStandupAction(LogEvent.EndStandup, roomId, {
                       surface: 'controls',
                     });
                     onLeave();
-                  }}
-                >
-                  Leave
-                </Button>
-              </TooltipButton>
+                  })
+                }
+              >
+                End standup
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                size={ButtonSize.Small}
+                variant={ButtonVariant.Primary}
+                icon={<PhoneIcon />}
+                aria-label="Leave"
+                onClick={() => {
+                  logStandupAction(LogEvent.LeaveStandup, roomId, {
+                    surface: 'controls',
+                  });
+                  onLeave();
+                }}
+              >
+                Leave
+              </Button>
             )}
           </ControlGroup>
         </div>

--- a/packages/shared/src/components/post/MarkdownPostContent.tsx
+++ b/packages/shared/src/components/post/MarkdownPostContent.tsx
@@ -10,6 +10,7 @@ import { LazyImage, LazyVideo } from '../LazyImage';
 import { cloudinaryPostImageCoverPlaceholder } from '../../lib/image';
 import { useSmartTitle } from '../../hooks/post/useSmartTitle';
 import { PostClickbaitShield } from './common/PostClickbaitShield';
+import { ContentEmbeds } from '../contentEmbeds/ContentEmbeds';
 
 interface MarkdownPostContentProps {
   post: Post;
@@ -41,7 +42,8 @@ function MarkdownPostContent({
   isCompactSpacing,
 }: MarkdownPostContentProps): ReactElement {
   const { title } = useSmartTitle(post);
-  const hasVideo = !!post.flags?.coverVideo;
+  const coverVideo = post.flags?.coverVideo;
+  const hasVideo = !!coverVideo;
   const headerClassName = isCompactSpacing ? 'my-4' : 'my-6';
   const mediaMarginClassName = isCompactSpacing ? 'mb-7' : 'mb-10';
 
@@ -77,7 +79,7 @@ function MarkdownPostContent({
             <LazyVideo
               eager
               ratio="52%"
-              videoSrc={post.flags.coverVideo}
+              videoSrc={coverVideo}
               poster={post.image}
               className={classNames(
                 mediaMarginClassName,
@@ -88,11 +90,16 @@ function MarkdownPostContent({
         </>
       )}
       <Markdown
-        content={post.contentHtml}
+        content={post.contentHtml ?? ''}
         className={classNames(
           'break-words',
           post.type !== PostType.Welcome && 'mb-5',
         )}
+      />
+      <ContentEmbeds
+        embeds={post.contentEmbeds}
+        variant="post"
+        className={post.type !== PostType.Welcome ? 'mb-5' : undefined}
       />
       {post.type === PostType.Welcome && post.image && (
         <MarkdownPostImage imgSrc={post.image} className="mb-5 mt-8" />

--- a/packages/shared/src/components/post/PostUpvotesCommentsCount.tsx
+++ b/packages/shared/src/components/post/PostUpvotesCommentsCount.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import React from 'react';
+import classNames from 'classnames';
 import { POST_REPOSTS_BY_ID_QUERY, type Post } from '../../graphql/posts';
 import { ClickableText } from '../buttons/ClickableText';
 import { largeNumberFormat } from '../../lib';
@@ -16,93 +17,124 @@ import { webappUrl } from '../../lib/constants';
 
 const DEFAULT_REPOSTS_PER_PAGE = 20;
 
+type PostUpvotesCommentsCountPost = Pick<
+  Post,
+  'analytics' | 'numAwards' | 'numComments' | 'numReposts' | 'numUpvotes'
+> &
+  Partial<Pick<Post, 'id'>> & {
+    author?: Pick<NonNullable<Post['author']>, 'id'>;
+    featuredAward?: {
+      award?: Pick<
+        NonNullable<NonNullable<Post['featuredAward']>['award']>,
+        'image' | 'name'
+      >;
+    };
+  };
+
 interface PostUpvotesCommentsCountProps {
-  post: Post;
+  post: PostUpvotesCommentsCountPost;
   onUpvotesClick?: (upvotes: number) => unknown;
+  className?: string;
+  compact?: boolean;
+  passive?: boolean;
 }
 
-export function PostUpvotesCommentsCount({
+type PostUpvotesCommentsCountContentProps = PostUpvotesCommentsCountProps & {
+  onRepostsClick?: () => unknown;
+  onAwardsClick?: () => unknown;
+  showPostAnalytics?: boolean;
+};
+
+const PostUpvotesCommentsCountContent = ({
   post,
   onUpvotesClick,
-}: PostUpvotesCommentsCountProps): ReactElement {
-  const { openModal } = useLazyModal();
-  const { user } = useAuthContext();
+  onRepostsClick,
+  onAwardsClick,
+  showPostAnalytics = false,
+  className,
+  compact = false,
+  passive = false,
+}: PostUpvotesCommentsCountContentProps): ReactElement => {
   const upvotes = post.numUpvotes || 0;
   const comments = post.numComments || 0;
   const awards = post.numAwards || 0;
   const reposts = post.numReposts || 0;
-  const hasAccessToCores = useHasAccessToCores();
-  const onRepostsClick = () =>
-    openModal({
-      type: LazyModal.RepostsPopup,
-      props: {
-        requestQuery: {
-          queryKey: ['postReposts', post.id],
-          query: POST_REPOSTS_BY_ID_QUERY,
-          params: {
-            id: post.id,
-            first: DEFAULT_REPOSTS_PER_PAGE,
-            supportedTypes: ['share'],
-          },
-        },
-      },
-    });
+  const getText = ({ count, label }: { count: number; label: string }) =>
+    `${largeNumberFormat(count)} ${label}${count > 1 ? 's' : ''}`;
+
+  const renderText = ({
+    key,
+    onClick,
+    children,
+  }: {
+    key: string;
+    onClick?: () => unknown;
+    children: ReactElement | string;
+  }) => {
+    if (passive || !onClick) {
+      return <span key={key}>{children}</span>;
+    }
+
+    return (
+      <ClickableText key={key} onClick={onClick}>
+        {children}
+      </ClickableText>
+    );
+  };
 
   return (
     <div
-      className="mb-3 flex flex-wrap items-center gap-x-4 !leading-7 text-text-tertiary typo-callout"
+      className={classNames(
+        'flex flex-wrap items-center text-text-tertiary',
+        compact
+          ? 'mb-0 gap-x-3 gap-y-1 !leading-5 typo-caption1'
+          : 'mb-3 gap-x-4 !leading-7 typo-callout',
+        className,
+      )}
       data-testid="statsBar"
     >
       {!!post.analytics?.impressions && (
         <span>
-          {largeNumberFormat(post.analytics.impressions)} Impression
-          {post.analytics.impressions > 1 ? 's' : ''}
+          {getText({ count: post.analytics.impressions, label: 'Impression' })}
         </span>
       )}
-      {upvotes > 0 && (
-        <ClickableText onClick={() => onUpvotesClick?.(upvotes)}>
-          {largeNumberFormat(upvotes)} Upvote{upvotes > 1 ? 's' : ''}
-        </ClickableText>
-      )}
+      {upvotes > 0 &&
+        renderText({
+          key: 'upvotes',
+          onClick: () => onUpvotesClick?.(upvotes),
+          children: getText({ count: upvotes, label: 'Upvote' }),
+        })}
       {comments > 0 && (
         <span>
           {largeNumberFormat(comments)}
           {` Comment${comments === 1 ? '' : 's'}`}
         </span>
       )}
-      {reposts > 0 && (
-        <ClickableText onClick={onRepostsClick}>
-          {largeNumberFormat(reposts)} Repost{reposts > 1 ? 's' : ''}
-        </ClickableText>
-      )}
-      {hasAccessToCores && awards > 0 && (
-        <ClickableText
-          onClick={() => {
-            openModal({
-              type: LazyModal.ListAwards,
-              props: {
-                queryProps: {
-                  id: post.id,
-                  type: 'POST',
-                },
-              },
-            });
-          }}
-        >
-          <span className="flex items-center gap-1">
-            {!!post.featuredAward?.award && (
-              <Image
-                src={post.featuredAward.award.image}
-                alt={post.featuredAward.award.name}
-                className="size-6"
-              />
-            )}
-            {largeNumberFormat(awards)}
-            {` Award${awards === 1 ? '' : 's'}`}
-          </span>
-        </ClickableText>
-      )}
-      {canViewPostAnalytics({ user, post }) && (
+      {reposts > 0 &&
+        renderText({
+          key: 'reposts',
+          onClick: onRepostsClick,
+          children: getText({ count: reposts, label: 'Repost' }),
+        })}
+      {awards > 0 &&
+        renderText({
+          key: 'awards',
+          onClick: onAwardsClick,
+          children: (
+            <span className="flex items-center gap-1">
+              {!!post.featuredAward?.award && (
+                <Image
+                  src={post.featuredAward.award.image}
+                  alt={post.featuredAward.award.name}
+                  className={compact ? 'size-4' : 'size-6'}
+                />
+              )}
+              {largeNumberFormat(awards)}
+              {` Award${awards === 1 ? '' : 's'}`}
+            </span>
+          ),
+        })}
+      {showPostAnalytics && (
         <Link href={`${webappUrl}posts/${post.id}/analytics`} passHref>
           <Button
             tag="a"
@@ -116,4 +148,80 @@ export function PostUpvotesCommentsCount({
       )}
     </div>
   );
+};
+
+const InteractivePostUpvotesCommentsCount = ({
+  post,
+  onUpvotesClick,
+  className,
+  compact,
+}: PostUpvotesCommentsCountProps): ReactElement => {
+  const { openModal } = useLazyModal();
+  const { user } = useAuthContext();
+  const awards = post.numAwards || 0;
+  const hasAccessToCores = useHasAccessToCores();
+  if (!post.id) {
+    return (
+      <PostUpvotesCommentsCountContent
+        post={post}
+        onUpvotesClick={onUpvotesClick}
+        className={className}
+        compact={compact}
+      />
+    );
+  }
+  const postId = post.id;
+
+  const onRepostsClick = () =>
+    openModal({
+      type: LazyModal.RepostsPopup,
+      props: {
+        requestQuery: {
+          queryKey: ['postReposts', postId],
+          query: POST_REPOSTS_BY_ID_QUERY,
+          params: {
+            id: postId,
+            first: DEFAULT_REPOSTS_PER_PAGE,
+            supportedTypes: ['share'],
+          },
+        },
+      },
+    });
+
+  return (
+    <PostUpvotesCommentsCountContent
+      post={post}
+      onUpvotesClick={onUpvotesClick}
+      onRepostsClick={onRepostsClick}
+      onAwardsClick={
+        hasAccessToCores && awards > 0
+          ? () => {
+              openModal({
+                type: LazyModal.ListAwards,
+                props: {
+                  queryProps: {
+                    id: postId,
+                    type: 'POST',
+                  },
+                },
+              });
+            }
+          : undefined
+      }
+      showPostAnalytics={canViewPostAnalytics({ user, post })}
+      className={className}
+      compact={compact}
+    />
+  );
+};
+
+export function PostUpvotesCommentsCount({
+  passive,
+  ...props
+}: PostUpvotesCommentsCountProps): ReactElement {
+  if (passive) {
+    return <PostUpvotesCommentsCountContent passive={passive} {...props} />;
+  }
+
+  return <InteractivePostUpvotesCommentsCount {...props} />;
 }

--- a/packages/shared/src/graphql/comments.ts
+++ b/packages/shared/src/graphql/comments.ts
@@ -3,7 +3,7 @@ import type { Connection, gqlClient } from './common';
 import { COMMENT_FRAGMENT, USER_SHORT_INFO_FRAGMENT } from './fragments';
 import type { EmptyResponse } from './emptyResponse';
 import type { UserShortProfile } from '../lib/user';
-import type { Post, UserVote } from './posts';
+import type { ContentEmbed, Post, UserVote } from './posts';
 import type { Company } from '../lib/userCompany';
 import type { ContentPreference } from './contentPreference';
 import type { TopReader } from '../components/badges/TopReaderBadge';
@@ -38,6 +38,7 @@ export interface Comment {
   id: string;
   content?: string;
   contentHtml: string;
+  contentEmbeds?: ContentEmbed[];
   createdAt: string;
   lastUpdatedAt?: string;
   author?: Author;

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -92,6 +92,50 @@ export const USER_AUTHOR_FRAGMENT = gql`
   ${USER_SHORT_INFO_TOP_READER_FRAGMENT}
 `;
 
+export const CONTENT_EMBED_FRAGMENT = gql`
+  fragment ContentEmbedFragment on ContentEmbed {
+    id
+    referenceType
+    url
+    sortOrder
+    post {
+      title
+      image
+      createdAt
+      readTime
+      numUpvotes
+      numComments
+      numAwards
+      numReposts
+      analytics {
+        impressions
+      }
+      numCollectionSources
+      numPollVotes
+      endsAt
+      featuredAward {
+        award {
+          name
+          image
+        }
+      }
+      type
+      sharedPost {
+        type
+      }
+      commentsPermalink
+      source {
+        handle
+        name
+        image
+      }
+      author {
+        id
+      }
+    }
+  }
+`;
+
 export const USER_BASIC_INFO = gql`
   fragment UserBasicInfo on User {
     id
@@ -418,6 +462,9 @@ export const COMMENT_FRAGMENT = gql`
   fragment CommentFragment on Comment {
     id
     contentHtml
+    contentEmbeds {
+      ...ContentEmbedFragment
+    }
     createdAt
     lastUpdatedAt
     permalink
@@ -441,6 +488,7 @@ export const COMMENT_FRAGMENT = gql`
       }
     }
   }
+  ${CONTENT_EMBED_FRAGMENT}
   ${USER_AUTHOR_FRAGMENT}
   ${FEATURED_AWARD_FRAGMENT}
 `;

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -9,6 +9,7 @@ import {
   POST_CODE_SNIPPET_FRAGMENT,
   RELATED_POST_FRAGMENT,
   SHARED_POST_INFO_FRAGMENT,
+  CONTENT_EMBED_FRAGMENT,
   USER_AUTHOR_FRAGMENT,
 } from './fragments';
 import type { Bookmark, BookmarkFolder } from './bookmarks';
@@ -171,6 +172,42 @@ type PostFlags = {
   ad?: DigestPostAd | null;
 };
 
+export type ContentEmbedPost = {
+  __typename?: string;
+  title?: string;
+  image?: string;
+  source?: Pick<Source, 'handle' | 'name' | 'image'>;
+  author?: Pick<Author, 'id'>;
+  createdAt?: string;
+  readTime?: number;
+  numUpvotes?: number;
+  numComments?: number;
+  numAwards?: number;
+  numReposts?: number;
+  numCollectionSources?: number;
+  numPollVotes?: number;
+  endsAt?: string;
+  analytics?: Partial<Pick<PostAnalytics, 'impressions'>>;
+  featuredAward?: {
+    award?: Pick<FeaturedAward, 'name' | 'image'>;
+  };
+  type: PostType;
+  sharedPost?: { type: PostType };
+  commentsPermalink?: string;
+};
+
+export type ContentEmbed = {
+  __typename?: string;
+  id: string;
+  url: string;
+  sortOrder: number;
+  startOffset?: number;
+  endOffset?: number;
+  referenceType: string;
+  referenceId?: string;
+  post?: ContentEmbedPost | null;
+};
+
 export enum UserVote {
   Up = 1,
   None = 0,
@@ -197,6 +234,7 @@ export interface Post {
   image: string;
   content?: string;
   contentHtml?: string;
+  contentEmbeds?: ContentEmbed[];
   createdAt?: string;
   pinnedAt?: Date | string;
   readTime?: number;
@@ -327,6 +365,9 @@ export const POST_BY_ID_QUERY = gql`
       trending
       content
       contentHtml
+      contentEmbeds {
+        ...ContentEmbedFragment
+      }
       pinnedAt
       bookmarkList {
         id
@@ -368,6 +409,7 @@ export const POST_BY_ID_QUERY = gql`
   }
   ${SHARED_POST_INFO_FRAGMENT}
   ${RELATED_POST_FRAGMENT}
+  ${CONTENT_EMBED_FRAGMENT}
 `;
 
 export const getPostById = (id: string) =>

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -301,7 +301,7 @@ export const canViewPostAnalytics = ({
   post,
 }: {
   user?: Pick<LoggedUser, 'id' | 'isTeamMember'>;
-  post?: Pick<Post, 'author'>;
+  post?: { author?: Pick<NonNullable<Post['author']>, 'id'> };
 }): boolean => {
   if (user?.isTeamMember) {
     return true;


### PR DESCRIPTION
## What changed
- Add a shared `ContentEmbeds` component for post-link embed cards.
- Render content embeds under post markdown and comment markdown.
- Request the new embed fragment from post and comment GraphQL payloads.

## Why
Posts and comments that link to daily.dev posts should render a native embed instead of looking like ordinary markdown links.

## Validation
- `pnpm run lint` from `packages/shared`
- `node ./scripts/typecheck-strict-changed.js`
- `git diff --check`

### Preview domain
https://codex-post-content-embeds.preview.app.daily.dev