### PR TITLE
fix: wait for standup flag before initializing create-post tab

### DIFF
--- a/packages/webapp/pages/squads/create.tsx
+++ b/packages/webapp/pages/squads/create.tsx
@@ -35,7 +35,8 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import CreatePoll from '@dailydotdev/shared/src/components/post/poll/CreatePoll';
 import { CreateLiveRoomForm } from '@dailydotdev/shared/src/components/liveRooms/CreateLiveRoomForm';
-import { useStandupCreation } from '@dailydotdev/shared/src/hooks/liveRooms/useStandupCreation';
+import { useConditionalFeature } from '@dailydotdev/shared/src/hooks';
+import { featureStandupCreation } from '@dailydotdev/shared/src/lib/featureManagement';
 import { Pill, PillSize } from '@dailydotdev/shared/src/components/Pill';
 import { useMultipleSourcePost } from '@dailydotdev/shared/src/features/squads/hooks/useMultipleSourcePost';
 import { settingsUrl, webappUrl } from '@dailydotdev/shared/src/lib/constants';
@@ -74,13 +75,17 @@ const getSubmitCopy = (tab: WriteFormTab): string => {
 function CreatePost(): ReactElement {
   const client = useQueryClient();
   const { isActionsFetched, completeAction, checkHasCompleted } = useActions();
-  const isStandupCreationEnabled = useStandupCreation();
   const hasSeenStandupTab = useMemo(
     () => checkHasCompleted(ActionType.SeenStandupTab),
     [checkHasCompleted],
   );
   const { push, isReady: isRouteReady, query } = useRouter();
   const { squads, user, isAuthReady, isFetched } = useAuthContext();
+  const { value: isStandupCreationEnabled, isLoading: isStandupFlagLoading } =
+    useConditionalFeature({
+      feature: featureStandupCreation,
+      shouldEvaluate: isAuthReady && !!user,
+    });
   const {
     flags: { defaultWriteTab },
     loadedSettings,
@@ -212,7 +217,13 @@ function CreatePost(): ReactElement {
   const initialSelected = !!activeSquads?.length && (query.sid as string);
   useEffect(() => {
     // Only run this once after router and user are ready
-    if (!user || !isRouteReady || !isDraftReady || isInitialized.current) {
+    if (
+      !user ||
+      !isRouteReady ||
+      !isDraftReady ||
+      isStandupFlagLoading ||
+      isInitialized.current
+    ) {
       return;
     }
 
@@ -260,6 +271,7 @@ function CreatePost(): ReactElement {
     defaultWriteTab,
     prefillState.initialDisplay,
     isStandupCreationEnabled,
+    isStandupFlagLoading,
   ]);
 
   useEffect(() => {
@@ -273,7 +285,8 @@ function CreatePost(): ReactElement {
     !isAuthReady ||
     !isRouteReady ||
     !loadedSettings ||
-    !isDraftReady
+    !isDraftReady ||
+    isStandupFlagLoading
   ) {
     return <WriteFreeFormSkeleton />;
   }

--- a/packages/webapp/pages/squads/create.tsx
+++ b/packages/webapp/pages/squads/create.tsx
@@ -24,6 +24,7 @@ import { verifyPermission } from '@dailydotdev/shared/src/graphql/squads';
 import { SourcePermissions } from '@dailydotdev/shared/src/graphql/sources';
 import {
   useActions,
+  useConditionalFeature,
   useViewSize,
   ViewSize,
 } from '@dailydotdev/shared/src/hooks';
@@ -35,7 +36,6 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import CreatePoll from '@dailydotdev/shared/src/components/post/poll/CreatePoll';
 import { CreateLiveRoomForm } from '@dailydotdev/shared/src/components/liveRooms/CreateLiveRoomForm';
-import { useConditionalFeature } from '@dailydotdev/shared/src/hooks';
 import { featureStandupCreation } from '@dailydotdev/shared/src/lib/featureManagement';
 import { Pill, PillSize } from '@dailydotdev/shared/src/components/Pill';
 import { useMultipleSourcePost } from '@dailydotdev/shared/src/features/squads/hooks/useMultipleSourcePost';


### PR DESCRIPTION
## Summary
- `/squads/create?standup=1` was silently falling back to the default tab even when the user had the `standup_creation` flag enabled.
- The init effect in `pages/squads/create.tsx` ran as soon as router + draft were ready and latched `isInitialized.current = true`, but `useStandupCreation()` returns `false` on the first render before GrowthBook resolves features. That meant the effect saw the flag as off, nulled `initialDisplay`, and never re-ran when the flag flipped on.
- Read the flag via `useConditionalFeature` directly so we can observe `isLoading`, gate the init effect (and the page skeleton) on the flag having resolved.

## Test plan
- [ ] With `standup_creation` enabled, visit `/squads/create?standup=1` on desktop -> lands on the Standup tab.
- [ ] Same URL on mobile width -> lands on the Standup tab with the "Start a standup" heading.
- [ ] With `standup_creation` disabled, visit the same URL -> falls back to the default tab (no Standup tab rendered).
- [ ] `?poll=true` and `?share=true` deep links still work.

### Preview domain
https://fix-standup-deeplink-flag-loadin.preview.app.daily.dev