### PR TITLE
fix: default missing apple signup name

### DIFF
--- a/packages/shared/src/components/auth/SocialRegistrationForm.spec.tsx
+++ b/packages/shared/src/components/auth/SocialRegistrationForm.spec.tsx
@@ -111,7 +111,35 @@ describe('SocialRegistrationForm', () => {
     );
   });
 
-  it('shows Apple identity fields when the provider did not return them', () => {
+  it('generates an Apple profile name when the provider only returned email', () => {
+    const onSignup = jest.fn();
+    renderForm(
+      <SocialRegistrationForm
+        provider={SocialProvider.Apple}
+        hints={{}}
+        onSignup={onSignup}
+      />,
+      {
+        ...user,
+        name: undefined,
+      } as unknown as LoggedUser,
+    );
+
+    expect(screen.queryByText('Email')).not.toBeInTheDocument();
+    expect(screen.queryByText('Name')).not.toBeInTheDocument();
+
+    fireEvent.submit(screen.getByTestId('registration_form'));
+
+    expect(onSignup).toHaveBeenCalledWith({
+      email: 'apple@example.com',
+      name: 'Apple',
+      username: 'daily_apple',
+      experienceLevel: 'LESS_THAN_1_YEAR',
+      acceptedMarketing: true,
+    });
+  });
+
+  it('shows Apple email when missing and generates the profile name from it', () => {
     const onSignup = jest.fn();
     renderForm(
       <SocialRegistrationForm
@@ -127,21 +155,17 @@ describe('SocialRegistrationForm', () => {
     );
 
     const emailInput = screen.getByPlaceholderText('Email');
-    const nameInput = screen.getByPlaceholderText('Name');
 
+    expect(screen.queryByText('Name')).not.toBeInTheDocument();
     fireEvent.input(emailInput, {
       target: { value: 'missing@example.com' },
     });
-    fireEvent.input(nameInput, {
-      target: { value: 'Missing User' },
-    });
     fireEvent.blur(emailInput);
-    fireEvent.blur(nameInput);
     fireEvent.submit(screen.getByTestId('registration_form'));
 
     expect(onSignup).toHaveBeenCalledWith({
       email: 'missing@example.com',
-      name: 'Missing User',
+      name: 'Missing',
       username: 'daily_apple',
       experienceLevel: 'LESS_THAN_1_YEAR',
       acceptedMarketing: true,

--- a/packages/shared/src/components/auth/SocialRegistrationForm.tsx
+++ b/packages/shared/src/components/auth/SocialRegistrationForm.tsx
@@ -26,6 +26,7 @@ import { useSignBack } from '../../hooks/auth/useSignBack';
 import ExperienceLevelDropdown from '../profile/ExperienceLevelDropdown';
 import { Loader } from '../Loader';
 import { labels } from '../../lib';
+import { generateNameFromEmail } from '../../lib/strings';
 
 export interface SocialRegistrationFormProps extends AuthFormProps {
   className?: string;
@@ -58,7 +59,6 @@ export const SocialRegistrationForm = ({
   const { user } = useContext(AuthContext);
   const isAppleRegistration = provider === SocialProvider.Apple;
   const shouldShowAppleEmail = isAppleRegistration && !user?.email;
-  const shouldShowAppleName = isAppleRegistration && !user?.name;
   const [nameHint, setNameHint] = useState<string>(null);
   const [usernameHint, setUsernameHint] = useState<string>(null);
   const [experienceLevelHint, setExperienceLevelHint] = useState<string>(null);
@@ -110,8 +110,13 @@ export const SocialRegistrationForm = ({
     const values = formToJson<SocialRegistrationFormValues>(
       formRef?.current ?? form,
     );
-    const submittedName = values.name || currentName;
     const submittedEmail = values.email || currentEmail;
+    const submittedName =
+      values.name ||
+      currentName ||
+      (isAppleRegistration && submittedEmail
+        ? generateNameFromEmail(submittedEmail, 'User')
+        : undefined);
 
     if (!submittedEmail) {
       logError('Email not provided');
@@ -187,7 +192,7 @@ export const SocialRegistrationForm = ({
         id="auth-form"
         data-testid="registration_form"
       >
-        {isAppleRegistration && !shouldShowAppleName && (
+        {isAppleRegistration && currentName && (
           <input name="name" type="hidden" value={currentName} readOnly />
         )}
         {isAppleRegistration && !shouldShowAppleEmail && (
@@ -216,7 +221,7 @@ export const SocialRegistrationForm = ({
             onBlur={(e) => setEmail(e.target.value)}
           />
         )}
-        {(!isAppleRegistration || shouldShowAppleName) && (
+        {!isAppleRegistration && (
           <TextField
             saveHintSpace
             className={{ container: 'w-full' }}


### PR DESCRIPTION
## Summary
- keep the Apple signup name field hidden even when Apple omits the name
- generate a fallback display name from the available Apple email before submitting the social registration form
- update Apple signup form coverage for missing-name and missing-email cases

## Tests
- NODE_ENV=test pnpm --dir packages/shared exec jest src/components/auth/SocialRegistrationForm.spec.tsx --runInBand
- pnpm --dir packages/shared exec eslint src/components/auth/SocialRegistrationForm.tsx src/components/auth/SocialRegistrationForm.spec.tsx --max-warnings 0
- node ./scripts/typecheck-strict-changed.js

### Preview domain
https://fix-apple-signup-default-name.preview.app.daily.dev