### PR TITLE
fix(shared): hide moderation prompt cancel button

### DIFF
--- a/packages/shared/src/components/modals/Prompt.spec.tsx
+++ b/packages/shared/src/components/modals/Prompt.spec.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type { PromptOptions } from '../../hooks/usePrompt';
+import { PROMPT_KEY } from '../../hooks/usePrompt';
+import { PromptElement } from './Prompt';
+
+const renderPrompt = (options: PromptOptions) => {
+  const client = new QueryClient();
+
+  client.setQueryData(PROMPT_KEY, {
+    options,
+    onSuccess: jest.fn(),
+    onFail: jest.fn(),
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <PromptElement ariaHideApp={false} />
+    </QueryClientProvider>,
+  );
+};
+
+describe('PromptElement', () => {
+  it('does not render cancel button when cancelButton is null', () => {
+    renderPrompt({
+      title: 'Confirm action',
+      okButton: { title: 'Got it' },
+      cancelButton: null,
+    });
+
+    expect(screen.getByRole('button', { name: 'Got it' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /cancel/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders explicit cancel button', () => {
+    renderPrompt({
+      title: 'Confirm action',
+      okButton: { title: 'Continue' },
+      cancelButton: { title: 'Cancel' },
+    });
+
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Continue' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/squads/utils.spec.tsx
+++ b/packages/shared/src/components/squads/utils.spec.tsx
@@ -1,0 +1,11 @@
+import {
+  createModerationPromptProps,
+  editModerationPromptProps,
+} from './utils';
+
+describe('moderation prompt props', () => {
+  it('hides the cancel button for post and edit review confirmations', () => {
+    expect(createModerationPromptProps.cancelButton).toBeNull();
+    expect(editModerationPromptProps.cancelButton).toBeNull();
+  });
+});

--- a/packages/shared/src/components/squads/utils.tsx
+++ b/packages/shared/src/components/squads/utils.tsx
@@ -60,7 +60,7 @@ export const createModerationPromptProps: PromptOptions = {
     title: 'Got it',
     className: 'tablet:w-full',
   },
-  cancelButton: undefined,
+  cancelButton: null,
   promptSize: ModalSize.XSmall,
   icon: <TimerIcon size={IconSize.XXXLarge} />,
 };

--- a/packages/shared/src/hooks/usePrompt.ts
+++ b/packages/shared/src/hooks/usePrompt.ts
@@ -16,7 +16,7 @@ export type PromptOptions = {
   icon?: ReactNode;
   description?: string | ReactNode;
   okButton?: PromptButtonProps;
-  cancelButton?: PromptButtonProps;
+  cancelButton?: PromptButtonProps | null;
   content?: ReactNode;
   promptSize?: ModalSize.XSmall | ModalSize.Small;
   className?: {


### PR DESCRIPTION
Fixes the moderated Squad submission confirmation prompt so it hides the cancel action instead of rendering a clipped default Cancel button.

Key decisions:
- Use the existing `cancelButton: null` sentinel for moderation confirmation prompts.
- Keep the default Prompt behavior unchanged when `cancelButton` is omitted.
- Type only the cancel button sentinel as nullable and cover both Prompt behavior and Squad prompt props with focused tests.

Closes ENG-1751

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1751-feedback-bug-report-the.preview.app.daily.dev