### PR TITLE
fix: persist notification unread count

### DIFF
--- a/packages/shared/src/contexts/BootProvider.spec.tsx
+++ b/packages/shared/src/contexts/BootProvider.spec.tsx
@@ -17,11 +17,13 @@ import SettingsContext, {
 } from './SettingsContext';
 import { mockGraphQL } from '../../__tests__/helpers/graphql';
 import AlertContext from './AlertContext';
+import NotificationsContext from './NotificationsContext';
 import type { Alerts } from '../graphql/alerts';
 import { UPDATE_ALERTS } from '../graphql/alerts';
 import type { RemoteSettings, Spaciness } from '../graphql/settings';
 import { UPDATE_USER_SETTINGS_MUTATION } from '../graphql/settings';
 import { BootDataProvider } from './BootProvider';
+import { BOOT_LOCAL_KEY } from './common';
 import type { Boot, BootCacheData } from '../lib/boot';
 import { BootApp, getBootData } from '../lib/boot';
 import type { AuthTriggersType } from '../lib/auth';
@@ -411,6 +413,51 @@ it('should trigger update alerts callback', async () => {
   await expectToHaveTestValue(alertsEl, JSON.stringify(defaultAlerts));
   fireEvent.click(alertsEl);
   await expectToHaveTestValue(alertsEl, JSON.stringify(alerts));
+});
+
+interface NotificationsMockProps {
+  incrementBy?: number;
+}
+
+const NotificationsMock = ({ incrementBy = 1 }: NotificationsMockProps) => {
+  const { unreadCount, clearUnreadCount, incrementUnreadCount } =
+    useContext(NotificationsContext);
+
+  return (
+    <>
+      <button
+        onClick={clearUnreadCount}
+        type="button"
+        data-test-value={unreadCount}
+      >
+        Clear notifications
+      </button>
+      <button onClick={() => incrementUnreadCount(incrementBy)} type="button">
+        Increment notifications
+      </button>
+    </>
+  );
+};
+
+const getStoredBootData = (): BootCacheData =>
+  JSON.parse(localStorage.getItem(BOOT_LOCAL_KEY) as string);
+
+it('should persist notification count updates to local boot data', async () => {
+  renderComponent(<NotificationsMock incrementBy={2} />, {
+    ...defaultBootData,
+    notifications: { unreadNotificationsCount: 4 },
+  });
+
+  const clearNotifications = await screen.findByText('Clear notifications');
+  await expectToHaveTestValue(clearNotifications, '4');
+
+  fireEvent.click(clearNotifications);
+  await expectToHaveTestValue(clearNotifications, '0');
+  expect(getStoredBootData().notifications.unreadNotificationsCount).toEqual(0);
+
+  fireEvent.click(screen.getByText('Increment notifications'));
+  await expectToHaveTestValue(clearNotifications, '2');
+  expect(getStoredBootData().notifications.unreadNotificationsCount).toEqual(2);
 });
 
 interface AuthMockProps {

--- a/packages/shared/src/contexts/BootProvider.tsx
+++ b/packages/shared/src/contexts/BootProvider.tsx
@@ -258,6 +258,14 @@ export const BootDataProvider = ({
     [updateBootData],
   );
 
+  const updateNotificationsCount = useCallback(
+    (unreadNotificationsCount: number) =>
+      updateBootData({
+        notifications: { unreadNotificationsCount },
+      }),
+    [updateBootData],
+  );
+
   const updateExperimentation = useCallback(
     (exp: BootCacheData['exp']) => {
       updateLocalBootData(cachedBootData, { exp });
@@ -383,6 +391,7 @@ export const BootDataProvider = ({
                   <NotificationsContextProvider
                     isNotificationsReady={isBootReady}
                     unreadCount={notifications?.unreadNotificationsCount}
+                    onUpdateUnreadCount={updateNotificationsCount}
                   >
                     {children}
                   </NotificationsContextProvider>

--- a/packages/shared/src/contexts/NotificationsContext.spec.tsx
+++ b/packages/shared/src/contexts/NotificationsContext.spec.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  NotificationsContextProvider,
+  useNotificationContext,
+} from './NotificationsContext';
+
+interface NotificationsMockProps {
+  incrementBy?: number;
+}
+
+const NotificationsMock = ({ incrementBy = 1 }: NotificationsMockProps) => {
+  const { unreadCount, clearUnreadCount, incrementUnreadCount } =
+    useNotificationContext();
+
+  return (
+    <>
+      <span data-test-value={unreadCount}>Unread count</span>
+      <button onClick={clearUnreadCount} type="button">
+        Clear
+      </button>
+      <button onClick={() => incrementUnreadCount(incrementBy)} type="button">
+        Increment
+      </button>
+    </>
+  );
+};
+
+it('should clear unread count and notify persistence callback', () => {
+  const onUpdateUnreadCount = jest.fn();
+
+  render(
+    <NotificationsContextProvider
+      unreadCount={3}
+      onUpdateUnreadCount={onUpdateUnreadCount}
+    >
+      <NotificationsMock />
+    </NotificationsContextProvider>,
+  );
+
+  fireEvent.click(screen.getByText('Clear'));
+
+  expect(screen.getByText('Unread count')).toHaveAttribute(
+    'data-test-value',
+    '0',
+  );
+  expect(onUpdateUnreadCount).toHaveBeenCalledWith(0);
+});
+
+it('should increment unread count and notify persistence callback', () => {
+  const onUpdateUnreadCount = jest.fn();
+
+  render(
+    <NotificationsContextProvider
+      unreadCount={1}
+      onUpdateUnreadCount={onUpdateUnreadCount}
+    >
+      <NotificationsMock incrementBy={2} />
+    </NotificationsContextProvider>,
+  );
+
+  fireEvent.click(screen.getByText('Increment'));
+  fireEvent.click(screen.getByText('Increment'));
+
+  expect(screen.getByText('Unread count')).toHaveAttribute(
+    'data-test-value',
+    '5',
+  );
+  expect(onUpdateUnreadCount).toHaveBeenNthCalledWith(1, 3);
+  expect(onUpdateUnreadCount).toHaveBeenNthCalledWith(2, 5);
+});
+
+it('should update unread count without a persistence callback', () => {
+  render(
+    <NotificationsContextProvider unreadCount={2}>
+      <NotificationsMock />
+    </NotificationsContextProvider>,
+  );
+
+  fireEvent.click(screen.getByText('Clear'));
+  expect(screen.getByText('Unread count')).toHaveAttribute(
+    'data-test-value',
+    '0',
+  );
+
+  fireEvent.click(screen.getByText('Increment'));
+  expect(screen.getByText('Unread count')).toHaveAttribute(
+    'data-test-value',
+    '1',
+  );
+});

--- a/packages/shared/src/contexts/NotificationsContext.tsx
+++ b/packages/shared/src/contexts/NotificationsContext.tsx
@@ -5,7 +5,7 @@ export interface NotificationsContextData {
   unreadCount: number;
   isNotificationsReady?: boolean;
   clearUnreadCount: () => void;
-  incrementUnreadCount: () => void;
+  incrementUnreadCount: (value?: number) => void;
 }
 
 const NotificationsContext = React.createContext<NotificationsContextData>(
@@ -18,11 +18,13 @@ export interface NotificationsContextProviderProps {
   children: ReactNode;
   unreadCount?: number;
   isNotificationsReady?: boolean;
+  onUpdateUnreadCount?: (unreadCount: number) => void;
 }
 
 export const NotificationsContextProvider = ({
   children,
   isNotificationsReady,
+  onUpdateUnreadCount,
   unreadCount = 0,
 }: NotificationsContextProviderProps): ReactElement => {
   const [currentUnreadCount, setCurrentUnreadCount] = useState(unreadCount);
@@ -31,10 +33,19 @@ export const NotificationsContextProvider = ({
     setCurrentUnreadCount(unreadCount);
   }, [unreadCount]);
 
-  const clearUnreadCount = useCallback(() => setCurrentUnreadCount(0), []);
+  const clearUnreadCount = useCallback(() => {
+    setCurrentUnreadCount(0);
+    onUpdateUnreadCount?.(0);
+  }, [onUpdateUnreadCount]);
+
   const incrementUnreadCount = useCallback(
-    (value = 1) => setCurrentUnreadCount((current) => current + value),
-    [],
+    (value = 1) => {
+      const nextUnreadCount = currentUnreadCount + value;
+
+      setCurrentUnreadCount(nextUnreadCount);
+      onUpdateUnreadCount?.(nextUnreadCount);
+    },
+    [currentUnreadCount, onUpdateUnreadCount],
   );
 
   const data: NotificationsContextData = {

--- a/packages/webapp/__tests__/NotificationsPage.tsx
+++ b/packages/webapp/__tests__/NotificationsPage.tsx
@@ -75,6 +75,7 @@ let client: QueryClient;
 const renderComponent = (
   mocks: MockedGraphQLResponse[] = [fetchNotificationsMock()],
   unreadCount = 0,
+  onUpdateUnreadCount = jest.fn(),
 ) => {
   client = new QueryClient();
 
@@ -96,7 +97,10 @@ const renderComponent = (
           isAuthReady: true,
         }}
       >
-        <NotificationsContextProvider unreadCount={unreadCount}>
+        <NotificationsContextProvider
+          unreadCount={unreadCount}
+          onUpdateUnreadCount={onUpdateUnreadCount}
+        >
           <NotificationsPage />
         </NotificationsContextProvider>
       </AuthContext.Provider>
@@ -138,6 +142,7 @@ it('should get all notifications', async () => {
 it('should get all notifications and send a mutation to read all unread notifications', async () => {
   let mutationCalled = false;
   const unreadCount = 2;
+  const onUpdateUnreadCount = jest.fn();
   const testData: NotificationsData = { ...sampleNotificationData };
   testData.notifications.edges[0].node.readAt = undefined;
   renderComponent(
@@ -152,9 +157,11 @@ it('should get all notifications and send a mutation to read all unread notifica
       },
     ],
     unreadCount,
+    onUpdateUnreadCount,
   );
 
   await screen.findByText(sampleNotification.title);
   await waitForNock();
   expect(mutationCalled).toBeTruthy();
+  expect(onUpdateUnreadCount).toHaveBeenCalledWith(0);
 });


### PR DESCRIPTION
## Summary
- Persist notification unread count updates through `BootProvider`, keeping cached boot data and localStorage aligned after notifications are read.
- Add an optional notification count persistence callback while keeping existing context consumers unchanged.
- Cover the regression with focused context, boot provider, and notifications page tests.

## Key decisions
- Reuse the existing `updateBootData` path instead of invalidating/refetching boot data, so extension cache handling stays centralized.
- Persist both read-clears and realtime increments through the same count update callback.

## Verification
- `NODE_ENV=test pnpm --filter @dailydotdev/shared exec jest --runInBand src/contexts/NotificationsContext.spec.tsx src/contexts/BootProvider.spec.tsx`
- `NODE_ENV=test pnpm --filter webapp exec jest --runInBand __tests__/NotificationsPage.tsx`
- `pnpm --filter @dailydotdev/shared exec eslint src/contexts/NotificationsContext.tsx src/contexts/NotificationsContext.spec.tsx src/contexts/BootProvider.tsx src/contexts/BootProvider.spec.tsx --max-warnings 0`
- `pnpm --filter webapp exec eslint __tests__/NotificationsPage.tsx --max-warnings 0`
- `node ./scripts/typecheck-strict-changed.js`

Closes ENG-1617

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1617-feedback-bug-report-not.preview.app.daily.dev