### PR TITLE
feat: improve mobile standup experience

### DIFF
--- a/packages/shared/src/components/fields/RichTextInput.tsx
+++ b/packages/shared/src/components/fields/RichTextInput.tsx
@@ -146,6 +146,7 @@ interface RichTextInputProps {
   allowBlockFormatting?: boolean;
   minHeightClassName?: string;
   markdownToHtml?: (markdown: string) => string;
+  hideToolbar?: boolean;
 }
 
 export interface RichTextInputRef {
@@ -181,6 +182,7 @@ function RichTextInput(
     allowBlockFormatting = true,
     minHeightClassName = 'min-h-[8rem]',
     markdownToHtml = markdownToHtmlBasic,
+    hideToolbar = false,
   }: RichTextInputProps,
   ref: ForwardedRef<RichTextInputRef>,
 ): ReactElement {
@@ -780,48 +782,53 @@ function RichTextInput(
             </>
           ) : (
             <>
-              <RichTextToolbar
-                ref={toolbarRef}
-                editor={editor}
-                allowBlockFormatting={allowBlockFormatting}
-                onLinkAdd={(url, label) => {
-                  if (!editor) {
-                    return;
+              {hideToolbar ? null : (
+                <RichTextToolbar
+                  ref={toolbarRef}
+                  editor={editor}
+                  allowBlockFormatting={allowBlockFormatting}
+                  onLinkAdd={(url, label) => {
+                    if (!editor) {
+                      return;
+                    }
+                    if (!editor.state.selection.empty) {
+                      editor.chain().focus().setLink({ href: url }).run();
+                      return;
+                    }
+                    const linkText = label || url;
+                    editor
+                      .chain()
+                      .focus()
+                      .insertContent({
+                        type: 'text',
+                        text: linkText,
+                        marks: [{ type: 'link', attrs: { href: url } }],
+                      })
+                      .run();
+                  }}
+                  inlineActions={hasToolbarActions ? toolbarActions : null}
+                  rightActions={
+                    <div className="flex items-center gap-0">
+                      {savingLabel}
+                      <SimpleTooltip content="Switch to Markdown Editor">
+                        <Button
+                          type="button"
+                          variant={ButtonVariant.Tertiary}
+                          size={ButtonSize.Small}
+                          icon={<MarkdownIcon />}
+                          onClick={switchToMarkdownMode}
+                        />
+                      </SimpleTooltip>
+                      {onClose && (
+                        <CloseButton
+                          size={ButtonSize.Small}
+                          onClick={onClose}
+                        />
+                      )}
+                    </div>
                   }
-                  if (!editor.state.selection.empty) {
-                    editor.chain().focus().setLink({ href: url }).run();
-                    return;
-                  }
-                  const linkText = label || url;
-                  editor
-                    .chain()
-                    .focus()
-                    .insertContent({
-                      type: 'text',
-                      text: linkText,
-                      marks: [{ type: 'link', attrs: { href: url } }],
-                    })
-                    .run();
-                }}
-                inlineActions={hasToolbarActions ? toolbarActions : null}
-                rightActions={
-                  <div className="flex items-center gap-0">
-                    {savingLabel}
-                    <SimpleTooltip content="Switch to Markdown Editor">
-                      <Button
-                        type="button"
-                        variant={ButtonVariant.Tertiary}
-                        size={ButtonSize.Small}
-                        icon={<MarkdownIcon />}
-                        onClick={switchToMarkdownMode}
-                      />
-                    </SimpleTooltip>
-                    {onClose && (
-                      <CloseButton size={ButtonSize.Small} onClick={onClose} />
-                    )}
-                  </div>
-                }
-              />
+                />
+              )}
               {isUploadEnabled && (
                 <input
                   type="file"

--- a/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
@@ -20,6 +20,7 @@ const mockUsePushNotificationContext = jest.fn();
 const mockSubscribeToLiveRoom = jest.fn();
 const mockUnsubscribeFromLiveRoom = jest.fn();
 const mockEnablePush = jest.fn();
+const mockUseViewSize = jest.fn<boolean, [unknown]>(() => true);
 const mockUseQueries = useQueries as jest.Mock;
 
 jest.mock('@tanstack/react-query', () => {
@@ -72,6 +73,14 @@ jest.mock('../../hooks/notifications/usePushNotificationMutation', () => ({
 jest.mock('../../hooks/useToastNotification', () => ({
   useToastNotification: () => ({ displayToast: mockDisplayToast }),
 }));
+
+jest.mock('../../hooks', () => {
+  const actual = jest.requireActual('../../hooks');
+  return {
+    ...actual,
+    useViewSize: (size: unknown) => mockUseViewSize(size),
+  };
+});
 
 jest.mock('../../graphql/users', () => ({
   getUserShortInfo: jest.fn(),
@@ -257,6 +266,7 @@ const createParticipant = (
 describe('LiveRoom', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseViewSize.mockReturnValue(true);
     mockUseLiveRoomParticipantStreams.mockReturnValue(new Map());
     mockSubscribeToLiveRoom.mockResolvedValue({});
     mockUnsubscribeFromLiveRoom.mockResolvedValue({});
@@ -944,6 +954,49 @@ describe('LiveRoom', () => {
 
     expect(screen.getByText('Page 1 / 2')).toBeInTheDocument();
     expect(screen.getAllByTestId('live-room-tile')).toHaveLength(12);
+  });
+
+  it('limits stage pagination to four visible speakers on mobile', () => {
+    mockUseViewSize.mockReturnValue(false);
+    const activeSpeakerParticipantIds = Array.from(
+      { length: 12 },
+      (_, index) => `speaker-${index + 1}`,
+    );
+    const participants = activeSpeakerParticipantIds.reduce<
+      NonNullable<LiveRoomContextValue['roomState']>['participants']
+    >(
+      (acc, participantId) => ({
+        ...acc,
+        [participantId]: createParticipant(participantId),
+      }),
+      {
+        host: createParticipant('host', 'host'),
+      },
+    );
+
+    mockUseLiveRoomConnection.mockReturnValue(
+      createContextValue({
+        roomState: {
+          ...createContextValue().roomState!,
+          participants,
+          stage: {
+            speakerQueueParticipantIds: [],
+            activeSpeakerParticipantIds,
+            raisedHandParticipantIds: [],
+          },
+        },
+      }),
+    );
+
+    renderLiveRoom();
+
+    expect(screen.getByText('Page 1 / 4')).toBeInTheDocument();
+    expect(screen.getAllByTestId('live-room-tile')).toHaveLength(4);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    expect(screen.getByText('Page 2 / 4')).toBeInTheDocument();
+    expect(screen.getAllByTestId('live-room-tile')).toHaveLength(4);
   });
 
   it('logs a room query error only once for the same failure', () => {

--- a/packages/shared/src/components/liveRooms/LiveRoom.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.tsx
@@ -8,6 +8,7 @@ import React, {
 } from 'react';
 import { useRouter } from 'next/router';
 import classNames from 'classnames';
+import { useSwipeable } from 'react-swipeable';
 import {
   Typography,
   TypographyColor,
@@ -41,6 +42,7 @@ import { useStreamDuration } from '../../hooks/liveRooms/useStreamDuration';
 import useLogEventOnce from '../../hooks/log/useLogEventOnce';
 import { useToastNotification } from '../../hooks/useToastNotification';
 import { useExitConfirmation } from '../../hooks/useExitConfirmation';
+import { useViewSize, ViewSize } from '../../hooks';
 import { clearStoredLiveRoomResumeSession } from '../../lib/liveRoom/resumeSessionStorage';
 import { UserIcon } from '../icons';
 import { IconSize } from '../Icon';
@@ -65,11 +67,15 @@ interface LiveRoomProps {
 }
 
 const MAX_STAGE_TILES_PER_PAGE = 12;
+const MOBILE_MAX_STAGE_TILES_PER_PAGE = 4;
 const EMPTY_PARTICIPANT_IDS: string[] = [];
 
-const getStageGridColumnCount = (count: number): number => {
+const getStageGridColumnCount = (count: number, isMobile: boolean): number => {
   if (count <= 1) {
     return 1;
+  }
+  if (isMobile) {
+    return 2;
   }
   if (count <= 4) {
     return 2;
@@ -170,13 +176,13 @@ const useCountdownSeconds = (target: string | null | undefined): number => {
 const LiveBadge = ({ isLive }: { isLive: boolean }): ReactElement => (
   <span
     className={classNames(
-      'inline-flex items-center gap-1.5 rounded-8 px-2 py-0.5 typo-caption1',
+      'inline-flex items-center gap-1 rounded-8 px-1.5 py-px typo-caption2 tablet:gap-1.5 tablet:px-2 tablet:py-0.5 tablet:typo-caption1',
       isLive
         ? 'bg-accent-ketchup-default text-white'
         : 'bg-accent-bacon-default text-white',
     )}
   >
-    <span className="size-1.5 animate-pulse rounded-full bg-white" />
+    <span className="size-1 animate-pulse rounded-full bg-white tablet:size-1.5" />
     <span className="font-bold uppercase tracking-wide">
       {isLive ? 'Live' : 'Lobby'}
     </span>
@@ -188,7 +194,7 @@ const LiveRoomLobbyContent = ({
 }: {
   room: LiveRoomModel;
 }): ReactElement => (
-  <div className="min-h-0 flex-1 overflow-y-auto p-1.5 pb-24 tablet:pb-28">
+  <div className="min-h-0 flex-1 overflow-y-auto px-3 py-1.5 pb-20 tablet:p-1.5 tablet:pb-28">
     <article className="mx-auto flex w-full max-w-[42rem] flex-col gap-5">
       {room.descriptionHtml ? (
         <Markdown
@@ -213,6 +219,8 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   const { displayToast } = useToastNotification();
   const { isAuthReady, showLogin, user } = useAuthContext();
   const { logEvent } = useLogContext();
+  const isTablet = useViewSize(ViewSize.Tablet);
+  const isMobile = !isTablet;
   const { isPushSupported, isSubscribed: isPushEnabled } =
     usePushNotificationContext();
   const { onEnablePush } = usePushNotificationMutation();
@@ -262,6 +270,9 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   const [moderationBusy, setModerationBusy] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<LiveRoomSidePanelTab>('chat');
   const [stagePage, setStagePage] = useState(0);
+  const [focusedSpeakerIndex, setFocusedSpeakerIndex] = useState<number | null>(
+    null,
+  );
   const lastLoggedRoomErrorRef = useRef<string | null>(null);
   const buildStandupExtra = useCallback(
     (extra: Record<string, unknown> = {}) =>
@@ -486,7 +497,10 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     },
     [logStandupAction, revokeCoHost],
   );
-  const handleTabChange = (tab: LiveRoomSidePanelTab): void => {
+  const handleTabChange = (
+    tab: LiveRoomSidePanelTab,
+    source: 'tab_click' | 'swipe' = 'tab_click',
+  ): void => {
     if (tab === activeTab) {
       return;
     }
@@ -494,6 +508,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     logStandupAction(LogEvent.SwitchStandupPanelTab, tab, {
       surface: 'side_panel',
       previousTab: activeTab,
+      source,
     });
     setActiveTab(tab);
   };
@@ -702,18 +717,22 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   const visibleStageSpeakers = stageSpeakers.filter(
     (speaker) => !speaker.selfView || !videoSettings.hideSelfView,
   );
+  const stageTilesPerPage = isMobile
+    ? MOBILE_MAX_STAGE_TILES_PER_PAGE
+    : MAX_STAGE_TILES_PER_PAGE;
   const stagePageCount = Math.max(
     1,
-    Math.ceil(visibleStageSpeakers.length / MAX_STAGE_TILES_PER_PAGE),
+    Math.ceil(visibleStageSpeakers.length / stageTilesPerPage),
   );
   const clampedStagePage = Math.min(stagePage, stagePageCount - 1);
-  const stagePageStart = clampedStagePage * MAX_STAGE_TILES_PER_PAGE;
+  const stagePageStart = clampedStagePage * stageTilesPerPage;
   const paginatedStageSpeakers = visibleStageSpeakers.slice(
     stagePageStart,
-    stagePageStart + MAX_STAGE_TILES_PER_PAGE,
+    stagePageStart + stageTilesPerPage,
   );
   const stageGridColumnCount = getStageGridColumnCount(
     paginatedStageSpeakers.length,
+    isMobile,
   );
   const stageGridRowCount = Math.max(
     1,
@@ -732,6 +751,99 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   useEffect(() => {
     setStagePage((currentPage) => Math.min(currentPage, stagePageCount - 1));
   }, [stagePageCount]);
+
+  useEffect(() => {
+    if (
+      focusedSpeakerIndex !== null &&
+      focusedSpeakerIndex >= paginatedStageSpeakers.length
+    ) {
+      setFocusedSpeakerIndex(null);
+    }
+  }, [focusedSpeakerIndex, paginatedStageSpeakers.length]);
+
+  const focusSpeaker = (index: number): void => {
+    const speaker = paginatedStageSpeakers[index];
+    if (!speaker) {
+      return;
+    }
+    logStandupAction(LogEvent.FocusStandupSpeaker, speaker.id, {
+      surface: 'stage_tile',
+      action: 'open',
+      source: 'tap',
+      isSelf: !!speaker.selfView,
+      position: index,
+      totalSpeakers: paginatedStageSpeakers.length,
+    });
+    setFocusedSpeakerIndex(index);
+  };
+  const unfocusSpeaker = (): void => {
+    if (focusedSpeakerIndex === null) {
+      return;
+    }
+    const speaker = paginatedStageSpeakers[focusedSpeakerIndex];
+    logStandupAction(LogEvent.FocusStandupSpeaker, speaker?.id ?? '', {
+      surface: 'stage_tile',
+      action: 'close',
+      source: 'backdrop',
+      position: focusedSpeakerIndex,
+      totalSpeakers: paginatedStageSpeakers.length,
+    });
+    setFocusedSpeakerIndex(null);
+  };
+  const handleSpeakerFocusNavigate = (delta: 1 | -1): void => {
+    if (focusedSpeakerIndex === null || paginatedStageSpeakers.length === 0) {
+      return;
+    }
+    const total = paginatedStageSpeakers.length;
+    const nextIndex = (((focusedSpeakerIndex + delta) % total) + total) % total;
+    const nextSpeaker = paginatedStageSpeakers[nextIndex];
+    logStandupAction(LogEvent.FocusStandupSpeaker, nextSpeaker?.id ?? '', {
+      surface: 'stage_tile',
+      action: 'navigate',
+      source: delta === 1 ? 'swipe_next' : 'swipe_prev',
+      isSelf: !!nextSpeaker?.selfView,
+      position: nextIndex,
+      totalSpeakers: total,
+    });
+    setFocusedSpeakerIndex(nextIndex);
+  };
+
+  const sidePanelTabs: {
+    id: LiveRoomSidePanelTab;
+    label: string;
+    count?: number;
+  }[] = [
+    { id: 'chat', label: 'Chat' },
+    ...(isFreeForAll
+      ? []
+      : [
+          {
+            id: 'queue' as const,
+            label: 'Queue',
+            count: queuedParticipantIds.length,
+          },
+        ]),
+    {
+      id: 'audience',
+      label: 'Audience',
+      count: audienceParticipantIds.length,
+    },
+  ];
+  const sidePanelTabIds = sidePanelTabs.map((tab) => tab.id);
+  const activeTabIndex = sidePanelTabIds.indexOf(activeTab);
+  const navigateSidePanelTab = (delta: 1 | -1): void => {
+    const nextIndex = activeTabIndex + delta;
+    if (nextIndex < 0 || nextIndex >= sidePanelTabIds.length) {
+      return;
+    }
+    handleTabChange(sidePanelTabIds[nextIndex], 'swipe');
+  };
+  const sidePanelSwipeHandlers = useSwipeable({
+    onSwipedLeft: () => navigateSidePanelTab(1),
+    onSwipedRight: () => navigateSidePanelTab(-1),
+    trackTouch: true,
+    trackMouse: false,
+  });
 
   useEffect(() => {
     if (!roomError) {
@@ -815,10 +927,10 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   }
 
   return (
-    <div className="relative flex flex-1 flex-col gap-3 overflow-hidden p-3 tablet:p-4">
+    <div className="relative flex flex-1 flex-col overflow-hidden tablet:gap-3 tablet:p-4">
       <ReactionOverlay reactions={reactions} />
 
-      <header className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 rounded-16 border border-border-subtlest-tertiary bg-surface-float px-4 py-3">
+      <header className="flex flex-wrap items-center justify-between gap-x-3 gap-y-0.5 rounded-none border-x-0 border-b border-t-0 border-border-subtlest-tertiary bg-surface-float px-3 py-1.5 tablet:gap-x-4 tablet:gap-y-2 tablet:rounded-16 tablet:border-x tablet:border-t tablet:px-4 tablet:py-3">
         <div className="flex min-w-0 items-center gap-3">
           <LiveBadge isLive={!!isLive} />
           <Typography
@@ -879,7 +991,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
         </div>
       </header>
 
-      <div className="grid min-h-0 flex-1 grid-cols-1 gap-3 laptop:grid-cols-[minmax(0,1fr)_22rem]">
+      <div className="grid min-h-0 flex-1 grid-cols-1 grid-rows-[1fr_auto] tablet:grid-rows-none tablet:gap-3 laptop:grid-cols-[minmax(0,1fr)_22rem]">
         <section
           aria-label="Speakers"
           className="relative flex min-h-0 flex-col"
@@ -927,7 +1039,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
                 gridTemplateRows: `repeat(${stageGridRowCount}, minmax(0, 1fr))`,
               }}
             >
-              {paginatedStageSpeakers.map((speaker) => {
+              {paginatedStageSpeakers.map((speaker, index) => {
                 const canModerate = hasHostPrivileges && !speaker.isHost;
                 const canManageCoHosts = isHost && !speaker.isHost;
 
@@ -944,6 +1056,11 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
                       isCoHost={speaker.isCoHost}
                       raisedHandQueuePosition={speaker.raisedHandQueuePosition}
                       isMuted={speaker.isMuted}
+                      isFocused={focusedSpeakerIndex === index}
+                      onFocus={() => focusSpeaker(index)}
+                      onUnfocus={unfocusSpeaker}
+                      onSwipeNext={() => handleSpeakerFocusNavigate(1)}
+                      onSwipePrev={() => handleSpeakerFocusNavigate(-1)}
                       onGrantCoHost={
                         canManageCoHosts && !speaker.isCoHost
                           ? () =>
@@ -1053,30 +1170,14 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
 
         <aside
           aria-label="Standup side panel"
-          className="flex min-h-0 flex-col overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-surface-float"
+          className="flex h-[40dvh] min-h-0 flex-col overflow-hidden rounded-none border-x-0 border-b-0 border-t border-border-subtlest-tertiary bg-surface-float tablet:h-auto tablet:rounded-16 tablet:border-x tablet:border-b"
         >
           <LiveRoomSidePanelTabs
             active={activeTab}
-            tabs={[
-              { id: 'chat', label: 'Chat' },
-              ...(isFreeForAll
-                ? []
-                : [
-                    {
-                      id: 'queue' as const,
-                      label: 'Queue',
-                      count: queuedParticipantIds.length,
-                    },
-                  ]),
-              {
-                id: 'audience',
-                label: 'Audience',
-                count: audienceParticipantIds.length,
-              },
-            ]}
+            tabs={sidePanelTabs}
             onChange={handleTabChange}
           />
-          <div className="min-h-0 flex-1">
+          <div {...sidePanelSwipeHandlers} className="min-h-0 flex-1">
             {activeTab === 'chat' ? (
               <LiveRoomChatPanel
                 chatMessages={chatMessages}

--- a/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
@@ -11,6 +11,10 @@ import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { ProfilePicture, ProfileImageSize } from '../ProfilePicture';
 import Markdown from '../Markdown';
 import RichTextInput, { type RichTextInputRef } from '../fields/RichTextInput';
+import { Drawer } from '../drawers';
+import { RootPortal } from '../tooltips/Portal';
+import { EmojiPicker } from '../fields/EmojiPicker';
+import { LIVE_ROOM_QUICK_REACTION_EMOJIS } from '../../lib/liveRoom/reactions';
 import {
   Typography,
   TypographyColor,
@@ -21,11 +25,15 @@ import {
   DiscussIcon,
   LockIcon,
   MenuIcon,
+  PlusIcon,
+  SendAirplaneIcon,
   TrashIcon,
 } from '../icons';
 import { IconSize } from '../Icon';
 import type { LiveRoomChatEntry } from '../../contexts/LiveRoomContext';
 import { MarkdownCommand } from '../../hooks/input/useMarkdownInput';
+import { useViewSize, ViewSize } from '../../hooks';
+import { useTouchLongPress } from '../../hooks/useTouchLongPress';
 import { chatMarkdownToHtml } from '../../lib/liveRoom/chatMarkdown';
 import type { UserShortProfile } from '../../lib/user';
 import {
@@ -34,6 +42,7 @@ import {
 } from './liveRoomParticipants';
 import {
   LiveRoomChatReactions,
+  getChatReactionGroups,
   type ChatReactionAnalytics,
 } from './LiveRoomChatReactions';
 
@@ -59,6 +68,7 @@ const LiveRoomChatComposer = ({
   const inputRef = useRef<RichTextInputRef | null>(null);
   const [isSending, setIsSending] = useState(false);
   const [draft, setDraft] = useState('');
+  const isTablet = useViewSize(ViewSize.Tablet);
 
   let disabledReason = 'The host disabled your chat access.';
   if (!isLoggedIn) {
@@ -88,8 +98,8 @@ const LiveRoomChatComposer = ({
 
   if (!canChat) {
     return (
-      <div className="border-t border-border-subtlest-tertiary p-2.5">
-        <div className="flex flex-col gap-2 rounded-12 border border-dashed border-border-subtlest-tertiary px-3 py-2.5">
+      <div className="border-t border-border-subtlest-tertiary p-1.5 tablet:p-2.5">
+        <div className="flex flex-col gap-2 rounded-12 border border-dashed border-border-subtlest-tertiary px-2 py-1.5 tablet:px-3 tablet:py-2.5">
           <Typography
             type={TypographyType.Caption1}
             color={TypographyColor.Tertiary}
@@ -112,7 +122,7 @@ const LiveRoomChatComposer = ({
   }
 
   return (
-    <div className="border-t border-border-subtlest-tertiary">
+    <div className="border-t border-border-subtlest-tertiary pb-2 pl-1.5 pr-2 pt-1.5 tablet:p-0">
       <form
         onSubmit={(event) => {
           event.preventDefault();
@@ -122,15 +132,18 @@ const LiveRoomChatComposer = ({
         <RichTextInput
           ref={inputRef}
           className={{
-            container: '!rounded-none !bg-transparent',
-            input: '!p-2.5',
+            container:
+              '!flex-row !items-end !gap-1 !rounded-none !bg-transparent tablet:!flex-col tablet:!items-stretch tablet:!gap-0 [&>*:first-child]:min-w-0',
+            input:
+              'max-h-[2.75rem] overflow-y-auto break-words !p-1.5 tablet:max-h-none tablet:overflow-visible tablet:!p-2.5 [&_.ProseMirror]:!min-h-[1.5rem] tablet:[&_.ProseMirror]:!min-h-[6rem]',
           }}
           showUserAvatar={false}
           submitCopy="Send"
           isLoading={isSending}
           maxInputLength={1000}
           allowBlockFormatting={false}
-          minHeightClassName="min-h-[3rem]"
+          hideToolbar={!isTablet}
+          minHeightClassName="min-h-[2rem] tablet:min-h-[3rem]"
           mentionSuggestions={mentionSuggestions}
           markdownToHtml={chatMarkdownToHtml}
           enabledCommand={{
@@ -141,8 +154,21 @@ const LiveRoomChatComposer = ({
           textareaProps={{
             name: 'chat-message',
             placeholder: 'Write a message',
-            rows: 2,
+            rows: isTablet ? 2 : 1,
           }}
+          footer={
+            isTablet ? undefined : (
+              <Button
+                type="submit"
+                size={ButtonSize.Small}
+                variant={ButtonVariant.Primary}
+                icon={<SendAirplaneIcon />}
+                aria-label="Send"
+                disabled={isSending || !draft.trim()}
+                loading={isSending}
+              />
+            )
+          }
           onValueUpdate={setDraft}
           onSubmit={(event) =>
             handleSubmit(event.currentTarget.value).catch(() => undefined)
@@ -212,6 +238,39 @@ export const LiveRoomChatPanel = ({
   const [moderationBusy, setModerationBusy] = useState<string | null>(null);
   const [reactionBusy, setReactionBusy] = useState<string | null>(null);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const isTablet = useViewSize(ViewSize.Tablet);
+  const isMobile = !isTablet;
+  const [pickerMessageId, setPickerMessageId] = useState<string | null>(null);
+  const longPressHandlers = useTouchLongPress<string>({
+    enabled: isMobile && canChat,
+    onLongPress: setPickerMessageId,
+  });
+
+  const pickerMessage = pickerMessageId
+    ? chatMessages.find((m) => m.messageId === pickerMessageId) ?? null
+    : null;
+  const pickerReactionKeysSet = new Set(
+    pickerMessage
+      ? getChatReactionGroups(pickerMessage, currentParticipantId).map(
+          (r) => r.key,
+        )
+      : [],
+  );
+  const pickerQuickReactionKeys = LIVE_ROOM_QUICK_REACTION_EMOJIS.filter(
+    (key) => !pickerReactionKeysSet.has(key),
+  );
+  const pickerBaseAnalytics = {
+    activeReactionCount: pickerReactionKeysSet.size,
+    quickReactionCount: pickerQuickReactionKeys.length,
+  };
+
+  const closePicker = (): void => setPickerMessageId(null);
+
+  useEffect(() => {
+    if (pickerMessageId && !pickerMessage) {
+      closePicker();
+    }
+  }, [pickerMessage, pickerMessageId]);
 
   useEffect(() => {
     const scrollContainer = scrollRef.current;
@@ -272,6 +331,20 @@ export const LiveRoomChatPanel = ({
       .finally(() => setReactionBusy(null));
   };
 
+  const applyLongPressReaction = (
+    reactionKey: string,
+    source: 'long_press_quick' | 'long_press_picker',
+  ): void => {
+    if (!pickerMessageId) {
+      return;
+    }
+    runReactionAction(pickerMessageId, reactionKey, {
+      ...pickerBaseAnalytics,
+      source,
+    });
+    closePicker();
+  };
+
   return (
     <div className="flex h-full flex-col">
       <div
@@ -317,7 +390,21 @@ export const LiveRoomChatPanel = ({
             return (
               <article
                 key={message.messageId}
-                className="group flex items-start gap-2 px-1 py-1.5"
+                className={classNames(
+                  'group flex items-start gap-2 px-1 py-1.5',
+                  isMobile && 'select-none [-webkit-touch-callout:none]',
+                )}
+                onTouchStart={(event) =>
+                  longPressHandlers.onTouchStart(event, message.messageId)
+                }
+                onTouchEnd={longPressHandlers.onTouchEnd}
+                onTouchMove={longPressHandlers.onTouchMove}
+                onTouchCancel={longPressHandlers.onTouchCancel}
+                onContextMenu={(event) => {
+                  if (isMobile) {
+                    event.preventDefault();
+                  }
+                }}
               >
                 <ProfilePicture user={sender} size={ProfileImageSize.Small} />
                 <div className="min-w-0 flex-1">
@@ -346,6 +433,7 @@ export const LiveRoomChatPanel = ({
                     canChat={canChat}
                     senderName={senderName}
                     reactionBusy={reactionBusy}
+                    hideQuickReactions={isMobile}
                     onReactionAction={runReactionAction}
                   />
                 </div>
@@ -445,6 +533,61 @@ export const LiveRoomChatPanel = ({
         onSendMessage={onSendMessage}
         onRequestLogin={onRequestLogin}
       />
+      <RootPortal>
+        <Drawer
+          isOpen={!!pickerMessageId}
+          onClose={closePicker}
+          title="Add reaction"
+          displayCloseButton={false}
+          className={{
+            wrapper: '!overflow-hidden',
+            title: 'sticky top-0 z-1 bg-background-default',
+          }}
+        >
+          <div className="overflow-y-auto">
+            <div className="flex flex-wrap items-center justify-center gap-2 px-3 py-2">
+              {pickerQuickReactionKeys.map((emoji) => (
+                <Button
+                  key={emoji}
+                  type="button"
+                  size={ButtonSize.Small}
+                  variant={ButtonVariant.Float}
+                  aria-label={`React ${emoji}`}
+                  onClick={() =>
+                    applyLongPressReaction(emoji, 'long_press_quick')
+                  }
+                >
+                  <span className="text-base leading-none">{emoji}</span>
+                </Button>
+              ))}
+              <EmojiPicker
+                value=""
+                label={null}
+                className="shrink-0"
+                onChange={(reactionKey) => {
+                  if (!reactionKey) {
+                    return;
+                  }
+                  applyLongPressReaction(reactionKey, 'long_press_picker');
+                }}
+                renderTrigger={({ isOpen, toggleOpen }) => (
+                  <Button
+                    type="button"
+                    size={ButtonSize.Small}
+                    variant={
+                      isOpen ? ButtonVariant.Primary : ButtonVariant.Float
+                    }
+                    icon={<PlusIcon />}
+                    aria-label="Custom reaction"
+                    aria-expanded={isOpen}
+                    onClick={toggleOpen}
+                  />
+                )}
+              />
+            </div>
+          </div>
+        </Drawer>
+      </RootPortal>
     </div>
   );
 };

--- a/packages/shared/src/components/liveRooms/LiveRoomChatReactions.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatReactions.tsx
@@ -11,7 +11,9 @@ import { LIVE_ROOM_QUICK_REACTION_EMOJIS } from '../../lib/liveRoom/reactions';
 export type ChatReactionSource =
   | 'active_chip'
   | 'quick_shortcut'
-  | 'custom_picker';
+  | 'custom_picker'
+  | 'long_press_quick'
+  | 'long_press_picker';
 
 export interface ChatReactionAnalytics {
   source: ChatReactionSource;
@@ -53,7 +55,7 @@ const FIRST_REACTION_BURST_CLEAR_DELAY_MS =
   FIRST_REACTION_BURST_DURATION_MS + FIRST_REACTION_PARTICLE_MAX_DELAY_MS;
 const MAX_REACTION_SLOTS = 5;
 
-const getChatReactionGroups = (
+export const getChatReactionGroups = (
   message: LiveRoomChatEntry,
   currentParticipantId: string | null,
 ): ChatReactionGroup[] => {
@@ -290,6 +292,7 @@ interface LiveRoomChatReactionsProps {
   canChat: boolean;
   senderName: string;
   reactionBusy: string | null;
+  hideQuickReactions?: boolean;
   onReactionAction: (
     messageId: string,
     reactionKey: string,
@@ -304,6 +307,7 @@ export const LiveRoomChatReactions = ({
   canChat,
   senderName,
   reactionBusy,
+  hideQuickReactions = false,
   onReactionAction,
 }: LiveRoomChatReactionsProps): ReactElement | null => {
   const { firstReactionBurst, getPulseSignal } =
@@ -320,9 +324,15 @@ export const LiveRoomChatReactions = ({
     quickReactionCount: quickReactionKeys.length,
   };
 
+  if (hideQuickReactions && reactionGroups.length === 0) {
+    return null;
+  }
+
   if (!canChat && reactionGroups.length === 0) {
     return null;
   }
+
+  const renderQuickReactionsTray = !hideQuickReactions;
 
   return (
     <div
@@ -369,7 +379,7 @@ export const LiveRoomChatReactions = ({
           />
         );
       })}
-      {showQuickReactions || canChat ? (
+      {renderQuickReactionsTray && (showQuickReactions || canChat) ? (
         <div
           key={hasActiveReactions ? 'active-reactions' : 'empty-reactions'}
           className={classNames(

--- a/packages/shared/src/components/liveRooms/LiveRoomControlPrimitives.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControlPrimitives.tsx
@@ -274,7 +274,7 @@ export const DeviceSplitButton = ({
           loading={isLoading}
           aria-label={toggleAriaLabel}
           onClick={onToggle}
-          className="!rounded-r-none"
+          className="tablet:!rounded-r-none"
         />
       </Tooltip>
       <DropdownMenu>
@@ -288,7 +288,7 @@ export const DeviceSplitButton = ({
             variant={variant}
             icon={<ArrowIcon className="rotate-180" />}
             aria-label={caretAriaLabel}
-            className="!w-6 !rounded-l-none !border-l-0 !px-0"
+            className="hidden !w-6 !rounded-l-none !border-l-0 !px-0 tablet:inline-flex"
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent

--- a/packages/shared/src/components/liveRooms/LiveRoomControls.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControls.spec.tsx
@@ -92,8 +92,21 @@ jest.mock('../modals/common/Modal', () => {
     return <div>{children}</div>;
   }
 
-  function MockModal({ children }: { children: React.ReactNode }) {
-    return <div role="dialog">{children}</div>;
+  function MockModal({
+    children,
+    drawerProps,
+  }: {
+    children: React.ReactNode;
+    drawerProps?: { appendOnRoot?: boolean };
+  }) {
+    return (
+      <div
+        role="dialog"
+        data-append-on-root={drawerProps?.appendOnRoot ? 'true' : 'false'}
+      >
+        {children}
+      </div>
+    );
   }
 
   Object.assign(MockModal, {
@@ -772,6 +785,25 @@ describe('LiveRoomControls', () => {
     expect(screen.getByLabelText('Audio only')).toBeInTheDocument();
     expect(screen.queryByLabelText('Hide my preview')).not.toBeInTheDocument();
     expect(setVideoSetting).not.toHaveBeenCalled();
+  });
+
+  it('renders mobile room settings drawer outside the controls hit area', () => {
+    mockUseLiveRoom.mockReturnValue(
+      createContextValue({
+        role: 'audience',
+        participantId: 'audience',
+        canPublish: false,
+      }),
+    );
+
+    renderLiveRoomControls();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Standup settings' }));
+
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'data-append-on-root',
+      'true',
+    );
   });
 
   it('updates the audio only setting from the room settings modal', () => {

--- a/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
@@ -725,6 +725,7 @@ export const LiveRoomControls = ({
           kind={Modal.Kind.FixedCenter}
           size={Modal.Size.Small}
           isDrawerOnMobile
+          drawerProps={{ appendOnRoot: true }}
           onRequestClose={() => setIsSettingsOpen(false)}
         >
           <Modal.Header title="Standup settings" />

--- a/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
@@ -7,7 +7,13 @@ import {
   ButtonVariant,
 } from '../buttons/Button';
 import { EmojiPicker } from '../fields/EmojiPicker';
-import { CameraIcon, MegaphoneIcon, PlusIcon, SettingsIcon } from '../icons';
+import {
+  CameraIcon,
+  ExitIcon,
+  MegaphoneIcon,
+  PlusIcon,
+  SettingsIcon,
+} from '../icons';
 import { RaiseHandIcon } from '../icons/RaiseHand';
 import { IconSize } from '../Icon';
 import { useLiveRoom } from '../../contexts/LiveRoomContext';
@@ -21,6 +27,7 @@ import {
 } from '../typography/Typography';
 import { Tooltip } from '../tooltip/Tooltip';
 import { useAuthContext } from '../../contexts/AuthContext';
+import { useViewSize, ViewSize } from '../../hooks';
 import { AuthTriggers } from '../../lib/auth';
 import { buildStandupAnalyticsExtra } from '../../lib/liveRoom/analytics';
 import { getLiveRoomPrivilegeState } from '../../lib/liveRoom/privileges';
@@ -72,6 +79,7 @@ export const LiveRoomControls = ({
 }: LiveRoomControlsProps): ReactElement => {
   const { user, showLogin } = useAuthContext();
   const { logEvent } = useLogContext();
+  const isTablet = useViewSize(ViewSize.Tablet);
   const {
     status,
     canPublish,
@@ -258,8 +266,8 @@ export const LiveRoomControls = ({
   const joinStageTooltip = isStageFull ? 'Speakers full' : 'Join as speaker';
 
   return (
-    <div className="pointer-events-none absolute inset-x-0 bottom-4 z-2 px-1.5 tablet:bottom-6">
-      <div className="pointer-events-auto relative mx-auto flex w-full max-w-[42rem] flex-col items-center gap-2">
+    <div className="pointer-events-none absolute inset-x-0 bottom-2 z-2 px-1.5 tablet:bottom-6">
+      <div className="pointer-events-auto relative mx-auto flex w-full max-w-[42rem] flex-col items-center gap-1.5 tablet:gap-2">
         {reactionsOpen && isLive ? (
           <div className="flex items-center gap-1 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-1.5 shadow-2">
             {LIVE_ROOM_QUICK_REACTION_EMOJIS.map((emoji) => (
@@ -329,7 +337,7 @@ export const LiveRoomControls = ({
           </div>
         ) : null}
 
-        <div className="flex items-center gap-2 rounded-16 border border-border-subtlest-tertiary bg-background-default p-1.5 shadow-2 backdrop-blur">
+        <div className="flex items-center gap-1 rounded-12 border border-border-subtlest-tertiary bg-background-default p-1 shadow-2 backdrop-blur tablet:gap-2 tablet:rounded-16 tablet:p-1.5">
           {showMediaControls ? (
             <ControlGroup>
               <DeviceSplitButton
@@ -676,6 +684,8 @@ export const LiveRoomControls = ({
                 variant={ButtonVariant.Primary}
                 color={ButtonColor.Ketchup}
                 loading={isBusy('end')}
+                icon={isTablet ? undefined : <ExitIcon />}
+                aria-label="End standup"
                 onClick={() =>
                   guarded('end', async () => {
                     await endRoom();
@@ -686,7 +696,7 @@ export const LiveRoomControls = ({
                   })
                 }
               >
-                End standup
+                {isTablet ? 'End standup' : null}
               </Button>
             ) : (
               <Button
@@ -694,6 +704,8 @@ export const LiveRoomControls = ({
                 size={ButtonSize.Small}
                 variant={ButtonVariant.Primary}
                 color={ButtonColor.Ketchup}
+                icon={isTablet ? undefined : <ExitIcon />}
+                aria-label="Leave"
                 onClick={() => {
                   logStandupAction(LogEvent.LeaveStandup, roomId, {
                     surface: 'controls',
@@ -701,7 +713,7 @@ export const LiveRoomControls = ({
                   onLeave();
                 }}
               >
-                Leave
+                {isTablet ? 'Leave' : null}
               </Button>
             )}
           </ControlGroup>

--- a/packages/shared/src/components/liveRooms/LiveRoomSidePanelTabs.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomSidePanelTabs.tsx
@@ -18,7 +18,7 @@ export const LiveRoomSidePanelTabs = ({
   <div
     role="tablist"
     aria-label="Standup side panel"
-    className="flex items-center gap-1 border-b border-border-subtlest-tertiary p-1"
+    className="flex items-center gap-0.5 border-b border-border-subtlest-tertiary p-0.5 tablet:gap-1 tablet:p-1"
   >
     {tabs.map((tab) => {
       const isActive = tab.id === active;
@@ -31,7 +31,7 @@ export const LiveRoomSidePanelTabs = ({
           aria-selected={isActive}
           onClick={() => onChange(tab.id)}
           className={classNames(
-            'flex flex-1 items-center justify-center gap-2 rounded-10 px-3 py-2 transition-colors typo-callout',
+            'flex flex-1 items-center justify-center gap-1.5 rounded-8 px-2 py-1 transition-colors typo-footnote tablet:gap-2 tablet:rounded-10 tablet:px-3 tablet:py-2 tablet:typo-callout',
             isActive
               ? 'bg-surface-float font-bold text-text-primary'
               : 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary',

--- a/packages/shared/src/components/liveRooms/LiveRoomTileActions.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomTileActions.tsx
@@ -27,6 +27,7 @@ import type { UserShortProfile } from '../../lib/user';
 interface LiveRoomTileActionsProps {
   user: UserShortProfile;
   className?: string;
+  variant?: 'inline' | 'drawer';
   onGrantCoHost?: () => void;
   onRevokeCoHost?: () => void;
   onRemoveSpeaker?: () => void;
@@ -36,11 +37,23 @@ interface LiveRoomTileActionsProps {
   isRemoving?: boolean;
   isKicking?: boolean;
   moderationDisabled?: boolean;
+  onActionComplete?: () => void;
+}
+
+interface LiveRoomTileActionItem {
+  key: string;
+  drawerLabel: string;
+  ariaLabel: string;
+  icon: ReactElement;
+  loading?: boolean;
+  disabled?: boolean;
+  onClick: () => void | Promise<void>;
 }
 
 export const LiveRoomTileActions = ({
   user,
   className,
+  variant = 'inline',
   onGrantCoHost,
   onRevokeCoHost,
   onRemoveSpeaker,
@@ -50,6 +63,7 @@ export const LiveRoomTileActions = ({
   isRemoving = false,
   isKicking = false,
   moderationDisabled = false,
+  onActionComplete,
 }: LiveRoomTileActionsProps): ReactElement | null => {
   const { user: viewer, showLogin } = useAuthContext();
   const { follow, unfollow } = useContentPreference();
@@ -127,102 +141,131 @@ export const LiveRoomTileActions = ({
     ? `Unfollow ${user.name}`
     : `Follow ${user.name}`;
 
+  const actionItems: LiveRoomTileActionItem[] = [];
+
+  if (showSocial) {
+    actionItems.push(
+      {
+        key: 'follow',
+        drawerLabel: followLabel,
+        ariaLabel: followLabel,
+        icon: isFollowing ? <VIcon secondary /> : <AddUserIcon />,
+        loading: followBusy,
+        disabled: followBusy,
+        onClick: handleFollow,
+      },
+      {
+        key: 'award',
+        drawerLabel: `Award ${user.name}`,
+        ariaLabel: `Award ${user.name}`,
+        icon: <MedalBadgeIcon secondary />,
+        onClick: handleAward,
+      },
+    );
+  }
+
+  if (showGrantCoHost) {
+    actionItems.push({
+      key: 'grant',
+      drawerLabel: 'Grant co-host',
+      ariaLabel: `Grant co-host to ${user.name}`,
+      icon: <ShieldIcon />,
+      loading: isGrantingCoHost,
+      disabled: moderationDisabled || isGrantingCoHost,
+      onClick: () => onGrantCoHost?.(),
+    });
+  }
+
+  if (showRevokeCoHost) {
+    actionItems.push({
+      key: 'revoke',
+      drawerLabel: 'Revoke co-host',
+      ariaLabel: `Revoke co-host from ${user.name}`,
+      icon: <ShieldCheckIcon />,
+      loading: isRevokingCoHost,
+      disabled: moderationDisabled || isRevokingCoHost,
+      onClick: () => onRevokeCoHost?.(),
+    });
+  }
+
+  if (showRemove) {
+    actionItems.push({
+      key: 'remove',
+      drawerLabel: 'Remove from stage',
+      ariaLabel: `Remove ${user.name} from stage`,
+      icon: <RemoveUserIcon />,
+      loading: isRemoving,
+      disabled: moderationDisabled || isRemoving,
+      onClick: () => onRemoveSpeaker?.(),
+    });
+  }
+
+  if (showKick) {
+    actionItems.push({
+      key: 'kick',
+      drawerLabel: 'Kick from room',
+      ariaLabel: `Kick ${user.name} from room`,
+      icon: <BlockIcon />,
+      loading: isKicking,
+      disabled: moderationDisabled || isKicking,
+      onClick: () => onKick?.(),
+    });
+  }
+
+  if (actionItems.length === 0) {
+    return null;
+  }
+
+  const runDrawerAction = (handler: () => void | Promise<void>) => () => {
+    handler();
+    onActionComplete?.();
+  };
+
+  if (variant === 'drawer') {
+    return (
+      <div className={classNames('flex flex-col gap-1 p-2', className)}>
+        {actionItems.map((item) => (
+          <Button
+            key={item.key}
+            type="button"
+            size={ButtonSize.Medium}
+            variant={ButtonVariant.Tertiary}
+            icon={item.icon}
+            loading={item.loading}
+            disabled={item.disabled}
+            className="!justify-start"
+            onClick={runDrawerAction(item.onClick)}
+          >
+            {item.drawerLabel}
+          </Button>
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div
       className={classNames(
-        'pointer-events-auto flex max-w-0 items-center gap-1 overflow-hidden opacity-0 transition-[max-width,opacity,transform] duration-200 ease-out group-hover:max-w-[14rem] group-hover:opacity-100',
+        'pointer-events-auto hidden max-w-0 items-center gap-1 overflow-hidden opacity-0 transition-[max-width,opacity,transform] duration-200 ease-out group-hover:max-w-[14rem] group-hover:opacity-100 tablet:flex',
         '-translate-x-1 group-hover:translate-x-0',
         className,
       )}
     >
-      {showSocial ? (
-        <Tooltip content={followLabel}>
+      {actionItems.map((item) => (
+        <Tooltip key={item.key} content={item.ariaLabel}>
           <Button
             type="button"
             size={ButtonSize.XSmall}
             variant={ButtonVariant.Tertiary}
             className="!text-white"
-            icon={isFollowing ? <VIcon secondary /> : <AddUserIcon />}
-            loading={followBusy}
-            disabled={followBusy}
-            aria-label={followLabel}
-            onClick={handleFollow}
+            icon={item.icon}
+            loading={item.loading}
+            disabled={item.disabled}
+            aria-label={item.ariaLabel}
+            onClick={item.onClick}
           />
         </Tooltip>
-      ) : null}
-      {showSocial ? (
-        <Tooltip content={`Award ${user.name}`}>
-          <Button
-            type="button"
-            size={ButtonSize.XSmall}
-            variant={ButtonVariant.Tertiary}
-            className="!text-white"
-            icon={<MedalBadgeIcon secondary />}
-            aria-label={`Award ${user.name}`}
-            onClick={handleAward}
-          />
-        </Tooltip>
-      ) : null}
-      {showGrantCoHost ? (
-        <Tooltip content={`Grant co-host to ${user.name}`}>
-          <Button
-            type="button"
-            size={ButtonSize.XSmall}
-            variant={ButtonVariant.Tertiary}
-            className="!text-white"
-            icon={<ShieldIcon />}
-            loading={isGrantingCoHost}
-            disabled={moderationDisabled || isGrantingCoHost}
-            aria-label={`Grant co-host to ${user.name}`}
-            onClick={onGrantCoHost}
-          />
-        </Tooltip>
-      ) : null}
-      {showRevokeCoHost ? (
-        <Tooltip content={`Revoke co-host from ${user.name}`}>
-          <Button
-            type="button"
-            size={ButtonSize.XSmall}
-            variant={ButtonVariant.Tertiary}
-            className="!text-white"
-            icon={<ShieldCheckIcon />}
-            loading={isRevokingCoHost}
-            disabled={moderationDisabled || isRevokingCoHost}
-            aria-label={`Revoke co-host from ${user.name}`}
-            onClick={onRevokeCoHost}
-          />
-        </Tooltip>
-      ) : null}
-      {showRemove ? (
-        <Tooltip content={`Remove ${user.name} from stage`}>
-          <Button
-            type="button"
-            size={ButtonSize.XSmall}
-            variant={ButtonVariant.Tertiary}
-            className="!text-white"
-            icon={<RemoveUserIcon />}
-            loading={isRemoving}
-            disabled={moderationDisabled || isRemoving}
-            aria-label={`Remove ${user.name} from stage`}
-            onClick={onRemoveSpeaker}
-          />
-        </Tooltip>
-      ) : null}
-      {showKick ? (
-        <Tooltip content={`Kick ${user.name} from room`}>
-          <Button
-            type="button"
-            size={ButtonSize.XSmall}
-            variant={ButtonVariant.Tertiary}
-            className="!text-white"
-            icon={<BlockIcon />}
-            loading={isKicking}
-            disabled={moderationDisabled || isKicking}
-            aria-label={`Kick ${user.name} from room`}
-            onClick={onKick}
-          />
-        </Tooltip>
-      ) : null}
+      ))}
     </div>
   );
 };

--- a/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
+import { useSwipeable } from 'react-swipeable';
 import {
   Typography,
   TypographyColor,
@@ -19,6 +20,10 @@ import {
   useLiveRoomAudioLevel,
 } from './useLiveRoomAudioLevel';
 import { LiveRoomTileActions } from './LiveRoomTileActions';
+import { Drawer } from '../drawers';
+import { RootPortal } from '../tooltips/Portal';
+import { useViewSize, ViewSize } from '../../hooks';
+import { useTouchLongPress } from '../../hooks/useTouchLongPress';
 
 interface LiveRoomVideoTileProps {
   stream: MediaStream | null;
@@ -39,6 +44,11 @@ interface LiveRoomVideoTileProps {
   isRemoving?: boolean;
   isKicking?: boolean;
   moderationDisabled?: boolean;
+  isFocused?: boolean;
+  onFocus?: () => void;
+  onUnfocus?: () => void;
+  onSwipeNext?: () => void;
+  onSwipePrev?: () => void;
 }
 
 const pickLiveTrack = (
@@ -71,10 +81,54 @@ export const LiveRoomVideoTile = ({
   isRemoving = false,
   isKicking = false,
   moderationDisabled = false,
+  isFocused = false,
+  onFocus,
+  onUnfocus,
+  onSwipeNext,
+  onSwipePrev,
 }: LiveRoomVideoTileProps): ReactElement => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [needsAudioGesture, setNeedsAudioGesture] = useState(false);
+  const isTablet = useViewSize(ViewSize.Tablet);
+  const isMobile = !isTablet;
+  const [actionsOpen, setActionsOpen] = useState(false);
+  const longPressFiredRef = useRef(false);
+  const longPressHandlers = useTouchLongPress<undefined>({
+    enabled: isMobile && !selfView,
+    onLongPress: () => {
+      longPressFiredRef.current = true;
+      setActionsOpen(true);
+    },
+  });
+  const handlePressStart = (event: React.TouchEvent): void => {
+    longPressFiredRef.current = false;
+    longPressHandlers.onTouchStart(event, undefined);
+  };
+  const handleFocusButtonClick = (): void => {
+    if (longPressFiredRef.current) {
+      longPressFiredRef.current = false;
+      return;
+    }
+    if (isFocused) {
+      return;
+    }
+    onFocus?.();
+  };
+  const swipeHandlers = useSwipeable({
+    onSwipedLeft: () => {
+      if (isFocused) {
+        onSwipeNext?.();
+      }
+    },
+    onSwipedRight: () => {
+      if (isFocused) {
+        onSwipePrev?.();
+      }
+    },
+    trackTouch: true,
+    trackMouse: false,
+  });
 
   // Pick stable track references based on the source stream so identity
   // changes only when the underlying track changes.
@@ -160,7 +214,7 @@ export const LiveRoomVideoTile = ({
       bold
       truncate
       className={classNames(
-        'min-w-0 !text-white',
+        'min-w-0 !text-white !typo-caption2 tablet:!typo-footnote',
         hasProfileLink && 'pointer-events-auto hover:underline',
       )}
     >
@@ -168,15 +222,34 @@ export const LiveRoomVideoTile = ({
     </Typography>
   );
 
+  const gestureHandlers = isFocused
+    ? swipeHandlers
+    : {
+        onTouchStart: handlePressStart,
+        onTouchEnd: longPressHandlers.onTouchEnd,
+        onTouchMove: longPressHandlers.onTouchMove,
+        onTouchCancel: longPressHandlers.onTouchCancel,
+      };
+
   return (
     <div
+      {...gestureHandlers}
       className={classNames(
-        'group relative flex h-full max-h-full w-full max-w-full items-center justify-center overflow-hidden rounded-16 border bg-surface-float transition-[border-color,box-shadow] duration-150',
+        'group flex items-center justify-center overflow-hidden rounded-16 border bg-surface-float transition-[border-color,box-shadow] duration-150',
+        isFocused
+          ? 'fixed left-1/2 top-1/2 z-modal h-[80vh] max-h-[90vh] w-[90vw] max-w-[64rem] -translate-x-1/2 -translate-y-1/2'
+          : 'relative h-full max-h-full w-full max-w-full cursor-zoom-in',
         isSpeaking
           ? 'border-accent-avocado-default shadow-[0_0_0_3px_var(--theme-accent-avocado-subtle)]'
           : 'border-border-subtlest-tertiary',
+        isMobile && 'select-none [-webkit-touch-callout:none]',
         className,
       )}
+      onContextMenu={(event) => {
+        if (isMobile) {
+          event.preventDefault();
+        }
+      }}
     >
       {videoStream ? (
         // eslint-disable-next-line jsx-a11y/media-has-caption
@@ -210,6 +283,14 @@ export const LiveRoomVideoTile = ({
         // eslint-disable-next-line jsx-a11y/media-has-caption
         <audio ref={audioRef} autoPlay />
       ) : null}
+      {!isFocused && onFocus ? (
+        <button
+          type="button"
+          aria-label={`Enlarge ${user.name}`}
+          className="focus-outline absolute inset-0 cursor-zoom-in"
+          onClick={handleFocusButtonClick}
+        />
+      ) : null}
       {raisedHandQueuePosition ? (
         <span
           aria-label={`Hand raised, position ${raisedHandQueuePosition}`}
@@ -225,13 +306,21 @@ export const LiveRoomVideoTile = ({
           </span>
         </span>
       ) : null}
-      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 p-3">
-        <div className="flex min-w-0 items-center gap-2 rounded-12 bg-overlay-dark-dark3 px-2.5 py-1 backdrop-blur transition-[padding] duration-200 ease-out group-hover:pr-1">
+      {isMuted ? (
+        <span
+          aria-label="Muted"
+          className="pointer-events-none absolute right-3 top-3 inline-flex size-7 items-center justify-center rounded-10 bg-overlay-dark-dark3 backdrop-blur"
+        >
+          <VolumeOffIcon size={IconSize.XSmall} className="text-status-error" />
+        </span>
+      ) : null}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 pb-3 pl-1.5 pr-3 pt-3 tablet:pl-3">
+        <div className="flex min-h-8 min-w-0 items-center gap-1.5 rounded-12 bg-overlay-dark-dark3 px-2 py-1 backdrop-blur transition-[padding] duration-200 ease-out tablet:gap-2 tablet:px-2.5 tablet:group-hover:pr-1">
           {isHost ? (
             <Typography
               type={TypographyType.Caption2}
               bold
-              className="shrink-0 uppercase tracking-wide !text-accent-bun-default"
+              className="hidden shrink-0 uppercase tracking-wide !text-accent-bun-default tablet:inline"
             >
               Host
             </Typography>
@@ -240,17 +329,10 @@ export const LiveRoomVideoTile = ({
             <Typography
               type={TypographyType.Caption2}
               bold
-              className="shrink-0 uppercase tracking-wide !text-accent-water-bolder"
+              className="hidden shrink-0 uppercase tracking-wide !text-accent-water-bolder tablet:inline"
             >
               Co-host
             </Typography>
-          ) : null}
-          {isMuted ? (
-            <VolumeOffIcon
-              size={IconSize.XSmall}
-              aria-label="Muted"
-              className="shrink-0 text-status-error"
-            />
           ) : null}
           {hasProfileLink ? (
             <Link href={user.permalink} passHref>
@@ -291,6 +373,36 @@ export const LiveRoomVideoTile = ({
           Tap to unmute
         </Button>
       ) : null}
+      <RootPortal>
+        <Drawer
+          isOpen={actionsOpen}
+          onClose={() => setActionsOpen(false)}
+          displayCloseButton={false}
+        >
+          <LiveRoomTileActions
+            user={user}
+            variant="drawer"
+            onGrantCoHost={onGrantCoHost}
+            onRevokeCoHost={onRevokeCoHost}
+            onRemoveSpeaker={onRemoveSpeaker}
+            onKick={onKick}
+            isGrantingCoHost={isGrantingCoHost}
+            isRevokingCoHost={isRevokingCoHost}
+            isRemoving={isRemoving}
+            isKicking={isKicking}
+            moderationDisabled={moderationDisabled}
+            onActionComplete={() => setActionsOpen(false)}
+          />
+        </Drawer>
+        {isFocused ? (
+          <button
+            type="button"
+            aria-label="Close enlarged tile"
+            className="fixed inset-0 z-popup cursor-zoom-out bg-overlay-quaternary-onion backdrop-blur"
+            onClick={() => onUnfocus?.()}
+          />
+        ) : null}
+      </RootPortal>
     </div>
   );
 };

--- a/packages/shared/src/hooks/useTouchLongPress.ts
+++ b/packages/shared/src/hooks/useTouchLongPress.ts
@@ -1,0 +1,93 @@
+import type { TouchEvent } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+
+interface UseTouchLongPressOptions<T> {
+  enabled: boolean;
+  delayMs?: number;
+  moveTolerancePx?: number;
+  onLongPress: (value: T) => void;
+}
+
+export interface TouchLongPressHandlers<T> {
+  onTouchStart: (event: TouchEvent, value: T) => void;
+  onTouchEnd: () => void;
+  onTouchMove: (event: TouchEvent) => void;
+  onTouchCancel: () => void;
+}
+
+const DEFAULT_LONG_PRESS_DELAY_MS = 500;
+const DEFAULT_MOVE_TOLERANCE_PX = 10;
+
+export const useTouchLongPress = <T>({
+  enabled,
+  delayMs = DEFAULT_LONG_PRESS_DELAY_MS,
+  moveTolerancePx = DEFAULT_MOVE_TOLERANCE_PX,
+  onLongPress,
+}: UseTouchLongPressOptions<T>): TouchLongPressHandlers<T> => {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startPosRef = useRef<{ x: number; y: number } | null>(null);
+
+  const cancelLongPress = useCallback((): void => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    startPosRef.current = null;
+  }, []);
+
+  useEffect(() => cancelLongPress, [cancelLongPress]);
+
+  useEffect(() => {
+    if (!enabled) {
+      cancelLongPress();
+    }
+  }, [cancelLongPress, enabled]);
+
+  const onTouchStart = useCallback(
+    (event: TouchEvent, value: T): void => {
+      cancelLongPress();
+      if (!enabled) {
+        return;
+      }
+
+      const touch = event.touches[0];
+      if (!touch) {
+        return;
+      }
+
+      startPosRef.current = { x: touch.clientX, y: touch.clientY };
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        onLongPress(value);
+      }, delayMs);
+    },
+    [cancelLongPress, delayMs, enabled, onLongPress],
+  );
+
+  const onTouchMove = useCallback(
+    (event: TouchEvent): void => {
+      if (!startPosRef.current) {
+        return;
+      }
+
+      const touch = event.touches[0];
+      if (!touch) {
+        return;
+      }
+
+      const dx = Math.abs(touch.clientX - startPosRef.current.x);
+      const dy = Math.abs(touch.clientY - startPosRef.current.y);
+      if (dx > moveTolerancePx || dy > moveTolerancePx) {
+        cancelLongPress();
+      }
+    },
+    [cancelLongPress, moveTolerancePx],
+  );
+
+  return {
+    onTouchStart,
+    onTouchEnd: cancelLongPress,
+    onTouchMove,
+    onTouchCancel: cancelLongPress,
+  };
+};

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -286,6 +286,7 @@ export enum LogEvent {
   KickStandupParticipant = 'kick standup participant',
   ChangeStandupSettings = 'change standup settings',
   StandupError = 'standup error',
+  FocusStandupSpeaker = 'focus standup speaker',
   // End standups
   // Integrations
   StartAddingWorkspace = 'start adding workspace',

--- a/packages/webapp/pages/standups/[id].tsx
+++ b/packages/webapp/pages/standups/[id].tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/router';
 import type { NextSeoProps } from 'next-seo';
 import { Loader } from '@dailydotdev/shared/src/components/Loader';
 import { LiveRoom } from '@dailydotdev/shared/src/components/liveRooms/LiveRoom';
-import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
 import { getLayout } from '../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 
@@ -25,7 +24,7 @@ const StandupPage = (): ReactElement => {
   const { id } = router.query;
 
   return (
-    <main className="relative z-1 flex h-[calc(100dvh-4rem)] w-full flex-col">
+    <main className="relative flex h-[100dvh] w-full flex-col laptop:h-[calc(100dvh-4rem)]">
       {typeof id === 'string' ? (
         <LiveRoom roomId={id} />
       ) : (
@@ -37,10 +36,7 @@ const StandupPage = (): ReactElement => {
   );
 };
 
-const getStandupPageLayout: typeof getLayout = (...props) =>
-  getFooterNavBarLayout(getLayout(...props));
-
-StandupPage.getLayout = getStandupPageLayout;
+StandupPage.getLayout = getLayout;
 StandupPage.layoutProps = {
   screenCentered: false,
   hideFeedbackWidget: true,


### PR DESCRIPTION
## What changed
- Optimized the standup room layout for mobile, including full-height mobile page treatment, compact header/controls, smaller chat composer, and four-speaker mobile stage pagination.
- Added mobile speaker focus, swipe navigation, side-panel swipe navigation, long-press chat reactions, and mobile drawer actions for stage tiles.
- Extracted shared long-press touch handling and deduplicated live-room tile action rendering.
- Added/updated live-room tests for responsive pagination and stabilized the test viewport default.

## Validation
- `pnpm --filter shared exec eslint src/components/liveRooms/LiveRoom.tsx src/components/liveRooms/LiveRoom.spec.tsx src/components/liveRooms/LiveRoomChatPanel.tsx src/components/liveRooms/LiveRoomVideoTile.tsx src/components/liveRooms/LiveRoomTileActions.tsx src/components/liveRooms/LiveRoomChatReactions.tsx src/components/liveRooms/LiveRoomControls.tsx src/components/liveRooms/LiveRoomControlPrimitives.tsx src/components/liveRooms/LiveRoomSidePanelTabs.tsx src/components/fields/RichTextInput.tsx src/hooks/useTouchLongPress.ts src/lib/log.ts`
- `pnpm --filter webapp exec eslint 'pages/standups/[id].tsx'`
- `node ./scripts/typecheck-strict-changed.js`
- `NODE_ENV=test pnpm --filter shared exec jest src/components/liveRooms/LiveRoom.spec.tsx src/components/liveRooms/LiveRoomControls.spec.tsx --runInBand`

Note: the focused Jest run passes but still prints the existing React `act(...)` warning from `LiveRoomControls.spec.tsx`.


### Preview domain
https://codex-mobile-standup-experience.preview.app.daily.dev