### PR TITLE
fix(bookmarks): resolve previous folder name on move-undo toast

### DIFF
--- a/packages/shared/src/components/modals/bookmark/MoveBookmarkModal.spec.tsx
+++ b/packages/shared/src/components/modals/bookmark/MoveBookmarkModal.spec.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import MoveBookmarkModal from './MoveBookmarkModal';
+import Toast from '../../notifications/Toast';
+import type { BookmarkFolder } from '../../../graphql/bookmarks';
+
+const mockMoveBookmarkToFolder = jest.fn();
+const mockUseBookmarkFolderList = jest.fn();
+
+jest.mock('../../../hooks/bookmark/useMoveBookmarkToFolder', () => ({
+  useMoveBookmarkToFolder: () => ({
+    isPending: false,
+    moveBookmarkToFolder: (...args: unknown[]) =>
+      mockMoveBookmarkToFolder(...args),
+  }),
+}));
+
+jest.mock('../../../hooks/bookmark', () => ({
+  useBookmarkFolderList: () => mockUseBookmarkFolderList(),
+  useCreateBookmarkFolder: () => ({
+    isPending: false,
+    createFolder: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../hooks/useLazyModal', () => ({
+  useLazyModal: () => ({
+    openModal: jest.fn(),
+    closeModal: jest.fn(),
+    modal: null,
+  }),
+}));
+
+const folderA: BookmarkFolder = {
+  id: 'folder-a',
+  name: 'Folder A',
+  icon: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+const folderB: BookmarkFolder = {
+  id: 'folder-b',
+  name: 'Folder B',
+  icon: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const renderModal = (listId?: string) => {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <MoveBookmarkModal
+        postId="post-1"
+        listId={listId}
+        isOpen
+        onRequestClose={jest.fn()}
+        ariaHideApp={false}
+      />
+      <Toast />
+    </QueryClientProvider>,
+  );
+};
+
+describe('MoveBookmarkModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '<div id="__next"></div>';
+    mockMoveBookmarkToFolder.mockResolvedValue({ _: true });
+    mockUseBookmarkFolderList.mockReturnValue({
+      isPending: false,
+      isSuccess: true,
+      folders: [folderA, folderB],
+    });
+  });
+
+  it('shows "Moved to Quick saves" when moving to Quick saves from a folder', async () => {
+    renderModal(folderA.id);
+
+    fireEvent.click(screen.getByRole('radio', { name: /Quick saves/ }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        '✅ Moved to Quick saves',
+      ),
+    );
+    expect(screen.queryByText(/undefined/)).not.toBeInTheDocument();
+  });
+
+  it('undo restores back to "Quick saves" when the post originated from Quick saves', async () => {
+    renderModal(undefined);
+
+    fireEvent.click(screen.getByRole('radio', { name: /Folder B/ }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        '✅ Moved to Folder B',
+      ),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        '✅ Moved to Quick saves',
+      ),
+    );
+    expect(screen.queryByText(/undefined/)).not.toBeInTheDocument();
+    expect(mockMoveBookmarkToFolder).toHaveBeenLastCalledWith({
+      postId: 'post-1',
+      listId: undefined,
+    });
+  });
+
+  it('undo restores back to the originating folder by name', async () => {
+    renderModal(folderA.id);
+
+    fireEvent.click(screen.getByRole('radio', { name: /Folder B/ }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        '✅ Moved to Folder B',
+      ),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        '✅ Moved to Folder A',
+      ),
+    );
+    expect(screen.queryByText(/undefined/)).not.toBeInTheDocument();
+    expect(mockMoveBookmarkToFolder).toHaveBeenLastCalledWith({
+      postId: 'post-1',
+      listId: folderA.id,
+    });
+  });
+
+  it('falls back to generic copy when the originating folder is missing', async () => {
+    renderModal('folder-deleted');
+
+    fireEvent.click(screen.getByRole('radio', { name: /Folder B/ }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        '✅ Moved to Folder B',
+      ),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undo' }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('✅ Bookmark moved'),
+    );
+    expect(screen.queryByText(/undefined/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/modals/bookmark/MoveBookmarkModal.tsx
+++ b/packages/shared/src/components/modals/bookmark/MoveBookmarkModal.tsx
@@ -18,7 +18,7 @@ import { useMoveBookmarkToFolder } from '../../../hooks/bookmark/useMoveBookmark
 type MoveBookmarkFolderModalProps = Omit<ModalProps, 'children'> & {
   listId?: string;
   postId: string;
-  onMoveBookmark?: (targetId: string) => void;
+  onMoveBookmark?: (targetId?: string) => void;
 };
 
 const MoveBookmarkModal = ({
@@ -42,18 +42,29 @@ const MoveBookmarkModal = ({
       return;
     }
     await moveBookmarkToFolder({ postId, listId: folder?.id });
-    displayToast(`✅ Moved to ${folder?.name}`, {
-      action: {
-        copy: 'Undo',
-        onClick: () => handleMoveBookmark({ id: listId }),
+    displayToast(
+      folder?.name ? `✅ Moved to ${folder.name}` : '✅ Bookmark moved',
+      {
+        action: {
+          copy: 'Undo',
+          onClick: () => {
+            const previousFolderName = listId
+              ? folders?.find((f) => f.id === listId)?.name
+              : 'Quick saves';
+            handleMoveBookmark({ id: listId, name: previousFolderName });
+          },
+        },
       },
-    });
+    );
     onMoveBookmark?.(folder?.id);
     closeModal();
   };
 
   const onCreateNewFolder = async (folder: BookmarkFolder) => {
     const newFolder = await createFolder(folder);
+    if (!newFolder) {
+      return;
+    }
     handleMoveBookmark(newFolder);
     closeModal();
   };

--- a/packages/shared/src/components/modals/bookmark/MoveBookmarkModal.tsx
+++ b/packages/shared/src/components/modals/bookmark/MoveBookmarkModal.tsx
@@ -15,6 +15,8 @@ import type { BookmarkFolder } from '../../../graphql/bookmarks';
 import { useToastNotification } from '../../../hooks';
 import { useMoveBookmarkToFolder } from '../../../hooks/bookmark/useMoveBookmarkToFolder';
 
+const QUICK_SAVES_LABEL = 'Quick saves';
+
 type MoveBookmarkFolderModalProps = Omit<ModalProps, 'children'> & {
   listId?: string;
   postId: string;
@@ -42,20 +44,21 @@ const MoveBookmarkModal = ({
       return;
     }
     await moveBookmarkToFolder({ postId, listId: folder?.id });
-    displayToast(
-      folder?.name ? `✅ Moved to ${folder.name}` : '✅ Bookmark moved',
-      {
-        action: {
-          copy: 'Undo',
-          onClick: () => {
-            const previousFolderName = listId
+    const message = folder?.name
+      ? `✅ Moved to ${folder.name}`
+      : '✅ Bookmark moved';
+    displayToast(message, {
+      action: {
+        copy: 'Undo',
+        onClick: () =>
+          handleMoveBookmark({
+            id: listId,
+            name: listId
               ? folders?.find((f) => f.id === listId)?.name
-              : 'Quick saves';
-            handleMoveBookmark({ id: listId, name: previousFolderName });
-          },
-        },
+              : QUICK_SAVES_LABEL,
+          }),
       },
-    );
+    });
     onMoveBookmark?.(folder?.id);
     closeModal();
   };
@@ -102,13 +105,13 @@ const MoveBookmarkModal = ({
           New folder
         </Button>
         <Button
-          onClick={() => handleMoveBookmark({ name: 'Quick saves' })}
+          onClick={() => handleMoveBookmark({ name: QUICK_SAVES_LABEL })}
           icon={<BookmarkIcon />}
           variant={ButtonVariant.Option}
           role="radio"
           aria-checked={!listId}
         >
-          Quick saves
+          {QUICK_SAVES_LABEL}
           {!listId && (
             <span className="ml-auto">
               <VIcon secondary aria-hidden />

--- a/packages/shared/src/graphql/bookmarks.ts
+++ b/packages/shared/src/graphql/bookmarks.ts
@@ -49,7 +49,7 @@ export const MOVE_BOOKMARK_TO_FOLDER = gql`
 
 export interface MoveBookmarkToFolderProps {
   postId: string;
-  listId: string;
+  listId?: string;
 }
 
 export const moveBookmarkToFolder = ({

--- a/packages/shared/src/hooks/bookmark/useMoveBookmarkToFolder.ts
+++ b/packages/shared/src/hooks/bookmark/useMoveBookmarkToFolder.ts
@@ -9,7 +9,7 @@ import { useToastNotification } from '../useToastNotification';
 interface UseMoveBookmarkToFolder {
   isPending: boolean;
   moveBookmarkToFolder: (
-    options: Record<'postId' | 'listId', string>,
+    options: MoveBookmarkToFolderProps,
   ) => Promise<EmptyResponse>;
 }
 


### PR DESCRIPTION
## Summary

The Undo action on the Move Bookmark toast was passing only `{ id: listId }` to the move handler, so the follow-up toast rendered `Moved to undefined`. This PR resolves the previous folder's name at undo time:

- If the post originated in a folder, look the name up in the cached bookmark folder list.
- If the post originated in Quick saves (no `listId`), fall back to the `Quick saves` label.
- If the folder cannot be resolved (e.g. deleted between move and undo), the toast degrades to a generic `Bookmark moved` rather than showing the literal `undefined`.

### Key decisions

- **Resolve the name at click time, not at toast creation**, so a folder rename between move and undo is reflected correctly.
- **Adjacent strict-type cleanup** surfaced by touching this file: widened `MoveBookmarkToFolderProps.listId` to optional to match the GraphQL schema (`$listId: ID`), aligned `useMoveBookmarkToFolder`'s param type with that interface, broadened `onMoveBookmark` to accept `targetId?: string`, and added a null guard on the `createFolder` result. All callers were checked — backwards-compatible.
- **Extracted `QUICK_SAVES_LABEL`** to de-duplicate the literal across the toast resolver and the Quick saves button.

### Test plan

- [x] New `MoveBookmarkModal.spec.tsx` (4 cases): folder→Quick saves move, Quick saves→folder→undo, folder A→folder B→undo, deleted-folder fallback.
- [x] `node ./scripts/typecheck-strict-changed.js`
- [x] `pnpm --filter shared lint` on impacted files
- [x] `pnpm --filter shared test` — 4/4 pass

Closes ENG-1599

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1599-feedback-bug-report-boo.preview.app.daily.dev