### PR TITLE
feat: simplify ad attribution to plain "Promoted" label

### DIFF
--- a/packages/shared/src/components/cards/ad/AdCard.spec.tsx
+++ b/packages/shared/src/components/cards/ad/AdCard.spec.tsx
@@ -116,16 +116,39 @@ it('should render advertise link on grid ad', () => {
   );
 });
 
-it('should render promoted attribution outside of list title clamp', async () => {
-  const promotedMatcher = (_: string, element?: Element | null): boolean => {
-    const text = getNormalizedText(element);
-    return text === 'Promoted' || text.startsWith('Promoted by ');
-  };
+const promotedMatcher = (_: string, element?: Element | null): boolean =>
+  getNormalizedText(element) === 'Promoted';
 
+it('should render promoted attribution outside of list title clamp', async () => {
   renderListComponent();
 
   const title = screen.getByRole('heading', { level: 3 });
   expect(getNormalizedText(title)).not.toContain('Promoted');
+  expect(await screen.findByText(promotedMatcher)).toBeInTheDocument();
+});
+
+it('should render plain Promoted attribution without source link', async () => {
+  renderListComponent({
+    ad: {
+      ...ad,
+      referralLink: 'https://example.com/referral',
+      source: 'Carbon',
+    },
+  });
+
+  const attribution = await screen.findByText(promotedMatcher);
+  expect(attribution.tagName).not.toBe('A');
+  expect(screen.queryByText(/Promoted by/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Carbon/)).not.toBeInTheDocument();
+});
+
+it('should render Promoted attribution in grid variant', async () => {
+  renderGridComponent();
+  expect(await screen.findByText(promotedMatcher)).toBeInTheDocument();
+});
+
+it('should render Promoted attribution in signal variant', async () => {
+  renderSignalListComponent();
   expect(await screen.findByText(promotedMatcher)).toBeInTheDocument();
 });
 

--- a/packages/shared/src/components/cards/ad/AdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/AdGrid.tsx
@@ -54,7 +54,7 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
             className="!items-end"
           />
         ) : null}
-        <AdAttribution ad={ad} className={{ main: 'font-normal' }} />
+        <AdAttribution className={{ main: 'font-normal' }} />
       </CardTextContainer>
       <AdImage className="mx-1 mb-0" ad={ad} ImageComponent={CardImage} />
       <CardTextContainer className="!mx-1 my-1">

--- a/packages/shared/src/components/cards/ad/AdList.tsx
+++ b/packages/shared/src/components/cards/ad/AdList.tsx
@@ -76,10 +76,7 @@ export const AdList = forwardRef<HTMLElement, AdCardProps>(function AdCard(
           {adImprovementsV3 && matchingTags.length > 0 ? (
             <PostTags post={{ tags: matchingTags.slice(0, 6) }} />
           ) : null}
-          <AdAttribution
-            ad={ad}
-            className={{ main: 'mt-2 block font-normal' }}
-          />
+          <AdAttribution className={{ main: 'mt-2 block font-normal' }} />
         </CardTextContainer>
         <AdImage ad={ad} ImageComponent={CardImage} />
       </CardContent>

--- a/packages/shared/src/components/cards/ad/SignalAdList.tsx
+++ b/packages/shared/src/components/cards/ad/SignalAdList.tsx
@@ -86,7 +86,6 @@ export const SignalAdList = forwardRef(function SignalAdList(
           </span>
           <span>&middot;</span>
           <AdAttribution
-            ad={ad}
             className={{
               typo: 'typo-callout',
               main: 'inline',

--- a/packages/shared/src/components/cards/ad/common/AdAttribution.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdAttribution.tsx
@@ -16,7 +16,7 @@ export default function AdAttribution({
   className,
 }: AdAttributionProps): ReactElement {
   const elementClass = classNames(
-    'text-text-quaternary no-underline',
+    'text-text-quaternary',
     className?.typo ?? 'typo-footnote',
     className?.main,
   );

--- a/packages/shared/src/components/cards/ad/common/AdAttribution.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdAttribution.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import type { ReactElement } from 'react';
 import classNames from 'classnames';
-import type { Ad } from '../../../../graphql/posts';
 import { useScrambler } from '../../../../hooks/useScrambler';
 
 interface AdClassName {
@@ -10,12 +9,10 @@ interface AdClassName {
 }
 
 interface AdAttributionProps {
-  ad: Ad;
   className?: AdClassName;
 }
 
 export default function AdAttribution({
-  ad,
   className,
 }: AdAttributionProps): ReactElement {
   const elementClass = classNames(
@@ -24,22 +21,7 @@ export default function AdAttribution({
     className?.main,
   );
 
-  const text = ad.referralLink ? `Promoted by ${ad.source}` : 'Promoted';
-  const promotedText = useScrambler(text);
-
-  if (ad.referralLink) {
-    return (
-      <a
-        href={ad.referralLink}
-        target="_blank"
-        rel="noopener"
-        className={elementClass}
-        suppressHydrationWarning
-      >
-        {promotedText}
-      </a>
-    );
-  }
+  const promotedText = useScrambler('Promoted');
 
   return (
     <div className={elementClass} suppressHydrationWarning>

--- a/packages/shared/src/components/post/PostSidebarAdWidget.tsx
+++ b/packages/shared/src/components/post/PostSidebarAdWidget.tsx
@@ -137,7 +137,7 @@ export function PostSidebarAdWidget({
             {company}
           </Typography>
         )}
-        <AdAttribution ad={ad} className={{ main: 'relative z-1' }} />
+        <AdAttribution className={{ main: 'relative z-1' }} />
         {hasDescription && (
           <Typography
             tag={TypographyTag.P}


### PR DESCRIPTION
## What

Standard ad labels now always render plain **"Promoted"** text instead of network/advertiser attribution like "Promoted by Carbon".

Ad networks (BSA/Carbon, EthicalAds) don't contractually require named attribution, so we simplify the shared `AdAttribution` component to a single rendering path. This affects all standard ad consumers: `AdGrid`, `AdList`, `SignalAdList`, and `PostSidebarAdWidget`.

## Key decisions

- **Dropped the `referralLink` anchor** — the label is now plain non-link text (no `<a>`, no source/advertiser name), per the ticket's default direction ("just Promoted, nothing fancy"). Trivially revertible if a network later requires named attribution.
- **Removed the now-unused `ad` prop** from `AdAttribution` and updated all four call sites (delete dead code).
- **Preserved** the `useScrambler` treatment and `suppressHydrationWarning` (ad-disclosure requirement).
- **Out of scope:** Squad-promoted ads ("Promoted by @username") and `SignalAdList`'s header advertiser name/avatar are unchanged.

## Testing

- Updated `AdCard.spec.tsx`: asserts exact `Promoted` text in grid/list/signal variants, and that with `referralLink` set the attribution is not a link and omits the source/company name.
- Strict typecheck, lint, and tests (12/12) pass on impacted files.

Closes ENG-1641

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1641-show-advertiser-name-in.preview.app.daily.dev