### PR TITLE
feat(giveback): campaign tab (story, your causes, FAQ)

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackBudgetStory.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackBudgetStory.tsx
@@ -1,0 +1,52 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { FlexCol, FlexRow } from '../../../components/utilities';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { useContributionStatus } from '../hooks/useContributionStatus';
+import { formatDonationAmount } from '../utils';
+import { GivebackSection } from './GivebackSection';
+import { GivebackHeadline } from './GivebackHeadline';
+import { GivebackMascot } from './GivebackMascot';
+
+interface GivebackBudgetStoryProps {
+  headline: { title: string; highlight: string };
+}
+
+// "Why we do it" — kept short and emotional. The headline + reason stack in a
+// left column with the charm beside both as the "genie" who grants the
+// community's wishes, so the row stays tight with no empty space top/bottom.
+export const GivebackBudgetStory = ({
+  headline,
+}: GivebackBudgetStoryProps): ReactElement => {
+  const { status } = useContributionStatus();
+  const goal = status?.currentCycleTargetPoints ?? 0;
+
+  return (
+    <GivebackSection id="giveback-why">
+      <FlexRow className="flex-col-reverse items-center gap-6 tablet:flex-row tablet:items-start tablet:gap-10">
+        <FlexCol className="gap-4 tablet:flex-1">
+          <GivebackHeadline {...headline} />
+          <Typography
+            tag={TypographyTag.P}
+            type={TypographyType.Title3}
+            color={TypographyColor.Secondary}
+            className="max-w-md"
+          >
+            {goal > 0
+              ? `${formatDonationAmount(goal)} goes`
+              : 'Every dollar goes'}{' '}
+            straight to the causes you pick: scholarships, open source, and
+            access to tech. We could have spent it on ads. We would rather let
+            the community decide what its work is worth.
+          </Typography>
+        </FlexCol>
+        <GivebackMascot className="shrink-0 tablet:ml-auto tablet:items-end" />
+      </FlexRow>
+    </GivebackSection>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackCampaignPanel.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackCampaignPanel.spec.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { GivebackCampaignPanel } from './GivebackCampaignPanel';
+import { useContributionStatus } from '../hooks/useContributionStatus';
+import { useContributionCausePicker } from '../hooks/useContributionCausePicker';
+import type { ContributionCause } from '../types';
+
+jest.mock('../hooks/useContributionStatus');
+jest.mock('../hooks/useContributionCausePicker');
+jest.mock('./GivebackEditCausesModal', () => ({
+  GivebackEditCausesModal: (): JSX.Element => (
+    <div role="dialog">Edit your causes</div>
+  ),
+}));
+
+const mockStatus = useContributionStatus as jest.MockedFunction<
+  typeof useContributionStatus
+>;
+const mockPicker = useContributionCausePicker as jest.MockedFunction<
+  typeof useContributionCausePicker
+>;
+
+const cause = (id: string, title: string): ContributionCause => ({
+  id,
+  title,
+  url: 'https://example.com',
+  description: null,
+  category: 'Open source',
+  logoUrl: null,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockStatus.mockReturnValue({
+    status: {
+      enabled: true,
+      eligible: true,
+      currentCyclePoints: 0,
+      currentCycleTargetPoints: 50000,
+      lifetimePoints: 0,
+      lifetimeAmountCents: 0,
+      contributorsCount: 0,
+      userPoints: 0,
+    },
+    isPending: false,
+  });
+  mockPicker.mockReturnValue({
+    causes: [cause('c1', 'Open Source Fund'), cause('c2', 'Code Scholarships')],
+    selectedCauseIds: ['c1'],
+    isPending: false,
+  });
+});
+
+it('renders the campaign headline and reason', () => {
+  render(<GivebackCampaignPanel />);
+
+  expect(screen.getByText('Big tech buys ads.')).toBeInTheDocument();
+  expect(screen.getByText('We fund developers.')).toBeInTheDocument();
+  expect(screen.getByText(/\$50,000 goes/)).toBeInTheDocument();
+});
+
+it('lists only the picked causes', () => {
+  render(<GivebackCampaignPanel />);
+
+  expect(screen.getByText('Open Source Fund')).toBeInTheDocument();
+  expect(screen.queryByText('Code Scholarships')).not.toBeInTheDocument();
+});
+
+it('opens the edit modal from the causes section', () => {
+  render(<GivebackCampaignPanel />);
+
+  fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  expect(screen.getByText('Edit your causes')).toBeInTheDocument();
+});
+
+it('expands an FAQ answer on click', () => {
+  render(<GivebackCampaignPanel />);
+
+  expect(screen.getByText('Frequently asked questions')).toBeInTheDocument();
+  const question = screen.getByRole('button', {
+    name: 'Who chooses the causes?',
+  });
+  expect(question).toHaveAttribute('aria-expanded', 'false');
+
+  fireEvent.click(question);
+
+  expect(question).toHaveAttribute('aria-expanded', 'true');
+});
+
+it('prompts to pick causes when none are selected', () => {
+  mockPicker.mockReturnValue({
+    causes: [cause('c1', 'Open Source Fund')],
+    selectedCauseIds: [],
+    isPending: false,
+  });
+  render(<GivebackCampaignPanel />);
+
+  expect(
+    screen.getByRole('button', { name: 'Pick your causes' }),
+  ).toBeInTheDocument();
+});

--- a/packages/shared/src/features/giveback/components/GivebackCampaignPanel.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackCampaignPanel.spec.tsx
@@ -3,10 +3,13 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { GivebackCampaignPanel } from './GivebackCampaignPanel';
 import { useContributionStatus } from '../hooks/useContributionStatus';
 import { useContributionCausePicker } from '../hooks/useContributionCausePicker';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
 import type { ContributionCause } from '../types';
 
 jest.mock('../hooks/useContributionStatus');
 jest.mock('../hooks/useContributionCausePicker');
+jest.mock('../../../contexts/LogContext');
 jest.mock('./GivebackEditCausesModal', () => ({
   GivebackEditCausesModal: (): JSX.Element => (
     <div role="dialog">Edit your causes</div>
@@ -19,6 +22,8 @@ const mockStatus = useContributionStatus as jest.MockedFunction<
 const mockPicker = useContributionCausePicker as jest.MockedFunction<
   typeof useContributionCausePicker
 >;
+const mockLog = useLogContext as jest.MockedFunction<typeof useLogContext>;
+const logEvent = jest.fn();
 
 const cause = (id: string, title: string): ContributionCause => ({
   id,
@@ -31,6 +36,9 @@ const cause = (id: string, title: string): ContributionCause => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockLog.mockReturnValue({ logEvent } as unknown as ReturnType<
+    typeof useLogContext
+  >);
   mockStatus.mockReturnValue({
     status: {
       enabled: true,
@@ -66,13 +74,17 @@ it('lists only the picked causes', () => {
   expect(screen.queryByText('Code Scholarships')).not.toBeInTheDocument();
 });
 
-it('opens the edit modal from the causes section', () => {
+it('opens the edit modal and logs it', () => {
   render(<GivebackCampaignPanel />);
 
   fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
 
   expect(screen.getByRole('dialog')).toBeInTheDocument();
   expect(screen.getByText('Edit your causes')).toBeInTheDocument();
+  expect(logEvent).toHaveBeenCalledWith({
+    event_name: LogEvent.ClickGivebackEditCauses,
+    extra: JSON.stringify({ has_causes: true }),
+  });
 });
 
 it('expands an FAQ answer on click', () => {
@@ -87,6 +99,10 @@ it('expands an FAQ answer on click', () => {
   fireEvent.click(question);
 
   expect(question).toHaveAttribute('aria-expanded', 'true');
+  expect(logEvent).toHaveBeenCalledWith({
+    event_name: LogEvent.ClickGivebackFaq,
+    target_id: 'causes',
+  });
 });
 
 it('prompts to pick causes when none are selected', () => {

--- a/packages/shared/src/features/giveback/components/GivebackCampaignPanel.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackCampaignPanel.tsx
@@ -1,0 +1,22 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { FlexCol } from '../../../components/utilities';
+import { GivebackBudgetStory } from './GivebackBudgetStory';
+import { GivebackSelectedCauses } from './GivebackSelectedCauses';
+import { GivebackFaq } from './GivebackFaq';
+
+// The Campaign tab ("why"): the short emotional reason for the campaign with the
+// charm, the visitor's picked causes (editable), and the FAQ. The big two-part
+// headline rides inside the story so it sits beside the charm.
+const headline = {
+  title: 'Big tech buys ads.',
+  highlight: 'We fund developers.',
+};
+
+export const GivebackCampaignPanel = (): ReactElement => (
+  <FlexCol className="gap-8">
+    <GivebackBudgetStory headline={headline} />
+    <GivebackSelectedCauses />
+    <GivebackFaq />
+  </FlexCol>
+);

--- a/packages/shared/src/features/giveback/components/GivebackEditCausesModal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackEditCausesModal.tsx
@@ -1,0 +1,130 @@
+import type { ReactElement } from 'react';
+import React, { useEffect } from 'react';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../components/buttons/Button';
+import {
+  Typography,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { FlexCol, FlexRow } from '../../../components/utilities';
+import { RootPortal } from '../../../components/tooltips/Portal';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
+import { useGivebackCauseSelection } from '../hooks/useGivebackCauseSelection';
+import { GivebackCauseSelection } from './GivebackCauseSelection';
+
+interface GivebackEditCausesModalProps {
+  onClose: () => void;
+}
+
+// Edits the visitor's cause preferences in place, reusing the onboarding picker
+// grid and its save hook. Seeds from the saved selection, so opening it shows
+// the current picks ready to toggle.
+export const GivebackEditCausesModal = ({
+  onClose,
+}: GivebackEditCausesModalProps): ReactElement => {
+  const { logEvent } = useLogContext();
+  const {
+    causes,
+    isLoading,
+    selectedIds,
+    toggleCause,
+    selectedCount,
+    save,
+    isSaving,
+  } = useGivebackCauseSelection(true);
+
+  // Close on Escape, matching the backdrop click below.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  const onSave = async () => {
+    const saved = await save();
+    if (!saved) {
+      return;
+    }
+    logEvent({
+      event_name: LogEvent.SaveGivebackCauses,
+      extra: JSON.stringify({
+        cause_count: selectedIds.size,
+        cause_ids: [...selectedIds],
+      }),
+    });
+    onClose();
+  };
+
+  return (
+    <RootPortal>
+      <div className="fixed inset-0 z-modal flex items-center justify-center bg-overlay-primary-pepper px-4 backdrop-blur-sm">
+        <button
+          type="button"
+          aria-label="Close"
+          tabIndex={-1}
+          className="absolute inset-0 cursor-default"
+          onClick={onClose}
+        />
+        <section
+          aria-modal="true"
+          role="dialog"
+          aria-labelledby="giveback-edit-causes-title"
+          className="relative z-1 flex max-h-[calc(100vh-2rem)] w-full max-w-[42rem] flex-col overflow-hidden rounded-24 border border-border-subtlest-secondary bg-background-default shadow-2"
+        >
+          <FlexCol className="gap-1 border-b border-border-subtlest-tertiary p-5 tablet:p-6">
+            <Typography
+              id="giveback-edit-causes-title"
+              tag={TypographyTag.H2}
+              type={TypographyType.Title2}
+              bold
+            >
+              Edit your causes
+            </Typography>
+            <Typography type={TypographyType.Callout} bold={false}>
+              Choose where your actions send the money.
+            </Typography>
+          </FlexCol>
+
+          <div className="overflow-y-auto p-5 tablet:p-6">
+            <GivebackCauseSelection
+              causes={causes}
+              isLoading={isLoading}
+              selectedIds={selectedIds}
+              onToggle={toggleCause}
+            />
+          </div>
+
+          <FlexRow className="items-center justify-end gap-3 border-t border-border-subtlest-tertiary p-5 tablet:p-6">
+            <Button
+              type="button"
+              size={ButtonSize.Medium}
+              variant={ButtonVariant.Float}
+              onClick={onClose}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size={ButtonSize.Medium}
+              variant={ButtonVariant.Primary}
+              onClick={onSave}
+              loading={isSaving}
+              disabled={selectedCount === 0}
+            >
+              Save causes
+            </Button>
+          </FlexRow>
+        </section>
+      </div>
+    </RootPortal>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackEditCausesModal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackEditCausesModal.tsx
@@ -94,7 +94,7 @@ export const GivebackEditCausesModal = ({
             </Typography>
           </FlexCol>
 
-          <div className="overflow-y-auto p-5 tablet:p-6">
+          <div className="min-h-0 flex-1 overflow-y-auto p-5 tablet:p-6">
             <GivebackCauseSelection
               causes={causes}
               isLoading={isLoading}

--- a/packages/shared/src/features/giveback/components/GivebackFaq.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackFaq.tsx
@@ -1,0 +1,126 @@
+import type { ReactElement } from 'react';
+import React, { useState } from 'react';
+import classNames from 'classnames';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { ArrowIcon } from '../../../components/icons';
+import { IconSize } from '../../../components/Icon';
+import { GivebackSection } from './GivebackSection';
+
+interface FaqItem {
+  id: string;
+  question: string;
+  answer: string;
+}
+
+const faqs: FaqItem[] = [
+  {
+    id: 'cost',
+    question: 'Does this cost me anything?',
+    answer:
+      'No. daily.dev funds every donation. You never pay a cent. You just take small actions and we turn them into money for good causes.',
+  },
+  {
+    id: 'how',
+    question: 'How do my actions turn into donations?',
+    answer:
+      'Each approved action unlocks a fixed amount that daily.dev donates to the causes you picked. The community meter is the sum of everyone’s actions.',
+  },
+  {
+    id: 'causes',
+    question: 'Who chooses the causes?',
+    answer:
+      'You do. Pick from vetted nonprofits, or suggest your own. We review every suggestion before it goes live.',
+  },
+  {
+    id: 'rejected',
+    question: 'What if one of my actions gets rejected?',
+    answer:
+      'We add it to your contribution the moment you submit, because we trust you. If validation fails, we simply subtract it. No penalties, ever.',
+  },
+  {
+    id: 'where',
+    question: 'Where does the money actually go?',
+    answer:
+      'Straight to vetted nonprofits. We report receipts so every dollar the community unlocks is accounted for.',
+  },
+  {
+    id: 'why',
+    question: 'Why is daily.dev doing this?',
+    answer:
+      'We’d rather put our growth budget into causes the community cares about than burn it in ad auctions.',
+  },
+  {
+    id: 'geo',
+    question: 'Is Giveback available in my country?',
+    answer:
+      'We’re rolling it out gradually. If it isn’t live where you are yet, you’ll see a notice, and we’re working to reach everyone.',
+  },
+];
+
+export const GivebackFaq = (): ReactElement => {
+  const [openId, setOpenId] = useState<string | null>(faqs[0].id);
+
+  return (
+    <GivebackSection id="giveback-faq" title="Frequently asked questions">
+      <div className="divide-y divide-border-subtlest-tertiary">
+        {faqs.map((faq) => {
+          const isOpen = openId === faq.id;
+
+          return (
+            <div key={faq.id}>
+              <button
+                type="button"
+                aria-expanded={isOpen}
+                onClick={() => setOpenId(isOpen ? null : faq.id)}
+                className="group flex w-full items-center justify-between gap-4 py-4 text-left"
+              >
+                <Typography
+                  tag={TypographyTag.Span}
+                  bold
+                  type={TypographyType.Callout}
+                  className={classNames(
+                    'transition-colors',
+                    !isOpen && 'group-hover:text-text-secondary',
+                  )}
+                >
+                  {faq.question}
+                </Typography>
+                <ArrowIcon
+                  size={IconSize.Small}
+                  className={classNames(
+                    'shrink-0 transition-transform duration-300 ease-out',
+                    isOpen
+                      ? 'rotate-0 text-accent-cabbage-default'
+                      : 'rotate-180 text-text-tertiary group-hover:text-text-primary',
+                  )}
+                />
+              </button>
+              <div
+                className={classNames(
+                  'grid transition-[grid-template-rows] duration-300 ease-out motion-reduce:transition-none',
+                  isOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]',
+                )}
+              >
+                <div className="overflow-hidden">
+                  <Typography
+                    tag={TypographyTag.P}
+                    type={TypographyType.Callout}
+                    color={TypographyColor.Secondary}
+                    className="max-w-2xl pb-4"
+                  >
+                    {faq.answer}
+                  </Typography>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </GivebackSection>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackFaq.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackFaq.tsx
@@ -9,6 +9,8 @@ import {
 } from '../../../components/typography/Typography';
 import { ArrowIcon } from '../../../components/icons';
 import { IconSize } from '../../../components/Icon';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
 import { GivebackSection } from './GivebackSection';
 
 interface FaqItem {
@@ -63,7 +65,15 @@ const faqs: FaqItem[] = [
 ];
 
 export const GivebackFaq = (): ReactElement => {
+  const { logEvent } = useLogContext();
   const [openId, setOpenId] = useState<string | null>(faqs[0].id);
+
+  const toggle = (id: string, isOpen: boolean) => {
+    if (!isOpen) {
+      logEvent({ event_name: LogEvent.ClickGivebackFaq, target_id: id });
+    }
+    setOpenId(isOpen ? null : id);
+  };
 
   return (
     <GivebackSection id="giveback-faq" title="Frequently asked questions">
@@ -76,7 +86,7 @@ export const GivebackFaq = (): ReactElement => {
               <button
                 type="button"
                 aria-expanded={isOpen}
-                onClick={() => setOpenId(isOpen ? null : faq.id)}
+                onClick={() => toggle(faq.id, isOpen)}
                 className="group flex w-full items-center justify-between gap-4 py-4 text-left"
               >
                 <Typography

--- a/packages/shared/src/features/giveback/components/GivebackHeadline.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackHeadline.tsx
@@ -1,0 +1,34 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import {
+  Typography,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+
+interface GivebackHeadlineProps {
+  title: string;
+  highlight: string;
+  className?: string;
+}
+
+// One big two-part headline per tab: a white line plus a gradient payoff,
+// matching the hero. Sections beneath only carry small plain sub-titles.
+export const GivebackHeadline = ({
+  title,
+  highlight,
+  className,
+}: GivebackHeadlineProps): ReactElement => (
+  <Typography
+    tag={TypographyTag.H2}
+    type={TypographyType.LargeTitle}
+    bold
+    className={classNames('max-w-3xl', className)}
+  >
+    {title}
+    <span className="block bg-gradient-to-r from-accent-avocado-default via-accent-cabbage-default to-accent-cheese-default bg-clip-text text-transparent">
+      {highlight}
+    </span>
+  </Typography>
+);

--- a/packages/shared/src/features/giveback/components/GivebackImpactPanel.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackImpactPanel.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { GivebackImpactPanel } from './GivebackImpactPanel';
 import { useContributionStatus } from '../hooks/useContributionStatus';
 import { useContributionSponsors } from '../hooks/useContributionSponsors';
@@ -7,6 +7,8 @@ import { useGivebackContribution } from '../hooks/useGivebackContribution';
 import { useContributionRewards } from '../hooks/useContributionRewards';
 import { useContributionUserRewards } from '../hooks/useContributionUserRewards';
 import { useClaimContributionReward } from '../hooks/useClaimContributionReward';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
 import { ContributionRewardType, type ContributionRewardTier } from '../types';
 
 jest.mock('../hooks/useContributionStatus');
@@ -15,6 +17,7 @@ jest.mock('../hooks/useGivebackContribution');
 jest.mock('../hooks/useContributionRewards');
 jest.mock('../hooks/useContributionUserRewards');
 jest.mock('../hooks/useClaimContributionReward');
+jest.mock('../../../contexts/LogContext');
 
 // Resolve the reveal/count-up animations synchronously so assertions read final
 // values, not mid-animation frames.
@@ -41,6 +44,8 @@ const mockUserRewards = useContributionUserRewards as jest.MockedFunction<
 const mockClaim = useClaimContributionReward as jest.MockedFunction<
   typeof useClaimContributionReward
 >;
+const mockLog = useLogContext as jest.MockedFunction<typeof useLogContext>;
+const logEvent = jest.fn();
 
 const tiers: ContributionRewardTier[] = [
   {
@@ -93,7 +98,13 @@ beforeEach(() => {
   });
   mockRewards.mockReturnValue({ rewardTiers: tiers, isPending: false });
   mockUserRewards.mockReturnValue({ claimedRewardIds: [], isPending: false });
-  mockClaim.mockReturnValue({ claim: jest.fn(), isPending: false });
+  mockClaim.mockReturnValue({
+    claim: jest.fn().mockResolvedValue(undefined),
+    isPending: false,
+  });
+  mockLog.mockReturnValue({ logEvent } as unknown as ReturnType<
+    typeof useLogContext
+  >);
 });
 
 it('renders the funding progress section with live totals', () => {
@@ -116,12 +127,26 @@ it('renders the reward-ladder journey with the current level', () => {
   expect(screen.getByText('$60 to go')).toBeInTheDocument();
 });
 
-it('offers a claim for an unlocked, unclaimed tier', () => {
+it('offers a claim for an unlocked, unclaimed tier and logs it', async () => {
   render(<GivebackImpactPanel onTakeAction={jest.fn()} />);
 
   // The $25 tier is reached at $40 and not yet claimed.
-  expect(screen.getByRole('button', { name: 'Claim' })).toBeInTheDocument();
+  const claimButton = screen.getByRole('button', { name: 'Claim' });
+  expect(claimButton).toBeInTheDocument();
   expect(screen.getByText(/ready to claim/)).toBeInTheDocument();
+
+  await act(async () => {
+    fireEvent.click(claimButton);
+  });
+
+  expect(logEvent).toHaveBeenCalledWith({
+    event_name: LogEvent.ClaimGivebackReward,
+    target_id: 't1',
+    extra: JSON.stringify({
+      reward_type: ContributionRewardType.Custom,
+      threshold: 25,
+    }),
+  });
 });
 
 it('shows an empty journey when no reward tiers exist', () => {

--- a/packages/shared/src/features/giveback/components/GivebackMascot.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackMascot.tsx
@@ -1,0 +1,46 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+
+// The daily.dev charm, themed as a "wish-granting genie" for Giveback: you make
+// a wish (pick a cause / take an action) and daily.dev grants it.
+export const GIVEBACK_CHARM_IMAGE = {
+  src: 'https://media.daily.dev/image/upload/s--d1dldAty--/f_auto,q_auto/v1780848838/public/daily.dev%20Charm%20-%20Giveback%20(1)',
+  alt: 'daily.dev charm celebrating community impact for the Giveback campaign',
+};
+
+interface GivebackMascotProps {
+  className?: string;
+  imageClassName?: string;
+}
+
+export const GivebackMascot = ({
+  className,
+  imageClassName,
+}: GivebackMascotProps): ReactElement => (
+  <div
+    className={classNames(
+      'pointer-events-none relative flex flex-col items-center gap-3',
+      className,
+    )}
+  >
+    <div className="relative flex items-center justify-center">
+      {/* Magic "lamp smoke" glow behind the charm. */}
+      <span
+        aria-hidden
+        className="bg-accent-cabbage-default/20 absolute inset-0 m-auto size-3/4 rounded-full blur-3xl motion-safe:animate-glow-pulse"
+      />
+      {/* The render sits on solid black; `mix-blend-screen` drops the black so
+          the charm reads as floating on the dark page. */}
+      <img
+        src={GIVEBACK_CHARM_IMAGE.src}
+        alt={GIVEBACK_CHARM_IMAGE.alt}
+        loading="lazy"
+        className={classNames(
+          'relative h-44 w-auto select-none object-contain mix-blend-screen motion-safe:animate-mascot-bob tablet:h-56',
+          imageClassName,
+        )}
+      />
+    </div>
+  </div>
+);

--- a/packages/shared/src/features/giveback/components/GivebackPage.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackPage.tsx
@@ -17,6 +17,7 @@ import { GivebackTabNav, givebackTabs } from './GivebackTabNav';
 import { GivebackActionCatalog } from './GivebackActionCatalog';
 import { GivebackContributionSummary } from './GivebackContributionSummary';
 import { GivebackImpactPanel } from './GivebackImpactPanel';
+import { GivebackCampaignPanel } from './GivebackCampaignPanel';
 import { GivebackFundingBar } from './GivebackFundingBar';
 import type { GivebackTabId } from './GivebackTabNav';
 import { useLogContext } from '../../../contexts/LogContext';
@@ -177,23 +178,7 @@ export const GivebackPage = (): ReactElement => {
               {activeTab === 'impact' && (
                 <GivebackImpactPanel onTakeAction={goToActions} />
               )}
-              {activeTab === 'why' && (
-                <FlexCol className="min-h-[40vh] items-center justify-center gap-2 rounded-16 border border-dashed border-border-subtlest-tertiary p-10 text-center">
-                  <Typography
-                    tag={TypographyTag.H2}
-                    type={TypographyType.Title3}
-                    bold
-                  >
-                    {activeLabel}
-                  </Typography>
-                  <Typography
-                    type={TypographyType.Callout}
-                    color={TypographyColor.Tertiary}
-                  >
-                    Coming soon
-                  </Typography>
-                </FlexCol>
-              )}
+              {activeTab === 'why' && <GivebackCampaignPanel />}
             </div>
           </div>
         )}

--- a/packages/shared/src/features/giveback/components/GivebackPersonalRoadmap.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackPersonalRoadmap.tsx
@@ -24,6 +24,8 @@ import {
   VIcon,
 } from '../../../components/icons';
 import ConfettiSvg from '../../../svg/ConfettiSvg';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
 import { useGivebackContribution } from '../hooks/useGivebackContribution';
 import { useContributionRewards } from '../hooks/useContributionRewards';
 import { useContributionUserRewards } from '../hooks/useContributionUserRewards';
@@ -374,6 +376,7 @@ interface GivebackPersonalRoadmapProps {
 export const GivebackPersonalRoadmap = ({
   onTakeAction,
 }: GivebackPersonalRoadmapProps): ReactElement => {
+  const { logEvent } = useLogContext();
   const { earnedPoints, currentLevel, isPending } =
     useGivebackContribution(true);
   const { rewardTiers } = useContributionRewards(true);
@@ -481,12 +484,29 @@ export const GivebackPersonalRoadmap = ({
   };
 
   const onClaim = async (tierId: string) => {
+    const level = levels.find((item) => item.id === tierId);
+    logEvent({
+      event_name: LogEvent.ClaimGivebackReward,
+      target_id: tierId,
+      extra: JSON.stringify({
+        reward_type: level?.reward.type,
+        threshold: level?.requiredApprovedAmount,
+      }),
+    });
     setClaimingId(tierId);
     try {
       await claim(tierId);
     } finally {
       setClaimingId(null);
     }
+  };
+
+  const handleTakeAction = () => {
+    logEvent({
+      event_name: LogEvent.ClickGivebackTakeAction,
+      extra: JSON.stringify({ origin: 'roadmap' }),
+    });
+    onTakeAction();
   };
 
   // Window: current level + the next few. "Show more" extends it; "Show
@@ -615,7 +635,7 @@ export const GivebackPersonalRoadmap = ({
               segmentProgress={segmentProgress}
               isClaiming={isClaiming && claimingId === node.level.id}
               onClaim={onClaim}
-              onTakeAction={onTakeAction}
+              onTakeAction={handleTakeAction}
             />
           ))}
 

--- a/packages/shared/src/features/giveback/components/GivebackSection.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSection.tsx
@@ -1,0 +1,60 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import { FlexCol } from '../../../components/utilities';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+
+interface GivebackSectionProps {
+  id?: string;
+  // Optional plain sub-heading. The big gradient tab headline lives separately.
+  title?: string;
+  description?: ReactNode;
+  className?: string;
+  children: ReactNode;
+}
+
+// Open, editorial section shell for the onboarded tabs: sections are separated
+// by spacing alone, each carrying a small plain header.
+export const GivebackSection = ({
+  id,
+  title,
+  description,
+  className,
+  children,
+}: GivebackSectionProps): ReactElement => (
+  <section
+    id={id}
+    className={classNames('relative w-full scroll-mt-16', className)}
+  >
+    <FlexCol className="gap-6">
+      {(title || description) && (
+        <FlexCol className="gap-1.5">
+          {title && (
+            <Typography
+              tag={TypographyTag.H3}
+              type={TypographyType.Title3}
+              bold
+            >
+              {title}
+            </Typography>
+          )}
+          {description && (
+            <Typography
+              tag={TypographyTag.P}
+              type={TypographyType.Callout}
+              color={TypographyColor.Secondary}
+            >
+              {description}
+            </Typography>
+          )}
+        </FlexCol>
+      )}
+      {children}
+    </FlexCol>
+  </section>
+);

--- a/packages/shared/src/features/giveback/components/GivebackSelectedCauses.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSelectedCauses.tsx
@@ -15,6 +15,8 @@ import { EditIcon, OpenLinkIcon } from '../../../components/icons';
 import { IconSize } from '../../../components/Icon';
 import { FlexCol, FlexRow } from '../../../components/utilities';
 import { anchorDefaultRel } from '../../../lib/strings';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
 import { useContributionCausePicker } from '../hooks/useContributionCausePicker';
 import { GivebackSection } from './GivebackSection';
 import { CauseEmblem } from './CauseEmblem';
@@ -24,6 +26,7 @@ import { GivebackEditCausesModal } from './GivebackEditCausesModal';
 // picked, with a quick action to open the picker and edit. Editing lives here
 // now instead of a gear button in the tab bar.
 export const GivebackSelectedCauses = (): ReactElement => {
+  const { logEvent } = useLogContext();
   const { causes, selectedCauseIds } = useContributionCausePicker(true);
   const [isEditOpen, setIsEditOpen] = useState(false);
 
@@ -32,6 +35,17 @@ export const GivebackSelectedCauses = (): ReactElement => {
   const selectedCauses = causes
     .map((cause, index) => ({ cause, index }))
     .filter(({ cause }) => selectedCauseIds.includes(cause.id));
+
+  const openEdit = () => {
+    logEvent({
+      event_name: LogEvent.ClickGivebackEditCauses,
+      extra: JSON.stringify({ has_causes: selectedCauses.length > 0 }),
+    });
+    setIsEditOpen(true);
+  };
+
+  const onCauseClick = (causeId: string) =>
+    logEvent({ event_name: LogEvent.ClickGivebackCause, target_id: causeId });
 
   return (
     <GivebackSection
@@ -73,6 +87,7 @@ export const GivebackSelectedCauses = (): ReactElement => {
                     target="_blank"
                     rel={anchorDefaultRel}
                     aria-label={`Learn more about ${cause.title}`}
+                    onClick={() => onCauseClick(cause.id)}
                     className="flex size-8 shrink-0 items-center justify-center rounded-10 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary"
                   >
                     <OpenLinkIcon size={IconSize.Small} />
@@ -87,7 +102,7 @@ export const GivebackSelectedCauses = (): ReactElement => {
               size={ButtonSize.Small}
               variant={ButtonVariant.Float}
               icon={<EditIcon />}
-              onClick={() => setIsEditOpen(true)}
+              onClick={openEdit}
             >
               Edit
             </Button>
@@ -107,7 +122,7 @@ export const GivebackSelectedCauses = (): ReactElement => {
             size={ButtonSize.Small}
             variant={ButtonVariant.Primary}
             icon={<EditIcon />}
-            onClick={() => setIsEditOpen(true)}
+            onClick={openEdit}
           >
             Pick your causes
           </Button>

--- a/packages/shared/src/features/giveback/components/GivebackSelectedCauses.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSelectedCauses.tsx
@@ -1,0 +1,122 @@
+import type { ReactElement } from 'react';
+import React, { useState } from 'react';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../components/buttons/Button';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { EditIcon, OpenLinkIcon } from '../../../components/icons';
+import { IconSize } from '../../../components/Icon';
+import { FlexCol, FlexRow } from '../../../components/utilities';
+import { anchorDefaultRel } from '../../../lib/strings';
+import { useContributionCausePicker } from '../hooks/useContributionCausePicker';
+import { GivebackSection } from './GivebackSection';
+import { CauseEmblem } from './CauseEmblem';
+import { GivebackEditCausesModal } from './GivebackEditCausesModal';
+
+// "Your causes" recap on the Campaign tab. Shows only the causes the visitor
+// picked, with a quick action to open the picker and edit. Editing lives here
+// now instead of a gear button in the tab bar.
+export const GivebackSelectedCauses = (): ReactElement => {
+  const { causes, selectedCauseIds } = useContributionCausePicker(true);
+  const [isEditOpen, setIsEditOpen] = useState(false);
+
+  // Keep each cause's position in the full list so the fallback emblem tint
+  // stays stable between the picker and this recap.
+  const selectedCauses = causes
+    .map((cause, index) => ({ cause, index }))
+    .filter(({ cause }) => selectedCauseIds.includes(cause.id));
+
+  return (
+    <GivebackSection
+      id="giveback-your-causes"
+      title="Your causes"
+      description="Where your actions send the money"
+    >
+      {selectedCauses.length > 0 ? (
+        <FlexCol className="gap-4">
+          <div className="grid gap-3 tablet:grid-cols-2 laptop:grid-cols-3">
+            {selectedCauses.map(({ cause, index }) => (
+              <FlexRow
+                key={cause.id}
+                className="items-center gap-3 rounded-16 bg-surface-float p-3"
+              >
+                <CauseEmblem cause={cause} index={index} />
+                <FlexCol className="min-w-0 flex-1 gap-0.5">
+                  <Typography
+                    bold
+                    type={TypographyType.Callout}
+                    className="truncate"
+                  >
+                    {cause.title}
+                  </Typography>
+                  {cause.category && (
+                    <Typography
+                      tag={TypographyTag.Span}
+                      type={TypographyType.Caption1}
+                      color={TypographyColor.Tertiary}
+                      className="truncate"
+                    >
+                      {cause.category}
+                    </Typography>
+                  )}
+                </FlexCol>
+                {cause.url && (
+                  <a
+                    href={cause.url}
+                    target="_blank"
+                    rel={anchorDefaultRel}
+                    aria-label={`Learn more about ${cause.title}`}
+                    className="flex size-8 shrink-0 items-center justify-center rounded-10 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary"
+                  >
+                    <OpenLinkIcon size={IconSize.Small} />
+                  </a>
+                )}
+              </FlexRow>
+            ))}
+          </div>
+          <FlexRow>
+            <Button
+              type="button"
+              size={ButtonSize.Small}
+              variant={ButtonVariant.Float}
+              icon={<EditIcon />}
+              onClick={() => setIsEditOpen(true)}
+            >
+              Edit
+            </Button>
+          </FlexRow>
+        </FlexCol>
+      ) : (
+        <FlexCol className="items-start gap-3 rounded-16 bg-surface-float p-5">
+          <Typography
+            type={TypographyType.Callout}
+            color={TypographyColor.Secondary}
+          >
+            You haven&apos;t picked any causes yet. Choose where your actions
+            send the money.
+          </Typography>
+          <Button
+            type="button"
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Primary}
+            icon={<EditIcon />}
+            onClick={() => setIsEditOpen(true)}
+          >
+            Pick your causes
+          </Button>
+        </FlexCol>
+      )}
+
+      {isEditOpen && (
+        <GivebackEditCausesModal onClose={() => setIsEditOpen(false)} />
+      )}
+    </GivebackSection>
+  );
+};

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -504,6 +504,10 @@ export enum LogEvent {
   SubmitGivebackAction = 'submit giveback action',
   SubmitGivebackActionError = 'submit giveback action error',
   ClickGivebackLoveAction = 'click giveback love action',
+  ClaimGivebackReward = 'claim giveback reward',
+  ClickGivebackEditCauses = 'click giveback edit causes',
+  ClickGivebackCause = 'click giveback cause',
+  ClickGivebackFaq = 'click giveback faq',
 }
 
 export enum TargetType {

--- a/packages/shared/tailwind.config.ts
+++ b/packages/shared/tailwind.config.ts
@@ -310,6 +310,10 @@ export default {
           '55%': { transform: 'scale(1.18)', opacity: '1' },
           '100%': { transform: 'scale(1)', opacity: '1' },
         },
+        'mascot-bob': {
+          '0%, 100%': { transform: 'translateY(0)' },
+          '50%': { transform: 'translateY(-6px)' },
+        },
       },
       animation: {
         'scale-down-pulse':
@@ -329,6 +333,7 @@ export default {
         'meter-shine': 'meter-shine 2.8s cubic-bezier(0.4, 0, 0.2, 1) infinite',
         'glow-pulse': 'glow-pulse 3s ease-in-out infinite',
         'reward-pop': 'reward-pop 480ms cubic-bezier(0.34, 1.56, 0.64, 1) both',
+        'mascot-bob': 'mascot-bob 4s ease-in-out infinite',
       },
     },
     lineClamp: {


### PR DESCRIPTION
Builds the **Campaign** tab (the `why` tab) from the designer mockup (`feat/giveback-mvp`). Replaces the "Coming soon" placeholder.

## Sections
**Budget story** (ported `BudgetRedirectStory`) — the two-part gradient headline ("Big tech buys ads. / We fund developers.") + the short emotional reason, with the daily.dev charm beside it. Goal amount is live from `contributionStatus`.

**Your causes** (ported `GivebackSelectedCauses`) — a recap of the causes the visitor picked, each linking out, with an **Edit** action that opens the picker (reusing the onboarding `GivebackCauseSelection` grid + `useGivebackCauseSelection` save) to update preferences in place.

**FAQ** (ported `GivebackFaq`) — the campaign FAQ accordion.

## Backend adaptations
Same approach as the Impact tab — mock-only bits with no backend are dropped:
- "Suggest a cause" flow + the suggested-causes pending list (no submission API).
- The "Still have a question?" composer (it was a fake form that discarded input).

No new GraphQL: the story reuses `contributionStatus`, "Your causes" reuses `contributionCauses` + `contributionCausePreferences` (the picker query), and editing reuses the existing `updateContributionCausePreferences` mutation. Re-introduced a lean shared `GivebackSection` (now used by all three sections). Added the mock-branch-only `mascot-bob` keyframe to tailwind.

## Tests
`GivebackCampaignPanel.spec.tsx` covers the headline + reason, the picked-causes list, opening the edit modal, the FAQ accordion, and the empty "pick your causes" state (56 giveback specs green).

### Preview domain
https://feat-giveback-campaign-tab.preview.app.daily.dev