### PR TITLE
fix: use pnpm 10 for storybook vercel build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "installCommand": "pnpm install"
+  "installCommand": "if [ -f pnpm-workspace.yaml ]; then corepack pnpm@10.33.4 install; elif [ -f ../../pnpm-workspace.yaml ]; then corepack pnpm@10.33.4 --dir ../.. install; else corepack pnpm@10.33.4 install; fi"
 }


### PR DESCRIPTION
## Problem

The **Vercel – storybook** check fails on every PR that triggers a real storybook deploy (e.g. [#6118](https://github.com/dailydotdev/apps/pull/6118), [#6129](https://github.com/dailydotdev/apps/pull/6129)) with:

```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation.
The current "patchedDependencies" configuration doesn't match the value found in the lockfile
```

## Cause

The storybook Vercel project uses the **root** `vercel.json`, which ran a bare `pnpm install`. Vercel pins that project to **pnpm@9.x**, which can't read the pnpm-10-format `patchedDependencies` object in `pnpm-lock.yaml` (regenerated when the lockfile was migrated to pnpm 10 in [#6044](https://github.com/dailydotdev/apps/pull/6044)). [#6044](https://github.com/dailydotdev/apps/pull/6044) fixed this for `packages/webapp/vercel.json` but missed the root config.

## Fix

Force `corepack pnpm@10.33.4` in the root `vercel.json`, mirroring the webapp fix. webapp is unaffected (it has its own override).

Verified locally: `pnpm@10.33.4 install --frozen-lockfile` passes; `pnpm@9` fails on the same lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://fix-storybook-vercel-pnpm10.preview.app.daily.dev