### PR TITLE
fix: fall back to shared post title in ShareBar

### DIFF
--- a/packages/shared/src/components/ShareBar.spec.tsx
+++ b/packages/shared/src/components/ShareBar.spec.tsx
@@ -5,11 +5,11 @@ import React from 'react';
 import nock from 'nock';
 import { useRouter } from 'next/router';
 import ShareBar from './ShareBar';
-import Post from '../../__tests__/fixture/post';
+import Post, { sharePost } from '../../__tests__/fixture/post';
 import { AuthContextProvider } from '../contexts/AuthContext';
 import loggedUser from '../../__tests__/fixture/loggedUser';
 import { generateTestSquad } from '../../__tests__/fixture/squads';
-import { getFacebookShareLink } from '../lib/share';
+import { getFacebookShareLink, getTwitterShareLink } from '../lib/share';
 import { LazyModalElement } from './modals/LazyModalElement';
 import { NotificationsContextProvider } from '../contexts/NotificationsContext';
 
@@ -50,6 +50,7 @@ const manySquads = Array.from({ length: 5 }, (_, index) =>
 const renderComponent = (
   loggedIn = true,
   customSquads: typeof squads = squads,
+  post = defaultPost,
 ): RenderResult => {
   const client = new QueryClient();
 
@@ -66,7 +67,7 @@ const renderComponent = (
       >
         <NotificationsContextProvider>
           <LazyModalElement />
-          <ShareBar post={defaultPost} />
+          <ShareBar post={post} />
         </NotificationsContextProvider>
       </AuthContextProvider>
     </QueryClientProvider>,
@@ -132,6 +133,24 @@ describe('ShareBar Test Suite:', () => {
     await waitFor(() => {
       expect(mockWindowOpen).toHaveBeenCalledWith(
         getFacebookShareLink(defaultPost.commentsPermalink),
+        '_blank',
+      );
+    });
+  });
+
+  it('should fall back to shared post title on Twitter share when shared post has no title', async () => {
+    const sharedPostWithoutTitle = { ...sharePost, title: undefined };
+    renderComponent(true, squads, sharedPostWithoutTitle);
+    const btn = await screen.findByTestId('social-share-X');
+
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(mockWindowOpen).toHaveBeenCalledWith(
+        getTwitterShareLink(
+          sharedPostWithoutTitle.commentsPermalink,
+          sharePost.sharedPost!.title,
+        ),
         '_blank',
       );
     });

--- a/packages/shared/src/components/ShareBar.spec.tsx
+++ b/packages/shared/src/components/ShareBar.spec.tsx
@@ -139,18 +139,14 @@ describe('ShareBar Test Suite:', () => {
   });
 
   it('should fall back to shared post title on Twitter share when shared post has no title', async () => {
-    const sharedPostWithoutTitle = { ...sharePost, title: undefined };
-    renderComponent(true, squads, sharedPostWithoutTitle);
-    const btn = await screen.findByTestId('social-share-X');
+    const post = { ...sharePost, title: undefined };
+    renderComponent(true, squads, post);
 
-    fireEvent.click(btn);
+    fireEvent.click(await screen.findByTestId('social-share-X'));
 
     await waitFor(() => {
       expect(mockWindowOpen).toHaveBeenCalledWith(
-        getTwitterShareLink(
-          sharedPostWithoutTitle.commentsPermalink,
-          sharePost.sharedPost!.title,
-        ),
+        getTwitterShareLink(post.commentsPermalink, post.sharedPost!.title),
         '_blank',
       );
     });

--- a/packages/shared/src/components/ShareBar.tsx
+++ b/packages/shared/src/components/ShareBar.tsx
@@ -65,7 +65,7 @@ export default function ShareBar({ post }: ShareBarProps): ReactElement {
     const shareLink = getShareLink({
       provider,
       link: shortLink,
-      text: post?.title,
+      text: post?.title || post?.sharedPost?.title,
     });
     window.open(shareLink, '_blank');
   };


### PR DESCRIPTION
## Summary

For shared posts with no title (commentary), the post sidebar's share buttons were passing an undefined description to the Twitter/X share link (and other social providers). Now we fall back to the referenced post's title, matching the existing `post.title || post.sharedPost?.title` pattern used in `PostItemCard`, the squad moderation components, and `PostSEOSchema`.

## Changes

- `ShareBar.tsx`: `text: post?.title` → `text: post?.title || post?.sharedPost?.title`
- `ShareBar.spec.tsx`: added a regression test that mounts a shared post with `title: undefined` and asserts the Twitter share link is built with `sharedPost.title`

## Test plan

- [x] `pnpm --filter @dailydotdev/shared exec eslint` on changed files
- [x] `node scripts/typecheck-strict-changed.js`
- [x] `pnpm --filter @dailydotdev/shared exec jest src/components/ShareBar.spec.tsx` (7/7 pass)

Closes ENG-1532

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1532-feedback-bug-report-des.preview.app.daily.dev