### PR TITLE
fix: add profile tooltips to live room participants

### DIFF
--- a/packages/shared/src/components/liveRooms/LiveRoomChatPanel.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatPanel.spec.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
 import React from 'react';
 import type { LiveRoomChatEntry } from '../../contexts/LiveRoomContext';
 import type { UserShortProfile } from '../../lib/user';
@@ -12,6 +13,19 @@ jest.mock('../Markdown', () => ({
 jest.mock('../ProfilePicture', () => ({
   ProfilePicture: () => <div>avatar</div>,
   ProfileImageSize: { Small: 'small' },
+}));
+
+jest.mock('../profile/ProfileTooltip', () => ({
+  ProfileTooltip: (props: { children: ReactElement; userId: string }) => {
+    const mockReact = jest.requireActual('react') as Pick<
+      typeof React,
+      'cloneElement'
+    >;
+
+    return mockReact.cloneElement(props.children, {
+      'data-profile-tooltip-user-id': props.userId,
+    });
+  },
 }));
 
 jest.mock('../tooltips/Portal', () => ({
@@ -163,6 +177,36 @@ describe('LiveRoomChatPanel', () => {
     window.requestAnimationFrame = originalRequestAnimationFrame;
     window.cancelAnimationFrame = originalCancelAnimationFrame;
     jest.useRealTimers();
+  });
+
+  it('links and shows the profile tooltip on resolved sender names and avatars', () => {
+    render(<LiveRoomChatPanel {...defaultProps} />);
+
+    const senderNameLink = screen.getByRole('link', { name: '@participant' });
+    expect(senderNameLink).toHaveAttribute(
+      'href',
+      participantProfile.permalink,
+    );
+    expect(senderNameLink).toHaveAttribute('target', '_blank');
+    expect(senderNameLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(senderNameLink).toHaveAttribute(
+      'data-profile-tooltip-user-id',
+      participantProfile.id,
+    );
+
+    const senderAvatarLink = screen.getByRole('link', {
+      name: 'Open @participant profile',
+    });
+    expect(senderAvatarLink).toHaveAttribute(
+      'href',
+      participantProfile.permalink,
+    );
+    expect(senderAvatarLink).toHaveAttribute('target', '_blank');
+    expect(senderAvatarLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(senderAvatarLink).toHaveAttribute(
+      'data-profile-tooltip-user-id',
+      participantProfile.id,
+    );
   });
 
   it('scrolls to the full height of a newly added long message', () => {

--- a/packages/shared/src/components/liveRooms/LiveRoomChatPanel.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatPanel.spec.tsx
@@ -16,7 +16,11 @@ jest.mock('../ProfilePicture', () => ({
 }));
 
 jest.mock('../profile/ProfileTooltip', () => ({
-  ProfileTooltip: (props: { children: ReactElement; userId: string }) => {
+  ProfileTooltip: (props: {
+    children: ReactElement;
+    initialUser?: { name: string };
+    userId: string;
+  }) => {
     const mockReact = jest.requireActual('react') as Pick<
       typeof React,
       'cloneElement'
@@ -24,6 +28,7 @@ jest.mock('../profile/ProfileTooltip', () => ({
 
     return mockReact.cloneElement(props.children, {
       'data-profile-tooltip-user-id': props.userId,
+      'data-profile-tooltip-user-name': props.initialUser?.name,
     });
   },
 }));
@@ -193,6 +198,10 @@ describe('LiveRoomChatPanel', () => {
       'data-profile-tooltip-user-id',
       participantProfile.id,
     );
+    expect(senderNameLink).toHaveAttribute(
+      'data-profile-tooltip-user-name',
+      participantProfile.name,
+    );
 
     const senderAvatarLink = screen.getByRole('link', {
       name: 'Open @participant profile',
@@ -206,6 +215,10 @@ describe('LiveRoomChatPanel', () => {
     expect(senderAvatarLink).toHaveAttribute(
       'data-profile-tooltip-user-id',
       participantProfile.id,
+    );
+    expect(senderAvatarLink).toHaveAttribute(
+      'data-profile-tooltip-user-name',
+      participantProfile.name,
     );
   });
 

--- a/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
@@ -501,7 +501,10 @@ export const LiveRoomChatPanel = ({
               message.participantId !== '';
             const senderName = userDisplayName(sender);
             const senderNameNode = senderProfile ? (
-              <ProfileTooltip userId={senderProfile.id} eager>
+              <ProfileTooltip
+                userId={senderProfile.id}
+                initialUser={senderProfile}
+              >
                 <a
                   href={senderProfile.permalink}
                   target="_blank"
@@ -515,7 +518,10 @@ export const LiveRoomChatPanel = ({
               <span className="font-bold">{senderName}</span>
             );
             const senderAvatar = senderProfile ? (
-              <ProfileTooltip userId={senderProfile.id} eager>
+              <ProfileTooltip
+                userId={senderProfile.id}
+                initialUser={senderProfile}
+              >
                 <a
                   href={senderProfile.permalink}
                   target="_blank"

--- a/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomChatPanel.tsx
@@ -14,6 +14,7 @@ import RichTextInput, { type RichTextInputRef } from '../fields/RichTextInput';
 import { Drawer } from '../drawers';
 import { RootPortal } from '../tooltips/Portal';
 import { EmojiPicker } from '../fields/EmojiPicker';
+import { ProfileTooltip } from '../profile/ProfileTooltip';
 import { LIVE_ROOM_QUICK_REACTION_EMOJIS } from '../../lib/liveRoom/reactions';
 import {
   Typography,
@@ -36,6 +37,7 @@ import { MarkdownCommand } from '../../hooks/input/useMarkdownInput';
 import { useViewSize, ViewSize } from '../../hooks';
 import { useTouchLongPress } from '../../hooks/useTouchLongPress';
 import { chatMarkdownToHtml } from '../../lib/liveRoom/chatMarkdown';
+import { anchorDefaultRel } from '../../lib/strings';
 import type { UserShortProfile } from '../../lib/user';
 import {
   buildParticipantProfile,
@@ -481,9 +483,11 @@ export const LiveRoomChatPanel = ({
           </div>
         ) : (
           chatMessages.map((message, messageIndex) => {
+            const senderProfile = participantProfilesById.get(
+              message.participantId,
+            );
             const sender =
-              participantProfilesById.get(message.participantId) ??
-              buildParticipantProfile(message.participantId);
+              senderProfile ?? buildParticipantProfile(message.participantId);
             const isSenderBlocked =
               (participantChatPermissions[message.participantId] ?? true) ===
               false;
@@ -496,6 +500,35 @@ export const LiveRoomChatPanel = ({
               message.participantId !== hostParticipantId &&
               message.participantId !== '';
             const senderName = userDisplayName(sender);
+            const senderNameNode = senderProfile ? (
+              <ProfileTooltip userId={senderProfile.id} eager>
+                <a
+                  href={senderProfile.permalink}
+                  target="_blank"
+                  rel={anchorDefaultRel}
+                  className="font-bold hover:underline"
+                >
+                  {senderName}
+                </a>
+              </ProfileTooltip>
+            ) : (
+              <span className="font-bold">{senderName}</span>
+            );
+            const senderAvatar = senderProfile ? (
+              <ProfileTooltip userId={senderProfile.id} eager>
+                <a
+                  href={senderProfile.permalink}
+                  target="_blank"
+                  rel={anchorDefaultRel}
+                  aria-label={`Open ${senderName} profile`}
+                  className="shrink-0"
+                >
+                  <ProfilePicture user={sender} size={ProfileImageSize.Small} />
+                </a>
+              </ProfileTooltip>
+            ) : (
+              <ProfilePicture user={sender} size={ProfileImageSize.Small} />
+            );
 
             return (
               <article
@@ -516,11 +549,11 @@ export const LiveRoomChatPanel = ({
                   }
                 }}
               >
-                <ProfilePicture user={sender} size={ProfileImageSize.Small} />
+                {senderAvatar}
                 <div className="min-w-0 flex-1">
                   <div className="min-w-0 text-[0.9375rem] leading-[1.5]">
                     <span className="mr-2 inline-flex items-center gap-1">
-                      <span className="font-bold">{senderName}</span>
+                      {senderNameNode}
                       {isSenderHost ? (
                         <ShieldIcon
                           secondary

--- a/packages/shared/src/components/liveRooms/LiveRoomQueuePanel.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomQueuePanel.spec.tsx
@@ -11,7 +11,11 @@ jest.mock('../ProfilePicture', () => ({
 }));
 
 jest.mock('../profile/ProfileTooltip', () => ({
-  ProfileTooltip: (props: { children: ReactElement; userId: string }) => {
+  ProfileTooltip: (props: {
+    children: ReactElement;
+    initialUser?: { name: string };
+    userId: string;
+  }) => {
     const mockReact = jest.requireActual('react') as Pick<
       typeof React,
       'cloneElement'
@@ -19,6 +23,7 @@ jest.mock('../profile/ProfileTooltip', () => ({
 
     return mockReact.cloneElement(props.children, {
       'data-profile-tooltip-user-id': props.userId,
+      'data-profile-tooltip-user-name': props.initialUser?.name,
     });
   },
 }));
@@ -78,6 +83,10 @@ const expectProfileLinks = (): void => {
     'data-profile-tooltip-user-id',
     participantProfile.id,
   );
+  expect(nameLink).toHaveAttribute(
+    'data-profile-tooltip-user-name',
+    participantProfile.name,
+  );
 
   const avatarLink = screen.getByRole('link', {
     name: 'Open @participant profile',
@@ -88,6 +97,10 @@ const expectProfileLinks = (): void => {
   expect(avatarLink).toHaveAttribute(
     'data-profile-tooltip-user-id',
     participantProfile.id,
+  );
+  expect(avatarLink).toHaveAttribute(
+    'data-profile-tooltip-user-name',
+    participantProfile.name,
   );
 };
 

--- a/packages/shared/src/components/liveRooms/LiveRoomQueuePanel.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomQueuePanel.spec.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { LiveRoomParticipantRecord } from '../../lib/liveRoom/protocol';
+import type { UserShortProfile } from '../../lib/user';
+import { LiveRoomQueuePanel } from './LiveRoomQueuePanel';
+
+jest.mock('../ProfilePicture', () => ({
+  ProfilePicture: () => <div>avatar</div>,
+  ProfileImageSize: { Small: 'small' },
+}));
+
+jest.mock('../profile/ProfileTooltip', () => ({
+  ProfileTooltip: (props: { children: ReactElement; userId: string }) => {
+    const mockReact = jest.requireActual('react') as Pick<
+      typeof React,
+      'cloneElement'
+    >;
+
+    return mockReact.cloneElement(props.children, {
+      'data-profile-tooltip-user-id': props.userId,
+    });
+  },
+}));
+
+const createdAt = '2026-05-12T10:00:00.000Z';
+
+const participantProfile: UserShortProfile = {
+  id: 'participant-1',
+  name: 'Participant',
+  username: 'participant',
+  image: '',
+  createdAt,
+  reputation: 0,
+  permalink: '/participant',
+};
+
+const createParticipant = (
+  participantId: string,
+  role: LiveRoomParticipantRecord['role'] = 'audience',
+): LiveRoomParticipantRecord => ({
+  participantId,
+  role,
+  sessionIds: [`session-${participantId}`],
+  joinedAt: createdAt,
+  updatedAt: createdAt,
+});
+
+const defaultProps = {
+  tab: 'queue' as const,
+  mode: 'moderated' as const,
+  activeSpeakerParticipantIds: [],
+  queuedParticipantIds: ['participant-1'],
+  audienceParticipantIds: [],
+  participantsById: {
+    'participant-1': createParticipant('participant-1'),
+  },
+  participantProfilesById: new Map([['participant-1', participantProfile]]),
+  coHostParticipantIds: [],
+  canModerate: false,
+  canManageCoHosts: false,
+  stageLimit: null,
+  moderationBusy: null,
+  guardedModerationAction: jest.fn(async (_key, fn) => fn()),
+  grantCoHost: jest.fn(),
+  revokeCoHost: jest.fn(),
+  promoteSpeaker: jest.fn(),
+  removeSpeaker: jest.fn(),
+  kickParticipant: jest.fn(),
+};
+
+const expectProfileLinks = (): void => {
+  const nameLink = screen.getByRole('link', { name: '@participant' });
+  expect(nameLink).toHaveAttribute('href', participantProfile.permalink);
+  expect(nameLink).toHaveAttribute('target', '_blank');
+  expect(nameLink).toHaveAttribute('rel', 'noopener noreferrer');
+  expect(nameLink).toHaveAttribute(
+    'data-profile-tooltip-user-id',
+    participantProfile.id,
+  );
+
+  const avatarLink = screen.getByRole('link', {
+    name: 'Open @participant profile',
+  });
+  expect(avatarLink).toHaveAttribute('href', participantProfile.permalink);
+  expect(avatarLink).toHaveAttribute('target', '_blank');
+  expect(avatarLink).toHaveAttribute('rel', 'noopener noreferrer');
+  expect(avatarLink).toHaveAttribute(
+    'data-profile-tooltip-user-id',
+    participantProfile.id,
+  );
+};
+
+describe('LiveRoomQueuePanel', () => {
+  it('links and shows the profile tooltip on queued participant names and avatars', () => {
+    render(<LiveRoomQueuePanel {...defaultProps} />);
+
+    expectProfileLinks();
+  });
+
+  it('links and shows the profile tooltip on audience participant names and avatars', () => {
+    render(
+      <LiveRoomQueuePanel
+        {...defaultProps}
+        tab="audience"
+        queuedParticipantIds={[]}
+        audienceParticipantIds={['participant-1']}
+      />,
+    );
+
+    expectProfileLinks();
+  });
+});

--- a/packages/shared/src/components/liveRooms/LiveRoomQueuePanel.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomQueuePanel.tsx
@@ -49,7 +49,7 @@ const StageParticipantItem = ({
   const displayName = userDisplayName(user);
   const profilePermalink = profile?.permalink;
   const avatar = profilePermalink ? (
-    <ProfileTooltip userId={profile.id} eager>
+    <ProfileTooltip userId={profile.id} initialUser={profile}>
       <a
         href={profilePermalink}
         target="_blank"
@@ -64,7 +64,7 @@ const StageParticipantItem = ({
     <ProfilePicture user={user} size={ProfileImageSize.Small} />
   );
   const name = profilePermalink ? (
-    <ProfileTooltip userId={profile.id} eager>
+    <ProfileTooltip userId={profile.id} initialUser={profile}>
       <a
         href={profilePermalink}
         target="_blank"

--- a/packages/shared/src/components/liveRooms/LiveRoomQueuePanel.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomQueuePanel.tsx
@@ -5,6 +5,7 @@ import { Tooltip } from '../tooltip/Tooltip';
 import {
   Typography,
   TypographyColor,
+  TypographyTag,
   TypographyType,
 } from '../typography/Typography';
 import {
@@ -17,8 +18,10 @@ import {
 } from '../icons';
 import { IconSize } from '../Icon';
 import { ProfilePicture, ProfileImageSize } from '../ProfilePicture';
+import { ProfileTooltip } from '../profile/ProfileTooltip';
 import type { LiveRoomParticipantRecord } from '../../lib/liveRoom/protocol';
 import type { UserShortProfile } from '../../lib/user';
+import { anchorDefaultRel } from '../../lib/strings';
 import {
   buildParticipantProfile,
   userDisplayName,
@@ -43,21 +46,62 @@ const StageParticipantItem = ({
   actions,
 }: StageParticipantItemProps): ReactElement => {
   const user = profile ?? buildParticipantProfile(participantId);
+  const displayName = userDisplayName(user);
+  const profilePermalink = profile?.permalink;
+  const avatar = profilePermalink ? (
+    <ProfileTooltip userId={profile.id} eager>
+      <a
+        href={profilePermalink}
+        target="_blank"
+        rel={anchorDefaultRel}
+        aria-label={`Open ${displayName} profile`}
+        className="shrink-0"
+      >
+        <ProfilePicture user={user} size={ProfileImageSize.Small} />
+      </a>
+    </ProfileTooltip>
+  ) : (
+    <ProfilePicture user={user} size={ProfileImageSize.Small} />
+  );
+  const name = profilePermalink ? (
+    <ProfileTooltip userId={profile.id} eager>
+      <a
+        href={profilePermalink}
+        target="_blank"
+        rel={anchorDefaultRel}
+        className="min-w-0"
+      >
+        <Typography
+          tag={TypographyTag.Span}
+          type={TypographyType.Footnote}
+          bold
+          truncate
+          className="hover:underline"
+          title={displayName}
+        >
+          {displayName}
+        </Typography>
+      </a>
+    </ProfileTooltip>
+  ) : (
+    <Typography
+      tag={TypographyTag.Span}
+      type={TypographyType.Footnote}
+      bold
+      truncate
+      title={displayName}
+    >
+      {displayName}
+    </Typography>
+  );
 
   return (
     <li className="flex min-w-0 items-center gap-3 rounded-12 border border-border-subtlest-tertiary px-3 py-2">
       {leading}
-      <ProfilePicture user={user} size={ProfileImageSize.Small} />
+      {avatar}
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 items-center gap-2">
-          <Typography
-            type={TypographyType.Footnote}
-            bold
-            truncate
-            title={userDisplayName(user)}
-          >
-            {userDisplayName(user)}
-          </Typography>
+          {name}
           {badgeLabel ? (
             <span className="shrink-0 rounded-6 bg-surface-float px-1.5 py-0.5 text-[0.6875rem] font-bold uppercase tracking-wide text-accent-water-bolder">
               {badgeLabel}

--- a/packages/shared/src/components/liveRooms/LiveRoomVideoTile.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomVideoTile.spec.tsx
@@ -53,7 +53,11 @@ jest.mock('../ProfilePicture', () => ({
 }));
 
 jest.mock('../profile/ProfileTooltip', () => ({
-  ProfileTooltip: (props: { children: ReactElement; userId: string }) => {
+  ProfileTooltip: (props: {
+    children: ReactElement;
+    initialUser?: { name: string };
+    userId: string;
+  }) => {
     const mockReact = jest.requireActual('react') as Pick<
       typeof React,
       'cloneElement'
@@ -61,6 +65,7 @@ jest.mock('../profile/ProfileTooltip', () => ({
 
     return mockReact.cloneElement(props.children, {
       'data-profile-tooltip-user-id': props.userId,
+      'data-profile-tooltip-user-name': props.initialUser?.name,
     });
   },
 }));
@@ -106,18 +111,19 @@ describe('LiveRoomVideoTile', () => {
     expect(
       screen.getByRole('link', { name: defaultUser.name }),
     ).toHaveAttribute('data-profile-tooltip-user-id', defaultUser.id);
+    expect(
+      screen.getByRole('link', { name: defaultUser.name }),
+    ).toHaveAttribute('data-profile-tooltip-user-name', defaultUser.name);
   });
 
-  it('shows the profile tooltip on speaker names without profile links', () => {
+  it('does not show the profile tooltip on speaker names without profile links', () => {
     const user = { ...defaultUser, permalink: '' };
 
     render(<LiveRoomVideoTile stream={null} user={user} selfView={false} />);
 
     expect(
-      screen.getByText(user.name, {
-        selector: '[data-profile-tooltip-user-id]',
-      }),
-    ).toHaveAttribute('data-profile-tooltip-user-id', user.id);
+      screen.getByText(user.name, { selector: 'span' }),
+    ).not.toHaveAttribute('data-profile-tooltip-user-id');
   });
 
   it('unmutes the current speaker from the muted badge', () => {

--- a/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomVideoTile.tsx
@@ -166,7 +166,7 @@ export const LiveRoomVideoTile = ({
   }, [videoStream]);
 
   const hasProfileLink = !!user.permalink && user.permalink !== '#';
-  const hasProfileTooltip = !!user.id;
+  const hasProfileTooltip = hasProfileLink;
   const nameLabel = (
     <Typography
       tag={TypographyTag.Span}
@@ -194,7 +194,7 @@ export const LiveRoomVideoTile = ({
     nameLabel
   );
   const speakerName = hasProfileTooltip ? (
-    <ProfileTooltip userId={user.id} eager>
+    <ProfileTooltip userId={user.id} initialUser={user}>
       {linkedSpeakerName}
     </ProfileTooltip>
   ) : (

--- a/packages/shared/src/components/profile/ProfileTooltip.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltip.spec.tsx
@@ -4,15 +4,20 @@ import type { TooltipProps } from '../tooltips/BaseTooltip';
 import { ProfileTooltip } from './ProfileTooltip';
 import { useLogContext } from '../../contexts/LogContext';
 import { LogEvent } from '../../lib/log';
+import type { UserShortProfile } from '../../lib/user';
 
 const mockSetQueryData = jest.fn();
 const mockLogEvent = jest.fn();
 const mockSimpleTooltipSpy = jest.fn();
+const mockUseQuery = jest.fn<
+  { data: null; isLoading: boolean },
+  [options: unknown]
+>(() => ({ data: null, isLoading: false }));
 
 jest.mock('@tanstack/react-query', () => ({
   ...jest.requireActual('@tanstack/react-query'),
   useQueryClient: () => ({ setQueryData: mockSetQueryData }),
-  useQuery: () => ({ data: null, isLoading: false }),
+  useQuery: (options: unknown) => mockUseQuery(options),
 }));
 
 jest.mock('../../contexts/LogContext', () => ({
@@ -29,6 +34,7 @@ jest.mock('../tooltips/SimpleTooltip', () => ({
 describe('ProfileTooltip', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseQuery.mockReturnValue({ data: null, isLoading: false });
     (useLogContext as jest.Mock).mockReturnValue({ logEvent: mockLogEvent });
   });
 
@@ -70,5 +76,29 @@ describe('ProfileTooltip', () => {
     });
 
     expect(tooltipOnShow).toHaveBeenCalledWith(instance);
+  });
+
+  it('uses an initial user without enabling the profile fetch', () => {
+    const initialUser: UserShortProfile = {
+      id: 'user-3',
+      name: 'User Three',
+      username: 'user-three',
+      image: '',
+      createdAt: '2026-05-13T00:00:00.000Z',
+      reputation: 0,
+      permalink: '/user-three',
+    };
+
+    render(
+      <ProfileTooltip userId={initialUser.id} initialUser={initialUser}>
+        <button type="button">User</button>
+      </ProfileTooltip>,
+    );
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: false }),
+    );
+    const [props] = mockSimpleTooltipSpy.mock.calls[0] as [TooltipProps];
+    expect(props.content).toBeTruthy();
   });
 });

--- a/packages/shared/src/components/profile/ProfileTooltip.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltip.tsx
@@ -12,6 +12,7 @@ import UserEntityCard from '../cards/entity/UserEntityCard';
 import { useLogContext } from '../../contexts/LogContext';
 import { LogEvent } from '../../lib/log';
 import { generateQueryKey, RequestKey } from '../../lib/query';
+import type { UserShortProfile } from '../../lib/user';
 
 type TippyInstance = Parameters<NonNullable<BaseTooltipProps['onShow']>>[0];
 
@@ -24,6 +25,7 @@ export interface ProfileTooltipProps extends ProfileTooltipContentProps {
   onTooltipMouseEnter?: () => void;
   onTooltipMouseLeave?: () => void;
   eager?: boolean;
+  initialUser?: UserShortProfile;
 }
 
 export type UserTooltipContentData = {
@@ -46,11 +48,15 @@ export function ProfileTooltip({
   onTooltipMouseEnter,
   onTooltipMouseLeave,
   eager = false,
+  initialUser,
 }: Omit<ProfileTooltipProps, 'user'>): ReactElement {
   const query = useQueryClient();
   const { logEvent } = useLogContext();
   const handler = useRef<() => void>();
-  const [id, setId] = useState<string | undefined>(eager ? userId : undefined);
+  const hasInitialUser = initialUser?.id === userId;
+  const [id, setId] = useState<string | undefined>(
+    eager && !hasInitialUser ? userId : undefined,
+  );
   const { data, isLoading } = useQuery({
     queryKey: generateQueryKey(
       RequestKey.UserShortById,
@@ -63,14 +69,22 @@ export function ProfileTooltip({
 
       return getUserShortInfo(id);
     },
-    enabled: !!id,
+    enabled: !hasInitialUser && !!id,
   });
+  const tooltipUser = hasInitialUser ? initialUser : data;
 
   useEffect(() => {
-    if (eager) {
-      setId(userId);
+    if (!eager) {
+      return;
     }
-  }, [eager, userId]);
+
+    if (hasInitialUser) {
+      setId(undefined);
+      return;
+    }
+
+    setId(userId);
+  }, [eager, hasInitialUser, userId]);
 
   const handleShow = () => {
     if (!scrollingContainer) {
@@ -143,7 +157,10 @@ export function ProfileTooltip({
     onHide,
     appendTo: tooltip?.appendTo || globalThis?.document?.body,
     container: { bgClassName: '' },
-    content: !isLoading && data ? <UserEntityCard user={data} /> : undefined,
+    content:
+      !isLoading && tooltipUser ? (
+        <UserEntityCard user={tooltipUser} />
+      ) : undefined,
     plugins:
       onTooltipMouseEnter || onTooltipMouseLeave ? [hoverPlugin] : undefined,
     ...tooltip,
@@ -152,7 +169,7 @@ export function ProfileTooltip({
         event_name: LogEvent.HoverUserCard,
         target_id: userId,
       });
-      if (id !== userId) {
+      if (!hasInitialUser && id !== userId) {
         setId(userId);
       }
       if (typeof tooltip.onShow === 'function') {


### PR DESCRIPTION
## What changed

- Added profile tooltip + new-tab profile links to live room chat sender names and avatars.
- Applied the same behavior to queue and audience participant rows.
- Kept unresolved/anonymous participant fallbacks plain so we do not query invalid profile ids.

## Validation

- `NODE_ENV=test pnpm --filter shared exec jest src/components/liveRooms/LiveRoomQueuePanel.spec.tsx src/components/liveRooms/LiveRoomChatPanel.spec.tsx --runInBand`
- `pnpm --filter shared exec eslint src/components/liveRooms/LiveRoomQueuePanel.tsx src/components/liveRooms/LiveRoomQueuePanel.spec.tsx src/components/liveRooms/LiveRoomChatPanel.tsx src/components/liveRooms/LiveRoomChatPanel.spec.tsx`
- `node ./scripts/typecheck-strict-changed.js`


### Preview domain
https://codex-live-room-profile-tooltips.preview.app.daily.dev