### PR TITLE
fix: update onboarding hero mobile background

### DIFF
--- a/packages/shared/src/features/onboarding/components/OnboardingSignupHero.spec.tsx
+++ b/packages/shared/src/features/onboarding/components/OnboardingSignupHero.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { OnboardingSignupHero } from './OnboardingSignupHero';
+import { cloudinaryOnboardingLoginBackground } from '../../../lib/image';
+import { useViewSize } from '../../../hooks';
 
 jest.mock('../../../contexts/SettingsContext', () => ({
   ThemeMode: { Dark: 'dark' },
@@ -20,6 +22,11 @@ jest.mock('../../../components/footer/FooterLinks', () => ({
 jest.mock('../../../components/auth/SignupDisclaimer', () => ({
   __esModule: true,
   default: () => <div data-testid="disclaimer" />,
+}));
+
+jest.mock('../../../hooks', () => ({
+  ViewSize: { MobileL: 'mobileL' },
+  useViewSize: jest.fn(() => false),
 }));
 
 // Isolate the shell from the (gql/context-heavy) background blocks.
@@ -49,11 +56,51 @@ const renderHero = (
   );
 
 describe('OnboardingSignupHero', () => {
+  const mockUseViewSize = useViewSize as jest.MockedFunction<
+    typeof useViewSize
+  >;
+  const getMobileImage = (container: HTMLElement): HTMLImageElement => {
+    const image = container.querySelector('img[alt="Onboarding background"]');
+
+    if (!(image instanceof HTMLImageElement)) {
+      throw new Error('Expected hero mobile image to render');
+    }
+
+    return image;
+  };
+
+  beforeEach(() => {
+    mockUseViewSize.mockReturnValue(false);
+  });
+
   it('passes background and image mode to the background layer', () => {
     renderHero({ background: 'desk', imageMode: 'colors' });
     const layer = screen.getByTestId('bg-layer');
     expect(layer).toHaveAttribute('data-background', 'desk');
     expect(layer).toHaveAttribute('data-image-mode', 'colors');
+  });
+
+  it('renders the default mobile image background', () => {
+    mockUseViewSize.mockReturnValue(true);
+    const { container } = renderHero();
+    expect(getMobileImage(container)).toHaveAttribute(
+      'src',
+      cloudinaryOnboardingLoginBackground,
+    );
+  });
+
+  it('supports a custom mobile image background', () => {
+    mockUseViewSize.mockReturnValue(true);
+    const imageMobile = 'https://media.daily.dev/custom-mobile-background';
+    const { container } = renderHero({ imageMobile });
+    expect(getMobileImage(container)).toHaveAttribute('src', imageMobile);
+  });
+
+  it('uses the organic signup mobile headline treatment', () => {
+    mockUseViewSize.mockReturnValue(true);
+    renderHero({ headline: 'Hello devs' });
+    expect(screen.getByText('Hello devs')).toHaveClass('typo-title2');
+    expect(screen.getByText('Hello devs')).not.toHaveClass('onb-headline');
   });
 
   it('renders aurora orbs by default', () => {

--- a/packages/shared/src/features/onboarding/components/OnboardingSignupHero.tsx
+++ b/packages/shared/src/features/onboarding/components/OnboardingSignupHero.tsx
@@ -4,10 +4,18 @@ import classNames from 'classnames';
 import Logo, { LogoPosition } from '../../../components/Logo';
 import { FooterLinks } from '../../../components/footer/FooterLinks';
 import SignupDisclaimer from '../../../components/auth/SignupDisclaimer';
+import { OnboardingHeader } from '../../../components/onboarding/OnboardingHeader';
+import { wrapperMaxWidth } from '../../../components/onboarding/common';
 import {
   ThemeMode,
   useSettingsContext,
 } from '../../../contexts/SettingsContext';
+import { useViewSize, ViewSize } from '../../../hooks';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../../components/typography/Typography';
 import type {
   FunnelSignupHeroBackground,
   FunnelSignupHeroImageMode,
@@ -15,6 +23,8 @@ import type {
 import { HERO_STYLES } from './signupHero/heroStyles';
 import { HeroBackgroundLayer } from './signupHero/HeroBackgroundLayer';
 import { AuroraOrbs } from './signupHero/HeroDecorations';
+import { cloudinaryOnboardingLoginBackground } from '../../../lib/image';
+import { sanitizeMessage } from '../lib/utils';
 
 // =============================================================
 // Onboarding signup hero — a shell that composes individually
@@ -33,6 +43,7 @@ type Props = {
   headline?: string | null;
   background?: FunnelSignupHeroBackground;
   imageMode?: FunnelSignupHeroImageMode;
+  imageMobile?: string;
   showOrbs?: boolean;
   forceDarkTheme?: boolean;
 };
@@ -46,10 +57,12 @@ export const OnboardingSignupHero = ({
   headline = DEFAULT_HEADLINE,
   background = 'cards',
   imageMode = 'image',
+  imageMobile = cloudinaryOnboardingLoginBackground,
   showOrbs = true,
   forceDarkTheme = true,
 }: Props): ReactElement => {
   const { applyThemeMode } = useSettingsContext();
+  const isMobile = useViewSize(ViewSize.MobileL);
 
   useEffect(() => {
     if (!forceDarkTheme) {
@@ -64,6 +77,54 @@ export const OnboardingSignupHero = ({
   const isSplitLayout = background === 'split';
   const isDeskVariant = background === 'desk';
   const showOrbsLayer = showOrbs;
+
+  if (isMobile) {
+    return (
+      <div className="relative z-3 flex min-h-dvh w-full flex-col justify-end overflow-x-hidden bg-background-default pt-40 text-text-primary">
+        <style dangerouslySetInnerHTML={{ __html: HERO_STYLES }} />
+        <OnboardingHeader
+          isLanding
+          className="!-my-8 !justify-center bg-gradient-to-t from-background-default to-transparent py-8"
+        />
+        <div className="relative z-1 after:absolute after:inset-0 after:top-8 after:-z-1 after:bg-background-default">
+          <div
+            className={classNames(
+              'flex w-full flex-col flex-wrap content-center justify-center px-4 tablet:flex-row tablet:gap-10 tablet:px-6',
+              wrapperMaxWidth,
+            )}
+          >
+            <div className="mt-5 flex flex-1 flex-col tablet:my-5 tablet:flex-grow">
+              {!isFormExpanded && headline && (
+                <div className="mb-8 flex flex-col gap-4">
+                  <Typography
+                    className="text-balance text-center"
+                    color={TypographyColor.Primary}
+                    dangerouslySetInnerHTML={{
+                      __html: sanitizeMessage(headline),
+                    }}
+                    type={TypographyType.Title2}
+                  />
+                </div>
+              )}
+              {children}
+            </div>
+            <div className="flex flex-1 tablet:ml-auto tablet:flex-1 laptop:max-w-[37.5rem]" />
+          </div>
+        </div>
+        <img
+          alt="Onboarding background"
+          aria-hidden
+          className={classNames(
+            'pointer-events-none absolute inset-0 -z-1 size-full object-cover transition-opacity duration-150',
+            { 'opacity-[.24]': isFormExpanded },
+          )}
+          loading="eager"
+          role="presentation"
+          src={imageMobile}
+        />
+      </div>
+    );
+  }
 
   const splitSignupColumn = (
     <>
@@ -235,7 +296,7 @@ export const OnboardingSignupHero = ({
 
       <div
         className={classNames(
-          'pointer-events-auto relative z-1 flex w-full flex-col items-center gap-4 px-5',
+          'pointer-events-auto relative z-1 flex w-full flex-col items-center gap-3 px-5',
           isSplitLayout ? 'laptop:hidden' : 'tablet:hidden',
         )}
       >

--- a/packages/shared/src/features/onboarding/steps/FunnelHeroLanding.tsx
+++ b/packages/shared/src/features/onboarding/steps/FunnelHeroLanding.tsx
@@ -49,6 +49,7 @@ export const FunnelHeroLanding = withIsActiveGuard(
       headline,
       background,
       imageMode,
+      imageMobile,
       showOrbs,
       forceDarkTheme,
       oauthOrder,
@@ -174,6 +175,7 @@ export const FunnelHeroLanding = withIsActiveGuard(
         headline={headline}
         background={background}
         imageMode={imageMode}
+        imageMobile={imageMobile}
         showOrbs={showOrbs}
         forceDarkTheme={forceDarkTheme}
       >

--- a/packages/shared/src/features/onboarding/types/funnel.ts
+++ b/packages/shared/src/features/onboarding/types/funnel.ts
@@ -331,6 +331,7 @@ export interface FunnelStepHeroLanding
     headline?: string;
     background?: FunnelSignupHeroBackground;
     imageMode?: FunnelSignupHeroImageMode;
+    imageMobile?: string;
     showOrbs?: boolean;
     oauthOrder?: FunnelSignupOauthOrder;
     forceDarkTheme?: boolean;

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -137,6 +137,9 @@ export const cloudinaryOnboardingFullBackgroundMobile =
 export const cloudinaryOnboardingFullBackgroundDesktop =
   'https://media.daily.dev/image/upload/s--r2ffZPB4--/f_auto/v1716969841/dailydev_where_developers_suffer_together_sfvfog';
 
+export const cloudinaryOnboardingLoginBackground =
+  'https://media.daily.dev/image/upload/s--r4MiKjLD--/f_auto/v1743601527/public/login%20background';
+
 export const cloudinaryGenericNotFoundLight =
   'https://media.daily.dev/image/upload/s--t81_4qLS--/f_auto/v1708330060/404-lightmode_eweviu';
 


### PR DESCRIPTION
## Summary
- replace the onboarding hero feed background with a configurable mobile image on phone widths
- keep the existing fade/halo treatment over the mobile image
- wire the new `imageMobile` funnel parameter through the hero landing step

## Validation
- pnpm --filter shared exec eslint src/features/onboarding/components/OnboardingSignupHero.tsx src/features/onboarding/components/OnboardingSignupHero.spec.tsx src/features/onboarding/steps/FunnelHeroLanding.tsx src/features/onboarding/types/funnel.ts src/lib/image.ts --max-warnings 0
- node ./scripts/typecheck-strict-changed.js
- NODE_ENV=test pnpm --filter shared exec jest packages/shared/src/features/onboarding/components/OnboardingSignupHero.spec.tsx --runInBand
- git diff --check


### Preview domain
https://codex-onboarding-hero-mobile-ima.preview.app.daily.dev