### PR TITLE
feat(tags): include share and freeform posts on tag page

### DIFF
--- a/packages/webapp/__tests__/TagPage.tsx
+++ b/packages/webapp/__tests__/TagPage.tsx
@@ -1,5 +1,6 @@
 import type { FeedData } from '@dailydotdev/shared/src/graphql/posts';
 import { TAG_FEED_QUERY } from '@dailydotdev/shared/src/graphql/feed';
+import { PostType } from '@dailydotdev/shared/src/graphql/posts';
 import nock from 'nock';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import React from 'react';
@@ -69,6 +70,14 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
+const tagFeedSupportedTypes = [
+  PostType.Article,
+  PostType.VideoYouTube,
+  PostType.Collection,
+  PostType.Share,
+  PostType.Freeform,
+];
+
 const createFeedMock = (
   page = defaultFeedPage,
   query: string = TAG_FEED_QUERY,
@@ -78,6 +87,7 @@ const createFeedMock = (
     loggedIn: true,
     tag: 'react',
     ranking: 'TIME',
+    supportedTypes: tagFeedSupportedTypes,
   },
 ): MockedGraphQLResponse<FeedData> => ({
   request: {
@@ -264,6 +274,7 @@ it('should show follow and block buttons when logged-out', async () => {
         loggedIn: false,
         tag: 'react',
         ranking: 'TIME',
+        supportedTypes: tagFeedSupportedTypes,
       }),
     ],
     null,
@@ -284,6 +295,7 @@ it('should show login popup when logged-out on follow click', async () => {
         loggedIn: false,
         tag: 'react',
         ranking: 'TIME',
+        supportedTypes: tagFeedSupportedTypes,
       }),
     ],
     null,
@@ -313,6 +325,7 @@ it('should show login popup when logged-out on block click', async () => {
         loggedIn: false,
         tag: 'react',
         ranking: 'TIME',
+        supportedTypes: tagFeedSupportedTypes,
       }),
     ],
     null,

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -296,6 +296,8 @@ const TagPage = ({
         PostType.Article,
         PostType.VideoYouTube,
         PostType.Collection,
+        PostType.Share,
+        PostType.Freeform,
       ],
       period: 365,
     }),
@@ -309,6 +311,8 @@ const TagPage = ({
         PostType.Article,
         PostType.VideoYouTube,
         PostType.Collection,
+        PostType.Share,
+        PostType.Freeform,
       ],
     }),
     [tag],
@@ -317,11 +321,31 @@ const TagPage = ({
     () => ({
       tag,
       period: 365,
+      supportedTypes: [
+        PostType.Article,
+        PostType.VideoYouTube,
+        PostType.Collection,
+        PostType.Share,
+        PostType.Freeform,
+      ],
     }),
     [tag],
   );
   // Must be memoized to prevent refreshing the feed
-  const queryVariables = useMemo(() => ({ tag, ranking: 'TIME' }), [tag]);
+  const queryVariables = useMemo(
+    () => ({
+      tag,
+      ranking: 'TIME',
+      supportedTypes: [
+        PostType.Article,
+        PostType.VideoYouTube,
+        PostType.Collection,
+        PostType.Share,
+        PostType.Freeform,
+      ],
+    }),
+    [tag],
+  );
   const { feedSettings } = useFeedSettings();
   const { FeedPageLayoutComponent } = useFeedLayout();
   const { onFollowTags, onUnfollowTags, onBlockTags, onUnblockTags } =


### PR DESCRIPTION
## Summary

The `/tags/[tag]` page's four post feeds (Top posts, Most upvoted, Best discussed, All posts) either passed a `supportedTypes` list that omitted `share` and `freeform`, or passed none at all (which defaults to `['article']` on the API). As a result, squad posts never appeared on tag pages.

This widens `supportedTypes` on all four feeds to include `Share` and `Freeform` so public-threshold squad posts now surface alongside articles, YouTube videos, and collections.

## Test plan

- [ ] On `/tags/php` (or any populated tag), verify squad-originated posts (share/freeform) now appear in Top posts, Most upvoted, Best discussed, and the main feed
- [ ] Confirm private squads / non-public-threshold squads are still excluded (handled API-side by `allowPrivatePosts: false` + `removeNonPublicThresholdSquads`)
- [ ] Confirm the SSR top-posts JSON-LD/SEO output still renders

### Preview domain
https://tag-page-include-squad-posts.preview.app.daily.dev