### PR TITLE
feat: add agenda tab and per-standup SEO to standup page

### DIFF
--- a/packages/shared/src/components/liveRooms/LiveRoom.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.tsx
@@ -45,6 +45,7 @@ import {
   LiveRoomSidePanelTabs,
   type LiveRoomSidePanelTab,
 } from './LiveRoomSidePanelTabs';
+import { LiveRoomAgendaPanel } from './LiveRoomAgendaPanel';
 import { LiveRoomControls } from './LiveRoomControls';
 import { LiveRoomHeader } from './LiveRoomHeader';
 import { LiveRoomLobby } from './LiveRoomLobby';
@@ -407,6 +408,9 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
   const isCreated = (roomState?.status ?? room?.status) === 'created';
   const isLive = (roomState?.status ?? room?.status) === 'live';
   const isEnded = roomState?.status === 'ended' || room?.status === 'ended';
+  const hasAgendaContent =
+    !!room?.descriptionHtml ||
+    (!!room?.contentEmbeds && room.contentEmbeds.length > 0);
   const streamTimerReference = isLive ? room?.startedAt ?? null : null;
   const streamDuration = useStreamDuration(streamTimerReference);
   const participantCount = roomState
@@ -452,6 +456,12 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
       setActiveTab('audience');
     }
   }, [activeTab, isFreeForAll]);
+
+  useEffect(() => {
+    if (activeTab === 'agenda' && !hasAgendaContent) {
+      setActiveTab('chat');
+    }
+  }, [activeTab, hasAgendaContent]);
 
   useEffect(() => {
     if (!roomState) {
@@ -573,6 +583,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
       label: 'Audience',
       count: audienceParticipantIds.length,
     },
+    ...(hasAgendaContent ? [{ id: 'agenda' as const, label: 'Agenda' }] : []),
   ];
   const sidePanelTabIds = sidePanelTabs.map((tab) => tab.id);
   const activeTabIndex = sidePanelTabIds.indexOf(activeTab);
@@ -796,9 +807,14 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
             hasAttention={hasUnseenQueueJoins}
           />
           <div {...sidePanelSwipeHandlers} className="min-h-0 flex-1">
-            {activeTab === 'chat' ? (
-              chatPanelNode
-            ) : (
+            {activeTab === 'chat' ? chatPanelNode : null}
+            {activeTab === 'agenda' ? (
+              <LiveRoomAgendaPanel
+                descriptionHtml={room.descriptionHtml}
+                contentEmbeds={room.contentEmbeds}
+              />
+            ) : null}
+            {activeTab === 'queue' || activeTab === 'audience' ? (
               <LiveRoomQueuePanel
                 tab={activeTab}
                 mode={roomMode}
@@ -829,7 +845,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
                   handleKickParticipant(targetParticipantId, 'queue_panel')
                 }
               />
-            )}
+            ) : null}
           </div>
         </aside>
       </div>

--- a/packages/shared/src/components/liveRooms/LiveRoomAgendaPanel.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomAgendaPanel.tsx
@@ -1,0 +1,47 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../typography/Typography';
+import Markdown from '../Markdown';
+import { ContentEmbeds } from '../contentEmbeds/ContentEmbeds';
+import type { ContentEmbed } from '../../graphql/posts';
+
+interface LiveRoomAgendaPanelProps {
+  descriptionHtml?: string | null;
+  contentEmbeds?: ContentEmbed[];
+}
+
+export const LiveRoomAgendaPanel = ({
+  descriptionHtml,
+  contentEmbeds,
+}: LiveRoomAgendaPanelProps): ReactElement => {
+  const hasEmbeds = !!contentEmbeds && contentEmbeds.length > 0;
+  const hasDescription = !!descriptionHtml;
+
+  return (
+    <div className="flex h-full flex-col gap-3 overflow-y-auto p-4 tablet:p-5">
+      {hasDescription ? (
+        <Markdown
+          content={descriptionHtml}
+          className="break-words text-text-primary"
+          openLinksInNewTab
+        />
+      ) : null}
+      {hasEmbeds ? (
+        <ContentEmbeds embeds={contentEmbeds} variant="post" />
+      ) : null}
+      {!hasDescription && !hasEmbeds ? (
+        <Typography
+          type={TypographyType.Callout}
+          color={TypographyColor.Tertiary}
+        >
+          The host hasn&apos;t shared an agenda yet. Drop into the chat to ask
+          what&apos;s on the docket.
+        </Typography>
+      ) : null}
+    </div>
+  );
+};

--- a/packages/shared/src/components/liveRooms/LiveRoomSidePanelTabs.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomSidePanelTabs.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { RaiseHandIcon } from '../icons/RaiseHand';
 import { IconSize } from '../Icon';
 
-export type LiveRoomSidePanelTab = 'chat' | 'queue' | 'audience';
+export type LiveRoomSidePanelTab = 'chat' | 'queue' | 'audience' | 'agenda';
 
 interface LiveRoomSidePanelTabsProps {
   active: LiveRoomSidePanelTab;

--- a/packages/webapp/pages/standups/[id].tsx
+++ b/packages/webapp/pages/standups/[id].tsx
@@ -1,23 +1,36 @@
 import type { ReactElement } from 'react';
 import React from 'react';
 import { useRouter } from 'next/router';
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 import type { NextSeoProps } from 'next-seo';
+import type { ClientError } from 'graphql-request';
 import { Loader } from '@dailydotdev/shared/src/components/Loader';
 import { LiveRoom } from '@dailydotdev/shared/src/components/liveRooms/LiveRoom';
+import { ApiError, gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import {
+  LIVE_ROOM_QUERY,
+  LiveRoomStatus,
+  type LiveRoom as LiveRoomModel,
+  type LiveRoomData,
+} from '@dailydotdev/shared/src/graphql/liveRooms';
+import { stripHtmlTags } from '@dailydotdev/shared/src/lib/strings';
+import { StaleTime } from '@dailydotdev/shared/src/lib/query';
 import { getLayout } from '../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
+import type { DynamicSeoProps } from '../../components/common';
+import { getAppOrigin } from '../../lib/seo';
+import { getTemplatedTitle } from '../../components/layouts/utils';
 
-const seo: NextSeoProps = {
-  title: 'Standup | daily.dev',
-  description: 'Join a developer standup on daily.dev.',
-  openGraph: {
-    ...defaultOpenGraph,
-    type: 'website',
-  },
-  ...defaultSeo,
-  noindex: true,
-  nofollow: true,
-};
+const META_DESCRIPTION_LIMIT = 200;
+
+interface StandupPageParams {
+  id: string;
+  [key: string]: string | string[] | undefined;
+}
+
+interface StandupPageProps extends DynamicSeoProps {
+  id?: string;
+}
 
 const StandupPage = (): ReactElement => {
   const router = useRouter();
@@ -40,7 +53,151 @@ StandupPage.getLayout = getLayout;
 StandupPage.layoutProps = {
   screenCentered: false,
   hideFeedbackWidget: true,
-  seo,
 };
 
 export default StandupPage;
+
+const truncate = (value: string, max: number): string => {
+  const trimmed = value.trim();
+  if (trimmed.length <= max) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, max - 1).trimEnd()}…`;
+};
+
+const formatScheduledTime = (value: string): string => {
+  try {
+    const date = new Date(value);
+    return date.toLocaleString('en-US', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZoneName: 'short',
+    });
+  } catch {
+    return '';
+  }
+};
+
+const buildStandupSeo = (room: LiveRoomModel, url: string): NextSeoProps => {
+  const topic = room.topic.trim();
+  const hostName = room.host?.name ?? 'a daily.dev developer';
+
+  const title = getTemplatedTitle(topic);
+  const ogTopicByStatus: Record<LiveRoomStatus, string> = {
+    [LiveRoomStatus.Live]: `Live: ${topic}`,
+    [LiveRoomStatus.Created]: topic,
+    [LiveRoomStatus.Ended]: topic,
+  };
+  const openGraphTitle = `${ogTopicByStatus[room.status] ?? topic} | daily.dev`;
+
+  const baseDescription = room.description
+    ? stripHtmlTags(room.description)
+    : '';
+  const scheduledLine =
+    room.status === LiveRoomStatus.Created && room.scheduledStart
+      ? `Starts ${formatScheduledTime(room.scheduledStart)}.`
+      : '';
+  const fallbackByStatus: Record<LiveRoomStatus, string> = {
+    [LiveRoomStatus.Live]: `Live now with ${hostName}. Tune in, ask questions, and join the conversation on daily.dev.`,
+    [LiveRoomStatus.Created]:
+      `Hosted by ${hostName}. ${scheduledLine} Listen in, take the mic, and join the conversation on daily.dev.`.trim(),
+    [LiveRoomStatus.Ended]: `This developer standup with ${hostName} has ended. Catch the next one live on daily.dev.`,
+  };
+  const description = truncate(
+    baseDescription ||
+      fallbackByStatus[room.status] ||
+      fallbackByStatus[LiveRoomStatus.Created],
+    META_DESCRIPTION_LIMIT,
+  );
+
+  const openGraphDescription = truncate(
+    baseDescription ||
+      [
+        `Hosted by ${hostName}.`,
+        room.status === LiveRoomStatus.Live ? 'Live now on daily.dev.' : null,
+        room.status === LiveRoomStatus.Created ? scheduledLine : null,
+        'Tune in, ask questions, and join the conversation.',
+      ]
+        .filter(Boolean)
+        .join(' '),
+    META_DESCRIPTION_LIMIT,
+  );
+
+  return {
+    ...defaultSeo,
+    title,
+    description,
+    canonical: url,
+    noindex: true,
+    nofollow: true,
+    openGraph: {
+      ...defaultOpenGraph,
+      type: 'website',
+      url,
+      title: openGraphTitle,
+      description: openGraphDescription,
+    },
+    twitter: {
+      cardType: 'summary_large_image',
+    },
+  };
+};
+
+const fallbackSeo: NextSeoProps = {
+  ...defaultSeo,
+  title: 'Standup | daily.dev',
+  description: 'Join a developer standup on daily.dev.',
+  openGraph: {
+    ...defaultOpenGraph,
+    type: 'website',
+  },
+  noindex: true,
+  nofollow: true,
+};
+
+export async function getServerSideProps({
+  params,
+  res,
+}: GetServerSidePropsContext<StandupPageParams>): Promise<
+  GetServerSidePropsResult<StandupPageProps>
+> {
+  const id = params?.id;
+  if (!id) {
+    return { notFound: true };
+  }
+
+  res.setHeader(
+    'Cache-Control',
+    `public, max-age=0, must-revalidate, s-maxage=${
+      StaleTime.OneMinute / 1000
+    }, stale-while-revalidate=${StaleTime.OneMinute / 1000}`,
+  );
+
+  try {
+    const data = await gqlClient.request<LiveRoomData>(LIVE_ROOM_QUERY, {
+      id,
+    });
+    const url = `${getAppOrigin()}/standups/${id}`;
+    return {
+      props: {
+        id,
+        seo: buildStandupSeo(data.liveRoom, url),
+      },
+    };
+  } catch (err) {
+    const errorCode = (err as ClientError)?.response?.errors?.[0]?.extensions
+      ?.code;
+    if (errorCode === ApiError.NotFound) {
+      return { notFound: true };
+    }
+    return {
+      props: {
+        id,
+        seo: fallbackSeo,
+      },
+    };
+  }
+}

--- a/packages/webapp/pages/standups/[id].tsx
+++ b/packages/webapp/pages/standups/[id].tsx
@@ -4,6 +4,11 @@ import { useRouter } from 'next/router';
 import type { GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
 import type { NextSeoProps } from 'next-seo';
 import type { ClientError } from 'graphql-request';
+import {
+  type DehydratedState,
+  QueryClient,
+  dehydrate,
+} from '@tanstack/react-query';
 import { Loader } from '@dailydotdev/shared/src/components/Loader';
 import { LiveRoom } from '@dailydotdev/shared/src/components/liveRooms/LiveRoom';
 import { ApiError, gqlClient } from '@dailydotdev/shared/src/graphql/common';
@@ -14,7 +19,11 @@ import {
   type LiveRoomData,
 } from '@dailydotdev/shared/src/graphql/liveRooms';
 import { stripHtmlTags } from '@dailydotdev/shared/src/lib/strings';
-import { StaleTime } from '@dailydotdev/shared/src/lib/query';
+import {
+  RequestKey,
+  StaleTime,
+  generateQueryKey,
+} from '@dailydotdev/shared/src/lib/query';
 import { getLayout } from '../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 import type { DynamicSeoProps } from '../../components/common';
@@ -30,6 +39,7 @@ interface StandupPageParams {
 
 interface StandupPageProps extends DynamicSeoProps {
   id?: string;
+  dehydratedState?: DehydratedState;
 }
 
 const StandupPage = (): ReactElement => {
@@ -181,10 +191,16 @@ export async function getServerSideProps({
       id,
     });
     const url = `${getAppOrigin()}/standups/${id}`;
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(
+      generateQueryKey(RequestKey.LiveRooms, undefined, 'detail', id),
+      data.liveRoom,
+    );
     return {
       props: {
         id,
         seo: buildStandupSeo(data.liveRoom, url),
+        dehydratedState: dehydrate(queryClient),
       },
     };
   } catch (err) {


### PR DESCRIPTION
## Summary
- Add an Agenda tab to the live room side panel, rendering the host's description and content embeds. The tab is hidden when there's no agenda content, and falls back to chat if it's cleared mid-session.
- Server-render dynamic title, description, and OG metadata for `/standups/[id]`. Page title uses `getTemplatedTitle(topic)`; OG title is `Live: {topic} | daily.dev` when live, `{topic} | daily.dev` otherwise. Description is sourced from the room (HTML stripped, truncated) with a status-aware host fallback. Default OG image is unchanged.
- `noindex` / `nofollow` preserved.

## Test plan
- [ ] Open a standup in the lobby state — Agenda tab is hidden when the host hasn't set one, visible (and renders Markdown + embeds) when they have.
- [ ] When live, side panel still shows Chat / Queue / Audience / Agenda; swipe between them on mobile.
- [ ] If the host clears the agenda while you're on the Agenda tab, the panel falls back to Chat.
- [ ] View page source / share to Slack: title shows the topic, OG title shows `Live: {topic} | daily.dev` when live, description reflects host + scheduled time when in the lobby.
- [ ] Hitting an unknown standup ID returns 404.

### Preview domain
https://feat-standup-agenda-tab-and-seo.preview.app.daily.dev