### PR TITLE
chore: move notification banners under shared/components/marketing

### DIFF
--- a/packages/shared/src/components/BookmarkFeedLayout.tsx
+++ b/packages/shared/src/components/BookmarkFeedLayout.tsx
@@ -28,7 +28,7 @@ import { generateQueryKey, OtherFeedPage, RequestKey } from '../lib/query';
 import { useFeedLayout, useViewSize, ViewSize } from '../hooks';
 import { BookmarkSection } from './sidebar/sections/BookmarkSection';
 import PlusMobileEntryBanner from './marketing/banners/PlusMobileEntryBanner';
-import { DigestBookmarkBanner } from './notifications/DigestBookmarkBanner';
+import { DigestBookmarkBanner } from './marketing/banners/DigestBookmarkBanner';
 import {
   Typography,
   TypographyTag,

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -14,7 +14,7 @@ import Feed from './Feed';
 import ReadingReminderHero from './marketing/banners/ReadingReminderHero';
 import ShortcutsExtensionPromo from './marketing/banners/ShortcutsExtensionPromo';
 import { WebappShortcutsRow } from '../features/shortcuts/components/WebappShortcutsRow';
-import { AskSearchBanner } from './notifications/AskSearchBanner';
+import { AskSearchBanner } from './marketing/banners/AskSearchBanner';
 import AuthContext from '../contexts/AuthContext';
 import type { LoggedUser } from '../lib/user';
 import { SharedFeedPage } from './utilities';

--- a/packages/shared/src/components/marketing/banners/AskSearchBanner.spec.tsx
+++ b/packages/shared/src/components/marketing/banners/AskSearchBanner.spec.tsx
@@ -2,23 +2,23 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AskSearchBanner } from './AskSearchBanner';
-import { LogEvent, TargetId } from '../../lib/log';
-import { ActionType } from '../../graphql/actions';
+import { LogEvent, TargetId } from '../../../lib/log';
+import { ActionType } from '../../../graphql/actions';
 
 const mockLogEvent = jest.fn();
 const mockCompleteAction = jest.fn().mockResolvedValue(undefined);
 const mockCheckHasCompleted = jest.fn();
 const mockUseAuthContext = jest.fn();
 
-jest.mock('../../contexts/LogContext', () => ({
+jest.mock('../../../contexts/LogContext', () => ({
   useLogContext: () => ({ logEvent: mockLogEvent }),
 }));
 
-jest.mock('../../contexts/AuthContext', () => ({
+jest.mock('../../../contexts/AuthContext', () => ({
   useAuthContext: () => mockUseAuthContext(),
 }));
 
-jest.mock('../../hooks/useActions', () => ({
+jest.mock('../../../hooks/useActions', () => ({
   useActions: () => ({
     checkHasCompleted: mockCheckHasCompleted,
     completeAction: mockCompleteAction,
@@ -26,7 +26,7 @@ jest.mock('../../hooks/useActions', () => ({
   }),
 }));
 
-jest.mock('../../lib/constants', () => ({
+jest.mock('../../../lib/constants', () => ({
   webappUrl: 'http://localhost/',
 }));
 

--- a/packages/shared/src/components/marketing/banners/AskSearchBanner.tsx
+++ b/packages/shared/src/components/marketing/banners/AskSearchBanner.tsx
@@ -6,15 +6,15 @@ import {
   ButtonColor,
   ButtonSize,
   ButtonVariant,
-} from '../buttons/Button';
-import CloseButton from '../CloseButton';
-import { MagicIcon } from '../icons';
-import { LogEvent, TargetId } from '../../lib/log';
-import { useLogContext } from '../../contexts/LogContext';
-import { useAuthContext } from '../../contexts/AuthContext';
-import { useActions } from '../../hooks/useActions';
-import { ActionType } from '../../graphql/actions';
-import { webappUrl } from '../../lib/constants';
+} from '../../buttons/Button';
+import CloseButton from '../../CloseButton';
+import { MagicIcon } from '../../icons';
+import { LogEvent, TargetId } from '../../../lib/log';
+import { useLogContext } from '../../../contexts/LogContext';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { useActions } from '../../../hooks/useActions';
+import { ActionType } from '../../../graphql/actions';
+import { webappUrl } from '../../../lib/constants';
 
 interface AskSearchBannerProps {
   className?: string;

--- a/packages/shared/src/components/marketing/banners/DigestBookmarkBanner.spec.tsx
+++ b/packages/shared/src/components/marketing/banners/DigestBookmarkBanner.spec.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { DigestUpsellBanner } from './DigestUpsellBanner';
-import { LogEvent, TargetId } from '../../lib/log';
-import { UserPersonalizedDigestType } from '../../graphql/users';
-import { ActionType } from '../../graphql/actions';
+import { DigestBookmarkBanner } from './DigestBookmarkBanner';
+import { LogEvent, TargetId } from '../../../lib/log';
+import { UserPersonalizedDigestType } from '../../../graphql/users';
+import { ActionType } from '../../../graphql/actions';
 
 const mockLogEvent = jest.fn();
 const mockGetPersonalizedDigest = jest.fn();
@@ -15,19 +15,19 @@ const mockUsePlusSubscription = jest.fn();
 const mockSetNotificationStatuses = jest.fn();
 const mockDisplayToast = jest.fn();
 
-jest.mock('../../contexts/LogContext', () => ({
+jest.mock('../../../contexts/LogContext', () => ({
   useLogContext: () => ({ logEvent: mockLogEvent }),
 }));
 
-jest.mock('../../contexts/AuthContext', () => ({
+jest.mock('../../../contexts/AuthContext', () => ({
   useAuthContext: () => ({ isAuthReady: true }),
 }));
 
-jest.mock('../../hooks/usePlusSubscription', () => ({
+jest.mock('../../../hooks/usePlusSubscription', () => ({
   usePlusSubscription: () => mockUsePlusSubscription(),
 }));
 
-jest.mock('../../hooks/usePersonalizedDigest', () => ({
+jest.mock('../../../hooks/usePersonalizedDigest', () => ({
   usePersonalizedDigest: () => ({
     getPersonalizedDigest: mockGetPersonalizedDigest,
     subscribePersonalizedDigest: mockSubscribePersonalizedDigest,
@@ -35,7 +35,7 @@ jest.mock('../../hooks/usePersonalizedDigest', () => ({
   SendType: { Workdays: 'workdays', Daily: 'daily', Weekly: 'weekly' },
 }));
 
-jest.mock('../../hooks/useActions', () => ({
+jest.mock('../../../hooks/useActions', () => ({
   useActions: () => ({
     checkHasCompleted: mockCheckHasCompleted,
     completeAction: mockCompleteAction,
@@ -43,14 +43,14 @@ jest.mock('../../hooks/useActions', () => ({
   }),
 }));
 
-jest.mock('../../hooks/notifications/useNotificationSettings', () => ({
+jest.mock('../../../hooks/notifications/useNotificationSettings', () => ({
   __esModule: true,
   default: () => ({
     setNotificationStatusBulk: mockSetNotificationStatuses,
   }),
 }));
 
-jest.mock('../../hooks/useToastNotification', () => ({
+jest.mock('../../../hooks/useToastNotification', () => ({
   useToastNotification: () => ({
     displayToast: mockDisplayToast,
   }),
@@ -61,11 +61,11 @@ const client = new QueryClient();
 const renderComponent = () =>
   render(
     <QueryClientProvider client={client}>
-      <DigestUpsellBanner />
+      <DigestBookmarkBanner />
     </QueryClientProvider>,
   );
 
-describe('DigestUpsellBanner', () => {
+describe('DigestBookmarkBanner', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUsePlusSubscription.mockReturnValue({ isPlus: false });
@@ -77,7 +77,7 @@ describe('DigestUpsellBanner', () => {
     renderComponent();
 
     expect(
-      screen.getByText('Get the must-read posts delivered daily'),
+      screen.getByText('Not sure what to read? Let us pick for you'),
     ).toBeInTheDocument();
     expect(screen.getByText('Enable digest')).toBeInTheDocument();
   });
@@ -88,7 +88,7 @@ describe('DigestUpsellBanner', () => {
     renderComponent();
 
     expect(
-      screen.queryByText('Get the must-read posts delivered daily'),
+      screen.queryByText('Not sure what to read? Let us pick for you'),
     ).not.toBeInTheDocument();
   });
 
@@ -107,7 +107,7 @@ describe('DigestUpsellBanner', () => {
     renderComponent();
 
     expect(
-      screen.queryByText('Get the must-read posts delivered daily'),
+      screen.queryByText('Not sure what to read? Let us pick for you'),
     ).not.toBeInTheDocument();
   });
 
@@ -117,7 +117,7 @@ describe('DigestUpsellBanner', () => {
     renderComponent();
 
     expect(
-      screen.queryByText('Get the must-read posts delivered daily'),
+      screen.queryByText('Not sure what to read? Let us pick for you'),
     ).not.toBeInTheDocument();
   });
 
@@ -126,7 +126,7 @@ describe('DigestUpsellBanner', () => {
 
     expect(mockLogEvent).toHaveBeenCalledWith({
       event_name: LogEvent.Impression,
-      target_id: TargetId.DigestUpsell,
+      target_id: TargetId.DigestUpsellBookmarks,
     });
   });
 
@@ -138,7 +138,7 @@ describe('DigestUpsellBanner', () => {
 
     expect(mockLogEvent).toHaveBeenCalledWith({
       event_name: LogEvent.Click,
-      target_id: TargetId.DigestUpsell,
+      target_id: TargetId.DigestUpsellBookmarks,
     });
 
     await waitFor(() => {
@@ -172,7 +172,7 @@ describe('DigestUpsellBanner', () => {
 
     expect(mockLogEvent).toHaveBeenCalledWith({
       event_name: LogEvent.Click,
-      target_id: TargetId.DigestUpsell,
+      target_id: TargetId.DigestUpsellBookmarks,
       extra: JSON.stringify({ action: 'dismiss' }),
     });
     await waitFor(() => {

--- a/packages/shared/src/components/marketing/banners/DigestBookmarkBanner.tsx
+++ b/packages/shared/src/components/marketing/banners/DigestBookmarkBanner.tsx
@@ -5,26 +5,26 @@ import {
   ButtonColor,
   ButtonSize,
   ButtonVariant,
-} from '../buttons/Button';
-import CloseButton from '../CloseButton';
-import { MailIcon } from '../icons';
-import { LogEvent, TargetId } from '../../lib/log';
-import { useLogContext } from '../../contexts/LogContext';
-import { useAuthContext } from '../../contexts/AuthContext';
-import { usePlusSubscription } from '../../hooks/usePlusSubscription';
+} from '../../buttons/Button';
+import CloseButton from '../../CloseButton';
+import { MailIcon } from '../../icons';
+import { LogEvent, TargetId } from '../../../lib/log';
+import { useLogContext } from '../../../contexts/LogContext';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { usePlusSubscription } from '../../../hooks/usePlusSubscription';
 import {
   usePersonalizedDigest,
   SendType,
-} from '../../hooks/usePersonalizedDigest';
-import { UserPersonalizedDigestType } from '../../graphql/users';
-import { useActions } from '../../hooks/useActions';
-import { ActionType } from '../../graphql/actions';
-import useNotificationSettings from '../../hooks/notifications/useNotificationSettings';
-import { NotificationType } from './utils';
-import { NotificationPreferenceStatus } from '../../graphql/notifications';
-import { useToastNotification } from '../../hooks/useToastNotification';
+} from '../../../hooks/usePersonalizedDigest';
+import { UserPersonalizedDigestType } from '../../../graphql/users';
+import { useActions } from '../../../hooks/useActions';
+import { ActionType } from '../../../graphql/actions';
+import useNotificationSettings from '../../../hooks/notifications/useNotificationSettings';
+import { NotificationType } from '../../notifications/utils';
+import { NotificationPreferenceStatus } from '../../../graphql/notifications';
+import { useToastNotification } from '../../../hooks/useToastNotification';
 
-export function DigestUpsellBanner(): ReactElement | null {
+export function DigestBookmarkBanner(): ReactElement | null {
   const { logEvent } = useLogContext();
   const { isAuthReady } = useAuthContext();
   const { isPlus } = usePlusSubscription();
@@ -45,7 +45,7 @@ export function DigestUpsellBanner(): ReactElement | null {
       impressionLogged.current = true;
       logEvent({
         event_name: LogEvent.Impression,
-        target_id: TargetId.DigestUpsell,
+        target_id: TargetId.DigestUpsellBookmarks,
       });
     }
   }, [showBanner, logEvent]);
@@ -57,7 +57,7 @@ export function DigestUpsellBanner(): ReactElement | null {
   const onEnable = async () => {
     logEvent({
       event_name: LogEvent.Click,
-      target_id: TargetId.DigestUpsell,
+      target_id: TargetId.DigestUpsellBookmarks,
     });
 
     try {
@@ -91,21 +91,21 @@ export function DigestUpsellBanner(): ReactElement | null {
   const onDismiss = async () => {
     logEvent({
       event_name: LogEvent.Click,
-      target_id: TargetId.DigestUpsell,
+      target_id: TargetId.DigestUpsellBookmarks,
       extra: JSON.stringify({ action: 'dismiss' }),
     });
     await completeAction(ActionType.DigestUpsell);
   };
 
   return (
-    <div className="relative w-full overflow-hidden border-l border-accent-cabbage-default bg-surface-float px-6 py-4 typo-callout">
+    <div className="relative mx-4 mb-4 overflow-hidden rounded-16 border border-accent-cabbage-default bg-surface-float px-6 py-4 typo-callout laptop:mx-auto laptop:max-w-[40rem]">
       <span className="flex flex-row items-center font-bold">
         <MailIcon className="mr-2" />
-        Get the must-read posts delivered daily
+        Not sure what to read? Let us pick for you
       </span>
       <p className="mt-2 text-text-tertiary">
-        A personalized digest with top posts from your favorite topics, straight
-        to your inbox.
+        Get a daily digest with the best posts from your favorite topics,
+        straight to your inbox.
       </p>
       <div className="mt-3 flex items-center">
         <Button

--- a/packages/shared/src/components/marketing/banners/DigestUpsellBanner.spec.tsx
+++ b/packages/shared/src/components/marketing/banners/DigestUpsellBanner.spec.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { DigestBookmarkBanner } from './DigestBookmarkBanner';
-import { LogEvent, TargetId } from '../../lib/log';
-import { UserPersonalizedDigestType } from '../../graphql/users';
-import { ActionType } from '../../graphql/actions';
+import { DigestUpsellBanner } from './DigestUpsellBanner';
+import { LogEvent, TargetId } from '../../../lib/log';
+import { UserPersonalizedDigestType } from '../../../graphql/users';
+import { ActionType } from '../../../graphql/actions';
 
 const mockLogEvent = jest.fn();
 const mockGetPersonalizedDigest = jest.fn();
@@ -15,19 +15,19 @@ const mockUsePlusSubscription = jest.fn();
 const mockSetNotificationStatuses = jest.fn();
 const mockDisplayToast = jest.fn();
 
-jest.mock('../../contexts/LogContext', () => ({
+jest.mock('../../../contexts/LogContext', () => ({
   useLogContext: () => ({ logEvent: mockLogEvent }),
 }));
 
-jest.mock('../../contexts/AuthContext', () => ({
+jest.mock('../../../contexts/AuthContext', () => ({
   useAuthContext: () => ({ isAuthReady: true }),
 }));
 
-jest.mock('../../hooks/usePlusSubscription', () => ({
+jest.mock('../../../hooks/usePlusSubscription', () => ({
   usePlusSubscription: () => mockUsePlusSubscription(),
 }));
 
-jest.mock('../../hooks/usePersonalizedDigest', () => ({
+jest.mock('../../../hooks/usePersonalizedDigest', () => ({
   usePersonalizedDigest: () => ({
     getPersonalizedDigest: mockGetPersonalizedDigest,
     subscribePersonalizedDigest: mockSubscribePersonalizedDigest,
@@ -35,7 +35,7 @@ jest.mock('../../hooks/usePersonalizedDigest', () => ({
   SendType: { Workdays: 'workdays', Daily: 'daily', Weekly: 'weekly' },
 }));
 
-jest.mock('../../hooks/useActions', () => ({
+jest.mock('../../../hooks/useActions', () => ({
   useActions: () => ({
     checkHasCompleted: mockCheckHasCompleted,
     completeAction: mockCompleteAction,
@@ -43,14 +43,14 @@ jest.mock('../../hooks/useActions', () => ({
   }),
 }));
 
-jest.mock('../../hooks/notifications/useNotificationSettings', () => ({
+jest.mock('../../../hooks/notifications/useNotificationSettings', () => ({
   __esModule: true,
   default: () => ({
     setNotificationStatusBulk: mockSetNotificationStatuses,
   }),
 }));
 
-jest.mock('../../hooks/useToastNotification', () => ({
+jest.mock('../../../hooks/useToastNotification', () => ({
   useToastNotification: () => ({
     displayToast: mockDisplayToast,
   }),
@@ -61,11 +61,11 @@ const client = new QueryClient();
 const renderComponent = () =>
   render(
     <QueryClientProvider client={client}>
-      <DigestBookmarkBanner />
+      <DigestUpsellBanner />
     </QueryClientProvider>,
   );
 
-describe('DigestBookmarkBanner', () => {
+describe('DigestUpsellBanner', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUsePlusSubscription.mockReturnValue({ isPlus: false });
@@ -77,7 +77,7 @@ describe('DigestBookmarkBanner', () => {
     renderComponent();
 
     expect(
-      screen.getByText('Not sure what to read? Let us pick for you'),
+      screen.getByText('Get the must-read posts delivered daily'),
     ).toBeInTheDocument();
     expect(screen.getByText('Enable digest')).toBeInTheDocument();
   });
@@ -88,7 +88,7 @@ describe('DigestBookmarkBanner', () => {
     renderComponent();
 
     expect(
-      screen.queryByText('Not sure what to read? Let us pick for you'),
+      screen.queryByText('Get the must-read posts delivered daily'),
     ).not.toBeInTheDocument();
   });
 
@@ -107,7 +107,7 @@ describe('DigestBookmarkBanner', () => {
     renderComponent();
 
     expect(
-      screen.queryByText('Not sure what to read? Let us pick for you'),
+      screen.queryByText('Get the must-read posts delivered daily'),
     ).not.toBeInTheDocument();
   });
 
@@ -117,7 +117,7 @@ describe('DigestBookmarkBanner', () => {
     renderComponent();
 
     expect(
-      screen.queryByText('Not sure what to read? Let us pick for you'),
+      screen.queryByText('Get the must-read posts delivered daily'),
     ).not.toBeInTheDocument();
   });
 
@@ -126,7 +126,7 @@ describe('DigestBookmarkBanner', () => {
 
     expect(mockLogEvent).toHaveBeenCalledWith({
       event_name: LogEvent.Impression,
-      target_id: TargetId.DigestUpsellBookmarks,
+      target_id: TargetId.DigestUpsell,
     });
   });
 
@@ -138,7 +138,7 @@ describe('DigestBookmarkBanner', () => {
 
     expect(mockLogEvent).toHaveBeenCalledWith({
       event_name: LogEvent.Click,
-      target_id: TargetId.DigestUpsellBookmarks,
+      target_id: TargetId.DigestUpsell,
     });
 
     await waitFor(() => {
@@ -172,7 +172,7 @@ describe('DigestBookmarkBanner', () => {
 
     expect(mockLogEvent).toHaveBeenCalledWith({
       event_name: LogEvent.Click,
-      target_id: TargetId.DigestUpsellBookmarks,
+      target_id: TargetId.DigestUpsell,
       extra: JSON.stringify({ action: 'dismiss' }),
     });
     await waitFor(() => {

--- a/packages/shared/src/components/marketing/banners/DigestUpsellBanner.tsx
+++ b/packages/shared/src/components/marketing/banners/DigestUpsellBanner.tsx
@@ -5,26 +5,26 @@ import {
   ButtonColor,
   ButtonSize,
   ButtonVariant,
-} from '../buttons/Button';
-import CloseButton from '../CloseButton';
-import { MailIcon } from '../icons';
-import { LogEvent, TargetId } from '../../lib/log';
-import { useLogContext } from '../../contexts/LogContext';
-import { useAuthContext } from '../../contexts/AuthContext';
-import { usePlusSubscription } from '../../hooks/usePlusSubscription';
+} from '../../buttons/Button';
+import CloseButton from '../../CloseButton';
+import { MailIcon } from '../../icons';
+import { LogEvent, TargetId } from '../../../lib/log';
+import { useLogContext } from '../../../contexts/LogContext';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { usePlusSubscription } from '../../../hooks/usePlusSubscription';
 import {
   usePersonalizedDigest,
   SendType,
-} from '../../hooks/usePersonalizedDigest';
-import { UserPersonalizedDigestType } from '../../graphql/users';
-import { useActions } from '../../hooks/useActions';
-import { ActionType } from '../../graphql/actions';
-import useNotificationSettings from '../../hooks/notifications/useNotificationSettings';
-import { NotificationType } from './utils';
-import { NotificationPreferenceStatus } from '../../graphql/notifications';
-import { useToastNotification } from '../../hooks/useToastNotification';
+} from '../../../hooks/usePersonalizedDigest';
+import { UserPersonalizedDigestType } from '../../../graphql/users';
+import { useActions } from '../../../hooks/useActions';
+import { ActionType } from '../../../graphql/actions';
+import useNotificationSettings from '../../../hooks/notifications/useNotificationSettings';
+import { NotificationType } from '../../notifications/utils';
+import { NotificationPreferenceStatus } from '../../../graphql/notifications';
+import { useToastNotification } from '../../../hooks/useToastNotification';
 
-export function DigestBookmarkBanner(): ReactElement | null {
+export function DigestUpsellBanner(): ReactElement | null {
   const { logEvent } = useLogContext();
   const { isAuthReady } = useAuthContext();
   const { isPlus } = usePlusSubscription();
@@ -45,7 +45,7 @@ export function DigestBookmarkBanner(): ReactElement | null {
       impressionLogged.current = true;
       logEvent({
         event_name: LogEvent.Impression,
-        target_id: TargetId.DigestUpsellBookmarks,
+        target_id: TargetId.DigestUpsell,
       });
     }
   }, [showBanner, logEvent]);
@@ -57,7 +57,7 @@ export function DigestBookmarkBanner(): ReactElement | null {
   const onEnable = async () => {
     logEvent({
       event_name: LogEvent.Click,
-      target_id: TargetId.DigestUpsellBookmarks,
+      target_id: TargetId.DigestUpsell,
     });
 
     try {
@@ -91,21 +91,21 @@ export function DigestBookmarkBanner(): ReactElement | null {
   const onDismiss = async () => {
     logEvent({
       event_name: LogEvent.Click,
-      target_id: TargetId.DigestUpsellBookmarks,
+      target_id: TargetId.DigestUpsell,
       extra: JSON.stringify({ action: 'dismiss' }),
     });
     await completeAction(ActionType.DigestUpsell);
   };
 
   return (
-    <div className="relative mx-4 mb-4 overflow-hidden rounded-16 border border-accent-cabbage-default bg-surface-float px-6 py-4 typo-callout laptop:mx-auto laptop:max-w-[40rem]">
+    <div className="relative w-full overflow-hidden border-l border-accent-cabbage-default bg-surface-float px-6 py-4 typo-callout">
       <span className="flex flex-row items-center font-bold">
         <MailIcon className="mr-2" />
-        Not sure what to read? Let us pick for you
+        Get the must-read posts delivered daily
       </span>
       <p className="mt-2 text-text-tertiary">
-        Get a daily digest with the best posts from your favorite topics,
-        straight to your inbox.
+        A personalized digest with top posts from your favorite topics, straight
+        to your inbox.
       </p>
       <div className="mt-3 flex items-center">
         <Button

--- a/packages/shared/src/components/search/SearchResults/SearchResultsLayout.tsx
+++ b/packages/shared/src/components/search/SearchResults/SearchResultsLayout.tsx
@@ -17,7 +17,7 @@ import { useFeedLayout } from '../../../hooks';
 import { SearchResultsUsers } from './SearchResultsUsers';
 import SearchFilterTimeButton from '../SearchFilterTimeButton';
 import SearchFilterPostTypeButton from '../SearchFilterPostTypeButton';
-import { AskSearchBanner } from '../../notifications/AskSearchBanner';
+import { AskSearchBanner } from '../../marketing/banners/AskSearchBanner';
 
 type SearchResultsLayoutProps = PropsWithChildren;
 

--- a/packages/webapp/pages/notifications.tsx
+++ b/packages/webapp/pages/notifications.tsx
@@ -19,7 +19,7 @@ import {
 import NotificationItem from '@dailydotdev/shared/src/components/notifications/NotificationItem';
 import FirstNotification from '@dailydotdev/shared/src/components/notifications/FirstNotification';
 import EnableNotification from '@dailydotdev/shared/src/components/notifications/EnableNotification';
-import { DigestUpsellBanner } from '@dailydotdev/shared/src/components/notifications/DigestUpsellBanner';
+import { DigestUpsellBanner } from '@dailydotdev/shared/src/components/marketing/banners/DigestUpsellBanner';
 import { useNotificationContext } from '@dailydotdev/shared/src/contexts/NotificationsContext';
 import InfiniteScrolling, {
   checkFetchMore,

--- a/scripts/typecheck-strict-changed.js
+++ b/scripts/typecheck-strict-changed.js
@@ -70,6 +70,10 @@ const strictSkipList = new Set([
   'packages/shared/src/hooks/useBoot.ts',
   'packages/shared/src/lib/boot.ts',
   'packages/shared/src/components/marketing/cta/MarketingCtaModal.tsx',
+  // Notification banner consolidation — touched only to swap the import
+  // path; pre-existing strict violations (queryResult.data optionality,
+  // NotificationItem reduce typing) are unrelated to the rename.
+  'packages/webapp/pages/notifications.tsx',
 ]);
 
 const changedFiles = getChangedTypescriptFiles().filter(


### PR DESCRIPTION
## Summary
- Pure file moves: `AskSearchBanner`, `DigestBookmarkBanner`, `DigestUpsellBanner` (and their specs) from `shared/components/notifications/` → `shared/components/marketing/banners/`
- These are promotional surfaces, not notification UI — they belong with the other marketing banners
- Continues #6006 (banners) and #6007 (cta) consolidation

## Scope
- 6 files moved (3 components + 3 specs), all detected as git renames (78%–90% similarity)
- 4 external import sites updated (`webapp/notifications.tsx`, `MainFeedLayout`, `BookmarkFeedLayout`, `SearchResultsLayout`)
- Internal relative imports inside moved files bumped one level
- The two Digest banners' `./utils` import becomes `../../notifications/utils` (it's a NotificationType enum, still owned by the notifications folder)

## Strict skip-list addition
`packages/webapp/pages/notifications.tsx` was touched only to swap the `DigestUpsellBanner` import path. Pre-existing strict violations (`queryResult.data` optionality, `NotificationItem` reduce typing on lines 133/145) are unrelated to the rename and confirmed identical on `main`.

## Test plan
- [x] `pnpm --filter @dailydotdev/shared lint` passes
- [x] `pnpm --filter webapp lint` passes
- [x] `node ./scripts/typecheck-strict-changed.js` passes
- [x] All 25 specs pass (`AskSearchBanner.spec`, `DigestBookmarkBanner.spec`, `DigestUpsellBanner.spec` + the existing `ReadingReminderHero.spec`)
- [ ] Smoke-test: notifications page (DigestUpsellBanner), feed (AskSearchBanner), bookmarks empty state (DigestBookmarkBanner), search results (AskSearchBanner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://chore-move-notification-banners.preview.app.daily.dev