### PR TITLE
feat: apply feed v2 highlights by default

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -27,13 +27,13 @@ import {
   ANONYMOUS_FEED_QUERY,
   baseFeedSupportedTypes,
   CUSTOM_FEED_QUERY,
+  feedV2SupportedTypes,
   FEED_BY_TAGS_QUERY,
   FEED_V2_QUERY,
   FOLLOWING_FEED_QUERY,
   MOST_DISCUSSED_FEED_QUERY,
   MOST_UPVOTED_FEED_QUERY,
   SEARCH_POSTS_QUERY,
-  getFeedV2SupportedTypes,
 } from '../graphql/feed';
 import { generateQueryKey, OtherFeedPage, RequestKey } from '../lib/query';
 import SettingsContext from '../contexts/SettingsContext';
@@ -61,7 +61,6 @@ import {
   discussedFeedVersion,
   feature,
   featureFeedTagChips,
-  featureFeedV2Highlights,
   followingFeedVersion,
   latestFeedVersion,
   popularFeedVersion,
@@ -322,16 +321,6 @@ export default function MainFeedLayout({
     feature: customFeedVersion,
     shouldEvaluate: feedName === SharedFeedPage.Custom,
   });
-  const shouldEvaluateFeedV2Highlights =
-    !!user &&
-    ((feedName === SharedFeedPage.MyFeed && !isCustomDefaultFeed) ||
-      feedName === SharedFeedPage.Search ||
-      (feedName === SharedFeedPage.CustomForm &&
-        router.query?.slugOrId === user?.id));
-  const { value: isFeedV2HighlightsEnabled } = useConditionalFeature({
-    feature: featureFeedV2Highlights,
-    shouldEvaluate: shouldEvaluateFeedV2Highlights,
-  });
 
   const isChipStripPage =
     router.pathname === '/' || router.pathname === '/explore/[tag]';
@@ -424,8 +413,7 @@ export default function MainFeedLayout({
       dynamicFeedConfig?.query || feedConfig.query,
       dynamicFeedConfig?.queryIfLogged || feedConfig.queryIfLogged || null,
     );
-    const shouldRequestFeedV2Highlights =
-      query === FEED_V2_QUERY && isFeedV2HighlightsEnabled;
+    const shouldRequestFeedV2Highlights = query === FEED_V2_QUERY;
 
     return {
       requestKey: feedConfig.requestKey,
@@ -435,7 +423,7 @@ export default function MainFeedLayout({
         ...dynamicFeedConfig?.variables,
         ...(shouldRequestFeedV2Highlights
           ? {
-              supportedTypes: getFeedV2SupportedTypes(true),
+              supportedTypes: feedV2SupportedTypes,
               highlightsLimit: FEED_V2_HIGHLIGHTS_LIMIT,
             }
           : {}),
@@ -460,7 +448,6 @@ export default function MainFeedLayout({
     customFeedV,
     tokenRefreshed,
     feedVersion,
-    isFeedV2HighlightsEnabled,
   ]);
 
   const [selectedAlgo, setSelectedAlgo, loadedAlgo] = usePersistentContext(

--- a/packages/shared/src/graphql/feed.spec.ts
+++ b/packages/shared/src/graphql/feed.spec.ts
@@ -3,7 +3,7 @@ import {
   baseFeedSupportedTypes,
   FEED_V2_HIGHLIGHTS_LIMIT,
   FEED_V2_QUERY,
-  getFeedV2SupportedTypes,
+  feedV2SupportedTypes,
   normalizeFeedPage,
 } from './feed';
 
@@ -20,9 +20,8 @@ describe('normalizeFeedPage', () => {
     expect(FEED_V2_HIGHLIGHTS_LIMIT).toBe(5);
   });
 
-  it('should add highlight to feedV2 supported types only when enabled', () => {
-    expect(getFeedV2SupportedTypes(false)).toEqual(baseFeedSupportedTypes);
-    expect(getFeedV2SupportedTypes(true)).toEqual([
+  it('should always include highlight in feedV2 supported types', () => {
+    expect(feedV2SupportedTypes).toEqual([
       ...baseFeedSupportedTypes,
       'highlight',
     ]);

--- a/packages/shared/src/graphql/feed.ts
+++ b/packages/shared/src/graphql/feed.ts
@@ -36,12 +36,7 @@ const joinedTypes = baseFeedSupportedTypes.join('","');
 export const SUPPORTED_TYPES = `$supportedTypes: [String!] = ["${joinedTypes}"]`;
 export const FEED_V2_HIGHLIGHTS_LIMIT = 5;
 
-export const getFeedV2SupportedTypes = (
-  shouldSupportHighlights: boolean,
-): string[] =>
-  shouldSupportHighlights
-    ? [...baseFeedSupportedTypes, 'highlight']
-    : [...baseFeedSupportedTypes];
+export const feedV2SupportedTypes = [...baseFeedSupportedTypes, 'highlight'];
 
 export interface FeedData {
   page: Connection<Post>;

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -32,7 +32,6 @@ export const upvotedFeedVersion = new Feature('upvoted_feed_version', 2);
 export const discussedFeedVersion = new Feature('discussed_feed_version', 2);
 export const latestFeedVersion = new Feature('latest_feed_version', 2);
 export const customFeedVersion = new Feature('custom_feed_version', 2);
-export const featureFeedV2Highlights = new Feature('feed_v2_highlights', false);
 export const featurePostPageHighlights = new Feature(
   'post_page_highlights',
   false,


### PR DESCRIPTION
## Summary
- Removed the `feed_v2_highlights` feature flag definition and usage.
- Made the feedV2 highlights treatment permanent by requesting highlight support for every `FEED_V2_QUERY`.
- Simplified feedV2 supported type handling to a fixed `feedV2SupportedTypes` list.

## Key Decisions
- Treated `FEED_V2_QUERY` as the activation point instead of preserving the old flag eligibility gate.
- Kept focused existing feed query and rendering coverage rather than adding broad layout mocks.

## Verification
- `git diff --check origin/main...HEAD`
- `pnpm --filter @dailydotdev/shared exec eslint src/components/MainFeedLayout.tsx src/graphql/feed.ts src/graphql/feed.spec.ts src/lib/featureManagement.ts --max-warnings 0`
- `node ./scripts/typecheck-strict-changed.js`
- `NODE_ENV=test pnpm --filter @dailydotdev/shared exec jest src/graphql/feed.spec.ts src/components/Feed.spec.tsx --runInBand`

Linear: https://linear.app/dailydev/issue/ENG-1575/remove-feed-v2-highlights-feature-flag-apply-treatment

Closes ENG-1575

---
Created by Huginn 🐦‍⬛


### Preview domain
https://eng-1575-remove-feed-v2-highligh.preview.app.daily.dev