### PR TITLE
fix: disconnect standup before navigating home

### DIFF
--- a/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
@@ -199,6 +199,7 @@ const createContextValue = (
   },
   role: 'host',
   participantId: 'host',
+  disconnect: jest.fn().mockResolvedValue(undefined),
   preflightMediaPermissions: jest.fn(),
   startRoom: jest.fn(),
   endRoom: jest.fn(),
@@ -413,6 +414,28 @@ describe('LiveRoom', () => {
     expect(screen.getByText('tile-host')).toBeInTheDocument();
     expect(screen.getByText('tile-speaker1')).toBeInTheDocument();
     expect(screen.getByText('tile-speaker2')).toBeInTheDocument();
+  });
+
+  it('disconnects before navigating home from the ended standup state', async () => {
+    const disconnect = jest.fn().mockResolvedValue(undefined);
+    mockUseLiveRoomConnection.mockReturnValue(
+      createContextValue({
+        disconnect,
+        roomState: {
+          ...createContextValue().roomState!,
+          status: 'ended',
+        },
+      }),
+    );
+
+    renderLiveRoom();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back home' }));
+
+    await waitFor(() => {
+      expect(disconnect).toHaveBeenCalledTimes(1);
+      expect(mockPush).toHaveBeenCalledWith('/');
+    });
   });
 
   it('passes raised hand queue positions to matching stage tiles', () => {

--- a/packages/shared/src/components/liveRooms/LiveRoom.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.tsx
@@ -37,7 +37,6 @@ import useLogEventOnce from '../../hooks/log/useLogEventOnce';
 import { useToastNotification } from '../../hooks/useToastNotification';
 import { useExitConfirmation } from '../../hooks/useExitConfirmation';
 import { useViewSize, ViewSize } from '../../hooks';
-import { clearStoredLiveRoomResumeSession } from '../../lib/liveRoom/resumeSessionStorage';
 import { useLiveRoomSubscription } from '../../hooks/liveRooms/useLiveRoomSubscription';
 import { usePushNotificationContext } from '../../contexts/PushNotificationContext';
 import { usePushNotificationMutation } from '../../hooks/notifications/usePushNotificationMutation';
@@ -73,6 +72,7 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     roomState,
     role,
     participantId,
+    disconnect,
     sendChatMessage,
     deleteChatMessage,
     sendChatMessageReaction,
@@ -135,10 +135,14 @@ const LiveRoomInner = ({ roomId }: LiveRoomProps): ReactElement => {
     videoSettings,
   });
 
-  const handleLeave = (): void => {
+  const navigateHome = useCallback(async (): Promise<void> => {
     onAskConfirmation(false);
-    clearStoredLiveRoomResumeSession(roomId);
-    router.push('/');
+    await disconnect();
+    await router.push('/');
+  }, [disconnect, onAskConfirmation, router]);
+
+  const handleLeave = (): void => {
+    navigateHome().catch(() => undefined);
   };
   const handleNavigateBack = (surface: string): void => {
     logStandupAction(LogEvent.LeaveStandup, roomId, { surface });

--- a/packages/shared/src/components/liveRooms/LiveRoomControls.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomControls.spec.tsx
@@ -166,6 +166,7 @@ const createContextValue = (
   },
   role: 'audience',
   participantId: 'audience',
+  disconnect: jest.fn().mockResolvedValue(undefined),
   preflightMediaPermissions: jest.fn(),
   startRoom: jest.fn(),
   endRoom: jest.fn(),

--- a/packages/shared/src/contexts/LiveRoomContext.tsx
+++ b/packages/shared/src/contexts/LiveRoomContext.tsx
@@ -138,6 +138,7 @@ export interface LiveRoomContextValue {
   role: LiveRoomParticipantRoleValue | null;
   participantId: string | null;
 
+  disconnect: () => Promise<void>;
   preflightMediaPermissions: () => Promise<void>;
   startRoom: () => Promise<void>;
   endRoom: () => Promise<void>;
@@ -450,6 +451,7 @@ export const LiveRoomProvider = ({
     recv: false,
   });
   const mediaRebuildQueuedRef = useRef(false);
+  const intentionalDisconnectRef = useRef(false);
   const currentRole =
     (participantId && roomState?.participants[participantId]?.role) || role;
   const privilegeState = getLiveRoomPrivilegeState(
@@ -690,6 +692,19 @@ export const LiveRoomProvider = ({
     setIsCameraOn(false);
     setIsMicOn(false);
   }, []);
+
+  const disconnect = useCallback(async () => {
+    intentionalDisconnectRef.current = true;
+    clearStoredLiveRoomResumeSession(roomId);
+    setStoredResumeSession(null);
+    setResumeSessionTtlMs(null);
+    setErrorMessage(null);
+    setStatus('idle');
+    closeMediaSession(true);
+    stopLocalCapture();
+    connectionRef.current?.close();
+    connectionRef.current = null;
+  }, [closeMediaSession, roomId, stopLocalCapture]);
 
   const queueMediaRebuild = useCallback(() => {
     if (mediaRebuildQueuedRef.current || status !== 'connected') {
@@ -1064,6 +1079,7 @@ export const LiveRoomProvider = ({
         : { token: joinToken?.token ?? '' }),
     });
     connectionRef.current = connection;
+    intentionalDisconnectRef.current = false;
     setStatus('connecting');
     setErrorMessage(null);
     const openingWithResume = !!storedResumeSession;
@@ -1114,6 +1130,9 @@ export const LiveRoomProvider = ({
       },
     );
     const offClose = connection.onClose(({ code, reason }) => {
+      if (intentionalDisconnectRef.current) {
+        return;
+      }
       if (openingWithResume && !sessionReady) {
         requestFreshJoinToken();
         return;
@@ -1126,6 +1145,9 @@ export const LiveRoomProvider = ({
       setErrorMessage(reason || 'Standup connection closed');
     });
     const offError = connection.onError((error) => {
+      if (intentionalDisconnectRef.current) {
+        return;
+      }
       if (openingWithResume && !sessionReady) {
         return;
       }
@@ -2163,6 +2185,7 @@ export const LiveRoomProvider = ({
       roomState,
       role: currentRole,
       participantId,
+      disconnect,
       preflightMediaPermissions,
       startRoom,
       endRoom,
@@ -2212,6 +2235,7 @@ export const LiveRoomProvider = ({
       roomState,
       currentRole,
       participantId,
+      disconnect,
       preflightMediaPermissions,
       startRoom,
       endRoom,


### PR DESCRIPTION
## Summary
This fixes the standup end-state "Back home" path so leaving an ended room performs an intentional disconnect before routing away.

## Root cause
The ended-state CTA navigated away without explicitly tearing down the live-room connection first. That left a late websocket close or error event free to surface during navigation, which could produce a stray connection-related UI artifact after clicking back home.

## Changes
- add a shared `disconnect()` action to the live-room context
- treat intentional standup disconnects as non-user-facing close or error events
- route the ended-state and leave flows through the intentional disconnect path
- add a regression test for the ended-state "Back home" CTA

## Impact
Closing a standup and clicking back home should now return to the home page without the weird follow-up toast or transient connection error state.

## Validation
- `node ./scripts/typecheck-strict-changed.js`
- `pnpm --filter @dailydotdev/shared exec eslint src/contexts/LiveRoomContext.tsx src/components/liveRooms/LiveRoom.tsx src/components/liveRooms/LiveRoom.spec.tsx src/components/liveRooms/LiveRoomControls.spec.tsx --max-warnings 0`
- `NODE_ENV=test pnpm --filter @dailydotdev/shared exec jest src/components/liveRooms/LiveRoom.spec.tsx src/components/liveRooms/LiveRoomControls.spec.tsx src/contexts/LiveRoomContext.spec.tsx --runInBand`


### Preview domain
https://codex-standup-ended-back-home-di.preview.app.daily.dev