### PR TITLE
feat(giveback): giveback page with hero, sponsors and footer

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackBackground.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackBackground.tsx
@@ -1,0 +1,53 @@
+import type { CSSProperties, ReactElement } from 'react';
+import React from 'react';
+
+// daily.dev brand canvas: the signature pink → purple → blue gradient (cabbage →
+// onion → blueCheese) glowing softly from the top of a dark surface, the way the
+// marketing site and Plus pages feel — smooth and pastel, no hard shapes or
+// grids. Every tint is a theme token via color-mix so it tracks the design
+// system, and a whisper of grain keeps the gradient from banding.
+const brandSweep: CSSProperties = {
+  backgroundImage:
+    'linear-gradient(125deg, ' +
+    'color-mix(in srgb, var(--theme-accent-cabbage-default) 34%, transparent), ' +
+    'color-mix(in srgb, var(--theme-accent-onion-default) 34%, transparent) 38%, ' +
+    'color-mix(in srgb, var(--theme-accent-blueCheese-default) 30%, transparent) 62%, ' +
+    'color-mix(in srgb, var(--theme-accent-onion-default) 34%, transparent) 82%, ' +
+    'color-mix(in srgb, var(--theme-accent-cabbage-default) 34%, transparent))',
+  maskImage: 'radial-gradient(125% 75% at 50% -10%, black, transparent 70%)',
+  WebkitMaskImage:
+    'radial-gradient(125% 75% at 50% -10%, black, transparent 70%)',
+};
+
+// A soft horizon glow anchored to the bottom edge for depth — a wide, flat
+// ellipse, so it's ambient light rather than a circle.
+const horizonGlow: CSSProperties = {
+  background:
+    'radial-gradient(120% 38% at 50% 102%, color-mix(in srgb, var(--theme-accent-onion-default) 16%, transparent), transparent 72%)',
+};
+
+// Faint film grain, only to prevent banding across the smooth gradient.
+const grain: CSSProperties = {
+  backgroundImage:
+    "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")",
+};
+
+const vignette: CSSProperties = {
+  background:
+    'radial-gradient(125% 80% at 50% 24%, transparent 52%, color-mix(in srgb, var(--theme-background-default) 80%, transparent) 100%)',
+};
+
+export const GivebackBackground = (): ReactElement => (
+  <div
+    aria-hidden
+    className="pointer-events-none absolute inset-0 overflow-hidden"
+  >
+    {/* The brand glow is a fixed-height hero band anchored to the top. Sizing it
+        in px (not inset-0) keeps it consistent — otherwise its mask scales with
+        the page height and the glow spreads down on longer pages. */}
+    <div className="absolute inset-x-0 top-0 h-[42rem]" style={brandSweep} />
+    <div className="absolute inset-0" style={horizonGlow} />
+    <div className="absolute inset-0 opacity-[0.04]" style={grain} />
+    <div className="absolute inset-0" style={vignette} />
+  </div>
+);

--- a/packages/shared/src/features/giveback/components/GivebackCampaignVideo.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackCampaignVideo.tsx
@@ -1,0 +1,84 @@
+import type { CSSProperties, ReactElement } from 'react';
+import React, { useState } from 'react';
+import { FlexCol } from '../../../components/utilities';
+import { PlayIcon } from '../../../components/icons';
+import { IconSize } from '../../../components/Icon';
+
+// The campaign clip behind a lightweight click-to-play facade — the heavy embed
+// only mounts on click, so the hero never autoplays or loads the iframe up
+// front. The placeholder poster shows the Giveback charm on the brand backdrop;
+// swap VIDEO_ID for the final film when it's ready.
+const VIDEO_ID = 'GAIOnX3S2jg';
+const START_SECONDS = 1;
+
+const CHARM_IMAGE_SRC =
+  'https://media.daily.dev/image/upload/s--d1dldAty--/f_auto,q_auto/v1780848838/public/daily.dev%20Charm%20-%20Giveback%20(1)';
+
+// A dark, on-brand backdrop (page background + a soft cabbage glow from the top)
+// so the charm — rendered with `mix-blend-screen` — reads as floating, exactly
+// like it does elsewhere on the dark page.
+const posterBackdrop: CSSProperties = {
+  background:
+    'radial-gradient(120% 95% at 50% 0%, color-mix(in srgb, var(--theme-accent-cabbage-default) 22%, transparent), transparent 68%), var(--theme-background-default)',
+};
+
+export const GivebackCampaignVideo = (): ReactElement => {
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  return (
+    <FlexCol className="w-full gap-2">
+      <div className="group relative aspect-video w-full overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-surface-float">
+        {isPlaying ? (
+          <iframe
+            title="Giveback campaign video"
+            src={`https://www.youtube.com/embed/${VIDEO_ID}?autoplay=1&start=${START_SECONDS}&rel=0`}
+            className="absolute inset-0 size-full"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setIsPlaying(true)}
+            aria-label="Play the Giveback campaign video"
+            className="absolute inset-0 size-full"
+          >
+            <span
+              aria-hidden
+              className="absolute inset-0"
+              style={posterBackdrop}
+            />
+
+            {/* The charm as the poster: a soft glow behind it, then the artwork
+                with the black baked-in background dropped via mix-blend-screen. */}
+            <span className="absolute inset-0 flex items-center justify-center">
+              <span
+                aria-hidden
+                className="bg-accent-cabbage-default/20 absolute size-1/2 rounded-full blur-3xl motion-safe:animate-glow-pulse"
+              />
+              <img
+                src={CHARM_IMAGE_SRC}
+                alt=""
+                aria-hidden
+                loading="lazy"
+                className="relative max-h-[80%] w-auto select-none object-contain mix-blend-screen transition-transform duration-500 motion-safe:group-hover:scale-105"
+              />
+            </span>
+
+            <span className="absolute inset-0 flex items-center justify-center">
+              {/* Dark halo so the button keeps strong contrast even over the
+                  bright parts of the charm. */}
+              <span
+                aria-hidden
+                className="absolute size-24 rounded-full bg-overlay-primary-pepper blur-2xl"
+              />
+              <span className="group-hover:ring-white/60 relative flex size-14 items-center justify-center rounded-full bg-white shadow-2 ring-4 ring-white/40 transition-transform duration-200 motion-safe:group-hover:scale-110">
+                <PlayIcon secondary size={IconSize.Size48} className="ml-0.5" />
+              </span>
+            </span>
+          </button>
+        )}
+      </div>
+    </FlexCol>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackFundingSummary.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackFundingSummary.spec.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { GivebackFundingSummary } from './GivebackFundingSummary';
+import { useContributionStatus } from '../hooks/useContributionStatus';
+import type { ContributionStatus } from '../types';
+
+jest.mock('../hooks/useContributionStatus');
+
+// Resolve the reveal/count-up animations synchronously so assertions read the
+// final values instead of mid-animation frames.
+jest.mock('../useGivebackMotion', () => ({
+  useInView: () => ({ ref: { current: null }, inView: true }),
+  useCountUp: (target: number) => target,
+}));
+
+const mockUseContributionStatus = useContributionStatus as jest.MockedFunction<
+  typeof useContributionStatus
+>;
+
+const renderSummary = (status: Partial<ContributionStatus>) => {
+  mockUseContributionStatus.mockReturnValue({
+    status: {
+      enabled: true,
+      eligible: null,
+      currentCyclePoints: 0,
+      currentCycleTargetPoints: 0,
+      lifetimePoints: 0,
+      lifetimeAmountCents: 0,
+      contributorsCount: 0,
+      userPoints: null,
+      ...status,
+    },
+    isPending: false,
+  });
+
+  return render(<GivebackFundingSummary />);
+};
+
+it('renders campaign points as dollars against the cycle goal with backers', () => {
+  renderSummary({
+    currentCyclePoints: 5000,
+    currentCycleTargetPoints: 10000,
+    contributorsCount: 12480,
+  });
+
+  expect(screen.getByText('$5,000')).toBeInTheDocument();
+  expect(screen.getByText('pledged of $10,000 goal')).toBeInTheDocument();
+  expect(screen.getByText('50%')).toBeInTheDocument();
+  expect(screen.getByText(/12,480 backers/)).toBeInTheDocument();
+});
+
+it('shows a goal-forward empty state when nothing is pledged yet', () => {
+  renderSummary({
+    currentCyclePoints: 0,
+    currentCycleTargetPoints: 10000,
+    contributorsCount: 0,
+  });
+
+  expect(screen.getByText('$10,000')).toBeInTheDocument();
+  expect(
+    screen.getByText('goal to unlock for good causes'),
+  ).toBeInTheDocument();
+  expect(screen.getByText('Be the first to back this.')).toBeInTheDocument();
+  // None of the "$0 / 0% / 0 backers" zeros leak through.
+  expect(screen.queryByText('$0')).not.toBeInTheDocument();
+  expect(screen.queryByText(/0 backers/)).not.toBeInTheDocument();
+});
+
+it('renders a skeleton without zeros before data arrives', () => {
+  mockUseContributionStatus.mockReturnValue({
+    status: undefined,
+    isPending: true,
+  });
+
+  render(<GivebackFundingSummary />);
+
+  expect(screen.queryByText('$0')).not.toBeInTheDocument();
+  expect(screen.queryByText(/pledged of/)).not.toBeInTheDocument();
+});

--- a/packages/shared/src/features/giveback/components/GivebackFundingSummary.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackFundingSummary.tsx
@@ -1,0 +1,164 @@
+import type { ReactElement, RefObject } from 'react';
+import React from 'react';
+import { FlexCol, FlexRow } from '../../../components/utilities';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { ProgressBar } from '../../../components/fields/ProgressBar';
+import { useContributionStatus } from '../hooks/useContributionStatus';
+import { useCountUp, useInView } from '../useGivebackMotion';
+import { formatDonationAmount, getGoalProgressPercentage } from '../utils';
+import { GivebackMeterShine } from './GivebackMeterShine';
+
+const barColor =
+  'bg-gradient-to-r from-accent-avocado-default via-accent-cabbage-default to-accent-cheese-default';
+
+const Meter = ({
+  meterRef,
+  percentage,
+  empty = false,
+}: {
+  meterRef: RefObject<HTMLDivElement>;
+  percentage: number;
+  empty?: boolean;
+}): ReactElement => (
+  <div className="relative" ref={meterRef}>
+    <ProgressBar
+      percentage={percentage}
+      shouldShowBg
+      className={{
+        wrapper: 'h-3 rounded-12',
+        bar: 'h-full rounded-12 transition-[width] duration-700 ease-out',
+        barColor,
+      }}
+    />
+    {empty ? (
+      // A faint shimmer travelling across the empty track so a $0 meter reads as
+      // "ready to fill" rather than broken.
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 overflow-hidden rounded-12"
+      >
+        <div className="via-accent-cabbage-default/40 absolute inset-y-0 -left-1/3 w-1/3 -skew-x-12 bg-gradient-to-r from-transparent to-transparent motion-safe:animate-meter-shine" />
+      </div>
+    ) : (
+      <GivebackMeterShine
+        percentage={percentage}
+        radiusClassName="rounded-12"
+      />
+    )}
+  </div>
+);
+
+// Compact funding block for the hero sidebar — the crowdfunding "pledge panel":
+// raised, goal and progress at a glance. Points come back from the contribution
+// API as whole currency units, so they format directly as dollars.
+export const GivebackFundingSummary = (): ReactElement => {
+  const { status } = useContributionStatus();
+  const { ref: meterRef, inView } = useInView<HTMLDivElement>();
+
+  const raised = status?.currentCyclePoints ?? 0;
+  const goal = status?.currentCycleTargetPoints ?? 0;
+  const contributorsCount = status?.contributorsCount ?? 0;
+  const percentage = getGoalProgressPercentage(raised, goal);
+  const animatedPercentage = useCountUp(Math.round(percentage), inView);
+
+  // No data yet (or no goal configured): a quiet skeleton so we never flash a
+  // wall of zeros before the campaign numbers land.
+  if (!status || goal === 0) {
+    return (
+      <FlexCol className="gap-3">
+        <div className="h-8 w-40 animate-pulse rounded-8 bg-surface-float" />
+        <div className="h-3 w-full rounded-12 bg-surface-float" />
+        <div className="h-4 w-48 animate-pulse rounded-8 bg-surface-float" />
+      </FlexCol>
+    );
+  }
+
+  // Empty state: nothing pledged yet. Lead with the goal so the panel feels
+  // aspirational instead of showing "$0 · 0% · 0 backers" everywhere.
+  if (raised === 0) {
+    return (
+      <FlexCol className="gap-3">
+        <FlexRow className="items-end gap-2">
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Title1}
+            bold
+          >
+            {formatDonationAmount(goal)}
+          </Typography>
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+            className="pb-1"
+          >
+            goal to unlock for good causes
+          </Typography>
+        </FlexRow>
+
+        <Meter meterRef={meterRef} percentage={0} empty />
+
+        <FlexRow className="flex-wrap items-baseline gap-1">
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Footnote}
+            color={TypographyColor.Primary}
+            bold
+          >
+            Be the first to back this.
+          </Typography>
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Footnote}
+            color={TypographyColor.Tertiary}
+          >
+            Take an action to start the meter.
+          </Typography>
+        </FlexRow>
+      </FlexCol>
+    );
+  }
+
+  return (
+    <FlexCol className="gap-3">
+      <FlexRow className="items-end gap-2">
+        <Typography tag={TypographyTag.Span} type={TypographyType.Title1} bold>
+          {formatDonationAmount(raised)}
+        </Typography>
+        <Typography
+          tag={TypographyTag.Span}
+          type={TypographyType.Caption1}
+          color={TypographyColor.Tertiary}
+          className="pb-1"
+        >
+          pledged of {formatDonationAmount(goal)} goal
+        </Typography>
+      </FlexRow>
+
+      <Meter meterRef={meterRef} percentage={animatedPercentage} />
+
+      <FlexRow className="flex-wrap items-baseline gap-1">
+        <Typography
+          tag={TypographyTag.Span}
+          type={TypographyType.Footnote}
+          color={TypographyColor.StatusSuccess}
+          bold
+        >
+          {Math.round(percentage)}%
+        </Typography>
+        <Typography
+          tag={TypographyTag.Span}
+          type={TypographyType.Footnote}
+          color={TypographyColor.Tertiary}
+        >
+          funded · {contributorsCount.toLocaleString('en-US')} backers
+        </Typography>
+      </FlexRow>
+    </FlexCol>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackHero.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackHero.tsx
@@ -1,0 +1,94 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { FlexCol, FlexRow } from '../../../components/utilities';
+import Logo, { LogoPosition } from '../../../components/Logo';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { GivebackStartPanel } from './GivebackStartPanel';
+import { GivebackCampaignVideo } from './GivebackCampaignVideo';
+import { GivebackFundingSummary } from './GivebackFundingSummary';
+
+interface GivebackHeroProps {
+  onJoin: () => void;
+}
+
+export const GivebackHero = ({ onJoin }: GivebackHeroProps): ReactElement => {
+  return (
+    <section className="relative w-full">
+      {/* Clip only the decorative glows, not the content, so hover effects on
+          buttons (scale + shadow) aren't cut off by the section bounds. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 overflow-hidden"
+      >
+        <div className="bg-accent-cabbage-default/25 absolute -left-24 -top-24 size-80 rounded-full blur-3xl motion-safe:animate-glow-pulse" />
+        <div
+          className="bg-accent-onion-default/20 absolute -right-10 top-10 size-72 rounded-full blur-3xl motion-safe:animate-glow-pulse"
+          style={{ animationDelay: '1s' }}
+        />
+        <div
+          className="bg-accent-cheese-default/15 absolute -bottom-16 left-1/3 size-64 rounded-full blur-3xl motion-safe:animate-glow-pulse"
+          style={{ animationDelay: '2s' }}
+        />
+      </div>
+
+      <FlexCol className="relative gap-10 py-2">
+        <FlexCol className="gap-2">
+          <FlexRow className="mb-6 w-fit items-center gap-3">
+            <Logo
+              position={LogoPosition.Initial}
+              logoClassName={{ container: 'h-6' }}
+            />
+            <span
+              aria-hidden
+              className="h-6 w-px bg-border-subtlest-tertiary"
+            />
+            <Typography
+              tag={TypographyTag.Span}
+              type={TypographyType.Title3}
+              color={TypographyColor.Primary}
+              bold
+            >
+              Giveback
+            </Typography>
+          </FlexRow>
+
+          <Typography
+            tag={TypographyTag.H1}
+            type={TypographyType.Title1}
+            bold
+            className="max-w-3xl"
+          >
+            Grow the community. Redirect the budget.
+            <span className="block bg-gradient-to-r from-accent-avocado-default via-accent-cabbage-default to-accent-cheese-default bg-clip-text text-transparent">
+              Fund good causes.
+            </span>
+          </Typography>
+          <Typography
+            tag={TypographyTag.P}
+            type={TypographyType.Callout}
+            color={TypographyColor.Secondary}
+            className="max-w-2xl"
+          >
+            Ad giants don&apos;t need our money. The causes you care about do.
+            We redirect our growth budget to them, and you never pay a cent.
+          </Typography>
+        </FlexCol>
+
+        <div className="grid items-stretch gap-6 laptop:grid-cols-[1.45fr_1fr] laptop:gap-8">
+          <GivebackCampaignVideo />
+
+          <FlexCol className="h-full justify-center gap-5">
+            <GivebackFundingSummary />
+            <div className="via-accent-cabbage-default/30 h-px w-full bg-gradient-to-r from-transparent to-transparent" />
+            <GivebackStartPanel onJoin={onJoin} />
+          </FlexCol>
+        </div>
+      </FlexCol>
+    </section>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackHero.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackHero.tsx
@@ -12,11 +12,7 @@ import { GivebackStartPanel } from './GivebackStartPanel';
 import { GivebackCampaignVideo } from './GivebackCampaignVideo';
 import { GivebackFundingSummary } from './GivebackFundingSummary';
 
-interface GivebackHeroProps {
-  onJoin: () => void;
-}
-
-export const GivebackHero = ({ onJoin }: GivebackHeroProps): ReactElement => {
+export const GivebackHero = (): ReactElement => {
   return (
     <section className="relative w-full">
       {/* Clip only the decorative glows, not the content, so hover effects on
@@ -85,7 +81,7 @@ export const GivebackHero = ({ onJoin }: GivebackHeroProps): ReactElement => {
           <FlexCol className="h-full justify-center gap-5">
             <GivebackFundingSummary />
             <div className="via-accent-cabbage-default/30 h-px w-full bg-gradient-to-r from-transparent to-transparent" />
-            <GivebackStartPanel onJoin={onJoin} />
+            <GivebackStartPanel />
           </FlexCol>
         </div>
       </FlexCol>

--- a/packages/shared/src/features/giveback/components/GivebackLegalFooter.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackLegalFooter.tsx
@@ -1,0 +1,46 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { FlexRow } from '../../../components/utilities';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { privacyPolicy, termsOfService } from '../../../lib/constants';
+
+// Legal/footer home for the campaign. One quiet line: funding disclaimer on the
+// left, the terms/rules/privacy links on the right. Cookie policy is omitted on
+// purpose since the global cookie banner already covers it.
+const legalLinks: { label: string; href: string }[] = [
+  { label: 'Campaign rules', href: termsOfService },
+  { label: 'Terms of Service', href: termsOfService },
+  { label: 'Privacy Policy', href: privacyPolicy },
+];
+
+export const GivebackLegalFooter = (): ReactElement => (
+  <div className="flex w-full flex-col items-center justify-between gap-2 border-t border-border-subtlest-tertiary pt-5 text-center tablet:flex-row tablet:text-left">
+    <Typography
+      tag={TypographyTag.P}
+      type={TypographyType.Caption2}
+      color={TypographyColor.Quaternary}
+    >
+      Funded by daily.dev. Participants never pay. © {new Date().getFullYear()}{' '}
+      Daily Dev Ltd.
+    </Typography>
+
+    <FlexRow className="flex-wrap items-center justify-center gap-x-4 gap-y-1">
+      {legalLinks.map((link) => (
+        <a
+          key={link.label}
+          href={link.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-bold text-text-tertiary transition-colors typo-caption1 hover:text-text-primary"
+        >
+          {link.label}
+        </a>
+      ))}
+    </FlexRow>
+  </div>
+);

--- a/packages/shared/src/features/giveback/components/GivebackMeterShine.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackMeterShine.tsx
@@ -1,0 +1,28 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+
+interface GivebackMeterShineProps {
+  percentage: number;
+  /** Match the meter's corner radius so the sweep stays inside the bar. */
+  radiusClassName?: string;
+}
+
+// Light sweep that rides across the filled portion of a funding meter, making
+// the money raised feel alive. Clipped to `percentage` so the shine only
+// travels over what's already been pledged.
+export const GivebackMeterShine = ({
+  percentage,
+  radiusClassName = 'rounded-16',
+}: GivebackMeterShineProps): ReactElement => (
+  <div
+    aria-hidden
+    className={classNames(
+      'pointer-events-none absolute inset-y-0 left-0 overflow-hidden',
+      radiusClassName,
+    )}
+    style={{ width: `${Math.min(Math.max(percentage, 0), 100)}%` }}
+  >
+    <div className="via-white/55 absolute inset-y-0 -left-1/4 w-1/4 -skew-x-12 bg-gradient-to-r from-transparent to-transparent motion-safe:animate-meter-shine" />
+  </div>
+);

--- a/packages/shared/src/features/giveback/components/GivebackPage.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackPage.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useCallback } from 'react';
+import React from 'react';
 import { FlexCol } from '../../../components/utilities';
 import { GivebackBackground } from './GivebackBackground';
 import { GivebackReveal } from './GivebackReveal';
@@ -8,18 +8,13 @@ import { GivebackSponsorTiers } from './GivebackSponsorTiers';
 import { GivebackLegalFooter } from './GivebackLegalFooter';
 
 export const GivebackPage = (): ReactElement => {
-  // Authenticated entry point into the join flow. The post-login onboarding
-  // (cause selection, action catalog) lands in a later step; for now opting in
-  // from the hero is the login gateway.
-  const handleJoin = useCallback(() => {}, []);
-
   return (
     <div className="relative min-h-page w-full">
       <GivebackBackground />
 
       <FlexCol className="relative mx-auto w-full max-w-6xl gap-14 px-4 py-8 tablet:py-14">
         <GivebackReveal>
-          <GivebackHero onJoin={handleJoin} />
+          <GivebackHero />
         </GivebackReveal>
 
         <GivebackReveal>

--- a/packages/shared/src/features/giveback/components/GivebackPage.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackPage.tsx
@@ -1,0 +1,35 @@
+import type { ReactElement } from 'react';
+import React, { useCallback } from 'react';
+import { FlexCol } from '../../../components/utilities';
+import { GivebackBackground } from './GivebackBackground';
+import { GivebackReveal } from './GivebackReveal';
+import { GivebackHero } from './GivebackHero';
+import { GivebackSponsorTiers } from './GivebackSponsorTiers';
+import { GivebackLegalFooter } from './GivebackLegalFooter';
+
+export const GivebackPage = (): ReactElement => {
+  // Authenticated entry point into the join flow. The post-login onboarding
+  // (cause selection, action catalog) lands in a later step; for now opting in
+  // from the hero is the login gateway.
+  const handleJoin = useCallback(() => {}, []);
+
+  return (
+    <div className="relative min-h-page w-full">
+      <GivebackBackground />
+
+      <FlexCol className="relative mx-auto w-full max-w-6xl gap-14 px-4 py-8 tablet:py-14">
+        <GivebackReveal>
+          <GivebackHero onJoin={handleJoin} />
+        </GivebackReveal>
+
+        <GivebackReveal>
+          <GivebackSponsorTiers />
+        </GivebackReveal>
+
+        <GivebackReveal>
+          <GivebackLegalFooter />
+        </GivebackReveal>
+      </FlexCol>
+    </div>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackReveal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackReveal.tsx
@@ -1,0 +1,36 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import { useInView } from '../useGivebackMotion';
+
+interface GivebackRevealProps {
+  children: ReactNode;
+  className?: string;
+  /** Stagger the reveal, in ms. */
+  delay?: number;
+}
+
+// Fades and slides content up the first time it scrolls into view. Honors
+// reduced-motion via the motion-reduce utilities so the final state always
+// renders without movement.
+export const GivebackReveal = ({
+  children,
+  className,
+  delay = 0,
+}: GivebackRevealProps): ReactElement => {
+  const { ref, inView } = useInView<HTMLDivElement>();
+
+  return (
+    <div
+      ref={ref}
+      style={delay ? { transitionDelay: `${delay}ms` } : undefined}
+      className={classNames(
+        'transition-all duration-700 ease-out motion-reduce:!translate-y-0 motion-reduce:!opacity-100 motion-reduce:transition-none',
+        inView ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackReveal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackReveal.tsx
@@ -6,8 +6,6 @@ import { useInView } from '../useGivebackMotion';
 interface GivebackRevealProps {
   children: ReactNode;
   className?: string;
-  /** Stagger the reveal, in ms. */
-  delay?: number;
 }
 
 // Fades and slides content up the first time it scrolls into view. Honors
@@ -16,14 +14,12 @@ interface GivebackRevealProps {
 export const GivebackReveal = ({
   children,
   className,
-  delay = 0,
 }: GivebackRevealProps): ReactElement => {
   const { ref, inView } = useInView<HTMLDivElement>();
 
   return (
     <div
       ref={ref}
-      style={delay ? { transitionDelay: `${delay}ms` } : undefined}
       className={classNames(
         'transition-all duration-700 ease-out motion-reduce:!translate-y-0 motion-reduce:!opacity-100 motion-reduce:transition-none',
         inView ? 'translate-y-0 opacity-100' : 'translate-y-6 opacity-0',

--- a/packages/shared/src/features/giveback/components/GivebackSponsorTiers.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSponsorTiers.spec.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { GivebackSponsorTiers } from './GivebackSponsorTiers';
+import { useContributionSponsors } from '../hooks/useContributionSponsors';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
+import { ContributionSponsorTier } from '../types';
+import type { ContributionSponsor } from '../types';
+
+jest.mock('../hooks/useContributionSponsors');
+jest.mock('../../../contexts/LogContext');
+
+const mockUseContributionSponsors =
+  useContributionSponsors as jest.MockedFunction<
+    typeof useContributionSponsors
+  >;
+const mockUseLogContext = useLogContext as jest.MockedFunction<
+  typeof useLogContext
+>;
+
+const logEvent = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseLogContext.mockReturnValue({ logEvent } as unknown as ReturnType<
+    typeof useLogContext
+  >);
+});
+
+const sponsor = (
+  overrides: Partial<ContributionSponsor> & Pick<ContributionSponsor, 'id'>,
+): ContributionSponsor => ({
+  name: 'Acme',
+  amountCents: 300000,
+  url: 'https://acme.test',
+  logoUrl: 'https://logos.test/acme.svg',
+  tier: ContributionSponsorTier.Gold,
+  ...overrides,
+});
+
+it('groups sponsors under their tier labels and renders brand logo cards', () => {
+  mockUseContributionSponsors.mockReturnValue({
+    sponsors: [
+      sponsor({ id: '1', name: 'Vercel', tier: ContributionSponsorTier.Gold }),
+      sponsor({
+        id: '2',
+        name: 'GitHub',
+        tier: ContributionSponsorTier.Silver,
+      }),
+      sponsor({
+        id: '3',
+        name: 'Datadog',
+        tier: ContributionSponsorTier.Bronze,
+      }),
+    ],
+    isPending: false,
+  });
+
+  render(<GivebackSponsorTiers />);
+
+  expect(screen.getByText('Sponsored by')).toBeInTheDocument();
+  expect(screen.getByText('Gold')).toBeInTheDocument();
+  expect(screen.getByText('Bronze')).toBeInTheDocument();
+
+  const link = screen.getByRole('link', { name: 'Vercel' });
+  expect(link).toHaveAttribute('href', 'https://acme.test');
+  expect(screen.getByAltText('Vercel logo')).toHaveAttribute(
+    'src',
+    'https://logos.test/acme.svg',
+  );
+});
+
+it('logs a sponsor click with the sponsor id and tier', () => {
+  mockUseContributionSponsors.mockReturnValue({
+    sponsors: [
+      sponsor({ id: 's1', name: 'Vercel', tier: ContributionSponsorTier.Gold }),
+    ],
+    isPending: false,
+  });
+
+  render(<GivebackSponsorTiers />);
+  fireEvent.click(screen.getByRole('link', { name: 'Vercel' }));
+
+  expect(logEvent).toHaveBeenCalledWith({
+    event_name: LogEvent.ClickGivebackSponsor,
+    target_id: 's1',
+    extra: JSON.stringify({
+      name: 'Vercel',
+      tier: ContributionSponsorTier.Gold,
+    }),
+  });
+});
+
+it('falls back to a name pill when a sponsor has no logo', () => {
+  mockUseContributionSponsors.mockReturnValue({
+    sponsors: [
+      sponsor({
+        id: '1',
+        name: 'Dana K.',
+        tier: ContributionSponsorTier.Bronze,
+        logoUrl: null,
+        url: null,
+      }),
+    ],
+    isPending: false,
+  });
+
+  render(<GivebackSponsorTiers />);
+
+  expect(screen.getByText('Dana K.')).toBeInTheDocument();
+});
+
+it('renders nothing when there are no sponsors', () => {
+  mockUseContributionSponsors.mockReturnValue({
+    sponsors: [],
+    isPending: false,
+  });
+
+  const { container } = render(<GivebackSponsorTiers />);
+
+  expect(container).toBeEmptyDOMElement();
+});

--- a/packages/shared/src/features/giveback/components/GivebackSponsorTiers.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSponsorTiers.tsx
@@ -1,0 +1,258 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import { FlexCol, FlexRow } from '../../../components/utilities';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
+import { useContributionSponsors } from '../hooks/useContributionSponsors';
+import { sponsorTierLabel } from '../utils';
+import type { ContributionSponsor } from '../types';
+import { ContributionSponsorTier } from '../types';
+
+interface TierStyle {
+  // Tier marker dot + label color (soft, on-brand accent tints).
+  dotClass: string;
+  labelClass: string;
+  // White-card padding + logo height, stepping down platinum → backer.
+  chipClass: string;
+  logoClass: string;
+}
+
+const tierStyles: Record<ContributionSponsorTier, TierStyle> = {
+  [ContributionSponsorTier.Gold]: {
+    dotClass: 'bg-accent-cheese-default',
+    labelClass: 'text-accent-cheese-default',
+    chipClass: 'px-4 py-2.5',
+    logoClass: 'h-8 tablet:h-9',
+  },
+  [ContributionSponsorTier.Silver]: {
+    dotClass: 'bg-text-quaternary',
+    labelClass: 'text-text-secondary',
+    chipClass: 'px-3.5 py-2',
+    logoClass: 'h-6 tablet:h-7',
+  },
+  [ContributionSponsorTier.Bronze]: {
+    dotClass: 'bg-accent-bacon-default',
+    labelClass: 'text-accent-bacon-default',
+    chipClass: 'px-3 py-1.5',
+    logoClass: 'h-5 tablet:h-6',
+  },
+};
+
+// The headline tier sits on its own row inside a warm glow; the lower two
+// tiers share the row beneath it.
+const HEADLINE_TIERS = [ContributionSponsorTier.Gold];
+const LOWER_TIERS = [
+  ContributionSponsorTier.Silver,
+  ContributionSponsorTier.Bronze,
+];
+
+// Brand logos rest on white "medal cards" so they stay legible on the dark page
+// regardless of the logo's own colors; logo-less sponsors (e.g. individuals)
+// fall back to a quiet name pill so the card is never empty.
+const SponsorChip = ({
+  sponsor,
+  style,
+}: {
+  sponsor: ContributionSponsor;
+  style: TierStyle;
+}): ReactElement => {
+  const { logEvent } = useLogContext();
+
+  const onClick = () =>
+    logEvent({
+      event_name: LogEvent.ClickGivebackSponsor,
+      target_id: sponsor.id,
+      extra: JSON.stringify({ name: sponsor.name, tier: sponsor.tier }),
+    });
+
+  if (!sponsor.logoUrl) {
+    const pillClass =
+      'flex shrink-0 items-center rounded-12 border border-border-subtlest-tertiary bg-surface-float px-3 py-1.5 transition-transform duration-200 hover:-translate-y-0.5 motion-reduce:transform-none';
+    const name = (
+      <Typography
+        tag={TypographyTag.Span}
+        type={TypographyType.Footnote}
+        color={TypographyColor.Primary}
+        bold
+        className="whitespace-nowrap"
+      >
+        {sponsor.name}
+      </Typography>
+    );
+
+    if (!sponsor.url) {
+      return <span className={pillClass}>{name}</span>;
+    }
+
+    return (
+      <a
+        href={sponsor.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={sponsor.name}
+        className={pillClass}
+        onClick={onClick}
+      >
+        {name}
+      </a>
+    );
+  }
+
+  const cardClass = classNames(
+    'flex shrink-0 items-center rounded-12 bg-white shadow-[0_10px_28px_-12px_rgba(0,0,0,0.6)] transition-transform duration-200 hover:-translate-y-1 motion-reduce:transform-none',
+    style.chipClass,
+  );
+  const logo = (
+    <img
+      src={sponsor.logoUrl}
+      alt={`${sponsor.name} logo`}
+      loading="lazy"
+      className={classNames(
+        'w-auto max-w-[140px] object-contain',
+        style.logoClass,
+      )}
+    />
+  );
+
+  if (!sponsor.url) {
+    return (
+      <span aria-label={sponsor.name} className={cardClass}>
+        {logo}
+      </span>
+    );
+  }
+
+  return (
+    <a
+      href={sponsor.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={sponsor.name}
+      className={cardClass}
+      onClick={onClick}
+    >
+      {logo}
+    </a>
+  );
+};
+
+const SponsorTierGroup = ({
+  tier,
+  sponsors,
+}: {
+  tier: ContributionSponsorTier;
+  sponsors: ContributionSponsor[];
+}): ReactElement => {
+  const style = tierStyles[tier];
+
+  return (
+    <FlexRow className="flex-wrap items-center gap-x-4 gap-y-3">
+      <FlexRow className="shrink-0 items-center gap-2">
+        <span className={classNames('size-2 rounded-full', style.dotClass)} />
+        <Typography
+          tag={TypographyTag.Span}
+          type={TypographyType.Caption1}
+          bold
+          className={classNames('uppercase tracking-wider', style.labelClass)}
+        >
+          {sponsorTierLabel[tier]}
+        </Typography>
+      </FlexRow>
+      {sponsors.map((sponsor) => (
+        <SponsorChip key={sponsor.id} sponsor={sponsor} style={style} />
+      ))}
+    </FlexRow>
+  );
+};
+
+export const GivebackSponsorTiers = (): ReactElement | null => {
+  const { sponsors } = useContributionSponsors();
+
+  if (!sponsors.length) {
+    return null;
+  }
+
+  const byTier = (tier: ContributionSponsorTier) =>
+    sponsors.filter((sponsor) => sponsor.tier === tier);
+
+  const headlineTiers = HEADLINE_TIERS.filter(
+    (tier) => byTier(tier).length > 0,
+  );
+  const lowerTiers = LOWER_TIERS.filter((tier) => byTier(tier).length > 0);
+
+  return (
+    <section className="relative w-full">
+      {/* Soft brand glows, echoing the hero, so the wall feels native to the
+          page rather than a hard panel dropped on top of it. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 overflow-hidden"
+      >
+        <div className="bg-accent-cheese-default/15 absolute -left-16 -top-10 size-56 rounded-full blur-3xl motion-safe:animate-glow-pulse" />
+        <div
+          className="bg-accent-cabbage-default/12 absolute -right-12 bottom-0 size-52 rounded-full blur-3xl motion-safe:animate-glow-pulse"
+          style={{ animationDelay: '1.4s' }}
+        />
+      </div>
+
+      <FlexCol className="relative gap-6">
+        <Typography
+          tag={TypographyTag.Span}
+          type={TypographyType.Caption1}
+          color={TypographyColor.Tertiary}
+          bold
+          className="uppercase tracking-wider"
+        >
+          Sponsored by
+        </Typography>
+
+        <FlexCol className="gap-6">
+          {headlineTiers.length > 0 && (
+            <div className="relative">
+              {/* Warm halo so the headline tiers glow softly above the rest. */}
+              <div aria-hidden className="pointer-events-none absolute inset-0">
+                <div className="bg-accent-cheese-default/12 absolute -left-6 -top-4 h-28 w-72 rounded-full blur-3xl" />
+              </div>
+              <FlexCol className="relative gap-5">
+                {headlineTiers.map((tier) => (
+                  <SponsorTierGroup
+                    key={tier}
+                    tier={tier}
+                    sponsors={byTier(tier)}
+                  />
+                ))}
+              </FlexCol>
+            </div>
+          )}
+
+          {lowerTiers.length > 0 && (
+            <>
+              {headlineTiers.length > 0 && (
+                <div
+                  aria-hidden
+                  className="h-px w-full bg-gradient-to-r from-transparent via-border-subtlest-tertiary to-transparent"
+                />
+              )}
+              <FlexRow className="flex-wrap items-center gap-x-10 gap-y-4">
+                {lowerTiers.map((tier) => (
+                  <SponsorTierGroup
+                    key={tier}
+                    tier={tier}
+                    sponsors={byTier(tier)}
+                  />
+                ))}
+              </FlexRow>
+            </>
+          )}
+        </FlexCol>
+      </FlexCol>
+    </section>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackStartPanel.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackStartPanel.spec.tsx
@@ -18,7 +18,6 @@ const mockUseLogContext = useLogContext as jest.MockedFunction<
 >;
 
 const showLogin = jest.fn();
-const onJoin = jest.fn();
 const logEvent = jest.fn();
 
 beforeEach(() => {
@@ -34,26 +33,24 @@ const renderPanel = (user: LoggedUser | null) => {
     showLogin,
   } as unknown as ReturnType<typeof useAuthContext>);
 
-  return render(<GivebackStartPanel onJoin={onJoin} />);
+  return render(<GivebackStartPanel />);
 };
 
-it('prompts login for logged-out visitors instead of starting the flow', () => {
+it('prompts login for logged-out visitors without logging the join event', () => {
   renderPanel(null);
 
   fireEvent.click(screen.getByRole('button', { name: 'Join the campaign' }));
 
   expect(showLogin).toHaveBeenCalledWith({ trigger: AuthTriggers.Giveback });
-  expect(onJoin).not.toHaveBeenCalled();
   // The join event must not fire when the click only opens login.
   expect(logEvent).not.toHaveBeenCalled();
 });
 
-it('starts the join flow and logs the join event for authenticated visitors', () => {
+it('logs the join event for authenticated visitors', () => {
   renderPanel({ id: 'u1' } as LoggedUser);
 
   fireEvent.click(screen.getByRole('button', { name: 'Join the campaign' }));
 
-  expect(onJoin).toHaveBeenCalledTimes(1);
   expect(showLogin).not.toHaveBeenCalled();
   expect(logEvent).toHaveBeenCalledWith({
     event_name: LogEvent.ClickJoinGiveback,

--- a/packages/shared/src/features/giveback/components/GivebackStartPanel.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackStartPanel.spec.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { GivebackStartPanel } from './GivebackStartPanel';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { useLogContext } from '../../../contexts/LogContext';
+import { AuthTriggers } from '../../../lib/auth';
+import { LogEvent } from '../../../lib/log';
+import type { LoggedUser } from '../../../lib/user';
+
+jest.mock('../../../contexts/AuthContext');
+jest.mock('../../../contexts/LogContext');
+
+const mockUseAuthContext = useAuthContext as jest.MockedFunction<
+  typeof useAuthContext
+>;
+const mockUseLogContext = useLogContext as jest.MockedFunction<
+  typeof useLogContext
+>;
+
+const showLogin = jest.fn();
+const onJoin = jest.fn();
+const logEvent = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseLogContext.mockReturnValue({ logEvent } as unknown as ReturnType<
+    typeof useLogContext
+  >);
+});
+
+const renderPanel = (user: LoggedUser | null) => {
+  mockUseAuthContext.mockReturnValue({
+    user,
+    showLogin,
+  } as unknown as ReturnType<typeof useAuthContext>);
+
+  return render(<GivebackStartPanel onJoin={onJoin} />);
+};
+
+it('prompts login for logged-out visitors instead of starting the flow', () => {
+  renderPanel(null);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Join the campaign' }));
+
+  expect(showLogin).toHaveBeenCalledWith({ trigger: AuthTriggers.Giveback });
+  expect(onJoin).not.toHaveBeenCalled();
+  // The join event must not fire when the click only opens login.
+  expect(logEvent).not.toHaveBeenCalled();
+});
+
+it('starts the join flow and logs the join event for authenticated visitors', () => {
+  renderPanel({ id: 'u1' } as LoggedUser);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Join the campaign' }));
+
+  expect(onJoin).toHaveBeenCalledTimes(1);
+  expect(showLogin).not.toHaveBeenCalled();
+  expect(logEvent).toHaveBeenCalledWith({
+    event_name: LogEvent.ClickJoinGiveback,
+  });
+});

--- a/packages/shared/src/features/giveback/components/GivebackStartPanel.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackStartPanel.tsx
@@ -1,0 +1,78 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { FlexCol } from '../../../components/utilities';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import {
+  Button,
+  ButtonIconPosition,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../components/buttons/Button';
+import { MoveToIcon } from '../../../components/icons';
+import { IconSize } from '../../../components/Icon';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { useLogContext } from '../../../contexts/LogContext';
+import { AuthTriggers } from '../../../lib/auth';
+import { LogEvent } from '../../../lib/log';
+
+interface GivebackStartPanelProps {
+  // Entry point into the (post-login) join flow, owned by the page. Only called
+  // once the visitor is authenticated.
+  onJoin: () => void;
+}
+
+// Hero gateway: one clear decision above the fold — "do you want to join?".
+// Logged-out visitors get the login prompt first; authenticated visitors move
+// straight into the join flow.
+export const GivebackStartPanel = ({
+  onJoin,
+}: GivebackStartPanelProps): ReactElement => {
+  const { user, showLogin } = useAuthContext();
+  const { logEvent } = useLogContext();
+
+  const handleJoin = () => {
+    if (!user) {
+      showLogin({ trigger: AuthTriggers.Giveback });
+      return;
+    }
+
+    // Only logged-in visitors actually enter the join flow; a logged-out click
+    // opens login instead, so the join event fires here only.
+    logEvent({ event_name: LogEvent.ClickJoinGiveback });
+    onJoin();
+  };
+
+  return (
+    <FlexCol className="gap-4">
+      <Typography
+        tag={TypographyTag.P}
+        type={TypographyType.Title3}
+        color={TypographyColor.Primary}
+        bold
+      >
+        Take small actions and we turn them into{' '}
+        <span className="bg-gradient-to-r from-accent-avocado-default via-accent-cabbage-default to-accent-cheese-default bg-clip-text text-transparent">
+          real donations
+        </span>
+        . daily.dev funds every cent, so you never pay.
+      </Typography>
+
+      <Button
+        type="button"
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Large}
+        icon={<MoveToIcon size={IconSize.Size16} />}
+        iconPosition={ButtonIconPosition.Right}
+        onClick={handleJoin}
+        className="shadow-2-cabbage transition-transform duration-200 ease-out hover:scale-[1.02]"
+      >
+        Join the campaign
+      </Button>
+    </FlexCol>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackStartPanel.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackStartPanel.tsx
@@ -20,18 +20,9 @@ import { useLogContext } from '../../../contexts/LogContext';
 import { AuthTriggers } from '../../../lib/auth';
 import { LogEvent } from '../../../lib/log';
 
-interface GivebackStartPanelProps {
-  // Entry point into the (post-login) join flow, owned by the page. Only called
-  // once the visitor is authenticated.
-  onJoin: () => void;
-}
-
 // Hero gateway: one clear decision above the fold — "do you want to join?".
-// Logged-out visitors get the login prompt first; authenticated visitors move
-// straight into the join flow.
-export const GivebackStartPanel = ({
-  onJoin,
-}: GivebackStartPanelProps): ReactElement => {
+// Logged-out visitors get the login prompt first; authenticated visitors opt in.
+export const GivebackStartPanel = (): ReactElement => {
   const { user, showLogin } = useAuthContext();
   const { logEvent } = useLogContext();
 
@@ -41,10 +32,8 @@ export const GivebackStartPanel = ({
       return;
     }
 
-    // Only logged-in visitors actually enter the join flow; a logged-out click
-    // opens login instead, so the join event fires here only.
+    // A logged-out click opens login instead, so the join event fires here only.
     logEvent({ event_name: LogEvent.ClickJoinGiveback });
-    onJoin();
   };
 
   return (

--- a/packages/shared/src/features/giveback/graphql.ts
+++ b/packages/shared/src/features/giveback/graphql.ts
@@ -1,0 +1,31 @@
+export const CONTRIBUTION_STATUS_QUERY = `
+  query ContributionStatus {
+    contributionStatus {
+      enabled
+      eligible
+      currentCyclePoints
+      currentCycleTargetPoints
+      lifetimePoints
+      lifetimeAmountCents
+      contributorsCount
+      userPoints
+    }
+  }
+`;
+
+export const CONTRIBUTION_SPONSORS_QUERY = `
+  query ContributionSponsors($first: Int, $after: String) {
+    contributionSponsors(first: $first, after: $after) {
+      edges {
+        node {
+          id
+          name
+          amountCents
+          url
+          logoUrl
+          tier
+        }
+      }
+    }
+  }
+`;

--- a/packages/shared/src/features/giveback/hooks/useContributionSponsors.ts
+++ b/packages/shared/src/features/giveback/hooks/useContributionSponsors.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import type { Connection } from '../../../graphql/common';
+import { gqlClient } from '../../../graphql/common';
+import { disabledRefetch } from '../../../lib/func';
+import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
+import { CONTRIBUTION_SPONSORS_QUERY } from '../graphql';
+import type { ContributionSponsor } from '../types';
+
+interface UseContributionSponsors {
+  sponsors: ContributionSponsor[];
+  isPending: boolean;
+}
+
+const MAX_SPONSORS = 100;
+
+// Public query: the sponsor wall is campaign social proof and renders for
+// everyone. A single page covers the whole wall (no pagination UI here).
+export const useContributionSponsors = (): UseContributionSponsors => {
+  const { isAuthReady } = useAuthContext();
+
+  const { data, isPending } = useQuery({
+    queryKey: generateQueryKey(RequestKey.ContributionSponsors),
+    queryFn: async () => {
+      const res = await gqlClient.request<{
+        contributionSponsors: Connection<ContributionSponsor>;
+      }>(CONTRIBUTION_SPONSORS_QUERY, { first: MAX_SPONSORS });
+
+      return res.contributionSponsors.edges.map((edge) => edge.node);
+    },
+    enabled: isAuthReady,
+    staleTime: StaleTime.Default,
+    ...disabledRefetch,
+  });
+
+  return { sponsors: data ?? [], isPending };
+};

--- a/packages/shared/src/features/giveback/hooks/useContributionStatus.ts
+++ b/packages/shared/src/features/giveback/hooks/useContributionStatus.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { gqlClient } from '../../../graphql/common';
+import { disabledRefetch } from '../../../lib/func';
+import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
+import { CONTRIBUTION_STATUS_QUERY } from '../graphql';
+import type { ContributionStatus } from '../types';
+
+interface UseContributionStatus {
+  status?: ContributionStatus;
+  isPending: boolean;
+}
+
+// Public query: campaign-wide numbers come back for everyone, while the
+// user-specific fields (`eligible`, `userPoints`) are null until the visitor
+// signs in. Keyed by user so signing in/out refetches their own progress.
+export const useContributionStatus = (): UseContributionStatus => {
+  const { user, isAuthReady } = useAuthContext();
+
+  const { data, isPending } = useQuery({
+    queryKey: generateQueryKey(RequestKey.ContributionStatus, user),
+    queryFn: async () => {
+      const res = await gqlClient.request<{
+        contributionStatus: ContributionStatus;
+      }>(CONTRIBUTION_STATUS_QUERY);
+
+      return res.contributionStatus;
+    },
+    enabled: isAuthReady,
+    staleTime: StaleTime.Default,
+    ...disabledRefetch,
+  });
+
+  return { status: data, isPending };
+};

--- a/packages/shared/src/features/giveback/types.ts
+++ b/packages/shared/src/features/giveback/types.ts
@@ -1,0 +1,35 @@
+// Frontend "Giveback" is the brand name for the backend "contribution"
+// program. Shapes here mirror the daily-api GraphQL contract so the UI can bind
+// directly to live queries. User-specific fields are null for anonymous
+// visitors (see the public `contributionStatus` query).
+
+export interface ContributionStatus {
+  enabled: boolean;
+  eligible: boolean | null;
+  // Campaign points unlocked this cycle. Points map 1:1 to currency.
+  currentCyclePoints: number;
+  currentCycleTargetPoints: number;
+  lifetimePoints: number;
+  // Total amount donated to causes so far, in cents.
+  lifetimeAmountCents: number;
+  // Distinct developers who have contributed at least one approved action.
+  contributorsCount: number;
+  userPoints: number | null;
+}
+
+// Derived from the sponsored amount on the backend, so a pledge can never
+// disagree with its badge.
+export enum ContributionSponsorTier {
+  Gold = 'gold',
+  Silver = 'silver',
+  Bronze = 'bronze',
+}
+
+export interface ContributionSponsor {
+  id: string;
+  name: string;
+  amountCents: number;
+  url: string | null;
+  logoUrl: string | null;
+  tier: ContributionSponsorTier;
+}

--- a/packages/shared/src/features/giveback/useGivebackMotion.ts
+++ b/packages/shared/src/features/giveback/useGivebackMotion.ts
@@ -1,7 +1,7 @@
 import type { RefObject } from 'react';
 import { useEffect, useRef, useState } from 'react';
 
-export const usePrefersReducedMotion = (): boolean => {
+const usePrefersReducedMotion = (): boolean => {
   const [reduced, setReduced] = useState(false);
 
   useEffect(() => {

--- a/packages/shared/src/features/giveback/useGivebackMotion.ts
+++ b/packages/shared/src/features/giveback/useGivebackMotion.ts
@@ -1,0 +1,143 @@
+import type { RefObject } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+export const usePrefersReducedMotion = (): boolean => {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return undefined;
+    }
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReduced(query.matches);
+    const onChange = (event: MediaQueryListEvent) => setReduced(event.matches);
+
+    if (typeof query.addEventListener === 'function') {
+      query.addEventListener('change', onChange);
+      return () => query.removeEventListener('change', onChange);
+    }
+    // Fallback for older MediaQueryList implementations (and some test envs).
+    if (typeof query.addListener === 'function') {
+      query.addListener(onChange);
+      return () => query.removeListener(onChange);
+    }
+    return undefined;
+  }, []);
+
+  return reduced;
+};
+
+interface UseInViewResult<T extends Element> {
+  ref: RefObject<T>;
+  inView: boolean;
+}
+
+// Reveals once and stays revealed. Falls back to visible when
+// IntersectionObserver is unavailable, and a safety timeout guarantees content
+// is never left hidden in environments where observer callbacks are throttled.
+export const useInView = <T extends Element>(
+  fallbackMs = 1400,
+): UseInViewResult<T> => {
+  const ref = useRef<T>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return undefined;
+    }
+
+    if (
+      typeof IntersectionObserver === 'undefined' ||
+      typeof window === 'undefined'
+    ) {
+      setInView(true);
+      return undefined;
+    }
+
+    const reveal = () => setInView(true);
+
+    const rect = element.getBoundingClientRect();
+    if (rect.top < window.innerHeight && rect.bottom > 0) {
+      reveal();
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          reveal();
+          observer.disconnect();
+        }
+      },
+      { rootMargin: '0px 0px -10% 0px', threshold: 0.15 },
+    );
+    observer.observe(element);
+
+    const fallback = window.setTimeout(reveal, fallbackMs);
+
+    return () => {
+      observer.disconnect();
+      window.clearTimeout(fallback);
+    };
+  }, [fallbackMs]);
+
+  return { ref, inView };
+};
+
+// Counts to `target` once `active` is true, animating from the value it's
+// currently showing. The first reveal fills from 0; later target changes roll
+// from the previous number to the new one (so the meter visibly ticks up when
+// fresh data lands). Reduced motion or no rAF resolves immediately to the
+// target.
+export const useCountUp = (
+  target: number,
+  active: boolean,
+  durationMs = 1100,
+): number => {
+  const reducedMotion = usePrefersReducedMotion();
+  const [value, setValue] = useState(0);
+  const valueRef = useRef(0);
+  const frameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!active) {
+      return undefined;
+    }
+    if (
+      reducedMotion ||
+      typeof window === 'undefined' ||
+      typeof window.requestAnimationFrame !== 'function'
+    ) {
+      valueRef.current = target;
+      setValue(target);
+      return undefined;
+    }
+
+    const from = valueRef.current;
+    const delta = target - from;
+    if (delta === 0) {
+      return undefined;
+    }
+
+    const start = performance.now();
+    const step = (now: number) => {
+      const progress = Math.min(1, (now - start) / durationMs);
+      const eased = 1 - (1 - progress) ** 3;
+      const next = Math.round(from + delta * eased);
+      valueRef.current = next;
+      setValue(next);
+      if (progress < 1) {
+        frameRef.current = window.requestAnimationFrame(step);
+      }
+    };
+    frameRef.current = window.requestAnimationFrame(step);
+
+    return () => {
+      if (frameRef.current) {
+        window.cancelAnimationFrame(frameRef.current);
+      }
+    };
+  }, [active, target, durationMs, reducedMotion]);
+
+  return value;
+};

--- a/packages/shared/src/features/giveback/utils.ts
+++ b/packages/shared/src/features/giveback/utils.ts
@@ -1,6 +1,6 @@
 import { ContributionSponsorTier } from './types';
 
-export const GIVEBACK_CURRENCY = 'USD';
+const GIVEBACK_CURRENCY = 'USD';
 
 export const formatDonationAmount = (
   amount: number,
@@ -22,15 +22,6 @@ export const getGoalProgressPercentage = (
 
   return Math.max(0, Math.min(100, (raised / goal) * 100));
 };
-
-// Up to two uppercase initials for a sponsor avatar fallback.
-export const getSponsorInitials = (name: string): string =>
-  name
-    .split(' ')
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((word) => word[0]?.toUpperCase() ?? '')
-    .join('');
 
 export const sponsorTierLabel: Record<ContributionSponsorTier, string> = {
   [ContributionSponsorTier.Gold]: 'Gold',

--- a/packages/shared/src/features/giveback/utils.ts
+++ b/packages/shared/src/features/giveback/utils.ts
@@ -1,0 +1,39 @@
+import { ContributionSponsorTier } from './types';
+
+export const GIVEBACK_CURRENCY = 'USD';
+
+export const formatDonationAmount = (
+  amount: number,
+  currency = GIVEBACK_CURRENCY,
+): string =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    maximumFractionDigits: 0,
+  }).format(amount);
+
+export const getGoalProgressPercentage = (
+  raised: number,
+  goal: number,
+): number => {
+  if (!goal) {
+    return 0;
+  }
+
+  return Math.max(0, Math.min(100, (raised / goal) * 100));
+};
+
+// Up to two uppercase initials for a sponsor avatar fallback.
+export const getSponsorInitials = (name: string): string =>
+  name
+    .split(' ')
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? '')
+    .join('');
+
+export const sponsorTierLabel: Record<ContributionSponsorTier, string> = {
+  [ContributionSponsorTier.Gold]: 'Gold',
+  [ContributionSponsorTier.Silver]: 'Silver',
+  [ContributionSponsorTier.Bronze]: 'Bronze',
+};

--- a/packages/shared/src/lib/auth.ts
+++ b/packages/shared/src/lib/auth.ts
@@ -78,6 +78,7 @@ export enum AuthTriggers {
   AddToStack = 'add to stack',
   PostPage = 'post page',
   Hackathon = 'hackathon',
+  Giveback = 'giveback',
 }
 
 export type AuthTriggersType =

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -179,6 +179,8 @@ export const featureNewTabCustomizer = new Feature(
   false,
 );
 
+export const featureGiveback = new Feature('giveback', isDevelopment);
+
 export const featureCompanionDemoWidget = new Feature(
   'companion_demo_widget',
   false,

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -492,6 +492,9 @@ export enum LogEvent {
   ExtensionPrimerShown = 'impression extension primer',
   ExtensionPrimerCtaClick = 'click extension primer cta',
   ExtensionPrimerSkipped = 'skip extension primer',
+  // Giveback
+  ClickJoinGiveback = 'click join giveback',
+  ClickGivebackSponsor = 'click giveback sponsor',
 }
 
 export enum TargetType {

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -274,6 +274,8 @@ export enum RequestKey {
   HackathonParticipation = 'hackathon_participation',
   BrowserExtensionInstalled = 'browser_extension_installed',
   LiveRooms = 'live_rooms',
+  ContributionStatus = 'contribution_status',
+  ContributionSponsors = 'contribution_sponsors',
 }
 
 export const getPostByIdKey = (id: string): QueryKey => [RequestKey.Post, id];

--- a/packages/shared/tailwind.config.ts
+++ b/packages/shared/tailwind.config.ts
@@ -297,6 +297,18 @@ export default {
           '60%': { transform: 'translateX(3px) rotate(2deg)' },
           '75%': { transform: 'translateX(-2px) rotate(-1deg)' },
         },
+        'meter-shine': {
+          '0%': { transform: 'translateX(-120%)' },
+          '60%, 100%': { transform: 'translateX(320%)' },
+        },
+        'glow-pulse': {
+          '0%, 100%': { opacity: '0.35', transform: 'scale(1)' },
+          '50%': { opacity: '0.7', transform: 'scale(1.08)' },
+        },
+        'mascot-bob': {
+          '0%, 100%': { transform: 'translateY(0)' },
+          '50%': { transform: 'translateY(-6px)' },
+        },
       },
       animation: {
         'scale-down-pulse':
@@ -313,6 +325,9 @@ export default {
         'queue-attention-wave':
           'queue-attention-wave 1.6s ease-in-out infinite',
         'nudge-shake': 'nudge-shake 600ms ease-in-out',
+        'meter-shine': 'meter-shine 2.8s cubic-bezier(0.4, 0, 0.2, 1) infinite',
+        'glow-pulse': 'glow-pulse 3s ease-in-out infinite',
+        'mascot-bob': 'mascot-bob 4s ease-in-out infinite',
       },
     },
     lineClamp: {

--- a/packages/shared/tailwind.config.ts
+++ b/packages/shared/tailwind.config.ts
@@ -305,10 +305,6 @@ export default {
           '0%, 100%': { opacity: '0.35', transform: 'scale(1)' },
           '50%': { opacity: '0.7', transform: 'scale(1.08)' },
         },
-        'mascot-bob': {
-          '0%, 100%': { transform: 'translateY(0)' },
-          '50%': { transform: 'translateY(-6px)' },
-        },
       },
       animation: {
         'scale-down-pulse':
@@ -327,7 +323,6 @@ export default {
         'nudge-shake': 'nudge-shake 600ms ease-in-out',
         'meter-shine': 'meter-shine 2.8s cubic-bezier(0.4, 0, 0.2, 1) infinite',
         'glow-pulse': 'glow-pulse 3s ease-in-out infinite',
-        'mascot-bob': 'mascot-bob 4s ease-in-out infinite',
       },
     },
     lineClamp: {

--- a/packages/webapp/pages/giveback/index.tsx
+++ b/packages/webapp/pages/giveback/index.tsx
@@ -1,0 +1,56 @@
+import type { ReactElement } from 'react';
+import React, { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import type { NextSeoProps } from 'next-seo';
+import { useConditionalFeature } from '@dailydotdev/shared/src/hooks';
+import { featureGiveback } from '@dailydotdev/shared/src/lib/featureManagement';
+import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
+import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
+import { GivebackPage } from '@dailydotdev/shared/src/features/giveback/components/GivebackPage';
+import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
+import { getLayout } from '../../components/layouts/MainLayout';
+import { defaultOpenGraph, defaultSeo } from '../../next-seo';
+import { getPageSeoTitles } from '../../components/layouts/utils';
+
+const seoTitles = getPageSeoTitles('Giveback');
+const seo: NextSeoProps = {
+  title: seoTitles.title,
+  openGraph: {
+    ...defaultOpenGraph,
+    ...seoTitles.openGraph,
+  },
+  ...defaultSeo,
+  description:
+    'Help daily.dev grow and we will fund good causes. Complete community actions to help unlock donations toward a shared goal.',
+  nofollow: true,
+  noindex: true,
+};
+
+const GivebackRoute = (): ReactElement | null => {
+  const router = useRouter();
+  const { isAuthReady } = useAuthContext();
+  const { value: isEnabled, isLoading } = useConditionalFeature({
+    feature: featureGiveback,
+    shouldEvaluate: isAuthReady,
+  });
+
+  useEffect(() => {
+    if (!isLoading && !isEnabled) {
+      router.replace(webappUrl);
+    }
+  }, [isLoading, isEnabled, router]);
+
+  if (!isEnabled) {
+    return null;
+  }
+
+  return <GivebackPage />;
+};
+
+const getGivebackLayout: typeof getLayout = (...props) =>
+  getFooterNavBarLayout(getLayout(...props));
+
+GivebackRoute.getLayout = getGivebackLayout;
+GivebackRoute.layoutProps = { screenCentered: false, seo };
+
+export default GivebackRoute;


### PR DESCRIPTION
First slice of the Giveback MVP: the `/giveback` page from the hero down through the sponsor wall and footer. Re-implemented from the designer prototype (`feat/giveback-mvp`) against the real contribution API rather than the mock layer.

## What
- **`/giveback` page** gated behind the `giveback` feature flag (defaults on in development).
- **Hero**: logo + headline, click-to-play campaign video, and a funding meter wired to `contributionStatus`. Points render as dollars; includes a goal-forward **empty state** ($0 pledged) and a loading skeleton so it never flashes zeros. Shows `N backers` from `contributorsCount`.
- **Sponsor wall**: gold/silver/bronze white "medal cards" wired to the public `contributionSponsors` query (logo cards, with a name-pill fallback).
- **Legal footer**.
- **Join the campaign** CTA: opens login for logged-out visitors; authenticated clicks enter the (next-step) join flow.
- **Analytics**: `click join giveback` (logged-in only) and `click giveback sponsor` (`target_id` + `{ name, tier }`).

## Out of scope (later steps)
Onboarding/cause selection, action catalog, leaderboard, tabs, the authed join flow (currently a stub).

## Tests
Component specs for the funding summary (funded/empty), sponsor wall (grouping/empty/click), and join CTA (login vs flow + analytics).

⚠️ Depends on dailydotdev/daily-api#3936 (public `contributionStatus`/`contributionSponsors`, `contributorsCount`, gold/silver/bronze tiers).

### Preview domain
https://feat-giveback-mvp-impl.preview.app.daily.dev