### PR TITLE
fix(webapp): redirect logged-in users away from login onboarding page

### DIFF
--- a/packages/webapp/pages/onboarding.spec.tsx
+++ b/packages/webapp/pages/onboarding.spec.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { NextRouter } from 'next/router';
+import { useRouter } from 'next/router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import type {
+  AnonymousUser,
+  LoggedUser,
+} from '@dailydotdev/shared/src/lib/user';
+import { FeaturesReadyContext } from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import user from '@dailydotdev/shared/__tests__/fixture/loggedUser';
+import { useOnboardingBoot } from '@dailydotdev/shared/src/features/onboarding/hooks/useOnboardingBoot';
+import { useOnboardingActions } from '@dailydotdev/shared/src/hooks/auth';
+import OnboardingPage from './onboarding';
+
+jest.mock(
+  '@dailydotdev/shared/src/features/onboarding/hooks/useOnboardingBoot',
+  () => ({
+    ONBOARDING_BOOT_QUERY_KEY: ['onboarding-boot'],
+    useOnboardingBoot: jest.fn(),
+  }),
+);
+
+jest.mock('@dailydotdev/shared/src/hooks/auth', () => ({
+  useOnboardingActions: jest.fn(),
+}));
+
+jest.mock('@dailydotdev/shared/src/hooks/useConditionalFeature', () => ({
+  useConditionalFeature: () => ({ value: false }),
+}));
+
+jest.mock('@dailydotdev/shared/src/contexts/SettingsContext', () => ({
+  ...jest.requireActual('@dailydotdev/shared/src/contexts/SettingsContext'),
+  useSettingsContext: () => ({ autoDismissNotifications: true }),
+}));
+
+jest.mock('@dailydotdev/shared/src/components/notifications/Toast', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('@dailydotdev/shared/src/components/auth/AuthOptions', () => ({
+  __esModule: true,
+  default: () => <div data-testid="auth-options">auth options</div>,
+}));
+
+jest.mock(
+  '@dailydotdev/shared/src/features/onboarding/shared/FunnelStepper',
+  () => ({
+    FunnelStepper: () => <div data-testid="funnel-stepper">funnel</div>,
+  }),
+);
+
+const routerReplace = jest.fn();
+
+const funnelState = {
+  funnel: { chapters: [] },
+  session: {},
+} as never;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  window.history.replaceState({}, '', '/onboarding');
+  jest.mocked(useRouter).mockImplementation(
+    () =>
+      ({
+        pathname: '/onboarding',
+        query: { action: 'login' },
+        replace: routerReplace,
+        push: jest.fn(),
+        isReady: true,
+      } as unknown as NextRouter),
+  );
+  jest.mocked(useOnboardingBoot).mockReturnValue({
+    data: { funnelState },
+  } as never);
+  jest.mocked(useOnboardingActions).mockReturnValue({
+    isOnboardingComplete: true,
+    isOnboardingActionsReady: true,
+    shouldShowAuthBanner: false,
+    completeStep: jest.fn(),
+  });
+});
+
+type AuthValue = {
+  user?: LoggedUser;
+  anonymous?: AnonymousUser;
+  isLoggedIn: boolean;
+};
+
+const renderPage = ({ user: authUser, anonymous, isLoggedIn }: AuthValue) => {
+  const client = new QueryClient();
+
+  return render(
+    <QueryClientProvider client={client}>
+      <FeaturesReadyContext.Provider
+        value={{
+          ready: true,
+          getFeatureValue: (feature) => feature.defaultValue,
+        }}
+      >
+        <AuthContext.Provider
+          value={
+            {
+              user: authUser,
+              anonymous,
+              isLoggedIn,
+              isAuthReady: true,
+              shouldShowLogin: false,
+              showLogin: jest.fn(),
+              logout: jest.fn(),
+              updateUser: jest.fn(),
+              tokenRefreshed: true,
+              getRedirectUri: jest.fn(),
+              closeLogin: jest.fn(),
+            } as never
+          }
+        >
+          <OnboardingPage dehydratedState={{} as never} initialStepId={null} />
+        </AuthContext.Provider>
+      </FeaturesReadyContext.Provider>
+    </QueryClientProvider>,
+  );
+};
+
+it('redirects a logged-in user landing with action=login to the app', async () => {
+  renderPage({ user, anonymous: undefined, isLoggedIn: true });
+
+  await waitFor(() => expect(routerReplace).toHaveBeenCalledWith('/'));
+  expect(screen.queryByTestId('auth-options')).not.toBeInTheDocument();
+});
+
+it('honors the after_auth destination when redirecting', async () => {
+  window.history.replaceState({}, '', '/onboarding?after_auth=/my-feed');
+
+  renderPage({ user, anonymous: undefined, isLoggedIn: true });
+
+  await waitFor(() => expect(routerReplace).toHaveBeenCalledWith('/my-feed'));
+});
+
+it('keeps showing the auth UI for a logged-out user with action=login', async () => {
+  renderPage({ user: undefined, anonymous: undefined, isLoggedIn: false });
+
+  expect(await screen.findByTestId('auth-options')).toBeInTheDocument();
+  expect(routerReplace).not.toHaveBeenCalled();
+});
+
+it('keeps showing email verification for a logged-in user needing verification', async () => {
+  jest.mocked(useRouter).mockImplementation(
+    () =>
+      ({
+        pathname: '/onboarding',
+        query: { action: 'verify' },
+        replace: routerReplace,
+        push: jest.fn(),
+        isReady: true,
+      } as unknown as NextRouter),
+  );
+
+  renderPage({
+    user,
+    anonymous: { id: user.id, shouldVerify: true } as AnonymousUser,
+    isLoggedIn: true,
+  });
+
+  expect(await screen.findByTestId('auth-options')).toBeInTheDocument();
+  expect(routerReplace).not.toHaveBeenCalled();
+});

--- a/packages/webapp/pages/onboarding.tsx
+++ b/packages/webapp/pages/onboarding.tsx
@@ -168,6 +168,12 @@ const isValidAction = (
   return typeof action === 'string' && action in actionToAuthDisplay;
 };
 
+// login/signup are no-ops for an already-authenticated user: there is nothing
+// to authenticate, so we redirect to the app instead of rendering a blank
+// funnel. verify/recover/changePassword stay valid for a logged-in user.
+const isLoginOrSignupAction = (action?: string | string[]): boolean =>
+  action === OnboardingActions.Login || action === OnboardingActions.Signup;
+
 const useOnboardingAuth = () => {
   const formRef = useRef<HTMLFormElement>(null as unknown as HTMLFormElement);
   const isMobile = useViewSize(ViewSize.MobileL);
@@ -279,6 +285,7 @@ const useOnboardingAuth = () => {
     isAuthenticating: auth.isAuthenticating,
     updateAuth,
     isLoggedIn,
+    shouldVerify: anonymous?.shouldVerify,
   };
 };
 
@@ -290,6 +297,7 @@ function Onboarding({ initialStepId }: PageProps): ReactElement | null {
     authOptionProps,
     funnelState,
     isLoggedIn,
+    shouldVerify,
   } = useOnboardingAuth();
   const { isOnboardingComplete, isOnboardingActionsReady, completeStep } =
     useOnboardingActions();
@@ -335,10 +343,21 @@ function Onboarding({ initialStepId }: PageProps): ReactElement | null {
       query: { action },
     } = router;
 
+    if (!isAuthReady) {
+      return;
+    }
+
+    // A logged-in user (with no pending verification) can't act on a
+    // login/signup action, so redirect to the app instead of leaving them on a
+    // blank render. redirectToApp handles query cleanup and the afterAuth target.
+    if (isLoggedIn && !shouldVerify && isLoginOrSignupAction(action)) {
+      redirectToApp(router);
+      return;
+    }
+
     if (
       action ||
       isAuthenticating !== false || // also cover the case when auth is still undefined at load time
-      !isAuthReady ||
       isFunnelReady ||
       (isLoggedIn && !isOnboardingActionsReady)
     ) {
@@ -362,6 +381,7 @@ function Onboarding({ initialStepId }: PageProps): ReactElement | null {
     isFunnelReady,
     isSwipeOnboardingPreviewForced,
     isLoggedIn,
+    shouldVerify,
     isOnboardingActionsReady,
     router,
   ]);


### PR DESCRIPTION
## What

`/onboarding?action=login` rendered a blank screen for users who are already authenticated: the effect that decides between "redirect to app" and "activate the funnel" early-returned on any `action` query param, while there was nothing to authenticate — so neither branch ran and the render fell through to `return null`.

This adds a guard that redirects already-logged-in users (with no pending verification) to the app when they land with a `login`/`signup` action, reusing the existing `redirectToApp(router)` helper for query cleanup and `after_auth` handling.

## Key decisions

- **Scope to `login`/`signup` only.** These are the actions a logged-in user can't act on. `verify`, `recover`, and `changePassword` stay valid for an authenticated user and continue through their existing displays.
- **Gated behind `isAuthReady`.** The guard runs only after auth state resolves, so it never bounces a user mid-auth-resolution.
- **Reused `redirectToApp`** rather than hand-rolling `router.replace('/')`, keeping `after_auth`/`id`/`stepId` handling consistent.

## Tests

Added `pages/onboarding.spec.tsx` covering: logged-in + `login` → redirect to `/`; redirect honors `after_auth`; logged-out + `login` → auth UI still shows; logged-in + `verify` with `shouldVerify` → verification still shows.

Closes ENG-1616

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1616-redirect-logged-in-user.preview.app.daily.dev