### PR TITLE
fix: restore laptop breakpoint for post content row layout

### DIFF
--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -366,7 +366,7 @@ export function PostContentRaw({
   }, []);
 
   const containerClass = classNames(
-    'tablet:flex-row tablet:pb-0',
+    'laptop:flex-row laptop:pb-0',
     className?.container,
   );
 


### PR DESCRIPTION
## Summary
- The post page/modal layout was broken on tablet viewports: the post body was squeezed to a single-character-wide column while `PageWidgets` ate all the horizontal space.
- Root cause: PR #5854 (`bebddfe83` — inline article preview embed) changed `PostContent.tsx`'s container from `laptop:flex-row laptop:pb-0` to `tablet:flex-row tablet:pb-0`. `PageWidgets` only sets its explicit `21.25rem` width at the laptop breakpoint, so flipping the row layout on at tablet let the widgets stay `w-full` and steal all the width from `PostContainer`.
- Reverting that one className brings `PostContent` back in line with every other PostContent variant (Squad, Poll, Brief, Collection, Digest, SocialTwitter, PostLoadingSkeleton), all of which still use `laptop:flex-row laptop:pb-0`.
- The new article-preview branch in this component runs through its own internal grid (`grid-cols-[…]`) and doesn't depend on the parent being flex-row at the tablet breakpoint, so the new feature is unaffected.

## Test plan
- On a tablet-sized viewport (≈768–1023px), open an article post page and confirm the post body and widgets sidebar render side-by-side with the original proportions instead of the body collapsing.
- Open the article post modal at the same width and confirm the same.
- On laptop+ widths, confirm the layout is unchanged (post body + 21.25rem widgets sidebar).
- On mobile, confirm the post body and widgets remain stacked vertically as before.


Made with [Cursor](https://cursor.com)

### Preview domain
https://fix-post-page-tablet-layout-regr.preview.app.daily.dev