### PR TITLE
fix(archive): add null-post guard in ArchiveFeedPage

### DIFF
--- a/packages/shared/src/components/archive/ArchiveFeedPage.tsx
+++ b/packages/shared/src/components/archive/ArchiveFeedPage.tsx
@@ -94,7 +94,7 @@ export function ArchiveFeedPage({
     scopeType,
     scopeId,
   } as ArchiveScopeInfo);
-  const items = archive?.items ?? [];
+  const items = (archive?.items ?? []).filter((item) => item.post);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- Filter out archive items with `null` posts in `ArchiveFeedPage` before rendering, preventing SSR crashes (`TypeError: Cannot read properties of null`) when the backend returns items referencing deleted posts

Defense-in-depth frontend guard complementing the backend fix in dailydotdev/daily-api#3863.

Closes ENG-1421

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1421-fix-500-on-best-of-arch.preview.app.daily.dev