### PR TITLE
fix(profile): restore profile back affordance in PWA

### DIFF
--- a/packages/shared/src/components/post/GoBackHeaderMobile.tsx
+++ b/packages/shared/src/components/post/GoBackHeaderMobile.tsx
@@ -29,7 +29,7 @@ export const GoBackButton = ({
   showLogo = true,
 }: WithClassNameProps & {
   showLogo?: boolean;
-}): JSX.Element => {
+}): JSX.Element | null => {
   const router = useRouter();
   const goHome = useCallback(() => router.push('/'), [router]);
   const featureTheme = useFeatureTheme();
@@ -53,6 +53,8 @@ export const GoBackButton = ({
       variant={ButtonVariant.Tertiary}
       onClick={router.back}
       className={className}
+      type="button"
+      aria-label="Go back"
     />
   ) : (
     logoButton
@@ -62,7 +64,7 @@ export const GoBackButton = ({
 export function GoBackHeaderMobile({
   children,
   className,
-}: PropsWithChildren<WithClassNameProps>): ReactElement {
+}: PropsWithChildren<WithClassNameProps>): ReactElement | null {
   const router = useRouter();
   const isLaptop = useViewSize(ViewSize.Laptop);
   const featureTheme = useFeatureTheme();

--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -17,8 +17,6 @@ import {
 } from '../../lib';
 import { ProfileSettingsMenuMobile } from './ProfileSettingsMenu';
 import { RootPortal } from '../tooltips/Portal';
-import { GoBackButton } from '../post/GoBackHeaderMobile';
-import { useViewSize, ViewSize } from '../../hooks';
 import { FollowButton } from '../contentPreference/FollowButton';
 import {
   ContentPreferenceStatus,
@@ -46,6 +44,7 @@ import {
 } from '../../hooks/useCoresFeature';
 import Link from '../utilities/Link';
 import type { MenuItemProps } from '../dropdown/common';
+import { ProfileMobileBackButton } from './ProfileBackButton';
 
 export interface HeaderProps {
   user: PublicProfile;
@@ -69,7 +68,6 @@ export function Header({
     TargetId.ProfilePage,
   );
   const { openModal } = useLazyModal();
-  const isMobile = useViewSize(ViewSize.MobileL);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { follow, unfollow } = useContentPreference();
   const router = useRouter();
@@ -152,12 +150,7 @@ export function Header({
       style={style}
     >
       <>
-        {isMobile && (
-          <GoBackButton
-            showLogo={false}
-            className={!sticky ? 'mr-3' : undefined}
-          />
-        )}
+        <ProfileMobileBackButton className={!sticky ? 'mr-3' : undefined} />
         {sticky ? (
           <>
             <ProfilePicture

--- a/packages/shared/src/components/profile/ProfileBackButton.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileBackButton.spec.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { isPWA } from '../../lib/func';
+import {
+  useViewSize,
+  useViewSizeClient,
+  ViewSize,
+} from '../../hooks/useViewSize';
+import {
+  ProfileDesktopPwaBackButton,
+  ProfileMobileBackButton,
+} from './ProfileBackButton';
+
+jest.mock('../../hooks/useViewSize', () => ({
+  ...jest.requireActual('../../hooks/useViewSize'),
+  useViewSize: jest.fn(),
+  useViewSizeClient: jest.fn(),
+}));
+
+jest.mock('../../lib/func', () => ({
+  ...jest.requireActual('../../lib/func'),
+  isPWA: jest.fn(),
+}));
+
+jest.mock('../post/GoBackHeaderMobile', () => ({
+  GoBackButton: ({ className }: { className?: string }) => (
+    <button type="button" className={className}>
+      Go back
+    </button>
+  ),
+}));
+
+const mockUseViewSize = useViewSize as jest.MockedFunction<typeof useViewSize>;
+const mockUseViewSizeClient = useViewSizeClient as jest.MockedFunction<
+  typeof useViewSizeClient
+>;
+const mockIsPWA = isPWA as jest.MockedFunction<typeof isPWA>;
+
+describe('ProfileMobileBackButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders below laptop widths', () => {
+    mockUseViewSize.mockImplementation((size) => size !== ViewSize.Laptop);
+
+    render(<ProfileMobileBackButton className="mr-3" />);
+
+    const button = screen.getByRole('button', { name: 'Go back' });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveClass('mr-3');
+  });
+
+  it('does not render at laptop widths', () => {
+    mockUseViewSize.mockImplementation((size) => size === ViewSize.Laptop);
+
+    render(<ProfileMobileBackButton />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Go back' }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('ProfileDesktopPwaBackButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsPWA.mockReturnValue(false);
+  });
+
+  it('renders at laptop widths in standalone PWA', async () => {
+    mockUseViewSizeClient.mockImplementation(
+      (size) => size === ViewSize.Laptop,
+    );
+    mockIsPWA.mockReturnValue(true);
+
+    render(<ProfileDesktopPwaBackButton className="absolute left-4 top-4" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Go back' }),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: 'Go back' })).toHaveClass(
+      'hidden',
+      'laptop:flex',
+      'absolute',
+      'left-4',
+      'top-4',
+    );
+  });
+
+  it('does not render at laptop widths outside standalone PWA', async () => {
+    mockUseViewSizeClient.mockImplementation(
+      (size) => size === ViewSize.Laptop,
+    );
+
+    render(<ProfileDesktopPwaBackButton />);
+
+    await waitFor(() => {
+      expect(mockIsPWA).toHaveBeenCalled();
+    });
+    expect(
+      screen.queryByRole('button', { name: 'Go back' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render below laptop widths in standalone PWA', async () => {
+    mockUseViewSizeClient.mockImplementation(
+      (size) => size !== ViewSize.Laptop,
+    );
+    mockIsPWA.mockReturnValue(true);
+
+    render(<ProfileDesktopPwaBackButton />);
+
+    await waitFor(() => {
+      expect(mockIsPWA).toHaveBeenCalled();
+    });
+    expect(
+      screen.queryByRole('button', { name: 'Go back' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/profile/ProfileBackButton.tsx
+++ b/packages/shared/src/components/profile/ProfileBackButton.tsx
@@ -1,0 +1,41 @@
+import type { ReactElement } from 'react';
+import React, { useEffect, useState } from 'react';
+import classNames from 'classnames';
+import { useViewSize, useViewSizeClient, ViewSize } from '../../hooks';
+import { isPWA } from '../../lib/func';
+import type { WithClassNameProps } from '../utilities';
+import { GoBackButton } from '../post/GoBackHeaderMobile';
+
+export const ProfileMobileBackButton = ({
+  className,
+}: WithClassNameProps): ReactElement | null => {
+  const isLaptop = useViewSize(ViewSize.Laptop);
+
+  if (isLaptop) {
+    return null;
+  }
+
+  return <GoBackButton showLogo={false} className={className} />;
+};
+
+export const ProfileDesktopPwaBackButton = ({
+  className,
+}: WithClassNameProps): ReactElement | null => {
+  const isLaptop = useViewSizeClient(ViewSize.Laptop);
+  const [isStandalonePWA, setIsStandalonePWA] = useState(false);
+
+  useEffect(() => {
+    setIsStandalonePWA(isPWA());
+  }, []);
+
+  if (!isLaptop || !isStandalonePWA) {
+    return null;
+  }
+
+  return (
+    <GoBackButton
+      showLogo={false}
+      className={classNames('hidden laptop:flex', className)}
+    />
+  );
+};

--- a/packages/shared/src/components/profile/ProfileHeader.tsx
+++ b/packages/shared/src/components/profile/ProfileHeader.tsx
@@ -22,6 +22,7 @@ import { VerifiedCompanyUserBadge } from '../VerifiedCompanyUserBadge';
 import { locationToString } from '../../lib/utils';
 import { IconSize } from '../Icon';
 import { fallbackImages } from '../../lib/config';
+import { ProfileDesktopPwaBackButton } from './ProfileBackButton';
 
 import { ElementPlaceholder } from '../ElementPlaceholder';
 
@@ -60,8 +61,10 @@ const ProfileHeader = ({
   const { name, username, bio, image, cover, isPlus } = user;
   const { user: loggedUser } = useAuthContext();
   const isSameUser = propIsSameUser ?? loggedUser?.id === user.id;
+
   return (
     <div className="relative w-full overflow-hidden laptop:rounded-t-16">
+      <ProfileDesktopPwaBackButton className="absolute left-4 top-4 z-1" />
       <div className="h-36">
         <Image src={cover} alt="Cover" className="h-full w-full object-cover" />
       </div>


### PR DESCRIPTION
## Summary
- Restores the profile back affordance below laptop widths by reusing the shared `GoBackButton`.
- Adds a standalone-PWA-only desktop profile back affordance for laptop+ layouts.
- Keeps the desktop browser profile layout unchanged and centralizes profile back-button viewport/PWA gating in a small profile component.

## Verification
- `env NODE_ENV=test pnpm --filter @dailydotdev/shared exec jest src/components/profile/ProfileBackButton.spec.tsx --runInBand`
- `node ./scripts/typecheck-strict-changed.js`
- `pnpm --filter @dailydotdev/shared exec eslint src/components/post/GoBackHeaderMobile.tsx src/components/profile/Header.tsx src/components/profile/ProfileBackButton.tsx src/components/profile/ProfileBackButton.spec.tsx src/components/profile/ProfileHeader.tsx --max-warnings 0`
- `git diff --check main...HEAD`

Issue: https://linear.app/dailydev/issue/ENG-1632/feedback-bug-report-user-reports-missing-back-button-on-profile

Closes ENG-1632

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1632-feedback-bug-report-use.preview.app.daily.dev