### PR TITLE
fix: preserve standup audio across pages

### DIFF
--- a/packages/shared/src/components/liveRooms/LiveRoom.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.tsx
@@ -796,6 +796,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
           stageGridColumnCount={stageGridColumnCount}
           stageGridRowCount={stageGridRowCount}
           speakers={paginatedStageSpeakers}
+          audioSpeakers={visibleStageSpeakers}
           stagePageStart={stagePageStart}
           focusedSpeakerIndex={focusedSpeakerIndex}
           waitingPrompt={waitingPrompt}

--- a/packages/shared/src/components/liveRooms/LiveRoomAudioPlayer.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomAudioPlayer.tsx
@@ -1,0 +1,88 @@
+import type { ReactElement } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { pickLiveTrack } from './liveRoomMedia';
+
+export type LiveRoomAudioPlaybackState = 'none' | 'blocked' | 'playing';
+
+interface LiveRoomAudioPlayerProps {
+  stream: MediaStream | null;
+  selfView?: boolean;
+  onAudioPlaybackStateChange?: (state: LiveRoomAudioPlaybackState) => void;
+  onRegisterAudioRetry?: (retry: (() => void) | null) => void;
+}
+
+export const LiveRoomAudioPlayer = ({
+  stream,
+  selfView = false,
+  onAudioPlaybackStateChange,
+  onRegisterAudioRetry,
+}: LiveRoomAudioPlayerProps): ReactElement | null => {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const audioTrack = useMemo(
+    () => (selfView ? null : pickLiveTrack(stream, 'audio')),
+    [selfView, stream],
+  );
+  const audioStream = useMemo(
+    () => (audioTrack ? new MediaStream([audioTrack]) : null),
+    [audioTrack],
+  );
+
+  const tryPlayAudio = useCallback((): void => {
+    const node = audioRef.current;
+    if (!node) {
+      onAudioPlaybackStateChange?.('none');
+      return;
+    }
+
+    const playPromise = node.play();
+    if (!playPromise) {
+      onAudioPlaybackStateChange?.('playing');
+      return;
+    }
+
+    playPromise
+      .then(() => onAudioPlaybackStateChange?.('playing'))
+      .catch(() => onAudioPlaybackStateChange?.('blocked'));
+  }, [onAudioPlaybackStateChange]);
+
+  useEffect(() => {
+    const node = audioRef.current;
+    if (!node) {
+      onAudioPlaybackStateChange?.('none');
+      return;
+    }
+
+    if (node.srcObject !== audioStream) {
+      node.srcObject = audioStream;
+    }
+
+    if (audioStream) {
+      tryPlayAudio();
+      return;
+    }
+
+    onAudioPlaybackStateChange?.('none');
+  }, [audioStream, onAudioPlaybackStateChange, tryPlayAudio]);
+
+  useEffect(() => {
+    if (!audioStream) {
+      onRegisterAudioRetry?.(null);
+      return undefined;
+    }
+
+    onRegisterAudioRetry?.(tryPlayAudio);
+
+    return () => {
+      onRegisterAudioRetry?.(null);
+    };
+  }, [audioStream, onRegisterAudioRetry, tryPlayAudio]);
+
+  if (!audioStream) {
+    return null;
+  }
+
+  return (
+    // eslint-disable-next-line jsx-a11y/media-has-caption
+    <audio ref={audioRef} autoPlay style={{ display: 'none' }} />
+  );
+};

--- a/packages/shared/src/components/liveRooms/LiveRoomStage.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomStage.spec.tsx
@@ -5,16 +5,26 @@ import { LiveRoomStage } from './LiveRoomStage';
 
 const mockRetryHandlers = new Map<string, jest.Mock>();
 
-jest.mock('./LiveRoomVideoTile', () => {
+jest.mock('./LiveRoomVideoTile', () => ({
+  LiveRoomVideoTile: ({ user }: { user: { id: string; name: string } }) => (
+    <div data-testid={`tile-${user.id}`}>
+      <span>{user.name}</span>
+    </div>
+  ),
+}));
+
+jest.mock('./LiveRoomAudioPlayer', () => {
   const mockReact = jest.requireActual('react');
 
   return {
-    LiveRoomVideoTile: ({
-      user,
+    LiveRoomAudioPlayer: ({
+      stream,
+      selfView,
       onAudioPlaybackStateChange,
       onRegisterAudioRetry,
     }: {
-      user: { id: string; name: string };
+      stream: MediaStream | null;
+      selfView?: boolean;
       onAudioPlaybackStateChange?: (
         state: 'none' | 'blocked' | 'playing',
       ) => void;
@@ -22,29 +32,33 @@ jest.mock('./LiveRoomVideoTile', () => {
     }) => {
       mockReact.useEffect(() => {
         const retry = jest.fn();
-        mockRetryHandlers.set(user.id, retry);
+        const speakerId = stream?.id ?? 'unknown';
+        mockRetryHandlers.set(speakerId, retry);
         onRegisterAudioRetry?.(retry);
 
         return () => {
-          mockRetryHandlers.delete(user.id);
+          mockRetryHandlers.delete(speakerId);
           onRegisterAudioRetry?.(null);
         };
-      }, [onRegisterAudioRetry, user.id]);
+      }, [onRegisterAudioRetry, stream]);
+
+      if (selfView) {
+        return null;
+      }
 
       return (
-        <div data-testid={`tile-${user.id}`}>
-          <span>{user.name}</span>
+        <div data-testid={`audio-player-${stream?.id ?? 'unknown'}`}>
           <button
             type="button"
             onClick={() => onAudioPlaybackStateChange?.('blocked')}
           >
-            {`block-${user.id}`}
+            {`block-${stream?.id ?? 'unknown'}`}
           </button>
           <button
             type="button"
             onClick={() => onAudioPlaybackStateChange?.('playing')}
           >
-            {`play-${user.id}`}
+            {`play-${stream?.id ?? 'unknown'}`}
           </button>
         </div>
       );
@@ -71,7 +85,7 @@ const createSpeaker = (id: string): LiveRoomStageSpeaker => ({
     createdAt: '',
     reputation: 0,
   },
-  stream: null,
+  stream: { id } as MediaStream,
   selfView: false,
   isHost: false,
   isCoHost: false,
@@ -88,7 +102,8 @@ const renderStage = () =>
       setStagePage={jest.fn()}
       stageGridColumnCount={2}
       stageGridRowCount={1}
-      speakers={[createSpeaker('speaker-1'), createSpeaker('speaker-2')]}
+      speakers={[createSpeaker('speaker-1')]}
+      audioSpeakers={[createSpeaker('speaker-1'), createSpeaker('speaker-2')]}
       stagePageStart={0}
       focusedSpeakerIndex={null}
       waitingPrompt="Waiting"
@@ -143,5 +158,15 @@ describe('LiveRoomStage', () => {
 
     expect(mockRetryHandlers.get('speaker-1')).toHaveBeenCalledTimes(1);
     expect(mockRetryHandlers.get('speaker-2')).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces blocked audio from an off-page speaker', () => {
+    renderStage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'block-speaker-2' }));
+
+    expect(
+      screen.getByRole('button', { name: 'Tap to unmute' }),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/shared/src/components/liveRooms/LiveRoomStage.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomStage.tsx
@@ -20,9 +20,10 @@ import type { UserShortProfile } from '../../lib/user';
 import { LiveRoomControls } from './LiveRoomControls';
 import { LiveRoomStagePager } from './LiveRoomStagePager';
 import {
-  LiveRoomVideoTile,
-  type LiveRoomTileAudioPlaybackState,
-} from './LiveRoomVideoTile';
+  LiveRoomAudioPlayer,
+  type LiveRoomAudioPlaybackState,
+} from './LiveRoomAudioPlayer';
+import { LiveRoomVideoTile } from './LiveRoomVideoTile';
 
 export interface LiveRoomStageSpeaker {
   id: string;
@@ -44,6 +45,7 @@ interface LiveRoomStageProps {
   stageGridColumnCount: number;
   stageGridRowCount: number;
   speakers: LiveRoomStageSpeaker[];
+  audioSpeakers: LiveRoomStageSpeaker[];
   stagePageStart: number;
   focusedSpeakerIndex: number | null;
   waitingPrompt: string;
@@ -88,6 +90,7 @@ export const LiveRoomStage = ({
   stageGridColumnCount,
   stageGridRowCount,
   speakers,
+  audioSpeakers,
   stagePageStart,
   focusedSpeakerIndex,
   waitingPrompt,
@@ -108,13 +111,18 @@ export const LiveRoomStage = ({
   onLeave,
 }: LiveRoomStageProps): ReactElement => {
   const [speakerAudioStates, setSpeakerAudioStates] = useState<
-    Record<string, LiveRoomTileAudioPlaybackState>
+    Record<string, LiveRoomAudioPlaybackState>
   >({});
   const audioRetryHandlersRef = useRef(new Map<string, () => void>());
   const hasMultiplePages = stagePageCount > 1;
-  const visibleSpeakerIds = useMemo(
-    () => new Set(speakers.map((speaker) => speaker.id)),
-    [speakers],
+  const audioSpeakerIds = useMemo(
+    () =>
+      new Set(
+        audioSpeakers
+          .filter((speaker) => !speaker.selfView)
+          .map((speaker) => speaker.id),
+      ),
+    [audioSpeakers],
   );
   const goToPage = useCallback(
     (page: number) => {
@@ -150,20 +158,20 @@ export const LiveRoomStage = ({
     setSpeakerAudioStates((current) =>
       Object.fromEntries(
         Object.entries(current).filter(([speakerId]) =>
-          visibleSpeakerIds.has(speakerId),
+          audioSpeakerIds.has(speakerId),
         ),
       ),
     );
 
     audioRetryHandlersRef.current.forEach((_, speakerId) => {
-      if (!visibleSpeakerIds.has(speakerId)) {
+      if (!audioSpeakerIds.has(speakerId)) {
         audioRetryHandlersRef.current.delete(speakerId);
       }
     });
-  }, [visibleSpeakerIds]);
+  }, [audioSpeakerIds]);
 
   const handleSpeakerAudioPlaybackStateChange = useCallback(
-    (speakerId: string, state: LiveRoomTileAudioPlaybackState): void => {
+    (speakerId: string, state: LiveRoomAudioPlaybackState): void => {
       setSpeakerAudioStates((current) => {
         if (state === 'none') {
           if (!(speakerId in current)) {
@@ -197,10 +205,10 @@ export const LiveRoomStage = ({
     [],
   );
 
-  const hasBlockedAudio = speakers.some(
+  const hasBlockedAudio = audioSpeakers.some(
     (speaker) => speakerAudioStates[speaker.id] === 'blocked',
   );
-  const hasPlayingAudio = speakers.some(
+  const hasPlayingAudio = audioSpeakers.some(
     (speaker) => speakerAudioStates[speaker.id] === 'playing',
   );
   const showAudioPrompt = hasBlockedAudio && !hasPlayingAudio;
@@ -211,6 +219,19 @@ export const LiveRoomStage = ({
 
   return (
     <section aria-label="Speakers" className="relative flex min-h-0 flex-col">
+      {audioSpeakers.map((speaker) => (
+        <LiveRoomAudioPlayer
+          key={speaker.id}
+          stream={speaker.stream}
+          selfView={speaker.selfView}
+          onAudioPlaybackStateChange={(state) =>
+            handleSpeakerAudioPlaybackStateChange(speaker.id, state)
+          }
+          onRegisterAudioRetry={(retry) =>
+            registerSpeakerAudioRetry(speaker.id, retry)
+          }
+        />
+      ))}
       {showAudioPrompt ? (
         <Button
           type="button"
@@ -260,12 +281,6 @@ export const LiveRoomStage = ({
                     onUnfocus={onUnfocusSpeaker}
                     onSwipeNext={() => onSpeakerFocusNavigate(1)}
                     onSwipePrev={() => onSpeakerFocusNavigate(-1)}
-                    onAudioPlaybackStateChange={(state) =>
-                      handleSpeakerAudioPlaybackStateChange(speaker.id, state)
-                    }
-                    onRegisterAudioRetry={(retry) =>
-                      registerSpeakerAudioRetry(speaker.id, retry)
-                    }
                     onGrantCoHost={
                       canManageCoHosts && !speaker.isCoHost
                         ? () =>

--- a/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
@@ -1,12 +1,5 @@
 import type { ReactElement } from 'react';
-import React, {
-  useCallback,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useEffect, useId, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { useSwipeable } from 'react-swipeable';
 import {
@@ -24,14 +17,13 @@ import {
   SPEAKING_LEVEL_THRESHOLD,
   useLiveRoomAudioLevel,
 } from './useLiveRoomAudioLevel';
+import { pickLiveTrack } from './liveRoomMedia';
 import { LiveRoomTileActions } from './LiveRoomTileActions';
 import { Drawer } from '../drawers';
 import { RootPortal } from '../tooltips/Portal';
 import { useViewSize, ViewSize } from '../../hooks';
 import { useTouchLongPress } from '../../hooks/useTouchLongPress';
 import { anchorDefaultRel } from '../../lib/strings';
-
-export type LiveRoomTileAudioPlaybackState = 'none' | 'blocked' | 'playing';
 
 interface LiveRoomVideoTileProps {
   stream: MediaStream | null;
@@ -58,21 +50,7 @@ interface LiveRoomVideoTileProps {
   onUnfocus?: () => void;
   onSwipeNext?: () => void;
   onSwipePrev?: () => void;
-  onAudioPlaybackStateChange?: (state: LiveRoomTileAudioPlaybackState) => void;
-  onRegisterAudioRetry?: (retry: (() => void) | null) => void;
 }
-
-const pickLiveTrack = (
-  source: MediaStream | null,
-  kind: 'audio' | 'video',
-): MediaStreamTrack | null => {
-  if (!source) {
-    return null;
-  }
-  const tracks =
-    kind === 'audio' ? source.getAudioTracks() : source.getVideoTracks();
-  return tracks.find((t) => t.readyState === 'live') ?? null;
-};
 
 export const LiveRoomVideoTile = ({
   stream,
@@ -98,11 +76,8 @@ export const LiveRoomVideoTile = ({
   onUnfocus,
   onSwipeNext,
   onSwipePrev,
-  onAudioPlaybackStateChange,
-  onRegisterAudioRetry,
 }: LiveRoomVideoTileProps): ReactElement => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
-  const audioRef = useRef<HTMLAudioElement | null>(null);
   const mutedNoticeId = useId();
   const isTablet = useViewSize(ViewSize.Tablet);
   const isMobile = !isTablet;
@@ -179,22 +154,6 @@ export const LiveRoomVideoTile = ({
   const level = useLiveRoomAudioLevel(levelStream);
   const isSpeaking = level >= SPEAKING_LEVEL_THRESHOLD;
 
-  const tryPlayAudio = useCallback((): void => {
-    const node = audioRef.current;
-    if (!node) {
-      onAudioPlaybackStateChange?.('none');
-      return;
-    }
-    const playPromise = node.play();
-    if (!playPromise) {
-      onAudioPlaybackStateChange?.('playing');
-      return;
-    }
-    playPromise
-      .then(() => onAudioPlaybackStateChange?.('playing'))
-      .catch(() => onAudioPlaybackStateChange?.('blocked'));
-  }, [onAudioPlaybackStateChange]);
-
   useEffect(() => {
     const node = videoRef.current;
     if (!node) {
@@ -204,35 +163,6 @@ export const LiveRoomVideoTile = ({
       node.srcObject = videoStream;
     }
   }, [videoStream]);
-
-  useEffect(() => {
-    const node = audioRef.current;
-    if (!node) {
-      onAudioPlaybackStateChange?.('none');
-      return;
-    }
-    if (node.srcObject !== audioStream) {
-      node.srcObject = audioStream;
-    }
-    if (audioStream) {
-      tryPlayAudio();
-    } else {
-      onAudioPlaybackStateChange?.('none');
-    }
-  }, [audioStream, onAudioPlaybackStateChange, tryPlayAudio]);
-
-  useEffect(() => {
-    if (!audioStream) {
-      onRegisterAudioRetry?.(null);
-      return undefined;
-    }
-
-    onRegisterAudioRetry?.(tryPlayAudio);
-
-    return () => {
-      onRegisterAudioRetry?.(null);
-    };
-  }, [audioStream, onRegisterAudioRetry, tryPlayAudio]);
 
   const hasProfileLink = !!user.permalink && user.permalink !== '#';
   const nameLabel = (
@@ -308,14 +238,6 @@ export const LiveRoomVideoTile = ({
           autoPlay
           playsInline
           muted
-          // Re-attempt audio playback once video starts — Chrome's autoplay
-          // policy sometimes blocks the audio element until something visible
-          // is playing.
-          onPlay={() => {
-            if (audioStream) {
-              tryPlayAudio();
-            }
-          }}
           className="h-full w-full object-cover"
         />
       ) : (
@@ -329,10 +251,6 @@ export const LiveRoomVideoTile = ({
           </Typography>
         </div>
       )}
-      {audioStream ? (
-        // eslint-disable-next-line jsx-a11y/media-has-caption
-        <audio ref={audioRef} autoPlay />
-      ) : null}
       {!isFocused && onFocus ? (
         <button
           type="button"

--- a/packages/shared/src/components/liveRooms/liveRoomMedia.ts
+++ b/packages/shared/src/components/liveRooms/liveRoomMedia.ts
@@ -1,0 +1,13 @@
+export const pickLiveTrack = (
+  source: MediaStream | null,
+  kind: 'audio' | 'video',
+): MediaStreamTrack | null => {
+  if (!source) {
+    return null;
+  }
+
+  const tracks =
+    kind === 'audio' ? source.getAudioTracks() : source.getVideoTracks();
+
+  return tracks.find((track) => track.readyState === 'live') ?? null;
+};

--- a/packages/shared/src/contexts/LiveRoomContext.spec.tsx
+++ b/packages/shared/src/contexts/LiveRoomContext.spec.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from 'react';
 import React from 'react';
-import { render, waitFor } from '@testing-library/react';
+import { act, render, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { LiveRoomProvider } from './LiveRoomContext';
+import { LiveRoomProvider, useLiveRoom } from './LiveRoomContext';
 import {
   readStoredLiveRoomResumeSession,
   writeStoredLiveRoomResumeSession,
@@ -12,13 +12,28 @@ import { gqlClient } from '../graphql/common';
 const mockUseAuthContext = jest.fn();
 const mockUseLogContext = jest.fn();
 const mockUseLiveRoomQuery = jest.fn();
-const connectionInstances: Array<{
+type MockConnectionInstance = {
   options: {
     token?: string;
     resumeToken?: string;
     url: string;
   };
-}> = [];
+  open: jest.Mock;
+  close: jest.Mock;
+  send: jest.Mock;
+  onSessionReady: jest.Mock;
+  onSnapshot: jest.Mock;
+  onRoomUpdated: jest.Mock;
+  onReactionSent: jest.Mock;
+  onChatMessage: jest.Mock;
+  onChatMessageDeleted: jest.Mock;
+  onChatMessageReaction: jest.Mock;
+  onChatMessageReactionRemoved: jest.Mock;
+  onClose: jest.Mock;
+  onError: jest.Mock;
+  resumeToken: string | null;
+};
+const connectionInstances: MockConnectionInstance[] = [];
 
 jest.mock('./AuthContext', () => ({
   useAuthContext: () => mockUseAuthContext(),
@@ -39,27 +54,7 @@ jest.mock('../graphql/common', () => ({
 }));
 
 function MockLiveRoomConnection(
-  this: {
-    options: {
-      token?: string;
-      resumeToken?: string;
-      url: string;
-    };
-    open: jest.Mock;
-    close: jest.Mock;
-    send: jest.Mock;
-    onSessionReady: jest.Mock;
-    onSnapshot: jest.Mock;
-    onRoomUpdated: jest.Mock;
-    onReactionSent: jest.Mock;
-    onChatMessage: jest.Mock;
-    onChatMessageDeleted: jest.Mock;
-    onChatMessageReaction: jest.Mock;
-    onChatMessageReactionRemoved: jest.Mock;
-    onClose: jest.Mock;
-    onError: jest.Mock;
-    resumeToken: string | null;
-  },
+  this: MockConnectionInstance,
   options: {
     token?: string;
     resumeToken?: string;
@@ -89,12 +84,39 @@ jest.mock('../lib/liveRoom/connection', () => ({
   LiveRoomConnection: MockLiveRoomConnection,
 }));
 
+const createMockTrack = (kind: 'audio' | 'video'): MediaStreamTrack =>
+  ({
+    kind,
+    readyState: 'live',
+    enabled: true,
+    stop: jest.fn(),
+    addEventListener: jest.fn(),
+  } as unknown as MediaStreamTrack);
+
+class MockMediaStream {
+  constructor(private readonly tracks: MediaStreamTrack[] = []) {}
+
+  getAudioTracks(): MediaStreamTrack[] {
+    return this.tracks.filter((track) => track.kind === 'audio');
+  }
+
+  getVideoTracks(): MediaStreamTrack[] {
+    return this.tracks.filter((track) => track.kind === 'video');
+  }
+}
+
 describe('LiveRoomContext', () => {
   let queryClient = new QueryClient();
+  let latestContext: ReturnType<typeof useLiveRoom> | null = null;
 
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
   );
+
+  const ContextProbe = (): null => {
+    latestContext = useLiveRoom();
+    return null;
+  };
 
   beforeEach(() => {
     queryClient = new QueryClient({
@@ -105,8 +127,15 @@ describe('LiveRoomContext', () => {
       },
     });
     connectionInstances.length = 0;
+    latestContext = null;
     jest.clearAllMocks();
     sessionStorage.clear();
+
+    Object.defineProperty(global, 'MediaStream', {
+      configurable: true,
+      writable: true,
+      value: MockMediaStream,
+    });
 
     Object.defineProperty(global.navigator, 'mediaDevices', {
       configurable: true,
@@ -115,6 +144,10 @@ describe('LiveRoomContext', () => {
         addEventListener: jest.fn(),
         removeEventListener: jest.fn(),
         getSupportedConstraints: jest.fn().mockReturnValue({}),
+        getUserMedia: jest.fn().mockResolvedValue({
+          getAudioTracks: () => [createMockTrack('audio')],
+          getVideoTracks: () => [],
+        }),
       },
     });
 
@@ -190,5 +223,72 @@ describe('LiveRoomContext', () => {
 
     expect(gqlClient.request).not.toHaveBeenCalled();
     expect(connectionInstances).toHaveLength(0);
+  });
+
+  it('lowers a raised hand after successfully unmuting', async () => {
+    render(
+      <LiveRoomProvider roomId="room-1">
+        <ContextProbe />
+      </LiveRoomProvider>,
+      { wrapper },
+    );
+
+    await waitFor(() => expect(connectionInstances).toHaveLength(1));
+
+    const connection = connectionInstances[0];
+    connection.send.mockResolvedValue(undefined);
+
+    const handleSessionReady = connection.onSessionReady.mock.calls[0][0];
+    const handleSnapshot = connection.onSnapshot.mock.calls[0][0];
+
+    act(() => {
+      handleSessionReady({
+        roomId: 'room-1',
+        participantId: 'speaker-1',
+        role: 'speaker',
+        resumeToken: 'resume-token-1',
+        resumeSessionTtlMs: 30_000,
+      });
+      handleSnapshot({
+        room: {
+          roomId: 'room-1',
+          mode: 'moderated',
+          status: 'live',
+          version: 1,
+          participants: {
+            'speaker-1': {
+              participantId: 'speaker-1',
+              role: 'speaker',
+              sessionIds: ['session-speaker-1'],
+              joinedAt: '2026-05-12T10:00:00.000Z',
+              updatedAt: '2026-05-12T10:00:00.000Z',
+            },
+          },
+          coHostParticipantIds: [],
+          chatPermissions: {},
+          sessions: {},
+          stage: {
+            speakerQueueParticipantIds: [],
+            activeSpeakerParticipantIds: ['speaker-1'],
+            raisedHandParticipantIds: ['speaker-1'],
+          },
+          mediaPublications: {},
+          mediaRuntimeOwner: null,
+          createdAt: '2026-05-12T10:00:00.000Z',
+          updatedAt: '2026-05-12T10:00:00.000Z',
+        },
+      });
+    });
+
+    await waitFor(() => expect(latestContext?.participantId).toBe('speaker-1'));
+
+    await act(async () => {
+      await latestContext?.toggleMic();
+    });
+
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+    expect(connection.send).toHaveBeenCalledWith({
+      type: 'stage.hand.remove',
+    });
   });
 });

--- a/packages/shared/src/contexts/LiveRoomContext.tsx
+++ b/packages/shared/src/contexts/LiveRoomContext.tsx
@@ -1774,6 +1774,26 @@ export const LiveRoomProvider = ({
     setIsCameraOn(true);
   }, [isCameraOn, selectedCameraId, startCapture, stopCapture]);
 
+  const removeRaisedHandOnUnmute = useCallback(async () => {
+    if (!participantId) {
+      return;
+    }
+
+    if (!roomState?.stage.raisedHandParticipantIds.includes(participantId)) {
+      return;
+    }
+
+    try {
+      await sendConnectionCommand('remove hand', { type: 'stage.hand.remove' });
+    } catch {
+      // The command path already logs the error; keep the successful unmute.
+    }
+  }, [
+    participantId,
+    roomState?.stage.raisedHandParticipantIds,
+    sendConnectionCommand,
+  ]);
+
   const toggleMic = useCallback(async () => {
     if (isMicOn) {
       const track = localTracksRef.current.audio;
@@ -1813,6 +1833,7 @@ export const LiveRoomProvider = ({
         await publishLocalTrack('audio');
       }
       setIsMicOn(true);
+      await removeRaisedHandOnUnmute();
       return;
     }
 
@@ -1820,10 +1841,12 @@ export const LiveRoomProvider = ({
     mutedAudioTrackRef.current = null;
     await startCapture('audio', selectedMicId);
     setIsMicOn(true);
+    await removeRaisedHandOnUnmute();
   }, [
     canPublish,
     isMicOn,
     micSettings,
+    removeRaisedHandOnUnmute,
     publishLocalTrack,
     refreshLocalStream,
     roomState?.status,


### PR DESCRIPTION
## What changed
- keep standup audio playing for speakers on non-visible stage pages by moving remote audio playback out of paginated video tiles and into hidden stage-level audio players
- reuse the live-track picker between tile rendering and audio playback
- automatically lower a speaker's raised hand when they successfully unmute
- add focused regression coverage for off-page audio playback and raised-hand removal on unmute

## Why
The stage pagination optimization stopped rendering tiles for speakers on other pages. Because each tile owned its own `<audio>` element, paginated-away speakers became silent even though we still wanted to hear them. Separately, once a queued speaker unmutes and joins the conversation, their raised hand should be cleared automatically.

## Impact
- standup participants can keep hearing speakers across stage pages without restoring off-page video rendering
- speakers no longer stay in the raised-hand queue after they unmute

## Validation
- `node ./scripts/typecheck-strict-changed.js`
- `pnpm --filter shared exec eslint src/components/liveRooms/LiveRoom.tsx src/components/liveRooms/LiveRoomStage.tsx src/components/liveRooms/LiveRoomVideoTile.tsx src/components/liveRooms/LiveRoomAudioPlayer.tsx src/components/liveRooms/liveRoomMedia.ts src/components/liveRooms/LiveRoomStage.spec.tsx src/contexts/LiveRoomContext.tsx src/contexts/LiveRoomContext.spec.tsx`
- `NODE_ENV=test pnpm --filter shared exec jest packages/shared/src/components/liveRooms/LiveRoom.spec.tsx packages/shared/src/components/liveRooms/LiveRoomStage.spec.tsx packages/shared/src/components/liveRooms/LiveRoomVideoTile.spec.tsx packages/shared/src/contexts/LiveRoomContext.spec.tsx --runInBand`


### Preview domain
https://codex-standup-audio-pages.preview.app.daily.dev