### PR TITLE
Fix standup stage interactions

### DIFF
--- a/packages/shared/src/components/fields/RichTextInput.tsx
+++ b/packages/shared/src/components/fields/RichTextInput.tsx
@@ -606,14 +606,6 @@ function RichTextInput(
   }));
 
   useEffect(() => {
-    if (!editor) {
-      return;
-    }
-
-    editor.commands.focus('end');
-  }, [editor]);
-
-  useEffect(() => {
     if (dirtyRef.current) {
       return;
     }

--- a/packages/shared/src/components/liveRooms/LiveRoomControls.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControls.spec.tsx
@@ -532,6 +532,43 @@ describe('LiveRoomControls', () => {
     });
   });
 
+  it('lets a speaker leave the stage in a moderated room', async () => {
+    const leaveStage = jest.fn(() => new Promise<void>(() => undefined));
+    mockUseLiveRoom.mockReturnValue(
+      createContextValue({
+        leaveStage,
+        role: 'speaker',
+        roomState: {
+          ...createRoomState(),
+          participants: {
+            ...createRoomState().participants,
+            audience: {
+              participantId: 'audience',
+              role: 'speaker',
+              sessionIds: ['session-audience'],
+              joinedAt: '2026-04-27T09:01:00.000Z',
+              updatedAt: '2026-04-27T09:01:00.000Z',
+            },
+          },
+          stage: {
+            speakerQueueParticipantIds: [],
+            activeSpeakerParticipantIds: ['audience'],
+            raisedHandParticipantIds: [],
+          },
+        },
+      }),
+    );
+
+    renderLiveRoomControls();
+
+    await click(screen.getByRole('button', { name: 'Stop speaking' }));
+    await flushAsyncUpdates();
+
+    await waitFor(() => {
+      expect(leaveStage).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('keeps the leave-stage control visible while a reaction is pending', async () => {
     let resolveReaction: (() => void) | undefined;
     const sendReaction = jest.fn(

--- a/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
@@ -199,7 +199,7 @@ export const LiveRoomControls = ({
     activeSpeakerCount >= speakerLimit;
   const canJoinQueue = isModerated && isAudience && isLive && !isQueued;
   const canJoinStage = isFreeForAll && isAudience && isLive && !isStageFull;
-  const canLeaveStage = isFreeForAll && isSpeaker && isLive;
+  const canLeaveStage = isSpeaker && isLive;
   const canRaiseHand =
     isLive && (isSpeaker || privilegeState.hasHostPrivileges);
   const showGoLive = privilegeState.isHost && roomState?.status === 'created';

--- a/packages/shared/src/components/liveRooms/LiveRoomStage.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomStage.spec.tsx
@@ -1,0 +1,146 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import type { LiveRoomStageSpeaker } from './LiveRoomStage';
+import { LiveRoomStage } from './LiveRoomStage';
+
+const mockRetryHandlers = new Map<string, jest.Mock>();
+
+jest.mock('./LiveRoomVideoTile', () => {
+  const mockReact = jest.requireActual('react');
+
+  return {
+    LiveRoomVideoTile: ({
+      user,
+      onAudioPlaybackStateChange,
+      onRegisterAudioRetry,
+    }: {
+      user: { id: string; name: string };
+      onAudioPlaybackStateChange?: (
+        state: 'none' | 'blocked' | 'playing',
+      ) => void;
+      onRegisterAudioRetry?: (retry: (() => void) | null) => void;
+    }) => {
+      mockReact.useEffect(() => {
+        const retry = jest.fn();
+        mockRetryHandlers.set(user.id, retry);
+        onRegisterAudioRetry?.(retry);
+
+        return () => {
+          mockRetryHandlers.delete(user.id);
+          onRegisterAudioRetry?.(null);
+        };
+      }, [onRegisterAudioRetry, user.id]);
+
+      return (
+        <div data-testid={`tile-${user.id}`}>
+          <span>{user.name}</span>
+          <button
+            type="button"
+            onClick={() => onAudioPlaybackStateChange?.('blocked')}
+          >
+            {`block-${user.id}`}
+          </button>
+          <button
+            type="button"
+            onClick={() => onAudioPlaybackStateChange?.('playing')}
+          >
+            {`play-${user.id}`}
+          </button>
+        </div>
+      );
+    },
+  };
+});
+
+jest.mock('./LiveRoomControls', () => ({
+  LiveRoomControls: () => <div>controls</div>,
+}));
+
+jest.mock('./LiveRoomStagePager', () => ({
+  LiveRoomStagePager: () => null,
+}));
+
+const createSpeaker = (id: string): LiveRoomStageSpeaker => ({
+  id,
+  profile: {
+    id,
+    username: id,
+    name: id,
+    image: '',
+    permalink: '#',
+    createdAt: '',
+    reputation: 0,
+  },
+  stream: null,
+  selfView: false,
+  isHost: false,
+  isCoHost: false,
+  isMuted: false,
+});
+
+const renderStage = () =>
+  render(
+    <LiveRoomStage
+      roomId="room-1"
+      isEnded={false}
+      stagePageCount={1}
+      clampedStagePage={0}
+      setStagePage={jest.fn()}
+      stageGridColumnCount={2}
+      stageGridRowCount={1}
+      speakers={[createSpeaker('speaker-1'), createSpeaker('speaker-2')]}
+      stagePageStart={0}
+      focusedSpeakerIndex={null}
+      waitingPrompt="Waiting"
+      hasHostPrivileges={false}
+      isHost={false}
+      moderationBusy={null}
+      onFocusSpeaker={jest.fn()}
+      onUnfocusSpeaker={jest.fn()}
+      onSpeakerFocusNavigate={jest.fn()}
+      guardedModerationAction={jest.fn()}
+      onGrantCoHost={jest.fn()}
+      onRevokeCoHost={jest.fn()}
+      onRemoveSpeaker={jest.fn()}
+      onKickParticipant={jest.fn()}
+      onNavigateBack={jest.fn()}
+      showControls={false}
+      onLeave={jest.fn()}
+    />,
+  );
+
+describe('LiveRoomStage', () => {
+  beforeEach(() => {
+    mockRetryHandlers.clear();
+  });
+
+  it('shows a single tap-to-unmute prompt only while audio is blocked globally', () => {
+    renderStage();
+
+    expect(
+      screen.queryByRole('button', { name: 'Tap to unmute' }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'block-speaker-1' }));
+
+    expect(
+      screen.getByRole('button', { name: 'Tap to unmute' }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'play-speaker-2' }));
+
+    expect(
+      screen.queryByRole('button', { name: 'Tap to unmute' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('retries audio playback for every visible tile from the shared prompt', () => {
+    renderStage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'block-speaker-1' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Tap to unmute' }));
+
+    expect(mockRetryHandlers.get('speaker-1')).toHaveBeenCalledTimes(1);
+    expect(mockRetryHandlers.get('speaker-2')).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/shared/src/components/liveRooms/LiveRoomStage.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomStage.tsx
@@ -1,5 +1,11 @@
 import type { Dispatch, ReactElement, SetStateAction } from 'react';
-import React, { useCallback } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import classNames from 'classnames';
 import { useSwipeable } from 'react-swipeable';
 import { Button, ButtonVariant } from '../buttons/Button';
@@ -13,7 +19,10 @@ import { IconSize } from '../Icon';
 import type { UserShortProfile } from '../../lib/user';
 import { LiveRoomControls } from './LiveRoomControls';
 import { LiveRoomStagePager } from './LiveRoomStagePager';
-import { LiveRoomVideoTile } from './LiveRoomVideoTile';
+import {
+  LiveRoomVideoTile,
+  type LiveRoomTileAudioPlaybackState,
+} from './LiveRoomVideoTile';
 
 export interface LiveRoomStageSpeaker {
   id: string;
@@ -96,7 +105,15 @@ export const LiveRoomStage = ({
   showControls,
   onLeave,
 }: LiveRoomStageProps): ReactElement => {
+  const [speakerAudioStates, setSpeakerAudioStates] = useState<
+    Record<string, LiveRoomTileAudioPlaybackState>
+  >({});
+  const audioRetryHandlersRef = useRef(new Map<string, () => void>());
   const hasMultiplePages = stagePageCount > 1;
+  const visibleSpeakerIds = useMemo(
+    () => new Set(speakers.map((speaker) => speaker.id)),
+    [speakers],
+  );
   const goToPage = useCallback(
     (page: number) => {
       setStagePage(() => Math.max(0, Math.min(stagePageCount - 1, page)));
@@ -127,8 +144,81 @@ export const LiveRoomStage = ({
     trackMouse: false,
   });
 
+  useEffect(() => {
+    setSpeakerAudioStates((current) =>
+      Object.fromEntries(
+        Object.entries(current).filter(([speakerId]) =>
+          visibleSpeakerIds.has(speakerId),
+        ),
+      ),
+    );
+
+    audioRetryHandlersRef.current.forEach((_, speakerId) => {
+      if (!visibleSpeakerIds.has(speakerId)) {
+        audioRetryHandlersRef.current.delete(speakerId);
+      }
+    });
+  }, [visibleSpeakerIds]);
+
+  const handleSpeakerAudioPlaybackStateChange = useCallback(
+    (speakerId: string, state: LiveRoomTileAudioPlaybackState): void => {
+      setSpeakerAudioStates((current) => {
+        if (state === 'none') {
+          if (!(speakerId in current)) {
+            return current;
+          }
+
+          const next = { ...current };
+          delete next[speakerId];
+          return next;
+        }
+
+        if (current[speakerId] === state) {
+          return current;
+        }
+
+        return { ...current, [speakerId]: state };
+      });
+    },
+    [],
+  );
+
+  const registerSpeakerAudioRetry = useCallback(
+    (speakerId: string, retry: (() => void) | null): void => {
+      if (retry) {
+        audioRetryHandlersRef.current.set(speakerId, retry);
+        return;
+      }
+
+      audioRetryHandlersRef.current.delete(speakerId);
+    },
+    [],
+  );
+
+  const hasBlockedAudio = speakers.some(
+    (speaker) => speakerAudioStates[speaker.id] === 'blocked',
+  );
+  const hasPlayingAudio = speakers.some(
+    (speaker) => speakerAudioStates[speaker.id] === 'playing',
+  );
+  const showAudioPrompt = hasBlockedAudio && !hasPlayingAudio;
+
+  const retrySpeakerAudioPlayback = (): void => {
+    audioRetryHandlersRef.current.forEach((retry) => retry());
+  };
+
   return (
     <section aria-label="Speakers" className="relative flex min-h-0 flex-col">
+      {showAudioPrompt ? (
+        <Button
+          type="button"
+          className="absolute right-3 top-3 z-1"
+          variant={ButtonVariant.Primary}
+          onClick={retrySpeakerAudioPlayback}
+        >
+          Tap to unmute
+        </Button>
+      ) : null}
       {speakers.length > 0 ? (
         <div className="relative flex min-h-0 flex-1 flex-col">
           <div
@@ -165,6 +255,12 @@ export const LiveRoomStage = ({
                     onUnfocus={onUnfocusSpeaker}
                     onSwipeNext={() => onSpeakerFocusNavigate(1)}
                     onSwipePrev={() => onSpeakerFocusNavigate(-1)}
+                    onAudioPlaybackStateChange={(state) =>
+                      handleSpeakerAudioPlaybackStateChange(speaker.id, state)
+                    }
+                    onRegisterAudioRetry={(retry) =>
+                      registerSpeakerAudioRetry(speaker.id, retry)
+                    }
                     onGrantCoHost={
                       canManageCoHosts && !speaker.isCoHost
                         ? () =>

--- a/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
@@ -1,5 +1,11 @@
 import type { ReactElement } from 'react';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import classNames from 'classnames';
 import { useSwipeable } from 'react-swipeable';
 import {
@@ -9,7 +15,6 @@ import {
   TypographyType,
 } from '../typography/Typography';
 import { ProfilePicture, ProfileImageSize } from '../ProfilePicture';
-import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import type { UserShortProfile } from '../../lib/user';
 import { MegaphoneIcon, VolumeOffIcon } from '../icons';
 import { RaiseHandIcon } from '../icons/RaiseHand';
@@ -24,6 +29,8 @@ import { Drawer } from '../drawers';
 import { RootPortal } from '../tooltips/Portal';
 import { useViewSize, ViewSize } from '../../hooks';
 import { useTouchLongPress } from '../../hooks/useTouchLongPress';
+
+export type LiveRoomTileAudioPlaybackState = 'none' | 'blocked' | 'playing';
 
 interface LiveRoomVideoTileProps {
   stream: MediaStream | null;
@@ -49,6 +56,8 @@ interface LiveRoomVideoTileProps {
   onUnfocus?: () => void;
   onSwipeNext?: () => void;
   onSwipePrev?: () => void;
+  onAudioPlaybackStateChange?: (state: LiveRoomTileAudioPlaybackState) => void;
+  onRegisterAudioRetry?: (retry: (() => void) | null) => void;
 }
 
 const pickLiveTrack = (
@@ -86,10 +95,11 @@ export const LiveRoomVideoTile = ({
   onUnfocus,
   onSwipeNext,
   onSwipePrev,
+  onAudioPlaybackStateChange,
+  onRegisterAudioRetry,
 }: LiveRoomVideoTileProps): ReactElement => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
-  const [needsAudioGesture, setNeedsAudioGesture] = useState(false);
   const isTablet = useViewSize(ViewSize.Tablet);
   const isMobile = !isTablet;
   const [actionsOpen, setActionsOpen] = useState(false);
@@ -164,19 +174,21 @@ export const LiveRoomVideoTile = ({
   const level = useLiveRoomAudioLevel(levelStream);
   const isSpeaking = level >= SPEAKING_LEVEL_THRESHOLD;
 
-  const tryPlayAudio = (): void => {
+  const tryPlayAudio = useCallback((): void => {
     const node = audioRef.current;
     if (!node) {
+      onAudioPlaybackStateChange?.('none');
       return;
     }
     const playPromise = node.play();
     if (!playPromise) {
+      onAudioPlaybackStateChange?.('playing');
       return;
     }
     playPromise
-      .then(() => setNeedsAudioGesture(false))
-      .catch(() => setNeedsAudioGesture(true));
-  };
+      .then(() => onAudioPlaybackStateChange?.('playing'))
+      .catch(() => onAudioPlaybackStateChange?.('blocked'));
+  }, [onAudioPlaybackStateChange]);
 
   useEffect(() => {
     const node = videoRef.current;
@@ -191,6 +203,7 @@ export const LiveRoomVideoTile = ({
   useEffect(() => {
     const node = audioRef.current;
     if (!node) {
+      onAudioPlaybackStateChange?.('none');
       return;
     }
     if (node.srcObject !== audioStream) {
@@ -199,13 +212,23 @@ export const LiveRoomVideoTile = ({
     if (audioStream) {
       tryPlayAudio();
     } else {
-      setNeedsAudioGesture(false);
+      onAudioPlaybackStateChange?.('none');
     }
-  }, [audioStream]);
+  }, [audioStream, onAudioPlaybackStateChange, tryPlayAudio]);
 
-  const handleEnableAudio = (): void => {
-    tryPlayAudio();
-  };
+  useEffect(() => {
+    if (!audioStream) {
+      onRegisterAudioRetry?.(null);
+      return undefined;
+    }
+
+    onRegisterAudioRetry?.(tryPlayAudio);
+
+    return () => {
+      onRegisterAudioRetry?.(null);
+    };
+  }, [audioStream, onRegisterAudioRetry, tryPlayAudio]);
+
   const hasProfileLink = !!user.permalink && user.permalink !== '#';
   const nameLabel = (
     <Typography
@@ -371,16 +394,6 @@ export const LiveRoomVideoTile = ({
           </span>
         ) : null}
       </div>
-      {needsAudioGesture ? (
-        <Button
-          className="absolute right-3 top-3"
-          size={ButtonSize.Small}
-          variant={ButtonVariant.Primary}
-          onClick={handleEnableAudio}
-        >
-          Tap to unmute
-        </Button>
-      ) : null}
       <RootPortal>
         <Drawer
           isOpen={actionsOpen}


### PR DESCRIPTION
## What changed
- moved the autoplay recovery CTA from per-tile overlays to one stage-level "Tap to unmute" prompt
- kept the prompt hidden once any remote tile is already playing audio, to avoid false positives for users who can already hear the room
- allowed speakers to use `Stop speaking` in moderated rooms
- removed RichTextInput's mount-time autofocus so swiping to Chat on mobile no longer opens the keyboard

## Why
The standup mobile flow had three linked UX problems: repeated unmute CTAs on every tile, chat opening the keyboard when users only switched tabs, and no leave-stage control in moderated rooms even though the product wanted one.

## Validation
- `node ./scripts/typecheck-strict-changed.js`
- `pnpm exec eslint src/components/fields/RichTextInput.tsx src/components/liveRooms/LiveRoomControls.tsx src/components/liveRooms/LiveRoomVideoTile.tsx src/components/liveRooms/LiveRoomStage.tsx src/components/liveRooms/LiveRoomControls.spec.tsx src/components/liveRooms/LiveRoomStage.spec.tsx --ext .ts,.tsx --max-warnings 0`
- `NODE_ENV=test pnpm --filter shared exec jest src/components/liveRooms/LiveRoomControls.spec.tsx src/components/liveRooms/LiveRoomStage.spec.tsx`

## Notes
- the targeted Jest run still prints the existing `act(...)` warning from `LiveRoomControls.spec.tsx`, but the suite passes


### Preview domain
https://codex-standup-stage-polish.preview.app.daily.dev