### PR TITLE
feat: allow landscape orientation in PWA manifest

### DIFF
--- a/packages/webapp/AGENTS.md
+++ b/packages/webapp/AGENTS.md
@@ -204,7 +204,3 @@ export default function ProtectedPage() {
 
 - For `pages/settings/api.tsx`, free users should see the full API/Skills page content, but token creation should be gated only inside the token empty-state widget.
 - Avoid adding header upsell markers/badges for this flow unless product explicitly asks for it.
-
-## PWA Manifest
-
-- Installed-PWA screen orientation is controlled solely by `orientation` in `public/manifest.json` — NOT by the viewport `<meta>` in `pages/_app.tsx` or any CSS. The viewport meta (`width=device-width`) already adapts to landscape. To support both portrait and landscape, use `"orientation": "any"`; do not chase orientation behavior in HTML/CSS.

--- a/packages/webapp/AGENTS.md
+++ b/packages/webapp/AGENTS.md
@@ -204,3 +204,7 @@ export default function ProtectedPage() {
 
 - For `pages/settings/api.tsx`, free users should see the full API/Skills page content, but token creation should be gated only inside the token empty-state widget.
 - Avoid adding header upsell markers/badges for this flow unless product explicitly asks for it.
+
+## PWA Manifest
+
+- Installed-PWA screen orientation is controlled solely by `orientation` in `public/manifest.json` — NOT by the viewport `<meta>` in `pages/_app.tsx` or any CSS. The viewport meta (`width=device-width`) already adapts to landscape. To support both portrait and landscape, use `"orientation": "any"`; do not chase orientation behavior in HTML/CSS.

--- a/packages/webapp/public/manifest.json
+++ b/packages/webapp/public/manifest.json
@@ -25,5 +25,5 @@
   "background_color": "#151618",
   "start_url": "/?pwa=true",
   "display": "standalone",
-  "orientation": "portrait"
+  "orientation": "any"
 }


### PR DESCRIPTION
## Changes

The installed PWA was locked to portrait via `orientation: "portrait"` in the web app manifest, preventing tablet users from reading daily.dev in landscape.

Changed the manifest `orientation` to `"any"` so the device/user controls orientation — both portrait and landscape are now supported.

## Key decisions

- Used `"any"` rather than removing the key: it keeps the intent explicit (we deliberately allow all orientations) and doesn't force landscape, so existing portrait users are unaffected.
- Only the webapp PWA manifest was affected; the extension `manifest.json` is a browser-extension manifest and unrelated. No code, tests, or comments reference the orientation value.

Closes ENG-1454

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1454-feedback-bug-report-use.preview.app.daily.dev