### PR TITLE
fix: navigate spotlight tag search to normalized tag value

### DIFF
--- a/packages/shared/src/components/spotlight/commands/search.spec.ts
+++ b/packages/shared/src/components/spotlight/commands/search.spec.ts
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react';
+import {
+  SearchProviderEnum,
+  type SearchSuggestion,
+} from '../../../graphql/search';
+import { webappUrl } from '../../../lib/constants';
+import { useSearchProviderSuggestions } from '../../../hooks/search';
+import { useSpotlightSearchCommands } from './search';
+
+jest.mock('../../../hooks/search', () => ({
+  useSearchProviderSuggestions: jest.fn(),
+}));
+
+const mockedUseSuggestions = useSearchProviderSuggestions as jest.Mock;
+
+const mockTagHits = (hits: SearchSuggestion[]) => {
+  mockedUseSuggestions.mockImplementation(({ provider }) => ({
+    isLoading: false,
+    suggestions: provider === SearchProviderEnum.Tags ? { hits } : { hits: [] },
+    queryKey: [],
+  }));
+};
+
+const renderTagCommands = (hits: SearchSuggestion[]) => {
+  mockTagHits(hits);
+  const router = { push: jest.fn() };
+  const { result } = renderHook(() =>
+    useSpotlightSearchCommands({ router, query: 'elixir' }),
+  );
+  return { router, result };
+};
+
+describe('useSpotlightSearchCommands tag navigation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('navigates using the normalized tag id, not the humanized title', () => {
+    const { router, result } = renderTagCommands([
+      { id: 'elixir', title: 'Elixir' },
+    ]);
+
+    result.current.tags[0].perform();
+
+    expect(router.push).toHaveBeenCalledWith(`${webappUrl}tags/elixir`);
+    expect(result.current.tags[0].meta).toMatchObject({ tagName: 'Elixir' });
+  });
+
+  it('falls back to the title when id is missing', () => {
+    const { router, result } = renderTagCommands([{ title: 'Elixir' }]);
+
+    result.current.tags[0].perform();
+
+    expect(router.push).toHaveBeenCalledWith(`${webappUrl}tags/Elixir`);
+  });
+
+  it('encodes the tag segment', () => {
+    const { router, result } = renderTagCommands([{ id: 'c#', title: 'C#' }]);
+
+    result.current.tags[0].perform();
+
+    expect(router.push).toHaveBeenCalledWith(`${webappUrl}tags/c%23`);
+  });
+});

--- a/packages/shared/src/components/spotlight/commands/search.ts
+++ b/packages/shared/src/components/spotlight/commands/search.ts
@@ -66,7 +66,9 @@ const buildTagCommand = (
   group: SpotlightGroup.Search,
   meta: { kind: 'tag', tagName: hit.title },
   perform: () => {
-    router.push(`${webappUrl}tags/${hit.title}`);
+    // `id` is the normalized tag value; `title` is the humanized label and
+    // would 404 the tag page, so navigate with the normalized value.
+    router.push(`${webappUrl}tags/${encodeURIComponent(hit.id ?? hit.title)}`);
   },
 });
 

--- a/packages/shared/src/components/spotlight/commands/search.ts
+++ b/packages/shared/src/components/spotlight/commands/search.ts
@@ -9,6 +9,7 @@ import {
 } from '../../../graphql/search';
 import { useSearchProviderSuggestions } from '../../../hooks/search';
 import { webappUrl } from '../../../lib/constants';
+import { getTagPageLink } from '../../../lib/links';
 import {
   SpotlightGroup,
   SpotlightScope,
@@ -68,7 +69,7 @@ const buildTagCommand = (
   perform: () => {
     // `id` is the normalized tag value; `title` is the humanized label and
     // would 404 the tag page, so navigate with the normalized value.
-    router.push(`${webappUrl}tags/${encodeURIComponent(hit.id ?? hit.title)}`);
+    router.push(getTagPageLink(hit.id ?? hit.title));
   },
 });
 


### PR DESCRIPTION
## Changes

The spotlight/global-search tag suggestion navigated using the humanized display title (e.g. `Elixir`) instead of the normalized tag value (e.g. `elixir`). The tag page treats the URL param as a keyword, so the humanized value matched nothing — rendering 0 stories and a non-functional Follow button.

- `buildTagCommand` now navigates with the normalized `hit.id` (falling back to `hit.title` if absent, mirroring the post/source commands).
- Reuses the existing shared `getTagPageLink` helper from `lib/links.ts` rather than building the encoded tag URL inline, keeping the encoding logic in one place.
- `meta.tagName` keeps the humanized `title` since it's display-only (the rendered `#Tag` chip).
- Added `search.spec.ts` covering normalized-id navigation, the title fallback, and URL-segment encoding.

## Key decisions

- No backend changes: the resolver contract (`id` = normalized, `title` = humanized) is correct and other consumers rely on it. The fix is purely consuming the right field on the frontend.

Closes ENG-1748

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1748-tag-search-returns-huma.preview.app.daily.dev