### PR TITLE
fix: open add hot take modal from hot takes CTA

### DIFF
--- a/packages/shared/src/components/modals/hotTakes/HotAndColdModal.spec.tsx
+++ b/packages/shared/src/components/modals/hotTakes/HotAndColdModal.spec.tsx
@@ -6,6 +6,8 @@ import { useVoteHotTake } from '../../../hooks/vote/useVoteHotTake';
 import { useLogContext } from '../../../contexts/LogContext';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { LogEvent, Origin } from '../../../lib/log';
+import { useHotTakes } from '../../../features/profile/hooks/useHotTakes';
+import { useToastNotification } from '../../../hooks/useToastNotification';
 import HotAndColdModal from './HotAndColdModal';
 
 jest.mock('../../../hooks/useDiscoverHotTakes', () => ({
@@ -26,10 +28,22 @@ jest.mock('../../../contexts/AuthContext', () => ({
   useAuthContext: jest.fn(),
 }));
 
+jest.mock('../../../features/profile/hooks/useHotTakes', () => ({
+  HOT_TAKE_LIMIT_REACHED_MESSAGE:
+    'You already have all 5 hot takes. Remove one to add a new one.',
+  useHotTakes: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useToastNotification', () => ({
+  useToastNotification: jest.fn(),
+}));
+
 const mockedUseDiscoverHotTakes = useDiscoverHotTakes as jest.Mock;
 const mockedUseVoteHotTake = useVoteHotTake as jest.Mock;
 const mockedUseLogContext = useLogContext as jest.Mock;
 const mockedUseAuthContext = useAuthContext as jest.Mock;
+const mockedUseHotTakes = useHotTakes as jest.Mock;
+const mockedUseToastNotification = useToastNotification as jest.Mock;
 
 const createHotTake = (id = 'take-1'): HotTake => ({
   id,
@@ -60,6 +74,7 @@ describe('HotAndColdModal', () => {
   const cancelHotTakeVote = jest.fn();
   const dismissCurrent = jest.fn();
   const logEvent = jest.fn();
+  const displayToast = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -73,6 +88,14 @@ describe('HotAndColdModal', () => {
     });
     mockedUseAuthContext.mockReturnValue({
       user: { username: 'tester' },
+    });
+    mockedUseHotTakes.mockReturnValue({
+      canAddMore: true,
+      isLoading: false,
+    });
+    mockedUseToastNotification.mockReturnValue({
+      displayToast,
+      dismissToast: jest.fn(),
     });
     mockedUseDiscoverHotTakes.mockReturnValue({
       hotTakes: [createHotTake()],
@@ -229,7 +252,7 @@ describe('HotAndColdModal', () => {
     const shareLink = screen.getByRole('link', {
       name: 'Share your hot takes',
     });
-    expect(shareLink).toHaveAttribute('href', '/tester#hot-takes');
+    expect(shareLink).toHaveAttribute('href', '/tester?addHotTake=1#hot-takes');
 
     fireEvent.click(shareLink);
 
@@ -242,11 +265,30 @@ describe('HotAndColdModal', () => {
     const addButton = screen.getByRole('link', {
       name: 'Add your own hot take',
     });
-    expect(addButton).toHaveAttribute('href', '/tester#hot-takes');
+    expect(addButton).toHaveAttribute('href', '/tester?addHotTake=1#hot-takes');
 
     fireEvent.click(addButton);
 
     expect(onRequestClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show a toast and keep the modal open when the user cannot add more hot takes', () => {
+    mockedUseHotTakes.mockReturnValue({
+      canAddMore: false,
+      isLoading: false,
+    });
+
+    const { onRequestClose } = renderComponent();
+
+    const addButton = screen.getByRole('link', {
+      name: 'Add your own hot take',
+    });
+
+    expect(fireEvent.click(addButton)).toBe(false);
+    expect(displayToast).toHaveBeenCalledWith(
+      'You already have all 5 hot takes. Remove one to add a new one.',
+    );
+    expect(onRequestClose).not.toHaveBeenCalled();
   });
 
   it('should keep subtitle visible even when title is very long', () => {

--- a/packages/shared/src/components/modals/hotTakes/HotAndColdModal.spec.tsx
+++ b/packages/shared/src/components/modals/hotTakes/HotAndColdModal.spec.tsx
@@ -6,8 +6,6 @@ import { useVoteHotTake } from '../../../hooks/vote/useVoteHotTake';
 import { useLogContext } from '../../../contexts/LogContext';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { LogEvent, Origin } from '../../../lib/log';
-import { useHotTakes } from '../../../features/profile/hooks/useHotTakes';
-import { useToastNotification } from '../../../hooks/useToastNotification';
 import HotAndColdModal from './HotAndColdModal';
 
 jest.mock('../../../hooks/useDiscoverHotTakes', () => ({
@@ -28,22 +26,10 @@ jest.mock('../../../contexts/AuthContext', () => ({
   useAuthContext: jest.fn(),
 }));
 
-jest.mock('../../../features/profile/hooks/useHotTakes', () => ({
-  HOT_TAKE_LIMIT_REACHED_MESSAGE:
-    'You already have all 5 hot takes. Remove one to add a new one.',
-  useHotTakes: jest.fn(),
-}));
-
-jest.mock('../../../hooks/useToastNotification', () => ({
-  useToastNotification: jest.fn(),
-}));
-
 const mockedUseDiscoverHotTakes = useDiscoverHotTakes as jest.Mock;
 const mockedUseVoteHotTake = useVoteHotTake as jest.Mock;
 const mockedUseLogContext = useLogContext as jest.Mock;
 const mockedUseAuthContext = useAuthContext as jest.Mock;
-const mockedUseHotTakes = useHotTakes as jest.Mock;
-const mockedUseToastNotification = useToastNotification as jest.Mock;
 
 const createHotTake = (id = 'take-1'): HotTake => ({
   id,
@@ -74,7 +60,6 @@ describe('HotAndColdModal', () => {
   const cancelHotTakeVote = jest.fn();
   const dismissCurrent = jest.fn();
   const logEvent = jest.fn();
-  const displayToast = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -88,14 +73,6 @@ describe('HotAndColdModal', () => {
     });
     mockedUseAuthContext.mockReturnValue({
       user: { username: 'tester' },
-    });
-    mockedUseHotTakes.mockReturnValue({
-      canAddMore: true,
-      isLoading: false,
-    });
-    mockedUseToastNotification.mockReturnValue({
-      displayToast,
-      dismissToast: jest.fn(),
     });
     mockedUseDiscoverHotTakes.mockReturnValue({
       hotTakes: [createHotTake()],
@@ -270,25 +247,6 @@ describe('HotAndColdModal', () => {
     fireEvent.click(addButton);
 
     expect(onRequestClose).toHaveBeenCalledTimes(1);
-  });
-
-  it('should show a toast and keep the modal open when the user cannot add more hot takes', () => {
-    mockedUseHotTakes.mockReturnValue({
-      canAddMore: false,
-      isLoading: false,
-    });
-
-    const { onRequestClose } = renderComponent();
-
-    const addButton = screen.getByRole('link', {
-      name: 'Add your own hot take',
-    });
-
-    expect(fireEvent.click(addButton)).toBe(false);
-    expect(displayToast).toHaveBeenCalledWith(
-      'You already have all 5 hot takes. Remove one to add a new one.',
-    );
-    expect(onRequestClose).not.toHaveBeenCalled();
   });
 
   it('should keep subtitle visible even when title is very long', () => {

--- a/packages/shared/src/components/modals/hotTakes/HotAndColdModal.tsx
+++ b/packages/shared/src/components/modals/hotTakes/HotAndColdModal.tsx
@@ -1,5 +1,11 @@
 import type { ReactElement } from 'react';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useSwipeable } from 'react-swipeable';
 import classNames from 'classnames';
 import type { ModalProps } from '../common/Modal';
@@ -10,7 +16,6 @@ import { useVoteHotTake } from '../../../hooks/vote/useVoteHotTake';
 import { useLogContext } from '../../../contexts/LogContext';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { LogEvent, Origin } from '../../../lib/log';
-import { webappUrl } from '../../../lib/constants';
 import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
 import { HotIcon } from '../../icons/Hot';
 import {
@@ -23,6 +28,13 @@ import { ReputationUserBadge } from '../../ReputationUserBadge';
 import { VerifiedCompanyUserBadge } from '../../VerifiedCompanyUserBadge';
 import { PlusUserBadge } from '../../PlusUserBadge';
 import type { HotTake } from '../../../graphql/user/userHotTake';
+import type { PublicProfile } from '../../../lib/user';
+import { getAddHotTakeProfileUrl } from '../../../features/profile/components/hotTakes/common';
+import {
+  HOT_TAKE_LIMIT_REACHED_MESSAGE,
+  useHotTakes,
+} from '../../../features/profile/hooks/useHotTakes';
+import { useToastNotification } from '../../../hooks/useToastNotification';
 
 const SWIPE_THRESHOLD = 80;
 const DISMISS_ANIMATION_MS = 340;
@@ -795,10 +807,10 @@ const HotTakeCard = ({
 };
 
 const EmptyState = ({
-  onClose,
+  onAddOwnHotTakeClick,
   username,
 }: {
-  onClose: ModalProps['onRequestClose'];
+  onAddOwnHotTakeClick: (e: React.MouseEvent) => void;
   username?: string;
 }): ReactElement => (
   <div className="flex flex-1 flex-col items-center justify-center gap-4 p-6">
@@ -823,10 +835,8 @@ const EmptyState = ({
         variant={ButtonVariant.Primary}
         size={ButtonSize.Large}
         tag="a"
-        href={`${webappUrl}${username}#hot-takes`}
-        onClick={(e: React.MouseEvent) => {
-          onClose?.(e);
-        }}
+        href={getAddHotTakeProfileUrl(username)}
+        onClick={onAddOwnHotTakeClick}
       >
         Share your hot takes
       </Button>
@@ -843,6 +853,33 @@ const HotAndColdModal = ({
   const { toggleUpvote, toggleDownvote, cancelHotTakeVote } = useVoteHotTake();
   const { logEvent } = useLogContext();
   const { user } = useAuthContext();
+  const { displayToast } = useToastNotification();
+  const loggedUserProfile = useMemo<PublicProfile | null>(() => {
+    if (!user) {
+      return null;
+    }
+
+    return {
+      id: user.id,
+      name: user.name,
+      username: user.username,
+      socialLinks: user.socialLinks,
+      bio: user.bio,
+      createdAt: user.createdAt,
+      premium: user.premium ?? false,
+      image: user.image,
+      reputation: user.reputation ?? 0,
+      permalink: user.permalink,
+      cover: user.cover,
+      companies: user.companies,
+      contentPreference: user.contentPreference,
+      isPlus: user.isPlus,
+      experienceLevel: user.experienceLevel,
+      location: user.location,
+    };
+  }, [user]);
+  const { canAddMore: canAddOwnHotTake, isLoading: isUserHotTakesLoading } =
+    useHotTakes(loggedUserProfile);
   const [swipeDelta, setSwipeDelta] = useState(0);
   const swipeDeltaRef = useRef(0);
   const [isAnimating, setIsAnimating] = useState(false);
@@ -1032,6 +1069,19 @@ const HotAndColdModal = ({
     ],
   );
 
+  const handleAddOwnHotTakeClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (!isUserHotTakesLoading && !canAddOwnHotTake) {
+        e.preventDefault();
+        displayToast(HOT_TAKE_LIMIT_REACHED_MESSAGE);
+        return;
+      }
+
+      onRequestClose?.(e);
+    },
+    [canAddOwnHotTake, displayToast, isUserHotTakesLoading, onRequestClose],
+  );
+
   const isCurrentTakeAnimating =
     !!currentTake && isAnimating && animatingTakeId === currentTake.id;
   const cardSwipeDelta =
@@ -1103,7 +1153,10 @@ const HotAndColdModal = ({
         )}
 
         {!isLoading && isEmpty && (
-          <EmptyState onClose={onRequestClose} username={user?.username} />
+          <EmptyState
+            onAddOwnHotTakeClick={handleAddOwnHotTakeClick}
+            username={user?.username}
+          />
         )}
 
         {!isLoading && !isEmpty && currentTake && (
@@ -1186,11 +1239,9 @@ const HotAndColdModal = ({
                   variant={ButtonVariant.Tertiary}
                   size={ButtonSize.Medium}
                   tag="a"
-                  href={`${webappUrl}${user.username}#hot-takes`}
+                  href={getAddHotTakeProfileUrl(user.username)}
                   className="w-full"
-                  onClick={(e: React.MouseEvent) => {
-                    onRequestClose?.(e);
-                  }}
+                  onClick={handleAddOwnHotTakeClick}
                 >
                   Add your own hot take
                 </Button>

--- a/packages/shared/src/components/modals/hotTakes/HotAndColdModal.tsx
+++ b/packages/shared/src/components/modals/hotTakes/HotAndColdModal.tsx
@@ -1,11 +1,5 @@
 import type { ReactElement } from 'react';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useSwipeable } from 'react-swipeable';
 import classNames from 'classnames';
 import type { ModalProps } from '../common/Modal';
@@ -28,13 +22,7 @@ import { ReputationUserBadge } from '../../ReputationUserBadge';
 import { VerifiedCompanyUserBadge } from '../../VerifiedCompanyUserBadge';
 import { PlusUserBadge } from '../../PlusUserBadge';
 import type { HotTake } from '../../../graphql/user/userHotTake';
-import type { PublicProfile } from '../../../lib/user';
 import { getAddHotTakeProfileUrl } from '../../../features/profile/components/hotTakes/common';
-import {
-  HOT_TAKE_LIMIT_REACHED_MESSAGE,
-  useHotTakes,
-} from '../../../features/profile/hooks/useHotTakes';
-import { useToastNotification } from '../../../hooks/useToastNotification';
 
 const SWIPE_THRESHOLD = 80;
 const DISMISS_ANIMATION_MS = 340;
@@ -853,33 +841,6 @@ const HotAndColdModal = ({
   const { toggleUpvote, toggleDownvote, cancelHotTakeVote } = useVoteHotTake();
   const { logEvent } = useLogContext();
   const { user } = useAuthContext();
-  const { displayToast } = useToastNotification();
-  const loggedUserProfile = useMemo<PublicProfile | null>(() => {
-    if (!user) {
-      return null;
-    }
-
-    return {
-      id: user.id,
-      name: user.name,
-      username: user.username,
-      socialLinks: user.socialLinks,
-      bio: user.bio,
-      createdAt: user.createdAt,
-      premium: user.premium ?? false,
-      image: user.image,
-      reputation: user.reputation ?? 0,
-      permalink: user.permalink,
-      cover: user.cover,
-      companies: user.companies,
-      contentPreference: user.contentPreference,
-      isPlus: user.isPlus,
-      experienceLevel: user.experienceLevel,
-      location: user.location,
-    };
-  }, [user]);
-  const { canAddMore: canAddOwnHotTake, isLoading: isUserHotTakesLoading } =
-    useHotTakes(loggedUserProfile);
   const [swipeDelta, setSwipeDelta] = useState(0);
   const swipeDeltaRef = useRef(0);
   const [isAnimating, setIsAnimating] = useState(false);
@@ -1071,15 +1032,9 @@ const HotAndColdModal = ({
 
   const handleAddOwnHotTakeClick = useCallback(
     (e: React.MouseEvent) => {
-      if (!isUserHotTakesLoading && !canAddOwnHotTake) {
-        e.preventDefault();
-        displayToast(HOT_TAKE_LIMIT_REACHED_MESSAGE);
-        return;
-      }
-
       onRequestClose?.(e);
     },
-    [canAddOwnHotTake, displayToast, isUserHotTakesLoading, onRequestClose],
+    [onRequestClose],
   );
 
   const isCurrentTakeAnimating =

--- a/packages/shared/src/features/profile/components/hotTakes/ProfileUserHotTakes.spec.tsx
+++ b/packages/shared/src/features/profile/components/hotTakes/ProfileUserHotTakes.spec.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { NextRouter } from 'next/router';
+import { useRouter } from 'next/router';
+import type { PublicProfile } from '../../../../lib/user';
+import type { HotTake } from '../../../../graphql/user/userHotTake';
+import { useHotTakes } from '../../hooks/useHotTakes';
+import { useToastNotification } from '../../../../hooks/useToastNotification';
+import { usePrompt } from '../../../../hooks/usePrompt';
+import { useVoteHotTake } from '../../../../hooks/vote/useVoteHotTake';
+import { useLogContext } from '../../../../contexts/LogContext';
+import { LogEvent } from '../../../../lib/log';
+import { ProfileUserHotTakes } from './ProfileUserHotTakes';
+
+jest.mock('../../hooks/useHotTakes', () => ({
+  HOT_TAKE_LIMIT_REACHED_MESSAGE:
+    'You already have all 5 hot takes. Remove one to add a new one.',
+  useHotTakes: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useToastNotification', () => ({
+  useToastNotification: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/usePrompt', () => ({
+  usePrompt: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/vote/useVoteHotTake', () => ({
+  useVoteHotTake: jest.fn(),
+}));
+
+jest.mock('../../../../contexts/LogContext', () => ({
+  ...jest.requireActual('../../../../contexts/LogContext'),
+  useLogContext: jest.fn(),
+}));
+
+jest.mock('./HotTakeModal', () => ({
+  HotTakeModal: () => <div data-testid="hot-take-modal" />,
+}));
+
+jest.mock('./HotTakeItem', () => ({
+  HotTakeItem: ({ item }: { item: { title: string } }) => (
+    <div>{item.title}</div>
+  ),
+}));
+
+const mockedUseRouter = useRouter as jest.Mock;
+const mockedUseHotTakes = useHotTakes as jest.Mock;
+const mockedUseToastNotification = useToastNotification as jest.Mock;
+const mockedUsePrompt = usePrompt as jest.Mock;
+const mockedUseVoteHotTake = useVoteHotTake as jest.Mock;
+const mockedUseLogContext = useLogContext as jest.Mock;
+
+const user: PublicProfile = {
+  id: 'user-1',
+  name: 'Tester',
+  username: 'tester',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  premium: false,
+  image: '',
+  reputation: 0,
+  permalink: '/tester',
+};
+
+const createHotTake = (position: number): HotTake => ({
+  id: `take-${position}`,
+  emoji: '🔥',
+  title: `Hot take ${position}`,
+  subtitle: null,
+  position,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  upvotes: 0,
+  upvoted: false,
+});
+
+const mockRouter = (query: NextRouter['query'] = {}) => {
+  const replace = jest.fn();
+
+  mockedUseRouter.mockReturnValue({
+    query,
+    pathname: '/[userId]',
+    replace,
+  } as unknown as NextRouter);
+
+  return { replace };
+};
+
+describe('ProfileUserHotTakes', () => {
+  const displayToast = jest.fn();
+  const logEvent = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.history.pushState({}, '', '/tester');
+    mockRouter();
+    mockedUseToastNotification.mockReturnValue({
+      displayToast,
+      dismissToast: jest.fn(),
+    });
+    mockedUsePrompt.mockReturnValue({
+      showPrompt: jest.fn(),
+    });
+    mockedUseVoteHotTake.mockReturnValue({
+      toggleUpvote: jest.fn(),
+    });
+    mockedUseLogContext.mockReturnValue({
+      logEvent,
+    });
+    mockedUseHotTakes.mockReturnValue({
+      hotTakes: [],
+      isOwner: true,
+      canAddMore: true,
+      isLoading: false,
+      add: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    });
+  });
+
+  it('should open the add hot take modal from the profile query param', async () => {
+    window.history.pushState({}, '', '/tester?addHotTake=1#hot-takes');
+    const { replace } = mockRouter({
+      userId: 'tester',
+      addHotTake: '1',
+    });
+
+    render(<ProfileUserHotTakes user={user} />);
+
+    expect(await screen.findByTestId('hot-take-modal')).toBeVisible();
+    expect(logEvent).toHaveBeenCalledWith({
+      event_name: LogEvent.StartAddHotTake,
+    });
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/tester#hot-takes', undefined, {
+        shallow: true,
+      });
+    });
+  });
+
+  it('should show the limit toast from the profile query param when the user cannot add more', async () => {
+    window.history.pushState({}, '', '/tester?addHotTake=1#hot-takes');
+    const { replace } = mockRouter({
+      userId: 'tester',
+      addHotTake: '1',
+    });
+    mockedUseHotTakes.mockReturnValue({
+      hotTakes: Array.from({ length: 5 }, (_, index) =>
+        createHotTake(index + 1),
+      ),
+      isOwner: true,
+      canAddMore: false,
+      isLoading: false,
+      add: jest.fn(),
+      update: jest.fn(),
+      remove: jest.fn(),
+    });
+
+    render(<ProfileUserHotTakes user={user} />);
+
+    await waitFor(() => {
+      expect(displayToast).toHaveBeenCalledWith(
+        'You already have all 5 hot takes. Remove one to add a new one.',
+      );
+    });
+    expect(screen.queryByTestId('hot-take-modal')).not.toBeInTheDocument();
+    expect(replace).toHaveBeenCalledWith('/tester#hot-takes', undefined, {
+      shallow: true,
+    });
+  });
+});

--- a/packages/shared/src/features/profile/components/hotTakes/ProfileUserHotTakes.tsx
+++ b/packages/shared/src/features/profile/components/hotTakes/ProfileUserHotTakes.tsx
@@ -1,7 +1,11 @@
 import type { ReactElement } from 'react';
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
+import { useRouter } from 'next/router';
 import type { PublicProfile } from '../../../../lib/user';
-import { useHotTakes, MAX_HOT_TAKES } from '../../hooks/useHotTakes';
+import {
+  HOT_TAKE_LIMIT_REACHED_MESSAGE,
+  useHotTakes,
+} from '../../hooks/useHotTakes';
 import {
   Typography,
   TypographyType,
@@ -24,6 +28,11 @@ import { usePrompt } from '../../../../hooks/usePrompt';
 import { useVoteHotTake } from '../../../../hooks/vote/useVoteHotTake';
 import { useLogContext } from '../../../../contexts/LogContext';
 import { LogEvent, Origin } from '../../../../lib/log';
+import {
+  HOT_TAKES_ANCHOR,
+  isOpenAddHotTakeQuery,
+  OPEN_ADD_HOT_TAKE_QUERY_PARAM,
+} from './common';
 
 interface ProfileUserHotTakesProps {
   user: PublicProfile;
@@ -32,7 +41,8 @@ interface ProfileUserHotTakesProps {
 export function ProfileUserHotTakes({
   user,
 }: ProfileUserHotTakesProps): ReactElement | null {
-  const { hotTakes, isOwner, canAddMore, add, update, remove } =
+  const router = useRouter();
+  const { hotTakes, isOwner, canAddMore, add, update, remove, isLoading } =
     useHotTakes(user);
   const { displayToast } = useToastNotification();
   const { showPrompt } = usePrompt();
@@ -41,6 +51,7 @@ export function ProfileUserHotTakes({
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<HotTake | null>(null);
+  const handledOpenAddHotTakeQueryRef = useRef(false);
 
   const handleAdd = useCallback(
     async (input: AddHotTakeInput) => {
@@ -111,7 +122,7 @@ export function ProfileUserHotTakes({
 
   const handleOpenModal = useCallback(() => {
     if (!canAddMore) {
-      displayToast(`Maximum of ${MAX_HOT_TAKES} hot takes allowed`);
+      displayToast(HOT_TAKE_LIMIT_REACHED_MESSAGE);
       return;
     }
     logEvent({
@@ -119,6 +130,47 @@ export function ProfileUserHotTakes({
     });
     setIsModalOpen(true);
   }, [canAddMore, displayToast, logEvent]);
+
+  const clearOpenAddHotTakeQuery = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const url = new URL(window.location.href);
+    if (!url.searchParams.has(OPEN_ADD_HOT_TAKE_QUERY_PARAM)) {
+      return;
+    }
+
+    url.searchParams.delete(OPEN_ADD_HOT_TAKE_QUERY_PARAM);
+    router.replace(`${url.pathname}${url.search}${url.hash}`, undefined, {
+      shallow: true,
+    });
+  }, [router]);
+
+  const shouldOpenAddHotTakeFromQuery = isOpenAddHotTakeQuery(
+    router.query[OPEN_ADD_HOT_TAKE_QUERY_PARAM],
+  );
+
+  useEffect(() => {
+    if (!shouldOpenAddHotTakeFromQuery) {
+      handledOpenAddHotTakeQueryRef.current = false;
+      return;
+    }
+
+    if (handledOpenAddHotTakeQueryRef.current || isLoading || !isOwner) {
+      return;
+    }
+
+    handledOpenAddHotTakeQueryRef.current = true;
+    handleOpenModal();
+    clearOpenAddHotTakeQuery();
+  }, [
+    clearOpenAddHotTakeQuery,
+    handleOpenModal,
+    isLoading,
+    isOwner,
+    shouldOpenAddHotTakeFromQuery,
+  ]);
 
   const handleUpvote = useCallback(
     async (item: HotTake) => {
@@ -136,7 +188,7 @@ export function ProfileUserHotTakes({
   return (
     <div className="flex flex-col gap-4 py-4">
       {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
-      <a id="hot-takes" />
+      <a id={HOT_TAKES_ANCHOR} />
       <div className="flex items-center justify-between">
         <Typography
           type={TypographyType.Body}

--- a/packages/shared/src/features/profile/components/hotTakes/common.ts
+++ b/packages/shared/src/features/profile/components/hotTakes/common.ts
@@ -1,0 +1,14 @@
+import { webappUrl } from '../../../../lib/constants';
+
+export const HOT_TAKES_ANCHOR = 'hot-takes';
+export const OPEN_ADD_HOT_TAKE_QUERY_PARAM = 'addHotTake';
+export const OPEN_ADD_HOT_TAKE_QUERY_VALUE = '1';
+
+export const getAddHotTakeProfileUrl = (username: string): string =>
+  `${webappUrl}${username}?${OPEN_ADD_HOT_TAKE_QUERY_PARAM}=${OPEN_ADD_HOT_TAKE_QUERY_VALUE}#${HOT_TAKES_ANCHOR}`;
+
+export const isOpenAddHotTakeQuery = (
+  value: string | string[] | undefined,
+): boolean =>
+  value === OPEN_ADD_HOT_TAKE_QUERY_VALUE ||
+  (Array.isArray(value) && value.includes(OPEN_ADD_HOT_TAKE_QUERY_VALUE));

--- a/packages/shared/src/features/profile/hooks/useHotTakes.ts
+++ b/packages/shared/src/features/profile/hooks/useHotTakes.ts
@@ -19,6 +19,7 @@ import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
 
 export const MAX_HOT_TAKES = 5;
+export const HOT_TAKE_LIMIT_REACHED_MESSAGE = `You already have all ${MAX_HOT_TAKES} hot takes. Remove one to add a new one.`;
 
 export const useHotTakes = (user: PublicProfile | null) => {
   const queryClient = useQueryClient();

--- a/packages/shared/src/graphql/leaderboard.ts
+++ b/packages/shared/src/graphql/leaderboard.ts
@@ -31,6 +31,12 @@ export const LEADERBOARD_QUERY = gql`
         image
       }
     }
+  }
+  ${LEADERBOARD_FRAGMENT}
+`;
+
+export const POPULAR_HOT_TAKES_QUERY = gql`
+  query PopularHotTakes($limit: Int = 10) {
     popularHotTakes(limit: $limit) {
       score
       hotTake {
@@ -44,7 +50,6 @@ export const LEADERBOARD_QUERY = gql`
       }
     }
   }
-  ${LEADERBOARD_FRAGMENT}
 `;
 
 export enum LeaderboardType {

--- a/packages/webapp/__tests__/UsersLeaderboardStaticProps.spec.ts
+++ b/packages/webapp/__tests__/UsersLeaderboardStaticProps.spec.ts
@@ -6,6 +6,7 @@ import {
   LeaderboardType,
   MOST_QUESTS_COMPLETED_LIMIT,
   MOST_QUESTS_COMPLETED_QUERY,
+  POPULAR_HOT_TAKES_QUERY,
 } from '@dailydotdev/shared/src/graphql/leaderboard';
 import { getStaticProps as getUsersStaticProps } from '../pages/users';
 import { getStaticProps as getLeaderboardDetailStaticProps } from '../pages/users/[id]';
@@ -32,7 +33,6 @@ const baseLeaderboardResponse = {
   mostReadingDays: [],
   mostAchievementPoints: [],
   mostVerifiedUsers: [],
-  popularHotTakes: [],
 };
 
 const createMissingSchemaError = (message: string) => ({
@@ -50,6 +50,10 @@ describe('leaderboard static props', () => {
     mockRequest.mockImplementation((query: string) => {
       if (query === LEADERBOARD_QUERY) {
         return Promise.resolve(baseLeaderboardResponse);
+      }
+
+      if (query === POPULAR_HOT_TAKES_QUERY) {
+        return Promise.resolve({ popularHotTakes: [] });
       }
 
       if (query === HIGHEST_LEVEL_QUERY) {
@@ -101,6 +105,10 @@ describe('leaderboard static props', () => {
         return Promise.resolve(baseLeaderboardResponse);
       }
 
+      if (query === POPULAR_HOT_TAKES_QUERY) {
+        return Promise.resolve({ popularHotTakes: [] });
+      }
+
       if (query === HIGHEST_LEVEL_QUERY) {
         return Promise.resolve({ highestLevel });
       }
@@ -114,6 +122,36 @@ describe('leaderboard static props', () => {
       props: {
         highestLevel,
         isHighestLevelSupported: true,
+      },
+    });
+  });
+
+  it('should hide popular hot takes when API schema does not support it', async () => {
+    mockRequest.mockImplementation((query: string) => {
+      if (query === LEADERBOARD_QUERY) {
+        return Promise.resolve(baseLeaderboardResponse);
+      }
+
+      if (query === POPULAR_HOT_TAKES_QUERY) {
+        return Promise.reject(
+          createMissingSchemaError(
+            'Cannot query field "popularHotTakes" on type "Query".',
+          ),
+        );
+      }
+
+      if (query === HIGHEST_LEVEL_QUERY) {
+        return Promise.resolve({ highestLevel: [] });
+      }
+
+      return Promise.reject(new Error('Unexpected query'));
+    });
+
+    const result = await getUsersStaticProps();
+
+    expect(result).toMatchObject({
+      props: {
+        popularHotTakes: [],
       },
     });
   });

--- a/packages/webapp/pages/users.tsx
+++ b/packages/webapp/pages/users.tsx
@@ -7,6 +7,7 @@ import {
   HIGHEST_LEVEL_QUERY,
   LEADERBOARD_QUERY,
   LeaderboardType,
+  POPULAR_HOT_TAKES_QUERY,
 } from '@dailydotdev/shared/src/graphql/leaderboard';
 import { useRouter } from 'next/router';
 import { BreadCrumbs } from '@dailydotdev/shared/src/components/header';
@@ -53,6 +54,14 @@ const isHighestLevelSchemaMissing = (error: GraphQLError): boolean => {
       ({ message }) =>
         message?.includes('Cannot query field "highestLevel"') ||
         message?.includes('Cannot query field "level" on type "Leaderboard"'),
+    ) ?? false
+  );
+};
+
+const isPopularHotTakesSchemaMissing = (error: GraphQLError): boolean => {
+  return (
+    error?.response?.errors?.some(({ message }) =>
+      message?.includes('Cannot query field "popularHotTakes"'),
     ) ?? false
   );
 };
@@ -187,12 +196,27 @@ export async function getStaticProps(): Promise<
   GetStaticPropsResult<PageProps>
 > {
   try {
-    const res = await gqlClient.request<Omit<PageProps, 'highestLevel'>>(
-      LEADERBOARD_QUERY,
-    );
+    const res = await gqlClient.request<
+      Omit<PageProps, 'highestLevel' | 'popularHotTakes'>
+    >(LEADERBOARD_QUERY);
 
     let highestLevel: UserLeaderboard[] = [];
     let isHighestLevelSupported = false;
+    let popularHotTakes: PopularHotTakes[] = [];
+
+    try {
+      const hotTakesRes = await gqlClient.request<{
+        popularHotTakes: PopularHotTakes[];
+      }>(POPULAR_HOT_TAKES_QUERY, { limit: 10 });
+      popularHotTakes = hotTakesRes.popularHotTakes ?? [];
+    } catch (hotTakesError: unknown) {
+      const error = hotTakesError as GraphQLError;
+
+      if (!isPopularHotTakesSchemaMissing(error)) {
+        throw hotTakesError;
+      }
+    }
+
     try {
       const levelRes = await gqlClient.request<{
         highestLevel: UserLeaderboard[];
@@ -219,7 +243,7 @@ export async function getStaticProps(): Promise<
         highestLevel,
         isHighestLevelSupported,
         mostVerifiedUsers: res.mostVerifiedUsers,
-        popularHotTakes: res.popularHotTakes,
+        popularHotTakes,
       },
       revalidate: 3600,
     };


### PR DESCRIPTION
## Summary
- Route Hot Takes modal CTAs to the profile hot-takes section with addHotTake=1
- Open the add hot take modal from that query param and clear it after handling
- Show the max hot-take toast instead of navigating when the user cannot add more

## Tests
- NODE_ENV=test pnpm --filter @dailydotdev/shared exec jest src/components/modals/hotTakes/HotAndColdModal.spec.tsx src/features/profile/components/hotTakes/ProfileUserHotTakes.spec.tsx --runInBand
- node ./scripts/typecheck-strict-changed.js
- pnpm --filter @dailydotdev/shared exec eslint src/components/modals/hotTakes/HotAndColdModal.tsx src/components/modals/hotTakes/HotAndColdModal.spec.tsx src/features/profile/components/hotTakes/ProfileUserHotTakes.tsx src/features/profile/components/hotTakes/ProfileUserHotTakes.spec.tsx src/features/profile/components/hotTakes/common.ts src/features/profile/hooks/useHotTakes.ts --max-warnings 0

### Preview domain
https://codex-hot-take-modal-query.preview.app.daily.dev