### PR TITLE
fix: hide apple signup identity fields

### DIFF
--- a/packages/shared/src/components/auth/AuthOptionsInner.tsx
+++ b/packages/shared/src/components/auth/AuthOptionsInner.tsx
@@ -36,7 +36,7 @@ import { generateUsername, claimClaimableItem } from '../../graphql/users';
 import useRegistration from '../../hooks/useRegistration';
 import { storageWrapper as storage } from '../../lib/storageWrapper';
 import type { AuthOptionsProps } from './common';
-import { AuthDisplay, providers } from './common';
+import { AuthDisplay, providers, SocialProvider } from './common';
 import useLogin from '../../hooks/useLogin';
 import type { UpdateProfileParameters } from '../../hooks/useProfileForm';
 import useProfileForm from '../../hooks/useProfileForm';
@@ -172,6 +172,14 @@ function AuthOptionsInner({
     CHOSEN_PROVIDER_KEY,
     null,
   );
+  const [activeSocialProvider, setActiveSocialProvider] = useState<
+    string | null
+  >(null);
+  const userSocialProvider = user?.providers?.find((provider) =>
+    Object.values(SocialProvider).includes(provider as SocialProvider),
+  );
+  const socialRegistrationProvider =
+    activeSocialProvider || chosenProvider || userSocialProvider;
   const [isRegistration, setIsRegistration] = useState(false);
   const [isSocialAuthLoading, setIsSocialAuthLoading] = useState(false);
   const windowPopup = useRef<Window | null>(null);
@@ -261,7 +269,7 @@ function AuthOptionsInner({
     }
 
     if (data.user && setSignBack) {
-      const provider = chosenProvider || 'password';
+      const provider = socialRegistrationProvider || 'password';
       onSignBackLogin(data.user as LoggedUser, provider as SignBackProvider);
     }
 
@@ -375,7 +383,12 @@ function AuthOptionsInner({
     return e.data.login === 'true' && e.data.eventKey === AuthEvent.Login;
   };
 
-  const handleLoginMessage = async (e?: MessageEvent) => {
+  const handleLoginMessage = async (
+    e?: MessageEvent,
+    providerOverride?: string,
+  ) => {
+    const authProvider = providerOverride || chosenProvider;
+    setActiveSocialProvider(authProvider);
     authFlowCompletedRef.current = true;
     clearPopupCheck();
     const popup = windowPopup.current;
@@ -408,7 +421,7 @@ function AuthOptionsInner({
       logEvent({
         event_name: socialErrorEventName.current,
         extra: JSON.stringify({
-          provider: chosenProvider,
+          provider: authProvider,
           error: getBetterAuthErrorMessage(
             error,
             'Failed to refresh Better Auth social auth state',
@@ -430,7 +443,7 @@ function AuthOptionsInner({
       logEvent({
         event_name: socialErrorEventName.current,
         extra: JSON.stringify({
-          provider: chosenProvider,
+          provider: authProvider,
           error:
             callbackError ||
             'Could not find authenticated user after social authentication',
@@ -451,7 +464,7 @@ function AuthOptionsInner({
     // If user is confirmed we can proceed with logging them in
     if ('infoConfirmed' in boot.user && boot.user.infoConfirmed) {
       setIsSocialAuthLoading(false);
-      await onSignBackLogin(boot.user, chosenProvider as SignBackProvider);
+      await onSignBackLogin(boot.user, authProvider as SignBackProvider);
       const isAlreadyOnboarded = await checkForOnboardedUser(boot.user);
       if (!isAlreadyOnboarded) {
         onSuccessfulLogin?.();
@@ -467,7 +480,7 @@ function AuthOptionsInner({
     }
 
     setIsSocialAuthLoading(false);
-    await setChosenProvider(chosenProvider || 'password');
+    await setChosenProvider(authProvider || 'password');
     onAuthStateUpdate({ defaultDisplay: AuthDisplay.SocialRegistration });
     onSetActiveDisplay(AuthDisplay.SocialRegistration);
   };
@@ -490,6 +503,7 @@ function AuthOptionsInner({
     });
     socialErrorEventName.current = authErrorEventName;
     authFlowSucceededRef.current = false;
+    setActiveSocialProvider(provider);
     setIsSocialAuthLoading(true);
 
     const additionalData = { timezone: getUserDefaultTimezone() };
@@ -520,7 +534,7 @@ function AuthOptionsInner({
         return;
       }
       await setChosenProvider(provider);
-      await handleLoginMessage();
+      await handleLoginMessage(undefined, provider);
       return;
     }
     const shouldUsePopup = shouldUseSocialAuthPopup();
@@ -552,6 +566,7 @@ function AuthOptionsInner({
       return;
     }
     if (!windowPopup.current) {
+      await setChosenProvider(provider);
       window.location.href = socialUrl;
       return;
     }
@@ -682,7 +697,7 @@ function AuthOptionsInner({
         <Tab label={AuthDisplay.SocialRegistration}>
           <SocialRegistrationForm
             formRef={formRef}
-            provider={chosenProvider}
+            provider={socialRegistrationProvider}
             onSignup={onSocialCompletion}
             hints={hint}
             isLoading={isProfileUpdateLoading}

--- a/packages/shared/src/components/auth/SocialRegistrationForm.spec.tsx
+++ b/packages/shared/src/components/auth/SocialRegistrationForm.spec.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import AuthContext from '../../contexts/AuthContext';
+import type { AuthContextData } from '../../contexts/AuthContext';
+import type { LoggedUser } from '../../lib/user';
+import { SocialProvider } from './common';
+import { SocialRegistrationForm } from './SocialRegistrationForm';
+import { useGenerateUsername } from '../../hooks';
+
+const mockOnUpdateSignBack = jest.fn();
+
+jest.mock('../../hooks', () => ({
+  useGenerateUsername: jest.fn(),
+}));
+
+jest.mock('../../hooks/auth/useSignBack', () => ({
+  useSignBack: () => ({
+    onUpdateSignBack: mockOnUpdateSignBack,
+  }),
+}));
+
+jest.mock('../profile/ExperienceLevelDropdown', () => {
+  const actualReact = jest.requireActual('react');
+
+  return {
+    __esModule: true,
+    default: ({ name }: { name: string }) =>
+      actualReact.createElement('input', {
+        'aria-label': 'Experience level',
+        name,
+        defaultValue: 'LESS_THAN_1_YEAR',
+      }),
+  };
+});
+
+const user = {
+  id: 'user-id',
+  email: 'apple@example.com',
+  name: 'Apple User',
+  image: 'https://daily.dev/avatar.png',
+  username: 'apple_user',
+  providers: ['apple'],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  permalink: 'https://daily.dev/apple_user',
+} as LoggedUser;
+
+const renderForm = (component: ReactElement, authUser = user) =>
+  render(
+    <AuthContext.Provider
+      value={
+        {
+          user: authUser,
+          isLoggedIn: true,
+          isAuthReady: true,
+          updateUser: jest.fn(),
+        } as unknown as AuthContextData
+      }
+    >
+      {component}
+    </AuthContext.Provider>,
+  );
+
+beforeEach(() => {
+  mockOnUpdateSignBack.mockReset();
+  jest.mocked(useGenerateUsername).mockReturnValue({
+    username: 'daily_apple',
+    setUsername: jest.fn(),
+    isLoading: false,
+  });
+});
+
+describe('SocialRegistrationForm', () => {
+  it('hides Apple identity fields while submitting the internal profile name', () => {
+    const onSignup = jest.fn();
+    renderForm(
+      <SocialRegistrationForm
+        provider={SocialProvider.Apple}
+        hints={{}}
+        onSignup={onSignup}
+      />,
+    );
+    const hiddenNameInput = screen.getByDisplayValue('Apple User');
+    const hiddenEmailInput = screen.getByDisplayValue('apple@example.com');
+
+    expect(screen.queryByText('Email')).not.toBeInTheDocument();
+    expect(screen.queryByText('Name')).not.toBeInTheDocument();
+    expect(hiddenNameInput).toHaveAttribute('type', 'hidden');
+    expect(hiddenNameInput).toHaveAttribute('name', 'name');
+    expect(hiddenEmailInput).toHaveAttribute('type', 'hidden');
+    expect(hiddenEmailInput).toHaveAttribute('name', 'email');
+    expect(screen.getByDisplayValue('daily_apple')).toBeInTheDocument();
+    expect(screen.getByLabelText('Experience level')).toBeInTheDocument();
+
+    fireEvent.submit(screen.getByTestId('registration_form'));
+
+    expect(onSignup).toHaveBeenCalledWith({
+      email: 'apple@example.com',
+      name: 'Apple User',
+      username: 'daily_apple',
+      experienceLevel: 'LESS_THAN_1_YEAR',
+      acceptedMarketing: true,
+    });
+    expect(mockOnUpdateSignBack).toHaveBeenCalledWith(
+      {
+        name: 'Apple User',
+        email: 'apple@example.com',
+        image: 'https://daily.dev/avatar.png',
+      },
+      SocialProvider.Apple,
+    );
+  });
+
+  it('shows Apple identity fields when the provider did not return them', () => {
+    const onSignup = jest.fn();
+    renderForm(
+      <SocialRegistrationForm
+        provider={SocialProvider.Apple}
+        hints={{}}
+        onSignup={onSignup}
+      />,
+      {
+        ...user,
+        email: undefined,
+        name: undefined,
+      } as unknown as LoggedUser,
+    );
+
+    const emailInput = screen.getByPlaceholderText('Email');
+    const nameInput = screen.getByPlaceholderText('Name');
+
+    fireEvent.input(emailInput, {
+      target: { value: 'missing@example.com' },
+    });
+    fireEvent.input(nameInput, {
+      target: { value: 'Missing User' },
+    });
+    fireEvent.blur(emailInput);
+    fireEvent.blur(nameInput);
+    fireEvent.submit(screen.getByTestId('registration_form'));
+
+    expect(onSignup).toHaveBeenCalledWith({
+      email: 'missing@example.com',
+      name: 'Missing User',
+      username: 'daily_apple',
+      experienceLevel: 'LESS_THAN_1_YEAR',
+      acceptedMarketing: true,
+    });
+  });
+});

--- a/packages/shared/src/components/auth/SocialRegistrationForm.tsx
+++ b/packages/shared/src/components/auth/SocialRegistrationForm.tsx
@@ -10,7 +10,7 @@ import { TextField } from '../fields/TextField';
 import { MailIcon, UserIcon, LockIcon, AtIcon } from '../icons';
 import AuthHeader from './AuthHeader';
 import type { AuthFormProps } from './common';
-import { providerMap } from './common';
+import { providerMap, SocialProvider } from './common';
 import AuthContext from '../../contexts/AuthContext';
 import type { ProfileFormHint } from '../../hooks/useProfileForm';
 import { Checkbox } from '../fields/Checkbox';
@@ -56,15 +56,24 @@ export const SocialRegistrationForm = ({
 }: SocialRegistrationFormProps): ReactElement => {
   const { logEvent } = useLogContext();
   const { user } = useContext(AuthContext);
+  const isAppleRegistration = provider === SocialProvider.Apple;
+  const shouldShowAppleEmail = isAppleRegistration && !user?.email;
+  const shouldShowAppleName = isAppleRegistration && !user?.name;
   const [nameHint, setNameHint] = useState<string>(null);
   const [usernameHint, setUsernameHint] = useState<string>(null);
   const [experienceLevelHint, setExperienceLevelHint] = useState<string>(null);
   const [name, setName] = useState(user?.name);
+  const [email, setEmail] = useState(user?.email);
+  const currentName = name || user?.name;
+  const currentEmail = email || user?.email;
+  const usernameSeed = isAppleRegistration
+    ? currentName || currentEmail
+    : currentName;
   const {
     username,
     setUsername,
     isLoading: isLoadingUsername,
-  } = useGenerateUsername(name);
+  } = useGenerateUsername(usernameSeed);
   const { onUpdateSignBack } = useSignBack();
 
   useEffect(() => {
@@ -101,8 +110,15 @@ export const SocialRegistrationForm = ({
     const values = formToJson<SocialRegistrationFormValues>(
       formRef?.current ?? form,
     );
+    const submittedName = values.name || currentName;
+    const submittedEmail = values.email || currentEmail;
 
-    if (!values.name) {
+    if (!submittedEmail) {
+      logError('Email not provided');
+      return;
+    }
+
+    if (!submittedName) {
       logError('Name not provided');
       setNameHint('Please prove your name');
       return;
@@ -131,11 +147,16 @@ export const SocialRegistrationForm = ({
     });
 
     onUpdateSignBack(
-      { name: values.name, email: user.email, image: user.image },
+      { name: submittedName, email: submittedEmail, image: user.image },
       provider as SignBackProvider,
     );
     const { file, optOutMarketing, ...rest } = values;
-    onSignup({ ...rest, acceptedMarketing: !optOutMarketing });
+    onSignup({
+      ...rest,
+      email: submittedEmail,
+      name: submittedName,
+      acceptedMarketing: !optOutMarketing,
+    });
   };
 
   const emailFieldIcon = (providerI: string) => {
@@ -149,7 +170,7 @@ export const SocialRegistrationForm = ({
     return <MailIcon size={IconSize.Small} />;
   };
 
-  if (!user?.email) {
+  if (!user) {
     return <></>;
   }
 
@@ -166,44 +187,57 @@ export const SocialRegistrationForm = ({
         id="auth-form"
         data-testid="registration_form"
       >
-        <ImageInput
-          className={{ container: 'mb-4' }}
-          initialValue={user?.image}
-          size="medium"
-          viewOnly
-        />
-        <TextField
-          saveHintSpace
-          className={{ container: 'w-full' }}
-          leftIcon={emailFieldIcon(provider)}
-          name="email"
-          inputId="email"
-          label="Email"
-          type="email"
-          value={user?.email}
-          readOnly
-          rightIcon={<LockIcon />}
-        />
-        <TextField
-          saveHintSpace
-          className={{ container: 'w-full' }}
-          leftIcon={<UserIcon size={IconSize.Small} />}
-          name="name"
-          inputId="name"
-          label="Name"
-          value={name}
-          valid={!nameHint && !hints?.name}
-          hint={hints?.name || nameHint}
-          onBlur={(e) => setName(e.target.value)}
-          valueChanged={() => {
-            if (hints?.name) {
-              onUpdateHints?.({ ...hints, name: '' });
-            }
-            if (nameHint) {
-              setNameHint('');
-            }
-          }}
-        />
+        {isAppleRegistration && !shouldShowAppleName && (
+          <input name="name" type="hidden" value={currentName} readOnly />
+        )}
+        {isAppleRegistration && !shouldShowAppleEmail && (
+          <input name="email" type="hidden" value={currentEmail} readOnly />
+        )}
+        {!isAppleRegistration && (
+          <ImageInput
+            className={{ container: 'mb-4' }}
+            initialValue={user?.image}
+            size="medium"
+            viewOnly
+          />
+        )}
+        {(!isAppleRegistration || shouldShowAppleEmail) && (
+          <TextField
+            saveHintSpace
+            className={{ container: 'w-full' }}
+            leftIcon={emailFieldIcon(provider)}
+            name="email"
+            inputId="email"
+            label="Email"
+            type="email"
+            value={currentEmail}
+            readOnly={!isAppleRegistration}
+            rightIcon={!isAppleRegistration ? <LockIcon /> : undefined}
+            onBlur={(e) => setEmail(e.target.value)}
+          />
+        )}
+        {(!isAppleRegistration || shouldShowAppleName) && (
+          <TextField
+            saveHintSpace
+            className={{ container: 'w-full' }}
+            leftIcon={<UserIcon size={IconSize.Small} />}
+            name="name"
+            inputId="name"
+            label="Name"
+            value={currentName}
+            valid={!nameHint && !hints?.name}
+            hint={hints?.name || nameHint}
+            onBlur={(e) => setName(e.target.value)}
+            valueChanged={() => {
+              if (hints?.name) {
+                onUpdateHints?.({ ...hints, name: '' });
+              }
+              if (nameHint) {
+                setNameHint('');
+              }
+            }}
+          />
+        )}
         <TextField
           saveHintSpace
           className={{ container: 'w-full' }}

--- a/packages/shared/src/components/auth/socialAuth.spec.ts
+++ b/packages/shared/src/components/auth/socialAuth.spec.ts
@@ -28,12 +28,18 @@ describe('socialAuth', () => {
   });
 
   describe('hasSocialAuthBootUser', () => {
-    it('requires a boot user with an email field', () => {
+    it('requires an authenticated boot user', () => {
       expect(hasSocialAuthBootUser({ id: 'anonymous' })).toBe(false);
       expect(
         hasSocialAuthBootUser({
           id: 'user',
           email: 'user@daily.dev',
+        }),
+      ).toBe(true);
+      expect(
+        hasSocialAuthBootUser({
+          id: 'user',
+          providers: ['apple'],
         }),
       ).toBe(true);
     });

--- a/packages/shared/src/components/auth/socialAuth.ts
+++ b/packages/shared/src/components/auth/socialAuth.ts
@@ -18,7 +18,9 @@ const delay = (delayMs: number): Promise<void> =>
 export const hasSocialAuthBootUser = (
   user?: BootUser,
 ): user is NonNullable<BootUser> =>
-  !!user && typeof user === 'object' && 'email' in user;
+  !!user &&
+  typeof user === 'object' &&
+  ('email' in user || 'providers' in user);
 
 const refetchSocialAuthBootAttempt = async (
   refetchBoot: RefetchBoot,

--- a/packages/shared/src/lib/auth.ts
+++ b/packages/shared/src/lib/auth.ts
@@ -125,6 +125,7 @@ export type ErrorMessages<T extends string | number> = { [key in T]?: string };
 export type RegistrationError = ErrorMessages<keyof RegistrationParameters>;
 
 export interface SocialRegistrationParameters {
+  email?: string;
   name?: string;
   username?: string;
   file?: string;


### PR DESCRIPTION
## What changed
- Hide Apple-provided identity fields on the social signup completion form.
- Show email/name fields when Apple does not return those values, instead of generating a default name.
- Keep submitting the provided or collected profile identity fields so the existing profile completion mutation still receives required profile data.
- Pass the active social provider through the callback/render path so Apple registration reliably renders the Apple-specific completion form.
- Allow provider-backed social auth boot users to continue to profile completion even when email is missing.
- Add focused regression tests for the Apple social registration form and social auth boot detection.

## Why
Apple feedback requires the app to avoid asking for or displaying name/email again after Sign up with Apple when Apple already provided them, and only request additional profile information. If Apple does not provide name or email, the user still needs to be asked for the missing required information.

## Validation
- `NODE_ENV=test pnpm --dir packages/shared exec jest src/components/auth/SocialRegistrationForm.spec.tsx src/components/auth/socialAuth.spec.ts --runInBand`
- `pnpm --dir packages/shared exec eslint src/components/auth/SocialRegistrationForm.tsx src/components/auth/AuthOptionsInner.tsx src/components/auth/SocialRegistrationForm.spec.tsx src/components/auth/socialAuth.ts src/components/auth/socialAuth.spec.ts src/lib/auth.ts --max-warnings 0`
- `node ./scripts/typecheck-strict-changed.js`


### Preview domain
https://codex-apple-signup-additional-in.preview.app.daily.dev