### PR TITLE
fix(shared): preserve dash-prefixed paragraphs in editor markdown

### DIFF
--- a/packages/shared/src/lib/markdownConversion.spec.ts
+++ b/packages/shared/src/lib/markdownConversion.spec.ts
@@ -172,4 +172,52 @@ describe('markdownConversion', () => {
 
     expect(markdown).toBe('__EMPTY_PARAGRAPH__\n\nnext');
   });
+
+  it('should escape dash-prefixed paragraph text in html to markdown', () => {
+    const markdown = htmlToMarkdownBasic('<p>- text</p>');
+
+    expect(markdown).toBe('\\- text');
+  });
+
+  it('should escape asterisk-prefixed paragraph text in html to markdown', () => {
+    const markdown = htmlToMarkdownBasic('<p>* text</p>');
+
+    expect(markdown).toBe('\\* text');
+  });
+
+  it('should escape plus-prefixed paragraph text in html to markdown', () => {
+    const markdown = htmlToMarkdownBasic('<p>+ text</p>');
+
+    expect(markdown).toBe('\\+ text');
+  });
+
+  it('should escape ordered-list-prefixed paragraph text in html to markdown', () => {
+    const markdown = htmlToMarkdownBasic('<p>1. text</p>');
+
+    expect(markdown).toBe('1\\. text');
+  });
+
+  it('should keep escaped dash-prefixed markdown as a paragraph', () => {
+    const html = markdownToHtmlBasic('\\- text');
+
+    expect(html).toBe('<p>- text</p>');
+  });
+
+  it('should preserve dash-prefixed paragraph text across round-trips', () => {
+    const initialHtml = '<p>- text</p>';
+    const markdown = htmlToMarkdownBasic(initialHtml);
+    const html = markdownToHtmlBasic(markdown);
+
+    expect(markdown).toBe('\\- text');
+    expect(html).toBe(initialHtml);
+  });
+
+  it('should preserve bullet lists across round-trips', () => {
+    const initialHtml = '<ul><li>text</li></ul>';
+    const markdown = htmlToMarkdownBasic(initialHtml);
+    const html = markdownToHtmlBasic(markdown);
+
+    expect(markdown).toBe('- text');
+    expect(html).toBe(initialHtml);
+  });
 });

--- a/packages/shared/src/lib/markdownConversion.ts
+++ b/packages/shared/src/lib/markdownConversion.ts
@@ -6,13 +6,15 @@ const escapeAttribute = (value: string): string =>
 
 const normalizeText = (value: string): string => value.replace(/\u00a0/g, ' ');
 
-const unescapeMarkdownText = (value: string): string =>
-  value.replace(/\\([\\`*_[\]{}()#+\-.!~>])/g, '$1');
-
 const escapeParagraphListMarkers = (value: string): string =>
   value
     .replace(/^([ \t]*)([-+*])\s+/gm, '$1\\$2 ')
     .replace(/^([ \t]*)(\d+)\.\s+/gm, '$1$2\\. ');
+
+const unescapeParagraphListMarkers = (value: string): string =>
+  value
+    .replace(/^([ \t]*)\\([-+*])\s+/gm, '$1$2 ')
+    .replace(/^([ \t]*)(\d+)\\\.\s+/gm, '$1$2. ');
 
 const applyInlineTextFormatting = (value: string): string => {
   let result = value;
@@ -44,9 +46,7 @@ const inlineMarkdownToHtml = (value: string): string => {
   return result
     .split(/(<[^>]+>)/g)
     .map((part) =>
-      part.startsWith('<')
-        ? part
-        : applyInlineTextFormatting(unescapeMarkdownText(part)),
+      part.startsWith('<') ? part : applyInlineTextFormatting(part),
     )
     .join('');
 };
@@ -179,7 +179,9 @@ export const markdownToHtmlBasic = (markdown: string): string => {
 
     flushList();
     flushPendingEmptyParagraphs();
-    htmlParts.push(`<p>${inlineMarkdownToHtml(line)}</p>`);
+    htmlParts.push(
+      `<p>${inlineMarkdownToHtml(unescapeParagraphListMarkers(line))}</p>`,
+    );
     hasRenderedBlock = true;
   });
 

--- a/packages/shared/src/lib/markdownConversion.ts
+++ b/packages/shared/src/lib/markdownConversion.ts
@@ -6,6 +6,14 @@ const escapeAttribute = (value: string): string =>
 
 const normalizeText = (value: string): string => value.replace(/\u00a0/g, ' ');
 
+const unescapeMarkdownText = (value: string): string =>
+  value.replace(/\\([\\`*_[\]{}()#+\-.!~>])/g, '$1');
+
+const escapeParagraphListMarkers = (value: string): string =>
+  value
+    .replace(/^([ \t]*)([-+*])\s+/gm, '$1\\$2 ')
+    .replace(/^([ \t]*)(\d+)\.\s+/gm, '$1$2\\. ');
+
 const applyInlineTextFormatting = (value: string): string => {
   let result = value;
 
@@ -36,7 +44,9 @@ const inlineMarkdownToHtml = (value: string): string => {
   return result
     .split(/(<[^>]+>)/g)
     .map((part) =>
-      part.startsWith('<') ? part : applyInlineTextFormatting(part),
+      part.startsWith('<')
+        ? part
+        : applyInlineTextFormatting(unescapeMarkdownText(part)),
     )
     .join('');
 };
@@ -116,7 +126,7 @@ export const markdownToHtmlBasic = (markdown: string): string => {
       return;
     }
 
-    const unorderedMatch = /^[-*]\s+(.+)$/.exec(trimmed);
+    const unorderedMatch = /^[-+*]\s+(.+)$/.exec(trimmed);
     const orderedMatch = /^(\d+)\.\s+(.+)$/.exec(trimmed);
     const headingMatch = /^(#{1,6})\s+(.+)$/.exec(trimmed);
 
@@ -300,7 +310,7 @@ export const htmlToMarkdownBasic = (html: string): string => {
       switch (tagName) {
         case 'p': {
           const content = serializeChildren(node).trim();
-          return content;
+          return escapeParagraphListMarkers(content);
         }
         case 'pre': {
           const code = node.textContent ?? '';


### PR DESCRIPTION
## Summary
- preserve plain dialogue lines that start with markdown list markers when comments round-trip through the rich text editor
- escape paragraph-leading `-`, `*`, `+`, and `1.` markers during HTML-to-markdown serialization so undoing TipTap auto-lists survives save and reload
- keep actual `<ul>` and `<ol>` content unchanged and add focused regression coverage for paragraph and list round-trips

## Key Decisions
- kept TipTap's built-in list input rules enabled and fixed the markdown round-trip instead of changing editor behavior
- limited markdown unescaping to escaped list markers at the start of paragraph lines to avoid widening parser behavior unnecessarily

Closes ENG-1362

---
Created by Huginn 🐦‍⬛


### Preview domain
https://eng-1362-feedback-bug-report-the.preview.app.daily.dev