### PR TITLE
feat(extension): scaffold Chrome Web Store localization

### DIFF
--- a/packages/extension/docs/chrome-web-store-localization.md
+++ b/packages/extension/docs/chrome-web-store-localization.md
@@ -1,0 +1,43 @@
+# Chrome Web Store localization
+
+The Chrome Web Store listing has two localization layers:
+
+1. Extension package metadata: `name`, `short_name`, and `description` come from `public/_locales/<locale>/messages.json` and are referenced from `src/manifest.json`.
+2. Store listing copy: the long description, category, screenshots, promo text, and other listing fields are managed in the Chrome Web Store developer dashboard per language.
+
+## Supported locales
+
+English is the default locale. Phase 1 adds these target locales as translations become available:
+
+| Language | Chrome locale folder |
+| --- | --- |
+| Portuguese (Brazil) | `pt_BR` |
+| Spanish | `es` |
+| German | `de` |
+| Japanese | `ja` |
+| French | `fr` |
+
+## Adding a new language
+
+1. Create `packages/extension/public/_locales/<locale>/messages.json`.
+2. Copy the same message keys from `public/_locales/en/messages.json`.
+3. Translate each `message` value. Keep placeholders, punctuation, brand casing, and character limits aligned with the English source.
+4. Build the Chrome extension with `pnpm --filter extension build`.
+5. Confirm the generated package includes `_locales/<locale>/messages.json`.
+6. Upload the package in the Chrome Web Store developer dashboard.
+7. In the dashboard, add the matching localized store listing fields for the same language.
+
+Do not add a locale folder with English placeholder copy. Chrome can expose that locale as supported, so only commit a locale when the translation is ready to ship.
+
+## Store listing fields to translate
+
+For each language, prepare:
+
+- Extension name
+- Short description
+- Detailed description
+- Screenshot captions or translated screenshots, if used
+- Promotional tile text, if used
+- Any support or policy text shown on the listing
+
+The dashboard work is manual; these longer listing fields are not stored in the extension package.

--- a/packages/extension/docs/chrome-web-store-localization.md
+++ b/packages/extension/docs/chrome-web-store-localization.md
@@ -2,8 +2,8 @@
 
 The Chrome Web Store listing has two localization layers:
 
-1. Extension package metadata: `name`, `short_name`, and `description` come from `public/_locales/<locale>/messages.json` and are referenced from `src/manifest.json`.
-2. Store listing copy: the long description, category, screenshots, promo text, and other listing fields are managed in the Chrome Web Store developer dashboard per language.
+1. Extension package metadata: `name` and `description` come from `public/_locales/<locale>/messages.json` and are referenced from `src/manifest.json`.
+2. Store listing copy: the long description, localized screenshots, and localized promo video are managed in the Chrome Web Store developer dashboard per language.
 
 ## Supported locales
 
@@ -37,7 +37,7 @@ For each language, prepare:
 - Short description
 - Detailed description
 - Screenshot captions or translated screenshots, if used
-- Promotional tile text, if used
+- Localized promo video URL, if used
 - Any support or policy text shown on the listing
 
 The dashboard work is manual; these longer listing fields are not stored in the extension package.

--- a/packages/extension/public/_locales/de/messages.json
+++ b/packages/extension/public/_locales/de/messages.json
@@ -1,0 +1,14 @@
+{
+  "extensionName": {
+    "message": "daily.dev | Entwickler-News, richtig gemacht, in jedem neuen Tab",
+    "description": "Extension name shown in browser extension surfaces and Chrome Web Store metadata."
+  },
+  "extensionShortName": {
+    "message": "daily.dev",
+    "description": "Short extension name shown when space is limited."
+  },
+  "extensionDescription": {
+    "message": "Entwickler-News, personalisiert für Ihren Stack, in jedem neuen Tab. Schließen Sie sich über 400.000 Entwicklern an. Kostenlos und Open Source.",
+    "description": "Short extension description shown in browser extension surfaces and Chrome Web Store metadata."
+  }
+}

--- a/packages/extension/public/_locales/de/messages.json
+++ b/packages/extension/public/_locales/de/messages.json
@@ -1,14 +1,11 @@
 {
   "extensionName": {
-    "message": "daily.dev | Entwickler-News, richtig gemacht, in jedem neuen Tab",
-    "description": "Extension name shown in browser extension surfaces and Chrome Web Store metadata."
+    "message": "daily.dev | Entwickler-News, richtig gemacht, in jedem neuen Tab"
   },
   "extensionShortName": {
-    "message": "daily.dev",
-    "description": "Short extension name shown when space is limited."
+    "message": "daily.dev"
   },
   "extensionDescription": {
-    "message": "Entwickler-News, personalisiert für Ihren Stack, in jedem neuen Tab. Schließen Sie sich über 400.000 Entwicklern an. Kostenlos und Open Source.",
-    "description": "Short extension description shown in browser extension surfaces and Chrome Web Store metadata."
+    "message": "Entwickler-News, personalisiert für Ihren Stack, in jedem neuen Tab. Schließen Sie sich über 400.000 Entwicklern an. Kostenlos und Open Source."
   }
 }

--- a/packages/extension/public/_locales/de/messages.json
+++ b/packages/extension/public/_locales/de/messages.json
@@ -2,10 +2,7 @@
   "extensionName": {
     "message": "daily.dev | Entwickler-News, richtig gemacht, in jedem neuen Tab"
   },
-  "extensionShortName": {
-    "message": "daily.dev"
-  },
   "extensionDescription": {
-    "message": "Entwickler-News, personalisiert für Ihren Stack, in jedem neuen Tab. Schließen Sie sich über 400.000 Entwicklern an. Kostenlos und Open Source."
+    "message": "Entwickler-News, personalisiert für Ihren Stack, in jedem neuen Tab. Über 400.000 Entwickler. Kostenlos und Open Source."
   }
 }

--- a/packages/extension/public/_locales/en/messages.json
+++ b/packages/extension/public/_locales/en/messages.json
@@ -1,0 +1,14 @@
+{
+  "extensionName": {
+    "message": "daily.dev | The homepage developers deserve",
+    "description": "Extension name shown in browser extension surfaces and Chrome Web Store metadata."
+  },
+  "extensionShortName": {
+    "message": "daily.dev",
+    "description": "Short extension name shown when space is limited."
+  },
+  "extensionDescription": {
+    "message": "Turn every new tab into your personalized developer feed. Trusted by 400,000+ devs. AI-powered & open source.",
+    "description": "Short extension description shown in browser extension surfaces and Chrome Web Store metadata."
+  }
+}

--- a/packages/extension/public/_locales/en/messages.json
+++ b/packages/extension/public/_locales/en/messages.json
@@ -3,10 +3,6 @@
     "message": "daily.dev | Developer News Done Right, in Every New Tab",
     "description": "Extension name shown in browser extension surfaces and Chrome Web Store metadata."
   },
-  "extensionShortName": {
-    "message": "daily.dev",
-    "description": "Short extension name shown when space is limited."
-  },
   "extensionDescription": {
     "message": "Developer news, personalized to your stack, in every new tab. Join 400,000+ developers. Free and open source.",
     "description": "Short extension description shown in browser extension surfaces and Chrome Web Store metadata."

--- a/packages/extension/public/_locales/en/messages.json
+++ b/packages/extension/public/_locales/en/messages.json
@@ -1,10 +1,8 @@
 {
   "extensionName": {
-    "message": "daily.dev | Developer News Done Right, in Every New Tab",
-    "description": "Extension name shown in browser extension surfaces and Chrome Web Store metadata."
+    "message": "daily.dev | Developer News Done Right, in Every New Tab"
   },
   "extensionDescription": {
-    "message": "Developer news, personalized to your stack, in every new tab. Join 400,000+ developers. Free and open source.",
-    "description": "Short extension description shown in browser extension surfaces and Chrome Web Store metadata."
+    "message": "Developer news, personalized to your stack, in every new tab. Join 400,000+ developers. Free and open source."
   }
 }

--- a/packages/extension/public/_locales/en/messages.json
+++ b/packages/extension/public/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "daily.dev | The homepage developers deserve",
+    "message": "daily.dev | Developer News Done Right, in Every New Tab",
     "description": "Extension name shown in browser extension surfaces and Chrome Web Store metadata."
   },
   "extensionShortName": {
@@ -8,7 +8,7 @@
     "description": "Short extension name shown when space is limited."
   },
   "extensionDescription": {
-    "message": "Turn every new tab into your personalized developer feed. Trusted by 400,000+ devs. AI-powered & open source.",
+    "message": "Developer news, personalized to your stack, in every new tab. Join 400,000+ developers. Free and open source.",
     "description": "Short extension description shown in browser extension surfaces and Chrome Web Store metadata."
   }
 }

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -1,14 +1,11 @@
 {
   "extensionName": {
-    "message": "daily.dev | Noticias para desarrolladores bien hechas, en cada pestaña nueva",
-    "description": "Extension name shown in browser extension surfaces and Chrome Web Store metadata."
+    "message": "daily.dev | Noticias para desarrolladores bien hechas, en cada pestaña nueva"
   },
   "extensionShortName": {
-    "message": "daily.dev",
-    "description": "Short extension name shown when space is limited."
+    "message": "daily.dev"
   },
   "extensionDescription": {
-    "message": "Noticias para desarrolladores, personalizadas según tu pila tecnológica, en cada pestaña nueva. Únete a más de 400 000 de desarrolladores. Gratuito y de código abierto.",
-    "description": "Short extension description shown in browser extension surfaces and Chrome Web Store metadata."
+    "message": "Noticias para desarrolladores, personalizadas según tu pila tecnológica, en cada pestaña nueva. Únete a más de 400 000 de desarrolladores. Gratuito y de código abierto."
   }
 }

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -1,0 +1,14 @@
+{
+  "extensionName": {
+    "message": "daily.dev | Noticias para desarrolladores bien hechas, en cada pestaña nueva",
+    "description": "Extension name shown in browser extension surfaces and Chrome Web Store metadata."
+  },
+  "extensionShortName": {
+    "message": "daily.dev",
+    "description": "Short extension name shown when space is limited."
+  },
+  "extensionDescription": {
+    "message": "Noticias para desarrolladores, personalizadas según tu pila tecnológica, en cada pestaña nueva. Únete a más de 400 000 de desarrolladores. Gratuito y de código abierto.",
+    "description": "Short extension description shown in browser extension surfaces and Chrome Web Store metadata."
+  }
+}

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -1,11 +1,8 @@
 {
   "extensionName": {
-    "message": "daily.dev | Noticias para desarrolladores bien hechas, en cada pestaña nueva"
-  },
-  "extensionShortName": {
-    "message": "daily.dev"
+    "message": "daily.dev | Noticias para devs bien hechas, en cada pestaña nueva"
   },
   "extensionDescription": {
-    "message": "Noticias para desarrolladores, personalizadas según tu pila tecnológica, en cada pestaña nueva. Únete a más de 400 000 de desarrolladores. Gratuito y de código abierto."
+    "message": "Noticias para desarrolladores, personalizadas según tu stack, en cada pestaña nueva. +400.000 devs. Gratis y open source."
   }
 }

--- a/packages/extension/public/_locales/fr/messages.json
+++ b/packages/extension/public/_locales/fr/messages.json
@@ -1,11 +1,8 @@
 {
   "extensionName": {
-    "message": "daily.dev | L'actualité des développeurs, bien présentée, dans chaque nouvel onglet"
-  },
-  "extensionShortName": {
-    "message": "daily.dev"
+    "message": "daily.dev | L'actualité dev, bien présentée, à chaque nouvel onglet"
   },
   "extensionDescription": {
-    "message": "Des actualités pour les développeurs, personnalisées en fonction de votre stack, dans chaque nouvel onglet. Rejoignez plus de 400 000 développeurs. Gratuit et open source."
+    "message": "L'actualité des développeurs, personnalisée selon votre stack, dans chaque nouvel onglet. +400 000 devs. Gratuit et open source."
   }
 }

--- a/packages/extension/public/_locales/fr/messages.json
+++ b/packages/extension/public/_locales/fr/messages.json
@@ -1,14 +1,11 @@
 {
   "extensionName": {
-    "message": "daily.dev | L'actualité des développeurs, bien présentée, dans chaque nouvel onglet",
-    "description": "Extension name shown in browser extension surfaces and Chrome Web Store metadata."
+    "message": "daily.dev | L'actualité des développeurs, bien présentée, dans chaque nouvel onglet"
   },
   "extensionShortName": {
-    "message": "daily.dev",
-    "description": "Short extension name shown when space is limited."
+    "message": "daily.dev"
   },
   "extensionDescription": {
-    "message": "Des actualités pour les développeurs, personnalisées en fonction de votre stack, dans chaque nouvel onglet. Rejoignez plus de 400 000 développeurs. Gratuit et open source.",
-    "description": "Short extension description shown in browser extension surfaces and Chrome Web Store metadata."
+    "message": "Des actualités pour les développeurs, personnalisées en fonction de votre stack, dans chaque nouvel onglet. Rejoignez plus de 400 000 développeurs. Gratuit et open source."
   }
 }

--- a/packages/extension/public/_locales/fr/messages.json
+++ b/packages/extension/public/_locales/fr/messages.json
@@ -1,0 +1,14 @@
+{
+  "extensionName": {
+    "message": "daily.dev | L'actualité des développeurs, bien présentée, dans chaque nouvel onglet",
+    "description": "Extension name shown in browser extension surfaces and Chrome Web Store metadata."
+  },
+  "extensionShortName": {
+    "message": "daily.dev",
+    "description": "Short extension name shown when space is limited."
+  },
+  "extensionDescription": {
+    "message": "Des actualités pour les développeurs, personnalisées en fonction de votre stack, dans chaque nouvel onglet. Rejoignez plus de 400 000 développeurs. Gratuit et open source.",
+    "description": "Short extension description shown in browser extension surfaces and Chrome Web Store metadata."
+  }
+}

--- a/packages/extension/public/_locales/ja/messages.json
+++ b/packages/extension/public/_locales/ja/messages.json
@@ -2,9 +2,6 @@
   "extensionName": {
     "message": "daily.dev | 開発者向けニュースを、新しいタブごとに適切に提供"
   },
-  "extensionShortName": {
-    "message": "daily.dev"
-  },
   "extensionDescription": {
     "message": "開発者向けニュースを、お使いのスタックに合わせてパーソナライズ。新しいタブを開くたびに表示されます。40万人以上の開発者の仲間入りをしましょう。無料でオープンソース。"
   }

--- a/packages/extension/public/_locales/ja/messages.json
+++ b/packages/extension/public/_locales/ja/messages.json
@@ -1,14 +1,11 @@
 {
   "extensionName": {
-    "message": "daily.dev | 開発者向けニュースを、新しいタブごとに適切に提供",
-    "description": "Extension name shown in browser extension surfaces and Chrome Web Store metadata."
+    "message": "daily.dev | 開発者向けニュースを、新しいタブごとに適切に提供"
   },
   "extensionShortName": {
-    "message": "daily.dev",
-    "description": "Short extension name shown when space is limited."
+    "message": "daily.dev"
   },
   "extensionDescription": {
-    "message": "開発者向けニュースを、お使いのスタックに合わせてパーソナライズ。新しいタブを開くたびに表示されます。40万人以上の開発者の仲間入りをしましょう。無料でオープンソース。",
-    "description": "Short extension description shown in browser extension surfaces and Chrome Web Store metadata."
+    "message": "開発者向けニュースを、お使いのスタックに合わせてパーソナライズ。新しいタブを開くたびに表示されます。40万人以上の開発者の仲間入りをしましょう。無料でオープンソース。"
   }
 }

--- a/packages/extension/public/_locales/ja/messages.json
+++ b/packages/extension/public/_locales/ja/messages.json
@@ -1,0 +1,14 @@
+{
+  "extensionName": {
+    "message": "daily.dev | 開発者向けニュースを、新しいタブごとに適切に提供",
+    "description": "Extension name shown in browser extension surfaces and Chrome Web Store metadata."
+  },
+  "extensionShortName": {
+    "message": "daily.dev",
+    "description": "Short extension name shown when space is limited."
+  },
+  "extensionDescription": {
+    "message": "開発者向けニュースを、お使いのスタックに合わせてパーソナライズ。新しいタブを開くたびに表示されます。40万人以上の開発者の仲間入りをしましょう。無料でオープンソース。",
+    "description": "Short extension description shown in browser extension surfaces and Chrome Web Store metadata."
+  }
+}

--- a/packages/extension/public/_locales/pt_BR/messages.json
+++ b/packages/extension/public/_locales/pt_BR/messages.json
@@ -1,14 +1,11 @@
 {
   "extensionName": {
-    "message": "daily.dev | Notícias para desenvolvedores do jeito certo, em cada nova guia",
-    "description": "Extension name shown in browser extension surfaces and Chrome Web Store metadata."
+    "message": "daily.dev | Notícias para desenvolvedores do jeito certo, em cada nova guia"
   },
   "extensionShortName": {
-    "message": "daily.dev",
-    "description": "Short extension name shown when space is limited."
+    "message": "daily.dev"
   },
   "extensionDescription": {
-    "message": "Notícias para desenvolvedores, personalizadas para a sua tecnologia, em cada nova guia. Junte-se a mais de 400.000 desenvolvedores. Grátis e de código aberto.",
-    "description": "Short extension description shown in browser extension surfaces and Chrome Web Store metadata."
+    "message": "Notícias para desenvolvedores, personalizadas para a sua tecnologia, em cada nova guia. Junte-se a mais de 400.000 desenvolvedores. Grátis e de código aberto."
   }
 }

--- a/packages/extension/public/_locales/pt_BR/messages.json
+++ b/packages/extension/public/_locales/pt_BR/messages.json
@@ -1,0 +1,14 @@
+{
+  "extensionName": {
+    "message": "daily.dev | Notícias para desenvolvedores do jeito certo, em cada nova guia",
+    "description": "Extension name shown in browser extension surfaces and Chrome Web Store metadata."
+  },
+  "extensionShortName": {
+    "message": "daily.dev",
+    "description": "Short extension name shown when space is limited."
+  },
+  "extensionDescription": {
+    "message": "Notícias para desenvolvedores, personalizadas para a sua tecnologia, em cada nova guia. Junte-se a mais de 400.000 desenvolvedores. Grátis e de código aberto.",
+    "description": "Short extension description shown in browser extension surfaces and Chrome Web Store metadata."
+  }
+}

--- a/packages/extension/public/_locales/pt_BR/messages.json
+++ b/packages/extension/public/_locales/pt_BR/messages.json
@@ -2,10 +2,7 @@
   "extensionName": {
     "message": "daily.dev | Notícias para desenvolvedores do jeito certo, em cada nova guia"
   },
-  "extensionShortName": {
-    "message": "daily.dev"
-  },
   "extensionDescription": {
-    "message": "Notícias para desenvolvedores, personalizadas para a sua tecnologia, em cada nova guia. Junte-se a mais de 400.000 desenvolvedores. Grátis e de código aberto."
+    "message": "Notícias para desenvolvedores, personalizadas para sua tecnologia, em cada nova guia. +400.000 devs. Grátis e open source."
   }
 }

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -2,9 +2,10 @@
   "manifest_version": 3,
   "__firefox__manifest_version": 2,
   "version": "0.0.0",
-  "name": "daily.dev | The homepage developers deserve",
-  "short_name": "daily.dev",
-  "description": "Turn every new tab into your personalized developer feed. Trusted by 400,000+ devs. AI-powered & open source.",
+  "default_locale": "en",
+  "name": "__MSG_extensionName__",
+  "short_name": "__MSG_extensionShortName__",
+  "description": "__MSG_extensionDescription__",
   "homepage_url": "https://daily.dev",
   "icons": {
     "16": "icons/16.png",

--- a/packages/extension/src/manifest.json
+++ b/packages/extension/src/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "default_locale": "en",
   "name": "__MSG_extensionName__",
-  "short_name": "__MSG_extensionShortName__",
+  "short_name": "daily.dev",
   "description": "__MSG_extensionDescription__",
   "homepage_url": "https://daily.dev",
   "icons": {


### PR DESCRIPTION
## Summary
- Localizes extension manifest metadata through Chrome's `_locales` message files.
- Adds English as the default locale so translated locale folders can be added as each language is ready.
- Documents the step-by-step workflow for adding Portuguese (Brazil), Spanish, German, Japanese, and French store listing localization.

## Test plan
- `pnpm --filter extension build`
- Confirmed `packages/extension/dist/chrome.zip` contains `manifest.json` and `_locales/en/messages.json`.


Made with [Cursor](https://cursor.com)

### Preview domain
https://feat-chrome-web-store-localizati.preview.app.daily.dev