### PR TITLE
fix: polish standup live room interactions

### DIFF
--- a/packages/shared/src/components/Markdown.tsx
+++ b/packages/shared/src/components/Markdown.tsx
@@ -36,6 +36,7 @@ interface MarkdownProps {
   className?: string;
   content: string;
   appendTooltipTo?: () => HTMLElement;
+  openLinksInNewTab?: boolean;
 }
 
 const TOOLTIP_SPACING = 8;
@@ -61,6 +62,7 @@ export default function Markdown({
   className,
   content,
   appendTooltipTo,
+  openLinksInNewTab = false,
 }: MarkdownProps): ReactElement {
   const purify = useDomPurify();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -91,7 +93,24 @@ export default function Markdown({
       img.setAttribute('role', 'button');
       img.setAttribute('aria-label', 'Open image in new tab');
     });
-  }, [content]);
+  });
+
+  useEffect(() => {
+    if (!openLinksInNewTab) {
+      return;
+    }
+
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+
+    const links = container.querySelectorAll('a[href]');
+    links.forEach((link) => {
+      link.setAttribute('target', '_blank');
+      link.setAttribute('rel', 'noopener noreferrer');
+    });
+  });
 
   const onHoverHandler: MouseEventHandler<HTMLDivElement> = useCallback(
     (e) => {

--- a/packages/shared/src/components/contentEmbeds/ContentEmbeds.spec.tsx
+++ b/packages/shared/src/components/contentEmbeds/ContentEmbeds.spec.tsx
@@ -65,6 +65,15 @@ it('should keep comment embeds compact while showing engagement stats', () => {
   expect(screen.getByText('3 Comments')).toBeInTheDocument();
 });
 
+it('should open embedded post links in a new tab', () => {
+  render(renderComponent());
+
+  expect(screen.getByRole('link', { name: /Embedded post/i })).toHaveAttribute(
+    'target',
+    '_blank',
+  );
+});
+
 it('should reuse collection metadata for source count', () => {
   render(
     renderComponent({

--- a/packages/shared/src/components/contentEmbeds/ContentEmbeds.tsx
+++ b/packages/shared/src/components/contentEmbeds/ContentEmbeds.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 import type { ContentEmbed, ContentEmbedPost } from '../../graphql/posts';
 import { PostType } from '../../graphql/posts';
-import Link from '../utilities/Link';
 import { Image, ImageType } from '../image/Image';
 import { SourceAvatar } from '../profile/source/SourceAvatar';
 import { ProfileImageSize } from '../ProfilePicture';
@@ -16,6 +15,7 @@ import PostMetadata from '../cards/common/PostMetadata';
 import { Separator } from '../cards/common/common';
 import { PostUpvotesCommentsCount } from '../post/PostUpvotesCommentsCount';
 import { useAuthContext } from '../../contexts/AuthContext';
+import { anchorDefaultRel } from '../../lib/strings';
 
 type ContentEmbedVariant = 'post' | 'comment';
 
@@ -69,76 +69,77 @@ const DailyPostEmbed = ({
     !!pollMetadata;
 
   return (
-    <Link href={href} passHref>
-      <a
+    <a
+      href={href}
+      target="_blank"
+      rel={anchorDefaultRel}
+      className={classNames(
+        'flex min-w-0 items-center gap-3 rounded-12 border border-border-subtlest-tertiary bg-background-subtle p-3 hover:border-border-subtlest-secondary',
+        isCommentVariant ? 'mt-3' : 'mt-4',
+      )}
+    >
+      <Image
+        src={post.image}
+        alt={post.title || 'Embedded post cover image'}
+        type={ImageType.Post}
+        loading="lazy"
         className={classNames(
-          'flex min-w-0 items-center gap-3 rounded-12 border border-border-subtlest-tertiary bg-background-subtle p-3 hover:border-border-subtlest-secondary',
-          isCommentVariant ? 'mt-3' : 'mt-4',
+          'shrink-0 rounded-10 object-cover',
+          isCommentVariant ? 'size-16' : 'size-24',
         )}
-      >
-        <Image
-          src={post.image}
-          alt={post.title || 'Embedded post cover image'}
-          type={ImageType.Post}
-          loading="lazy"
-          className={classNames(
-            'shrink-0 rounded-10 object-cover',
-            isCommentVariant ? 'size-16' : 'size-24',
-          )}
-        />
-        <div className="flex min-w-0 flex-1 flex-col gap-2">
-          {(source || hasPostMetadata) && (
-            <div className="flex min-w-0 items-center overflow-hidden text-text-tertiary typo-caption1">
-              {source && (
-                <>
-                  <SourceAvatar
-                    source={source}
-                    size={ProfileImageSize.Size16}
-                    className="mr-1 shrink-0"
-                  />
-                  <Typography
-                    type={TypographyType.Caption1}
-                    color={TypographyColor.Secondary}
-                    className="min-w-0 shrink truncate leading-4"
-                  >
-                    {sourceLabel}
-                  </Typography>
-                </>
-              )}
-              {source && hasPostMetadata && <Separator className="shrink-0" />}
-              {hasPostMetadata && (
-                <PostMetadata
-                  createdAt={post.createdAt}
-                  readTime={post.readTime}
-                  isVideoType={isEmbedVideoPost(post)}
-                  numSources={post.numCollectionSources}
-                  pollMetadata={pollMetadata}
-                  className="!typo-caption1"
+      />
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        {(source || hasPostMetadata) && (
+          <div className="flex min-w-0 items-center overflow-hidden text-text-tertiary typo-caption1">
+            {source && (
+              <>
+                <SourceAvatar
+                  source={source}
+                  size={ProfileImageSize.Size16}
+                  className="mr-1 shrink-0"
                 />
-              )}
-            </div>
-          )}
-          <Typography
-            type={
-              isCommentVariant ? TypographyType.Footnote : TypographyType.Body
-            }
-            color={TypographyColor.Primary}
-            className={classNames(
-              'line-clamp-2 break-words font-bold',
-              isCommentVariant && 'leading-5',
+                <Typography
+                  type={TypographyType.Caption1}
+                  color={TypographyColor.Secondary}
+                  className="min-w-0 shrink truncate leading-4"
+                >
+                  {sourceLabel}
+                </Typography>
+              </>
             )}
-          >
-            {post.title}
-          </Typography>
-          <PostUpvotesCommentsCount
-            post={post}
-            passive
-            compact
-            className="!typo-caption1"
-          />
-        </div>
-      </a>
-    </Link>
+            {source && hasPostMetadata && <Separator className="shrink-0" />}
+            {hasPostMetadata && (
+              <PostMetadata
+                createdAt={post.createdAt}
+                readTime={post.readTime}
+                isVideoType={isEmbedVideoPost(post)}
+                numSources={post.numCollectionSources}
+                pollMetadata={pollMetadata}
+                className="!typo-caption1"
+              />
+            )}
+          </div>
+        )}
+        <Typography
+          type={
+            isCommentVariant ? TypographyType.Footnote : TypographyType.Body
+          }
+          color={TypographyColor.Primary}
+          className={classNames(
+            'line-clamp-2 break-words font-bold',
+            isCommentVariant && 'leading-5',
+          )}
+        >
+          {post.title}
+        </Typography>
+        <PostUpvotesCommentsCount
+          post={post}
+          passive
+          compact
+          className="!typo-caption1"
+        />
+      </div>
+    </a>
   );
 };
 

--- a/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import {
   QueryClient,
   QueryClientProvider,
@@ -756,7 +762,7 @@ describe('LiveRoom', () => {
     expect(screen.getByText('tile-host')).toBeInTheDocument();
   });
 
-  it('renders chat messages with sanitized markdown and send controls', () => {
+  it('renders chat messages with sanitized markdown and send controls', async () => {
     mockUseLiveRoomConnection.mockReturnValue(
       createContextValue({
         chatMessages: [
@@ -775,7 +781,65 @@ describe('LiveRoom', () => {
     expect(screen.getByText('@speaker1')).toBeInTheDocument();
     expect(screen.getByText('# heading')).toBeInTheDocument();
     expect(screen.getByText('hello')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: 'daily' })).toHaveAttribute(
+        'target',
+        '_blank',
+      ),
+    );
     expect(screen.getByRole('button', { name: 'Send' })).toBeInTheDocument();
+  });
+
+  it('keeps other chat reactions clickable while one reaction is still pending', async () => {
+    let resolveFirstReaction = (): void => undefined;
+    const firstReactionPromise = new Promise<void>((resolve) => {
+      resolveFirstReaction = resolve;
+    });
+    const sendChatMessageReaction = jest
+      .fn()
+      .mockImplementation(() => firstReactionPromise);
+    mockUseLiveRoomConnection.mockReturnValue(
+      createContextValue({
+        sendChatMessageReaction,
+        chatMessages: [
+          {
+            messageId: 'message-1',
+            participantId: 'speaker1',
+            body: 'hello',
+            createdAt: '2026-04-27T09:04:00.000Z',
+          },
+        ],
+      }),
+    );
+
+    renderLiveRoom();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'React 🔥 to message from @speaker1',
+      }),
+    );
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'React 👀 to message from @speaker1',
+      }),
+    );
+
+    expect(sendChatMessageReaction).toHaveBeenNthCalledWith(
+      1,
+      'message-1',
+      '🔥',
+    );
+    expect(sendChatMessageReaction).toHaveBeenNthCalledWith(
+      2,
+      'message-1',
+      '👀',
+    );
+
+    await act(async () => {
+      resolveFirstReaction();
+      await firstReactionPromise;
+    });
   });
 
   it('always shows all quick reactions and toggles a reacted emoji off when clicked', async () => {

--- a/packages/shared/src/components/liveRooms/LiveRoom.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.tsx
@@ -88,6 +88,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     reactions,
     chatMessages,
     isMicOn,
+    toggleMic,
   } = useLiveRoomConnection();
   const privilegeState = getLiveRoomPrivilegeState(
     roomState,
@@ -283,6 +284,19 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     },
     [kickParticipant, logStandupAction],
   );
+  const handleToggleSelfTileMute = useCallback(async (): Promise<void> => {
+    try {
+      await toggleMic();
+      logStandupAction(LogEvent.ChangeStandupSettings, 'mic', {
+        surface: 'stage_tile',
+        value: !isMicOn,
+      });
+    } catch (error) {
+      displayToast(
+        error instanceof Error ? error.message : 'Failed to update mic',
+      );
+    }
+  }, [displayToast, isMicOn, logStandupAction, toggleMic]);
   const handleGrantCoHost = useCallback(
     async (targetParticipantId: string, surface: string): Promise<void> => {
       await grantCoHost(targetParticipantId);
@@ -764,6 +778,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
           onRevokeCoHost={handleRevokeCoHost}
           onRemoveSpeaker={handleRemoveSpeaker}
           onKickParticipant={handleKickParticipant}
+          onToggleSelfMute={handleToggleSelfTileMute}
           onNavigateBack={handleNavigateBack}
           showControls={!!roomState}
           onLeave={handleLeave}

--- a/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
@@ -236,7 +236,7 @@ export const LiveRoomChatPanel = ({
   const scrollRef = useRef<HTMLDivElement>(null);
   const shouldAutoScrollRef = useRef(true);
   const [moderationBusy, setModerationBusy] = useState<string | null>(null);
-  const [reactionBusy, setReactionBusy] = useState<string | null>(null);
+  const [reactionBusyKeys, setReactionBusyKeys] = useState<string[]>([]);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
   const isTablet = useViewSize(ViewSize.Tablet);
   const isMobile = !isTablet;
@@ -321,17 +321,21 @@ export const LiveRoomChatPanel = ({
     shouldRemove = false,
   ): void => {
     const key = `${messageId}-${reactionKey}`;
-    if (reactionBusy || !canChat) {
+    if (reactionBusyKeys.includes(key) || !canChat) {
       return;
     }
 
-    setReactionBusy(key);
+    setReactionBusyKeys((current) => [...current, key]);
     const action = shouldRemove
       ? onRemoveMessageReaction
       : onSendMessageReaction;
     action(messageId, reactionKey, analytics)
       .catch(() => undefined)
-      .finally(() => setReactionBusy(null));
+      .finally(() =>
+        setReactionBusyKeys((current) =>
+          current.filter((busyKey) => busyKey !== key),
+        ),
+      );
   };
 
   const applyLongPressReaction = (
@@ -428,6 +432,7 @@ export const LiveRoomChatPanel = ({
                       content={chatMarkdownToHtml(message.body, {
                         mentions: mentionSuggestions,
                       })}
+                      openLinksInNewTab
                     />
                   </div>
                   <LiveRoomChatReactions
@@ -435,7 +440,7 @@ export const LiveRoomChatPanel = ({
                     currentParticipantId={currentParticipantId}
                     canChat={canChat}
                     senderName={senderName}
-                    reactionBusy={reactionBusy}
+                    reactionBusyKeys={reactionBusyKeys}
                     hideQuickReactions={isMobile}
                     floatingTrayPlacement={
                       messageIndex === 0 ? 'below' : 'above'

--- a/packages/shared/src/components/liveRooms/LiveRoomChatReactions.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatReactions.tsx
@@ -289,7 +289,7 @@ interface LiveRoomChatReactionsProps {
   currentParticipantId: string | null;
   canChat: boolean;
   senderName: string;
-  reactionBusy: string | null;
+  reactionBusyKeys: string[];
   hideQuickReactions?: boolean;
   floatingTrayPlacement?: 'above' | 'below';
   onReactionAction: (
@@ -305,7 +305,7 @@ export const LiveRoomChatReactions = ({
   currentParticipantId,
   canChat,
   senderName,
-  reactionBusy,
+  reactionBusyKeys,
   hideQuickReactions = false,
   floatingTrayPlacement = 'above',
   onReactionAction,
@@ -350,6 +350,7 @@ export const LiveRoomChatReactions = ({
           ) : null}
           {reactionGroups.map((reaction) => {
             const reactionKey = `${message.messageId}-${reaction.key}`;
+            const isBusy = reactionBusyKeys.includes(reactionKey);
 
             return (
               <ChatReactionChip
@@ -363,8 +364,8 @@ export const LiveRoomChatReactions = ({
                     ? 'reaction from'
                     : 'to'
                 } message from ${senderName}`}
-                disabled={!canChat || !!reactionBusy}
-                isSending={reactionBusy === reactionKey}
+                disabled={!canChat || isBusy}
+                isSending={isBusy}
                 pulseSignal={getPulseSignal(reaction.key)}
                 onClick={() =>
                   onReactionAction(
@@ -395,6 +396,7 @@ export const LiveRoomChatReactions = ({
               ? quickReactionKeys.map((reactionKey) => {
                   const busyKey = `${message.messageId}-${reactionKey}`;
                   const isReacted = myReactionKeys.has(reactionKey);
+                  const isBusy = reactionBusyKeys.includes(busyKey);
 
                   return (
                     <button
@@ -411,7 +413,7 @@ export const LiveRoomChatReactions = ({
                         isReacted ? 'reaction from' : 'to'
                       } message from ${senderName}`}
                       aria-pressed={isReacted}
-                      disabled={!!reactionBusy}
+                      disabled={isBusy}
                       onClick={() =>
                         onReactionAction(
                           message.messageId,
@@ -425,9 +427,7 @@ export const LiveRoomChatReactions = ({
                       }
                     >
                       <span>{reactionKey}</span>
-                      {reactionBusy === busyKey ? (
-                        <span className="sr-only">Sending</span>
-                      ) : null}
+                      {isBusy ? <span className="sr-only">Sending</span> : null}
                     </button>
                   );
                 })
@@ -457,7 +457,6 @@ export const LiveRoomChatReactions = ({
                   icon={<PlusIcon size={IconSize.Size16} />}
                   aria-label={`Custom reaction to message from ${senderName}`}
                   aria-expanded={isOpen}
-                  disabled={!!reactionBusy}
                   onClick={toggleOpen}
                 />
               )}

--- a/packages/shared/src/components/liveRooms/LiveRoomLobby.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomLobby.tsx
@@ -10,7 +10,6 @@ import {
 } from '../typography/Typography';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { ProfilePicture, ProfileImageSize } from '../ProfilePicture';
-import Link from '../utilities/Link';
 import Markdown from '../Markdown';
 import { ContentEmbeds } from '../contentEmbeds/ContentEmbeds';
 import {
@@ -24,6 +23,7 @@ import {
 import { RaiseHandIcon } from '../icons/RaiseHand';
 import { IconSize } from '../Icon';
 import type { LiveRoom as LiveRoomModel } from '../../graphql/liveRooms';
+import { anchorDefaultRel } from '../../lib/strings';
 import type { UserShortProfile } from '../../lib/user';
 
 const padNumber = (value: number): string => value.toString().padStart(2, '0');
@@ -314,31 +314,34 @@ export const LiveRoomLobby = ({
                     {room.topic}
                   </Typography>
                   <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-                    <Link href={room.host.permalink}>
-                      <a className="-m-1 inline-flex min-w-0 items-center gap-2 rounded-12 p-1 transition-colors hover:bg-surface-hover">
-                        <ProfilePicture
-                          user={room.host}
-                          size={ProfileImageSize.Medium}
-                        />
-                        <div className="flex min-w-0 flex-col">
-                          <Typography
-                            type={TypographyType.Caption2}
-                            color={TypographyColor.Tertiary}
-                            className="font-bold uppercase tracking-[0.18em]"
-                          >
-                            Hosted by
-                          </Typography>
-                          <Typography
-                            type={TypographyType.Footnote}
-                            bold
-                            truncate
-                            className="min-w-0"
-                          >
-                            {room.host.name}
-                          </Typography>
-                        </div>
-                      </a>
-                    </Link>
+                    <a
+                      href={room.host.permalink}
+                      target="_blank"
+                      rel={anchorDefaultRel}
+                      className="-m-1 inline-flex min-w-0 items-center gap-2 rounded-12 p-1 transition-colors hover:bg-surface-hover"
+                    >
+                      <ProfilePicture
+                        user={room.host}
+                        size={ProfileImageSize.Medium}
+                      />
+                      <div className="flex min-w-0 flex-col">
+                        <Typography
+                          type={TypographyType.Caption2}
+                          color={TypographyColor.Tertiary}
+                          className="font-bold uppercase tracking-[0.18em]"
+                        >
+                          Hosted by
+                        </Typography>
+                        <Typography
+                          type={TypographyType.Footnote}
+                          bold
+                          truncate
+                          className="min-w-0"
+                        >
+                          {room.host.name}
+                        </Typography>
+                      </div>
+                    </a>
                     {hasScheduledStart ? (
                       <Typography
                         type={TypographyType.Footnote}
@@ -442,6 +445,7 @@ export const LiveRoomLobby = ({
                 <Markdown
                   content={room.descriptionHtml}
                   className="break-words text-text-primary"
+                  openLinksInNewTab
                 />
               ) : (
                 <Typography

--- a/packages/shared/src/components/liveRooms/LiveRoomStage.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomStage.spec.tsx
@@ -103,6 +103,7 @@ const renderStage = () =>
       onRevokeCoHost={jest.fn()}
       onRemoveSpeaker={jest.fn()}
       onKickParticipant={jest.fn()}
+      onToggleSelfMute={jest.fn()}
       onNavigateBack={jest.fn()}
       showControls={false}
       onLeave={jest.fn()}

--- a/packages/shared/src/components/liveRooms/LiveRoomStage.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomStage.tsx
@@ -73,6 +73,7 @@ interface LiveRoomStageProps {
     targetParticipantId: string,
     surface: string,
   ) => Promise<void>;
+  onToggleSelfMute: () => Promise<void>;
   onNavigateBack: (surface: string) => void;
   showControls: boolean;
   onLeave: () => void;
@@ -101,6 +102,7 @@ export const LiveRoomStage = ({
   onRevokeCoHost,
   onRemoveSpeaker,
   onKickParticipant,
+  onToggleSelfMute,
   onNavigateBack,
   showControls,
   onLeave,
@@ -250,6 +252,9 @@ export const LiveRoomStage = ({
                     isCoHost={speaker.isCoHost}
                     raisedHandQueuePosition={speaker.raisedHandQueuePosition}
                     isMuted={speaker.isMuted}
+                    onToggleSelfMute={
+                      speaker.selfView ? onToggleSelfMute : undefined
+                    }
                     isFocused={focusedSpeakerIndex === globalIndex}
                     onFocus={() => onFocusSpeaker(globalIndex)}
                     onUnfocus={onUnfocusSpeaker}

--- a/packages/shared/src/components/liveRooms/LiveRoomVideoTile.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomVideoTile.spec.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { LiveRoomVideoTile } from './LiveRoomVideoTile';
+
+jest.mock('./useLiveRoomAudioLevel', () => ({
+  SPEAKING_LEVEL_THRESHOLD: 0.5,
+  useLiveRoomAudioLevel: () => 0,
+}));
+
+jest.mock('../../hooks', () => {
+  const actual = jest.requireActual('../../hooks');
+  return {
+    ...actual,
+    useViewSize: () => true,
+  };
+});
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuthContext: () => ({ user: undefined, showLogin: jest.fn() }),
+}));
+
+jest.mock('../../hooks/contentPreference/useContentPreference', () => ({
+  useContentPreference: () => ({
+    follow: jest.fn(),
+    unfollow: jest.fn(),
+  }),
+}));
+
+jest.mock(
+  '../../hooks/contentPreference/useContentPreferenceStatusQuery',
+  () => ({
+    useContentPreferenceStatusQuery: () => ({ data: undefined }),
+  }),
+);
+
+jest.mock('../../hooks/useLazyModal', () => ({
+  useLazyModal: () => ({ openModal: jest.fn() }),
+}));
+
+jest.mock('./LiveRoomTileActions', () => ({
+  LiveRoomTileActions: () => null,
+}));
+
+jest.mock('../ProfilePicture', () => ({
+  ProfilePicture: ({ user }: { user: { name: string } }) => (
+    <div>{user.name}</div>
+  ),
+  ProfileImageSize: {
+    Small: 'small',
+    XXLarge: 'xxlarge',
+  },
+}));
+
+jest.mock('../drawers', () => ({
+  Drawer: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+jest.mock('../tooltips/Portal', () => ({
+  RootPortal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('../../hooks/useTouchLongPress', () => ({
+  useTouchLongPress: () => ({
+    onTouchStart: jest.fn(),
+    onTouchEnd: jest.fn(),
+    onTouchMove: jest.fn(),
+    onTouchCancel: jest.fn(),
+  }),
+}));
+
+const defaultUser = {
+  id: 'user-1',
+  username: 'user-1',
+  name: 'User One',
+  image: '',
+  permalink: '/u/user-1',
+  createdAt: '',
+  reputation: 0,
+};
+
+describe('LiveRoomVideoTile', () => {
+  it('unmutes the current speaker from the muted badge', () => {
+    const onToggleSelfMute = jest.fn();
+
+    render(
+      <LiveRoomVideoTile
+        stream={null}
+        user={defaultUser}
+        selfView
+        isMuted
+        onToggleSelfMute={onToggleSelfMute}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unmute yourself' }));
+
+    expect(onToggleSelfMute).toHaveBeenCalledTimes(1);
+  });
+
+  it('expands a short muted-by-user note for other speakers', () => {
+    render(
+      <LiveRoomVideoTile
+        stream={null}
+        user={defaultUser}
+        isMuted
+        selfView={false}
+      />,
+    );
+
+    const mutedButton = screen.getByRole('button', { name: 'Muted by user' });
+
+    expect(mutedButton).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(mutedButton);
+
+    expect(mutedButton).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Muted by user')).toHaveAttribute(
+      'aria-hidden',
+      'false',
+    );
+
+    fireEvent.mouseLeave(mutedButton);
+
+    expect(mutedButton).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByText('Muted by user')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+  });
+});

--- a/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react';
 import React, {
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -19,7 +20,6 @@ import type { UserShortProfile } from '../../lib/user';
 import { MegaphoneIcon, VolumeOffIcon } from '../icons';
 import { RaiseHandIcon } from '../icons/RaiseHand';
 import { IconSize } from '../Icon';
-import Link from '../utilities/Link';
 import {
   SPEAKING_LEVEL_THRESHOLD,
   useLiveRoomAudioLevel,
@@ -29,6 +29,7 @@ import { Drawer } from '../drawers';
 import { RootPortal } from '../tooltips/Portal';
 import { useViewSize, ViewSize } from '../../hooks';
 import { useTouchLongPress } from '../../hooks/useTouchLongPress';
+import { anchorDefaultRel } from '../../lib/strings';
 
 export type LiveRoomTileAudioPlaybackState = 'none' | 'blocked' | 'playing';
 
@@ -42,6 +43,7 @@ interface LiveRoomVideoTileProps {
   raisedHandQueuePosition?: number;
   isMuted?: boolean;
   className?: string;
+  onToggleSelfMute?: () => void | Promise<void>;
   onGrantCoHost?: () => void;
   onRevokeCoHost?: () => void;
   onRemoveSpeaker?: () => void;
@@ -81,6 +83,7 @@ export const LiveRoomVideoTile = ({
   raisedHandQueuePosition,
   isMuted = false,
   className,
+  onToggleSelfMute,
   onGrantCoHost,
   onRevokeCoHost,
   onRemoveSpeaker,
@@ -100,9 +103,11 @@ export const LiveRoomVideoTile = ({
 }: LiveRoomVideoTileProps): ReactElement => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const mutedNoticeId = useId();
   const isTablet = useViewSize(ViewSize.Tablet);
   const isMobile = !isTablet;
   const [actionsOpen, setActionsOpen] = useState(false);
+  const [isMutedNoticeOpen, setIsMutedNoticeOpen] = useState(false);
   const longPressFiredRef = useRef(false);
   const longPressHandlers = useTouchLongPress<undefined>({
     enabled: isMobile && !selfView,
@@ -232,7 +237,7 @@ export const LiveRoomVideoTile = ({
   const hasProfileLink = !!user.permalink && user.permalink !== '#';
   const nameLabel = (
     <Typography
-      tag={hasProfileLink ? TypographyTag.Link : TypographyTag.Span}
+      tag={TypographyTag.Span}
       type={TypographyType.Footnote}
       bold
       truncate
@@ -253,6 +258,28 @@ export const LiveRoomVideoTile = ({
         onTouchMove: longPressHandlers.onTouchMove,
         onTouchCancel: longPressHandlers.onTouchCancel,
       };
+  const mutedBadgeCopy = 'Muted by user';
+  const isSelfMutedTile = selfView && !!onToggleSelfMute;
+  const handleMutedBadgeClick = (
+    event: React.MouseEvent<HTMLButtonElement>,
+  ): void => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (isSelfMutedTile) {
+      onToggleSelfMute?.();
+      return;
+    }
+
+    setIsMutedNoticeOpen((current) => !current);
+  };
+  const closeMutedNotice = (): void => {
+    if (isSelfMutedTile) {
+      return;
+    }
+
+    setIsMutedNoticeOpen(false);
+  };
 
   return (
     <div
@@ -338,12 +365,37 @@ export const LiveRoomVideoTile = ({
         </span>
       ) : null}
       {isMuted ? (
-        <span
-          aria-label="Muted"
-          className="pointer-events-none absolute right-3 top-3 inline-flex size-7 items-center justify-center rounded-10 bg-overlay-dark-dark3 backdrop-blur"
+        <button
+          type="button"
+          aria-label={isSelfMutedTile ? 'Unmute yourself' : mutedBadgeCopy}
+          aria-controls={!isSelfMutedTile ? mutedNoticeId : undefined}
+          aria-expanded={!isSelfMutedTile ? isMutedNoticeOpen : undefined}
+          className="hover:bg-overlay-dark-dark4 absolute right-3 top-3 z-1 inline-flex items-center justify-end rounded-10 bg-overlay-dark-dark3 px-1 py-1 text-white backdrop-blur transition-colors"
+          onClick={handleMutedBadgeClick}
+          onMouseLeave={closeMutedNotice}
+          onBlur={closeMutedNotice}
         >
-          <VolumeOffIcon size={IconSize.XSmall} className="text-status-error" />
-        </span>
+          {!isSelfMutedTile ? (
+            <span
+              id={mutedNoticeId}
+              aria-hidden={!isMutedNoticeOpen}
+              className={classNames(
+                'overflow-hidden whitespace-nowrap text-left text-status-error transition-[max-width,opacity,transform,margin,padding] duration-200 ease-out typo-caption1',
+                isMutedNoticeOpen
+                  ? 'mr-1.5 max-w-[7.5rem] translate-x-0 pl-1 opacity-100'
+                  : 'max-w-0 -translate-x-1 pl-0 opacity-0',
+              )}
+            >
+              {mutedBadgeCopy}
+            </span>
+          ) : null}
+          <span className="flex size-5 items-center justify-center">
+            <VolumeOffIcon
+              size={IconSize.XSmall}
+              className="text-status-error"
+            />
+          </span>
+        </button>
       ) : null}
       <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 pb-3 pl-1.5 pr-3 pt-3 tablet:pl-3">
         <div className="flex min-h-8 min-w-0 items-center gap-1.5 rounded-12 bg-overlay-dark-dark3 px-2 py-1 backdrop-blur transition-[padding] duration-200 ease-out tablet:gap-2 tablet:px-2.5 tablet:group-hover:pr-1">
@@ -366,9 +418,14 @@ export const LiveRoomVideoTile = ({
             </Typography>
           ) : null}
           {hasProfileLink ? (
-            <Link href={user.permalink} passHref>
+            <a
+              href={user.permalink}
+              target="_blank"
+              rel={anchorDefaultRel}
+              className="pointer-events-auto min-w-0"
+            >
               {nameLabel}
-            </Link>
+            </a>
           ) : (
             nameLabel
           )}

--- a/packages/shared/src/contexts/LiveRoomContext.tsx
+++ b/packages/shared/src/contexts/LiveRoomContext.tsx
@@ -123,6 +123,12 @@ interface RemoteSubscriptionHandle {
 
 type MediaTransportDirection = 'send' | 'recv';
 
+interface CachedMutedAudioTrack {
+  track: MediaStreamTrack;
+  deviceId: string | null;
+  micSettingsSignature: string;
+}
+
 export interface LiveRoomContextValue {
   status: LiveRoomConnectionStatus;
   errorMessage: string | null;
@@ -325,6 +331,9 @@ const buildAudioConstraints = (
   return constraints;
 };
 
+const getMicSettingsSignature = (micSettings: LiveRoomMicSettings): string =>
+  JSON.stringify(micSettings);
+
 const buildConstraints = (
   kind: 'audio' | 'video',
   deviceId: string | null,
@@ -419,6 +428,7 @@ export const LiveRoomProvider = ({
     audio: MediaStreamTrack | null;
     video: MediaStreamTrack | null;
   }>({ audio: null, video: null });
+  const mutedAudioTrackRef = useRef<CachedMutedAudioTrack | null>(null);
   const subscriptionsRef = useRef<Map<string, RemoteSubscriptionHandle>>(
     new Map(),
   );
@@ -661,6 +671,8 @@ export const LiveRoomProvider = ({
   }, []);
 
   const stopLocalCapture = useCallback(() => {
+    mutedAudioTrackRef.current?.track.stop();
+    mutedAudioTrackRef.current = null;
     localTracksRef.current.audio?.stop();
     localTracksRef.current.video?.stop();
     localTracksRef.current.audio = null;
@@ -1606,6 +1618,10 @@ export const LiveRoomProvider = ({
         if (typeof navigator === 'undefined' || !navigator.mediaDevices) {
           throw new Error('Media devices are not available');
         }
+        if (kind === 'audio') {
+          mutedAudioTrackRef.current?.track.stop();
+          mutedAudioTrackRef.current = null;
+        }
         const stream = await navigator.mediaDevices.getUserMedia(
           buildConstraints(kind, deviceId, nextMicSettings, micSettingSupport),
         );
@@ -1712,13 +1728,61 @@ export const LiveRoomProvider = ({
 
   const toggleMic = useCallback(async () => {
     if (isMicOn) {
-      await stopCapture('audio');
+      const track = localTracksRef.current.audio;
+      await unpublishKind('audio');
+      if (track) {
+        mutedAudioTrackRef.current?.track.stop();
+        track.enabled = false;
+        mutedAudioTrackRef.current = {
+          track,
+          deviceId: selectedMicId,
+          micSettingsSignature: getMicSettingsSignature(micSettings),
+        };
+        localTracksRef.current.audio = null;
+      }
+      refreshLocalStream();
       setIsMicOn(false);
       return;
     }
+
+    const cachedTrack = mutedAudioTrackRef.current;
+    const canReuseMutedTrack =
+      !!cachedTrack &&
+      cachedTrack.track.readyState === 'live' &&
+      cachedTrack.deviceId === selectedMicId &&
+      cachedTrack.micSettingsSignature === getMicSettingsSignature(micSettings);
+
+    if (canReuseMutedTrack && cachedTrack) {
+      mutedAudioTrackRef.current = null;
+      cachedTrack.track.enabled = true;
+      localTracksRef.current.audio = cachedTrack.track;
+      refreshLocalStream();
+      if (
+        sendTransportRef.current &&
+        roomState?.status === 'live' &&
+        canPublish
+      ) {
+        await publishLocalTrack('audio');
+      }
+      setIsMicOn(true);
+      return;
+    }
+
+    cachedTrack?.track.stop();
+    mutedAudioTrackRef.current = null;
     await startCapture('audio', selectedMicId);
     setIsMicOn(true);
-  }, [isMicOn, selectedMicId, startCapture, stopCapture]);
+  }, [
+    canPublish,
+    isMicOn,
+    micSettings,
+    publishLocalTrack,
+    refreshLocalStream,
+    roomState?.status,
+    selectedMicId,
+    startCapture,
+    unpublishKind,
+  ]);
 
   const selectCamera = useCallback(
     async (deviceId: string) => {
@@ -1732,6 +1796,8 @@ export const LiveRoomProvider = ({
 
   const selectMic = useCallback(
     async (deviceId: string) => {
+      mutedAudioTrackRef.current?.track.stop();
+      mutedAudioTrackRef.current = null;
       setSelectedMicId(deviceId);
       if (isMicOn) {
         await startCapture('audio', deviceId);
@@ -1752,6 +1818,8 @@ export const LiveRoomProvider = ({
         [setting]: enabled,
       };
       setMicSettings(nextSettings);
+      mutedAudioTrackRef.current?.track.stop();
+      mutedAudioTrackRef.current = null;
 
       if (!isMicOn) {
         return;


### PR DESCRIPTION
## Summary
Polishes the `/standups/[id]` live-room UX across chat reactions, mic toggling, muted tile behavior, and outbound links.

## What Changed
- let chat reactions stay clickable per emoji while another reaction is still pending
- keep a warm muted mic track so speaker unmute avoids the slow recapture gap
- open standup chat, lobby, embed, and participant links in a new tab
- make the muted tile badge unmute your own tile, and show a short left-expanding `Muted by user` notice for other participants
- collapse that muted notice automatically on leave/blur
- add focused coverage for live-room tile, stage, and embed behavior

## Why
The standup surface had a few small but visible interaction regressions:
- chat reactions briefly felt blocked or flickery because pending state was shared too broadly
- speaker unmute incurred a dead-air gap because audio capture was torn down and rebuilt
- muted tiles did not explain remote mute state clearly, and self tiles did not provide a direct recovery action
- standup links were not consistently opening in a new tab

## Impact
The standup/live-room surface should feel tighter in the common interaction paths without changing broader room semantics.

## Validation
- `node ./scripts/typecheck-strict-changed.js`
- `pnpm --filter shared exec eslint src/components/Markdown.tsx src/components/liveRooms/LiveRoomChatPanel.tsx src/components/liveRooms/LiveRoomChatReactions.tsx src/components/liveRooms/LiveRoomLobby.tsx src/components/contentEmbeds/ContentEmbeds.tsx src/components/liveRooms/LiveRoomVideoTile.tsx src/contexts/LiveRoomContext.tsx src/components/liveRooms/LiveRoom.spec.tsx src/components/contentEmbeds/ContentEmbeds.spec.tsx --max-warnings 0`
- `NODE_ENV=test pnpm --filter shared exec jest src/components/liveRooms/LiveRoom.spec.tsx src/components/contentEmbeds/ContentEmbeds.spec.tsx --runInBand`
- `pnpm --filter shared exec eslint src/components/liveRooms/LiveRoom.tsx src/components/liveRooms/LiveRoomStage.tsx src/components/liveRooms/LiveRoomVideoTile.tsx src/components/liveRooms/LiveRoomStage.spec.tsx src/components/liveRooms/LiveRoomVideoTile.spec.tsx --max-warnings 0`
- `NODE_ENV=test pnpm --filter shared exec jest src/components/liveRooms/LiveRoom.spec.tsx src/components/liveRooms/LiveRoomStage.spec.tsx src/components/liveRooms/LiveRoomVideoTile.spec.tsx --runInBand`

### Preview domain
https://codex-standup-live-room-polish.preview.app.daily.dev