### PR TITLE
fix: use real names and shield host badges in live rooms

### DIFF
--- a/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
@@ -27,6 +27,7 @@ import {
   MenuIcon,
   PlusIcon,
   SendAirplaneIcon,
+  ShieldIcon,
   TrashIcon,
 } from '../icons';
 import { IconSize } from '../Icon';
@@ -518,17 +519,25 @@ export const LiveRoomChatPanel = ({
                 <ProfilePicture user={sender} size={ProfileImageSize.Small} />
                 <div className="min-w-0 flex-1">
                   <div className="min-w-0 text-[0.9375rem] leading-[1.5]">
-                    <span className="mr-2 inline font-bold">{senderName}</span>
-                    {isSenderHost ? (
-                      <span className="mr-2 inline rounded-6 bg-surface-float px-1.5 py-0.5 text-[0.6875rem] font-bold uppercase tracking-wide text-accent-bun-default">
-                        Host
-                      </span>
-                    ) : null}
-                    {isSenderCoHost ? (
-                      <span className="mr-2 inline rounded-6 bg-surface-float px-1.5 py-0.5 text-[0.6875rem] font-bold uppercase tracking-wide text-accent-water-bolder">
-                        Co-host
-                      </span>
-                    ) : null}
+                    <span className="mr-2 inline-flex items-center gap-1">
+                      <span className="font-bold">{senderName}</span>
+                      {isSenderHost ? (
+                        <ShieldIcon
+                          secondary
+                          size={IconSize.XXSmall}
+                          className="text-accent-bun-default"
+                          aria-label="Host"
+                        />
+                      ) : null}
+                      {isSenderCoHost ? (
+                        <ShieldIcon
+                          secondary
+                          size={IconSize.XXSmall}
+                          className="text-accent-water-bolder"
+                          aria-label="Co-host"
+                        />
+                      ) : null}
+                    </span>
                     <Markdown
                       className="inline !text-[0.9375rem] [&_a]:!text-[0.9375rem] [&_code]:rounded-[0.375rem] [&_code]:bg-surface-hover [&_code]:px-1 [&_code]:py-0.5 [&_p]:inline [&_p]:!text-[0.9375rem] [&_p]:!leading-[1.5]"
                       content={chatMarkdownToHtml(message.body, {

--- a/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
@@ -10,7 +10,7 @@ import {
 } from '../typography/Typography';
 import { ProfilePicture, ProfileImageSize } from '../ProfilePicture';
 import type { UserShortProfile } from '../../lib/user';
-import { MicrophoneIcon, VolumeOffIcon } from '../icons';
+import { MicrophoneIcon, ShieldIcon, VolumeOffIcon } from '../icons';
 import { RaiseHandIcon } from '../icons/RaiseHand';
 import { IconSize } from '../Icon';
 import {
@@ -318,29 +318,45 @@ export const LiveRoomVideoTile = ({
       <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 pb-3 pl-1.5 pr-3 pt-3 tablet:pl-3">
         <div className="flex min-h-8 min-w-0 items-center gap-1.5 rounded-12 bg-overlay-dark-dark3 px-2 py-1 backdrop-blur transition-[padding] duration-200 ease-out tablet:gap-2 tablet:px-2.5 tablet:group-hover:pr-1">
           {isHost ? (
-            <Typography
-              type={TypographyType.Caption2}
-              bold
-              className="hidden shrink-0 uppercase tracking-wide !text-accent-bun-default tablet:inline"
-            >
-              Host
-            </Typography>
+            <>
+              <ShieldIcon
+                secondary
+                size={IconSize.XXSmall}
+                className="shrink-0 text-accent-bun-default tablet:hidden"
+                aria-label="Host"
+              />
+              <Typography
+                type={TypographyType.Caption2}
+                bold
+                className="hidden shrink-0 uppercase tracking-wide !text-accent-bun-default tablet:inline"
+              >
+                Host
+              </Typography>
+            </>
           ) : null}
           {isCoHost ? (
-            <Typography
-              type={TypographyType.Caption2}
-              bold
-              className="hidden shrink-0 uppercase tracking-wide !text-accent-water-bolder tablet:inline"
-            >
-              Co-host
-            </Typography>
+            <>
+              <ShieldIcon
+                secondary
+                size={IconSize.XXSmall}
+                className="shrink-0 text-accent-water-bolder tablet:hidden"
+                aria-label="Co-host"
+              />
+              <Typography
+                type={TypographyType.Caption2}
+                bold
+                className="hidden shrink-0 uppercase tracking-wide !text-accent-water-bolder tablet:inline"
+              >
+                Co-host
+              </Typography>
+            </>
           ) : null}
           {hasProfileLink ? (
             <a
               href={user.permalink}
               target="_blank"
               rel={anchorDefaultRel}
-              className="pointer-events-auto min-w-0"
+              className="pointer-events-auto inline-flex min-w-0 items-center"
             >
               {nameLabel}
             </a>

--- a/packages/shared/src/components/liveRooms/liveRoomParticipants.ts
+++ b/packages/shared/src/components/liveRooms/liveRoomParticipants.ts
@@ -19,4 +19,3 @@ export const buildParticipantProfile = (
   reputation: 0,
   permalink: '',
 });
-

--- a/packages/shared/src/components/liveRooms/liveRoomParticipants.ts
+++ b/packages/shared/src/components/liveRooms/liveRoomParticipants.ts
@@ -20,9 +20,3 @@ export const buildParticipantProfile = (
   permalink: '',
 });
 
-export const buildDisplayProfile = (
-  user: UserShortProfile,
-): UserShortProfile => ({
-  ...user,
-  name: userDisplayName(user),
-});

--- a/packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.ts
+++ b/packages/shared/src/hooks/liveRooms/useLiveRoomStageModel.ts
@@ -2,10 +2,7 @@ import { useMemo } from 'react';
 import type { LiveRoomContextValue } from '../../contexts/LiveRoomContext';
 import type { LiveRoom as LiveRoomModel } from '../../graphql/liveRooms';
 import type { UserShortProfile } from '../../lib/user';
-import {
-  buildDisplayProfile,
-  buildParticipantProfile,
-} from '../../components/liveRooms/liveRoomParticipants';
+import { buildParticipantProfile } from '../../components/liveRooms/liveRoomParticipants';
 import type { LiveRoomStageSpeaker } from '../../components/liveRooms/LiveRoomStage';
 import { useLiveRoomParticipantProfiles } from './useLiveRoomParticipantProfiles';
 import { useLiveRoomParticipantStreams } from './useLiveRoomParticipantStreams';
@@ -229,7 +226,7 @@ export const useLiveRoomStageModel = ({
     ? [
         {
           id: room.host.id,
-          profile: buildDisplayProfile(room.host),
+          profile: room.host,
           stream: participantStreamsById.get(room.host.id) ?? null,
           selfView: room.host.id === participantId,
           isHost: true,
@@ -238,9 +235,8 @@ export const useLiveRoomStageModel = ({
         },
         ...activeSpeakerIds.map((id) => ({
           id,
-          profile: buildDisplayProfile(
+          profile:
             participantProfilesById.get(id) ?? buildParticipantProfile(id),
-          ),
           stream: participantStreamsById.get(id) ?? null,
           selfView: id === participantId,
           isHost: false,


### PR DESCRIPTION
## Summary
- Stage tiles use the user's real name instead of `@handle`.
- Host/Co-host text badges replaced by a filled shield icon on mobile (tile) and in chat, colored bun (Host) / water (Co-host).
- Fixed alignment of the name anchor and chat name+icon group.

## Test plan
- [ ] Open `/standups/[id]` and confirm stage tiles show the speaker's name.
- [ ] Verify Host/Co-host badges render correctly on mobile (icon) and desktop (text label).
- [ ] Check chat messages from a host/co-host show the colored shield next to the handle with consistent baseline.

### Preview domain
https://fix-live-room-name-and-host-badg.preview.app.daily.dev