### PR TITLE
feat(search): support time filter via URL param

### DIFF
--- a/packages/shared/src/components/search/SearchFilterTimeButton.spec.tsx
+++ b/packages/shared/src/components/search/SearchFilterTimeButton.spec.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { NextRouter } from 'next/router';
+import { useRouter } from 'next/router';
+import SearchFilterTimeButton from './SearchFilterTimeButton';
+import {
+  SearchProvider,
+  useSearchContextProvider,
+} from '../../contexts/search/SearchContext';
+import type { SearchTimeKey } from '../../graphql/search';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+const replace = jest.fn();
+
+const mockRouter = (query: Record<string, string> = {}) =>
+  jest.mocked(useRouter).mockImplementation(
+    () =>
+      ({
+        pathname: '/search',
+        query: { q: 'react', ...query },
+        replace,
+        isReady: true,
+      } as unknown as NextRouter),
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockRouter();
+});
+
+const renderComponent = () =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <SearchProvider>
+        <SearchFilterTimeButton />
+      </SearchProvider>
+    </QueryClientProvider>,
+  );
+
+it('should default to All Time when no time param is in the URL', async () => {
+  renderComponent();
+
+  expect(
+    await screen.findByLabelText('Open time filter menu'),
+  ).toHaveTextContent('All Time');
+});
+
+it('should hydrate the filter label from the time URL param', async () => {
+  mockRouter({ time: '7d' });
+  renderComponent();
+
+  await waitFor(() =>
+    expect(screen.getByLabelText('Open time filter menu')).toHaveTextContent(
+      'Last 7 Days',
+    ),
+  );
+});
+
+const SetTimeButton = ({ value }: { value: SearchTimeKey }) => {
+  const { setTime } = useSearchContextProvider();
+  return (
+    <button type="button" onClick={() => setTime(value)}>
+      set
+    </button>
+  );
+};
+
+const renderSetter = (value: SearchTimeKey) =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <SearchProvider>
+        <SetTimeButton value={value} />
+      </SearchProvider>
+    </QueryClientProvider>,
+  );
+
+it('should write the selected time frame to the URL', async () => {
+  renderSetter('LastSevenDays');
+
+  await userEvent.click(screen.getByText('set'));
+
+  expect(replace).toHaveBeenCalledWith(
+    {
+      pathname: '/search',
+      query: { q: 'react', time: '7d' },
+    },
+    undefined,
+    { shallow: true },
+  );
+});
+
+it('should remove the time param when selecting All Time', async () => {
+  mockRouter({ time: '7d' });
+  renderSetter('AllTime');
+
+  await userEvent.click(screen.getByText('set'));
+
+  expect(replace).toHaveBeenCalledWith(
+    {
+      pathname: '/search',
+      query: { q: 'react' },
+    },
+    undefined,
+    { shallow: true },
+  );
+});

--- a/packages/shared/src/components/search/SearchFilterTimeButton.tsx
+++ b/packages/shared/src/components/search/SearchFilterTimeButton.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { VIcon } from '../icons';
 import { useSearchContextProvider } from '../../contexts/search/SearchContext';
+import type { SearchTimeKey } from '../../graphql/search';
 import { SearchTime } from '../../graphql/search';
 import {
   DropdownMenu,
@@ -23,14 +24,14 @@ const SearchFilterTimeButton = () => {
             size={ButtonSize.Small}
             aria-label="Open time filter menu"
           >
-            {SearchTime[time as keyof typeof SearchTime]}
+            {SearchTime[time]}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>
           {Object.entries(SearchTime).map(([value, label]) => (
             <DropdownMenuItem
               key={label}
-              onClick={() => setTime(value as keyof SearchTime)}
+              onClick={() => setTime(value as SearchTimeKey)}
               className={classNames(
                 'flex',
                 time === value

--- a/packages/shared/src/contexts/search/SearchContext.tsx
+++ b/packages/shared/src/contexts/search/SearchContext.tsx
@@ -1,13 +1,52 @@
 import { createContextProvider } from '@kickass-coderz/react';
-import { useMemo, useState } from 'react';
-import type { SearchTime } from '../../graphql/search';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
+import type { SearchTimeKey } from '../../graphql/search';
+import {
+  defaultSearchTime,
+  getSearchTimeFromUrl,
+  getSearchTimeQueryParam,
+} from '../../graphql/search';
 
 const [SearchProvider, useSearchContextProvider] = createContextProvider(
   () => {
-    const [time, setTime] = useState<keyof SearchTime>(
-      'AllTime' as keyof SearchTime,
-    );
+    const router = useRouter();
+    const [time, setTimeState] = useState<SearchTimeKey>(defaultSearchTime);
     const [postTypes, setPostTypes] = useState<Record<string, boolean>>({});
+
+    // Hydrate the time filter from the URL so shared/bookmarked links like
+    // /search?q=react&time=7d apply the filter on load. Runs once the router is
+    // ready since query params are not populated during the first render.
+    useEffect(() => {
+      if (!router?.isReady) {
+        return;
+      }
+
+      setTimeState(
+        getSearchTimeFromUrl(router.query?.time?.toString()) ??
+          defaultSearchTime,
+      );
+    }, [router?.isReady, router?.query?.time]);
+
+    const setTime = useCallback(
+      (value: SearchTimeKey) => {
+        setTimeState(value);
+
+        if (!router?.isReady) {
+          return;
+        }
+
+        const query = { ...router.query, ...getSearchTimeQueryParam(value) };
+        if (value === defaultSearchTime) {
+          delete query.time;
+        }
+
+        router.replace({ pathname: router.pathname, query }, undefined, {
+          shallow: true,
+        });
+      },
+      [router],
+    );
 
     const contentCurationFilter = useMemo(
       () => Object.keys(postTypes).filter((key) => postTypes[key] === true),

--- a/packages/shared/src/graphql/search.ts
+++ b/packages/shared/src/graphql/search.ts
@@ -15,6 +15,38 @@ export enum SearchTime {
   LastYear = 'Last Year',
 }
 
+export type SearchTimeKey = keyof typeof SearchTime;
+
+export const defaultSearchTime: SearchTimeKey = 'AllTime';
+
+// URL-friendly slugs for the search time filter so it can be shared/bookmarked
+// via the `time` query param (e.g. /search?q=react&time=7d).
+const searchTimeUrlSlug: Record<SearchTimeKey, string> = {
+  AllTime: 'all',
+  Today: 'today',
+  Yesterday: 'yesterday',
+  LastSevenDays: '7d',
+  LastThirtyDays: '30d',
+  LastMonth: 'last-month',
+  ThisYear: 'this-year',
+  LastYear: 'last-year',
+};
+
+const urlSlugToSearchTime = Object.fromEntries(
+  Object.entries(searchTimeUrlSlug).map(([key, slug]) => [slug, key]),
+) as Record<string, SearchTimeKey>;
+
+export const getSearchTimeFromUrl = (
+  value?: string,
+): SearchTimeKey | undefined =>
+  value ? urlSlugToSearchTime[value] : undefined;
+
+// `AllTime` is the default and is omitted from the URL to keep links clean.
+export const getSearchTimeQueryParam = (
+  time: SearchTimeKey,
+): { time?: string } =>
+  time === defaultSearchTime ? {} : { time: searchTimeUrlSlug[time] };
+
 export enum SearchProviderEnum {
   Posts = 'posts',
   Tags = 'tags',

--- a/packages/webapp/components/RouterPostsSearch.tsx
+++ b/packages/webapp/components/RouterPostsSearch.tsx
@@ -5,7 +5,10 @@ import PostsSearch from '@dailydotdev/shared/src/components/PostsSearch';
 import { useRouter } from 'next/router';
 import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
 import { LogEvent } from '@dailydotdev/shared/src/lib/log';
-import { SearchProviderEnum } from '@dailydotdev/shared/src/graphql/search';
+import {
+  getSearchTimeQueryParam,
+  SearchProviderEnum,
+} from '@dailydotdev/shared/src/graphql/search';
 import { useSearchContextProvider } from '@dailydotdev/shared/src/contexts/search/SearchContext';
 
 export default function RouterPostsSearch(
@@ -27,7 +30,7 @@ export default function RouterPostsSearch(
 
     return router.replace({
       pathname: router?.pathname ? router?.pathname : '/search',
-      query: { q: query },
+      query: { q: query, ...getSearchTimeQueryParam(time) },
     });
   };
 


### PR DESCRIPTION
## Changes

Adds support for a `time` URL query param on the search page so the time filter can be shared and bookmarked (e.g. `/search?q=wordpress&time=7d`).

- `SearchContext` hydrates the time filter from the URL once the router is ready, and persists selections back to the URL on change (shallow `router.replace`).
- Submitting a new query preserves the active time frame.
- Added a `searchTimeUrlSlug` map (`7d`, `30d`, `today`, `this-year`, ...) with `getSearchTimeFromUrl` / `getSearchTimeQueryParam` helpers in `graphql/search.ts`. Only supported time frames are accepted; unknown values fall back to the default.

Key decisions:
- `AllTime` is the default and is omitted from the URL to keep links clean (and is still accepted on read, so URLs round-trip).
- Introduced a `SearchTimeKey` type alias (`keyof typeof SearchTime`) to replace the prior `keyof SearchTime` typing and remove scattered casts.
- Slug-to-query logic is centralized in one shared helper to avoid duplication between the context and `RouterPostsSearch`.

## Events

No new tracking events. The existing `SubmitSearch` event already logs the `time` filter.

## Experiment

No new experiments.

## Manual Testing

- Loading `/search?q=...&time=7d` applies the Last 7 Days filter on load.
- Changing the filter updates the URL; selecting All Time removes the param.
- Submitting a new search keeps the active time frame.

Covered by `SearchFilterTimeButton.spec.tsx` (default, URL hydration, URL write, param removal).

Closes ENG-1648

---
Created by Huginn 🐦‍⬛


### Preview domain
https://eng-1648-feedback-feature-reques.preview.app.daily.dev