### PR TITLE
feat: add contextual referral and review prompts

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -37,6 +37,7 @@ import { SpotlightHost } from './spotlight/SpotlightHost';
 import { FeedbackWidget } from './feedback';
 import { isExtension } from '../lib/func';
 import { ExtensionStoreReviewPrompt } from './referral/ExtensionStoreReviewPrompt';
+import { ReferralGrowthTestingPanel } from './referral/ReferralGrowthTestingPanel';
 
 const GoBackHeaderMobile = dynamic(
   () =>
@@ -187,6 +188,7 @@ function MainLayoutComponent({
       <InAppNotificationElement />
       <PromptElement />
       <Toast autoDismissNotifications={autoDismissNotifications} />
+      <ReferralGrowthTestingPanel />
       <ExtensionStoreReviewPrompt />
       <BootPopups />
       <SpotlightHost />

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -36,6 +36,7 @@ import { SpotlightProvider } from './spotlight/SpotlightContext';
 import { SpotlightHost } from './spotlight/SpotlightHost';
 import { FeedbackWidget } from './feedback';
 import { isExtension } from '../lib/func';
+import { ExtensionStoreReviewPrompt } from './referral/ExtensionStoreReviewPrompt';
 
 const GoBackHeaderMobile = dynamic(
   () =>
@@ -186,6 +187,7 @@ function MainLayoutComponent({
       <InAppNotificationElement />
       <PromptElement />
       <Toast autoDismissNotifications={autoDismissNotifications} />
+      <ExtensionStoreReviewPrompt />
       <BootPopups />
       <SpotlightHost />
       <StreakMilestonePopup />

--- a/packages/shared/src/components/modals/badges/TopReaderBadgeModal.tsx
+++ b/packages/shared/src/components/modals/badges/TopReaderBadgeModal.tsx
@@ -17,6 +17,12 @@ import { LogEvent, TargetId, TargetType } from '../../../lib/log';
 import { formatDate, TimeFormatType } from '../../../lib/dateFormat';
 import { useTopReader } from '../../../hooks/useTopReader';
 import { ModalClose } from '../common/ModalClose';
+import { ContextualReferralLink } from '../../referral/ContextualReferralLink';
+import { ReferralCampaignKey } from '../../../lib/referral';
+import { ReferralGrowthSurface } from '../../../lib/referralGrowth';
+import { webappUrl } from '../../../lib/constants';
+import { useConditionalFeature } from '../../../hooks/useConditionalFeature';
+import { featureReferralGrowthLoops } from '../../../lib/featureManagement';
 
 type TopReaderBadgeModalProps = {
   badgeId?: string;
@@ -25,15 +31,24 @@ type TopReaderBadgeModalProps = {
 
 const TopReaderBadgeModal = (
   props: ModalProps & TopReaderBadgeModalProps,
-): ReactElement => {
+): ReactElement | null => {
   const { onRequestClose, onAfterOpen, onAfterClose, badgeId, origin } = props;
 
   const { user } = useAuthContext();
   const { logEvent } = useLogContext();
   const isMobile = useViewSize(ViewSize.MobileL);
 
-  const { data: topReaders } = useTopReader({ user, limit: 1, badgeId });
+  const { data: topReaders } = useTopReader({
+    user: user!,
+    limit: 1,
+    badgeId,
+  });
   const topReader = topReaders?.[0];
+  const { value: showReferralGrowthLoop } = useConditionalFeature({
+    feature: featureReferralGrowthLoops,
+    shouldEvaluate: !!user?.id,
+  });
+  const profileUrl = user?.username ? `${webappUrl}${user.username}` : '';
 
   const { mutateAsync: onDownloadUrl, isPending: downloading } = useMutation({
     mutationFn: downloadUrl,
@@ -55,7 +70,7 @@ const TopReaderBadgeModal = (
   );
 
   const onClickDownload = useCallback(async () => {
-    if (!topReader) {
+    if (!topReader?.image) {
       return;
     }
 
@@ -101,7 +116,7 @@ const TopReaderBadgeModal = (
           You&apos;ve earned the top reader badge!
         </h1>
         <TopReaderBadge
-          user={user}
+          user={user!}
           keyword={topReader.keyword}
           issuedAt={topReader.issuedAt}
         />
@@ -116,6 +131,17 @@ const TopReaderBadgeModal = (
         >
           Download badge
         </Button>
+        {showReferralGrowthLoop && (
+          <ContextualReferralLink
+            className={classNames('w-full', !isMobile && 'max-w-80')}
+            url={profileUrl}
+            campaignKey={ReferralCampaignKey.ShareProfile}
+            surface={ReferralGrowthSurface.TopReaderBadge}
+            origin={origin ?? 'top reader badge modal'}
+            title="Let other devs see your badge"
+            description="Share your profile so friends can check your reader status and get their own."
+          />
+        )}
       </Modal.Body>
     </Modal>
   );

--- a/packages/shared/src/components/modals/badges/TopReaderBadgeModal.tsx
+++ b/packages/shared/src/components/modals/badges/TopReaderBadgeModal.tsx
@@ -19,10 +19,12 @@ import { useTopReader } from '../../../hooks/useTopReader';
 import { ModalClose } from '../common/ModalClose';
 import { ContextualReferralLink } from '../../referral/ContextualReferralLink';
 import { ReferralCampaignKey } from '../../../lib/referral';
-import { ReferralGrowthSurface } from '../../../lib/referralGrowth';
+import {
+  featureReferralGrowthLoops,
+  ReferralGrowthSurface,
+} from '../../../lib/referralGrowth';
 import { webappUrl } from '../../../lib/constants';
 import { useConditionalFeature } from '../../../hooks/useConditionalFeature';
-import { featureReferralGrowthLoops } from '../../../lib/featureManagement';
 
 type TopReaderBadgeModalProps = {
   badgeId?: string;

--- a/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
+++ b/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
@@ -20,10 +20,12 @@ import { ActionType } from '../../../graphql/actions';
 import StreakReminderSwitch from '../../streak/StreakReminderSwitch';
 import { ContextualReferralLink } from '../../referral/ContextualReferralLink';
 import { ReferralCampaignKey } from '../../../lib/referral';
-import { ReferralGrowthSurface } from '../../../lib/referralGrowth';
+import {
+  featureReferralGrowthLoops,
+  ReferralGrowthSurface,
+} from '../../../lib/referralGrowth';
 import { webappUrl } from '../../../lib/constants';
 import { useConditionalFeature } from '../../../hooks/useConditionalFeature';
-import { featureReferralGrowthLoops } from '../../../lib/featureManagement';
 
 const Paragraph = classed('p', 'text-center text-text-tertiary');
 

--- a/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
+++ b/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
@@ -12,18 +12,14 @@ import {
 } from '../../../lib/image';
 import type { StreakModalProps } from './common';
 import { useLogContext } from '../../../contexts/LogContext';
-import { LogEvent, Origin, TargetType } from '../../../lib/log';
+import { LogEvent, TargetType } from '../../../lib/log';
 import { generateQueryKey, RequestKey } from '../../../lib/query';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { useActions } from '../../../hooks';
 import { ActionType } from '../../../graphql/actions';
 import StreakReminderSwitch from '../../streak/StreakReminderSwitch';
-import { ContextualReferralLink } from '../../referral/ContextualReferralLink';
-import { ReferralCampaignKey } from '../../../lib/referral';
-import {
-  featureReferralGrowthLoops,
-  ReferralGrowthSurface,
-} from '../../../lib/referralGrowth';
+import { StreakShareCallout } from '../../referral/StreakShareCallout';
+import { featureReferralGrowthLoops } from '../../../lib/referralGrowth';
 import { webappUrl } from '../../../lib/constants';
 import { useConditionalFeature } from '../../../hooks/useConditionalFeature';
 
@@ -134,14 +130,10 @@ export default function NewStreakModal({
             : `New milestone reached! You are unstoppable.`}
         </Paragraph>
         {showReferralGrowthLoop && (
-          <ContextualReferralLink
+          <StreakShareCallout
             className="mt-6"
             url={profileUrl}
-            campaignKey={ReferralCampaignKey.ShareProfile}
-            surface={ReferralGrowthSurface.StreakMilestone}
-            origin={Origin.PostContent}
-            title="Challenge a friend to keep up"
-            description={`${currentStreak} ${daysPlural} strong. Share your profile and invite someone to build the habit with you.`}
+            currentStreak={currentStreak}
           />
         )}
         <Checkbox

--- a/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
+++ b/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
@@ -12,12 +12,18 @@ import {
 } from '../../../lib/image';
 import type { StreakModalProps } from './common';
 import { useLogContext } from '../../../contexts/LogContext';
-import { LogEvent, TargetType } from '../../../lib/log';
+import { LogEvent, Origin, TargetType } from '../../../lib/log';
 import { generateQueryKey, RequestKey } from '../../../lib/query';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { useActions } from '../../../hooks';
 import { ActionType } from '../../../graphql/actions';
 import StreakReminderSwitch from '../../streak/StreakReminderSwitch';
+import { ContextualReferralLink } from '../../referral/ContextualReferralLink';
+import { ReferralCampaignKey } from '../../../lib/referral';
+import { ReferralGrowthSurface } from '../../../lib/referralGrowth';
+import { webappUrl } from '../../../lib/constants';
+import { useConditionalFeature } from '../../../hooks/useConditionalFeature';
+import { featureReferralGrowthLoops } from '../../../lib/featureManagement';
 
 const Paragraph = classed('p', 'text-center text-text-tertiary');
 
@@ -37,6 +43,11 @@ export default function NewStreakModal({
   const shouldShowSplash = currentStreak >= maxStreak;
   const daysPlural = currentStreak === 1 ? 'day' : 'days';
   const loggedImpression = useRef(false);
+  const { value: showReferralGrowthLoop } = useConditionalFeature({
+    feature: featureReferralGrowthLoops,
+    shouldEvaluate: !!user?.id,
+  });
+  const profileUrl = user?.username ? `${webappUrl}${user.username}` : '';
 
   useEffect(() => {
     if (loggedImpression.current) {
@@ -120,9 +131,20 @@ export default function NewStreakModal({
             ? 'Epic win! You are in a league of your own'
             : `New milestone reached! You are unstoppable.`}
         </Paragraph>
+        {showReferralGrowthLoop && (
+          <ContextualReferralLink
+            className="mt-6"
+            url={profileUrl}
+            campaignKey={ReferralCampaignKey.ShareProfile}
+            surface={ReferralGrowthSurface.StreakMilestone}
+            origin={Origin.PostContent}
+            title="Challenge a friend to keep up"
+            description={`${currentStreak} ${daysPlural} strong. Share your profile and invite someone to build the habit with you.`}
+          />
+        )}
         <Checkbox
           name="show_streaks"
-          className="mt-10"
+          className={showReferralGrowthLoop ? 'mt-6' : 'mt-10'}
           checked={isStreakModalDisabled}
           onToggleCallback={handleOptOut}
         >

--- a/packages/shared/src/components/post/brief/BriefPostHeaderActions.tsx
+++ b/packages/shared/src/components/post/brief/BriefPostHeaderActions.tsx
@@ -35,8 +35,11 @@ export const BriefPostHeaderActions = ({
           <Button
             icon={<LinkIcon />}
             size={ButtonSize.Medium}
+            aria-label="Share this brief with a colleague"
             onClick={() => copyLink({ post })}
-          />
+          >
+            Share brief
+          </Button>
         )}
         <Link passHref href={`${settingsUrl}/notifications`}>
           <Button icon={<SettingsIcon />} tag="a" size={ButtonSize.Medium} />

--- a/packages/shared/src/components/post/common/PostContentShare.tsx
+++ b/packages/shared/src/components/post/common/PostContentShare.tsx
@@ -9,6 +9,7 @@ import { ReferralCampaignKey, useGetShortUrl } from '../../../hooks';
 import { PostContentWidget } from './PostContentWidget';
 import { useActiveFeedContext } from '../../../contexts';
 import { postLogEvent } from '../../../lib/feed';
+import { ReferralGrowthSurface } from '../../../lib/referralGrowth';
 
 interface PostContentShareProps {
   post: Post;
@@ -34,7 +35,7 @@ export function PostContentShare({
   return (
     <PostContentWidget
       className="mt-6"
-      title="Should anyone else see this post?"
+      title="Know a developer who should see this?"
     >
       <InviteLinkInput
         className={{ container: 'w-full flex-1' }}
@@ -44,6 +45,7 @@ export function PostContentShare({
           extra: {
             provider: ShareProvider.CopyLink,
             origin: Origin.PostContent,
+            surface: ReferralGrowthSurface.PostUpvote,
           },
           ...(logOpts && logOpts),
         })}

--- a/packages/shared/src/components/referral/ContextualReferralLink.tsx
+++ b/packages/shared/src/components/referral/ContextualReferralLink.tsx
@@ -16,6 +16,8 @@ import { ShareProvider } from '../../lib/share';
 import type { Origin } from '../../lib/log';
 import { LogEvent, TargetType } from '../../lib/log';
 import type { ReferralGrowthSurface } from '../../lib/referralGrowth';
+import { UserShareIcon, VIcon } from '../icons';
+import { IconSize } from '../Icon';
 
 type ContextualReferralLinkProps = {
   url: string;
@@ -36,7 +38,7 @@ export function ContextualReferralLink({
   description,
   origin,
   className,
-  buttonText = 'Copy invite link',
+  buttonText = 'Copy link',
 }: ContextualReferralLinkProps): ReactElement | null {
   const { user } = useAuthContext();
   const { logEvent } = useLogContext();
@@ -91,31 +93,51 @@ export function ContextualReferralLink({
   return (
     <div
       className={classNames(
-        'flex w-full flex-col gap-3 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-4 text-left',
+        'border-accent-cabbage-default/20 from-accent-onion-default/5 to-accent-cabbage-default/10 relative overflow-hidden rounded-16 border bg-gradient-to-br via-surface-float p-4 text-left',
         className,
       )}
     >
-      <div className="flex flex-col gap-1">
-        <Typography bold type={TypographyType.Callout}>
-          {title}
-        </Typography>
-        <Typography
-          type={TypographyType.Footnote}
-          color={TypographyColor.Tertiary}
-        >
-          {description}
-        </Typography>
+      {/* Background glow */}
+      <div className="bg-accent-cabbage-default/15 pointer-events-none absolute -right-8 -top-8 h-24 w-24 rounded-full blur-2xl" />
+
+      <div className="relative flex flex-col gap-3">
+        {/* Icon + copy */}
+        <div className="flex items-start gap-3">
+          <span className="bg-accent-cabbage-default/15 flex h-9 w-9 shrink-0 items-center justify-center rounded-12 text-accent-cabbage-default">
+            <UserShareIcon size={IconSize.Small} />
+          </span>
+          <div className="flex flex-col gap-0.5">
+            <Typography bold type={TypographyType.Callout}>
+              {title}
+            </Typography>
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+            >
+              {description}
+            </Typography>
+          </div>
+        </div>
+
+        {/* URL display + inline copy button */}
+        <div className="flex items-center gap-2 rounded-10 border border-border-subtlest-tertiary bg-surface-primary py-1.5 pl-3 pr-1.5">
+          <span className="min-w-0 flex-1 truncate text-text-tertiary typo-caption1">
+            {isLoading ? 'Preparing your link…' : link ?? url}
+          </span>
+          <Button
+            size={ButtonSize.XSmall}
+            type="button"
+            variant={copied ? ButtonVariant.Primary : ButtonVariant.Secondary}
+            icon={
+              copied ? <VIcon secondary size={IconSize.XSmall} /> : undefined
+            }
+            onClick={onCopy}
+            disabled={isLoading || !link}
+          >
+            {copied ? 'Copied!' : buttonText}
+          </Button>
+        </div>
       </div>
-      <Button
-        className="w-full"
-        disabled={isLoading || !link}
-        size={ButtonSize.Small}
-        type="button"
-        variant={ButtonVariant.Secondary}
-        onClick={onCopy}
-      >
-        {copied ? 'Copied' : buttonText}
-      </Button>
     </div>
   );
 }

--- a/packages/shared/src/components/referral/ContextualReferralLink.tsx
+++ b/packages/shared/src/components/referral/ContextualReferralLink.tsx
@@ -1,0 +1,121 @@
+import type { ReactElement } from 'react';
+import React, { useEffect, useRef } from 'react';
+import classNames from 'classnames';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../typography/Typography';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { useLogContext } from '../../contexts/LogContext';
+import { useCopyLink } from '../../hooks/useCopy';
+import { useGetShortUrl } from '../../hooks/utils/useGetShortUrl';
+import type { ReferralCampaignKey } from '../../lib/referral';
+import { ShareProvider } from '../../lib/share';
+import type { Origin } from '../../lib/log';
+import { LogEvent, TargetType } from '../../lib/log';
+import type { ReferralGrowthSurface } from '../../lib/referralGrowth';
+
+type ContextualReferralLinkProps = {
+  url: string;
+  campaignKey: ReferralCampaignKey;
+  surface: ReferralGrowthSurface;
+  title: string;
+  description: string;
+  origin: Origin | string;
+  className?: string;
+  buttonText?: string;
+};
+
+export function ContextualReferralLink({
+  url,
+  campaignKey,
+  surface,
+  title,
+  description,
+  origin,
+  className,
+  buttonText = 'Copy invite link',
+}: ContextualReferralLinkProps): ReactElement | null {
+  const { user } = useAuthContext();
+  const { logEvent } = useLogContext();
+  const loggedImpression = useRef(false);
+  const { getTrackedUrl, shareLink, isLoading } = useGetShortUrl({
+    query: {
+      url,
+      cid: campaignKey,
+      enabled: !!url && !!user?.id,
+    },
+  });
+  const trackedUrl = getTrackedUrl(url, campaignKey);
+  const link = shareLink || trackedUrl;
+  const [copied, copyLink] = useCopyLink(() => link);
+
+  useEffect(() => {
+    if (!user?.id || !url || loggedImpression.current) {
+      return;
+    }
+
+    logEvent({
+      event_name: LogEvent.ReferralPromptImpression,
+      target_type: TargetType.ReferralPrompt,
+      target_id: surface,
+      extra: JSON.stringify({
+        campaign: campaignKey,
+        origin,
+      }),
+    });
+
+    loggedImpression.current = true;
+  }, [campaignKey, logEvent, origin, surface, url, user?.id]);
+
+  if (!user?.id || !url) {
+    return null;
+  }
+
+  const onCopy = () => {
+    copyLink();
+    logEvent({
+      event_name: LogEvent.ReferralPromptClick,
+      target_type: TargetType.ReferralPrompt,
+      target_id: surface,
+      extra: JSON.stringify({
+        campaign: campaignKey,
+        origin,
+        provider: ShareProvider.CopyLink,
+      }),
+    });
+  };
+
+  return (
+    <div
+      className={classNames(
+        'flex w-full flex-col gap-3 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-4 text-left',
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-1">
+        <Typography bold type={TypographyType.Callout}>
+          {title}
+        </Typography>
+        <Typography
+          type={TypographyType.Footnote}
+          color={TypographyColor.Tertiary}
+        >
+          {description}
+        </Typography>
+      </div>
+      <Button
+        className="w-full"
+        disabled={isLoading || !link}
+        size={ButtonSize.Small}
+        type="button"
+        variant={ButtonVariant.Secondary}
+        onClick={onCopy}
+      >
+        {copied ? 'Copied' : buttonText}
+      </Button>
+    </div>
+  );
+}

--- a/packages/shared/src/components/referral/ExtensionStoreReviewPrompt.tsx
+++ b/packages/shared/src/components/referral/ExtensionStoreReviewPrompt.tsx
@@ -1,0 +1,160 @@
+import type { ReactElement } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../typography/Typography';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { useActions } from '../../hooks/useActions';
+import { ActionType } from '../../graphql/actions';
+import { isExtension } from '../../lib/func';
+import { useConditionalFeature } from '../../hooks/useConditionalFeature';
+import { featureExtensionStoreReviewPrompt } from '../../lib/featureManagement';
+import { useLogContext } from '../../contexts/LogContext';
+import { LogEvent, TargetType } from '../../lib/log';
+import { chromeWebStoreReviewUrl } from '../../lib/constants';
+import { useLazyModal } from '../../hooks/useLazyModal';
+import { LazyModal } from '../modals/common/types';
+
+export function ExtensionStoreReviewPrompt(): ReactElement | null {
+  const { user } = useAuthContext();
+  const { logEvent } = useLogContext();
+  const { openModal } = useLazyModal();
+  const { checkHasCompleted, completeAction, isActionsFetched } = useActions();
+  const [isPositive, setIsPositive] = useState(false);
+  const loggedImpression = useRef(false);
+  const { value: isFeatureEnabled } = useConditionalFeature({
+    feature: featureExtensionStoreReviewPrompt,
+    shouldEvaluate: isExtension && !!user?.id,
+  });
+
+  const hasPositiveSignal =
+    checkHasCompleted(ActionType.StreakMilestone) ||
+    checkHasCompleted(ActionType.VotePost) ||
+    checkHasCompleted(ActionType.BookmarkPost);
+  const shouldShow =
+    isExtension &&
+    isFeatureEnabled &&
+    !!user?.id &&
+    isActionsFetched &&
+    hasPositiveSignal &&
+    !checkHasCompleted(ActionType.ChromeStoreReviewPrompt);
+
+  useEffect(() => {
+    if (!shouldShow || loggedImpression.current) {
+      return;
+    }
+
+    logEvent({
+      event_name: LogEvent.StoreReviewPromptImpression,
+      target_type: TargetType.StoreReviewPrompt,
+    });
+    loggedImpression.current = true;
+  }, [logEvent, shouldShow]);
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  const completePrompt = () =>
+    completeAction(ActionType.ChromeStoreReviewPrompt);
+
+  const onPositive = () => {
+    setIsPositive(true);
+    logEvent({
+      event_name: LogEvent.StoreReviewPromptPositive,
+      target_type: TargetType.StoreReviewPrompt,
+    });
+  };
+
+  const onNegative = () => {
+    logEvent({
+      event_name: LogEvent.StoreReviewPromptNegative,
+      target_type: TargetType.StoreReviewPrompt,
+    });
+    completePrompt();
+    openModal({ type: LazyModal.Feedback });
+  };
+
+  const onDismiss = () => {
+    logEvent({
+      event_name: LogEvent.StoreReviewPromptDismiss,
+      target_type: TargetType.StoreReviewPrompt,
+    });
+    completePrompt();
+  };
+
+  const onReview = () => {
+    logEvent({
+      event_name: LogEvent.StoreReviewPromptClick,
+      target_type: TargetType.StoreReviewPrompt,
+    });
+    completePrompt();
+  };
+
+  return (
+    <div className="relative z-modal flex w-full justify-center border-b border-border-subtlest-tertiary bg-surface-float px-4 py-3">
+      <div className="flex w-full max-w-[44rem] flex-col items-center gap-3 text-center tablet:flex-row tablet:text-left">
+        <div className="flex flex-1 flex-col gap-1">
+          <Typography bold type={TypographyType.Callout}>
+            {isPositive
+              ? 'Would you mind leaving a quick review?'
+              : 'Are you enjoying daily.dev on your new tab?'}
+          </Typography>
+          <Typography
+            type={TypographyType.Footnote}
+            color={TypographyColor.Tertiary}
+          >
+            {isPositive
+              ? 'Honest Chrome Web Store reviews help other developers discover daily.dev.'
+              : 'Your feedback helps us understand whether this is the right moment to ask.'}
+          </Typography>
+        </div>
+        <div className="flex flex-wrap justify-center gap-2">
+          {isPositive ? (
+            <Button
+              tag="a"
+              href={chromeWebStoreReviewUrl}
+              target="_blank"
+              rel="noopener"
+              size={ButtonSize.Small}
+              variant={ButtonVariant.Primary}
+              onClick={onReview}
+            >
+              Review on Chrome Web Store
+            </Button>
+          ) : (
+            <>
+              <Button
+                type="button"
+                size={ButtonSize.Small}
+                variant={ButtonVariant.Primary}
+                onClick={onPositive}
+              >
+                Yes
+              </Button>
+              <Button
+                type="button"
+                size={ButtonSize.Small}
+                variant={ButtonVariant.Secondary}
+                onClick={onNegative}
+              >
+                Not really
+              </Button>
+            </>
+          )}
+          <Button
+            type="button"
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Tertiary}
+            onClick={onDismiss}
+          >
+            Not now
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/shared/src/components/referral/ExtensionStoreReviewPrompt.tsx
+++ b/packages/shared/src/components/referral/ExtensionStoreReviewPrompt.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
+import classNames from 'classnames';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import {
   Typography,
@@ -17,6 +18,10 @@ import { LogEvent, TargetType } from '../../lib/log';
 import { chromeWebStoreReviewUrl } from '../../lib/constants';
 import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
+import { StarIcon, MiniCloseIcon } from '../icons';
+import { IconSize } from '../Icon';
+
+const STAR_INDICES = [0, 1, 2, 3, 4] as const;
 
 export function ExtensionStoreReviewPrompt(): ReactElement | null {
   const { user } = useAuthContext();
@@ -95,12 +100,36 @@ export function ExtensionStoreReviewPrompt(): ReactElement | null {
   };
 
   return (
-    <div className="relative z-modal flex w-full justify-center border-b border-border-subtlest-tertiary bg-surface-float px-4 py-3">
-      <div className="flex w-full max-w-[44rem] flex-col items-center gap-3 text-center tablet:flex-row tablet:text-left">
-        <div className="flex flex-1 flex-col gap-1">
+    <div
+      className={classNames(
+        'relative z-modal flex w-full justify-center border-b px-4 py-3 transition-colors duration-300',
+        isPositive
+          ? 'border-accent-cheese-default/30 via-accent-cheese-default/8 bg-gradient-to-r from-surface-float to-surface-float'
+          : 'border-border-subtlest-tertiary bg-surface-float',
+      )}
+    >
+      <div className="flex w-full max-w-[44rem] items-center gap-4">
+        {/* Star row — shows outline stars initially, filled gold stars in positive step */}
+        <div className="hidden shrink-0 items-center gap-0.5 tablet:flex">
+          {STAR_INDICES.map((i) => (
+            <StarIcon
+              key={i}
+              secondary={isPositive}
+              size={IconSize.XSmall}
+              className={
+                isPositive
+                  ? 'text-accent-cheese-default'
+                  : 'text-accent-cheese-default/50'
+              }
+            />
+          ))}
+        </div>
+
+        {/* Text */}
+        <div className="flex flex-1 flex-col gap-0.5 text-left">
           <Typography bold type={TypographyType.Callout}>
             {isPositive
-              ? 'Would you mind leaving a quick review?'
+              ? 'Would you leave a quick review?'
               : 'Are you enjoying daily.dev on your new tab?'}
           </Typography>
           <Typography
@@ -108,11 +137,13 @@ export function ExtensionStoreReviewPrompt(): ReactElement | null {
             color={TypographyColor.Tertiary}
           >
             {isPositive
-              ? 'Honest Chrome Web Store reviews help other developers discover daily.dev.'
-              : 'Your feedback helps us understand whether this is the right moment to ask.'}
+              ? 'Honest reviews help other developers discover daily.dev — it takes 30 seconds.'
+              : 'Let us know if this is a good moment to ask.'}
           </Typography>
         </div>
-        <div className="flex flex-wrap justify-center gap-2">
+
+        {/* Actions */}
+        <div className="flex shrink-0 items-center gap-2">
           {isPositive ? (
             <Button
               tag="a"
@@ -123,7 +154,7 @@ export function ExtensionStoreReviewPrompt(): ReactElement | null {
               variant={ButtonVariant.Primary}
               onClick={onReview}
             >
-              Review on Chrome Web Store
+              Leave a review ↗
             </Button>
           ) : (
             <>
@@ -133,26 +164,28 @@ export function ExtensionStoreReviewPrompt(): ReactElement | null {
                 variant={ButtonVariant.Primary}
                 onClick={onPositive}
               >
-                Yes
+                Yes, loving it!
               </Button>
               <Button
                 type="button"
                 size={ButtonSize.Small}
-                variant={ButtonVariant.Secondary}
+                variant={ButtonVariant.Tertiary}
                 onClick={onNegative}
               >
-                Not really
+                Not yet
               </Button>
             </>
           )}
-          <Button
+
+          {/* Dismiss */}
+          <button
             type="button"
-            size={ButtonSize.Small}
-            variant={ButtonVariant.Tertiary}
+            aria-label="Dismiss review prompt"
+            className="ml-1 flex h-7 w-7 items-center justify-center rounded-8 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary"
             onClick={onDismiss}
           >
-            Not now
-          </Button>
+            <MiniCloseIcon size={IconSize.XSmall} />
+          </button>
         </div>
       </div>
     </div>

--- a/packages/shared/src/components/referral/ExtensionStoreReviewPrompt.tsx
+++ b/packages/shared/src/components/referral/ExtensionStoreReviewPrompt.tsx
@@ -11,7 +11,7 @@ import { useActions } from '../../hooks/useActions';
 import { ActionType } from '../../graphql/actions';
 import { isExtension } from '../../lib/func';
 import { useConditionalFeature } from '../../hooks/useConditionalFeature';
-import { featureExtensionStoreReviewPrompt } from '../../lib/featureManagement';
+import { featureExtensionStoreReviewPrompt } from '../../lib/referralGrowth';
 import { useLogContext } from '../../contexts/LogContext';
 import { LogEvent, TargetType } from '../../lib/log';
 import { chromeWebStoreReviewUrl } from '../../lib/constants';

--- a/packages/shared/src/components/referral/ReferralGrowthTestingPanel.tsx
+++ b/packages/shared/src/components/referral/ReferralGrowthTestingPanel.tsx
@@ -16,7 +16,7 @@ import {
   settingsUrl,
 } from '../../lib/constants';
 import { useGrowthBookContext } from '../GrowthBookProvider';
-import { StarIcon, MiniCloseIcon } from '../icons';
+import { MiniCloseIcon, ReadingStreakIcon, StarIcon } from '../icons';
 import { IconSize } from '../Icon';
 
 const STAR_INDICES = [0, 1, 2, 3, 4] as const;
@@ -40,28 +40,29 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
     return null;
   }
 
-  const toggleFlags = () => {
-    if (flagsForced) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (growthbook as any)?.setForcedFeatures?.(new Map());
-      setFlagsForced(false);
-    } else {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (growthbook as any)?.setForcedFeatures?.(
+  const setFlagsForcedOn = (on: boolean) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const gb = growthbook as any;
+    if (on) {
+      gb?.setForcedFeatures?.(
         new Map([
           ['referral_growth_loops', true],
           ['extension_store_review_prompt', true],
         ]),
       );
-      setFlagsForced(true);
+    } else {
+      gb?.setForcedFeatures?.(new Map());
     }
+    setFlagsForced(on);
   };
 
-  const openStreakModal = (currentStreak: number, maxStreak: number) =>
+  const launchStreakInvite = (currentStreak: number, maxStreak: number) => {
+    setFlagsForcedOn(true);
     openModal({
       type: LazyModal.NewStreak,
       props: { currentStreak, maxStreak },
     });
+  };
 
   const openFeedbackModal = () => openModal({ type: LazyModal.Feedback });
 
@@ -70,11 +71,6 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
     setReviewPositive(false);
   };
 
-  /*
-   * The review banner renders fixed at the top of the viewport — exactly the
-   * width and position it occupies in the real extension new-tab layout.
-   * JSX mirrors ExtensionStoreReviewPrompt so what you see here is what users see.
-   */
   const reviewBanner = reviewOpen ? (
     <div
       className={classNames(
@@ -85,7 +81,6 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
       )}
     >
       <div className="flex w-full max-w-[44rem] items-center gap-4">
-        {/* Stars */}
         <div className="hidden shrink-0 items-center gap-0.5 tablet:flex">
           {STAR_INDICES.map((i) => (
             <StarIcon
@@ -100,8 +95,6 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
             />
           ))}
         </div>
-
-        {/* Text */}
         <div className="flex flex-1 flex-col gap-0.5 text-left">
           <Typography bold type={TypographyType.Callout}>
             {reviewPositive
@@ -117,8 +110,6 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
               : 'Let us know if this is a good moment to ask.'}
           </Typography>
         </div>
-
-        {/* Actions */}
         <div className="flex shrink-0 items-center gap-2">
           {reviewPositive ? (
             <Button
@@ -174,10 +165,11 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
         {reviewBanner}
         <button
           type="button"
-          className="text-text-inverted fixed bottom-4 right-4 z-max rounded-12 border border-border-subtlest-tertiary bg-accent-cabbage-default px-3 py-2 font-bold typo-footnote"
+          className="border-accent-bacon-default/40 fixed bottom-4 right-4 z-max flex items-center gap-1.5 rounded-12 border bg-accent-bacon-default px-3 py-2 font-bold text-white shadow-2 typo-footnote"
           onClick={() => setIsCollapsed(false)}
         >
-          Open referral QA
+          <ReadingStreakIcon secondary size={IconSize.XSmall} /> Open referral
+          QA
         </button>
       </>
     );
@@ -186,7 +178,8 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
   return (
     <>
       {reviewBanner}
-      <aside className="fixed bottom-4 right-4 z-max flex max-h-[calc(100dvh-2rem)] w-[22rem] max-w-[calc(100vw-2rem)] flex-col gap-4 overflow-auto rounded-16 border border-border-subtlest-tertiary bg-background-default p-4 shadow-2">
+      <aside className="fixed bottom-4 right-4 z-max flex max-h-[calc(100dvh-2rem)] w-[24rem] max-w-[calc(100vw-2rem)] flex-col gap-4 overflow-auto rounded-16 border border-border-subtlest-tertiary bg-background-default p-4 shadow-2">
+        {/* Header */}
         <div className="flex items-start justify-between gap-3">
           <div className="flex flex-col gap-0.5">
             <Typography bold type={TypographyType.Callout}>
@@ -196,7 +189,7 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
               type={TypographyType.Footnote}
               color={TypographyColor.Tertiary}
             >
-              Triggers the real interactions — remove before launch.
+              Real interactions, not mockups. Remove before launch.
             </Typography>
           </div>
           <Button
@@ -209,153 +202,171 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
           </Button>
         </div>
 
-        {/* Step 1: force GrowthBook flags so referral sections appear in modals */}
-        <div className="flex flex-col gap-2 rounded-12 border border-border-subtlest-tertiary p-3">
-          <Typography bold type={TypographyType.Footnote}>
-            1. Enable flags first
-          </Typography>
-          <Typography
-            type={TypographyType.Footnote}
-            color={TypographyColor.Tertiary}
-          >
-            Forces <code className="typo-footnote">referral_growth_loops</code>{' '}
-            on so the invite sections appear inside the modals below.
-          </Typography>
+        {/* HERO: the focus design */}
+        <div className="border-accent-bacon-default/30 from-accent-bacon-default/15 to-accent-cheese-default/15 relative overflow-hidden rounded-16 border bg-gradient-to-br via-surface-float p-4">
+          <div className="bg-accent-bacon-default/30 pointer-events-none absolute -right-8 -top-8 h-24 w-24 rounded-full blur-2xl" />
+          <div className="relative flex flex-col gap-3">
+            <div className="flex items-center gap-2">
+              <span className="bg-accent-bacon-default/25 flex h-8 w-8 items-center justify-center rounded-10 text-accent-bacon-default">
+                <ReadingStreakIcon secondary size={IconSize.XSmall} />
+              </span>
+              <div className="flex flex-col">
+                <Typography bold type={TypographyType.Callout}>
+                  Streak invite — focus design
+                </Typography>
+                <Typography
+                  type={TypographyType.Caption1}
+                  color={TypographyColor.Tertiary}
+                >
+                  Polished invite moment built for the streak modal
+                </Typography>
+              </div>
+            </div>
+
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+            >
+              One click forces the feature flag and opens the streak modal so
+              you can see the new <strong>StreakShareCallout</strong> live —
+              chat-bubble preview, pre-written message with your streak count, 5
+              channel buttons (WhatsApp, X, Telegram, Email, Copy), tracked
+              links per channel.
+            </Typography>
+
+            <div className="flex flex-col gap-2">
+              <Button
+                type="button"
+                size={ButtonSize.Medium}
+                variant={ButtonVariant.Primary}
+                className="w-full"
+                onClick={() => launchStreakInvite(7, 3)}
+              >
+                Open 7-day streak invite
+              </Button>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  size={ButtonSize.Small}
+                  variant={ButtonVariant.Secondary}
+                  className="flex-1"
+                  onClick={() => launchStreakInvite(30, 14)}
+                >
+                  30-day milestone
+                </Button>
+                <Button
+                  type="button"
+                  size={ButtonSize.Small}
+                  variant={ButtonVariant.Secondary}
+                  className="flex-1"
+                  onClick={() => launchStreakInvite(100, 100)}
+                >
+                  100 days 🏆
+                </Button>
+              </div>
+            </div>
+
+            <Typography
+              type={TypographyType.Caption1}
+              color={TypographyColor.Tertiary}
+              className="border-t border-border-subtlest-tertiary pt-2"
+            >
+              💡 The invite text adapts to streak length: friendly at 7 days,
+              cocky at 30, dominant at 100.
+            </Typography>
+          </div>
+        </div>
+
+        {/* Manual flag toggle */}
+        <div className="flex items-center justify-between gap-3 rounded-12 border border-border-subtlest-tertiary px-3 py-2">
+          <div className="flex flex-col gap-0.5">
+            <Typography bold type={TypographyType.Caption1}>
+              Force flags
+            </Typography>
+            <Typography
+              type={TypographyType.Caption2}
+              color={TypographyColor.Tertiary}
+            >
+              referral_growth_loops + store_review_prompt
+            </Typography>
+          </div>
           <Button
             type="button"
-            size={ButtonSize.Small}
+            size={ButtonSize.XSmall}
             variant={
               flagsForced ? ButtonVariant.Primary : ButtonVariant.Secondary
             }
-            onClick={toggleFlags}
+            onClick={() => setFlagsForcedOn(!flagsForced)}
           >
-            {flagsForced ? '✓ Flags forced on' : 'Force flags on'}
+            {flagsForced ? '✓ On' : 'Off'}
           </Button>
         </div>
 
-        {/* Step 2: streak modals — opens the real modal users see */}
-        <div className="flex flex-col gap-2 rounded-12 border border-border-subtlest-tertiary p-3">
-          <Typography bold type={TypographyType.Footnote}>
-            2. Streak milestone modal
-          </Typography>
-          <Typography
-            type={TypographyType.Footnote}
-            color={TypographyColor.Tertiary}
-          >
-            Opens the exact modal users see when reaching a streak. Enable flags
-            first to see the invite section inside.
-          </Typography>
-          <div className="flex gap-2">
+        {/* Other surfaces (collapsed-style group) */}
+        <details className="rounded-12 border border-border-subtlest-tertiary">
+          <summary className="cursor-pointer list-none px-3 py-2 text-text-tertiary typo-footnote">
+            Other referral surfaces ▾
+          </summary>
+          <div className="flex flex-col gap-2 border-t border-border-subtlest-tertiary p-3">
             <Button
               type="button"
               size={ButtonSize.Small}
-              variant={ButtonVariant.Secondary}
-              onClick={() => openStreakModal(7, 3)}
+              variant={
+                reviewOpen ? ButtonVariant.Primary : ButtonVariant.Secondary
+              }
+              onClick={toggleReview}
             >
-              7-day streak
+              {reviewOpen ? 'Hide review banner' : 'Show review banner'}
             </Button>
-            <Button
-              type="button"
-              size={ButtonSize.Small}
-              variant={ButtonVariant.Secondary}
-              onClick={() => openStreakModal(10, 10)}
-            >
-              New record 🏆
-            </Button>
+            <div className="grid grid-cols-2 gap-2">
+              <Button
+                tag="a"
+                href={`${settingsUrl}/customization/devcard`}
+                size={ButtonSize.XSmall}
+                variant={ButtonVariant.Tertiary}
+              >
+                DevCard
+              </Button>
+              <Button
+                tag="a"
+                href={`${settingsUrl}/invite`}
+                size={ButtonSize.XSmall}
+                variant={ButtonVariant.Tertiary}
+              >
+                Invite page
+              </Button>
+              <Button
+                tag="a"
+                href="/squads/new"
+                size={ButtonSize.XSmall}
+                variant={ButtonVariant.Tertiary}
+              >
+                New Squad
+              </Button>
+              <Button
+                tag="a"
+                href="/briefing"
+                size={ButtonSize.XSmall}
+                variant={ButtonVariant.Tertiary}
+              >
+                Brief
+              </Button>
+              <Button
+                type="button"
+                size={ButtonSize.XSmall}
+                variant={ButtonVariant.Tertiary}
+                onClick={openFeedbackModal}
+              >
+                Feedback modal
+              </Button>
+            </div>
           </div>
-        </div>
-
-        {/* Step 3: Chrome Web Store review — real banner, full width, at top of page */}
-        <div className="flex flex-col gap-2 rounded-12 border border-border-subtlest-tertiary p-3">
-          <Typography bold type={TypographyType.Footnote}>
-            3. Chrome review banner
-          </Typography>
-          <Typography
-            type={TypographyType.Footnote}
-            color={TypographyColor.Tertiary}
-          >
-            Renders the real two-step banner at the top of the page — same width
-            and position as extension users see it on their new tab.
-          </Typography>
-          <Button
-            type="button"
-            size={ButtonSize.Small}
-            variant={
-              reviewOpen ? ButtonVariant.Primary : ButtonVariant.Secondary
-            }
-            onClick={toggleReview}
-          >
-            {reviewOpen ? 'Hide banner' : 'Show review banner'}
-          </Button>
-        </div>
-
-        {/* Step 4: DevCard — navigate to the settings page that embeds the invite */}
-        <div className="flex flex-col gap-2 rounded-12 border border-border-subtlest-tertiary p-3">
-          <Typography bold type={TypographyType.Footnote}>
-            4. DevCard invite
-          </Typography>
-          <Typography
-            type={TypographyType.Footnote}
-            color={TypographyColor.Tertiary}
-          >
-            Enable flags first — the tracked invite link appears in DevCard
-            settings step&nbsp;2.
-          </Typography>
-          <Button
-            tag="a"
-            href={`${settingsUrl}/customization/devcard`}
-            size={ButtonSize.Small}
-            variant={ButtonVariant.Secondary}
-          >
-            Go to DevCard settings →
-          </Button>
-        </div>
-
-        {/* More contextual surfaces */}
-        <div className="flex flex-col gap-2">
-          <Typography bold type={TypographyType.Footnote}>
-            More flows
-          </Typography>
-          <div className="grid grid-cols-2 gap-2">
-            <Button
-              tag="a"
-              href={`${settingsUrl}/invite`}
-              size={ButtonSize.XSmall}
-              variant={ButtonVariant.Tertiary}
-            >
-              Invite page
-            </Button>
-            <Button
-              tag="a"
-              href="/squads/new"
-              size={ButtonSize.XSmall}
-              variant={ButtonVariant.Tertiary}
-            >
-              New Squad
-            </Button>
-            <Button
-              tag="a"
-              href="/briefing"
-              size={ButtonSize.XSmall}
-              variant={ButtonVariant.Tertiary}
-            >
-              Brief share
-            </Button>
-            <Button
-              type="button"
-              size={ButtonSize.XSmall}
-              variant={ButtonVariant.Tertiary}
-              onClick={openFeedbackModal}
-            >
-              Feedback modal
-            </Button>
-          </div>
-        </div>
+        </details>
 
         {!user?.id && (
           <Typography
             type={TypographyType.Footnote}
-            color={TypographyColor.Secondary}
+            color={TypographyColor.StatusHelp}
           >
             ⚠ Log in to test tracked invite links.
           </Typography>

--- a/packages/shared/src/components/referral/ReferralGrowthTestingPanel.tsx
+++ b/packages/shared/src/components/referral/ReferralGrowthTestingPanel.tsx
@@ -49,15 +49,28 @@ const demoSurfaces = [
   },
 ];
 
+const getWebappUrl = (): string => {
+  if (webappUrl) {
+    return webappUrl;
+  }
+
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  return `${window.location.origin}/`;
+};
+
 export function ReferralGrowthTestingPanel(): ReactElement {
   const { user } = useAuthContext();
   const { openModal } = useLazyModal();
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [selectedSurface, setSelectedSurface] = useState(demoSurfaces[0]);
   const [showReviewStep, setShowReviewStep] = useState(false);
+  const qaWebappUrl = getWebappUrl();
   const profileUrl = user?.username
-    ? `${webappUrl}${user.username}`
-    : webappUrl;
+    ? `${qaWebappUrl}${user.username}`
+    : qaWebappUrl;
 
   if (isCollapsed) {
     return (
@@ -119,7 +132,7 @@ export function ReferralGrowthTestingPanel(): ReactElement {
         </Button>
         <Button
           tag="a"
-          href={`${webappUrl}squads/new`}
+          href={`${qaWebappUrl}squads/new`}
           size={ButtonSize.Small}
           variant={ButtonVariant.Secondary}
         >

--- a/packages/shared/src/components/referral/ReferralGrowthTestingPanel.tsx
+++ b/packages/shared/src/components/referral/ReferralGrowthTestingPanel.tsx
@@ -1,0 +1,223 @@
+import type { ReactElement } from 'react';
+import React, { useState } from 'react';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../typography/Typography';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { useLazyModal } from '../../hooks/useLazyModal';
+import { LazyModal } from '../modals/common/types';
+import {
+  chromeWebStoreReviewUrl,
+  settingsUrl,
+  webappUrl,
+} from '../../lib/constants';
+import { ReferralCampaignKey } from '../../lib/referral';
+import { ReferralGrowthSurface } from '../../lib/referralGrowth';
+import { ContextualReferralLink } from './ContextualReferralLink';
+
+const demoSurfaces = [
+  {
+    surface: ReferralGrowthSurface.DevCard,
+    title: 'DevCard invite',
+    description:
+      'Demo the tracked invite prompt shown after someone prepares their DevCard.',
+    buttonText: 'Copy DevCard invite',
+  },
+  {
+    surface: ReferralGrowthSurface.StreakMilestone,
+    title: 'Streak challenge',
+    description:
+      'Demo the tracked invite prompt attached to a reading streak milestone.',
+    buttonText: 'Copy streak invite',
+  },
+  {
+    surface: ReferralGrowthSurface.TopReaderBadge,
+    title: 'Top reader badge',
+    description:
+      'Demo the tracked invite prompt shown from the top-reader badge moment.',
+    buttonText: 'Copy badge invite',
+  },
+  {
+    surface: ReferralGrowthSurface.Brief,
+    title: 'Brief share',
+    description:
+      'Demo the tracked invite prompt for sharing a useful brief with a colleague.',
+    buttonText: 'Copy brief invite',
+  },
+];
+
+export function ReferralGrowthTestingPanel(): ReactElement {
+  const { user } = useAuthContext();
+  const { openModal } = useLazyModal();
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [selectedSurface, setSelectedSurface] = useState(demoSurfaces[0]);
+  const [showReviewStep, setShowReviewStep] = useState(false);
+  const profileUrl = user?.username
+    ? `${webappUrl}${user.username}`
+    : webappUrl;
+
+  if (isCollapsed) {
+    return (
+      <button
+        type="button"
+        className="text-text-inverted fixed bottom-4 right-4 z-max rounded-12 border border-border-subtlest-tertiary bg-accent-cabbage-default px-3 py-2 font-bold typo-footnote"
+        onClick={() => setIsCollapsed(false)}
+      >
+        Open referral QA
+      </button>
+    );
+  }
+
+  return (
+    <aside className="fixed bottom-4 right-4 z-max flex max-h-[calc(100dvh-2rem)] w-[22rem] max-w-[calc(100vw-2rem)] flex-col gap-3 overflow-auto rounded-16 border border-border-subtlest-tertiary bg-background-default p-4 shadow-2">
+      {/*
+        TEMPORARY QA PANEL: remove this component and its MainLayout render
+        completely after referral/review preview testing is done.
+      */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <Typography bold type={TypographyType.Callout}>
+            Referral/review QA panel
+          </Typography>
+          <Typography
+            type={TypographyType.Footnote}
+            color={TypographyColor.Tertiary}
+          >
+            Temporary testing panel. Remove completely before this experiment is
+            finalized.
+          </Typography>
+        </div>
+        <Button
+          type="button"
+          size={ButtonSize.XSmall}
+          variant={ButtonVariant.Tertiary}
+          onClick={() => setIsCollapsed(true)}
+        >
+          Hide
+        </Button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <Button
+          tag="a"
+          href={`${settingsUrl}/customization/devcard`}
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Secondary}
+        >
+          DevCard
+        </Button>
+        <Button
+          tag="a"
+          href={`${settingsUrl}/invite`}
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Secondary}
+        >
+          Invite page
+        </Button>
+        <Button
+          tag="a"
+          href={`${webappUrl}squads/new`}
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Secondary}
+        >
+          New Squad
+        </Button>
+        <Button
+          type="button"
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Secondary}
+          onClick={() => openModal({ type: LazyModal.Feedback })}
+        >
+          Feedback
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Typography bold type={TypographyType.Footnote}>
+          Demo invite prompt
+        </Typography>
+        <div className="flex flex-wrap gap-2">
+          {demoSurfaces.map((item) => (
+            <Button
+              key={item.surface}
+              type="button"
+              size={ButtonSize.XSmall}
+              variant={
+                selectedSurface.surface === item.surface
+                  ? ButtonVariant.Primary
+                  : ButtonVariant.Tertiary
+              }
+              onClick={() => setSelectedSurface(item)}
+            >
+              {item.title}
+            </Button>
+          ))}
+        </div>
+        {!user?.id && (
+          <Typography
+            type={TypographyType.Footnote}
+            color={TypographyColor.Tertiary}
+          >
+            Log in to test tracked copy links.
+          </Typography>
+        )}
+        <ContextualReferralLink
+          url={profileUrl}
+          campaignKey={ReferralCampaignKey.ShareProfile}
+          surface={selectedSurface.surface}
+          origin="temporary referral QA panel"
+          title={selectedSurface.title}
+          description={selectedSurface.description}
+          buttonText={selectedSurface.buttonText}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-3">
+        <Typography bold type={TypographyType.Footnote}>
+          Demo review ask
+        </Typography>
+        <Typography
+          type={TypographyType.Footnote}
+          color={TypographyColor.Tertiary}
+        >
+          This mirrors the two-step Chrome Web Store ask without completing the
+          one-time action.
+        </Typography>
+        {showReviewStep ? (
+          <Button
+            tag="a"
+            href={chromeWebStoreReviewUrl}
+            target="_blank"
+            rel="noopener"
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Primary}
+          >
+            Review on Chrome Web Store
+          </Button>
+        ) : (
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              size={ButtonSize.Small}
+              variant={ButtonVariant.Primary}
+              onClick={() => setShowReviewStep(true)}
+            >
+              Yes
+            </Button>
+            <Button
+              type="button"
+              size={ButtonSize.Small}
+              variant={ButtonVariant.Secondary}
+              onClick={() => openModal({ type: LazyModal.Feedback })}
+            >
+              Not really
+            </Button>
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/packages/shared/src/components/referral/ReferralGrowthTestingPanel.tsx
+++ b/packages/shared/src/components/referral/ReferralGrowthTestingPanel.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import React, { useState } from 'react';
+import classNames from 'classnames';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import {
   Typography,
@@ -15,6 +16,10 @@ import {
   settingsUrl,
 } from '../../lib/constants';
 import { useGrowthBookContext } from '../GrowthBookProvider';
+import { StarIcon, MiniCloseIcon } from '../icons';
+import { IconSize } from '../Icon';
+
+const STAR_INDICES = [0, 1, 2, 3, 4] as const;
 
 /*
  * TEMPORARY QA PANEL
@@ -53,7 +58,10 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
   };
 
   const openStreakModal = (currentStreak: number, maxStreak: number) =>
-    openModal({ type: LazyModal.NewStreak, props: { currentStreak, maxStreak } });
+    openModal({
+      type: LazyModal.NewStreak,
+      props: { currentStreak, maxStreak },
+    });
 
   const openFeedbackModal = () => openModal({ type: LazyModal.Feedback });
 
@@ -65,23 +73,53 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
   /*
    * The review banner renders fixed at the top of the viewport — exactly the
    * width and position it occupies in the real extension new-tab layout.
+   * JSX mirrors ExtensionStoreReviewPrompt so what you see here is what users see.
    */
   const reviewBanner = reviewOpen ? (
-    <div className="fixed inset-x-0 top-0 z-max flex w-full justify-center border-b border-border-subtlest-tertiary bg-surface-float px-4 py-3">
-      <div className="flex w-full max-w-[44rem] flex-col items-center gap-3 text-center tablet:flex-row tablet:text-left">
-        <div className="flex flex-1 flex-col gap-1">
+    <div
+      className={classNames(
+        'fixed inset-x-0 top-0 z-max flex w-full justify-center border-b px-4 py-3 transition-colors duration-300',
+        reviewPositive
+          ? 'border-accent-cheese-default/30 via-accent-cheese-default/8 bg-gradient-to-r from-surface-float to-surface-float'
+          : 'border-border-subtlest-tertiary bg-surface-float',
+      )}
+    >
+      <div className="flex w-full max-w-[44rem] items-center gap-4">
+        {/* Stars */}
+        <div className="hidden shrink-0 items-center gap-0.5 tablet:flex">
+          {STAR_INDICES.map((i) => (
+            <StarIcon
+              key={i}
+              secondary={reviewPositive}
+              size={IconSize.XSmall}
+              className={
+                reviewPositive
+                  ? 'text-accent-cheese-default'
+                  : 'text-accent-cheese-default/50'
+              }
+            />
+          ))}
+        </div>
+
+        {/* Text */}
+        <div className="flex flex-1 flex-col gap-0.5 text-left">
           <Typography bold type={TypographyType.Callout}>
             {reviewPositive
-              ? 'Would you mind leaving a quick review?'
+              ? 'Would you leave a quick review?'
               : 'Are you enjoying daily.dev on your new tab?'}
           </Typography>
-          <Typography type={TypographyType.Footnote} color={TypographyColor.Tertiary}>
+          <Typography
+            type={TypographyType.Footnote}
+            color={TypographyColor.Tertiary}
+          >
             {reviewPositive
-              ? 'Honest Chrome Web Store reviews help other developers discover daily.dev.'
-              : 'Your feedback helps us understand whether this is the right moment to ask.'}
+              ? 'Honest reviews help other developers discover daily.dev — it takes 30 seconds.'
+              : 'Let us know if this is a good moment to ask.'}
           </Typography>
         </div>
-        <div className="flex flex-wrap justify-center gap-2">
+
+        {/* Actions */}
+        <div className="flex shrink-0 items-center gap-2">
           {reviewPositive ? (
             <Button
               tag="a"
@@ -92,7 +130,7 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
               variant={ButtonVariant.Primary}
               onClick={toggleReview}
             >
-              Review on Chrome Web Store
+              Leave a review ↗
             </Button>
           ) : (
             <>
@@ -102,29 +140,29 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
                 variant={ButtonVariant.Primary}
                 onClick={() => setReviewPositive(true)}
               >
-                Yes
+                Yes, loving it!
               </Button>
               <Button
                 type="button"
                 size={ButtonSize.Small}
-                variant={ButtonVariant.Secondary}
+                variant={ButtonVariant.Tertiary}
                 onClick={() => {
                   setReviewOpen(false);
                   openFeedbackModal();
                 }}
               >
-                Not really
+                Not yet
               </Button>
             </>
           )}
-          <Button
+          <button
             type="button"
-            size={ButtonSize.Small}
-            variant={ButtonVariant.Tertiary}
+            aria-label="Dismiss"
+            className="ml-1 flex h-7 w-7 items-center justify-center rounded-8 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary"
             onClick={toggleReview}
           >
-            Not now
-          </Button>
+            <MiniCloseIcon size={IconSize.XSmall} />
+          </button>
         </div>
       </div>
     </div>
@@ -154,7 +192,10 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
             <Typography bold type={TypographyType.Callout}>
               Referral/review QA
             </Typography>
-            <Typography type={TypographyType.Footnote} color={TypographyColor.Tertiary}>
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+            >
               Triggers the real interactions — remove before launch.
             </Typography>
           </div>
@@ -173,15 +214,19 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
           <Typography bold type={TypographyType.Footnote}>
             1. Enable flags first
           </Typography>
-          <Typography type={TypographyType.Footnote} color={TypographyColor.Tertiary}>
-            Forces{' '}
-            <code className="typo-footnote">referral_growth_loops</code> on so
-            the invite sections appear inside the modals below.
+          <Typography
+            type={TypographyType.Footnote}
+            color={TypographyColor.Tertiary}
+          >
+            Forces <code className="typo-footnote">referral_growth_loops</code>{' '}
+            on so the invite sections appear inside the modals below.
           </Typography>
           <Button
             type="button"
             size={ButtonSize.Small}
-            variant={flagsForced ? ButtonVariant.Primary : ButtonVariant.Secondary}
+            variant={
+              flagsForced ? ButtonVariant.Primary : ButtonVariant.Secondary
+            }
             onClick={toggleFlags}
           >
             {flagsForced ? '✓ Flags forced on' : 'Force flags on'}
@@ -193,7 +238,10 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
           <Typography bold type={TypographyType.Footnote}>
             2. Streak milestone modal
           </Typography>
-          <Typography type={TypographyType.Footnote} color={TypographyColor.Tertiary}>
+          <Typography
+            type={TypographyType.Footnote}
+            color={TypographyColor.Tertiary}
+          >
             Opens the exact modal users see when reaching a streak. Enable flags
             first to see the invite section inside.
           </Typography>
@@ -222,14 +270,19 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
           <Typography bold type={TypographyType.Footnote}>
             3. Chrome review banner
           </Typography>
-          <Typography type={TypographyType.Footnote} color={TypographyColor.Tertiary}>
+          <Typography
+            type={TypographyType.Footnote}
+            color={TypographyColor.Tertiary}
+          >
             Renders the real two-step banner at the top of the page — same width
             and position as extension users see it on their new tab.
           </Typography>
           <Button
             type="button"
             size={ButtonSize.Small}
-            variant={reviewOpen ? ButtonVariant.Primary : ButtonVariant.Secondary}
+            variant={
+              reviewOpen ? ButtonVariant.Primary : ButtonVariant.Secondary
+            }
             onClick={toggleReview}
           >
             {reviewOpen ? 'Hide banner' : 'Show review banner'}
@@ -241,7 +294,10 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
           <Typography bold type={TypographyType.Footnote}>
             4. DevCard invite
           </Typography>
-          <Typography type={TypographyType.Footnote} color={TypographyColor.Tertiary}>
+          <Typography
+            type={TypographyType.Footnote}
+            color={TypographyColor.Tertiary}
+          >
             Enable flags first — the tracked invite link appears in DevCard
             settings step&nbsp;2.
           </Typography>
@@ -297,7 +353,10 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
         </div>
 
         {!user?.id && (
-          <Typography type={TypographyType.Footnote} color={TypographyColor.Secondary}>
+          <Typography
+            type={TypographyType.Footnote}
+            color={TypographyColor.Secondary}
+          >
             ⚠ Log in to test tracked invite links.
           </Typography>
         )}

--- a/packages/shared/src/components/referral/ReferralGrowthTestingPanel.tsx
+++ b/packages/shared/src/components/referral/ReferralGrowthTestingPanel.tsx
@@ -13,229 +13,295 @@ import {
   chromeWebStoreReviewUrl,
   isTesting,
   settingsUrl,
-  webappUrl,
 } from '../../lib/constants';
-import { ReferralCampaignKey } from '../../lib/referral';
-import { ReferralGrowthSurface } from '../../lib/referralGrowth';
-import { ContextualReferralLink } from './ContextualReferralLink';
+import { useGrowthBookContext } from '../GrowthBookProvider';
 
-const demoSurfaces = [
-  {
-    surface: ReferralGrowthSurface.DevCard,
-    title: 'DevCard invite',
-    description:
-      'Demo the tracked invite prompt shown after someone prepares their DevCard.',
-    buttonText: 'Copy DevCard invite',
-  },
-  {
-    surface: ReferralGrowthSurface.StreakMilestone,
-    title: 'Streak challenge',
-    description:
-      'Demo the tracked invite prompt attached to a reading streak milestone.',
-    buttonText: 'Copy streak invite',
-  },
-  {
-    surface: ReferralGrowthSurface.TopReaderBadge,
-    title: 'Top reader badge',
-    description:
-      'Demo the tracked invite prompt shown from the top-reader badge moment.',
-    buttonText: 'Copy badge invite',
-  },
-  {
-    surface: ReferralGrowthSurface.Brief,
-    title: 'Brief share',
-    description:
-      'Demo the tracked invite prompt for sharing a useful brief with a colleague.',
-    buttonText: 'Copy brief invite',
-  },
-];
-
-const getWebappUrl = (): string => {
-  if (webappUrl) {
-    return webappUrl;
-  }
-
-  if (typeof window === 'undefined') {
-    return '';
-  }
-
-  return `${window.location.origin}/`;
-};
+/*
+ * TEMPORARY QA PANEL
+ * Remove this component and its registration in MainLayout entirely
+ * after the referral/review growth experiment has been reviewed and approved.
+ */
 
 export function ReferralGrowthTestingPanel(): ReactElement | null {
   const { user } = useAuthContext();
+  const { growthbook } = useGrowthBookContext();
   const { openModal } = useLazyModal();
   const [isCollapsed, setIsCollapsed] = useState(false);
-  const [selectedSurface, setSelectedSurface] = useState(demoSurfaces[0]);
-  const [showReviewStep, setShowReviewStep] = useState(false);
-  const qaWebappUrl = getWebappUrl();
-  const profileUrl = user?.username
-    ? `${qaWebappUrl}${user.username}`
-    : qaWebappUrl;
+  const [flagsForced, setFlagsForced] = useState(false);
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const [reviewPositive, setReviewPositive] = useState(false);
 
   if (isTesting) {
     return null;
   }
 
+  const toggleFlags = () => {
+    if (flagsForced) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (growthbook as any)?.setForcedFeatures?.(new Map());
+      setFlagsForced(false);
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (growthbook as any)?.setForcedFeatures?.(
+        new Map([
+          ['referral_growth_loops', true],
+          ['extension_store_review_prompt', true],
+        ]),
+      );
+      setFlagsForced(true);
+    }
+  };
+
+  const openStreakModal = (currentStreak: number, maxStreak: number) =>
+    openModal({ type: LazyModal.NewStreak, props: { currentStreak, maxStreak } });
+
+  const openFeedbackModal = () => openModal({ type: LazyModal.Feedback });
+
+  const toggleReview = () => {
+    setReviewOpen((prev) => !prev);
+    setReviewPositive(false);
+  };
+
+  /*
+   * The review banner renders fixed at the top of the viewport — exactly the
+   * width and position it occupies in the real extension new-tab layout.
+   */
+  const reviewBanner = reviewOpen ? (
+    <div className="fixed inset-x-0 top-0 z-max flex w-full justify-center border-b border-border-subtlest-tertiary bg-surface-float px-4 py-3">
+      <div className="flex w-full max-w-[44rem] flex-col items-center gap-3 text-center tablet:flex-row tablet:text-left">
+        <div className="flex flex-1 flex-col gap-1">
+          <Typography bold type={TypographyType.Callout}>
+            {reviewPositive
+              ? 'Would you mind leaving a quick review?'
+              : 'Are you enjoying daily.dev on your new tab?'}
+          </Typography>
+          <Typography type={TypographyType.Footnote} color={TypographyColor.Tertiary}>
+            {reviewPositive
+              ? 'Honest Chrome Web Store reviews help other developers discover daily.dev.'
+              : 'Your feedback helps us understand whether this is the right moment to ask.'}
+          </Typography>
+        </div>
+        <div className="flex flex-wrap justify-center gap-2">
+          {reviewPositive ? (
+            <Button
+              tag="a"
+              href={chromeWebStoreReviewUrl}
+              target="_blank"
+              rel="noopener"
+              size={ButtonSize.Small}
+              variant={ButtonVariant.Primary}
+              onClick={toggleReview}
+            >
+              Review on Chrome Web Store
+            </Button>
+          ) : (
+            <>
+              <Button
+                type="button"
+                size={ButtonSize.Small}
+                variant={ButtonVariant.Primary}
+                onClick={() => setReviewPositive(true)}
+              >
+                Yes
+              </Button>
+              <Button
+                type="button"
+                size={ButtonSize.Small}
+                variant={ButtonVariant.Secondary}
+                onClick={() => {
+                  setReviewOpen(false);
+                  openFeedbackModal();
+                }}
+              >
+                Not really
+              </Button>
+            </>
+          )}
+          <Button
+            type="button"
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Tertiary}
+            onClick={toggleReview}
+          >
+            Not now
+          </Button>
+        </div>
+      </div>
+    </div>
+  ) : null;
+
   if (isCollapsed) {
     return (
-      <button
-        type="button"
-        className="text-text-inverted fixed bottom-4 right-4 z-max rounded-12 border border-border-subtlest-tertiary bg-accent-cabbage-default px-3 py-2 font-bold typo-footnote"
-        onClick={() => setIsCollapsed(false)}
-      >
-        Open referral QA
-      </button>
+      <>
+        {reviewBanner}
+        <button
+          type="button"
+          className="text-text-inverted fixed bottom-4 right-4 z-max rounded-12 border border-border-subtlest-tertiary bg-accent-cabbage-default px-3 py-2 font-bold typo-footnote"
+          onClick={() => setIsCollapsed(false)}
+        >
+          Open referral QA
+        </button>
+      </>
     );
   }
 
   return (
-    <aside className="fixed bottom-4 right-4 z-max flex max-h-[calc(100dvh-2rem)] w-[22rem] max-w-[calc(100vw-2rem)] flex-col gap-3 overflow-auto rounded-16 border border-border-subtlest-tertiary bg-background-default p-4 shadow-2">
-      {/*
-        TEMPORARY QA PANEL: remove this component and its MainLayout render
-        completely after referral/review preview testing is done.
-      */}
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex flex-col gap-1">
-          <Typography bold type={TypographyType.Callout}>
-            Referral/review QA panel
-          </Typography>
-          <Typography
-            type={TypographyType.Footnote}
-            color={TypographyColor.Tertiary}
-          >
-            Temporary testing panel. Remove completely before this experiment is
-            finalized.
-          </Typography>
-        </div>
-        <Button
-          type="button"
-          size={ButtonSize.XSmall}
-          variant={ButtonVariant.Tertiary}
-          onClick={() => setIsCollapsed(true)}
-        >
-          Hide
-        </Button>
-      </div>
-
-      <div className="grid grid-cols-2 gap-2">
-        <Button
-          tag="a"
-          href={`${settingsUrl}/customization/devcard`}
-          size={ButtonSize.Small}
-          variant={ButtonVariant.Secondary}
-        >
-          DevCard
-        </Button>
-        <Button
-          tag="a"
-          href={`${settingsUrl}/invite`}
-          size={ButtonSize.Small}
-          variant={ButtonVariant.Secondary}
-        >
-          Invite page
-        </Button>
-        <Button
-          tag="a"
-          href={`${qaWebappUrl}squads/new`}
-          size={ButtonSize.Small}
-          variant={ButtonVariant.Secondary}
-        >
-          New Squad
-        </Button>
-        <Button
-          type="button"
-          size={ButtonSize.Small}
-          variant={ButtonVariant.Secondary}
-          onClick={() => openModal({ type: LazyModal.Feedback })}
-        >
-          Feedback
-        </Button>
-      </div>
-
-      <div className="flex flex-col gap-2">
-        <Typography bold type={TypographyType.Footnote}>
-          Demo invite prompt
-        </Typography>
-        <div className="flex flex-wrap gap-2">
-          {demoSurfaces.map((item) => (
-            <Button
-              key={item.surface}
-              type="button"
-              size={ButtonSize.XSmall}
-              variant={
-                selectedSurface.surface === item.surface
-                  ? ButtonVariant.Primary
-                  : ButtonVariant.Tertiary
-              }
-              onClick={() => setSelectedSurface(item)}
-            >
-              {item.title}
-            </Button>
-          ))}
-        </div>
-        {!user?.id && (
-          <Typography
-            type={TypographyType.Footnote}
-            color={TypographyColor.Tertiary}
-          >
-            Log in to test tracked copy links.
-          </Typography>
-        )}
-        <ContextualReferralLink
-          url={profileUrl}
-          campaignKey={ReferralCampaignKey.ShareProfile}
-          surface={selectedSurface.surface}
-          origin="temporary referral QA panel"
-          title={selectedSurface.title}
-          description={selectedSurface.description}
-          buttonText={selectedSurface.buttonText}
-        />
-      </div>
-
-      <div className="flex flex-col gap-2 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-3">
-        <Typography bold type={TypographyType.Footnote}>
-          Demo review ask
-        </Typography>
-        <Typography
-          type={TypographyType.Footnote}
-          color={TypographyColor.Tertiary}
-        >
-          This mirrors the two-step Chrome Web Store ask without completing the
-          one-time action.
-        </Typography>
-        {showReviewStep ? (
+    <>
+      {reviewBanner}
+      <aside className="fixed bottom-4 right-4 z-max flex max-h-[calc(100dvh-2rem)] w-[22rem] max-w-[calc(100vw-2rem)] flex-col gap-4 overflow-auto rounded-16 border border-border-subtlest-tertiary bg-background-default p-4 shadow-2">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-col gap-0.5">
+            <Typography bold type={TypographyType.Callout}>
+              Referral/review QA
+            </Typography>
+            <Typography type={TypographyType.Footnote} color={TypographyColor.Tertiary}>
+              Triggers the real interactions — remove before launch.
+            </Typography>
+          </div>
           <Button
-            tag="a"
-            href={chromeWebStoreReviewUrl}
-            target="_blank"
-            rel="noopener"
-            size={ButtonSize.Small}
-            variant={ButtonVariant.Primary}
+            type="button"
+            size={ButtonSize.XSmall}
+            variant={ButtonVariant.Tertiary}
+            onClick={() => setIsCollapsed(true)}
           >
-            Review on Chrome Web Store
+            Hide
           </Button>
-        ) : (
+        </div>
+
+        {/* Step 1: force GrowthBook flags so referral sections appear in modals */}
+        <div className="flex flex-col gap-2 rounded-12 border border-border-subtlest-tertiary p-3">
+          <Typography bold type={TypographyType.Footnote}>
+            1. Enable flags first
+          </Typography>
+          <Typography type={TypographyType.Footnote} color={TypographyColor.Tertiary}>
+            Forces{' '}
+            <code className="typo-footnote">referral_growth_loops</code> on so
+            the invite sections appear inside the modals below.
+          </Typography>
+          <Button
+            type="button"
+            size={ButtonSize.Small}
+            variant={flagsForced ? ButtonVariant.Primary : ButtonVariant.Secondary}
+            onClick={toggleFlags}
+          >
+            {flagsForced ? '✓ Flags forced on' : 'Force flags on'}
+          </Button>
+        </div>
+
+        {/* Step 2: streak modals — opens the real modal users see */}
+        <div className="flex flex-col gap-2 rounded-12 border border-border-subtlest-tertiary p-3">
+          <Typography bold type={TypographyType.Footnote}>
+            2. Streak milestone modal
+          </Typography>
+          <Typography type={TypographyType.Footnote} color={TypographyColor.Tertiary}>
+            Opens the exact modal users see when reaching a streak. Enable flags
+            first to see the invite section inside.
+          </Typography>
           <div className="flex gap-2">
             <Button
               type="button"
               size={ButtonSize.Small}
-              variant={ButtonVariant.Primary}
-              onClick={() => setShowReviewStep(true)}
+              variant={ButtonVariant.Secondary}
+              onClick={() => openStreakModal(7, 3)}
             >
-              Yes
+              7-day streak
             </Button>
             <Button
               type="button"
               size={ButtonSize.Small}
               variant={ButtonVariant.Secondary}
-              onClick={() => openModal({ type: LazyModal.Feedback })}
+              onClick={() => openStreakModal(10, 10)}
             >
-              Not really
+              New record 🏆
             </Button>
           </div>
+        </div>
+
+        {/* Step 3: Chrome Web Store review — real banner, full width, at top of page */}
+        <div className="flex flex-col gap-2 rounded-12 border border-border-subtlest-tertiary p-3">
+          <Typography bold type={TypographyType.Footnote}>
+            3. Chrome review banner
+          </Typography>
+          <Typography type={TypographyType.Footnote} color={TypographyColor.Tertiary}>
+            Renders the real two-step banner at the top of the page — same width
+            and position as extension users see it on their new tab.
+          </Typography>
+          <Button
+            type="button"
+            size={ButtonSize.Small}
+            variant={reviewOpen ? ButtonVariant.Primary : ButtonVariant.Secondary}
+            onClick={toggleReview}
+          >
+            {reviewOpen ? 'Hide banner' : 'Show review banner'}
+          </Button>
+        </div>
+
+        {/* Step 4: DevCard — navigate to the settings page that embeds the invite */}
+        <div className="flex flex-col gap-2 rounded-12 border border-border-subtlest-tertiary p-3">
+          <Typography bold type={TypographyType.Footnote}>
+            4. DevCard invite
+          </Typography>
+          <Typography type={TypographyType.Footnote} color={TypographyColor.Tertiary}>
+            Enable flags first — the tracked invite link appears in DevCard
+            settings step&nbsp;2.
+          </Typography>
+          <Button
+            tag="a"
+            href={`${settingsUrl}/customization/devcard`}
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Secondary}
+          >
+            Go to DevCard settings →
+          </Button>
+        </div>
+
+        {/* More contextual surfaces */}
+        <div className="flex flex-col gap-2">
+          <Typography bold type={TypographyType.Footnote}>
+            More flows
+          </Typography>
+          <div className="grid grid-cols-2 gap-2">
+            <Button
+              tag="a"
+              href={`${settingsUrl}/invite`}
+              size={ButtonSize.XSmall}
+              variant={ButtonVariant.Tertiary}
+            >
+              Invite page
+            </Button>
+            <Button
+              tag="a"
+              href="/squads/new"
+              size={ButtonSize.XSmall}
+              variant={ButtonVariant.Tertiary}
+            >
+              New Squad
+            </Button>
+            <Button
+              tag="a"
+              href="/briefing"
+              size={ButtonSize.XSmall}
+              variant={ButtonVariant.Tertiary}
+            >
+              Brief share
+            </Button>
+            <Button
+              type="button"
+              size={ButtonSize.XSmall}
+              variant={ButtonVariant.Tertiary}
+              onClick={openFeedbackModal}
+            >
+              Feedback modal
+            </Button>
+          </div>
+        </div>
+
+        {!user?.id && (
+          <Typography type={TypographyType.Footnote} color={TypographyColor.Secondary}>
+            ⚠ Log in to test tracked invite links.
+          </Typography>
         )}
-      </div>
-    </aside>
+      </aside>
+    </>
   );
 }

--- a/packages/shared/src/components/referral/ReferralGrowthTestingPanel.tsx
+++ b/packages/shared/src/components/referral/ReferralGrowthTestingPanel.tsx
@@ -18,6 +18,7 @@ import {
 import { useGrowthBookContext } from '../GrowthBookProvider';
 import { MiniCloseIcon, ReadingStreakIcon, StarIcon } from '../icons';
 import { IconSize } from '../Icon';
+import { StreakShareFlowDemo } from './StreakShareFlowDemo';
 
 const STAR_INDICES = [0, 1, 2, 3, 4] as const;
 
@@ -35,6 +36,8 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
   const [flagsForced, setFlagsForced] = useState(false);
   const [reviewOpen, setReviewOpen] = useState(false);
   const [reviewPositive, setReviewPositive] = useState(false);
+  const [demoStreak, setDemoStreak] = useState(7);
+  const [demoOpen, setDemoOpen] = useState(false);
 
   if (isTesting) {
     return null;
@@ -58,11 +61,28 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
 
   const launchStreakInvite = (currentStreak: number, maxStreak: number) => {
     setFlagsForcedOn(true);
+    setDemoStreak(currentStreak);
     openModal({
       type: LazyModal.NewStreak,
       props: { currentStreak, maxStreak },
     });
   };
+
+  const buildDemoMessage = (streak: number) => {
+    const firstName = user?.name?.split(' ')[0] ?? 'I';
+    if (streak >= 100) {
+      return `🔥 ${firstName} read dev content every day for ${streak} days straight on daily.dev. Worth a look:`;
+    }
+    if (streak >= 30) {
+      return `🔥 ${streak} days reading dev news on daily.dev — no skips. Want to give it a try?`;
+    }
+    return `🔥 ${streak}-day reading streak on daily.dev. Read with me:`;
+  };
+
+  const demoUsername = user?.username ?? 'you';
+  const demoLink = user?.username
+    ? `daily.dev/${user.username}`
+    : 'daily.dev/your-profile';
 
   const openFeedbackModal = () => openModal({ type: LazyModal.Feedback });
 
@@ -227,11 +247,8 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
               type={TypographyType.Footnote}
               color={TypographyColor.Tertiary}
             >
-              One click forces the feature flag and opens the streak modal so
-              you can see the new <strong>StreakShareCallout</strong> live —
-              chat-bubble preview, pre-written message with your streak count, 5
-              channel buttons (WhatsApp, X, Telegram, Email, Copy), tracked
-              links per channel.
+              Designed Trophy Card with the streak count, 5 share channels, and
+              an honest pre-written message that matches the destination page.
             </Typography>
 
             <div className="flex flex-col gap-2">
@@ -264,6 +281,28 @@ export function ReferralGrowthTestingPanel(): ReactElement | null {
                   100 days 🏆
                 </Button>
               </div>
+            </div>
+
+            {/* Demo flow — shows what happens after a friend taps WhatsApp */}
+            <div className="border-accent-bacon-default/30 flex flex-col gap-2 border-t pt-3">
+              <Button
+                type="button"
+                size={ButtonSize.Small}
+                variant={ButtonVariant.Tertiary}
+                onClick={() => setDemoOpen((v) => !v)}
+              >
+                {demoOpen
+                  ? 'Hide WhatsApp flow demo'
+                  : '👁 Preview the WhatsApp flow'}
+              </Button>
+              {demoOpen && (
+                <StreakShareFlowDemo
+                  username={demoUsername}
+                  currentStreak={demoStreak}
+                  message={buildDemoMessage(demoStreak)}
+                  link={demoLink}
+                />
+              )}
             </div>
 
             <Typography

--- a/packages/shared/src/components/referral/ReferralGrowthTestingPanel.tsx
+++ b/packages/shared/src/components/referral/ReferralGrowthTestingPanel.tsx
@@ -11,6 +11,7 @@ import { useLazyModal } from '../../hooks/useLazyModal';
 import { LazyModal } from '../modals/common/types';
 import {
   chromeWebStoreReviewUrl,
+  isTesting,
   settingsUrl,
   webappUrl,
 } from '../../lib/constants';
@@ -61,7 +62,7 @@ const getWebappUrl = (): string => {
   return `${window.location.origin}/`;
 };
 
-export function ReferralGrowthTestingPanel(): ReactElement {
+export function ReferralGrowthTestingPanel(): ReactElement | null {
   const { user } = useAuthContext();
   const { openModal } = useLazyModal();
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -71,6 +72,10 @@ export function ReferralGrowthTestingPanel(): ReactElement {
   const profileUrl = user?.username
     ? `${qaWebappUrl}${user.username}`
     : qaWebappUrl;
+
+  if (isTesting) {
+    return null;
+  }
 
   if (isCollapsed) {
     return (

--- a/packages/shared/src/components/referral/StreakShareCallout.tsx
+++ b/packages/shared/src/components/referral/StreakShareCallout.tsx
@@ -1,0 +1,350 @@
+import type { ReactElement } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import classNames from 'classnames';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../typography/Typography';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { useLogContext } from '../../contexts/LogContext';
+import { useCopyLink } from '../../hooks/useCopy';
+import { useGetShortUrl } from '../../hooks/utils/useGetShortUrl';
+import { ReferralCampaignKey } from '../../lib/referral';
+import { ShareProvider } from '../../lib/share';
+import { Origin, LogEvent, TargetType } from '../../lib/log';
+import { ReferralGrowthSurface } from '../../lib/referralGrowth';
+import {
+  CopyIcon,
+  MailIcon,
+  ReadingStreakIcon,
+  TelegramIcon,
+  TwitterIcon,
+  VIcon,
+  WhatsappIcon,
+} from '../icons';
+import { IconSize } from '../Icon';
+
+type StreakShareCalloutProps = {
+  /** Profile or share URL to invite friends to. */
+  url: string;
+  /** Streak count to celebrate. */
+  currentStreak: number;
+  className?: string;
+};
+
+type ChannelKey = 'whatsapp' | 'twitter' | 'telegram' | 'email' | 'copy';
+
+type Channel = {
+  key: ChannelKey;
+  provider: ShareProvider;
+  label: string;
+  icon: ReactElement;
+  className: string;
+};
+
+/**
+ * Build a share URL that includes both the pre-written message AND the link
+ * for providers that support text. This works around `getWhatsappShareLink`
+ * encoding only the URL.
+ */
+const buildShareHref = (
+  channel: ChannelKey,
+  message: string,
+  link: string,
+): string => {
+  const fullText = `${message}\n${link}`;
+
+  if (channel === 'whatsapp') {
+    return `https://wa.me/?text=${encodeURIComponent(fullText)}`;
+  }
+
+  if (channel === 'twitter') {
+    return `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+      `${message} via @dailydotdev`,
+    )}&url=${encodeURIComponent(link)}`;
+  }
+
+  if (channel === 'telegram') {
+    return `https://t.me/share/url?url=${encodeURIComponent(
+      link,
+    )}&text=${encodeURIComponent(message)}`;
+  }
+
+  if (channel === 'email') {
+    return `mailto:?subject=${encodeURIComponent(
+      'Think you can beat my reading streak?',
+    )}&body=${encodeURIComponent(`${message}\n\n${link}`)}`;
+  }
+
+  return link;
+};
+
+const buildMessage = (currentStreak: number): string => {
+  const days = currentStreak === 1 ? 'day' : 'days';
+  if (currentStreak >= 100) {
+    return `🔥 ${currentStreak} ${days} of reading dev content every single day. Think you can hang?`;
+  }
+  if (currentStreak >= 30) {
+    return `🔥 I'm on a ${currentStreak}-${
+      days === 'days' ? 'day' : 'day'
+    } reading streak on daily.dev. Bet you'd quit by day 5.`;
+  }
+  return `🔥 I just hit a ${currentStreak}-day reading streak on daily.dev. Think you can beat me?`;
+};
+
+export function StreakShareCallout({
+  url,
+  currentStreak,
+  className,
+}: StreakShareCalloutProps): ReactElement | null {
+  const { user } = useAuthContext();
+  const { logEvent } = useLogContext();
+  const loggedImpression = useRef(false);
+  const { getTrackedUrl, shareLink, isLoading } = useGetShortUrl({
+    query: {
+      url,
+      cid: ReferralCampaignKey.ShareProfile,
+      enabled: !!url && !!user?.id,
+    },
+  });
+  const trackedUrl = getTrackedUrl(url, ReferralCampaignKey.ShareProfile);
+  const link = shareLink || trackedUrl;
+  const message = useMemo(() => buildMessage(currentStreak), [currentStreak]);
+  const [copied, copy] = useCopyLink(() => `${message}\n${link}`);
+  const [nativeShared, setNativeShared] = useState(false);
+
+  const canNativeShare =
+    typeof globalThis !== 'undefined' &&
+    typeof globalThis.navigator?.share === 'function';
+
+  useEffect(() => {
+    if (!user?.id || !url || loggedImpression.current) {
+      return;
+    }
+
+    logEvent({
+      event_name: LogEvent.ReferralPromptImpression,
+      target_type: TargetType.ReferralPrompt,
+      target_id: ReferralGrowthSurface.StreakMilestone,
+      extra: JSON.stringify({
+        campaign: ReferralCampaignKey.ShareProfile,
+        origin: Origin.PostContent,
+        streak: currentStreak,
+      }),
+    });
+
+    loggedImpression.current = true;
+  }, [currentStreak, logEvent, url, user?.id]);
+
+  if (!user?.id || !url) {
+    return null;
+  }
+
+  const logShare = (provider: ShareProvider) => {
+    logEvent({
+      event_name: LogEvent.ReferralPromptClick,
+      target_type: TargetType.ReferralPrompt,
+      target_id: ReferralGrowthSurface.StreakMilestone,
+      extra: JSON.stringify({
+        campaign: ReferralCampaignKey.ShareProfile,
+        origin: Origin.PostContent,
+        provider,
+        streak: currentStreak,
+      }),
+    });
+  };
+
+  const onCopy = () => {
+    copy();
+    logShare(ShareProvider.CopyLink);
+  };
+
+  const onNativeShare = async () => {
+    try {
+      await globalThis.navigator.share({
+        title: 'Think you can beat my reading streak?',
+        text: message,
+        url: link,
+      });
+      setNativeShared(true);
+      logShare(ShareProvider.Native);
+    } catch {
+      // User cancelled or share failed — no-op
+    }
+  };
+
+  const channels: Channel[] = [
+    {
+      key: 'whatsapp',
+      provider: ShareProvider.WhatsApp,
+      label: 'WhatsApp',
+      icon: <WhatsappIcon size={IconSize.Small} />,
+      className: 'bg-[#25D366]/15 text-[#25D366] hover:bg-[#25D366]/25',
+    },
+    {
+      key: 'twitter',
+      provider: ShareProvider.Twitter,
+      label: 'X',
+      icon: <TwitterIcon size={IconSize.Small} />,
+      className:
+        'bg-text-primary/10 text-text-primary hover:bg-text-primary/20',
+    },
+    {
+      key: 'telegram',
+      provider: ShareProvider.Telegram,
+      label: 'Telegram',
+      icon: <TelegramIcon size={IconSize.Small} />,
+      className: 'bg-[#229ED9]/15 text-[#229ED9] hover:bg-[#229ED9]/25',
+    },
+    {
+      key: 'email',
+      provider: ShareProvider.Email,
+      label: 'Email',
+      icon: <MailIcon size={IconSize.Small} />,
+      className:
+        'bg-text-tertiary/15 text-text-tertiary hover:bg-text-tertiary/25',
+    },
+  ];
+
+  return (
+    <div
+      className={classNames(
+        'border-accent-bacon-default/25 from-accent-bacon-default/10 to-accent-cheese-default/10 relative w-full overflow-hidden rounded-16 border bg-gradient-to-br via-surface-float p-4 text-left',
+        className,
+      )}
+    >
+      {/* Decorative glow */}
+      <div className="bg-accent-bacon-default/20 pointer-events-none absolute -right-10 -top-10 h-32 w-32 rounded-full blur-3xl" />
+      <div className="bg-accent-cheese-default/15 pointer-events-none absolute -bottom-12 -left-10 h-32 w-32 rounded-full blur-3xl" />
+
+      <div className="relative flex flex-col gap-3">
+        {/* Header */}
+        <div className="flex items-center gap-2.5">
+          <span className="bg-accent-bacon-default/20 flex h-8 w-8 shrink-0 items-center justify-center rounded-10 text-accent-bacon-default">
+            <ReadingStreakIcon secondary size={IconSize.XSmall} />
+          </span>
+          <div className="flex flex-col">
+            <Typography bold type={TypographyType.Callout}>
+              Challenge a friend
+            </Typography>
+            <Typography
+              type={TypographyType.Caption1}
+              color={TypographyColor.Tertiary}
+            >
+              Drop your streak — bet they can&apos;t keep up
+            </Typography>
+          </div>
+        </div>
+
+        {/* Chat-bubble preview of the actual outgoing message */}
+        <div className="relative ml-1 rounded-16 rounded-bl-4 border border-border-subtlest-tertiary bg-surface-primary px-3.5 py-2.5">
+          <Typography
+            tag={TypographyTag.P}
+            type={TypographyType.Footnote}
+            className="whitespace-pre-line"
+          >
+            {message}
+          </Typography>
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption1}
+            color={TypographyColor.Link}
+            className="mt-1 block truncate"
+          >
+            {isLoading ? 'Preparing your link…' : link}
+          </Typography>
+          {/* Tail of the chat bubble */}
+          <span
+            aria-hidden
+            className="rounded-sm absolute -bottom-px -left-1.5 h-2.5 w-2.5 rotate-45 border-b border-l border-border-subtlest-tertiary bg-surface-primary"
+          />
+        </div>
+
+        {/* Channel row */}
+        <div className="mt-1 flex items-center justify-between gap-2">
+          {channels.map((c) => (
+            <a
+              key={c.key}
+              href={buildShareHref(c.key, message, link ?? url)}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`Share via ${c.label}`}
+              onClick={() => logShare(c.provider)}
+              className={classNames(
+                'group flex flex-1 flex-col items-center gap-1.5',
+                (isLoading || !link) && 'pointer-events-none opacity-50',
+              )}
+            >
+              <span
+                className={classNames(
+                  'flex h-10 w-10 items-center justify-center rounded-12 transition-all duration-200 group-hover:-translate-y-0.5',
+                  c.className,
+                )}
+              >
+                {c.icon}
+              </span>
+              <Typography
+                type={TypographyType.Caption2}
+                color={TypographyColor.Tertiary}
+              >
+                {c.label}
+              </Typography>
+            </a>
+          ))}
+
+          {/* Copy is the always-available fallback */}
+          <button
+            type="button"
+            onClick={onCopy}
+            disabled={isLoading || !link}
+            aria-label="Copy invite message"
+            className={classNames(
+              'group flex flex-1 flex-col items-center gap-1.5',
+              (isLoading || !link) && 'pointer-events-none opacity-50',
+            )}
+          >
+            <span
+              className={classNames(
+                'flex h-10 w-10 items-center justify-center rounded-12 transition-all duration-200 group-hover:-translate-y-0.5',
+                copied
+                  ? 'bg-accent-avocado-default/20 text-accent-avocado-default'
+                  : 'bg-accent-cabbage-default/15 hover:bg-accent-cabbage-default/25 text-accent-cabbage-default',
+              )}
+            >
+              {copied ? (
+                <VIcon secondary size={IconSize.Small} />
+              ) : (
+                <CopyIcon size={IconSize.Small} />
+              )}
+            </span>
+            <Typography
+              type={TypographyType.Caption2}
+              color={
+                copied
+                  ? TypographyColor.StatusSuccess
+                  : TypographyColor.Tertiary
+              }
+            >
+              {copied ? 'Copied!' : 'Copy'}
+            </Typography>
+          </button>
+        </div>
+
+        {/* Native share — surfaces on mobile only */}
+        {canNativeShare && (
+          <Button
+            type="button"
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Secondary}
+            onClick={onNativeShare}
+          >
+            {nativeShared ? '✓ Shared' : 'More sharing options…'}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/shared/src/components/referral/StreakShareCallout.tsx
+++ b/packages/shared/src/components/referral/StreakShareCallout.tsx
@@ -18,6 +18,7 @@ import { Origin, LogEvent, TargetType } from '../../lib/log';
 import { ReferralGrowthSurface } from '../../lib/referralGrowth';
 import {
   CopyIcon,
+  EyeIcon,
   MailIcon,
   ReadingStreakIcon,
   TelegramIcon,
@@ -28,27 +29,29 @@ import {
 import { IconSize } from '../Icon';
 
 type StreakShareCalloutProps = {
-  /** Profile or share URL to invite friends to. */
+  /** Profile or share URL the recipient will land on. */
   url: string;
-  /** Streak count to celebrate. */
   currentStreak: number;
   className?: string;
 };
 
-type ChannelKey = 'whatsapp' | 'twitter' | 'telegram' | 'email' | 'copy';
+type ChannelKey = 'whatsapp' | 'twitter' | 'telegram' | 'email';
 
 type Channel = {
   key: ChannelKey;
   provider: ShareProvider;
   label: string;
   icon: ReactElement;
-  className: string;
+  /**
+   * Pill background uses the design system Button color tokens
+   * (`btn-primary-*` classes) so dark/light mode are handled by the theme.
+   */
+  pillClassName: string;
 };
 
 /**
- * Build a share URL that includes both the pre-written message AND the link
- * for providers that support text. This works around `getWhatsappShareLink`
- * encoding only the URL.
+ * Build provider URLs that include both the message AND the link.
+ * Works around `getWhatsappShareLink` only encoding the URL.
  */
 const buildShareHref = (
   channel: ChannelKey,
@@ -60,40 +63,89 @@ const buildShareHref = (
   if (channel === 'whatsapp') {
     return `https://wa.me/?text=${encodeURIComponent(fullText)}`;
   }
-
   if (channel === 'twitter') {
     return `https://twitter.com/intent/tweet?text=${encodeURIComponent(
       `${message} via @dailydotdev`,
     )}&url=${encodeURIComponent(link)}`;
   }
-
   if (channel === 'telegram') {
     return `https://t.me/share/url?url=${encodeURIComponent(
       link,
     )}&text=${encodeURIComponent(message)}`;
   }
-
   if (channel === 'email') {
     return `mailto:?subject=${encodeURIComponent(
-      'Think you can beat my reading streak?',
+      'I read with daily.dev — you should too',
     )}&body=${encodeURIComponent(`${message}\n\n${link}`)}`;
   }
-
   return link;
 };
 
-const buildMessage = (currentStreak: number): string => {
-  const days = currentStreak === 1 ? 'day' : 'days';
+/**
+ * Pre-written, honest message: it tells the friend what they'll see when they
+ * tap the link (the inviter's profile + streak), not a misleading "challenge"
+ * that doesn't exist.
+ */
+const buildMessage = (currentStreak: number, name?: string): string => {
+  const who = name ? `${name}` : 'I';
   if (currentStreak >= 100) {
-    return `🔥 ${currentStreak} ${days} of reading dev content every single day. Think you can hang?`;
+    return `🔥 ${who} read dev content every day for ${currentStreak} days straight on daily.dev. Worth a look:`;
   }
   if (currentStreak >= 30) {
-    return `🔥 I'm on a ${currentStreak}-${
-      days === 'days' ? 'day' : 'day'
-    } reading streak on daily.dev. Bet you'd quit by day 5.`;
+    return `🔥 ${currentStreak} days reading dev news on daily.dev — no skips. Want to give it a try?`;
   }
-  return `🔥 I just hit a ${currentStreak}-day reading streak on daily.dev. Think you can beat me?`;
+  return `🔥 ${currentStreak}-day reading streak on daily.dev. Read with me:`;
 };
+
+const milestoneLabel = (streak: number): string => {
+  if (streak >= 100) {
+    return 'Streak royalty';
+  }
+  if (streak >= 60) {
+    return 'Unstoppable';
+  }
+  if (streak >= 30) {
+    return 'On fire';
+  }
+  if (streak >= 14) {
+    return 'Two weeks strong';
+  }
+  if (streak >= 7) {
+    return 'Week strong';
+  }
+  return 'Building the habit';
+};
+
+const channels: Channel[] = [
+  {
+    key: 'whatsapp',
+    provider: ShareProvider.WhatsApp,
+    label: 'WhatsApp',
+    icon: <WhatsappIcon size={IconSize.Small} />,
+    pillClassName: 'btn-primary-whatsapp',
+  },
+  {
+    key: 'twitter',
+    provider: ShareProvider.Twitter,
+    label: 'X',
+    icon: <TwitterIcon size={IconSize.Small} />,
+    pillClassName: 'btn-primary-twitter',
+  },
+  {
+    key: 'telegram',
+    provider: ShareProvider.Telegram,
+    label: 'Telegram',
+    icon: <TelegramIcon size={IconSize.Small} />,
+    pillClassName: 'btn-primary-telegram',
+  },
+  {
+    key: 'email',
+    provider: ShareProvider.Email,
+    label: 'Email',
+    icon: <MailIcon size={IconSize.Small} />,
+    pillClassName: 'btn-primary-bacon',
+  },
+];
 
 export function StreakShareCallout({
   url,
@@ -103,6 +155,7 @@ export function StreakShareCallout({
   const { user } = useAuthContext();
   const { logEvent } = useLogContext();
   const loggedImpression = useRef(false);
+  const [showPreview, setShowPreview] = useState(false);
   const { getTrackedUrl, shareLink, isLoading } = useGetShortUrl({
     query: {
       url,
@@ -112,9 +165,12 @@ export function StreakShareCallout({
   });
   const trackedUrl = getTrackedUrl(url, ReferralCampaignKey.ShareProfile);
   const link = shareLink || trackedUrl;
-  const message = useMemo(() => buildMessage(currentStreak), [currentStreak]);
-  const [copied, copy] = useCopyLink(() => `${message}\n${link}`);
-  const [nativeShared, setNativeShared] = useState(false);
+  const message = useMemo(
+    () => buildMessage(currentStreak, user?.name?.split(' ')[0]),
+    [currentStreak, user?.name],
+  );
+  const fullText = `${message}\n${link}`;
+  const [copied, copy] = useCopyLink(() => fullText);
 
   const canNativeShare =
     typeof globalThis !== 'undefined' &&
@@ -135,7 +191,6 @@ export function StreakShareCallout({
         streak: currentStreak,
       }),
     });
-
     loggedImpression.current = true;
   }, [currentStreak, logEvent, url, user?.id]);
 
@@ -165,106 +220,82 @@ export function StreakShareCallout({
   const onNativeShare = async () => {
     try {
       await globalThis.navigator.share({
-        title: 'Think you can beat my reading streak?',
+        title: `${user?.name ?? 'I'} read with daily.dev`,
         text: message,
         url: link,
       });
-      setNativeShared(true);
       logShare(ShareProvider.Native);
     } catch {
-      // User cancelled or share failed — no-op
+      // user cancelled
     }
   };
 
-  const channels: Channel[] = [
-    {
-      key: 'whatsapp',
-      provider: ShareProvider.WhatsApp,
-      label: 'WhatsApp',
-      icon: <WhatsappIcon size={IconSize.Small} />,
-      className: 'bg-[#25D366]/15 text-[#25D366] hover:bg-[#25D366]/25',
-    },
-    {
-      key: 'twitter',
-      provider: ShareProvider.Twitter,
-      label: 'X',
-      icon: <TwitterIcon size={IconSize.Small} />,
-      className:
-        'bg-text-primary/10 text-text-primary hover:bg-text-primary/20',
-    },
-    {
-      key: 'telegram',
-      provider: ShareProvider.Telegram,
-      label: 'Telegram',
-      icon: <TelegramIcon size={IconSize.Small} />,
-      className: 'bg-[#229ED9]/15 text-[#229ED9] hover:bg-[#229ED9]/25',
-    },
-    {
-      key: 'email',
-      provider: ShareProvider.Email,
-      label: 'Email',
-      icon: <MailIcon size={IconSize.Small} />,
-      className:
-        'bg-text-tertiary/15 text-text-tertiary hover:bg-text-tertiary/25',
-    },
-  ];
+  const username = user.username || 'you';
+  const milestone = milestoneLabel(currentStreak);
 
   return (
-    <div
-      className={classNames(
-        'border-accent-bacon-default/25 from-accent-bacon-default/10 to-accent-cheese-default/10 relative w-full overflow-hidden rounded-16 border bg-gradient-to-br via-surface-float p-4 text-left',
-        className,
-      )}
-    >
-      {/* Decorative glow */}
-      <div className="bg-accent-bacon-default/20 pointer-events-none absolute -right-10 -top-10 h-32 w-32 rounded-full blur-3xl" />
-      <div className="bg-accent-cheese-default/15 pointer-events-none absolute -bottom-12 -left-10 h-32 w-32 rounded-full blur-3xl" />
+    <div className={classNames('flex w-full flex-col gap-3', className)}>
+      {/* The "Trophy Card" — designed shareable visual */}
+      <div className="relative overflow-hidden rounded-16 bg-gradient-to-br from-accent-bacon-default to-accent-cheese-default p-5 text-white shadow-2">
+        {/* Decorative blobs */}
+        <div
+          aria-hidden
+          className="bg-white/15 pointer-events-none absolute -right-8 -top-8 h-24 w-24 rounded-full blur-2xl"
+        />
+        <div
+          aria-hidden
+          className="bg-white/10 pointer-events-none absolute -bottom-10 -left-10 h-28 w-28 rounded-full blur-2xl"
+        />
 
-      <div className="relative flex flex-col gap-3">
-        {/* Header */}
-        <div className="flex items-center gap-2.5">
-          <span className="bg-accent-bacon-default/20 flex h-8 w-8 shrink-0 items-center justify-center rounded-10 text-accent-bacon-default">
-            <ReadingStreakIcon secondary size={IconSize.XSmall} />
+        <div className="relative flex items-start justify-between">
+          <span className="bg-white/20 flex h-9 w-9 items-center justify-center rounded-10 backdrop-blur-sm">
+            <ReadingStreakIcon
+              secondary
+              size={IconSize.XSmall}
+              className="text-white"
+            />
           </span>
-          <div className="flex flex-col">
-            <Typography bold type={TypographyType.Callout}>
-              Challenge a friend
-            </Typography>
-            <Typography
-              type={TypographyType.Caption1}
-              color={TypographyColor.Tertiary}
-            >
-              Drop your streak — bet they can&apos;t keep up
-            </Typography>
-          </div>
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption2}
+            className="!text-white/80"
+          >
+            daily.dev
+          </Typography>
         </div>
 
-        {/* Chat-bubble preview of the actual outgoing message */}
-        <div className="relative ml-1 rounded-16 rounded-bl-4 border border-border-subtlest-tertiary bg-surface-primary px-3.5 py-2.5">
-          <Typography
-            tag={TypographyTag.P}
-            type={TypographyType.Footnote}
-            className="whitespace-pre-line"
-          >
-            {message}
-          </Typography>
+        <div className="relative mt-4 flex items-baseline gap-2">
+          <span className="font-bold leading-none text-white typo-mega3">
+            {currentStreak}
+          </span>
+          <span className="!text-white/90 font-bold typo-callout">
+            day streak
+          </span>
+        </div>
+
+        <div className="relative mt-4 flex items-center justify-between">
           <Typography
             tag={TypographyTag.Span}
             type={TypographyType.Caption1}
-            color={TypographyColor.Link}
-            className="mt-1 block truncate"
+            className="!text-white/85"
           >
-            {isLoading ? 'Preparing your link…' : link}
+            @{username}
           </Typography>
-          {/* Tail of the chat bubble */}
-          <span
-            aria-hidden
-            className="rounded-sm absolute -bottom-px -left-1.5 h-2.5 w-2.5 rotate-45 border-b border-l border-border-subtlest-tertiary bg-surface-primary"
-          />
+          <span className="bg-white/20 rounded-full px-2 py-0.5 text-white typo-caption2">
+            {milestone}
+          </span>
         </div>
+      </div>
 
-        {/* Channel row */}
-        <div className="mt-1 flex items-center justify-between gap-2">
+      {/* Share row */}
+      <div className="flex flex-col gap-2">
+        <Typography
+          type={TypographyType.Footnote}
+          color={TypographyColor.Tertiary}
+        >
+          Send your streak to a friend
+        </Typography>
+        <div className="flex items-center justify-between gap-1.5">
           {channels.map((c) => (
             <a
               key={c.key}
@@ -274,14 +305,14 @@ export function StreakShareCallout({
               aria-label={`Share via ${c.label}`}
               onClick={() => logShare(c.provider)}
               className={classNames(
-                'group flex flex-1 flex-col items-center gap-1.5',
+                'group flex flex-1 flex-col items-center gap-1',
                 (isLoading || !link) && 'pointer-events-none opacity-50',
               )}
             >
               <span
                 className={classNames(
-                  'flex h-10 w-10 items-center justify-center rounded-12 transition-all duration-200 group-hover:-translate-y-0.5',
-                  c.className,
+                  'flex h-10 w-10 items-center justify-center rounded-12 transition-transform duration-200 group-hover:-translate-y-0.5',
+                  c.pillClassName,
                 )}
               >
                 {c.icon}
@@ -295,23 +326,20 @@ export function StreakShareCallout({
             </a>
           ))}
 
-          {/* Copy is the always-available fallback */}
           <button
             type="button"
             onClick={onCopy}
             disabled={isLoading || !link}
             aria-label="Copy invite message"
             className={classNames(
-              'group flex flex-1 flex-col items-center gap-1.5',
+              'group flex flex-1 flex-col items-center gap-1',
               (isLoading || !link) && 'pointer-events-none opacity-50',
             )}
           >
             <span
               className={classNames(
-                'flex h-10 w-10 items-center justify-center rounded-12 transition-all duration-200 group-hover:-translate-y-0.5',
-                copied
-                  ? 'bg-accent-avocado-default/20 text-accent-avocado-default'
-                  : 'bg-accent-cabbage-default/15 hover:bg-accent-cabbage-default/25 text-accent-cabbage-default',
+                'flex h-10 w-10 items-center justify-center rounded-12 transition-transform duration-200 group-hover:-translate-y-0.5',
+                copied ? 'btn-primary-avocado' : 'btn-primary-cabbage',
               )}
             >
               {copied ? (
@@ -332,19 +360,48 @@ export function StreakShareCallout({
             </Typography>
           </button>
         </div>
-
-        {/* Native share — surfaces on mobile only */}
-        {canNativeShare && (
-          <Button
-            type="button"
-            size={ButtonSize.Small}
-            variant={ButtonVariant.Secondary}
-            onClick={onNativeShare}
-          >
-            {nativeShared ? '✓ Shared' : 'More sharing options…'}
-          </Button>
-        )}
       </div>
+
+      {/* Preview disclosure — shows the actual outgoing message */}
+      <button
+        type="button"
+        className="flex items-center justify-center gap-1.5 text-text-tertiary transition-colors typo-caption1 hover:text-text-primary"
+        onClick={() => setShowPreview((v) => !v)}
+      >
+        <EyeIcon size={IconSize.XSmall} />
+        {showPreview ? 'Hide message preview' : 'Preview the message'}
+      </button>
+
+      {showPreview && (
+        <div className="rounded-12 rounded-bl-4 border border-border-subtlest-tertiary bg-surface-float p-3">
+          <Typography
+            tag={TypographyTag.P}
+            type={TypographyType.Footnote}
+            className="whitespace-pre-line"
+          >
+            {message}
+          </Typography>
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption1}
+            color={TypographyColor.Link}
+            className="mt-1 block truncate"
+          >
+            {isLoading ? 'Preparing your link…' : link}
+          </Typography>
+        </div>
+      )}
+
+      {canNativeShare && (
+        <Button
+          type="button"
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Secondary}
+          onClick={onNativeShare}
+        >
+          More sharing options…
+        </Button>
+      )}
     </div>
   );
 }

--- a/packages/shared/src/components/referral/StreakShareFlowDemo.tsx
+++ b/packages/shared/src/components/referral/StreakShareFlowDemo.tsx
@@ -1,0 +1,284 @@
+import type { ReactElement } from 'react';
+import React, { useState } from 'react';
+import classNames from 'classnames';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../typography/Typography';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { ArrowIcon, ReadingStreakIcon, WhatsappIcon } from '../icons';
+import { IconSize } from '../Icon';
+
+/**
+ * TEMPORARY QA helper — visual mock of the WhatsApp invite flow so reviewers
+ * can see *what the friend actually receives* without leaving the app.
+ * Three tiny screens stacked: outgoing message → friend's WhatsApp → tapped
+ * link landing on the inviter's daily.dev profile/streak.
+ *
+ * This file lives next to the QA panel — delete it together with the panel.
+ */
+
+type Step = 'send' | 'receive' | 'land';
+
+const STEPS: Step[] = ['send', 'receive', 'land'];
+
+type StreakShareFlowDemoProps = {
+  username: string;
+  currentStreak: number;
+  message: string;
+  link: string;
+};
+
+// --- Step 1: outgoing message in WhatsApp composer
+
+function SendStep({
+  username,
+  message,
+  link,
+}: {
+  username: string;
+  message: string;
+  link: string;
+}): ReactElement {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2 border-b border-border-subtlest-tertiary px-3 py-2">
+        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-accent-avocado-default text-white">
+          <WhatsappIcon size={IconSize.XXSmall} />
+        </span>
+        <Typography bold type={TypographyType.Caption1}>
+          To: a friend
+        </Typography>
+      </div>
+      <div className="flex flex-col gap-2 p-3">
+        <div className="bg-accent-avocado-default/15 ml-auto max-w-[88%] rounded-12 rounded-br-4 px-3 py-2 text-text-primary">
+          <Typography
+            tag={TypographyTag.P}
+            type={TypographyType.Caption1}
+            className="whitespace-pre-line"
+          >
+            {message}
+          </Typography>
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption2}
+            color={TypographyColor.Link}
+            className="mt-1 block truncate"
+          >
+            {link}
+          </Typography>
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption2}
+            color={TypographyColor.Tertiary}
+            className="mt-0.5 block text-right"
+          >
+            sent · just now ✓✓
+          </Typography>
+        </div>
+        <Typography
+          type={TypographyType.Caption2}
+          color={TypographyColor.Tertiary}
+          className="text-center"
+        >
+          You ({username}) just shared your streak.
+        </Typography>
+      </div>
+    </div>
+  );
+}
+
+// --- Step 2: friend's WhatsApp inbox
+
+function ReceiveStep({
+  username,
+  message,
+  link,
+}: {
+  username: string;
+  message: string;
+  link: string;
+}): ReactElement {
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2 border-b border-border-subtlest-tertiary px-3 py-2">
+        <span className="flex h-6 w-6 items-center justify-center rounded-full bg-accent-avocado-default text-white">
+          <WhatsappIcon size={IconSize.XXSmall} />
+        </span>
+        <Typography bold type={TypographyType.Caption1}>
+          From: {username}
+        </Typography>
+      </div>
+      <div className="flex flex-col gap-2 p-3">
+        <div className="mr-auto max-w-[88%] rounded-12 rounded-bl-4 bg-surface-float px-3 py-2">
+          <Typography
+            tag={TypographyTag.P}
+            type={TypographyType.Caption1}
+            className="whitespace-pre-line"
+          >
+            {message}
+          </Typography>
+          <a
+            href={link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-1 block truncate text-text-link underline typo-caption2"
+          >
+            {link}
+          </a>
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption2}
+            color={TypographyColor.Tertiary}
+            className="mt-0.5 block"
+          >
+            received · just now
+          </Typography>
+        </div>
+        <div className="mx-auto flex items-center gap-1 text-text-tertiary">
+          <ArrowIcon size={IconSize.XXSmall} className="rotate-180" />
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption2}
+            color={TypographyColor.Tertiary}
+          >
+            Friend taps the link
+          </Typography>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// --- Step 3: friend lands on inviter's profile/streak
+
+function LandStep({
+  username,
+  currentStreak,
+}: {
+  username: string;
+  currentStreak: number;
+}): ReactElement {
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center justify-between border-b border-border-subtlest-tertiary px-3 py-2">
+        <Typography
+          type={TypographyType.Caption2}
+          color={TypographyColor.Tertiary}
+        >
+          🔒 daily.dev/{username}
+        </Typography>
+      </div>
+      <div className="flex flex-col items-center gap-2 px-3 py-4">
+        <span className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-accent-bacon-default to-accent-cheese-default text-white">
+          <ReadingStreakIcon secondary size={IconSize.Small} />
+        </span>
+        <Typography bold type={TypographyType.Callout}>
+          @{username}
+        </Typography>
+        <div className="flex items-baseline gap-1.5">
+          <span className="font-bold leading-none text-accent-bacon-default typo-title2">
+            {currentStreak}
+          </span>
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+          >
+            day reading streak
+          </Typography>
+        </div>
+        <Button
+          type="button"
+          size={ButtonSize.XSmall}
+          variant={ButtonVariant.Primary}
+        >
+          Start your own streak →
+        </Button>
+        <Typography
+          type={TypographyType.Caption2}
+          color={TypographyColor.Tertiary}
+          className="text-center"
+        >
+          They sign up · their streak starts · you both keep reading
+        </Typography>
+      </div>
+    </div>
+  );
+}
+
+export function StreakShareFlowDemo({
+  username,
+  currentStreak,
+  message,
+  link,
+}: StreakShareFlowDemoProps): ReactElement {
+  const [step, setStep] = useState<Step>('send');
+  const stepIndex = STEPS.indexOf(step);
+
+  const goNext = () =>
+    setStep(STEPS[Math.min(stepIndex + 1, STEPS.length - 1)] ?? 'send');
+  const goPrev = () => setStep(STEPS[Math.max(stepIndex - 1, 0)] ?? 'send');
+
+  return (
+    <div className="flex flex-col gap-3 rounded-12 border border-border-subtlest-tertiary bg-surface-float p-3">
+      {/* Step indicator */}
+      <div className="flex items-center justify-between">
+        <Typography bold type={TypographyType.Caption1}>
+          {step === 'send' && '1 of 3 — You hit “Send”'}
+          {step === 'receive' && '2 of 3 — Your friend opens WhatsApp'}
+          {step === 'land' && '3 of 3 — They tap the link'}
+        </Typography>
+        <div className="flex items-center gap-1">
+          {STEPS.map((s, i) => (
+            <span
+              key={s}
+              className={classNames(
+                'h-1 w-4 rounded-full transition-colors',
+                i <= stepIndex
+                  ? 'bg-accent-bacon-default'
+                  : 'bg-border-subtlest-tertiary',
+              )}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Mock device frame */}
+      <div className="overflow-hidden rounded-12 border border-border-subtlest-tertiary bg-background-default">
+        {step === 'send' && (
+          <SendStep username={username} message={message} link={link} />
+        )}
+        {step === 'receive' && (
+          <ReceiveStep username={username} message={message} link={link} />
+        )}
+        {step === 'land' && (
+          <LandStep username={username} currentStreak={currentStreak} />
+        )}
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <Button
+          type="button"
+          size={ButtonSize.XSmall}
+          variant={ButtonVariant.Tertiary}
+          onClick={goPrev}
+          disabled={stepIndex === 0}
+        >
+          Back
+        </Button>
+        <Button
+          type="button"
+          size={ButtonSize.XSmall}
+          variant={ButtonVariant.Primary}
+          onClick={goNext}
+          disabled={stepIndex === STEPS.length - 1}
+        >
+          {stepIndex === STEPS.length - 1 ? 'End of flow' : 'Next →'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/shared/src/components/squads/SquadHeaderBar.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderBar.tsx
@@ -42,7 +42,7 @@ const SquadSlackButton = <T extends AllowedTags>({
 }: SquadBarButtonProps<T>) => {
   const { user } = useAuthContext();
   const { data: sourceIntegration, isPending } = useSourceIntegrationQuery({
-    sourceId: squad.id,
+    sourceId: squad.id!,
     userIntegrationType: UserIntegrationType.Slack,
   });
 
@@ -59,7 +59,7 @@ const SquadSlackButton = <T extends AllowedTags>({
       return 'Connect to Slack';
     }
 
-    if (sourceIntegration?.userIntegration.userId === user.id) {
+    if (sourceIntegration?.userIntegration.userId === user?.id) {
       return 'Manage';
     }
 
@@ -87,7 +87,7 @@ const SquadAwardButton = ({
 }: Pick<SquadMemberShortListProps, 'squad'>) => {
   const { user } = useAuthContext();
   const eligibleAdmin = useGetSquadAwardAdmin({
-    sendingUser: user,
+    sendingUser: user!,
     squad,
   });
   const canAwardSquad = !!eligibleAdmin;
@@ -99,11 +99,11 @@ const SquadAwardButton = ({
     <AwardButton
       type="SQUAD"
       entity={{
-        id: squad.id,
+        id: squad.id!,
         receiver: {
           ...eligibleAdmin,
           name: squad.name,
-          image: squad.image,
+          image: squad.image!,
         } as LoggedUser,
       }}
       variant={ButtonVariant.Float}
@@ -131,7 +131,7 @@ const SquadInviteButton = <T extends AllowedTags>({
       icon={<AddUserIcon />}
       {...props}
     >
-      Invitation link
+      Invite colleagues
     </Button>
   );
 };

--- a/packages/shared/src/graphql/actions.ts
+++ b/packages/shared/src/graphql/actions.ts
@@ -62,6 +62,7 @@ export enum ActionType {
   DisableAchievementCompletion = 'disable_achievement_completion',
   DismissInstallExtension = 'dismiss_install_extension',
   DismissShortcutsExtensionPromo = 'dismiss_shortcuts_extension_promo',
+  ChromeStoreReviewPrompt = 'chrome_store_review_prompt',
   DismissBriefCard = 'dismiss_brief_card',
   DigestUpsell = 'digest_upsell',
   AskUpsellSearch = 'ask_upsell_search',

--- a/packages/shared/src/hooks/useSquadInvitation.ts
+++ b/packages/shared/src/hooks/useSquadInvitation.ts
@@ -5,6 +5,7 @@ import { LogEvent } from '../lib/log';
 import type { Squad } from '../graphql/sources';
 import { useActions } from './useActions';
 import { ActionType } from '../graphql/actions';
+import { ReferralGrowthSurface } from '../lib/referralGrowth';
 
 export interface UseSquadInvitationProps {
   squad: Squad;
@@ -30,7 +31,11 @@ export const useSquadInvitation = ({
   const logAndCopyLink = () => {
     logEvent({
       event_name: LogEvent.ShareSquadInvitation,
-      extra: JSON.stringify({ origin, squad: squad.id }),
+      extra: JSON.stringify({
+        origin,
+        squad: squad.id,
+        surface: ReferralGrowthSurface.Squad,
+      }),
     });
 
     completeAction(ActionType.SquadInvite);

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -29,6 +29,8 @@ export const firstNotificationLink = 'https://r.daily.dev/notifications';
 export const reportSquadMember = 'https://r.daily.dev/report-squad-member';
 export const squadFeedback = 'https://r.daily.dev/squad-feedback';
 export const downloadBrowserExtension = 'https://r.daily.dev/extension';
+export const chromeWebStoreReviewUrl =
+  'https://chromewebstore.google.com/detail/dailydev-where-developers/jlmpjdjjbgclbocgajdjefcidcncaied/reviews';
 export const twitter = 'https://r.daily.dev/twitter';
 export const slackIntegration = 'https://r.daily.dev/slack';
 export const statusPage = 'https://r.daily.dev/status';

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -195,16 +195,6 @@ export const featureShortcutsExtensionPromoCopy = new Feature(
 
 export const featureShortcutsHub = new Feature('shortcuts_hub', false);
 
-export const featureReferralGrowthLoops = new Feature(
-  'referral_growth_loops',
-  false,
-);
-
-export const featureExtensionStoreReviewPrompt = new Feature(
-  'extension_store_review_prompt',
-  false,
-);
-
 export const featureNewTabCustomizer = new Feature(
   'extension_newtab_customizer',
   false,

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -195,6 +195,16 @@ export const featureShortcutsExtensionPromoCopy = new Feature(
 
 export const featureShortcutsHub = new Feature('shortcuts_hub', false);
 
+export const featureReferralGrowthLoops = new Feature(
+  'referral_growth_loops',
+  false,
+);
+
+export const featureExtensionStoreReviewPrompt = new Feature(
+  'extension_store_review_prompt',
+  false,
+);
+
 export const featureNewTabCustomizer = new Feature(
   'extension_newtab_customizer',
   false,

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -204,6 +204,13 @@ export enum LogEvent {
   // Referral campaign
   CopyReferralLink = 'copy referral link',
   InviteReferral = 'invite referral',
+  ReferralPromptImpression = 'impression referral prompt',
+  ReferralPromptClick = 'click referral prompt',
+  StoreReviewPromptImpression = 'impression store review prompt',
+  StoreReviewPromptPositive = 'positive store review prompt',
+  StoreReviewPromptNegative = 'negative store review prompt',
+  StoreReviewPromptClick = 'click store review prompt',
+  StoreReviewPromptDismiss = 'dismiss store review prompt',
   // Shortcuts
   RevokeShortcutAccess = 'revoke shortcut access',
   SaveShortcutAccess = 'save shortcut access',
@@ -491,6 +498,8 @@ export enum TargetType {
   InviteFriendsPage = 'invite friends page',
   ProfilePage = 'profile page',
   GenericReferralPopup = 'generic referral popup',
+  ReferralPrompt = 'referral prompt',
+  StoreReviewPrompt = 'store review prompt',
   Shortcuts = 'shortcuts',
   VerifyEmail = 'verify email',
   ResendVerificationCode = 'resend verification code',

--- a/packages/shared/src/lib/referralGrowth.ts
+++ b/packages/shared/src/lib/referralGrowth.ts
@@ -1,0 +1,50 @@
+import { ReferralCampaignKey } from './referral';
+
+export enum ReferralGrowthSurface {
+  PostUpvote = 'post_upvote',
+  StreakMilestone = 'streak_milestone',
+  TopReaderBadge = 'top_reader_badge',
+  DevCard = 'devcard',
+  Squad = 'squad',
+  Brief = 'brief',
+}
+
+export const referralGrowthTriggerMatrix: Record<
+  ReferralGrowthSurface,
+  {
+    campaignKey: ReferralCampaignKey;
+    trigger: string;
+    shareUnit: string;
+  }
+> = {
+  [ReferralGrowthSurface.PostUpvote]: {
+    campaignKey: ReferralCampaignKey.SharePost,
+    trigger: 'post_upvote',
+    shareUnit: 'post_link',
+  },
+  [ReferralGrowthSurface.StreakMilestone]: {
+    campaignKey: ReferralCampaignKey.ShareProfile,
+    trigger: 'streak_milestone',
+    shareUnit: 'profile_link',
+  },
+  [ReferralGrowthSurface.TopReaderBadge]: {
+    campaignKey: ReferralCampaignKey.ShareProfile,
+    trigger: 'top_reader_badge',
+    shareUnit: 'profile_link',
+  },
+  [ReferralGrowthSurface.DevCard]: {
+    campaignKey: ReferralCampaignKey.ShareProfile,
+    trigger: 'devcard_generated',
+    shareUnit: 'devcard_profile_link',
+  },
+  [ReferralGrowthSurface.Squad]: {
+    campaignKey: ReferralCampaignKey.Generic,
+    trigger: 'squad_invite',
+    shareUnit: 'squad_invitation_link',
+  },
+  [ReferralGrowthSurface.Brief]: {
+    campaignKey: ReferralCampaignKey.SharePost,
+    trigger: 'brief_share',
+    shareUnit: 'brief_post_link',
+  },
+};

--- a/packages/shared/src/lib/referralGrowth.ts
+++ b/packages/shared/src/lib/referralGrowth.ts
@@ -1,5 +1,15 @@
 import { ReferralCampaignKey } from './referral';
 
+export const featureReferralGrowthLoops = {
+  id: 'referral_growth_loops',
+  defaultValue: false,
+};
+
+export const featureExtensionStoreReviewPrompt = {
+  id: 'extension_store_review_prompt',
+  defaultValue: false,
+};
+
 export enum ReferralGrowthSurface {
   PostUpvote = 'post_upvote',
   StreakMilestone = 'streak_milestone',

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -96,7 +96,14 @@ export function addLogQueryParams({
     return link;
   }
 
-  const url = new URL(link);
+  let url: URL;
+
+  try {
+    url = new URL(link);
+  } catch {
+    return link;
+  }
+
   url.searchParams.set('userid', userId);
   url.searchParams.set('cid', cid);
 

--- a/packages/webapp/__tests__/SquadFeedPage.tsx
+++ b/packages/webapp/__tests__/SquadFeedPage.tsx
@@ -464,7 +464,7 @@ describe('squad header bar', () => {
       permissions: [SourcePermissions.Invite],
     };
     renderComponent();
-    const invite = await screen.findByText('Invitation link');
+    const invite = await screen.findByText('Invite colleagues');
 
     mockGraphQL({
       request: {
@@ -494,7 +494,7 @@ describe('squad header bar', () => {
       createBasicSourceMembersMock(),
       createTopMembersBySquadMock(),
     ]);
-    const invite = await screen.findByText('Invitation link');
+    const invite = await screen.findByText('Invite colleagues');
 
     mockGraphQL({
       request: {

--- a/packages/webapp/components/layouts/SettingsLayout/Customization/DevCard/DevCardStep2.tsx
+++ b/packages/webapp/components/layouts/SettingsLayout/Customization/DevCard/DevCardStep2.tsx
@@ -22,7 +22,7 @@ import {
 } from '@dailydotdev/shared/src/lib/query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
-import { LogEvent } from '@dailydotdev/shared/src/lib/log';
+import { LogEvent, Origin } from '@dailydotdev/shared/src/lib/log';
 import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
 import { ClickableText } from '@dailydotdev/shared/src/components/buttons/ClickableText';
 import {
@@ -37,7 +37,7 @@ import {
   TwitterIcon,
 } from '@dailydotdev/shared/src/components/icons';
 import { DevCardFetchWrapper } from '@dailydotdev/shared/src/components/profile/devcard/DevCardFetchWrapper';
-import { devCard } from '@dailydotdev/shared/src/lib/constants';
+import { devCard, webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import { checkLowercaseEquality } from '@dailydotdev/shared/src/lib/strings';
 import classNames from 'classnames';
 import { isNullOrUndefined } from '@dailydotdev/shared/src/lib/func';
@@ -49,6 +49,12 @@ import {
   TypographyType,
 } from '@dailydotdev/shared/src/components/typography/Typography';
 import { Tooltip } from '@dailydotdev/shared/src/components/tooltip/Tooltip';
+import { ContextualReferralLink } from '@dailydotdev/shared/src/components/referral/ContextualReferralLink';
+import { ReferralCampaignKey } from '@dailydotdev/shared/src/lib/referral';
+import { ReferralGrowthSurface } from '@dailydotdev/shared/src/lib/referralGrowth';
+import { addLogQueryParams } from '@dailydotdev/shared/src/lib/share';
+import { useConditionalFeature } from '@dailydotdev/shared/src/hooks/useConditionalFeature';
+import { featureReferralGrowthLoops } from '@dailydotdev/shared/src/lib/featureManagement';
 import { GENERATE_DEVCARD_MUTATION } from '../../../../../graphql/devcard';
 import type { GenerateDevCardParams } from '../../../../../graphql/devcard';
 
@@ -61,7 +67,11 @@ export const DevCardStep2 = ({
 }: Step2Props): ReactElement => {
   const [type, setType] = useState(DevCardType.Vertical);
   const { user } = useAuthContext();
-  const { devcard } = useDevCard(user?.id);
+  const userId = user?.id ?? '';
+  const username = user?.username ?? '';
+  const userName = user?.name ?? username;
+  const reputation = user?.reputation ?? 0;
+  const { devcard } = useDevCard(userId);
   const { theme, showBorder, isProfileCover } = devcard ?? {
     theme: DevCardTheme.Default,
     showBorder: true,
@@ -72,23 +82,32 @@ export const DevCardStep2 = ({
 
   const [devCardSrc, setDevCardSrc] = useState<string>(
     initialDevCardSrc ??
-      `${process.env.NEXT_PUBLIC_API_URL}/devcards/v2/${user.id}.png?type=default&r=${randomStr}`,
+      `${process.env.NEXT_PUBLIC_API_URL}/devcards/v2/${userId}.png?type=default&r=${randomStr}`,
   );
 
   const client = useQueryClient();
   const { logEvent } = useLogContext();
   const key = useMemo(
-    () => generateQueryKey(RequestKey.DevCard, { id: user?.id }),
-    [user],
+    () => generateQueryKey(RequestKey.DevCard, { id: userId }),
+    [userId],
   );
+  const profileUrl = username ? `${webappUrl}${username}` : webappUrl;
+  const trackedProfileUrl =
+    addLogQueryParams({
+      link: profileUrl,
+      userId,
+      cid: ReferralCampaignKey.ShareProfile,
+    }) ?? profileUrl;
+  const { value: showReferralGrowthLoop } = useConditionalFeature({
+    feature: featureReferralGrowthLoops,
+    shouldEvaluate: !!userId,
+  });
   const embedCode = useMemo(
     () =>
-      `<a href="https://app.daily.dev/${
-        user?.username
-      }"><img src="${devCardSrc}" width="${
+      `<a href="${trackedProfileUrl}"><img src="${devCardSrc}" width="${
         type === DevCardType.Horizontal ? 652 : 356
-      }" alt="${user?.name}'s Dev Card"/></a>`,
-    [user?.name, user?.username, devCardSrc, type],
+      }" alt="${userName}'s Dev Card"/></a>`,
+    [userName, devCardSrc, trackedProfileUrl, type],
   );
   const [copyingEmbed, copyEmbed] = useCopyLink(() => embedCode);
   const [selectedTab, setSelectedTab] = useState(0);
@@ -98,7 +117,7 @@ export const DevCardStep2 = ({
 
   const downloadImage = async (url?: string): Promise<void> => {
     const finalUrl = url ?? devCardSrc;
-    await onDownloadUrl({ url: finalUrl, filename: `${user.username}.png` });
+    await onDownloadUrl({ url: finalUrl, filename: `${username}.png` });
   };
 
   const { mutateAsync: onGenerate, isPending: isLoading } = useMutation({
@@ -111,7 +130,7 @@ export const DevCardStep2 = ({
     },
 
     onSuccess: (data, vars) => {
-      if (!data?.devCard?.imageUrl || vars.type === DevCardType.Twitter) {
+      if (!data?.devCard?.imageUrl || vars?.type === DevCardType.Twitter) {
         return;
       }
 
@@ -158,7 +177,10 @@ export const DevCardStep2 = ({
       logEvent({
         event_name: LogEvent.DownloadDevcard,
         extra: JSON.stringify({
-          format: devcardTypeToEventFormat[type],
+          format:
+            devcardTypeToEventFormat[
+              type as keyof typeof devcardTypeToEventFormat
+            ],
         }),
       });
     }
@@ -213,7 +235,7 @@ export const DevCardStep2 = ({
             style={{ transformStyle: 'preserve-3d' }}
           >
             <DevCardFetchWrapper
-              userId={user.id}
+              userId={userId}
               type={type}
               isInteractive={false}
             />
@@ -275,6 +297,17 @@ export const DevCardStep2 = ({
                 Add your DevCard to GitHub, your website, or use it as your X
                 header image.
               </Typography>
+              {showReferralGrowthLoop && (
+                <ContextualReferralLink
+                  url={profileUrl}
+                  campaignKey={ReferralCampaignKey.ShareProfile}
+                  surface={ReferralGrowthSurface.DevCard}
+                  origin={Origin.Settings}
+                  title="Turn your DevCard into an invite"
+                  description="Share your developer card so friends can see your profile and build their own."
+                  buttonText="Copy DevCard invite"
+                />
+              )}
 
               <div>
                 <Typography
@@ -376,13 +409,14 @@ export const DevCardStep2 = ({
 
                 <div className="flex flex-row flex-wrap">
                   {Object.keys(themeToLinearGradient).map((value) => {
-                    const isLocked = user?.reputation < requiredPoints[value];
+                    const themeValue = value as DevCardTheme;
+                    const isLocked = reputation < requiredPoints[themeValue];
                     return (
                       <Tooltip
                         key={value}
                         content={
                           isLocked ? (
-                            `Earn ${requiredPoints[value]} reputation points to unlock ${value} theme`
+                            `Earn ${requiredPoints[themeValue]} reputation points to unlock ${value} theme`
                           ) : (
                             <span className="capitalize">{value}</span>
                           )
@@ -396,11 +430,13 @@ export const DevCardStep2 = ({
                             className={classNames(
                               'h-10 w-10 rounded-full',
                               isLocked && 'opacity-32',
-                              checkLowercaseEquality(theme, value) &&
-                                'border-4 border-accent-cabbage-default',
+                              checkLowercaseEquality(
+                                theme ?? DevCardTheme.Default,
+                                value,
+                              ) && 'border-4 border-accent-cabbage-default',
                             )}
                             style={{
-                              background: themeToLinearGradient[value],
+                              background: themeToLinearGradient[themeValue],
                             }}
                             onClick={() =>
                               onUpdatePreference({
@@ -441,7 +477,7 @@ export const DevCardStep2 = ({
                 </RadioItem>
 
                 <RadioItem
-                  disabled={isLoading || !user.cover}
+                  disabled={isLoading || !user?.cover}
                   name="profileCover"
                   checked={isProfileCover}
                   onChange={() => onUpdatePreference({ isProfileCover: true })}

--- a/packages/webapp/components/layouts/SettingsLayout/Customization/DevCard/DevCardStep2.tsx
+++ b/packages/webapp/components/layouts/SettingsLayout/Customization/DevCard/DevCardStep2.tsx
@@ -51,10 +51,12 @@ import {
 import { Tooltip } from '@dailydotdev/shared/src/components/tooltip/Tooltip';
 import { ContextualReferralLink } from '@dailydotdev/shared/src/components/referral/ContextualReferralLink';
 import { ReferralCampaignKey } from '@dailydotdev/shared/src/lib/referral';
-import { ReferralGrowthSurface } from '@dailydotdev/shared/src/lib/referralGrowth';
+import {
+  featureReferralGrowthLoops,
+  ReferralGrowthSurface,
+} from '@dailydotdev/shared/src/lib/referralGrowth';
 import { addLogQueryParams } from '@dailydotdev/shared/src/lib/share';
 import { useConditionalFeature } from '@dailydotdev/shared/src/hooks/useConditionalFeature';
-import { featureReferralGrowthLoops } from '@dailydotdev/shared/src/lib/featureManagement';
 import { GENERATE_DEVCARD_MUTATION } from '../../../../../graphql/devcard';
 import type { GenerateDevCardParams } from '../../../../../graphql/devcard';
 


### PR DESCRIPTION
## Summary
- Adds contextual referral prompts for DevCard, streak milestones, top-reader badges, post upvote shares, brief sharing, and Squad invite surfaces.
- Adds referral growth surface/event definitions plus impression/click instrumentation for funnel tracking.
- Adds an extension-only, one-time Chrome Web Store review prompt with a two-step sentiment gate and no incentives.

## Policy and rollout notes
- Store review flow is non-incentivized, does not ask for a specific rating, and permanently records dismissal/completion through `ActionType.ChromeStoreReviewPrompt`.
- Referral loops are gated by `referral_growth_loops`; review prompt is gated by `extension_store_review_prompt`.
- Rollback: disable the GrowthBook flags to hide the new referral surfaces and review prompt.

## Test plan
- `node ./scripts/typecheck-strict-changed.js`
- `pnpm --filter shared lint`
- `pnpm --filter webapp lint`


Made with [Cursor](https://cursor.com)

### Preview domain
https://feat-referral-review-growth-pr.preview.app.daily.dev