### PR TITLE
refactor: split live room standup components

### DIFF
--- a/packages/shared/src/components/liveRooms/LiveRoom.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.tsx
@@ -1,224 +1,55 @@
 import type { ReactElement } from 'react';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
-import classNames from 'classnames';
 import { useSwipeable } from 'react-swipeable';
 import {
   Typography,
   TypographyColor,
-  TypographyTag,
   TypographyType,
 } from '../typography/Typography';
-import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/Button';
 import { Loader } from '../Loader';
-import { LiveRoomVideoTile } from './LiveRoomVideoTile';
-import { LiveRoomControls } from './LiveRoomControls';
 import { LiveRoomChatPanel } from './LiveRoomChatPanel';
 import type { ChatReactionAnalytics } from './LiveRoomChatReactions';
 import { LiveRoomQueuePanel } from './LiveRoomQueuePanel';
 import {
   LiveRoomProvider,
   useLiveRoom as useLiveRoomConnection,
-  type LiveRoomReaction,
 } from '../../contexts/LiveRoomContext';
 import { useAuthContext } from '../../contexts/AuthContext';
-import { useLogContext } from '../../contexts/LogContext';
 import { AuthTriggers } from '../../lib/auth';
 import { isDevelopment } from '../../lib/constants';
-import { buildStandupAnalyticsExtra } from '../../lib/liveRoom/analytics';
 import { getLiveRoomPrivilegeState } from '../../lib/liveRoom/privileges';
 import { LogEvent, NotificationPromptSource } from '../../lib/log';
-import type { LiveRoom as LiveRoomModel } from '../../graphql/liveRooms';
 import { useLiveRoom as useLiveRoomQuery } from '../../hooks/liveRooms/useLiveRoom';
-import { useLiveRoomParticipantProfiles } from '../../hooks/liveRooms/useLiveRoomParticipantProfiles';
-import { useLiveRoomParticipantStreams } from '../../hooks/liveRooms/useLiveRoomParticipantStreams';
 import { useStreamDuration } from '../../hooks/liveRooms/useStreamDuration';
+import { useCountdownSeconds } from '../../hooks/liveRooms/useCountdownSeconds';
+import { useLiveRoomStandupAnalytics } from '../../hooks/liveRooms/useLiveRoomStandupAnalytics';
+import { useLiveRoomStageModel } from '../../hooks/liveRooms/useLiveRoomStageModel';
 import useLogEventOnce from '../../hooks/log/useLogEventOnce';
 import { useToastNotification } from '../../hooks/useToastNotification';
 import { useExitConfirmation } from '../../hooks/useExitConfirmation';
 import { useViewSize, ViewSize } from '../../hooks';
 import { clearStoredLiveRoomResumeSession } from '../../lib/liveRoom/resumeSessionStorage';
-import { UserIcon } from '../icons';
-import { IconSize } from '../Icon';
-import type { UserShortProfile } from '../../lib/user';
-import Markdown from '../Markdown';
-import { ContentEmbeds } from '../contentEmbeds/ContentEmbeds';
 import { useLiveRoomSubscription } from '../../hooks/liveRooms/useLiveRoomSubscription';
 import { usePushNotificationContext } from '../../contexts/PushNotificationContext';
 import { usePushNotificationMutation } from '../../hooks/notifications/usePushNotificationMutation';
 import {
-  buildDisplayProfile,
-  buildParticipantProfile,
-} from './liveRoomParticipants';
-import {
   LiveRoomSidePanelTabs,
   type LiveRoomSidePanelTab,
 } from './LiveRoomSidePanelTabs';
-import { Separator } from '../cards/common/common';
+import { LiveRoomHeader } from './LiveRoomHeader';
+import { LiveRoomReactionOverlay } from './LiveRoomReactionOverlay';
+import { LiveRoomStage } from './LiveRoomStage';
 
 interface LiveRoomProps {
   roomId: string;
 }
 
-const MAX_STAGE_TILES_PER_PAGE = 12;
-const MOBILE_MAX_STAGE_TILES_PER_PAGE = 4;
-const EMPTY_PARTICIPANT_IDS: string[] = [];
-
-const getStageGridColumnCount = (count: number, isMobile: boolean): number => {
-  if (count <= 1) {
-    return 1;
-  }
-  if (isMobile) {
-    return 2;
-  }
-  if (count <= 4) {
-    return 2;
-  }
-  if (count <= 9) {
-    return 3;
-  }
-  return 4;
-};
-
-const formatStreamDuration = (seconds: number): string => {
-  const safeSeconds = Math.max(0, Math.floor(seconds));
-  const hours = Math.floor(safeSeconds / 3600);
-  const minutes = Math.floor((safeSeconds % 3600) / 60);
-  const remainingSeconds = safeSeconds % 60;
-  const pad = (value: number) => value.toString().padStart(2, '0');
-
-  if (hours > 0) {
-    return `${hours}:${pad(minutes)}:${pad(remainingSeconds)}`;
-  }
-
-  return `${pad(minutes)}:${pad(remainingSeconds)}`;
-};
-
-const AnimatedCount = ({ value }: { value: number }): ReactElement => (
-  <span key={value} className="live-room-count-bump tabular-nums">
-    {value}
-  </span>
-);
-
-const ReactionOverlay = ({
-  reactions,
-}: {
-  reactions: LiveRoomReaction[];
-}): ReactElement | null => {
-  if (reactions.length === 0) {
-    return null;
-  }
-
-  return (
-    <div
-      className="pointer-events-none absolute inset-x-0 bottom-0 top-1/4 z-3 overflow-hidden"
-      aria-hidden
-    >
-      {reactions.map((reaction) => (
-        <span
-          key={reaction.id}
-          className="live-room-reaction absolute bottom-0 text-4xl"
-          style={
-            {
-              '--live-room-reaction-left': `${16 + reaction.lane * 16}%`,
-              '--live-room-reaction-drift':
-                reaction.lane % 2 === 0 ? '-1rem' : '1rem',
-            } as React.CSSProperties
-          }
-        >
-          {reaction.emoji}
-        </span>
-      ))}
-    </div>
-  );
-};
-
-const useCountdownSeconds = (target: string | null | undefined): number => {
-  const [seconds, setSeconds] = useState(() => {
-    if (!target) {
-      return 0;
-    }
-
-    return Math.max(
-      0,
-      Math.ceil((new Date(target).getTime() - Date.now()) / 1000),
-    );
-  });
-
-  useEffect(() => {
-    if (!target) {
-      setSeconds(0);
-      return undefined;
-    }
-
-    const update = (): void => {
-      setSeconds(
-        Math.max(
-          0,
-          Math.ceil((new Date(target).getTime() - Date.now()) / 1000),
-        ),
-      );
-    };
-    update();
-    const interval = window.setInterval(update, 1000);
-    return () => window.clearInterval(interval);
-  }, [target]);
-
-  return seconds;
-};
-
-const LiveBadge = ({ isLive }: { isLive: boolean }): ReactElement => (
-  <span
-    className={classNames(
-      'inline-flex items-center gap-1 rounded-8 px-1.5 py-px typo-caption2 tablet:gap-1.5 tablet:px-2 tablet:py-0.5 tablet:typo-caption1',
-      isLive
-        ? 'bg-accent-ketchup-default text-white'
-        : 'bg-accent-bacon-default text-white',
-    )}
-  >
-    <span className="size-1 animate-pulse rounded-full bg-white tablet:size-1.5" />
-    <span className="font-bold uppercase tracking-wide">
-      {isLive ? 'Live' : 'Lobby'}
-    </span>
-  </span>
-);
-
-const LiveRoomLobbyContent = ({
-  room,
-}: {
-  room: LiveRoomModel;
-}): ReactElement => (
-  <div className="min-h-0 flex-1 overflow-y-auto px-3 py-1.5 pb-20 tablet:p-1.5 tablet:pb-28">
-    <article className="mx-auto flex w-full max-w-[42rem] flex-col gap-5">
-      {room.descriptionHtml ? (
-        <Markdown
-          content={room.descriptionHtml}
-          className="break-words text-text-primary"
-        />
-      ) : (
-        <Typography
-          type={TypographyType.Callout}
-          color={TypographyColor.Tertiary}
-        >
-          No agenda has been added yet.
-        </Typography>
-      )}
-      <ContentEmbeds embeds={room.contentEmbeds} variant="post" />
-    </article>
-  </div>
-);
-
 const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   const router = useRouter();
   const { displayToast } = useToastNotification();
   const { isAuthReady, showLogin, user } = useAuthContext();
-  const { logEvent } = useLogContext();
   const isTablet = useViewSize(ViewSize.Tablet);
   const isMobile = !isTablet;
   const { isPushSupported, isSubscribed: isPushEnabled } =
@@ -274,57 +105,18 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     null,
   );
   const lastLoggedRoomErrorRef = useRef<string | null>(null);
-  const buildStandupExtra = useCallback(
-    (extra: Record<string, unknown> = {}) =>
-      buildStandupAnalyticsExtra(
-        {
-          roomId,
-          authKind: user ? 'authenticated' : 'anonymous',
-          role,
-          roomStatus: roomState?.status ?? room?.status ?? null,
-          roomMode: roomState?.mode ?? room?.mode ?? null,
-          connectionStatus: status,
-          participantId,
-          isCoHost: privilegeState.isCoHost,
-          hasLocalAudioTrack: !!localStream?.getAudioTracks()[0],
-          hasLocalVideoTrack: !!localStream?.getVideoTracks()[0],
-          videoQuality: videoSettings.quality,
-          audioOnly: videoSettings.audioOnly,
-          hideSelfView: videoSettings.hideSelfView,
-        },
-        extra,
-      ),
-    [
-      roomId,
-      user,
-      role,
-      roomState?.status,
-      roomState?.mode,
-      room?.status,
-      room?.mode,
-      status,
-      participantId,
-      privilegeState.isCoHost,
-      localStream,
-      videoSettings.quality,
-      videoSettings.audioOnly,
-      videoSettings.hideSelfView,
-    ],
-  );
-  const logStandupAction = useCallback(
-    (
-      eventName: LogEvent,
-      targetId: string,
-      extra: Record<string, unknown> = {},
-    ) => {
-      logEvent({
-        event_name: eventName,
-        target_id: targetId,
-        extra: buildStandupExtra(extra),
-      });
-    },
-    [buildStandupExtra, logEvent],
-  );
+  const { buildStandupExtra, logStandupAction } = useLiveRoomStandupAnalytics({
+    roomId,
+    user,
+    role,
+    roomStatus: roomState?.status ?? room?.status ?? null,
+    roomMode: roomState?.mode ?? room?.mode ?? null,
+    connectionStatus: status,
+    participantId,
+    isCoHost: privilegeState.isCoHost,
+    localStream,
+    videoSettings,
+  });
 
   const handleLeave = (): void => {
     onAskConfirmation(false);
@@ -563,181 +355,43 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     { condition: !!room && !roomError && !isRoomLoading && isAuthReady },
   );
 
-  const participantIds = useMemo(() => {
-    const ids = new Set<string>();
-    const hostId = room?.host.id;
-
-    Object.keys(roomState?.participants ?? {}).forEach((id) => {
-      if (id && id !== hostId) {
-        ids.add(id);
-      }
-    });
-
-    chatMessages.forEach((message) => {
-      if (message.participantId && message.participantId !== hostId) {
-        ids.add(message.participantId);
-      }
-    });
-
-    return [...ids];
-  }, [chatMessages, room?.host.id, roomState?.participants]);
-  const visibleRemoteStreams = useMemo(
-    () =>
-      videoSettings.audioOnly
-        ? remoteStreams.filter((stream) => stream.kind !== 'video')
-        : remoteStreams,
-    [remoteStreams, videoSettings.audioOnly],
-  );
-  const participantProfiles = useLiveRoomParticipantProfiles(participantIds);
-  const participantStreamsById = useLiveRoomParticipantStreams(
-    visibleRemoteStreams,
-    localStream,
-    participantId,
-  );
   const { hasHostPrivileges, isHost } = privilegeState;
   const isCreated = (roomState?.status ?? room?.status) === 'created';
   const isLive = (roomState?.status ?? room?.status) === 'live';
   const isEnded = roomState?.status === 'ended' || room?.status === 'ended';
-  const roomMode = roomState?.mode ?? room?.mode ?? 'moderated';
-  const isFreeForAll = roomMode === 'free_for_all';
   const streamTimerReference = isLive ? room?.startedAt ?? null : null;
   const streamDuration = useStreamDuration(streamTimerReference);
   const participantCount = roomState
     ? Object.keys(roomState.participants).length
     : room?.participantCount ?? 0;
-  const hostId = room?.host.id ?? '';
-  const coHostParticipantIds = roomState?.coHostParticipantIds ?? [];
-  const activeSpeakerIds =
-    roomState?.stage.activeSpeakerParticipantIds.filter(
-      (id) => !!roomState.participants[id] && id !== hostId,
-    ) ?? [];
-  const queuedParticipantIds =
-    roomState?.stage.speakerQueueParticipantIds.filter(
-      (id) => !!roomState.participants[id],
-    ) ?? [];
-  const raisedHandParticipantIds =
-    roomState?.stage.raisedHandParticipantIds ?? EMPTY_PARTICIPANT_IDS;
-  const raisedHandQueuePositions = useMemo(() => {
-    const positions = new Map<string, number>();
-    if (!roomState) {
-      return positions;
-    }
-
-    raisedHandParticipantIds.forEach((id) => {
-      if (roomState.participants[id]) {
-        positions.set(id, positions.size + 1);
-      }
-    });
-
-    return positions;
-  }, [raisedHandParticipantIds, roomState]);
-  const audienceParticipantIds = roomState
-    ? Object.values(roomState.participants)
-        .map((participant) => participant.participantId)
-        .filter(
-          (id) =>
-            id !== hostId &&
-            !activeSpeakerIds.includes(id) &&
-            !queuedParticipantIds.includes(id),
-        )
-    : [];
-  const stageLimit = roomState?.stage.speakerLimit ?? null;
-  const remainingSeats =
-    stageLimit === null
-      ? null
-      : Math.max(stageLimit - activeSpeakerIds.length, 0);
-  let waitingPrompt = 'Audience can join the queue';
-  if (isFreeForAll && remainingSeats !== null) {
-    waitingPrompt =
-      remainingSeats === 0
-        ? 'The stage is full right now'
-        : `${remainingSeats} open stage spots`;
-  } else if (queuedParticipantIds.length > 0) {
-    waitingPrompt = `${queuedParticipantIds.length} in queue`;
-  }
-  const participantProfilesById = useMemo(() => {
-    const nextProfiles = new Map(participantProfiles);
-
-    if (room?.host) {
-      nextProfiles.set(room.host.id, room.host);
-    }
-
-    return nextProfiles;
-  }, [participantProfiles, room?.host]);
-  const mentionSuggestions = useMemo(() => {
-    if (!room?.host) {
-      return [] as UserShortProfile[];
-    }
-
-    const suggestions: UserShortProfile[] = [room.host];
-
-    participantIds.forEach((id) => {
-      const profile = participantProfilesById.get(id);
-      if (profile) {
-        suggestions.push(profile);
-      }
-    });
-
-    return suggestions;
-  }, [participantIds, participantProfilesById, room?.host]);
-  const audioPublisherIds = new Set(
-    Object.values(roomState?.mediaPublications ?? {})
-      .filter((publication) => publication.kind === 'audio')
-      .map((publication) => publication.participantId),
-  );
-  const isParticipantMuted = (id: string, selfView: boolean): boolean =>
-    selfView ? !isMicOn : !audioPublisherIds.has(id);
-  const stageSpeakers = room?.host
-    ? [
-        {
-          id: room.host.id,
-          profile: buildDisplayProfile(room.host),
-          stream: participantStreamsById.get(room.host.id) ?? null,
-          selfView: room.host.id === participantId,
-          isHost: true,
-          isCoHost: false,
-          raisedHandQueuePosition: raisedHandQueuePositions.get(room.host.id),
-        },
-        ...activeSpeakerIds.map((id) => ({
-          id,
-          profile: buildDisplayProfile(
-            participantProfilesById.get(id) ?? buildParticipantProfile(id),
-          ),
-          stream: participantStreamsById.get(id) ?? null,
-          selfView: id === participantId,
-          isHost: false,
-          isCoHost: coHostParticipantIds.includes(id),
-          raisedHandQueuePosition: raisedHandQueuePositions.get(id),
-        })),
-      ].map((speaker) => ({
-        ...speaker,
-        isMuted: isParticipantMuted(speaker.id, speaker.selfView),
-      }))
-    : [];
-  const visibleStageSpeakers = stageSpeakers.filter(
-    (speaker) => !speaker.selfView || !videoSettings.hideSelfView,
-  );
-  const stageTilesPerPage = isMobile
-    ? MOBILE_MAX_STAGE_TILES_PER_PAGE
-    : MAX_STAGE_TILES_PER_PAGE;
-  const stagePageCount = Math.max(
-    1,
-    Math.ceil(visibleStageSpeakers.length / stageTilesPerPage),
-  );
-  const clampedStagePage = Math.min(stagePage, stagePageCount - 1);
-  const stagePageStart = clampedStagePage * stageTilesPerPage;
-  const paginatedStageSpeakers = visibleStageSpeakers.slice(
-    stagePageStart,
-    stagePageStart + stageTilesPerPage,
-  );
-  const stageGridColumnCount = getStageGridColumnCount(
-    paginatedStageSpeakers.length,
+  const {
+    participantProfilesById,
+    mentionSuggestions,
+    roomMode,
+    isFreeForAll,
+    activeSpeakerIds,
+    queuedParticipantIds,
+    audienceParticipantIds,
+    coHostParticipantIds,
+    stageLimit,
+    waitingPrompt,
+    stagePageCount,
+    clampedStagePage,
+    paginatedStageSpeakers,
+    stageGridColumnCount,
+    stageGridRowCount,
+  } = useLiveRoomStageModel({
+    room,
+    roomState,
+    chatMessages,
+    remoteStreams,
+    localStream,
+    participantId,
+    isMicOn,
+    videoSettings,
     isMobile,
-  );
-  const stageGridRowCount = Math.max(
-    1,
-    Math.ceil(paginatedStageSpeakers.length / stageGridColumnCount),
-  );
+    stagePage,
+  });
   const canSubscribeToLobby =
     isCreated && !!room?.scheduledStart && user?.id !== room?.host.id;
   const subscriptionBusy = subscribe.isPending || unsubscribe.isPending;
@@ -857,16 +511,12 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     }
     lastLoggedRoomErrorRef.current = errorKey;
 
-    logEvent({
-      event_name: LogEvent.StandupError,
-      target_id: 'room query',
-      extra: buildStandupExtra({
-        surface: 'page',
-        source: 'room_query',
-        message: roomError.message,
-      }),
+    logStandupAction(LogEvent.StandupError, 'room query', {
+      surface: 'page',
+      source: 'room_query',
+      message: roomError.message,
     });
-  }, [buildStandupExtra, logEvent, roomError, roomId]);
+  }, [logStandupAction, roomError, roomId]);
 
   if (!isAuthReady || isRoomLoading) {
     return (
@@ -928,245 +578,52 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
 
   return (
     <div className="relative flex flex-1 flex-col overflow-hidden tablet:gap-3 tablet:p-4">
-      <ReactionOverlay reactions={reactions} />
+      <LiveRoomReactionOverlay reactions={reactions} />
 
-      <header className="flex flex-wrap items-center justify-between gap-x-3 gap-y-0.5 rounded-none border-x-0 border-b border-t-0 border-border-subtlest-tertiary bg-surface-float px-3 py-1.5 tablet:gap-x-4 tablet:gap-y-2 tablet:rounded-16 tablet:border-x tablet:border-t tablet:px-4 tablet:py-3">
-        <div className="flex min-w-0 items-center gap-3">
-          <LiveBadge isLive={!!isLive} />
-          <Typography
-            tag={TypographyTag.H1}
-            type={TypographyType.Title3}
-            bold
-            truncate
-            className="min-w-0"
-          >
-            {room.topic}
-          </Typography>
-        </div>
-        <div className="flex flex-wrap items-center justify-end gap-3 text-text-tertiary typo-caption1">
-          {canSubscribeToLobby ? (
-            <Button
-              type="button"
-              size={ButtonSize.Small}
-              variant={
-                room.subscribed
-                  ? ButtonVariant.Secondary
-                  : ButtonVariant.Primary
-              }
-              loading={subscriptionBusy}
-              disabled={subscriptionBusy}
-              onClick={() => handleToggleSubscription()}
-            >
-              {room.subscribed ? 'Unsubscribe' : 'Notify me'}
-            </Button>
-          ) : null}
-          {roomState || room.scheduledStart ? (
-            <span className="inline-flex flex-wrap items-center">
-              {isLive ? (
-                <span className="font-bold tabular-nums text-text-primary">
-                  {formatStreamDuration(streamDuration)}
-                </span>
-              ) : null}
-              {isCreated && room.scheduledStart ? (
-                <span className="inline-flex items-center gap-1.5">
-                  <span>Starting in</span>
-                  <span className="font-bold tabular-nums text-text-primary">
-                    {formatStreamDuration(lobbyCountdown)}
-                  </span>
-                </span>
-              ) : null}
-              {roomState && (isLive || (isCreated && room.scheduledStart)) ? (
-                <Separator className="mx-2" />
-              ) : null}
-              {roomState ? (
-                <span className="inline-flex items-center gap-1.5">
-                  <span className="font-bold text-text-primary">
-                    <AnimatedCount value={participantCount} />
-                  </span>
-                  <span>watching</span>
-                </span>
-              ) : null}
-            </span>
-          ) : null}
-        </div>
-      </header>
+      <LiveRoomHeader
+        title={room.topic}
+        isLive={!!isLive}
+        isCreated={!!isCreated}
+        scheduledStart={room.scheduledStart}
+        streamDuration={streamDuration}
+        lobbyCountdown={lobbyCountdown}
+        participantCount={participantCount}
+        showParticipantCount={!!roomState}
+        canSubscribeToLobby={canSubscribeToLobby}
+        subscribed={room.subscribed}
+        subscriptionBusy={subscriptionBusy}
+        onToggleSubscription={handleToggleSubscription}
+      />
 
       <div className="grid min-h-0 flex-1 grid-cols-1 grid-rows-[1fr_auto] tablet:grid-rows-none tablet:gap-3 laptop:grid-cols-[minmax(0,1fr)_22rem]">
-        <section
-          aria-label="Speakers"
-          className="relative flex min-h-0 flex-col"
-        >
-          {!isCreated && stagePageCount > 1 ? (
-            <div className="flex items-center justify-end gap-2 px-1.5 pb-3">
-              <Typography
-                type={TypographyType.Caption1}
-                color={TypographyColor.Tertiary}
-              >
-                Page {clampedStagePage + 1} / {stagePageCount}
-              </Typography>
-              <Button
-                type="button"
-                size={ButtonSize.Small}
-                variant={ButtonVariant.Tertiary}
-                disabled={clampedStagePage === 0}
-                onClick={() =>
-                  setStagePage((currentPage) => Math.max(0, currentPage - 1))
-                }
-              >
-                Prev
-              </Button>
-              <Button
-                type="button"
-                size={ButtonSize.Small}
-                variant={ButtonVariant.Tertiary}
-                disabled={clampedStagePage >= stagePageCount - 1}
-                onClick={() =>
-                  setStagePage((currentPage) =>
-                    Math.min(stagePageCount - 1, currentPage + 1),
-                  )
-                }
-              >
-                Next
-              </Button>
-            </div>
-          ) : null}
-          {isCreated ? <LiveRoomLobbyContent room={room} /> : null}
-          {!isCreated && paginatedStageSpeakers.length > 0 ? (
-            <div
-              className="grid min-h-0 flex-1 gap-3 overflow-hidden p-1.5 pb-24 tablet:pb-28"
-              style={{
-                gridTemplateColumns: `repeat(${stageGridColumnCount}, minmax(0, 1fr))`,
-                gridTemplateRows: `repeat(${stageGridRowCount}, minmax(0, 1fr))`,
-              }}
-            >
-              {paginatedStageSpeakers.map((speaker, index) => {
-                const canModerate = hasHostPrivileges && !speaker.isHost;
-                const canManageCoHosts = isHost && !speaker.isHost;
-
-                return (
-                  <div
-                    key={speaker.id}
-                    className="flex min-h-0 min-w-0 items-center justify-center"
-                  >
-                    <LiveRoomVideoTile
-                      stream={speaker.stream}
-                      user={speaker.profile}
-                      selfView={speaker.selfView}
-                      isHost={speaker.isHost}
-                      isCoHost={speaker.isCoHost}
-                      raisedHandQueuePosition={speaker.raisedHandQueuePosition}
-                      isMuted={speaker.isMuted}
-                      isFocused={focusedSpeakerIndex === index}
-                      onFocus={() => focusSpeaker(index)}
-                      onUnfocus={unfocusSpeaker}
-                      onSwipeNext={() => handleSpeakerFocusNavigate(1)}
-                      onSwipePrev={() => handleSpeakerFocusNavigate(-1)}
-                      onGrantCoHost={
-                        canManageCoHosts && !speaker.isCoHost
-                          ? () =>
-                              guardedModerationAction(
-                                `tile-grant-cohost-${speaker.id}`,
-                                () =>
-                                  handleGrantCoHost(speaker.id, 'stage_tile'),
-                              )
-                          : undefined
-                      }
-                      onRevokeCoHost={
-                        canManageCoHosts && speaker.isCoHost
-                          ? () =>
-                              guardedModerationAction(
-                                `tile-revoke-cohost-${speaker.id}`,
-                                () =>
-                                  handleRevokeCoHost(speaker.id, 'stage_tile'),
-                              )
-                          : undefined
-                      }
-                      onRemoveSpeaker={
-                        canModerate
-                          ? () =>
-                              guardedModerationAction(
-                                `tile-remove-${speaker.id}`,
-                                () =>
-                                  handleRemoveSpeaker(speaker.id, 'stage_tile'),
-                              )
-                          : undefined
-                      }
-                      onKick={
-                        canModerate
-                          ? () =>
-                              guardedModerationAction(
-                                `tile-kick-${speaker.id}`,
-                                () =>
-                                  handleKickParticipant(
-                                    speaker.id,
-                                    'stage_tile',
-                                  ),
-                              )
-                          : undefined
-                      }
-                      isRemoving={
-                        moderationBusy === `tile-remove-${speaker.id}`
-                      }
-                      isGrantingCoHost={
-                        moderationBusy === `tile-grant-cohost-${speaker.id}`
-                      }
-                      isRevokingCoHost={
-                        moderationBusy === `tile-revoke-cohost-${speaker.id}`
-                      }
-                      isKicking={moderationBusy === `tile-kick-${speaker.id}`}
-                      moderationDisabled={!!moderationBusy}
-                    />
-                  </div>
-                );
-              })}
-            </div>
-          ) : null}
-          {!isCreated && paginatedStageSpeakers.length === 0 ? (
-            <div className="flex flex-1 items-center justify-center rounded-16 border border-dashed border-border-subtlest-tertiary p-6 text-center">
-              <div className="flex flex-col items-center gap-2">
-                <span className="flex size-10 items-center justify-center rounded-full bg-surface-float text-text-tertiary">
-                  <UserIcon size={IconSize.Small} />
-                </span>
-                <Typography type={TypographyType.Footnote} bold>
-                  No visible speakers
-                </Typography>
-                <Typography
-                  type={TypographyType.Caption1}
-                  color={TypographyColor.Tertiary}
-                >
-                  {waitingPrompt}
-                </Typography>
-              </div>
-            </div>
-          ) : null}
-
-          {isEnded ? (
-            <div className="absolute inset-0 flex items-center justify-center bg-background-default p-6">
-              <div className="flex flex-col items-center gap-3 text-center">
-                <Typography type={TypographyType.Title3} bold>
-                  This standup has ended
-                </Typography>
-                <Typography
-                  type={TypographyType.Callout}
-                  color={TypographyColor.Tertiary}
-                >
-                  Thanks for joining — catch the next one soon.
-                </Typography>
-                <Button
-                  className="mt-2"
-                  variant={ButtonVariant.Primary}
-                  onClick={() => handleNavigateBack('ended_state')}
-                >
-                  Back home
-                </Button>
-              </div>
-            </div>
-          ) : null}
-
-          {roomState && !isEnded ? (
-            <LiveRoomControls roomId={roomId} onLeave={handleLeave} />
-          ) : null}
-        </section>
+        <LiveRoomStage
+          room={room}
+          roomId={roomId}
+          isCreated={!!isCreated}
+          isEnded={!!isEnded}
+          stagePageCount={stagePageCount}
+          clampedStagePage={clampedStagePage}
+          setStagePage={setStagePage}
+          stageGridColumnCount={stageGridColumnCount}
+          stageGridRowCount={stageGridRowCount}
+          speakers={paginatedStageSpeakers}
+          focusedSpeakerIndex={focusedSpeakerIndex}
+          waitingPrompt={waitingPrompt}
+          hasHostPrivileges={hasHostPrivileges}
+          isHost={isHost}
+          moderationBusy={moderationBusy}
+          onFocusSpeaker={focusSpeaker}
+          onUnfocusSpeaker={unfocusSpeaker}
+          onSpeakerFocusNavigate={handleSpeakerFocusNavigate}
+          guardedModerationAction={guardedModerationAction}
+          onGrantCoHost={handleGrantCoHost}
+          onRevokeCoHost={handleRevokeCoHost}
+          onRemoveSpeaker={handleRemoveSpeaker}
+          onKickParticipant={handleKickParticipant}
+          onNavigateBack={handleNavigateBack}
+          showControls={!!roomState}
+          onLeave={handleLeave}
+        />
 
         <aside
           aria-label="Standup side panel"

--- a/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
@@ -6,18 +6,9 @@ import {
   ButtonSize,
   ButtonVariant,
 } from '../buttons/Button';
-import { EmojiPicker } from '../fields/EmojiPicker';
-import {
-  CameraIcon,
-  ExitIcon,
-  MegaphoneIcon,
-  PlusIcon,
-  SettingsIcon,
-} from '../icons';
+import { CameraIcon, ExitIcon, MegaphoneIcon, SettingsIcon } from '../icons';
 import { RaiseHandIcon } from '../icons/RaiseHand';
-import { IconSize } from '../Icon';
 import { useLiveRoom } from '../../contexts/LiveRoomContext';
-import { useLogContext } from '../../contexts/LogContext';
 import { useToastNotification } from '../../hooks/useToastNotification';
 import { LiveRoomMicLevel } from './LiveRoomMicLevel';
 import {
@@ -25,60 +16,35 @@ import {
   TypographyColor,
   TypographyType,
 } from '../typography/Typography';
-import { Tooltip } from '../tooltip/Tooltip';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useViewSize, ViewSize } from '../../hooks';
 import { AuthTriggers } from '../../lib/auth';
-import { buildStandupAnalyticsExtra } from '../../lib/liveRoom/analytics';
 import { getLiveRoomPrivilegeState } from '../../lib/liveRoom/privileges';
-import { LIVE_ROOM_QUICK_REACTION_EMOJIS } from '../../lib/liveRoom/reactions';
 import { LogEvent } from '../../lib/log';
-import { Modal } from '../modals/common/Modal';
+import { useLiveRoomStandupAnalytics } from '../../hooks/liveRooms/useLiveRoomStandupAnalytics';
 import {
-  AUDIO_ONLY_LABEL,
   ControlGroup,
   DeviceSplitButton,
   Divider,
   HIDE_SELF_VIEW_LABEL,
   MIC_SETTING_ITEMS,
   MicSettingRow,
-  SelectSettingRow,
   SlashedIcon,
-  VIDEO_QUALITY_ITEMS,
-  VIDEO_QUALITY_LABEL,
 } from './LiveRoomControlPrimitives';
+import { LiveRoomSettingsModal } from './LiveRoomSettingsModal';
+import { LiveRoomReactionsToolbar } from './LiveRoomReactionsToolbar';
+import { LiveRoomTooltipButton } from './LiveRoomTooltipButton';
 
 interface LiveRoomControlsProps {
   roomId: string;
   onLeave: () => void;
 }
 
-const TooltipButton = ({
-  tooltip,
-  children,
-  wrapDisabled = false,
-}: {
-  tooltip: string;
-  children: ReactElement;
-  wrapDisabled?: boolean;
-}): ReactElement => {
-  if (wrapDisabled) {
-    return (
-      <Tooltip content={tooltip}>
-        <span className="inline-flex">{children}</span>
-      </Tooltip>
-    );
-  }
-
-  return <Tooltip content={tooltip}>{children}</Tooltip>;
-};
-
 export const LiveRoomControls = ({
   roomId,
   onLeave,
 }: LiveRoomControlsProps): ReactElement => {
   const { user, showLogin } = useAuthContext();
-  const { logEvent } = useLogContext();
   const isTablet = useViewSize(ViewSize.Tablet);
   const {
     status,
@@ -128,36 +94,18 @@ export const LiveRoomControls = ({
     () => (localAudioTrack ? new MediaStream([localAudioTrack]) : null),
     [localAudioTrack],
   );
-  const buildStandupExtra = (extra: Record<string, unknown> = {}): string =>
-    buildStandupAnalyticsExtra(
-      {
-        roomId,
-        authKind: user ? 'authenticated' : 'anonymous',
-        role,
-        roomStatus: roomState?.status ?? null,
-        roomMode: roomState?.mode ?? null,
-        connectionStatus: status,
-        participantId,
-        isCoHost: privilegeState.isCoHost,
-        hasLocalAudioTrack: !!localStream?.getAudioTracks()[0],
-        hasLocalVideoTrack: !!localStream?.getVideoTracks()[0],
-        videoQuality: videoSettings.quality,
-        audioOnly: videoSettings.audioOnly,
-        hideSelfView: videoSettings.hideSelfView,
-      },
-      extra,
-    );
-  const logStandupAction = (
-    eventName: LogEvent,
-    targetId: string,
-    extra: Record<string, unknown> = {},
-  ): void => {
-    logEvent({
-      event_name: eventName,
-      target_id: targetId,
-      extra: buildStandupExtra(extra),
-    });
-  };
+  const { logStandupAction } = useLiveRoomStandupAnalytics({
+    roomId,
+    user,
+    role,
+    roomStatus: roomState?.status ?? null,
+    roomMode: roomState?.mode ?? null,
+    connectionStatus: status,
+    participantId,
+    isCoHost: privilegeState.isCoHost,
+    localStream,
+    videoSettings,
+  });
 
   const isBusy = (key: string): boolean => busyKeys.includes(key);
 
@@ -269,72 +217,19 @@ export const LiveRoomControls = ({
     <div className="pointer-events-none absolute inset-x-0 bottom-2 z-2 px-1.5 tablet:bottom-6">
       <div className="pointer-events-auto relative mx-auto flex w-full max-w-[42rem] flex-col items-center gap-1.5 tablet:gap-2">
         {reactionsOpen && isLive ? (
-          <div className="flex items-center gap-1 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-1.5 shadow-2">
-            {LIVE_ROOM_QUICK_REACTION_EMOJIS.map((emoji) => (
-              <TooltipButton key={emoji} tooltip={`React ${emoji}`}>
-                <Button
-                  type="button"
-                  size={ButtonSize.Small}
-                  variant={ButtonVariant.Float}
-                  loading={isBusy(`reaction-${emoji}`)}
-                  aria-label={`React ${emoji}`}
-                  onClick={() =>
-                    runAuthenticatedAction(`reaction-${emoji}`, async () => {
-                      await sendReaction(emoji);
-                      logStandupAction(LogEvent.SendStandupReaction, emoji, {
-                        surface: 'controls',
-                      });
-                    })
-                  }
-                >
-                  <span className="text-lg leading-none">{emoji}</span>
-                </Button>
-              </TooltipButton>
-            ))}
-            <EmojiPicker
-              value=""
-              label={null}
-              onChange={(emoji) => {
-                if (!emoji) {
-                  return;
-                }
-
-                runAuthenticatedAction('reaction-custom', async () => {
-                  await sendReaction(emoji);
-                  logStandupAction(LogEvent.SendStandupReaction, emoji, {
-                    surface: 'controls',
-                  });
+          <LiveRoomReactionsToolbar
+            isBusy={isBusy}
+            isAuthenticated={!!user}
+            onRequestLogin={promptSignup}
+            onSendReaction={(key, emoji) =>
+              runAuthenticatedAction(key, async () => {
+                await sendReaction(emoji);
+                logStandupAction(LogEvent.SendStandupReaction, emoji, {
+                  surface: 'controls',
                 });
-              }}
-              renderTrigger={({ isOpen, toggleOpen }) => (
-                <TooltipButton
-                  tooltip="Custom reaction"
-                  wrapDisabled={isBusy('reaction-custom')}
-                >
-                  <Button
-                    type="button"
-                    size={ButtonSize.Small}
-                    variant={
-                      isOpen ? ButtonVariant.Primary : ButtonVariant.Float
-                    }
-                    className="!w-9 shrink-0"
-                    icon={<PlusIcon size={IconSize.Size16} />}
-                    aria-label="Custom reaction"
-                    aria-expanded={isOpen}
-                    disabled={isBusy('reaction-custom')}
-                    onClick={() => {
-                      if (!user) {
-                        promptSignup();
-                        return;
-                      }
-
-                      toggleOpen();
-                    }}
-                  />
-                </TooltipButton>
-              )}
-            />
-          </div>
+              })
+            }
+          />
         ) : null}
 
         <div className="flex items-center gap-1 rounded-12 border border-border-subtlest-tertiary bg-background-default p-1 shadow-2 backdrop-blur tablet:gap-2 tablet:rounded-16 tablet:p-1.5">
@@ -473,7 +368,7 @@ export const LiveRoomControls = ({
           {showLiveInteractionControls ? (
             <>
               <ControlGroup>
-                <TooltipButton tooltip={reactionTooltip}>
+                <LiveRoomTooltipButton tooltip={reactionTooltip}>
                   <Button
                     type="button"
                     size={ButtonSize.Small}
@@ -505,9 +400,9 @@ export const LiveRoomControls = ({
                   >
                     <span className="text-base leading-none">😀</span>
                   </Button>
-                </TooltipButton>
+                </LiveRoomTooltipButton>
                 {canRaiseHand ? (
-                  <TooltipButton
+                  <LiveRoomTooltipButton
                     tooltip={isHandRaised ? 'Lower hand' : 'Raise hand'}
                     wrapDisabled={isBusy('hand')}
                   >
@@ -551,9 +446,9 @@ export const LiveRoomControls = ({
                         })
                       }
                     />
-                  </TooltipButton>
+                  </LiveRoomTooltipButton>
                 ) : null}
-                <TooltipButton tooltip={settingsTooltip}>
+                <LiveRoomTooltipButton tooltip={settingsTooltip}>
                   <Button
                     type="button"
                     size={ButtonSize.Small}
@@ -576,7 +471,7 @@ export const LiveRoomControls = ({
                       setIsSettingsOpen(true);
                     }}
                   />
-                </TooltipButton>
+                </LiveRoomTooltipButton>
                 {isModerated && isAudience ? (
                   <Button
                     type="button"
@@ -599,7 +494,7 @@ export const LiveRoomControls = ({
                   </Button>
                 ) : null}
                 {isFreeForAll && isAudience ? (
-                  <TooltipButton
+                  <LiveRoomTooltipButton
                     tooltip={joinStageTooltip}
                     wrapDisabled={!canJoinStage || isBusy('join-stage')}
                   >
@@ -624,10 +519,10 @@ export const LiveRoomControls = ({
                     >
                       {joinStageTooltip}
                     </Button>
-                  </TooltipButton>
+                  </LiveRoomTooltipButton>
                 ) : null}
                 {canLeaveStage ? (
-                  <TooltipButton
+                  <LiveRoomTooltipButton
                     tooltip="Stop speaking"
                     wrapDisabled={isBusy('leave-stage')}
                   >
@@ -647,7 +542,7 @@ export const LiveRoomControls = ({
                     >
                       Stop speaking
                     </Button>
-                  </TooltipButton>
+                  </LiveRoomTooltipButton>
                 ) : null}
               </ControlGroup>
 
@@ -657,7 +552,10 @@ export const LiveRoomControls = ({
 
           <ControlGroup>
             {showGoLive ? (
-              <TooltipButton tooltip="Go live" wrapDisabled={isBusy('go-live')}>
+              <LiveRoomTooltipButton
+                tooltip="Go live"
+                wrapDisabled={isBusy('go-live')}
+              >
                 <Button
                   type="button"
                   size={ButtonSize.Small}
@@ -675,7 +573,7 @@ export const LiveRoomControls = ({
                 >
                   Go live
                 </Button>
-              </TooltipButton>
+              </LiveRoomTooltipButton>
             ) : null}
             {privilegeState.hasHostPrivileges ? (
               <Button
@@ -720,52 +618,17 @@ export const LiveRoomControls = ({
         </div>
       </div>
       {isSettingsOpen ? (
-        <Modal
-          isOpen
-          kind={Modal.Kind.FixedCenter}
-          size={Modal.Size.Small}
-          isDrawerOnMobile
-          drawerProps={{ appendOnRoot: true }}
-          onRequestClose={() => setIsSettingsOpen(false)}
-        >
-          <Modal.Header title="Standup settings" />
-          <Modal.Body className="gap-1">
-            <SelectSettingRow
-              label={VIDEO_QUALITY_LABEL}
-              description="Choose how aggressively remote video should use your connection."
-              value={videoSettings.quality}
-              options={VIDEO_QUALITY_ITEMS.map((item) => ({
-                value: item.value,
-                label: item.label,
-              }))}
-              onSelect={(quality) => {
-                setVideoSetting('quality', quality);
-                logStandupAction(
-                  LogEvent.ChangeStandupSettings,
-                  'video_quality',
-                  {
-                    surface: 'settings_modal',
-                    value: quality,
-                  },
-                );
-              }}
-            />
-            <MicSettingRow
-              id="live-room-video-setting-audio-only"
-              label={AUDIO_ONLY_LABEL}
-              description="Hide remote video and keep the standup playing through audio."
-              checked={videoSettings.audioOnly}
-              onToggle={() => {
-                const nextValue = !videoSettings.audioOnly;
-                setVideoSetting('audioOnly', nextValue);
-                logStandupAction(LogEvent.ChangeStandupSettings, 'audio_only', {
-                  surface: 'settings_modal',
-                  value: nextValue,
-                });
-              }}
-            />
-          </Modal.Body>
-        </Modal>
+        <LiveRoomSettingsModal
+          videoSettings={videoSettings}
+          setVideoSetting={setVideoSetting}
+          onClose={() => setIsSettingsOpen(false)}
+          onTrackSettingChange={(targetId, surface, value) => {
+            logStandupAction(LogEvent.ChangeStandupSettings, targetId, {
+              surface,
+              value,
+            });
+          }}
+        />
       ) : null}
     </div>
   );

--- a/packages/shared/src/components/liveRooms/LiveRoomHeader.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomHeader.tsx
@@ -1,0 +1,133 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import {
+  Typography,
+  TypographyTag,
+  TypographyType,
+} from '../typography/Typography';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { Separator } from '../cards/common/common';
+
+interface LiveRoomHeaderProps {
+  title: string;
+  isLive: boolean;
+  isCreated: boolean;
+  scheduledStart?: string | null;
+  streamDuration: number;
+  lobbyCountdown: number;
+  participantCount: number;
+  showParticipantCount: boolean;
+  canSubscribeToLobby: boolean;
+  subscribed: boolean;
+  subscriptionBusy: boolean;
+  onToggleSubscription: () => void;
+}
+
+const formatStreamDuration = (seconds: number): string => {
+  const safeSeconds = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(safeSeconds / 3600);
+  const minutes = Math.floor((safeSeconds % 3600) / 60);
+  const remainingSeconds = safeSeconds % 60;
+  const pad = (value: number) => value.toString().padStart(2, '0');
+
+  if (hours > 0) {
+    return `${hours}:${pad(minutes)}:${pad(remainingSeconds)}`;
+  }
+
+  return `${pad(minutes)}:${pad(remainingSeconds)}`;
+};
+
+const AnimatedCount = ({ value }: { value: number }): ReactElement => (
+  <span key={value} className="live-room-count-bump tabular-nums">
+    {value}
+  </span>
+);
+
+const LiveBadge = ({ isLive }: { isLive: boolean }): ReactElement => (
+  <span
+    className={classNames(
+      'inline-flex items-center gap-1 rounded-8 px-1.5 py-px typo-caption2 tablet:gap-1.5 tablet:px-2 tablet:py-0.5 tablet:typo-caption1',
+      isLive
+        ? 'bg-accent-ketchup-default text-white'
+        : 'bg-accent-bacon-default text-white',
+    )}
+  >
+    <span className="size-1 animate-pulse rounded-full bg-white tablet:size-1.5" />
+    <span className="font-bold uppercase tracking-wide">
+      {isLive ? 'Live' : 'Lobby'}
+    </span>
+  </span>
+);
+
+export const LiveRoomHeader = ({
+  title,
+  isLive,
+  isCreated,
+  scheduledStart,
+  streamDuration,
+  lobbyCountdown,
+  participantCount,
+  showParticipantCount,
+  canSubscribeToLobby,
+  subscribed,
+  subscriptionBusy,
+  onToggleSubscription,
+}: LiveRoomHeaderProps): ReactElement => (
+  <header className="flex flex-wrap items-center justify-between gap-x-3 gap-y-0.5 rounded-none border-x-0 border-b border-t-0 border-border-subtlest-tertiary bg-surface-float px-3 py-1.5 tablet:gap-x-4 tablet:gap-y-2 tablet:rounded-16 tablet:border-x tablet:border-t tablet:px-4 tablet:py-3">
+    <div className="flex min-w-0 items-center gap-3">
+      <LiveBadge isLive={isLive} />
+      <Typography
+        tag={TypographyTag.H1}
+        type={TypographyType.Title3}
+        bold
+        truncate
+        className="min-w-0"
+      >
+        {title}
+      </Typography>
+    </div>
+    <div className="flex flex-wrap items-center justify-end gap-3 text-text-tertiary typo-caption1">
+      {canSubscribeToLobby ? (
+        <Button
+          type="button"
+          size={ButtonSize.Small}
+          variant={subscribed ? ButtonVariant.Secondary : ButtonVariant.Primary}
+          loading={subscriptionBusy}
+          disabled={subscriptionBusy}
+          onClick={onToggleSubscription}
+        >
+          {subscribed ? 'Unsubscribe' : 'Notify me'}
+        </Button>
+      ) : null}
+      {showParticipantCount || scheduledStart ? (
+        <span className="inline-flex flex-wrap items-center">
+          {isLive ? (
+            <span className="font-bold tabular-nums text-text-primary">
+              {formatStreamDuration(streamDuration)}
+            </span>
+          ) : null}
+          {isCreated && scheduledStart ? (
+            <span className="inline-flex items-center gap-1.5">
+              <span>Starting in</span>
+              <span className="font-bold tabular-nums text-text-primary">
+                {formatStreamDuration(lobbyCountdown)}
+              </span>
+            </span>
+          ) : null}
+          {showParticipantCount && (isLive || (isCreated && scheduledStart)) ? (
+            <Separator className="mx-2" />
+          ) : null}
+          {showParticipantCount ? (
+            <span className="inline-flex items-center gap-1.5">
+              <span className="font-bold text-text-primary">
+                <AnimatedCount value={participantCount} />
+              </span>
+              <span>watching</span>
+            </span>
+          ) : null}
+        </span>
+      ) : null}
+    </div>
+  </header>
+);

--- a/packages/shared/src/components/liveRooms/LiveRoomLobbyContent.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomLobbyContent.tsx
@@ -1,0 +1,35 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import Markdown from '../Markdown';
+import { ContentEmbeds } from '../contentEmbeds/ContentEmbeds';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../typography/Typography';
+import type { LiveRoom as LiveRoomModel } from '../../graphql/liveRooms';
+
+export const LiveRoomLobbyContent = ({
+  room,
+}: {
+  room: LiveRoomModel;
+}): ReactElement => (
+  <div className="min-h-0 flex-1 overflow-y-auto px-3 py-1.5 pb-20 tablet:p-1.5 tablet:pb-28">
+    <article className="mx-auto flex w-full max-w-[42rem] flex-col gap-5">
+      {room.descriptionHtml ? (
+        <Markdown
+          content={room.descriptionHtml}
+          className="break-words text-text-primary"
+        />
+      ) : (
+        <Typography
+          type={TypographyType.Callout}
+          color={TypographyColor.Tertiary}
+        >
+          No agenda has been added yet.
+        </Typography>
+      )}
+      <ContentEmbeds embeds={room.contentEmbeds} variant="post" />
+    </article>
+  </div>
+);

--- a/packages/shared/src/components/liveRooms/LiveRoomReactionOverlay.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomReactionOverlay.tsx
@@ -1,0 +1,36 @@
+import type { CSSProperties, ReactElement } from 'react';
+import React from 'react';
+import type { LiveRoomReaction } from '../../contexts/LiveRoomContext';
+
+export const LiveRoomReactionOverlay = ({
+  reactions,
+}: {
+  reactions: LiveRoomReaction[];
+}): ReactElement | null => {
+  if (reactions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-x-0 bottom-0 top-1/4 z-3 overflow-hidden"
+      aria-hidden
+    >
+      {reactions.map((reaction) => (
+        <span
+          key={reaction.id}
+          className="live-room-reaction absolute bottom-0 text-4xl"
+          style={
+            {
+              '--live-room-reaction-left': `${16 + reaction.lane * 16}%`,
+              '--live-room-reaction-drift':
+                reaction.lane % 2 === 0 ? '-1rem' : '1rem',
+            } as CSSProperties
+          }
+        >
+          {reaction.emoji}
+        </span>
+      ))}
+    </div>
+  );
+};

--- a/packages/shared/src/components/liveRooms/LiveRoomReactionsToolbar.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomReactionsToolbar.tsx
@@ -1,0 +1,75 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { EmojiPicker } from '../fields/EmojiPicker';
+import { PlusIcon } from '../icons';
+import { IconSize } from '../Icon';
+import { LIVE_ROOM_QUICK_REACTION_EMOJIS } from '../../lib/liveRoom/reactions';
+import { LiveRoomTooltipButton } from './LiveRoomTooltipButton';
+
+interface LiveRoomReactionsToolbarProps {
+  isBusy: (key: string) => boolean;
+  isAuthenticated: boolean;
+  onRequestLogin: () => void;
+  onSendReaction: (key: string, emoji: string) => void;
+}
+
+export const LiveRoomReactionsToolbar = ({
+  isBusy,
+  isAuthenticated,
+  onRequestLogin,
+  onSendReaction,
+}: LiveRoomReactionsToolbarProps): ReactElement => (
+  <div className="flex items-center gap-1 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-1.5 shadow-2">
+    {LIVE_ROOM_QUICK_REACTION_EMOJIS.map((emoji) => (
+      <LiveRoomTooltipButton key={emoji} tooltip={`React ${emoji}`}>
+        <Button
+          type="button"
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Float}
+          loading={isBusy(`reaction-${emoji}`)}
+          aria-label={`React ${emoji}`}
+          onClick={() => onSendReaction(`reaction-${emoji}`, emoji)}
+        >
+          <span className="text-lg leading-none">{emoji}</span>
+        </Button>
+      </LiveRoomTooltipButton>
+    ))}
+    <EmojiPicker
+      value=""
+      label={null}
+      onChange={(emoji) => {
+        if (!emoji) {
+          return;
+        }
+
+        onSendReaction('reaction-custom', emoji);
+      }}
+      renderTrigger={({ isOpen, toggleOpen }) => (
+        <LiveRoomTooltipButton
+          tooltip="Custom reaction"
+          wrapDisabled={isBusy('reaction-custom')}
+        >
+          <Button
+            type="button"
+            size={ButtonSize.Small}
+            variant={isOpen ? ButtonVariant.Primary : ButtonVariant.Float}
+            className="!w-9 shrink-0"
+            icon={<PlusIcon size={IconSize.Size16} />}
+            aria-label="Custom reaction"
+            aria-expanded={isOpen}
+            disabled={isBusy('reaction-custom')}
+            onClick={() => {
+              if (!isAuthenticated) {
+                onRequestLogin();
+                return;
+              }
+
+              toggleOpen();
+            }}
+          />
+        </LiveRoomTooltipButton>
+      )}
+    />
+  </div>
+);

--- a/packages/shared/src/components/liveRooms/LiveRoomSettingsModal.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomSettingsModal.tsx
@@ -1,0 +1,66 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { LiveRoomContextValue } from '../../contexts/LiveRoomContext';
+import { Modal } from '../modals/common/Modal';
+import {
+  AUDIO_ONLY_LABEL,
+  MicSettingRow,
+  SelectSettingRow,
+  VIDEO_QUALITY_ITEMS,
+  VIDEO_QUALITY_LABEL,
+} from './LiveRoomControlPrimitives';
+
+interface LiveRoomSettingsModalProps {
+  videoSettings: LiveRoomContextValue['videoSettings'];
+  setVideoSetting: LiveRoomContextValue['setVideoSetting'];
+  onClose: () => void;
+  onTrackSettingChange: (
+    targetId: string,
+    surface: 'settings_modal',
+    value: unknown,
+  ) => void;
+}
+
+export const LiveRoomSettingsModal = ({
+  videoSettings,
+  setVideoSetting,
+  onClose,
+  onTrackSettingChange,
+}: LiveRoomSettingsModalProps): ReactElement => (
+  <Modal
+    isOpen
+    kind={Modal.Kind.FixedCenter}
+    size={Modal.Size.Small}
+    isDrawerOnMobile
+    drawerProps={{ appendOnRoot: true }}
+    onRequestClose={onClose}
+  >
+    <Modal.Header title="Standup settings" />
+    <Modal.Body className="gap-1">
+      <SelectSettingRow
+        label={VIDEO_QUALITY_LABEL}
+        description="Choose how aggressively remote video should use your connection."
+        value={videoSettings.quality}
+        options={VIDEO_QUALITY_ITEMS.map((item) => ({
+          value: item.value,
+          label: item.label,
+        }))}
+        onSelect={(quality) => {
+          setVideoSetting('quality', quality);
+          onTrackSettingChange('video_quality', 'settings_modal', quality);
+        }}
+      />
+      <MicSettingRow
+        id="live-room-video-setting-audio-only"
+        label={AUDIO_ONLY_LABEL}
+        description="Hide remote video and keep the standup playing through audio."
+        checked={videoSettings.audioOnly}
+        onToggle={() => {
+          const nextValue = !videoSettings.audioOnly;
+          setVideoSetting('audioOnly', nextValue);
+          onTrackSettingChange('audio_only', 'settings_modal', nextValue);
+        }}
+      />
+    </Modal.Body>
+  </Modal>
+);

--- a/packages/shared/src/components/liveRooms/LiveRoomStage.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomStage.tsx
@@ -1,0 +1,262 @@
+import type { Dispatch, ReactElement, SetStateAction } from 'react';
+import React from 'react';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../typography/Typography';
+import { UserIcon } from '../icons';
+import { IconSize } from '../Icon';
+import type { LiveRoom as LiveRoomModel } from '../../graphql/liveRooms';
+import type { UserShortProfile } from '../../lib/user';
+import { LiveRoomControls } from './LiveRoomControls';
+import { LiveRoomLobbyContent } from './LiveRoomLobbyContent';
+import { LiveRoomVideoTile } from './LiveRoomVideoTile';
+
+export interface LiveRoomStageSpeaker {
+  id: string;
+  profile: UserShortProfile;
+  stream: MediaStream | null;
+  selfView: boolean;
+  isHost: boolean;
+  isCoHost: boolean;
+  raisedHandQueuePosition?: number;
+  isMuted: boolean;
+}
+
+interface LiveRoomStageProps {
+  room: LiveRoomModel;
+  roomId: string;
+  isCreated: boolean;
+  isEnded: boolean;
+  stagePageCount: number;
+  clampedStagePage: number;
+  setStagePage: Dispatch<SetStateAction<number>>;
+  stageGridColumnCount: number;
+  stageGridRowCount: number;
+  speakers: LiveRoomStageSpeaker[];
+  focusedSpeakerIndex: number | null;
+  waitingPrompt: string;
+  hasHostPrivileges: boolean;
+  isHost: boolean;
+  moderationBusy: string | null;
+  onFocusSpeaker: (index: number) => void;
+  onUnfocusSpeaker: () => void;
+  onSpeakerFocusNavigate: (delta: 1 | -1) => void;
+  guardedModerationAction: (
+    key: string,
+    action: () => Promise<void>,
+  ) => Promise<void>;
+  onGrantCoHost: (
+    targetParticipantId: string,
+    surface: string,
+  ) => Promise<void>;
+  onRevokeCoHost: (
+    targetParticipantId: string,
+    surface: string,
+  ) => Promise<void>;
+  onRemoveSpeaker: (
+    targetParticipantId: string,
+    surface: string,
+  ) => Promise<void>;
+  onKickParticipant: (
+    targetParticipantId: string,
+    surface: string,
+  ) => Promise<void>;
+  onNavigateBack: (surface: string) => void;
+  showControls: boolean;
+  onLeave: () => void;
+}
+
+export const LiveRoomStage = ({
+  room,
+  roomId,
+  isCreated,
+  isEnded,
+  stagePageCount,
+  clampedStagePage,
+  setStagePage,
+  stageGridColumnCount,
+  stageGridRowCount,
+  speakers,
+  focusedSpeakerIndex,
+  waitingPrompt,
+  hasHostPrivileges,
+  isHost,
+  moderationBusy,
+  onFocusSpeaker,
+  onUnfocusSpeaker,
+  onSpeakerFocusNavigate,
+  guardedModerationAction,
+  onGrantCoHost,
+  onRevokeCoHost,
+  onRemoveSpeaker,
+  onKickParticipant,
+  onNavigateBack,
+  showControls,
+  onLeave,
+}: LiveRoomStageProps): ReactElement => (
+  <section aria-label="Speakers" className="relative flex min-h-0 flex-col">
+    {!isCreated && stagePageCount > 1 ? (
+      <div className="flex items-center justify-end gap-2 px-1.5 pb-3">
+        <Typography
+          type={TypographyType.Caption1}
+          color={TypographyColor.Tertiary}
+        >
+          Page {clampedStagePage + 1} / {stagePageCount}
+        </Typography>
+        <Button
+          type="button"
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Tertiary}
+          disabled={clampedStagePage === 0}
+          onClick={() =>
+            setStagePage((currentPage) => Math.max(0, currentPage - 1))
+          }
+        >
+          Prev
+        </Button>
+        <Button
+          type="button"
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Tertiary}
+          disabled={clampedStagePage >= stagePageCount - 1}
+          onClick={() =>
+            setStagePage((currentPage) =>
+              Math.min(stagePageCount - 1, currentPage + 1),
+            )
+          }
+        >
+          Next
+        </Button>
+      </div>
+    ) : null}
+    {isCreated ? <LiveRoomLobbyContent room={room} /> : null}
+    {!isCreated && speakers.length > 0 ? (
+      <div
+        className="grid min-h-0 flex-1 gap-3 overflow-hidden p-1.5 pb-24 tablet:pb-28"
+        style={{
+          gridTemplateColumns: `repeat(${stageGridColumnCount}, minmax(0, 1fr))`,
+          gridTemplateRows: `repeat(${stageGridRowCount}, minmax(0, 1fr))`,
+        }}
+      >
+        {speakers.map((speaker, index) => {
+          const canModerate = hasHostPrivileges && !speaker.isHost;
+          const canManageCoHosts = isHost && !speaker.isHost;
+
+          return (
+            <div
+              key={speaker.id}
+              className="flex min-h-0 min-w-0 items-center justify-center"
+            >
+              <LiveRoomVideoTile
+                stream={speaker.stream}
+                user={speaker.profile}
+                selfView={speaker.selfView}
+                isHost={speaker.isHost}
+                isCoHost={speaker.isCoHost}
+                raisedHandQueuePosition={speaker.raisedHandQueuePosition}
+                isMuted={speaker.isMuted}
+                isFocused={focusedSpeakerIndex === index}
+                onFocus={() => onFocusSpeaker(index)}
+                onUnfocus={onUnfocusSpeaker}
+                onSwipeNext={() => onSpeakerFocusNavigate(1)}
+                onSwipePrev={() => onSpeakerFocusNavigate(-1)}
+                onGrantCoHost={
+                  canManageCoHosts && !speaker.isCoHost
+                    ? () =>
+                        guardedModerationAction(
+                          `tile-grant-cohost-${speaker.id}`,
+                          () => onGrantCoHost(speaker.id, 'stage_tile'),
+                        )
+                    : undefined
+                }
+                onRevokeCoHost={
+                  canManageCoHosts && speaker.isCoHost
+                    ? () =>
+                        guardedModerationAction(
+                          `tile-revoke-cohost-${speaker.id}`,
+                          () => onRevokeCoHost(speaker.id, 'stage_tile'),
+                        )
+                    : undefined
+                }
+                onRemoveSpeaker={
+                  canModerate
+                    ? () =>
+                        guardedModerationAction(
+                          `tile-remove-${speaker.id}`,
+                          () => onRemoveSpeaker(speaker.id, 'stage_tile'),
+                        )
+                    : undefined
+                }
+                onKick={
+                  canModerate
+                    ? () =>
+                        guardedModerationAction(`tile-kick-${speaker.id}`, () =>
+                          onKickParticipant(speaker.id, 'stage_tile'),
+                        )
+                    : undefined
+                }
+                isRemoving={moderationBusy === `tile-remove-${speaker.id}`}
+                isGrantingCoHost={
+                  moderationBusy === `tile-grant-cohost-${speaker.id}`
+                }
+                isRevokingCoHost={
+                  moderationBusy === `tile-revoke-cohost-${speaker.id}`
+                }
+                isKicking={moderationBusy === `tile-kick-${speaker.id}`}
+                moderationDisabled={!!moderationBusy}
+              />
+            </div>
+          );
+        })}
+      </div>
+    ) : null}
+    {!isCreated && speakers.length === 0 ? (
+      <div className="flex flex-1 items-center justify-center rounded-16 border border-dashed border-border-subtlest-tertiary p-6 text-center">
+        <div className="flex flex-col items-center gap-2">
+          <span className="flex size-10 items-center justify-center rounded-full bg-surface-float text-text-tertiary">
+            <UserIcon size={IconSize.Small} />
+          </span>
+          <Typography type={TypographyType.Footnote} bold>
+            No visible speakers
+          </Typography>
+          <Typography
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+          >
+            {waitingPrompt}
+          </Typography>
+        </div>
+      </div>
+    ) : null}
+
+    {isEnded ? (
+      <div className="absolute inset-0 flex items-center justify-center bg-background-default p-6">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <Typography type={TypographyType.Title3} bold>
+            This standup has ended
+          </Typography>
+          <Typography
+            type={TypographyType.Callout}
+            color={TypographyColor.Tertiary}
+          >
+            Thanks for joining — catch the next one soon.
+          </Typography>
+          <Button
+            className="mt-2"
+            variant={ButtonVariant.Primary}
+            onClick={() => onNavigateBack('ended_state')}
+          >
+            Back home
+          </Button>
+        </div>
+      </div>
+    ) : null}
+
+    {showControls && !isEnded ? (
+      <LiveRoomControls roomId={roomId} onLeave={onLeave} />
+    ) : null}
+  </section>
+);

--- a/packages/shared/src/components/liveRooms/LiveRoomTooltipButton.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomTooltipButton.tsx
@@ -1,0 +1,25 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { Tooltip } from '../tooltip/Tooltip';
+
+interface LiveRoomTooltipButtonProps {
+  tooltip: string;
+  children: ReactElement;
+  wrapDisabled?: boolean;
+}
+
+export const LiveRoomTooltipButton = ({
+  tooltip,
+  children,
+  wrapDisabled = false,
+}: LiveRoomTooltipButtonProps): ReactElement => {
+  if (wrapDisabled) {
+    return (
+      <Tooltip content={tooltip}>
+        <span className="inline-flex">{children}</span>
+      </Tooltip>
+    );
+  }
+
+  return <Tooltip content={tooltip}>{children}</Tooltip>;
+};

--- a/packages/shared/src/hooks/liveRooms/useCountdownSeconds.ts
+++ b/packages/shared/src/hooks/liveRooms/useCountdownSeconds.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+
+const getRemainingSeconds = (target: string | null | undefined): number => {
+  if (!target) {
+    return 0;
+  }
+
+  return Math.max(
+    0,
+    Math.ceil((new Date(target).getTime() - Date.now()) / 1000),
+  );
+};
+
+export const useCountdownSeconds = (
+  target: string | null | undefined,
+): number => {
+  const [seconds, setSeconds] = useState(() => getRemainingSeconds(target));
+
+  useEffect(() => {
+    if (!target) {
+      setSeconds(0);
+      return undefined;
+    }
+
+    const update = (): void => setSeconds(getRemainingSeconds(target));
+    update();
+    const interval = window.setInterval(update, 1000);
+    return () => window.clearInterval(interval);
+  }, [target]);
+
+  return seconds;
+};

--- a/packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.ts
+++ b/packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.ts
@@ -1,0 +1,248 @@
+import { useMemo } from 'react';
+import type { LiveRoomContextValue } from '../../contexts/LiveRoomContext';
+import type { LiveRoom as LiveRoomModel } from '../../graphql/liveRooms';
+import type { UserShortProfile } from '../../lib/user';
+import {
+  buildDisplayProfile,
+  buildParticipantProfile,
+} from '../../components/liveRooms/liveRoomParticipants';
+import type { LiveRoomStageSpeaker } from '../../components/liveRooms/LiveRoomStage';
+import { useLiveRoomParticipantProfiles } from './useLiveRoomParticipantProfiles';
+import { useLiveRoomParticipantStreams } from './useLiveRoomParticipantStreams';
+
+const MAX_STAGE_TILES_PER_PAGE = 12;
+const MOBILE_MAX_STAGE_TILES_PER_PAGE = 4;
+const EMPTY_PARTICIPANT_IDS: string[] = [];
+
+const getStageGridColumnCount = (count: number, isMobile: boolean): number => {
+  if (count <= 1) {
+    return 1;
+  }
+  if (isMobile) {
+    return 2;
+  }
+  if (count <= 4) {
+    return 2;
+  }
+  if (count <= 9) {
+    return 3;
+  }
+  return 4;
+};
+
+interface UseLiveRoomStageModelProps {
+  room?: LiveRoomModel;
+  roomState: LiveRoomContextValue['roomState'];
+  chatMessages: LiveRoomContextValue['chatMessages'];
+  remoteStreams: LiveRoomContextValue['remoteStreams'];
+  localStream: MediaStream | null;
+  participantId: string | null;
+  isMicOn: boolean;
+  videoSettings: LiveRoomContextValue['videoSettings'];
+  isMobile: boolean;
+  stagePage: number;
+}
+
+export const useLiveRoomStageModel = ({
+  room,
+  roomState,
+  chatMessages,
+  remoteStreams,
+  localStream,
+  participantId,
+  isMicOn,
+  videoSettings,
+  isMobile,
+  stagePage,
+}: UseLiveRoomStageModelProps) => {
+  const participantIds = useMemo(() => {
+    const ids = new Set<string>();
+    const hostId = room?.host.id;
+
+    Object.keys(roomState?.participants ?? {}).forEach((id) => {
+      if (id && id !== hostId) {
+        ids.add(id);
+      }
+    });
+
+    chatMessages.forEach((message) => {
+      if (message.participantId && message.participantId !== hostId) {
+        ids.add(message.participantId);
+      }
+    });
+
+    return [...ids];
+  }, [chatMessages, room?.host.id, roomState?.participants]);
+
+  const visibleRemoteStreams = useMemo(
+    () =>
+      videoSettings.audioOnly
+        ? remoteStreams.filter((stream) => stream.kind !== 'video')
+        : remoteStreams,
+    [remoteStreams, videoSettings.audioOnly],
+  );
+  const participantProfiles = useLiveRoomParticipantProfiles(participantIds);
+  const participantStreamsById = useLiveRoomParticipantStreams(
+    visibleRemoteStreams,
+    localStream,
+    participantId,
+  );
+  const hostId = room?.host.id ?? '';
+  const coHostParticipantIds = roomState?.coHostParticipantIds ?? [];
+  const activeSpeakerIds =
+    roomState?.stage.activeSpeakerParticipantIds.filter(
+      (id) => !!roomState.participants[id] && id !== hostId,
+    ) ?? [];
+  const queuedParticipantIds =
+    roomState?.stage.speakerQueueParticipantIds.filter(
+      (id) => !!roomState.participants[id],
+    ) ?? [];
+  const raisedHandParticipantIds =
+    roomState?.stage.raisedHandParticipantIds ?? EMPTY_PARTICIPANT_IDS;
+  const raisedHandQueuePositions = useMemo(() => {
+    const positions = new Map<string, number>();
+    if (!roomState) {
+      return positions;
+    }
+
+    raisedHandParticipantIds.forEach((id) => {
+      if (roomState.participants[id]) {
+        positions.set(id, positions.size + 1);
+      }
+    });
+
+    return positions;
+  }, [raisedHandParticipantIds, roomState]);
+  const audienceParticipantIds = roomState
+    ? Object.values(roomState.participants)
+        .map((participant) => participant.participantId)
+        .filter(
+          (id) =>
+            id !== hostId &&
+            !activeSpeakerIds.includes(id) &&
+            !queuedParticipantIds.includes(id),
+        )
+    : [];
+  const stageLimit = roomState?.stage.speakerLimit ?? null;
+  const participantProfilesById = useMemo(() => {
+    const nextProfiles = new Map(participantProfiles);
+
+    if (room?.host) {
+      nextProfiles.set(room.host.id, room.host);
+    }
+
+    return nextProfiles;
+  }, [participantProfiles, room?.host]);
+  const mentionSuggestions = useMemo(() => {
+    if (!room?.host) {
+      return [] as UserShortProfile[];
+    }
+
+    const suggestions: UserShortProfile[] = [room.host];
+
+    participantIds.forEach((id) => {
+      const profile = participantProfilesById.get(id);
+      if (profile) {
+        suggestions.push(profile);
+      }
+    });
+
+    return suggestions;
+  }, [participantIds, participantProfilesById, room?.host]);
+  const audioPublisherIds = useMemo(
+    () =>
+      new Set(
+        Object.values(roomState?.mediaPublications ?? {})
+          .filter((publication) => publication.kind === 'audio')
+          .map((publication) => publication.participantId),
+      ),
+    [roomState?.mediaPublications],
+  );
+  const roomMode = roomState?.mode ?? room?.mode ?? 'moderated';
+  const isFreeForAll = roomMode === 'free_for_all';
+  const remainingSeats =
+    stageLimit === null
+      ? null
+      : Math.max(stageLimit - activeSpeakerIds.length, 0);
+  let waitingPrompt = 'Audience can join the queue';
+  if (isFreeForAll && remainingSeats !== null) {
+    waitingPrompt =
+      remainingSeats === 0
+        ? 'The stage is full right now'
+        : `${remainingSeats} open stage spots`;
+  } else if (queuedParticipantIds.length > 0) {
+    waitingPrompt = `${queuedParticipantIds.length} in queue`;
+  }
+
+  const stageSpeakers: LiveRoomStageSpeaker[] = room?.host
+    ? [
+        {
+          id: room.host.id,
+          profile: buildDisplayProfile(room.host),
+          stream: participantStreamsById.get(room.host.id) ?? null,
+          selfView: room.host.id === participantId,
+          isHost: true,
+          isCoHost: false,
+          raisedHandQueuePosition: raisedHandQueuePositions.get(room.host.id),
+        },
+        ...activeSpeakerIds.map((id) => ({
+          id,
+          profile: buildDisplayProfile(
+            participantProfilesById.get(id) ?? buildParticipantProfile(id),
+          ),
+          stream: participantStreamsById.get(id) ?? null,
+          selfView: id === participantId,
+          isHost: false,
+          isCoHost: coHostParticipantIds.includes(id),
+          raisedHandQueuePosition: raisedHandQueuePositions.get(id),
+        })),
+      ].map((speaker) => ({
+        ...speaker,
+        isMuted: speaker.selfView
+          ? !isMicOn
+          : !audioPublisherIds.has(speaker.id),
+      }))
+    : [];
+  const visibleStageSpeakers = stageSpeakers.filter(
+    (speaker) => !speaker.selfView || !videoSettings.hideSelfView,
+  );
+  const stageTilesPerPage = isMobile
+    ? MOBILE_MAX_STAGE_TILES_PER_PAGE
+    : MAX_STAGE_TILES_PER_PAGE;
+  const stagePageCount = Math.max(
+    1,
+    Math.ceil(visibleStageSpeakers.length / stageTilesPerPage),
+  );
+  const clampedStagePage = Math.min(stagePage, stagePageCount - 1);
+  const stagePageStart = clampedStagePage * stageTilesPerPage;
+  const paginatedStageSpeakers = visibleStageSpeakers.slice(
+    stagePageStart,
+    stagePageStart + stageTilesPerPage,
+  );
+  const stageGridColumnCount = getStageGridColumnCount(
+    paginatedStageSpeakers.length,
+    isMobile,
+  );
+  const stageGridRowCount = Math.max(
+    1,
+    Math.ceil(paginatedStageSpeakers.length / stageGridColumnCount),
+  );
+
+  return {
+    participantProfilesById,
+    mentionSuggestions,
+    roomMode,
+    isFreeForAll,
+    activeSpeakerIds,
+    queuedParticipantIds,
+    audienceParticipantIds,
+    coHostParticipantIds,
+    stageLimit,
+    waitingPrompt,
+    stagePageCount,
+    clampedStagePage,
+    paginatedStageSpeakers,
+    stageGridColumnCount,
+    stageGridRowCount,
+  };
+};

--- a/packages/shared/src/hooks/liveRooms/useLiveRoomStandupAnalytics.ts
+++ b/packages/shared/src/hooks/liveRooms/useLiveRoomStandupAnalytics.ts
@@ -1,0 +1,90 @@
+import { useCallback } from 'react';
+import type {
+  LiveRoomConnectionStatus,
+  LiveRoomContextValue,
+} from '../../contexts/LiveRoomContext';
+import { useLogContext } from '../../contexts/LogContext';
+import type { LoggedUser } from '../../lib/user';
+import { buildStandupAnalyticsExtra } from '../../lib/liveRoom/analytics';
+import type { LogEvent } from '../../lib/log';
+
+interface UseLiveRoomStandupAnalyticsProps {
+  roomId: string;
+  user?: LoggedUser | null;
+  role: LiveRoomContextValue['role'];
+  roomStatus?: string | null;
+  roomMode?: string | null;
+  connectionStatus: LiveRoomConnectionStatus;
+  participantId: string | null;
+  isCoHost: boolean;
+  localStream: MediaStream | null;
+  videoSettings: LiveRoomContextValue['videoSettings'];
+}
+
+export const useLiveRoomStandupAnalytics = ({
+  roomId,
+  user,
+  role,
+  roomStatus,
+  roomMode,
+  connectionStatus,
+  participantId,
+  isCoHost,
+  localStream,
+  videoSettings,
+}: UseLiveRoomStandupAnalyticsProps) => {
+  const { logEvent } = useLogContext();
+
+  const buildStandupExtra = useCallback(
+    (extra: Record<string, unknown> = {}) =>
+      buildStandupAnalyticsExtra(
+        {
+          roomId,
+          authKind: user ? 'authenticated' : 'anonymous',
+          role,
+          roomStatus: roomStatus ?? null,
+          roomMode: roomMode ?? null,
+          connectionStatus,
+          participantId,
+          isCoHost,
+          hasLocalAudioTrack: !!localStream?.getAudioTracks()[0],
+          hasLocalVideoTrack: !!localStream?.getVideoTracks()[0],
+          videoQuality: videoSettings.quality,
+          audioOnly: videoSettings.audioOnly,
+          hideSelfView: videoSettings.hideSelfView,
+        },
+        extra,
+      ),
+    [
+      roomId,
+      user,
+      role,
+      roomStatus,
+      roomMode,
+      connectionStatus,
+      participantId,
+      isCoHost,
+      localStream,
+      videoSettings.quality,
+      videoSettings.audioOnly,
+      videoSettings.hideSelfView,
+    ],
+  );
+
+  const logStandupAction = useCallback(
+    (
+      eventName: LogEvent,
+      targetId: string,
+      extra: Record<string, unknown> = {},
+    ): void => {
+      logEvent({
+        event_name: eventName,
+        target_id: targetId,
+        extra: buildStandupExtra(extra),
+      });
+    },
+    [buildStandupExtra, logEvent],
+  );
+
+  return { buildStandupExtra, logStandupAction };
+};


### PR DESCRIPTION
## What changed
- Split the `/standups/[id]` live room surface into focused header, stage, lobby, reactions, settings, and tooltip components.
- Moved countdown, standup analytics, and stage data shaping into dedicated hooks.
- Kept the existing page wrapper and live room behavior intact while reducing the amount of logic inside `LiveRoom.tsx` and `LiveRoomControls.tsx`.

## Impact
- Makes the standup/live room components easier to follow and maintain without changing the user-facing flow.
- Keeps chat, queue, moderation, stage rendering, reactions, settings, and subscription behavior on the existing contracts.

## Validation
- `pnpm --filter @dailydotdev/shared exec eslint src/components/liveRooms/LiveRoom.tsx src/components/liveRooms/LiveRoomControls.tsx src/components/liveRooms/LiveRoomHeader.tsx src/components/liveRooms/LiveRoomLobbyContent.tsx src/components/liveRooms/LiveRoomReactionOverlay.tsx src/components/liveRooms/LiveRoomReactionsToolbar.tsx src/components/liveRooms/LiveRoomSettingsModal.tsx src/components/liveRooms/LiveRoomStage.tsx src/components/liveRooms/LiveRoomTooltipButton.tsx src/hooks/liveRooms/useCountdownSeconds.ts src/hooks/liveRooms/useLiveRoomStandupAnalytics.ts src/hooks/liveRooms/useLiveRoomStageModel.ts`
- `node ./scripts/typecheck-strict-changed.js`
- `NODE_ENV=test pnpm --filter @dailydotdev/shared exec jest src/components/liveRooms/LiveRoom.spec.tsx src/components/liveRooms/LiveRoomControls.spec.tsx --runInBand`

Note: the focused Jest run passes with the existing React `act(...)` warning around async busy-state cleanup in `LiveRoomControls`.

### Preview domain
https://codex-refactor-live-room-standup.preview.app.daily.dev