### PR TITLE
fix(shared): close squad share modal after external link post

### DIFF
--- a/packages/shared/src/components/modals/post/CreateSharedPostModal.spec.tsx
+++ b/packages/shared/src/components/modals/post/CreateSharedPostModal.spec.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CreateSharedPostModal } from './CreateSharedPostModal';
+import { usePostToSquad } from '../../../hooks';
+import { useNotificationToggle } from '../../../hooks/notifications';
+
+jest.mock('../../../hooks', () => ({
+  ...(jest.requireActual('../../../hooks') as Iterable<unknown>),
+  usePostToSquad: jest.fn(),
+}));
+
+jest.mock('../../../hooks/notifications', () => ({
+  useNotificationToggle: jest.fn(),
+}));
+
+jest.mock('../common/Modal', () => {
+  const MockModal = ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  );
+  const MockModalHeader = () => null;
+  const MockModalFooter = ({ children }: React.PropsWithChildren) => (
+    <div>{children}</div>
+  );
+
+  MockModal.Kind = { FlexibleCenter: 'FlexibleCenter' };
+  MockModal.Size = { Medium: 'Medium' };
+  MockModal.Header = MockModalHeader;
+  MockModal.Footer = MockModalFooter;
+
+  return {
+    Modal: MockModal,
+  };
+});
+
+jest.mock('../../fields/RichTextInput', () => {
+  const { forwardRef } = jest.requireActual('react') as typeof React;
+
+  return forwardRef(() => null);
+});
+jest.mock('../../post/write', () => ({
+  WriteLinkPreview: () => null,
+  WritePreviewSkeleton: () => null,
+}));
+jest.mock('../../cards/common/SourceButton', () => () => null);
+
+describe('CreateSharedPostModal', () => {
+  const onRequestClose = jest.fn();
+  const onSharedSuccessfully = jest.fn();
+  const onSubmitted = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(useNotificationToggle).mockReturnValue({
+      shouldShowCta: false,
+      isEnabled: false,
+      onToggle: jest.fn(),
+      onSubmitted,
+    } as unknown as ReturnType<typeof useNotificationToggle>);
+    jest.mocked(usePostToSquad).mockReturnValue({
+      getLinkPreview: jest.fn(),
+      isLoadingPreview: false,
+      preview: {},
+      isPosting: false,
+      onSubmitPost: jest.fn(),
+    } as unknown as ReturnType<typeof usePostToSquad>);
+  });
+
+  it('closes the modal from the shared completion callback', () => {
+    render(
+      <CreateSharedPostModal
+        isOpen
+        preview={{ url: 'https://daily.dev/post' }}
+        squad={{ id: 'squad-1', name: 'Squad', handle: 'squad' } as never}
+        onRequestClose={onRequestClose}
+        onSharedSuccessfully={onSharedSuccessfully}
+      />,
+    );
+
+    const hookProps = jest.mocked(usePostToSquad).mock.calls[0]?.[0];
+
+    expect(hookProps?.onComplete).toBeDefined();
+
+    hookProps?.onComplete?.();
+
+    expect(onSharedSuccessfully).toHaveBeenCalledTimes(1);
+    expect(onSubmitted).toHaveBeenCalledTimes(1);
+    expect(onRequestClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
+++ b/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
@@ -36,14 +36,14 @@ export function CreateSharedPostModal({
   onRequestClose,
   ...props
 }: CreateSharedPostModalProps): ReactElement {
-  const richTextRef = useRef<RichTextInputRef>();
+  const richTextRef = useRef<RichTextInputRef | null>(null);
   const [link, setLink] = useState(preview?.permalink ?? preview?.url ?? '');
   const { shouldShowCta, isEnabled, onToggle, onSubmitted } =
     useNotificationToggle();
   const onSuccess = () => {
     onSharedSuccessfully?.();
     onSubmitted();
-    onRequestClose(null);
+    onRequestClose?.(undefined as never);
   };
   const {
     getLinkPreview,
@@ -53,8 +53,7 @@ export function CreateSharedPostModal({
     onSubmitPost,
   } = usePostToSquad({
     initialPreview: preview,
-    onPostSuccess: onSuccess,
-    onSourcePostModerationSuccess: onSuccess,
+    onComplete: onSuccess,
   });
 
   const onFormSubmit: FormEventHandler<HTMLFormElement> = (e) => {
@@ -65,8 +64,15 @@ export function CreateSharedPostModal({
   };
 
   const links = [updatedPreview?.url, updatedPreview?.permalink];
-  const [checkUrl] = useDebouncedUrl(getLinkPreview, (value) =>
-    links.every((url) => url !== value),
+  const [checkUrl] = useDebouncedUrl(
+    (value) => {
+      if (!value) {
+        return undefined;
+      }
+
+      return getLinkPreview(value);
+    },
+    (value) => links.every((url) => url !== value),
   );
 
   const onInput: FormEventHandler<HTMLInputElement> = (e) => {

--- a/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
+++ b/packages/shared/src/components/modals/post/CreateSharedPostModal.tsx
@@ -1,6 +1,6 @@
 import type { FormEventHandler, ReactElement } from 'react';
 import React, { useRef, useState } from 'react';
-import type { ModalProps } from '../common/Modal';
+import type { LazyModalCommonProps } from '../common/Modal';
 import { Modal } from '../common/Modal';
 import type { ExternalLinkPreview } from '../../../graphql/posts';
 import type { RichTextInputRef } from '../../fields/RichTextInput';
@@ -23,7 +23,7 @@ import { useNotificationToggle } from '../../../hooks/notifications';
 import { Switch } from '../../fields/Switch';
 import { ProfileImageSize } from '../../ProfilePicture';
 
-export interface CreateSharedPostModalProps extends ModalProps {
+export interface CreateSharedPostModalProps extends LazyModalCommonProps {
   preview: ExternalLinkPreview;
   onSharedSuccessfully?: (enableNotification?: boolean) => void;
   squad: Squad;
@@ -43,7 +43,7 @@ export function CreateSharedPostModal({
   const onSuccess = () => {
     onSharedSuccessfully?.();
     onSubmitted();
-    onRequestClose?.(undefined as never);
+    onRequestClose();
   };
   const {
     getLinkPreview,

--- a/packages/shared/src/hooks/squads/usePostToSquad.spec.tsx
+++ b/packages/shared/src/hooks/squads/usePostToSquad.spec.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import { usePostToSquad } from './usePostToSquad';
+import { submitExternalLink } from '../../graphql/posts';
+import { addPostToSquad } from '../../graphql/squads';
+import { useToastNotification } from '../useToastNotification';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { useActions } from '../useActions';
+import { useRequestProtocol } from '../useRequestProtocol';
+import useSourcePostModeration from '../source/useSourcePostModeration';
+import useNotificationSettings from '../notifications/useNotificationSettings';
+
+jest.mock('../../graphql/posts', () => ({
+  ...(jest.requireActual('../../graphql/posts') as Iterable<unknown>),
+  submitExternalLink: jest.fn(),
+}));
+
+jest.mock('../../graphql/squads', () => ({
+  ...(jest.requireActual('../../graphql/squads') as Iterable<unknown>),
+  addPostToSquad: jest.fn(),
+}));
+
+jest.mock('../useToastNotification', () => ({
+  useToastNotification: jest.fn(),
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  ...(jest.requireActual('../../contexts/AuthContext') as Iterable<unknown>),
+  useAuthContext: jest.fn(),
+}));
+
+jest.mock('../useActions', () => ({
+  useActions: jest.fn(),
+}));
+
+jest.mock('../useRequestProtocol', () => ({
+  useRequestProtocol: jest.fn(),
+}));
+
+jest.mock('../source/useSourcePostModeration', () => jest.fn());
+
+jest.mock('../notifications/useNotificationSettings', () => jest.fn());
+
+describe('usePostToSquad', () => {
+  const displayToast = jest.fn();
+  const completeAction = jest.fn();
+  const requestMethod = jest.fn();
+  const onComplete = jest.fn();
+  const onPostSuccess = jest.fn();
+  let client: QueryClient;
+
+  const wrapper = ({ children }: React.PropsWithChildren) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    client = new QueryClient();
+    jest.clearAllMocks();
+
+    jest.mocked(useToastNotification).mockReturnValue({
+      displayToast,
+    } as unknown as ReturnType<typeof useToastNotification>);
+    jest.mocked(useAuthContext).mockReturnValue({
+      user: { id: 'user-1' },
+    } as ReturnType<typeof useAuthContext>);
+    jest.mocked(useActions).mockReturnValue({
+      completeAction,
+    } as unknown as ReturnType<typeof useActions>);
+    jest.mocked(useRequestProtocol).mockReturnValue({
+      requestMethod,
+    } as unknown as ReturnType<typeof useRequestProtocol>);
+    jest.mocked(useSourcePostModeration).mockReturnValue({
+      onCreatePostModeration: jest.fn(),
+      isSuccess: false,
+      isPending: false,
+    } as unknown as ReturnType<typeof useSourcePostModeration>);
+    jest.mocked(useNotificationSettings).mockReturnValue({
+      toggleGroup: jest.fn(),
+      getGroupStatus: jest.fn(() => true),
+    } as unknown as ReturnType<typeof useNotificationSettings>);
+    jest.mocked(addPostToSquad).mockReturnValue(jest.fn());
+  });
+
+  it('fires onComplete after submitting an external link without a preview id', async () => {
+    jest.mocked(submitExternalLink).mockResolvedValue({} as never);
+
+    const { result } = renderHook(
+      () =>
+        usePostToSquad({
+          initialPreview: {
+            url: 'https://daily.dev/post',
+            finalUrl: 'https://daily.dev/post',
+            title: 'Daily',
+            image: 'https://daily.dev/post.png',
+          },
+          onComplete,
+          onPostSuccess,
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.onSubmitPost(
+        { preventDefault: jest.fn() } as never,
+        { id: 'squad-1', moderationRequired: false } as never,
+        'Nice post',
+      );
+    });
+
+    expect(submitExternalLink).toHaveBeenCalledWith(
+      {
+        commentary: 'Nice post',
+        image: 'https://daily.dev/post.png',
+        sourceId: 'squad-1',
+        title: 'Daily',
+        url: 'https://daily.dev/post',
+      },
+      requestMethod,
+    );
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onPostSuccess).not.toHaveBeenCalled();
+  });
+
+  it('fires onComplete alongside onPostSuccess for shared post submissions', async () => {
+    const mutatePost = jest.fn().mockResolvedValue({
+      id: 'post-1',
+      permalink: 'https://daily.dev/posts/1',
+    });
+    jest.mocked(addPostToSquad).mockReturnValue(mutatePost);
+
+    const { result } = renderHook(
+      () =>
+        usePostToSquad({
+          initialPreview: {
+            id: 'shared-1',
+            permalink: 'https://daily.dev/shared/1',
+          },
+          onComplete,
+          onPostSuccess,
+        }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.onSubmitPost(
+        { preventDefault: jest.fn() } as never,
+        { id: 'squad-1', moderationRequired: false } as never,
+        'Commentary',
+      );
+    });
+
+    expect(mutatePost).toHaveBeenCalledWith({
+      commentary: 'Commentary',
+      id: 'shared-1',
+      sourceId: 'squad-1',
+    });
+    expect(onPostSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'post-1',
+        permalink: 'https://daily.dev/posts/1',
+      }),
+      'https://daily.dev/posts/1',
+    );
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/shared/src/hooks/squads/usePostToSquad.tsx
+++ b/packages/shared/src/hooks/squads/usePostToSquad.tsx
@@ -75,6 +75,7 @@ interface UsePostToSquad {
 
 interface UsePostToSquadProps {
   onPostSuccess?: (post: Post, url: string) => void;
+  onComplete?: () => void;
   onSourcePostModerationSuccess?: (data: SourcePostModeration) => void;
   onExternalLinkSuccess?: (data: ExternalLinkPreview, url: string) => void;
   getSharedPostSuccessToast?: (params: {
@@ -95,6 +96,7 @@ const getSquadIdOrThrow = (squad: Squad): string => {
 
 export const usePostToSquad = ({
   onPostSuccess,
+  onComplete,
   onMutate,
   onError,
   onExternalLinkSuccess,
@@ -126,13 +128,10 @@ export const usePostToSquad = ({
 
   const handlePostSuccess = useCallback(
     (post: Post): void => {
-      if (!onPostSuccess) {
-        return;
-      }
-
-      onPostSuccess(post, post?.permalink ?? '');
+      onPostSuccess?.(post, post?.permalink ?? '');
+      onComplete?.();
     },
-    [onPostSuccess],
+    [onComplete, onPostSuccess],
   );
 
   const {
@@ -207,6 +206,7 @@ export const usePostToSquad = ({
     onSuccess: (data) => {
       completeAction(ActionType.SquadFirstPost);
       onSourcePostModerationSuccess?.(data);
+      onComplete?.();
     },
     onError: () => {
       displayToast(DEFAULT_ERROR);
@@ -297,6 +297,7 @@ export const usePostToSquad = ({
         throw new Error('Missing external link url in usePostToSquad');
       }
       onExternalLinkSuccess?.(preview, url);
+      onComplete?.();
     },
     onError: (err: ApiErrorResult) => {
       const rateLimited = getApiError(err, ApiError.RateLimited);

--- a/packages/shared/src/hooks/squads/usePostToSquad.tsx
+++ b/packages/shared/src/hooks/squads/usePostToSquad.tsx
@@ -134,6 +134,8 @@ export const usePostToSquad = ({
     [onComplete, onPostSuccess],
   );
 
+  const handleComplete = useCallback((): void => onComplete?.(), [onComplete]);
+
   const {
     mutateAsync: onCreatePost,
     isPending: isLoadingFreeform,
@@ -206,7 +208,7 @@ export const usePostToSquad = ({
     onSuccess: (data) => {
       completeAction(ActionType.SquadFirstPost);
       onSourcePostModerationSuccess?.(data);
-      onComplete?.();
+      handleComplete();
     },
     onError: () => {
       displayToast(DEFAULT_ERROR);
@@ -297,7 +299,7 @@ export const usePostToSquad = ({
         throw new Error('Missing external link url in usePostToSquad');
       }
       onExternalLinkSuccess?.(preview, url);
-      onComplete?.();
+      handleComplete();
     },
     onError: (err: ApiErrorResult) => {
       const rateLimited = getApiError(err, ApiError.RateLimited);


### PR DESCRIPTION
## Summary
- close the squad share modal after successful external-link submissions
- keep existing modal close behavior for the other successful post flows
- add focused regression tests for the shared hook and modal wiring

## Key Decisions
- introduced a dedicated `onComplete` callback in `usePostToSquad` so the external-link path can signal success without fabricating a `Post` object
- kept `onPostSuccess` reserved for flows that actually return a `Post`
- narrowed `CreateSharedPostModal` back to lazy-modal props to keep the close path simple

Closes ENG-1358

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1358-feedback-feature-reques.preview.app.daily.dev