### PR TITLE
fix: use microphone icon for standup mic controls

### DIFF
--- a/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControls.tsx
@@ -6,7 +6,7 @@ import {
   ButtonSize,
   ButtonVariant,
 } from '../buttons/Button';
-import { CameraIcon, ExitIcon, MegaphoneIcon, SettingsIcon } from '../icons';
+import { CameraIcon, ExitIcon, MicrophoneIcon, SettingsIcon } from '../icons';
 import { RaiseHandIcon } from '../icons/RaiseHand';
 import { useLiveRoom } from '../../contexts/LiveRoomContext';
 import { useToastNotification } from '../../hooks/useToastNotification';
@@ -245,7 +245,7 @@ export const LiveRoomControls = ({
                 caretAriaLabel="Microphone devices"
                 caretMenuLabel="Microphone"
                 toggleIcon={
-                  <SlashedIcon icon={<MegaphoneIcon />} slashed={!isMicOn} />
+                  <SlashedIcon icon={<MicrophoneIcon />} slashed={!isMicOn} />
                 }
                 onToggle={() =>
                   guarded('mic', async () => {

--- a/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
@@ -17,7 +17,7 @@ import {
 } from '../typography/Typography';
 import { ProfilePicture, ProfileImageSize } from '../ProfilePicture';
 import type { UserShortProfile } from '../../lib/user';
-import { MegaphoneIcon, VolumeOffIcon } from '../icons';
+import { MicrophoneIcon, VolumeOffIcon } from '../icons';
 import { RaiseHandIcon } from '../icons/RaiseHand';
 import { IconSize } from '../Icon';
 import {
@@ -447,7 +447,7 @@ export const LiveRoomVideoTile = ({
             aria-label="Speaking"
             className="pointer-events-none flex size-6 shrink-0 items-center justify-center rounded-full bg-accent-avocado-default text-white"
           >
-            <MegaphoneIcon size={IconSize.XSmall} />
+            <MicrophoneIcon size={IconSize.XSmall} />
           </span>
         ) : null}
       </div>


### PR DESCRIPTION
## What changed
- replaced the standup live-room mic toggle icon with the existing `MicrophoneIcon`
- replaced the speaking-state badge icon on live-room participant tiles with `MicrophoneIcon`

## Why
Mic-related controls and speaking state on `/standups/[id]` were using a megaphone icon instead of a microphone icon.

## Impact
Standup/live-room mic UI now matches the actual mic semantics without changing behavior.

## Validation
- `node ./scripts/typecheck-strict-changed.js`


### Preview domain
https://codex-standup-microphone-icon.preview.app.daily.dev