### PR TITLE
fix(standups): show ended state for finished rooms

### DIFF
--- a/packages/shared/src/contexts/LiveRoomContext.spec.tsx
+++ b/packages/shared/src/contexts/LiveRoomContext.spec.tsx
@@ -11,6 +11,7 @@ import { gqlClient } from '../graphql/common';
 
 const mockUseAuthContext = jest.fn();
 const mockUseLogContext = jest.fn();
+const mockUseLiveRoomQuery = jest.fn();
 const connectionInstances: Array<{
   options: {
     token?: string;
@@ -25,6 +26,10 @@ jest.mock('./AuthContext', () => ({
 
 jest.mock('./LogContext', () => ({
   useLogContext: () => mockUseLogContext(),
+}));
+
+jest.mock('../hooks/liveRooms/useLiveRoom', () => ({
+  useLiveRoom: (...args: unknown[]) => mockUseLiveRoomQuery(...args),
 }));
 
 jest.mock('../graphql/common', () => ({
@@ -120,6 +125,13 @@ describe('LiveRoomContext', () => {
     mockUseLogContext.mockReturnValue({
       logEvent: jest.fn(),
     });
+    mockUseLiveRoomQuery.mockReturnValue({
+      data: {
+        id: 'room-1',
+        status: 'live',
+      },
+      isLoading: false,
+    });
     (gqlClient.request as jest.Mock).mockResolvedValue({
       liveRoomJoinToken: {
         token: 'fresh-token',
@@ -154,5 +166,29 @@ describe('LiveRoomContext', () => {
       }),
     );
     expect(connectionInstances[0].options.resumeToken).toBeUndefined();
+  });
+
+  it('does not fetch a join token or open a websocket for an ended standup', async () => {
+    mockUseLiveRoomQuery.mockReturnValue({
+      data: {
+        id: 'room-1',
+        status: 'ended',
+      },
+      isLoading: false,
+    });
+
+    render(
+      <LiveRoomProvider roomId="room-1">
+        <div>standup</div>
+      </LiveRoomProvider>,
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(mockUseLiveRoomQuery).toHaveBeenCalledWith('room-1');
+    });
+
+    expect(gqlClient.request).not.toHaveBeenCalled();
+    expect(connectionInstances).toHaveLength(0);
   });
 });

--- a/packages/shared/src/contexts/LiveRoomContext.tsx
+++ b/packages/shared/src/contexts/LiveRoomContext.tsx
@@ -19,6 +19,7 @@ import { useQuery } from '@tanstack/react-query';
 import { gqlClient } from '../graphql/common';
 import {
   LIVE_ROOM_JOIN_TOKEN_MUTATION,
+  LiveRoomStatus,
   type LiveRoomJoinToken,
   type LiveRoomJoinTokenData,
 } from '../graphql/liveRooms';
@@ -58,6 +59,7 @@ import type {
   MediaTransportCreatePayload,
   ReactionSentEvent,
 } from '../lib/liveRoom/protocol';
+import { useLiveRoom as useLiveRoomQuery } from '../hooks/liveRooms/useLiveRoom';
 
 export type LiveRoomConnectionStatus =
   | 'idle'
@@ -379,6 +381,7 @@ export const LiveRoomProvider = ({
   children,
 }: LiveRoomProviderProps): ReactElement => {
   const { user, isAuthReady } = useAuthContext();
+  const { data: room, isLoading: isRoomLoading } = useLiveRoomQuery(roomId);
   const { logEvent } = useLogContext();
   const [status, setStatus] = useState<LiveRoomConnectionStatus>('idle');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -852,7 +855,13 @@ export const LiveRoomProvider = ({
       joinTokenRequestId,
     ),
     queryFn: () => fetchJoinToken(roomId),
-    enabled: isAuthReady && !!roomId && !storedResumeSession,
+    enabled:
+      isAuthReady &&
+      !!roomId &&
+      !storedResumeSession &&
+      !!room &&
+      !isRoomLoading &&
+      room?.status !== LiveRoomStatus.Ended,
     retry: false,
     staleTime: Infinity,
     gcTime: 0,
@@ -874,6 +883,18 @@ export const LiveRoomProvider = ({
   useEffect(() => {
     setStoredResumeSession(readStoredLiveRoomResumeSession(roomId));
   }, [roomId]);
+
+  useEffect(() => {
+    if (room?.status !== LiveRoomStatus.Ended) {
+      return;
+    }
+
+    clearStoredLiveRoomResumeSession(roomId);
+    setStoredResumeSession(null);
+    setResumeSessionTtlMs(null);
+    setErrorMessage(null);
+    setStatus('idle');
+  }, [room?.status, roomId]);
 
   const requestFreshJoinToken = useCallback(() => {
     clearStoredLiveRoomResumeSession(roomId);
@@ -1002,6 +1023,10 @@ export const LiveRoomProvider = ({
 
   // Open the websocket once we have a fresh join token or a cached resume token.
   useEffect(() => {
+    if (isRoomLoading || !room || room.status === LiveRoomStatus.Ended) {
+      return undefined;
+    }
+
     if (
       storedResumeSession &&
       user?.id &&
@@ -1122,6 +1147,7 @@ export const LiveRoomProvider = ({
       connectionRef.current = null;
     };
   }, [
+    isRoomLoading,
     joinToken,
     pushChatMessage,
     pushChatMessageReaction,
@@ -1131,6 +1157,7 @@ export const LiveRoomProvider = ({
     roomId,
     storedResumeSession,
     requestFreshJoinToken,
+    room,
     user?.id,
   ]);
 


### PR DESCRIPTION
## What changed
- stop the standup provider from requesting join tokens or opening websocket sessions once the room is already ended
- clear stale resume-session state for ended standups so the existing ended UI can render instead of a connection error
- add provider regression coverage for ended standups

## Why
Ended standup pages already had a designed ended state, but the client still tried to join the room. That join attempt failed and replaced the intended UI with a generic connection error.

## Validation
- `NODE_ENV=test pnpm --filter shared exec jest src/contexts/LiveRoomContext.spec.tsx --runInBand`
- `node ./scripts/typecheck-strict-changed.js`
- `pnpm --filter shared exec eslint src/contexts/LiveRoomContext.tsx src/contexts/LiveRoomContext.spec.tsx --max-warnings 0`


### Preview domain
https://codex-standup-ended-state.preview.app.daily.dev