### PR TITLE
feat: refine live room stage pagination

### DIFF
--- a/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
@@ -942,17 +942,21 @@ describe('LiveRoom', () => {
 
     renderLiveRoom();
 
-    expect(screen.getByText('Page 1 / 2')).toBeInTheDocument();
+    expect(screen.getByText('1/2')).toBeInTheDocument();
     expect(screen.getAllByTestId('live-room-tile')).toHaveLength(12);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    fireEvent.click(
+      screen.getByRole('tab', { name: 'Go to stage page 2 of 2' }),
+    );
 
-    expect(screen.getByText('Page 2 / 2')).toBeInTheDocument();
+    expect(screen.getByText('2/2')).toBeInTheDocument();
     expect(screen.getAllByTestId('live-room-tile')).toHaveLength(1);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Prev' }));
+    fireEvent.click(
+      screen.getByRole('tab', { name: 'Go to stage page 1 of 2' }),
+    );
 
-    expect(screen.getByText('Page 1 / 2')).toBeInTheDocument();
+    expect(screen.getByText('1/2')).toBeInTheDocument();
     expect(screen.getAllByTestId('live-room-tile')).toHaveLength(12);
   });
 
@@ -990,12 +994,14 @@ describe('LiveRoom', () => {
 
     renderLiveRoom();
 
-    expect(screen.getByText('Page 1 / 4')).toBeInTheDocument();
+    expect(screen.getByText('1/4')).toBeInTheDocument();
     expect(screen.getAllByTestId('live-room-tile')).toHaveLength(4);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    fireEvent.click(
+      screen.getByRole('tab', { name: 'Go to stage page 2 of 4' }),
+    );
 
-    expect(screen.getByText('Page 2 / 4')).toBeInTheDocument();
+    expect(screen.getByText('2/4')).toBeInTheDocument();
     expect(screen.getAllByTestId('live-room-tile')).toHaveLength(4);
   });
 

--- a/packages/shared/src/components/liveRooms/LiveRoom.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.tsx
@@ -377,7 +377,10 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     waitingPrompt,
     stagePageCount,
     clampedStagePage,
+    visibleStageSpeakers,
     paginatedStageSpeakers,
+    stagePageStart,
+    stageTilesPerPage,
     stageGridColumnCount,
     stageGridRowCount,
   } = useLiveRoomStageModel({
@@ -409,14 +412,14 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   useEffect(() => {
     if (
       focusedSpeakerIndex !== null &&
-      focusedSpeakerIndex >= paginatedStageSpeakers.length
+      focusedSpeakerIndex >= visibleStageSpeakers.length
     ) {
       setFocusedSpeakerIndex(null);
     }
-  }, [focusedSpeakerIndex, paginatedStageSpeakers.length]);
+  }, [focusedSpeakerIndex, visibleStageSpeakers.length]);
 
-  const focusSpeaker = (index: number): void => {
-    const speaker = paginatedStageSpeakers[index];
+  const focusSpeaker = (globalIndex: number): void => {
+    const speaker = visibleStageSpeakers[globalIndex];
     if (!speaker) {
       return;
     }
@@ -425,32 +428,32 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
       action: 'open',
       source: 'tap',
       isSelf: !!speaker.selfView,
-      position: index,
-      totalSpeakers: paginatedStageSpeakers.length,
+      position: globalIndex,
+      totalSpeakers: visibleStageSpeakers.length,
     });
-    setFocusedSpeakerIndex(index);
+    setFocusedSpeakerIndex(globalIndex);
   };
   const unfocusSpeaker = (): void => {
     if (focusedSpeakerIndex === null) {
       return;
     }
-    const speaker = paginatedStageSpeakers[focusedSpeakerIndex];
+    const speaker = visibleStageSpeakers[focusedSpeakerIndex];
     logStandupAction(LogEvent.FocusStandupSpeaker, speaker?.id ?? '', {
       surface: 'stage_tile',
       action: 'close',
       source: 'backdrop',
       position: focusedSpeakerIndex,
-      totalSpeakers: paginatedStageSpeakers.length,
+      totalSpeakers: visibleStageSpeakers.length,
     });
     setFocusedSpeakerIndex(null);
   };
   const handleSpeakerFocusNavigate = (delta: 1 | -1): void => {
-    if (focusedSpeakerIndex === null || paginatedStageSpeakers.length === 0) {
+    if (focusedSpeakerIndex === null || visibleStageSpeakers.length === 0) {
       return;
     }
-    const total = paginatedStageSpeakers.length;
+    const total = visibleStageSpeakers.length;
     const nextIndex = (((focusedSpeakerIndex + delta) % total) + total) % total;
-    const nextSpeaker = paginatedStageSpeakers[nextIndex];
+    const nextSpeaker = visibleStageSpeakers[nextIndex];
     logStandupAction(LogEvent.FocusStandupSpeaker, nextSpeaker?.id ?? '', {
       surface: 'stage_tile',
       action: 'navigate',
@@ -459,6 +462,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
       position: nextIndex,
       totalSpeakers: total,
     });
+    setStagePage(Math.floor(nextIndex / stageTilesPerPage));
     setFocusedSpeakerIndex(nextIndex);
   };
 
@@ -607,6 +611,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
           stageGridColumnCount={stageGridColumnCount}
           stageGridRowCount={stageGridRowCount}
           speakers={paginatedStageSpeakers}
+          stagePageStart={stagePageStart}
           focusedSpeakerIndex={focusedSpeakerIndex}
           waitingPrompt={waitingPrompt}
           hasHostPrivileges={hasHostPrivileges}

--- a/packages/shared/src/components/liveRooms/LiveRoomStage.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomStage.tsx
@@ -1,6 +1,8 @@
 import type { Dispatch, ReactElement, SetStateAction } from 'react';
-import React from 'react';
-import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import React, { useCallback } from 'react';
+import classNames from 'classnames';
+import { useSwipeable } from 'react-swipeable';
+import { Button, ButtonVariant } from '../buttons/Button';
 import {
   Typography,
   TypographyColor,
@@ -12,6 +14,7 @@ import type { LiveRoom as LiveRoomModel } from '../../graphql/liveRooms';
 import type { UserShortProfile } from '../../lib/user';
 import { LiveRoomControls } from './LiveRoomControls';
 import { LiveRoomLobbyContent } from './LiveRoomLobbyContent';
+import { LiveRoomStagePager } from './LiveRoomStagePager';
 import { LiveRoomVideoTile } from './LiveRoomVideoTile';
 
 export interface LiveRoomStageSpeaker {
@@ -36,6 +39,7 @@ interface LiveRoomStageProps {
   stageGridColumnCount: number;
   stageGridRowCount: number;
   speakers: LiveRoomStageSpeaker[];
+  stagePageStart: number;
   focusedSpeakerIndex: number | null;
   waitingPrompt: string;
   hasHostPrivileges: boolean;
@@ -80,6 +84,7 @@ export const LiveRoomStage = ({
   stageGridColumnCount,
   stageGridRowCount,
   speakers,
+  stagePageStart,
   focusedSpeakerIndex,
   waitingPrompt,
   hasHostPrivileges,
@@ -96,167 +101,181 @@ export const LiveRoomStage = ({
   onNavigateBack,
   showControls,
   onLeave,
-}: LiveRoomStageProps): ReactElement => (
-  <section aria-label="Speakers" className="relative flex min-h-0 flex-col">
-    {!isCreated && stagePageCount > 1 ? (
-      <div className="flex items-center justify-end gap-2 px-1.5 pb-3">
-        <Typography
-          type={TypographyType.Caption1}
-          color={TypographyColor.Tertiary}
-        >
-          Page {clampedStagePage + 1} / {stagePageCount}
-        </Typography>
-        <Button
-          type="button"
-          size={ButtonSize.Small}
-          variant={ButtonVariant.Tertiary}
-          disabled={clampedStagePage === 0}
-          onClick={() =>
-            setStagePage((currentPage) => Math.max(0, currentPage - 1))
-          }
-        >
-          Prev
-        </Button>
-        <Button
-          type="button"
-          size={ButtonSize.Small}
-          variant={ButtonVariant.Tertiary}
-          disabled={clampedStagePage >= stagePageCount - 1}
-          onClick={() =>
-            setStagePage((currentPage) =>
-              Math.min(stagePageCount - 1, currentPage + 1),
-            )
-          }
-        >
-          Next
-        </Button>
-      </div>
-    ) : null}
-    {isCreated ? <LiveRoomLobbyContent room={room} /> : null}
-    {!isCreated && speakers.length > 0 ? (
-      <div
-        className="grid min-h-0 flex-1 gap-3 overflow-hidden p-1.5 pb-24 tablet:pb-28"
-        style={{
-          gridTemplateColumns: `repeat(${stageGridColumnCount}, minmax(0, 1fr))`,
-          gridTemplateRows: `repeat(${stageGridRowCount}, minmax(0, 1fr))`,
-        }}
-      >
-        {speakers.map((speaker, index) => {
-          const canModerate = hasHostPrivileges && !speaker.isHost;
-          const canManageCoHosts = isHost && !speaker.isHost;
+}: LiveRoomStageProps): ReactElement => {
+  const hasMultiplePages = !isCreated && stagePageCount > 1;
+  const goToPage = useCallback(
+    (page: number) => {
+      setStagePage(() => Math.max(0, Math.min(stagePageCount - 1, page)));
+    },
+    [setStagePage, stagePageCount],
+  );
+  const goToPrevPage = useCallback(() => {
+    setStagePage((currentPage) => Math.max(0, currentPage - 1));
+  }, [setStagePage]);
+  const goToNextPage = useCallback(() => {
+    setStagePage((currentPage) =>
+      Math.min(stagePageCount - 1, currentPage + 1),
+    );
+  }, [setStagePage, stagePageCount]);
 
-          return (
-            <div
-              key={speaker.id}
-              className="flex min-h-0 min-w-0 items-center justify-center"
+  const swipeHandlers = useSwipeable({
+    onSwipedLeft: () => {
+      if (hasMultiplePages && focusedSpeakerIndex === null) {
+        goToNextPage();
+      }
+    },
+    onSwipedRight: () => {
+      if (hasMultiplePages && focusedSpeakerIndex === null) {
+        goToPrevPage();
+      }
+    },
+    trackTouch: true,
+    trackMouse: false,
+  });
+
+  return (
+    <section aria-label="Speakers" className="relative flex min-h-0 flex-col">
+      {isCreated ? <LiveRoomLobbyContent room={room} /> : null}
+      {!isCreated && speakers.length > 0 ? (
+        <div className="relative flex min-h-0 flex-1 flex-col">
+          <div
+            {...swipeHandlers}
+            className={classNames(
+              'grid min-h-0 flex-1 gap-3 overflow-hidden p-1.5',
+              hasMultiplePages ? 'pb-32 tablet:pb-36' : 'pb-24 tablet:pb-28',
+            )}
+            style={{
+              gridTemplateColumns: `repeat(${stageGridColumnCount}, minmax(0, 1fr))`,
+              gridTemplateRows: `repeat(${stageGridRowCount}, minmax(0, 1fr))`,
+            }}
+          >
+            {speakers.map((speaker, index) => {
+              const canModerate = hasHostPrivileges && !speaker.isHost;
+              const canManageCoHosts = isHost && !speaker.isHost;
+              const globalIndex = stagePageStart + index;
+
+              return (
+                <div
+                  key={speaker.id}
+                  className="flex min-h-0 min-w-0 items-center justify-center"
+                >
+                  <LiveRoomVideoTile
+                    stream={speaker.stream}
+                    user={speaker.profile}
+                    selfView={speaker.selfView}
+                    isHost={speaker.isHost}
+                    isCoHost={speaker.isCoHost}
+                    raisedHandQueuePosition={speaker.raisedHandQueuePosition}
+                    isMuted={speaker.isMuted}
+                    isFocused={focusedSpeakerIndex === globalIndex}
+                    onFocus={() => onFocusSpeaker(globalIndex)}
+                    onUnfocus={onUnfocusSpeaker}
+                    onSwipeNext={() => onSpeakerFocusNavigate(1)}
+                    onSwipePrev={() => onSpeakerFocusNavigate(-1)}
+                    onGrantCoHost={
+                      canManageCoHosts && !speaker.isCoHost
+                        ? () =>
+                            guardedModerationAction(
+                              `tile-grant-cohost-${speaker.id}`,
+                              () => onGrantCoHost(speaker.id, 'stage_tile'),
+                            )
+                        : undefined
+                    }
+                    onRevokeCoHost={
+                      canManageCoHosts && speaker.isCoHost
+                        ? () =>
+                            guardedModerationAction(
+                              `tile-revoke-cohost-${speaker.id}`,
+                              () => onRevokeCoHost(speaker.id, 'stage_tile'),
+                            )
+                        : undefined
+                    }
+                    onRemoveSpeaker={
+                      canModerate
+                        ? () =>
+                            guardedModerationAction(
+                              `tile-remove-${speaker.id}`,
+                              () => onRemoveSpeaker(speaker.id, 'stage_tile'),
+                            )
+                        : undefined
+                    }
+                    onKick={
+                      canModerate
+                        ? () =>
+                            guardedModerationAction(
+                              `tile-kick-${speaker.id}`,
+                              () => onKickParticipant(speaker.id, 'stage_tile'),
+                            )
+                        : undefined
+                    }
+                    isRemoving={moderationBusy === `tile-remove-${speaker.id}`}
+                    isGrantingCoHost={
+                      moderationBusy === `tile-grant-cohost-${speaker.id}`
+                    }
+                    isRevokingCoHost={
+                      moderationBusy === `tile-revoke-cohost-${speaker.id}`
+                    }
+                    isKicking={moderationBusy === `tile-kick-${speaker.id}`}
+                    moderationDisabled={!!moderationBusy}
+                  />
+                </div>
+              );
+            })}
+          </div>
+          <LiveRoomStagePager
+            pageCount={stagePageCount}
+            currentPage={clampedStagePage}
+            onPageSelect={goToPage}
+            onPrev={goToPrevPage}
+            onNext={goToNextPage}
+          />
+        </div>
+      ) : null}
+      {!isCreated && speakers.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center rounded-16 border border-dashed border-border-subtlest-tertiary p-6 text-center">
+          <div className="flex flex-col items-center gap-2">
+            <span className="flex size-10 items-center justify-center rounded-full bg-surface-float text-text-tertiary">
+              <UserIcon size={IconSize.Small} />
+            </span>
+            <Typography type={TypographyType.Footnote} bold>
+              No visible speakers
+            </Typography>
+            <Typography
+              type={TypographyType.Caption1}
+              color={TypographyColor.Tertiary}
             >
-              <LiveRoomVideoTile
-                stream={speaker.stream}
-                user={speaker.profile}
-                selfView={speaker.selfView}
-                isHost={speaker.isHost}
-                isCoHost={speaker.isCoHost}
-                raisedHandQueuePosition={speaker.raisedHandQueuePosition}
-                isMuted={speaker.isMuted}
-                isFocused={focusedSpeakerIndex === index}
-                onFocus={() => onFocusSpeaker(index)}
-                onUnfocus={onUnfocusSpeaker}
-                onSwipeNext={() => onSpeakerFocusNavigate(1)}
-                onSwipePrev={() => onSpeakerFocusNavigate(-1)}
-                onGrantCoHost={
-                  canManageCoHosts && !speaker.isCoHost
-                    ? () =>
-                        guardedModerationAction(
-                          `tile-grant-cohost-${speaker.id}`,
-                          () => onGrantCoHost(speaker.id, 'stage_tile'),
-                        )
-                    : undefined
-                }
-                onRevokeCoHost={
-                  canManageCoHosts && speaker.isCoHost
-                    ? () =>
-                        guardedModerationAction(
-                          `tile-revoke-cohost-${speaker.id}`,
-                          () => onRevokeCoHost(speaker.id, 'stage_tile'),
-                        )
-                    : undefined
-                }
-                onRemoveSpeaker={
-                  canModerate
-                    ? () =>
-                        guardedModerationAction(
-                          `tile-remove-${speaker.id}`,
-                          () => onRemoveSpeaker(speaker.id, 'stage_tile'),
-                        )
-                    : undefined
-                }
-                onKick={
-                  canModerate
-                    ? () =>
-                        guardedModerationAction(`tile-kick-${speaker.id}`, () =>
-                          onKickParticipant(speaker.id, 'stage_tile'),
-                        )
-                    : undefined
-                }
-                isRemoving={moderationBusy === `tile-remove-${speaker.id}`}
-                isGrantingCoHost={
-                  moderationBusy === `tile-grant-cohost-${speaker.id}`
-                }
-                isRevokingCoHost={
-                  moderationBusy === `tile-revoke-cohost-${speaker.id}`
-                }
-                isKicking={moderationBusy === `tile-kick-${speaker.id}`}
-                moderationDisabled={!!moderationBusy}
-              />
-            </div>
-          );
-        })}
-      </div>
-    ) : null}
-    {!isCreated && speakers.length === 0 ? (
-      <div className="flex flex-1 items-center justify-center rounded-16 border border-dashed border-border-subtlest-tertiary p-6 text-center">
-        <div className="flex flex-col items-center gap-2">
-          <span className="flex size-10 items-center justify-center rounded-full bg-surface-float text-text-tertiary">
-            <UserIcon size={IconSize.Small} />
-          </span>
-          <Typography type={TypographyType.Footnote} bold>
-            No visible speakers
-          </Typography>
-          <Typography
-            type={TypographyType.Caption1}
-            color={TypographyColor.Tertiary}
-          >
-            {waitingPrompt}
-          </Typography>
+              {waitingPrompt}
+            </Typography>
+          </div>
         </div>
-      </div>
-    ) : null}
+      ) : null}
 
-    {isEnded ? (
-      <div className="absolute inset-0 flex items-center justify-center bg-background-default p-6">
-        <div className="flex flex-col items-center gap-3 text-center">
-          <Typography type={TypographyType.Title3} bold>
-            This standup has ended
-          </Typography>
-          <Typography
-            type={TypographyType.Callout}
-            color={TypographyColor.Tertiary}
-          >
-            Thanks for joining — catch the next one soon.
-          </Typography>
-          <Button
-            className="mt-2"
-            variant={ButtonVariant.Primary}
-            onClick={() => onNavigateBack('ended_state')}
-          >
-            Back home
-          </Button>
+      {isEnded ? (
+        <div className="absolute inset-0 flex items-center justify-center bg-background-default p-6">
+          <div className="flex flex-col items-center gap-3 text-center">
+            <Typography type={TypographyType.Title3} bold>
+              This standup has ended
+            </Typography>
+            <Typography
+              type={TypographyType.Callout}
+              color={TypographyColor.Tertiary}
+            >
+              Thanks for joining — catch the next one soon.
+            </Typography>
+            <Button
+              className="mt-2"
+              variant={ButtonVariant.Primary}
+              onClick={() => onNavigateBack('ended_state')}
+            >
+              Back home
+            </Button>
+          </div>
         </div>
-      </div>
-    ) : null}
+      ) : null}
 
-    {showControls && !isEnded ? (
-      <LiveRoomControls roomId={roomId} onLeave={onLeave} />
-    ) : null}
-  </section>
-);
+      {showControls && !isEnded ? (
+        <LiveRoomControls roomId={roomId} onLeave={onLeave} />
+      ) : null}
+    </section>
+  );
+};

--- a/packages/shared/src/components/liveRooms/LiveRoomStagePager.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomStagePager.tsx
@@ -1,0 +1,84 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import { ArrowIcon } from '../icons';
+import { IconSize } from '../Icon';
+
+interface LiveRoomStagePagerProps {
+  pageCount: number;
+  currentPage: number;
+  onPageSelect: (page: number) => void;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+export const LiveRoomStagePager = ({
+  pageCount,
+  currentPage,
+  onPageSelect,
+  onPrev,
+  onNext,
+}: LiveRoomStagePagerProps): ReactElement | null => {
+  if (pageCount <= 1) {
+    return null;
+  }
+
+  const isAtFirst = currentPage === 0;
+  const isAtLast = currentPage >= pageCount - 1;
+
+  return (
+    <div
+      role="tablist"
+      aria-label="Stage pages"
+      className="pointer-events-none absolute inset-x-0 bottom-[4.75rem] z-2 flex justify-center tablet:bottom-[5.5rem]"
+    >
+      <div className="pointer-events-auto flex items-center gap-1 rounded-12 border border-border-subtlest-tertiary bg-background-default p-1 shadow-2">
+        <button
+          type="button"
+          aria-label="Previous page"
+          disabled={isAtFirst}
+          onClick={onPrev}
+          className="flex size-6 shrink-0 items-center justify-center rounded-8 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:text-text-disabled disabled:hover:bg-transparent"
+        >
+          <ArrowIcon className="-rotate-90" size={IconSize.XSmall} />
+        </button>
+        <div className="flex items-center gap-1.5 px-1">
+          {Array.from({ length: pageCount }, (_, index) => {
+            const isActive = index === currentPage;
+            return (
+              <button
+                key={index}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                aria-label={`Go to stage page ${index + 1} of ${pageCount}`}
+                onClick={() => onPageSelect(index)}
+                className={classNames(
+                  'flex shrink-0 items-center justify-center transition-all duration-200 ease-out',
+                  isActive
+                    ? 'h-5 rounded-6 bg-text-primary px-1.5 text-surface-invert'
+                    : 'size-1.5 rounded-full bg-text-quaternary hover:bg-text-tertiary',
+                )}
+              >
+                {isActive ? (
+                  <span className="font-bold tabular-nums leading-none typo-caption2">
+                    {index + 1}/{pageCount}
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+        <button
+          type="button"
+          aria-label="Next page"
+          disabled={isAtLast}
+          onClick={onNext}
+          className="flex size-6 shrink-0 items-center justify-center rounded-8 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary disabled:cursor-not-allowed disabled:text-text-disabled disabled:hover:bg-transparent"
+        >
+          <ArrowIcon className="rotate-90" size={IconSize.XSmall} />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.ts
+++ b/packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.ts
@@ -241,7 +241,10 @@ export const useLiveRoomStageModel = ({
     waitingPrompt,
     stagePageCount,
     clampedStagePage,
+    visibleStageSpeakers,
     paginatedStageSpeakers,
+    stagePageStart,
+    stageTilesPerPage,
     stageGridColumnCount,
     stageGridRowCount,
   };


### PR DESCRIPTION
## What changed
- Replaces the text-based stage pager with a compact page control for live-room speaker tiles.
- Keeps tile focus/navigation indexed across all visible speakers so enlarged-tile swipes can move across page boundaries.
- Updates live-room stage pagination tests for the new page control.

## Validation
- `node ./scripts/typecheck-strict-changed.js`
- `pnpm --filter shared lint -- src/components/liveRooms/LiveRoom.tsx src/components/liveRooms/LiveRoomStage.tsx src/components/liveRooms/LiveRoomStagePager.tsx src/hooks/liveRooms/useLiveRoomStageModel.ts src/components/liveRooms/LiveRoom.spec.tsx`
- `NODE_ENV=test pnpm --filter shared exec jest src/components/liveRooms/LiveRoom.spec.tsx --runInBand`


### Preview domain
https://codex-live-room-stage-pagination.preview.app.daily.dev