### PR TITLE
fix: prioritize recent live room mention suggestions

### DIFF
--- a/packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.spec.ts
+++ b/packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.spec.ts
@@ -1,0 +1,108 @@
+import type { LiveRoomChatEntry } from '../../contexts/LiveRoomContext';
+import type { UserShortProfile } from '../../lib/user';
+import { getLiveRoomMentionSuggestions } from './useLiveRoomStageModel';
+
+const createProfile = (id: string): UserShortProfile => ({
+  id,
+  username: id,
+  name: id,
+  image: '',
+  createdAt: '2026-05-12T10:00:00.000Z',
+  reputation: 0,
+  permalink: `/${id}`,
+});
+
+const createMessage = (participantId: string, messageId: string): LiveRoomChatEntry => ({
+  messageId,
+  participantId,
+  body: messageId,
+  createdAt: '2026-05-12T10:00:00.000Z',
+  reactions: [],
+});
+
+describe('getLiveRoomMentionSuggestions', () => {
+  it('keeps the host first and prioritizes recent unique chat senders', () => {
+    const host = createProfile('host');
+    const profiles = [
+      host,
+      createProfile('speaker-1'),
+      createProfile('speaker-2'),
+      createProfile('speaker-3'),
+      createProfile('speaker-4'),
+      createProfile('speaker-5'),
+      createProfile('speaker-6'),
+      createProfile('speaker-7'),
+      createProfile('speaker-8'),
+      createProfile('audience-1'),
+    ];
+
+    const participantProfilesById = new Map(
+      profiles.map((profile) => [profile.id, profile]),
+    );
+
+    const suggestions = getLiveRoomMentionSuggestions({
+      host,
+      participantIds: [
+        'speaker-1',
+        'speaker-2',
+        'speaker-3',
+        'speaker-4',
+        'speaker-5',
+        'speaker-6',
+        'speaker-7',
+        'speaker-8',
+        'audience-1',
+      ],
+      participantProfilesById,
+      chatMessages: [
+        createMessage('speaker-1', 'message-1'),
+        createMessage('speaker-2', 'message-2'),
+        createMessage('speaker-3', 'message-3'),
+        createMessage('speaker-4', 'message-4'),
+        createMessage('speaker-5', 'message-5'),
+        createMessage('speaker-6', 'message-6'),
+        createMessage('speaker-7', 'message-7'),
+        createMessage('speaker-8', 'message-8'),
+      ],
+    });
+
+    expect(suggestions.map(({ id }) => id)).toEqual([
+      'host',
+      'speaker-8',
+      'speaker-7',
+      'speaker-6',
+      'speaker-5',
+      'speaker-4',
+      'speaker-3',
+      'speaker-2',
+      'speaker-1',
+      'audience-1',
+    ]);
+  });
+
+  it('deduplicates repeated senders and skips the host from recent sender ranking', () => {
+    const host = createProfile('host');
+    const speaker = createProfile('speaker');
+    const audience = createProfile('audience');
+    const participantProfilesById = new Map(
+      [host, speaker, audience].map((profile) => [profile.id, profile]),
+    );
+
+    const suggestions = getLiveRoomMentionSuggestions({
+      host,
+      participantIds: ['speaker', 'audience'],
+      participantProfilesById,
+      chatMessages: [
+        createMessage('speaker', 'message-1'),
+        createMessage('host', 'message-2'),
+        createMessage('speaker', 'message-3'),
+      ],
+    });
+
+    expect(suggestions.map(({ id }) => id)).toEqual([
+      'host',
+      'speaker',
+      'audience',
+    ]);
+  });
+});

--- a/packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.spec.ts
+++ b/packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.spec.ts
@@ -12,7 +12,10 @@ const createProfile = (id: string): UserShortProfile => ({
   permalink: `/${id}`,
 });
 
-const createMessage = (participantId: string, messageId: string): LiveRoomChatEntry => ({
+const createMessage = (
+  participantId: string,
+  messageId: string,
+): LiveRoomChatEntry => ({
   messageId,
   participantId,
   body: messageId,

--- a/packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.ts
+++ b/packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.ts
@@ -13,6 +13,7 @@ import { useLiveRoomParticipantStreams } from './useLiveRoomParticipantStreams';
 const MAX_STAGE_TILES_PER_PAGE = 12;
 const MOBILE_MAX_STAGE_TILES_PER_PAGE = 4;
 const EMPTY_PARTICIPANT_IDS: string[] = [];
+const INITIAL_CHAT_MENTION_RECENT_SENDER_COUNT = 7;
 
 const getStageGridColumnCount = (count: number, isMobile: boolean): number => {
   if (count <= 1) {
@@ -28,6 +29,65 @@ const getStageGridColumnCount = (count: number, isMobile: boolean): number => {
     return 3;
   }
   return 4;
+};
+
+export const getLiveRoomMentionSuggestions = ({
+  host,
+  participantIds,
+  participantProfilesById,
+  chatMessages,
+}: {
+  host?: UserShortProfile;
+  participantIds: string[];
+  participantProfilesById: Map<string, UserShortProfile>;
+  chatMessages: LiveRoomContextValue['chatMessages'];
+}): UserShortProfile[] => {
+  if (!host) {
+    return [];
+  }
+
+  const suggestionIds = new Set<string>([host.id]);
+  const suggestions: UserShortProfile[] = [host];
+  const recentSenderIds: string[] = [];
+
+  for (let index = chatMessages.length - 1; index >= 0; index -= 1) {
+    const senderId = chatMessages[index]?.participantId;
+
+    if (
+      !senderId ||
+      senderId === host.id ||
+      suggestionIds.has(senderId) ||
+      recentSenderIds.length >= INITIAL_CHAT_MENTION_RECENT_SENDER_COUNT
+    ) {
+      continue;
+    }
+
+    recentSenderIds.push(senderId);
+    suggestionIds.add(senderId);
+  }
+
+  recentSenderIds.forEach((id) => {
+    const profile = participantProfilesById.get(id);
+    if (profile) {
+      suggestions.push(profile);
+    }
+  });
+
+  participantIds.forEach((id) => {
+    if (suggestionIds.has(id)) {
+      return;
+    }
+
+    const profile = participantProfilesById.get(id);
+    if (!profile) {
+      return;
+    }
+
+    suggestionIds.add(id);
+    suggestions.push(profile);
+  });
+
+  return suggestions;
 };
 
 interface UseLiveRoomStageModelProps {
@@ -134,21 +194,13 @@ export const useLiveRoomStageModel = ({
     return nextProfiles;
   }, [participantProfiles, room?.host]);
   const mentionSuggestions = useMemo(() => {
-    if (!room?.host) {
-      return [] as UserShortProfile[];
-    }
-
-    const suggestions: UserShortProfile[] = [room.host];
-
-    participantIds.forEach((id) => {
-      const profile = participantProfilesById.get(id);
-      if (profile) {
-        suggestions.push(profile);
-      }
+    return getLiveRoomMentionSuggestions({
+      host: room?.host,
+      participantIds,
+      participantProfilesById,
+      chatMessages,
     });
-
-    return suggestions;
-  }, [participantIds, participantProfilesById, room?.host]);
+  }, [chatMessages, participantIds, participantProfilesById, room?.host]);
   const audioPublisherIds = useMemo(
     () =>
       new Set(

--- a/packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.ts
+++ b/packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.ts
@@ -53,17 +53,16 @@ export const getLiveRoomMentionSuggestions = ({
   for (let index = chatMessages.length - 1; index >= 0; index -= 1) {
     const senderId = chatMessages[index]?.participantId;
 
-    if (
-      !senderId ||
-      senderId === host.id ||
-      suggestionIds.has(senderId) ||
-      recentSenderIds.length >= INITIAL_CHAT_MENTION_RECENT_SENDER_COUNT
-    ) {
-      continue;
-    }
+    const shouldIncludeSender =
+      !!senderId &&
+      senderId !== host.id &&
+      !suggestionIds.has(senderId) &&
+      recentSenderIds.length < INITIAL_CHAT_MENTION_RECENT_SENDER_COUNT;
 
-    recentSenderIds.push(senderId);
-    suggestionIds.add(senderId);
+    if (shouldIncludeSender) {
+      recentSenderIds.push(senderId);
+      suggestionIds.add(senderId);
+    }
   }
 
   recentSenderIds.forEach((id) => {


### PR DESCRIPTION
## What changed
- prioritize live-room mention suggestions by recency instead of generic participant order
- keep the host pinned first and then surface the most recent unique chat senders
- add a focused spec for ordering and deduplication

## Why
People replying in chat are most likely to mention the host or someone who just posted. The previous initial ordering did not reflect recent conversation context.

## Validation
- `pnpm --filter shared exec jest packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.spec.ts --runInBand`
- `node ./scripts/typecheck-strict-changed.js`


### Preview domain
https://codex-live-room-mention-recency.preview.app.daily.dev