### PR TITLE
fix: use static import for HoverCard in PostCardHeader variants

### DIFF
--- a/packages/shared/src/components/cards/common/PostCardHeader.tsx
+++ b/packages/shared/src/components/cards/common/PostCardHeader.tsx
@@ -26,10 +26,7 @@ import { ProfileImageSize } from '../../ProfilePicture';
 import { DeletedPostId } from '../../../lib/constants';
 import { PostOptionButton } from '../../../features/posts/PostOptionButton';
 import type { UserShortProfile } from '../../../lib/user';
-
-const HoverCard = dynamic(
-  /* webpackChunkName: "hoverCard" */ () => import('./HoverCard'),
-);
+import HoverCard from './HoverCard';
 
 const UserEntityCard = dynamic(
   /* webpackChunkName: "userEntityCard" */ () =>

--- a/packages/shared/src/components/cards/common/SquadPostCardHeader.tsx
+++ b/packages/shared/src/components/cards/common/SquadPostCardHeader.tsx
@@ -15,14 +15,11 @@ import type { UserShortProfile } from '../../../lib/user';
 import { PostOptionButton } from '../../../features/posts/PostOptionButton';
 import { isSourceUserSource } from '../../../graphql/sources';
 import type { SourceTooltip } from '../../../graphql/sources';
+import HoverCard from './HoverCard';
 
 const UserEntityCard = dynamic(
   /* webpackChunkName: "userEntityCard" */ () =>
     import('../entity/UserEntityCard'),
-);
-
-const HoverCard = dynamic(
-  /* webpackChunkName: "hoverCard" */ () => import('./HoverCard'),
 );
 
 type SquadPostCardHeaderProps = { post: Post; enableSourceHeader?: boolean };

--- a/packages/shared/src/components/cards/common/list/PostCardHeader.tsx
+++ b/packages/shared/src/components/cards/common/list/PostCardHeader.tsx
@@ -19,10 +19,7 @@ import { ProfileImageLink } from '../../../profile/ProfileImageLink';
 import type { UserShortProfile } from '../../../../lib/user';
 import { PostOptionButton } from '../../../../features/posts/PostOptionButton';
 import { isSourceUserSource } from '../../../../graphql/sources';
-
-const HoverCard = dynamic(
-  /* webpackChunkName: "hoverCard" */ () => import('../HoverCard'),
-);
+import HoverCard from '../HoverCard';
 
 const UserEntityCard = dynamic(
   /* webpackChunkName: "userEntityCard" */ () =>


### PR DESCRIPTION
## Summary
- The author (second) image popover on cards was not appearing because `HoverCard` was dynamically imported via `next/dynamic` in all three `PostCardHeader` variants (grid, list, squad)
- The dynamic import prevented Radix UI event handlers from attaching before hover, so the popover never triggered
- Changed to a static import matching the pattern already used by `SourceButton`, which works reliably
- `UserEntityCard` remains dynamically imported since it's popover content (lazy-loading on hover is fine for content, but the event-handling wrapper must be synchronous)
- Zero bundle impact — `SourceButton` already statically imports `HoverCard` in the same render tree

## Test plan
- [x] ESLint passes with 0 warnings
- [x] Strict typecheck passes
- [x] Related card test suites pass (ArticleGrid, ShareGrid, ShareList, SquadGrid, SquadList — 41 tests)
- [ ] Manual: hover over author image on grid, list, and squad cards — popover should appear
- [ ] Manual: verify source image popover still works

Closes ENG-1367

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1367-second-image-on-card-no.preview.app.daily.dev