### PR TITLE
feat(shared): add ExtensionShowcase onboarding component

### DIFF
--- a/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.spec.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { ExtensionShowcase } from './ExtensionShowcase';
 import { defaultExtensionShowcaseFeatures } from './defaultFeatures';
+import type { ExtensionShowcaseFeature } from './types';
 
 describe('ExtensionShowcase', () => {
   it('shows the first feature detail by default', () => {
@@ -14,35 +15,69 @@ describe('ExtensionShowcase', () => {
     expect(screen.getByText(first.description)).toBeInTheDocument();
   });
 
-  it('swaps the detail panel when a feature is selected', () => {
+  it('keeps the heading static and swaps the detail panel on selection', () => {
     const onFeatureChange = jest.fn();
-    render(<ExtensionShowcase onFeatureChange={onFeatureChange} />);
+    render(
+      <ExtensionShowcase
+        title="Static title"
+        onFeatureChange={onFeatureChange}
+      />,
+    );
 
     const target = defaultExtensionShowcaseFeatures[2];
-    // both desktop dock and mobile strip render a button per feature
     const [button] = screen.getAllByRole('button', { name: target.label });
     fireEvent.click(button);
 
     expect(onFeatureChange).toHaveBeenCalledWith(target.id);
     expect(
-      screen.getByRole('heading', { name: target.title }),
+      screen.getByRole('heading', { name: 'Static title' }),
     ).toBeInTheDocument();
-  });
-
-  it('respects defaultFeatureId', () => {
-    const target = defaultExtensionShowcaseFeatures[3];
-    render(<ExtensionShowcase defaultFeatureId={target.id} />);
-
     expect(
       screen.getByRole('heading', { name: target.title }),
     ).toBeInTheDocument();
   });
 
-  it('hides the CTA when ctaLabel is empty', () => {
-    render(<ExtensionShowcase ctaLabel="" />);
+  it('shows the active feature CTA and updates it when switching', () => {
+    render(<ExtensionShowcase />);
 
+    const [first] = defaultExtensionShowcaseFeatures;
+    expect(screen.getByRole('link', { name: first.cta })).toBeInTheDocument();
+
+    const target = defaultExtensionShowcaseFeatures[2];
+    const [button] = screen.getAllByRole('button', { name: target.label });
+    fireEvent.click(button);
+
+    expect(screen.getByRole('link', { name: target.cta })).toBeInTheDocument();
     expect(
-      screen.queryByRole('link', { name: /add to browser/i }),
+      screen.queryByRole('link', { name: first.cta }),
     ).not.toBeInTheDocument();
+  });
+
+  it('falls back to ctaLabel when the feature has no cta', () => {
+    const feature: ExtensionShowcaseFeature = {
+      id: 'solo',
+      label: 'Solo',
+      icon: <span />,
+      title: 'Solo title',
+      description: 'Solo description',
+    };
+    render(<ExtensionShowcase features={[feature]} ctaLabel="Fallback CTA" />);
+
+    expect(
+      screen.getByRole('link', { name: 'Fallback CTA' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the CTA when neither feature cta nor ctaLabel is set', () => {
+    const feature: ExtensionShowcaseFeature = {
+      id: 'solo',
+      label: 'Solo',
+      icon: <span />,
+      title: 'Solo title',
+      description: 'Solo description',
+    };
+    render(<ExtensionShowcase features={[feature]} ctaLabel="" />);
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 });

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.spec.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.spec.tsx
@@ -4,18 +4,22 @@ import { ExtensionShowcase } from './ExtensionShowcase';
 import { defaultExtensionShowcaseFeatures } from './defaultFeatures';
 import type { ExtensionShowcaseFeature } from './types';
 
+const soloFeature: ExtensionShowcaseFeature = {
+  id: 'solo',
+  label: 'Solo',
+  icon: <span />,
+  description: 'Solo description',
+};
+
 describe('ExtensionShowcase', () => {
-  it('shows the first feature detail by default', () => {
+  it('shows the first feature message by default', () => {
     render(<ExtensionShowcase />);
 
     const [first] = defaultExtensionShowcaseFeatures;
-    expect(
-      screen.getByRole('heading', { name: first.title }),
-    ).toBeInTheDocument();
     expect(screen.getByText(first.description)).toBeInTheDocument();
   });
 
-  it('keeps the heading static and swaps the detail panel on selection', () => {
+  it('keeps the heading static and swaps the message on selection', () => {
     const onFeatureChange = jest.fn();
     render(
       <ExtensionShowcase
@@ -32,9 +36,7 @@ describe('ExtensionShowcase', () => {
     expect(
       screen.getByRole('heading', { name: 'Static title' }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { name: target.title }),
-    ).toBeInTheDocument();
+    expect(screen.getByText(target.description)).toBeInTheDocument();
   });
 
   it('shows the active feature CTA and updates it when switching', () => {
@@ -54,14 +56,9 @@ describe('ExtensionShowcase', () => {
   });
 
   it('falls back to ctaLabel when the feature has no cta', () => {
-    const feature: ExtensionShowcaseFeature = {
-      id: 'solo',
-      label: 'Solo',
-      icon: <span />,
-      title: 'Solo title',
-      description: 'Solo description',
-    };
-    render(<ExtensionShowcase features={[feature]} ctaLabel="Fallback CTA" />);
+    render(
+      <ExtensionShowcase features={[soloFeature]} ctaLabel="Fallback CTA" />,
+    );
 
     expect(
       screen.getByRole('link', { name: 'Fallback CTA' }),
@@ -69,14 +66,7 @@ describe('ExtensionShowcase', () => {
   });
 
   it('hides the CTA when neither feature cta nor ctaLabel is set', () => {
-    const feature: ExtensionShowcaseFeature = {
-      id: 'solo',
-      label: 'Solo',
-      icon: <span />,
-      title: 'Solo title',
-      description: 'Solo description',
-    };
-    render(<ExtensionShowcase features={[feature]} ctaLabel="" />);
+    render(<ExtensionShowcase features={[soloFeature]} ctaLabel="" />);
 
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.spec.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.spec.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ExtensionShowcase } from './ExtensionShowcase';
+import { defaultExtensionShowcaseFeatures } from './defaultFeatures';
+
+describe('ExtensionShowcase', () => {
+  it('shows the first feature detail by default', () => {
+    render(<ExtensionShowcase />);
+
+    const [first] = defaultExtensionShowcaseFeatures;
+    expect(
+      screen.getByRole('heading', { name: first.title }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(first.description)).toBeInTheDocument();
+  });
+
+  it('swaps the detail panel when a feature is selected', () => {
+    const onFeatureChange = jest.fn();
+    render(<ExtensionShowcase onFeatureChange={onFeatureChange} />);
+
+    const target = defaultExtensionShowcaseFeatures[2];
+    // both desktop dock and mobile strip render a button per feature
+    const [button] = screen.getAllByRole('button', { name: target.label });
+    fireEvent.click(button);
+
+    expect(onFeatureChange).toHaveBeenCalledWith(target.id);
+    expect(
+      screen.getByRole('heading', { name: target.title }),
+    ).toBeInTheDocument();
+  });
+
+  it('respects defaultFeatureId', () => {
+    const target = defaultExtensionShowcaseFeatures[3];
+    render(<ExtensionShowcase defaultFeatureId={target.id} />);
+
+    expect(
+      screen.getByRole('heading', { name: target.title }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides the CTA when ctaLabel is empty', () => {
+    render(<ExtensionShowcase ctaLabel="" />);
+
+    expect(
+      screen.queryByRole('link', { name: /add to browser/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.tsx
@@ -1,0 +1,201 @@
+import type { ReactElement } from 'react';
+import React, { useState } from 'react';
+import classNames from 'classnames';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../typography/Typography';
+import { Button } from '../../buttons/Button';
+import { ButtonVariant, ButtonSize } from '../../buttons/common';
+import { ChromeIcon } from '../../icons';
+import { downloadBrowserExtension } from '../../../lib/constants';
+import { anchorDefaultRel } from '../../../lib/strings';
+import { ExtensionShowcaseMedia } from './ExtensionShowcaseMedia';
+import { defaultExtensionShowcaseFeatures } from './defaultFeatures';
+import type { ExtensionShowcaseFeature } from './types';
+
+export interface ExtensionShowcaseProps {
+  /** Features to render. Defaults to the daily.dev extension feature set. */
+  features?: ExtensionShowcaseFeature[];
+  /** Feature selected on first render. Defaults to the first feature. */
+  defaultFeatureId?: string;
+  /** Optional heading above the showcase. */
+  title?: string;
+  /** Optional sub-heading above the showcase. */
+  description?: string;
+  /** CTA button label. Pass an empty string to hide the CTA. */
+  ctaLabel?: string;
+  /** CTA destination. Defaults to the extension download link. */
+  ctaHref?: string;
+  /** Fires when the CTA is clicked (for tracking / step transitions). */
+  onCtaClick?: () => void;
+  /** Fires when the selected feature changes. */
+  onFeatureChange?: (featureId: string) => void;
+  className?: string;
+}
+
+interface ShowcaseNavItemProps {
+  feature: ExtensionShowcaseFeature;
+  isActive: boolean;
+  vertical: boolean;
+  onClick: () => void;
+}
+
+function ShowcaseNavItem({
+  feature,
+  isActive,
+  vertical,
+  onClick,
+}: ShowcaseNavItemProps): ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={isActive}
+      className={classNames(
+        'flex items-center rounded-12 transition-colors',
+        vertical
+          ? 'w-full flex-row gap-3 p-3'
+          : 'shrink-0 flex-row gap-2 px-3 py-2',
+        isActive ? 'bg-surface-float' : 'hover:bg-surface-hover',
+      )}
+    >
+      {React.cloneElement(feature.icon, {
+        secondary: isActive,
+        className: classNames(!isActive && 'text-text-tertiary'),
+      })}
+      <Typography
+        tag={TypographyTag.Span}
+        type={TypographyType.Callout}
+        color={isActive ? TypographyColor.Primary : TypographyColor.Tertiary}
+        className="whitespace-nowrap"
+        bold={isActive}
+      >
+        {feature.label}
+      </Typography>
+    </button>
+  );
+}
+
+export function ExtensionShowcase({
+  features = defaultExtensionShowcaseFeatures,
+  defaultFeatureId,
+  title,
+  description,
+  ctaLabel = 'Add to browser',
+  ctaHref = downloadBrowserExtension,
+  onCtaClick,
+  onFeatureChange,
+  className,
+}: ExtensionShowcaseProps): ReactElement {
+  if (!features.length) {
+    throw new Error('ExtensionShowcase requires at least one feature');
+  }
+
+  const [activeId, setActiveId] = useState(defaultFeatureId ?? features[0].id);
+  const activeFeature =
+    features.find((feature) => feature.id === activeId) ?? features[0];
+
+  const selectFeature = (featureId: string): void => {
+    setActiveId(featureId);
+    onFeatureChange?.(featureId);
+  };
+
+  return (
+    <section className={classNames('flex w-full flex-col gap-6', className)}>
+      {(title || description) && (
+        <header className="flex flex-col items-center gap-2 text-center">
+          {title && (
+            <Typography
+              tag={TypographyTag.H2}
+              type={TypographyType.Title2}
+              bold
+            >
+              {title}
+            </Typography>
+          )}
+          {description && (
+            <Typography
+              tag={TypographyTag.P}
+              type={TypographyType.Body}
+              color={TypographyColor.Secondary}
+              className="max-w-xl text-balance"
+            >
+              {description}
+            </Typography>
+          )}
+        </header>
+      )}
+
+      <div className="flex flex-col gap-4 laptop:flex-row laptop:gap-8">
+        <nav
+          aria-label="Extension features"
+          className="hidden laptop:flex laptop:w-64 laptop:shrink-0 laptop:flex-col laptop:gap-1"
+        >
+          {features.map((feature) => (
+            <ShowcaseNavItem
+              key={feature.id}
+              feature={feature}
+              isActive={feature.id === activeFeature.id}
+              vertical
+              onClick={() => selectFeature(feature.id)}
+            />
+          ))}
+        </nav>
+
+        <nav
+          aria-label="Extension features"
+          className="no-scrollbar -mx-4 flex gap-2 overflow-x-auto px-4 laptop:hidden"
+        >
+          {features.map((feature) => (
+            <ShowcaseNavItem
+              key={feature.id}
+              feature={feature}
+              isActive={feature.id === activeFeature.id}
+              vertical={false}
+              onClick={() => selectFeature(feature.id)}
+            />
+          ))}
+        </nav>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-4">
+          <ExtensionShowcaseMedia media={activeFeature.media} />
+          <div className="flex flex-col gap-2">
+            <Typography
+              tag={TypographyTag.H3}
+              type={TypographyType.Title3}
+              bold
+            >
+              {activeFeature.title}
+            </Typography>
+            <Typography
+              tag={TypographyTag.P}
+              type={TypographyType.Body}
+              color={TypographyColor.Secondary}
+            >
+              {activeFeature.description}
+            </Typography>
+          </div>
+        </div>
+      </div>
+
+      {ctaLabel && (
+        <Button
+          className="self-center"
+          tag="a"
+          href={ctaHref}
+          target="_blank"
+          rel={anchorDefaultRel}
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Large}
+          icon={<ChromeIcon aria-hidden />}
+          onClick={onCtaClick}
+        >
+          {ctaLabel}
+        </Button>
+      )}
+    </section>
+  );
+}

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.tsx
@@ -136,7 +136,7 @@ export function ExtensionShowcase({
         </header>
       )}
 
-      <div className="w-full rounded-24 border border-border-subtlest-tertiary bg-background-default p-4 shadow-2 laptop:p-6">
+      <div className="flex w-full flex-col gap-6 rounded-24 border border-border-subtlest-tertiary bg-background-default p-4 shadow-2 laptop:p-6">
         <div className="flex flex-col gap-4 laptop:flex-row laptop:gap-8">
           <nav
             aria-label="Extension features"
@@ -170,41 +170,28 @@ export function ExtensionShowcase({
 
           <div className="flex min-w-0 flex-1 flex-col gap-4">
             <ExtensionShowcaseMedia media={activeFeature.media} />
-            <div className="flex flex-col gap-2">
-              <Typography
-                tag={TypographyTag.H3}
-                type={TypographyType.Title3}
-                bold
-              >
-                {activeFeature.title}
-              </Typography>
-              <Typography
-                tag={TypographyTag.P}
-                type={TypographyType.Body}
-                color={TypographyColor.Secondary}
-              >
-                {activeFeature.description}
-              </Typography>
-            </div>
+            <Typography tag={TypographyTag.P} type={TypographyType.Title3}>
+              {activeFeature.description}
+            </Typography>
           </div>
         </div>
-      </div>
 
-      {ctaText && (
-        <Button
-          className="w-full max-w-lg"
-          tag="a"
-          href={ctaHref}
-          target="_blank"
-          rel={anchorDefaultRel}
-          variant={ButtonVariant.Primary}
-          size={ButtonSize.XLarge}
-          icon={<ChromeIcon aria-hidden />}
-          onClick={onCtaClick}
-        >
-          {ctaText}
-        </Button>
-      )}
+        {ctaText && (
+          <Button
+            className="w-full"
+            tag="a"
+            href={ctaHref}
+            target="_blank"
+            rel={anchorDefaultRel}
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.XLarge}
+            icon={<ChromeIcon aria-hidden />}
+            onClick={onCtaClick}
+          >
+            {ctaText}
+          </Button>
+        )}
+      </div>
     </section>
   );
 }

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.tsx
@@ -136,7 +136,7 @@ export function ExtensionShowcase({
         </header>
       )}
 
-      <div className="flex w-full flex-col gap-6 rounded-24 border border-border-subtlest-tertiary bg-background-default p-4 shadow-2 laptop:p-6">
+      <div className="w-full rounded-24 border border-border-subtlest-tertiary bg-background-default p-4 shadow-2 laptop:p-6">
         <div className="flex flex-col gap-4 laptop:flex-row laptop:gap-8">
           <nav
             aria-label="Extension features"
@@ -173,24 +173,23 @@ export function ExtensionShowcase({
             <Typography tag={TypographyTag.P} type={TypographyType.Title3}>
               {activeFeature.description}
             </Typography>
+            {ctaText && (
+              <Button
+                className="w-full"
+                tag="a"
+                href={ctaHref}
+                target="_blank"
+                rel={anchorDefaultRel}
+                variant={ButtonVariant.Primary}
+                size={ButtonSize.XLarge}
+                icon={<ChromeIcon aria-hidden />}
+                onClick={onCtaClick}
+              >
+                {ctaText}
+              </Button>
+            )}
           </div>
         </div>
-
-        {ctaText && (
-          <Button
-            className="w-full"
-            tag="a"
-            href={ctaHref}
-            target="_blank"
-            rel={anchorDefaultRel}
-            variant={ButtonVariant.Primary}
-            size={ButtonSize.XLarge}
-            icon={<ChromeIcon aria-hidden />}
-            onClick={onCtaClick}
-          >
-            {ctaText}
-          </Button>
-        )}
       </div>
     </section>
   );

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '../../buttons/Button';
 import { ButtonVariant, ButtonSize } from '../../buttons/common';
 import { ChromeIcon } from '../../icons';
+import { IconSize } from '../../Icon';
 import { downloadBrowserExtension } from '../../../lib/constants';
 import { anchorDefaultRel } from '../../../lib/strings';
 import { ExtensionShowcaseMedia } from './ExtensionShowcaseMedia';
@@ -182,7 +183,7 @@ export function ExtensionShowcase({
                 rel={anchorDefaultRel}
                 variant={ButtonVariant.Primary}
                 size={ButtonSize.XLarge}
-                icon={<ChromeIcon aria-hidden />}
+                icon={<ChromeIcon aria-hidden size={IconSize.Small} />}
                 onClick={onCtaClick}
               >
                 {ctaText}

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.tsx
@@ -82,8 +82,8 @@ function ShowcaseNavItem({
 export function ExtensionShowcase({
   features = defaultExtensionShowcaseFeatures,
   defaultFeatureId,
-  title = 'Everything daily.dev adds to your browser',
-  subtitle = 'A quick tour of what you unlock the moment you install it.',
+  title = 'Everything the extension unlocks',
+  subtitle,
   ctaLabel = 'Get the daily.dev extension',
   ctaHref = downloadBrowserExtension,
   onCtaClick,
@@ -108,7 +108,7 @@ export function ExtensionShowcase({
   return (
     <section
       className={classNames(
-        'flex w-full flex-col items-center gap-6 rounded-24 bg-gradient-to-b from-accent-cabbage-subtlest to-background-default px-4 py-8 laptop:gap-8 laptop:px-10 laptop:py-10',
+        'flex w-full flex-col items-center gap-6 rounded-24 bg-overlay-float-cabbage px-4 py-8 laptop:gap-8 laptop:px-10 laptop:py-10',
         className,
       )}
     >

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.tsx
@@ -9,7 +9,8 @@ import {
 } from '../../typography/Typography';
 import { Button } from '../../buttons/Button';
 import { ButtonVariant, ButtonSize } from '../../buttons/common';
-import { ChromeIcon } from '../../icons';
+import { ChromeIcon, SparkleIcon } from '../../icons';
+import { IconSize } from '../../Icon';
 import { downloadBrowserExtension } from '../../../lib/constants';
 import { anchorDefaultRel } from '../../../lib/strings';
 import { ExtensionShowcaseMedia } from './ExtensionShowcaseMedia';
@@ -21,11 +22,7 @@ export interface ExtensionShowcaseProps {
   features?: ExtensionShowcaseFeature[];
   /** Feature selected on first render. Defaults to the first feature. */
   defaultFeatureId?: string;
-  /** Optional heading above the showcase. */
-  title?: string;
-  /** Optional sub-heading above the showcase. */
-  description?: string;
-  /** CTA button label. Pass an empty string to hide the CTA. */
+  /** Big primary CTA label. Pass an empty string to hide the CTA. */
   ctaLabel?: string;
   /** CTA destination. Defaults to the extension download link. */
   ctaHref?: string;
@@ -82,9 +79,7 @@ function ShowcaseNavItem({
 export function ExtensionShowcase({
   features = defaultExtensionShowcaseFeatures,
   defaultFeatureId,
-  title,
-  description,
-  ctaLabel = 'Add to browser',
+  ctaLabel = 'Get the daily.dev extension',
   ctaHref = downloadBrowserExtension,
   onCtaClick,
   onFeatureChange,
@@ -104,72 +99,69 @@ export function ExtensionShowcase({
   };
 
   return (
-    <section className={classNames('flex w-full flex-col gap-6', className)}>
-      {(title || description) && (
-        <header className="flex flex-col items-center gap-2 text-center">
-          {title && (
-            <Typography
-              tag={TypographyTag.H2}
-              type={TypographyType.Title2}
-              bold
-            >
-              {title}
-            </Typography>
-          )}
-          {description && (
-            <Typography
-              tag={TypographyTag.P}
-              type={TypographyType.Body}
-              color={TypographyColor.Secondary}
-              className="max-w-xl text-balance"
-            >
-              {description}
-            </Typography>
-          )}
-        </header>
+    <section
+      className={classNames(
+        'flex w-full flex-col items-center gap-6 rounded-24 bg-gradient-to-br from-accent-cabbage-subtlest to-accent-onion-subtlest px-4 py-8 laptop:gap-8 laptop:px-12 laptop:py-12',
+        className,
       )}
-
-      <div className="flex flex-col gap-4 laptop:flex-row laptop:gap-8">
-        <nav
-          aria-label="Extension features"
-          className="hidden laptop:flex laptop:w-64 laptop:shrink-0 laptop:flex-col laptop:gap-1"
+    >
+      <header className="flex flex-col items-center gap-2 text-center">
+        <span className="flex items-center gap-1.5 text-brand-default">
+          <SparkleIcon size={IconSize.Small} />
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Footnote}
+            color={TypographyColor.Brand}
+            bold
+            className="uppercase tracking-wider"
+          >
+            {activeFeature.label}
+          </Typography>
+        </span>
+        <Typography
+          tag={TypographyTag.H1}
+          type={TypographyType.LargeTitle}
+          bold
+          className="max-w-2xl text-balance"
         >
-          {features.map((feature) => (
-            <ShowcaseNavItem
-              key={feature.id}
-              feature={feature}
-              isActive={feature.id === activeFeature.id}
-              vertical
-              onClick={() => selectFeature(feature.id)}
-            />
-          ))}
-        </nav>
+          {activeFeature.title}
+        </Typography>
+      </header>
 
-        <nav
-          aria-label="Extension features"
-          className="no-scrollbar -mx-4 flex gap-2 overflow-x-auto px-4 laptop:hidden"
-        >
-          {features.map((feature) => (
-            <ShowcaseNavItem
-              key={feature.id}
-              feature={feature}
-              isActive={feature.id === activeFeature.id}
-              vertical={false}
-              onClick={() => selectFeature(feature.id)}
-            />
-          ))}
-        </nav>
+      <div className="w-full rounded-24 border border-border-subtlest-tertiary bg-background-default p-4 shadow-2 laptop:p-6">
+        <div className="flex flex-col gap-4 laptop:flex-row laptop:gap-8">
+          <nav
+            aria-label="Extension features"
+            className="hidden laptop:flex laptop:w-64 laptop:shrink-0 laptop:flex-col laptop:gap-1"
+          >
+            {features.map((feature) => (
+              <ShowcaseNavItem
+                key={feature.id}
+                feature={feature}
+                isActive={feature.id === activeFeature.id}
+                vertical
+                onClick={() => selectFeature(feature.id)}
+              />
+            ))}
+          </nav>
 
-        <div className="flex min-w-0 flex-1 flex-col gap-4">
-          <ExtensionShowcaseMedia media={activeFeature.media} />
-          <div className="flex flex-col gap-2">
-            <Typography
-              tag={TypographyTag.H3}
-              type={TypographyType.Title3}
-              bold
-            >
-              {activeFeature.title}
-            </Typography>
+          <nav
+            aria-label="Extension features"
+            className="no-scrollbar -mx-4 flex gap-2 overflow-x-auto px-4 laptop:hidden"
+          >
+            {features.map((feature) => (
+              <ShowcaseNavItem
+                key={feature.id}
+                feature={feature}
+                isActive={feature.id === activeFeature.id}
+                vertical={false}
+                onClick={() => selectFeature(feature.id)}
+              />
+            ))}
+          </nav>
+
+          <div className="flex min-w-0 flex-1 flex-col gap-4">
+            <ExtensionShowcaseMedia media={activeFeature.media} />
             <Typography
               tag={TypographyTag.P}
               type={TypographyType.Body}
@@ -183,13 +175,13 @@ export function ExtensionShowcase({
 
       {ctaLabel && (
         <Button
-          className="self-center"
+          className="w-full max-w-lg"
           tag="a"
           href={ctaHref}
           target="_blank"
           rel={anchorDefaultRel}
           variant={ButtonVariant.Primary}
-          size={ButtonSize.Large}
+          size={ButtonSize.XLarge}
           icon={<ChromeIcon aria-hidden />}
           onClick={onCtaClick}
         >

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase.tsx
@@ -9,8 +9,7 @@ import {
 } from '../../typography/Typography';
 import { Button } from '../../buttons/Button';
 import { ButtonVariant, ButtonSize } from '../../buttons/common';
-import { ChromeIcon, SparkleIcon } from '../../icons';
-import { IconSize } from '../../Icon';
+import { ChromeIcon } from '../../icons';
 import { downloadBrowserExtension } from '../../../lib/constants';
 import { anchorDefaultRel } from '../../../lib/strings';
 import { ExtensionShowcaseMedia } from './ExtensionShowcaseMedia';
@@ -22,7 +21,11 @@ export interface ExtensionShowcaseProps {
   features?: ExtensionShowcaseFeature[];
   /** Feature selected on first render. Defaults to the first feature. */
   defaultFeatureId?: string;
-  /** Big primary CTA label. Pass an empty string to hide the CTA. */
+  /** Static heading above the card. */
+  title?: string;
+  /** Static sub-heading above the card. */
+  subtitle?: string;
+  /** Fallback CTA label used when the active feature defines no `cta`. */
   ctaLabel?: string;
   /** CTA destination. Defaults to the extension download link. */
   ctaHref?: string;
@@ -79,6 +82,8 @@ function ShowcaseNavItem({
 export function ExtensionShowcase({
   features = defaultExtensionShowcaseFeatures,
   defaultFeatureId,
+  title = 'Everything daily.dev adds to your browser',
+  subtitle = 'A quick tour of what you unlock the moment you install it.',
   ctaLabel = 'Get the daily.dev extension',
   ctaHref = downloadBrowserExtension,
   onCtaClick,
@@ -98,35 +103,38 @@ export function ExtensionShowcase({
     onFeatureChange?.(featureId);
   };
 
+  const ctaText = activeFeature.cta ?? ctaLabel;
+
   return (
     <section
       className={classNames(
-        'flex w-full flex-col items-center gap-6 rounded-24 bg-gradient-to-br from-accent-cabbage-subtlest to-accent-onion-subtlest px-4 py-8 laptop:gap-8 laptop:px-12 laptop:py-12',
+        'flex w-full flex-col items-center gap-6 rounded-24 bg-gradient-to-b from-accent-cabbage-subtlest to-background-default px-4 py-8 laptop:gap-8 laptop:px-10 laptop:py-10',
         className,
       )}
     >
-      <header className="flex flex-col items-center gap-2 text-center">
-        <span className="flex items-center gap-1.5 text-brand-default">
-          <SparkleIcon size={IconSize.Small} />
-          <Typography
-            tag={TypographyTag.Span}
-            type={TypographyType.Footnote}
-            color={TypographyColor.Brand}
-            bold
-            className="uppercase tracking-wider"
-          >
-            {activeFeature.label}
-          </Typography>
-        </span>
-        <Typography
-          tag={TypographyTag.H1}
-          type={TypographyType.LargeTitle}
-          bold
-          className="max-w-2xl text-balance"
-        >
-          {activeFeature.title}
-        </Typography>
-      </header>
+      {(title || subtitle) && (
+        <header className="flex flex-col items-center gap-2 text-center">
+          {title && (
+            <Typography
+              tag={TypographyTag.H2}
+              type={TypographyType.Title1}
+              bold
+            >
+              {title}
+            </Typography>
+          )}
+          {subtitle && (
+            <Typography
+              tag={TypographyTag.P}
+              type={TypographyType.Body}
+              color={TypographyColor.Secondary}
+              className="max-w-xl text-balance"
+            >
+              {subtitle}
+            </Typography>
+          )}
+        </header>
+      )}
 
       <div className="w-full rounded-24 border border-border-subtlest-tertiary bg-background-default p-4 shadow-2 laptop:p-6">
         <div className="flex flex-col gap-4 laptop:flex-row laptop:gap-8">
@@ -162,18 +170,27 @@ export function ExtensionShowcase({
 
           <div className="flex min-w-0 flex-1 flex-col gap-4">
             <ExtensionShowcaseMedia media={activeFeature.media} />
-            <Typography
-              tag={TypographyTag.P}
-              type={TypographyType.Body}
-              color={TypographyColor.Secondary}
-            >
-              {activeFeature.description}
-            </Typography>
+            <div className="flex flex-col gap-2">
+              <Typography
+                tag={TypographyTag.H3}
+                type={TypographyType.Title3}
+                bold
+              >
+                {activeFeature.title}
+              </Typography>
+              <Typography
+                tag={TypographyTag.P}
+                type={TypographyType.Body}
+                color={TypographyColor.Secondary}
+              >
+                {activeFeature.description}
+              </Typography>
+            </div>
           </div>
         </div>
       </div>
 
-      {ctaLabel && (
+      {ctaText && (
         <Button
           className="w-full max-w-lg"
           tag="a"
@@ -185,7 +202,7 @@ export function ExtensionShowcase({
           icon={<ChromeIcon aria-hidden />}
           onClick={onCtaClick}
         >
-          {ctaLabel}
+          {ctaText}
         </Button>
       )}
     </section>

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcaseMedia.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcaseMedia.tsx
@@ -1,0 +1,56 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import type { ExtensionShowcaseMedia as Media } from './types';
+
+interface ExtensionShowcaseMediaProps {
+  media?: Media;
+  className?: string;
+}
+
+export function ExtensionShowcaseMedia({
+  media,
+  className,
+}: ExtensionShowcaseMediaProps): ReactElement {
+  const wrapperClass = classNames(
+    'relative aspect-video w-full overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-surface-float',
+    className,
+  );
+
+  if (!media) {
+    return <div className={wrapperClass} aria-hidden />;
+  }
+
+  if (media.type === 'video') {
+    return (
+      <div className={wrapperClass}>
+        <video
+          // key forces a remount so the clip restarts when the feature changes
+          key={media.src}
+          className="h-full w-full object-cover"
+          src={media.src}
+          poster={media.poster}
+          aria-label={media.alt}
+          autoPlay
+          muted
+          loop
+          playsInline
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className={wrapperClass}>
+      <img
+        className="h-full w-full object-cover"
+        src={media.src}
+        srcSet={
+          media.retinaSrc ? `${media.src} 1x, ${media.retinaSrc} 2x` : undefined
+        }
+        alt={media.alt ?? ''}
+        loading="lazy"
+      />
+    </div>
+  );
+}

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import {
-  BriefIcon,
-  EmbedIcon,
-  HomeIcon,
+  NewTabIcon,
   SitesIcon,
-  ShortcutsIcon,
   TLDRIcon,
-  ReadingStreakIcon,
-  PauseIcon,
+  StarIcon,
+  ShortcutsIcon,
+  SidebarArrowLeft,
+  HotIcon,
+  MoonIcon,
 } from '../../icons';
 import {
   cloudinaryOnboardingActivationDemo,
@@ -36,7 +36,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
   {
     id: 'feed',
     label: 'New tab feed',
-    icon: <HomeIcon />,
+    icon: <NewTabIcon />,
     description:
       'Every new tab becomes a feed tuned to your stack, so staying current happens in the gaps of your day — with zero effort.',
     cta: 'Get daily.dev on every new tab',
@@ -49,7 +49,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
   {
     id: 'read-here',
     label: 'Read it here',
-    icon: <EmbedIcon />,
+    icon: <SitesIcon />,
     description:
       'Open any article inside daily.dev in a clean reader with the discussion beside it — no more graveyard of half-read tabs.',
     cta: 'Get the in-app reader',
@@ -58,7 +58,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
   {
     id: 'brief',
     label: 'Daily brief',
-    icon: <BriefIcon />,
+    icon: <TLDRIcon />,
     description:
       'Your first tab of the day opens to an AI-built brief that compresses everything that matters into a two-minute read.',
     cta: 'Get your daily brief',
@@ -67,7 +67,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
   {
     id: 'most-visited',
     label: 'Most visited',
-    icon: <SitesIcon />,
+    icon: <StarIcon />,
     description:
       'Your most-visited sites come straight from your browser, so the new tab still knows where you were headed — no setup.',
     cta: 'Bring my top sites back',
@@ -85,7 +85,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
   {
     id: 'companion',
     label: 'Companion',
-    icon: <TLDRIcon />,
+    icon: <SidebarArrowLeft />,
     description:
       'The companion rides along on any site you visit, adding an instant TLDR, what the community thinks, and related reads.',
     cta: 'Get the companion',
@@ -94,7 +94,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
   {
     id: 'streak',
     label: 'Reading streak',
-    icon: <ReadingStreakIcon />,
+    icon: <HotIcon />,
     description:
       'daily.dev greets you on every new tab, so keeping your reading streak alive takes no willpower.',
     cta: 'Start my reading streak',
@@ -103,7 +103,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
   {
     id: 'focus',
     label: 'Focus mode',
-    icon: <PauseIcon />,
+    icon: <MoonIcon />,
     description:
       'Need to focus? Pause the new tab for as long as you like and point it anywhere — full control, in one click.',
     cta: 'Add daily.dev to my browser',

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
@@ -37,9 +37,8 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     id: 'feed',
     label: 'New tab feed',
     icon: <HomeIcon />,
-    title: 'Every new tab becomes your dev briefing',
     description:
-      'You open dozens of blank tabs a day. The extension turns each one into a feed tuned to your stack — so staying current happens in the gaps of your workday, with zero effort.',
+      'Every new tab becomes a feed tuned to your stack, so staying current happens in the gaps of your day — with zero effort.',
     cta: 'Get daily.dev on every new tab',
     media: {
       type: 'video',
@@ -51,9 +50,8 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     id: 'read-here',
     label: 'Read it here',
     icon: <EmbedIcon />,
-    title: 'Read any article right inside daily.dev',
     description:
-      'No more graveyard of half-read tabs. Open links inside daily.dev in a clean reader with the discussion right beside them, and close the loop without ever leaving your feed.',
+      'Open any article inside daily.dev in a clean reader with the discussion beside it — no more graveyard of half-read tabs.',
     cta: 'Get the in-app reader',
     media: placeholderImage,
   },
@@ -61,9 +59,8 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     id: 'brief',
     label: 'Daily brief',
     icon: <BriefIcon />,
-    title: 'Your brief opens itself, the moment you start your day',
     description:
-      'No inbox to dig through, no app to open. The first new tab of your day greets you with a brief built just for you — an AI agent reads the dev world overnight (releases, discussions, hot takes) and compresses what actually matters into a two-minute read. You stop trying to keep up, because it already did.',
+      'Your first tab of the day opens to an AI-built brief that compresses everything that matters into a two-minute read.',
     cta: 'Get your daily brief',
     media: placeholderImage,
   },
@@ -71,9 +68,8 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     id: 'most-visited',
     label: 'Most visited',
     icon: <SitesIcon />,
-    title: 'Your most-visited sites, right where you left them',
     description:
-      'daily.dev pulls the sites you open most straight from your browser, so the new tab still knows where you were headed. No setup, nothing to relearn.',
+      'Your most-visited sites come straight from your browser, so the new tab still knows where you were headed — no setup.',
     cta: 'Bring my top sites back',
     media: placeholderImage,
   },
@@ -81,9 +77,8 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     id: 'shortcuts',
     label: 'Shortcuts',
     icon: <ShortcutsIcon />,
-    title: 'Pin the apps and tools you live in',
     description:
-      'Add your own shortcuts to GitHub, Jira, your docs — or import your whole bookmarks bar in a click. Your essentials stay one click from every new tab, and nothing leaves your browser.',
+      'Pin the apps you live in — or import your bookmarks bar in a click — so your essentials stay one click from every tab.',
     cta: 'Get my shortcuts everywhere',
     media: placeholderImage,
   },
@@ -91,9 +86,8 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     id: 'companion',
     label: 'Companion',
     icon: <TLDRIcon />,
-    title: 'Bring daily.dev onto any site you visit',
     description:
-      'Reading a doc, a blog, or a Hacker News thread? The companion sidebar rides along on the page itself — instant TLDR, what the community thinks in the comments, and related reads. This is the one thing only the extension can do.',
+      'The companion rides along on any site you visit, adding an instant TLDR, what the community thinks, and related reads.',
     cta: 'Get the companion',
     media: placeholderImage,
   },
@@ -101,9 +95,8 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     id: 'streak',
     label: 'Reading streak',
     icon: <ReadingStreakIcon />,
-    title: 'A daily habit that builds itself',
     description:
-      'Because daily.dev greets you on every new tab, keeping your streak alive takes no willpower. Show up, read one thing, stay sharp — day after day.',
+      'daily.dev greets you on every new tab, so keeping your reading streak alive takes no willpower.',
     cta: 'Start my reading streak',
     media: placeholderImage,
   },
@@ -111,9 +104,8 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     id: 'focus',
     label: 'Focus mode',
     icon: <PauseIcon />,
-    title: 'Heads-down? Pause it in one click',
     description:
-      'Need to focus, or just want your blank tab back for a while? Pause the new tab for as long as you like and point it anywhere — full control, only because the extension owns the page.',
+      'Need to focus? Pause the new tab for as long as you like and point it anywhere — full control, in one click.',
     cta: 'Add daily.dev to my browser',
     media: placeholderImage,
   },

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import {
-  HomeIcon,
-  TLDRIcon,
   EmbedIcon,
+  HomeIcon,
+  SitesIcon,
   ShortcutsIcon,
+  TLDRIcon,
   ReadingStreakIcon,
   PauseIcon,
 } from '../../icons';
@@ -26,10 +27,20 @@ const placeholderImage: ExtensionShowcaseFeature['media'] = {
   alt: 'daily.dev extension preview',
 };
 
-// Every item here answers "why the extension, not just the website?" — these
-// are browser-level powers the webapp can't replicate (owning the new tab,
-// injecting into other sites, reading browser top sites, pausing the new tab).
+// Every item answers "why the extension, not just the website?" — these are
+// browser-level powers the webapp can't replicate. Ordered by install pull:
+// lead with reading inside daily.dev, then the new-tab experience and the two
+// shortcut flavors (auto most-visited vs. custom pins), then the rest.
 export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
+  {
+    id: 'read-here',
+    label: 'Read it here',
+    icon: <EmbedIcon />,
+    title: 'Read any article right inside daily.dev',
+    description:
+      'No more graveyard of half-read tabs. Open links inside daily.dev in a clean reader with the discussion right beside them, and close the loop without ever leaving your feed.',
+    media: placeholderImage,
+  },
   {
     id: 'feed',
     label: 'New tab feed',
@@ -44,30 +55,30 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     },
   },
   {
-    id: 'companion',
-    label: 'Companion',
-    icon: <TLDRIcon />,
-    title: 'Bring daily.dev onto any site you visit',
+    id: 'most-visited',
+    label: 'Most visited',
+    icon: <SitesIcon />,
+    title: 'Your most-visited sites, right where you left them',
     description:
-      'Reading a doc, a blog, or a Hacker News thread? The companion sidebar rides along on the page itself — instant TLDR, what the community thinks in the comments, and related reads. This is the one thing only the extension can do.',
-    media: placeholderImage,
-  },
-  {
-    id: 'read-here',
-    label: 'Read it here',
-    icon: <EmbedIcon />,
-    title: 'Read articles without drowning in tabs',
-    description:
-      'Open any post right inside daily.dev instead of spawning yet another tab. Distraction-free reading with the discussion beside it — your browser stays clean.',
+      'daily.dev pulls the sites you open most straight from your browser, so the new tab still knows where you were headed. No setup, nothing to relearn.',
     media: placeholderImage,
   },
   {
     id: 'shortcuts',
     label: 'Shortcuts',
     icon: <ShortcutsIcon />,
-    title: 'Your most-visited sites, pinned to every tab',
+    title: 'Pin the apps and tools you live in',
     description:
-      'The extension pulls your top sites straight from the browser, so GitHub, your docs, and your dashboards stay one click away. Your muscle memory keeps working, even with daily.dev on the new tab.',
+      'Add your own shortcuts to GitHub, Jira, your docs — whatever you open all day — so your essentials sit one click from every new tab.',
+    media: placeholderImage,
+  },
+  {
+    id: 'companion',
+    label: 'Companion',
+    icon: <TLDRIcon />,
+    title: 'Bring daily.dev onto any site you visit',
+    description:
+      'Reading a doc, a blog, or a Hacker News thread? The companion sidebar rides along on the page itself — instant TLDR, what the community thinks in the comments, and related reads. This is the one thing only the extension can do.',
     media: placeholderImage,
   },
   {

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import {
   HomeIcon,
-  EmbedIcon,
   TLDRIcon,
-  SearchIcon,
-  BookmarkIcon,
+  EmbedIcon,
   ShortcutsIcon,
   ReadingStreakIcon,
-  SquadIcon,
+  PauseIcon,
 } from '../../icons';
 import {
   cloudinaryOnboardingActivationDemo,
@@ -28,8 +26,9 @@ const placeholderImage: ExtensionShowcaseFeature['media'] = {
   alt: 'daily.dev extension preview',
 };
 
-// Ordered for conversion: lead with what the extension *is* (the new tab),
-// then the "aha" tab-saving and context features, then habit and community.
+// Every item here answers "why the extension, not just the website?" — these
+// are browser-level powers the webapp can't replicate (owning the new tab,
+// injecting into other sites, reading browser top sites, pausing the new tab).
 export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
   {
     id: 'feed',
@@ -37,7 +36,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     icon: <HomeIcon />,
     title: 'Every new tab becomes your dev briefing',
     description:
-      'Stop staring at a blank page. Every new tab opens to a feed tuned to your stack, so you stay in the loop on the best dev content throughout your work routine — without ever going looking for it.',
+      'You open dozens of blank tabs a day. The extension turns each one into a feed tuned to your stack — so staying current happens in the gaps of your workday, with zero effort.',
     media: {
       type: 'video',
       src: cloudinaryOnboardingActivationDemo,
@@ -45,66 +44,48 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     },
   },
   {
-    id: 'read-here',
-    label: 'Read it here',
-    icon: <EmbedIcon />,
-    title: 'Read articles without the tab chaos',
-    description:
-      'Open any post right inside daily.dev instead of spawning yet another tab. Read distraction-free with the discussion right beside it, and keep your browser clean.',
-    media: placeholderImage,
-  },
-  {
     id: 'companion',
     label: 'Companion',
     icon: <TLDRIcon />,
-    title: 'Context on every article you read',
+    title: 'Bring daily.dev onto any site you visit',
     description:
-      'The daily.dev companion rides along on any site you visit. Get an instant TLDR, see what the community thinks in the comments, and surface more relevant articles — right on the page.',
+      'Reading a doc, a blog, or a Hacker News thread? The companion sidebar rides along on the page itself — instant TLDR, what the community thinks in the comments, and related reads. This is the one thing only the extension can do.',
     media: placeholderImage,
   },
   {
-    id: 'search',
-    label: 'AI search',
-    icon: <SearchIcon />,
-    title: 'Ask anything, get real dev answers',
+    id: 'read-here',
+    label: 'Read it here',
+    icon: <EmbedIcon />,
+    title: 'Read articles without drowning in tabs',
     description:
-      'Skip the SEO spam. daily.dev search only pulls from developer content the community has actually read and upvoted, so your answers come from sources you can trust.',
-    media: placeholderImage,
-  },
-  {
-    id: 'bookmarks',
-    label: 'Bookmarks',
-    icon: <BookmarkIcon />,
-    title: 'Save now, read when it clicks',
-    description:
-      'Bookmark anything in a click and pick it back up later on any device. Never lose that article you meant to get to.',
+      'Open any post right inside daily.dev instead of spawning yet another tab. Distraction-free reading with the discussion beside it — your browser stays clean.',
     media: placeholderImage,
   },
   {
     id: 'shortcuts',
     label: 'Shortcuts',
     icon: <ShortcutsIcon />,
-    title: 'Keep your shortcuts on every new tab',
+    title: 'Your most-visited sites, pinned to every tab',
     description:
-      'Pin the tools and sites you open all day — GitHub, your docs, your dashboards — so they stay one click away and you never lose them when daily.dev takes over the new tab.',
+      'The extension pulls your top sites straight from the browser, so GitHub, your docs, and your dashboards stay one click away. Your muscle memory keeps working, even with daily.dev on the new tab.',
     media: placeholderImage,
   },
   {
     id: 'streak',
     label: 'Reading streak',
     icon: <ReadingStreakIcon />,
-    title: 'Keep your streak, keep your momentum',
+    title: 'A daily habit that builds itself',
     description:
-      'With daily.dev in every new tab, staying sharp becomes automatic. Show up, keep your streak alive, and always find something worth reading.',
+      'Because daily.dev greets you on every new tab, keeping your streak alive takes no willpower. Show up, read one thing, stay sharp — day after day.',
     media: placeholderImage,
   },
   {
-    id: 'squads',
-    label: 'Squads',
-    icon: <SquadIcon />,
-    title: 'Find your people in Squads',
+    id: 'focus',
+    label: 'Focus mode',
+    icon: <PauseIcon />,
+    title: 'Heads-down? Pause it in one click',
     description:
-      'Join developer communities built around the tools and topics you love. Share what you are learning and grow alongside millions of developers.',
+      'Need to focus, or just want your blank tab back for a while? Pause the new tab for as long as you like and point it anywhere — full control, only because the extension owns the page.',
     media: placeholderImage,
   },
 ];

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import {
+  HomeIcon,
+  SearchIcon,
+  BookmarkIcon,
+  TLDRIcon,
+  ReadingStreakIcon,
+  SquadIcon,
+  ShortcutsIcon,
+} from '../../icons';
+import {
+  cloudinaryOnboardingActivationDemo,
+  cloudinaryOnboardingExtension,
+} from '../../../lib/image';
+import { BrowserName } from '../../../lib/func';
+import type { ExtensionShowcaseFeature } from './types';
+
+const screenshot = cloudinaryOnboardingExtension[BrowserName.Chrome];
+
+// Real per-feature demo assets do not exist yet — these reuse the existing
+// onboarding screenshot/video as placeholders. Swap `media` per feature once
+// design delivers dedicated clips.
+const placeholderImage: ExtensionShowcaseFeature['media'] = {
+  type: 'image',
+  src: screenshot.default,
+  retinaSrc: screenshot.retina,
+  alt: 'daily.dev extension preview',
+};
+
+export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
+  {
+    id: 'feed',
+    label: 'New tab feed',
+    icon: <HomeIcon />,
+    title: 'Your personalized feed in every new tab',
+    description:
+      'Turn every new tab into a developer feed tuned to your stack. The moment you open your browser, the best content from across the dev world is already waiting for you.',
+    media: {
+      type: 'video',
+      src: cloudinaryOnboardingActivationDemo,
+      alt: 'daily.dev new tab feed in action',
+    },
+  },
+  {
+    id: 'search',
+    label: 'AI search',
+    icon: <SearchIcon />,
+    title: 'Search the dev world, powered by AI',
+    description:
+      'Ask anything and get answers pulled from real developer content instead of generic results. Your AI co-pilot lives one tab away.',
+    media: placeholderImage,
+  },
+  {
+    id: 'bookmarks',
+    label: 'Bookmarks',
+    icon: <BookmarkIcon />,
+    title: 'Save now, read when it clicks',
+    description:
+      'Bookmark any post in a click and pick it back up later on any device. Never lose that article you meant to get to.',
+    media: placeholderImage,
+  },
+  {
+    id: 'companion',
+    label: 'Companion',
+    icon: <TLDRIcon />,
+    title: 'Read smarter with the companion',
+    description:
+      'The daily.dev companion rides along on any article, giving you an instant TLDR, the upvotes, and the discussion right on the page you are reading.',
+    media: placeholderImage,
+  },
+  {
+    id: 'streak',
+    label: 'Reading streaks',
+    icon: <ReadingStreakIcon />,
+    title: 'Build a reading habit that sticks',
+    description:
+      'Keep your streak alive and stay sharp. A little every day adds up, and daily.dev keeps you coming back.',
+    media: placeholderImage,
+  },
+  {
+    id: 'squads',
+    label: 'Squads',
+    icon: <SquadIcon />,
+    title: 'Find your people in Squads',
+    description:
+      'Join developer communities built around what you love. Share, learn, and grow alongside millions of developers.',
+    media: placeholderImage,
+  },
+  {
+    id: 'shortcuts',
+    label: 'Shortcuts',
+    icon: <ShortcutsIcon />,
+    title: 'Your shortcuts, one tab away',
+    description:
+      'Pin the tools and sites you open every day so they are always a click away from your new tab.',
+    media: placeholderImage,
+  },
+];

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import {
   HomeIcon,
+  EmbedIcon,
+  TLDRIcon,
   SearchIcon,
   BookmarkIcon,
-  TLDRIcon,
+  ShortcutsIcon,
   ReadingStreakIcon,
   SquadIcon,
-  ShortcutsIcon,
 } from '../../icons';
 import {
   cloudinaryOnboardingActivationDemo,
@@ -27,14 +28,16 @@ const placeholderImage: ExtensionShowcaseFeature['media'] = {
   alt: 'daily.dev extension preview',
 };
 
+// Ordered for conversion: lead with what the extension *is* (the new tab),
+// then the "aha" tab-saving and context features, then habit and community.
 export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
   {
     id: 'feed',
     label: 'New tab feed',
     icon: <HomeIcon />,
-    title: 'Your personalized feed in every new tab',
+    title: 'Every new tab becomes your dev briefing',
     description:
-      'Turn every new tab into a developer feed tuned to your stack. The moment you open your browser, the best content from across the dev world is already waiting for you.',
+      'Stop staring at a blank page. Every new tab opens to a feed tuned to your stack, so you stay in the loop on the best dev content throughout your work routine — without ever going looking for it.',
     media: {
       type: 'video',
       src: cloudinaryOnboardingActivationDemo,
@@ -42,12 +45,30 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     },
   },
   {
+    id: 'read-here',
+    label: 'Read it here',
+    icon: <EmbedIcon />,
+    title: 'Read articles without the tab chaos',
+    description:
+      'Open any post right inside daily.dev instead of spawning yet another tab. Read distraction-free with the discussion right beside it, and keep your browser clean.',
+    media: placeholderImage,
+  },
+  {
+    id: 'companion',
+    label: 'Companion',
+    icon: <TLDRIcon />,
+    title: 'Context on every article you read',
+    description:
+      'The daily.dev companion rides along on any site you visit. Get an instant TLDR, see what the community thinks in the comments, and surface more relevant articles — right on the page.',
+    media: placeholderImage,
+  },
+  {
     id: 'search',
     label: 'AI search',
     icon: <SearchIcon />,
-    title: 'Search the dev world, powered by AI',
+    title: 'Ask anything, get real dev answers',
     description:
-      'Ask anything and get answers pulled from real developer content instead of generic results. Your AI co-pilot lives one tab away.',
+      'Skip the SEO spam. daily.dev search only pulls from developer content the community has actually read and upvoted, so your answers come from sources you can trust.',
     media: placeholderImage,
   },
   {
@@ -56,25 +77,25 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     icon: <BookmarkIcon />,
     title: 'Save now, read when it clicks',
     description:
-      'Bookmark any post in a click and pick it back up later on any device. Never lose that article you meant to get to.',
+      'Bookmark anything in a click and pick it back up later on any device. Never lose that article you meant to get to.',
     media: placeholderImage,
   },
   {
-    id: 'companion',
-    label: 'Companion',
-    icon: <TLDRIcon />,
-    title: 'Read smarter with the companion',
+    id: 'shortcuts',
+    label: 'Shortcuts',
+    icon: <ShortcutsIcon />,
+    title: 'Keep your shortcuts on every new tab',
     description:
-      'The daily.dev companion rides along on any article, giving you an instant TLDR, the upvotes, and the discussion right on the page you are reading.',
+      'Pin the tools and sites you open all day — GitHub, your docs, your dashboards — so they stay one click away and you never lose them when daily.dev takes over the new tab.',
     media: placeholderImage,
   },
   {
     id: 'streak',
-    label: 'Reading streaks',
+    label: 'Reading streak',
     icon: <ReadingStreakIcon />,
-    title: 'Build a reading habit that sticks',
+    title: 'Keep your streak, keep your momentum',
     description:
-      'Keep your streak alive and stay sharp. A little every day adds up, and daily.dev keeps you coming back.',
+      'With daily.dev in every new tab, staying sharp becomes automatic. Show up, keep your streak alive, and always find something worth reading.',
     media: placeholderImage,
   },
   {
@@ -83,16 +104,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     icon: <SquadIcon />,
     title: 'Find your people in Squads',
     description:
-      'Join developer communities built around what you love. Share, learn, and grow alongside millions of developers.',
-    media: placeholderImage,
-  },
-  {
-    id: 'shortcuts',
-    label: 'Shortcuts',
-    icon: <ShortcutsIcon />,
-    title: 'Your shortcuts, one tab away',
-    description:
-      'Pin the tools and sites you open every day so they are always a click away from your new tab.',
+      'Join developer communities built around the tools and topics you love. Share what you are learning and grow alongside millions of developers.',
     media: placeholderImage,
   },
 ];

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
@@ -37,9 +37,9 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     id: 'brief',
     label: 'Daily brief',
     icon: <BriefIcon />,
-    title: 'Your morning brief, on your first tab of the day',
+    title: 'Your brief opens itself, the moment you start your day',
     description:
-      'Open your browser to a brief built just for you. An AI agent reads the dev world overnight — releases, discussions, hot takes — and compresses what actually matters into a two-minute read. You stop trying to keep up, because it already did.',
+      'No inbox to dig through, no app to open. The first new tab of your day greets you with a brief built just for you — an AI agent reads the dev world overnight (releases, discussions, hot takes) and compresses what actually matters into a two-minute read. You stop trying to keep up, because it already did.',
     media: placeholderImage,
   },
   {

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  BriefIcon,
   EmbedIcon,
   HomeIcon,
   SitesIcon,
@@ -27,11 +28,20 @@ const placeholderImage: ExtensionShowcaseFeature['media'] = {
   alt: 'daily.dev extension preview',
 };
 
-// Every item answers "why the extension, not just the website?" — these are
-// browser-level powers the webapp can't replicate. Ordered by install pull:
-// lead with reading inside daily.dev, then the new-tab experience and the two
-// shortcut flavors (auto most-visited vs. custom pins), then the rest.
+// Ordered by install pull. Lead with the daily brief (the morning ritual the
+// extension delivers on your first tab), then reading inside daily.dev, the
+// new-tab experience, the two shortcut flavors, and the rest. Every item leans
+// on something the extension does that the website alone can't.
 export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
+  {
+    id: 'brief',
+    label: 'Daily brief',
+    icon: <BriefIcon />,
+    title: 'Your morning brief, on your first tab of the day',
+    description:
+      'Open your browser to a brief built just for you. An AI agent reads the dev world overnight — releases, discussions, hot takes — and compresses what actually matters into a two-minute read. You stop trying to keep up, because it already did.',
+    media: placeholderImage,
+  },
   {
     id: 'read-here',
     label: 'Read it here',
@@ -69,7 +79,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     icon: <ShortcutsIcon />,
     title: 'Pin the apps and tools you live in',
     description:
-      'Add your own shortcuts to GitHub, Jira, your docs — whatever you open all day — so your essentials sit one click from every new tab.',
+      'Add your own shortcuts to GitHub, Jira, your docs — or import your whole bookmarks bar in a click. Your essentials stay one click from every new tab, and nothing leaves your browser.',
     media: placeholderImage,
   },
   {

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
@@ -28,29 +28,11 @@ const placeholderImage: ExtensionShowcaseFeature['media'] = {
   alt: 'daily.dev extension preview',
 };
 
-// Ordered by install pull. Lead with the daily brief (the morning ritual the
-// extension delivers on your first tab), then reading inside daily.dev, the
-// new-tab experience, the two shortcut flavors, and the rest. Every item leans
-// on something the extension does that the website alone can't.
+// Ordered by install pull. Lead with the new-tab feed (what the extension is),
+// then reading inside daily.dev, the daily brief, the two shortcut flavors, the
+// companion, and the rest. Every item leans on something the extension does
+// that the website alone can't.
 export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
-  {
-    id: 'brief',
-    label: 'Daily brief',
-    icon: <BriefIcon />,
-    title: 'Your brief opens itself, the moment you start your day',
-    description:
-      'No inbox to dig through, no app to open. The first new tab of your day greets you with a brief built just for you — an AI agent reads the dev world overnight (releases, discussions, hot takes) and compresses what actually matters into a two-minute read. You stop trying to keep up, because it already did.',
-    media: placeholderImage,
-  },
-  {
-    id: 'read-here',
-    label: 'Read it here',
-    icon: <EmbedIcon />,
-    title: 'Read any article right inside daily.dev',
-    description:
-      'No more graveyard of half-read tabs. Open links inside daily.dev in a clean reader with the discussion right beside them, and close the loop without ever leaving your feed.',
-    media: placeholderImage,
-  },
   {
     id: 'feed',
     label: 'New tab feed',
@@ -63,6 +45,24 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
       src: cloudinaryOnboardingActivationDemo,
       alt: 'daily.dev new tab feed in action',
     },
+  },
+  {
+    id: 'read-here',
+    label: 'Read it here',
+    icon: <EmbedIcon />,
+    title: 'Read any article right inside daily.dev',
+    description:
+      'No more graveyard of half-read tabs. Open links inside daily.dev in a clean reader with the discussion right beside them, and close the loop without ever leaving your feed.',
+    media: placeholderImage,
+  },
+  {
+    id: 'brief',
+    label: 'Daily brief',
+    icon: <BriefIcon />,
+    title: 'Your brief opens itself, the moment you start your day',
+    description:
+      'No inbox to dig through, no app to open. The first new tab of your day greets you with a brief built just for you — an AI agent reads the dev world overnight (releases, discussions, hot takes) and compresses what actually matters into a two-minute read. You stop trying to keep up, because it already did.',
+    media: placeholderImage,
   },
   {
     id: 'most-visited',

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/defaultFeatures.tsx
@@ -40,6 +40,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     title: 'Every new tab becomes your dev briefing',
     description:
       'You open dozens of blank tabs a day. The extension turns each one into a feed tuned to your stack — so staying current happens in the gaps of your workday, with zero effort.',
+    cta: 'Get daily.dev on every new tab',
     media: {
       type: 'video',
       src: cloudinaryOnboardingActivationDemo,
@@ -53,6 +54,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     title: 'Read any article right inside daily.dev',
     description:
       'No more graveyard of half-read tabs. Open links inside daily.dev in a clean reader with the discussion right beside them, and close the loop without ever leaving your feed.',
+    cta: 'Get the in-app reader',
     media: placeholderImage,
   },
   {
@@ -62,6 +64,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     title: 'Your brief opens itself, the moment you start your day',
     description:
       'No inbox to dig through, no app to open. The first new tab of your day greets you with a brief built just for you — an AI agent reads the dev world overnight (releases, discussions, hot takes) and compresses what actually matters into a two-minute read. You stop trying to keep up, because it already did.',
+    cta: 'Get your daily brief',
     media: placeholderImage,
   },
   {
@@ -71,6 +74,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     title: 'Your most-visited sites, right where you left them',
     description:
       'daily.dev pulls the sites you open most straight from your browser, so the new tab still knows where you were headed. No setup, nothing to relearn.',
+    cta: 'Bring my top sites back',
     media: placeholderImage,
   },
   {
@@ -80,6 +84,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     title: 'Pin the apps and tools you live in',
     description:
       'Add your own shortcuts to GitHub, Jira, your docs — or import your whole bookmarks bar in a click. Your essentials stay one click from every new tab, and nothing leaves your browser.',
+    cta: 'Get my shortcuts everywhere',
     media: placeholderImage,
   },
   {
@@ -89,6 +94,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     title: 'Bring daily.dev onto any site you visit',
     description:
       'Reading a doc, a blog, or a Hacker News thread? The companion sidebar rides along on the page itself — instant TLDR, what the community thinks in the comments, and related reads. This is the one thing only the extension can do.',
+    cta: 'Get the companion',
     media: placeholderImage,
   },
   {
@@ -98,6 +104,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     title: 'A daily habit that builds itself',
     description:
       'Because daily.dev greets you on every new tab, keeping your streak alive takes no willpower. Show up, read one thing, stay sharp — day after day.',
+    cta: 'Start my reading streak',
     media: placeholderImage,
   },
   {
@@ -107,6 +114,7 @@ export const defaultExtensionShowcaseFeatures: ExtensionShowcaseFeature[] = [
     title: 'Heads-down? Pause it in one click',
     description:
       'Need to focus, or just want your blank tab back for a while? Pause the new tab for as long as you like and point it anywhere — full control, only because the extension owns the page.',
+    cta: 'Add daily.dev to my browser',
     media: placeholderImage,
   },
 ];

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/types.ts
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/types.ts
@@ -21,9 +21,7 @@ export interface ExtensionShowcaseFeature {
   label: string;
   /** Icon rendered in the dock. Should accept `secondary` and `className`. */
   icon: ReactElement;
-  /** Detail panel heading. */
-  title: string;
-  /** Detail panel body copy. */
+  /** Single-sentence value message shown in the detail panel. */
   description: string;
   /** Optional CTA label shown while this feature is active. Falls back to the
    * component's `ctaLabel` when omitted. */

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/types.ts
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/types.ts
@@ -25,6 +25,9 @@ export interface ExtensionShowcaseFeature {
   title: string;
   /** Detail panel body copy. */
   description: string;
+  /** Optional CTA label shown while this feature is active. Falls back to the
+   * component's `ctaLabel` when omitted. */
+  cta?: string;
   /** Right-side media. Video is autoplayed muted/looped; image supports retina. */
   media?: ExtensionShowcaseMedia;
 }

--- a/packages/shared/src/components/onboarding/ExtensionShowcase/types.ts
+++ b/packages/shared/src/components/onboarding/ExtensionShowcase/types.ts
@@ -1,0 +1,30 @@
+import type { ReactElement } from 'react';
+
+export type ExtensionShowcaseMedia =
+  | {
+      type: 'video';
+      src: string;
+      poster?: string;
+      alt?: string;
+    }
+  | {
+      type: 'image';
+      src: string;
+      retinaSrc?: string;
+      alt?: string;
+    };
+
+export interface ExtensionShowcaseFeature {
+  /** Stable identifier, also used for tracking. */
+  id: string;
+  /** Short label shown in the left dock / mobile tab strip. */
+  label: string;
+  /** Icon rendered in the dock. Should accept `secondary` and `className`. */
+  icon: ReactElement;
+  /** Detail panel heading. */
+  title: string;
+  /** Detail panel body copy. */
+  description: string;
+  /** Right-side media. Video is autoplayed muted/looped; image supports retina. */
+  media?: ExtensionShowcaseMedia;
+}

--- a/packages/storybook/stories/components/ExtensionShowcase.stories.tsx
+++ b/packages/storybook/stories/components/ExtensionShowcase.stories.tsx
@@ -18,20 +18,17 @@ export default meta;
 type Story = StoryObj<typeof ExtensionShowcase>;
 
 export const Default: Story = {
-  args: {
-    title: 'Everything daily.dev does in your browser',
-    description:
-      'A quick tour of what the extension unlocks the moment you install it.',
-  },
-};
-
-export const WithoutHeader: Story = {
   args: {},
 };
 
 export const CustomCta: Story = {
   args: {
-    title: 'Make every tab count',
-    ctaLabel: 'Get it for Chrome',
+    ctaLabel: 'Add daily.dev to Chrome — free',
+  },
+};
+
+export const StartOnBrief: Story = {
+  args: {
+    defaultFeatureId: 'brief',
   },
 };

--- a/packages/storybook/stories/components/ExtensionShowcase.stories.tsx
+++ b/packages/storybook/stories/components/ExtensionShowcase.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ExtensionShowcase } from '@dailydotdev/shared/src/components/onboarding/ExtensionShowcase/ExtensionShowcase';
+
+const meta: Meta<typeof ExtensionShowcase> = {
+  title: 'Components/Onboarding/ExtensionShowcase',
+  component: ExtensionShowcase,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  render: (args) => (
+    <div className="mx-auto max-w-screen-laptop p-6">
+      <ExtensionShowcase {...args} />
+    </div>
+  ),
+};
+
+export default meta;
+type Story = StoryObj<typeof ExtensionShowcase>;
+
+export const Default: Story = {
+  args: {
+    title: 'Everything daily.dev does in your browser',
+    description:
+      'A quick tour of what the extension unlocks the moment you install it.',
+  },
+};
+
+export const WithoutHeader: Story = {
+  args: {},
+};
+
+export const CustomCta: Story = {
+  args: {
+    title: 'Make every tab count',
+    ctaLabel: 'Get it for Chrome',
+  },
+};


### PR DESCRIPTION
## What

A reusable, Sider-style feature walkthrough that explains the value of the daily.dev browser extension.

- **Vertical feature dock** on the left (desktop) listing each capability with an icon + label, and an active highlight.
- **Detail panel** on the right that swaps **media (video or image) + title + description** as you select a feature.
- **Mobile**: the dock collapses into a horizontally-scrollable tab strip above the detail panel.
- **Prop-driven**: pass your own `features`, `defaultFeatureId`, CTA, and `onFeatureChange`/`onCtaClick` handlers. Ships with the default daily.dev feature set (new tab feed, AI search, bookmarks, companion, reading streaks, Squads, shortcuts).
- Video is video-first (autoplay/muted/loop) with image + retina fallback. Real per-feature clips can be dropped in later via the `media` prop — current assets reuse the existing onboarding screenshot/video as placeholders.

Decoupled shared component so it can be reused in onboarding, modals, and pages. A Storybook story (`Components/Onboarding/ExtensionShowcase`) is included as the live preview.

## Files
- `packages/shared/src/components/onboarding/ExtensionShowcase/` — component, media renderer, default features, types, tests
- `packages/storybook/stories/components/ExtensionShowcase.stories.tsx`

## Verification
- Strict typecheck passes
- ESLint clean
- Component tests pass (default selection, feature switching, `defaultFeatureId`, CTA toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-sharp-chebyshev-cf08f4.preview.app.daily.dev