### PR TITLE
feat(squads): reveal favorite star on row hover (desktop)

### DIFF
--- a/packages/shared/src/components/cards/squad/SquadList.tsx
+++ b/packages/shared/src/components/cards/squad/SquadList.tsx
@@ -40,7 +40,7 @@ export const SquadList = ({
   return (
     <div
       {...attrs}
-      className="relative flex flex-row items-center gap-4"
+      className="group/squad-row relative flex flex-row items-center gap-4"
       ref={ad ? ref : undefined}
     >
       <Link

--- a/packages/shared/src/components/sidebar/sections/NetworkSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/NetworkSection.tsx
@@ -43,6 +43,7 @@ export const NetworkSection = ({
             ),
           title: name,
           path: `${webappUrl}squads/${handle}`,
+          itemClassName: 'group/squad-row',
           rightIcon: () => <SquadFavoriteButton squad={squad} />,
         };
       }) ?? [];

--- a/packages/shared/src/components/squads/SquadFavoriteButton.spec.tsx
+++ b/packages/shared/src/components/squads/SquadFavoriteButton.spec.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SquadFavoriteButton } from './SquadFavoriteButton';
+import { useSquadFavorite } from '../../hooks/squads/useSquadFavorite';
+import { generateTestSquad } from '../../../__tests__/fixture/squads';
+import type { Squad } from '../../graphql/sources';
+
+jest.mock('../../hooks/squads/useSquadFavorite', () => ({
+  useSquadFavorite: jest.fn(),
+}));
+
+const toggleFavorite = jest.fn();
+
+const renderButton = (overrides: Partial<Squad> = {}) =>
+  render(<SquadFavoriteButton squad={generateTestSquad(overrides)} />);
+
+describe('SquadFavoriteButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useSquadFavorite).mockReturnValue({
+      toggleFavorite,
+      isPending: false,
+    });
+  });
+
+  it('renders an unpressed star with the correct aria label when not favorited', () => {
+    renderButton({ favoritedAt: null });
+
+    const button = screen.getByRole('button', { name: 'Favorite squad' });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('renders a pressed star with the unfavorite aria label when favorited', () => {
+    renderButton({ favoritedAt: '2025-01-01T00:00:00.000Z' });
+
+    const button = screen.getByRole('button', { name: 'Unfavorite squad' });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('calls toggleFavorite with the squad when clicked', async () => {
+    const squad = generateTestSquad({ favoritedAt: null });
+    render(<SquadFavoriteButton squad={squad} />);
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Favorite squad' }),
+    );
+
+    expect(toggleFavorite).toHaveBeenCalledWith(squad);
+  });
+
+  it('applies hover-reveal classes when the squad is not favorited', () => {
+    renderButton({ favoritedAt: null });
+
+    const button = screen.getByRole('button', { name: 'Favorite squad' });
+    expect(button).toHaveClass('laptop:opacity-0');
+    expect(button).toHaveClass('laptop:group-hover/squad-row:opacity-100');
+    expect(button).toHaveClass(
+      'laptop:group-focus-within/squad-row:opacity-100',
+    );
+  });
+
+  it('does not apply hover-reveal classes when the squad is already favorited', () => {
+    renderButton({ favoritedAt: '2025-01-01T00:00:00.000Z' });
+
+    const button = screen.getByRole('button', { name: 'Unfavorite squad' });
+    expect(button).not.toHaveClass('laptop:opacity-0');
+    expect(button).not.toHaveClass('laptop:group-hover/squad-row:opacity-100');
+    expect(button).not.toHaveClass(
+      'laptop:group-focus-within/squad-row:opacity-100',
+    );
+  });
+});

--- a/packages/shared/src/components/squads/SquadFavoriteButton.tsx
+++ b/packages/shared/src/components/squads/SquadFavoriteButton.tsx
@@ -38,6 +38,8 @@ export const SquadFavoriteButton = ({
       onClick={onClick}
       className={classNames(
         'relative z-1 flex items-center justify-center disabled:opacity-50',
+        !isFavorited &&
+          'laptop:opacity-0 laptop:transition-opacity laptop:group-focus-within/squad-row:opacity-100 laptop:group-hover/squad-row:opacity-100',
         className,
       )}
     >


### PR DESCRIPTION
## Summary

Hide the empty favorite star by default on laptop+ and reveal it on row hover or keyboard focus. Already-favorited stars stay visible so users keep the affordance signaling which squads they have favorited. Mobile (< laptop breakpoint) is untouched — the star remains always visible.

## Key decisions

- Used named Tailwind group `group/squad-row` to avoid colliding with the existing `group` on `SidebarAside` (which drives collapsed-sidebar expand-on-hover).
- Visibility is gated on `!isFavorited` so favorited stars stay persistently visible.
- Kept the button in the DOM with `opacity-0` (not `display:none`) so screen readers and keyboard users can still reach it. Used `group-focus-within` so tabbing into the row reveals the star.
- Added `transition-opacity` to match the smooth fade pattern used elsewhere in the codebase.
- Hover behavior is baked into `SquadFavoriteButton` because every current call-site wants the same behavior. If a future call-site needs the always-visible variant, add an optional prop rather than forking the component.

## Test plan

- [x] Jest: `SquadFavoriteButton.spec.tsx` covers aria attributes, click toggling, and conditional class application
- [x] Existing `SquadList.spec.tsx` and `SidebarItem.spec.tsx` still pass
- [x] ESLint + strict typecheck clean on changed files
- [ ] Manual: sidebar — star hidden by default, revealed on row hover, persists once favorited
- [ ] Manual: "My Squads" page — same behavior in list rows
- [ ] Manual: keyboard tab order reaches the star and reveals it via focus-within
- [ ] Manual: mobile viewport (< laptop) — star always visible

Closes ENG-1591

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1591-favorite-squad-on-hover.preview.app.daily.dev