### PR TITLE
feat(post): redesigned reader (PostFocusCard) for modal + page

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -335,7 +335,11 @@ function MainLayoutComponent({
             <div
               className={classNames(
                 'relative flex min-h-0 flex-1 flex-col',
-                'laptop:overflow-hidden laptop:rounded-24 laptop:border laptop:border-border-subtlest-quaternary laptop:bg-background-default laptop:p-0.5 laptop:shadow-2',
+                // `overflow-clip` (not `hidden`) clips content to the rounded
+                // card without establishing a scroll container, so descendant
+                // `position: sticky` elements (e.g. the post action bar) stick
+                // to the viewport instead of being inert.
+                'laptop:overflow-clip laptop:rounded-24 laptop:border laptop:border-border-subtlest-quaternary laptop:bg-background-default laptop:p-0.5 laptop:shadow-2',
                 !hasTopBanners &&
                   !topBanner &&
                   'laptop:min-h-[calc(100vh-1.5rem)]',

--- a/packages/shared/src/components/modals/ArticlePostModal.tsx
+++ b/packages/shared/src/components/modals/ArticlePostModal.tsx
@@ -9,6 +9,8 @@ import type { Post } from '../../graphql/posts';
 import { PostType } from '../../graphql/posts';
 import type { PassedPostNavigationProps } from '../post/common';
 import { Origin } from '../../lib/log';
+import { usePostDiscoveryExperience } from '../../hooks/post/usePostDiscoveryExperience';
+import { PostFocusCard } from '../post/discovery/PostFocusCard';
 
 interface ArticlePostModalProps extends ModalProps, PassedPostNavigationProps {
   id: string;
@@ -29,12 +31,15 @@ export default function ArticlePostModal({
     isDisplayed: props.isOpen,
     offset: 0,
   });
+  const { showDiscovery } = usePostDiscoveryExperience(post);
 
   return (
     <BasePostModal
       {...props}
       post={post}
       onAfterOpen={onLoad}
+      size={showDiscovery ? Modal.Size.Large : Modal.Size.XLarge}
+      className={showDiscovery ? 'laptop:!overflow-visible' : undefined}
       onRequestClose={onRequestClose}
       postType={PostType.Article}
       source={post.source}
@@ -43,24 +48,32 @@ export default function ArticlePostModal({
       onPreviousPost={onPreviousPost}
       onNextPost={onNextPost}
     >
-      <PostContent
-        position={position}
-        post={post}
-        postPosition={postPosition}
-        onPreviousPost={onPreviousPost}
-        onNextPost={onNextPost}
-        inlineActions
-        className={{
-          onboarding: 'mt-8',
-          navigation: { actions: 'ml-auto tablet:hidden' },
-          fixedNavigation: {
-            container: modalSizeToClassName[Modal.Size.XLarge],
-            actions: 'ml-auto',
-          },
-        }}
-        onClose={onRequestClose}
-        origin={Origin.ArticleModal}
-      />
+      {showDiscovery ? (
+        <PostFocusCard
+          post={post}
+          origin={Origin.ArticleModal}
+          onClose={() => onRequestClose?.(undefined as never)}
+        />
+      ) : (
+        <PostContent
+          position={position}
+          post={post}
+          postPosition={postPosition}
+          onPreviousPost={onPreviousPost}
+          onNextPost={onNextPost}
+          inlineActions
+          className={{
+            onboarding: 'mt-8',
+            navigation: { actions: 'ml-auto tablet:hidden' },
+            fixedNavigation: {
+              container: modalSizeToClassName[Modal.Size.XLarge],
+              actions: 'ml-auto',
+            },
+          }}
+          onClose={onRequestClose}
+          origin={Origin.ArticleModal}
+        />
+      )}
     </BasePostModal>
   );
 }

--- a/packages/shared/src/components/modals/CollectionPostModal.tsx
+++ b/packages/shared/src/components/modals/CollectionPostModal.tsx
@@ -9,6 +9,8 @@ import type { Post } from '../../graphql/posts';
 import { PostType } from '../../graphql/posts';
 import type { PassedPostNavigationProps } from '../post/common';
 import { CollectionPostContent } from '../post/collection';
+import { usePostDiscoveryExperience } from '../../hooks/post/usePostDiscoveryExperience';
+import { PostFocusCard } from '../post/discovery/PostFocusCard';
 
 interface CollectionPostModalProps
   extends ModalProps,
@@ -31,12 +33,15 @@ export default function CollectionPostModal({
     isDisplayed: props.isOpen,
     offset: 0,
   });
+  const { showDiscovery } = usePostDiscoveryExperience(post);
 
   return (
     <BasePostModal
       {...props}
       post={post}
       onAfterOpen={onLoad}
+      size={showDiscovery ? Modal.Size.Large : Modal.Size.XLarge}
+      className={showDiscovery ? 'laptop:!overflow-visible' : undefined}
       onRequestClose={onRequestClose}
       postType={PostType.Collection}
       source={post.source}
@@ -45,24 +50,32 @@ export default function CollectionPostModal({
       onPreviousPost={onPreviousPost}
       onNextPost={onNextPost}
     >
-      <CollectionPostContent
-        position={position}
-        post={post}
-        postPosition={postPosition}
-        onPreviousPost={onPreviousPost}
-        onNextPost={onNextPost}
-        inlineActions
-        className={{
-          onboarding: 'mt-8',
-          navigation: { actions: 'ml-auto laptop:hidden' },
-          fixedNavigation: {
-            container: modalSizeToClassName[Modal.Size.XLarge],
-            actions: 'ml-auto',
-          },
-        }}
-        onClose={onRequestClose}
-        origin={Origin.CollectionModal}
-      />
+      {showDiscovery ? (
+        <PostFocusCard
+          post={post}
+          origin={Origin.CollectionModal}
+          onClose={() => onRequestClose?.(undefined as never)}
+        />
+      ) : (
+        <CollectionPostContent
+          position={position}
+          post={post}
+          postPosition={postPosition}
+          onPreviousPost={onPreviousPost}
+          onNextPost={onNextPost}
+          inlineActions
+          className={{
+            onboarding: 'mt-8',
+            navigation: { actions: 'ml-auto laptop:hidden' },
+            fixedNavigation: {
+              container: modalSizeToClassName[Modal.Size.XLarge],
+              actions: 'ml-auto',
+            },
+          }}
+          onClose={onRequestClose}
+          origin={Origin.CollectionModal}
+        />
+      )}
     </BasePostModal>
   );
 }

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -50,6 +50,16 @@ export default function PostModal({
       onPreviousPost={onPreviousPost}
       onNextPost={onNextPost}
     >
+      {/* The squad notification prompt is shown for share posts regardless of
+          which layout renders below it. */}
+      <EnableNotification
+        source={NotificationPromptSource.SquadPostModal}
+        label={
+          isSourceUserSource(post?.source)
+            ? post?.author?.username
+            : post?.source?.handle
+        }
+      />
       {showDiscovery ? (
         <PostFocusCard
           post={post}
@@ -57,34 +67,24 @@ export default function PostModal({
           onClose={() => onRequestClose?.(undefined as never)}
         />
       ) : (
-        <>
-          <EnableNotification
-            source={NotificationPromptSource.SquadPostModal}
-            label={
-              isSourceUserSource(post?.source)
-                ? post?.author?.username
-                : post?.source?.handle
-            }
-          />
-          <SquadPostContent
-            position={position}
-            post={post}
-            onPreviousPost={onPreviousPost}
-            onNextPost={onNextPost}
-            postPosition={postPosition}
-            inlineActions
-            onClose={onRequestClose}
-            origin={Origin.ArticleModal}
-            className={{
-              fixedNavigation: {
-                container: '!w-[inherit]',
-                actions: 'ml-auto',
-              },
-              navigation: { actions: 'ml-auto tablet:hidden' },
-              onboarding: 'mb-0 mt-8',
-            }}
-          />
-        </>
+        <SquadPostContent
+          position={position}
+          post={post}
+          onPreviousPost={onPreviousPost}
+          onNextPost={onNextPost}
+          postPosition={postPosition}
+          inlineActions
+          onClose={onRequestClose}
+          origin={Origin.ArticleModal}
+          className={{
+            fixedNavigation: {
+              container: '!w-[inherit]',
+              actions: 'ml-auto',
+            },
+            navigation: { actions: 'ml-auto tablet:hidden' },
+            onboarding: 'mb-0 mt-8',
+          }}
+        />
       )}
     </BasePostModal>
   );

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -11,6 +11,8 @@ import { PostType } from '../../graphql/posts';
 import EnableNotification from '../notifications/EnableNotification';
 import { SquadPostContent } from '../post/SquadPostContent';
 import { isSourceUserSource } from '../../graphql/sources';
+import { usePostDiscoveryExperience } from '../../hooks/post/usePostDiscoveryExperience';
+import { PostFocusCard } from '../post/discovery/PostFocusCard';
 
 interface PostModalProps extends ModalProps, PassedPostNavigationProps {
   id: string;
@@ -31,13 +33,15 @@ export default function PostModal({
     isDisplayed: props.isOpen,
     offset: 0,
   });
+  const { showDiscovery } = usePostDiscoveryExperience(post);
 
   return (
     <BasePostModal
       {...props}
       post={post}
       onAfterOpen={onLoad}
-      size={Modal.Size.XLarge}
+      size={showDiscovery ? Modal.Size.Large : Modal.Size.XLarge}
+      className={showDiscovery ? 'laptop:!overflow-visible' : undefined}
       onRequestClose={onRequestClose}
       postType={PostType.Share}
       source={post.source}
@@ -46,29 +50,42 @@ export default function PostModal({
       onPreviousPost={onPreviousPost}
       onNextPost={onNextPost}
     >
-      <EnableNotification
-        source={NotificationPromptSource.SquadPostModal}
-        label={
-          isSourceUserSource(post?.source)
-            ? post?.author?.username
-            : post?.source?.handle
-        }
-      />
-      <SquadPostContent
-        position={position}
-        post={post}
-        onPreviousPost={onPreviousPost}
-        onNextPost={onNextPost}
-        postPosition={postPosition}
-        inlineActions
-        onClose={onRequestClose}
-        origin={Origin.ArticleModal}
-        className={{
-          fixedNavigation: { container: '!w-[inherit]', actions: 'ml-auto' },
-          navigation: { actions: 'ml-auto tablet:hidden' },
-          onboarding: 'mb-0 mt-8',
-        }}
-      />
+      {showDiscovery ? (
+        <PostFocusCard
+          post={post}
+          origin={Origin.ArticleModal}
+          onClose={() => onRequestClose?.(undefined as never)}
+        />
+      ) : (
+        <>
+          <EnableNotification
+            source={NotificationPromptSource.SquadPostModal}
+            label={
+              isSourceUserSource(post?.source)
+                ? post?.author?.username
+                : post?.source?.handle
+            }
+          />
+          <SquadPostContent
+            position={position}
+            post={post}
+            onPreviousPost={onPreviousPost}
+            onNextPost={onNextPost}
+            postPosition={postPosition}
+            inlineActions
+            onClose={onRequestClose}
+            origin={Origin.ArticleModal}
+            className={{
+              fixedNavigation: {
+                container: '!w-[inherit]',
+                actions: 'ml-auto',
+              },
+              navigation: { actions: 'ml-auto tablet:hidden' },
+              onboarding: 'mb-0 mt-8',
+            }}
+          />
+        </>
+      )}
     </BasePostModal>
   );
 }

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -44,6 +44,12 @@ interface PostCommentsProps {
   onClickUpvote?: (commentId: string, upvotes: number) => unknown;
   className?: CommentClassName;
   onCommented?: MainCommentProps['onCommented'];
+  /**
+   * Drop the list's top margin. Use when comments are the first element in
+   * their container (e.g. the discovery discussion panel) so they don't get an
+   * extra gap above the first item.
+   */
+  removeTopSpacing?: boolean;
 }
 
 const noopShare = (): void => {};
@@ -61,6 +67,7 @@ export function PostComments({
   joinNotificationCommentId,
   className = {},
   onCommented,
+  removeTopSpacing = false,
 }: PostCommentsProps): ReactElement {
   const { id } = post;
   const container = useRef<HTMLDivElement | null>(null);
@@ -119,9 +126,12 @@ export function PostComments({
         isModalThread
           ? classNames(
               'mb-12 flex flex-col gap-4',
-              isComposerOpen ? 'mt-2' : 'mt-5',
+              !removeTopSpacing && (isComposerOpen ? 'mt-2' : 'mt-5'),
             )
-          : '-mx-4 mb-12 mt-6 flex flex-col gap-4 mobileL:mx-0'
+          : classNames(
+              '-mx-4 mb-12 flex flex-col gap-4 mobileL:mx-0',
+              !removeTopSpacing && 'mt-6',
+            )
       }
       ref={container}
     >

--- a/packages/shared/src/components/post/PostSidebarAdWidget.tsx
+++ b/packages/shared/src/components/post/PostSidebarAdWidget.tsx
@@ -26,9 +26,16 @@ import {
   TypographyType,
 } from '../typography/Typography';
 import { AdvertiseLink } from '../cards/ad/common/AdvertiseLink';
+import { Image } from '../image/Image';
 
 interface PostSidebarAdWidgetProps {
   postId: string;
+  /**
+   * `card` (default) is the boxed sidebar widget. `inline` is a flat,
+   * borderless-background layout for in-content placements: the company name
+   * sits on the favicon line, with "Promoted" + the advertise link below it.
+   */
+  variant?: 'card' | 'inline';
   className?: {
     container?: string;
   };
@@ -36,6 +43,7 @@ interface PostSidebarAdWidgetProps {
 
 export function PostSidebarAdWidget({
   postId,
+  variant = 'card',
   className,
 }: PostSidebarAdWidgetProps): ReactElement | null {
   const { user } = useAuthContext();
@@ -93,6 +101,92 @@ export function PostSidebarAdWidget({
     adImprovementsV3,
     size: 24,
   });
+
+  if (variant === 'inline') {
+    const tagLine = ad.tagLine?.trim();
+    const description = ad.description?.trim();
+    // Always surface a title on the icon line: the company, else the
+    // tagline, else the description. Whatever is left over renders in the
+    // body — so a description-only ad has no extra body row.
+    const inlineTitle = company || tagLine || description;
+    const inlineBodyTagLine = company ? tagLine : undefined;
+    const inlineBodyDescription = company || tagLine ? description : undefined;
+    const inlineHasBody = !!inlineBodyTagLine || !!inlineBodyDescription;
+
+    return (
+      <div
+        className={classNames(
+          'relative flex w-full flex-col gap-2 rounded-16 border border-border-subtlest-tertiary p-3 transition-colors hover:bg-surface-hover',
+          className?.container,
+        )}
+      >
+        <a
+          href={ad.link}
+          target="_blank"
+          rel="noopener"
+          title={ad.description}
+          className="absolute inset-0 z-0"
+          {...combinedClicks(() => onAdAction(AdActions.Click))}
+        />
+        <div className="flex w-full items-center gap-3">
+          <Image
+            src={imageLink}
+            alt={ad.source}
+            className="size-10 shrink-0 rounded-full object-cover"
+          />
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            {inlineTitle && (
+              <Typography
+                tag={TypographyTag.P}
+                type={TypographyType.Callout}
+                color={TypographyColor.Primary}
+                className="line-clamp-2 font-medium"
+              >
+                {inlineTitle}
+              </Typography>
+            )}
+            <div className="flex items-center gap-1.5">
+              <AdAttribution className={{ main: 'relative z-1' }} />
+              <span aria-hidden className="text-text-quaternary typo-footnote">
+                ·
+              </span>
+              <AdvertiseLink
+                targetId={TargetId.AdSidebar}
+                className="relative z-1 whitespace-nowrap hover:underline"
+              />
+            </div>
+          </div>
+          <Button
+            tag="a"
+            href={ad.link}
+            target="_blank"
+            rel="noopener"
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Small}
+            className="relative z-1 ml-auto shrink-0"
+            onClick={() => onAdAction(AdActions.Click)}
+          >
+            Visit
+          </Button>
+        </div>
+        {inlineHasBody && (
+          <Typography
+            tag={TypographyTag.P}
+            type={TypographyType.Callout}
+            color={TypographyColor.Primary}
+            className="relative z-1 whitespace-pre-line"
+          >
+            {inlineBodyTagLine && <strong>{inlineBodyTagLine}</strong>}
+            {inlineBodyTagLine && inlineBodyDescription ? ' ' : ''}
+            {inlineBodyDescription}
+          </Typography>
+        )}
+        <span className="absolute bottom-0 left-0">
+          <AdPixel pixel={ad.pixel} />
+        </span>
+      </div>
+    );
+  }
 
   return (
     <EntityCard

--- a/packages/shared/src/components/post/PostUpvotesCommentsCount.tsx
+++ b/packages/shared/src/components/post/PostUpvotesCommentsCount.tsx
@@ -34,6 +34,7 @@ type PostUpvotesCommentsCountPost = Pick<
 interface PostUpvotesCommentsCountProps {
   post: PostUpvotesCommentsCountPost;
   onUpvotesClick?: (upvotes: number) => unknown;
+  onCommentsClick?: () => unknown;
   className?: string;
   compact?: boolean;
   passive?: boolean;
@@ -48,6 +49,7 @@ type PostUpvotesCommentsCountContentProps = PostUpvotesCommentsCountProps & {
 const PostUpvotesCommentsCountContent = ({
   post,
   onUpvotesClick,
+  onCommentsClick,
   onRepostsClick,
   onAwardsClick,
   showPostAnalytics = false,
@@ -104,12 +106,12 @@ const PostUpvotesCommentsCountContent = ({
           onClick: () => onUpvotesClick?.(upvotes),
           children: getText({ count: upvotes, label: 'Upvote' }),
         })}
-      {comments > 0 && (
-        <span>
-          {largeNumberFormat(comments)}
-          {` Comment${comments === 1 ? '' : 's'}`}
-        </span>
-      )}
+      {comments > 0 &&
+        renderText({
+          key: 'comments',
+          onClick: onCommentsClick,
+          children: getText({ count: comments, label: 'Comment' }),
+        })}
       {reposts > 0 &&
         renderText({
           key: 'reposts',
@@ -153,6 +155,7 @@ const PostUpvotesCommentsCountContent = ({
 const InteractivePostUpvotesCommentsCount = ({
   post,
   onUpvotesClick,
+  onCommentsClick,
   className,
   compact,
 }: PostUpvotesCommentsCountProps): ReactElement => {
@@ -165,6 +168,7 @@ const InteractivePostUpvotesCommentsCount = ({
       <PostUpvotesCommentsCountContent
         post={post}
         onUpvotesClick={onUpvotesClick}
+        onCommentsClick={onCommentsClick}
         className={className}
         compact={compact}
       />
@@ -192,6 +196,7 @@ const InteractivePostUpvotesCommentsCount = ({
     <PostUpvotesCommentsCountContent
       post={post}
       onUpvotesClick={onUpvotesClick}
+      onCommentsClick={onCommentsClick}
       onRepostsClick={onRepostsClick}
       onAwardsClick={
         hasAccessToCores && awards > 0

--- a/packages/shared/src/components/post/common/PostClickbaitShield.tsx
+++ b/packages/shared/src/components/post/common/PostClickbaitShield.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../hooks';
 import { useLazyModal } from '../../../hooks/useLazyModal';
 import { LazyModal } from '../../modals/common/types';
+import { IconSize } from '../../Icon';
 
 import { useSmartTitle } from '../../../hooks/post/useSmartTitle';
 import type { Post } from '../../../graphql/posts';
@@ -23,7 +24,13 @@ import { Typography, TypographyType } from '../../typography/Typography';
 import { PostUpgradeToPlus } from '../../plus/PostUpgradeToPlus';
 import { TargetId } from '../../../lib/log';
 
-export const PostClickbaitShield = ({ post }: { post: Post }): ReactElement => {
+export const PostClickbaitShield = ({
+  post,
+  iconOnly = false,
+}: {
+  post: Post;
+  iconOnly?: boolean;
+}): ReactElement => {
   const { openModal } = useLazyModal();
   const { isPlus } = usePlusSubscription();
   const { fetchSmartTitle, fetchedSmartTitle, shieldActive } =
@@ -32,6 +39,64 @@ export const PostClickbaitShield = ({ post }: { post: Post }): ReactElement => {
   const router = useRouter();
   const { user } = useAuthContext();
   const { hasUsedFreeTrial, triesLeft } = useClickbaitTries();
+
+  if (iconOnly) {
+    const isActive = isPlus ? shieldActive : fetchedSmartTitle;
+    const handleIconClick = async () => {
+      if (isPlus || !hasUsedFreeTrial) {
+        await fetchSmartTitle();
+        return;
+      }
+
+      if (isMobile) {
+        openModal({ type: LazyModal.ClickbaitShield });
+        return;
+      }
+
+      if (!user) {
+        throw new Error(
+          'PostClickbaitShield requires an authenticated user to edit feed settings',
+        );
+      }
+
+      router.push(
+        `${webappUrl}feeds/${user.id}/edit?dview=${FeedSettingsMenu.AI}`,
+      );
+    };
+
+    const tooltipContent = (() => {
+      if (isActive) {
+        return 'Click to see the original title';
+      }
+      return isPlus
+        ? 'Click to see the optimized title'
+        : 'Optimize this title with Clickbait Shield';
+    })();
+
+    const renderIcon = () => {
+      if (isActive) {
+        return <ShieldCheckIcon size={IconSize.Small} />;
+      }
+      if (isPlus) {
+        return <ShieldIcon size={IconSize.Small} />;
+      }
+      return <ShieldWarningIcon size={IconSize.Small} />;
+    };
+
+    return (
+      <Tooltip content={tooltipContent}>
+        <Button
+          aria-label="Clickbait Shield"
+          icon={renderIcon()}
+          iconSecondaryOnHover
+          onClick={handleIconClick}
+          size={ButtonSize.Small}
+          type="button"
+          variant={ButtonVariant.Tertiary}
+        />
+      </Tooltip>
+    );
+  }
 
   if (!isPlus) {
     return (

--- a/packages/shared/src/components/post/common/PostClickbaitShield.tsx
+++ b/packages/shared/src/components/post/common/PostClickbaitShield.tsx
@@ -19,6 +19,7 @@ import type { Post } from '../../../graphql/posts';
 import { FeedSettingsMenu } from '../../feeds/FeedSettings/types';
 import { webappUrl } from '../../../lib/constants';
 import { useAuthContext } from '../../../contexts/AuthContext';
+import { AuthTriggers } from '../../../lib/auth';
 import { Tooltip } from '../../tooltip/Tooltip';
 import { Typography, TypographyType } from '../../typography/Typography';
 import { PostUpgradeToPlus } from '../../plus/PostUpgradeToPlus';
@@ -37,7 +38,7 @@ export const PostClickbaitShield = ({
     useSmartTitle(post);
   const isMobile = useViewSize(ViewSize.MobileL);
   const router = useRouter();
-  const { user } = useAuthContext();
+  const { user, showLogin } = useAuthContext();
   const { hasUsedFreeTrial, triesLeft } = useClickbaitTries();
 
   if (iconOnly) {
@@ -54,9 +55,8 @@ export const PostClickbaitShield = ({
       }
 
       if (!user) {
-        throw new Error(
-          'PostClickbaitShield requires an authenticated user to edit feed settings',
-        );
+        showLogin({ trigger: AuthTriggers.Filter });
+        return;
       }
 
       router.push(

--- a/packages/shared/src/components/post/discovery/CollectionSources.tsx
+++ b/packages/shared/src/components/post/discovery/CollectionSources.tsx
@@ -1,0 +1,85 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { Post } from '../../../graphql/posts';
+import { PostRelationType } from '../../../graphql/posts';
+import { useRelatedPosts } from '../../../hooks/post/useRelatedPosts';
+import { SourceAvatar } from '../../profile/source';
+import { ProfileImageSize } from '../../ProfilePicture';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../typography/Typography';
+import { pluralize } from '../../../lib/strings';
+
+interface CollectionSourcesProps {
+  post: Post;
+}
+
+/**
+ * The collection's reference sources, integrated into the main reading flow as
+ * a horizontal carousel of source cards instead of the classic right-rail list.
+ */
+export const CollectionSources = ({
+  post,
+}: CollectionSourcesProps): ReactElement | null => {
+  const { relatedPosts, isLoading } = useRelatedPosts({
+    postId: post.id,
+    relationType: PostRelationType.Collection,
+    perPage: 20,
+  });
+  const edges = relatedPosts?.pages.flatMap((page) => page.edges) ?? [];
+
+  if (!isLoading && edges.length === 0) {
+    return null;
+  }
+
+  const count = post.numCollectionSources ?? edges.length;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <Typography
+        tag={TypographyTag.H2}
+        type={TypographyType.Body}
+        color={TypographyColor.Primary}
+        bold
+      >
+        {count} {pluralize('source', count)}
+      </Typography>
+      <div className="-mx-1 flex gap-3 overflow-x-auto px-1 pb-2">
+        {edges.map(({ node }) => (
+          <a
+            key={node.id}
+            href={node.commentsPermalink}
+            rel="noopener"
+            target="_blank"
+            title={node.title}
+            className="flex w-64 shrink-0 flex-col gap-2 rounded-16 border border-border-subtlest-tertiary p-3 transition-colors hover:border-border-subtlest-primary"
+          >
+            <div className="flex min-w-0 items-center gap-2">
+              <SourceAvatar
+                source={node.source}
+                size={ProfileImageSize.Small}
+              />
+              <Typography
+                type={TypographyType.Footnote}
+                color={TypographyColor.Tertiary}
+                className="truncate"
+              >
+                {node.source.name}
+              </Typography>
+            </div>
+            <Typography
+              type={TypographyType.Callout}
+              color={TypographyColor.Primary}
+              className="line-clamp-3"
+            >
+              {node.title}
+            </Typography>
+          </a>
+        ))}
+      </div>
+    </section>
+  );
+};

--- a/packages/shared/src/components/post/discovery/DiscussionMetaBar.tsx
+++ b/packages/shared/src/components/post/discovery/DiscussionMetaBar.tsx
@@ -1,0 +1,106 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import type { Post } from '../../../graphql/posts';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { useUpvoteQuery } from '../../../hooks/useUpvoteQuery';
+import { useSettingsContext } from '../../../contexts/SettingsContext';
+import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
+import { TimeSortIcon } from '../../icons/Sort/Time';
+import { AnalyticsIcon } from '../../icons';
+import { SortCommentsBy } from '../../../graphql/comments';
+import { ClickableText } from '../../buttons/ClickableText';
+import Link from '../../utilities/Link';
+import { largeNumberFormat } from '../../../lib';
+import { canViewPostAnalytics } from '../../../lib/user';
+import { webappUrl } from '../../../lib/constants';
+
+interface DiscussionMetaBarProps {
+  post: Post;
+  className?: string;
+  /** Optional content rendered on the right edge of the strip (e.g. clickbait shield). */
+  rightSlot?: ReactNode;
+}
+
+/**
+ * Post stats + comment sort strip. Lives in the left content column above the
+ * action bar; the sort toggle updates the shared settings context, so the
+ * discussion panel re-sorts its comments accordingly.
+ */
+export const DiscussionMetaBar = ({
+  post,
+  className,
+  rightSlot,
+}: DiscussionMetaBarProps): ReactElement => {
+  const { user } = useAuthContext();
+  const { onShowUpvoted } = useUpvoteQuery();
+  const { sortCommentsBy: sortBy, updateSortCommentsBy: setSortBy } =
+    useSettingsContext();
+  const upvotes = post.numUpvotes || 0;
+  const comments = post.numComments || 0;
+  const canSeeAnalytics = canViewPostAnalytics({ user, post });
+  const isNewestFirst = sortBy === SortCommentsBy.NewestFirst;
+  const sortLabel = isNewestFirst ? 'Sort: Newest first' : 'Sort: Oldest first';
+
+  return (
+    <div
+      className={classNames(
+        'flex min-w-0 flex-wrap items-center justify-between gap-x-4 gap-y-2 text-text-secondary typo-callout',
+        className,
+      )}
+    >
+      <div className="flex min-w-0 flex-wrap items-center gap-x-4">
+        {upvotes > 0 && (
+          <ClickableText onClick={() => onShowUpvoted(post.id, upvotes)}>
+            {largeNumberFormat(upvotes)} Upvote{upvotes > 1 ? 's' : ''}
+          </ClickableText>
+        )}
+        <span>
+          {largeNumberFormat(comments)} Comment{comments === 1 ? '' : 's'}
+        </span>
+        {canSeeAnalytics && (
+          <Link
+            href={`${webappUrl}posts/${post.id}/analytics`}
+            passHref
+            prefetch={false}
+          >
+            <ClickableText
+              tag="a"
+              className="gap-1"
+              textClassName="text-text-secondary"
+            >
+              <AnalyticsIcon />
+              Analytics
+            </ClickableText>
+          </Link>
+        )}
+        <Button
+          type="button"
+          size={ButtonSize.XSmall}
+          variant={ButtonVariant.Tertiary}
+          icon={
+            <TimeSortIcon
+              secondary
+              className={isNewestFirst ? undefined : 'rotate-180'}
+            />
+          }
+          onClick={() =>
+            setSortBy(
+              isNewestFirst
+                ? SortCommentsBy.OldestFirst
+                : SortCommentsBy.NewestFirst,
+            )
+          }
+          aria-label={sortLabel}
+          title={sortLabel}
+          className="!text-text-secondary"
+        />
+      </div>
+      {rightSlot && (
+        <div className="flex shrink-0 items-center [&_.mr-2]:!mr-0 [&_.mt-4]:!mt-0 [&_.mt-6]:!mt-0">
+          {rightSlot}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/shared/src/components/post/discovery/DiscussionShareRow.tsx
+++ b/packages/shared/src/components/post/discovery/DiscussionShareRow.tsx
@@ -1,0 +1,181 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import type { Post } from '../../../graphql/posts';
+import type { Squad } from '../../../graphql/sources';
+import { Button } from '../../buttons/Button';
+import { ButtonSize, ButtonVariant } from '../../buttons/common';
+import { Tooltip } from '../../tooltip/Tooltip';
+import { CopyIcon, ShareIcon, TwitterIcon, WhatsappIcon } from '../../icons';
+import { useCopyPostLink } from '../../../hooks/useCopyPostLink';
+import { useGetShortUrl } from '../../../hooks';
+import { getShareLink, ShareProvider } from '../../../lib/share';
+import { useLogContext } from '../../../contexts/LogContext';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { postLogEvent } from '../../../lib/feed';
+import { LogEvent, Origin } from '../../../lib/log';
+import { useLazyModal } from '../../../hooks/useLazyModal';
+import { LazyModal } from '../../modals/common/types';
+import { ReferralCampaignKey } from '../../../lib';
+import { getShareableSquads } from '../../squads/SquadsToShare';
+import SourceProfilePicture from '../../profile/SourceProfilePicture';
+import { ProfileImageSize } from '../../ProfilePicture';
+
+interface DiscussionShareRowProps {
+  post: Post;
+  className?: string;
+  /**
+   * Surfaces the user's squads as inline avatar buttons for quick sharing.
+   * The trailing "more" action still opens the full share modal with every
+   * squad and option.
+   */
+  withSquads?: boolean;
+}
+
+const maxInlineSquads = 4;
+const mobileInlineSquads = 2;
+
+/**
+ * Compact share row for the discussion panel. Surfaces the most-used quick
+ * actions (copy, X, WhatsApp) inline and defers the long tail (Facebook,
+ * squads, native share) to the full Share modal behind a single "more" action.
+ */
+export const DiscussionShareRow = ({
+  post,
+  className,
+  withSquads = false,
+}: DiscussionShareRowProps): ReactElement => {
+  const href = post.commentsPermalink;
+  const cid = ReferralCampaignKey.SharePost;
+  const { getShortUrl } = useGetShortUrl();
+  const [copying, copyLink] = useCopyPostLink();
+  const { logEvent } = useLogContext();
+  const { openModal } = useLazyModal();
+  const { squads } = useAuthContext();
+  const inlineSquads = withSquads
+    ? getShareableSquads(squads).slice(0, maxInlineSquads)
+    : [];
+
+  const onShareToSquad = (squad: Squad) => {
+    logEvent(postLogEvent(LogEvent.StartShareToSquad, post));
+    openModal({
+      type: LazyModal.CreateSharedPost,
+      props: {
+        squad,
+        preview: post,
+        onSharedSuccessfully: () =>
+          logEvent(postLogEvent(LogEvent.ShareToSquad, post)),
+      },
+    });
+  };
+
+  const logShareEvent = (provider: ShareProvider) =>
+    logEvent(
+      postLogEvent(LogEvent.SharePost, post, {
+        extra: { provider, origin: Origin.ShareBar },
+      }),
+    );
+
+  const onShare = async (provider: ShareProvider) => {
+    logShareEvent(provider);
+    const shortLink = await getShortUrl(href, cid);
+    const shareLink = getShareLink({
+      provider,
+      link: shortLink,
+      text: post?.title,
+    });
+    globalThis.window?.open(shareLink, '_blank');
+  };
+
+  const onCopy = async () => {
+    const shortLink = await getShortUrl(href, cid);
+    copyLink({ link: shortLink });
+    logShareEvent(ShareProvider.CopyLink);
+  };
+
+  const onMore = () =>
+    openModal({
+      type: LazyModal.Share,
+      props: { post, origin: Origin.ShareBar },
+    });
+
+  return (
+    <div
+      className={classNames(
+        'flex items-center justify-between gap-2',
+        className,
+      )}
+    >
+      <span className="text-text-tertiary typo-footnote">Share this post</span>
+      <div className="flex items-center gap-1">
+        <Tooltip content={copying ? 'Copied!' : 'Copy link'}>
+          <Button
+            aria-label="Copy link"
+            icon={
+              <CopyIcon
+                className={copying ? 'text-accent-avocado-default' : undefined}
+                secondary={copying}
+              />
+            }
+            onClick={onCopy}
+            size={ButtonSize.Small}
+            type="button"
+            variant={ButtonVariant.Tertiary}
+          />
+        </Tooltip>
+        <Tooltip content="Share on X">
+          <Button
+            aria-label="Share on X"
+            icon={<TwitterIcon />}
+            onClick={() => onShare(ShareProvider.Twitter)}
+            size={ButtonSize.Small}
+            type="button"
+            variant={ButtonVariant.Tertiary}
+          />
+        </Tooltip>
+        <Tooltip content="Share on WhatsApp">
+          <Button
+            aria-label="Share on WhatsApp"
+            icon={<WhatsappIcon secondary />}
+            onClick={() => onShare(ShareProvider.WhatsApp)}
+            size={ButtonSize.Small}
+            type="button"
+            variant={ButtonVariant.Tertiary}
+          />
+        </Tooltip>
+        {inlineSquads.map((squad, index) => (
+          <Tooltip key={squad.id} content={`Share to @${squad.handle}`}>
+            <Button
+              aria-label={`Share to ${squad.name}`}
+              // Keep the row compact on mobile: only the first two squads
+              // show; the rest appear from tablet up.
+              className={
+                index >= mobileInlineSquads ? 'hidden tablet:flex' : undefined
+              }
+              icon={
+                <SourceProfilePicture
+                  source={squad}
+                  size={ProfileImageSize.Small}
+                />
+              }
+              onClick={() => onShareToSquad(squad)}
+              size={ButtonSize.Small}
+              type="button"
+              variant={ButtonVariant.Tertiary}
+            />
+          </Tooltip>
+        ))}
+        <Tooltip content="See all squads and sharing options">
+          <Button
+            aria-label="More sharing options"
+            icon={<ShareIcon />}
+            onClick={onMore}
+            size={ButtonSize.Small}
+            type="button"
+            variant={ButtonVariant.Tertiary}
+          />
+        </Tooltip>
+      </div>
+    </div>
+  );
+};

--- a/packages/shared/src/components/post/discovery/PostDiscoveryActionBar.tsx
+++ b/packages/shared/src/components/post/discovery/PostDiscoveryActionBar.tsx
@@ -144,7 +144,9 @@ export const PostDiscoveryActionBar = ({
       <div ref={sentinelRef} aria-hidden className="pointer-events-none h-0" />
       <div
         className={classNames(
-          'sticky z-3 flex items-center justify-between gap-2 border-b border-border-subtlest-tertiary bg-background-default px-1 py-2',
+          // Static on mobile (no sticky), sticky from tablet up so the bar
+          // never overlaps the small-screen reading flow.
+          'relative z-3 flex items-center justify-between gap-2 border-b border-border-subtlest-tertiary bg-background-default px-1 py-2 tablet:sticky',
           // Drop the top border once pinned so it doesn't double up with the
           // header border above it.
           !isStuck && 'border-t',
@@ -221,25 +223,34 @@ export const PostDiscoveryActionBar = ({
               size: ButtonSize.Medium,
             }}
           />
-          <Tooltip content="Copy link">
-            <CardAction
-              label="Copy link"
-              color={ButtonColor.Cabbage}
-              icon={<LinkIcon />}
-              onClick={() => onCopyLinkClick?.(post)}
-            />
-          </Tooltip>
+          {/* As the viewport narrows we fold the lowest-priority utilities into
+              the "…" menu (which already offers Share and Post analytics),
+              closest-to-the-menu first: analytics below laptop, then share/copy
+              below tablet. Bookmark stays — it is the primary save action and
+              is not in the menu. */}
+          <div className="hidden tablet:flex">
+            <Tooltip content="Copy link">
+              <CardAction
+                label="Copy link"
+                color={ButtonColor.Cabbage}
+                icon={<LinkIcon />}
+                onClick={() => onCopyLinkClick?.(post)}
+              />
+            </Tooltip>
+          </div>
           {post.clickbaitTitleDetected && (
             <PostClickbaitShield post={post} iconOnly />
           )}
           {canSeeAnalytics && (
-            <Tooltip content="Analytics">
-              <CardAction
-                label="Analytics"
-                icon={<AnalyticsIcon />}
-                href={`${webappUrl}posts/${post.id}/analytics`}
-              />
-            </Tooltip>
+            <div className="hidden laptop:flex">
+              <Tooltip content="Analytics">
+                <CardAction
+                  label="Analytics"
+                  icon={<AnalyticsIcon />}
+                  href={`${webappUrl}posts/${post.id}/analytics`}
+                />
+              </Tooltip>
+            </div>
           )}
           <PostMenuOptions
             post={post}

--- a/packages/shared/src/components/post/discovery/PostDiscoveryActionBar.tsx
+++ b/packages/shared/src/components/post/discovery/PostDiscoveryActionBar.tsx
@@ -1,0 +1,256 @@
+import type { ReactElement } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import classNames from 'classnames';
+import type { Post } from '../../../graphql/posts';
+import { UserVote } from '../../../graphql/posts';
+import { useVotePost } from '../../../hooks';
+import { useBookmarkPost } from '../../../hooks/useBookmarkPost';
+import { useBlockPostPanel } from '../../../hooks/post/useBlockPostPanel';
+import { useCanAwardUser } from '../../../hooks/useCoresFeature';
+import { useLazyModal } from '../../../hooks/useLazyModal';
+import { LazyModal } from '../../modals/common/types';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import type { PostOrigin } from '../../../hooks/log/useLogContextData';
+import { Origin } from '../../../lib/log';
+import { AuthTriggers } from '../../../lib/auth';
+import { ButtonSize } from '../../buttons/Button';
+import { ButtonColor } from '../../buttons/ButtonV2';
+import { CardAction } from '../../buttons/CardAction';
+import { BookmarkButton } from '../../buttons/BookmarkButton';
+import CloseButton from '../../CloseButton';
+import { UpvoteButtonIcon } from '../../cards/common/UpvoteButtonIcon';
+import { IconSize } from '../../Icon';
+import {
+  AnalyticsIcon,
+  DiscussIcon as CommentIcon,
+  DownvoteIcon,
+  LinkIcon,
+  MedalBadgeIcon,
+} from '../../icons';
+import { Tooltip } from '../../tooltip/Tooltip';
+import type { LoggedUser } from '../../../lib/user';
+import { canViewPostAnalytics } from '../../../lib/user';
+import { webappUrl } from '../../../lib/constants';
+import { PostMenuOptions } from '../PostMenuOptions';
+import { PostClickbaitShield } from '../common/PostClickbaitShield';
+
+interface PostDiscoveryActionBarProps {
+  post: Post;
+  origin?: PostOrigin;
+  onComment?: () => void;
+  onCopyLinkClick?: (post?: Post) => void;
+  /** When provided (post modal), renders an X close button next to the menu. */
+  onClose?: () => void;
+  className?: string;
+}
+
+/**
+ * Engagement bar for the discovery focus card, built on the CardAction
+ * primitives (PR #6064 guideline): each action's count lives inside the click
+ * target so the icon or number performs the action. Sticks to the top while
+ * scrolling; the modal X appears only once the bar is pinned.
+ */
+export const PostDiscoveryActionBar = ({
+  post,
+  origin = Origin.ArticlePage,
+  onComment,
+  onCopyLinkClick,
+  onClose,
+  className,
+}: PostDiscoveryActionBarProps): ReactElement => {
+  const { user, showLogin } = useAuthContext();
+  const { toggleUpvote, toggleDownvote } = useVotePost();
+  const { toggleBookmark } = useBookmarkPost();
+  const { onShowPanel, onClose: onCloseBlockPanel } = useBlockPostPanel(post);
+  const { openModal } = useLazyModal();
+  const canAward = useCanAwardUser({
+    sendingUser: user,
+    receivingUser: post.author as LoggedUser | undefined,
+  });
+
+  // Detect when the sticky bar is pinned to the top so the X close button
+  // (modal only) appears just for the stuck state.
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [isStuck, setIsStuck] = useState(false);
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || typeof IntersectionObserver === 'undefined') {
+      return undefined;
+    }
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsStuck(!entry.isIntersecting),
+      { threshold: 0 },
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const isUpvoteActive = post?.userState?.vote === UserVote.Up;
+  const isDownvoteActive = post?.userState?.vote === UserVote.Down;
+  const isAwarded = !!post?.userState?.awarded;
+  const upvotes = post.numUpvotes || 0;
+  const comments = post.numComments || 0;
+  const awards = post.numAwards || 0;
+  const canSeeAnalytics = canViewPostAnalytics({ user, post });
+  // In the modal there is no app header, so pin to the very top; on the post
+  // page the bar must sit below the fixed laptop header (4rem). `onClose` is
+  // only provided by the post modal, so it doubles as the surface flag.
+  const stickyTopClassName = onClose ? 'top-0' : 'top-0 laptop:top-16';
+
+  const onToggleUpvote = async () => {
+    if (post?.userState?.vote === UserVote.None) {
+      onCloseBlockPanel(true);
+    }
+    await toggleUpvote({ payload: post, origin });
+  };
+
+  const onToggleDownvote = async () => {
+    if (post.userState?.vote !== UserVote.Down) {
+      onShowPanel();
+    } else {
+      onCloseBlockPanel(true);
+    }
+    await toggleDownvote({ payload: post, origin });
+  };
+
+  const onToggleBookmark = async () => {
+    await toggleBookmark({ post, origin });
+  };
+
+  const onGiveAward = () => {
+    if (!user) {
+      showLogin({ trigger: AuthTriggers.GiveAward });
+      return;
+    }
+    if (!post.author || isAwarded) {
+      return;
+    }
+    openModal({
+      type: LazyModal.GiveAward,
+      props: {
+        type: 'POST',
+        entity: {
+          id: post.id,
+          receiver: post.author,
+          numAwards: post.numAwards,
+        },
+        post,
+      },
+    });
+  };
+
+  return (
+    <>
+      <div ref={sentinelRef} aria-hidden className="pointer-events-none h-0" />
+      <div
+        className={classNames(
+          'sticky z-3 flex items-center justify-between gap-2 border-b border-border-subtlest-tertiary bg-background-default px-1 py-2',
+          // Drop the top border once pinned so it doesn't double up with the
+          // header border above it.
+          !isStuck && 'border-t',
+          stickyTopClassName,
+          className,
+        )}
+      >
+        <div className="flex items-center gap-1">
+          <Tooltip
+            content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
+          >
+            <CardAction
+              id="upvote-post-btn"
+              label="Upvote"
+              color={ButtonColor.Avocado}
+              icon={<UpvoteButtonIcon />}
+              iconPressed={<UpvoteButtonIcon secondary />}
+              count={upvotes}
+              pressed={isUpvoteActive}
+              onClick={onToggleUpvote}
+            />
+          </Tooltip>
+          <Tooltip
+            content={isDownvoteActive ? 'Remove downvote' : 'Less like this'}
+          >
+            <CardAction
+              id="downvote-post-btn"
+              label="Downvote"
+              color={ButtonColor.Ketchup}
+              icon={<DownvoteIcon />}
+              iconPressed={<DownvoteIcon secondary />}
+              pressed={isDownvoteActive}
+              onClick={onToggleDownvote}
+            />
+          </Tooltip>
+          <Tooltip content="Comment">
+            <CardAction
+              id="comment-post-btn"
+              label="Comment"
+              color={ButtonColor.BlueCheese}
+              icon={<CommentIcon />}
+              iconPressed={<CommentIcon secondary />}
+              count={comments}
+              pressed={post.commented}
+              onClick={onComment}
+            />
+          </Tooltip>
+          {canAward && (
+            <Tooltip
+              content={isAwarded ? 'You already awarded this post!' : 'Award'}
+            >
+              <CardAction
+                id="award-post-btn"
+                label="Award"
+                color={ButtonColor.Cabbage}
+                icon={<MedalBadgeIcon secondary />}
+                iconPressed={<MedalBadgeIcon />}
+                count={awards}
+                pressed={isAwarded}
+                onClick={onGiveAward}
+              />
+            </Tooltip>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1">
+          <BookmarkButton
+            post={post}
+            iconSize={IconSize.Small}
+            buttonProps={{
+              id: 'bookmark-post-btn',
+              pressed: post.bookmarked,
+              onClick: onToggleBookmark,
+              size: ButtonSize.Medium,
+            }}
+          />
+          <Tooltip content="Copy link">
+            <CardAction
+              label="Copy link"
+              color={ButtonColor.Cabbage}
+              icon={<LinkIcon />}
+              onClick={() => onCopyLinkClick?.(post)}
+            />
+          </Tooltip>
+          {post.clickbaitTitleDetected && (
+            <PostClickbaitShield post={post} iconOnly />
+          )}
+          {canSeeAnalytics && (
+            <Tooltip content="Analytics">
+              <CardAction
+                label="Analytics"
+                icon={<AnalyticsIcon />}
+                href={`${webappUrl}posts/${post.id}/analytics`}
+              />
+            </Tooltip>
+          )}
+          <PostMenuOptions
+            post={post}
+            origin={Origin.ArticleModal}
+            buttonSize={ButtonSize.Medium}
+          />
+          {isStuck && onClose && (
+            <CloseButton size={ButtonSize.Medium} onClick={() => onClose()} />
+          )}
+        </div>
+      </div>
+    </>
+  );
+};

--- a/packages/shared/src/components/post/discovery/PostDiscoveryActionBar.tsx
+++ b/packages/shared/src/components/post/discovery/PostDiscoveryActionBar.tsx
@@ -9,6 +9,7 @@ import { useBlockPostPanel } from '../../../hooks/post/useBlockPostPanel';
 import { useCanAwardUser } from '../../../hooks/useCoresFeature';
 import { useLazyModal } from '../../../hooks/useLazyModal';
 import { LazyModal } from '../../modals/common/types';
+import { useLayoutVariant } from '../../../hooks/layout/useLayoutVariant';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import type { PostOrigin } from '../../../hooks/log/useLogContextData';
 import { Origin } from '../../../lib/log';
@@ -59,6 +60,7 @@ export const PostDiscoveryActionBar = ({
   className,
 }: PostDiscoveryActionBarProps): ReactElement => {
   const { user, showLogin } = useAuthContext();
+  const { isV2 } = useLayoutVariant();
   const { toggleUpvote, toggleDownvote } = useVotePost();
   const { toggleBookmark } = useBookmarkPost();
   const { onShowPanel, onClose: onCloseBlockPanel } = useBlockPostPanel(post);
@@ -92,10 +94,14 @@ export const PostDiscoveryActionBar = ({
   const comments = post.numComments || 0;
   const awards = post.numAwards || 0;
   const canSeeAnalytics = canViewPostAnalytics({ user, post });
-  // In the modal there is no app header, so pin to the very top; on the post
-  // page the bar must sit below the fixed laptop header (4rem). `onClose` is
-  // only provided by the post modal, so it doubles as the surface flag.
-  const stickyTopClassName = onClose ? 'top-0' : 'top-0 laptop:top-16';
+  // Sticky offset depends on the top chrome. The modal has no app header (pin
+  // to the very top). On the post page, the v2 rail layout hides the global
+  // header on laptop for logged-in users, so the bar sticks to the very top
+  // like the feed nav; the legacy/logged-out layout keeps a fixed 4rem header
+  // the bar must clear. `onClose` is only provided by the modal.
+  const railOwnsHeader = isV2 && !!user;
+  const stickyTopClassName =
+    onClose || railOwnsHeader ? 'top-0' : 'top-0 laptop:top-16';
 
   const onToggleUpvote = async () => {
     if (post?.userState?.vote === UserVote.None) {

--- a/packages/shared/src/components/post/discovery/PostDiscoveryActionBar.tsx
+++ b/packages/shared/src/components/post/discovery/PostDiscoveryActionBar.tsx
@@ -73,6 +73,9 @@ export const PostDiscoveryActionBar = ({
   // Detect when the sticky bar is pinned to the top so the X close button
   // (modal only) appears just for the stuck state.
   const sentinelRef = useRef<HTMLDivElement>(null);
+  const barRef = useRef<HTMLDivElement>(null);
+  const copyLinkRef = useRef<HTMLDivElement>(null);
+  const analyticsRef = useRef<HTMLDivElement>(null);
   const [isStuck, setIsStuck] = useState(false);
   useEffect(() => {
     const el = sentinelRef.current;
@@ -102,6 +105,52 @@ export const PostDiscoveryActionBar = ({
   const railOwnsHeader = isV2 && !!user;
   const stickyTopClassName =
     onClose || railOwnsHeader ? 'top-0' : 'top-0 laptop:top-16';
+
+  // Dynamically fold the lowest-priority utilities into the "…" menu (which
+  // already lists Share and Post analytics) whenever the bar would overflow,
+  // and bring them back inline when there is room again. Measured against the
+  // real available width — not breakpoints — so it reacts to page/modal
+  // resizing. Priority (first to fold): analytics, then copy/share.
+  useEffect(() => {
+    const bar = barRef.current;
+    if (!bar) {
+      return undefined;
+    }
+    const fit = () => {
+      const copyLink = copyLinkRef.current;
+      const analytics = analyticsRef.current;
+      // Show both first (inline display overrides the SSR fallback classes),
+      // then hide in priority order until the row stops overflowing.
+      if (copyLink) {
+        copyLink.style.display = 'flex';
+      }
+      if (analytics) {
+        analytics.style.display = 'flex';
+      }
+      const overflows = () => bar.scrollWidth > bar.clientWidth;
+      if (analytics && overflows()) {
+        analytics.style.display = 'none';
+      }
+      if (copyLink && overflows()) {
+        copyLink.style.display = 'none';
+      }
+    };
+    fit();
+    if (typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+    const observer = new ResizeObserver(fit);
+    observer.observe(bar);
+    return () => observer.disconnect();
+  }, [
+    canSeeAnalytics,
+    upvotes,
+    comments,
+    awards,
+    canAward,
+    post.clickbaitTitleDetected,
+    post.bookmarked,
+  ]);
 
   const onToggleUpvote = async () => {
     if (post?.userState?.vote === UserVote.None) {
@@ -149,6 +198,7 @@ export const PostDiscoveryActionBar = ({
     <>
       <div ref={sentinelRef} aria-hidden className="pointer-events-none h-0" />
       <div
+        ref={barRef}
         className={classNames(
           // Static on mobile (no sticky), sticky from tablet up so the bar
           // never overlaps the small-screen reading flow.
@@ -229,12 +279,12 @@ export const PostDiscoveryActionBar = ({
               size: ButtonSize.Medium,
             }}
           />
-          {/* As the viewport narrows we fold the lowest-priority utilities into
-              the "…" menu (which already offers Share and Post analytics),
-              closest-to-the-menu first: analytics below laptop, then share/copy
-              below tablet. Bookmark stays — it is the primary save action and
-              is not in the menu. */}
-          <div className="hidden tablet:flex">
+          {/* Bookmark stays — it is the primary save action and is not in the
+              menu. Copy/share and analytics fold into the "…" menu when space
+              is tight (see the overflow effect); the `hidden tablet:flex` /
+              `hidden laptop:flex` classes are only the pre-measurement (SSR)
+              fallback — the effect overrides display once it measures. */}
+          <div ref={copyLinkRef} className="hidden tablet:flex">
             <Tooltip content="Copy link">
               <CardAction
                 label="Copy link"
@@ -248,7 +298,7 @@ export const PostDiscoveryActionBar = ({
             <PostClickbaitShield post={post} iconOnly />
           )}
           {canSeeAnalytics && (
-            <div className="hidden laptop:flex">
+            <div ref={analyticsRef} className="hidden laptop:flex">
               <Tooltip content="Analytics">
                 <CardAction
                   label="Analytics"

--- a/packages/shared/src/components/post/discovery/PostDiscussionPanel.tsx
+++ b/packages/shared/src/components/post/discovery/PostDiscussionPanel.tsx
@@ -1,0 +1,231 @@
+import dynamic from 'next/dynamic';
+import type { LegacyRef, ReactElement } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import classNames from 'classnames';
+import type { Post } from '../../../graphql/posts';
+import { useShareComment } from '../../../hooks/useShareComment';
+import { useUpvoteQuery } from '../../../hooks/useUpvoteQuery';
+import { Origin } from '../../../lib/log';
+import { PostComments } from '../PostComments';
+import type {
+  NewCommentRef,
+  NewCommentTriggerRenderProps,
+} from '../NewComment';
+import { NewComment } from '../NewComment';
+import { useSettingsContext } from '../../../contexts/SettingsContext';
+import {
+  getProfilePictureClasses,
+  ProfileImageSize,
+  ProfilePicture,
+} from '../../ProfilePicture';
+import { Image } from '../../image/Image';
+import { fallbackImages } from '../../../lib/config';
+import {
+  Button,
+  ButtonIconPosition,
+  ButtonSize,
+  ButtonVariant,
+} from '../../buttons/Button';
+import { TimeSortIcon } from '../../icons/Sort/Time';
+import { SortCommentsBy } from '../../../graphql/comments';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../typography/Typography';
+import { DiscussionMetaBar } from './DiscussionMetaBar';
+import { DiscussionShareRow } from './DiscussionShareRow';
+
+const CommentInputOrModal = dynamic(
+  () =>
+    import(
+      /* webpackChunkName: "commentInputOrModal" */ '../../comments/CommentInputOrModal'
+    ),
+);
+
+export interface PostDiscussionPanelProps {
+  post: Post;
+  origin?: Origin;
+  className?: string;
+  /**
+   * Renders the post stats + comment sort strip inside the panel. Disable it
+   * when a parent (e.g. the discovery focus card) surfaces the strip elsewhere.
+   */
+  showMetaBar?: boolean;
+  /**
+   * Renders a small comment-sort toggle ("Newest first"/"Oldest first") at the
+   * top of the comment list. Used by the discovery focus card, which moves the
+   * post stats/actions out of this panel.
+   */
+  showSortHeader?: boolean;
+  /**
+   * Lets a parent (e.g. a floating "comment" action) focus the composer.
+   */
+  onRegisterFocusComment?: (fn: () => void) => void;
+  /**
+   * The element the comment edit/reply modals portal into. Defaults to the
+   * panel root so modals stay scoped to this surface.
+   */
+  modalParentSelector?: () => HTMLElement;
+}
+
+const noopFocus = (): void => {};
+
+/**
+ * The discussion surface (comments, composer, share) shared by the reader's
+ * EngagementRail and the post discovery focus card. Extracted so both surfaces
+ * stay in sync instead of duplicating the comment stack.
+ */
+export const PostDiscussionPanel = ({
+  post,
+  origin = Origin.ArticlePage,
+  className,
+  showMetaBar = true,
+  showSortHeader = false,
+  onRegisterFocusComment,
+  modalParentSelector,
+}: PostDiscussionPanelProps): ReactElement => {
+  const { sortCommentsBy: sortBy, updateSortCommentsBy: setSortBy } =
+    useSettingsContext();
+  const isNewestFirst = sortBy === SortCommentsBy.NewestFirst;
+  const commentRef = useRef<NewCommentRef | null>(null);
+  const rootRef = useRef<HTMLElement | null>(null);
+  const [isComposerOpen, setIsComposerOpen] = useState(false);
+  const { onShowUpvoted } = useUpvoteQuery();
+  const { openShareComment } = useShareComment(origin);
+
+  useEffect(() => {
+    if (!onRegisterFocusComment) {
+      return undefined;
+    }
+
+    const run = (): void => {
+      commentRef.current?.onShowInput(Origin.PostCommentButton);
+    };
+    onRegisterFocusComment(run);
+
+    return () => {
+      onRegisterFocusComment(noopFocus);
+    };
+  }, [onRegisterFocusComment, post.id]);
+
+  const resolveModalParent = (): HTMLElement => {
+    if (modalParentSelector) {
+      return modalParentSelector();
+    }
+
+    return rootRef.current ?? document.body;
+  };
+
+  const renderComposerTrigger = ({
+    user: triggerUser,
+    onCommentClick,
+  }: NewCommentTriggerRenderProps): ReactElement => (
+    <button
+      type="button"
+      aria-label="Add a comment"
+      onClick={() => onCommentClick(Origin.StartDiscussion)}
+      className="group flex w-full items-center gap-3 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-3 text-left transition-colors hover:border-border-subtlest-primary hover:bg-surface-hover"
+    >
+      {triggerUser ? (
+        <ProfilePicture
+          className="shrink-0"
+          nativeLazyLoading
+          size={ProfileImageSize.Medium}
+          user={triggerUser}
+        />
+      ) : (
+        <Image
+          alt="Placeholder image for anonymous user"
+          aria-hidden
+          className={classNames(
+            'shrink-0',
+            getProfilePictureClasses(ProfileImageSize.Medium),
+          )}
+          fetchPriority="low"
+          height={32}
+          loading="lazy"
+          role="presentation"
+          src={fallbackImages.avatar}
+          width={32}
+        />
+      )}
+      <span className="min-w-0 flex-1 truncate text-text-tertiary typo-callout">
+        Share your thoughts…
+      </span>
+      <span className="shrink-0 rounded-10 bg-background-default px-3 py-1.5 text-text-secondary transition-colors typo-footnote group-hover:text-text-primary">
+        Comment
+      </span>
+    </button>
+  );
+
+  return (
+    <section
+      ref={rootRef}
+      aria-label="Discussion"
+      className={classNames('flex min-h-0 min-w-0 flex-col gap-2', className)}
+    >
+      <div className={classNames(isComposerOpen && 'animate-composer-in')}>
+        <NewComment
+          post={post}
+          ref={commentRef as LegacyRef<NewCommentRef>}
+          shouldHandleCommentQuery
+          onComposerOpenChange={setIsComposerOpen}
+          size={ProfileImageSize.Medium}
+          CommentInputOrModal={CommentInputOrModal}
+          renderTrigger={renderComposerTrigger}
+        />
+      </div>
+      <DiscussionShareRow post={post} withSquads />
+      {showSortHeader && (
+        <span className="flex shrink-0 flex-row items-center">
+          <Typography
+            color={TypographyColor.Tertiary}
+            type={TypographyType.Footnote}
+          >
+            Sort:
+          </Typography>
+          <Button
+            className="ml-1 !px-1 !text-text-tertiary"
+            icon={
+              <TimeSortIcon
+                secondary
+                className={isNewestFirst ? undefined : 'rotate-180'}
+              />
+            }
+            iconPosition={ButtonIconPosition.Right}
+            onClick={() =>
+              setSortBy(
+                isNewestFirst
+                  ? SortCommentsBy.OldestFirst
+                  : SortCommentsBy.NewestFirst,
+              )
+            }
+            size={ButtonSize.XSmall}
+            type="button"
+            variant={ButtonVariant.Tertiary}
+          >
+            {isNewestFirst ? 'Newest first' : 'Oldest first'}
+          </Button>
+        </span>
+      )}
+      <div className="min-w-0">
+        <PostComments
+          post={post}
+          sortBy={sortBy}
+          origin={origin}
+          isComposerOpen={isComposerOpen}
+          onShare={(comment) => openShareComment(comment, post)}
+          onClickUpvote={(id, count) => onShowUpvoted(id, count, 'comment')}
+          modalParentSelector={resolveModalParent}
+          removeTopSpacing
+        />
+      </div>
+      {showMetaBar && (
+        <div className="flex shrink-0 flex-col gap-3 pt-3">
+          <DiscussionMetaBar post={post} />
+        </div>
+      )}
+    </section>
+  );
+};

--- a/packages/shared/src/components/post/discovery/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/discovery/PostFocusCard.tsx
@@ -357,36 +357,41 @@ export const PostFocusCard = ({
             {!isShared && isCollection && (
               <p className="text-text-tertiary typo-footnote">Collection</p>
             )}
-            <div className="flex min-w-0 flex-row items-start gap-4">
-              <h1
-                className="min-w-0 flex-1 break-words font-bold text-text-primary typo-title3 tablet:typo-title1"
-                data-testid="post-modal-title"
-              >
-                {title}
-              </h1>
-              {!isVideoType && article.image && (
-                <a
-                  className="block h-fit w-32 shrink-0 overflow-hidden rounded-16 bg-background-subtle tablet:w-40"
-                  href={readHref}
-                  onClick={handleImageClick}
-                  rel="noopener"
-                  target="_blank"
-                  title="Go to post"
+            {/* Below the 656px (tablet) breakpoint we keep the read button
+                directly under the title with a tight gap; from tablet up the
+                read button moves to the top row and this one is hidden. */}
+            <div className="flex min-w-0 flex-col gap-1.5">
+              <div className="flex min-w-0 flex-row items-start gap-4">
+                <h1
+                  className="min-w-0 flex-1 break-words font-bold text-text-primary typo-title3 tablet:typo-title1"
+                  data-testid="post-modal-title"
                 >
-                  <LazyImage
-                    eager
-                    // Square crop on mobile/tablet; laptop+ keeps the
-                    // original wide cover ratio (52% => 25/13).
-                    className="aspect-square w-full laptop:aspect-[25/13]"
-                    fallbackSrc={cloudinaryPostImageCoverPlaceholder}
-                    fetchPriority="high"
-                    imgAlt="Post cover image"
-                    imgSrc={article.image}
-                  />
-                </a>
-              )}
+                  {title}
+                </h1>
+                {!isVideoType && article.image && (
+                  <a
+                    className="block h-fit w-24 shrink-0 overflow-hidden rounded-16 bg-background-subtle tablet:w-40"
+                    href={readHref}
+                    onClick={handleImageClick}
+                    rel="noopener"
+                    target="_blank"
+                    title="Go to post"
+                  >
+                    <LazyImage
+                      eager
+                      // Small square thumbnail below tablet; from tablet (656px)
+                      // up it uses the original wide cover ratio (52% => 25/13).
+                      className="aspect-square w-full tablet:aspect-[25/13]"
+                      fallbackSrc={cloudinaryPostImageCoverPlaceholder}
+                      fetchPriority="high"
+                      imgAlt="Post cover image"
+                      imgSrc={article.image}
+                    />
+                  </a>
+                )}
+              </div>
+              {renderReadButton('w-fit tablet:hidden')}
             </div>
-            {renderReadButton('w-fit tablet:hidden')}
           </div>
 
           <PostDiscoveryActionBar

--- a/packages/shared/src/components/post/discovery/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/discovery/PostFocusCard.tsx
@@ -26,7 +26,6 @@ import { ContentEmbeds } from '../../contentEmbeds/ContentEmbeds';
 import { LazyImage } from '../../LazyImage';
 import { cloudinaryPostImageCoverPlaceholder } from '../../../lib/image';
 import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
-import { ClickableText } from '../../buttons/ClickableText';
 import { getReadPostButtonIcon } from '../../cards/common/ReadArticleButton';
 import { PostUpvotesCommentsCount } from '../PostUpvotesCommentsCount';
 import { PostTagList } from '../tags/PostTagList';
@@ -128,18 +127,25 @@ const VideoSummary = ({ summary }: { summary: string }): ReactElement => {
         {summary}
       </p>
       {isClamped && !isExpanded && (
-        <span className="absolute bottom-0 right-0 flex items-center bg-background-default pl-1">
+        // Sits on the last clamped line: typo-markdown matches the paragraph's
+        // font size and line height, so the button (and its background/fade)
+        // are exactly one line tall and align to the text it continues. We
+        // render an ellipsis before the link so the cut-off reads naturally.
+        <button
+          type="button"
+          aria-label="Show more"
+          onClick={() => setIsExpanded(true)}
+          className="absolute bottom-0 right-0 flex items-center bg-background-default text-text-secondary typo-markdown"
+        >
           <span
             aria-hidden
             className="pointer-events-none absolute right-full top-0 h-full w-8 bg-gradient-to-l from-background-default to-transparent"
           />
-          <ClickableText
-            className="!text-text-link"
-            onClick={() => setIsExpanded(true)}
-          >
+          <span aria-hidden>…&nbsp;</span>
+          <span className="font-bold text-text-link hover:underline">
             Show more
-          </ClickableText>
-        </span>
+          </span>
+        </button>
       )}
     </div>
   );

--- a/packages/shared/src/components/post/discovery/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/discovery/PostFocusCard.tsx
@@ -365,9 +365,15 @@ export const PostFocusCard = ({
                 sits right under it regardless of the image height; from tablet
                 (656px) up the button moves to the top row and this one hides. */}
             <div className="flex min-w-0 flex-row items-start gap-4">
-              <div className="flex min-w-0 flex-1 flex-col gap-2.5">
+              <div className="flex min-w-0 flex-1 flex-col gap-4">
                 <h1
-                  className="line-clamp-3 break-words font-bold text-text-primary typo-title3 tablet:typo-title1"
+                  className={classNames(
+                    'break-words font-bold text-text-primary typo-title3 tablet:typo-title1',
+                    // On the post page the reader came to read, so the title is
+                    // always shown in full and the button flows below it; only
+                    // the modal (a feed preview) clamps it.
+                    onClose && 'line-clamp-3',
+                  )}
                   data-testid="post-modal-title"
                 >
                   {title}

--- a/packages/shared/src/components/post/discovery/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/discovery/PostFocusCard.tsx
@@ -357,9 +357,9 @@ export const PostFocusCard = ({
             {!isShared && isCollection && (
               <p className="text-text-tertiary typo-footnote">Collection</p>
             )}
-            <div className="flex min-w-0 flex-col gap-4 tablet:flex-row tablet:items-start">
+            <div className="flex min-w-0 flex-row items-start gap-4">
               <h1
-                className="min-w-0 break-words font-bold text-text-primary typo-title2 tablet:flex-1 tablet:typo-large-title"
+                className="min-w-0 flex-1 break-words font-bold text-text-primary typo-title3 tablet:typo-title1"
                 data-testid="post-modal-title"
               >
                 {title}

--- a/packages/shared/src/components/post/discovery/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/discovery/PostFocusCard.tsx
@@ -1,0 +1,463 @@
+import dynamic from 'next/dynamic';
+import type { ComponentProps, ReactElement } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import classNames from 'classnames';
+import type { Post } from '../../../graphql/posts';
+import {
+  getReadArticleHref,
+  getReadPostButtonText,
+  isInternalReadType,
+  isVideoPost,
+  PostType,
+} from '../../../graphql/posts';
+import type { SourceTooltip } from '../../../graphql/sources';
+import { SourceType } from '../../../graphql/sources';
+import type { PostOrigin } from '../../../hooks/log/useLogContextData';
+import usePostContent from '../../../hooks/usePostContent';
+import { useSmartTitle } from '../../../hooks/post/useSmartTitle';
+import { useUpvoteQuery } from '../../../hooks/useUpvoteQuery';
+import { useReaderInstallPromptGate } from '../../../hooks/useReaderInstallPromptGate';
+import PostMetadata from '../../cards/common/PostMetadata';
+import YoutubeVideo from '../../video/YoutubeVideo';
+import { PlayIcon } from '../../icons';
+import { IconSize } from '../../Icon';
+import Markdown from '../../Markdown';
+import { ContentEmbeds } from '../../contentEmbeds/ContentEmbeds';
+import { LazyImage } from '../../LazyImage';
+import { cloudinaryPostImageCoverPlaceholder } from '../../../lib/image';
+import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
+import { ClickableText } from '../../buttons/ClickableText';
+import { getReadPostButtonIcon } from '../../cards/common/ReadArticleButton';
+import { PostUpvotesCommentsCount } from '../PostUpvotesCommentsCount';
+import { PostTagList } from '../tags/PostTagList';
+import { TruncateText } from '../../utilities';
+import { combinedClicks } from '../../../lib/click';
+import { useFeature } from '../../GrowthBookProvider';
+import { feature } from '../../../lib/featureManagement';
+import { SourceStrip } from '../reader/SourceStrip';
+import Link from '../../utilities/Link';
+import HoverCard from '../../cards/common/HoverCard';
+import SourceEntityCard from '../../cards/entity/SourceEntityCard';
+import { UserShortInfo } from '../../profile/UserShortInfo';
+import { ProfileImageSize } from '../../ProfilePicture';
+import type { UserShortProfile } from '../../../lib/user';
+import { FollowButton } from '../../contentPreference/FollowButton';
+import { ContentPreferenceType } from '../../../graphql/contentPreference';
+import { PostSidebarAdWidget } from '../PostSidebarAdWidget';
+import { PostDiscoveryActionBar } from './PostDiscoveryActionBar';
+import { PostDiscussionPanel } from './PostDiscussionPanel';
+import { CollectionSources } from './CollectionSources';
+
+const PostCodeSnippets = dynamic(() =>
+  import(/* webpackChunkName: "postCodeSnippets" */ '../PostCodeSnippets').then(
+    (mod) => ({ default: mod.PostCodeSnippets }),
+  ),
+);
+
+export type FocusCardLeftVariant = 'lean' | 'rich';
+
+interface PostFocusCardProps {
+  post: Post;
+  origin: PostOrigin;
+  leftVariant?: FocusCardLeftVariant;
+  /** When opened in the post modal, lets the sticky action bar close it. */
+  onClose?: () => void;
+}
+
+const ArticleLink = ({
+  href,
+  onClick,
+  children,
+  ...props
+}: ComponentProps<'a'> & {
+  href?: string;
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
+}) => {
+  const clickHandlers = onClick
+    ? combinedClicks<HTMLAnchorElement>(onClick)
+    : undefined;
+  return (
+    <a
+      href={href}
+      title="Go to post"
+      target="_blank"
+      rel="noopener"
+      {...clickHandlers}
+      {...props}
+    >
+      {children}
+    </a>
+  );
+};
+
+/**
+ * Video TL;DR capped to four lines. When the text overflows, a blue "Show
+ * more" link sits at the end of the last visible line (with a fade so it
+ * blends into the clamped text) and expands the summary to full length.
+ */
+const VideoSummary = ({ summary }: { summary: string }): ReactElement => {
+  const ref = useRef<HTMLParagraphElement>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isClamped, setIsClamped] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) {
+      return undefined;
+    }
+    const measure = () => setIsClamped(el.scrollHeight - el.clientHeight > 1);
+    measure();
+    if (typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [summary]);
+
+  return (
+    <div className="relative">
+      <p
+        ref={ref}
+        className={classNames(
+          'select-text break-words text-text-secondary typo-markdown',
+          !isExpanded && 'line-clamp-4',
+        )}
+        data-testid="tldr-container"
+      >
+        {summary}
+      </p>
+      {isClamped && !isExpanded && (
+        <span className="absolute bottom-0 right-0 flex items-center bg-background-default pl-1">
+          <span
+            aria-hidden
+            className="pointer-events-none absolute right-full top-0 h-full w-8 bg-gradient-to-l from-background-default to-transparent"
+          />
+          <ClickableText
+            className="!text-text-link"
+            onClick={() => setIsExpanded(true)}
+          >
+            Show more
+          </ClickableText>
+        </span>
+      )}
+    </div>
+  );
+};
+
+export const PostFocusCard = ({
+  post,
+  origin,
+  leftVariant,
+  onClose,
+}: PostFocusCardProps): ReactElement => {
+  // A shared post (someone reposting a post into a squad or onto their profile)
+  // wraps an underlying post. Only true Share-type posts get the "Shared via"
+  // treatment — auto-written articles/freeform posts render their own source.
+  const isShared = post.type === PostType.Share && !!post.sharedPost;
+  const article = (isShared ? post.sharedPost : post) as Post;
+  // Shared into a squad → "Shared via {squad}"; shared to a profile → just
+  // "Shared post" (we don't repeat the author's name).
+  const sharedVia =
+    isShared && post.source?.type === SourceType.Squad
+      ? post.source
+      : undefined;
+  const isCollection = article.type === PostType.Collection;
+  // Posts authored by a user (shared, freeform, welcome) lead with that
+  // user, shown exactly like a comment author. Publication-sourced posts
+  // (article/video/collection) keep their source strip.
+  const author =
+    post.type === PostType.Share ||
+    post.type === PostType.Freeform ||
+    post.type === PostType.Welcome
+      ? post.author
+      : undefined;
+  const isVideoType = isVideoPost(article);
+  const { title } = useSmartTitle(article);
+  const { onCopyPostLink, onReadArticle } = usePostContent({ origin, post });
+  const { onShowUpvoted } = useUpvoteQuery();
+  const { onReadClick: onReaderInstallGateClick } =
+    useReaderInstallPromptGate(post);
+  const showCodeSnippets = useFeature(feature.showCodeSnippets);
+  const focusCommentRef = useRef<() => void>(() => {});
+  const discussionRef = useRef<HTMLDivElement>(null);
+  const [isVideoPlaying, setIsVideoPlaying] = useState(false);
+  const readHref = getReadArticleHref(post);
+  const handleImageClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (onReaderInstallGateClick(event)) {
+      return;
+    }
+    onReadArticle();
+  };
+  const scrollToDiscussion = () =>
+    discussionRef.current?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'start',
+    });
+  const scrollToComment = () => {
+    scrollToDiscussion();
+    focusCommentRef.current();
+  };
+
+  // Rendered in the header on tablet+ (next to Follow) but moved below the
+  // title on mobile, where the header row is too tight to hold both.
+  const renderReadButton = (className: string): ReactElement | null =>
+    readHref && !isInternalReadType(post) ? (
+      <Button
+        tag="a"
+        href={readHref}
+        target="_blank"
+        rel="noopener"
+        icon={getReadPostButtonIcon(post)}
+        onClick={onReadArticle}
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Small}
+        className={className}
+      >
+        {getReadPostButtonText(post)}
+      </Button>
+    ) : null;
+
+  return (
+    <article
+      className="flex w-full flex-col rounded-24 bg-background-default"
+      data-testid="post-focus-card"
+    >
+      <div className="flex flex-col px-4 tablet:px-6 laptop:px-8">
+        <div className="relative mx-auto flex w-full min-w-0 flex-col gap-4 py-6 laptop:max-w-[768px]">
+          <div className="flex min-h-8 min-w-0 items-center gap-2">
+            {author ? (
+              <div className="flex min-w-0 items-center gap-3">
+                <UserShortInfo
+                  user={author as unknown as UserShortProfile}
+                  imageSize={ProfileImageSize.Large}
+                  showDescription={false}
+                  transformUsername={() => null}
+                  className={{
+                    container: 'min-w-0 !p-0 hover:bg-transparent',
+                    textWrapper: 'min-w-0',
+                  }}
+                />
+                <FollowButton
+                  className="shrink-0"
+                  entityId={author.id}
+                  entityName={`@${author.username}`}
+                  type={ContentPreferenceType.User}
+                  status={author.contentPreference?.status}
+                  variant={ButtonVariant.Subtle}
+                  showSubscribe={false}
+                  buttonClassName="!h-7 !px-2"
+                />
+              </div>
+            ) : (
+              article.source && (
+                <SourceStrip
+                  compact
+                  className="min-w-0 shrink"
+                  followButtonVariant={ButtonVariant.Subtle}
+                  source={article.source as SourceTooltip}
+                />
+              )
+            )}
+            {renderReadButton('ml-auto hidden shrink-0 tablet:flex')}
+          </div>
+
+          <div className="flex min-w-0 flex-col gap-3">
+            {sharedVia && (
+              <p className="flex items-center gap-1 text-text-tertiary typo-footnote">
+                <span>Shared via</span>
+                <HoverCard
+                  appendTo={globalThis?.document?.body}
+                  side="top"
+                  align="start"
+                  sideOffset={8}
+                  trigger={
+                    <span className="inline-flex items-center">
+                      <Link
+                        href={sharedVia.permalink}
+                        passHref
+                        prefetch={false}
+                      >
+                        <a className="inline-flex items-center gap-1 font-bold text-text-link hover:underline">
+                          {sharedVia.image && (
+                            <img
+                              src={sharedVia.image}
+                              alt=""
+                              aria-hidden
+                              className="size-4 rounded-full object-cover"
+                              loading="lazy"
+                            />
+                          )}
+                          {sharedVia.name}
+                        </a>
+                      </Link>
+                    </span>
+                  }
+                >
+                  <SourceEntityCard source={sharedVia as SourceTooltip} />
+                </HoverCard>
+              </p>
+            )}
+            {isShared && !sharedVia && (
+              <p className="text-text-tertiary typo-footnote">Shared post</p>
+            )}
+            {!isShared && isCollection && (
+              <p className="text-text-tertiary typo-footnote">Collection</p>
+            )}
+            <div className="flex min-w-0 flex-col gap-4 tablet:flex-row tablet:items-start">
+              <h1
+                className="min-w-0 break-words font-bold text-text-primary typo-title2 tablet:flex-1 tablet:typo-large-title"
+                data-testid="post-modal-title"
+              >
+                {title}
+              </h1>
+              {!isVideoType && article.image && (
+                <a
+                  className="block h-fit w-32 shrink-0 overflow-hidden rounded-16 bg-background-subtle tablet:w-40"
+                  href={readHref}
+                  onClick={handleImageClick}
+                  rel="noopener"
+                  target="_blank"
+                  title="Go to post"
+                >
+                  <LazyImage
+                    eager
+                    // Square crop on mobile/tablet; laptop+ keeps the
+                    // original wide cover ratio (52% => 25/13).
+                    className="aspect-square w-full laptop:aspect-[25/13]"
+                    fallbackSrc={cloudinaryPostImageCoverPlaceholder}
+                    fetchPriority="high"
+                    imgAlt="Post cover image"
+                    imgSrc={article.image}
+                  />
+                </a>
+              )}
+            </div>
+            {renderReadButton('w-fit tablet:hidden')}
+          </div>
+
+          <PostDiscoveryActionBar
+            post={post}
+            origin={origin}
+            onComment={scrollToComment}
+            onCopyLinkClick={onCopyPostLink}
+            onClose={onClose}
+          />
+
+          <PostMetadata
+            className="!typo-callout"
+            createdAt={article.createdAt}
+            domain={
+              !isVideoType &&
+              article.domain &&
+              article.domain.length > 0 && (
+                <TruncateText>
+                  From{' '}
+                  <ArticleLink
+                    className="hover:underline"
+                    href={article.permalink}
+                    onClick={onReadArticle}
+                    title={article.domain}
+                  >
+                    {article.domain}
+                  </ArticleLink>
+                </TruncateText>
+              )
+            }
+            isVideoType={isVideoType}
+            readTime={article.readTime}
+          />
+
+          {isVideoType && (
+            <div
+              className={classNames(
+                'shadow-1 w-full overflow-hidden rounded-24 border border-border-subtlest-tertiary bg-surface-float p-3 transition-[max-width] duration-300 ease-out',
+                isVideoPlaying ? 'max-w-full' : 'max-w-[70%]',
+              )}
+            >
+              {isVideoPlaying ? (
+                <YoutubeVideo
+                  autoplay
+                  placeholderProps={{
+                    post: article,
+                    onWatchVideo: onReadArticle,
+                  }}
+                  videoId={article.videoId ?? ''}
+                />
+              ) : (
+                <button
+                  type="button"
+                  aria-label="Play video"
+                  onClick={() => setIsVideoPlaying(true)}
+                  className="group relative block w-full overflow-hidden rounded-16"
+                >
+                  <LazyImage
+                    eager
+                    fallbackSrc={cloudinaryPostImageCoverPlaceholder}
+                    imgAlt="Video thumbnail"
+                    imgSrc={article.image}
+                    ratio="56.25%"
+                  />
+                  <span className="pointer-events-none absolute inset-0 flex items-center justify-center">
+                    <span className="flex size-14 items-center justify-center rounded-full bg-background-default text-text-primary shadow-2 transition-transform group-hover:scale-110">
+                      <PlayIcon secondary size={IconSize.XLarge} />
+                    </span>
+                  </span>
+                </button>
+              )}
+            </div>
+          )}
+
+          {article.contentHtml ? (
+            <>
+              <Markdown content={article.contentHtml} className="break-words" />
+              <ContentEmbeds embeds={article.contentEmbeds} variant="post" />
+            </>
+          ) : (
+            article.summary &&
+            (isVideoType ? (
+              <VideoSummary summary={article.summary} />
+            ) : (
+              <p
+                className="select-text break-words text-text-secondary typo-markdown"
+                data-testid="tldr-container"
+              >
+                {article.summary}
+              </p>
+            ))
+          )}
+
+          <PostTagList post={article} />
+
+          <PostUpvotesCommentsCount
+            post={post}
+            onUpvotesClick={(upvotes) => onShowUpvoted(post.id, upvotes)}
+            onCommentsClick={scrollToComment}
+          />
+
+          {isCollection && <CollectionSources post={article} />}
+
+          {showCodeSnippets && (
+            <div className={leftVariant === 'lean' ? 'mb-4' : 'mb-6'}>
+              <PostCodeSnippets post={article} />
+            </div>
+          )}
+
+          <PostSidebarAdWidget postId={post.id} variant="inline" />
+
+          <div ref={discussionRef} className="scroll-mt-16">
+            <PostDiscussionPanel
+              showMetaBar={false}
+              showSortHeader
+              onRegisterFocusComment={(fn) => {
+                focusCommentRef.current = fn;
+              }}
+              post={post}
+              origin={origin}
+            />
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+};

--- a/packages/shared/src/components/post/discovery/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/discovery/PostFocusCard.tsx
@@ -357,40 +357,41 @@ export const PostFocusCard = ({
             {!isShared && isCollection && (
               <p className="text-text-tertiary typo-footnote">Collection</p>
             )}
-            {/* Below the 656px (tablet) breakpoint we keep the read button
-                directly under the title with a tight gap; from tablet up the
-                read button moves to the top row and this one is hidden. */}
-            <div className="flex min-w-0 flex-col gap-1.5">
-              <div className="flex min-w-0 flex-row items-start gap-4">
+            {/* Title and image are top-aligned columns. The below-title read
+                button lives in the SAME column as the title (tight gap) so it
+                sits right under it regardless of the image height; from tablet
+                (656px) up the button moves to the top row and this one hides. */}
+            <div className="flex min-w-0 flex-row items-start gap-4">
+              <div className="flex min-w-0 flex-1 flex-col gap-2">
                 <h1
-                  className="min-w-0 flex-1 break-words font-bold text-text-primary typo-title3 tablet:typo-title1"
+                  className="line-clamp-3 break-words font-bold text-text-primary typo-title3 tablet:typo-title1"
                   data-testid="post-modal-title"
                 >
                   {title}
                 </h1>
-                {!isVideoType && article.image && (
-                  <a
-                    className="block h-fit w-24 shrink-0 overflow-hidden rounded-16 bg-background-subtle tablet:w-40"
-                    href={readHref}
-                    onClick={handleImageClick}
-                    rel="noopener"
-                    target="_blank"
-                    title="Go to post"
-                  >
-                    <LazyImage
-                      eager
-                      // Small square thumbnail below tablet; from tablet (656px)
-                      // up it uses the original wide cover ratio (52% => 25/13).
-                      className="aspect-square w-full tablet:aspect-[25/13]"
-                      fallbackSrc={cloudinaryPostImageCoverPlaceholder}
-                      fetchPriority="high"
-                      imgAlt="Post cover image"
-                      imgSrc={article.image}
-                    />
-                  </a>
-                )}
+                {renderReadButton('w-fit tablet:hidden')}
               </div>
-              {renderReadButton('w-fit tablet:hidden')}
+              {!isVideoType && article.image && (
+                <a
+                  className="block h-fit w-24 shrink-0 overflow-hidden rounded-16 bg-background-subtle tablet:w-40"
+                  href={readHref}
+                  onClick={handleImageClick}
+                  rel="noopener"
+                  target="_blank"
+                  title="Go to post"
+                >
+                  <LazyImage
+                    eager
+                    // Small square thumbnail below tablet; from tablet (656px)
+                    // up it uses the original wide cover ratio (52% => 25/13).
+                    className="aspect-square w-full tablet:aspect-[25/13]"
+                    fallbackSrc={cloudinaryPostImageCoverPlaceholder}
+                    fetchPriority="high"
+                    imgAlt="Post cover image"
+                    imgSrc={article.image}
+                  />
+                </a>
+              )}
             </div>
           </div>
 

--- a/packages/shared/src/components/post/discovery/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/discovery/PostFocusCard.tsx
@@ -365,7 +365,7 @@ export const PostFocusCard = ({
                 sits right under it regardless of the image height; from tablet
                 (656px) up the button moves to the top row and this one hides. */}
             <div className="flex min-w-0 flex-row items-start gap-4">
-              <div className="flex min-w-0 flex-1 flex-col gap-2">
+              <div className="flex min-w-0 flex-1 flex-col gap-2.5">
                 <h1
                   className="line-clamp-3 break-words font-bold text-text-primary typo-title3 tablet:typo-title1"
                   data-testid="post-modal-title"

--- a/packages/shared/src/components/post/discovery/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/discovery/PostFocusCard.tsx
@@ -89,22 +89,74 @@ const ArticleLink = ({
   );
 };
 
+const SHOW_MORE_SUFFIX = '… Show more';
+
 /**
- * Video TL;DR capped to four lines. When the text overflows, a blue "Show
- * more" link sits at the end of the last visible line (with a fade so it
- * blends into the clamped text) and expands the summary to full length.
+ * Video TL;DR capped to four lines. When the text overflows we truncate it at a
+ * word boundary and append an inline "… Show more" in the same font as the body
+ * (only the link is recoloured) — a real ellipsis cut rather than a fade
+ * overlay. The fitting prefix is measured with an off-screen clone so the
+ * suffix always lands on the last visible line.
  */
 const VideoSummary = ({ summary }: { summary: string }): ReactElement => {
   const ref = useRef<HTMLParagraphElement>(null);
   const [isExpanded, setIsExpanded] = useState(false);
-  const [isClamped, setIsClamped] = useState(false);
+  // `null` => not measured yet or text fits; a string => the truncated prefix.
+  const [truncated, setTruncated] = useState<string | null>(null);
 
   useEffect(() => {
     const el = ref.current;
-    if (!el) {
+    if (!el || isExpanded) {
+      setTruncated(null);
       return undefined;
     }
-    const measure = () => setIsClamped(el.scrollHeight - el.clientHeight > 1);
+
+    const measure = () => {
+      const clone = el.cloneNode(false) as HTMLElement;
+      clone.classList.remove('line-clamp-4');
+      Object.assign(clone.style, {
+        position: 'absolute',
+        visibility: 'hidden',
+        pointerEvents: 'none',
+        width: `${el.clientWidth}px`,
+        height: 'auto',
+        maxHeight: 'none',
+      });
+      el.parentElement?.appendChild(clone);
+
+      clone.textContent = 'Mg';
+      const maxHeight = clone.scrollHeight * 4 + 1;
+
+      clone.textContent = summary;
+      if (clone.scrollHeight <= maxHeight) {
+        clone.remove();
+        setTruncated(null);
+        return;
+      }
+
+      let lo = 0;
+      let hi = summary.length;
+      let best = 0;
+      while (lo <= hi) {
+        const mid = Math.floor((lo + hi) / 2);
+        clone.textContent = `${summary
+          .slice(0, mid)
+          .trimEnd()}${SHOW_MORE_SUFFIX}`;
+        if (clone.scrollHeight <= maxHeight) {
+          best = mid;
+          lo = mid + 1;
+        } else {
+          hi = mid - 1;
+        }
+      }
+      clone.remove();
+
+      // Snap back to the previous word boundary so we never cut mid-word.
+      const prefix = summary.slice(0, best).trimEnd();
+      const lastSpace = prefix.lastIndexOf(' ');
+      setTruncated(lastSpace > 0 ? prefix.slice(0, lastSpace) : prefix);
+    };
+
     measure();
     if (typeof ResizeObserver === 'undefined') {
       return undefined;
@@ -112,42 +164,37 @@ const VideoSummary = ({ summary }: { summary: string }): ReactElement => {
     const observer = new ResizeObserver(measure);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [summary]);
+  }, [summary, isExpanded]);
+
+  const isTruncated = !isExpanded && truncated !== null;
 
   return (
-    <div className="relative">
-      <p
-        ref={ref}
-        className={classNames(
-          'select-text break-words text-text-secondary typo-markdown',
-          !isExpanded && 'line-clamp-4',
-        )}
-        data-testid="tldr-container"
-      >
-        {summary}
-      </p>
-      {isClamped && !isExpanded && (
-        // Sits on the last clamped line: typo-markdown matches the paragraph's
-        // font size and line height, so the button (and its background/fade)
-        // are exactly one line tall and align to the text it continues. We
-        // render an ellipsis before the link so the cut-off reads naturally.
-        <button
-          type="button"
-          aria-label="Show more"
-          onClick={() => setIsExpanded(true)}
-          className="absolute bottom-0 right-0 flex items-center bg-background-default text-text-secondary typo-markdown"
-        >
-          <span
-            aria-hidden
-            className="pointer-events-none absolute right-full top-0 h-full w-8 bg-gradient-to-l from-background-default to-transparent"
-          />
-          <span aria-hidden>…&nbsp;</span>
-          <span className="font-bold text-text-link hover:underline">
-            Show more
-          </span>
-        </button>
+    <p
+      ref={ref}
+      className={classNames(
+        'select-text break-words text-text-secondary typo-markdown',
+        // Fallback clamp until the prefix is measured (and on SSR) so the full
+        // text never flashes.
+        truncated === null && !isExpanded && 'line-clamp-4',
       )}
-    </div>
+      data-testid="tldr-container"
+    >
+      {isTruncated ? (
+        <>
+          {truncated}
+          {'… '}
+          <button
+            type="button"
+            onClick={() => setIsExpanded(true)}
+            className="text-text-link hover:underline"
+          >
+            Show more
+          </button>
+        </>
+      ) : (
+        summary
+      )}
+    </p>
   );
 };
 

--- a/packages/shared/src/components/post/discovery/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/discovery/PostFocusCard.tsx
@@ -154,7 +154,10 @@ const VideoSummary = ({ summary }: { summary: string }): ReactElement => {
       // Snap back to the previous word boundary so we never cut mid-word.
       const prefix = summary.slice(0, best).trimEnd();
       const lastSpace = prefix.lastIndexOf(' ');
-      setTruncated(lastSpace > 0 ? prefix.slice(0, lastSpace) : prefix);
+      const snapped = lastSpace > 0 ? prefix.slice(0, lastSpace) : prefix;
+      // Never render a bare "… Show more" with no preview; fall back to the
+      // CSS line-clamp instead.
+      setTruncated(snapped || null);
     };
 
     measure();

--- a/packages/shared/src/components/post/reader/SourceStrip.tsx
+++ b/packages/shared/src/components/post/reader/SourceStrip.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import React from 'react';
+import classNames from 'classnames';
 import type { SourceTooltip } from '../../../graphql/sources';
 import { FollowButton } from '../../contentPreference/FollowButton';
 import { useContentPreferenceStatusQuery } from '../../../hooks/contentPreference/useContentPreferenceStatusQuery';
@@ -18,9 +19,17 @@ import SourceEntityCard from '../../cards/entity/SourceEntityCard';
 
 type SourceStripProps = {
   source: SourceTooltip;
+  className?: string;
+  compact?: boolean;
+  followButtonVariant?: ButtonVariant;
 };
 
-export function SourceStrip({ source }: SourceStripProps): ReactElement | null {
+export function SourceStrip({
+  source,
+  className,
+  compact = false,
+  followButtonVariant = ButtonVariant.Secondary,
+}: SourceStripProps): ReactElement | null {
   const sourceId = source?.id ?? '';
   const sourceName = source?.name ?? '';
   const { showActionBtn } = useShowFollowAction({
@@ -38,14 +47,25 @@ export function SourceStrip({ source }: SourceStripProps): ReactElement | null {
   const sourceHandle = source.handle ? `@${source.handle}` : null;
 
   return (
-    <div className="flex min-w-0 items-center gap-2">
+    <div
+      className={classNames(
+        'flex min-w-0 items-center',
+        compact ? 'gap-3' : 'gap-2',
+        className,
+      )}
+    >
       <HoverCard
         appendTo={globalThis?.document?.body}
         side="top"
         align="start"
         sideOffset={10}
         trigger={
-          <div className="group flex min-w-0 flex-1 items-center gap-3 rounded-10 px-1 py-0.5">
+          <div
+            className={classNames(
+              'group flex min-w-0 flex-1 items-center rounded-10',
+              compact ? 'gap-3 px-0 py-0' : 'gap-3 px-1 py-0.5',
+            )}
+          >
             <Link passHref href={source.permalink} prefetch={false}>
               <a
                 className="shrink-0"
@@ -55,7 +75,10 @@ export function SourceStrip({ source }: SourceStripProps): ReactElement | null {
                 <img
                   src={source.image}
                   alt=""
-                  className="size-8 rounded-full"
+                  className={classNames(
+                    'rounded-full',
+                    compact ? 'size-10' : 'size-8',
+                  )}
                   loading="lazy"
                   aria-hidden
                 />
@@ -65,7 +88,9 @@ export function SourceStrip({ source }: SourceStripProps): ReactElement | null {
               <Link passHref href={source.permalink} prefetch={false}>
                 <Typography
                   tag={TypographyTag.Link}
-                  type={TypographyType.Subhead}
+                  type={
+                    compact ? TypographyType.Callout : TypographyType.Subhead
+                  }
                   color={TypographyColor.Primary}
                   className="truncate group-hover:underline group-focus-visible:underline"
                   title={source.name}
@@ -74,7 +99,7 @@ export function SourceStrip({ source }: SourceStripProps): ReactElement | null {
                   {source.name}
                 </Typography>
               </Link>
-              {sourceHandle && (
+              {!compact && sourceHandle && (
                 <Typography
                   tag={TypographyTag.Span}
                   type={TypographyType.Caption1}
@@ -95,10 +120,10 @@ export function SourceStrip({ source }: SourceStripProps): ReactElement | null {
           entityId={sourceId}
           entityName={sourceName}
           type={ContentPreferenceType.Source}
-          variant={ButtonVariant.Secondary}
+          variant={followButtonVariant}
           status={contentPreference?.status}
           showSubscribe={false}
-          buttonClassName="!h-8"
+          buttonClassName={compact ? '!h-7 !px-2' : '!h-8'}
         />
       )}
     </div>

--- a/packages/shared/src/components/video/YoutubeVideo.tsx
+++ b/packages/shared/src/components/video/YoutubeVideo.tsx
@@ -12,6 +12,7 @@ import { webappUrl } from '../../lib/constants';
 interface YoutubeVideoProps extends HTMLAttributes<HTMLIFrameElement> {
   videoId: string;
   className?: string;
+  autoplay?: boolean;
   placeholderProps: Pick<
     YoutubeVideoWithoutConsentProps,
     'post' | 'onWatchVideo'
@@ -21,6 +22,7 @@ interface YoutubeVideoProps extends HTMLAttributes<HTMLIFrameElement> {
 const YoutubeVideo = ({
   videoId,
   className,
+  autoplay = false,
   placeholderProps,
   ...props
 }: YoutubeVideoProps): ReactElement => {
@@ -47,11 +49,15 @@ const YoutubeVideo = ({
     );
   }
 
+  // Cross-origin iframes block UNMUTED autoplay even with a parent click
+  // gesture, so YouTube would fall back to its play button (a second press).
+  // Muted autoplay is reliably permitted; YouTube shows its native unmute.
+  const autoplayParam = autoplay ? '?autoplay=1&mute=1' : '';
   // Extension pages don't send Referer header, causing YouTube Error 153
   // Use webapp as intermediate page which sends proper Referer
   const embedSrc = isExtension
-    ? `${webappUrl}embed/youtube/${videoId}`
-    : `https://www.youtube-nocookie.com/embed/${videoId}`;
+    ? `${webappUrl}embed/youtube/${videoId}${autoplayParam}`
+    : `https://www.youtube-nocookie.com/embed/${videoId}${autoplayParam}`;
 
   return (
     <YoutubeVideoContainer className={className}>

--- a/packages/shared/src/hooks/post/usePostDiscoveryExperience.ts
+++ b/packages/shared/src/hooks/post/usePostDiscoveryExperience.ts
@@ -1,0 +1,42 @@
+import type { Post } from '../../graphql/posts';
+import { PostType } from '../../graphql/posts';
+import { useConditionalFeature } from '../useConditionalFeature';
+import { featurePostDiscoveryExperience } from '../../lib/featureManagement';
+
+// Post types the Pinterest-style discovery layout knows how to render. Each is
+// rendered fully in PostFocusCard: articles/videos show the TLDR, while
+// collections and squad posts render their full markdown body. Specialized
+// types (poll, brief, social, digest) keep their dedicated layouts.
+export const postDiscoveryEligibleTypes: PostType[] = [
+  PostType.Article,
+  PostType.VideoYouTube,
+  PostType.Share,
+  PostType.Collection,
+  PostType.Freeform,
+  PostType.Welcome,
+];
+
+export const isPostDiscoveryEligible = (
+  post?: Pick<Post, 'type'> | null,
+): boolean => !!post && postDiscoveryEligibleTypes.includes(post.type);
+
+interface UsePostDiscoveryExperience {
+  isEligible: boolean;
+  showDiscovery: boolean;
+}
+
+/**
+ * Single source of truth for whether a post should render with the discovery
+ * layout, so the post page and the post modal stay in sync.
+ */
+export const usePostDiscoveryExperience = (
+  post?: Post,
+): UsePostDiscoveryExperience => {
+  const isEligible = isPostDiscoveryEligible(post);
+  const { value: isFlagOn } = useConditionalFeature({
+    feature: featurePostDiscoveryExperience,
+    shouldEvaluate: isEligible,
+  });
+
+  return { isEligible, showDiscovery: isEligible && isFlagOn };
+};

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -37,6 +37,10 @@ export const featurePostPageHighlights = new Feature(
   false,
 );
 export const featurePostPageFeed = new Feature('post_page_feed', false);
+export const featurePostDiscoveryExperience = new Feature(
+  'post_discovery_experience',
+  false,
+);
 
 // @ts-expect-error stale feature without default
 export const plusTakeoverContent = new Feature<{

--- a/packages/shared/tailwind.config.ts
+++ b/packages/shared/tailwind.config.ts
@@ -310,6 +310,7 @@ export default {
         'scale-down-pulse':
           'scale-down-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
         'fade-slide-up': 'fade-slide-up 0.5s ease-out 1s both',
+        'composer-in': 'fade-slide-up 0.2s ease-out both',
         'highlight-fade': 'highlight-fade 2.5s ease-out forwards',
         'reaction-burst':
           'reaction-burst 720ms cubic-bezier(0.2, 0.7, 0.4, 1) forwards',

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -84,6 +84,10 @@ jest.mock('next/router', () => ({
   useRouter: jest.fn(),
 }));
 
+// Toggled per-test to exercise the discovery (PostFocusCard) redesign; the flag
+// defaults off so the classic layout renders unless a test flips this on.
+let mockDiscoveryOn = false;
+
 jest.mock('@dailydotdev/shared/src/hooks/useConditionalFeature', () => ({
   __esModule: true,
   useConditionalFeature: (args: {
@@ -96,6 +100,9 @@ jest.mock('@dailydotdev/shared/src/hooks/useConditionalFeature', () => ({
     if (args?.feature?.id === 'post_page_feed') {
       return { value: true, isLoading: false };
     }
+    if (args?.feature?.id === 'post_discovery_experience') {
+      return { value: mockDiscoveryOn, isLoading: false };
+    }
     return { value: args?.feature?.defaultValue, isLoading: false };
   },
 }));
@@ -103,6 +110,7 @@ jest.mock('@dailydotdev/shared/src/hooks/useConditionalFeature', () => ({
 beforeEach(() => {
   nock.cleanAll();
   jest.clearAllMocks();
+  mockDiscoveryOn = false;
   jest.mocked(useRouter).mockImplementation(
     () =>
       ({
@@ -1076,5 +1084,48 @@ describe('post page feed', () => {
       usePostPageFeed({ ...(defaultPost as Post), type: PostType.Brief }),
     );
     expect(result.current.isEligible).toBe(false);
+  });
+});
+
+describe('post discovery experience', () => {
+  const mockRouterQuery = (query: Record<string, string>) => {
+    jest.mocked(useRouter).mockImplementation(
+      () =>
+        ({
+          isFallback: false,
+          pathname: '/posts',
+          isReady: true,
+          query,
+        } as unknown as NextRouter),
+    );
+  };
+
+  it('should render the focus card redesign when the flag is on', async () => {
+    mockDiscoveryOn = true;
+    renderPost();
+    expect(await screen.findByTestId('post-focus-card')).toBeInTheDocument();
+    expect(screen.queryByTestId('postContainer')).not.toBeInTheDocument();
+  });
+
+  it('should keep the classic layout when the flag is off', async () => {
+    mockDiscoveryOn = false;
+    renderPost();
+    expect(await screen.findByTestId('postContainer')).toBeInTheDocument();
+    expect(screen.queryByTestId('post-focus-card')).not.toBeInTheDocument();
+  });
+
+  it('should force the redesign on with ?discovery=1 while the flag is off', async () => {
+    mockDiscoveryOn = false;
+    mockRouterQuery({ discovery: '1' });
+    renderPost();
+    expect(await screen.findByTestId('post-focus-card')).toBeInTheDocument();
+  });
+
+  it('should force the classic layout with ?discovery=0 while the flag is on', async () => {
+    mockDiscoveryOn = true;
+    mockRouterQuery({ discovery: '0' });
+    renderPost();
+    expect(await screen.findByTestId('postContainer')).toBeInTheDocument();
+    expect(screen.queryByTestId('post-focus-card')).not.toBeInTheDocument();
   });
 });

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -1128,4 +1128,12 @@ describe('post discovery experience', () => {
     expect(await screen.findByTestId('postContainer')).toBeInTheDocument();
     expect(screen.queryByTestId('post-focus-card')).not.toBeInTheDocument();
   });
+
+  it('should keep the classic layout for author onboarding even when the flag is on', async () => {
+    mockDiscoveryOn = true;
+    mockRouterQuery({ author: 'true' });
+    renderPost();
+    expect(await screen.findByTestId('postContainer')).toBeInTheDocument();
+    expect(screen.queryByTestId('post-focus-card')).not.toBeInTheDocument();
+  });
 });

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -212,9 +212,13 @@ export const PostPage = ({
     router.query.discovery === '1' || router.query.discovery === 'true';
   const forceClassic =
     router.query.discovery === '0' || router.query.discovery === 'false';
+  // Entry-specific flows the focus card doesn't render (author onboarding via
+  // `?author`, back-to-squad via `?squad`) stay on the classic layout.
+  const requiresClassicLayout = !!router.query?.author || !!router.query?.squad;
   const showDiscovery =
     isDiscoveryEligible &&
     !forceClassic &&
+    !requiresClassicLayout &&
     (isDiscoveryFlagOn || forceDiscovery);
   const featureTheme = useFeatureTheme();
   const containerClass = classNames(

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -50,6 +50,10 @@ import { useEngagementAdsContext } from '@dailydotdev/shared/src/contexts/Engage
 import { CompanionDemoWidget } from '@dailydotdev/shared/src/components/post/CompanionDemoWidget';
 import { PostPageFeed } from '@dailydotdev/shared/src/components/post/PostPageFeed';
 import { usePostPageFeed } from '@dailydotdev/shared/src/hooks/post/usePostPageFeed';
+import { useConditionalFeature } from '@dailydotdev/shared/src/hooks/useConditionalFeature';
+import { isPostDiscoveryEligible } from '@dailydotdev/shared/src/hooks/post/usePostDiscoveryExperience';
+import { featurePostDiscoveryExperience } from '@dailydotdev/shared/src/lib/featureManagement';
+import { PostFocusCard } from '@dailydotdev/shared/src/components/post/discovery/PostFocusCard';
 import { getPageSeoTitles } from '../../../components/layouts/utils';
 import { getLayout } from '../../../components/layouts/MainLayout';
 import FooterNavBarLayout from '../../../components/layouts/FooterNavBarLayout';
@@ -197,6 +201,21 @@ export const PostPage = ({
     },
   });
   const { isEligible: showPostPageFeed } = usePostPageFeed(post);
+  const isDiscoveryEligible = isPostDiscoveryEligible(post);
+  const { value: isDiscoveryFlagOn } = useConditionalFeature({
+    feature: featurePostDiscoveryExperience,
+    shouldEvaluate: isDiscoveryEligible,
+  });
+  // `?discovery=1`/`0` lets us preview/force the redesign for review while the
+  // flag default stays off; absent, it follows the flag.
+  const forceDiscovery =
+    router.query.discovery === '1' || router.query.discovery === 'true';
+  const forceClassic =
+    router.query.discovery === '0' || router.query.discovery === 'false';
+  const showDiscovery =
+    isDiscoveryEligible &&
+    !forceClassic &&
+    (isDiscoveryFlagOn || forceDiscovery);
   const featureTheme = useFeatureTheme();
   const containerClass = classNames(
     'mb-16 min-h-page max-w-[69.25rem] tablet:mb-8 laptop:mb-0 laptop:pb-6 laptopL:pb-0',
@@ -273,25 +292,33 @@ export const PostPage = ({
             <link rel="preload" as="image" href={post?.image} />
           </Head>
           <PostSEOSchema post={post} topComments={topComments} />
-          <Content
-            position={position}
-            isPostPage
-            post={post}
-            isFallback={isFallback}
-            backToSquad={!!router?.query?.squad}
-            shouldOnboardAuthor={!!router.query?.author}
-            origin={Origin.ArticlePage}
-            isBannerVisible={shouldShowAuthBanner && !isLaptop}
-            className={{
-              container: containerClass,
-              fixedNavigation: { container: 'flex laptop:hidden' },
-              navigation: {
-                container: 'flex tablet:hidden',
-                actions: 'flex-1 justify-between',
-              },
-            }}
-          />
-          {shouldShowAuthBanner && isLaptop && <PostAuthBanner />}
+          {showDiscovery ? (
+            <div className="mx-auto w-full max-w-[63.75rem]">
+              <PostFocusCard post={post} origin={Origin.ArticlePage} />
+            </div>
+          ) : (
+            <Content
+              position={position}
+              isPostPage
+              post={post}
+              isFallback={isFallback}
+              backToSquad={!!router?.query?.squad}
+              shouldOnboardAuthor={!!router.query?.author}
+              origin={Origin.ArticlePage}
+              isBannerVisible={shouldShowAuthBanner && !isLaptop}
+              className={{
+                container: containerClass,
+                fixedNavigation: { container: 'flex laptop:hidden' },
+                navigation: {
+                  container: 'flex tablet:hidden',
+                  actions: 'flex-1 justify-between',
+                },
+              }}
+            />
+          )}
+          {!showDiscovery && shouldShowAuthBanner && isLaptop && (
+            <PostAuthBanner />
+          )}
           <CompanionDemoWidget />
           {showPostPageFeed && <PostPageFeed />}
         </FooterNavBarLayout>


### PR DESCRIPTION
## Summary

PR 2 of 3 split from the [#6130](https://github.com/dailydotdev/apps/pull/6130) mockup, productionized cleanly. This brings the **redesigned post reader** — the region from the **top of the post down to the end of the comments** — to the real post **modals** and **post page**, behind the `post_discovery_experience` flag (**default off**).

Stacked on PR 1 ([apps#6174](https://github.com/dailydotdev/apps/pull/6174)); rebase to `main` once that merges.

### What's included
- **`discovery/` components** (ported at their final mockup state): `PostFocusCard` (single-column reader: source/author header → title+image → sticky action bar → metadata → TLDR/video/body → tags → inline counts → inline ad → discussion), `PostDiscussionPanel`, `DiscussionMetaBar`, `DiscussionShareRow`, `CollectionSources`, and the **pre-glass** `PostDiscoveryActionBar`.
- **Additive, backward-compatible props** on shared components (defaults preserve current behavior): `SourceStrip` (compact), `PostSidebarAdWidget` (inline variant), `PostClickbaitShield` (iconOnly), `PostComments` (removeTopSpacing), `PostUpvotesCommentsCount` (onCommentsClick), `YoutubeVideo` (autoplay).
- **Wiring**: `usePostDiscoveryExperience` gates `ArticlePostModal` / `CollectionPostModal` / `SharePostModal` and the post page. The page also honors `?discovery=1` / `?discovery=0` to preview/force the design for review while the flag default stays off.

### Deliberately excluded (per scope)
- The **Liquid-Glass "morphing" action bar** (`25a1a81ff`) — shipped the pre-glass bar instead.
- The discovery **feed** (already shipped in PR 1), the **signup hero**, the `discovery.tsx` mockup route, and the unrelated anonymous-conversion "experience" layer (`post/experience/*`, the `PostContent`/`PostEngagements` refactor).

### Notes
- `PostSidebarAdWidget` inline variant renders `AdAttribution` without the tip's new `ad` prop (that refactor would touch 3 unrelated callers); only the "Promoted by {source}" referral text is dropped — flag for follow-up if wanted.
- Default off → classic layout and all existing tests stay green; flip on (or `?discovery=1`) to review.

## Test plan
- [ ] `?discovery=1` on an article: focus card on the **page** and in the **modal** (open from a feed), desktop + mobile.
- [ ] Verify a video, a Share, a Collection (sources carousel), a freeform/welcome.
- [ ] Flag off + no `?discovery=`: current production design unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-post-redesign-modal-page.preview.app.daily.dev