### PR TITLE
feat: live standups promo strip on the home feed

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -16,6 +16,7 @@ import { buildPersonalizedCategories } from './feeds/exploreCategories';
 import { useFeedTagsList } from '../hooks/useFeedTagsList';
 import ReadingReminderHero from './marketing/banners/ReadingReminderHero';
 import { WebappShortcutsRow } from '../features/shortcuts/components/WebappShortcutsRow';
+import { LiveStandupsStrip } from './liveRooms/LiveStandupsStrip';
 import { AskSearchBanner } from './marketing/banners/AskSearchBanner';
 import AuthContext from '../contexts/AuthContext';
 import type { LoggedUser } from '../lib/user';
@@ -713,6 +714,9 @@ export default function MainFeedLayout({
           onEnable={onEnable}
           onDismiss={onDismiss}
         />
+      )}
+      {isHomePage && (
+        <LiveStandupsStrip className="mx-0 mb-3 tablet:mx-2 laptop:mx-0" />
       )}
       {!isExtension && isHomePage && (
         <WebappShortcutsRow className="px-4 pb-2" />

--- a/packages/shared/src/components/feeds/FeedSettings/sections/FeedSettingsContentPreferencesSection.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/sections/FeedSettingsContentPreferencesSection.tsx
@@ -16,7 +16,7 @@ import {
 import { FilterCheckbox } from '../../../fields/FilterCheckbox';
 import { FeedType } from '../../../../graphql/feed';
 
-export const TOGGLEABLE_TYPES = ['Videos', 'Polls', 'Social'];
+export const TOGGLEABLE_TYPES = ['Videos', 'Polls', 'Social', 'Standups'];
 const CUSTOM_FEEDS_ONLY = ['Article'];
 const ADVANCED_SETTINGS_KEY = 'advancedSettings';
 

--- a/packages/shared/src/components/filters/useFeedContentTypeAction.tsx
+++ b/packages/shared/src/components/filters/useFeedContentTypeAction.tsx
@@ -5,13 +5,22 @@ import { BlockIcon, PlusIcon } from '../icons';
 import { useAdvancedSettings } from '../../hooks';
 import { MenuIcon } from '../MenuIcon';
 import { capitalize } from '../../lib/strings';
-import type { Post } from '../../graphql/posts';
+import { PostType, type Post } from '../../graphql/posts';
 
 interface UseFeedContentTypeAction {
   post: Post;
   customFeedId?: string;
   onActionSuccess: (copy: string, onUndo: () => void) => Promise<void>;
 }
+
+const getContentTypeActionTarget = (type: string): string => {
+  if (type === PostType.LiveRoom) {
+    return 'Standups';
+  }
+
+  const [target] = type.split(':');
+  return target;
+};
 
 export const useFeedContentTypeAction = ({
   post,
@@ -45,9 +54,15 @@ export const useFeedContentTypeAction = ({
     return null;
   }
 
+  const type = contentType.options?.type;
+
+  if (!type) {
+    return null;
+  }
+
   const { id } = contentType;
   const isEnabled = checkSettingsEnabledState(id);
-  const [target] = contentType.options.type.split(':');
+  const target = getContentTypeActionTarget(type);
 
   const onToggle = async () => {
     const icon = isEnabled ? '⛔️' : '✅';

--- a/packages/shared/src/components/liveRooms/LiveStandupsStrip.module.css
+++ b/packages/shared/src/components/liveRooms/LiveStandupsStrip.module.css
@@ -1,0 +1,150 @@
+@property --strip-angle {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+}
+
+.strip {
+  contain: layout paint style;
+  background: linear-gradient(
+        var(--theme-background-subtle),
+        var(--theme-background-subtle)
+      )
+      padding-box,
+    conic-gradient(
+        from var(--strip-angle),
+        var(--theme-border-subtlest-tertiary) 0deg,
+        var(--theme-border-subtlest-tertiary) 210deg,
+        var(--theme-accent-bacon-default) 290deg,
+        var(--theme-border-subtlest-tertiary) 360deg
+      )
+      border-box;
+  border: 1px solid transparent;
+  animation: stripBorderSpin 6s linear infinite;
+}
+
+.carouselViewport {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    #000 0.5rem,
+    #000 calc(100% - 2rem),
+    transparent 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    #000 0.5rem,
+    #000 calc(100% - 2rem),
+    transparent 100%
+  );
+}
+
+@keyframes stripBorderSpin {
+  to {
+    --strip-angle: 360deg;
+  }
+}
+
+.marqueeTrack {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  will-change: transform;
+}
+
+.slide {
+  flex: 0 0 100%;
+  min-width: 0;
+}
+
+.loadingBar {
+  position: absolute;
+  inset: 50% 0 auto 0;
+  height: 0.5rem;
+  max-width: 22rem;
+  transform: translateY(-50%);
+  overflow: hidden;
+  border-radius: 9999px;
+  background: var(--theme-surface-float);
+}
+
+.loadingBar span {
+  display: block;
+  width: 35%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--theme-surface-hover);
+  animation: stripLoading 1.2s ease-in-out infinite;
+}
+
+@keyframes stripLoading {
+  0% {
+    transform: translateX(-100%);
+  }
+
+  100% {
+    transform: translateX(320%);
+  }
+}
+
+@media (max-width: 655.98px) {
+  .strip {
+    background: var(--theme-background-subtle);
+    border: none;
+    animation: none;
+  }
+
+  .strip::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: linear-gradient(
+      to right,
+      transparent 0%,
+      var(--theme-accent-bacon-default) 50%,
+      transparent 100%
+    );
+    animation: stripBottomGlow 3.5s ease-in-out infinite;
+    pointer-events: none;
+  }
+}
+
+@keyframes stripBottomGlow {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scaleX(0.9);
+  }
+
+  50% {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .strip {
+    animation: none;
+  }
+
+  .strip::after {
+    animation: none;
+  }
+
+  .marqueeTrack {
+    transition: none !important;
+  }
+
+  .loadingBar span {
+    animation: none;
+  }
+}

--- a/packages/shared/src/components/liveRooms/LiveStandupsStrip.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveStandupsStrip.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
 import { TestBootProvider } from '../../../__tests__/helpers/boot';
 import { BOOT_QUERY_KEY } from '../../contexts/common';
@@ -9,6 +9,7 @@ import {
   ACTIVE_LIVE_ROOMS_QUERY,
   LiveRoomStatus,
 } from '../../graphql/liveRooms';
+import { LogEvent } from '../../lib/log';
 import { LiveStandupsStrip } from './LiveStandupsStrip';
 
 jest.mock('../../graphql/common', () => ({
@@ -41,12 +42,17 @@ const room: ActiveLiveRoom = {
   },
 };
 
-const renderComponent = (client = createClient()) =>
-  render(
-    <TestBootProvider client={client}>
+const renderComponent = (
+  client = createClient(),
+  log = { logEvent: jest.fn() },
+) => ({
+  log,
+  ...render(
+    <TestBootProvider client={client} log={log}>
       <LiveStandupsStrip />
     </TestBootProvider>,
-  );
+  ),
+});
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -82,5 +88,46 @@ it('fetches and renders active standups when boot has a live-room hint', async (
       ACTIVE_LIVE_ROOMS_QUERY,
       expect.objectContaining({ limit: expect.any(Number) }),
     ),
+  );
+});
+
+it('logs impression once when the strip renders with live standups', async () => {
+  const client = createClient();
+  client.setQueryData(BOOT_QUERY_KEY, { liveRooms: { hasLive: true } });
+  jest.mocked(gqlClient.request).mockResolvedValue({
+    activeLiveRooms: [room],
+  });
+
+  const { log } = renderComponent(client);
+
+  await screen.findByText('Weekly product standup');
+  await waitFor(() =>
+    expect(log.logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: LogEvent.ImpressionStandupsStrip,
+        extra: expect.stringContaining('"surface":"home_strip"'),
+      }),
+    ),
+  );
+});
+
+it('logs a click event when a standup link is activated', async () => {
+  const client = createClient();
+  client.setQueryData(BOOT_QUERY_KEY, { liveRooms: { hasLive: true } });
+  jest.mocked(gqlClient.request).mockResolvedValue({
+    activeLiveRooms: [room],
+  });
+
+  const { log } = renderComponent(client);
+
+  const link = await screen.findByRole('link');
+  fireEvent.click(link);
+
+  expect(log.logEvent).toHaveBeenCalledWith(
+    expect.objectContaining({
+      event_name: LogEvent.ClickStandupsStrip,
+      target_id: 'room-1',
+      extra: expect.stringContaining('"surface":"home_strip"'),
+    }),
   );
 });

--- a/packages/shared/src/components/liveRooms/LiveStandupsStrip.spec.tsx
+++ b/packages/shared/src/components/liveRooms/LiveStandupsStrip.spec.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import { BOOT_QUERY_KEY } from '../../contexts/common';
+import { gqlClient } from '../../graphql/common';
+import type { ActiveLiveRoom } from '../../graphql/liveRooms';
+import {
+  ACTIVE_LIVE_ROOMS_QUERY,
+  LiveRoomStatus,
+} from '../../graphql/liveRooms';
+import { LiveStandupsStrip } from './LiveStandupsStrip';
+
+jest.mock('../../graphql/common', () => ({
+  ...jest.requireActual('../../graphql/common'),
+  gqlClient: {
+    request: jest.fn(),
+  },
+}));
+
+const createClient = (): QueryClient =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+const room: ActiveLiveRoom = {
+  id: 'room-1',
+  topic: 'Weekly product standup',
+  status: LiveRoomStatus.Live,
+  participantCount: 12,
+  host: {
+    id: 'host-1',
+    name: 'Ido Shamun',
+    username: 'idoshamun',
+    image: '',
+    permalink: 'https://app.daily.dev/idoshamun',
+  },
+};
+
+const renderComponent = (client = createClient()) =>
+  render(
+    <TestBootProvider client={client}>
+      <LiveStandupsStrip />
+    </TestBootProvider>,
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('does not query active standups when boot has no live-room hint', () => {
+  const client = createClient();
+  client.setQueryData(BOOT_QUERY_KEY, { liveRooms: { hasLive: false } });
+
+  renderComponent(client);
+
+  expect(screen.queryByLabelText('Live standups')).not.toBeInTheDocument();
+  expect(gqlClient.request).not.toHaveBeenCalledWith(
+    ACTIVE_LIVE_ROOMS_QUERY,
+    expect.anything(),
+  );
+});
+
+it('fetches and renders active standups when boot has a live-room hint', async () => {
+  const client = createClient();
+  client.setQueryData(BOOT_QUERY_KEY, { liveRooms: { hasLive: true } });
+  jest.mocked(gqlClient.request).mockResolvedValue({
+    activeLiveRooms: [room],
+  });
+
+  renderComponent(client);
+
+  expect(await screen.findByText('Weekly product standup')).toBeInTheDocument();
+  expect(screen.getByText('with Ido Shamun · 12 watching')).toBeInTheDocument();
+  expect(screen.getByRole('link')).toHaveAttribute('href', '/standups/room-1');
+  await waitFor(() =>
+    expect(gqlClient.request).toHaveBeenCalledWith(
+      ACTIVE_LIVE_ROOMS_QUERY,
+      expect.objectContaining({ limit: expect.any(Number) }),
+    ),
+  );
+});

--- a/packages/shared/src/components/liveRooms/LiveStandupsStrip.tsx
+++ b/packages/shared/src/components/liveRooms/LiveStandupsStrip.tsx
@@ -1,0 +1,280 @@
+import type { ReactElement } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import classNames from 'classnames';
+import { useQuery } from '@tanstack/react-query';
+import Link from '../utilities/Link';
+import { ProfilePicture, ProfileImageSize } from '../ProfilePicture';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../typography/Typography';
+import { ArrowIcon, MicrophoneIcon } from '../icons';
+import { IconSize } from '../Icon';
+import type { ActiveLiveRoom } from '../../graphql/liveRooms';
+import { LiveRoomStatus } from '../../graphql/liveRooms';
+import { BOOT_QUERY_KEY } from '../../contexts/common';
+import type { Boot } from '../../lib/boot';
+import { useActiveLiveRooms } from '../../hooks/liveRooms/useActiveLiveRooms';
+import styles from './LiveStandupsStrip.module.css';
+
+const HOLD_MS = 5000;
+const SLIDE_MS = 1200;
+const ACTIVE_ROOMS_LIMIT = 5;
+
+const StandupItem = ({
+  item,
+  ariaHidden = false,
+}: {
+  item: ActiveLiveRoom;
+  ariaHidden?: boolean;
+}): ReactElement => (
+  <Link href={`/standups/${item.id}`}>
+    <a
+      aria-hidden={ariaHidden}
+      tabIndex={ariaHidden ? -1 : undefined}
+      className="flex w-full min-w-0 items-center gap-2 rounded-8 px-2 py-0.5 transition-colors hover:bg-surface-hover"
+    >
+      <ProfilePicture
+        user={item.host}
+        size={ProfileImageSize.Small}
+        rounded="full"
+        nativeLazyLoading
+        className="shrink-0"
+      />
+      <Typography
+        type={TypographyType.Footnote}
+        bold
+        className="min-w-0 truncate whitespace-nowrap"
+      >
+        {item.topic}
+      </Typography>
+      <Typography
+        type={TypographyType.Caption2}
+        color={TypographyColor.Tertiary}
+        className="hidden shrink-0 whitespace-nowrap tabular-nums tablet:inline"
+      >
+        with {item.host.name}
+        {item.participantCount ? ` · ${item.participantCount} watching` : ''}
+      </Typography>
+    </a>
+  </Link>
+);
+
+interface LiveStandupsStripProps {
+  items?: ActiveLiveRoom[];
+  className?: string;
+}
+
+export const LiveStandupsStrip = ({
+  items,
+  className,
+}: LiveStandupsStripProps): ReactElement | null => {
+  const { data: boot } = useQuery<Partial<Boot>>({
+    queryKey: BOOT_QUERY_KEY,
+    queryFn: () => Promise.resolve({} as Partial<Boot>),
+    enabled: false,
+  });
+  const hasLiveRoomsHint = boot?.liveRooms?.hasLive === true;
+  const shouldFetchLiveRooms = !items && hasLiveRoomsHint;
+  const { data: activeRooms, isLoading: isFetchingActive } = useActiveLiveRooms(
+    {
+      enabled: shouldFetchLiveRooms,
+      limit: ACTIVE_ROOMS_LIMIT,
+    },
+  );
+  const liveItems = useMemo(
+    () =>
+      (items ?? activeRooms ?? []).filter(
+        (item) => item.status === LiveRoomStatus.Live,
+      ),
+    [activeRooms, items],
+  );
+
+  const totalLive = liveItems.length;
+  const liveItemsFingerprint = useMemo(
+    () => liveItems.map((item) => item.id).join('|'),
+    [liveItems],
+  );
+  const [index, setIndex] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+  const [withTransition, setWithTransition] = useState(true);
+  const rafIdsRef = useRef<number[]>([]);
+
+  const scheduleRaf = (cb: () => void): void => {
+    const id = window.requestAnimationFrame(() => {
+      rafIdsRef.current = rafIdsRef.current.filter((rid) => rid !== id);
+      cb();
+    });
+    rafIdsRef.current.push(id);
+  };
+
+  useEffect(
+    () => () => {
+      rafIdsRef.current.forEach((id) => window.cancelAnimationFrame(id));
+      rafIdsRef.current = [];
+    },
+    [],
+  );
+
+  useEffect(() => {
+    setIndex(0);
+    setWithTransition(true);
+  }, [liveItemsFingerprint]);
+
+  useEffect(() => {
+    if (totalLive <= 1 || isPaused) {
+      return undefined;
+    }
+    const interval = window.setInterval(() => {
+      setIndex((current) => (current >= totalLive ? current : current + 1));
+    }, HOLD_MS + SLIDE_MS);
+    return () => window.clearInterval(interval);
+  }, [totalLive, isPaused]);
+
+  useEffect(() => {
+    if (totalLive === 0 || index !== totalLive) {
+      return undefined;
+    }
+    const t = window.setTimeout(() => {
+      setWithTransition(false);
+      setIndex(0);
+      scheduleRaf(() => {
+        scheduleRaf(() => setWithTransition(true));
+      });
+    }, SLIDE_MS + 50);
+    return () => window.clearTimeout(t);
+  }, [index, totalLive]);
+
+  if (!items && !hasLiveRoomsHint) {
+    return null;
+  }
+
+  if (!liveItems.length && !isFetchingActive) {
+    return null;
+  }
+
+  const isLoading = !liveItems.length && isFetchingActive;
+  const hasPagination = totalLive > 1;
+  const trackItems = hasPagination ? [...liveItems, liveItems[0]] : liveItems;
+  const displayIndex = totalLive === 0 ? 0 : (index % totalLive) + 1;
+
+  const goNext = () => {
+    if (index >= totalLive) {
+      return;
+    }
+    setIndex((current) => current + 1);
+  };
+  const goPrev = () => {
+    if (index >= totalLive) {
+      return;
+    }
+    if (index === 0 && totalLive > 1) {
+      setWithTransition(false);
+      setIndex(totalLive);
+      scheduleRaf(() => {
+        scheduleRaf(() => {
+          setWithTransition(true);
+          setIndex(totalLive - 1);
+        });
+      });
+      return;
+    }
+    setIndex((current) => current - 1);
+  };
+
+  return (
+    <section
+      aria-label="Live standups"
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+      onFocus={() => setIsPaused(true)}
+      onBlur={() => setIsPaused(false)}
+      className={classNames(
+        styles.strip,
+        'relative w-full overflow-hidden rounded-b-12 tablet:h-10 tablet:w-fit tablet:max-w-full tablet:rounded-12',
+        className,
+      )}
+    >
+      <div className="relative flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 p-1 tablet:h-full tablet:flex-nowrap">
+        <span className="inline-flex shrink-0 items-center gap-1.5 rounded-6 bg-accent-ketchup-default px-2 py-0.5 font-bold uppercase tracking-wide text-white typo-caption2">
+          <span className="size-1.5 animate-pulse rounded-full bg-white" />
+          Live
+        </span>
+
+        <Typography
+          type={TypographyType.Caption2}
+          bold
+          className="inline-flex shrink-0 items-center gap-1.5 uppercase tracking-[0.18em] text-accent-bacon-default"
+        >
+          <MicrophoneIcon size={IconSize.XSmall} secondary />
+          Standup
+        </Typography>
+
+        <div aria-hidden className="basis-full tablet:hidden" />
+
+        <div
+          className={classNames(
+            styles.carouselViewport,
+            'w-[11rem] flex-none tablet:w-[17.5rem] laptop:w-[21rem]',
+          )}
+        >
+          {isLoading && (
+            <div aria-hidden className={styles.loadingBar}>
+              <span />
+            </div>
+          )}
+          <div
+            className={styles.marqueeTrack}
+            style={{
+              transform: `translate3d(-${index * 100}%, 0, 0)`,
+              transition: withTransition
+                ? `transform ${SLIDE_MS}ms cubic-bezier(0.4, 0, 0.2, 1)`
+                : 'none',
+            }}
+          >
+            {trackItems.map((item, i) => {
+              const isDuplicate = i >= totalLive;
+              return (
+                <div
+                  key={isDuplicate ? `dup-${item.id}` : item.id}
+                  className={styles.slide}
+                >
+                  <StandupItem item={item} ariaHidden={isDuplicate} />
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {hasPagination ? (
+          <div className="flex shrink-0 items-center gap-0.5">
+            <button
+              type="button"
+              onClick={goPrev}
+              aria-label="Previous live standup"
+              className="flex size-6 items-center justify-center rounded-6 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary"
+            >
+              <ArrowIcon className="-rotate-90" size={IconSize.XSmall} />
+            </button>
+            <Typography
+              type={TypographyType.Caption2}
+              color={TypographyColor.Tertiary}
+              className="px-0.5 tabular-nums"
+            >
+              {displayIndex}/{totalLive}
+            </Typography>
+            <button
+              type="button"
+              onClick={goNext}
+              aria-label="Next live standup"
+              className="flex size-6 items-center justify-center rounded-6 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary"
+            >
+              <ArrowIcon className="rotate-90" size={IconSize.XSmall} />
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+};

--- a/packages/shared/src/components/liveRooms/LiveStandupsStrip.tsx
+++ b/packages/shared/src/components/liveRooms/LiveStandupsStrip.tsx
@@ -16,7 +16,12 @@ import { LiveRoomStatus } from '../../graphql/liveRooms';
 import { BOOT_QUERY_KEY } from '../../contexts/common';
 import type { Boot } from '../../lib/boot';
 import { useActiveLiveRooms } from '../../hooks/liveRooms/useActiveLiveRooms';
+import { useLogContext } from '../../contexts/LogContext';
+import useLogEventOnce from '../../hooks/log/useLogEventOnce';
+import { LogEvent } from '../../lib/log';
 import styles from './LiveStandupsStrip.module.css';
+
+const STRIP_SURFACE = 'home_strip';
 
 const HOLD_MS = 5000;
 const SLIDE_MS = 1200;
@@ -25,14 +30,19 @@ const ACTIVE_ROOMS_LIMIT = 5;
 const StandupItem = ({
   item,
   ariaHidden = false,
+  onItemClick,
 }: {
   item: ActiveLiveRoom;
   ariaHidden?: boolean;
+  onItemClick?: (item: ActiveLiveRoom) => void;
 }): ReactElement => (
   <Link href={`/standups/${item.id}`}>
     <a
+      href={`/standups/${item.id}`}
       aria-hidden={ariaHidden}
       tabIndex={ariaHidden ? -1 : undefined}
+      onClick={() => onItemClick?.(item)}
+      onAuxClick={() => onItemClick?.(item)}
       className="flex w-full min-w-0 items-center gap-2 rounded-8 px-2 py-0.5 transition-colors hover:bg-surface-hover"
     >
       <ProfilePicture
@@ -100,6 +110,31 @@ export const LiveStandupsStrip = ({
   const [isPaused, setIsPaused] = useState(false);
   const [withTransition, setWithTransition] = useState(true);
   const rafIdsRef = useRef<number[]>([]);
+  const { logEvent } = useLogContext();
+
+  useLogEventOnce(
+    () => ({
+      event_name: LogEvent.ImpressionStandupsStrip,
+      extra: JSON.stringify({
+        surface: STRIP_SURFACE,
+        total: totalLive,
+        room_ids: liveItems.map((item) => item.id),
+      }),
+    }),
+    { condition: totalLive > 0 },
+  );
+
+  const onItemClick = (room: ActiveLiveRoom) => {
+    logEvent({
+      event_name: LogEvent.ClickStandupsStrip,
+      target_id: room.id,
+      extra: JSON.stringify({
+        surface: STRIP_SURFACE,
+        position: liveItems.findIndex((item) => item.id === room.id),
+        total: totalLive,
+      }),
+    });
+  };
 
   const scheduleRaf = (cb: () => void): void => {
     const id = window.requestAnimationFrame(() => {
@@ -240,7 +275,11 @@ export const LiveStandupsStrip = ({
                   key={isDuplicate ? `dup-${item.id}` : item.id}
                   className={styles.slide}
                 >
-                  <StandupItem item={item} ariaHidden={isDuplicate} />
+                  <StandupItem
+                    item={item}
+                    ariaHidden={isDuplicate}
+                    onItemClick={isDuplicate ? undefined : onItemClick}
+                  />
                 </div>
               );
             })}

--- a/packages/shared/src/graphql/liveRooms.ts
+++ b/packages/shared/src/graphql/liveRooms.ts
@@ -42,6 +42,20 @@ export type LiveRoomPost = Pick<
   'id' | 'topic' | 'status' | 'scheduledStart' | 'subscribed'
 >;
 
+export type ActiveLiveRoom = Pick<
+  LiveRoom,
+  'id' | 'topic' | 'status' | 'participantCount'
+> & {
+  host: Pick<
+    UserShortProfile,
+    'id' | 'name' | 'username' | 'image' | 'permalink'
+  >;
+};
+
+export interface ActiveLiveRoomsData {
+  activeLiveRooms: ActiveLiveRoom[];
+}
+
 export interface LiveRoomJoinToken {
   room: LiveRoom;
   role: LiveRoomParticipantRole;
@@ -121,6 +135,24 @@ export const LIVE_ROOM_QUERY = gql`
     }
   }
   ${LIVE_ROOM_DETAIL_FRAGMENT}
+`;
+
+export const ACTIVE_LIVE_ROOMS_QUERY = gql`
+  query ActiveLiveRooms($limit: Int) {
+    activeLiveRooms(limit: $limit) {
+      id
+      topic
+      status
+      participantCount
+      host {
+        id
+        name
+        username
+        image
+        permalink
+      }
+    }
+  }
 `;
 
 export const CREATE_LIVE_ROOM_MUTATION = gql`

--- a/packages/shared/src/hooks/liveRooms/useActiveLiveRooms.ts
+++ b/packages/shared/src/hooks/liveRooms/useActiveLiveRooms.ts
@@ -1,0 +1,37 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import {
+  ACTIVE_LIVE_ROOMS_QUERY,
+  type ActiveLiveRoom,
+  type ActiveLiveRoomsData,
+} from '../../graphql/liveRooms';
+import { gqlClient } from '../../graphql/common';
+import { generateQueryKey, RequestKey } from '../../lib/query';
+import { ONE_MINUTE } from '../../lib/time';
+
+interface UseActiveLiveRoomsProps {
+  enabled: boolean;
+  limit?: number;
+}
+
+export const useActiveLiveRooms = ({
+  enabled,
+  limit = 5,
+}: UseActiveLiveRoomsProps): UseQueryResult<ActiveLiveRoom[]> => {
+  return useQuery<ActiveLiveRoom[]>({
+    queryKey: generateQueryKey(
+      RequestKey.LiveRooms,
+      undefined,
+      'active',
+      limit,
+    ),
+    queryFn: async () => {
+      const data = await gqlClient.request<ActiveLiveRoomsData>(
+        ACTIVE_LIVE_ROOMS_QUERY,
+        { limit },
+      );
+      return data.activeLiveRooms;
+    },
+    enabled,
+    staleTime: ONE_MINUTE / 2,
+  });
+};

--- a/packages/shared/src/lib/boot.ts
+++ b/packages/shared/src/lib/boot.ts
@@ -18,6 +18,10 @@ interface NotificationsBootData {
   unreadNotificationsCount: number;
 }
 
+interface LiveRoomsBootData {
+  hasLive: boolean;
+}
+
 export type PostBootData = Pick<
   Post,
   | 'id'
@@ -83,6 +87,7 @@ export type Boot = {
   };
   isAndroidApp?: boolean;
   engagementCreatives?: EngagementCreative[];
+  liveRooms?: LiveRoomsBootData;
 };
 
 export type BootCacheData = Pick<

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -295,6 +295,8 @@ export enum LogEvent {
   ChangeStandupSettings = 'change standup settings',
   StandupError = 'standup error',
   FocusStandupSpeaker = 'focus standup speaker',
+  ImpressionStandupsStrip = 'impression standups strip',
+  ClickStandupsStrip = 'click standups strip',
   // End standups
   // Integrations
   StartAddingWorkspace = 'start adding workspace',


### PR DESCRIPTION
## Summary
- Adds a promotional strip above the home feed that surfaces currently live standups, with a ketchup `LIVE` badge, the existing bacon `STANDUP` kicker, host avatar, topic, host + watcher count, and `‹ index/total ›` pagination.
- Auto-rotates between rooms (5s hold, 1.2s slide) with a seamless forward-direction wrap-around via a duplicate slot and a no-transition snap-back. Pauses on hover/focus.
- Gates the network call: boot now carries a `liveRooms.hasLive` hint and the new `useActiveLiveRooms` hook (`activeLiveRooms` GraphQL query) only fires when the hint is true and the consumer didn't pass `items`.
- Mobile renders flat: full-width, `rounded-b-12` only, no border around the box, with a gently pulsing bacon shine glued to the bottom edge. Two rows on mobile (badge + kicker, then carousel + pagination), single row on `tablet+` where the box keeps the animated conic-gradient border.
- Hooks up Standups as a toggleable content type in feed settings (`TOGGLEABLE_TYPES`) and maps `PostType.LiveRoom` in `useFeedContentTypeAction` so per-post hide/unhide flows route to the same advanced setting.

## Test plan
- [ ] On the home feed with one or more live standups present, verify the strip appears, rotates through rooms, and links each item to `/standups/{id}`.
- [ ] With no live standups in boot (`liveRooms.hasLive: false`), confirm the component never renders and the `activeLiveRooms` query is not fired.
- [ ] Resize from mobile to tablet+: mobile shows two rows with a flat top + bottom shine; tablet+ shows a single row with the rounded animated border.
- [ ] Hover and tab into the strip while it's auto-rotating — auto-advance pauses; leaving / blurring resumes.
- [ ] Click prev from item 1 and next from the last item; verify both transitions go forward (no reverse-scroll on wrap).
- [ ] Toggle `Standups` under Feed settings → Content preferences and confirm the advanced setting updates; hide a live-room post and confirm the toast/action references "Standups".
- [ ] `prefers-reduced-motion: reduce` disables the border spin, marquee transition, loading bar, and bottom shine.

### Preview domain
https://feat-live-standups-strip.preview.app.daily.dev