### PR TITLE
chore: remove plus_api_landing_v2 flag

### DIFF
--- a/packages/shared/src/components/CustomFeedEmptyScreen.tsx
+++ b/packages/shared/src/components/CustomFeedEmptyScreen.tsx
@@ -19,18 +19,13 @@ import {
 } from './typography/Typography';
 import { LogEvent, TargetId } from '../lib/log';
 import { Button } from './buttons/Button';
-import { useConditionalFeature, usePlusSubscription } from '../hooks';
+import { usePlusSubscription } from '../hooks';
 import { IconSize } from './Icon';
-import { featurePlusApiLanding } from '../lib/featureManagement';
 import Link from './utilities/Link';
 
 export const CustomFeedEmptyScreen = (): ReactElement => {
   const { logSubscriptionEvent, isPlus } = usePlusSubscription();
-  const { value: isApiLanding } = useConditionalFeature({
-    feature: featurePlusApiLanding,
-    shouldEvaluate: !isPlus,
-  });
-  const plusCta = isApiLanding ? 'Get API Access' : 'Level Up with Plus';
+  const plusCta = 'Get API Access';
   const [selectedAlgo, setSelectedAlgo] = usePersistentContext(
     DEFAULT_ALGORITHM_KEY,
     DEFAULT_ALGORITHM_INDEX,

--- a/packages/shared/src/components/PlusUserBadge.tsx
+++ b/packages/shared/src/components/PlusUserBadge.tsx
@@ -15,8 +15,6 @@ import { DateFormat } from './utilities';
 import { TimeFormatType } from '../lib/dateFormat';
 import { usePlusSubscription } from '../hooks/usePlusSubscription';
 import { LogEvent, TargetId } from '../lib/log';
-import { featurePlusApiLanding } from '../lib/featureManagement';
-import { useConditionalFeature } from '../hooks';
 import { IconSize } from './Icon';
 
 export type Props = {
@@ -31,11 +29,7 @@ export const PlusUserBadge = ({
   size = IconSize.Size16,
 }: Props): ReactElement | null => {
   const { isPlus, logSubscriptionEvent } = usePlusSubscription();
-  const { value: isApiLanding } = useConditionalFeature({
-    feature: featurePlusApiLanding,
-    shouldEvaluate: !isPlus,
-  });
-  const plusCta = isApiLanding ? 'Get API Access' : 'Level Up with Plus';
+  const plusCta = 'Get API Access';
 
   if (!user.isPlus) {
     return null;

--- a/packages/shared/src/components/UpgradeToPlus.tsx
+++ b/packages/shared/src/components/UpgradeToPlus.tsx
@@ -6,14 +6,13 @@ import { ButtonColor, Button, ButtonVariant } from './buttons/Button';
 import { DevPlusIcon } from './icons';
 import Link from './utilities/Link';
 import { plusUrl } from '../lib/constants';
-import { useConditionalFeature, useViewSize, ViewSize } from '../hooks';
+import { useViewSize, ViewSize } from '../hooks';
 import { usePlusSubscription } from '../hooks/usePlusSubscription';
 import type { TargetId } from '../lib/log';
 import { LogEvent } from '../lib/log';
 import { useAuthContext } from '../contexts/AuthContext';
 import { AuthTriggers } from '../lib/auth';
 import type { WithClassNameProps } from './utilities';
-import { featurePlusApiLanding } from '../lib/featureManagement';
 
 type Props = {
   iconOnly?: boolean;
@@ -37,15 +36,9 @@ export const UpgradeToPlus = ({
   const isLaptopXL = useViewSize(ViewSize.LaptopXL);
   const isFullCTAText = !isLaptop || isLaptopXL;
   const { isPlus, logSubscriptionEvent } = usePlusSubscription();
-  const { value: isApiLanding } = useConditionalFeature({
-    feature: featurePlusApiLanding,
-    shouldEvaluate: !isPlus,
-  });
-  const ctaCopy = isApiLanding
-    ? { full: 'Get API Access', short: 'API access' }
-    : { full: 'Level Up with Plus', short: 'Upgrade' };
+  const ctaCopy = { full: 'Get API Access', short: 'API access' };
   const content = isFullCTAText ? ctaCopy.full : ctaCopy.short;
-  const defaultColor = isApiLanding ? ButtonColor.Bacon : ButtonColor.Avocado;
+  const defaultColor = ButtonColor.Bacon;
 
   const onClick = useCallback(
     (e: React.MouseEvent) => {

--- a/packages/shared/src/components/cards/plus/PlusGrid.tsx
+++ b/packages/shared/src/components/cards/plus/PlusGrid.tsx
@@ -13,8 +13,6 @@ import { useBoot } from '../../../hooks';
 import { LogEvent, TargetType } from '../../../lib/log';
 import { useLogContext } from '../../../contexts/LogContext';
 import { PlusItemStatus, PlusListItem } from '../../plus/PlusListItem';
-import { useFeature } from '../../GrowthBookProvider';
-import { featurePlusApiLanding } from '../../../lib/featureManagement';
 
 const bulletPointsControl = [
   {
@@ -42,13 +40,12 @@ const bulletPointsControl = [
 const PlusGrid = ({ flags, campaignId }: MarketingCta) => {
   const { logEvent } = useLogContext();
   const { clearMarketingCta } = useBoot();
-  const isApiLanding = useFeature(featurePlusApiLanding);
 
   if (!flags) {
     return null;
   }
   const { title, description, ctaText, ctaUrl } = flags;
-  const ctaColor = isApiLanding ? ButtonColor.Bacon : ButtonColor.Avocado;
+  const ctaColor = ButtonColor.Bacon;
 
   const handleClose = () => {
     logEvent({

--- a/packages/shared/src/components/marketing/banners/PlusMobileEntryBanner.tsx
+++ b/packages/shared/src/components/marketing/banners/PlusMobileEntryBanner.tsx
@@ -14,8 +14,6 @@ import type { TargetType } from '../../../lib/log';
 import { LogEvent } from '../../../lib/log';
 import { useLogContext } from '../../../contexts/LogContext';
 import { useBoot } from '../../../hooks';
-import { useFeature } from '../../GrowthBookProvider';
-import { featurePlusApiLanding } from '../../../lib/featureManagement';
 
 type PlusBannerProps = Omit<MarketingCta, 'flags'> & {
   targetType: TargetType;
@@ -33,12 +31,11 @@ const PlusMobileEntryBanner = ({
 }: PlusBannerProps): ReactElement | null => {
   const { logEvent } = useLogContext();
   const { clearMarketingCta } = useBoot();
-  const isApiLanding = useFeature(featurePlusApiLanding);
   if (!flags) {
     return null;
   }
   const { leadIn, description, ctaText, ctaUrl } = flags;
-  const ctaColor = isApiLanding ? ButtonColor.Bacon : ButtonColor.Avocado;
+  const ctaColor = ButtonColor.Bacon;
 
   const handleClose = () => {
     logEvent({

--- a/packages/shared/src/components/plus/PlusDesktop.tsx
+++ b/packages/shared/src/components/plus/PlusDesktop.tsx
@@ -13,8 +13,6 @@ import { usePlusSubscription } from '../../hooks';
 
 import { PurchaseType } from '../../graphql/paddle';
 import { PlusProductToggle } from './PlusProductToggle';
-import { useFeature } from '../GrowthBookProvider';
-import { featurePlusApiLanding } from '../../lib/featureManagement';
 
 const PlusFAQs = dynamic(() => import('./PlusFAQ').then((mod) => mod.PlusFAQ));
 const PlusApiShowcase = dynamic(() =>
@@ -37,7 +35,6 @@ export const PlusDesktop = ({
     query: { selectedPlan },
   } = useRouter();
   const { isPlus } = usePlusSubscription();
-  const isApiLanding = useFeature(featurePlusApiLanding);
   const initialPaymentOption = selectedPlan ? `${selectedPlan}` : null;
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const ref = useRef<HTMLDivElement>(null);
@@ -126,7 +123,7 @@ export const PlusDesktop = ({
           )}
         </div>
       </div>
-      {isApiLanding && !isOrganization && !giftToUser && <PlusApiShowcase />}
+      {!isOrganization && !giftToUser && <PlusApiShowcase />}
       <PlusFAQs />
     </>
   );

--- a/packages/shared/src/components/plus/PlusFAQ.tsx
+++ b/packages/shared/src/components/plus/PlusFAQ.tsx
@@ -9,12 +9,9 @@ import {
 import { Accordion } from '../accordion';
 import { anchorDefaultRel } from '../../lib/strings';
 import { feedback } from '../../lib/constants';
-import { plusFAQItemsApi, plusFAQItemsControl } from './common';
+import { plusFAQItemsApi } from './common';
 import { useLogContext } from '../../contexts/LogContext';
 import { LogEvent } from '../../lib/log';
-import { useConditionalFeature } from '../../hooks';
-import { featurePlusApiLanding } from '../../lib/featureManagement';
-import { usePlusSubscription } from '../../hooks/usePlusSubscription';
 
 interface FAQ {
   question: string;
@@ -53,12 +50,7 @@ const FAQItem = ({ item }: { item: FAQ }): ReactElement => {
 export const PlusFAQ = (): ReactElement => {
   const id = useId();
   const titleId = `${id}-title`;
-  const { isPlus } = usePlusSubscription();
-  const { value: isApiLanding } = useConditionalFeature({
-    feature: featurePlusApiLanding,
-    shouldEvaluate: !isPlus,
-  });
-  const items = isApiLanding ? plusFAQItemsApi : plusFAQItemsControl;
+  const items = plusFAQItemsApi;
   return (
     <section aria-labelledby={titleId} className="my-10">
       <Typography

--- a/packages/shared/src/components/plus/PlusInfo.tsx
+++ b/packages/shared/src/components/plus/PlusInfo.tsx
@@ -13,8 +13,7 @@ import {
   plusFeatureListApiFirst,
   plusOrganizationFeatureList,
 } from './PlusList';
-import { useConditionalFeature, usePlusSubscription } from '../../hooks';
-import { featurePlusApiLanding } from '../../lib/featureManagement';
+import { usePlusSubscription } from '../../hooks';
 import { usePaymentContext } from '../../contexts/payment/context';
 import type { OpenCheckoutFn } from '../../contexts/payment/context';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
@@ -149,24 +148,16 @@ export const PlusInfo = ({
   const { giftOneYear, isOrganization, checkoutItemsLoading } =
     usePaymentContext();
   const { openModal } = useLazyModal();
-  const { isPlus, logSubscriptionEvent } = usePlusSubscription();
+  const { logSubscriptionEvent } = usePlusSubscription();
   const { giftToUser } = useGiftUserContext();
 
   const [itemQuantity, setItemQuantity] = useState<number>(1);
-
-  const { value: isApiLanding } = useConditionalFeature({
-    feature: featurePlusApiLanding,
-    shouldEvaluate: !isPlus,
-  });
 
   const plusType = getPlusType({
     isGift: !!giftToUser,
     isOrganization,
   });
-  const copySource = isApiLanding
-    ? plusInfoCopyApi
-    : defaultPlusInfoCopyControl;
-  const defaultCopy = copySource[plusType];
+  const defaultCopy = plusInfoCopyApi[plusType];
   const titleCopy = title || defaultCopy.title;
   const descriptionCopy = description || defaultCopy.description;
   const subtitleCopy = subtitle || defaultCopy.subtitle;
@@ -177,7 +168,7 @@ export const PlusInfo = ({
   let plusListContent: ReactElement;
   if (isOrganization) {
     plusListContent = <PlusList items={plusOrganizationFeatureList} />;
-  } else if (isApiLanding && plusType === PlusType.Self) {
+  } else if (plusType === PlusType.Self) {
     plusListContent = <PlusList items={plusFeatureListApiFirst} />;
   } else {
     plusListContent = <PlusList />;

--- a/packages/shared/src/components/plus/PlusMobile.tsx
+++ b/packages/shared/src/components/plus/PlusMobile.tsx
@@ -11,8 +11,6 @@ import { plusUrl } from '../../lib/constants';
 import { objectToQueryParams } from '../../lib';
 import { PlusProductToggle } from './PlusProductToggle';
 import { PurchaseType } from '../../graphql/paddle';
-import { useFeature } from '../GrowthBookProvider';
-import { featurePlusApiLanding } from '../../lib/featureManagement';
 
 const PlusTrustRefund = dynamic(() =>
   import('./PlusTrustRefund').then((mod) => mod.PlusTrustRefund),
@@ -29,7 +27,6 @@ export const PlusMobile = ({
   const router = useRouter();
   const { giftToUser } = useGiftUserContext();
   const { productOptions, isOrganization } = usePaymentContext();
-  const isApiLanding = useFeature(featurePlusApiLanding);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
 
   const selectionChange: OpenCheckoutFn = useCallback(({ priceId }) => {
@@ -83,7 +80,7 @@ export const PlusMobile = ({
         shouldShowPlusHeader={shouldShowPlusHeader}
       />
       <PlusTrustRefund className="mt-6" />
-      {isApiLanding && !isOrganization && !giftToUser && <PlusApiShowcase />}
+      {!isOrganization && !giftToUser && <PlusApiShowcase />}
       <PlusFAQs />
     </div>
   );

--- a/packages/shared/src/components/sidebar/sections/MainSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/MainSection.tsx
@@ -30,7 +30,6 @@ import { useConditionalFeature } from '../../../hooks';
 import {
   DailyPageVariant,
   featureDailyPage,
-  featurePlusApiLanding,
   featureYearInReview,
 } from '../../../lib/featureManagement';
 import { useLayoutVariant } from '../../../hooks/layout/useLayoutVariant';
@@ -46,13 +45,7 @@ export const MainSection = ({
   const { isCustomDefaultFeed } = useCustomDefaultFeed();
   const { isV2 } = useLayoutVariant();
   const isPlus = user?.isPlus;
-  const { value: isApiLanding } = useConditionalFeature({
-    feature: featurePlusApiLanding,
-    shouldEvaluate: !isPlus,
-  });
-  const ctaCopy = isApiLanding
-    ? { full: 'Get API Access', short: 'API access' }
-    : { full: 'Level Up with Plus', short: 'Upgrade' };
+  const ctaCopy = { full: 'Get API Access', short: 'API access' };
   const { value: showYearInReview } = useConditionalFeature({
     feature: featureYearInReview,
     shouldEvaluate: isLoggedIn,
@@ -110,12 +103,8 @@ export const MainSection = ({
           path: plusUrl,
           isForcedLink: true,
           requiresLogin: true,
-          color: isApiLanding
-            ? 'text-action-plus-default'
-            : 'text-accent-avocado-default',
-          itemClassName: isApiLanding
-            ? 'bg-action-plus-float/50 hover:bg-action-plus-float'
-            : 'bg-action-upvote-float/50 hover:bg-action-upvote-float',
+          color: 'text-action-plus-default',
+          itemClassName: 'bg-action-plus-float/50 hover:bg-action-plus-float',
           disableDefaultBackground: true,
         }
       : undefined;
@@ -229,7 +218,6 @@ export const MainSection = ({
   }, [
     claimableMilestoneCount,
     ctaCopy.full,
-    isApiLanding,
     isCustomDefaultFeed,
     isLoggedIn,
     isPlus,

--- a/packages/shared/src/components/sidebar/sections/MainSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/MainSection.tsx
@@ -26,10 +26,7 @@ import useCustomDefaultFeed from '../../../hooks/feed/useCustomDefaultFeed';
 import { SharedFeedPage } from '../../utilities';
 import { isExtension } from '../../../lib/func';
 import { useConditionalFeature } from '../../../hooks';
-import {
-  featurePlusApiLanding,
-  featureYearInReview,
-} from '../../../lib/featureManagement';
+import { featureYearInReview } from '../../../lib/featureManagement';
 import { useQuestDashboard } from '../../../hooks/useQuestDashboard';
 import { Typography, TypographyColor } from '../../typography/Typography';
 
@@ -41,13 +38,7 @@ export const MainSection = ({
   const { user, isLoggedIn } = useAuthContext();
   const { isCustomDefaultFeed } = useCustomDefaultFeed();
   const isPlus = user?.isPlus;
-  const { value: isApiLanding } = useConditionalFeature({
-    feature: featurePlusApiLanding,
-    shouldEvaluate: !isPlus,
-  });
-  const ctaCopy = isApiLanding
-    ? { full: 'Get API Access', short: 'API access' }
-    : { full: 'Level Up with Plus', short: 'Upgrade' };
+  const ctaCopy = { full: 'Get API Access', short: 'API access' };
   const { value: showYearInReview } = useConditionalFeature({
     feature: featureYearInReview,
     shouldEvaluate: isLoggedIn,
@@ -96,12 +87,8 @@ export const MainSection = ({
           path: plusUrl,
           isForcedLink: true,
           requiresLogin: true,
-          color: isApiLanding
-            ? 'text-action-plus-default'
-            : 'text-accent-avocado-default',
-          itemClassName: isApiLanding
-            ? 'bg-action-plus-float/50 hover:bg-action-plus-float'
-            : 'bg-action-upvote-float/50 hover:bg-action-upvote-float',
+          color: 'text-action-plus-default',
+          itemClassName: 'bg-action-plus-float/50 hover:bg-action-plus-float',
           disableDefaultBackground: true,
         }
       : undefined;
@@ -192,7 +179,6 @@ export const MainSection = ({
   }, [
     claimableMilestoneCount,
     ctaCopy.full,
-    isApiLanding,
     isCustomDefaultFeed,
     isLoggedIn,
     isPlus,

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -57,8 +57,6 @@ export const featurePlusCtaCopy = new Feature('plus_cta_copy', {
   short: 'Upgrade',
 });
 
-export const featurePlusApiLanding = new Feature('plus_api_landing_v2', false);
-
 export const featureInlineLogin = new Feature('inline_login', false);
 
 export const featureLuckyButton = new Feature('lucky_button', false);

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -54,8 +54,6 @@ export const featurePlusCtaCopy = new Feature('plus_cta_copy', {
   short: 'Upgrade',
 });
 
-export const featurePlusApiLanding = new Feature('plus_api_landing_v2', false);
-
 export const featureLuckyButton = new Feature('lucky_button', false);
 
 export const featureSmartComposer = new Feature('smart_composer', false);


### PR DESCRIPTION
## Summary

The `plus_api_landing_v2` experiment won and rolled out to 100% of users. Remove the feature flag and hard-code the winning API-first variation across all consumer components so we no longer maintain the losing branch.

### What changed

- Deleted `featurePlusApiLanding` from `packages/shared/src/lib/featureManagement.ts`.
- Hard-coded `Get API Access` / `API access` CTA copy and `ButtonColor.Bacon` in `MainSection`, `UpgradeToPlus`, `PlusUserBadge`, `PlusMobileEntryBanner`, `PlusGrid`.
- Plus landing surfaces (`PlusInfo`, `PlusDesktop`, `PlusMobile`, `PlusFAQ`) now always use `plusInfoCopyApi`, `plusFeatureListApiFirst`, `plusFAQItemsApi`, and render `<PlusApiShowcase />`.
- Rebased onto latest `main`; `CustomFeedEmptyScreen` was dropped from this PR because main already removed the Plus upsell from that surface.

### Out of scope

- `featurePlusCtaCopy` (`plus_cta_copy`) is a separate, still-live flag and was intentionally left alone.
- `defaultPlusInfoCopyControl`, `plusFeatureListControl`, and `plusFAQItemsControl` are still consumed by non-experiment surfaces (settings/subscription, onboarding, internal helpers) and left in place.

## Test plan

- [x] `pnpm --filter shared lint`
- [x] CircleCI (lint, test, typecheck, build)
- [ ] Spot-check `/plus`, sidebar Plus CTA, and Plus user badge tooltip on preview after merge