### PR TITLE
fix: show profile tooltip on standup speaker names

### DIFF
--- a/packages/shared/src/components/cards/entity/UserEntityCard.tsx
+++ b/packages/shared/src/components/cards/entity/UserEntityCard.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from 'react';
 import Link from '../../utilities/Link';
 import type { UserShortProfile } from '../../../lib/user';
+import { fallbackImages } from '../../../lib/config';
 import EntityCard from './EntityCard';
 import {
   Typography,
@@ -82,7 +83,7 @@ const UserEntityCard = ({ user, className }: Props) => {
 
   const showActionBtns = !!user && !isLoading && !isSameUser;
 
-  if (!user || !id || !username || !image || !permalink || !createdAt) {
+  if (!user || !id || !username || !permalink || !createdAt) {
     return null;
   }
 
@@ -130,7 +131,7 @@ const UserEntityCard = ({ user, className }: Props) => {
   return (
     <EntityCard
       permalink={permalink}
-      image={image}
+      image={image || fallbackImages.avatar}
       type="user"
       className={{
         image: 'size-16 rounded-20',

--- a/packages/shared/src/components/liveRooms/LiveRoomVideoTile.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomVideoTile.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
 import React from 'react';
 import { LiveRoomVideoTile } from './LiveRoomVideoTile';
 
@@ -51,6 +52,19 @@ jest.mock('../ProfilePicture', () => ({
   },
 }));
 
+jest.mock('../profile/ProfileTooltip', () => ({
+  ProfileTooltip: (props: { children: ReactElement; userId: string }) => {
+    const mockReact = jest.requireActual('react') as Pick<
+      typeof React,
+      'cloneElement'
+    >;
+
+    return mockReact.cloneElement(props.children, {
+      'data-profile-tooltip-user-id': props.userId,
+    });
+  },
+}));
+
 jest.mock('../drawers', () => ({
   Drawer: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
@@ -81,6 +95,31 @@ const defaultUser = {
 };
 
 describe('LiveRoomVideoTile', () => {
+  it('shows the profile tooltip on linked speaker names', () => {
+    render(
+      <LiveRoomVideoTile stream={null} user={defaultUser} selfView={false} />,
+    );
+
+    expect(
+      screen.getByRole('link', { name: defaultUser.name }),
+    ).toHaveAttribute('href', defaultUser.permalink);
+    expect(
+      screen.getByRole('link', { name: defaultUser.name }),
+    ).toHaveAttribute('data-profile-tooltip-user-id', defaultUser.id);
+  });
+
+  it('shows the profile tooltip on speaker names without profile links', () => {
+    const user = { ...defaultUser, permalink: '' };
+
+    render(<LiveRoomVideoTile stream={null} user={user} selfView={false} />);
+
+    expect(
+      screen.getByText(user.name, {
+        selector: '[data-profile-tooltip-user-id]',
+      }),
+    ).toHaveAttribute('data-profile-tooltip-user-id', user.id);
+  });
+
   it('unmutes the current speaker from the muted badge', () => {
     const onToggleSelfMute = jest.fn();
 

--- a/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
@@ -24,6 +24,7 @@ import { RootPortal } from '../tooltips/Portal';
 import { useViewSize, ViewSize } from '../../hooks';
 import { useTouchLongPress } from '../../hooks/useTouchLongPress';
 import { anchorDefaultRel } from '../../lib/strings';
+import { ProfileTooltip } from '../profile/ProfileTooltip';
 
 interface LiveRoomVideoTileProps {
   stream: MediaStream | null;
@@ -165,6 +166,7 @@ export const LiveRoomVideoTile = ({
   }, [videoStream]);
 
   const hasProfileLink = !!user.permalink && user.permalink !== '#';
+  const hasProfileTooltip = !!user.id;
   const nameLabel = (
     <Typography
       tag={TypographyTag.Span}
@@ -173,11 +175,30 @@ export const LiveRoomVideoTile = ({
       truncate
       className={classNames(
         'min-w-0 !text-white !typo-caption2 tablet:!typo-footnote',
-        hasProfileLink && 'pointer-events-auto hover:underline',
+        hasProfileTooltip && 'pointer-events-auto hover:underline',
       )}
     >
       {user.name}
     </Typography>
+  );
+  const linkedSpeakerName = hasProfileLink ? (
+    <a
+      href={user.permalink}
+      target="_blank"
+      rel={anchorDefaultRel}
+      className="pointer-events-auto inline-flex min-w-0 items-center"
+    >
+      {nameLabel}
+    </a>
+  ) : (
+    nameLabel
+  );
+  const speakerName = hasProfileTooltip ? (
+    <ProfileTooltip userId={user.id} eager>
+      {linkedSpeakerName}
+    </ProfileTooltip>
+  ) : (
+    linkedSpeakerName
   );
 
   const gestureHandlers = isFocused
@@ -316,7 +337,7 @@ export const LiveRoomVideoTile = ({
         </button>
       ) : null}
       <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-between gap-2 pb-3 pl-1.5 pr-3 pt-3 tablet:pl-3">
-        <div className="flex min-h-8 min-w-0 items-center gap-1.5 rounded-12 bg-overlay-dark-dark3 px-2 py-1 backdrop-blur transition-[padding] duration-200 ease-out tablet:gap-2 tablet:px-2.5 tablet:group-hover:pr-1">
+        <div className="pointer-events-auto flex min-h-8 min-w-0 items-center gap-1.5 rounded-12 bg-overlay-dark-dark3 px-2 py-1 backdrop-blur transition-[padding] duration-200 ease-out tablet:gap-2 tablet:px-2.5 tablet:group-hover:pr-1">
           {isHost ? (
             <>
               <ShieldIcon
@@ -351,18 +372,7 @@ export const LiveRoomVideoTile = ({
               </Typography>
             </>
           ) : null}
-          {hasProfileLink ? (
-            <a
-              href={user.permalink}
-              target="_blank"
-              rel={anchorDefaultRel}
-              className="pointer-events-auto inline-flex min-w-0 items-center"
-            >
-              {nameLabel}
-            </a>
-          ) : (
-            nameLabel
-          )}
+          {speakerName}
           <LiveRoomTileActions
             user={user}
             onGrantCoHost={onGrantCoHost}

--- a/packages/shared/src/components/profile/ProfileTooltip.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltip.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { Author } from '../../graphql/comments';
 import type { BaseTooltipProps, TooltipProps } from '../tooltips/BaseTooltip';
@@ -23,6 +23,7 @@ export interface ProfileTooltipProps extends ProfileTooltipContentProps {
   scrollingContainer?: HTMLElement;
   onTooltipMouseEnter?: () => void;
   onTooltipMouseLeave?: () => void;
+  eager?: boolean;
 }
 
 export type UserTooltipContentData = {
@@ -44,25 +45,41 @@ export function ProfileTooltip({
   tooltip = {},
   onTooltipMouseEnter,
   onTooltipMouseLeave,
+  eager = false,
 }: Omit<ProfileTooltipProps, 'user'>): ReactElement {
   const query = useQueryClient();
   const { logEvent } = useLogContext();
   const handler = useRef<() => void>();
-  const [id, setId] = useState<string | undefined>(undefined);
+  const [id, setId] = useState<string | undefined>(eager ? userId : undefined);
   const { data, isLoading } = useQuery({
-    queryKey: generateQueryKey(RequestKey.UserShortById, { id }),
+    queryKey: generateQueryKey(
+      RequestKey.UserShortById,
+      id ? { id } : undefined,
+    ),
     queryFn: () => {
+      if (!id) {
+        throw new Error('Profile tooltip user id is required');
+      }
+
       return getUserShortInfo(id);
     },
     enabled: !!id,
   });
+
+  useEffect(() => {
+    if (eager) {
+      setId(userId);
+    }
+  }, [eager, userId]);
 
   const handleShow = () => {
     if (!scrollingContainer) {
       return;
     }
 
-    scrollingContainer.removeEventListener('scroll', handler.current);
+    if (handler.current) {
+      scrollingContainer.removeEventListener('scroll', handler.current);
+    }
     handler.current = () =>
       query.setQueryData(['readingRank', userId], () => {});
     scrollingContainer.addEventListener('scroll', handler.current);
@@ -72,7 +89,9 @@ export function ProfileTooltip({
     if (!scrollingContainer) {
       return;
     }
-    scrollingContainer.removeEventListener('scroll', handler.current);
+    if (handler.current) {
+      scrollingContainer.removeEventListener('scroll', handler.current);
+    }
   };
 
   // This is a workaround to fix the issue of the tooltip getting cleared
@@ -123,8 +142,8 @@ export function ProfileTooltip({
     interactive: true,
     onHide,
     appendTo: tooltip?.appendTo || globalThis?.document?.body,
-    container: { bgClassName: null },
-    content: !isLoading && data ? <UserEntityCard user={data} /> : null,
+    container: { bgClassName: '' },
+    content: !isLoading && data ? <UserEntityCard user={data} /> : undefined,
     plugins:
       onTooltipMouseEnter || onTooltipMouseLeave ? [hoverPlugin] : undefined,
     ...tooltip,


### PR DESCRIPTION
## What changed
- Added profile hover cards to standup speaker names in live-room tiles.
- Kept the hover target on the speaker name while preloading tooltip profile data for tile usage.
- Made user entity cards fall back to the shared avatar when profile image is empty.

## Why
Non-host speaker tooltips could appear unavailable because profile tooltip data was lazy-loaded only on hover and user cards rendered nothing for incomplete-but-valid profile image data.

## Validation
- `NODE_ENV=test pnpm --filter shared exec jest src/components/liveRooms/LiveRoomVideoTile.spec.tsx src/components/profile/ProfileTooltip.spec.tsx --runInBand`
- `pnpm --filter shared exec eslint src/components/liveRooms/LiveRoomVideoTile.tsx src/components/liveRooms/LiveRoomVideoTile.spec.tsx src/components/profile/ProfileTooltip.tsx src/components/profile/ProfileTooltip.spec.tsx src/components/cards/entity/UserEntityCard.tsx`
- `node ./scripts/typecheck-strict-changed.js`


### Preview domain
https://codex-standup-speaker-profile-to.preview.app.daily.dev