### PR TITLE
feat(referral): add generic referral popup v2 behind experiment

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"69451909-c5c9-4a28-97d2-2c648424f412","pid":29097,"procStart":"Sun May 10 13:40:00 2026","acquiredAt":1778443512183}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"69451909-c5c9-4a28-97d2-2c648424f412","pid":29097,"procStart":"Sun May 10 13:40:00 2026","acquiredAt":1778443512183}

--- a/packages/shared/src/components/modals/BootPopups.tsx
+++ b/packages/shared/src/components/modals/BootPopups.tsx
@@ -18,6 +18,8 @@ import { MarketingCtaPopoverSmall } from '../marketing/cta/MarketingCtaPopoverSm
 import { ButtonVariant } from '../buttons/common';
 import { isNullOrUndefined } from '../../lib/func';
 import useProfileForm from '../../hooks/useProfileForm';
+import { useConditionalFeature } from '../../hooks/useConditionalFeature';
+import { featureGenericReferralPopupV2 } from '../../lib/featureManagement';
 
 const REP_TRESHOLD = 250;
 
@@ -193,16 +195,24 @@ export const BootPopups = (): ReactElement => {
     }
   }, [marketingCtaPopoverSmall]);
 
+  const shouldShowGenericReferral = alerts?.showGenericReferral === true;
+  const { value: isGenericReferralV2 } = useConditionalFeature({
+    feature: featureGenericReferralPopupV2,
+    shouldEvaluate: shouldShowGenericReferral,
+  });
+
   /** *
    * Boot popup for generic referral campaign
    */
   useEffect(() => {
-    if (alerts?.showGenericReferral !== true) {
+    if (!shouldShowGenericReferral) {
       return;
     }
 
     addBootPopup({
-      type: LazyModal.GenericReferral,
+      type: isGenericReferralV2
+        ? LazyModal.GenericReferralV2
+        : LazyModal.GenericReferral,
       props: {
         onAfterOpen: () => {
           updateLastBootPopup();
@@ -210,7 +220,7 @@ export const BootPopups = (): ReactElement => {
         isDrawerOnMobile: true,
       },
     });
-  }, [alerts?.showGenericReferral, updateLastBootPopup]);
+  }, [shouldShowGenericReferral, isGenericReferralV2, updateLastBootPopup]);
 
   /**
    * Streak recovery modal

--- a/packages/shared/src/components/modals/common.tsx
+++ b/packages/shared/src/components/modals/common.tsx
@@ -91,6 +91,13 @@ const GenericReferralModal = dynamic(
     ),
 );
 
+const GenericReferralModalV2 = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "genericReferralModalV2" */ './referral/GenericReferralModalV2'
+    ),
+);
+
 const NewStreakModal = dynamic(
   () =>
     import(/* webpackChunkName: "newStreakModal" */ './streaks/NewStreakModal'),
@@ -494,6 +501,7 @@ export const modals = {
   [LazyModal.NewSource]: NewSource,
   [LazyModal.VerifySession]: VerifySession,
   [LazyModal.GenericReferral]: GenericReferralModal,
+  [LazyModal.GenericReferralV2]: GenericReferralModalV2,
   [LazyModal.Video]: VideoModal,
   [LazyModal.NewStreak]: NewStreakModal,
   [LazyModal.ReputationPrivileges]: ReputationPrivilegesModal,

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -39,6 +39,7 @@ export enum LazyModal {
   NewSource = 'newSource',
   VerifySession = 'verifySession',
   GenericReferral = 'genericReferral',
+  GenericReferralV2 = 'genericReferralV2',
   Video = 'video',
   NewStreak = 'newStreak',
   RecoverStreak = 'recoverStreak',

--- a/packages/shared/src/components/modals/referral/GenericReferralModalV2.tsx
+++ b/packages/shared/src/components/modals/referral/GenericReferralModalV2.tsx
@@ -1,0 +1,113 @@
+import type { ReactElement } from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
+import type { ModalProps } from '../common/Modal';
+import { Modal } from '../common/Modal';
+import { ButtonSize, ButtonVariant } from '../../buttons/Button';
+import { AddUserIcon } from '../../icons';
+import { IconSize } from '../../Icon';
+import { link } from '../../../lib/links';
+import { LogEvent, TargetId, TargetType } from '../../../lib/log';
+import { ReferralCampaignKey, useReferralCampaign } from '../../../hooks';
+import ReferralSocialShareButtons from '../../widgets/ReferralSocialShareButtons';
+import { useLogContext } from '../../../contexts/LogContext';
+import { InviteLinkInput } from '../../referral/InviteLinkInput';
+import { ModalClose } from '../common/ModalClose';
+import AlertContext from '../../../contexts/AlertContext';
+import type { ReferralCelebrationParticlesHandle } from './ReferralCelebrationParticles';
+import { ReferralCelebrationParticles } from './ReferralCelebrationParticles';
+
+function GenericReferralModalV2({
+  onRequestClose,
+  ...props
+}: ModalProps): ReactElement {
+  const { updateLastReferralReminder } = useContext(AlertContext);
+  const { url } = useReferralCampaign({
+    campaignKey: ReferralCampaignKey.Generic,
+  });
+  const inviteLink = url || link.referral.defaultUrl;
+  const { logEvent } = useLogContext();
+  const isLogged = useRef(false);
+  const particlesRef = useRef<ReferralCelebrationParticlesHandle>(null);
+
+  const celebrateFromClick = (event: React.MouseEvent) => {
+    const target = event.target as HTMLElement | null;
+    if (!target?.closest('button, a')) {
+      return;
+    }
+    particlesRef.current?.celebrate();
+  };
+
+  useEffect(() => {
+    if (isLogged.current) {
+      return;
+    }
+    updateLastReferralReminder?.();
+    isLogged.current = true;
+    logEvent({
+      event_name: LogEvent.Impression,
+      target_type: TargetType.ReferralPopup,
+    });
+  }, [logEvent, updateLastReferralReminder]);
+
+  return (
+    <Modal
+      {...props}
+      onRequestClose={onRequestClose}
+      kind={Modal.Kind.FlexibleCenter}
+      size={Modal.Size.Small}
+      overlayClassName="modal-backdrop-rays"
+      className="isolate z-50 !border-border-subtlest-primary tablet:!border-2 tablet:ring-1 tablet:ring-inset tablet:ring-white/10 tablet:!shadow-[0_40px_80px_-10px_rgba(0,0,0,0.85),0_15px_40px_-10px_rgba(0,0,0,0.6)]"
+    >
+      <ReferralCelebrationParticles ref={particlesRef} />
+      <ModalClose
+        onClick={onRequestClose}
+        variant={ButtonVariant.Tertiary}
+        size={ButtonSize.Small}
+        top="2"
+        right="2"
+      />
+      <div className="flex flex-col items-center gap-6 px-6 pb-6 pt-10 text-center">
+        <span className="flex size-16 items-center justify-center rounded-16 bg-theme-overlay-float-cabbage text-brand-default">
+          <AddUserIcon size={IconSize.XLarge} secondary />
+        </span>
+
+        <div className="flex flex-col gap-2">
+          <h1 className="font-bold text-text-primary typo-large-title">
+            Bring your friends
+          </h1>
+          <p className="text-text-secondary typo-callout">
+            Share your link before they discover it on their own and steal your
+            credibility.
+          </p>
+        </div>
+
+        <div className="w-full" onClickCapture={celebrateFromClick}>
+          <InviteLinkInput
+            className={{ container: 'w-full' }}
+            logProps={{
+              event_name: LogEvent.CopyReferralLink,
+              target_id: TargetId.GenericReferralPopup,
+            }}
+            link={inviteLink}
+            text={{ initial: 'Copy link', copied: 'Copied' }}
+          />
+        </div>
+
+        <div className="flex w-full items-center gap-3">
+          <span className="text-text-tertiary typo-callout">Or invite via</span>
+          <span
+            className="ml-auto flex items-center gap-2"
+            onClickCapture={celebrateFromClick}
+          >
+            <ReferralSocialShareButtons
+              url={url}
+              targetType={TargetType.GenericReferralPopup}
+            />
+          </span>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+export default GenericReferralModalV2;

--- a/packages/shared/src/components/modals/referral/GenericReferralModalV2.tsx
+++ b/packages/shared/src/components/modals/referral/GenericReferralModalV2.tsx
@@ -56,7 +56,7 @@ function GenericReferralModalV2({
       kind={Modal.Kind.FlexibleCenter}
       size={Modal.Size.Small}
       overlayClassName="modal-backdrop-rays"
-      className="isolate z-50 !border-border-subtlest-primary tablet:!border-2 tablet:ring-1 tablet:ring-inset tablet:ring-white/10 tablet:!shadow-[0_40px_80px_-10px_rgba(0,0,0,0.85),0_15px_40px_-10px_rgba(0,0,0,0.6)]"
+      className="z-50 tablet:ring-white/10 isolate !border-border-subtlest-primary tablet:!border-2 tablet:!shadow-[0_40px_80px_-10px_rgba(0,0,0,0.85),0_15px_40px_-10px_rgba(0,0,0,0.6)] tablet:ring-1 tablet:ring-inset"
     >
       <ReferralCelebrationParticles ref={particlesRef} />
       <ModalClose

--- a/packages/shared/src/components/modals/referral/ReferralCelebrationParticles.tsx
+++ b/packages/shared/src/components/modals/referral/ReferralCelebrationParticles.tsx
@@ -97,146 +97,145 @@ const drawParticle = (ctx: CanvasRenderingContext2D, p: Particle): void => {
   ctx.fill();
 };
 
-export const ReferralCelebrationParticles = forwardRef<
-  ReferralCelebrationParticlesHandle
->((_, ref): ReactElement => {
-  const anchorRef = useRef<HTMLSpanElement>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-  const particlesRef = useRef<Particle[]>([]);
-  const rafRef = useRef<number | null>(null);
-  const sizeRef = useRef({ width: 0, height: 0 });
-  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+export const ReferralCelebrationParticles =
+  forwardRef<ReferralCelebrationParticlesHandle>((_, ref): ReactElement => {
+    const anchorRef = useRef<HTMLSpanElement>(null);
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const particlesRef = useRef<Particle[]>([]);
+    const rafRef = useRef<number | null>(null);
+    const sizeRef = useRef({ width: 0, height: 0 });
+    const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
 
-  const resize = useCallback(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) {
-      return;
-    }
-    const dpr = window.devicePixelRatio || 1;
-    const width = window.innerWidth;
-    const height = window.innerHeight;
-    canvas.width = width * dpr;
-    canvas.height = height * dpr;
-    canvas.style.width = `${width}px`;
-    canvas.style.height = `${height}px`;
-    const ctx = canvas.getContext('2d');
-    ctx?.setTransform(dpr, 0, 0, dpr, 0, 0);
-    sizeRef.current = { width, height };
-  }, []);
-
-  const tick = useCallback(() => {
-    const canvas = canvasRef.current;
-    const ctx = canvas?.getContext('2d');
-    if (!canvas || !ctx) {
-      return;
-    }
-    const { width, height } = sizeRef.current;
-    ctx.clearRect(0, 0, width, height);
-
-    particlesRef.current.forEach((p) => {
-      const next = p;
-
-      const speedMultiplier = 1 + next.energy * SPEED_BOOST;
-      next.vx = next.baseVx * speedMultiplier;
-      next.vy = next.baseVy * speedMultiplier;
-
-      if (next.energy > 0) {
-        next.vx += random(-JITTER_STRENGTH, JITTER_STRENGTH) * next.energy;
-        next.vy += random(-JITTER_STRENGTH, JITTER_STRENGTH) * next.energy;
-        next.rotation += next.rotationSpeed;
-        next.energy *= ENERGY_DECAY;
+    const resize = useCallback(() => {
+      const canvas = canvasRef.current;
+      if (!canvas) {
+        return;
       }
+      const dpr = window.devicePixelRatio || 1;
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      const ctx = canvas.getContext('2d');
+      ctx?.setTransform(dpr, 0, 0, dpr, 0, 0);
+      sizeRef.current = { width, height };
+    }, []);
 
-      next.x += next.vx;
-      next.y += next.vy;
-
-      next.size = next.baseSize * (1 + next.energy * 0.6);
-      next.alpha = Math.min(1, next.baseAlpha + next.energy * 0.3);
-
-      if (next.y < -10) {
-        next.x = Math.random() * width;
-        next.y = height + 10;
-      } else if (next.y > height + 20) {
-        next.x = Math.random() * width;
-        next.y = -10;
+    const tick = useCallback(() => {
+      const canvas = canvasRef.current;
+      const ctx = canvas?.getContext('2d');
+      if (!canvas || !ctx) {
+        return;
       }
-      if (next.x < -10) {
-        next.x = width + 10;
-      } else if (next.x > width + 10) {
-        next.x = -10;
+      const { width, height } = sizeRef.current;
+      ctx.clearRect(0, 0, width, height);
+
+      particlesRef.current.forEach((p) => {
+        const next = p;
+
+        const speedMultiplier = 1 + next.energy * SPEED_BOOST;
+        next.vx = next.baseVx * speedMultiplier;
+        next.vy = next.baseVy * speedMultiplier;
+
+        if (next.energy > 0) {
+          next.vx += random(-JITTER_STRENGTH, JITTER_STRENGTH) * next.energy;
+          next.vy += random(-JITTER_STRENGTH, JITTER_STRENGTH) * next.energy;
+          next.rotation += next.rotationSpeed;
+          next.energy *= ENERGY_DECAY;
+        }
+
+        next.x += next.vx;
+        next.y += next.vy;
+
+        next.size = next.baseSize * (1 + next.energy * 0.6);
+        next.alpha = Math.min(1, next.baseAlpha + next.energy * 0.3);
+
+        if (next.y < -10) {
+          next.x = Math.random() * width;
+          next.y = height + 10;
+        } else if (next.y > height + 20) {
+          next.x = Math.random() * width;
+          next.y = -10;
+        }
+        if (next.x < -10) {
+          next.x = width + 10;
+        } else if (next.x > width + 10) {
+          next.x = -10;
+        }
+
+        drawParticle(ctx, next);
+      });
+
+      rafRef.current = requestAnimationFrame(tick);
+    }, []);
+
+    useEffect(() => {
+      const overlay = anchorRef.current?.closest<HTMLElement>(
+        '.ReactModal__Overlay',
+      );
+      if (!overlay) {
+        setPortalTarget(document.body);
+        return undefined;
       }
+      const wrapper = document.createElement('div');
+      wrapper.dataset.particlesPortal = 'true';
+      overlay.prepend(wrapper);
+      setPortalTarget(wrapper);
+      return () => {
+        wrapper.remove();
+      };
+    }, []);
 
-      drawParticle(ctx, next);
-    });
+    useEffect(() => {
+      if (!portalTarget) {
+        return undefined;
+      }
+      resize();
+      const { width, height } = sizeRef.current;
+      particlesRef.current = Array.from({ length: AMBIENT_COUNT }, () =>
+        createAmbientParticle(width, height),
+      );
+      rafRef.current = requestAnimationFrame(tick);
+      window.addEventListener('resize', resize);
+      return () => {
+        window.removeEventListener('resize', resize);
+        if (rafRef.current) {
+          cancelAnimationFrame(rafRef.current);
+        }
+      };
+    }, [portalTarget, resize, tick]);
 
-    rafRef.current = requestAnimationFrame(tick);
-  }, []);
-
-  useEffect(() => {
-    const overlay = anchorRef.current?.closest<HTMLElement>(
-      '.ReactModal__Overlay',
+    useImperativeHandle(
+      ref,
+      () => ({
+        celebrate: () => {
+          particlesRef.current.forEach((p) => {
+            const next = p;
+            next.energy = 1;
+            next.partyColor = pick(PARTY_COLORS);
+            next.rotationSpeed = random(-0.4, 0.4);
+          });
+        },
+      }),
+      [],
     );
-    if (!overlay) {
-      setPortalTarget(document.body);
-      return undefined;
-    }
-    const wrapper = document.createElement('div');
-    wrapper.dataset.particlesPortal = 'true';
-    overlay.prepend(wrapper);
-    setPortalTarget(wrapper);
-    return () => {
-      wrapper.remove();
-    };
-  }, []);
 
-  useEffect(() => {
-    if (!portalTarget) {
-      return undefined;
-    }
-    resize();
-    const { width, height } = sizeRef.current;
-    particlesRef.current = Array.from({ length: AMBIENT_COUNT }, () =>
-      createAmbientParticle(width, height),
+    const canvas = (
+      <canvas
+        ref={canvasRef}
+        aria-hidden
+        className="pointer-events-none fixed inset-0 z-[1]"
+      />
     );
-    rafRef.current = requestAnimationFrame(tick);
-    window.addEventListener('resize', resize);
-    return () => {
-      window.removeEventListener('resize', resize);
-      if (rafRef.current) {
-        cancelAnimationFrame(rafRef.current);
-      }
-    };
-  }, [portalTarget, resize, tick]);
 
-  useImperativeHandle(
-    ref,
-    () => ({
-      celebrate: () => {
-        particlesRef.current.forEach((p) => {
-          const next = p;
-          next.energy = 1;
-          next.partyColor = pick(PARTY_COLORS);
-          next.rotationSpeed = random(-0.4, 0.4);
-        });
-      },
-    }),
-    [],
-  );
-
-  const canvas = (
-    <canvas
-      ref={canvasRef}
-      aria-hidden
-      className="pointer-events-none fixed inset-0 z-[1]"
-    />
-  );
-
-  return (
-    <>
-      <span ref={anchorRef} aria-hidden className="hidden" />
-      {portalTarget ? createPortal(canvas, portalTarget) : null}
-    </>
-  );
-});
+    return (
+      <>
+        <span ref={anchorRef} aria-hidden className="hidden" />
+        {portalTarget ? createPortal(canvas, portalTarget) : null}
+      </>
+    );
+  });
 
 ReferralCelebrationParticles.displayName = 'ReferralCelebrationParticles';

--- a/packages/shared/src/components/modals/referral/ReferralCelebrationParticles.tsx
+++ b/packages/shared/src/components/modals/referral/ReferralCelebrationParticles.tsx
@@ -1,0 +1,242 @@
+import type { ReactElement } from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+
+interface Particle {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  baseVx: number;
+  baseVy: number;
+  baseSize: number;
+  baseAlpha: number;
+  size: number;
+  baseColor: string;
+  partyColor: string;
+  alpha: number;
+  rotation: number;
+  rotationSpeed: number;
+  energy: number;
+}
+
+export interface ReferralCelebrationParticlesHandle {
+  celebrate: () => void;
+}
+
+const BASE_COLORS = [
+  'rgb(206, 61, 245)',
+  'rgb(151, 87, 215)',
+  'rgb(91, 192, 235)',
+  'rgb(255, 255, 255)',
+];
+
+const PARTY_COLORS = [
+  'rgb(255, 78, 196)',
+  'rgb(255, 209, 71)',
+  'rgb(102, 224, 130)',
+  'rgb(91, 192, 235)',
+  'rgb(206, 61, 245)',
+  'rgb(255, 145, 77)',
+];
+
+const AMBIENT_COUNT = 50;
+const ENERGY_DECAY = 0.985;
+const SPEED_BOOST = 5;
+const JITTER_STRENGTH = 0.6;
+
+const random = (min: number, max: number): number =>
+  min + Math.random() * (max - min);
+
+const pick = <T,>(arr: T[]): T => arr[Math.floor(Math.random() * arr.length)];
+
+const createAmbientParticle = (width: number, height: number): Particle => {
+  const baseVx = random(-0.25, 0.25);
+  const baseVy = random(-0.55, -0.15);
+  const baseSize = random(2, 3.6);
+  const baseAlpha = random(0.5, 0.8);
+  return {
+    x: Math.random() * width,
+    y: Math.random() * height,
+    vx: baseVx,
+    vy: baseVy,
+    baseVx,
+    baseVy,
+    baseSize,
+    baseAlpha,
+    size: baseSize,
+    baseColor: pick(BASE_COLORS),
+    partyColor: pick(PARTY_COLORS),
+    alpha: baseAlpha,
+    rotation: Math.random() * Math.PI * 2,
+    rotationSpeed: 0,
+    energy: 0,
+  };
+};
+
+const drawParticle = (ctx: CanvasRenderingContext2D, p: Particle): void => {
+  ctx.globalAlpha = Math.min(1, Math.max(0, p.alpha));
+  ctx.fillStyle = p.energy > 0.15 ? p.partyColor : p.baseColor;
+  if (p.energy > 0.25) {
+    ctx.save();
+    ctx.translate(p.x, p.y);
+    ctx.rotate(p.rotation);
+    ctx.fillRect(-p.size / 2, -p.size / 2, p.size, p.size);
+    ctx.restore();
+    return;
+  }
+  ctx.beginPath();
+  ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2);
+  ctx.fill();
+};
+
+export const ReferralCelebrationParticles = forwardRef<
+  ReferralCelebrationParticlesHandle
+>((_, ref): ReactElement => {
+  const anchorRef = useRef<HTMLSpanElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const particlesRef = useRef<Particle[]>([]);
+  const rafRef = useRef<number | null>(null);
+  const sizeRef = useRef({ width: 0, height: 0 });
+  const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
+
+  const resize = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+    const dpr = window.devicePixelRatio || 1;
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    const ctx = canvas.getContext('2d');
+    ctx?.setTransform(dpr, 0, 0, dpr, 0, 0);
+    sizeRef.current = { width, height };
+  }, []);
+
+  const tick = useCallback(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas?.getContext('2d');
+    if (!canvas || !ctx) {
+      return;
+    }
+    const { width, height } = sizeRef.current;
+    ctx.clearRect(0, 0, width, height);
+
+    particlesRef.current.forEach((p) => {
+      const next = p;
+
+      const speedMultiplier = 1 + next.energy * SPEED_BOOST;
+      next.vx = next.baseVx * speedMultiplier;
+      next.vy = next.baseVy * speedMultiplier;
+
+      if (next.energy > 0) {
+        next.vx += random(-JITTER_STRENGTH, JITTER_STRENGTH) * next.energy;
+        next.vy += random(-JITTER_STRENGTH, JITTER_STRENGTH) * next.energy;
+        next.rotation += next.rotationSpeed;
+        next.energy *= ENERGY_DECAY;
+      }
+
+      next.x += next.vx;
+      next.y += next.vy;
+
+      next.size = next.baseSize * (1 + next.energy * 0.6);
+      next.alpha = Math.min(1, next.baseAlpha + next.energy * 0.3);
+
+      if (next.y < -10) {
+        next.x = Math.random() * width;
+        next.y = height + 10;
+      } else if (next.y > height + 20) {
+        next.x = Math.random() * width;
+        next.y = -10;
+      }
+      if (next.x < -10) {
+        next.x = width + 10;
+      } else if (next.x > width + 10) {
+        next.x = -10;
+      }
+
+      drawParticle(ctx, next);
+    });
+
+    rafRef.current = requestAnimationFrame(tick);
+  }, []);
+
+  useEffect(() => {
+    const overlay = anchorRef.current?.closest<HTMLElement>(
+      '.ReactModal__Overlay',
+    );
+    if (!overlay) {
+      setPortalTarget(document.body);
+      return undefined;
+    }
+    const wrapper = document.createElement('div');
+    wrapper.dataset.particlesPortal = 'true';
+    overlay.prepend(wrapper);
+    setPortalTarget(wrapper);
+    return () => {
+      wrapper.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!portalTarget) {
+      return undefined;
+    }
+    resize();
+    const { width, height } = sizeRef.current;
+    particlesRef.current = Array.from({ length: AMBIENT_COUNT }, () =>
+      createAmbientParticle(width, height),
+    );
+    rafRef.current = requestAnimationFrame(tick);
+    window.addEventListener('resize', resize);
+    return () => {
+      window.removeEventListener('resize', resize);
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current);
+      }
+    };
+  }, [portalTarget, resize, tick]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      celebrate: () => {
+        particlesRef.current.forEach((p) => {
+          const next = p;
+          next.energy = 1;
+          next.partyColor = pick(PARTY_COLORS);
+          next.rotationSpeed = random(-0.4, 0.4);
+        });
+      },
+    }),
+    [],
+  );
+
+  const canvas = (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      className="pointer-events-none fixed inset-0 z-[1]"
+    />
+  );
+
+  return (
+    <>
+      <span ref={anchorRef} aria-hidden className="hidden" />
+      {portalTarget ? createPortal(canvas, portalTarget) : null}
+    </>
+  );
+});
+
+ReferralCelebrationParticles.displayName = 'ReferralCelebrationParticles';

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -178,6 +178,11 @@ export const featureShortcutsExtensionPromo = new Feature(
   false,
 );
 
+export const featureGenericReferralPopupV2 = new Feature(
+  'generic_referral_popup_v2',
+  isDevelopment,
+);
+
 export const featureShortcutsExtensionPromoCopy = new Feature(
   'shortcuts_extension_promo_copy',
   {

--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -1093,3 +1093,54 @@ meter::-webkit-meter-bar {
     }
   }
 }
+
+.modal-backdrop-rays {
+  isolation: isolate;
+}
+
+.modal-backdrop-rays::before {
+  content: '';
+  position: fixed;
+  inset: -50%;
+  z-index: 0;
+  pointer-events: none;
+  background: conic-gradient(
+    from 0deg at 50% 50%,
+    transparent 0deg,
+    color-mix(in srgb, var(--theme-accent-cabbage-default) 65%, transparent) 18deg,
+    transparent 40deg 80deg,
+    color-mix(in srgb, var(--theme-accent-onion-default) 55%, transparent) 100deg,
+    transparent 120deg 170deg,
+    color-mix(in srgb, var(--theme-accent-cabbage-default) 60%, transparent) 190deg,
+    transparent 215deg 270deg,
+    color-mix(in srgb, var(--theme-accent-onion-default) 55%, transparent) 290deg,
+    transparent 320deg 360deg
+  );
+  -webkit-mask-image: radial-gradient(
+    circle at 50% 50%,
+    transparent 18%,
+    black 35%,
+    black 70%,
+    transparent 100%
+  );
+  mask-image: radial-gradient(
+    circle at 50% 50%,
+    transparent 18%,
+    black 35%,
+    black 70%,
+    transparent 100%
+  );
+  animation: modal-backdrop-rays-spin 30s linear infinite;
+}
+
+@keyframes modal-backdrop-rays-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal-backdrop-rays::before {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- New `GenericReferralModalV2` variant: animated rays backdrop, ambient party particles that energize on copy/share, punchier copy ("Bring your friends"), heavier panel border + drop shadow for separation from the animated backdrop.
- Gated by `featureGenericReferralPopupV2`. Evaluated via `useConditionalFeature` with `shouldEvaluate` tied to `alerts.showGenericReferral`, so users who would never see the popup aren't enrolled.
- Original `GenericReferral` modal kept; routing decision happens in `BootPopups`.

## Test plan
- [ ] Trigger the generic referral popup on a dev account (feature flag default is `isDevelopment`) and verify V2 renders with rays backdrop + particles.
- [ ] Click "Copy link" and each social share button — confirm particles energize (party colors + speed boost).
- [ ] Toggle the flag off and confirm the legacy `GenericReferral` modal still renders unchanged.
- [ ] Verify users without `alerts.showGenericReferral` are not enrolled in the experiment (check GrowthBook events).
- [ ] Mobile (`isDrawerOnMobile: true`) still renders as a drawer.

### Preview domain
https://feat-generic-referral-popup-v2.preview.app.daily.dev