### PR TITLE
fix: remove inline login feature flag

### DIFF
--- a/packages/shared/src/contexts/AuthContext.tsx
+++ b/packages/shared/src/contexts/AuthContext.tsx
@@ -8,8 +8,6 @@ import React, {
 } from 'react';
 import type { QueryObserverResult } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
-import type { GrowthBookContextValue } from '@growthbook/growthbook-react';
-import { GrowthBookContext } from '@growthbook/growthbook-react';
 import type { AnonymousUser, LoggedUser } from '../lib/user';
 import { deleteAccount, logout as dispatchLogout } from '../lib/user';
 import type { AccessToken, Boot, Visit } from '../lib/boot';
@@ -85,8 +83,6 @@ export interface AuthContextData {
 }
 
 const isExtension = checkIsExtension();
-const inlineLoginFeatureId = 'inline_login';
-const inlineLoginDefaultValue: boolean = false;
 const AuthContext = React.createContext<AuthContextData>(null);
 export const useAuthContext = (): AuthContextData => useContext(AuthContext);
 export default AuthContext;
@@ -171,10 +167,6 @@ export const AuthContextProvider = ({
   const referralOrigin = user?.referralOrigin;
   const router = useRouter();
   const isFunnelRef = useRef(!!router?.pathname?.startsWith(webFunnelPrefix));
-  const growthbookContext = useContext(
-    GrowthBookContext,
-  ) as unknown as GrowthBookContextValue;
-  const growthbook = growthbookContext?.growthbook;
   const isValidRegion = useMemo(
     () => !invalidPlusRegions.includes(geo?.region),
     [geo?.region],
@@ -201,37 +193,18 @@ export const AuthContextProvider = ({
               return;
             }
 
-            const params = new URLSearchParams(globalThis?.location.search);
-            const shouldUseInlineLogin =
-              !isExtension &&
-              growthbook?.getFeatureValue(
-                inlineLoginFeatureId,
-                inlineLoginDefaultValue,
-              ) === true;
-
             setLoginState({ ...options, trigger });
-            if (isExtension) {
-              params.delete(AFTER_AUTH_PARAM);
-            } else if (options.afterAuth) {
-              params.set(AFTER_AUTH_PARAM, options.afterAuth);
-            } else if (!params.get(AFTER_AUTH_PARAM)) {
-              params.set(AFTER_AUTH_PARAM, window.location.pathname);
-            }
 
-            const onboardingPath = isExtension
-              ? `${onboardingUrl}?${params.toString()}`
-              : `/onboarding?${params.toString()}`;
-
-            // Inline login experiment: render the modal in-place instead of
-            // redirecting to /onboarding. Extension keeps the redirect because
-            // it has no host page to mount the modal on.
-            if (shouldUseInlineLogin) {
+            if (!isExtension) {
               return;
             }
 
-            router.push(onboardingPath);
+            const params = new URLSearchParams(globalThis?.location.search);
+            params.delete(AFTER_AUTH_PARAM);
+
+            router.push(`${onboardingUrl}?${params.toString()}`);
           },
-          [growthbook, router],
+          [router],
         ),
         closeLogin: useCallback(() => setLoginState(null), []),
         loginState,

--- a/packages/shared/src/contexts/BootProvider.spec.tsx
+++ b/packages/shared/src/contexts/BootProvider.spec.tsx
@@ -76,6 +76,7 @@ const defaultSettings: RemoteSettings = {
   companionExpanded: false,
   sortingEnabled: false,
   optOutReadingStreak: true,
+  optOutAchievements: false,
   optOutLevelSystem: false,
   optOutQuestSystem: false,
   autoDismissNotifications: true,
@@ -513,7 +514,7 @@ it('should trigger show login callback', async () => {
   await expectToHaveTestValue(login, JSON.stringify({ trigger: expected }));
 });
 
-it('should keep inline login on page when enabled after auth intent', async () => {
+it('should keep login inline on the webapp after auth intent', async () => {
   const push = jest.fn();
   mockUseRouter({
     push,
@@ -523,16 +524,6 @@ it('should keep inline login on page when enabled after auth intent', async () =
   renderComponent(<AuthMock loginTrigger={AuthTriggers.Comment} />, {
     ...defaultBootData,
     user: defaultAnonymousUser,
-    exp: {
-      f: '{}',
-      e: [],
-      a: [],
-      features: {
-        inline_login: {
-          defaultValue: true,
-        },
-      },
-    },
   });
 
   const login = await screen.findByText('Log in');

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -54,8 +54,6 @@ export const featurePlusCtaCopy = new Feature('plus_cta_copy', {
 
 export const featurePlusApiLanding = new Feature('plus_api_landing_v2', false);
 
-export const featureInlineLogin = new Feature('inline_login', false);
-
 export const featureLuckyButton = new Feature('lucky_button', false);
 
 export const featureSmartComposer = new Feature('smart_composer', false);

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -21,9 +21,7 @@ import { ProgressiveEnhancementContextProvider } from '@dailydotdev/shared/src/c
 import { SubscriptionContextProvider } from '@dailydotdev/shared/src/contexts/SubscriptionContext';
 import { ShortcutsProvider } from '@dailydotdev/shared/src/features/shortcuts/contexts/ShortcutsProvider';
 import { canonicalFromRouter } from '@dailydotdev/shared/src/lib/canonical';
-import {
-  featureOnboardingPermissionPrimer,
-} from '@dailydotdev/shared/src/lib/featureManagement';
+import { featureOnboardingPermissionPrimer } from '@dailydotdev/shared/src/lib/featureManagement';
 import '@dailydotdev/shared/src/styles/globals.css';
 import useLogPageView from '@dailydotdev/shared/src/hooks/log/useLogPageView';
 import { BootDataProvider } from '@dailydotdev/shared/src/contexts/BootProvider';

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -22,7 +22,6 @@ import { SubscriptionContextProvider } from '@dailydotdev/shared/src/contexts/Su
 import { ShortcutsProvider } from '@dailydotdev/shared/src/features/shortcuts/contexts/ShortcutsProvider';
 import { canonicalFromRouter } from '@dailydotdev/shared/src/lib/canonical';
 import {
-  featureInlineLogin,
   featureOnboardingPermissionPrimer,
 } from '@dailydotdev/shared/src/lib/featureManagement';
 import '@dailydotdev/shared/src/styles/globals.css';
@@ -110,8 +109,8 @@ const onboardingExcludedPaths = [
   '/jobs',
   '/settings',
 ];
-// While inline_login is active for an auth intent, only force the rest of
-// onboarding when the user lands on the main feed.
+// While an auth intent is active, only force the rest of onboarding when the
+// user lands on the main feed.
 const mainFeedPathnames = new Set([
   '/',
   '/popular',
@@ -184,10 +183,6 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
     closeLogin,
     loginState,
   } = useAuthContext();
-  const { value: inlineLoginEnabled } = useConditionalFeature({
-    feature: featureInlineLogin,
-    shouldEvaluate: shouldShowLogin,
-  });
   // Users arriving from the extension install link land on `/?ref=install`.
   // Only evaluate the permission primer experiment for them while onboarding
   // is still pending, so we can route them to the activation step.
@@ -282,9 +277,9 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
       return;
     }
 
-    // Inline login experiment: while the auth intent is active, defer the rest
-    // of onboarding until they navigate to the main feed.
-    if (inlineLoginEnabled && !mainFeedPathnames.has(router.pathname)) {
+    // While the auth intent is active, defer the rest of onboarding until they
+    // navigate to the main feed.
+    if (shouldShowLogin && !mainFeedPathnames.has(router.pathname)) {
       return;
     }
 
@@ -300,7 +295,7 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
     router,
     router.pathname,
     isOnboardingComplete,
-    inlineLoginEnabled,
+    shouldShowLogin,
     isSwipeOnboardingPreviewForced,
     isComingFromInstall,
     isPermissionPrimerEnabled,
@@ -456,7 +451,7 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
         <DndContextProvider>
           {getLayout(<Component {...pageProps} />, pageProps, layoutProps)}
         </DndContextProvider>
-        {inlineLoginEnabled && shouldShowLogin && (
+        {shouldShowLogin && (
           <AuthModal
             isOpen={shouldShowLogin}
             onRequestClose={closeLogin}


### PR DESCRIPTION
## Summary
- remove the inline_login GrowthBook feature from feature management
- make webapp auth intents render the inline AuthModal permanently
- keep extension auth intents redirecting to onboarding

## Testing
- rg -n "inline_login|featureInlineLogin" .
- node ./scripts/typecheck-strict-changed.js
- NODE_ENV=test pnpm --filter shared exec jest src/contexts/BootProvider.spec.tsx --runInBand

### Preview domain
https://codex-remove-inline-login.preview.app.daily.dev