### PR TITLE
feat(giveback): take action tab (catalog, submission, rewards)

### DIFF
--- a/packages/shared/src/features/giveback/actionPlatform.ts
+++ b/packages/shared/src/features/giveback/actionPlatform.ts
@@ -1,0 +1,185 @@
+import type { ComponentType } from 'react';
+// AndroidIcon is not re-exported by the icons barrel, so import it directly.
+import { AndroidIcon } from '../../components/icons/Android';
+import {
+  AppleIcon,
+  BrowserGroupIcon,
+  CalendarIcon,
+  ChromeIcon,
+  DailyIcon,
+  DiscordIcon,
+  DiscussIcon,
+  DocsIcon,
+  EarthIcon,
+  EdgeIcon,
+  FeatherIcon,
+  GitHubIcon,
+  HashnodeIcon,
+  HotIcon,
+  LinkIcon,
+  LinkedInIcon,
+  MailIcon,
+  MegaphoneIcon,
+  MicrophoneIcon,
+  PlayIcon,
+  RedditIcon,
+  SitesIcon,
+  SlackIcon,
+  StackOverflowIcon,
+  StarIcon,
+  TelegramIcon,
+  TerminalIcon,
+  TrendingIcon,
+  TwitterIcon,
+  YoutubeIcon,
+} from '../../components/icons';
+import type { IconProps } from '../../components/Icon';
+
+interface ActionPlatformVisual {
+  name: string;
+  // Real brand logo rendered as an `<img>` on the card (preferred for branded
+  // surfaces). When absent, the card renders the internal `Icon` instead. If the
+  // remote logo ever fails to load, the card also falls back to `Icon`, so a
+  // tile can never render broken or blank.
+  logoUrl?: string;
+  // Internal glyph used either as the primary visual for generic surfaces
+  // (blogs, newsletters, forums, events...) that have no single brand, or as the
+  // offline fallback for branded surfaces.
+  Icon: ComponentType<IconProps>;
+  // Some internal brand glyphs ship only a hardcoded-white SVG (no color or
+  // `currentColor` variant), invisible on the light tile. Flag those so the card
+  // can force the fallback glyph to a dark silhouette.
+  forceDark?: boolean;
+}
+
+// Most brand logos come from Simple Icons' on-demand CDN (single, predictable
+// slug -> official brand-colored glyph). A few brands Simple Icons drops for
+// trademark reasons (LinkedIn, Slack, Edge) come from SVGL, the same open logo
+// library the sponsor wall uses.
+const simpleIcon = (slug: string): string =>
+  `https://cdn.simpleicons.org/${slug}`;
+const svglIcon = (slug: string): string =>
+  `https://svgl.app/library/${slug}.svg`;
+
+const fallbackVisual: ActionPlatformVisual = { name: 'Link', Icon: LinkIcon };
+
+// Real platform logos so each action reads as a growth move on a known surface
+// (post on X, video on YouTube, ship on GitHub...). Keyed by the platform slug
+// the backend stores on the action metadata. Branded surfaces get their actual
+// logo; surfaces without a dedicated brand reuse the closest semantic glyph
+// (reviews -> star, blogs -> globe, events -> calendar...).
+const actionPlatformVisual: Record<string, ActionPlatformVisual> = {
+  x: { name: 'X', logoUrl: simpleIcon('x'), Icon: TwitterIcon },
+  youtube: {
+    name: 'YouTube',
+    logoUrl: simpleIcon('youtube'),
+    Icon: YoutubeIcon,
+  },
+  hashnode: {
+    name: 'Hashnode',
+    logoUrl: simpleIcon('hashnode'),
+    Icon: HashnodeIcon,
+    forceDark: true,
+  },
+  github: { name: 'GitHub', logoUrl: simpleIcon('github'), Icon: GitHubIcon },
+  reddit: { name: 'Reddit', logoUrl: simpleIcon('reddit'), Icon: RedditIcon },
+  linkedin: {
+    name: 'LinkedIn',
+    logoUrl: svglIcon('linkedin'),
+    Icon: LinkedInIcon,
+  },
+  app_store: {
+    name: 'App Store',
+    logoUrl: simpleIcon('appstore'),
+    Icon: AppleIcon,
+    forceDark: true,
+  },
+  chrome_web_store: {
+    name: 'Chrome Web Store',
+    logoUrl: simpleIcon('googlechrome'),
+    Icon: ChromeIcon,
+  },
+  daily_dev: {
+    name: 'daily.dev',
+    logoUrl: simpleIcon('dailydotdev'),
+    Icon: DailyIcon,
+    forceDark: true,
+  },
+  edge_addons: {
+    name: 'Edge Add-ons',
+    logoUrl: svglIcon('edge'),
+    Icon: EdgeIcon,
+  },
+  firefox_addons: {
+    name: 'Firefox Add-ons',
+    logoUrl: simpleIcon('firefoxbrowser'),
+    Icon: BrowserGroupIcon,
+  },
+  google_play: {
+    name: 'Google Play',
+    logoUrl: simpleIcon('googleplay'),
+    Icon: AndroidIcon,
+  },
+  trustpilot: {
+    name: 'Trustpilot',
+    logoUrl: simpleIcon('trustpilot'),
+    Icon: StarIcon,
+  },
+  g2: { name: 'G2', logoUrl: simpleIcon('g2'), Icon: StarIcon },
+  // Capterra has no logo on either CDN, so it keeps the semantic review glyph.
+  capterra: { name: 'Capterra', Icon: StarIcon },
+  product_hunt: {
+    name: 'Product Hunt',
+    logoUrl: simpleIcon('producthunt'),
+    Icon: TrendingIcon,
+  },
+  directory: { name: 'Directories', Icon: SitesIcon },
+  medium: { name: 'Medium', logoUrl: simpleIcon('medium'), Icon: FeatherIcon },
+  dev: { name: 'DEV', logoUrl: simpleIcon('devdotto'), Icon: TerminalIcon },
+  blog: { name: 'Blog', Icon: EarthIcon },
+  newsletter: { name: 'Newsletter', Icon: MailIcon },
+  notion: { name: 'Notion', logoUrl: simpleIcon('notion'), Icon: DocsIcon },
+  website: { name: 'Website', Icon: EarthIcon },
+  hacker_news: {
+    name: 'Hacker News',
+    logoUrl: simpleIcon('ycombinator'),
+    Icon: HotIcon,
+  },
+  stack_overflow: {
+    name: 'Stack Overflow',
+    logoUrl: simpleIcon('stackoverflow'),
+    Icon: StackOverflowIcon,
+  },
+  discord: {
+    name: 'Discord',
+    logoUrl: simpleIcon('discord'),
+    Icon: DiscordIcon,
+  },
+  slack: { name: 'Slack', logoUrl: svglIcon('slack'), Icon: SlackIcon },
+  telegram: {
+    name: 'Telegram',
+    logoUrl: simpleIcon('telegram'),
+    Icon: TelegramIcon,
+  },
+  indie_hackers: {
+    name: 'Indie Hackers',
+    logoUrl: simpleIcon('indiehackers'),
+    Icon: MegaphoneIcon,
+  },
+  forum: { name: 'Forums', Icon: DiscussIcon },
+  twitch: { name: 'Twitch', logoUrl: simpleIcon('twitch'), Icon: PlayIcon },
+  podcast: { name: 'Podcast', Icon: MicrophoneIcon },
+  event: { name: 'Events', Icon: CalendarIcon },
+  wiki: {
+    name: 'Wikipedia',
+    logoUrl: simpleIcon('wikipedia'),
+    Icon: EarthIcon,
+  },
+};
+
+// Every platform is mapped, but unknown/missing slugs fall back to a neutral
+// link glyph so a card can never render a blank tile.
+export const getActionPlatformVisual = (
+  platform: string | null,
+): ActionPlatformVisual =>
+  (platform && actionPlatformVisual[platform.toLowerCase()]) || fallbackVisual;

--- a/packages/shared/src/features/giveback/components/GivebackActionCard.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCard.spec.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { GivebackActionCard } from './GivebackActionCard';
+import type { ContributionAction } from '../types';
+import { ContributionSubmissionStatus } from '../types';
+
+const makeAction = (
+  overrides: Partial<ContributionAction> = {},
+): ContributionAction => ({
+  id: 'a1',
+  categoryId: 'cat1',
+  title: 'Post about us on X',
+  description: null,
+  points: 5,
+  evidence: {},
+  metadata: {
+    platform: 'x',
+    instructions: null,
+    externalUrl: null,
+    isLoveAction: false,
+  },
+  cooldownSeconds: null,
+  maxPerUser: null,
+  userCooldownEndsAt: null,
+  userCompletions: 0,
+  latestUserSubmission: null,
+  ...overrides,
+});
+
+const onSubmit = jest.fn();
+
+beforeEach(() => jest.clearAllMocks());
+
+it('renders an actionable card with the payout and platform, and submits', () => {
+  render(<GivebackActionCard action={makeAction()} onSubmit={onSubmit} />);
+
+  expect(screen.getByText('Post about us on X')).toBeInTheDocument();
+  expect(screen.getByText('+$5')).toBeInTheDocument();
+  expect(screen.getByText('X')).toBeInTheDocument();
+
+  fireEvent.click(
+    screen.getByRole('button', { name: 'Submit proof for Post about us on X' }),
+  );
+  expect(onSubmit).toHaveBeenCalledWith(makeAction());
+});
+
+it('locks an approved action into a non-interactive Done state', () => {
+  render(
+    <GivebackActionCard
+      action={makeAction({
+        latestUserSubmission: {
+          id: 's1',
+          actionId: 'a1',
+          status: ContributionSubmissionStatus.Approved,
+          awardedPoints: 5,
+          createdAt: '2026-01-01',
+          reviewedAt: '2026-01-02',
+        },
+      })}
+      onSubmit={onSubmit}
+    />,
+  );
+
+  expect(screen.getByText('Done')).toBeInTheDocument();
+  expect(screen.queryByRole('button')).not.toBeInTheDocument();
+});
+
+it('shows In review for a flagged submission and stays non-interactive', () => {
+  render(
+    <GivebackActionCard
+      action={makeAction({
+        latestUserSubmission: {
+          id: 's1',
+          actionId: 'a1',
+          status: ContributionSubmissionStatus.Flagged,
+          awardedPoints: 0,
+          createdAt: '2026-01-01',
+          reviewedAt: null,
+        },
+      })}
+      onSubmit={onSubmit}
+    />,
+  );
+
+  expect(screen.getByText('In review')).toBeInTheDocument();
+  expect(screen.queryByRole('button')).not.toBeInTheDocument();
+});
+
+it('treats reaching the per-user cap as Done', () => {
+  render(
+    <GivebackActionCard
+      action={makeAction({ maxPerUser: 1, userCompletions: 1 })}
+      onSubmit={onSubmit}
+    />,
+  );
+
+  expect(screen.getByText('Done')).toBeInTheDocument();
+});
+
+it('keeps a rejected action submittable for a retry', () => {
+  render(
+    <GivebackActionCard
+      action={makeAction({
+        latestUserSubmission: {
+          id: 's1',
+          actionId: 'a1',
+          status: ContributionSubmissionStatus.Rejected,
+          awardedPoints: 0,
+          createdAt: '2026-01-01',
+          reviewedAt: '2026-01-02',
+        },
+      })}
+      onSubmit={onSubmit}
+    />,
+  );
+
+  expect(
+    screen.getByRole('button', { name: 'Submit proof for Post about us on X' }),
+  ).toBeInTheDocument();
+});
+
+it('renders a love action with its appreciation tag instead of a payout', () => {
+  render(
+    <GivebackActionCard
+      action={makeAction({
+        title: 'Star us on GitHub',
+        metadata: {
+          platform: 'github',
+          instructions: null,
+          externalUrl: null,
+          isLoveAction: true,
+        },
+      })}
+      onSubmit={onSubmit}
+    />,
+  );
+
+  expect(screen.getByText('Just for love')).toBeInTheDocument();
+  expect(screen.queryByText('+$5')).not.toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: 'Show some love: Star us on GitHub' }),
+  ).toBeInTheDocument();
+});

--- a/packages/shared/src/features/giveback/components/GivebackActionCard.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCard.spec.tsx
@@ -119,6 +119,46 @@ it('keeps a rejected action submittable for a retry', () => {
   ).toBeInTheDocument();
 });
 
+it('shows the remaining runs for a repeatable action and stays actionable', () => {
+  render(
+    <GivebackActionCard
+      action={makeAction({ maxPerUser: 3, userCompletions: 1 })}
+      onSubmit={onSubmit}
+    />,
+  );
+
+  expect(screen.getByText('2 left')).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: 'Submit proof for Post about us on X' }),
+  ).toBeInTheDocument();
+});
+
+it('locks a cooling-down action with an availability label', () => {
+  render(
+    <GivebackActionCard
+      action={makeAction({ userCooldownEndsAt: '2999-01-01T00:00:00.000Z' })}
+      onSubmit={onSubmit}
+    />,
+  );
+
+  expect(screen.getByText(/Available in/)).toBeInTheDocument();
+  expect(screen.queryByRole('button')).not.toBeInTheDocument();
+});
+
+it('ignores an elapsed cooldown and stays actionable', () => {
+  render(
+    <GivebackActionCard
+      action={makeAction({ userCooldownEndsAt: '2000-01-01T00:00:00.000Z' })}
+      onSubmit={onSubmit}
+    />,
+  );
+
+  expect(screen.queryByText(/Available in/)).not.toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: 'Submit proof for Post about us on X' }),
+  ).toBeInTheDocument();
+});
+
 it('renders a love action with its appreciation tag instead of a payout', () => {
   render(
     <GivebackActionCard

--- a/packages/shared/src/features/giveback/components/GivebackActionCard.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCard.spec.tsx
@@ -133,6 +133,17 @@ it('shows the remaining runs for a repeatable action and stays actionable', () =
   ).toBeInTheDocument();
 });
 
+it('hides the runs-left counter until the visitor has completed one', () => {
+  render(
+    <GivebackActionCard
+      action={makeAction({ maxPerUser: 3, userCompletions: 0 })}
+      onSubmit={onSubmit}
+    />,
+  );
+
+  expect(screen.queryByText(/\d+ left/)).not.toBeInTheDocument();
+});
+
 it('locks a cooling-down action with an availability label', () => {
   render(
     <GivebackActionCard

--- a/packages/shared/src/features/giveback/components/GivebackActionCard.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCard.tsx
@@ -7,7 +7,7 @@ import {
   TypographyTag,
   TypographyType,
 } from '../../../components/typography/Typography';
-import { FlexRow } from '../../../components/utilities';
+import { FlexCol, FlexRow } from '../../../components/utilities';
 import { IconSize } from '../../../components/Icon';
 import type { IconProps } from '../../../components/Icon';
 import { TimerIcon, VIcon } from '../../../components/icons';
@@ -21,22 +21,40 @@ interface GivebackActionCardProps {
   onSubmit?: (action: ContributionAction) => void;
 }
 
+interface StatusMeta {
+  label: string;
+  Icon: ComponentType<IconProps>;
+}
+
+// Coarse "available in" copy for a cooled-down action. Rounds up to the nearest
+// day/hour/minute so the card never claims an action is ready a tick early.
+const formatCooldownRemaining = (endsAt: string): string => {
+  const minutes = Math.ceil((new Date(endsAt).getTime() - Date.now()) / 60000);
+  if (minutes >= 1440) {
+    return `${Math.ceil(minutes / 1440)}d`;
+  }
+  if (minutes >= 60) {
+    return `${Math.ceil(minutes / 60)}h`;
+  }
+  return `${Math.max(1, minutes)}m`;
+};
+
 interface PlatformLogoProps {
   logoUrl?: string;
   Icon: ComponentType<IconProps>;
   forceDark?: boolean;
-  isDone: boolean;
+  isDimmed: boolean;
 }
 
 // Prefers the real brand logo (an SVG from the logo CDN) and falls back to the
 // internal glyph if there is no logo for the surface or the remote one fails to
 // load — so a tile is never broken or blank. The parent tile already pins the
-// background and applies the dimmed/grayscale "done" treatment.
+// background and applies the dimmed/grayscale treatment.
 const PlatformLogo = ({
   logoUrl,
   Icon,
   forceDark,
-  isDone,
+  isDimmed,
 }: PlatformLogoProps): ReactElement => {
   const [failed, setFailed] = useState(false);
 
@@ -57,14 +75,14 @@ const PlatformLogo = ({
     <Icon
       secondary
       size={IconSize.Small}
-      className={classNames(!isDone && forceDark && 'brightness-0')}
+      className={classNames(!isDimmed && forceDark && 'brightness-0')}
     />
   );
 };
 
 // One sharp, explicit title carries the ask — no competing subtitle. The
-// supporting details (payout, "just for love") sit in a calm top/bottom frame
-// around it so the card stays easy to scan at a glance.
+// supporting details (payout, status, "just for love") sit in a calm top/bottom
+// frame around it so the card stays easy to scan at a glance.
 export const GivebackActionCard = ({
   action,
   onSubmit,
@@ -78,13 +96,26 @@ export const GivebackActionCard = ({
     latestUserSubmission?.status === ContributionSubmissionStatus.Approved;
   const isInReview =
     latestUserSubmission?.status === ContributionSubmissionStatus.Flagged;
-  // "Done" = approved or you've hit the per-user cap, so it locks into a flat,
-  // dimmed claimed state. A rejected submission stays clickable to retry.
+  // "Done" = approved or you've hit the per-user cap. A rejected submission
+  // stays clickable to retry.
   const isDone = isApproved || reachedMax;
-  // Acted on already (done or awaiting review): the card drops into its dimmed,
-  // non-interactive treatment either way.
-  const hasActed = isDone || isInReview;
-  const isInteractive = !hasActed && !!onSubmit;
+  // Cooldown only gates an action that would otherwise be actionable.
+  const onCooldown =
+    !isDone &&
+    !isInReview &&
+    !!action.userCooldownEndsAt &&
+    new Date(action.userCooldownEndsAt).getTime() > Date.now();
+
+  // Repeatable actions surface how many runs are left until they cap out.
+  const { maxPerUser } = action;
+  const remaining =
+    maxPerUser != null ? Math.max(0, maxPerUser - action.userCompletions) : 0;
+  const showRemaining =
+    maxPerUser != null && maxPerUser > 1 && !isDone && remaining > 0;
+
+  // Any non-actionable state shares the same dimmed, non-interactive treatment.
+  const isDimmed = isDone || isInReview || onCooldown;
+  const isInteractive = !isDimmed && !!onSubmit;
 
   const {
     Icon,
@@ -93,23 +124,39 @@ export const GivebackActionCard = ({
     logoUrl,
   } = getActionPlatformVisual(metadata.platform);
 
-  const doneMeta = isDone
-    ? { label: 'Done', Icon: VIcon }
-    : { label: 'In review', Icon: TimerIcon };
+  const getStatusMeta = (): StatusMeta | null => {
+    if (isDone) {
+      return { label: 'Done', Icon: VIcon };
+    }
+    if (isInReview) {
+      return { label: 'In review', Icon: TimerIcon };
+    }
+    if (onCooldown && action.userCooldownEndsAt) {
+      return {
+        label: `Available in ${formatCooldownRemaining(
+          action.userCooldownEndsAt,
+        )}`,
+        Icon: TimerIcon,
+      };
+    }
+    return null;
+  };
+  const statusMeta = getStatusMeta();
 
-  // The top-right slot shows one of three mutually exclusive states: a status
-  // pill once acted on, a soft "love" tag for no-reward actions, or the payout.
+  // The top-right slot shows one of three mutually exclusive things: a status
+  // pill once acted on or cooling down, a soft "love" tag for no-reward actions,
+  // or the payout.
   const renderTopRightMeta = (): ReactNode => {
-    if (hasActed) {
+    if (statusMeta) {
       return (
         <FlexRow className="shrink-0 items-center gap-1 text-text-quaternary">
-          <doneMeta.Icon size={IconSize.XSmall} />
+          <statusMeta.Icon size={IconSize.XSmall} />
           <Typography
             tag={TypographyTag.Span}
             type={TypographyType.Caption1}
             className="uppercase tracking-wide"
           >
-            {doneMeta.label}
+            {statusMeta.label}
           </Typography>
         </FlexRow>
       );
@@ -149,7 +196,7 @@ export const GivebackActionCard = ({
               // logos keep their baked-in colors, while monochrome/semantic glyphs
               // (which follow currentColor) stay visible instead of disappearing
               // as white-on-white in dark mode.
-              hasActed
+              isDimmed
                 ? 'bg-surface-float text-text-quaternary opacity-40 grayscale'
                 : 'shadow-1 bg-white text-black group-hover:scale-105',
             )}
@@ -158,18 +205,25 @@ export const GivebackActionCard = ({
               logoUrl={logoUrl}
               Icon={Icon}
               forceDark={forceDark}
-              isDone={hasActed}
+              isDimmed={isDimmed}
             />
           </span>
-          <Typography
-            tag={TypographyTag.Span}
-            type={TypographyType.Caption1}
-            color={TypographyColor.Tertiary}
-            bold
-            className="min-w-0 truncate uppercase tracking-wider"
-          >
-            {platformName}
-          </Typography>
+          <FlexRow className="min-w-0 items-center gap-1.5">
+            <Typography
+              tag={TypographyTag.Span}
+              type={TypographyType.Caption1}
+              color={TypographyColor.Tertiary}
+              bold
+              className="min-w-0 truncate uppercase tracking-wider"
+            >
+              {platformName}
+            </Typography>
+            {showRemaining && (
+              <span className="shrink-0 rounded-6 border border-border-subtlest-tertiary px-1.5 py-0.5 font-bold uppercase tracking-wide text-text-tertiary typo-caption2">
+                {remaining} left
+              </span>
+            )}
+          </FlexRow>
         </FlexRow>
         {renderTopRightMeta()}
       </FlexRow>
@@ -178,7 +232,7 @@ export const GivebackActionCard = ({
         bold
         tag={TypographyTag.H3}
         type={TypographyType.Callout}
-        color={hasActed ? TypographyColor.Quaternary : undefined}
+        color={isDimmed ? TypographyColor.Quaternary : undefined}
         className={classNames('line-clamp-2', isDone && 'line-through')}
       >
         {action.title}
@@ -223,15 +277,20 @@ export const GivebackActionCard = ({
     );
   }
 
-  // Already acted on: a flat "claimed" state — a dashed outline, a grayscale
-  // icon, a struck-through title and a status pill — so it's unmistakably
-  // distinct from the actionable, tappable cards.
+  // Acted on or cooling down: a flat, non-interactive tile. "Done" gets the
+  // dashed claimed outline; in-review and cooldown keep a solid surface so they
+  // read as temporary rather than finished.
   return (
-    <div
-      aria-label={`${action.title} — ${doneMeta.label}`}
-      className="flex h-full w-full flex-col gap-3 rounded-16 border border-dashed border-border-subtlest-tertiary bg-transparent p-4"
+    <FlexCol
+      aria-label={`${action.title} — ${statusMeta?.label ?? ''}`}
+      className={classNames(
+        'h-full w-full gap-3 rounded-16 p-4',
+        isDone
+          ? 'border border-dashed border-border-subtlest-tertiary bg-transparent'
+          : 'bg-surface-float',
+      )}
     >
       {content}
-    </div>
+    </FlexCol>
   );
 };

--- a/packages/shared/src/features/giveback/components/GivebackActionCard.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCard.tsx
@@ -1,0 +1,237 @@
+import type { ComponentType, ReactElement, ReactNode } from 'react';
+import React, { useState } from 'react';
+import classNames from 'classnames';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { FlexRow } from '../../../components/utilities';
+import { IconSize } from '../../../components/Icon';
+import type { IconProps } from '../../../components/Icon';
+import { TimerIcon, VIcon } from '../../../components/icons';
+import type { ContributionAction } from '../types';
+import { ContributionSubmissionStatus } from '../types';
+import { formatDonationAmount } from '../utils';
+import { getActionPlatformVisual } from '../actionPlatform';
+
+interface GivebackActionCardProps {
+  action: ContributionAction;
+  onSubmit?: (action: ContributionAction) => void;
+}
+
+interface PlatformLogoProps {
+  logoUrl?: string;
+  Icon: ComponentType<IconProps>;
+  forceDark?: boolean;
+  isDone: boolean;
+}
+
+// Prefers the real brand logo (an SVG from the logo CDN) and falls back to the
+// internal glyph if there is no logo for the surface or the remote one fails to
+// load — so a tile is never broken or blank. The parent tile already pins the
+// background and applies the dimmed/grayscale "done" treatment.
+const PlatformLogo = ({
+  logoUrl,
+  Icon,
+  forceDark,
+  isDone,
+}: PlatformLogoProps): ReactElement => {
+  const [failed, setFailed] = useState(false);
+
+  if (logoUrl && !failed) {
+    return (
+      <img
+        src={logoUrl}
+        alt=""
+        aria-hidden
+        loading="lazy"
+        onError={() => setFailed(true)}
+        className="size-6 object-contain"
+      />
+    );
+  }
+
+  return (
+    <Icon
+      secondary
+      size={IconSize.Small}
+      className={classNames(!isDone && forceDark && 'brightness-0')}
+    />
+  );
+};
+
+// One sharp, explicit title carries the ask — no competing subtitle. The
+// supporting details (payout, "just for love") sit in a calm top/bottom frame
+// around it so the card stays easy to scan at a glance.
+export const GivebackActionCard = ({
+  action,
+  onSubmit,
+}: GivebackActionCardProps): ReactElement => {
+  const { metadata, latestUserSubmission } = action;
+  const isLove = metadata.isLoveAction;
+
+  const reachedMax =
+    action.maxPerUser != null && action.userCompletions >= action.maxPerUser;
+  const isApproved =
+    latestUserSubmission?.status === ContributionSubmissionStatus.Approved;
+  const isInReview =
+    latestUserSubmission?.status === ContributionSubmissionStatus.Flagged;
+  // "Done" = approved or you've hit the per-user cap, so it locks into a flat,
+  // dimmed claimed state. A rejected submission stays clickable to retry.
+  const isDone = isApproved || reachedMax;
+  // Acted on already (done or awaiting review): the card drops into its dimmed,
+  // non-interactive treatment either way.
+  const hasActed = isDone || isInReview;
+  const isInteractive = !hasActed && !!onSubmit;
+
+  const {
+    Icon,
+    name: platformName,
+    forceDark,
+    logoUrl,
+  } = getActionPlatformVisual(metadata.platform);
+
+  const doneMeta = isDone
+    ? { label: 'Done', Icon: VIcon }
+    : { label: 'In review', Icon: TimerIcon };
+
+  // The top-right slot shows one of three mutually exclusive states: a status
+  // pill once acted on, a soft "love" tag for no-reward actions, or the payout.
+  const renderTopRightMeta = (): ReactNode => {
+    if (hasActed) {
+      return (
+        <FlexRow className="shrink-0 items-center gap-1 text-text-quaternary">
+          <doneMeta.Icon size={IconSize.XSmall} />
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption1}
+            className="uppercase tracking-wide"
+          >
+            {doneMeta.label}
+          </Typography>
+        </FlexRow>
+      );
+    }
+
+    if (isLove) {
+      return (
+        <Typography
+          bold
+          type={TypographyType.Caption1}
+          className="shrink-0 text-accent-cabbage-default"
+        >
+          Just for love
+        </Typography>
+      );
+    }
+
+    return (
+      <Typography
+        bold
+        type={TypographyType.Title4}
+        className="shrink-0 origin-right tabular-nums text-status-success transition-transform duration-200 group-hover:scale-110 motion-reduce:transform-none"
+      >
+        +{formatDonationAmount(action.points)}
+      </Typography>
+    );
+  };
+
+  const content: ReactNode = (
+    <>
+      <FlexRow className="items-start justify-between gap-3">
+        <FlexRow className="min-w-0 items-center gap-2.5">
+          <span
+            className={classNames(
+              'flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-12 transition-transform duration-200',
+              // The tile is always light, so pin the icon ink dark: colored brand
+              // logos keep their baked-in colors, while monochrome/semantic glyphs
+              // (which follow currentColor) stay visible instead of disappearing
+              // as white-on-white in dark mode.
+              hasActed
+                ? 'bg-surface-float text-text-quaternary opacity-40 grayscale'
+                : 'shadow-1 bg-white text-black group-hover:scale-105',
+            )}
+          >
+            <PlatformLogo
+              logoUrl={logoUrl}
+              Icon={Icon}
+              forceDark={forceDark}
+              isDone={hasActed}
+            />
+          </span>
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+            bold
+            className="min-w-0 truncate uppercase tracking-wider"
+          >
+            {platformName}
+          </Typography>
+        </FlexRow>
+        {renderTopRightMeta()}
+      </FlexRow>
+
+      <Typography
+        bold
+        tag={TypographyTag.H3}
+        type={TypographyType.Callout}
+        color={hasActed ? TypographyColor.Quaternary : undefined}
+        className={classNames('line-clamp-2', isDone && 'line-through')}
+      >
+        {action.title}
+      </Typography>
+
+      {action.description && (
+        <Typography
+          type={TypographyType.Caption1}
+          color={TypographyColor.Tertiary}
+          className="mt-auto line-clamp-2"
+        >
+          {action.description}
+        </Typography>
+      )}
+    </>
+  );
+
+  if (isInteractive) {
+    return (
+      <button
+        type="button"
+        aria-label={
+          isLove
+            ? `Show some love: ${action.title}`
+            : `Submit proof for ${action.title}`
+        }
+        onClick={() => onSubmit?.(action)}
+        className={classNames(
+          'group relative flex h-full w-full flex-col gap-3 overflow-hidden rounded-16 p-4 text-left transition-all duration-200 hover:-translate-y-0.5 hover:shadow-2 active:translate-y-0 active:scale-[0.99] motion-reduce:transform-none',
+          isLove
+            ? 'bg-accent-cabbage-flat'
+            : 'bg-surface-float hover:bg-surface-hover',
+        )}
+      >
+        {/* Glossy sheen that sweeps across on hover — a small reward flourish. */}
+        <span
+          aria-hidden
+          className="via-white/10 pointer-events-none absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent to-transparent transition-transform duration-700 ease-out group-hover:translate-x-full motion-reduce:hidden"
+        />
+        {content}
+      </button>
+    );
+  }
+
+  // Already acted on: a flat "claimed" state — a dashed outline, a grayscale
+  // icon, a struck-through title and a status pill — so it's unmistakably
+  // distinct from the actionable, tappable cards.
+  return (
+    <div
+      aria-label={`${action.title} — ${doneMeta.label}`}
+      className="flex h-full w-full flex-col gap-3 rounded-16 border border-dashed border-border-subtlest-tertiary bg-transparent p-4"
+    >
+      {content}
+    </div>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackActionCard.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCard.tsx
@@ -10,7 +10,7 @@ import {
 import { FlexCol, FlexRow } from '../../../components/utilities';
 import { IconSize } from '../../../components/Icon';
 import type { IconProps } from '../../../components/Icon';
-import { TimerIcon, VIcon } from '../../../components/icons';
+import { RefreshIcon, TimerIcon, VIcon } from '../../../components/icons';
 import type { ContributionAction } from '../types';
 import { ContributionSubmissionStatus } from '../types';
 import { formatDonationAmount } from '../utils';
@@ -106,12 +106,17 @@ export const GivebackActionCard = ({
     !!action.userCooldownEndsAt &&
     new Date(action.userCooldownEndsAt).getTime() > Date.now();
 
-  // Repeatable actions surface how many runs are left until they cap out.
+  // Repeatable actions surface how many runs are left, but only once the
+  // visitor has started: a fresh card reads as a normal action, not a tracker.
   const { maxPerUser } = action;
   const remaining =
     maxPerUser != null ? Math.max(0, maxPerUser - action.userCompletions) : 0;
   const showRemaining =
-    maxPerUser != null && maxPerUser > 1 && !isDone && remaining > 0;
+    maxPerUser != null &&
+    maxPerUser > 1 &&
+    action.userCompletions > 0 &&
+    !isDone &&
+    remaining > 0;
 
   // Any non-actionable state shares the same dimmed, non-interactive treatment.
   const isDimmed = isDone || isInReview || onCooldown;
@@ -208,22 +213,15 @@ export const GivebackActionCard = ({
               isDimmed={isDimmed}
             />
           </span>
-          <FlexRow className="min-w-0 items-center gap-1.5">
-            <Typography
-              tag={TypographyTag.Span}
-              type={TypographyType.Caption1}
-              color={TypographyColor.Tertiary}
-              bold
-              className="min-w-0 truncate uppercase tracking-wider"
-            >
-              {platformName}
-            </Typography>
-            {showRemaining && (
-              <span className="shrink-0 rounded-6 border border-border-subtlest-tertiary px-1.5 py-0.5 font-bold uppercase tracking-wide text-text-tertiary typo-caption2">
-                {remaining} left
-              </span>
-            )}
-          </FlexRow>
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+            bold
+            className="min-w-0 truncate uppercase tracking-wider"
+          >
+            {platformName}
+          </Typography>
         </FlexRow>
         {renderTopRightMeta()}
       </FlexRow>
@@ -238,14 +236,31 @@ export const GivebackActionCard = ({
         {action.title}
       </Typography>
 
-      {action.description && (
-        <Typography
-          type={TypographyType.Caption1}
-          color={TypographyColor.Tertiary}
-          className="mt-auto line-clamp-2"
-        >
-          {action.description}
-        </Typography>
+      {(action.description || showRemaining) && (
+        <FlexCol className="mt-auto gap-1.5">
+          {action.description && (
+            <Typography
+              type={TypographyType.Caption1}
+              color={TypographyColor.Tertiary}
+              className="line-clamp-2"
+            >
+              {action.description}
+            </Typography>
+          )}
+          {showRemaining && (
+            <FlexRow className="items-center gap-1 text-text-tertiary [&_svg]:size-3.5">
+              <RefreshIcon />
+              <Typography
+                tag={TypographyTag.Span}
+                type={TypographyType.Caption2}
+                bold
+                className="uppercase tracking-wide"
+              >
+                {remaining} left
+              </Typography>
+            </FlexRow>
+          )}
+        </FlexCol>
       )}
     </>
   );

--- a/packages/shared/src/features/giveback/components/GivebackActionCatalog.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCatalog.spec.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { GivebackActionCatalog } from './GivebackActionCatalog';
+import { useContributionActions } from '../hooks/useContributionActions';
+import type { ContributionAction } from '../types';
+
+jest.mock('../hooks/useContributionActions');
+jest.mock('./GivebackActionSubmissionModal', () => ({
+  GivebackActionSubmissionModal: ({
+    action,
+  }: {
+    action: ContributionAction;
+  }): JSX.Element => <div data-testid="submission-modal">{action.title}</div>,
+}));
+
+const mockUseActions = useContributionActions as jest.MockedFunction<
+  typeof useContributionActions
+>;
+
+const makeAction = (
+  overrides: Partial<ContributionAction> = {},
+): ContributionAction => ({
+  id: 'a1',
+  categoryId: 'cat1',
+  title: 'Action',
+  description: null,
+  points: 5,
+  evidence: {},
+  metadata: {
+    platform: 'x',
+    instructions: null,
+    externalUrl: null,
+    isLoveAction: false,
+  },
+  cooldownSeconds: null,
+  maxPerUser: null,
+  userCooldownEndsAt: null,
+  userCompletions: 0,
+  latestUserSubmission: null,
+  ...overrides,
+});
+
+const categories = [
+  { id: 'cat1', title: 'Social' },
+  { id: 'cat2', title: 'Reviews' },
+];
+
+const mockReturn = (actions: ContributionAction[], isPending = false) =>
+  mockUseActions.mockReturnValue({ actions, categories, isPending });
+
+beforeEach(() => jest.clearAllMocks());
+
+it('renders a skeleton while loading', () => {
+  mockUseActions.mockReturnValue({
+    actions: [],
+    categories: [],
+    isPending: true,
+  });
+  render(<GivebackActionCatalog />);
+
+  expect(
+    screen.getByRole('status', { name: 'Loading actions' }),
+  ).toBeInTheDocument();
+});
+
+it('shows an empty message when there are no actions', () => {
+  mockReturn([]);
+  render(<GivebackActionCatalog />);
+
+  expect(
+    screen.getByText('No actions are available yet. Check back soon.'),
+  ).toBeInTheDocument();
+});
+
+it('filters the grid by the selected category', () => {
+  mockReturn([
+    makeAction({ id: 'a1', title: 'Post on X', categoryId: 'cat1' }),
+    makeAction({ id: 'a2', title: 'Leave a review', categoryId: 'cat2' }),
+  ]);
+  render(<GivebackActionCatalog />);
+
+  expect(screen.getByText('Post on X')).toBeInTheDocument();
+  expect(screen.getByText('Leave a review')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole('button', { name: 'Reviews' }));
+
+  expect(screen.queryByText('Post on X')).not.toBeInTheDocument();
+  expect(screen.getByText('Leave a review')).toBeInTheDocument();
+});
+
+it('caps the initial grid and expands on show more', () => {
+  const actions = Array.from({ length: 15 }, (_, index) =>
+    makeAction({ id: `a${index}`, title: `Action ${index}` }),
+  );
+  mockReturn(actions);
+  render(<GivebackActionCatalog />);
+
+  expect(screen.queryByText('Action 12')).not.toBeInTheDocument();
+
+  fireEvent.click(
+    screen.getByRole('button', { name: 'Show more actions (3)' }),
+  );
+
+  expect(screen.getByText('Action 12')).toBeInTheDocument();
+});
+
+it('renders love actions in their own group', () => {
+  mockReturn([
+    makeAction({ id: 'a1', title: 'Post on X' }),
+    makeAction({
+      id: 'a2',
+      title: 'Star us on GitHub',
+      metadata: {
+        platform: 'github',
+        instructions: null,
+        externalUrl: null,
+        isLoveAction: true,
+      },
+    }),
+  ]);
+  render(<GivebackActionCatalog />);
+
+  // The group heading plus the love card's own tag both read "Just for love".
+  expect(screen.getAllByText('Just for love')).toHaveLength(2);
+  expect(screen.getByText('Star us on GitHub')).toBeInTheDocument();
+});
+
+it('opens the submission modal when a card is chosen', () => {
+  mockReturn([makeAction({ id: 'a1', title: 'Post on X' })]);
+  render(<GivebackActionCatalog />);
+
+  fireEvent.click(
+    screen.getByRole('button', { name: 'Submit proof for Post on X' }),
+  );
+
+  expect(screen.getByTestId('submission-modal')).toHaveTextContent('Post on X');
+});

--- a/packages/shared/src/features/giveback/components/GivebackActionCatalog.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCatalog.spec.tsx
@@ -46,7 +46,12 @@ const categories = [
 ];
 
 const mockReturn = (actions: ContributionAction[], isPending = false) =>
-  mockUseActions.mockReturnValue({ actions, categories, isPending });
+  mockUseActions.mockReturnValue({
+    actions,
+    categories,
+    rewardTiers: [],
+    isPending,
+  });
 
 beforeEach(() => jest.clearAllMocks());
 
@@ -54,6 +59,7 @@ it('renders a skeleton while loading', () => {
   mockUseActions.mockReturnValue({
     actions: [],
     categories: [],
+    rewardTiers: [],
     isPending: true,
   });
   render(<GivebackActionCatalog />);

--- a/packages/shared/src/features/giveback/components/GivebackActionCatalog.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCatalog.tsx
@@ -1,0 +1,189 @@
+import type { ReactElement } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { FlexCol, FlexRow } from '../../../components/utilities';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../components/buttons/Button';
+import { ButtonIconPosition } from '../../../components/buttons/common';
+import { ArrowIcon } from '../../../components/icons';
+import type { ContributionAction } from '../types';
+import { useContributionActions } from '../hooks/useContributionActions';
+import { GivebackActionCard } from './GivebackActionCard';
+import { GivebackActionSubmissionModal } from './GivebackActionSubmissionModal';
+import { GivebackFilterChip } from './GivebackFilterChip';
+
+const ALL_FILTER = 'all';
+
+// Keep the initial grid short so the tab opens scannable; the rest expand on
+// demand. 12 fills four clean rows on the 3-column breakpoint.
+const INITIAL_VISIBLE_ACTIONS = 12;
+
+const ActionGrid = ({
+  actions,
+  onSubmit,
+}: {
+  actions: ContributionAction[];
+  onSubmit: (action: ContributionAction) => void;
+}): ReactElement => (
+  <div className="grid gap-3 tablet:grid-cols-2 laptop:grid-cols-3">
+    {actions.map((action) => (
+      <GivebackActionCard key={action.id} action={action} onSubmit={onSubmit} />
+    ))}
+  </div>
+);
+
+export const GivebackActionCatalog = (): ReactElement => {
+  const { actions, categories, isPending } = useContributionActions(true);
+  const [selectedCategory, setSelectedCategory] = useState<string>(ALL_FILTER);
+  const [showAll, setShowAll] = useState(false);
+  const [submissionAction, setSubmissionAction] =
+    useState<ContributionAction | null>(null);
+
+  // A new filter always opens to the short, scannable list.
+  useEffect(() => {
+    setShowAll(false);
+  }, [selectedCategory]);
+
+  const { paidActions, loveActions } = useMemo(() => {
+    const paid: ContributionAction[] = [];
+    const love: ContributionAction[] = [];
+    actions.forEach((action) => {
+      (action.metadata.isLoveAction ? love : paid).push(action);
+    });
+    return { paidActions: paid, loveActions: love };
+  }, [actions]);
+
+  const filteredPaid = useMemo(
+    () =>
+      selectedCategory === ALL_FILTER
+        ? paidActions
+        : paidActions.filter(
+            (action) => action.categoryId === selectedCategory,
+          ),
+    [paidActions, selectedCategory],
+  );
+
+  if (isPending) {
+    return (
+      <div
+        role="status"
+        aria-label="Loading actions"
+        className="grid gap-3 tablet:grid-cols-2 laptop:grid-cols-3"
+      >
+        {Array.from({ length: 6 }).map((_, index) => (
+          <div
+            // eslint-disable-next-line react/no-array-index-key
+            key={index}
+            className="h-32 animate-pulse rounded-16 bg-surface-float"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (!actions.length) {
+    return (
+      <Typography
+        type={TypographyType.Callout}
+        color={TypographyColor.Secondary}
+      >
+        No actions are available yet. Check back soon.
+      </Typography>
+    );
+  }
+
+  const visiblePaid = showAll
+    ? filteredPaid
+    : filteredPaid.slice(0, INITIAL_VISIBLE_ACTIONS);
+  const hiddenCount = filteredPaid.length - visiblePaid.length;
+
+  return (
+    <FlexCol className="gap-6">
+      <FlexRow className="flex-wrap gap-2">
+        <GivebackFilterChip
+          isSelected={selectedCategory === ALL_FILTER}
+          label="All"
+          onClick={() => setSelectedCategory(ALL_FILTER)}
+        />
+        {categories.map((category) => (
+          <GivebackFilterChip
+            key={category.id}
+            isSelected={selectedCategory === category.id}
+            label={category.title}
+            onClick={() => setSelectedCategory(category.id)}
+          />
+        ))}
+      </FlexRow>
+
+      {filteredPaid.length > 0 ? (
+        <FlexCol className="gap-4">
+          <ActionGrid actions={visiblePaid} onSubmit={setSubmissionAction} />
+          {hiddenCount > 0 && (
+            <FlexRow className="justify-center">
+              <Button
+                type="button"
+                size={ButtonSize.Medium}
+                variant={ButtonVariant.Secondary}
+                icon={
+                  <ArrowIcon className={showAll ? undefined : 'rotate-180'} />
+                }
+                iconPosition={ButtonIconPosition.Right}
+                onClick={() => setShowAll((value) => !value)}
+              >
+                {showAll ? 'Show fewer' : `Show more actions (${hiddenCount})`}
+              </Button>
+            </FlexRow>
+          )}
+        </FlexCol>
+      ) : (
+        <FlexCol className="items-center gap-1 py-10 text-center">
+          <Typography bold type={TypographyType.Callout}>
+            No actions match this filter
+          </Typography>
+          <Typography
+            type={TypographyType.Footnote}
+            color={TypographyColor.Tertiary}
+          >
+            Try another filter.
+          </Typography>
+        </FlexCol>
+      )}
+
+      {loveActions.length > 0 && (
+        <FlexCol className="gap-3">
+          <FlexCol className="gap-0.5">
+            <Typography
+              bold
+              type={TypographyType.Footnote}
+              className="text-accent-cabbage-default"
+            >
+              Just for love
+            </Typography>
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+            >
+              We can&apos;t pay for these, but we&apos;d genuinely appreciate
+              them.
+            </Typography>
+          </FlexCol>
+          <ActionGrid actions={loveActions} onSubmit={setSubmissionAction} />
+        </FlexCol>
+      )}
+
+      {submissionAction && (
+        <GivebackActionSubmissionModal
+          action={submissionAction}
+          onClose={() => setSubmissionAction(null)}
+        />
+      )}
+    </FlexCol>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackActionCatalog.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCatalog.tsx
@@ -13,6 +13,8 @@ import {
 } from '../../../components/buttons/Button';
 import { ButtonIconPosition } from '../../../components/buttons/common';
 import { ArrowIcon } from '../../../components/icons';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
 import type { ContributionAction } from '../types';
 import { useContributionActions } from '../hooks/useContributionActions';
 import { GivebackActionCard } from './GivebackActionCard';
@@ -40,6 +42,7 @@ const ActionGrid = ({
 );
 
 export const GivebackActionCatalog = (): ReactElement => {
+  const { logEvent } = useLogContext();
   const { actions, categories, isPending } = useContributionActions(true);
   const [selectedCategory, setSelectedCategory] = useState<string>(ALL_FILTER);
   const [showAll, setShowAll] = useState(false);
@@ -50,6 +53,36 @@ export const GivebackActionCatalog = (): ReactElement => {
   useEffect(() => {
     setShowAll(false);
   }, [selectedCategory]);
+
+  const openAction = (action: ContributionAction) => {
+    logEvent({
+      event_name: LogEvent.OpenGivebackAction,
+      target_id: action.id,
+      extra: JSON.stringify({
+        platform: action.metadata.platform,
+        points: action.points,
+        is_love: action.metadata.isLoveAction,
+      }),
+    });
+    setSubmissionAction(action);
+  };
+
+  const selectCategory = (categoryId: string) => {
+    logEvent({
+      event_name: LogEvent.FilterGivebackActions,
+      extra: JSON.stringify({ category_id: categoryId }),
+    });
+    setSelectedCategory(categoryId);
+  };
+
+  const toggleShowAll = () => {
+    setShowAll((value) => {
+      if (!value) {
+        logEvent({ event_name: LogEvent.ClickGivebackShowMoreActions });
+      }
+      return !value;
+    });
+  };
 
   const { paidActions, loveActions } = useMemo(() => {
     const paid: ContributionAction[] = [];
@@ -110,21 +143,21 @@ export const GivebackActionCatalog = (): ReactElement => {
         <GivebackFilterChip
           isSelected={selectedCategory === ALL_FILTER}
           label="All"
-          onClick={() => setSelectedCategory(ALL_FILTER)}
+          onClick={() => selectCategory(ALL_FILTER)}
         />
         {categories.map((category) => (
           <GivebackFilterChip
             key={category.id}
             isSelected={selectedCategory === category.id}
             label={category.title}
-            onClick={() => setSelectedCategory(category.id)}
+            onClick={() => selectCategory(category.id)}
           />
         ))}
       </FlexRow>
 
       {filteredPaid.length > 0 ? (
         <FlexCol className="gap-4">
-          <ActionGrid actions={visiblePaid} onSubmit={setSubmissionAction} />
+          <ActionGrid actions={visiblePaid} onSubmit={openAction} />
           {hiddenCount > 0 && (
             <FlexRow className="justify-center">
               <Button
@@ -135,7 +168,7 @@ export const GivebackActionCatalog = (): ReactElement => {
                   <ArrowIcon className={showAll ? undefined : 'rotate-180'} />
                 }
                 iconPosition={ButtonIconPosition.Right}
-                onClick={() => setShowAll((value) => !value)}
+                onClick={toggleShowAll}
               >
                 {showAll ? 'Show fewer' : `Show more actions (${hiddenCount})`}
               </Button>

--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
@@ -1,0 +1,328 @@
+import type { ReactElement } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../components/buttons/Button';
+import {
+  Typography,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { FlexCol, FlexRow } from '../../../components/utilities';
+import { RootPortal } from '../../../components/tooltips/Portal';
+import { uploadContentImage } from '../../../graphql/posts';
+import { useToastNotification } from '../../../hooks/useToastNotification';
+import { labels } from '../../../lib/labels';
+import type { ContributionAction } from '../types';
+import { formatDonationAmount } from '../utils';
+import { useSubmitContributionAction } from '../hooks/useSubmitContributionAction';
+import { GivebackScreenshotField } from './GivebackScreenshotField';
+
+interface GivebackActionSubmissionModalProps {
+  action: ContributionAction;
+  onClose: () => void;
+}
+
+const getDialogTitle = (isLove: boolean, isSubmitted: boolean): string => {
+  if (isLove) {
+    return 'Show some love';
+  }
+  if (isSubmitted) {
+    return 'Proof submitted';
+  }
+  return 'Submit proof';
+};
+
+export const GivebackActionSubmissionModal = ({
+  action,
+  onClose,
+}: GivebackActionSubmissionModalProps): ReactElement => {
+  const { displayToast } = useToastNotification();
+  const { submit, isPending } = useSubmitContributionAction();
+  const linkInputId = `giveback-proof-link-${action.id}`;
+  const noteInputId = `giveback-proof-note-${action.id}`;
+
+  const [link, setLink] = useState('');
+  const [screenshotPreview, setScreenshotPreview] = useState<string>();
+  const [screenshotUrl, setScreenshotUrl] = useState<string>();
+  const [isUploading, setIsUploading] = useState(false);
+  const [note, setNote] = useState('');
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const { evidence, metadata } = action;
+  const isLove = metadata.isLoveAction;
+  const showUrl = !!evidence.url;
+  const showScreenshot = !!evidence.screenshot;
+  const showNote = !!evidence.note;
+
+  const canSubmit = useMemo(() => {
+    if (isUploading) {
+      return false;
+    }
+    const hasLink = !evidence.url?.required || link.trim().length > 0;
+    const hasScreenshot = !evidence.screenshot?.required || !!screenshotUrl;
+    const hasNote = !evidence.note?.required || note.trim().length > 0;
+
+    return hasLink && hasScreenshot && hasNote;
+  }, [evidence, isUploading, link, note, screenshotUrl]);
+
+  const onScreenshotSelect = async (base64: string, file: File) => {
+    setScreenshotPreview(base64);
+    setIsUploading(true);
+    try {
+      const url = await uploadContentImage(file);
+      setScreenshotUrl(url);
+    } catch {
+      setScreenshotPreview(undefined);
+      setScreenshotUrl(undefined);
+      displayToast(labels.error.generic);
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const clearScreenshot = () => {
+    setScreenshotPreview(undefined);
+    setScreenshotUrl(undefined);
+  };
+
+  // Close on Escape, matching the backdrop click below.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  const onSubmit = async () => {
+    if (!canSubmit) {
+      return;
+    }
+
+    try {
+      await submit({
+        actionId: action.id,
+        evidence: {
+          url: link.trim() || undefined,
+          screenshotUrl: screenshotUrl || undefined,
+          note: note.trim() || undefined,
+        },
+      });
+      setIsSubmitted(true);
+    } catch {
+      displayToast(labels.error.generic);
+    }
+  };
+
+  return (
+    <RootPortal>
+      <div className="fixed inset-0 z-modal flex items-center justify-center bg-overlay-primary-pepper px-4 backdrop-blur-sm">
+        {/* Full-bleed backdrop target: a real button so it closes on click and
+            keyboard, while the dialog sits above it and is unaffected. */}
+        <button
+          type="button"
+          aria-label="Close"
+          tabIndex={-1}
+          className="absolute inset-0 cursor-default"
+          onClick={onClose}
+        />
+        <section
+          aria-modal="true"
+          role="dialog"
+          aria-labelledby="giveback-submission-title"
+          className="relative z-1 flex max-h-[calc(100vh-2rem)] w-full max-w-[35rem] flex-col overflow-hidden rounded-24 border border-border-subtlest-secondary bg-background-default shadow-2"
+        >
+          <div
+            aria-hidden
+            className="bg-accent-cabbage-default/20 pointer-events-none absolute -right-20 -top-20 size-56 rounded-full blur-3xl"
+          />
+          <div
+            aria-hidden
+            className="bg-accent-onion-default/20 pointer-events-none absolute -bottom-24 -left-16 size-56 rounded-full blur-3xl"
+          />
+          <FlexCol className="relative gap-5 overflow-y-auto p-5 tablet:p-6">
+            <FlexCol className="gap-2">
+              <Typography
+                bold
+                id="giveback-submission-title"
+                tag={TypographyTag.H2}
+                type={TypographyType.Title3}
+              >
+                {getDialogTitle(isLove, isSubmitted)}
+              </Typography>
+              <Typography
+                type={TypographyType.Callout}
+                className="text-text-tertiary"
+              >
+                {!isLove && isSubmitted
+                  ? "Added to your contribution. We'll only subtract it if validation fails."
+                  : action.title}
+              </Typography>
+            </FlexCol>
+
+            {isLove && (
+              <FlexCol className="gap-4">
+                <FlexCol className="gap-3 rounded-18 border border-accent-cabbage-default bg-accent-cabbage-flat p-5">
+                  <Typography
+                    bold
+                    type={TypographyType.Title4}
+                    className="text-accent-cabbage-default"
+                  >
+                    Just for love
+                  </Typography>
+                  <Typography
+                    type={TypographyType.Callout}
+                    className="text-text-tertiary"
+                  >
+                    This one&apos;s a voluntary thank-you — no reward or
+                    donation is attached. We just genuinely appreciate it.
+                  </Typography>
+                </FlexCol>
+                {metadata.instructions && (
+                  <Typography
+                    type={TypographyType.Footnote}
+                    className="text-text-tertiary"
+                  >
+                    {metadata.instructions}
+                  </Typography>
+                )}
+              </FlexCol>
+            )}
+
+            {!isLove && isSubmitted && (
+              <FlexCol className="relative gap-4 overflow-hidden rounded-18 border border-accent-cabbage-default bg-accent-cabbage-flat p-5 shadow-2-cabbage">
+                <Typography bold type={TypographyType.Title4}>
+                  You helped unlock {formatDonationAmount(action.points)}
+                </Typography>
+                <Typography
+                  type={TypographyType.Callout}
+                  className="text-text-tertiary"
+                >
+                  It already counts toward your contribution. If it&apos;s
+                  rejected, we&apos;ll subtract it.
+                </Typography>
+              </FlexCol>
+            )}
+
+            {!isLove && !isSubmitted && (
+              <FlexCol className="gap-4">
+                <FlexCol className="gap-3 border-b border-border-subtlest-tertiary pb-4">
+                  <FlexRow className="items-center justify-between gap-3">
+                    <Typography
+                      type={TypographyType.Caption1}
+                      className="text-text-tertiary"
+                    >
+                      Counts toward your contribution the moment you submit.
+                    </Typography>
+                    <Typography
+                      bold
+                      type={TypographyType.Callout}
+                      className="shrink-0 tabular-nums text-status-success"
+                    >
+                      +{formatDonationAmount(action.points)}
+                    </Typography>
+                  </FlexRow>
+                  {metadata.instructions && (
+                    <Typography
+                      type={TypographyType.Footnote}
+                      className="text-text-tertiary"
+                    >
+                      {metadata.instructions}
+                    </Typography>
+                  )}
+                </FlexCol>
+
+                {showUrl && (
+                  <label htmlFor={linkInputId} className="flex flex-col gap-2">
+                    <Typography bold type={TypographyType.Footnote}>
+                      Public link
+                    </Typography>
+                    <input
+                      id={linkInputId}
+                      className="rounded-12 border border-border-subtlest-tertiary bg-surface-float px-3 py-2 text-text-primary typo-callout"
+                      placeholder="https://..."
+                      value={link}
+                      onChange={(event) => setLink(event.target.value)}
+                    />
+                  </label>
+                )}
+
+                {showScreenshot && (
+                  <FlexCol className="gap-2">
+                    <Typography bold type={TypographyType.Footnote}>
+                      Screenshot
+                    </Typography>
+                    <GivebackScreenshotField
+                      inputId={`giveback-proof-${action.id}`}
+                      previewSrc={screenshotPreview}
+                      isUploading={isUploading}
+                      onSelect={onScreenshotSelect}
+                      onClear={clearScreenshot}
+                    />
+                  </FlexCol>
+                )}
+
+                {showNote && (
+                  <label htmlFor={noteInputId} className="flex flex-col gap-2">
+                    <Typography bold type={TypographyType.Footnote}>
+                      Note
+                    </Typography>
+                    <textarea
+                      id={noteInputId}
+                      maxLength={1000}
+                      className="min-h-24 rounded-12 border border-border-subtlest-tertiary bg-surface-float px-3 py-2 text-text-primary typo-callout"
+                      placeholder="Add any context that helps us validate this."
+                      value={note}
+                      onChange={(event) => setNote(event.target.value)}
+                    />
+                  </label>
+                )}
+              </FlexCol>
+            )}
+
+            <FlexRow className="justify-end gap-2">
+              {isLove ? (
+                <Button
+                  type="button"
+                  size={ButtonSize.Small}
+                  variant={ButtonVariant.Primary}
+                  onClick={onClose}
+                >
+                  Got it
+                </Button>
+              ) : (
+                <>
+                  <Button
+                    type="button"
+                    size={ButtonSize.Small}
+                    variant={ButtonVariant.Tertiary}
+                    onClick={onClose}
+                  >
+                    {isSubmitted ? 'Done' : 'Cancel'}
+                  </Button>
+                  {!isSubmitted && (
+                    <Button
+                      type="button"
+                      size={ButtonSize.Small}
+                      variant={ButtonVariant.Primary}
+                      disabled={!canSubmit}
+                      loading={isPending}
+                      onClick={onSubmit}
+                    >
+                      Submit for review
+                    </Button>
+                  )}
+                </>
+              )}
+            </FlexRow>
+          </FlexCol>
+        </section>
+      </div>
+    </RootPortal>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
@@ -14,6 +14,8 @@ import { FlexCol, FlexRow } from '../../../components/utilities';
 import { RootPortal } from '../../../components/tooltips/Portal';
 import { uploadContentImage } from '../../../graphql/posts';
 import { useToastNotification } from '../../../hooks/useToastNotification';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
 import { labels } from '../../../lib/labels';
 import type { ContributionAction } from '../types';
 import { formatDonationAmount } from '../utils';
@@ -40,6 +42,7 @@ export const GivebackActionSubmissionModal = ({
   onClose,
 }: GivebackActionSubmissionModalProps): ReactElement => {
   const { displayToast } = useToastNotification();
+  const { logEvent } = useLogContext();
   const { submit, isPending } = useSubmitContributionAction();
   const linkInputId = `giveback-proof-link-${action.id}`;
   const noteInputId = `giveback-proof-note-${action.id}`;
@@ -113,10 +116,34 @@ export const GivebackActionSubmissionModal = ({
           note: note.trim() || undefined,
         },
       });
+      logEvent({
+        event_name: LogEvent.SubmitGivebackAction,
+        target_id: action.id,
+        extra: JSON.stringify({
+          platform: metadata.platform,
+          points: action.points,
+          has_url: !!link.trim(),
+          has_screenshot: !!screenshotUrl,
+          has_note: !!note.trim(),
+        }),
+      });
       setIsSubmitted(true);
     } catch {
+      logEvent({
+        event_name: LogEvent.SubmitGivebackActionError,
+        target_id: action.id,
+      });
       displayToast(labels.error.generic);
     }
+  };
+
+  const onLoveAcknowledge = () => {
+    logEvent({
+      event_name: LogEvent.ClickGivebackLoveAction,
+      target_id: action.id,
+      extra: JSON.stringify({ platform: metadata.platform }),
+    });
+    onClose();
   };
 
   return (
@@ -291,7 +318,7 @@ export const GivebackActionSubmissionModal = ({
                   type="button"
                   size={ButtonSize.Small}
                   variant={ButtonVariant.Primary}
-                  onClick={onClose}
+                  onClick={onLoveAcknowledge}
                 >
                   Got it
                 </Button>

--- a/packages/shared/src/features/giveback/components/GivebackContributionSummary.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackContributionSummary.tsx
@@ -1,0 +1,152 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { FlexCol, FlexRow } from '../../../components/utilities';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { GiftIcon, InfoIcon } from '../../../components/icons';
+import { IconSize } from '../../../components/Icon';
+import {
+  ProfilePicture,
+  ProfileImageSize,
+} from '../../../components/ProfilePicture';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { useGivebackContribution } from '../hooks/useGivebackContribution';
+import { useContributionActions } from '../hooks/useContributionActions';
+import { formatDonationAmount } from '../utils';
+
+// Personal recap shown above the action catalog: how much the visitor has
+// unlocked for their causes and the next reward they're working toward. No
+// rank, level or leaderboard — the campaign starts from scratch, so this stays
+// a purely personal progress cue.
+export const GivebackContributionSummary = (): ReactElement => {
+  const { user } = useAuthContext();
+  const { earnedPoints, nextReward, pointsToNext, currentLevel, isPending } =
+    useGivebackContribution(true);
+  // Shares the catalog's query key, so this adds no extra request. Sums the
+  // visitor's completions across every action into one "actions taken" count.
+  const { actions, isPending: isActionsPending } = useContributionActions(true);
+  const actionsTaken = actions.reduce(
+    (sum, action) => sum + action.userCompletions,
+    0,
+  );
+
+  if (isPending) {
+    return (
+      <FlexCol className="gap-1.5">
+        <div className="h-3 w-32 animate-pulse rounded-8 bg-surface-float" />
+        <div className="h-8 w-44 animate-pulse rounded-8 bg-surface-float" />
+      </FlexCol>
+    );
+  }
+
+  return (
+    <FlexRow className="flex-wrap items-center gap-x-5 gap-y-4">
+      {user && (
+        <div className="relative shrink-0">
+          <ProfilePicture
+            user={user}
+            size={ProfileImageSize.XXLarge}
+            rounded="full"
+            className="ring-2 ring-accent-cabbage-default"
+          />
+          <span className="absolute -bottom-1.5 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-full bg-accent-cabbage-default px-2 py-0.5 font-bold uppercase tracking-wide text-white ring-2 ring-background-default typo-caption2">
+            Lvl {currentLevel}
+          </span>
+        </div>
+      )}
+
+      <FlexCol className="min-w-0 flex-1 gap-1">
+        <FlexRow className="items-center gap-1">
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+            bold
+            className="uppercase tracking-wider"
+          >
+            Your contribution
+          </Typography>
+          <span className="group/info relative flex">
+            <button
+              type="button"
+              aria-label="How your contribution is counted"
+              className="flex text-text-tertiary transition-colors hover:text-text-primary group-focus-within/info:text-text-primary"
+            >
+              <InfoIcon size={IconSize.Size16} />
+            </button>
+            <span
+              role="tooltip"
+              className="pointer-events-none absolute left-0 top-full z-3 mt-2 w-56 rounded-10 border border-border-subtlest-tertiary bg-background-default p-2.5 text-left opacity-0 shadow-2 transition-opacity duration-150 group-focus-within/info:opacity-100 group-hover/info:opacity-100"
+            >
+              <Typography
+                tag={TypographyTag.Span}
+                type={TypographyType.Caption1}
+                color={TypographyColor.Tertiary}
+              >
+                Counts the moment you act, because we trust you. If a submission
+                is rejected, we&apos;ll subtract it.
+              </Typography>
+            </span>
+          </span>
+        </FlexRow>
+        <FlexRow className="items-baseline gap-1.5">
+          <Typography
+            bold
+            type={TypographyType.Title2}
+            className="tabular-nums text-status-success"
+          >
+            {formatDonationAmount(earnedPoints)}
+          </Typography>
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+          >
+            unlocked for your causes
+          </Typography>
+        </FlexRow>
+        {!isActionsPending && (
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+          >
+            {actionsTaken} {actionsTaken === 1 ? 'action' : 'actions'} taken
+          </Typography>
+        )}
+      </FlexCol>
+
+      {nextReward && (
+        <FlexCol className="shrink-0 items-end gap-0.5">
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption2}
+            color={TypographyColor.Tertiary}
+            bold
+            className="uppercase tracking-wider"
+          >
+            Next reward
+          </Typography>
+          <FlexRow className="items-center gap-1.5 text-accent-cheese-default [&_svg]:size-4">
+            <GiftIcon />
+            <Typography bold type={TypographyType.Footnote}>
+              {nextReward.title}
+            </Typography>
+          </FlexRow>
+          <Typography
+            tag={TypographyTag.Span}
+            bold
+            type={TypographyType.Caption1}
+            className="tabular-nums text-accent-cabbage-default"
+          >
+            {formatDonationAmount(pointsToNext)} to go
+          </Typography>
+        </FlexCol>
+      )}
+    </FlexRow>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackFundingBar.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackFundingBar.tsx
@@ -13,6 +13,8 @@ import {
   ButtonVariant,
 } from '../../../components/buttons/Button';
 import ProgressCircle from '../../../components/ProgressCircle';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
 import { useGivebackContribution } from '../hooks/useGivebackContribution';
 import { formatDonationAmount } from '../utils';
 
@@ -26,6 +28,7 @@ interface GivebackFundingBarProps {
 export const GivebackFundingBar = ({
   onTakeAction,
 }: GivebackFundingBarProps): ReactElement => {
+  const { logEvent } = useLogContext();
   const {
     earnedPoints,
     nextReward,
@@ -34,6 +37,14 @@ export const GivebackFundingBar = ({
     hasRewards,
     isPending,
   } = useGivebackContribution(true);
+
+  const handleTakeAction = () => {
+    logEvent({
+      event_name: LogEvent.ClickGivebackTakeAction,
+      extra: JSON.stringify({ origin: 'funding_bar' }),
+    });
+    onTakeAction();
+  };
 
   const renderNextStep = (): ReactNode => {
     if (isPending) {
@@ -118,7 +129,7 @@ export const GivebackFundingBar = ({
             type="button"
             variant={ButtonVariant.Primary}
             size={ButtonSize.Medium}
-            onClick={onTakeAction}
+            onClick={handleTakeAction}
             className="shrink-0"
           >
             Take action

--- a/packages/shared/src/features/giveback/components/GivebackFundingBar.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackFundingBar.tsx
@@ -1,0 +1,130 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import { FlexCol, FlexRow } from '../../../components/utilities';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../components/buttons/Button';
+import ProgressCircle from '../../../components/ProgressCircle';
+import { useGivebackContribution } from '../hooks/useGivebackContribution';
+import { formatDonationAmount } from '../utils';
+
+interface GivebackFundingBarProps {
+  onTakeAction: () => void;
+}
+
+// Persistent personal-progress bar for the onboarded experience. Deliberately
+// spare: the exact amount you've unlocked, one explicit next reward, and the
+// CTA — nothing else competing for attention in the thumb zone.
+export const GivebackFundingBar = ({
+  onTakeAction,
+}: GivebackFundingBarProps): ReactElement => {
+  const {
+    earnedPoints,
+    nextReward,
+    pointsToNext,
+    progressPercentage,
+    hasRewards,
+    isPending,
+  } = useGivebackContribution(true);
+
+  const renderNextStep = (): ReactNode => {
+    if (isPending) {
+      return (
+        <span className="my-0.5 block h-3 w-40 animate-pulse rounded-8 bg-surface-float" />
+      );
+    }
+
+    if (nextReward) {
+      return (
+        <>
+          <span className="font-bold text-accent-avocado-default">
+            {formatDonationAmount(pointsToNext)}
+          </span>{' '}
+          to unlock{' '}
+          <span className="font-bold text-text-primary">
+            {nextReward.title}
+          </span>
+        </>
+      );
+    }
+
+    if (hasRewards) {
+      return <>You&apos;ve unlocked every reward. Keep the good going.</>;
+    }
+
+    return <>Take an action to start unlocking donations.</>;
+  };
+
+  return (
+    <div className="pointer-events-none sticky bottom-0 z-3">
+      <div className="bg-background-default/80 pointer-events-auto relative mx-auto w-full max-w-6xl border-t border-border-subtlest-secondary px-4 py-3 backdrop-blur-xl tablet:rounded-t-16 tablet:border-x">
+        {/* Brand hairline along the top edge, matching the sticky tabs bar. */}
+        <div
+          aria-hidden
+          className="via-accent-cabbage-default/40 pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent to-transparent"
+        />
+
+        <FlexRow className="items-center justify-between gap-4">
+          <FlexRow className="min-w-0 flex-1 items-center gap-3">
+            <div className="shrink-0">
+              <ProgressCircle
+                progress={isPending ? 0 : progressPercentage}
+                size={46}
+                showPercentage
+              />
+            </div>
+
+            <FlexCol className="min-w-0 gap-0.5">
+              <FlexRow className="min-w-0 items-baseline gap-1.5">
+                <Typography
+                  tag={TypographyTag.Span}
+                  type={TypographyType.Callout}
+                  bold
+                  className="shrink-0 tabular-nums text-status-success"
+                >
+                  {formatDonationAmount(earnedPoints)}
+                </Typography>
+                <Typography
+                  tag={TypographyTag.Span}
+                  type={TypographyType.Caption1}
+                  color={TypographyColor.Tertiary}
+                  className="truncate"
+                >
+                  unlocked
+                  <span className="hidden tablet:inline"> for your causes</span>
+                </Typography>
+              </FlexRow>
+
+              <Typography
+                tag={TypographyTag.Span}
+                type={TypographyType.Caption1}
+                color={TypographyColor.Tertiary}
+                className="truncate"
+              >
+                {renderNextStep()}
+              </Typography>
+            </FlexCol>
+          </FlexRow>
+
+          <Button
+            type="button"
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Medium}
+            onClick={onTakeAction}
+            className="shrink-0"
+          >
+            Take action
+          </Button>
+        </FlexRow>
+      </div>
+    </div>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackPage.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackPage.tsx
@@ -18,6 +18,8 @@ import { GivebackActionCatalog } from './GivebackActionCatalog';
 import { GivebackContributionSummary } from './GivebackContributionSummary';
 import { GivebackFundingBar } from './GivebackFundingBar';
 import type { GivebackTabId } from './GivebackTabNav';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
 import { useContributionStatus } from '../hooks/useContributionStatus';
 import { useGivebackCauseSelection } from '../hooks/useGivebackCauseSelection';
 
@@ -33,6 +35,7 @@ const scrollIntoView = (node: HTMLElement | null): void => {
 };
 
 export const GivebackPage = (): ReactElement => {
+  const { logEvent } = useLogContext();
   const { status } = useContributionStatus();
   // Eligibility gates the cause picker query (backend-gated), so only eligible
   // visitors load their picks — which also tells us whether to show the tabs.
@@ -71,13 +74,31 @@ export const GivebackPage = (): ReactElement => {
     scrollToTabs();
   }, [scrollToTabs]);
 
+  const handleSelectTab = useCallback(
+    (tab: GivebackTabId) => {
+      logEvent({
+        event_name: LogEvent.ClickGivebackTab,
+        extra: JSON.stringify({ tab }),
+      });
+      setActiveTab(tab);
+    },
+    [logEvent],
+  );
+
   const handleContinue = useCallback(async () => {
     const saved = await selection.save();
     if (saved) {
+      logEvent({
+        event_name: LogEvent.SaveGivebackCauses,
+        extra: JSON.stringify({
+          cause_count: selection.selectedIds.size,
+          cause_ids: [...selection.selectedIds],
+        }),
+      });
       setCompletedOnboarding(true);
       goToActions();
     }
-  }, [selection, goToActions]);
+  }, [selection, goToActions, logEvent]);
 
   // Reveal the picker, then bring it into view as it mounts.
   useEffect(() => {
@@ -138,7 +159,7 @@ export const GivebackPage = (): ReactElement => {
 
         {showTabs && (
           <div ref={tabsRef} className="scroll-mt-16">
-            <GivebackTabNav activeTab={activeTab} onSelect={setActiveTab} />
+            <GivebackTabNav activeTab={activeTab} onSelect={handleSelectTab} />
 
             <div
               key={activeTab}

--- a/packages/shared/src/features/giveback/components/GivebackPage.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackPage.tsx
@@ -14,6 +14,9 @@ import { GivebackCauseSelection } from './GivebackCauseSelection';
 import { GivebackOnboardingBar } from './GivebackOnboardingBar';
 import { GivebackLegalFooter } from './GivebackLegalFooter';
 import { GivebackTabNav, givebackTabs } from './GivebackTabNav';
+import { GivebackActionCatalog } from './GivebackActionCatalog';
+import { GivebackContributionSummary } from './GivebackContributionSummary';
+import { GivebackFundingBar } from './GivebackFundingBar';
 import type { GivebackTabId } from './GivebackTabNav';
 import { useContributionStatus } from '../hooks/useContributionStatus';
 import { useGivebackCauseSelection } from '../hooks/useGivebackCauseSelection';
@@ -143,21 +146,28 @@ export const GivebackPage = (): ReactElement => {
               aria-label={activeLabel}
               className={`${column} pt-8`}
             >
-              <FlexCol className="min-h-[40vh] items-center justify-center gap-2 rounded-16 border border-dashed border-border-subtlest-tertiary p-10 text-center">
-                <Typography
-                  tag={TypographyTag.H2}
-                  type={TypographyType.Title3}
-                  bold
-                >
-                  {activeLabel}
-                </Typography>
-                <Typography
-                  type={TypographyType.Callout}
-                  color={TypographyColor.Tertiary}
-                >
-                  Coming soon
-                </Typography>
-              </FlexCol>
+              {activeTab === 'actions' ? (
+                <FlexCol className="gap-6">
+                  <GivebackContributionSummary />
+                  <GivebackActionCatalog />
+                </FlexCol>
+              ) : (
+                <FlexCol className="min-h-[40vh] items-center justify-center gap-2 rounded-16 border border-dashed border-border-subtlest-tertiary p-10 text-center">
+                  <Typography
+                    tag={TypographyTag.H2}
+                    type={TypographyType.Title3}
+                    bold
+                  >
+                    {activeLabel}
+                  </Typography>
+                  <Typography
+                    type={TypographyType.Callout}
+                    color={TypographyColor.Tertiary}
+                  >
+                    Coming soon
+                  </Typography>
+                </FlexCol>
+              )}
             </div>
           </div>
         )}
@@ -174,6 +184,8 @@ export const GivebackPage = (): ReactElement => {
           onContinue={handleContinue}
         />
       )}
+
+      {showTabs && <GivebackFundingBar onTakeAction={goToActions} />}
     </div>
   );
 };

--- a/packages/shared/src/features/giveback/components/GivebackScreenshotField.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackScreenshotField.tsx
@@ -1,0 +1,115 @@
+import type { DragEvent, ReactElement } from 'react';
+import React, { useRef } from 'react';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { Loader } from '../../../components/Loader';
+import CloseButton from '../../../components/CloseButton';
+import { ButtonSize, ButtonVariant } from '../../../components/buttons/common';
+import { UploadIcon } from '../../../components/icons';
+import { IconSize } from '../../../components/Icon';
+import { useFileInput } from '../../../hooks/utils/useFileInput';
+import { ACCEPTED_TYPES, acceptedTypesList } from '../../../graphql/posts';
+
+const SIZE_LIMIT_MB = 5;
+
+interface GivebackScreenshotFieldProps {
+  inputId: string;
+  // Base64 of the picked file, shown immediately while the upload runs.
+  previewSrc?: string;
+  isUploading: boolean;
+  onSelect: (base64: string, file: File) => void;
+  onClear: () => void;
+}
+
+// Proof screenshot picker: a dashed drop zone when empty, a contained preview
+// with a remove control once a file is chosen, and an "uploading" overlay while
+// it transfers. Click or drag-and-drop to pick.
+export const GivebackScreenshotField = ({
+  inputId,
+  previewSrc,
+  isUploading,
+  onSelect,
+  onClear,
+}: GivebackScreenshotFieldProps): ReactElement => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { onFileChange } = useFileInput({
+    acceptedTypes: acceptedTypesList,
+    limitMb: SIZE_LIMIT_MB,
+    onChange: onSelect,
+  });
+
+  const openPicker = () => inputRef.current?.click();
+
+  const onDrop = (event: DragEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onFileChange(event.dataTransfer.files?.[0]);
+  };
+
+  return (
+    <div className="relative">
+      <input
+        id={inputId}
+        ref={inputRef}
+        type="file"
+        accept={ACCEPTED_TYPES}
+        className="hidden"
+        onChange={(event) => onFileChange(event.target.files?.[0])}
+      />
+
+      {previewSrc ? (
+        <div className="relative overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-surface-float">
+          <img
+            src={previewSrc}
+            alt="Screenshot preview"
+            className="max-h-56 w-full object-contain"
+          />
+          {isUploading ? (
+            <div className="absolute inset-0 flex items-center justify-center gap-2 bg-overlay-primary-pepper">
+              <Loader />
+              <Typography
+                type={TypographyType.Footnote}
+                color={TypographyColor.Primary}
+              >
+                Uploading…
+              </Typography>
+            </div>
+          ) : (
+            <CloseButton
+              type="button"
+              size={ButtonSize.Small}
+              variant={ButtonVariant.Primary}
+              className="absolute right-2 top-2 z-1 !shadow-2"
+              title="Remove screenshot"
+              onClick={onClear}
+            />
+          )}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={openPicker}
+          onDragOver={(event) => event.preventDefault()}
+          onDrop={onDrop}
+          className="group flex w-full flex-col items-center justify-center gap-2 rounded-16 border border-dashed border-border-subtlest-secondary bg-surface-float px-4 py-8 text-center transition-colors hover:border-accent-cabbage-default hover:bg-surface-hover"
+        >
+          <span className="flex size-10 items-center justify-center rounded-full bg-surface-hover text-text-secondary transition-colors group-hover:text-accent-cabbage-default">
+            <UploadIcon size={IconSize.Small} />
+          </span>
+          <Typography type={TypographyType.Callout} bold>
+            Upload a screenshot
+          </Typography>
+          <Typography
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+          >
+            PNG, JPG or WebP · up to {SIZE_LIMIT_MB} MB
+          </Typography>
+        </button>
+      )}
+    </div>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackStartPanel.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackStartPanel.spec.tsx
@@ -78,7 +78,10 @@ it('jumps onboarded visitors to the action tab without re-joining', () => {
 
   expect(onTakeAction).toHaveBeenCalled();
   expect(onJoin).not.toHaveBeenCalled();
-  expect(logEvent).not.toHaveBeenCalled();
+  expect(logEvent).toHaveBeenCalledWith({
+    event_name: LogEvent.ClickGivebackTakeAction,
+    extra: JSON.stringify({ origin: 'hero' }),
+  });
 });
 
 it('renders an empty CTA while resolving so its copy cannot flip mid-click', () => {

--- a/packages/shared/src/features/giveback/components/GivebackStartPanel.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackStartPanel.tsx
@@ -46,6 +46,10 @@ export const GivebackStartPanel = ({
 
   const handleClick = () => {
     if (hasSelectedCauses) {
+      logEvent({
+        event_name: LogEvent.ClickGivebackTakeAction,
+        extra: JSON.stringify({ origin: 'hero' }),
+      });
       onTakeAction();
       return;
     }

--- a/packages/shared/src/features/giveback/graphql.ts
+++ b/packages/shared/src/features/giveback/graphql.ts
@@ -53,10 +53,12 @@ export const CONTRIBUTION_CAUSE_PICKER_QUERY = `
   }
 `;
 
-// The action catalog and its filter categories in one request: the catalog tab
-// renders the grid and the filter chips from a single round trip. Each action
-// carries the visitor's own state (completions, cooldown, latest submission) so
-// the card knows whether it's actionable, in review or done.
+// Everything the onboarded experience needs in one request: the action catalog,
+// its filter categories, and the reward ladder. The catalog renders the grid and
+// chips; the contribution summary and floating bar read the reward tiers — all
+// from a single round trip. Each action carries the visitor's own state
+// (completions, cooldown, latest submission) so the card knows whether it's
+// actionable, in review or done.
 export const CONTRIBUTION_ACTIONS_QUERY = `
   query ContributionActions($first: Int) {
     contributionActions(first: $first) {
@@ -97,13 +99,6 @@ export const CONTRIBUTION_ACTIONS_QUERY = `
         }
       }
     }
-  }
-`;
-
-// The reward ladder, used to show a contributor their next milestone. Auth +
-// eligibility gated like the rest of the onboarded experience.
-export const CONTRIBUTION_REWARD_TIERS_QUERY = `
-  query ContributionRewardTiers($first: Int) {
     contributionRewardTiers(first: $first) {
       edges {
         node {

--- a/packages/shared/src/features/giveback/graphql.ts
+++ b/packages/shared/src/features/giveback/graphql.ts
@@ -53,6 +53,82 @@ export const CONTRIBUTION_CAUSE_PICKER_QUERY = `
   }
 `;
 
+// The action catalog and its filter categories in one request: the catalog tab
+// renders the grid and the filter chips from a single round trip. Each action
+// carries the visitor's own state (completions, cooldown, latest submission) so
+// the card knows whether it's actionable, in review or done.
+export const CONTRIBUTION_ACTIONS_QUERY = `
+  query ContributionActions($first: Int) {
+    contributionActions(first: $first) {
+      edges {
+        node {
+          id
+          categoryId
+          title
+          description
+          points
+          evidence
+          metadata {
+            platform
+            instructions
+            externalUrl
+            isLoveAction
+          }
+          cooldownSeconds
+          maxPerUser
+          userCooldownEndsAt
+          userCompletions
+          latestUserSubmission {
+            id
+            actionId
+            status
+            awardedPoints
+            createdAt
+            reviewedAt
+          }
+        }
+      }
+    }
+    contributionActionCategories(first: $first) {
+      edges {
+        node {
+          id
+          title
+        }
+      }
+    }
+  }
+`;
+
+// The reward ladder, used to show a contributor their next milestone. Auth +
+// eligibility gated like the rest of the onboarded experience.
+export const CONTRIBUTION_REWARD_TIERS_QUERY = `
+  query ContributionRewardTiers($first: Int) {
+    contributionRewardTiers(first: $first) {
+      edges {
+        node {
+          id
+          title
+          thresholdPoints
+        }
+      }
+    }
+  }
+`;
+
+export const SUBMIT_CONTRIBUTION_ACTION_MUTATION = `
+  mutation SubmitContributionAction($input: SubmitContributionActionInput!) {
+    submitContributionAction(input: $input) {
+      id
+      actionId
+      status
+      awardedPoints
+      createdAt
+      reviewedAt
+    }
+  }
+`;
+
 export const UPDATE_CONTRIBUTION_CAUSE_PREFERENCES_MUTATION = `
   mutation UpdateContributionCausePreferences($causeIds: [ID!]!) {
     updateContributionCausePreferences(causeIds: $causeIds) {

--- a/packages/shared/src/features/giveback/hooks/useContributionActions.ts
+++ b/packages/shared/src/features/giveback/hooks/useContributionActions.ts
@@ -1,0 +1,54 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import type { Connection } from '../../../graphql/common';
+import { gqlClient } from '../../../graphql/common';
+import { disabledRefetch } from '../../../lib/func';
+import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
+import { CONTRIBUTION_ACTIONS_QUERY } from '../graphql';
+import type { ContributionAction, ContributionActionCategory } from '../types';
+
+interface UseContributionActions {
+  actions: ContributionAction[];
+  categories: ContributionActionCategory[];
+  isPending: boolean;
+}
+
+const MAX_ACTIONS = 100;
+
+// The action catalog and its filter categories in one request. Auth +
+// eligibility gated on the backend (the catalog only renders once a visitor has
+// joined and picked causes), so only fetch when signed in and the caller marks
+// the tab reachable. Keyed by user since each action carries the visitor's own
+// completion state.
+export const useContributionActions = (
+  enabled: boolean,
+): UseContributionActions => {
+  const { isAuthReady, user } = useAuthContext();
+  const shouldFetch = isAuthReady && !!user && enabled;
+
+  const { data, isPending } = useQuery({
+    queryKey: generateQueryKey(RequestKey.ContributionActions, user),
+    queryFn: async () => {
+      const res = await gqlClient.request<{
+        contributionActions: Connection<ContributionAction>;
+        contributionActionCategories: Connection<ContributionActionCategory>;
+      }>(CONTRIBUTION_ACTIONS_QUERY, { first: MAX_ACTIONS });
+
+      return {
+        actions: res.contributionActions.edges.map((edge) => edge.node),
+        categories: res.contributionActionCategories.edges.map(
+          (edge) => edge.node,
+        ),
+      };
+    },
+    enabled: shouldFetch,
+    staleTime: StaleTime.Default,
+    ...disabledRefetch,
+  });
+
+  return {
+    actions: data?.actions ?? [],
+    categories: data?.categories ?? [],
+    isPending: shouldFetch && isPending,
+  };
+};

--- a/packages/shared/src/features/giveback/hooks/useContributionActions.ts
+++ b/packages/shared/src/features/giveback/hooks/useContributionActions.ts
@@ -5,21 +5,26 @@ import { gqlClient } from '../../../graphql/common';
 import { disabledRefetch } from '../../../lib/func';
 import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
 import { CONTRIBUTION_ACTIONS_QUERY } from '../graphql';
-import type { ContributionAction, ContributionActionCategory } from '../types';
+import type {
+  ContributionAction,
+  ContributionActionCategory,
+  ContributionRewardTier,
+} from '../types';
 
 interface UseContributionActions {
   actions: ContributionAction[];
   categories: ContributionActionCategory[];
+  rewardTiers: ContributionRewardTier[];
   isPending: boolean;
 }
 
 const MAX_ACTIONS = 100;
 
-// The action catalog and its filter categories in one request. Auth +
-// eligibility gated on the backend (the catalog only renders once a visitor has
-// joined and picked causes), so only fetch when signed in and the caller marks
-// the tab reachable. Keyed by user since each action carries the visitor's own
-// completion state.
+// The onboarded experience's data in one request: the action catalog, its filter
+// categories, and the reward ladder. Auth + eligibility gated on the backend
+// (this only renders once a visitor has joined and picked causes), so only fetch
+// when signed in and the caller marks the tab reachable. Keyed by user since each
+// action carries the visitor's own completion state.
 export const useContributionActions = (
   enabled: boolean,
 ): UseContributionActions => {
@@ -32,6 +37,7 @@ export const useContributionActions = (
       const res = await gqlClient.request<{
         contributionActions: Connection<ContributionAction>;
         contributionActionCategories: Connection<ContributionActionCategory>;
+        contributionRewardTiers: Connection<ContributionRewardTier>;
       }>(CONTRIBUTION_ACTIONS_QUERY, { first: MAX_ACTIONS });
 
       return {
@@ -39,6 +45,7 @@ export const useContributionActions = (
         categories: res.contributionActionCategories.edges.map(
           (edge) => edge.node,
         ),
+        rewardTiers: res.contributionRewardTiers.edges.map((edge) => edge.node),
       };
     },
     enabled: shouldFetch,
@@ -49,6 +56,7 @@ export const useContributionActions = (
   return {
     actions: data?.actions ?? [],
     categories: data?.categories ?? [],
+    rewardTiers: data?.rewardTiers ?? [],
     isPending: shouldFetch && isPending,
   };
 };

--- a/packages/shared/src/features/giveback/hooks/useContributionRewards.ts
+++ b/packages/shared/src/features/giveback/hooks/useContributionRewards.ts
@@ -1,0 +1,44 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import type { Connection } from '../../../graphql/common';
+import { gqlClient } from '../../../graphql/common';
+import { disabledRefetch } from '../../../lib/func';
+import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
+import { CONTRIBUTION_REWARD_TIERS_QUERY } from '../graphql';
+import type { ContributionRewardTier } from '../types';
+
+interface UseContributionRewards {
+  rewardTiers: ContributionRewardTier[];
+  isPending: boolean;
+}
+
+const MAX_TIERS = 100;
+
+// The reward ladder. Auth + eligibility gated on the backend, so only fetch once
+// the visitor has joined. Shared between the contribution summary and the
+// floating bar, which dedupe to one request via the query key.
+export const useContributionRewards = (
+  enabled: boolean,
+): UseContributionRewards => {
+  const { isAuthReady, user } = useAuthContext();
+  const shouldFetch = isAuthReady && !!user && enabled;
+
+  const { data, isPending } = useQuery({
+    queryKey: generateQueryKey(RequestKey.ContributionRewards, user),
+    queryFn: async () => {
+      const res = await gqlClient.request<{
+        contributionRewardTiers: Connection<ContributionRewardTier>;
+      }>(CONTRIBUTION_REWARD_TIERS_QUERY, { first: MAX_TIERS });
+
+      return res.contributionRewardTiers.edges.map((edge) => edge.node);
+    },
+    enabled: shouldFetch,
+    staleTime: StaleTime.Default,
+    ...disabledRefetch,
+  });
+
+  return {
+    rewardTiers: data ?? [],
+    isPending: shouldFetch && isPending,
+  };
+};

--- a/packages/shared/src/features/giveback/hooks/useContributionRewards.ts
+++ b/packages/shared/src/features/giveback/hooks/useContributionRewards.ts
@@ -1,10 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
-import { useAuthContext } from '../../../contexts/AuthContext';
-import type { Connection } from '../../../graphql/common';
-import { gqlClient } from '../../../graphql/common';
-import { disabledRefetch } from '../../../lib/func';
-import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
-import { CONTRIBUTION_REWARD_TIERS_QUERY } from '../graphql';
+import { useContributionActions } from './useContributionActions';
 import type { ContributionRewardTier } from '../types';
 
 interface UseContributionRewards {
@@ -12,33 +6,14 @@ interface UseContributionRewards {
   isPending: boolean;
 }
 
-const MAX_TIERS = 100;
-
-// The reward ladder. Auth + eligibility gated on the backend, so only fetch once
-// the visitor has joined. Shared between the contribution summary and the
-// floating bar, which dedupe to one request via the query key.
+// Thin facade over the combined catalog query (see `useContributionActions`),
+// which fetches the reward tiers alongside the actions in one request. Sharing
+// the query key means the summary and floating bar reuse the cached result
+// instead of firing a second request.
 export const useContributionRewards = (
   enabled: boolean,
 ): UseContributionRewards => {
-  const { isAuthReady, user } = useAuthContext();
-  const shouldFetch = isAuthReady && !!user && enabled;
+  const { rewardTiers, isPending } = useContributionActions(enabled);
 
-  const { data, isPending } = useQuery({
-    queryKey: generateQueryKey(RequestKey.ContributionRewards, user),
-    queryFn: async () => {
-      const res = await gqlClient.request<{
-        contributionRewardTiers: Connection<ContributionRewardTier>;
-      }>(CONTRIBUTION_REWARD_TIERS_QUERY, { first: MAX_TIERS });
-
-      return res.contributionRewardTiers.edges.map((edge) => edge.node);
-    },
-    enabled: shouldFetch,
-    staleTime: StaleTime.Default,
-    ...disabledRefetch,
-  });
-
-  return {
-    rewardTiers: data ?? [],
-    isPending: shouldFetch && isPending,
-  };
+  return { rewardTiers, isPending };
 };

--- a/packages/shared/src/features/giveback/hooks/useGivebackContribution.spec.tsx
+++ b/packages/shared/src/features/giveback/hooks/useGivebackContribution.spec.tsx
@@ -1,0 +1,114 @@
+import { renderHook } from '@testing-library/react';
+import { useGivebackContribution } from './useGivebackContribution';
+import { useContributionStatus } from './useContributionStatus';
+import { useContributionRewards } from './useContributionRewards';
+import type { ContributionStatus } from '../types';
+
+jest.mock('./useContributionStatus');
+jest.mock('./useContributionRewards');
+
+const mockUseStatus = useContributionStatus as jest.MockedFunction<
+  typeof useContributionStatus
+>;
+const mockUseRewards = useContributionRewards as jest.MockedFunction<
+  typeof useContributionRewards
+>;
+
+const tier = (id: string, thresholdPoints: number) => ({
+  id,
+  title: `Reward ${id}`,
+  thresholdPoints,
+});
+
+const setStatus = (userPoints: number | null, isPending = false) =>
+  mockUseStatus.mockReturnValue({
+    status: { userPoints } as ContributionStatus,
+    isPending,
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  setStatus(0);
+  mockUseRewards.mockReturnValue({ rewardTiers: [], isPending: false });
+});
+
+it('targets the next tier above the visitor points', () => {
+  setStatus(30);
+  mockUseRewards.mockReturnValue({
+    rewardTiers: [tier('a', 25), tier('b', 100), tier('c', 250)],
+    isPending: false,
+  });
+
+  const { result } = renderHook(() => useGivebackContribution(true));
+
+  expect(result.current.earnedPoints).toBe(30);
+  expect(result.current.nextReward?.thresholdPoints).toBe(100);
+  expect(result.current.pointsToNext).toBe(70);
+  // Progress through the 25 -> 100 segment: (30 - 25) / 75.
+  expect(Math.round(result.current.progressPercentage)).toBe(7);
+  expect(result.current.hasRewards).toBe(true);
+  // One tier (25) unlocked, so the visitor is on level 2.
+  expect(result.current.currentLevel).toBe(2);
+});
+
+it('measures from zero when no tier is unlocked yet', () => {
+  setStatus(0);
+  mockUseRewards.mockReturnValue({
+    rewardTiers: [tier('a', 25)],
+    isPending: false,
+  });
+
+  const { result } = renderHook(() => useGivebackContribution(true));
+
+  expect(result.current.nextReward?.thresholdPoints).toBe(25);
+  expect(result.current.pointsToNext).toBe(25);
+  expect(result.current.progressPercentage).toBe(0);
+  // No tier unlocked yet: level 1.
+  expect(result.current.currentLevel).toBe(1);
+});
+
+it('reports completion once every tier is unlocked', () => {
+  setStatus(1000);
+  mockUseRewards.mockReturnValue({
+    rewardTiers: [tier('a', 25), tier('b', 100)],
+    isPending: false,
+  });
+
+  const { result } = renderHook(() => useGivebackContribution(true));
+
+  expect(result.current.nextReward).toBeNull();
+  expect(result.current.progressPercentage).toBe(100);
+  expect(result.current.hasRewards).toBe(true);
+  // Both tiers cleared, so one past the top: level 3.
+  expect(result.current.currentLevel).toBe(3);
+});
+
+it('reports no rewards when none are configured', () => {
+  setStatus(50);
+
+  const { result } = renderHook(() => useGivebackContribution(true));
+
+  expect(result.current.nextReward).toBeNull();
+  expect(result.current.hasRewards).toBe(false);
+});
+
+it('treats null user points as zero earned', () => {
+  setStatus(null);
+  mockUseRewards.mockReturnValue({
+    rewardTiers: [tier('a', 25)],
+    isPending: false,
+  });
+
+  const { result } = renderHook(() => useGivebackContribution(true));
+
+  expect(result.current.earnedPoints).toBe(0);
+  expect(result.current.pointsToNext).toBe(25);
+});
+
+it('propagates pending from either query', () => {
+  setStatus(0, true);
+
+  const { result } = renderHook(() => useGivebackContribution(true));
+
+  expect(result.current.isPending).toBe(true);
+});

--- a/packages/shared/src/features/giveback/hooks/useGivebackContribution.ts
+++ b/packages/shared/src/features/giveback/hooks/useGivebackContribution.ts
@@ -1,0 +1,71 @@
+import { useMemo } from 'react';
+import { useContributionStatus } from './useContributionStatus';
+import { useContributionRewards } from './useContributionRewards';
+import type { ContributionRewardTier } from '../types';
+
+interface GivebackContribution {
+  // Points the visitor has unlocked. Points map 1:1 to currency, so this also
+  // formats directly as the donation amount.
+  earnedPoints: number;
+  // The next reward above the visitor's points, or null once every tier is
+  // unlocked.
+  nextReward: ContributionRewardTier | null;
+  pointsToNext: number;
+  // Progress through the current segment (last unlocked tier -> next), 0-100.
+  progressPercentage: number;
+  // 1-based standing on the reward ladder: how many tiers the visitor has
+  // unlocked, plus one. Level 1 before crossing the first tier.
+  currentLevel: number;
+  // Whether any reward tiers are configured, so the UI can stay silent about
+  // "next reward" until they load (or when none exist).
+  hasRewards: boolean;
+  isPending: boolean;
+}
+
+// Single source of truth for "what have I unlocked, what's next" so the
+// contribution summary and the floating bar can never disagree.
+export const useGivebackContribution = (
+  enabled: boolean,
+): GivebackContribution => {
+  const { status, isPending: isStatusPending } = useContributionStatus();
+  const { rewardTiers, isPending: isRewardsPending } =
+    useContributionRewards(enabled);
+
+  const earnedPoints = status?.userPoints ?? 0;
+
+  return useMemo(() => {
+    const sorted = [...rewardTiers].sort(
+      (a, b) => a.thresholdPoints - b.thresholdPoints,
+    );
+    const unlockedTiers = sorted.filter(
+      (tier) => tier.thresholdPoints <= earnedPoints,
+    );
+    const nextReward =
+      sorted.find((tier) => tier.thresholdPoints > earnedPoints) ?? null;
+    const previousThreshold = unlockedTiers.reduce(
+      (max, tier) => Math.max(max, tier.thresholdPoints),
+      0,
+    );
+
+    const pointsToNext = nextReward
+      ? Math.max(0, nextReward.thresholdPoints - earnedPoints)
+      : 0;
+    const segment = nextReward
+      ? nextReward.thresholdPoints - previousThreshold
+      : 0;
+    const progressPercentage =
+      nextReward && segment > 0
+        ? Math.min(100, ((earnedPoints - previousThreshold) / segment) * 100)
+        : 100;
+
+    return {
+      earnedPoints,
+      nextReward,
+      pointsToNext,
+      progressPercentage,
+      currentLevel: unlockedTiers.length + 1,
+      hasRewards: sorted.length > 0,
+      isPending: isStatusPending || isRewardsPending,
+    };
+  }, [earnedPoints, rewardTiers, isStatusPending, isRewardsPending]);
+};

--- a/packages/shared/src/features/giveback/hooks/useSubmitContributionAction.ts
+++ b/packages/shared/src/features/giveback/hooks/useSubmitContributionAction.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { gqlClient } from '../../../graphql/common';
+import { generateQueryKey, RequestKey } from '../../../lib/query';
+import { SUBMIT_CONTRIBUTION_ACTION_MUTATION } from '../graphql';
+import type { ContributionSubmission } from '../types';
+
+// Proof the contributor attaches to an action. Each field is only sent when the
+// action asks for it; the backend validates which are required.
+export interface ContributionActionEvidenceInput {
+  url?: string;
+  screenshotUrl?: string;
+  note?: string;
+}
+
+interface UseSubmitContributionAction {
+  submit: (input: {
+    actionId: string;
+    evidence: ContributionActionEvidenceInput;
+  }) => Promise<ContributionSubmission>;
+  isPending: boolean;
+}
+
+export const useSubmitContributionAction = (): UseSubmitContributionAction => {
+  const { user } = useAuthContext();
+  const queryClient = useQueryClient();
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: async (input: {
+      actionId: string;
+      evidence: ContributionActionEvidenceInput;
+    }) => {
+      const res = await gqlClient.request<{
+        submitContributionAction: ContributionSubmission;
+      }>(SUBMIT_CONTRIBUTION_ACTION_MUTATION, { input });
+
+      return res.submitContributionAction;
+    },
+    onSuccess: () => {
+      // Refresh the card's own state and the campaign totals the submission
+      // moved.
+      queryClient.invalidateQueries({
+        queryKey: generateQueryKey(RequestKey.ContributionActions, user),
+      });
+      queryClient.invalidateQueries({
+        queryKey: generateQueryKey(RequestKey.ContributionOverview, user),
+      });
+    },
+  });
+
+  return { submit: mutateAsync, isPending };
+};

--- a/packages/shared/src/features/giveback/types.ts
+++ b/packages/shared/src/features/giveback/types.ts
@@ -44,3 +44,72 @@ export interface ContributionCause {
   category: string | null;
   logoUrl: string | null;
 }
+
+// Filter bucket for the action catalog (e.g. "Social media", "Reviews").
+export interface ContributionActionCategory {
+  id: string;
+  title: string;
+}
+
+// A milestone reward unlocked once a contributor's points cross its threshold.
+// Drives the "next reward" cue in the contribution summary and floating bar.
+export interface ContributionRewardTier {
+  id: string;
+  title: string;
+  thresholdPoints: number;
+}
+
+// Review outcome for a submitted action. A fresh submission lands `flagged`
+// (awaiting review); `approved` counts toward the cause; `rejected` lets the
+// contributor try again.
+export enum ContributionSubmissionStatus {
+  Approved = 'approved',
+  Flagged = 'flagged',
+  Rejected = 'rejected',
+}
+
+export interface ContributionSubmission {
+  id: string;
+  actionId: string;
+  status: ContributionSubmissionStatus;
+  awardedPoints: number;
+  createdAt: string;
+  reviewedAt: string | null;
+}
+
+// What the action reads as on the catalog (which surface it lives on) plus the
+// optional how-to and outbound link. `isLoveAction` marks a voluntary
+// thank-you that carries no points and skips the proof flow.
+export interface ContributionActionMetadata {
+  platform: string | null;
+  instructions: string | null;
+  externalUrl: string | null;
+  isLoveAction: boolean;
+}
+
+// Which kinds of proof an action asks for, and whether each is mandatory. Drives
+// the submission form: a field is only rendered when its key is present.
+export interface ContributionActionEvidence {
+  url?: { required?: boolean; allowedDomains?: string[] };
+  screenshot?: { required?: boolean };
+  note?: { required?: boolean };
+}
+
+// A single growth move a contributor can take to unlock points for their causes.
+// `points` map 1:1 to currency, like the campaign totals. Per-user fields
+// (completions, cooldown, latest submission) are null/zero for anonymous
+// visitors and drive the card's done/in-review state.
+export interface ContributionAction {
+  id: string;
+  categoryId: string | null;
+  title: string;
+  description: string | null;
+  points: number;
+  evidence: ContributionActionEvidence;
+  metadata: ContributionActionMetadata;
+  cooldownSeconds: number | null;
+  maxPerUser: number | null;
+  userCooldownEndsAt: string | null;
+  userCompletions: number;
+  latestUserSubmission: ContributionSubmission | null;
+}

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -495,6 +495,15 @@ export enum LogEvent {
   // Giveback
   ClickJoinGiveback = 'click join giveback',
   ClickGivebackSponsor = 'click giveback sponsor',
+  SaveGivebackCauses = 'save giveback causes',
+  ClickGivebackTab = 'click giveback tab',
+  ClickGivebackTakeAction = 'click giveback take action',
+  FilterGivebackActions = 'filter giveback actions',
+  ClickGivebackShowMoreActions = 'click giveback show more actions',
+  OpenGivebackAction = 'open giveback action',
+  SubmitGivebackAction = 'submit giveback action',
+  SubmitGivebackActionError = 'submit giveback action error',
+  ClickGivebackLoveAction = 'click giveback love action',
 }
 
 export enum TargetType {

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -276,6 +276,8 @@ export enum RequestKey {
   LiveRooms = 'live_rooms',
   ContributionOverview = 'contribution_overview',
   ContributionCausePicker = 'contribution_cause_picker',
+  ContributionActions = 'contribution_actions',
+  ContributionRewards = 'contribution_rewards',
 }
 
 export const getPostByIdKey = (id: string): QueryKey => [RequestKey.Post, id];

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -277,7 +277,6 @@ export enum RequestKey {
   ContributionOverview = 'contribution_overview',
   ContributionCausePicker = 'contribution_cause_picker',
   ContributionActions = 'contribution_actions',
-  ContributionRewards = 'contribution_rewards',
 }
 
 export const getPostByIdKey = (id: string): QueryKey => [RequestKey.Post, id];

--- a/packages/storybook/stories/features/giveback/GivebackActionCard.stories.tsx
+++ b/packages/storybook/stories/features/giveback/GivebackActionCard.stories.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { GivebackActionCard } from '@dailydotdev/shared/src/features/giveback/components/GivebackActionCard';
+import type { ContributionAction } from '@dailydotdev/shared/src/features/giveback/types';
+import { ContributionSubmissionStatus } from '@dailydotdev/shared/src/features/giveback/types';
+
+const makeAction = (
+  overrides: Partial<ContributionAction> = {},
+): ContributionAction => ({
+  id: 'a1',
+  categoryId: 'cat1',
+  title: 'Post about daily.dev on X',
+  description: null,
+  points: 25,
+  evidence: { url: { required: true } },
+  metadata: {
+    platform: 'x',
+    instructions: null,
+    externalUrl: null,
+    isLoveAction: false,
+  },
+  cooldownSeconds: null,
+  maxPerUser: null,
+  userCooldownEndsAt: null,
+  userCompletions: 0,
+  latestUserSubmission: null,
+  ...overrides,
+});
+
+const inThreeHours = new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString();
+
+const states: { label: string; action: ContributionAction }[] = [
+  { label: 'Actionable', action: makeAction() },
+  {
+    label: 'With description',
+    action: makeAction({
+      title: 'Write a blog post',
+      points: 100,
+      description: 'Publish an article mentioning daily.dev.',
+      metadata: {
+        platform: 'blog',
+        instructions: null,
+        externalUrl: null,
+        isLoveAction: false,
+      },
+    }),
+  },
+  {
+    label: 'Repeatable (runs left)',
+    action: makeAction({
+      title: 'Refer a friend',
+      points: 40,
+      maxPerUser: 3,
+      userCompletions: 1,
+      metadata: {
+        platform: 'daily_dev',
+        instructions: null,
+        externalUrl: null,
+        isLoveAction: false,
+      },
+    }),
+  },
+  {
+    label: 'Cooldown',
+    action: makeAction({
+      title: 'Share on LinkedIn',
+      points: 30,
+      maxPerUser: 3,
+      userCompletions: 1,
+      userCooldownEndsAt: inThreeHours,
+      metadata: {
+        platform: 'linkedin',
+        instructions: null,
+        externalUrl: null,
+        isLoveAction: false,
+      },
+    }),
+  },
+  {
+    label: 'In review',
+    action: makeAction({
+      title: 'Leave a G2 review',
+      points: 70,
+      metadata: {
+        platform: 'g2',
+        instructions: null,
+        externalUrl: null,
+        isLoveAction: false,
+      },
+      latestUserSubmission: {
+        id: 's1',
+        actionId: 'a1',
+        status: ContributionSubmissionStatus.Flagged,
+        awardedPoints: 0,
+        createdAt: '2026-01-01',
+        reviewedAt: null,
+      },
+    }),
+  },
+  {
+    label: 'Done (approved)',
+    action: makeAction({
+      title: 'Star our GitHub repo',
+      points: 15,
+      metadata: {
+        platform: 'github',
+        instructions: null,
+        externalUrl: null,
+        isLoveAction: false,
+      },
+      latestUserSubmission: {
+        id: 's2',
+        actionId: 'a1',
+        status: ContributionSubmissionStatus.Approved,
+        awardedPoints: 15,
+        createdAt: '2026-01-01',
+        reviewedAt: '2026-01-02',
+      },
+    }),
+  },
+  {
+    label: 'Done (cap reached)',
+    action: makeAction({
+      title: 'Review the Edge add-on',
+      points: 50,
+      maxPerUser: 1,
+      userCompletions: 1,
+      metadata: {
+        platform: 'edge_addons',
+        instructions: null,
+        externalUrl: null,
+        isLoveAction: false,
+      },
+    }),
+  },
+  {
+    label: 'Just for love',
+    action: makeAction({
+      title: 'Follow daily.dev on X',
+      points: 0,
+      evidence: {},
+      metadata: {
+        platform: 'x',
+        instructions: null,
+        externalUrl: null,
+        isLoveAction: true,
+      },
+    }),
+  },
+];
+
+const meta: Meta<typeof GivebackActionCard> = {
+  title: 'Features/Giveback/ActionCard',
+  component: GivebackActionCard,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GivebackActionCard>;
+
+// Every card state side by side: actionable, repeatable, cooldown, in-review,
+// done (approved / cap reached) and just-for-love.
+export const AllStates: Story = {
+  render: () => (
+    <div className="min-h-screen bg-background-default p-6">
+      <div className="grid max-w-5xl gap-4 tablet:grid-cols-2 laptop:grid-cols-3">
+        {states.map(({ label, action }) => (
+          <div key={label} className="flex flex-col gap-2">
+            <span className="font-bold uppercase tracking-wider text-text-tertiary typo-caption2">
+              {label}
+            </span>
+            <GivebackActionCard action={action} onSubmit={() => undefined} />
+          </div>
+        ))}
+      </div>
+    </div>
+  ),
+};


### PR DESCRIPTION
Builds the **Take Action** tab content on top of the merged tab navigation, wired to the existing daily-api contribution API. No API changes.

## What's in it
- **Action catalog** — category filter chips, per-card done/in-review/actionable status (from `latestUserSubmission` + `maxPerUser`), show-more, and a separate "Just for love" group. Real brand logos per platform.
- **Proof submission modal** — evidence form driven by each action's schema (`url` / `screenshot` / `note`, required where the action says so), real screenshot upload, submit + success state. Closes on backdrop click / Escape.
- **Contribution summary** — avatar + level (derived from reward tiers), amount unlocked, actions taken, and the next reward.
- **Floating funding bar** — progress to next reward + a Take action CTA, shown across the onboarded tabs.

## Notes
- No community/activity surface (leaderboards, live counts, social proof) — the campaign starts from scratch, and the API exposes none of it.
- Reuses shared primitives: `ProgressCircle`, `ProfilePicture`, `TabList`, `useFileInput`/`uploadContentImage`.
- Data via existing queries: `contributionActions`, `contributionActionCategories`, `contributionRewardTiers`, `submitContributionAction`.

## Tests
51 specs pass (catalog filtering/show-more/love/empty/modal, card status states, contribution derivation). Lint, strict typecheck, and full webapp `tsc` clean.

### Preview domain
https://feat-giveback-action-catalog.preview.app.daily.dev