### PR TITLE
feat(highlights): add 'All' tab to the highlights page

### DIFF
--- a/packages/shared/src/components/highlights/HighlightsPage.tsx
+++ b/packages/shared/src/components/highlights/HighlightsPage.tsx
@@ -44,12 +44,6 @@ const useChannelHighlights = (channel: string | undefined) =>
     enabled: !!channel,
   });
 
-const useAllHighlights = (enabled: boolean) =>
-  useQuery({
-    ...postHighlightsFeedQueryOptions(),
-    enabled,
-  });
-
 interface HighlightFeedListProps {
   highlights: PostHighlightFeed[];
   loading: boolean;
@@ -140,17 +134,19 @@ const AllHighlightsTab = ({
   active: boolean;
   expandedId?: string;
 }): ReactElement => {
-  const { data, isFetching } = useAllHighlights(active);
+  const { data, isFetching } = useQuery({
+    ...postHighlightsFeedQueryOptions(),
+    enabled: active,
+  });
   const highlights = useMemo(
     () => data?.postHighlightsFeed?.edges?.map((edge) => edge.node) ?? [],
     [data],
   );
-  const loading = isFetching && !data;
 
   return (
     <HighlightFeedList
       highlights={highlights}
-      loading={loading}
+      loading={isFetching && !data}
       expandedId={expandedId}
     />
   );
@@ -170,16 +166,10 @@ export const HighlightsPage = (): ReactElement => {
   );
   const majorLoading = isFetching && !data;
 
-  let activeTab: string;
-  if (isAllTab) {
-    activeTab = ALL_HIGHLIGHTS_LABEL;
-  } else if (channel) {
-    activeTab =
-      channels.find((c) => c.channel === channel)?.displayName ??
-      MAJOR_HEADLINES_LABEL;
-  } else {
-    activeTab = MAJOR_HEADLINES_LABEL;
-  }
+  const channelLabel = channels.find((c) => c.channel === channel)?.displayName;
+  const activeTab = isAllTab
+    ? ALL_HIGHLIGHTS_LABEL
+    : channelLabel ?? MAJOR_HEADLINES_LABEL;
 
   return (
     <main className="mx-auto flex w-full max-w-2xl flex-col pb-8 laptop:min-h-page laptop:border-x laptop:border-border-subtlest-tertiary">

--- a/packages/shared/src/components/highlights/HighlightsPage.tsx
+++ b/packages/shared/src/components/highlights/HighlightsPage.tsx
@@ -9,14 +9,17 @@ import type {
 import {
   channelHighlightsFeedQueryOptions,
   highlightsPageQueryOptions,
+  postHighlightsFeedQueryOptions,
 } from '../../graphql/highlights';
 import { Tab, TabContainer } from '../tabs/TabContainer';
 import { DigestCTA } from './DigestCTA';
 import { HighlightItem } from './HighlightItem';
 
 const MAJOR_HEADLINES_LABEL = 'Headlines';
+const ALL_HIGHLIGHTS_LABEL = 'All';
 const SKELETON_COUNT = 5;
 const HIGHLIGHTS_BASE_URL = '/highlights';
+const ALL_HIGHLIGHTS_URL = `${HIGHLIGHTS_BASE_URL}/all`;
 
 const HighlightSkeleton = (): ReactElement => (
   <div className="flex flex-col gap-1 px-4 py-3">
@@ -39,6 +42,12 @@ const useChannelHighlights = (channel: string | undefined) =>
   useQuery({
     ...channelHighlightsFeedQueryOptions(channel ?? ''),
     enabled: !!channel,
+  });
+
+const useAllHighlights = (enabled: boolean) =>
+  useQuery({
+    ...postHighlightsFeedQueryOptions(),
+    enabled,
   });
 
 interface HighlightFeedListProps {
@@ -124,10 +133,34 @@ const ChannelTab = ({
   );
 };
 
+const AllHighlightsTab = ({
+  active,
+  expandedId,
+}: {
+  active: boolean;
+  expandedId?: string;
+}): ReactElement => {
+  const { data, isFetching } = useAllHighlights(active);
+  const highlights = useMemo(
+    () => data?.postHighlightsFeed?.edges?.map((edge) => edge.node) ?? [],
+    [data],
+  );
+  const loading = isFetching && !data;
+
+  return (
+    <HighlightFeedList
+      highlights={highlights}
+      loading={loading}
+      expandedId={expandedId}
+    />
+  );
+};
+
 export const HighlightsPage = (): ReactElement => {
   const router = useRouter();
   const channel = getSingleQueryParam(router.query.channel);
   const expandedId = getSingleQueryParam(router.query.highlight);
+  const isAllTab = router.pathname === ALL_HIGHLIGHTS_URL;
   const { data, isFetching } = useQuery(highlightsPageQueryOptions());
 
   const channels = data?.channelConfigurations ?? [];
@@ -137,9 +170,16 @@ export const HighlightsPage = (): ReactElement => {
   );
   const majorLoading = isFetching && !data;
 
-  const activeTab =
-    channels.find((c) => c.channel === channel)?.displayName ??
-    MAJOR_HEADLINES_LABEL;
+  let activeTab: string;
+  if (isAllTab) {
+    activeTab = ALL_HIGHLIGHTS_LABEL;
+  } else if (channel) {
+    activeTab =
+      channels.find((c) => c.channel === channel)?.displayName ??
+      MAJOR_HEADLINES_LABEL;
+  } else {
+    activeTab = MAJOR_HEADLINES_LABEL;
+  }
 
   return (
     <main className="mx-auto flex w-full max-w-2xl flex-col pb-8 laptop:min-h-page laptop:border-x laptop:border-border-subtlest-tertiary">
@@ -171,6 +211,9 @@ export const HighlightsPage = (): ReactElement => {
               loading={majorLoading}
               expandedId={expandedId}
             />
+          </Tab>,
+          <Tab key="all" label={ALL_HIGHLIGHTS_LABEL} url={ALL_HIGHLIGHTS_URL}>
+            <AllHighlightsTab active={isAllTab} expandedId={expandedId} />
           </Tab>,
           ...channels.map((ch) => (
             <Tab

--- a/packages/shared/src/graphql/highlights.ts
+++ b/packages/shared/src/graphql/highlights.ts
@@ -19,6 +19,7 @@ export interface PostHighlightFeed {
   channel: string;
   headline: string;
   highlightedAt: string;
+  significance?: string | null;
   post: {
     id: string;
     type: string;
@@ -109,6 +110,7 @@ export const POST_HIGHLIGHT_FEED_FRAGMENT = gql`
     channel
     headline
     highlightedAt
+    significance
     post {
       id
       type
@@ -140,6 +142,82 @@ export const POST_HIGHLIGHTS_FEED_QUERY = gql`
   }
   ${POST_HIGHLIGHT_FEED_FRAGMENT}
 `;
+
+export type PostHighlightSignificance =
+  | 'breaking'
+  | 'major'
+  | 'notable'
+  | 'routine';
+
+export interface PostHighlightsFeedPageData {
+  postHighlightsFeed: Connection<PostHighlightFeed>;
+}
+
+interface PostHighlightsFeedQueryArgs {
+  channel?: string;
+  significance?: PostHighlightSignificance[];
+  first?: number;
+  after?: string;
+}
+
+export const POST_HIGHLIGHTS_FEED_PAGE_QUERY = gql`
+  query PostHighlightsFeedPage(
+    $channel: String
+    $significance: [String!]
+    $first: Int
+    $after: String
+  ) {
+    postHighlightsFeed(
+      channel: $channel
+      significance: $significance
+      first: $first
+      after: $after
+    ) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      edges {
+        node {
+          ...PostHighlightFeedCard
+        }
+      }
+    }
+  }
+  ${POST_HIGHLIGHT_FEED_FRAGMENT}
+`;
+
+export const getPostHighlightsFeedQueryKey = ({
+  channel,
+  significance,
+}: Pick<PostHighlightsFeedQueryArgs, 'channel' | 'significance'>) => [
+  'post-highlights-feed',
+  channel ?? '',
+  [...(significance ?? [])].sort().join(','),
+];
+
+export const postHighlightsFeedQueryOptions = ({
+  channel,
+  significance,
+  first = MAJOR_HEADLINES_MAX_FIRST,
+  after,
+}: PostHighlightsFeedQueryArgs = {}) => ({
+  queryKey: [
+    ...getPostHighlightsFeedQueryKey({ channel, significance }),
+    first,
+  ],
+  queryFn: () =>
+    gqlClient.request<PostHighlightsFeedPageData>(
+      POST_HIGHLIGHTS_FEED_PAGE_QUERY,
+      {
+        channel: channel ?? null,
+        significance: significance ?? null,
+        first,
+        after,
+      },
+    ),
+  staleTime: ONE_MINUTE,
+});
 
 export interface ChannelDigestConfiguration {
   frequency: string;

--- a/packages/shared/src/graphql/highlights.ts
+++ b/packages/shared/src/graphql/highlights.ts
@@ -149,18 +149,11 @@ export type PostHighlightSignificance =
   | 'notable'
   | 'routine';
 
-export interface PostHighlightsFeedPageData {
+interface PostHighlightsFeedPageData {
   postHighlightsFeed: Connection<PostHighlightFeed>;
 }
 
-interface PostHighlightsFeedQueryArgs {
-  channel?: string;
-  significance?: PostHighlightSignificance[];
-  first?: number;
-  after?: string;
-}
-
-export const POST_HIGHLIGHTS_FEED_PAGE_QUERY = gql`
+const POST_HIGHLIGHTS_FEED_PAGE_QUERY = gql`
   query PostHighlightsFeedPage(
     $channel: String
     $significance: [String!]
@@ -187,24 +180,23 @@ export const POST_HIGHLIGHTS_FEED_PAGE_QUERY = gql`
   ${POST_HIGHLIGHT_FEED_FRAGMENT}
 `;
 
-export const getPostHighlightsFeedQueryKey = ({
-  channel,
-  significance,
-}: Pick<PostHighlightsFeedQueryArgs, 'channel' | 'significance'>) => [
-  'post-highlights-feed',
-  channel ?? '',
-  [...(significance ?? [])].sort().join(','),
-];
-
 export const postHighlightsFeedQueryOptions = ({
   channel,
   significance,
   first = MAJOR_HEADLINES_MAX_FIRST,
   after,
-}: PostHighlightsFeedQueryArgs = {}) => ({
+}: {
+  channel?: string;
+  significance?: PostHighlightSignificance[];
+  first?: number;
+  after?: string;
+} = {}) => ({
   queryKey: [
-    ...getPostHighlightsFeedQueryKey({ channel, significance }),
+    'post-highlights-feed',
+    channel ?? '',
+    [...(significance ?? [])].sort().join(','),
     first,
+    after ?? '',
   ],
   queryFn: () =>
     gqlClient.request<PostHighlightsFeedPageData>(

--- a/packages/webapp/pages/highlights/all.tsx
+++ b/packages/webapp/pages/highlights/all.tsx
@@ -1,0 +1,64 @@
+import type { GetStaticPropsResult } from 'next';
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { DehydratedState } from '@tanstack/react-query';
+import { dehydrate, QueryClient } from '@tanstack/react-query';
+import {
+  highlightsPageQueryOptions,
+  postHighlightsFeedQueryOptions,
+} from '@dailydotdev/shared/src/graphql/highlights';
+import { HighlightsPage } from '@dailydotdev/shared/src/components/highlights/HighlightsPage';
+import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
+import { getLayout } from '../../components/layouts/MainLayout';
+import { defaultOpenGraph, defaultSeo } from '../../next-seo';
+
+const HIGHLIGHTS_TITLE = 'All highlights | daily.dev';
+const HIGHLIGHTS_DESCRIPTION =
+  'Every highlight across the developer ecosystem in one place. Browse the most recent stories from every channel, newest first.';
+
+const AllHighlightsPage = (): ReactElement => <HighlightsPage />;
+
+const getHighlightsLayout: typeof getLayout = (...props) =>
+  getFooterNavBarLayout(getLayout(...props));
+
+AllHighlightsPage.getLayout = getHighlightsLayout;
+AllHighlightsPage.layoutProps = {
+  screenCentered: false,
+  seo: {
+    title: HIGHLIGHTS_TITLE,
+    description: HIGHLIGHTS_DESCRIPTION,
+    canonical: 'https://app.daily.dev/highlights/all',
+    openGraph: {
+      ...defaultOpenGraph,
+      title: HIGHLIGHTS_TITLE,
+      description: HIGHLIGHTS_DESCRIPTION,
+      url: 'https://app.daily.dev/highlights/all',
+      type: 'website',
+    },
+    ...defaultSeo,
+  },
+};
+
+export default AllHighlightsPage;
+
+interface AllHighlightsPageProps {
+  dehydratedState: DehydratedState;
+}
+
+export async function getStaticProps(): Promise<
+  GetStaticPropsResult<AllHighlightsPageProps>
+> {
+  const queryClient = new QueryClient();
+
+  await Promise.all([
+    queryClient.prefetchQuery(highlightsPageQueryOptions()),
+    queryClient.prefetchQuery(postHighlightsFeedQueryOptions()),
+  ]);
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+    revalidate: 60,
+  };
+}


### PR DESCRIPTION
## Summary

Adds an "All" tab after "Headlines" on `/highlights` that lists every highlight across channels, deduplicated by post and ordered by recency.

- New static page `pages/highlights/all.tsx` so the tab has its own URL (`/highlights/all`) that survives hard refresh and is prefetched at build time.
- Wired to the new backend `postHighlightsFeed` endpoint via `postHighlightsFeedQueryOptions`. The endpoint accepts optional `channel` and `significance` filters, so the same query can eventually replace `majorHeadlines` and per-channel `postHighlights`.
- The All tab's fetch is gated on `enabled: active` so it doesn't fire while the user is on another tab.

## Key decisions

- Picked a dedicated static route (`/highlights/all`) over a query-param so Next.js prefetches the data and the URL is shareable. Static routes win over `[channel].tsx` in routing, so no guard needed there.
- Added `significance` to `PostHighlightFeedCard` fragment now that it's a real field; the existing UI doesn't render it yet but the data is available.
- Kept `MajorHeadlinesTab` and `ChannelTab` untouched — they still hit their existing endpoints. Migration to `postHighlightsFeed` can happen incrementally.

## Test plan

- [ ] Visit `/highlights` — Headlines tab renders as before, new All tab appears second
- [ ] Click All — URL becomes `/highlights/all`, list shows newest highlights across all channels
- [ ] Hard-refresh on `/highlights/all` — page loads, All tab stays active
- [ ] Click a channel tab — All tab does not fire its query in the network panel
- [ ] Navigate to `/highlights/{channel}?highlight={id}` — expanded item still scrolls into view

Closes ENG-1590

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1590-add-all-tab-in-the-high.preview.app.daily.dev