### PR TITLE
chore(extension): update translator copy for PT, FR, ES, DE

### DIFF
--- a/packages/extension/public/_locales/de/messages.json
+++ b/packages/extension/public/_locales/de/messages.json
@@ -1,8 +1,8 @@
 {
   "extensionName": {
-    "message": "daily.dev | Entwickler-News, richtig gemacht, in jedem neuen Tab"
+    "message": "daily.dev | Developer-News, wie sie sein sollten – in jedem neuen Tab"
   },
   "extensionDescription": {
-    "message": "Entwickler-News, personalisiert für Ihren Stack, in jedem neuen Tab. Über 400.000 Entwickler. Kostenlos und Open Source."
+    "message": "Developer-News, personalisiert für deinen Stack, in jedem neuen Tab. Werde Teil von über 400.000 Entwicklern. Kostenlos und Open Source."
   }
 }

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -1,8 +1,8 @@
 {
   "extensionName": {
-    "message": "daily.dev | Noticias para developers como deberían ser, en cada nueva pestaña"
+    "message": "daily.dev | La forma inteligente de seguir la actualidad tech, en cada nueva pestaña"
   },
   "extensionDescription": {
-    "message": "Noticias para developers, personalizadas según tu stack, en cada nueva pestaña. Únete a más de 400.000 developers. Gratis y open source."
+    "message": "Noticias tech personalizadas para tu stack, en cada nueva pestaña. Únete a más de 400.000 developers. Gratis y open source."
   }
 }

--- a/packages/extension/public/_locales/es/messages.json
+++ b/packages/extension/public/_locales/es/messages.json
@@ -1,8 +1,8 @@
 {
   "extensionName": {
-    "message": "daily.dev | Noticias para devs bien hechas, en cada pestaña nueva"
+    "message": "daily.dev | Noticias para developers como deberían ser, en cada nueva pestaña"
   },
   "extensionDescription": {
-    "message": "Noticias para desarrolladores, personalizadas según tu stack, en cada pestaña nueva. +400.000 devs. Gratis y open source."
+    "message": "Noticias para developers, personalizadas según tu stack, en cada nueva pestaña. Únete a más de 400.000 developers. Gratis y open source."
   }
 }

--- a/packages/extension/public/_locales/fr/messages.json
+++ b/packages/extension/public/_locales/fr/messages.json
@@ -1,8 +1,8 @@
 {
   "extensionName": {
-    "message": "daily.dev | L'actualité dev, bien présentée, à chaque nouvel onglet"
+    "message": "daily.dev | L’actualité des développeurs comme elle devrait l’être, dans chaque nouvel onglet"
   },
   "extensionDescription": {
-    "message": "L'actualité des développeurs, personnalisée selon votre stack, dans chaque nouvel onglet. +400 000 devs. Gratuit et open source."
+    "message": "L’actualité des développeurs, personnalisée selon votre stack, dans chaque nouvel onglet. Rejoignez plus de 400 000 développeurs. Gratuit et open source."
   }
 }

--- a/packages/extension/public/_locales/pt_BR/messages.json
+++ b/packages/extension/public/_locales/pt_BR/messages.json
@@ -1,8 +1,8 @@
 {
   "extensionName": {
-    "message": "daily.dev | Notícias para desenvolvedores do jeito certo, em cada nova guia"
+    "message": "daily.dev | Notícias para devs, do jeito certo, em todas as abas"
   },
   "extensionDescription": {
-    "message": "Notícias para desenvolvedores, personalizadas para sua tecnologia, em cada nova guia. +400.000 devs. Grátis e open source."
+    "message": "Notícias para devs, personalizadas de acordo com sua stack, em todas as abas. Junte-se a mais de 400.000 desenvolvedores. Gratuito e open source."
   }
 }


### PR DESCRIPTION
## Summary

Refreshed translator copy for the Chrome extension `extensionName` (title) and `extensionDescription` (summary) in Portuguese (BR), French, Spanish, and German.

| Locale | Title | Summary |
|---|---|---|
| pt_BR | `daily.dev \| Notícias para devs, do jeito certo, em todas as abas` | `Notícias para devs, personalizadas de acordo com sua stack, em todas as abas. Junte-se a mais de 400.000 desenvolvedores. Gratuito e open source.` |
| fr | `daily.dev \| L’actualité des développeurs comme elle devrait l’être, dans chaque nouvel onglet` | `L’actualité des développeurs, personnalisée selon votre stack, dans chaque nouvel onglet. Rejoignez plus de 400 000 développeurs. Gratuit et open source.` |
| es | `daily.dev \| Noticias para developers como deberían ser, en cada nueva pestaña` | `Noticias para developers, personalizadas según tu stack, en cada nueva pestaña. Únete a más de 400.000 developers. Gratis y open source.` |
| de | `daily.dev \| Developer-News, wie sie sein sollten – in jedem neuen Tab` | `Developer-News, personalisiert für deinen Stack, in jedem neuen Tab. Werde Teil von über 400.000 Entwicklern. Kostenlos und Open Source.` |

English (`en`) and Japanese (`ja`) locales are unchanged.

## Test plan

- [ ] Verify each locale renders the new title/summary in the Chrome Web Store listing after release.

Made with [Cursor](https://cursor.com)

### Preview domain
https://chore-extension-i18n-copy-update.preview.app.daily.dev