### PR TITLE
feat(bookmarks): custom date and time for reminders

### DIFF
--- a/packages/shared/src/components/fields/dateTimeInput.module.css
+++ b/packages/shared/src/components/fields/dateTimeInput.module.css
@@ -1,0 +1,23 @@
+/*
+ * The native date/time picker icon is dark by default, so it disappears on the
+ * dark theme. Invert it on dark surfaces, and leave it untouched on light ones.
+ */
+.dateTimeInput::-webkit-calendar-picker-indicator {
+  cursor: pointer;
+  filter: invert(1);
+  opacity: 0.7;
+}
+
+.dateTimeInput::-webkit-calendar-picker-indicator:hover {
+  opacity: 1;
+}
+
+:global(html.light) .dateTimeInput::-webkit-calendar-picker-indicator {
+  filter: none;
+}
+
+@media (prefers-color-scheme: light) {
+  :global(html.auto) .dateTimeInput::-webkit-calendar-picker-indicator {
+    filter: none;
+  }
+}

--- a/packages/shared/src/components/liveRooms/CreateLiveRoomForm.module.css
+++ b/packages/shared/src/components/liveRooms/CreateLiveRoomForm.module.css
@@ -1,9 +1,0 @@
-.scheduledTimeInput::-webkit-calendar-picker-indicator {
-  cursor: pointer;
-  filter: invert(1);
-  opacity: 0.7;
-}
-
-.scheduledTimeInput::-webkit-calendar-picker-indicator:hover {
-  opacity: 1;
-}

--- a/packages/shared/src/components/liveRooms/CreateLiveRoomForm.tsx
+++ b/packages/shared/src/components/liveRooms/CreateLiveRoomForm.tsx
@@ -26,7 +26,7 @@ import {
 import { timezoneSettingsUrl } from '../../lib/constants';
 import Link from '../utilities/Link';
 import { CREATE_LIVE_ROOM_FORM_ID } from '../fields/form/common';
-import styles from './CreateLiveRoomForm.module.css';
+import styles from '../fields/dateTimeInput.module.css';
 
 const DEFAULT_SCHEDULE_DELAY_MS = 30 * 60 * 1000;
 const TOPIC_MAX_LENGTH = 280;
@@ -246,7 +246,7 @@ export const CreateLiveRoomForm = ({
                   onChange={field.onChange}
                   onBlur={field.onBlur}
                   valid={!fieldState.error}
-                  className={{ input: styles.scheduledTimeInput }}
+                  className={{ input: styles.dateTimeInput }}
                 />
                 <Typography
                   type={TypographyType.Caption1}

--- a/packages/shared/src/components/modals/post/BookmarkReminderModal.tsx
+++ b/packages/shared/src/components/modals/post/BookmarkReminderModal.tsx
@@ -1,14 +1,17 @@
 import type { FormEventHandler, ReactElement } from 'react';
-import React, { useState } from 'react';
-import { format } from 'date-fns';
+import React, { useMemo, useState } from 'react';
+import { addDays, format, set } from 'date-fns';
+import classNames from 'classnames';
 import type { LazyModalCommonProps } from '../common/Modal';
 import { Modal } from '../common/Modal';
 import { ModalHeader } from '../common/ModalHeader';
 import { ModalBody } from '../common/ModalBody';
 import { ModalSize } from '../common/types';
 import { Button, ButtonVariant } from '../../buttons/Button';
+import styles from '../../fields/dateTimeInput.module.css';
 import {
   getRemindAt,
+  MAX_CUSTOM_REMINDER_DAYS,
   ReminderPreference,
   useBookmarkReminder,
 } from '../../../hooks/notifications';
@@ -36,7 +39,10 @@ const MODAL_OPTION_ORDER: ReminderPreference[] = [
   ReminderPreference.Tomorrow,
   ReminderPreference.TwoDays,
   ReminderPreference.NextWeek,
+  ReminderPreference.Custom,
 ];
+
+const DATETIME_LOCAL_FORMAT = "yyyy-MM-dd'T'HH:mm";
 
 const MODAL_OPTIONS: Array<BookmarkReminderModalOptionProps['option']> =
   MODAL_OPTION_ORDER.filter((option) => {
@@ -56,6 +62,7 @@ const TIME_FOR_OPTION_FORMAT_MAP = {
   [ReminderPreference.Tomorrow]: 'eee, h:mm a',
   [ReminderPreference.TwoDays]: 'eee, h:mm a',
   [ReminderPreference.NextWeek]: 'eee, MMM d, h:mm a',
+  [ReminderPreference.Custom]: null,
 };
 
 const BookmarkReminderModalOption = (
@@ -98,15 +105,47 @@ export const BookmarkReminderModal = (
   const [selectedOption, setSelectedOption] = useState<ReminderPreference>(
     ReminderPreference.NextWeek,
   );
+
+  const { minCustom, maxCustom, defaultCustom } = useMemo(() => {
+    const now = new Date();
+    return {
+      minCustom: format(now, DATETIME_LOCAL_FORMAT),
+      maxCustom: format(
+        addDays(now, MAX_CUSTOM_REMINDER_DAYS),
+        DATETIME_LOCAL_FORMAT,
+      ),
+      defaultCustom: format(
+        set(addDays(now, 1), { hours: 9, minutes: 0 }),
+        DATETIME_LOCAL_FORMAT,
+      ),
+    };
+  }, []);
+  const [customDate, setCustomDate] = useState<string>(defaultCustom);
+
+  const isCustom = selectedOption === ReminderPreference.Custom;
+  const customRemindAt = customDate ? new Date(customDate) : null;
+  const isCustomValid =
+    !isCustom ||
+    (!!customRemindAt &&
+      !Number.isNaN(customRemindAt.getTime()) &&
+      customRemindAt > new Date(minCustom) &&
+      customRemindAt <= new Date(maxCustom));
+
   const { onBookmarkReminder } = useBookmarkReminder({ post });
 
   const handleSubmit: FormEventHandler = async (e) => {
     e.preventDefault();
+
+    if (!isCustomValid) {
+      return;
+    }
+
     onReminderSet?.(selectedOption);
     onBookmarkReminder({
       existingReminder: post.bookmark?.remindAt,
       postId: post.id,
       preference: selectedOption,
+      remindAt: isCustom && customRemindAt ? customRemindAt : undefined,
     }).then(() => {
       onRequestClose();
     });
@@ -143,9 +182,35 @@ export const BookmarkReminderModal = (
               />
             ))}
           </div>
+          {isCustom && (
+            <label
+              className="mt-2 flex flex-col gap-1 px-3"
+              htmlFor="customReminder"
+            >
+              <span className="text-text-tertiary typo-footnote">
+                Pick a date and time (up to {MAX_CUSTOM_REMINDER_DAYS} days
+                ahead)
+              </span>
+              <input
+                aria-label="Custom reminder date and time"
+                className={classNames(
+                  styles.dateTimeInput,
+                  'rounded-10 border border-border-subtlest-tertiary bg-transparent px-3 py-2 text-text-primary typo-callout',
+                )}
+                id="customReminder"
+                max={maxCustom}
+                min={minCustom}
+                name="customReminder"
+                onChange={(e) => setCustomDate(e.target.value)}
+                type="datetime-local"
+                value={customDate}
+              />
+            </label>
+          )}
           <div className="mt-5 flex flex-row justify-center">
             <Button
               className="w-full responsiveModalBreakpoint:w-auto"
+              disabled={!isCustomValid}
               variant={ButtonVariant.Primary}
             >
               Set reminder

--- a/packages/shared/src/components/post/composer/StandupForm.module.css
+++ b/packages/shared/src/components/post/composer/StandupForm.module.css
@@ -1,9 +1,0 @@
-.scheduledTimeInput::-webkit-calendar-picker-indicator {
-  cursor: pointer;
-  filter: invert(1);
-  opacity: 0.7;
-}
-
-.scheduledTimeInput::-webkit-calendar-picker-indicator:hover {
-  opacity: 1;
-}

--- a/packages/shared/src/components/post/composer/StandupForm.tsx
+++ b/packages/shared/src/components/post/composer/StandupForm.tsx
@@ -2,7 +2,7 @@ import type { ReactElement, ReactNode } from 'react';
 import React, { useEffect, useMemo, useRef } from 'react';
 import classNames from 'classnames';
 import RichTextInput from '../../fields/RichTextInput';
-import styles from './StandupForm.module.css';
+import styles from '../../fields/dateTimeInput.module.css';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import {
   dateFormatInTimezone,
@@ -191,7 +191,7 @@ export const StandupForm = ({
               }
               aria-label="Scheduled time"
               className={classNames(
-                styles.scheduledTimeInput,
+                styles.dateTimeInput,
                 'inline-flex h-8 shrink-0 items-center gap-1.5 rounded-8 border bg-surface-float px-3 text-text-primary outline-none typo-caption1',
                 scheduledStartError
                   ? 'border-status-error'

--- a/packages/shared/src/hooks/notifications/useBookmarkReminder.spec.tsx
+++ b/packages/shared/src/hooks/notifications/useBookmarkReminder.spec.tsx
@@ -312,6 +312,82 @@ describe('useBookmarkReminder hook', () => {
     });
   });
 
+  it('should set a custom remindAt when preference is Custom', async () => {
+    const { result } = renderHook(() => useBookmarkReminder({ post }), {
+      wrapper: Wrapper,
+    });
+
+    const customRemindAt = addDays(mockedNow, 5);
+    await result.current.onBookmarkReminder({
+      postId: 'p1',
+      preference: ReminderPreference.Custom,
+      remindAt: customRemindAt,
+    });
+
+    jest.useRealTimers();
+    await waitFor(() => {
+      expect(setBookmarkReminder).toHaveBeenCalledWith({
+        postId: 'p1',
+        remindAt: customRemindAt,
+      });
+    });
+
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: 'set bookmark reminder',
+        extra: '{"remind_in":"Custom"}',
+      }),
+    );
+  });
+
+  it('should throw when custom remindAt is missing', async () => {
+    const { result } = renderHook(() => useBookmarkReminder({ post }), {
+      wrapper: Wrapper,
+    });
+
+    expect(() =>
+      result.current.onBookmarkReminder({
+        postId: 'p1',
+        preference: ReminderPreference.Custom,
+      }),
+    ).toThrow('Invalid custom reminder time');
+
+    expect(logEvent).not.toHaveBeenCalled();
+    expect(setBookmarkReminder).not.toHaveBeenCalled();
+  });
+
+  it('should throw when custom remindAt is more than 14 days ahead', async () => {
+    const { result } = renderHook(() => useBookmarkReminder({ post }), {
+      wrapper: Wrapper,
+    });
+
+    expect(() =>
+      result.current.onBookmarkReminder({
+        postId: 'p1',
+        preference: ReminderPreference.Custom,
+        remindAt: addDays(mockedNow, 15),
+      }),
+    ).toThrow('Invalid custom reminder time');
+
+    expect(setBookmarkReminder).not.toHaveBeenCalled();
+  });
+
+  it('should throw when custom remindAt is in the past', async () => {
+    const { result } = renderHook(() => useBookmarkReminder({ post }), {
+      wrapper: Wrapper,
+    });
+
+    expect(() =>
+      result.current.onBookmarkReminder({
+        postId: 'p1',
+        preference: ReminderPreference.Custom,
+        remindAt: addHours(mockedNow, -1),
+      }),
+    ).toThrow('Invalid custom reminder time');
+
+    expect(setBookmarkReminder).not.toHaveBeenCalled();
+  });
+
   it('should properly remove bookmark reminder', async () => {
     const { result } = renderHook(() => useBookmarkReminder({ post }), {
       wrapper: Wrapper,

--- a/packages/shared/src/hooks/notifications/useBookmarkReminder.ts
+++ b/packages/shared/src/hooks/notifications/useBookmarkReminder.ts
@@ -1,7 +1,7 @@
 import type { InfiniteData } from '@tanstack/react-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
-import { addDays, addHours, nextMonday, set } from 'date-fns';
+import { addDays, addHours, format, nextMonday, set } from 'date-fns';
 import type {
   Bookmark,
   SetBookmarkReminderProps,
@@ -29,7 +29,10 @@ export enum ReminderPreference {
   Tomorrow = 'Tomorrow',
   TwoDays = 'In 2 days',
   NextWeek = 'Next week',
+  Custom = 'Custom',
 }
+
+export const MAX_CUSTOM_REMINDER_DAYS = 14;
 
 interface MutateBookmarkProps extends SetBookmarkReminderProps {
   existingReminder?: Date;
@@ -40,6 +43,8 @@ interface BookmarkReminderProps {
   postId: string;
   preference: ReminderPreference;
   existingReminder?: Date;
+  // Required when preference is ReminderPreference.Custom
+  remindAt?: Date;
 }
 
 interface UseBookmarkReminder {
@@ -142,7 +147,12 @@ export const useBookmarkReminder = ({
     onSuccess: (_, { postId, existingReminder, preference, remindAt }) => {
       onUpdateCache(postId, remindAt ?? undefined);
 
-      displayToast(`Reminder set for ${preference.toLowerCase()}`, {
+      const reminderLabel =
+        preference === ReminderPreference.Custom && remindAt
+          ? format(remindAt, 'eee, MMM d, h:mm a')
+          : preference.toLowerCase();
+
+      displayToast(`Reminder set for ${reminderLabel}`, {
         action: {
           copy: 'Undo',
           onClick: () =>
@@ -172,6 +182,19 @@ export const useBookmarkReminder = ({
         throw new Error('Invalid preference');
       }
 
+      const isCustom = preference === ReminderPreference.Custom;
+      const maxRemindAt = addDays(now, MAX_CUSTOM_REMINDER_DAYS);
+      if (
+        isCustom &&
+        (!props.remindAt ||
+          props.remindAt <= now ||
+          props.remindAt > maxRemindAt)
+      ) {
+        throw new Error('Invalid custom reminder time');
+      }
+
+      const remindAt = isCustom ? props.remindAt : getRemindAt(now, preference);
+
       logEvent(
         postLogEvent(LogEvent.SetBookmarkReminder, post, {
           extra: { remind_in: preference },
@@ -180,7 +203,7 @@ export const useBookmarkReminder = ({
 
       return onSetBookmarkReminder({
         ...props,
-        remindAt: getRemindAt(now, preference),
+        remindAt,
       });
     },
     [logEvent, onSetBookmarkReminder, post],


### PR DESCRIPTION
## What

Adds a **Custom** option to the bookmark reminder modal so users can pick any date and time, up to **14 days** ahead.

- New `ReminderPreference.Custom` + `MAX_CUSTOM_REMINDER_DAYS` constant.
- The modal reveals a native `datetime-local` input (defaulting to tomorrow 9:00 AM) with `min`/`max` bounds; the submit button is disabled while the value is empty, in the past, or beyond 14 days.
- The hook validates the custom `remindAt` (fails fast on invalid) and passes it straight through.
- The success toast formats custom reminders nicely (e.g. "Reminder set for Wed, Jul 17, 9:00 AM").

The `setBookmarkReminder` GraphQL mutation already accepts a `remindAt: DateTime`, so **no API change was needed**.

## Cleanup

The native date-picker icon CSS (`::-webkit-calendar-picker-indicator`) was duplicated byte-for-byte in `StandupForm` and `CreateLiveRoomForm`. Consolidated into a single shared `dateTimeInput.module.css` and made it **theme-aware** (only inverts the icon on the dark theme), then reused it across all three.

## Testing

- Added hook tests for the custom path: success + validation failures (missing, >14 days, in the past).
- All 11 `useBookmarkReminder` tests pass; lint + strict typecheck clean.

### Preview domain
https://eng-1746-feedback-feature-reques.preview.app.daily.dev