### PR TITLE
feat: redesign tag landing page

### DIFF
--- a/packages/shared/src/components/tags/TagBestOfShowcase.tsx
+++ b/packages/shared/src/components/tags/TagBestOfShowcase.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import { SparkleIcon } from '../icons';
+import { IconSize } from '../Icon';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../typography/Typography';
+
+interface TagBestOfShowcaseProps {
+  tag: string;
+  topPosts: ReactNode;
+  mostUpvoted: ReactNode;
+  bestDiscussed: ReactNode;
+  className?: string;
+}
+
+export const TagBestOfShowcase = ({
+  tag,
+  topPosts,
+  mostUpvoted,
+  bestDiscussed,
+  className,
+}: TagBestOfShowcaseProps): ReactElement => (
+  <section
+    id="best-posts"
+    className={classNames(
+      'shadow-1 mb-6 overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-surface-primary py-5',
+      className,
+    )}
+  >
+    <div className="mx-4 mb-5 flex flex-col gap-2 laptop:mx-6">
+      <span className="flex w-fit items-center gap-1.5 rounded-full bg-accent-cheese-subtlest px-3 py-1 font-bold text-accent-cheese-default typo-caption1">
+        <SparkleIcon size={IconSize.Size16} />
+        Editor scan
+      </span>
+      <Typography tag={TypographyTag.H2} type={TypographyType.Title2} bold>
+        Best of #{tag}
+      </Typography>
+      <Typography
+        type={TypographyType.Callout}
+        color={TypographyColor.Tertiary}
+        className="max-w-[42rem]"
+      >
+        Start with the strongest posts, then compare what the community upvoted
+        and debated.
+      </Typography>
+    </div>
+    <div className="flex flex-col">
+      <div id="top-posts">{topPosts}</div>
+      <div id="upvoted-posts">{mostUpvoted}</div>
+      <div id="discussed-posts">{bestDiscussed}</div>
+    </div>
+  </section>
+);

--- a/packages/shared/src/components/tags/TagBestOfShowcase.tsx
+++ b/packages/shared/src/components/tags/TagBestOfShowcase.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from 'react';
-import React from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
-import { DiscussIcon, HashtagIcon, SparkleIcon, UpvoteIcon } from '../icons';
+import { DiscussIcon, TrendingIcon, UpvoteIcon } from '../icons';
 import { IconSize } from '../Icon';
 import {
   Typography,
@@ -18,53 +18,35 @@ interface TagBestOfShowcaseProps {
   className?: string;
 }
 
-const SignalStep = ({
-  index,
-  title,
-  description,
-  icon,
-  accentClassName,
-}: {
-  index: string;
-  title: string;
+type LensId = 'top' | 'upvoted' | 'discussed';
+
+interface Lens {
+  id: LensId;
+  label: string;
   description: string;
   icon: ReactNode;
-  accentClassName: string;
-}): ReactElement => (
-  <div className="relative overflow-hidden rounded-18 border border-border-subtlest-tertiary bg-surface-float p-4">
-    <div
-      className={classNames(
-        'absolute -right-8 -top-8 size-24 rounded-full blur-2xl',
-        accentClassName,
-      )}
-    />
-    <div className="relative flex items-start gap-3">
-      <span className="flex size-10 shrink-0 items-center justify-center rounded-14 bg-surface-primary text-text-primary">
-        {icon}
-      </span>
-      <div className="min-w-0">
-        <Typography
-          tag={TypographyTag.Span}
-          type={TypographyType.Caption1}
-          color={TypographyColor.Tertiary}
-          bold
-        >
-          {index}
-        </Typography>
-        <Typography type={TypographyType.Callout} bold className="mt-1">
-          {title}
-        </Typography>
-        <Typography
-          type={TypographyType.Caption1}
-          color={TypographyColor.Tertiary}
-          className="mt-1"
-        >
-          {description}
-        </Typography>
-      </div>
-    </div>
-  </div>
-);
+}
+
+const lenses: Lens[] = [
+  {
+    id: 'top',
+    label: 'Top posts',
+    description: 'The broadest signal — start here to get oriented fast.',
+    icon: <TrendingIcon size={IconSize.Size16} />,
+  },
+  {
+    id: 'upvoted',
+    label: 'Most upvoted',
+    description: 'What the community decided was worth saving.',
+    icon: <UpvoteIcon size={IconSize.Size16} />,
+  },
+  {
+    id: 'discussed',
+    label: 'Best discussed',
+    description: 'The threads developers had the most to say about.',
+    icon: <DiscussIcon size={IconSize.Size16} />,
+  },
+];
 
 export const TagBestOfShowcase = ({
   tag,
@@ -72,97 +54,67 @@ export const TagBestOfShowcase = ({
   mostUpvoted,
   bestDiscussed,
   className,
-}: TagBestOfShowcaseProps): ReactElement => (
-  <section
-    id="best-posts"
-    className={classNames(
-      'mb-6 overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-background-default p-3 shadow-2',
-      className,
-    )}
-  >
-    <div className="rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-5 laptop:p-6">
-      <div className="grid gap-6 laptop:grid-cols-[minmax(0,1fr)_22rem]">
-        <div className="flex flex-col justify-between gap-6">
-          <div>
-            <span className="flex w-fit items-center gap-1.5 rounded-full bg-accent-cheese-subtlest px-3 py-1 font-bold text-accent-cheese-default typo-caption1">
-              <SparkleIcon size={IconSize.Size16} />
-              Signal board
-            </span>
-            <Typography
-              tag={TypographyTag.H2}
-              type={TypographyType.Mega3}
-              bold
-              className="mt-4"
-            >
-              The fastest way into #{tag}
-            </Typography>
-            <Typography
-              type={TypographyType.Callout}
-              color={TypographyColor.Tertiary}
-              className="mt-3 max-w-[42rem]"
-            >
-              Three rails, three intents. Scan what is broadly useful, validate
-              what the community trusts, then read where developers disagree.
-            </Typography>
-          </div>
-          <div className="grid gap-3 tablet:grid-cols-3">
-            <SignalStep
-              index="01"
-              title="Get oriented"
-              description="The broadest signal for first-time visitors."
-              icon={<HashtagIcon size={IconSize.Size16} />}
-              accentClassName="bg-accent-cabbage-default/20"
-            />
-            <SignalStep
-              index="02"
-              title="Find consensus"
-              description="Posts developers decided were worth saving."
-              icon={<UpvoteIcon size={IconSize.Size16} />}
-              accentClassName="bg-accent-avocado-default/20"
-            />
-            <SignalStep
-              index="03"
-              title="Read conflict"
-              description="Threads where the community has something to say."
-              icon={<DiscussIcon size={IconSize.Size16} />}
-              accentClassName="bg-accent-blueCheese-default/20"
-            />
-          </div>
-        </div>
-        <aside className="rounded-20 border border-border-subtlest-tertiary bg-surface-float p-4">
+}: TagBestOfShowcaseProps): ReactElement => {
+  const [active, setActive] = useState<LensId>('top');
+  const activeLens = lenses.find((lens) => lens.id === active) ?? lenses[0];
+  const railById: Record<LensId, ReactNode> = {
+    top: topPosts,
+    upvoted: mostUpvoted,
+    discussed: bestDiscussed,
+  };
+
+  return (
+    <section
+      id="best-posts"
+      className={classNames(
+        'overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-surface-primary',
+        className,
+      )}
+    >
+      <header className="flex flex-col gap-4 p-5 laptop:p-6">
+        <div>
+          <Typography tag={TypographyTag.H2} type={TypographyType.Title1} bold>
+            The best of #{tag}
+          </Typography>
           <Typography
-            type={TypographyType.Caption1}
+            type={TypographyType.Callout}
             color={TypographyColor.Tertiary}
-            bold
+            className="mt-1"
           >
-            Reader mode
+            {activeLens.description}
           </Typography>
-          <Typography type={TypographyType.Title3} bold className="mt-3">
-            8 minute topic scan
-          </Typography>
-          <ol className="mt-4 flex flex-col gap-3">
-            {[
-              'Open two top posts.',
-              'Save one upvoted piece.',
-              'Join one discussion.',
-              `Follow #${tag} when it earns a spot in your feed.`,
-            ].map((item) => (
-              <li
-                key={item}
-                className="flex gap-2 text-text-secondary typo-footnote"
+        </div>
+        <div
+          role="tablist"
+          aria-label="Choose how to explore the best posts"
+          className="no-scrollbar flex gap-1 overflow-x-auto rounded-12 bg-surface-float p-1"
+        >
+          {lenses.map((lens) => {
+            const isActive = lens.id === active;
+            return (
+              <button
+                key={lens.id}
+                type="button"
+                role="tab"
+                aria-selected={isActive}
+                onClick={() => setActive(lens.id)}
+                className={classNames(
+                  'flex flex-1 shrink-0 items-center justify-center gap-1.5 rounded-10 px-3 py-2 font-bold transition-colors duration-200 typo-footnote',
+                  isActive
+                    ? 'bg-surface-primary text-text-primary shadow-2'
+                    : 'text-text-tertiary hover:text-text-primary',
+                )}
               >
-                <span className="mt-1 size-1.5 shrink-0 rounded-full bg-accent-cabbage-default" />
-                {item}
-              </li>
-            ))}
-          </ol>
-        </aside>
+                {lens.icon}
+                <span className="whitespace-nowrap">{lens.label}</span>
+              </button>
+            );
+          })}
+        </div>
+      </header>
+      <div className="border-t border-border-subtlest-tertiary py-5">
+        {railById[active]}
       </div>
-    </div>
-    <div className="mt-3 flex flex-col rounded-24 border border-border-subtlest-tertiary bg-surface-primary py-5">
-      <div id="top-posts">{topPosts}</div>
-      <div id="upvoted-posts">{mostUpvoted}</div>
-      <div id="discussed-posts">{bestDiscussed}</div>
-    </div>
-  </section>
-);
+    </section>
+  );
+};

--- a/packages/shared/src/components/tags/TagBestOfShowcase.tsx
+++ b/packages/shared/src/components/tags/TagBestOfShowcase.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement, ReactNode } from 'react';
 import React from 'react';
 import classNames from 'classnames';
-import { SparkleIcon } from '../icons';
+import { DiscussIcon, HashtagIcon, SparkleIcon, UpvoteIcon } from '../icons';
 import { IconSize } from '../Icon';
 import {
   Typography,
@@ -18,6 +18,54 @@ interface TagBestOfShowcaseProps {
   className?: string;
 }
 
+const SignalStep = ({
+  index,
+  title,
+  description,
+  icon,
+  accentClassName,
+}: {
+  index: string;
+  title: string;
+  description: string;
+  icon: ReactNode;
+  accentClassName: string;
+}): ReactElement => (
+  <div className="relative overflow-hidden rounded-18 border border-border-subtlest-tertiary bg-surface-float p-4">
+    <div
+      className={classNames(
+        'absolute -right-8 -top-8 size-24 rounded-full blur-2xl',
+        accentClassName,
+      )}
+    />
+    <div className="relative flex items-start gap-3">
+      <span className="flex size-10 shrink-0 items-center justify-center rounded-14 bg-surface-primary text-text-primary">
+        {icon}
+      </span>
+      <div className="min-w-0">
+        <Typography
+          tag={TypographyTag.Span}
+          type={TypographyType.Caption1}
+          color={TypographyColor.Tertiary}
+          bold
+        >
+          {index}
+        </Typography>
+        <Typography type={TypographyType.Callout} bold className="mt-1">
+          {title}
+        </Typography>
+        <Typography
+          type={TypographyType.Caption1}
+          color={TypographyColor.Tertiary}
+          className="mt-1"
+        >
+          {description}
+        </Typography>
+      </div>
+    </div>
+  </div>
+);
+
 export const TagBestOfShowcase = ({
   tag,
   topPosts,
@@ -28,28 +76,90 @@ export const TagBestOfShowcase = ({
   <section
     id="best-posts"
     className={classNames(
-      'shadow-1 mb-6 overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-surface-primary py-5',
+      'mb-6 overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-background-default p-3 shadow-2',
       className,
     )}
   >
-    <div className="mx-4 mb-5 flex flex-col gap-2 laptop:mx-6">
-      <span className="flex w-fit items-center gap-1.5 rounded-full bg-accent-cheese-subtlest px-3 py-1 font-bold text-accent-cheese-default typo-caption1">
-        <SparkleIcon size={IconSize.Size16} />
-        Editor scan
-      </span>
-      <Typography tag={TypographyTag.H2} type={TypographyType.Title2} bold>
-        Best of #{tag}
-      </Typography>
-      <Typography
-        type={TypographyType.Callout}
-        color={TypographyColor.Tertiary}
-        className="max-w-[42rem]"
-      >
-        Start with the strongest posts, then compare what the community upvoted
-        and debated.
-      </Typography>
+    <div className="rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-5 laptop:p-6">
+      <div className="grid gap-6 laptop:grid-cols-[minmax(0,1fr)_22rem]">
+        <div className="flex flex-col justify-between gap-6">
+          <div>
+            <span className="flex w-fit items-center gap-1.5 rounded-full bg-accent-cheese-subtlest px-3 py-1 font-bold text-accent-cheese-default typo-caption1">
+              <SparkleIcon size={IconSize.Size16} />
+              Signal board
+            </span>
+            <Typography
+              tag={TypographyTag.H2}
+              type={TypographyType.Mega3}
+              bold
+              className="mt-4"
+            >
+              The fastest way into #{tag}
+            </Typography>
+            <Typography
+              type={TypographyType.Callout}
+              color={TypographyColor.Tertiary}
+              className="mt-3 max-w-[42rem]"
+            >
+              Three rails, three intents. Scan what is broadly useful, validate
+              what the community trusts, then read where developers disagree.
+            </Typography>
+          </div>
+          <div className="grid gap-3 tablet:grid-cols-3">
+            <SignalStep
+              index="01"
+              title="Get oriented"
+              description="The broadest signal for first-time visitors."
+              icon={<HashtagIcon size={IconSize.Size16} />}
+              accentClassName="bg-accent-cabbage-default/20"
+            />
+            <SignalStep
+              index="02"
+              title="Find consensus"
+              description="Posts developers decided were worth saving."
+              icon={<UpvoteIcon size={IconSize.Size16} />}
+              accentClassName="bg-accent-avocado-default/20"
+            />
+            <SignalStep
+              index="03"
+              title="Read conflict"
+              description="Threads where the community has something to say."
+              icon={<DiscussIcon size={IconSize.Size16} />}
+              accentClassName="bg-accent-blueCheese-default/20"
+            />
+          </div>
+        </div>
+        <aside className="rounded-20 border border-border-subtlest-tertiary bg-surface-float p-4">
+          <Typography
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+            bold
+          >
+            Reader mode
+          </Typography>
+          <Typography type={TypographyType.Title3} bold className="mt-3">
+            8 minute topic scan
+          </Typography>
+          <ol className="mt-4 flex flex-col gap-3">
+            {[
+              'Open two top posts.',
+              'Save one upvoted piece.',
+              'Join one discussion.',
+              `Follow #${tag} when it earns a spot in your feed.`,
+            ].map((item) => (
+              <li
+                key={item}
+                className="flex gap-2 text-text-secondary typo-footnote"
+              >
+                <span className="mt-1 size-1.5 shrink-0 rounded-full bg-accent-cabbage-default" />
+                {item}
+              </li>
+            ))}
+          </ol>
+        </aside>
+      </div>
     </div>
-    <div className="flex flex-col">
+    <div className="mt-3 flex flex-col rounded-24 border border-border-subtlest-tertiary bg-surface-primary py-5">
       <div id="top-posts">{topPosts}</div>
       <div id="upvoted-posts">{mostUpvoted}</div>
       <div id="discussed-posts">{bestDiscussed}</div>

--- a/packages/shared/src/components/tags/TagBestOfShowcase.tsx
+++ b/packages/shared/src/components/tags/TagBestOfShowcase.tsx
@@ -67,7 +67,7 @@ export const TagBestOfShowcase = ({
     <section
       id="best-posts"
       className={classNames(
-        'overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-surface-primary',
+        'overflow-hidden rounded-16 border border-border-subtlest-tertiary',
         className,
       )}
     >
@@ -87,7 +87,7 @@ export const TagBestOfShowcase = ({
         <div
           role="tablist"
           aria-label="Choose how to explore the best posts"
-          className="no-scrollbar flex gap-1 overflow-x-auto rounded-12 bg-surface-float p-1"
+          className="no-scrollbar flex gap-1 overflow-x-auto rounded-12 border border-border-subtlest-tertiary p-1"
         >
           {lenses.map((lens) => {
             const isActive = lens.id === active;
@@ -101,11 +101,17 @@ export const TagBestOfShowcase = ({
                 className={classNames(
                   'flex flex-1 shrink-0 items-center justify-center gap-1.5 rounded-10 px-3 py-2 font-bold transition-colors duration-200 typo-footnote',
                   isActive
-                    ? 'bg-surface-primary text-text-primary shadow-2'
-                    : 'text-text-tertiary hover:text-text-primary',
+                    ? 'bg-surface-float text-text-primary'
+                    : 'text-text-tertiary hover:bg-surface-hover hover:text-text-primary',
                 )}
               >
-                {lens.icon}
+                <span
+                  className={classNames(
+                    isActive && 'text-accent-cabbage-default',
+                  )}
+                >
+                  {lens.icon}
+                </span>
                 <span className="whitespace-nowrap">{lens.label}</span>
               </button>
             );

--- a/packages/shared/src/components/tags/TagJoinStrip.tsx
+++ b/packages/shared/src/components/tags/TagJoinStrip.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { IconSize } from '../Icon';
-import { DailyIcon, SparkleIcon } from '../icons';
+import { DailyIcon, DiscussIcon, HashtagIcon, SparkleIcon } from '../icons';
 import {
   Typography,
   TypographyColor,
@@ -24,39 +24,93 @@ export const TagJoinStrip = ({
 }: TagJoinStripProps): ReactElement => (
   <section
     className={classNames(
-      'border-accent-cabbage-default/30 shadow-1 relative mx-4 mb-6 overflow-hidden rounded-24 border bg-surface-primary p-4 laptop:mx-4 laptop:p-5',
+      'border-accent-cabbage-default/30 relative mx-4 mb-6 overflow-hidden rounded-24 border bg-background-default p-3 shadow-2 laptop:mx-4',
       className,
     )}
   >
-    <div className="bg-accent-cabbage-default/20 pointer-events-none absolute -right-12 -top-16 size-48 rounded-full blur-3xl" />
-    <div className="relative flex flex-col gap-4 laptop:flex-row laptop:items-center laptop:justify-between">
-      <div className="flex min-w-0 gap-3">
-        <span className="flex size-12 shrink-0 items-center justify-center rounded-16 bg-accent-cabbage-subtlest text-accent-cabbage-default">
-          <DailyIcon size={IconSize.Small} />
+    <div className="bg-accent-cabbage-default/25 pointer-events-none absolute -right-12 -top-16 size-56 rounded-full blur-3xl" />
+    <div className="bg-accent-onion-default/15 pointer-events-none absolute -bottom-20 left-16 size-52 rounded-full blur-3xl" />
+    <div className="relative grid gap-3 rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-5 laptop:grid-cols-[minmax(0,1fr)_18rem] laptop:p-6">
+      <div className="min-w-0">
+        <span className="flex w-fit items-center gap-1.5 rounded-full bg-accent-cabbage-subtlest px-3 py-1 font-bold text-accent-cabbage-default typo-caption1">
+          <DailyIcon size={IconSize.Size16} />
+          Aha moment
         </span>
-        <div className="min-w-0">
-          <Typography tag={TypographyTag.H2} type={TypographyType.Title3} bold>
-            Make #{tag} your daily brief
-          </Typography>
-          <Typography
-            type={TypographyType.Callout}
-            color={TypographyColor.Tertiary}
-          >
-            Follow the topic, train your feed, and join the developer
-            conversation around it.
-          </Typography>
+        <Typography
+          tag={TypographyTag.H2}
+          type={TypographyType.Mega3}
+          bold
+          className="mt-4"
+        >
+          Stop browsing #{tag}. Make it yours.
+        </Typography>
+        <Typography
+          type={TypographyType.Callout}
+          color={TypographyColor.Tertiary}
+          className="mt-3 max-w-[42rem]"
+        >
+          The directory gives you the map. A daily.dev account turns it into a
+          living feed tuned by what you read, save, upvote, and discuss.
+        </Typography>
+        <div className="mt-5 grid gap-2 tablet:grid-cols-3">
+          {[
+            {
+              icon: <HashtagIcon size={IconSize.Size16} />,
+              title: 'Seed',
+              description: `Start with #${tag}`,
+            },
+            {
+              icon: <SparkleIcon size={IconSize.Size16} />,
+              title: 'Train',
+              description: 'Save what matters',
+            },
+            {
+              icon: <DiscussIcon size={IconSize.Size16} />,
+              title: 'Join',
+              description: 'Discuss with developers',
+            },
+          ].map((item) => (
+            <div
+              key={item.title}
+              className="rounded-16 border border-border-subtlest-tertiary bg-surface-float p-3"
+            >
+              <span className="text-accent-cabbage-default">{item.icon}</span>
+              <Typography type={TypographyType.Footnote} bold className="mt-2">
+                {item.title}
+              </Typography>
+              <Typography
+                type={TypographyType.Caption1}
+                color={TypographyColor.Tertiary}
+              >
+                {item.description}
+              </Typography>
+            </div>
+          ))}
         </div>
       </div>
-      <Button
-        type="button"
-        variant={ButtonVariant.Primary}
-        size={ButtonSize.Medium}
-        icon={<SparkleIcon />}
-        onClick={onJoin}
-        className="w-full laptop:w-auto"
-      >
-        Build my #{tag} feed
-      </Button>
+      <aside className="flex flex-col justify-between gap-4 rounded-20 bg-surface-float p-4">
+        <div>
+          <Typography
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+          >
+            First action
+          </Typography>
+          <Typography type={TypographyType.Title3} bold className="mt-2">
+            Build a feed from this topic in one tap.
+          </Typography>
+        </div>
+        <Button
+          type="button"
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Medium}
+          icon={<SparkleIcon />}
+          onClick={onJoin}
+          className="w-full"
+        >
+          Build my #{tag} feed
+        </Button>
+      </aside>
     </div>
   </section>
 );

--- a/packages/shared/src/components/tags/TagJoinStrip.tsx
+++ b/packages/shared/src/components/tags/TagJoinStrip.tsx
@@ -1,0 +1,62 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { IconSize } from '../Icon';
+import { DailyIcon, SparkleIcon } from '../icons';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../typography/Typography';
+
+interface TagJoinStripProps {
+  tag: string;
+  onJoin: () => void;
+  className?: string;
+}
+
+export const TagJoinStrip = ({
+  tag,
+  onJoin,
+  className,
+}: TagJoinStripProps): ReactElement => (
+  <section
+    className={classNames(
+      'border-accent-cabbage-default/30 shadow-1 relative mx-4 mb-6 overflow-hidden rounded-24 border bg-surface-primary p-4 laptop:mx-4 laptop:p-5',
+      className,
+    )}
+  >
+    <div className="bg-accent-cabbage-default/20 pointer-events-none absolute -right-12 -top-16 size-48 rounded-full blur-3xl" />
+    <div className="relative flex flex-col gap-4 laptop:flex-row laptop:items-center laptop:justify-between">
+      <div className="flex min-w-0 gap-3">
+        <span className="flex size-12 shrink-0 items-center justify-center rounded-16 bg-accent-cabbage-subtlest text-accent-cabbage-default">
+          <DailyIcon size={IconSize.Small} />
+        </span>
+        <div className="min-w-0">
+          <Typography tag={TypographyTag.H2} type={TypographyType.Title3} bold>
+            Make #{tag} your daily brief
+          </Typography>
+          <Typography
+            type={TypographyType.Callout}
+            color={TypographyColor.Tertiary}
+          >
+            Follow the topic, train your feed, and join the developer
+            conversation around it.
+          </Typography>
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Medium}
+        icon={<SparkleIcon />}
+        onClick={onJoin}
+        className="w-full laptop:w-auto"
+      >
+        Build my #{tag} feed
+      </Button>
+    </div>
+  </section>
+);

--- a/packages/shared/src/components/tags/TagJoinStrip.tsx
+++ b/packages/shared/src/components/tags/TagJoinStrip.tsx
@@ -23,36 +23,32 @@ export const TagJoinStrip = ({
 }: TagJoinStripProps): ReactElement => (
   <section
     className={classNames(
-      'border-accent-cabbage-default/30 relative overflow-hidden rounded-16 border bg-surface-primary p-6 laptop:p-8',
+      'border-accent-cabbage-default/30 flex flex-col items-start gap-5 rounded-16 border bg-accent-cabbage-subtlest p-6 laptop:flex-row laptop:items-center laptop:justify-between laptop:p-8',
       className,
     )}
   >
-    <div className="bg-accent-cabbage-default/20 pointer-events-none absolute -right-16 -top-20 size-60 rounded-full blur-3xl" />
-    <div className="bg-accent-onion-default/15 pointer-events-none absolute -bottom-24 left-10 size-56 rounded-full blur-3xl" />
-    <div className="relative flex flex-col items-start gap-5 laptop:flex-row laptop:items-center laptop:justify-between">
-      <div className="min-w-0">
-        <Typography tag={TypographyTag.H2} type={TypographyType.Title1} bold>
-          Stop browsing #{tag}. Make it yours.
-        </Typography>
-        <Typography
-          type={TypographyType.Callout}
-          color={TypographyColor.Secondary}
-          className="mt-2 max-w-[44rem]"
-        >
-          This page is the map. A free daily.dev account turns it into a living
-          feed tuned by what you read, save, upvote, and discuss.
-        </Typography>
-      </div>
-      <Button
-        type="button"
-        variant={ButtonVariant.Primary}
-        size={ButtonSize.Large}
-        icon={<SparkleIcon />}
-        onClick={onJoin}
-        className="shrink-0"
+    <div className="min-w-0">
+      <Typography tag={TypographyTag.H2} type={TypographyType.Title1} bold>
+        Stop browsing #{tag}. Make it yours.
+      </Typography>
+      <Typography
+        type={TypographyType.Callout}
+        color={TypographyColor.Secondary}
+        className="mt-2 max-w-[44rem]"
       >
-        Build my #{tag} feed
-      </Button>
+        This page is the map. A free daily.dev account turns it into a living
+        feed tuned by what you read, save, upvote, and discuss.
+      </Typography>
     </div>
+    <Button
+      type="button"
+      variant={ButtonVariant.Primary}
+      size={ButtonSize.Large}
+      icon={<SparkleIcon />}
+      onClick={onJoin}
+      className="shrink-0"
+    >
+      Build my #{tag} feed
+    </Button>
   </section>
 );

--- a/packages/shared/src/components/tags/TagJoinStrip.tsx
+++ b/packages/shared/src/components/tags/TagJoinStrip.tsx
@@ -2,8 +2,7 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
-import { IconSize } from '../Icon';
-import { DailyIcon, DiscussIcon, HashtagIcon, SparkleIcon } from '../icons';
+import { SparkleIcon } from '../icons';
 import {
   Typography,
   TypographyColor,
@@ -24,93 +23,36 @@ export const TagJoinStrip = ({
 }: TagJoinStripProps): ReactElement => (
   <section
     className={classNames(
-      'border-accent-cabbage-default/30 relative mx-4 mb-6 overflow-hidden rounded-24 border bg-background-default p-3 shadow-2 laptop:mx-4',
+      'border-accent-cabbage-default/30 relative overflow-hidden rounded-16 border bg-surface-primary p-6 laptop:p-8',
       className,
     )}
   >
-    <div className="bg-accent-cabbage-default/25 pointer-events-none absolute -right-12 -top-16 size-56 rounded-full blur-3xl" />
-    <div className="bg-accent-onion-default/15 pointer-events-none absolute -bottom-20 left-16 size-52 rounded-full blur-3xl" />
-    <div className="relative grid gap-3 rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-5 laptop:grid-cols-[minmax(0,1fr)_18rem] laptop:p-6">
+    <div className="bg-accent-cabbage-default/20 pointer-events-none absolute -right-16 -top-20 size-60 rounded-full blur-3xl" />
+    <div className="bg-accent-onion-default/15 pointer-events-none absolute -bottom-24 left-10 size-56 rounded-full blur-3xl" />
+    <div className="relative flex flex-col items-start gap-5 laptop:flex-row laptop:items-center laptop:justify-between">
       <div className="min-w-0">
-        <span className="flex w-fit items-center gap-1.5 rounded-full bg-accent-cabbage-subtlest px-3 py-1 font-bold text-accent-cabbage-default typo-caption1">
-          <DailyIcon size={IconSize.Size16} />
-          Aha moment
-        </span>
-        <Typography
-          tag={TypographyTag.H2}
-          type={TypographyType.Mega3}
-          bold
-          className="mt-4"
-        >
+        <Typography tag={TypographyTag.H2} type={TypographyType.Title1} bold>
           Stop browsing #{tag}. Make it yours.
         </Typography>
         <Typography
           type={TypographyType.Callout}
-          color={TypographyColor.Tertiary}
-          className="mt-3 max-w-[42rem]"
+          color={TypographyColor.Secondary}
+          className="mt-2 max-w-[44rem]"
         >
-          The directory gives you the map. A daily.dev account turns it into a
-          living feed tuned by what you read, save, upvote, and discuss.
+          This page is the map. A free daily.dev account turns it into a living
+          feed tuned by what you read, save, upvote, and discuss.
         </Typography>
-        <div className="mt-5 grid gap-2 tablet:grid-cols-3">
-          {[
-            {
-              icon: <HashtagIcon size={IconSize.Size16} />,
-              title: 'Seed',
-              description: `Start with #${tag}`,
-            },
-            {
-              icon: <SparkleIcon size={IconSize.Size16} />,
-              title: 'Train',
-              description: 'Save what matters',
-            },
-            {
-              icon: <DiscussIcon size={IconSize.Size16} />,
-              title: 'Join',
-              description: 'Discuss with developers',
-            },
-          ].map((item) => (
-            <div
-              key={item.title}
-              className="rounded-16 border border-border-subtlest-tertiary bg-surface-float p-3"
-            >
-              <span className="text-accent-cabbage-default">{item.icon}</span>
-              <Typography type={TypographyType.Footnote} bold className="mt-2">
-                {item.title}
-              </Typography>
-              <Typography
-                type={TypographyType.Caption1}
-                color={TypographyColor.Tertiary}
-              >
-                {item.description}
-              </Typography>
-            </div>
-          ))}
-        </div>
       </div>
-      <aside className="flex flex-col justify-between gap-4 rounded-20 bg-surface-float p-4">
-        <div>
-          <Typography
-            type={TypographyType.Caption1}
-            color={TypographyColor.Tertiary}
-          >
-            First action
-          </Typography>
-          <Typography type={TypographyType.Title3} bold className="mt-2">
-            Build a feed from this topic in one tap.
-          </Typography>
-        </div>
-        <Button
-          type="button"
-          variant={ButtonVariant.Primary}
-          size={ButtonSize.Medium}
-          icon={<SparkleIcon />}
-          onClick={onJoin}
-          className="w-full"
-        >
-          Build my #{tag} feed
-        </Button>
-      </aside>
+      <Button
+        type="button"
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Large}
+        icon={<SparkleIcon />}
+        onClick={onJoin}
+        className="shrink-0"
+      >
+        Build my #{tag} feed
+      </Button>
     </div>
   </section>
 );

--- a/packages/shared/src/components/tags/TagPageHero.tsx
+++ b/packages/shared/src/components/tags/TagPageHero.tsx
@@ -3,8 +3,7 @@ import React, { Fragment } from 'react';
 import classNames from 'classnames';
 import type { ButtonProps } from '../buttons/Button';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
-import { IconSize } from '../Icon';
-import { BlockIcon, HashtagIcon, PlusIcon } from '../icons';
+import { BlockIcon, PlusIcon } from '../icons';
 import {
   Typography,
   TypographyColor,
@@ -20,22 +19,18 @@ export interface TagPageStat {
   caption?: string;
 }
 
-interface TagStatTickerProps {
-  stats: TagPageStat[];
-}
-
-const TagStatTicker = ({ stats }: TagStatTickerProps): ReactElement => (
-  <dl className="flex flex-wrap items-center gap-x-5 gap-y-3">
+const TagStatTicker = ({ stats }: { stats: TagPageStat[] }): ReactElement => (
+  <dl className="flex flex-wrap items-center gap-x-6 gap-y-4">
     {stats.map((stat, index) => (
       <Fragment key={stat.label}>
         {index > 0 && (
           <span
             aria-hidden
-            className="hidden h-8 w-px bg-border-subtlest-tertiary mobileL:block"
+            className="hidden h-9 w-px bg-border-subtlest-tertiary mobileL:block"
           />
         )}
         <div className="flex flex-col">
-          <dd className="font-bold tabular-nums text-text-primary typo-title2">
+          <dd className="font-bold tabular-nums text-text-primary typo-title1">
             {stat.value}
           </dd>
           <dt className="text-text-tertiary typo-caption1">{stat.label}</dt>
@@ -86,102 +81,89 @@ export const TagPageHero = ({
   return (
     <section
       className={classNames(
-        'relative overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-surface-primary p-5 laptop:p-8',
+        'flex flex-col gap-6 rounded-16 border border-border-subtlest-tertiary p-5 laptop:p-8',
         className,
       )}
     >
-      <div className="bg-accent-cabbage-default/20 pointer-events-none absolute -left-24 -top-24 size-72 rounded-full blur-3xl" />
-      <div className="bg-accent-onion-default/15 pointer-events-none absolute -right-20 -top-10 size-64 rounded-full blur-3xl" />
+      {sponsoredHero}
 
-      <div className="relative flex flex-col gap-6">
-        {sponsoredHero}
-
-        <div className="flex flex-col gap-5">
-          <div className="flex items-center gap-2 text-text-tertiary typo-footnote">
-            <span className="inline-flex items-center gap-1 font-bold text-accent-cabbage-default">
-              <HashtagIcon size={IconSize.Size16} />
-              Topic
-            </span>
-            <span aria-hidden>·</span>
-            <span>Updated daily</span>
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-4 laptop:flex-row laptop:items-start laptop:justify-between">
+          <div className="min-w-0">
+            <Typography
+              tag={TypographyTag.H1}
+              type={TypographyType.LargeTitle}
+              bold
+              className="break-words laptop:typo-mega2"
+            >
+              <span className="text-accent-cabbage-default">#</span>
+              {title}
+            </Typography>
+            <Typography
+              type={TypographyType.Body}
+              color={TypographyColor.Secondary}
+              className="mt-3 max-w-[44rem]"
+            >
+              {description ||
+                `Everything developers are reading, saving, upvoting, and debating around #${tag} — curated first, then the full live stream.`}
+            </Typography>
           </div>
 
-          <div className="flex flex-col gap-4 laptop:flex-row laptop:items-end laptop:justify-between">
-            <div className="min-w-0">
-              <Typography
-                tag={TypographyTag.H1}
-                type={TypographyType.LargeTitle}
+          <div className="flex shrink-0 flex-wrap items-center gap-2">
+            {tagStatus !== 'blocked' && (
+              <Button
+                type="button"
+                variant={ButtonVariant.Primary}
+                size={ButtonSize.Large}
+                icon={<PlusIcon />}
                 bold
-                className="break-words bg-gradient-to-r from-text-primary to-accent-cabbage-bolder bg-clip-text text-transparent laptop:typo-mega2"
+                {...followButtonProps}
+                aria-label={tagStatus === 'followed' ? 'Unfollow' : 'Follow'}
+                className={classNames(followButtonProps.className)}
               >
-                #{title}
-              </Typography>
-              <Typography
-                type={TypographyType.Body}
-                color={TypographyColor.Secondary}
-                className="mt-3 max-w-[44rem]"
+                {tagStatus === 'followed'
+                  ? `Following #${tag}`
+                  : `Follow #${tag}`}
+              </Button>
+            )}
+            {tagStatus !== 'followed' && (
+              <Button
+                type="button"
+                variant={ButtonVariant.Float}
+                size={ButtonSize.Large}
+                icon={<BlockIcon />}
+                {...blockButtonProps}
+                aria-label={tagStatus === 'blocked' ? 'Unblock' : 'Block'}
               >
-                {description ||
-                  `Everything developers are reading, saving, upvoting, and debating around #${tag} — curated first, then the full live stream.`}
-              </Typography>
-            </div>
-
-            <div className="flex shrink-0 flex-wrap items-center gap-2">
-              {tagStatus !== 'blocked' && (
-                <Button
-                  type="button"
-                  variant={ButtonVariant.Primary}
-                  size={ButtonSize.Large}
-                  icon={<PlusIcon />}
-                  bold
-                  {...followButtonProps}
-                  aria-label={tagStatus === 'followed' ? 'Unfollow' : 'Follow'}
-                  className={classNames(followButtonProps.className)}
-                >
-                  {tagStatus === 'followed'
-                    ? `Following #${tag}`
-                    : `Follow #${tag}`}
-                </Button>
-              )}
-              {tagStatus !== 'followed' && (
-                <Button
-                  type="button"
-                  variant={ButtonVariant.Float}
-                  size={ButtonSize.Large}
-                  icon={<BlockIcon />}
-                  {...blockButtonProps}
-                  aria-label={tagStatus === 'blocked' ? 'Unblock' : 'Block'}
-                >
-                  {tagStatus === 'blocked' ? 'Unblock' : 'Block'}
-                </Button>
-              )}
-              {optionsMenu}
-            </div>
+                {tagStatus === 'blocked' ? 'Unblock' : 'Block'}
+              </Button>
+            )}
+            {optionsMenu}
           </div>
-
-          <Typography
-            type={TypographyType.Footnote}
-            color={TypographyColor.Tertiary}
-          >
-            {microcopy}
-          </Typography>
         </div>
 
-        {stats.length > 0 && (
-          <div className="border-t border-border-subtlest-tertiary pt-5">
-            <TagStatTicker stats={stats} />
-          </div>
-        )}
-
-        {(recommendedTags || roadmap) && (
-          <div className="flex flex-col gap-4 border-t border-border-subtlest-tertiary pt-5">
-            {recommendedTags}
-            {roadmap}
-          </div>
-        )}
-
-        {crawlLinks}
+        <Typography
+          type={TypographyType.Footnote}
+          color={TypographyColor.Tertiary}
+        >
+          {microcopy}
+        </Typography>
       </div>
+
+      {stats.length > 0 && (
+        <div className="border-t border-border-subtlest-tertiary pt-6">
+          <TagStatTicker stats={stats} />
+        </div>
+      )}
+
+      {(recommendedTags || roadmap) && (
+        <div className="flex flex-col gap-4 border-t border-border-subtlest-tertiary pt-6">
+          {recommendedTags}
+          {roadmap}
+        </div>
+      )}
+
+      {crawlLinks}
     </section>
   );
 };

--- a/packages/shared/src/components/tags/TagPageHero.tsx
+++ b/packages/shared/src/components/tags/TagPageHero.tsx
@@ -4,7 +4,16 @@ import classNames from 'classnames';
 import type { ButtonProps } from '../buttons/Button';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { IconSize } from '../Icon';
-import { BlockIcon, HashtagIcon, PlusIcon } from '../icons';
+import {
+  ArrowIcon,
+  BlockIcon,
+  DiscussIcon,
+  HashtagIcon,
+  PlusIcon,
+  SparkleIcon,
+  TrendingIcon,
+  UpvoteIcon,
+} from '../icons';
 import {
   Typography,
   TypographyColor,
@@ -25,22 +34,71 @@ interface TagStatsBarProps {
 }
 
 const TagStatsBar = ({ stats }: TagStatsBarProps): ReactElement => (
-  <dl className="grid grid-cols-2 gap-2 laptop:grid-cols-4">
-    {stats.map((stat) => (
+  <dl className="grid grid-cols-1 gap-2 mobileL:grid-cols-2 laptop:grid-cols-4">
+    {stats.map((stat, index) => (
       <div
         key={stat.label}
-        className="rounded-14 border border-border-subtlest-tertiary bg-surface-float p-3 transition-colors hover:border-border-subtlest-secondary hover:bg-surface-hover"
+        className="group relative overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-surface-float p-4 transition-all duration-200 hover:-translate-y-0.5 hover:border-border-subtlest-secondary hover:bg-surface-hover hover:shadow-2"
       >
-        <dt className="text-text-tertiary typo-caption1">{stat.label}</dt>
-        <dd className="mt-1 font-bold text-text-primary typo-title3">
+        <div className="from-accent-cabbage-default/0 to-accent-onion-default/0 group-hover:opacity-5 pointer-events-none absolute inset-0 bg-gradient-to-br opacity-0 transition-opacity duration-200" />
+        <dt className="relative flex items-center justify-between gap-2 text-text-tertiary typo-caption1">
+          {stat.label}
+          <span className="rounded-8 bg-surface-hover px-1.5 py-0.5 font-bold text-text-quaternary typo-caption2">
+            0{index + 1}
+          </span>
+        </dt>
+        <dd className="relative mt-3 font-bold text-text-primary typo-title2">
           {stat.value}
         </dd>
-        <p className="mt-1 text-text-quaternary typo-caption1">
+        <p className="relative mt-1 text-text-quaternary typo-caption1">
           {stat.caption}
         </p>
       </div>
     ))}
   </dl>
+);
+
+const HeroLink = ({
+  href,
+  icon,
+  title,
+  description,
+}: {
+  href: string;
+  icon: ReactNode;
+  title: string;
+  description: string;
+}): ReactElement => (
+  <a
+    href={href}
+    className="group flex items-center gap-3 rounded-14 border border-border-subtlest-tertiary bg-surface-primary p-3 transition-all duration-200 hover:border-border-subtlest-secondary hover:bg-surface-hover"
+  >
+    <span className="flex size-9 shrink-0 items-center justify-center rounded-12 bg-surface-float text-accent-cabbage-default">
+      {icon}
+    </span>
+    <span className="min-w-0 flex-1">
+      <Typography
+        tag={TypographyTag.Span}
+        type={TypographyType.Footnote}
+        bold
+        className="block truncate"
+      >
+        {title}
+      </Typography>
+      <Typography
+        tag={TypographyTag.Span}
+        type={TypographyType.Caption1}
+        color={TypographyColor.Tertiary}
+        className="block truncate"
+      >
+        {description}
+      </Typography>
+    </span>
+    <ArrowIcon
+      size={IconSize.XSmall}
+      className="rotate-90 text-text-quaternary transition-transform group-hover:translate-x-0.5 group-hover:text-text-primary"
+    />
+  </a>
 );
 
 interface TagPageHeroProps {
@@ -76,52 +134,92 @@ export const TagPageHero = ({
 }: TagPageHeroProps): ReactElement => (
   <section
     className={classNames(
-      'shadow-1 relative mb-6 overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-4 laptop:p-6',
+      'relative mb-6 overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-background-default p-3 shadow-2 laptop:p-4',
       className,
     )}
   >
-    <div className="bg-accent-cabbage-default/20 pointer-events-none absolute -left-20 -top-20 size-64 rounded-full blur-3xl" />
-    <div className="bg-accent-onion-default/15 pointer-events-none absolute -right-16 top-8 size-52 rounded-full blur-3xl" />
-    <div className="bg-accent-cheese-default/10 pointer-events-none absolute bottom-0 left-1/3 size-40 rounded-full blur-3xl" />
+    <div className="bg-accent-cabbage-default/25 pointer-events-none absolute -left-24 -top-24 size-72 rounded-full blur-3xl" />
+    <div className="bg-accent-onion-default/20 pointer-events-none absolute -right-20 top-0 size-64 rounded-full blur-3xl" />
+    <div className="bg-accent-cheese-default/10 pointer-events-none absolute bottom-0 left-1/3 size-56 rounded-full blur-3xl" />
 
-    <div className="relative flex flex-col gap-5">
+    <div className="relative flex flex-col gap-3">
       {sponsoredHero}
-      <div className="flex flex-col gap-4 laptop:flex-row laptop:items-start laptop:justify-between">
-        <div className="min-w-0 flex-1">
-          <div className="mb-3 flex flex-wrap items-center gap-2">
-            <span className="border-accent-cabbage-default/30 inline-flex items-center gap-1.5 rounded-full border bg-accent-cabbage-subtlest px-3 py-1 font-bold text-accent-cabbage-default typo-caption1">
-              <HashtagIcon size={IconSize.Size16} />
-              Developer topic
-            </span>
-            <span className="rounded-full border border-border-subtlest-tertiary bg-surface-float px-3 py-1 text-text-tertiary typo-caption1">
-              Updated daily
-            </span>
+      <div className="grid gap-3 laptop:grid-cols-[minmax(0,1fr)_22rem]">
+        <div className="relative overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-5 laptop:p-7">
+          <div className="bg-accent-cabbage-default/10 pointer-events-none absolute -bottom-20 -right-20 size-56 rounded-full blur-3xl" />
+          <div className="relative flex h-full flex-col justify-between gap-8">
+            <div>
+              <div className="mb-5 flex flex-wrap items-center gap-2">
+                <span className="border-accent-cabbage-default/30 inline-flex items-center gap-1.5 rounded-full border bg-accent-cabbage-subtlest px-3 py-1 font-bold text-accent-cabbage-default typo-caption1">
+                  <HashtagIcon size={IconSize.Size16} />
+                  Topic intelligence hub
+                </span>
+                <span className="rounded-full border border-border-subtlest-tertiary bg-surface-float px-3 py-1 text-text-tertiary typo-caption1">
+                  Updated daily
+                </span>
+              </div>
+              <Typography
+                tag={TypographyTag.H1}
+                type={TypographyType.Mega1}
+                bold
+                className="max-w-[43rem] break-words bg-gradient-to-r from-text-primary via-accent-cabbage-bolder to-accent-onion-default bg-clip-text text-transparent"
+              >
+                #{title}
+              </Typography>
+              <Typography
+                type={TypographyType.Body}
+                color={TypographyColor.Secondary}
+                className="mt-5 max-w-[42rem]"
+              >
+                {description ||
+                  `A live map of what developers are reading, saving, upvoting, and debating around #${tag}. Start with the signal, then make it yours.`}
+              </Typography>
+            </div>
+            <div className="grid gap-2 tablet:grid-cols-3">
+              <HeroLink
+                href="#top-posts"
+                icon={<TrendingIcon size={IconSize.Size16} />}
+                title="Start with signal"
+                description="Scan top posts first"
+              />
+              <HeroLink
+                href="#upvoted-posts"
+                icon={<UpvoteIcon size={IconSize.Size16} />}
+                title="Find consensus"
+                description="See what developers saved"
+              />
+              <HeroLink
+                href="#discussed-posts"
+                icon={<DiscussIcon size={IconSize.Size16} />}
+                title="Read the debate"
+                description="Jump into the conversation"
+              />
+            </div>
           </div>
-          <div className="flex min-w-0 items-center gap-3">
-            <HashtagIcon
-              size={IconSize.XXLarge}
-              className="hidden shrink-0 text-accent-cabbage-default mobileL:block"
-            />
+        </div>
+        <aside className="flex flex-col gap-3 rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-4">
+          <div className="rounded-20 bg-surface-float p-4">
+            <span className="flex w-fit items-center gap-1.5 rounded-full bg-accent-cheese-subtlest px-2.5 py-1 font-bold text-accent-cheese-default typo-caption1">
+              <SparkleIcon size={IconSize.Size16} />
+              Your next move
+            </span>
             <Typography
-              tag={TypographyTag.H1}
-              type={TypographyType.Mega2}
+              tag={TypographyTag.H2}
+              type={TypographyType.Title2}
               bold
-              className="min-w-0 break-words bg-gradient-to-r from-text-primary via-accent-cabbage-bolder to-accent-onion-default bg-clip-text text-transparent"
+              className="mt-4"
             >
-              {title}
+              Turn #{tag} into your feed
+            </Typography>
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+              className="mt-2"
+            >
+              Follow once. daily.dev will start learning what parts of this
+              topic matter to you.
             </Typography>
           </div>
-          <Typography
-            type={TypographyType.Callout}
-            color={TypographyColor.Secondary}
-            className="mt-3 max-w-[45rem]"
-          >
-            {description ||
-              `Follow #${tag} to turn this topic into a personalized daily.dev feed.`}
-          </Typography>
-        </div>
-
-        <div className="flex shrink-0 flex-col gap-2 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-3 laptop:min-w-60">
           {tagStatus !== 'blocked' && (
             <Button
               type="button"
@@ -135,7 +233,7 @@ export const TagPageHero = ({
             >
               {tagStatus === 'followed'
                 ? `Following #${tag}`
-                : `Follow #${tag}`}
+                : `Personalize with #${tag}`}
             </Button>
           )}
           <Typography
@@ -145,9 +243,9 @@ export const TagPageHero = ({
           >
             {tagStatus === 'blocked'
               ? 'This topic is blocked from your feed.'
-              : 'Build a personal feed from this topic. Free, no card.'}
+              : 'Free account. No card. Your feed gets smarter immediately.'}
           </Typography>
-          <div className="flex gap-2">
+          <div className="grid grid-cols-[1fr_auto] gap-2">
             {tagStatus !== 'followed' && (
               <Button
                 type="button"
@@ -163,12 +261,20 @@ export const TagPageHero = ({
             )}
             {optionsMenu}
           </div>
-        </div>
+        </aside>
       </div>
 
       {stats.length > 0 && <TagStatsBar stats={stats} />}
-      {recommendedTags}
-      {roadmap}
+      <div className="grid gap-3 laptop:grid-cols-[minmax(0,1fr)_20rem]">
+        <div className="rounded-20 border border-border-subtlest-tertiary bg-surface-primary p-4">
+          {recommendedTags}
+        </div>
+        {roadmap && (
+          <div className="rounded-20 border border-border-subtlest-tertiary bg-surface-primary p-4">
+            {roadmap}
+          </div>
+        )}
+      </div>
       {crawlLinks}
     </div>
   </section>

--- a/packages/shared/src/components/tags/TagPageHero.tsx
+++ b/packages/shared/src/components/tags/TagPageHero.tsx
@@ -1,19 +1,10 @@
 import type { ReactElement, ReactNode } from 'react';
-import React from 'react';
+import React, { Fragment } from 'react';
 import classNames from 'classnames';
 import type { ButtonProps } from '../buttons/Button';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { IconSize } from '../Icon';
-import {
-  ArrowIcon,
-  BlockIcon,
-  DiscussIcon,
-  HashtagIcon,
-  PlusIcon,
-  SparkleIcon,
-  TrendingIcon,
-  UpvoteIcon,
-} from '../icons';
+import { BlockIcon, HashtagIcon, PlusIcon } from '../icons';
 import {
   Typography,
   TypographyColor,
@@ -26,79 +17,32 @@ export type TagStatus = 'followed' | 'blocked' | 'unfollowed';
 export interface TagPageStat {
   label: string;
   value: string;
-  caption: string;
+  caption?: string;
 }
 
-interface TagStatsBarProps {
+interface TagStatTickerProps {
   stats: TagPageStat[];
 }
 
-const TagStatsBar = ({ stats }: TagStatsBarProps): ReactElement => (
-  <dl className="grid grid-cols-1 gap-2 mobileL:grid-cols-2 laptop:grid-cols-4">
+const TagStatTicker = ({ stats }: TagStatTickerProps): ReactElement => (
+  <dl className="flex flex-wrap items-center gap-x-5 gap-y-3">
     {stats.map((stat, index) => (
-      <div
-        key={stat.label}
-        className="group relative overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-surface-float p-4 transition-all duration-200 hover:-translate-y-0.5 hover:border-border-subtlest-secondary hover:bg-surface-hover hover:shadow-2"
-      >
-        <div className="from-accent-cabbage-default/0 to-accent-onion-default/0 group-hover:opacity-5 pointer-events-none absolute inset-0 bg-gradient-to-br opacity-0 transition-opacity duration-200" />
-        <dt className="relative flex items-center justify-between gap-2 text-text-tertiary typo-caption1">
-          {stat.label}
-          <span className="rounded-8 bg-surface-hover px-1.5 py-0.5 font-bold text-text-quaternary typo-caption2">
-            0{index + 1}
-          </span>
-        </dt>
-        <dd className="relative mt-3 font-bold text-text-primary typo-title2">
-          {stat.value}
-        </dd>
-        <p className="relative mt-1 text-text-quaternary typo-caption1">
-          {stat.caption}
-        </p>
-      </div>
+      <Fragment key={stat.label}>
+        {index > 0 && (
+          <span
+            aria-hidden
+            className="hidden h-8 w-px bg-border-subtlest-tertiary mobileL:block"
+          />
+        )}
+        <div className="flex flex-col">
+          <dd className="font-bold tabular-nums text-text-primary typo-title2">
+            {stat.value}
+          </dd>
+          <dt className="text-text-tertiary typo-caption1">{stat.label}</dt>
+        </div>
+      </Fragment>
     ))}
   </dl>
-);
-
-const HeroLink = ({
-  href,
-  icon,
-  title,
-  description,
-}: {
-  href: string;
-  icon: ReactNode;
-  title: string;
-  description: string;
-}): ReactElement => (
-  <a
-    href={href}
-    className="group flex items-center gap-3 rounded-14 border border-border-subtlest-tertiary bg-surface-primary p-3 transition-all duration-200 hover:border-border-subtlest-secondary hover:bg-surface-hover"
-  >
-    <span className="flex size-9 shrink-0 items-center justify-center rounded-12 bg-surface-float text-accent-cabbage-default">
-      {icon}
-    </span>
-    <span className="min-w-0 flex-1">
-      <Typography
-        tag={TypographyTag.Span}
-        type={TypographyType.Footnote}
-        bold
-        className="block truncate"
-      >
-        {title}
-      </Typography>
-      <Typography
-        tag={TypographyTag.Span}
-        type={TypographyType.Caption1}
-        color={TypographyColor.Tertiary}
-        className="block truncate"
-      >
-        {description}
-      </Typography>
-    </span>
-    <ArrowIcon
-      size={IconSize.XSmall}
-      className="rotate-90 text-text-quaternary transition-transform group-hover:translate-x-0.5 group-hover:text-text-primary"
-    />
-  </a>
 );
 
 interface TagPageHeroProps {
@@ -131,151 +75,113 @@ export const TagPageHero = ({
   roadmap,
   crawlLinks,
   className,
-}: TagPageHeroProps): ReactElement => (
-  <section
-    className={classNames(
-      'relative mb-6 overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-background-default p-3 shadow-2 laptop:p-4',
-      className,
-    )}
-  >
-    <div className="bg-accent-cabbage-default/25 pointer-events-none absolute -left-24 -top-24 size-72 rounded-full blur-3xl" />
-    <div className="bg-accent-onion-default/20 pointer-events-none absolute -right-20 top-0 size-64 rounded-full blur-3xl" />
-    <div className="bg-accent-cheese-default/10 pointer-events-none absolute bottom-0 left-1/3 size-56 rounded-full blur-3xl" />
+}: TagPageHeroProps): ReactElement => {
+  const microcopy = {
+    blocked: 'This topic is blocked from your feed.',
+    followed: `#${tag} is shaping your feed.`,
+    unfollowed:
+      'Free account, no card. Your feed starts learning the moment you follow.',
+  }[tagStatus];
 
-    <div className="relative flex flex-col gap-3">
-      {sponsoredHero}
-      <div className="grid gap-3 laptop:grid-cols-[minmax(0,1fr)_22rem]">
-        <div className="relative overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-5 laptop:p-7">
-          <div className="bg-accent-cabbage-default/10 pointer-events-none absolute -bottom-20 -right-20 size-56 rounded-full blur-3xl" />
-          <div className="relative flex h-full flex-col justify-between gap-8">
-            <div>
-              <div className="mb-5 flex flex-wrap items-center gap-2">
-                <span className="border-accent-cabbage-default/30 inline-flex items-center gap-1.5 rounded-full border bg-accent-cabbage-subtlest px-3 py-1 font-bold text-accent-cabbage-default typo-caption1">
-                  <HashtagIcon size={IconSize.Size16} />
-                  Topic intelligence hub
-                </span>
-                <span className="rounded-full border border-border-subtlest-tertiary bg-surface-float px-3 py-1 text-text-tertiary typo-caption1">
-                  Updated daily
-                </span>
-              </div>
+  return (
+    <section
+      className={classNames(
+        'relative overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-surface-primary p-5 laptop:p-8',
+        className,
+      )}
+    >
+      <div className="bg-accent-cabbage-default/20 pointer-events-none absolute -left-24 -top-24 size-72 rounded-full blur-3xl" />
+      <div className="bg-accent-onion-default/15 pointer-events-none absolute -right-20 -top-10 size-64 rounded-full blur-3xl" />
+
+      <div className="relative flex flex-col gap-6">
+        {sponsoredHero}
+
+        <div className="flex flex-col gap-5">
+          <div className="flex items-center gap-2 text-text-tertiary typo-footnote">
+            <span className="inline-flex items-center gap-1 font-bold text-accent-cabbage-default">
+              <HashtagIcon size={IconSize.Size16} />
+              Topic
+            </span>
+            <span aria-hidden>·</span>
+            <span>Updated daily</span>
+          </div>
+
+          <div className="flex flex-col gap-4 laptop:flex-row laptop:items-end laptop:justify-between">
+            <div className="min-w-0">
               <Typography
                 tag={TypographyTag.H1}
-                type={TypographyType.Mega1}
+                type={TypographyType.LargeTitle}
                 bold
-                className="max-w-[43rem] break-words bg-gradient-to-r from-text-primary via-accent-cabbage-bolder to-accent-onion-default bg-clip-text text-transparent"
+                className="break-words bg-gradient-to-r from-text-primary to-accent-cabbage-bolder bg-clip-text text-transparent laptop:typo-mega2"
               >
                 #{title}
               </Typography>
               <Typography
                 type={TypographyType.Body}
                 color={TypographyColor.Secondary}
-                className="mt-5 max-w-[42rem]"
+                className="mt-3 max-w-[44rem]"
               >
                 {description ||
-                  `A live map of what developers are reading, saving, upvoting, and debating around #${tag}. Start with the signal, then make it yours.`}
+                  `Everything developers are reading, saving, upvoting, and debating around #${tag} — curated first, then the full live stream.`}
               </Typography>
             </div>
-            <div className="grid gap-2 tablet:grid-cols-3">
-              <HeroLink
-                href="#top-posts"
-                icon={<TrendingIcon size={IconSize.Size16} />}
-                title="Start with signal"
-                description="Scan top posts first"
-              />
-              <HeroLink
-                href="#upvoted-posts"
-                icon={<UpvoteIcon size={IconSize.Size16} />}
-                title="Find consensus"
-                description="See what developers saved"
-              />
-              <HeroLink
-                href="#discussed-posts"
-                icon={<DiscussIcon size={IconSize.Size16} />}
-                title="Read the debate"
-                description="Jump into the conversation"
-              />
+
+            <div className="flex shrink-0 flex-wrap items-center gap-2">
+              {tagStatus !== 'blocked' && (
+                <Button
+                  type="button"
+                  variant={ButtonVariant.Primary}
+                  size={ButtonSize.Large}
+                  icon={<PlusIcon />}
+                  bold
+                  {...followButtonProps}
+                  aria-label={tagStatus === 'followed' ? 'Unfollow' : 'Follow'}
+                  className={classNames(followButtonProps.className)}
+                >
+                  {tagStatus === 'followed'
+                    ? `Following #${tag}`
+                    : `Follow #${tag}`}
+                </Button>
+              )}
+              {tagStatus !== 'followed' && (
+                <Button
+                  type="button"
+                  variant={ButtonVariant.Float}
+                  size={ButtonSize.Large}
+                  icon={<BlockIcon />}
+                  {...blockButtonProps}
+                  aria-label={tagStatus === 'blocked' ? 'Unblock' : 'Block'}
+                >
+                  {tagStatus === 'blocked' ? 'Unblock' : 'Block'}
+                </Button>
+              )}
+              {optionsMenu}
             </div>
           </div>
-        </div>
-        <aside className="flex flex-col gap-3 rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-4">
-          <div className="rounded-20 bg-surface-float p-4">
-            <span className="flex w-fit items-center gap-1.5 rounded-full bg-accent-cheese-subtlest px-2.5 py-1 font-bold text-accent-cheese-default typo-caption1">
-              <SparkleIcon size={IconSize.Size16} />
-              Your next move
-            </span>
-            <Typography
-              tag={TypographyTag.H2}
-              type={TypographyType.Title2}
-              bold
-              className="mt-4"
-            >
-              Turn #{tag} into your feed
-            </Typography>
-            <Typography
-              type={TypographyType.Footnote}
-              color={TypographyColor.Tertiary}
-              className="mt-2"
-            >
-              Follow once. daily.dev will start learning what parts of this
-              topic matter to you.
-            </Typography>
-          </div>
-          {tagStatus !== 'blocked' && (
-            <Button
-              type="button"
-              variant={ButtonVariant.Primary}
-              size={ButtonSize.Medium}
-              icon={<PlusIcon />}
-              bold
-              {...followButtonProps}
-              aria-label={tagStatus === 'followed' ? 'Unfollow' : 'Follow'}
-              className={classNames('w-full', followButtonProps.className)}
-            >
-              {tagStatus === 'followed'
-                ? `Following #${tag}`
-                : `Personalize with #${tag}`}
-            </Button>
-          )}
-          <Typography
-            type={TypographyType.Caption1}
-            color={TypographyColor.Tertiary}
-            className="px-1"
-          >
-            {tagStatus === 'blocked'
-              ? 'This topic is blocked from your feed.'
-              : 'Free account. No card. Your feed gets smarter immediately.'}
-          </Typography>
-          <div className="grid grid-cols-[1fr_auto] gap-2">
-            {tagStatus !== 'followed' && (
-              <Button
-                type="button"
-                variant={ButtonVariant.Float}
-                size={ButtonSize.Small}
-                icon={<BlockIcon />}
-                {...blockButtonProps}
-                aria-label={tagStatus === 'blocked' ? 'Unblock' : 'Block'}
-                className={classNames('flex-1', blockButtonProps.className)}
-              >
-                {tagStatus === 'blocked' ? 'Unblock' : 'Block'}
-              </Button>
-            )}
-            {optionsMenu}
-          </div>
-        </aside>
-      </div>
 
-      {stats.length > 0 && <TagStatsBar stats={stats} />}
-      <div className="grid gap-3 laptop:grid-cols-[minmax(0,1fr)_20rem]">
-        <div className="rounded-20 border border-border-subtlest-tertiary bg-surface-primary p-4">
-          {recommendedTags}
+          <Typography
+            type={TypographyType.Footnote}
+            color={TypographyColor.Tertiary}
+          >
+            {microcopy}
+          </Typography>
         </div>
-        {roadmap && (
-          <div className="rounded-20 border border-border-subtlest-tertiary bg-surface-primary p-4">
+
+        {stats.length > 0 && (
+          <div className="border-t border-border-subtlest-tertiary pt-5">
+            <TagStatTicker stats={stats} />
+          </div>
+        )}
+
+        {(recommendedTags || roadmap) && (
+          <div className="flex flex-col gap-4 border-t border-border-subtlest-tertiary pt-5">
+            {recommendedTags}
             {roadmap}
           </div>
         )}
+
+        {crawlLinks}
       </div>
-      {crawlLinks}
-    </div>
-  </section>
-);
+    </section>
+  );
+};

--- a/packages/shared/src/components/tags/TagPageHero.tsx
+++ b/packages/shared/src/components/tags/TagPageHero.tsx
@@ -1,0 +1,175 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import type { ButtonProps } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { IconSize } from '../Icon';
+import { BlockIcon, HashtagIcon, PlusIcon } from '../icons';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../typography/Typography';
+
+export type TagStatus = 'followed' | 'blocked' | 'unfollowed';
+
+export interface TagPageStat {
+  label: string;
+  value: string;
+  caption: string;
+}
+
+interface TagStatsBarProps {
+  stats: TagPageStat[];
+}
+
+const TagStatsBar = ({ stats }: TagStatsBarProps): ReactElement => (
+  <dl className="grid grid-cols-2 gap-2 laptop:grid-cols-4">
+    {stats.map((stat) => (
+      <div
+        key={stat.label}
+        className="rounded-14 border border-border-subtlest-tertiary bg-surface-float p-3 transition-colors hover:border-border-subtlest-secondary hover:bg-surface-hover"
+      >
+        <dt className="text-text-tertiary typo-caption1">{stat.label}</dt>
+        <dd className="mt-1 font-bold text-text-primary typo-title3">
+          {stat.value}
+        </dd>
+        <p className="mt-1 text-text-quaternary typo-caption1">
+          {stat.caption}
+        </p>
+      </div>
+    ))}
+  </dl>
+);
+
+interface TagPageHeroProps {
+  tag: string;
+  title: string;
+  description?: string;
+  stats: TagPageStat[];
+  tagStatus: TagStatus;
+  followButtonProps: ButtonProps<'button'>;
+  blockButtonProps: ButtonProps<'button'>;
+  optionsMenu: ReactNode;
+  sponsoredHero?: ReactNode;
+  recommendedTags?: ReactNode;
+  roadmap?: ReactNode;
+  crawlLinks?: ReactNode;
+  className?: string;
+}
+
+export const TagPageHero = ({
+  tag,
+  title,
+  description,
+  stats,
+  tagStatus,
+  followButtonProps,
+  blockButtonProps,
+  optionsMenu,
+  sponsoredHero,
+  recommendedTags,
+  roadmap,
+  crawlLinks,
+  className,
+}: TagPageHeroProps): ReactElement => (
+  <section
+    className={classNames(
+      'shadow-1 relative mb-6 overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-4 laptop:p-6',
+      className,
+    )}
+  >
+    <div className="bg-accent-cabbage-default/20 pointer-events-none absolute -left-20 -top-20 size-64 rounded-full blur-3xl" />
+    <div className="bg-accent-onion-default/15 pointer-events-none absolute -right-16 top-8 size-52 rounded-full blur-3xl" />
+    <div className="bg-accent-cheese-default/10 pointer-events-none absolute bottom-0 left-1/3 size-40 rounded-full blur-3xl" />
+
+    <div className="relative flex flex-col gap-5">
+      {sponsoredHero}
+      <div className="flex flex-col gap-4 laptop:flex-row laptop:items-start laptop:justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="mb-3 flex flex-wrap items-center gap-2">
+            <span className="border-accent-cabbage-default/30 inline-flex items-center gap-1.5 rounded-full border bg-accent-cabbage-subtlest px-3 py-1 font-bold text-accent-cabbage-default typo-caption1">
+              <HashtagIcon size={IconSize.Size16} />
+              Developer topic
+            </span>
+            <span className="rounded-full border border-border-subtlest-tertiary bg-surface-float px-3 py-1 text-text-tertiary typo-caption1">
+              Updated daily
+            </span>
+          </div>
+          <div className="flex min-w-0 items-center gap-3">
+            <HashtagIcon
+              size={IconSize.XXLarge}
+              className="hidden shrink-0 text-accent-cabbage-default mobileL:block"
+            />
+            <Typography
+              tag={TypographyTag.H1}
+              type={TypographyType.Mega2}
+              bold
+              className="min-w-0 break-words bg-gradient-to-r from-text-primary via-accent-cabbage-bolder to-accent-onion-default bg-clip-text text-transparent"
+            >
+              {title}
+            </Typography>
+          </div>
+          <Typography
+            type={TypographyType.Callout}
+            color={TypographyColor.Secondary}
+            className="mt-3 max-w-[45rem]"
+          >
+            {description ||
+              `Follow #${tag} to turn this topic into a personalized daily.dev feed.`}
+          </Typography>
+        </div>
+
+        <div className="flex shrink-0 flex-col gap-2 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-3 laptop:min-w-60">
+          {tagStatus !== 'blocked' && (
+            <Button
+              type="button"
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Medium}
+              icon={<PlusIcon />}
+              bold
+              {...followButtonProps}
+              aria-label={tagStatus === 'followed' ? 'Unfollow' : 'Follow'}
+              className={classNames('w-full', followButtonProps.className)}
+            >
+              {tagStatus === 'followed'
+                ? `Following #${tag}`
+                : `Follow #${tag}`}
+            </Button>
+          )}
+          <Typography
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+            className="px-1"
+          >
+            {tagStatus === 'blocked'
+              ? 'This topic is blocked from your feed.'
+              : 'Build a personal feed from this topic. Free, no card.'}
+          </Typography>
+          <div className="flex gap-2">
+            {tagStatus !== 'followed' && (
+              <Button
+                type="button"
+                variant={ButtonVariant.Float}
+                size={ButtonSize.Small}
+                icon={<BlockIcon />}
+                {...blockButtonProps}
+                aria-label={tagStatus === 'blocked' ? 'Unblock' : 'Block'}
+                className={classNames('flex-1', blockButtonProps.className)}
+              >
+                {tagStatus === 'blocked' ? 'Unblock' : 'Block'}
+              </Button>
+            )}
+            {optionsMenu}
+          </div>
+        </div>
+      </div>
+
+      {stats.length > 0 && <TagStatsBar stats={stats} />}
+      {recommendedTags}
+      {roadmap}
+      {crawlLinks}
+    </div>
+  </section>
+);

--- a/packages/shared/src/components/tags/TagPeopleSources.tsx
+++ b/packages/shared/src/components/tags/TagPeopleSources.tsx
@@ -43,9 +43,9 @@ const EntityRail = ({
       <section id={id} className="flex flex-col gap-3">
         <ElementPlaceholder className="h-6 w-48 rounded-10" />
         <div className="grid grid-cols-1 gap-3 mobileL:grid-cols-2 laptop:grid-cols-3">
-          <ElementPlaceholder className="h-20 rounded-16" />
-          <ElementPlaceholder className="h-20 rounded-16" />
-          <ElementPlaceholder className="h-20 rounded-16" />
+          <ElementPlaceholder className="h-16 rounded-12" />
+          <ElementPlaceholder className="h-16 rounded-12" />
+          <ElementPlaceholder className="h-16 rounded-12" />
         </div>
       </section>
     );
@@ -60,20 +60,17 @@ const EntityRail = ({
   return (
     <section id={id} className="flex flex-col gap-3">
       <div className="flex items-center gap-2">
-        <span className="flex size-8 items-center justify-center rounded-10 bg-surface-float text-accent-cabbage-default">
-          <Icon size={IconSize.Small} />
-        </span>
-        <div className="min-w-0">
-          <Typography tag={TypographyTag.H3} type={TypographyType.Callout} bold>
-            {title}
-          </Typography>
-          <Typography
-            type={TypographyType.Caption1}
-            color={TypographyColor.Tertiary}
-          >
-            {description}
-          </Typography>
-        </div>
+        <Icon size={IconSize.Small} className="text-accent-cabbage-default" />
+        <Typography tag={TypographyTag.H3} type={TypographyType.Callout} bold>
+          {title}
+        </Typography>
+        <Typography
+          type={TypographyType.Caption1}
+          color={TypographyColor.Tertiary}
+          className="hidden mobileL:block"
+        >
+          · {description}
+        </Typography>
       </div>
       <div className="no-scrollbar flex gap-3 overflow-x-auto laptop:grid laptop:grid-cols-3 laptop:overflow-visible">
         {items.map((item) => (
@@ -83,11 +80,11 @@ const EntityRail = ({
             key={item.id || item.permalink}
             prefetch={false}
           >
-            <a className="group flex min-w-56 items-center gap-3 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-3 transition-all duration-200 hover:-translate-y-0.5 hover:border-border-subtlest-secondary hover:bg-surface-hover">
+            <a className="flex min-w-56 items-center gap-3 rounded-12 border border-border-subtlest-tertiary bg-surface-float p-3 transition-colors duration-200 hover:border-border-subtlest-secondary hover:bg-surface-hover">
               <img
                 src={item.image}
                 alt={item.imageAlt}
-                className="size-12 shrink-0 rounded-full border border-border-subtlest-tertiary object-cover"
+                className="size-10 shrink-0 rounded-full object-cover"
               />
               <div className="min-w-0">
                 <Typography
@@ -141,7 +138,7 @@ export const TagPeopleSources = ({
     <section
       id="people-sources"
       className={classNames(
-        'flex flex-col gap-6 rounded-16 border border-border-subtlest-tertiary bg-surface-primary p-5 laptop:p-6',
+        'flex flex-col gap-6 rounded-16 border border-border-subtlest-tertiary p-5 laptop:p-6',
         className,
       )}
     >
@@ -160,7 +157,7 @@ export const TagPeopleSources = ({
       <EntityRail
         id="contributors"
         title="Top contributors"
-        description="Developers consistently posting and discussing this topic."
+        description="consistently posting and discussing this topic"
         items={contributors}
         isLoading={isContributorsLoading}
         type="contributors"
@@ -168,7 +165,7 @@ export const TagPeopleSources = ({
       <EntityRail
         id="sources"
         title="Top sources covering it"
-        description="Publications and communities with repeated coverage."
+        description="publications and communities with repeated coverage"
         items={sources}
         isLoading={isSourcesLoading}
         type="sources"

--- a/packages/shared/src/components/tags/TagPeopleSources.tsx
+++ b/packages/shared/src/components/tags/TagPeopleSources.tsx
@@ -83,13 +83,13 @@ const EntityRail = ({
             key={item.id || item.permalink}
             prefetch={false}
           >
-            <a className="group relative flex min-w-56 overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-surface-float p-3 transition-all duration-200 hover:-translate-y-0.5 hover:border-border-subtlest-secondary hover:bg-surface-hover hover:shadow-2">
+            <a className="group relative flex min-w-56 overflow-hidden rounded-18 border border-border-subtlest-tertiary bg-surface-float p-4 transition-all duration-200 hover:-translate-y-0.5 hover:border-border-subtlest-secondary hover:bg-surface-hover hover:shadow-2">
               <div className="from-accent-cabbage-default/0 to-accent-onion-default/0 group-hover:opacity-5 pointer-events-none absolute inset-0 bg-gradient-to-br opacity-0 transition-opacity duration-200" />
               <div className="relative flex min-w-0 items-center gap-3">
                 <img
                   src={item.image}
                   alt={item.imageAlt}
-                  className="size-12 shrink-0 rounded-full object-cover"
+                  className="size-14 shrink-0 rounded-full border border-border-subtlest-tertiary object-cover"
                 />
                 <div className="min-w-0">
                   <Typography
@@ -104,7 +104,7 @@ const EntityRail = ({
                     color={TypographyColor.Tertiary}
                     className="truncate"
                   >
-                    {item.label}
+                    {item.label} signal
                   </Typography>
                 </div>
               </div>
@@ -144,41 +144,66 @@ export const TagPeopleSources = ({
     <section
       id="people-sources"
       className={classNames(
-        'shadow-1 mb-6 flex flex-col gap-6 rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-4 laptop:p-6',
+        'mb-6 overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-background-default p-3 shadow-2',
         className,
       )}
     >
-      <div className="flex flex-col gap-2">
-        <span className="w-fit rounded-full bg-accent-water-subtlest px-3 py-1 font-bold text-accent-water-default typo-caption1">
-          Community signal
-        </span>
-        <Typography tag={TypographyTag.H2} type={TypographyType.Title2} bold>
-          Who shapes #{tag}
-        </Typography>
-        <Typography
-          type={TypographyType.Callout}
-          color={TypographyColor.Tertiary}
-          className="max-w-[42rem]"
-        >
-          Follow the people and publications that keep this topic useful.
-        </Typography>
+      <div className="grid gap-3 laptop:grid-cols-[20rem_minmax(0,1fr)]">
+        <aside className="relative overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-5">
+          <div className="bg-accent-water-default/15 pointer-events-none absolute -right-14 -top-14 size-44 rounded-full blur-3xl" />
+          <div className="relative">
+            <span className="w-fit rounded-full bg-accent-water-subtlest px-3 py-1 font-bold text-accent-water-default typo-caption1">
+              Trust graph
+            </span>
+            <Typography
+              tag={TypographyTag.H2}
+              type={TypographyType.Title2}
+              bold
+              className="mt-4"
+            >
+              Who shapes #{tag}
+            </Typography>
+            <Typography
+              type={TypographyType.Callout}
+              color={TypographyColor.Tertiary}
+              className="mt-3"
+            >
+              Directories work when they tell you who to trust. This hub exposes
+              the developers and sources repeatedly connected to the topic.
+            </Typography>
+            <div className="mt-5 grid grid-cols-2 gap-2">
+              <div className="rounded-16 bg-surface-float p-3">
+                <p className="font-bold typo-title3">
+                  {contributors?.length ?? 0}
+                </p>
+                <p className="text-text-tertiary typo-caption1">contributors</p>
+              </div>
+              <div className="rounded-16 bg-surface-float p-3">
+                <p className="font-bold typo-title3">{sources?.length ?? 0}</p>
+                <p className="text-text-tertiary typo-caption1">sources</p>
+              </div>
+            </div>
+          </div>
+        </aside>
+        <div className="flex flex-col gap-6 rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-4 laptop:p-5">
+          <EntityRail
+            id="contributors"
+            title="Top contributors"
+            description="Developers consistently posting and discussing this topic."
+            items={contributors}
+            isLoading={isContributorsLoading}
+            type="contributors"
+          />
+          <EntityRail
+            id="sources"
+            title="Top sources covering it"
+            description="Publications and communities with repeated coverage."
+            items={sources}
+            isLoading={isSourcesLoading}
+            type="sources"
+          />
+        </div>
       </div>
-      <EntityRail
-        id="contributors"
-        title="Top contributors"
-        description="Developers consistently posting and discussing this topic."
-        items={contributors}
-        isLoading={isContributorsLoading}
-        type="contributors"
-      />
-      <EntityRail
-        id="sources"
-        title="Top sources covering it"
-        description="Publications and communities with repeated coverage."
-        items={sources}
-        isLoading={isSourcesLoading}
-        type="sources"
-      />
     </section>
   );
 };

--- a/packages/shared/src/components/tags/TagPeopleSources.tsx
+++ b/packages/shared/src/components/tags/TagPeopleSources.tsx
@@ -41,10 +41,11 @@ const EntityRail = ({
   if (isLoading && (!items || items.length === 0)) {
     return (
       <section id={id} className="flex flex-col gap-3">
-        <ElementPlaceholder className="h-7 w-48 rounded-10" />
-        <div className="grid grid-cols-1 gap-3 mobileL:grid-cols-2">
-          <ElementPlaceholder className="h-24 rounded-16" />
-          <ElementPlaceholder className="h-24 rounded-16" />
+        <ElementPlaceholder className="h-6 w-48 rounded-10" />
+        <div className="grid grid-cols-1 gap-3 mobileL:grid-cols-2 laptop:grid-cols-3">
+          <ElementPlaceholder className="h-20 rounded-16" />
+          <ElementPlaceholder className="h-20 rounded-16" />
+          <ElementPlaceholder className="h-20 rounded-16" />
         </div>
       </section>
     );
@@ -58,22 +59,21 @@ const EntityRail = ({
 
   return (
     <section id={id} className="flex flex-col gap-3">
-      <div className="flex flex-col gap-1">
-        <Typography
-          tag={TypographyTag.H3}
-          type={TypographyType.Title3}
-          bold
-          className="flex items-center gap-2"
-        >
-          <Icon size={IconSize.Small} className="text-accent-cabbage-default" />
-          {title}
-        </Typography>
-        <Typography
-          type={TypographyType.Footnote}
-          color={TypographyColor.Tertiary}
-        >
-          {description}
-        </Typography>
+      <div className="flex items-center gap-2">
+        <span className="flex size-8 items-center justify-center rounded-10 bg-surface-float text-accent-cabbage-default">
+          <Icon size={IconSize.Small} />
+        </span>
+        <div className="min-w-0">
+          <Typography tag={TypographyTag.H3} type={TypographyType.Callout} bold>
+            {title}
+          </Typography>
+          <Typography
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+          >
+            {description}
+          </Typography>
+        </div>
       </div>
       <div className="no-scrollbar flex gap-3 overflow-x-auto laptop:grid laptop:grid-cols-3 laptop:overflow-visible">
         {items.map((item) => (
@@ -83,30 +83,27 @@ const EntityRail = ({
             key={item.id || item.permalink}
             prefetch={false}
           >
-            <a className="group relative flex min-w-56 overflow-hidden rounded-18 border border-border-subtlest-tertiary bg-surface-float p-4 transition-all duration-200 hover:-translate-y-0.5 hover:border-border-subtlest-secondary hover:bg-surface-hover hover:shadow-2">
-              <div className="from-accent-cabbage-default/0 to-accent-onion-default/0 group-hover:opacity-5 pointer-events-none absolute inset-0 bg-gradient-to-br opacity-0 transition-opacity duration-200" />
-              <div className="relative flex min-w-0 items-center gap-3">
-                <img
-                  src={item.image}
-                  alt={item.imageAlt}
-                  className="size-14 shrink-0 rounded-full border border-border-subtlest-tertiary object-cover"
-                />
-                <div className="min-w-0">
-                  <Typography
-                    type={TypographyType.Callout}
-                    bold
-                    className="truncate"
-                  >
-                    {item.name}
-                  </Typography>
-                  <Typography
-                    type={TypographyType.Caption1}
-                    color={TypographyColor.Tertiary}
-                    className="truncate"
-                  >
-                    {item.label} signal
-                  </Typography>
-                </div>
+            <a className="group flex min-w-56 items-center gap-3 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-3 transition-all duration-200 hover:-translate-y-0.5 hover:border-border-subtlest-secondary hover:bg-surface-hover">
+              <img
+                src={item.image}
+                alt={item.imageAlt}
+                className="size-12 shrink-0 rounded-full border border-border-subtlest-tertiary object-cover"
+              />
+              <div className="min-w-0">
+                <Typography
+                  type={TypographyType.Footnote}
+                  bold
+                  className="truncate"
+                >
+                  {item.name}
+                </Typography>
+                <Typography
+                  type={TypographyType.Caption1}
+                  color={TypographyColor.Tertiary}
+                  className="truncate"
+                >
+                  {item.label}
+                </Typography>
               </div>
             </a>
           </Link>
@@ -144,66 +141,38 @@ export const TagPeopleSources = ({
     <section
       id="people-sources"
       className={classNames(
-        'mb-6 overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-background-default p-3 shadow-2',
+        'flex flex-col gap-6 rounded-16 border border-border-subtlest-tertiary bg-surface-primary p-5 laptop:p-6',
         className,
       )}
     >
-      <div className="grid gap-3 laptop:grid-cols-[20rem_minmax(0,1fr)]">
-        <aside className="relative overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-5">
-          <div className="bg-accent-water-default/15 pointer-events-none absolute -right-14 -top-14 size-44 rounded-full blur-3xl" />
-          <div className="relative">
-            <span className="w-fit rounded-full bg-accent-water-subtlest px-3 py-1 font-bold text-accent-water-default typo-caption1">
-              Trust graph
-            </span>
-            <Typography
-              tag={TypographyTag.H2}
-              type={TypographyType.Title2}
-              bold
-              className="mt-4"
-            >
-              Who shapes #{tag}
-            </Typography>
-            <Typography
-              type={TypographyType.Callout}
-              color={TypographyColor.Tertiary}
-              className="mt-3"
-            >
-              Directories work when they tell you who to trust. This hub exposes
-              the developers and sources repeatedly connected to the topic.
-            </Typography>
-            <div className="mt-5 grid grid-cols-2 gap-2">
-              <div className="rounded-16 bg-surface-float p-3">
-                <p className="font-bold typo-title3">
-                  {contributors?.length ?? 0}
-                </p>
-                <p className="text-text-tertiary typo-caption1">contributors</p>
-              </div>
-              <div className="rounded-16 bg-surface-float p-3">
-                <p className="font-bold typo-title3">{sources?.length ?? 0}</p>
-                <p className="text-text-tertiary typo-caption1">sources</p>
-              </div>
-            </div>
-          </div>
-        </aside>
-        <div className="flex flex-col gap-6 rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-4 laptop:p-5">
-          <EntityRail
-            id="contributors"
-            title="Top contributors"
-            description="Developers consistently posting and discussing this topic."
-            items={contributors}
-            isLoading={isContributorsLoading}
-            type="contributors"
-          />
-          <EntityRail
-            id="sources"
-            title="Top sources covering it"
-            description="Publications and communities with repeated coverage."
-            items={sources}
-            isLoading={isSourcesLoading}
-            type="sources"
-          />
-        </div>
+      <div>
+        <Typography tag={TypographyTag.H2} type={TypographyType.Title1} bold>
+          People &amp; sources shaping #{tag}
+        </Typography>
+        <Typography
+          type={TypographyType.Callout}
+          color={TypographyColor.Tertiary}
+          className="mt-1"
+        >
+          The developers and publications most consistently behind this topic.
+        </Typography>
       </div>
+      <EntityRail
+        id="contributors"
+        title="Top contributors"
+        description="Developers consistently posting and discussing this topic."
+        items={contributors}
+        isLoading={isContributorsLoading}
+        type="contributors"
+      />
+      <EntityRail
+        id="sources"
+        title="Top sources covering it"
+        description="Publications and communities with repeated coverage."
+        items={sources}
+        isLoading={isSourcesLoading}
+        type="sources"
+      />
     </section>
   );
 };

--- a/packages/shared/src/components/tags/TagPeopleSources.tsx
+++ b/packages/shared/src/components/tags/TagPeopleSources.tsx
@@ -1,0 +1,184 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import { ElementPlaceholder } from '../ElementPlaceholder';
+import { SourceIcon, UserIcon } from '../icons';
+import { IconSize } from '../Icon';
+import Link from '../utilities/Link';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../typography/Typography';
+
+export interface TagAuthorityEntity {
+  id?: string;
+  image: string;
+  imageAlt: string;
+  name: string;
+  permalink: string;
+  label: string;
+}
+
+interface EntityRailProps {
+  id: string;
+  title: string;
+  description: string;
+  items?: TagAuthorityEntity[];
+  isLoading: boolean;
+  type: 'sources' | 'contributors';
+}
+
+const EntityRail = ({
+  id,
+  title,
+  description,
+  items,
+  isLoading,
+  type,
+}: EntityRailProps): ReactElement | null => {
+  if (isLoading && (!items || items.length === 0)) {
+    return (
+      <section id={id} className="flex flex-col gap-3">
+        <ElementPlaceholder className="h-7 w-48 rounded-10" />
+        <div className="grid grid-cols-1 gap-3 mobileL:grid-cols-2">
+          <ElementPlaceholder className="h-24 rounded-16" />
+          <ElementPlaceholder className="h-24 rounded-16" />
+        </div>
+      </section>
+    );
+  }
+
+  if (!items || items.length === 0) {
+    return null;
+  }
+
+  const Icon = type === 'sources' ? SourceIcon : UserIcon;
+
+  return (
+    <section id={id} className="flex flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <Typography
+          tag={TypographyTag.H3}
+          type={TypographyType.Title3}
+          bold
+          className="flex items-center gap-2"
+        >
+          <Icon size={IconSize.Small} className="text-accent-cabbage-default" />
+          {title}
+        </Typography>
+        <Typography
+          type={TypographyType.Footnote}
+          color={TypographyColor.Tertiary}
+        >
+          {description}
+        </Typography>
+      </div>
+      <div className="no-scrollbar flex gap-3 overflow-x-auto laptop:grid laptop:grid-cols-3 laptop:overflow-visible">
+        {items.map((item) => (
+          <Link
+            href={item.permalink}
+            passHref
+            key={item.id || item.permalink}
+            prefetch={false}
+          >
+            <a className="group relative flex min-w-56 overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-surface-float p-3 transition-all duration-200 hover:-translate-y-0.5 hover:border-border-subtlest-secondary hover:bg-surface-hover hover:shadow-2">
+              <div className="from-accent-cabbage-default/0 to-accent-onion-default/0 group-hover:opacity-5 pointer-events-none absolute inset-0 bg-gradient-to-br opacity-0 transition-opacity duration-200" />
+              <div className="relative flex min-w-0 items-center gap-3">
+                <img
+                  src={item.image}
+                  alt={item.imageAlt}
+                  className="size-12 shrink-0 rounded-full object-cover"
+                />
+                <div className="min-w-0">
+                  <Typography
+                    type={TypographyType.Callout}
+                    bold
+                    className="truncate"
+                  >
+                    {item.name}
+                  </Typography>
+                  <Typography
+                    type={TypographyType.Caption1}
+                    color={TypographyColor.Tertiary}
+                    className="truncate"
+                  >
+                    {item.label}
+                  </Typography>
+                </div>
+              </div>
+            </a>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+interface TagPeopleSourcesProps {
+  tag: string;
+  sources?: TagAuthorityEntity[];
+  contributors?: TagAuthorityEntity[];
+  isSourcesLoading: boolean;
+  isContributorsLoading: boolean;
+  className?: string;
+}
+
+export const TagPeopleSources = ({
+  tag,
+  sources,
+  contributors,
+  isSourcesLoading,
+  isContributorsLoading,
+  className,
+}: TagPeopleSourcesProps): ReactElement | null => {
+  const hasSources = !!sources?.length || isSourcesLoading;
+  const hasContributors = !!contributors?.length || isContributorsLoading;
+
+  if (!hasSources && !hasContributors) {
+    return null;
+  }
+
+  return (
+    <section
+      id="people-sources"
+      className={classNames(
+        'shadow-1 mb-6 flex flex-col gap-6 rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-4 laptop:p-6',
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-2">
+        <span className="w-fit rounded-full bg-accent-water-subtlest px-3 py-1 font-bold text-accent-water-default typo-caption1">
+          Community signal
+        </span>
+        <Typography tag={TypographyTag.H2} type={TypographyType.Title2} bold>
+          Who shapes #{tag}
+        </Typography>
+        <Typography
+          type={TypographyType.Callout}
+          color={TypographyColor.Tertiary}
+          className="max-w-[42rem]"
+        >
+          Follow the people and publications that keep this topic useful.
+        </Typography>
+      </div>
+      <EntityRail
+        id="contributors"
+        title="Top contributors"
+        description="Developers consistently posting and discussing this topic."
+        items={contributors}
+        isLoading={isContributorsLoading}
+        type="contributors"
+      />
+      <EntityRail
+        id="sources"
+        title="Top sources covering it"
+        description="Publications and communities with repeated coverage."
+        items={sources}
+        isLoading={isSourcesLoading}
+        type="sources"
+      />
+    </section>
+  );
+};

--- a/packages/shared/src/components/tags/TagSectionNav.tsx
+++ b/packages/shared/src/components/tags/TagSectionNav.tsx
@@ -27,16 +27,22 @@ export const TagSectionNav = ({
     <nav
       aria-label="Tag page sections"
       className={classNames(
-        'bg-background-default/95 sticky top-0 z-1 mb-6 overflow-hidden rounded-16 border border-border-subtlest-tertiary p-1 backdrop-blur',
+        'bg-background-default/95 shadow-1 sticky top-0 z-1 mb-6 overflow-hidden rounded-20 border border-border-subtlest-tertiary p-2 backdrop-blur',
         className,
       )}
     >
-      <ul className="no-scrollbar flex gap-1 overflow-x-auto">
+      <div className="mb-2 flex items-center justify-between gap-3 px-2">
+        <p className="font-bold text-text-primary typo-caption1">Hub map</p>
+        <p className="hidden text-text-quaternary typo-caption1 mobileL:block">
+          Pick a path through the topic.
+        </p>
+      </div>
+      <ul className="no-scrollbar flex gap-1 overflow-x-auto rounded-16 bg-surface-primary p-1">
         {visibleItems.map((item) => (
           <li key={item.href} className="shrink-0">
             <a
               href={item.href}
-              className="block rounded-12 px-3 py-2 font-bold text-text-tertiary transition-colors typo-footnote hover:bg-surface-hover hover:text-text-primary"
+              className="block rounded-12 px-3 py-2 font-bold text-text-tertiary transition-all duration-200 typo-footnote hover:bg-surface-hover hover:text-text-primary"
             >
               {item.label}
             </a>

--- a/packages/shared/src/components/tags/TagSectionNav.tsx
+++ b/packages/shared/src/components/tags/TagSectionNav.tsx
@@ -1,6 +1,10 @@
 import type { ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
+import type { ButtonProps } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { PlusIcon } from '../icons';
+import type { TagStatus } from './TagPageHero';
 
 export interface TagSectionNavItem {
   href: string;
@@ -10,11 +14,17 @@ export interface TagSectionNavItem {
 
 interface TagSectionNavProps {
   items: TagSectionNavItem[];
+  tag: string;
+  tagStatus: TagStatus;
+  followButtonProps: ButtonProps<'button'>;
   className?: string;
 }
 
 export const TagSectionNav = ({
   items,
+  tag,
+  tagStatus,
+  followButtonProps,
   className,
 }: TagSectionNavProps): ReactElement | null => {
   const visibleItems = items.filter((item) => item.isVisible !== false);
@@ -27,28 +37,47 @@ export const TagSectionNav = ({
     <nav
       aria-label="Tag page sections"
       className={classNames(
-        'bg-background-default/95 shadow-1 sticky top-0 z-1 mb-6 overflow-hidden rounded-20 border border-border-subtlest-tertiary p-2 backdrop-blur',
+        'bg-background-default/80 sticky top-0 z-3 flex items-center gap-3 rounded-16 border border-border-subtlest-tertiary p-1.5 backdrop-blur-xl',
         className,
       )}
     >
-      <div className="mb-2 flex items-center justify-between gap-3 px-2">
-        <p className="font-bold text-text-primary typo-caption1">Hub map</p>
-        <p className="hidden text-text-quaternary typo-caption1 mobileL:block">
-          Pick a path through the topic.
-        </p>
-      </div>
-      <ul className="no-scrollbar flex gap-1 overflow-x-auto rounded-16 bg-surface-primary p-1">
+      <span className="ml-1.5 hidden shrink-0 font-bold text-text-primary typo-callout tablet:block">
+        #{tag}
+      </span>
+      <ul className="no-scrollbar flex flex-1 gap-1 overflow-x-auto">
         {visibleItems.map((item) => (
           <li key={item.href} className="shrink-0">
             <a
               href={item.href}
-              className="block rounded-12 px-3 py-2 font-bold text-text-tertiary transition-all duration-200 typo-footnote hover:bg-surface-hover hover:text-text-primary"
+              className="block rounded-10 px-3 py-1.5 font-bold text-text-tertiary transition-colors duration-200 typo-footnote hover:bg-surface-hover hover:text-text-primary"
             >
               {item.label}
             </a>
           </li>
         ))}
       </ul>
+      {tagStatus !== 'blocked' && (
+        <Button
+          type="button"
+          variant={
+            tagStatus === 'followed'
+              ? ButtonVariant.Subtle
+              : ButtonVariant.Primary
+          }
+          size={ButtonSize.Small}
+          icon={<PlusIcon />}
+          {...followButtonProps}
+          aria-label={
+            tagStatus === 'followed' ? `Unfollow #${tag}` : `Follow #${tag}`
+          }
+          className={classNames(
+            'hidden shrink-0 tablet:flex',
+            followButtonProps.className,
+          )}
+        >
+          {tagStatus === 'followed' ? 'Following' : 'Follow'}
+        </Button>
+      )}
     </nav>
   );
 };

--- a/packages/shared/src/components/tags/TagSectionNav.tsx
+++ b/packages/shared/src/components/tags/TagSectionNav.tsx
@@ -37,12 +37,13 @@ export const TagSectionNav = ({
     <nav
       aria-label="Tag page sections"
       className={classNames(
-        'bg-background-default/80 sticky top-0 z-3 flex items-center gap-3 rounded-16 border border-border-subtlest-tertiary p-1.5 backdrop-blur-xl',
+        'sticky top-0 z-3 flex items-center gap-3 rounded-16 border border-border-subtlest-tertiary bg-background-default p-1.5',
         className,
       )}
     >
-      <span className="ml-1.5 hidden shrink-0 font-bold text-text-primary typo-callout tablet:block">
-        #{tag}
+      <span className="ml-2 hidden shrink-0 font-bold text-text-primary typo-callout tablet:block">
+        <span className="text-accent-cabbage-default">#</span>
+        {tag}
       </span>
       <ul className="no-scrollbar flex flex-1 gap-1 overflow-x-auto">
         {visibleItems.map((item) => (

--- a/packages/shared/src/components/tags/TagSectionNav.tsx
+++ b/packages/shared/src/components/tags/TagSectionNav.tsx
@@ -1,0 +1,48 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+
+export interface TagSectionNavItem {
+  href: string;
+  label: string;
+  isVisible?: boolean;
+}
+
+interface TagSectionNavProps {
+  items: TagSectionNavItem[];
+  className?: string;
+}
+
+export const TagSectionNav = ({
+  items,
+  className,
+}: TagSectionNavProps): ReactElement | null => {
+  const visibleItems = items.filter((item) => item.isVisible !== false);
+
+  if (visibleItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <nav
+      aria-label="Tag page sections"
+      className={classNames(
+        'bg-background-default/95 sticky top-0 z-1 mb-6 overflow-hidden rounded-16 border border-border-subtlest-tertiary p-1 backdrop-blur',
+        className,
+      )}
+    >
+      <ul className="no-scrollbar flex gap-1 overflow-x-auto">
+        {visibleItems.map((item) => (
+          <li key={item.href} className="shrink-0">
+            <a
+              href={item.href}
+              className="block rounded-12 px-3 py-2 font-bold text-text-tertiary transition-colors typo-footnote hover:bg-surface-hover hover:text-text-primary"
+            >
+              {item.label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+};

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -37,6 +37,8 @@ export const featurePostPageHighlights = new Feature(
   false,
 );
 
+export const featureTagPageRedesign = new Feature('tag_page_redesign', true);
+
 // @ts-expect-error stale feature without default
 export const plusTakeoverContent = new Feature<{
   title: string;

--- a/packages/webapp/__tests__/TagPage.tsx
+++ b/packages/webapp/__tests__/TagPage.tsx
@@ -471,7 +471,7 @@ it('should load title and description for tag', async () => {
 
   await waitFor(() => {
     expect(
-      screen.getByRole('heading', { name: '#React custom title' }),
+      screen.getByRole('heading', { name: /React custom title/ }),
     ).toBeInTheDocument();
     expect(
       screen.getByText('React is an amazing framework'),

--- a/packages/webapp/__tests__/TagPage.tsx
+++ b/packages/webapp/__tests__/TagPage.tsx
@@ -471,7 +471,7 @@ it('should load title and description for tag', async () => {
 
   await waitFor(() => {
     expect(
-      screen.getByRole('heading', { name: 'React custom title' }),
+      screen.getByRole('heading', { name: '#React custom title' }),
     ).toBeInTheDocument();
     expect(
       screen.getByText('React is an amazing framework'),

--- a/packages/webapp/__tests__/TagPage.tsx
+++ b/packages/webapp/__tests__/TagPage.tsx
@@ -173,7 +173,9 @@ const renderComponent = (
     optOutReadingStreak: false,
     optOutLevelSystem: false,
     optOutQuestSystem: false,
+    optOutAchievements: false,
     optOutCompanion: false,
+    isGamificationEnabled: true,
     autoDismissNotifications: true,
     sortCommentsBy: SortCommentsBy.OldestFirst,
     showFeedbackButton: true,
@@ -191,7 +193,9 @@ const renderComponent = (
     toggleOptOutReadingStreak: jest.fn().mockResolvedValue(undefined),
     toggleOptOutLevelSystem: jest.fn().mockResolvedValue(undefined),
     toggleOptOutQuestSystem: jest.fn().mockResolvedValue(undefined),
+    toggleOptOutAchievements: jest.fn().mockResolvedValue(undefined),
     toggleOptOutCompanion: jest.fn().mockResolvedValue(undefined),
+    toggleAllGamification: jest.fn().mockResolvedValue(undefined),
     toggleAutoDismissNotifications: jest.fn().mockResolvedValue(undefined),
     toggleShowFeedbackButton: jest.fn().mockResolvedValue(undefined),
     updateCustomLinks: jest.fn().mockResolvedValue(undefined),
@@ -310,7 +314,7 @@ it('should show login popup when logged-out on follow click', async () => {
 it('should render top contributors section from static props', async () => {
   renderComponent(undefined, defaultUser, initialDataObj, [topContributor]);
 
-  expect(await screen.findByText('👥 Top contributors')).toBeInTheDocument();
+  expect(await screen.findByText('Top contributors')).toBeInTheDocument();
   expect(screen.getByText('Ido').closest('a')).toHaveAttribute(
     'href',
     '/idoshamun',

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -257,9 +257,9 @@ const getTagPageStats = ({
 
   if (recommendedTagsCount > 0) {
     stats.push({
-      label: 'Related tags',
+      label: 'Adjacent topics',
       value: recommendedTagsCount.toString(),
-      caption: 'nearby topics',
+      caption: 'ways to branch out',
     });
   }
 
@@ -706,16 +706,16 @@ const TagPage = ({
         <TagSectionNav
           className="mx-4"
           items={[
-            { href: '#best-posts', label: 'Best posts' },
-            { href: '#upvoted-posts', label: 'Upvoted' },
-            { href: '#discussed-posts', label: 'Discussed' },
+            { href: '#best-posts', label: 'Signal board' },
+            { href: '#upvoted-posts', label: 'Consensus' },
+            { href: '#discussed-posts', label: 'Debate' },
             {
               href: '#people-sources',
-              label: 'People & sources',
+              label: 'Trust graph',
               isVisible: topContributors.length > 0,
             },
             { href: '#archive', label: 'Archive' },
-            { href: '#all-posts', label: 'All posts' },
+            { href: '#all-posts', label: 'Live feed' },
           ]}
         />
         <TagBestOfShowcase
@@ -795,13 +795,28 @@ const TagPage = ({
           }
         />
         <TagPeopleSourcesSection tag={tag} initialUsers={topContributors} />
-        <div id="archive">
-          <ArchiveEntryCard
-            scopeType={ArchiveScopeType.Tag}
-            scopeId={tag}
-            scopeName={title}
-            className="mx-4 mb-6 laptop:mx-4"
-          />
+        <div
+          id="archive"
+          className="shadow-1 mx-4 mb-6 rounded-24 border border-border-subtlest-tertiary bg-background-default p-3"
+        >
+          <div className="rounded-20 border border-border-subtlest-tertiary bg-surface-primary p-5">
+            <p className="w-fit rounded-full bg-accent-burger-subtlest px-3 py-1 font-bold text-accent-burger-default typo-caption1">
+              Time machine
+            </p>
+            <h2 className="mt-4 font-bold typo-title2">
+              Best of #{tag}, by month
+            </h2>
+            <p className="mt-2 max-w-[42rem] text-text-tertiary typo-callout">
+              Use the archive when you need the durable version of the topic,
+              not just what is fresh today.
+            </p>
+            <ArchiveEntryCard
+              scopeType={ArchiveScopeType.Tag}
+              scopeId={tag}
+              scopeName={title}
+              className="mt-5"
+            />
+          </div>
         </div>
         {!user && (
           <TagJoinStrip
@@ -809,14 +824,17 @@ const TagPage = ({
             onJoin={() => showLogin({ trigger: AuthTriggers.Filter })}
           />
         )}
-        <section id="all-posts">
-          <div className="mx-4 mb-5 flex w-auto flex-col gap-1">
-            <p className="flex items-center font-bold typo-title3">
-              All posts about {tag}
+        <section id="all-posts" className="mx-4">
+          <div className="mb-5 rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-5">
+            <p className="w-fit rounded-full bg-accent-cabbage-subtlest px-3 py-1 font-bold text-accent-cabbage-default typo-caption1">
+              Live feed
             </p>
-            <p className="text-text-tertiary typo-callout">
-              The live feed keeps moving as developers publish, save, upvote,
-              and discuss.
+            <h2 className="mt-4 font-bold typo-title2">
+              Everything moving through #{tag}
+            </h2>
+            <p className="mt-2 max-w-[42rem] text-text-tertiary typo-callout">
+              After the curated signal, this is the full stream: newest posts,
+              videos, discussions, and updates as developers publish them.
             </p>
           </div>
           <Feed
@@ -828,7 +846,7 @@ const TagPage = ({
             ]}
             query={TAG_FEED_QUERY}
             variables={queryVariables}
-            className="!mx-4 !w-auto"
+            className="!mx-0 !w-auto"
           />
         </section>
       </FeedPageLayoutComponent>

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -798,7 +798,7 @@ const TagPage = ({
         <TagPeopleSourcesSection tag={tag} initialUsers={topContributors} />
         <section
           id="archive"
-          className="mx-4 mb-6 rounded-16 border border-border-subtlest-tertiary bg-surface-primary p-5 laptop:p-6"
+          className="mx-4 mb-6 rounded-16 border border-border-subtlest-tertiary p-5 laptop:p-6"
         >
           <h2 className="font-bold typo-title1">Best of #{tag}, by month</h2>
           <p className="mt-1 max-w-[44rem] text-text-tertiary typo-callout">

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -67,7 +67,10 @@ import { ActiveFeedNameContext } from '@dailydotdev/shared/src/contexts';
 import HorizontalFeed from '@dailydotdev/shared/src/components/feeds/HorizontalFeed';
 import { PostType } from '@dailydotdev/shared/src/graphql/posts';
 import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
-import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
+import {
+  feature,
+  featureTagPageRedesign,
+} from '@dailydotdev/shared/src/lib/featureManagement';
 import { cloudinarySourceRoadmap } from '@dailydotdev/shared/src/lib/image';
 import { anchorDefaultRel } from '@dailydotdev/shared/src/lib/strings';
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
@@ -80,6 +83,18 @@ import { ContentPreferenceType } from '@dailydotdev/shared/src/graphql/contentPr
 import { TOP_CREATORS_BY_TAG_QUERY } from '@dailydotdev/shared/src/graphql/users';
 import type { UserShortProfile } from '@dailydotdev/shared/src/lib/user';
 import { SponsoredTagHero } from '@dailydotdev/shared/src/components/brand/SponsoredTagHero';
+import { TagBestOfShowcase } from '@dailydotdev/shared/src/components/tags/TagBestOfShowcase';
+import { TagJoinStrip } from '@dailydotdev/shared/src/components/tags/TagJoinStrip';
+import {
+  TagPageHero,
+  type TagPageStat,
+} from '@dailydotdev/shared/src/components/tags/TagPageHero';
+import {
+  TagPeopleSources,
+  type TagAuthorityEntity,
+} from '@dailydotdev/shared/src/components/tags/TagPeopleSources';
+import { TagSectionNav } from '@dailydotdev/shared/src/components/tags/TagSectionNav';
+import { largeNumberFormat } from '@dailydotdev/shared/src/lib/numberFormat';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 import { getLayout } from '../../components/layouts/FeedLayout';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
@@ -211,6 +226,123 @@ const TagTopContributors = ({
   );
 };
 
+const getTagPageStats = ({
+  initialData,
+  topPostsCount,
+  recommendedTagsCount,
+  topContributorsCount,
+}: {
+  initialData: Keyword | null;
+  topPostsCount: number;
+  recommendedTagsCount: number;
+  topContributorsCount: number;
+}): TagPageStat[] => {
+  const stats: TagPageStat[] = [];
+
+  if (initialData?.occurrences) {
+    stats.push({
+      label: 'Indexed posts',
+      value: largeNumberFormat(initialData.occurrences) ?? '0',
+      caption: 'articles and discussions',
+    });
+  }
+
+  if (topPostsCount > 0) {
+    stats.push({
+      label: 'Top picks',
+      value: topPostsCount.toString(),
+      caption: 'ready to scan',
+    });
+  }
+
+  if (recommendedTagsCount > 0) {
+    stats.push({
+      label: 'Related tags',
+      value: recommendedTagsCount.toString(),
+      caption: 'nearby topics',
+    });
+  }
+
+  if (topContributorsCount > 0) {
+    stats.push({
+      label: 'Contributors',
+      value: topContributorsCount.toString(),
+      caption: 'developers to follow',
+    });
+  }
+
+  return stats;
+};
+
+const TagPeopleSourcesSection = ({
+  tag,
+  initialUsers = [],
+}: {
+  tag: string;
+  initialUsers?: UserShortProfile[];
+}): ReactElement | null => {
+  const { data: topSources, isPending: isSourcesPending } = useQuery({
+    queryKey: [RequestKey.SourceByTag, 'redesign', tag],
+
+    queryFn: async () =>
+      await gqlClient.request<{ sourcesByTag: Connection<Source> }>(
+        SOURCES_BY_TAG_QUERY,
+        {
+          tag,
+          first: 6,
+        },
+      ),
+
+    enabled: !!tag,
+    staleTime: StaleTime.OneHour,
+  });
+  const { data: topContributors, isPending: isContributorsPending } = useQuery({
+    queryKey: [RequestKey.TopCreatorsByTag, 'redesign', tag],
+
+    queryFn: async () =>
+      await gqlClient.request<{ topCreatorsByTag: UserShortProfile[] }>(
+        TOP_CREATORS_BY_TAG_QUERY,
+        {
+          tag,
+          limit: 6,
+        },
+      ),
+
+    enabled: !!tag,
+    staleTime: StaleTime.OneHour,
+  });
+
+  const sources: TagAuthorityEntity[] | undefined =
+    topSources?.sourcesByTag?.edges?.map((edge) => ({
+      id: edge.node.id,
+      image: edge.node.image,
+      imageAlt: `${edge.node.name} logo`,
+      name: edge.node.name,
+      permalink: edge.node.permalink,
+      label: 'Source',
+    }));
+  const users = topContributors?.topCreatorsByTag ?? initialUsers;
+  const contributors: TagAuthorityEntity[] = users.map((user) => ({
+    id: user.id,
+    image: user.image,
+    imageAlt: `${user.name} avatar`,
+    name: user.name,
+    permalink: user.permalink,
+    label: 'Contributor',
+  }));
+
+  return (
+    <TagPeopleSources
+      tag={tag}
+      sources={sources}
+      contributors={contributors}
+      isSourcesLoading={isSourcesPending}
+      isContributorsLoading={isContributorsPending && initialUsers.length === 0}
+      className="mx-4"
+    />
+  );
+};
+
 const getTagPageJsonLd = ({
   tag,
   initialData,
@@ -288,6 +420,7 @@ const TagPage = ({
 }: TagPageProps): ReactElement => {
   const { push } = useRouter();
   const showRoadmap = useFeature(feature.showRoadmap);
+  const isTagPageRedesign = useFeature(featureTagPageRedesign);
   const { user, showLogin } = useContext(AuthContext);
   const mostUpvotedQueryVariables = useMemo(
     () => ({
@@ -377,6 +510,22 @@ const TagPage = ({
     return 'unfollowed';
   }, [feedSettings, tag]);
 
+  const tagPageStats = useMemo(
+    () =>
+      getTagPageStats({
+        initialData,
+        topPostsCount: topPosts.length,
+        recommendedTagsCount: recommendedTags.length,
+        topContributorsCount: topContributors.length,
+      }),
+    [
+      initialData,
+      topContributors.length,
+      topPosts.length,
+      recommendedTags.length,
+    ],
+  );
+
   const followButtonProps: ButtonProps<'button'> = {
     size: ButtonSize.Small,
     icon: tagStatus === 'followed' ? <XIcon /> : <PlusIcon />,
@@ -408,6 +557,283 @@ const TagPage = ({
       }
     },
   };
+
+  if (isTagPageRedesign) {
+    return (
+      <FeedPageLayoutComponent>
+        {jsonLd && (
+          <Head>
+            <script
+              type="application/ld+json"
+              dangerouslySetInnerHTML={{ __html: jsonLd }}
+            />
+          </Head>
+        )}
+        <ArchiveBreadcrumbs
+          items={[{ label: 'Tags', href: '/tags' }, { label: title }]}
+          className="mx-4"
+        />
+        <TagPageHero
+          tag={tag}
+          title={title}
+          description={initialData?.flags?.description}
+          stats={tagPageStats}
+          tagStatus={tagStatus}
+          followButtonProps={followButtonProps}
+          blockButtonProps={blockButtonProps}
+          className="mx-4 !w-auto"
+          sponsoredHero={<SponsoredTagHero tag={tag} />}
+          optionsMenu={
+            <CustomFeedOptionsMenu
+              onCreateNewFeed={() =>
+                push(
+                  `/feeds/new?entityId=${tag}&entityType=${ContentPreferenceType.Keyword}`,
+                )
+              }
+              onAdd={(feedId) =>
+                follow({
+                  id: tag,
+                  entity: ContentPreferenceType.Keyword,
+                  entityName: tag,
+                  feedId,
+                })
+              }
+              onUndo={(feedId) =>
+                unfollow({
+                  id: tag,
+                  entity: ContentPreferenceType.Keyword,
+                  entityName: tag,
+                  feedId,
+                })
+              }
+              shareProps={{
+                text: `Check out the ${tag} tag on daily.dev`,
+                link: globalThis?.location?.href,
+                cid: ReferralCampaignKey.ShareTag,
+                logObject: () => ({
+                  event_name: LogEvent.ShareTag,
+                  target_id: tag,
+                }),
+              }}
+            />
+          }
+          crawlLinks={
+            <>
+              {topPosts.length > 0 && (
+                <div className="sr-only">
+                  {topPosts.map((post) => (
+                    <Link
+                      key={post.id}
+                      href={`/posts/${post.slug || post.id}`}
+                      prefetch={false}
+                    >
+                      <a>{post.title}</a>
+                    </Link>
+                  ))}
+                </div>
+              )}
+              {recommendedTags.length > 0 && (
+                <div className="sr-only">
+                  {recommendedTags
+                    .map((relatedTag) => relatedTag.name)
+                    .filter((relatedTag): relatedTag is string => !!relatedTag)
+                    .map((relatedTag) => (
+                      <Link
+                        key={relatedTag}
+                        href={`/tags/${relatedTag}`}
+                        prefetch={false}
+                      >
+                        <a>Posts about {relatedTag}</a>
+                      </Link>
+                    ))}
+                </div>
+              )}
+              {topContributors.length > 0 && (
+                <div className="sr-only">
+                  {topContributors.map((contributor) => (
+                    <Link
+                      key={contributor.id}
+                      href={contributor.permalink}
+                      prefetch={false}
+                    >
+                      <a>Posts by {contributor.name}</a>
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </>
+          }
+          recommendedTags={
+            tag ? (
+              <TagRecommendedTags
+                tag={tag}
+                blockedTags={feedSettings?.blockedTags}
+                initialTags={recommendedTags}
+              />
+            ) : null
+          }
+          roadmap={
+            showRoadmap && initialData?.flags?.roadmap ? (
+              <Link href={initialData.flags.roadmap} passHref prefetch={false}>
+                <a
+                  target="_blank"
+                  rel={anchorDefaultRel}
+                  className="mr-auto flex w-auto cursor-pointer items-center rounded-16 border border-border-subtlest-tertiary bg-surface-float p-4 transition-colors hover:bg-surface-hover"
+                >
+                  <img
+                    src={cloudinarySourceRoadmap}
+                    alt="roadmap.sh logo"
+                    className="size-10 rounded-full"
+                  />
+                  <div className="mx-3 flex-1">
+                    <p className="font-bold typo-callout">
+                      Comprehensive roadmap for {tag}
+                    </p>
+                    <p className="text-text-tertiary typo-footnote">
+                      By roadmap.sh
+                    </p>
+                  </div>
+                  <Button
+                    icon={<OpenLinkIcon />}
+                    size={ButtonSize.Small}
+                    variant={ButtonVariant.Tertiary}
+                  />
+                </a>
+              </Link>
+            ) : null
+          }
+        />
+        <TagSectionNav
+          className="mx-4"
+          items={[
+            { href: '#best-posts', label: 'Best posts' },
+            { href: '#upvoted-posts', label: 'Upvoted' },
+            { href: '#discussed-posts', label: 'Discussed' },
+            {
+              href: '#people-sources',
+              label: 'People & sources',
+              isVisible: topContributors.length > 0,
+            },
+            { href: '#archive', label: 'Archive' },
+            { href: '#all-posts', label: 'All posts' },
+          ]}
+        />
+        <TagBestOfShowcase
+          tag={tag}
+          className="mx-4"
+          topPosts={
+            <ActiveFeedNameContext.Provider
+              value={{ feedName: OtherFeedPage.TagsTopPosts }}
+            >
+              <HorizontalFeed
+                feedName={OtherFeedPage.TagsTopPosts}
+                feedQueryKey={[
+                  'tagsTopPosts',
+                  user?.id ?? 'anonymous',
+                  Object.values(topPostsQueryVariables),
+                ]}
+                query={TAG_FEED_QUERY}
+                variables={topPostsQueryVariables}
+                title={{
+                  copy: 'Top posts',
+                  icon: (
+                    <HashtagIcon size={IconSize.Medium} className="mr-1.5" />
+                  ),
+                }}
+                className="!mx-0 laptop:!mx-0"
+                emptyScreen={<></>}
+              />
+            </ActiveFeedNameContext.Provider>
+          }
+          mostUpvoted={
+            <ActiveFeedNameContext.Provider
+              value={{ feedName: OtherFeedPage.TagsMostUpvoted }}
+            >
+              <HorizontalFeed
+                feedName={OtherFeedPage.TagsMostUpvoted}
+                feedQueryKey={[
+                  'tagsMostUpvoted',
+                  user?.id ?? 'anonymous',
+                  Object.values(mostUpvotedQueryVariables),
+                ]}
+                query={MOST_UPVOTED_FEED_QUERY}
+                variables={mostUpvotedQueryVariables}
+                title={{
+                  copy: 'Most upvoted posts',
+                  icon: (
+                    <UpvoteIcon size={IconSize.Medium} className="mr-1.5" />
+                  ),
+                }}
+                className="!mx-0 laptop:!mx-0"
+                emptyScreen={<></>}
+              />
+            </ActiveFeedNameContext.Provider>
+          }
+          bestDiscussed={
+            <ActiveFeedNameContext.Provider
+              value={{ feedName: OtherFeedPage.TagsBestDiscussed }}
+            >
+              <HorizontalFeed
+                feedName={OtherFeedPage.TagsBestDiscussed}
+                feedQueryKey={[
+                  'tagsBestDiscussed',
+                  user?.id ?? 'anonymous',
+                  Object.values(bestDiscussedQueryVariables),
+                ]}
+                query={MOST_DISCUSSED_FEED_QUERY}
+                variables={bestDiscussedQueryVariables}
+                title={{
+                  copy: 'Best discussed posts',
+                  icon: (
+                    <DiscussIcon size={IconSize.Medium} className="mr-1.5" />
+                  ),
+                }}
+                className="!mx-0 laptop:!mx-0"
+                emptyScreen={<></>}
+              />
+            </ActiveFeedNameContext.Provider>
+          }
+        />
+        <TagPeopleSourcesSection tag={tag} initialUsers={topContributors} />
+        <div id="archive">
+          <ArchiveEntryCard
+            scopeType={ArchiveScopeType.Tag}
+            scopeId={tag}
+            scopeName={title}
+            className="mx-4 mb-6 laptop:mx-4"
+          />
+        </div>
+        {!user && (
+          <TagJoinStrip
+            tag={tag}
+            onJoin={() => showLogin({ trigger: AuthTriggers.Filter })}
+          />
+        )}
+        <section id="all-posts">
+          <div className="mx-4 mb-5 flex w-auto flex-col gap-1">
+            <p className="flex items-center font-bold typo-title3">
+              All posts about {tag}
+            </p>
+            <p className="text-text-tertiary typo-callout">
+              The live feed keeps moving as developers publish, save, upvote,
+              and discuss.
+            </p>
+          </div>
+          <Feed
+            feedName={OtherFeedPage.Tag}
+            feedQueryKey={[
+              'tagFeed',
+              user?.id ?? 'anonymous',
+              Object.values(queryVariables),
+            ]}
+            query={TAG_FEED_QUERY}
+            variables={queryVariables}
+            className="!mx-4 !w-auto"
+          />
+        </section>
+      </FeedPageLayoutComponent>
+    );
+  }
 
   return (
     <FeedPageLayoutComponent>

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -338,7 +338,7 @@ const TagPeopleSourcesSection = ({
       contributors={contributors}
       isSourcesLoading={isSourcesPending}
       isContributorsLoading={isContributorsPending && initialUsers.length === 0}
-      className="mx-4"
+      className="mx-4 mb-6"
     />
   );
 };
@@ -581,7 +581,7 @@ const TagPage = ({
           tagStatus={tagStatus}
           followButtonProps={followButtonProps}
           blockButtonProps={blockButtonProps}
-          className="mx-4 !w-auto"
+          className="mx-4 mb-4"
           sponsoredHero={<SponsoredTagHero tag={tag} />}
           optionsMenu={
             <CustomFeedOptionsMenu
@@ -704,14 +704,15 @@ const TagPage = ({
           }
         />
         <TagSectionNav
-          className="mx-4"
+          className="mx-4 mb-6"
+          tag={tag}
+          tagStatus={tagStatus}
+          followButtonProps={followButtonProps}
           items={[
-            { href: '#best-posts', label: 'Signal board' },
-            { href: '#upvoted-posts', label: 'Consensus' },
-            { href: '#discussed-posts', label: 'Debate' },
+            { href: '#best-posts', label: 'Best of' },
             {
               href: '#people-sources',
-              label: 'Trust graph',
+              label: 'People & sources',
               isVisible: topContributors.length > 0,
             },
             { href: '#archive', label: 'Archive' },
@@ -720,7 +721,7 @@ const TagPage = ({
         />
         <TagBestOfShowcase
           tag={tag}
-          className="mx-4"
+          className="mx-4 mb-6"
           topPosts={
             <ActiveFeedNameContext.Provider
               value={{ feedName: OtherFeedPage.TagsTopPosts }}
@@ -795,45 +796,36 @@ const TagPage = ({
           }
         />
         <TagPeopleSourcesSection tag={tag} initialUsers={topContributors} />
-        <div
+        <section
           id="archive"
-          className="shadow-1 mx-4 mb-6 rounded-24 border border-border-subtlest-tertiary bg-background-default p-3"
+          className="mx-4 mb-6 rounded-16 border border-border-subtlest-tertiary bg-surface-primary p-5 laptop:p-6"
         >
-          <div className="rounded-20 border border-border-subtlest-tertiary bg-surface-primary p-5">
-            <p className="w-fit rounded-full bg-accent-burger-subtlest px-3 py-1 font-bold text-accent-burger-default typo-caption1">
-              Time machine
-            </p>
-            <h2 className="mt-4 font-bold typo-title2">
-              Best of #{tag}, by month
-            </h2>
-            <p className="mt-2 max-w-[42rem] text-text-tertiary typo-callout">
-              Use the archive when you need the durable version of the topic,
-              not just what is fresh today.
-            </p>
-            <ArchiveEntryCard
-              scopeType={ArchiveScopeType.Tag}
-              scopeId={tag}
-              scopeName={title}
-              className="mt-5"
-            />
-          </div>
-        </div>
+          <h2 className="font-bold typo-title1">Best of #{tag}, by month</h2>
+          <p className="mt-1 max-w-[44rem] text-text-tertiary typo-callout">
+            The durable version of the topic — the standout posts from each
+            month, not just what is fresh today.
+          </p>
+          <ArchiveEntryCard
+            scopeType={ArchiveScopeType.Tag}
+            scopeId={tag}
+            scopeName={title}
+            className="mt-5"
+          />
+        </section>
         {!user && (
           <TagJoinStrip
             tag={tag}
+            className="mx-4 mb-6"
             onJoin={() => showLogin({ trigger: AuthTriggers.Filter })}
           />
         )}
         <section id="all-posts" className="mx-4">
-          <div className="mb-5 rounded-24 border border-border-subtlest-tertiary bg-surface-primary p-5">
-            <p className="w-fit rounded-full bg-accent-cabbage-subtlest px-3 py-1 font-bold text-accent-cabbage-default typo-caption1">
-              Live feed
-            </p>
-            <h2 className="mt-4 font-bold typo-title2">
+          <div className="mb-5">
+            <h2 className="font-bold typo-title1">
               Everything moving through #{tag}
             </h2>
-            <p className="mt-2 max-w-[42rem] text-text-tertiary typo-callout">
-              After the curated signal, this is the full stream: newest posts,
+            <p className="mt-1 max-w-[44rem] text-text-tertiary typo-callout">
+              After the curated signal, the full live stream: newest posts,
               videos, discussions, and updates as developers publish them.
             </p>
           </div>


### PR DESCRIPTION
## Summary
- Redesigns `/tags/[tag]` behind a default-on `tag_page_redesign` GrowthBook flag while preserving the existing flag-off layout.
- Adds an editorial tag hero, real at-a-glance stats, sticky section nav, best-of showcase, richer people/sources cards, and an anonymous join strip.
- Keeps existing SEO/data surfaces intact: JSON-LD, breadcrumbs, sr-only crawl links, related tags, roadmap, archive, all three horizontal feeds, and the main feed.

## Test plan
- `node ./scripts/typecheck-strict-changed.js`
- `pnpm --filter webapp exec eslint "pages/tags/[tag].tsx" "__tests__/TagPage.tsx" --max-warnings 0`
- `pnpm --filter @dailydotdev/shared exec eslint "src/components/tags/TagPageHero.tsx" "src/components/tags/TagSectionNav.tsx" "src/components/tags/TagBestOfShowcase.tsx" "src/components/tags/TagPeopleSources.tsx" "src/components/tags/TagJoinStrip.tsx" "src/lib/featureManagement.ts" --max-warnings 0`
- `NODE_ENV=test pnpm --filter webapp exec jest "__tests__/TagPage.tsx" --runInBand`


Made with [Cursor](https://cursor.com)

### Preview domain
https://feat-tag-page-redesign.preview.app.daily.dev