### PR TITLE
feat(collection): show "Trend" pill for trends source posts

### DIFF
--- a/packages/shared/src/components/cards/collection/CollectionCardHeader.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionCardHeader.tsx
@@ -1,7 +1,8 @@
 import type { ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
-import { CollectionPillSources } from '../../post/collection';
+import { CollectionPillSources } from '../../post/collection/CollectionPillSources';
+import { getCollectionPillLabel } from '../../post/collection/common';
 import {
   BookmakProviderHeader,
   headerHiddenClassName,
@@ -37,8 +38,9 @@ export const CollectionCardHeader = ({
             highlightBookmarkedPost && headerHiddenClassName,
           ),
         }}
-        sources={sources}
-        totalSources={totalSources}
+        sources={sources ?? []}
+        totalSources={totalSources ?? 0}
+        label={getCollectionPillLabel(post)}
       >
         <div className="flex-1" />
         <PostOptionButton

--- a/packages/shared/src/components/cards/collection/CollectionGrid.spec.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionGrid.spec.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/router';
 import { CollectionGrid } from './CollectionGrid';
 import { sharePost as collectionPost } from '../../../../__tests__/fixture/post';
 import type { PostCardProps } from '../common/common';
+import type { Post } from '../../../graphql/posts';
 import { TestBootProvider } from '../../../../__tests__/helpers/boot';
 
 jest.mock('next/router', () => ({
@@ -109,6 +110,17 @@ it('should hide read time when not available', async () => {
 it('should display the `collection` pill in the header', async () => {
   renderComponent();
   await screen.findByText('Collection');
+});
+
+it('should display the `Trend` pill when the post source is trends', async () => {
+  renderComponent({
+    post: {
+      ...post,
+      source: { ...post.source, id: 'trends' } as Post['source'],
+    },
+  });
+  await screen.findByText('Trend');
+  expect(screen.queryByText('Collection')).not.toBeInTheDocument();
 });
 
 it('should show options button on hover when in laptop size', async () => {

--- a/packages/shared/src/components/cards/collection/CollectionList.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionList.tsx
@@ -13,7 +13,8 @@ import {
 import ActionButtons from '../common/ActionButtons';
 import { usePostImage } from '../../../hooks/post/usePostImage';
 import { PostCardHeader } from '../common/list/PostCardHeader';
-import { CollectionPillSources } from '../../post/collection';
+import { CollectionPillSources } from '../../post/collection/CollectionPillSources';
+import { getCollectionPillLabel } from '../../post/collection/common';
 import { useTruncatedSummary, useViewSize, ViewSize } from '../../../hooks';
 import PostTags from '../common/PostTags';
 import { CardCoverList } from '../common/list/CardCover';
@@ -118,6 +119,7 @@ export const CollectionList = forwardRef(function CollectionCard(
             sources={post.collectionSources ?? []}
             totalSources={post.numCollectionSources ?? 0}
             alwaysShowSources
+            label={getCollectionPillLabel(post)}
           />
         </PostCardHeader>
 

--- a/packages/shared/src/components/post/collection/CollectionPillSources.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPillSources.tsx
@@ -18,6 +18,7 @@ interface CollectionPillSourcesProps {
   size?: ProfileImageSize;
   children?: ReactNode;
   limit?: number;
+  label?: string;
 }
 export const CollectionPillSources = ({
   className,
@@ -27,6 +28,7 @@ export const CollectionPillSources = ({
   size = ProfileImageSize.Medium,
   children,
   limit,
+  label = 'Collection',
 }: CollectionPillSourcesProps): ReactElement => {
   const hasSources = !!sources?.length;
 
@@ -61,7 +63,7 @@ export const CollectionPillSources = ({
       )}
       {(!hasSources || !alwaysShowSources) && (
         <Pill
-          label="Collection"
+          label={label}
           className={classNames(
             'inline-flex bg-theme-overlay-float-cabbage text-brand-default',
             hasSources && 'group-hover:hidden',

--- a/packages/shared/src/components/post/collection/CollectionPostContent.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPostContent.tsx
@@ -25,6 +25,8 @@ import { PostTagList } from '../tags/PostTagList';
 import { CollectionPostHeaderActions } from './CollectionPostHeaderActions';
 import { isPostUpdated, type Post } from '../../../graphql/posts';
 import { pluralize } from '../../../lib/strings';
+import { TRENDS_SOURCE_ID } from '../../../lib/utils';
+import { getCollectionPillLabel, isTrendsPost } from './common';
 
 type CollectionPostContentRawProps = Omit<PostContentProps, 'post'> & {
   post: Post;
@@ -59,6 +61,7 @@ const CollectionPostContentRaw = ({
   const wasUpdated = isPostUpdated(post);
   const dateToShow = wasUpdated ? updatedAt : createdAt;
   const hasSources = !!numCollectionSources && numCollectionSources > 0;
+  const sourceId = isTrendsPost(post) ? TRENDS_SOURCE_ID : 'collections';
   const { onCopyPostLink, onReadArticle } = engagementActions;
 
   const hasNavigation = !!onPreviousPost || !!onNextPost;
@@ -136,10 +139,10 @@ const CollectionPostContentRaw = ({
           <div className="mb-6 flex flex-col gap-6">
             <CollectionsIntro className="mt-6 laptop:hidden" />
             <div className="flex flex-row items-center gap-2 pt-6">
-              <Link href={`${webappUrl}sources/collections`} passHref>
+              <Link href={`${webappUrl}sources/${sourceId}`} passHref>
                 <Pill
                   tag="a"
-                  label="Collection"
+                  label={getCollectionPillLabel(post)}
                   className="bg-theme-overlay-float-cabbage text-brand-default"
                 />
               </Link>

--- a/packages/shared/src/components/post/collection/common.ts
+++ b/packages/shared/src/components/post/collection/common.ts
@@ -1,0 +1,8 @@
+import type { Post } from '../../../graphql/posts';
+import { TRENDS_SOURCE_ID } from '../../../lib/utils';
+
+export const isTrendsPost = (post: Pick<Post, 'source'>): boolean =>
+  post.source?.id === TRENDS_SOURCE_ID;
+
+export const getCollectionPillLabel = (post: Pick<Post, 'source'>): string =>
+  isTrendsPost(post) ? 'Trend' : 'Collection';

--- a/packages/shared/src/lib/utils.ts
+++ b/packages/shared/src/lib/utils.ts
@@ -2,6 +2,7 @@ import { largeNumberFormat } from './numberFormat';
 import type { TLocation } from '../graphql/autocomplete';
 
 export const UNKNOWN_SOURCE_ID = 'unknown';
+export const TRENDS_SOURCE_ID = 'trends';
 
 export const stringToBoolean = (value: string): boolean => {
   if (typeof value !== 'string') {


### PR DESCRIPTION
## Changes

The collection card and post modal/page render a "Collection" pill. Posts belonging to the new **Trends** source (`source.id === 'trends'`) now show a **"Trend"** pill instead.

- Added `TRENDS_SOURCE_ID` constant and a small `getCollectionPillLabel` / `isTrendsPost` helper in `post/collection/common.ts` (shared across the three pill call sites).
- `CollectionPillSources` gained an optional `label` prop (defaults to `"Collection"`, so brief/digest/brief-card usages are unaffected).
- `CollectionCardHeader`, `CollectionList`, and `CollectionPostContent` pass the source-derived label.
- On the post page the pill is a link, so its target now points at `sources/trends` vs `sources/collections` accordingly.

## Key decisions

- Centralized the label logic in one helper rather than inlining the `source.id` check at each site, per the repo's de-duplication guidance.
- Kept the change scoped to the label/link only; the existing "Collection" copy and behavior is preserved for all non-trends posts.

Closes ENG-1642

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1642-adjust-the-collection-p.preview.app.daily.dev