### PR TITLE
fix: clear iOS status bar when displaying toast notifications

### DIFF
--- a/packages/shared/src/components/notifications/Toast.module.css
+++ b/packages/shared/src/components/notifications/Toast.module.css
@@ -2,17 +2,20 @@
   z-index: 1000;
   /* Slides down from above on every breakpoint so the toast never overlaps
      bottom-anchored chrome (mobile floating bars, footer nav). Mirrors the
-     existing tablet+ behaviour, just applied to mobile too. */
+     existing tablet+ behaviour, just applied to mobile too.
+     Adds --safe-area-top so the toast clears the iOS status bar when running
+     as a PWA / native iOS app (otherwise it renders behind the system clock,
+     signal, and battery icons and is unreadable). */
   transform: translate(-50%, -5rem);
   transition: transform 0.14s ease-in-out;
   max-width: calc(100vw - 2rem);
   max-height: unset;
   min-height: unset;
   width: 100%;
-  top: 1rem;
+  top: calc(1rem + var(--safe-area-top, 0px));
 
   @screen tablet {
-    top: 2rem;
+    top: calc(2rem + var(--safe-area-top, 0px));
     width: fit-content;
     min-width: 12.5rem;
     max-width: 80vw;


### PR DESCRIPTION
## Summary
- Toast notifications (e.g. "Bookmarked! Saved to ..." with the "Change folder" action) render behind the iOS system status bar in the iOS PWA / native iOS app, making them unreadable ([ENG-1368](https://linear.app/dailydev/issue/ENG-1368/feedback-bug-report-bookmark-message-on-ios-app-is-unreadable-under)).
- Add `var(--safe-area-top, 0px)` to the toast container's `top` so it clears the iOS status bar. No-op on platforms where the variable resolves to `0` (every non-iOS surface).

## Test plan
- [ ] Open the iOS PWA / native iOS app, bookmark a post — confirm the toast appears below the status bar with "Change folder" readable.
- [ ] Verify desktop and Android toasts are unchanged.
- [ ] `pnpm --filter shared test src/components/notifications/Toast.spec.tsx` passes.

Made with [Cursor](https://cursor.com)

### Preview domain
https://fix-toast-ios-safe-area.preview.app.daily.dev