### PR TITLE
refactor: standup reminder icon state

### DIFF
--- a/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
@@ -4,6 +4,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from '@testing-library/react';
 import {
   QueryClient,
@@ -564,7 +565,16 @@ describe('LiveRoom', () => {
 
     renderLiveRoom();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Reminder set' }));
+    const reminderButton = screen.getByRole('button', { name: 'Reminder set' });
+
+    expect(
+      within(reminderButton).getByTestId('standup-reminder-set-icon'),
+    ).toBeVisible();
+    expect(
+      within(reminderButton).queryByTestId('standup-remind-icon'),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(reminderButton);
 
     await waitFor(() => {
       expect(mockUnsubscribeFromLiveRoom).toHaveBeenCalledTimes(1);

--- a/packages/shared/src/components/liveRooms/LiveRoomLobby.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomLobby.tsx
@@ -22,6 +22,7 @@ import {
   MegaphoneIcon,
   MicrosoftIcon,
   ShareIcon,
+  VIcon,
 } from '../icons';
 import { RaiseHandIcon } from '../icons/RaiseHand';
 import { IconSize } from '../Icon';
@@ -474,7 +475,16 @@ export const LiveRoomLobby = ({
                           ? ButtonVariant.Secondary
                           : ButtonVariant.Primary
                       }
-                      icon={<BellIcon secondary={subscribed} />}
+                      icon={
+                        subscribed ? (
+                          <VIcon
+                            secondary
+                            data-testid="standup-reminder-set-icon"
+                          />
+                        ) : (
+                          <BellIcon data-testid="standup-remind-icon" />
+                        )
+                      }
                       loading={subscriptionBusy}
                       disabled={subscriptionBusy}
                       onClick={onToggleSubscription}


### PR DESCRIPTION
## What changed
- switch the `/standups/[id]` lobby reminder CTA to show a checkmark icon after the user has already set a reminder
- keep the existing label, toggle behavior, and loading state unchanged
- add coverage in `LiveRoom.spec.tsx` to assert the subscribed reminder CTA renders the checkmark state

## Why
The standup lobby kept showing a bell even after a reminder was set, so the visual state did not match the saved subscription state.

## Impact
Users on scheduled standup lobbies now get a clear saved-state icon when their reminder is active.

## Validation
- `NODE_ENV=test pnpm --filter shared test -- LiveRoom.spec.tsx`
- `node ./scripts/typecheck-strict-changed.js`


### Preview domain
https://codex-standup-reminder-check-ico.preview.app.daily.dev