### PR TITLE
fix(profile): prevent ProfileTooltip from opening on keyboard focus

### DIFF
--- a/packages/shared/src/components/profile/ProfileTooltip.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltip.spec.tsx
@@ -101,4 +101,14 @@ describe('ProfileTooltip', () => {
     const [props] = mockSimpleTooltipSpy.mock.calls[0] as [TooltipProps];
     expect(props.content).toBeTruthy();
   });
+
+  it('only triggers on mouseenter ( not keyboard focus ) for WCAG 3.2.1', () => {
+    render(
+      <ProfileTooltip userId="user-1">
+        <button type="button">User</button>
+      </ProfileTooltip>,
+    );
+    const [props] = mockSimpleTooltipSpy.mock.calls[0] as [TooltipProps];
+    expect(props.trigger).toBe('mouseenter');
+  });
 });

--- a/packages/shared/src/components/profile/ProfileTooltip.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltip.tsx
@@ -163,6 +163,7 @@ export function ProfileTooltip({
       ) : undefined,
     plugins:
       onTooltipMouseEnter || onTooltipMouseLeave ? [hoverPlugin] : undefined,
+    trigger: 'mouseenter',
     ...tooltip,
     onShow: (instance) => {
       logEvent({


### PR DESCRIPTION
## Changes

Fix WCAG 2.1 SC 3.2.1 (On Focus) violation — `ProfileTooltip` was opening the user-preview card on keyboard `focus` because Tippy.js defaults `trigger` to `'mouseenter focus'`.

Closes dailydotdev/daily#1949

## Events

Did you introduce any new tracking events? ---> `No`

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments? ---> `No`

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrollment is approved.

-->

## Manual Testing

- [x] Sanity check in webapp (Tab through feed → no focus popup; mouse hover → popup opens)

<!--
If the branch name does not beging with a jira ticket, please copy and paste the
below line outside the HTML comment tags to link this PR to the ticket in Jira.

AS-{number}
or
MI-{number}
-->
