### PR TITLE
fix: prevent brief generate overflow on mobile

### DIFF
--- a/packages/shared/src/components/layout/common.spec.tsx
+++ b/packages/shared/src/components/layout/common.spec.tsx
@@ -8,6 +8,7 @@ import { useViewSize, ViewSize } from '../../hooks/useViewSize';
 import { useReadingStreak } from '../../hooks/streaks';
 import { useFeedName } from '../../hooks/feed/useFeedName';
 import { useQueryState } from '../../hooks/utils/useQueryState';
+import { useLayoutVariant } from '../../hooks/layout/useLayoutVariant';
 import {
   checkIsExtension,
   getCurrentBrowserName,
@@ -30,10 +31,7 @@ jest.mock('../../hooks/useActions', () => ({
 }));
 
 jest.mock('../../hooks/useViewSize', () => ({
-  ViewSize: {
-    Laptop: 'laptop',
-    MobileL: 'mobile',
-  },
+  ...jest.requireActual('../../hooks/useViewSize'),
   useViewSize: jest.fn(),
 }));
 
@@ -61,8 +59,13 @@ jest.mock('../../lib/func', () => ({
 
 jest.mock('../filters/MyFeedHeading', () => ({
   __esModule: true,
-  default: function MockMyFeedHeading() {
-    return null;
+  default: function MockMyFeedHeading({ iconOnly }: { iconOnly?: boolean }) {
+    return (
+      <div
+        data-icon-only={iconOnly ? 'true' : 'false'}
+        data-testid="my-feed-heading"
+      />
+    );
   },
 }));
 
@@ -104,6 +107,10 @@ jest.mock('../../hooks/useHasIntroQuests', () => ({
   useHasIntroQuests: jest.fn().mockReturnValue(false),
 }));
 
+jest.mock('../../hooks/layout/useLayoutVariant', () => ({
+  useLayoutVariant: jest.fn(),
+}));
+
 const mockUseAuthContext = useAuthContext as jest.Mock;
 const mockUseLogContext = useLogContext as jest.Mock;
 const mockUseActions = useActions as jest.Mock;
@@ -111,6 +118,7 @@ const mockUseViewSize = useViewSize as jest.Mock;
 const mockUseReadingStreak = useReadingStreak as jest.Mock;
 const mockUseFeedName = useFeedName as jest.Mock;
 const mockUseQueryState = useQueryState as jest.Mock;
+const mockUseLayoutVariant = useLayoutVariant as jest.Mock;
 const mockCheckIsExtension = checkIsExtension as jest.Mock;
 const mockGetCurrentBrowserName = getCurrentBrowserName as jest.Mock;
 const mockIsExtensionCapableBrowser = isExtensionCapableBrowser as jest.Mock;
@@ -135,21 +143,56 @@ const createActionsState = ({
   isActionsFetched,
 });
 
-const renderComponent = () =>
+const renderComponent = ({
+  chips,
+}: {
+  chips?: React.ReactNode;
+} = {}) =>
   render(
     <SettingsContext.Provider value={{ sortingEnabled: false } as never}>
       <SearchControlHeader
         feedName={SharedFeedPage.MyFeed}
         algoState={[0, jest.fn()]}
+        chips={chips}
       />
     </SettingsContext.Provider>,
   );
 
+const mockViewSize = ({
+  isMobile = false,
+  isTablet = true,
+  isLaptop = true,
+}: {
+  isMobile?: boolean;
+  isTablet?: boolean;
+  isLaptop?: boolean;
+} = {}) => {
+  mockUseViewSize.mockImplementation((size) => {
+    if (size === ViewSize.MobileL) {
+      return isMobile;
+    }
+
+    if (size === ViewSize.Tablet) {
+      return isTablet;
+    }
+
+    if (size === ViewSize.Laptop) {
+      return isLaptop;
+    }
+
+    return false;
+  });
+};
+
 describe('SearchControlHeader', () => {
   beforeEach(() => {
-    mockUseAuthContext.mockReturnValue({ user: { flags: {} } });
+    mockUseAuthContext.mockReturnValue({
+      isAuthReady: true,
+      isLoggedIn: true,
+      user: { flags: {} },
+    });
     mockUseLogContext.mockReturnValue({ logEvent: jest.fn() });
-    mockUseViewSize.mockImplementation((size) => size === ViewSize.Laptop);
+    mockViewSize();
     mockUseReadingStreak.mockReturnValue({
       streak: null,
       isLoading: false,
@@ -160,6 +203,7 @@ describe('SearchControlHeader', () => {
       isSortableFeed: false,
     });
     mockUseQueryState.mockReturnValue([0, jest.fn()]);
+    mockUseLayoutVariant.mockReturnValue({ isV2: false, isLoading: false });
     mockCheckIsExtension.mockReturnValue(false);
     mockGetCurrentBrowserName.mockReturnValue('Chrome');
     mockIsExtensionCapableBrowser.mockReturnValue(true);
@@ -236,5 +280,53 @@ describe('SearchControlHeader', () => {
     expect(
       screen.getByRole('link', { name: 'Get it for Chrome' }),
     ).toBeInTheDocument();
+  });
+
+  it('renders v2 feed actions icon-only below tablet without chips', () => {
+    mockUseActions.mockReturnValue(createActionsState());
+    mockUseLayoutVariant.mockReturnValue({ isV2: true, isLoading: false });
+    mockViewSize({ isTablet: false, isLaptop: false });
+
+    renderComponent();
+
+    expect(
+      screen.getByRole('link', { name: 'Generate brief' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Generate brief')).not.toBeInTheDocument();
+    expect(screen.getByTestId('my-feed-heading')).toHaveAttribute(
+      'data-icon-only',
+      'true',
+    );
+  });
+
+  it('renders the v2 brief shortcut label at tablet size without chips', () => {
+    mockUseActions.mockReturnValue(createActionsState());
+    mockUseLayoutVariant.mockReturnValue({ isV2: true, isLoading: false });
+    mockViewSize({ isTablet: true, isLaptop: false });
+
+    renderComponent();
+
+    expect(screen.getByText('Generate brief')).toBeInTheDocument();
+    expect(screen.getByTestId('my-feed-heading')).toHaveAttribute(
+      'data-icon-only',
+      'false',
+    );
+  });
+
+  it('keeps v2 feed actions icon-only when chips are present', () => {
+    mockUseActions.mockReturnValue(createActionsState());
+    mockUseLayoutVariant.mockReturnValue({ isV2: true, isLoading: false });
+    mockViewSize({ isTablet: true, isLaptop: false });
+
+    renderComponent({ chips: <div>Chips</div> });
+
+    expect(
+      screen.getByRole('link', { name: 'Generate brief' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Generate brief')).not.toBeInTheDocument();
+    expect(screen.getByTestId('my-feed-heading')).toHaveAttribute(
+      'data-icon-only',
+      'true',
+    );
   });
 });

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -96,6 +96,7 @@ export const SearchControlHeader = ({
   const { isUpvoted, isSortableFeed } = useFeedName({ feedName });
   const isLaptop = useViewSize(ViewSize.Laptop);
   const isMobile = useViewSize(ViewSize.MobileL);
+  const isTablet = useViewSize(ViewSize.Tablet);
   const { isV2 } = useLayoutVariant();
   const isV2Strip = isV2;
   const { streak, isLoading, isStreaksEnabled } = useReadingStreak();
@@ -183,21 +184,19 @@ export const SearchControlHeader = ({
   );
 
   const dropdownIconSize = isV2Strip ? IconSize.XSmall : IconSize.Medium;
-  // When chips are present in the v2 strip the actions cluster moves to
-  // the right and rendered icon-only so the chips have horizontal room
-  // to scroll on the left.
   const hasV2Chips = isV2Strip && !!chips;
+  const shouldUseCompactV2Actions = isV2Strip && (!!chips || !isTablet);
   const primaryActions = [
     hasFeedActions && (
       <MyFeedHeading
         key="my-feed"
-        iconOnly={hasV2Chips}
+        iconOnly={shouldUseCompactV2Actions}
         feedSettingsButtonProps={
           isV2Strip
             ? {
                 size: ButtonSize.Small,
                 variant: ButtonVariant.Tertiary,
-                className: hasV2Chips
+                className: shouldUseCompactV2Actions
                   ? compactIconButtonClassName
                   : compactTextButtonClassName,
                 iconSize: IconSize.XSmall,
@@ -209,9 +208,11 @@ export const SearchControlHeader = ({
     hasFeedActions && isV2Strip && (
       <BriefShortcutButton
         key="brief-shortcut"
-        iconOnly={hasV2Chips}
+        iconOnly={shouldUseCompactV2Actions}
         className={
-          hasV2Chips ? compactIconButtonClassName : compactTextButtonClassName
+          shouldUseCompactV2Actions
+            ? compactIconButtonClassName
+            : compactTextButtonClassName
         }
       />
     ),

--- a/packages/webapp/pages/briefing/index.tsx
+++ b/packages/webapp/pages/briefing/index.tsx
@@ -192,17 +192,23 @@ const Page = (): ReactElement => {
                   variant={ButtonVariant.Tertiary}
                 />
               </Link>
-              <Typography type={TypographyType.Title3} bold>
+              <Typography
+                className="min-w-0 flex-1 truncate"
+                type={TypographyType.Title3}
+                bold
+              >
                 Presidential briefings
               </Typography>
-              <div className="ml-auto flex items-center gap-2">
+              <div className="flex shrink-0 items-center gap-2">
                 {isNotPlus && !emptyFeed && !hasTodayBrief && (
                   <Button
+                    aria-label="Generate Brief"
                     icon={<MagicIcon aria-hidden />}
                     onClick={() => router.push('/briefing/generate')}
+                    size={isMobile ? ButtonSize.Small : ButtonSize.Medium}
                     variant={ButtonVariant.Primary}
                   >
-                    Generate Brief
+                    {isMobile ? null : 'Generate Brief'}
                   </Button>
                 )}
                 <Button
@@ -210,6 +216,7 @@ const Page = (): ReactElement => {
                   onClick={() => {
                     router?.push(`${settingsUrl}/notifications`);
                   }}
+                  size={isMobile ? ButtonSize.Small : ButtonSize.Medium}
                 />
               </div>
             </header>


### PR DESCRIPTION
## Summary
- Compact the shared v2 feed brief shortcut below tablet widths while preserving the accessible Generate brief label.
- Constrain the mobile /briefing header so the title can shrink and the Generate Brief action becomes icon-only on mobile.
- Keep the implementation scoped to the overflowing action rows instead of changing shared button primitives.

## Verification
- NODE_ENV=test jest src/components/layout/common.spec.tsx --runInBand
- Prettier checks on impacted shared and webapp files
- ESLint checks on impacted shared and webapp files
- node ./scripts/typecheck-strict-changed.js

Issue: https://linear.app/dailydev/issue/ENG-1673/feedback-bug-report-generate-button-overflows-off-the-screen-on-ios

Closes ENG-1673

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1673-feedback-bug-report-gen.preview.app.daily.dev