### PR TITLE
fix: recover standup iOS reconnect and dropped streams

### DIFF
--- a/packages/shared/src/contexts/LiveRoomContext.tsx
+++ b/packages/shared/src/contexts/LiveRoomContext.tsx
@@ -406,6 +406,9 @@ export const LiveRoomProvider = ({
   const [resumeSessionTtlMs, setResumeSessionTtlMs] = useState<number | null>(
     null,
   );
+  const [joinTokenRequestId, setJoinTokenRequestId] = useState(0);
+  const [remoteSubscriptionGeneration, setRemoteSubscriptionGeneration] =
+    useState(0);
 
   const connectionRef = useRef<LiveRoomConnection | null>(null);
   const deviceRef = useRef<MediasoupDevice | null>(null);
@@ -829,7 +832,13 @@ export const LiveRoomProvider = ({
     LiveRoomJoinToken,
     Error
   >({
-    queryKey: generateQueryKey(RequestKey.LiveRooms, user, 'join', roomId),
+    queryKey: generateQueryKey(
+      RequestKey.LiveRooms,
+      user,
+      'join',
+      roomId,
+      joinTokenRequestId,
+    ),
     queryFn: () => fetchJoinToken(roomId),
     enabled: isAuthReady && !!roomId && !storedResumeSession,
     retry: false,
@@ -852,6 +861,15 @@ export const LiveRoomProvider = ({
 
   useEffect(() => {
     setStoredResumeSession(readStoredLiveRoomResumeSession(roomId));
+  }, [roomId]);
+
+  const requestFreshJoinToken = useCallback(() => {
+    clearStoredLiveRoomResumeSession(roomId);
+    setStoredResumeSession(null);
+    setResumeSessionTtlMs(null);
+    setJoinTokenRequestId((current) => current + 1);
+    setStatus('connecting');
+    setErrorMessage(null);
   }, [roomId]);
 
   const refreshLocalStream = useCallback(() => {
@@ -1032,12 +1050,13 @@ export const LiveRoomProvider = ({
         removeChatMessageReactionFromState(event);
       },
     );
-    const offClose = connection.onClose(({ reason }) => {
+    const offClose = connection.onClose(({ code, reason }) => {
       if (openingWithResume && !sessionReady) {
-        clearStoredLiveRoomResumeSession(roomId);
-        setStoredResumeSession(null);
-        setStatus('idle');
-        setErrorMessage(null);
+        requestFreshJoinToken();
+        return;
+      }
+      if (code === 1008 && sessionReady && connection.resumeToken) {
+        requestFreshJoinToken();
         return;
       }
       setStatus('closed');
@@ -1079,6 +1098,7 @@ export const LiveRoomProvider = ({
     removeChatMessageReactionFromState,
     roomId,
     storedResumeSession,
+    requestFreshJoinToken,
   ]);
 
   useEffect(() => {
@@ -1337,12 +1357,17 @@ export const LiveRoomProvider = ({
             streamId: `${publication.participantId}-audio-video`,
           });
           const removeSubscription = () => {
-            subscriptionsRef.current.delete(publication.publicationId);
+            const deleted = subscriptionsRef.current.delete(
+              publication.publicationId,
+            );
             setRemoteStreams((prev) =>
               prev.filter(
                 (entry) => entry.publicationId !== publication.publicationId,
               ),
             );
+            if (deleted) {
+              setRemoteSubscriptionGeneration((current) => current + 1);
+            }
           };
           closeConsumer = () => consumer.close();
           consumer.on('transportclose', removeSubscription);
@@ -1412,7 +1437,12 @@ export const LiveRoomProvider = ({
         }
       })();
     });
-  }, [roomState, participantId, recvTransportReady]);
+  }, [
+    participantId,
+    recvTransportReady,
+    remoteSubscriptionGeneration,
+    roomState,
+  ]);
 
   useEffect(() => {
     const syncRemoteVideoSubscriptions = async () => {


### PR DESCRIPTION
## What changed
- retry standup admission with a fresh join token when a cached resume token is rejected during reconnect
- trigger a new remote subscription reconciliation pass when a mediasoup consumer is dropped locally

## Why
On `/standups/[id]`, iOS background/foreground cycles could leave the client stuck on a terminal connection-closed path after Flyting rejected a stale resume token. Separately, dropped remote consumers could remove a stream locally without any follow-up re-subscription, leaving lost video stuck until some unrelated room update arrived.

## Impact
- reduces the iOS/Safari background-resume path that lands on the standup error page
- lets lost remote streams recover when the underlying consumer disappears locally
- keeps this PR scoped to the shared apps-side recovery logic; the native `../ios` WebKit permission change is separate

## Validation
- `node ./scripts/typecheck-strict-changed.js`
- `pnpm exec eslint src/contexts/LiveRoomContext.tsx` (from `packages/shared`)


### Preview domain
https://codex-standup-ios-reconnect-reco.preview.app.daily.dev