### PR TITLE
feat: standup lobby calendar export and brand label

### DIFF
--- a/packages/shared/src/components/liveRooms/LiveRoom.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.tsx
@@ -733,6 +733,12 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
           isHost={isHost}
           onNavigateBack={handleNavigateBack}
           onShare={shareOrCopyStandup}
+          onAddToCalendar={(provider) =>
+            logStandupAction(LogEvent.AddStandupToCalendar, roomId, {
+              surface: 'lobby_hero',
+              provider,
+            })
+          }
           audienceParticipantIds={audienceParticipantIds}
           participantProfilesById={participantProfilesById}
           chatPanel={chatPanelNode}

--- a/packages/shared/src/components/liveRooms/LiveRoomLobby.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomLobby.tsx
@@ -194,6 +194,8 @@ const formatScheduledStart = (value: string): string => {
   })} at ${time}`;
 };
 
+export type AddToCalendarProvider = 'google' | 'outlook' | 'ics';
+
 interface LiveRoomLobbyProps {
   room: LiveRoomModel;
   lobbyCountdown: number;
@@ -206,6 +208,7 @@ interface LiveRoomLobbyProps {
   isHost: boolean;
   onNavigateBack: (surface: string) => void;
   onShare: () => void;
+  onAddToCalendar: (provider: AddToCalendarProvider) => void;
   audienceParticipantIds: string[];
   participantProfilesById: Map<string, UserShortProfile>;
   chatPanel: ReactNode;
@@ -400,6 +403,7 @@ export const LiveRoomLobby = ({
   isHost,
   onNavigateBack,
   onShare,
+  onAddToCalendar,
   audienceParticipantIds,
   participantProfilesById,
   chatPanel,
@@ -426,6 +430,7 @@ export const LiveRoomLobby = ({
         {
           icon: <MenuIcon Icon={GoogleIcon} />,
           label: 'Google Calendar',
+          action: () => onAddToCalendar('google'),
           anchorProps: {
             href: buildGoogleCalendarUrl(calendarEvent),
             target: '_blank',
@@ -435,6 +440,7 @@ export const LiveRoomLobby = ({
         {
           icon: <MenuIcon Icon={MicrosoftIcon} />,
           label: 'Outlook',
+          action: () => onAddToCalendar('outlook'),
           anchorProps: {
             href: buildOutlookCalendarUrl(calendarEvent),
             target: '_blank',
@@ -444,7 +450,10 @@ export const LiveRoomLobby = ({
         {
           icon: <MenuIcon Icon={AppleIcon} />,
           label: 'Apple Calendar (.ics)',
-          action: () => downloadIcs(calendarEvent),
+          action: () => {
+            onAddToCalendar('ics');
+            downloadIcs(calendarEvent);
+          },
         },
       ]
     : [];

--- a/packages/shared/src/components/liveRooms/LiveRoomLobby.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomLobby.tsx
@@ -35,6 +35,13 @@ import {
 import type { MenuItemProps } from '../dropdown/common';
 import type { LiveRoom as LiveRoomModel } from '../../graphql/liveRooms';
 import { anchorDefaultRel, stripHtmlTags } from '../../lib/strings';
+import {
+  buildGoogleCalendarUrl,
+  buildOutlookCalendarUrl,
+  downloadIcs,
+  type AddToCalendarProvider,
+  type CalendarEvent,
+} from '../../lib/calendar';
 import type { UserShortProfile } from '../../lib/user';
 
 const padNumber = (value: number): string => value.toString().padStart(2, '0');
@@ -66,27 +73,7 @@ const getCountdownParts = (totalSeconds: number): CountdownParts => {
   };
 };
 
-const formatCalendarDate = (date: Date): string => {
-  return `${date.toISOString().replace(/[-:]/g, '').split('.')[0]}Z`;
-};
-
-const escapeIcsText = (value: string): string =>
-  value
-    .replace(/\\/g, '\\\\')
-    .replace(/\n/g, '\\n')
-    .replace(/,/g, '\\,')
-    .replace(/;/g, '\\;');
-
-interface CalendarEvent {
-  title: string;
-  description: string;
-  location: string;
-  start: Date;
-  end: Date;
-  id: string;
-}
-
-const buildCalendarEvent = (
+const buildStandupCalendarEvent = (
   room: LiveRoomModel,
   standupUrl: string,
 ): CalendarEvent | null => {
@@ -108,71 +95,8 @@ const buildCalendarEvent = (
     location: standupUrl,
     start,
     end,
-    id: room.id,
+    id: `standup-${room.id}`,
   };
-};
-
-const buildGoogleCalendarUrl = (event: CalendarEvent): string => {
-  const params = new URLSearchParams({
-    action: 'TEMPLATE',
-    text: event.title,
-    dates: `${formatCalendarDate(event.start)}/${formatCalendarDate(
-      event.end,
-    )}`,
-    details: event.description,
-    location: event.location,
-  });
-  return `https://calendar.google.com/calendar/render?${params.toString()}`;
-};
-
-const buildOutlookCalendarUrl = (event: CalendarEvent): string => {
-  const params = new URLSearchParams({
-    path: '/calendar/action/compose',
-    rru: 'addevent',
-    startdt: event.start.toISOString(),
-    enddt: event.end.toISOString(),
-    subject: event.title,
-    body: event.description,
-    location: event.location,
-  });
-  return `https://outlook.live.com/calendar/0/deeplink/compose?${params.toString()}`;
-};
-
-const buildIcsContent = (event: CalendarEvent): string =>
-  [
-    'BEGIN:VCALENDAR',
-    'VERSION:2.0',
-    'PRODID:-//daily.dev//Standup//EN',
-    'CALSCALE:GREGORIAN',
-    'METHOD:PUBLISH',
-    'BEGIN:VEVENT',
-    `UID:standup-${event.id}@daily.dev`,
-    `DTSTAMP:${formatCalendarDate(new Date())}`,
-    `DTSTART:${formatCalendarDate(event.start)}`,
-    `DTEND:${formatCalendarDate(event.end)}`,
-    `SUMMARY:${escapeIcsText(event.title)}`,
-    `DESCRIPTION:${escapeIcsText(event.description)}`,
-    `LOCATION:${escapeIcsText(event.location)}`,
-    `URL:${event.location}`,
-    'END:VEVENT',
-    'END:VCALENDAR',
-  ].join('\r\n');
-
-const downloadIcs = (event: CalendarEvent): void => {
-  if (typeof window === 'undefined') {
-    return;
-  }
-  const blob = new Blob([buildIcsContent(event)], {
-    type: 'text/calendar;charset=utf-8',
-  });
-  const url = URL.createObjectURL(blob);
-  const anchor = document.createElement('a');
-  anchor.href = url;
-  anchor.download = `daily-dev-standup-${event.id}.ics`;
-  document.body.appendChild(anchor);
-  anchor.click();
-  document.body.removeChild(anchor);
-  URL.revokeObjectURL(url);
 };
 
 const formatScheduledStart = (value: string): string => {
@@ -193,8 +117,6 @@ const formatScheduledStart = (value: string): string => {
     day: 'numeric',
   })} at ${time}`;
 };
-
-export type AddToCalendarProvider = 'google' | 'outlook' | 'ics';
 
 interface LiveRoomLobbyProps {
   room: LiveRoomModel;
@@ -422,7 +344,7 @@ export const LiveRoomLobby = ({
   }, [room.id]);
   const calendarEvent =
     hasScheduledStart && standupFullUrl
-      ? buildCalendarEvent(room, standupFullUrl)
+      ? buildStandupCalendarEvent(room, standupFullUrl)
       : null;
   const [calendarMenuOpen, setCalendarMenuOpen] = useState(false);
   const calendarOptions: MenuItemProps[] = calendarEvent

--- a/packages/shared/src/components/liveRooms/LiveRoomLobby.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomLobby.tsx
@@ -116,7 +116,9 @@ const buildGoogleCalendarUrl = (event: CalendarEvent): string => {
   const params = new URLSearchParams({
     action: 'TEMPLATE',
     text: event.title,
-    dates: `${formatCalendarDate(event.start)}/${formatCalendarDate(event.end)}`,
+    dates: `${formatCalendarDate(event.start)}/${formatCalendarDate(
+      event.end,
+    )}`,
     details: event.description,
     location: event.location,
   });

--- a/packages/shared/src/components/liveRooms/LiveRoomLobby.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomLobby.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from 'react';
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import classNames from 'classnames';
 import { addDays, isSameDay } from 'date-fns';
 import {
@@ -13,23 +13,38 @@ import { ProfilePicture, ProfileImageSize } from '../ProfilePicture';
 import Markdown from '../Markdown';
 import { ContentEmbeds } from '../contentEmbeds/ContentEmbeds';
 import {
+  AppleIcon,
   ArrowIcon,
   BellIcon,
   CalendarIcon,
   DiscussIcon,
+  GoogleIcon,
   MegaphoneIcon,
+  MicrosoftIcon,
   ShareIcon,
 } from '../icons';
 import { RaiseHandIcon } from '../icons/RaiseHand';
 import { IconSize } from '../Icon';
+import { MenuIcon } from '../MenuIcon';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuOptions,
+  DropdownMenuTrigger,
+} from '../dropdown/DropdownMenu';
+import type { MenuItemProps } from '../dropdown/common';
 import type { LiveRoom as LiveRoomModel } from '../../graphql/liveRooms';
-import { anchorDefaultRel } from '../../lib/strings';
+import { anchorDefaultRel, stripHtmlTags } from '../../lib/strings';
 import type { UserShortProfile } from '../../lib/user';
 
 const padNumber = (value: number): string => value.toString().padStart(2, '0');
 
+const STANDUP_DURATION_MINUTES = 20;
+
 interface CountdownParts {
+  hasDays: boolean;
   hasHours: boolean;
+  days: string;
   hours: string;
   minutes: string;
   seconds: string;
@@ -37,15 +52,125 @@ interface CountdownParts {
 
 const getCountdownParts = (totalSeconds: number): CountdownParts => {
   const safeSeconds = Math.max(0, Math.floor(totalSeconds));
-  const hours = Math.floor(safeSeconds / 3600);
+  const days = Math.floor(safeSeconds / 86400);
+  const hours = Math.floor((safeSeconds % 86400) / 3600);
   const minutes = Math.floor((safeSeconds % 3600) / 60);
   const seconds = safeSeconds % 60;
   return {
-    hasHours: hours > 0,
+    hasDays: days > 0,
+    hasHours: hours > 0 || days > 0,
+    days: padNumber(days),
     hours: padNumber(hours),
     minutes: padNumber(minutes),
     seconds: padNumber(seconds),
   };
+};
+
+const formatCalendarDate = (date: Date): string => {
+  return `${date.toISOString().replace(/[-:]/g, '').split('.')[0]}Z`;
+};
+
+const escapeIcsText = (value: string): string =>
+  value
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/,/g, '\\,')
+    .replace(/;/g, '\\;');
+
+interface CalendarEvent {
+  title: string;
+  description: string;
+  location: string;
+  start: Date;
+  end: Date;
+  id: string;
+}
+
+const buildCalendarEvent = (
+  room: LiveRoomModel,
+  standupUrl: string,
+): CalendarEvent | null => {
+  if (!room.scheduledStart) {
+    return null;
+  }
+  const start = new Date(room.scheduledStart);
+  if (Number.isNaN(start.getTime())) {
+    return null;
+  }
+  const end = new Date(start.getTime() + STANDUP_DURATION_MINUTES * 60 * 1000);
+  const plainDescription = room.description
+    ? stripHtmlTags(room.description).trim()
+    : '';
+  return {
+    title: `daily.dev Standup: ${room.topic}`,
+    description:
+      plainDescription || `Join the standup on daily.dev: ${standupUrl}`,
+    location: standupUrl,
+    start,
+    end,
+    id: room.id,
+  };
+};
+
+const buildGoogleCalendarUrl = (event: CalendarEvent): string => {
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: event.title,
+    dates: `${formatCalendarDate(event.start)}/${formatCalendarDate(event.end)}`,
+    details: event.description,
+    location: event.location,
+  });
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+};
+
+const buildOutlookCalendarUrl = (event: CalendarEvent): string => {
+  const params = new URLSearchParams({
+    path: '/calendar/action/compose',
+    rru: 'addevent',
+    startdt: event.start.toISOString(),
+    enddt: event.end.toISOString(),
+    subject: event.title,
+    body: event.description,
+    location: event.location,
+  });
+  return `https://outlook.live.com/calendar/0/deeplink/compose?${params.toString()}`;
+};
+
+const buildIcsContent = (event: CalendarEvent): string =>
+  [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//daily.dev//Standup//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    'BEGIN:VEVENT',
+    `UID:standup-${event.id}@daily.dev`,
+    `DTSTAMP:${formatCalendarDate(new Date())}`,
+    `DTSTART:${formatCalendarDate(event.start)}`,
+    `DTEND:${formatCalendarDate(event.end)}`,
+    `SUMMARY:${escapeIcsText(event.title)}`,
+    `DESCRIPTION:${escapeIcsText(event.description)}`,
+    `LOCATION:${escapeIcsText(event.location)}`,
+    `URL:${event.location}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\r\n');
+
+const downloadIcs = (event: CalendarEvent): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const blob = new Blob([buildIcsContent(event)], {
+    type: 'text/calendar;charset=utf-8',
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = `daily-dev-standup-${event.id}.ics`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
 };
 
 const formatScheduledStart = (value: string): string => {
@@ -120,11 +245,16 @@ const CountdownDisplay = ({
   ariaLabel,
 }: CountdownDisplayProps): ReactElement => {
   const segments = [
+    ...(parts.hasDays
+      ? [{ key: 'days', value: parts.days, label: 'Days' }]
+      : []),
     ...(parts.hasHours
       ? [{ key: 'hours', value: parts.hours, label: 'Hours' }]
       : []),
     { key: 'minutes', value: parts.minutes, label: 'Minutes' },
-    { key: 'seconds', value: parts.seconds, label: 'Seconds' },
+    ...(parts.hasDays
+      ? []
+      : [{ key: 'seconds', value: parts.seconds, label: 'Seconds' }]),
   ];
 
   return (
@@ -278,6 +408,44 @@ export const LiveRoomLobby = ({
   const countdownLabel = isStartingNow ? 'Starting any moment' : 'Goes live in';
   const countdownParts = getCountdownParts(lobbyCountdown);
   const hasEmbeds = !!room.contentEmbeds && room.contentEmbeds.length > 0;
+  const standupFullUrl = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return '';
+    }
+    return `${window.location.origin}/standups/${room.id}`;
+  }, [room.id]);
+  const calendarEvent =
+    hasScheduledStart && standupFullUrl
+      ? buildCalendarEvent(room, standupFullUrl)
+      : null;
+  const [calendarMenuOpen, setCalendarMenuOpen] = useState(false);
+  const calendarOptions: MenuItemProps[] = calendarEvent
+    ? [
+        {
+          icon: <MenuIcon Icon={GoogleIcon} />,
+          label: 'Google Calendar',
+          anchorProps: {
+            href: buildGoogleCalendarUrl(calendarEvent),
+            target: '_blank',
+            rel: anchorDefaultRel,
+          },
+        },
+        {
+          icon: <MenuIcon Icon={MicrosoftIcon} />,
+          label: 'Outlook',
+          anchorProps: {
+            href: buildOutlookCalendarUrl(calendarEvent),
+            target: '_blank',
+            rel: anchorDefaultRel,
+          },
+        },
+        {
+          icon: <MenuIcon Icon={AppleIcon} />,
+          label: 'Apple Calendar (.ics)',
+          action: () => downloadIcs(calendarEvent),
+        },
+      ]
+    : [];
   const audienceProfiles = audienceParticipantIds
     .map((id) => participantProfilesById.get(id))
     .filter((profile): profile is UserShortProfile => !!profile);
@@ -305,6 +473,12 @@ export const LiveRoomLobby = ({
             >
               <div className="flex flex-col gap-5 p-5 tablet:gap-7 tablet:p-8">
                 <div className="flex flex-col gap-3">
+                  <Typography
+                    type={TypographyType.Caption1}
+                    className="font-bold uppercase tracking-[0.18em] text-accent-bacon-default"
+                  >
+                    daily.dev Standup
+                  </Typography>
                   <Typography
                     tag={TypographyTag.H1}
                     type={TypographyType.LargeTitle}
@@ -368,7 +542,6 @@ export const LiveRoomLobby = ({
                       loading={subscriptionBusy}
                       disabled={subscriptionBusy}
                       onClick={onToggleSubscription}
-                      className="flex-1 tablet:flex-none"
                     >
                       {subscribed ? 'Reminder set' : 'Remind me'}
                     </Button>
@@ -378,14 +551,30 @@ export const LiveRoomLobby = ({
                     variant={ButtonVariant.Secondary}
                     icon={<ShareIcon />}
                     onClick={onShare}
-                    className={
-                      canSubscribeToLobby
-                        ? 'flex-none'
-                        : 'flex-1 tablet:flex-none'
-                    }
                   >
                     Share
                   </Button>
+                  {calendarEvent ? (
+                    <DropdownMenu
+                      open={calendarMenuOpen}
+                      onOpenChange={setCalendarMenuOpen}
+                    >
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          type="button"
+                          variant={ButtonVariant.Secondary}
+                          icon={<CalendarIcon secondary />}
+                        >
+                          Add to calendar
+                        </Button>
+                      </DropdownMenuTrigger>
+                      {calendarMenuOpen ? (
+                        <DropdownMenuContent>
+                          <DropdownMenuOptions options={calendarOptions} />
+                        </DropdownMenuContent>
+                      ) : null}
+                    </DropdownMenu>
+                  ) : null}
                 </div>
 
                 <div className="flex flex-col gap-4 border-t border-border-subtlest-tertiary pt-5 tablet:gap-5 tablet:pt-7">
@@ -401,12 +590,18 @@ export const LiveRoomLobby = ({
                     <CountdownDisplay
                       parts={countdownParts}
                       ariaLabel={`${countdownLabel} ${
+                        countdownParts.hasDays
+                          ? `${countdownParts.days} days `
+                          : ''
+                      }${
                         countdownParts.hasHours
                           ? `${countdownParts.hours} hours `
                           : ''
-                      }${countdownParts.minutes} minutes ${
-                        countdownParts.seconds
-                      } seconds`}
+                      }${countdownParts.minutes} minutes${
+                        countdownParts.hasDays
+                          ? ''
+                          : ` ${countdownParts.seconds} seconds`
+                      }`}
                     />
                   ) : (
                     <Typography

--- a/packages/shared/src/lib/calendar.ts
+++ b/packages/shared/src/lib/calendar.ts
@@ -1,0 +1,90 @@
+export type AddToCalendarProvider = 'google' | 'outlook' | 'ics';
+
+export interface CalendarEvent {
+  title: string;
+  description: string;
+  location: string;
+  start: Date;
+  end: Date;
+  id: string;
+}
+
+const formatCalendarDate = (date: Date): string =>
+  `${date.toISOString().replace(/[-:]/g, '').split('.')[0]}Z`;
+
+const escapeIcsText = (value: string): string =>
+  value
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/,/g, '\\,')
+    .replace(/;/g, '\\;');
+
+export const buildGoogleCalendarUrl = (event: CalendarEvent): string => {
+  const params = new URLSearchParams({
+    action: 'TEMPLATE',
+    text: event.title,
+    dates: `${formatCalendarDate(event.start)}/${formatCalendarDate(
+      event.end,
+    )}`,
+    details: event.description,
+    location: event.location,
+  });
+  return `https://calendar.google.com/calendar/render?${params.toString()}`;
+};
+
+export const buildOutlookCalendarUrl = (event: CalendarEvent): string => {
+  const params = new URLSearchParams({
+    path: '/calendar/action/compose',
+    rru: 'addevent',
+    startdt: event.start.toISOString(),
+    enddt: event.end.toISOString(),
+    subject: event.title,
+    body: event.description,
+    location: event.location,
+  });
+  return `https://outlook.live.com/calendar/0/deeplink/compose?${params.toString()}`;
+};
+
+export const buildIcsContent = (event: CalendarEvent): string =>
+  [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//daily.dev//Calendar//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    'BEGIN:VEVENT',
+    `UID:${event.id}@daily.dev`,
+    `DTSTAMP:${formatCalendarDate(new Date())}`,
+    `DTSTART:${formatCalendarDate(event.start)}`,
+    `DTEND:${formatCalendarDate(event.end)}`,
+    `SUMMARY:${escapeIcsText(event.title)}`,
+    `DESCRIPTION:${escapeIcsText(event.description)}`,
+    `LOCATION:${escapeIcsText(event.location)}`,
+    `URL:${event.location}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ].join('\r\n');
+
+interface DownloadIcsOptions {
+  filename?: string;
+}
+
+export const downloadIcs = (
+  event: CalendarEvent,
+  { filename }: DownloadIcsOptions = {},
+): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  const blob = new Blob([buildIcsContent(event)], {
+    type: 'text/calendar;charset=utf-8',
+  });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename ?? `${event.id}.ics`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+};

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -280,6 +280,7 @@ export enum LogEvent {
   SubscribeStandup = 'subscribe standup',
   UnsubscribeStandup = 'unsubscribe standup',
   ShareStandup = 'share standup',
+  AddStandupToCalendar = 'add standup to calendar',
   GrantStandupCoHost = 'grant standup co-host',
   RevokeStandupCoHost = 'revoke standup co-host',
   PromoteStandupSpeaker = 'promote standup speaker',


### PR DESCRIPTION
## Summary
- Countdown now shows days when the standup is more than a day out, dropping seconds in that case so the layout stays at 3 segments and doesn't truncate on mobile.
- New **Add to calendar** dropdown next to Remind me / Share with Google Calendar, Outlook, and Apple Calendar (.ics download) options. Title is `daily.dev Standup: <topic>`, duration 20m, location/description use the full standup URL and the host's HTML-stripped description.
- Small `daily.dev Standup` brand label above the topic so users learn the feature name.
- Action row uses `flex-wrap` so the three buttons drop to a new line on narrow screens.

## Test plan
- [ ] Schedule a standup >1 day out and confirm countdown shows Days/Hours/Minutes (no seconds), no horizontal overflow on mobile width.
- [ ] Schedule a standup <1 day out and confirm Hours/Minutes/Seconds still works.
- [ ] Click **Add to calendar** → Google Calendar opens with correct title, time window (20m), location (full URL), description.
- [ ] Click **Add to calendar** → Outlook opens with the same fields populated.
- [ ] Click **Add to calendar** → Apple Calendar (.ics) downloads a file that imports cleanly into Apple Calendar / Outlook desktop.
- [ ] Confirm the brand label sits above the topic and reads "daily.dev Standup".
- [ ] Verify on narrow mobile that Remind me / Share / Add to calendar wrap to a new line.

### Preview domain
https://standup-lobby-calendar.preview.app.daily.dev