### PR TITLE
chore(extension): update Chrome Store listing copy

### DIFF
--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "__firefox__manifest_version": 2,
   "version": "0.0.0",
-  "name": "daily.dev — Developer News Done Right, in Every New Tab",
+  "name": "daily.dev | Developer News Done Right, in Every New Tab",
   "short_name": "daily.dev",
   "description": "Developer news, personalized to your stack, in every new tab. Join 1,000,000+ developers. Free and open source.",
   "homepage_url": "https://daily.dev",

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -2,9 +2,9 @@
   "manifest_version": 3,
   "__firefox__manifest_version": 2,
   "version": "0.0.0",
-  "name": "daily.dev | The homepage developers deserve",
+  "name": "daily.dev — Developer News Done Right, in Every New Tab",
   "short_name": "daily.dev",
-  "description": "Turn every new tab into your personalized developer feed. Trusted by 400,000+ devs. AI-powered & open source.",
+  "description": "Developer news, personalized to your stack, in every new tab. Join 1,000,000+ developers. Free and open source.",
   "homepage_url": "https://daily.dev",
   "icons": {
     "16": "icons/16.png",

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "name": "daily.dev | Developer News Done Right, in Every New Tab",
   "short_name": "daily.dev",
-  "description": "Developer news, personalized to your stack, in every new tab. Join 1,000,000+ developers. Free and open source.",
+  "description": "Developer news, personalized to your stack, in every new tab. Join 400,000+ developers. Free and open source.",
   "homepage_url": "https://daily.dev",
   "icons": {
     "16": "icons/16.png",


### PR DESCRIPTION
## Summary
- Updates the extension manifest title used by the Chrome Store listing.
- Updates the extension manifest summary copy with the new developer count and positioning.

## Test plan
- Parsed `packages/extension/src/manifest.json` with Node to verify valid JSON.
- Checked IDE lints for `packages/extension/src/manifest.json`.


Made with [Cursor](https://cursor.com)

### Preview domain
https://chore-chrome-store-listing-copy.preview.app.daily.dev