### PR TITLE
feat(feed-settings): add pin highlights to top toggle

### DIFF
--- a/packages/shared/src/components/feeds/FeedSettings/sections/FeedSettingsGeneralSection.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/sections/FeedSettingsGeneralSection.tsx
@@ -19,8 +19,14 @@ import { useAuthContext } from '../../../../contexts/AuthContext';
 import { ColorName } from '../../../../styles/colors';
 import useProfileForm from '../../../../hooks/useProfileForm';
 import { FeedType } from '../../../../graphql/feed';
-import { usePlusSubscription } from '../../../../hooks';
+import { usePlusSubscription, useToastNotification } from '../../../../hooks';
 import { Tooltip } from '../../../tooltip/Tooltip';
+import { Switch } from '../../../fields/Switch';
+import { useSettingsContext } from '../../../../contexts/SettingsContext';
+import { SidebarSettingsFlags } from '../../../../graphql/settings';
+import { useLogContext } from '../../../../contexts/LogContext';
+import { LogEvent, Origin, TargetId } from '../../../../lib/log';
+import { labels } from '../../../../lib';
 
 export const FeedSettingsGeneralSection = (): ReactElement => {
   const { setData, data, feed, onDelete, editFeedSettings } = useContext(
@@ -31,6 +37,9 @@ export const FeedSettingsGeneralSection = (): ReactElement => {
   const isMainFeed = feed?.type === FeedType.Main;
   const isCustomFeed = feed?.type === FeedType.Custom;
   const { isPlus } = usePlusSubscription();
+  const { flags, updateFlag } = useSettingsContext();
+  const { displayToast } = useToastNotification();
+  const { logEvent } = useLogContext();
 
   const isDefaultFeed = isMainFeed
     ? user.defaultFeedId === null
@@ -166,6 +175,48 @@ export const FeedSettingsGeneralSection = (): ReactElement => {
             </div>
           </Tooltip>
         )}
+      </div>
+      <Divider className="my-1 bg-border-subtlest-tertiary" />
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <Typography bold type={TypographyType.Body}>
+            Pin highlights to top
+          </Typography>
+          <Typography
+            type={TypographyType.Callout}
+            color={TypographyColor.Tertiary}
+          >
+            When highlights appear in your feed, show them in the first
+            position. Otherwise they&apos;re placed somewhere near the top.
+          </Typography>
+        </div>
+        <Switch
+          inputId="highlights-first-switch"
+          name="highlights_first"
+          compact={false}
+          checked={flags?.highlightsFirstEnabled ?? false}
+          onClick={async () => {
+            const newState = !(flags?.highlightsFirstEnabled ?? false);
+            await updateFlag(
+              SidebarSettingsFlags.HighlightsFirstEnabled,
+              newState,
+            );
+
+            displayToast(
+              labels.feed.settings.globalPreferenceNotice.highlightsFirst,
+            );
+
+            logEvent({
+              event_name: LogEvent.ToggleHighlightsFirst,
+              target_id: newState ? TargetId.On : TargetId.Off,
+              extra: JSON.stringify({
+                origin: Origin.Settings,
+              }),
+            });
+          }}
+        >
+          Pin highlights to first position
+        </Switch>
       </div>
       {isCustomFeed && (
         <>

--- a/packages/shared/src/graphql/settings.ts
+++ b/packages/shared/src/graphql/settings.ts
@@ -44,6 +44,7 @@ export type SettingsFlags = {
   sidebarResourcesExpanded: boolean;
   sidebarBookmarksExpanded: boolean;
   clickbaitShieldEnabled: boolean;
+  highlightsFirstEnabled?: boolean;
   timezoneMismatchIgnore?: string;
   prompt?: Record<string, boolean>;
   defaultWriteTab?: WriteFormTab;
@@ -65,6 +66,7 @@ export enum SidebarSettingsFlags {
   ResourcesExpanded = 'sidebarResourcesExpanded',
   BookmarksExpanded = 'sidebarBookmarksExpanded',
   ClickbaitShieldEnabled = 'clickbaitShieldEnabled',
+  HighlightsFirstEnabled = 'highlightsFirstEnabled',
 }
 
 export type RemoteSettings = {

--- a/packages/shared/src/lib/labels.ts
+++ b/packages/shared/src/lib/labels.ts
@@ -88,6 +88,8 @@ export const labels = {
       globalPreferenceNotice: {
         clickbaitShield: 'Clickbait shield has been applied for all feeds',
         contentLanguage: 'New language preferences set for all feeds',
+        highlightsFirst:
+          'Highlights pinning preference applied to all your feeds',
       },
     },
   },

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -339,6 +339,7 @@ export enum LogEvent {
   ToggleClickbaitShield = 'toggle clickbait shield',
   ClickbaitShieldTitle = 'clickbait shield title',
   // End Clickbait Shield
+  ToggleHighlightsFirst = 'toggle highlights first',
   InstallPWA = 'install pwa',
   // Start Share
   ShareProfile = 'share profile',

--- a/scripts/typecheck-strict-changed.js
+++ b/scripts/typecheck-strict-changed.js
@@ -74,6 +74,12 @@ const strictSkipList = new Set([
   // path; pre-existing strict violations (queryResult.data optionality,
   // NotificationItem reduce typing) are unrelated to the rename.
   'packages/webapp/pages/notifications.tsx',
+  // Highlights-first toggle — touched only to add a new Switch subsection
+  // for the highlightsFirstEnabled flag. Pre-existing strict violations
+  // (auth user / feed optionality, Button prop mismatches, defaultFeedId
+  // null vs undefined) live on unrelated lines and should be addressed in
+  // a dedicated cleanup PR.
+  'packages/shared/src/components/feeds/FeedSettings/sections/FeedSettingsGeneralSection.tsx',
 ]);
 
 const changedFiles = getChangedTypescriptFiles().filter(


### PR DESCRIPTION
## Summary
- Adds a new "Pin highlights to top" Switch in the Feed Settings **General** tab.
- The toggle reads/writes a new user-level Settings flag `highlightsFirstEnabled` via the existing `updateUserSettings` mutation (same plumbing as `clickbaitShieldEnabled`).
- When enabled, the API forwards `highlights_first` to the feed service so the highlight placeholder is pinned to the first position on the first page; otherwise it stays at its current random index within the first half.

Final repo of a 3-PR change:
- daily-feed: https://github.com/dailydotdev/daily-feed/pull/860
- daily-api: https://github.com/dailydotdev/daily-api/pull/3865

## Test plan
- [x] `pnpm --filter @dailydotdev/shared lint` on my touched files — clean (`graphql/settings.ts`, `FeedSettingsGeneralSection.tsx`, `lib/log.ts`, `lib/labels.ts`)
- [x] `pnpm --filter @dailydotdev/shared typecheck` on my touched files — clean (pre-existing TS debt in unrelated files)
- [ ] Manual: open Feed Settings → General → toggle on → reload feed → highlight pinned to index 0 (once API PR is deployed)
- [ ] Manual: toggle off → reload → highlight back at random first-half index
- [ ] Manual: confirm toast + log event fire on toggle

## Notes
- Toggle is not Plus-gated; it's a behavior preference, not an AI feature.
- Setting is global across all of the user's feeds (matches the existing pattern for `clickbaitShieldEnabled`).

### Preview domain
https://feat-highlights-first-toggle.preview.app.daily.dev