### PR TITLE
fix: keep split hero cards at two columns

### DIFF
--- a/packages/shared/src/features/onboarding/components/signupHero/CardsBackground.tsx
+++ b/packages/shared/src/features/onboarding/components/signupHero/CardsBackground.tsx
@@ -86,7 +86,7 @@ export const CardsBackground = ({
           className={classNames(
             'grid auto-rows-min gap-8 px-10 pb-5 pt-10 tablet:px-14 tablet:pb-7 tablet:pt-14',
             splitMode
-              ? 'grid-cols-2 laptop:grid-cols-2 laptopL:grid-cols-3'
+              ? 'grid-cols-2'
               : 'grid-cols-2 laptop:grid-cols-3 laptopL:grid-cols-4 laptopXL:grid-cols-5 desktop:grid-cols-6',
           )}
         >


### PR DESCRIPTION
## Summary
- keep split-mode onboarding hero cards at two columns on desktop
- avoid squeezing ArticleGrid cards into a third column in the split background

## Validation
- pnpm --filter shared exec eslint src/features/onboarding/components/signupHero/CardsBackground.tsx --max-warnings 0
- node ./scripts/typecheck-strict-changed.js
- git diff --check


### Preview domain
https://codex-split-hero-two-columns.preview.app.daily.dev