### PR TITLE
fix(shared): constrain hot take author row

### DIFF
--- a/packages/shared/src/components/modals/hotTakes/HotAndColdModal.spec.tsx
+++ b/packages/shared/src/components/modals/hotTakes/HotAndColdModal.spec.tsx
@@ -26,6 +26,10 @@ jest.mock('../../../contexts/AuthContext', () => ({
   useAuthContext: jest.fn(),
 }));
 
+jest.mock('../../../hooks/useRequestProtocol', () => ({
+  useRequestProtocol: () => ({ isCompanion: false }),
+}));
+
 const mockedUseDiscoverHotTakes = useDiscoverHotTakes as jest.Mock;
 const mockedUseVoteHotTake = useVoteHotTake as jest.Mock;
 const mockedUseLogContext = useLogContext as jest.Mock;
@@ -281,6 +285,48 @@ describe('HotAndColdModal', () => {
     expect(screen.getByText(currentTake.subtitle)).not.toHaveClass(
       'line-clamp-3',
     );
+  });
+
+  it('should keep long author names and handles shrinkable in the attribution row', () => {
+    const longName = 'Confident Coding With A Very Long Display Name';
+    const longUsername = 'confidentcodingwithaverylonghandle';
+    const currentTake = {
+      ...createHotTake('long-author'),
+      user: {
+        id: 'user-1',
+        name: longName,
+        username: longUsername,
+        image: 'https://daily.dev/avatar.png',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        reputation: 42,
+        permalink: '/confidentcodingwithaverylonghandle',
+        companies: [],
+        isPlus: false,
+      },
+    };
+
+    mockedUseDiscoverHotTakes.mockReturnValue({
+      hotTakes: [currentTake],
+      currentTake,
+      nextTake: null,
+      isEmpty: false,
+      isLoading: false,
+      dismissCurrent,
+    });
+
+    renderComponent();
+
+    const authorName = screen.getByText(longName);
+    const authorHandle = screen.getByText(`@${longUsername}`);
+
+    expect(authorName.parentElement).toHaveClass(
+      'flex',
+      'min-w-0',
+      'items-center',
+      'gap-1',
+    );
+    expect(authorName).toHaveClass('min-w-0', 'truncate');
+    expect(authorHandle).toHaveClass('min-w-0', 'truncate');
   });
 
   it('should keep onboarding mode clipped and scrollable inside the modal shell', () => {

--- a/packages/shared/src/components/modals/hotTakes/HotAndColdModal.tsx
+++ b/packages/shared/src/components/modals/hotTakes/HotAndColdModal.tsx
@@ -1351,8 +1351,8 @@ const HotTakeCard = ({
             nativeLazyLoading
           />
           <div className="flex min-w-0 flex-1 flex-col">
-            <div className="flex items-center gap-1">
-              <span className="truncate font-bold typo-callout">
+            <div className="flex min-w-0 items-center gap-1">
+              <span className="min-w-0 truncate font-bold typo-callout">
                 {hotTake.user.name}
               </span>
               {hotTake.user.isPlus && (
@@ -1361,7 +1361,7 @@ const HotTakeCard = ({
                   tooltip={false}
                 />
               )}
-              <span className="truncate text-text-tertiary typo-footnote">
+              <span className="min-w-0 truncate text-text-tertiary typo-footnote">
                 @{hotTake.user.username}
               </span>
             </div>


### PR DESCRIPTION
## Summary
- Fix the Hot Takes author attribution row so long display names and handles stay within the card on narrow mobile viewports.
- Add focused regression coverage for long author names and handles.

## Key decisions
- Targeted the Hot Takes modal because the reported screenshot maps to `LazyModal.HotAndCold`, not the feedback settings page.
- Kept the fix to Tailwind flex/truncation classes with no data-flow or API changes.

## Verification
- `NODE_ENV=test pnpm --filter @dailydotdev/shared exec jest src/components/modals/hotTakes/HotAndColdModal.spec.tsx --runInBand`
- `node ./scripts/typecheck-strict-changed.js`
- `pnpm --filter @dailydotdev/shared exec eslint src/components/modals/hotTakes/HotAndColdModal.tsx src/components/modals/hotTakes/HotAndColdModal.spec.tsx --max-warnings 0`
- `git diff --check main..HEAD`

Closes ENG-1475

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1475-feedback-ux-issue-user.preview.app.daily.dev