### PR TITLE
fix(header): keep profile-completion dot visible inside the stats pill

### DIFF
--- a/packages/shared/src/components/profile/ProfileButton.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.tsx
@@ -3,8 +3,8 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
 import { useAuthContext } from '../../contexts/AuthContext';
-import { ProfilePictureWithIndicator } from './ProfilePictureWithIndicator';
-import { ProfileImageSize } from '../ProfilePicture';
+import { ProfileImageSize, ProfilePicture } from '../ProfilePicture';
+import { useProfileCompletionIndicator } from '../../hooks/profile/useProfileCompletionIndicator';
 import { CoreIcon, ReputationIcon, SettingsIcon } from '../icons';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { IconSize } from '../Icon';
@@ -37,6 +37,7 @@ export default function ProfileButton({
 }: ProfileButtonProps): ReactElement {
   const { isOpen, onUpdate, wrapHandler } = useInteractivePopup();
   const { user, isAuthReady } = useAuthContext();
+  const { showIndicator } = useProfileCompletionIndicator();
   const { streak, isLoading, isStreaksEnabled } = useReadingStreak();
   const hasCoresAccess = useHasAccessToCores();
   const [animatedCores, setAnimatedCores] = useState<number | null>(null);
@@ -208,77 +209,85 @@ export default function ProfileButton({
           icon={<SettingsIcon />}
         />
       ) : (
-        <div className="flex h-10 items-stretch overflow-hidden rounded-12 border border-border-subtlest-tertiary bg-surface-float">
-          {isStreaksEnabled && streak && (
-            <ReadingStreakButton
-              streak={streak}
-              isLoading={isLoading}
-              compact
-              className="!h-full !rounded-none !pl-1.5 !pr-2"
+        <div className="relative">
+          <div className="flex h-10 items-stretch overflow-hidden rounded-12 border border-border-subtlest-tertiary bg-surface-float">
+            {isStreaksEnabled && streak && (
+              <ReadingStreakButton
+                streak={streak}
+                isLoading={isLoading}
+                compact
+                className="!h-full !rounded-none !pl-1.5 !pr-2"
+              />
+            )}
+            {hasCoresAccess && (
+              <Tooltip
+                content={
+                  <>
+                    Wallet
+                    <br />
+                    {preciseBalance} Cores
+                  </>
+                }
+              >
+                <div
+                  ref={coresCounterRef}
+                  className="flex origin-center justify-center will-change-transform"
+                >
+                  <Link href={walletUrl} passHref>
+                    <Button
+                      data-reward-target={QuestRewardType.Cores}
+                      icon={<CoreIcon />}
+                      tag="a"
+                      variant={ButtonVariant.Tertiary}
+                      size={ButtonSize.Small}
+                      className="!h-full !rounded-none !pl-1.5 !pr-2"
+                    >
+                      {largeNumberFormat(displayedBalance)}
+                    </Button>
+                  </Link>
+                </div>
+              </Tooltip>
+            )}
+            <Tooltip side="bottom" content="Profile settings">
+              <Button
+                type="button"
+                aria-label="Profile settings"
+                icon={
+                  <ReputationIcon
+                    className="text-accent-onion-default"
+                    size={IconSize.Medium}
+                  />
+                }
+                variant={ButtonVariant.Tertiary}
+                size={ButtonSize.Small}
+                className={classNames(
+                  '!h-full !gap-0 !rounded-none !pl-0.5 !pr-0',
+                  className,
+                )}
+                onClick={wrapHandler(() => onUpdate(!isOpen))}
+              >
+                <span
+                  ref={reputationCounterRef}
+                  data-reward-target={QuestRewardType.Reputation}
+                  className="inline-flex origin-center items-center will-change-transform"
+                >
+                  {largeNumberFormat(displayedReputation ?? 0)}
+                </span>
+                <ProfilePicture
+                  user={user}
+                  size={ProfileImageSize.Large}
+                  className="ml-2 !h-9 !w-9 !rounded-10"
+                  nativeLazyLoading
+                />
+              </Button>
+            </Tooltip>
+          </div>
+          {showIndicator && (
+            <div
+              aria-hidden
+              className="pointer-events-none absolute -bottom-1 right-[31px] size-3 rounded-full bg-accent-cheese-default"
             />
           )}
-          {hasCoresAccess && (
-            <Tooltip
-              content={
-                <>
-                  Wallet
-                  <br />
-                  {preciseBalance} Cores
-                </>
-              }
-            >
-              <div
-                ref={coresCounterRef}
-                className="flex origin-center justify-center will-change-transform"
-              >
-                <Link href={walletUrl} passHref>
-                  <Button
-                    data-reward-target={QuestRewardType.Cores}
-                    icon={<CoreIcon />}
-                    tag="a"
-                    variant={ButtonVariant.Tertiary}
-                    size={ButtonSize.Small}
-                    className="!h-full !rounded-none !pl-1.5 !pr-2"
-                  >
-                    {largeNumberFormat(displayedBalance)}
-                  </Button>
-                </Link>
-              </div>
-            </Tooltip>
-          )}
-          <Tooltip side="bottom" content="Profile settings">
-            <Button
-              type="button"
-              aria-label="Profile settings"
-              icon={
-                <ReputationIcon
-                  className="text-accent-onion-default"
-                  size={IconSize.Medium}
-                />
-              }
-              variant={ButtonVariant.Tertiary}
-              size={ButtonSize.Small}
-              className={classNames(
-                '!h-full !gap-0 !rounded-none !pl-0.5 !pr-0',
-                className,
-              )}
-              onClick={wrapHandler(() => onUpdate(!isOpen))}
-            >
-              <span
-                ref={reputationCounterRef}
-                data-reward-target={QuestRewardType.Reputation}
-                className="inline-flex origin-center items-center will-change-transform"
-              >
-                {largeNumberFormat(displayedReputation ?? 0)}
-              </span>
-              <ProfilePictureWithIndicator
-                user={user}
-                size={ProfileImageSize.Large}
-                className="!h-9 !w-9 !rounded-10"
-                wrapperClassName="relative ml-2"
-              />
-            </Button>
-          </Tooltip>
         </div>
       )}
       {isOpen && <ProfileMenu onClose={() => onUpdate(false)} />}

--- a/packages/shared/src/components/streak/ReadingStreakButton.tsx
+++ b/packages/shared/src/components/streak/ReadingStreakButton.tsx
@@ -122,18 +122,30 @@ export function ReadingStreakButton({
           type="button"
           iconPosition={iconPosition}
           icon={
-            <IconWrapper
-              size={compact ? IconSize.XSmall : undefined}
-              wrapperClassName={classnames(
-                'relative flex items-center gap-2',
-                compact && 'h-6 w-6 justify-center',
-              )}
-            >
-              <ReadingStreakIcon secondary={hasReadToday} />
-              {!isTimezoneOk && (
-                <WarningIcon className="!mr-0 text-raw-cheese-40" secondary />
-              )}
-            </IconWrapper>
+            compact ? (
+              <div className="relative flex h-6 w-6 items-center justify-center">
+                <IconWrapper
+                  size={IconSize.XSmall}
+                  wrapperClassName="flex h-full w-full items-center justify-center"
+                >
+                  <ReadingStreakIcon secondary={hasReadToday} />
+                </IconWrapper>
+                {!isTimezoneOk && (
+                  <WarningIcon
+                    size={IconSize.Size16}
+                    className="!absolute -bottom-1.5 -left-1.5 text-raw-cheese-40"
+                    secondary
+                  />
+                )}
+              </div>
+            ) : (
+              <IconWrapper wrapperClassName="relative flex items-center gap-2">
+                <ReadingStreakIcon secondary={hasReadToday} />
+                {!isTimezoneOk && (
+                  <WarningIcon className="!mr-0 text-raw-cheese-40" secondary />
+                )}
+              </IconWrapper>
+            )
           }
           variant={
             compact || isLaptop || isMobile


### PR DESCRIPTION
## Summary
Follow-up to #6106. The stats pill uses \`overflow-hidden\` so the hover backgrounds round cleanly at the pill's \`rounded-12\` corners. That same clip was hiding the bottom half of the yellow profile-completion indicator that \`ProfilePictureWithIndicator\` positions half outside the avatar via \`translate-y-1/2\`.

This PR:
- Renders \`ProfilePicture\` directly inside the combined profile \`Button\` (no \`ProfilePictureWithIndicator\` wrapper).
- Wraps the pill in a \`relative\` outer container.
- Lifts the indicator dot out to a sibling of the pill, absolute-positioned at \`right-[31px] -bottom-1\` so it lands at the same visual spot as the avatar's bottom-left corner — without being affected by the pill's overflow clip.

Reported via in-app feedback (Linear).

## Test plan
- [ ] As a user whose profile is incomplete, open the webapp and confirm the yellow dot appears fully at the bottom-left of the avatar inside the header stats pill.
- [ ] As a user with a completed profile, confirm no dot is shown.
- [ ] Confirm clicking the avatar/reputation still opens the profile menu and the streak / cores hover states still fill their slots cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-fix-profile-indicator-cli.preview.app.daily.dev