### PR TITLE
chore: harden pnpm supply chain settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,17 +7,20 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install pnpm
-          command: npm i --prefix=$HOME/.local -g pnpm@9.14.4
+          name: Enable pnpm
+          command: |
+            mkdir -p $HOME/.local/bin
+            corepack enable --install-directory $HOME/.local/bin
+            corepack prepare pnpm@10.33.4 --activate
       - restore_cache:
           keys:
-            - deps-v10-{{ checksum "pnpm-lock.yaml" }}
-            - deps-v10-{{ .Branch }}
+            - deps-pnpm-10-33-4-{{ checksum "pnpm-lock.yaml" }}
+            - deps-pnpm-10-33-4-{{ .Branch }}
       - run:
           name: Install dependencies
           command: pnpm install
       - save_cache:
-          key: deps-v10-{{ checksum "pnpm-lock.yaml" }}
+          key: deps-pnpm-10-33-4-{{ checksum "pnpm-lock.yaml" }}
           paths:
             - ./node_modules
             - ./packages/eslint-config/node_modules
@@ -35,8 +38,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps-v10-{{ checksum "pnpm-lock.yaml" }}
-            - deps-v10-{{ .Branch }}
+            - deps-pnpm-10-33-4-{{ checksum "pnpm-lock.yaml" }}
+            - deps-pnpm-10-33-4-{{ .Branch }}
       - run:
           name: Test
           command: |
@@ -56,8 +59,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps-v10-{{ checksum "pnpm-lock.yaml" }}
-            - deps-v10-{{ .Branch }}
+            - deps-pnpm-10-33-4-{{ checksum "pnpm-lock.yaml" }}
+            - deps-pnpm-10-33-4-{{ .Branch }}
       - run:
           name: Test
           command: |
@@ -77,8 +80,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps-v10-{{ checksum "pnpm-lock.yaml" }}
-            - deps-v10-{{ .Branch }}
+            - deps-pnpm-10-33-4-{{ checksum "pnpm-lock.yaml" }}
+            - deps-pnpm-10-33-4-{{ .Branch }}
       - run:
           name: Lint
           command: npm run pretest
@@ -91,8 +94,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps-v10-{{ checksum "pnpm-lock.yaml" }}
-            - deps-v10-{{ .Branch }}
+            - deps-pnpm-10-33-4-{{ checksum "pnpm-lock.yaml" }}
+            - deps-pnpm-10-33-4-{{ .Branch }}
       - run:
           name: Fetch base branch
           command: git fetch origin main
@@ -107,8 +110,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - deps-v10-{{ checksum "pnpm-lock.yaml" }}
-            - deps-v10-{{ .Branch }}
+            - deps-pnpm-10-33-4-{{ checksum "pnpm-lock.yaml" }}
+            - deps-pnpm-10-33-4-{{ .Branch }}
       - run:
           name: Test
           command: |
@@ -126,12 +129,15 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install pnpm
-          command: npm i --prefix=$HOME/.local -g pnpm@9.14.4
+          name: Enable pnpm
+          command: |
+            mkdir -p $HOME/.local/bin
+            corepack enable --install-directory $HOME/.local/bin
+            corepack prepare pnpm@10.33.4 --activate
       - restore_cache:
           keys:
-            - deps-v10-{{ checksum "pnpm-lock.yaml" }}
-            - deps-v10-{{ .Branch }}
+            - deps-pnpm-10-33-4-{{ checksum "pnpm-lock.yaml" }}
+            - deps-pnpm-10-33-4-{{ .Branch }}
       - run:
           name: Install dependencies
           command: pnpm install

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   e2e-tests:
     if: >-
@@ -32,7 +35,7 @@ jobs:
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 9.14.4
+        version: 10.33.4
 
     - name: Get pnpm store directory
       shell: bash
@@ -43,9 +46,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ env.STORE_PATH }}
-        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        key: ${{ runner.os }}-pnpm-10.33.4-store-${{ hashFiles('**/pnpm-lock.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-pnpm-store-
+          ${{ runner.os }}-pnpm-10.33.4-store-
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -36,7 +36,8 @@ tasks:
       nvm install
       nvm use
     init: |
-      npm i -g pnpm@9.14.4
+      corepack enable
+      corepack prepare pnpm@10.33.4 --activate
       pnpm install
     command: |
       cd packages/webapp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ This is a pnpm monorepo containing the daily.dev application suite:
 ## Technology Stack
 
 - **Node.js v24.14** (see `package.json` `volta` and `packageManager` properties, also `.nvmrc`)
-- **pnpm 9.14.4** for package management (see `package.json` `packageManager` property)
+- **pnpm 10.33.4** for package management (see `package.json` `packageManager` property)
 - **TypeScript** across all packages
 - **React 18.3.1** with Next.js 15 for webapp (Pages Router, NOT App Router/Server Components)
 - **TanStack Query v5** for server state and data fetching
@@ -171,7 +171,8 @@ This ensures type safety, reduces duplication, and keeps types automatically in 
 ```bash
 # Setup
 nvm use                   # Use correct Node version from .nvmrc
-npm i -g pnpm@9.14.4
+corepack enable
+corepack prepare pnpm@10.33.4 --activate
 pnpm install
 
 # Development

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN \
   apk --no-cache add \
   libc6-compat
 
-RUN npm i -g pnpm
+RUN corepack enable && corepack prepare pnpm@10.33.4 --activate
 RUN pnpm install
 
 COPY packages ./packages

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The decision was made to allow faster iterations and to keep features parity in 
 ## Technologies
 
 - Node v24.14 (a `.nvmrc` is presented for [nvm](https://github.com/nvm-sh/nvm) users).
-- [pnpm](https://pnpm.io/workspaces) for managing the monorepo and dependencies.
+- [pnpm](https://pnpm.io/workspaces) 10.33.4 for managing the monorepo and dependencies.
 
 ## Projects
 
@@ -87,9 +87,17 @@ We would appreciate if you dedicate the time and read them carefully:
 After cloning the project, please make sure to run the following commands to bootstrap the project:
 
 ```bash
-npm i -g pnpm@9.14.4
+nvm use
+corepack enable
+corepack prepare pnpm@10.33.4 --activate
 pnpm install
 ```
+
+## Dependency Supply-Chain Hardening
+
+This repo delays newly published package versions for seven days via `minimumReleaseAge: 10080` in `pnpm-workspace.yaml`. Keep using the pinned pnpm version from `package.json`; older pnpm versions do not enforce this setting.
+
+Keep `pnpm-lock.yaml` committed, use frozen-lockfile installs in CI, and avoid adding git or tarball dependencies unless they are reviewed explicitly. If an urgent dependency update must bypass the cooldown, add a temporary `minimumReleaseAgeExclude` entry in `pnpm-workspace.yaml`, review the package contents/provenance first, and remove the exception after the release ages out.
 
 ### Run Extension Locally
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test:e2e:headed": "pnpm --filter playwright test:headed",
     "test:e2e:ui": "pnpm --filter playwright test:ui"
   },
-  "packageManager": "pnpm@9.14.4",
+  "packageManager": "pnpm@10.33.4",
   "pnpm": {
     "patchedDependencies": {
       "graphql-request@3.7.0": "patches/graphql-request@3.7.0.patch"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "test:e2e:ui": "pnpm --filter playwright test:ui"
   },
   "packageManager": "pnpm@10.33.4",
+  "pnpm": {
+    "patchedDependencies": {
+      "graphql-request@3.7.0": "patches/graphql-request@3.7.0.patch"
+    }
+  },
   "volta": {
     "node": "24.14.0"
   }

--- a/package.json
+++ b/package.json
@@ -16,11 +16,6 @@
     "test:e2e:ui": "pnpm --filter playwright test:ui"
   },
   "packageManager": "pnpm@10.33.4",
-  "pnpm": {
-    "patchedDependencies": {
-      "graphql-request@3.7.0": "patches/graphql-request@3.7.0.patch"
-    }
-  },
   "volta": {
     "node": "24.14.0"
   }

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "webapp",
   "version": "0.0.0",
+  "packageManager": "pnpm@10.33.4",
   "scripts": {
     "dev": "next dev -p 5002 --experimental-https --experimental-https-key ./certificates/adhoc-server.key --experimental-https-cert ./certificates/adhoc-server.crt --experimental-https-ca ./certificates/root_ca.crt",
     "dev:turbo": "next dev --turbopack -p 5002 --experimental-https --experimental-https-key ./certificates/adhoc-server.key --experimental-https-cert ./certificates/adhoc-server.crt --experimental-https-ca ./certificates/root_ca.crt",

--- a/packages/webapp/vercel.json
+++ b/packages/webapp/vercel.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "pnpm --dir ../.. install",
+  "installCommand": "if [ -f pnpm-workspace.yaml ]; then pnpm install; elif [ -f ../../pnpm-workspace.yaml ]; then pnpm --dir ../.. install; else pnpm install; fi",
   "github": {
     "silent": true
   }

--- a/packages/webapp/vercel.json
+++ b/packages/webapp/vercel.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "pnpm --dir ../.. install",
   "github": {
     "silent": true
   }

--- a/packages/webapp/vercel.json
+++ b/packages/webapp/vercel.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "if [ -f pnpm-workspace.yaml ]; then pnpm install; elif [ -f ../../pnpm-workspace.yaml ]; then pnpm --dir ../.. install; else pnpm install; fi",
+  "installCommand": "if [ -f pnpm-workspace.yaml ]; then corepack pnpm@10.33.4 install; elif [ -f ../../pnpm-workspace.yaml ]; then corepack pnpm@10.33.4 --dir ../.. install; else corepack pnpm@10.33.4 install; fi",
   "github": {
     "silent": true
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   graphql-request@3.7.0:
-    hash: fxjjyfdyg6h6dchjekndlox4o4
+    hash: 0ab9ec08fff95d6fe401cbe554d4f92ca596df7c35c2636c4fd3fb2e914936aa
     path: patches/graphql-request@3.7.0.patch
 
 importers:
@@ -127,7 +127,7 @@ importers:
         version: 16.13.2
       graphql-request:
         specifier: ^3.6.1
-        version: 3.7.0(patch_hash=fxjjyfdyg6h6dchjekndlox4o4)(graphql@16.13.2)
+        version: 3.7.0(patch_hash=0ab9ec08fff95d6fe401cbe554d4f92ca596df7c35c2636c4fd3fb2e914936aa)(graphql@16.13.2)
       idb-keyval:
         specifier: ^5.1.5
         version: 5.1.5
@@ -639,7 +639,7 @@ importers:
         version: 16.13.2
       graphql-request:
         specifier: ^3.6.1
-        version: 3.7.0(patch_hash=fxjjyfdyg6h6dchjekndlox4o4)(graphql@16.13.2)
+        version: 3.7.0(patch_hash=0ab9ec08fff95d6fe401cbe554d4f92ca596df7c35c2636c4fd3fb2e914936aa)(graphql@16.13.2)
       idb-keyval:
         specifier: ^5.1.5
         version: 5.1.5
@@ -895,7 +895,7 @@ importers:
         version: 16.13.2
       graphql-request:
         specifier: ^3.7.0
-        version: 3.7.0(patch_hash=fxjjyfdyg6h6dchjekndlox4o4)(graphql@16.13.2)
+        version: 3.7.0(patch_hash=0ab9ec08fff95d6fe401cbe554d4f92ca596df7c35c2636c4fd3fb2e914936aa)(graphql@16.13.2)
       idb-keyval:
         specifier: ^5.1.5
         version: 5.1.5
@@ -16529,7 +16529,7 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql-request@3.7.0(patch_hash=fxjjyfdyg6h6dchjekndlox4o4)(graphql@16.13.2):
+  graphql-request@3.7.0(patch_hash=0ab9ec08fff95d6fe401cbe554d4f92ca596df7c35c2636c4fd3fb2e914936aa)(graphql@16.13.2):
     dependencies:
       cross-fetch: 3.1.8
       extract-files: 9.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,6 @@ packages:
 # Delay new package versions for 7 days before pnpm may resolve them.
 minimumReleaseAge: 10080
 blockExoticSubdeps: true
+
+patchedDependencies:
+  graphql-request@3.7.0: patches/graphql-request@3.7.0.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,3 @@ packages:
 # Delay new package versions for 7 days before pnpm may resolve them.
 minimumReleaseAge: 10080
 blockExoticSubdeps: true
-
-patchedDependencies:
-  graphql-request@3.7.0: patches/graphql-request@3.7.0.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 packages:
   - "packages/*"
+
+# Delay new package versions for 7 days before pnpm may resolve them.
+minimumReleaseAge: 10080
+blockExoticSubdeps: true


### PR DESCRIPTION
## Summary
- upgrade the pinned pnpm version to 10.33.4 so release-age gating is enforced
- add a 7-day `minimumReleaseAge` cooldown and block exotic transitive dependencies
- normalize the lockfile patch hash for pnpm 10 while keeping the existing patch config in `package.json` for build compatibility
- update CI/dev bootstrap paths and cache keys to use the pinned pnpm version
- document dependency supply-chain practices in the README

## Verification
- `git diff --check`
- parsed updated YAML files with Ruby
- `corepack pnpm install --frozen-lockfile --lockfile-only --ignore-scripts` from repo root
- `corepack pnpm install --frozen-lockfile --lockfile-only --ignore-scripts` from `packages/webapp`
- `corepack pnpm install --frozen-lockfile --ignore-scripts`

Lifecycle scripts were disabled for install verification. I did not run a bare `pnpm install`.

### Preview domain
https://codex-npm-supply-chain-hardening.preview.app.daily.dev