### PR TITLE
fix: redirect to post page after Smart Composer creation

### DIFF
--- a/packages/shared/src/components/post/composer/useComposerSubmit.ts
+++ b/packages/shared/src/components/post/composer/useComposerSubmit.ts
@@ -11,6 +11,8 @@ import type {
 } from '../../../graphql/posts';
 import type { Squad } from '../../../graphql/sources';
 import { moderationRequired } from '../../squads/utils';
+import { webappUrl } from '../../../lib/constants';
+import { useAuthContext } from '../../../contexts/AuthContext';
 import {
   POLL_OPTIONS_MIN,
   STANDUP_TOPIC_MAX_LENGTH,
@@ -98,6 +100,7 @@ export const useComposerSubmit = ({
 }: UseComposerSubmitProps): UseComposerSubmit => {
   const { displayToast } = useToastNotification();
   const router = useRouter();
+  const { user } = useAuthContext();
   const { submit: submitStandupMutation, isPending: isCreatingStandup } =
     useSubmitStandup();
   const [standupErrors, setStandupErrors] = useState<StandupFieldErrors>({});
@@ -114,10 +117,27 @@ export const useComposerSubmit = ({
     initialPreview,
     onComplete,
     displayMutationErrors: true,
+    onPostSuccess: (post) => {
+      if (editPostId) {
+        return;
+      }
+      router.push(
+        post.commentsPermalink ?? `${webappUrl}posts/${post.slug ?? post.id}`,
+      );
+    },
   });
   const { onCreate: createMulti, isPending: isMultiPending } =
     useMultipleSourcePost({
-      onSuccess: onComplete,
+      onSuccess: (result) => {
+        onComplete();
+        const isEveryItemPending = result.every(
+          (item) => item.type === 'moderationItem',
+        );
+        if (isEveryItemPending || !user?.username) {
+          return;
+        }
+        router.push(`${webappUrl}${user.username}/posts/`);
+      },
       onError: (error) =>
         displayToast(error.response?.errors?.[0]?.message ?? 'Failed to post'),
     });


### PR DESCRIPTION
## Summary
- The Smart Composer modal created posts (poll, text, share) successfully but only closed the modal — it never navigated to the new post, unlike the `/squads/create` page.
- Single-source creations now redirect to the new post page (via `commentsPermalink`, falling back to `posts/${slug ?? id}`).
- Multi-audience creations redirect to the user's posts list, skipping the redirect when every result is a moderation item.
- Edit and moderation flows are preserved (no redirect on edits; moderated posts don't navigate to a non-existent page).

## Test plan
- [ ] On laptop width (Smart Composer enabled), create a Poll in a single squad → lands on the poll's post page.
- [ ] Create a text post in a single squad → lands on the post page.
- [ ] Create a post across multiple audiences → lands on the user's posts list.
- [ ] Edit an existing post via the composer → updates and closes, no redirect.
- [ ] Post to a moderated squad → shows moderation toast, no redirect.

## Known limitations (pre-existing)
- Brand-new external link posts (single source) go through `submitExternalLink`, which returns no post id/slug, so they keep closing the modal without redirect. Sharing an existing post does redirect.

Made with [Cursor](https://cursor.com)

### Preview domain
https://fix-smart-composer-post-redirect.preview.app.daily.dev