### PR TITLE
fix: handle unscheduled standup lobby states

### DIFF
--- a/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoom.spec.tsx
@@ -613,6 +613,62 @@ describe('LiveRoom', () => {
     );
   });
 
+  it('shows unscheduled lobby copy without a countdown', () => {
+    mockUseLiveRoomConnection.mockReturnValue(
+      createContextValue({
+        role: 'audience',
+        participantId: 'user-1',
+        canPublish: false,
+        roomState: {
+          ...createContextValue().roomState!,
+          status: 'created',
+          participants: {
+            host: createParticipant('host', 'host'),
+            'user-1': createParticipant('user-1', 'audience'),
+          },
+          stage: {
+            speakerQueueParticipantIds: [],
+            activeSpeakerParticipantIds: [],
+            raisedHandParticipantIds: [],
+          },
+        },
+      }),
+    );
+    mockUseLiveRoomQuery.mockReturnValue({
+      data: {
+        id: 'room-1',
+        createdAt: '2026-05-04T08:55:00.000Z',
+        updatedAt: '2026-05-04T08:55:00.000Z',
+        topic: 'Instant standup',
+        mode: 'moderated',
+        status: 'created',
+        startedAt: null,
+        endedAt: null,
+        scheduledStart: null,
+        descriptionHtml: null,
+        subscribed: false,
+        contentEmbeds: [],
+        host: {
+          id: 'host',
+          username: 'host',
+          name: 'Host',
+          image: '',
+          permalink: '#',
+        },
+      },
+      error: null,
+      isLoading: false,
+    });
+
+    renderLiveRoom();
+
+    expect(screen.getByText('Waiting for the host to go live')).toBeVisible();
+    expect(screen.queryByText('Goes live in')).not.toBeInTheDocument();
+    expect(screen.queryByText('Awaiting host')).not.toBeInTheDocument();
+    expect(screen.queryByRole('timer')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("What we'll cover")).not.toBeInTheDocument();
+  });
+
   it('uses the shared share action without logging a duplicate event locally', () => {
     mockUseLiveRoomConnection.mockReturnValue(
       createContextValue({

--- a/packages/shared/src/components/liveRooms/LiveRoomLobby.tsx
+++ b/packages/shared/src/components/liveRooms/LiveRoomLobby.tsx
@@ -338,6 +338,9 @@ export const LiveRoomLobby = ({
   const hasScheduledStart = !!room.scheduledStart;
   const isStartingNow = hasScheduledStart && lobbyCountdown <= 0;
   const countdownLabel = isStartingNow ? 'Starting any moment' : 'Goes live in';
+  const unscheduledLobbyTitle = isHost
+    ? 'Ready to go live'
+    : 'Waiting for the host to go live';
   const countdownParts = getCountdownParts(lobbyCountdown);
   const hasEmbeds = !!room.contentEmbeds && room.contentEmbeds.length > 0;
   const standupFullUrl = useMemo(() => {
@@ -524,38 +527,39 @@ export const LiveRoomLobby = ({
                 </div>
 
                 <div className="flex flex-col gap-4 border-t border-border-subtlest-tertiary pt-5 tablet:gap-5 tablet:pt-7">
-                  <Typography
-                    type={TypographyType.Caption1}
-                    color={TypographyColor.Tertiary}
-                    className="font-bold uppercase tracking-[0.18em]"
-                  >
-                    {countdownLabel}
-                  </Typography>
-
                   {hasScheduledStart ? (
-                    <CountdownDisplay
-                      parts={countdownParts}
-                      ariaLabel={`${countdownLabel} ${
-                        countdownParts.hasDays
-                          ? `${countdownParts.days} days `
-                          : ''
-                      }${
-                        countdownParts.hasHours
-                          ? `${countdownParts.hours} hours `
-                          : ''
-                      }${countdownParts.minutes} minutes${
-                        countdownParts.hasDays
-                          ? ''
-                          : ` ${countdownParts.seconds} seconds`
-                      }`}
-                    />
+                    <>
+                      <Typography
+                        type={TypographyType.Caption1}
+                        color={TypographyColor.Tertiary}
+                        className="font-bold uppercase tracking-[0.18em]"
+                      >
+                        {countdownLabel}
+                      </Typography>
+                      <CountdownDisplay
+                        parts={countdownParts}
+                        ariaLabel={`${countdownLabel} ${
+                          countdownParts.hasDays
+                            ? `${countdownParts.days} days `
+                            : ''
+                        }${
+                          countdownParts.hasHours
+                            ? `${countdownParts.hours} hours `
+                            : ''
+                        }${countdownParts.minutes} minutes${
+                          countdownParts.hasDays
+                            ? ''
+                            : ` ${countdownParts.seconds} seconds`
+                        }`}
+                      />
+                    </>
                   ) : (
                     <Typography
                       type={TypographyType.Title2}
                       bold
                       color={TypographyColor.Primary}
                     >
-                      Awaiting host
+                      {unscheduledLobbyTitle}
                     </Typography>
                   )}
 
@@ -577,30 +581,24 @@ export const LiveRoomLobby = ({
               </div>
             </section>
 
-            <section
-              aria-label="What we'll cover"
-              className="flex flex-col gap-3 rounded-16 border border-border-subtlest-tertiary bg-background-subtle p-4 tablet:p-5"
-            >
-              <SectionLabel>What we&apos;ll cover</SectionLabel>
-              {room.descriptionHtml ? (
-                <Markdown
-                  content={room.descriptionHtml}
-                  className="break-words text-text-primary"
-                  openLinksInNewTab
-                />
-              ) : (
-                <Typography
-                  type={TypographyType.Callout}
-                  color={TypographyColor.Tertiary}
-                >
-                  The host hasn&apos;t shared an agenda yet. Drop into the chat
-                  to ask what&apos;s on the docket.
-                </Typography>
-              )}
-              {hasEmbeds ? (
-                <ContentEmbeds embeds={room.contentEmbeds} variant="post" />
-              ) : null}
-            </section>
+            {room.descriptionHtml || hasEmbeds ? (
+              <section
+                aria-label="What we'll cover"
+                className="flex flex-col gap-3 rounded-16 border border-border-subtlest-tertiary bg-background-subtle p-4 tablet:p-5"
+              >
+                <SectionLabel>What we&apos;ll cover</SectionLabel>
+                {room.descriptionHtml ? (
+                  <Markdown
+                    content={room.descriptionHtml}
+                    className="break-words text-text-primary"
+                    openLinksInNewTab
+                  />
+                ) : null}
+                {hasEmbeds ? (
+                  <ContentEmbeds embeds={room.contentEmbeds} variant="post" />
+                ) : null}
+              </section>
+            ) : null}
 
             <section
               aria-label="First standup?"

--- a/packages/webapp/__tests__/StandupPage.spec.ts
+++ b/packages/webapp/__tests__/StandupPage.spec.ts
@@ -1,0 +1,71 @@
+import type { GetServerSidePropsContext } from 'next';
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import { LiveRoomStatus } from '@dailydotdev/shared/src/graphql/liveRooms';
+import { getServerSideProps } from '../pages/standups/[id]';
+
+jest.mock('@dailydotdev/shared/src/graphql/common', () => ({
+  ...jest.requireActual('@dailydotdev/shared/src/graphql/common'),
+  gqlClient: {
+    request: jest.fn(),
+  },
+}));
+
+const mockGqlRequest = gqlClient.request as jest.MockedFunction<
+  typeof gqlClient.request
+>;
+
+const createContext = (): GetServerSidePropsContext<{
+  id: string;
+}> =>
+  ({
+    params: { id: 'room-1' },
+    req: {
+      headers: {
+        cookie: 'da2=test-session',
+      },
+    },
+    res: {
+      setHeader: jest.fn(),
+    },
+  } as unknown as GetServerSidePropsContext<{ id: string }>);
+
+describe('standup page getServerSideProps', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forwards request cookies when loading the standup', async () => {
+    mockGqlRequest.mockResolvedValueOnce({
+      liveRoom: {
+        id: 'room-1',
+        topic: 'Instant standup',
+        mode: 'moderated',
+        status: LiveRoomStatus.Created,
+        createdAt: '2026-05-17T00:00:00.000Z',
+        updatedAt: '2026-05-17T00:00:00.000Z',
+        startedAt: null,
+        endedAt: null,
+        scheduledStart: null,
+        descriptionHtml: null,
+        subscribed: false,
+        contentEmbeds: [],
+        host: {
+          id: 'user-1',
+          name: 'Host',
+          username: 'host',
+          image: '',
+          permalink: '#',
+        },
+      },
+    });
+
+    const result = await getServerSideProps(createContext());
+
+    expect(result).toHaveProperty('props');
+    expect(mockGqlRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      { id: 'room-1' },
+      { Cookie: 'da2=test-session' },
+    );
+  });
+});

--- a/packages/webapp/pages/standups/[id].tsx
+++ b/packages/webapp/pages/standups/[id].tsx
@@ -170,6 +170,7 @@ const fallbackSeo: NextSeoProps = {
 
 export async function getServerSideProps({
   params,
+  req,
   res,
 }: GetServerSidePropsContext<StandupPageParams>): Promise<
   GetServerSidePropsResult<StandupPageProps>
@@ -187,9 +188,11 @@ export async function getServerSideProps({
   );
 
   try {
-    const data = await gqlClient.request<LiveRoomData>(LIVE_ROOM_QUERY, {
-      id,
-    });
+    const data = await gqlClient.request<LiveRoomData>(
+      LIVE_ROOM_QUERY,
+      { id },
+      req.headers.cookie ? { Cookie: req.headers.cookie } : undefined,
+    );
     const url = `${getAppOrigin()}/standups/${id}`;
     const queryClient = new QueryClient();
     queryClient.setQueryData(


### PR DESCRIPTION
## What changed
- Forward the standup page SSR request cookie into the live room GraphQL query so creators can load newly created unscheduled rooms after redirect.
- Hide the scheduled countdown label/timer when a created standup has no scheduled start.
- Replace the unscheduled waiting copy and hide the lobby agenda block when there is no agenda content.

## Why
Unscheduled standups are created before they are live, and daily-api intentionally hides those created rooms from anonymous callers. The page SSR request was dropping the user cookie, which made the creator hit a 404. The lobby UI also showed scheduled-lobby copy even when the room had no schedule or agenda.

## Validation
- pnpm --filter webapp exec jest __tests__/StandupPage.spec.ts --runInBand
- pnpm --filter webapp exec eslint 'pages/standups/[id].tsx' __tests__/StandupPage.spec.ts --max-warnings 0
- pnpm --filter shared exec jest src/components/liveRooms/LiveRoom.spec.tsx --runInBand
- pnpm --filter shared exec eslint src/components/liveRooms/LiveRoomLobby.tsx src/components/liveRooms/LiveRoom.spec.tsx --max-warnings 0
- node ./scripts/typecheck-strict-changed.js


### Preview domain
https://codex-standup-unscheduled-lobby.preview.app.daily.dev