### PR TITLE
fix: improve hot takes mobile swipe performance

### DIFF
--- a/packages/shared/src/components/modals/hotTakes/HotAndColdModal.spec.tsx
+++ b/packages/shared/src/components/modals/hotTakes/HotAndColdModal.spec.tsx
@@ -5,8 +5,14 @@ import { useDiscoverHotTakes } from '../../../hooks/useDiscoverHotTakes';
 import { useVoteHotTake } from '../../../hooks/vote/useVoteHotTake';
 import { useLogContext } from '../../../contexts/LogContext';
 import { useAuthContext } from '../../../contexts/AuthContext';
+import { useMedia } from '../../../hooks/useMedia';
+import { useViewSize } from '../../../hooks/useViewSize';
 import { LogEvent, Origin } from '../../../lib/log';
-import HotAndColdModal from './HotAndColdModal';
+import HotAndColdModal, {
+  getElasticDelta,
+  quantizeIntensity,
+  smoothstep01,
+} from './HotAndColdModal';
 
 jest.mock('../../../hooks/useDiscoverHotTakes', () => ({
   useDiscoverHotTakes: jest.fn(),
@@ -26,6 +32,17 @@ jest.mock('../../../contexts/AuthContext', () => ({
   useAuthContext: jest.fn(),
 }));
 
+jest.mock('../../../hooks/useMedia', () => ({
+  useMedia: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useViewSize', () => ({
+  ViewSize: {
+    MobileL: 'mobileL',
+  },
+  useViewSize: jest.fn(),
+}));
+
 jest.mock('../../../hooks/useRequestProtocol', () => ({
   useRequestProtocol: () => ({ isCompanion: false }),
 }));
@@ -34,6 +51,8 @@ const mockedUseDiscoverHotTakes = useDiscoverHotTakes as jest.Mock;
 const mockedUseVoteHotTake = useVoteHotTake as jest.Mock;
 const mockedUseLogContext = useLogContext as jest.Mock;
 const mockedUseAuthContext = useAuthContext as jest.Mock;
+const mockedUseMedia = useMedia as jest.Mock;
+const mockedUseViewSize = useViewSize as jest.Mock;
 
 const createHotTake = (id = 'take-1'): HotTake => ({
   id,
@@ -47,7 +66,7 @@ const createHotTake = (id = 'take-1'): HotTake => ({
 });
 
 const renderComponent = (onRequestClose = jest.fn()) => {
-  render(
+  const view = render(
     <HotAndColdModal
       isOpen
       onRequestClose={onRequestClose}
@@ -55,7 +74,34 @@ const renderComponent = (onRequestClose = jest.fn()) => {
     />,
   );
 
-  return { onRequestClose };
+  return { onRequestClose, ...view };
+};
+
+const swipeCard = ({
+  deltaX = 0,
+  deltaY = 0,
+}: {
+  deltaX?: number;
+  deltaY?: number;
+}) => {
+  const swipeArea = screen.getAllByTestId('hot-takes-swipe-area')[0];
+  const startX = 200;
+  const startY = 400;
+
+  fireEvent.mouseDown(swipeArea, {
+    clientX: startX,
+    clientY: startY,
+    buttons: 1,
+  });
+  fireEvent.mouseMove(document, {
+    clientX: startX + deltaX,
+    clientY: startY + deltaY,
+    buttons: 1,
+  });
+  fireEvent.mouseUp(document, {
+    clientX: startX + deltaX,
+    clientY: startY + deltaY,
+  });
 };
 
 describe('HotAndColdModal', () => {
@@ -78,6 +124,8 @@ describe('HotAndColdModal', () => {
     mockedUseAuthContext.mockReturnValue({
       user: { username: 'tester' },
     });
+    mockedUseMedia.mockReturnValue(false);
+    mockedUseViewSize.mockReturnValue(false);
     mockedUseDiscoverHotTakes.mockReturnValue({
       hotTakes: [createHotTake()],
       currentTake: createHotTake(),
@@ -90,6 +138,17 @@ describe('HotAndColdModal', () => {
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  it('should keep swipe helper math bounded and quantized', () => {
+    expect(smoothstep01(-1)).toBe(0);
+    expect(smoothstep01(0.5)).toBe(0.5);
+    expect(smoothstep01(2)).toBe(1);
+    expect(getElasticDelta(40)).toBe(40);
+    expect(getElasticDelta(120)).toBe(92);
+    expect(getElasticDelta(-120)).toBe(-92);
+    expect(quantizeIntensity(0.53)).toBe(0.55);
+    expect(quantizeIntensity(1.2)).toBe(1);
   });
 
   it('should trigger upvote flow for hot action', () => {
@@ -135,6 +194,125 @@ describe('HotAndColdModal', () => {
     });
 
     expect(dismissCurrent).toHaveBeenCalledTimes(1);
+  });
+
+  it('should trigger upvote flow when swiped right past threshold', () => {
+    jest.useFakeTimers();
+    const currentTake = createHotTake('swipe-hot-take');
+
+    mockedUseDiscoverHotTakes.mockReturnValue({
+      hotTakes: [currentTake],
+      currentTake,
+      nextTake: null,
+      isEmpty: false,
+      isLoading: false,
+      dismissCurrent,
+    });
+
+    renderComponent();
+
+    swipeCard({ deltaX: 130 });
+
+    expect(toggleUpvote).toHaveBeenCalledWith({
+      payload: currentTake,
+      origin: Origin.HotAndCold,
+    });
+    expect(toggleDownvote).not.toHaveBeenCalled();
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: LogEvent.VoteHotAndCold,
+        target_id: currentTake.id,
+      }),
+    );
+    expect(dismissCurrent).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(dismissCurrent).toHaveBeenCalledTimes(1);
+  });
+
+  it('should snap back when swiped under threshold', () => {
+    renderComponent();
+
+    swipeCard({ deltaX: 50 });
+
+    expect(toggleUpvote).not.toHaveBeenCalled();
+    expect(toggleDownvote).not.toHaveBeenCalled();
+    expect(cancelHotTakeVote).not.toHaveBeenCalled();
+    expect(dismissCurrent).not.toHaveBeenCalled();
+  });
+
+  it('should trigger skip flow when swiped up past threshold', () => {
+    jest.useFakeTimers();
+    const currentTake = createHotTake('swipe-skip-take');
+
+    mockedUseDiscoverHotTakes.mockReturnValue({
+      hotTakes: [currentTake],
+      currentTake,
+      nextTake: null,
+      isEmpty: false,
+      isLoading: false,
+      dismissCurrent,
+    });
+
+    renderComponent();
+
+    swipeCard({ deltaY: -130 });
+
+    expect(cancelHotTakeVote).toHaveBeenCalledWith({ id: currentTake.id });
+    expect(toggleUpvote).not.toHaveBeenCalled();
+    expect(toggleDownvote).not.toHaveBeenCalled();
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: LogEvent.SkipHotTake,
+        target_id: currentTake.id,
+      }),
+    );
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(dismissCurrent).toHaveBeenCalledTimes(1);
+  });
+
+  it('should write the active drag transform outside React state', () => {
+    const originalRequestAnimationFrame = window.requestAnimationFrame;
+    const originalCancelAnimationFrame = window.cancelAnimationFrame;
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    }) as typeof window.requestAnimationFrame;
+    window.cancelAnimationFrame =
+      jest.fn() as typeof window.cancelAnimationFrame;
+
+    try {
+      renderComponent();
+
+      const swipeArea = screen.getByTestId('hot-takes-swipe-area');
+      fireEvent.mouseDown(swipeArea, {
+        clientX: 200,
+        clientY: 400,
+        buttons: 1,
+      });
+      fireEvent.mouseMove(document, {
+        clientX: 296,
+        clientY: 400,
+        buttons: 1,
+      });
+
+      const activeCard = document.querySelector(
+        '[data-testid="hot-take-card"][data-active-card="true"]',
+      ) as HTMLElement;
+
+      expect(activeCard.style.transform).toContain('translateX(96px)');
+      expect(activeCard).toHaveStyle({ willChange: 'transform' });
+    } finally {
+      window.requestAnimationFrame = originalRequestAnimationFrame;
+      window.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
   });
 
   it('should trigger downvote flow for cold action', () => {
@@ -370,5 +548,80 @@ describe('HotAndColdModal', () => {
       screen.getAllByRole('img', { name: 'daily.dev source icon' })[0],
     ).toBeVisible();
     expect(screen.getAllByText('Starter feed ready')[0]).toBeVisible();
+  });
+
+  it('should preserve onboarding swipe action metadata', () => {
+    jest.useFakeTimers();
+    const onSwipeAction = jest.fn();
+
+    render(
+      <HotAndColdModal
+        isOpen
+        onRequestClose={jest.fn()}
+        ariaHideApp={false}
+        onboardingCards={[
+          {
+            id: 'onboarding-card-1',
+            title: 'Figma launches MCP tool for AI agents to design on canvas',
+            source: { name: 'daily.dev' },
+          },
+        ]}
+        onSwipeAction={onSwipeAction}
+      />,
+    );
+
+    swipeCard({ deltaX: 130 });
+
+    expect(onSwipeAction).toHaveBeenCalledWith('right', {
+      onboardingCardId: 'onboarding-card-1',
+    });
+
+    act(() => {
+      jest.runAllTimers();
+    });
+  });
+
+  it('should render lightweight directional effects on mobile', () => {
+    mockedUseViewSize.mockReturnValue(true);
+    renderComponent();
+
+    const swipeArea = screen.getAllByTestId('hot-takes-swipe-area')[0];
+    fireEvent.mouseDown(swipeArea, {
+      clientX: 200,
+      clientY: 400,
+      buttons: 1,
+    });
+    fireEvent.mouseMove(document, {
+      clientX: 320,
+      clientY: 400,
+      buttons: 1,
+    });
+
+    expect(
+      document.querySelectorAll('[data-hot-take-particle="flame"]'),
+    ).toHaveLength(4);
+    expect(screen.getByText('HOT 🔥')).toBeInTheDocument();
+  });
+
+  it('should remove decorative particles for reduced motion', () => {
+    mockedUseMedia.mockReturnValue(true);
+    renderComponent();
+
+    const swipeArea = screen.getAllByTestId('hot-takes-swipe-area')[0];
+    fireEvent.mouseDown(swipeArea, {
+      clientX: 200,
+      clientY: 400,
+      buttons: 1,
+    });
+    fireEvent.mouseMove(document, {
+      clientX: 320,
+      clientY: 400,
+      buttons: 1,
+    });
+
+    expect(document.querySelectorAll('[data-hot-take-particle]')).toHaveLength(
+      0,
+    );
+    expect(screen.getByText('HOT 🔥')).toBeInTheDocument();
   });
 });

--- a/packages/shared/src/components/modals/hotTakes/HotAndColdModal.tsx
+++ b/packages/shared/src/components/modals/hotTakes/HotAndColdModal.tsx
@@ -74,8 +74,6 @@ type CSSPropertiesWithVars = React.CSSProperties & {
 
 type SwipeDirection = 'left' | 'right';
 
-type CssIntensity = number | string;
-
 export const smoothstep01 = (t: number): number => {
   const x = Math.min(Math.max(t, 0), 1);
   return x * x * (3 - 2 * x);
@@ -135,78 +133,6 @@ const getOnboardingSwipeVisualIntensities = (
 
   return { left: 0, right: 0 };
 };
-
-const cssNumber = (
-  intensity: CssIntensity,
-  multiplier: number,
-  offset = 0,
-): number | string => {
-  if (typeof intensity === 'number') {
-    return offset + intensity * multiplier;
-  }
-
-  if (offset === 0) {
-    return `calc(${intensity} * ${multiplier})`;
-  }
-
-  return `calc(${offset} + (${intensity} * ${multiplier}))`;
-};
-
-const cssPixels = (
-  intensity: CssIntensity,
-  multiplier: number,
-  offset = 0,
-): number | string => {
-  if (typeof intensity === 'number') {
-    return offset + intensity * multiplier;
-  }
-
-  if (offset === 0) {
-    return `calc(${intensity} * ${multiplier}px)`;
-  }
-
-  return `calc(${offset}px + (${intensity} * ${multiplier}px))`;
-};
-
-const cssPixelText = (
-  intensity: CssIntensity,
-  multiplier: number,
-  offset = 0,
-): string => {
-  const value = cssPixels(intensity, multiplier, offset);
-  return typeof value === 'number' ? `${value}px` : value;
-};
-
-const cssNegativePixelText = (
-  intensity: CssIntensity,
-  multiplier: number,
-  offset = 0,
-): string => {
-  const value = cssPixels(intensity, multiplier, offset);
-  return typeof value === 'number' ? `${-value}px` : `calc(-1 * ${value})`;
-};
-
-const cssPercent = (
-  intensity: CssIntensity,
-  multiplier: number,
-  offset = 0,
-): string => {
-  if (typeof intensity === 'number') {
-    return `${offset + intensity * multiplier}%`;
-  }
-
-  if (offset === 0) {
-    return `calc(${intensity} * ${multiplier}%)`;
-  }
-
-  return `calc(${offset}% + (${intensity} * ${multiplier}%))`;
-};
-
-const cssAlpha = (
-  intensity: CssIntensity,
-  multiplier: number,
-  offset = 0,
-): number | string => cssNumber(intensity, multiplier, offset);
 
 const HOT_INTENSITY_VAR = 'var(--hot-take-hot-intensity, 0)';
 const COLD_INTENSITY_VAR = 'var(--hot-take-cold-intensity, 0)';
@@ -1359,9 +1285,12 @@ const LIGHTWEIGHT_SLEEP_BUBBLES = SLEEP_BUBBLES.filter((_, index) =>
   [0, 3, 6].includes(index),
 );
 
-type FeedbackEffectLayerProps = {
+type SwipeEffectKind = 'hot' | 'cold' | 'skip';
+
+type SwipeEffectLayerProps = {
   active: boolean;
   intensity: number;
+  kind: SwipeEffectKind;
   lightweight: boolean;
   reducedMotion: boolean;
   useLiveIntensity: boolean;
@@ -1371,7 +1300,19 @@ const getEffectIntensityValue = (
   fallbackIntensity: number,
   liveIntensity: string,
   useLiveIntensity: boolean,
-): CssIntensity => (useLiveIntensity ? liveIntensity : fallbackIntensity);
+): number | string => (useLiveIntensity ? liveIntensity : fallbackIntensity);
+
+const getSwipeEffectLiveIntensity = (kind: SwipeEffectKind): string => {
+  if (kind === 'hot') {
+    return HOT_INTENSITY_VAR;
+  }
+
+  if (kind === 'cold') {
+    return COLD_INTENSITY_VAR;
+  }
+
+  return SKIP_INTENSITY_VAR;
+};
 
 const HotTakeEffectKeyframes = React.memo(
   function HotTakeEffectKeyframes(): ReactElement {
@@ -1382,339 +1323,207 @@ const HotTakeEffectKeyframes = React.memo(
   },
 );
 
-const HotSwipeEffectLayer = React.memo(function HotSwipeEffectLayer({
+const SwipeEffectLayer = React.memo(function SwipeEffectLayer({
   active,
   intensity: fallbackIntensity,
+  kind,
   lightweight,
   reducedMotion,
   useLiveIntensity,
-}: FeedbackEffectLayerProps): ReactElement | null {
+}: SwipeEffectLayerProps): ReactElement | null {
   if (!active) {
     return null;
   }
 
   const intensity = getEffectIntensityValue(
     fallbackIntensity,
-    HOT_INTENSITY_VAR,
+    getSwipeEffectLiveIntensity(kind),
     useLiveIntensity,
   );
-  const flames = lightweight ? LIGHTWEIGHT_FLAMES : FLAMES;
-  const embers = lightweight ? LIGHTWEIGHT_EMBERS : EMBERS;
   const showParticles = !reducedMotion;
 
-  return (
-    <div
-      aria-hidden
-      className="pointer-events-none absolute inset-0 overflow-hidden rounded-16"
-      style={{ opacity: intensity }}
-    >
-      <div
-        style={{
-          position: 'absolute',
-          inset: 0,
-          borderRadius: 'inherit',
-          background: `linear-gradient(180deg, rgba(255,150,20,${cssAlpha(
-            intensity,
-            0.08,
-          )}) 0%, rgba(255,90,0,${cssAlpha(
-            intensity,
-            0.16,
-          )}) 42%, rgba(100,20,0,${cssAlpha(intensity, 0.24)}) 100%)`,
-          boxShadow: lightweight
-            ? undefined
-            : [
-                `inset 0 ${cssNegativePixelText(intensity, 55)} ${cssPixelText(
-                  intensity,
-                  44,
-                )} ${cssNegativePixelText(intensity, 16)} rgba(255,100,0,0.4)`,
-                `inset ${cssPixelText(intensity, 26)} 0 ${cssPixelText(
-                  intensity,
-                  28,
-                )} ${cssNegativePixelText(intensity, 14)} rgba(255,60,0,0.15)`,
-                `inset ${cssNegativePixelText(intensity, 26)} 0 ${cssPixelText(
-                  intensity,
-                  28,
-                )} ${cssNegativePixelText(intensity, 14)} rgba(255,60,0,0.15)`,
-              ].join(', '),
-          animation: reducedMotion
-            ? undefined
-            : `hotTakeHeatShimmer ${cssNumber(
-                intensity,
-                -0.4,
-                1,
-              )}s ease-in-out infinite`,
-        }}
-      />
-      <div
-        style={{
-          position: 'absolute',
-          left: '-10%',
-          right: '-10%',
-          bottom: '-16%',
-          height: '44%',
-          borderRadius: '50%',
-          background: `radial-gradient(ellipse at 50% 100%, rgba(255,80,0,${cssAlpha(
-            intensity,
-            0.42,
-          )}) 0%, rgba(255,125,0,${cssAlpha(
-            intensity,
-            0.24,
-          )}) 40%, transparent 78%)`,
-          filter: lightweight
-            ? undefined
-            : `blur(${cssPixelText(intensity, 5, 5)})`,
-          animation: reducedMotion
-            ? undefined
-            : 'hotTakeHeatShimmer 1.1s ease-in-out infinite',
-        }}
-      />
-      {showParticles &&
-        flames.map((flame, i) => (
-          <div
-            key={flame.left}
-            data-hot-take-particle="flame"
-            style={{
-              position: 'absolute',
-              bottom: -2,
-              left: flame.left,
-              width: flame.size * 0.55,
-              height: cssPixels(intensity, flame.size),
-              background:
-                'radial-gradient(ellipse at 50% 88%, #fff29a 0%, #ffcf3d 20%, #ff8a00 45%, #ff3b00 66%, rgba(0,0,0,0) 84%)',
-              borderRadius: '50% 50% 20% 20%',
-              filter: lightweight
-                ? undefined
-                : `blur(${cssPixelText(
-                    intensity,
-                    1.8,
-                    1.4,
-                  )}) saturate(${cssNumber(intensity, 0.35, 1)})`,
-              animation: reducedMotion
-                ? undefined
-                : `hotTakeFlame ${
-                    0.3 + i * 0.06
-                  }s ease-in-out infinite alternate`,
-              animationDelay: `${flame.delay}s`,
-              transform: 'translateX(-50%)',
-              opacity: cssNumber(intensity, 0.55, 0.45),
-            }}
-          />
-        ))}
-      {showParticles &&
-        embers.map((ember) => (
-          <div
-            key={`${ember.left}-${ember.bottom}`}
-            data-hot-take-particle="ember"
-            style={{
-              position: 'absolute',
-              left: ember.left,
-              bottom: ember.bottom,
-              width: ember.size,
-              height: ember.size,
-              borderRadius: '50%',
-              background:
-                'radial-gradient(circle, #fff6ba 0%, #ffcb58 22%, #ff7a1a 54%, rgba(255,80,0,0.2) 80%, transparent 100%)',
-              boxShadow: lightweight
-                ? undefined
-                : `0 0 ${ember.size + 3}px rgba(255,120,0,${cssAlpha(
-                    intensity,
-                    0.55,
-                    0.35,
-                  )})`,
-              animation: reducedMotion
-                ? undefined
-                : `hotTakeEmber ${ember.duration}s ease-out infinite`,
-              animationDelay: `${ember.delay}s`,
-              opacity: cssNumber(intensity, 0.7, 0.3),
-            }}
-          />
-        ))}
-    </div>
-  );
-});
+  if (kind === 'hot') {
+    const flames = lightweight ? LIGHTWEIGHT_FLAMES : FLAMES;
+    const embers = lightweight ? LIGHTWEIGHT_EMBERS : EMBERS;
 
-const ColdSwipeEffectLayer = React.memo(function ColdSwipeEffectLayer({
-  active,
-  intensity: fallbackIntensity,
-  lightweight,
-  reducedMotion,
-  useLiveIntensity,
-}: FeedbackEffectLayerProps): ReactElement | null {
-  if (!active) {
-    return null;
+    return (
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 overflow-hidden rounded-16"
+        style={{ opacity: intensity }}
+      >
+        <div
+          className="absolute inset-0 rounded-16"
+          style={{
+            background:
+              'linear-gradient(180deg, rgba(255,150,20,0.08) 0%, rgba(255,90,0,0.16) 42%, rgba(100,20,0,0.24) 100%)',
+            boxShadow: lightweight
+              ? undefined
+              : 'inset 0 -55px 44px -16px rgba(255,100,0,0.4), inset 26px 0 28px -14px rgba(255,60,0,0.15), inset -26px 0 28px -14px rgba(255,60,0,0.15)',
+            animation: reducedMotion
+              ? undefined
+              : 'hotTakeHeatShimmer 0.9s ease-in-out infinite',
+          }}
+        />
+        <div
+          className="absolute bottom-[-16%] left-[-10%] right-[-10%] h-[44%] rounded-full"
+          style={{
+            background:
+              'radial-gradient(ellipse at 50% 100%, rgba(255,80,0,0.42) 0%, rgba(255,125,0,0.24) 40%, transparent 78%)',
+            filter: lightweight ? undefined : 'blur(10px)',
+            animation: reducedMotion
+              ? undefined
+              : 'hotTakeHeatShimmer 1.1s ease-in-out infinite',
+          }}
+        />
+        {showParticles &&
+          flames.map((flame, i) => (
+            <div
+              key={flame.left}
+              data-hot-take-particle="flame"
+              style={{
+                position: 'absolute',
+                bottom: -2,
+                left: flame.left,
+                width: flame.size * 0.55,
+                height: flame.size,
+                background:
+                  'radial-gradient(ellipse at 50% 88%, #fff29a 0%, #ffcf3d 20%, #ff8a00 45%, #ff3b00 66%, rgba(0,0,0,0) 84%)',
+                borderRadius: '50% 50% 20% 20%',
+                filter: lightweight ? undefined : 'blur(2px) saturate(1.2)',
+                animation: reducedMotion
+                  ? undefined
+                  : `hotTakeFlame ${
+                      0.3 + i * 0.06
+                    }s ease-in-out infinite alternate`,
+                animationDelay: `${flame.delay}s`,
+                transform: 'translateX(-50%)',
+                opacity: 0.9,
+              }}
+            />
+          ))}
+        {showParticles &&
+          embers.map((ember) => (
+            <div
+              key={`${ember.left}-${ember.bottom}`}
+              data-hot-take-particle="ember"
+              style={{
+                position: 'absolute',
+                left: ember.left,
+                bottom: ember.bottom,
+                width: ember.size,
+                height: ember.size,
+                borderRadius: '50%',
+                background:
+                  'radial-gradient(circle, #fff6ba 0%, #ffcb58 22%, #ff7a1a 54%, rgba(255,80,0,0.2) 80%, transparent 100%)',
+                boxShadow: lightweight
+                  ? undefined
+                  : `0 0 ${ember.size + 3}px rgba(255,120,0,0.7)`,
+                animation: reducedMotion
+                  ? undefined
+                  : `hotTakeEmber ${ember.duration}s ease-out infinite`,
+                animationDelay: `${ember.delay}s`,
+                opacity: 0.8,
+              }}
+            />
+          ))}
+      </div>
+    );
   }
 
-  const intensity = getEffectIntensityValue(
-    fallbackIntensity,
-    COLD_INTENSITY_VAR,
-    useLiveIntensity,
-  );
-  const icicles = lightweight ? LIGHTWEIGHT_ICICLES : ICICLES;
-  const snowflakes = lightweight ? LIGHTWEIGHT_SNOWFLAKES : SNOWFLAKES;
-  const showParticles = !reducedMotion;
+  if (kind === 'cold') {
+    const icicles = lightweight ? LIGHTWEIGHT_ICICLES : ICICLES;
+    const snowflakes = lightweight ? LIGHTWEIGHT_SNOWFLAKES : SNOWFLAKES;
 
-  return (
-    <div
-      aria-hidden
-      className="pointer-events-none absolute inset-0 overflow-hidden rounded-16"
-      style={{ opacity: intensity }}
-    >
+    return (
       <div
-        style={{
-          position: 'absolute',
-          inset: 0,
-          borderRadius: 'inherit',
-          background: `linear-gradient(180deg, rgba(210,240,255,${cssAlpha(
-            intensity,
-            0.22,
-          )}) 0%, rgba(140,210,255,${cssAlpha(
-            intensity,
-            0.12,
-          )}) 42%, rgba(120,170,255,${cssAlpha(intensity, 0.1)}) 100%)`,
-          boxShadow: lightweight
-            ? undefined
-            : [
-                `inset 0 ${cssPixelText(intensity, 52)} ${cssPixelText(
-                  intensity,
-                  42,
-                )} ${cssNegativePixelText(
-                  intensity,
-                  15,
-                )} rgba(150,210,255,0.35)`,
-                `inset ${cssPixelText(intensity, 24)} 0 ${cssPixelText(
-                  intensity,
-                  26,
-                )} ${cssNegativePixelText(
-                  intensity,
-                  15,
-                )} rgba(130,200,255,0.12)`,
-                `inset ${cssNegativePixelText(intensity, 24)} 0 ${cssPixelText(
-                  intensity,
-                  26,
-                )} ${cssNegativePixelText(
-                  intensity,
-                  15,
-                )} rgba(130,200,255,0.12)`,
-              ].join(', '),
-          backdropFilter: lightweight
-            ? undefined
-            : `blur(${cssPixelText(intensity, 1.2)})`,
-          animation: reducedMotion
-            ? undefined
-            : `hotTakeFrostBreath ${cssNumber(
-                intensity,
-                -0.35,
-                1.2,
-              )}s ease-in-out infinite`,
-        }}
-      />
-      <div
-        style={{
-          position: 'absolute',
-          left: 0,
-          right: 0,
-          top: 0,
-          height: cssPercent(intensity, 10, 18),
-          background: `linear-gradient(180deg, rgba(225,245,255,${cssAlpha(
-            intensity,
-            0.42,
-          )}) 0%, rgba(170,220,255,${cssAlpha(
-            intensity,
-            0.14,
-          )}) 75%, transparent 100%)`,
-          filter: lightweight
-            ? undefined
-            : `blur(${cssPixelText(intensity, 1.2, 1.5)})`,
-          animation: reducedMotion
-            ? undefined
-            : 'hotTakeFrostBreath 1.2s ease-in-out infinite',
-        }}
-      />
-      {showParticles &&
-        icicles.map((icicle, i) => (
-          <div
-            key={icicle.left}
-            data-hot-take-particle="icicle"
-            style={{
-              position: 'absolute',
-              top: -1,
-              left: icicle.left,
-              width: icicle.width,
-              height: cssPixels(intensity, icicle.height),
-              background:
-                'linear-gradient(180deg, rgba(220,240,255,0.95) 0%, rgba(140,210,255,0.85) 40%, rgba(100,180,255,0.5) 100%)',
-              clipPath: ICICLE_SHAPES[icicle.shape],
-              transform: `translateX(-50%) rotate(${icicle.rotate}deg)`,
-              transformOrigin: 'top center',
-              boxShadow: lightweight
-                ? undefined
-                : `0 2px ${cssPixelText(
-                    intensity,
-                    4,
-                    4,
-                  )} rgba(175,220,255,${cssAlpha(intensity, 0.4, 0.3)})`,
-              filter: lightweight
-                ? undefined
-                : `saturate(${cssNumber(intensity, 0.25, 1)})`,
-              animation: reducedMotion
-                ? undefined
-                : `hotTakeIcicleShimmer ${2 + i * 0.2}s ease-in-out infinite`,
-              animationDelay: `${icicle.delay}s`,
-            }}
-          />
-        ))}
-      {showParticles &&
-        snowflakes.map((flake) => (
-          <div
-            key={`${flake.left}-${flake.top}`}
-            data-hot-take-particle="snowflake"
-            style={{
-              position: 'absolute',
-              left: flake.left,
-              top: flake.top,
-              width: flake.size,
-              height: flake.size,
-              borderRadius: '50%',
-              background:
-                'radial-gradient(circle, white 0%, rgba(200,230,255,0.8) 60%, transparent 100%)',
-              boxShadow: lightweight
-                ? undefined
-                : `0 0 ${cssPixelText(
-                    intensity,
-                    2,
-                    flake.size,
-                  )} rgba(200,230,255,${cssAlpha(intensity, 0.5, 0.35)})`,
-              animation: reducedMotion
-                ? undefined
-                : `hotTakeSnowfall ${flake.duration}s ease-in-out infinite`,
-              animationDelay: `${flake.delay}s`,
-              opacity: cssNumber(intensity, 0.65, 0.35),
-            }}
-          />
-        ))}
-    </div>
-  );
-});
-
-const SkipSwipeEffectLayer = React.memo(function SkipSwipeEffectLayer({
-  active,
-  intensity: fallbackIntensity,
-  lightweight,
-  reducedMotion,
-  useLiveIntensity,
-}: FeedbackEffectLayerProps): ReactElement | null {
-  if (!active) {
-    return null;
+        aria-hidden
+        className="pointer-events-none absolute inset-0 overflow-hidden rounded-16"
+        style={{ opacity: intensity }}
+      >
+        <div
+          className="absolute inset-0 rounded-16"
+          style={{
+            background:
+              'linear-gradient(180deg, rgba(210,240,255,0.22) 0%, rgba(140,210,255,0.12) 42%, rgba(120,170,255,0.1) 100%)',
+            boxShadow: lightweight
+              ? undefined
+              : 'inset 0 52px 42px -15px rgba(150,210,255,0.35), inset 24px 0 26px -15px rgba(130,200,255,0.12), inset -24px 0 26px -15px rgba(130,200,255,0.12)',
+            backdropFilter: lightweight ? undefined : 'blur(1px)',
+            animation: reducedMotion
+              ? undefined
+              : 'hotTakeFrostBreath 1s ease-in-out infinite',
+          }}
+        />
+        <div
+          className="absolute left-0 right-0 top-0 h-[28%]"
+          style={{
+            background:
+              'linear-gradient(180deg, rgba(225,245,255,0.42) 0%, rgba(170,220,255,0.14) 75%, transparent 100%)',
+            filter: lightweight ? undefined : 'blur(2px)',
+            animation: reducedMotion
+              ? undefined
+              : 'hotTakeFrostBreath 1.2s ease-in-out infinite',
+          }}
+        />
+        {showParticles &&
+          icicles.map((icicle, i) => (
+            <div
+              key={icicle.left}
+              data-hot-take-particle="icicle"
+              style={{
+                position: 'absolute',
+                top: -1,
+                left: icicle.left,
+                width: icicle.width,
+                height: icicle.height,
+                background:
+                  'linear-gradient(180deg, rgba(220,240,255,0.95) 0%, rgba(140,210,255,0.85) 40%, rgba(100,180,255,0.5) 100%)',
+                clipPath: ICICLE_SHAPES[icicle.shape],
+                transform: `translateX(-50%) rotate(${icicle.rotate}deg)`,
+                transformOrigin: 'top center',
+                boxShadow: lightweight
+                  ? undefined
+                  : '0 2px 8px rgba(175,220,255,0.6)',
+                filter: lightweight ? undefined : 'saturate(1.15)',
+                animation: reducedMotion
+                  ? undefined
+                  : `hotTakeIcicleShimmer ${2 + i * 0.2}s ease-in-out infinite`,
+                animationDelay: `${icicle.delay}s`,
+              }}
+            />
+          ))}
+        {showParticles &&
+          snowflakes.map((flake) => (
+            <div
+              key={`${flake.left}-${flake.top}`}
+              data-hot-take-particle="snowflake"
+              style={{
+                position: 'absolute',
+                left: flake.left,
+                top: flake.top,
+                width: flake.size,
+                height: flake.size,
+                borderRadius: '50%',
+                background:
+                  'radial-gradient(circle, white 0%, rgba(200,230,255,0.8) 60%, transparent 100%)',
+                boxShadow: lightweight
+                  ? undefined
+                  : `0 0 ${flake.size + 2}px rgba(200,230,255,0.7)`,
+                animation: reducedMotion
+                  ? undefined
+                  : `hotTakeSnowfall ${flake.duration}s ease-in-out infinite`,
+                animationDelay: `${flake.delay}s`,
+                opacity: 0.8,
+              }}
+            />
+          ))}
+      </div>
+    );
   }
 
-  const intensity = getEffectIntensityValue(
-    fallbackIntensity,
-    SKIP_INTENSITY_VAR,
-    useLiveIntensity,
-  );
   const sleepZs = lightweight ? LIGHTWEIGHT_SLEEP_ZS : SLEEP_ZS;
   const bubbles = lightweight ? LIGHTWEIGHT_SLEEP_BUBBLES : SLEEP_BUBBLES;
-  const showParticles = !reducedMotion;
 
   return (
     <div
@@ -1723,72 +1532,25 @@ const SkipSwipeEffectLayer = React.memo(function SkipSwipeEffectLayer({
       style={{ opacity: intensity }}
     >
       <div
+        className="absolute inset-0 rounded-16"
         style={{
-          position: 'absolute',
-          inset: 0,
-          borderRadius: 'inherit',
-          background: `linear-gradient(180deg, rgba(222,246,255,${cssAlpha(
-            intensity,
-            0.2,
-          )}) 0%, rgba(180,230,255,${cssAlpha(
-            intensity,
-            0.12,
-          )}) 46%, rgba(120,186,240,${cssAlpha(intensity, 0.16)}) 100%)`,
+          background:
+            'linear-gradient(180deg, rgba(222,246,255,0.2) 0%, rgba(180,230,255,0.12) 46%, rgba(120,186,240,0.16) 100%)',
           boxShadow: lightweight
             ? undefined
-            : [
-                `inset 0 ${cssPixelText(intensity, 52)} ${cssPixelText(
-                  intensity,
-                  44,
-                )} ${cssNegativePixelText(
-                  intensity,
-                  15,
-                )} rgba(170,225,255,0.32)`,
-                `inset ${cssPixelText(intensity, 24)} 0 ${cssPixelText(
-                  intensity,
-                  24,
-                )} ${cssNegativePixelText(
-                  intensity,
-                  14,
-                )} rgba(140,210,255,0.18)`,
-                `inset ${cssNegativePixelText(intensity, 24)} 0 ${cssPixelText(
-                  intensity,
-                  24,
-                )} ${cssNegativePixelText(
-                  intensity,
-                  14,
-                )} rgba(140,210,255,0.18)`,
-              ].join(', '),
-          backdropFilter: lightweight
-            ? undefined
-            : `blur(${cssPixelText(intensity, 1.5, 0.4)})`,
+            : 'inset 0 52px 44px -15px rgba(170,225,255,0.32), inset 24px 0 24px -14px rgba(140,210,255,0.18), inset -24px 0 24px -14px rgba(140,210,255,0.18)',
+          backdropFilter: lightweight ? undefined : 'blur(1.5px)',
           animation: reducedMotion
             ? undefined
-            : `hotTakeSleepBreath ${cssNumber(
-                intensity,
-                -0.4,
-                1.6,
-              )}s ease-in-out infinite`,
+            : 'hotTakeSleepBreath 1.3s ease-in-out infinite',
         }}
       />
       <div
+        className="absolute left-[-8%] right-[-8%] top-[-16%] h-[42%] rounded-full"
         style={{
-          position: 'absolute',
-          left: '-8%',
-          right: '-8%',
-          top: '-16%',
-          height: '42%',
-          borderRadius: '50%',
-          background: `radial-gradient(ellipse at 50% 0%, rgba(220,245,255,${cssAlpha(
-            intensity,
-            0.52,
-          )}) 0%, rgba(170,220,255,${cssAlpha(
-            intensity,
-            0.22,
-          )}) 42%, transparent 78%)`,
-          filter: lightweight
-            ? undefined
-            : `blur(${cssPixelText(intensity, 5, 4)})`,
+          background:
+            'radial-gradient(ellipse at 50% 0%, rgba(220,245,255,0.52) 0%, rgba(170,220,255,0.22) 42%, transparent 78%)',
+          filter: lightweight ? undefined : 'blur(8px)',
         }}
       />
       {showParticles &&
@@ -1803,20 +1565,16 @@ const SkipSwipeEffectLayer = React.memo(function SkipSwipeEffectLayer({
               fontSize: sleepZ.size,
               fontWeight: 800,
               lineHeight: 1,
-              color: `rgba(230,248,255,${cssAlpha(intensity, 0.75, 0.25)})`,
+              color: 'rgba(230,248,255,0.8)',
               textShadow: lightweight
                 ? undefined
-                : `0 0 ${cssPixelText(
-                    intensity,
-                    10,
-                    4,
-                  )} rgba(150,220,255,${cssAlpha(intensity, 0.52, 0.18)})`,
+                : '0 0 10px rgba(150,220,255,0.6)',
               transform: `translateX(-50%) rotate(${sleepZ.rotate}deg)`,
               animation: reducedMotion
                 ? undefined
                 : `hotTakeSleepFloat ${sleepZ.duration}s ease-in infinite`,
               animationDelay: `${sleepZ.delay}s`,
-              opacity: cssNumber(intensity, 0.76, 0.24),
+              opacity: 0.85,
             }}
           >
             Z
@@ -1836,23 +1594,15 @@ const SkipSwipeEffectLayer = React.memo(function SkipSwipeEffectLayer({
               borderRadius: '50%',
               background:
                 'radial-gradient(circle at 28% 28%, rgba(255,255,255,0.95) 0%, rgba(225,245,255,0.55) 44%, rgba(170,220,255,0.2) 100%)',
-              border: `1px solid rgba(208,240,255,${cssAlpha(
-                intensity,
-                0.5,
-                0.18,
-              )})`,
+              border: '1px solid rgba(208,240,255,0.5)',
               boxShadow: lightweight
                 ? undefined
-                : `0 0 ${bubble.size + 4}px rgba(150,220,255,${cssAlpha(
-                    intensity,
-                    0.48,
-                    0.15,
-                  )})`,
+                : `0 0 ${bubble.size + 4}px rgba(150,220,255,0.5)`,
               animation: reducedMotion
                 ? undefined
                 : `hotTakeBubbleRise ${bubble.duration}s ease-out infinite`,
               animationDelay: `${bubble.delay}s`,
-              opacity: cssNumber(intensity, 0.8, 0.2),
+              opacity: 0.8,
             }}
           />
         ))}
@@ -1877,67 +1627,60 @@ const HotTakeFeedbackBadges = React.memo(function HotTakeFeedbackBadges({
     return null;
   }
 
-  const hotOpacity = getEffectIntensityValue(
-    hotIntensity,
-    HOT_INTENSITY_VAR,
-    useLiveIntensity,
-  );
-  const coldOpacity = getEffectIntensityValue(
-    coldIntensity,
-    COLD_INTENSITY_VAR,
-    useLiveIntensity,
-  );
-  const skipOpacity = getEffectIntensityValue(
-    skipIntensity,
-    SKIP_INTENSITY_VAR,
-    useLiveIntensity,
+  const renderBadge = ({
+    backgroundColor,
+    className,
+    intensity,
+    liveIntensity,
+    text,
+  }: {
+    backgroundColor?: string;
+    className: string;
+    intensity: number;
+    liveIntensity: string;
+    text: string;
+  }): ReactElement => (
+    <div
+      className={classNames(
+        'z-20 absolute left-1/2 top-4 -translate-x-1/2 rounded-10 px-4 py-1 font-bold text-white typo-title3',
+        className,
+      )}
+      style={{
+        opacity: getEffectIntensityValue(
+          intensity,
+          liveIntensity,
+          useLiveIntensity,
+        ),
+        animation: 'hotTakeBadgePulse 0.18s ease-out',
+        backgroundColor,
+        boxShadow: '0 6px 18px rgba(0,0,0,0.2)',
+      }}
+    >
+      {text}
+    </div>
   );
 
   return (
     <>
-      <div
-        className="z-20 absolute left-1/2 top-4 -translate-x-1/2 rounded-10 bg-accent-ketchup-default px-4 py-1 font-bold text-white typo-title3"
-        style={{
-          opacity: hotOpacity,
-          animation: 'hotTakeBadgePulse 0.18s ease-out',
-          boxShadow: `0 6px ${cssPixelText(
-            hotOpacity,
-            10,
-            12,
-          )} rgba(0,0,0,${cssAlpha(hotOpacity, 0.18, 0.1)})`,
-        }}
-      >
-        HOT 🔥
-      </div>
-      <div
-        className="z-20 absolute left-1/2 top-4 -translate-x-1/2 rounded-10 px-4 py-1 font-bold text-white typo-title3"
-        style={{
-          opacity: coldOpacity,
-          animation: 'hotTakeBadgePulse 0.18s ease-out',
-          backgroundColor: COLD_ACCENT_COLOR,
-          boxShadow: `0 6px ${cssPixelText(
-            coldOpacity,
-            10,
-            12,
-          )} rgba(0,0,0,${cssAlpha(coldOpacity, 0.18, 0.1)})`,
-        }}
-      >
-        COLD 🥶
-      </div>
-      <div
-        className="z-20 absolute left-1/2 top-4 -translate-x-1/2 rounded-10 bg-accent-blueCheese-default px-4 py-1 font-bold text-white typo-title3"
-        style={{
-          opacity: skipOpacity,
-          animation: 'hotTakeBadgePulse 0.18s ease-out',
-          boxShadow: `0 6px ${cssPixelText(
-            skipOpacity,
-            10,
-            12,
-          )} rgba(0,0,0,${cssAlpha(skipOpacity, 0.18, 0.1)})`,
-        }}
-      >
-        SKIP 😴
-      </div>
+      {renderBadge({
+        className: 'bg-accent-ketchup-default',
+        intensity: hotIntensity,
+        liveIntensity: HOT_INTENSITY_VAR,
+        text: 'HOT 🔥',
+      })}
+      {renderBadge({
+        className: '',
+        backgroundColor: COLD_ACCENT_COLOR,
+        intensity: coldIntensity,
+        liveIntensity: COLD_INTENSITY_VAR,
+        text: 'COLD 🥶',
+      })}
+      {renderBadge({
+        className: 'bg-accent-blueCheese-default',
+        intensity: skipIntensity,
+        liveIntensity: SKIP_INTENSITY_VAR,
+        text: 'SKIP 😴',
+      })}
     </>
   );
 });
@@ -2058,23 +1801,26 @@ const HotTakeCard = React.memo(
           } as CSSPropertiesWithVars
         }
       >
-        <HotSwipeEffectLayer
+        <SwipeEffectLayer
           active={feedbackActive}
           intensity={hotEffectIntensity}
+          kind="hot"
           lightweight={isLightweightEffects}
           reducedMotion={prefersReducedMotion}
           useLiveIntensity={useLiveIntensity}
         />
-        <ColdSwipeEffectLayer
+        <SwipeEffectLayer
           active={feedbackActive}
           intensity={coldEffectIntensity}
+          kind="cold"
           lightweight={isLightweightEffects}
           reducedMotion={prefersReducedMotion}
           useLiveIntensity={useLiveIntensity}
         />
-        <SkipSwipeEffectLayer
+        <SwipeEffectLayer
           active={feedbackActive}
           intensity={quantizedSkipEffectIntensity}
+          kind="skip"
           lightweight={isLightweightEffects}
           reducedMotion={prefersReducedMotion}
           useLiveIntensity={useLiveIntensity}

--- a/packages/shared/src/components/modals/hotTakes/HotAndColdModal.tsx
+++ b/packages/shared/src/components/modals/hotTakes/HotAndColdModal.tsx
@@ -13,6 +13,8 @@ import { Modal } from '../common/Modal';
 import { ModalSize } from '../common/types';
 import { useDiscoverHotTakes } from '../../../hooks/useDiscoverHotTakes';
 import { useVoteHotTake } from '../../../hooks/vote/useVoteHotTake';
+import { useMedia } from '../../../hooks/useMedia';
+import { useViewSize, ViewSize } from '../../../hooks/useViewSize';
 import { useLogContext } from '../../../contexts/LogContext';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { LogEvent, Origin } from '../../../lib/log';
@@ -52,6 +54,12 @@ const SKIP_DISMISS_FLY_DISTANCE = 600;
 const SKIP_DRAG_ELASTICITY_FACTOR = 0.3;
 const COLD_ACCENT_COLOR = '#123a88';
 const HOT_TAKE_CARD_HEIGHT = '28rem';
+const FEEDBACK_ACTIVATION_DELTA = 20;
+const MAX_SWIPE_ROTATION_DEG = 18;
+const SWIPE_ROTATION_DEG_PER_PX = 0.08;
+const INTENSITY_QUANTIZATION_STEP = 0.05;
+const PREFERS_REDUCED_MOTION_QUERY = ['(prefers-reduced-motion: reduce)'];
+const MATCHED_MEDIA_VALUES = [true];
 /** Title3 × 3 lines (typo-title3 line-height 1.625rem in tailwind/typography.ts). */
 const ONBOARDING_CARD_TITLE_MIN_HEIGHT = '4.875rem';
 /** Fixed onboarding post card (source, title, and topic tags). */
@@ -60,10 +68,164 @@ const ONBOARDING_POST_CARD_HEIGHT = 'clamp(13rem, 28dvh, 16rem)';
 const ONBOARDING_SWIPE_AREA_HEIGHT = `calc(${ONBOARDING_POST_CARD_HEIGHT} + 0.5rem)`;
 const ONBOARDING_SWIPE_FADE_DISTANCE = SWIPE_THRESHOLD * 4;
 
-const smoothstep01 = (t: number): number => {
+type CSSPropertiesWithVars = React.CSSProperties & {
+  [key: `--${string}`]: string | number;
+};
+
+type SwipeDirection = 'left' | 'right';
+
+type CssIntensity = number | string;
+
+export const smoothstep01 = (t: number): number => {
   const x = Math.min(Math.max(t, 0), 1);
   return x * x * (3 - 2 * x);
 };
+
+export const quantizeIntensity = (value: number): number =>
+  Math.min(
+    1,
+    Math.max(
+      0,
+      Math.round(value / INTENSITY_QUANTIZATION_STEP) *
+        INTENSITY_QUANTIZATION_STEP,
+    ),
+  );
+
+const formatIntensity = (value: number): string =>
+  Number.isInteger(value) ? String(value) : value.toFixed(3);
+
+const getSwipeRotation = (deltaX: number): number =>
+  Math.max(
+    Math.min(deltaX * SWIPE_ROTATION_DEG_PER_PX, MAX_SWIPE_ROTATION_DEG),
+    -MAX_SWIPE_ROTATION_DEG,
+  );
+
+const getSwipeDirectionFromDelta = (deltaX: number): SwipeDirection | null => {
+  if (Math.abs(deltaX) <= FEEDBACK_ACTIVATION_DELTA) {
+    return null;
+  }
+
+  return deltaX > 0 ? 'right' : 'left';
+};
+
+const getSwipeIntensity = (deltaX: number): number =>
+  Math.min(Math.abs(deltaX) / SWIPE_THRESHOLD, 1);
+
+const getSwipeEffectIntensity = (deltaX: number): number =>
+  getSwipeIntensity(deltaX) ** 0.78;
+
+const getSkipEffectIntensity = (skipDeltaY: number): number =>
+  Math.min(Math.abs(skipDeltaY) / SWIPE_THRESHOLD, 1) ** 0.78;
+
+const getOnboardingSwipeVisualIntensities = (
+  deltaX: number,
+): { left: number; right: number } => {
+  const intensity = Math.min(
+    Math.max(Math.abs(deltaX) / SWIPE_THRESHOLD, 0.18),
+    1,
+  );
+
+  if (deltaX > FEEDBACK_ACTIVATION_DELTA) {
+    return { left: intensity * 0.35, right: intensity };
+  }
+
+  if (deltaX < -FEEDBACK_ACTIVATION_DELTA) {
+    return { left: intensity, right: intensity * 0.35 };
+  }
+
+  return { left: 0, right: 0 };
+};
+
+const cssNumber = (
+  intensity: CssIntensity,
+  multiplier: number,
+  offset = 0,
+): number | string => {
+  if (typeof intensity === 'number') {
+    return offset + intensity * multiplier;
+  }
+
+  if (offset === 0) {
+    return `calc(${intensity} * ${multiplier})`;
+  }
+
+  return `calc(${offset} + (${intensity} * ${multiplier}))`;
+};
+
+const cssPixels = (
+  intensity: CssIntensity,
+  multiplier: number,
+  offset = 0,
+): number | string => {
+  if (typeof intensity === 'number') {
+    return offset + intensity * multiplier;
+  }
+
+  if (offset === 0) {
+    return `calc(${intensity} * ${multiplier}px)`;
+  }
+
+  return `calc(${offset}px + (${intensity} * ${multiplier}px))`;
+};
+
+const cssPixelText = (
+  intensity: CssIntensity,
+  multiplier: number,
+  offset = 0,
+): string => {
+  const value = cssPixels(intensity, multiplier, offset);
+  return typeof value === 'number' ? `${value}px` : value;
+};
+
+const cssNegativePixelText = (
+  intensity: CssIntensity,
+  multiplier: number,
+  offset = 0,
+): string => {
+  const value = cssPixels(intensity, multiplier, offset);
+  return typeof value === 'number' ? `${-value}px` : `calc(-1 * ${value})`;
+};
+
+const cssPercent = (
+  intensity: CssIntensity,
+  multiplier: number,
+  offset = 0,
+): string => {
+  if (typeof intensity === 'number') {
+    return `${offset + intensity * multiplier}%`;
+  }
+
+  if (offset === 0) {
+    return `calc(${intensity} * ${multiplier}%)`;
+  }
+
+  return `calc(${offset}% + (${intensity} * ${multiplier}%))`;
+};
+
+const cssAlpha = (
+  intensity: CssIntensity,
+  multiplier: number,
+  offset = 0,
+): number | string => cssNumber(intensity, multiplier, offset);
+
+const HOT_INTENSITY_VAR = 'var(--hot-take-hot-intensity, 0)';
+const COLD_INTENSITY_VAR = 'var(--hot-take-cold-intensity, 0)';
+const SKIP_INTENSITY_VAR = 'var(--hot-take-skip-intensity, 0)';
+const ONBOARDING_LEFT_INTENSITY_VAR =
+  'var(--onboarding-swipe-left-intensity, 0)';
+const ONBOARDING_RIGHT_INTENSITY_VAR =
+  'var(--onboarding-swipe-right-intensity, 0)';
+const ONBOARDING_LEFT_BADGE_INTENSITY_VAR =
+  'var(--onboarding-swipe-left-badge-intensity, 0)';
+const ONBOARDING_RIGHT_BADGE_INTENSITY_VAR =
+  'var(--onboarding-swipe-right-badge-intensity, 0)';
+
+const HOT_TAKE_REST_TRANSITION =
+  'transform 0.28s cubic-bezier(0.22, 1, 0.36, 1), border-color 0.2s ease, box-shadow 0.2s ease';
+const HOT_TAKE_DRAG_TRANSITION = 'border-color 0.2s ease, box-shadow 0.2s ease';
+const ONBOARDING_REST_TRANSITION =
+  'transform 0.28s cubic-bezier(0.22, 1, 0.36, 1)';
+const ONBOARDING_DRAG_TRANSITION = 'none';
 
 const pauseMs = (ms: number): Promise<void> =>
   new Promise((resolve) => {
@@ -407,106 +569,159 @@ const ONBOARDING_SCREEN_TRANSITION_KEYFRAMES = `
   }
 `;
 
-const OnboardingCardBehindParticles = (): ReactElement => (
-  <>
-    {/* eslint-disable-next-line react/no-unknown-property -- style tag for scoped keyframes */}
-    <style>{ONBOARDING_BEHIND_PARTICLES_CSS}</style>
-    <div
-      aria-hidden
-      className="opacity-70 pointer-events-none absolute inset-0 z-[21] overflow-hidden rounded-16"
-    >
-      <div
-        className="bg-accent-avocado-default/50 absolute left-[5%] top-[8%] h-[42%] w-[55%] rounded-full blur-2xl"
-        style={{
-          animation: 'onboardingAuraDrift 5.5s ease-in-out infinite',
-        }}
-      />
-      <div
-        className="bg-accent-bacon-default/45 absolute bottom-[6%] right-[4%] h-[38%] w-[52%] rounded-full blur-2xl"
-        style={{
-          animation: 'onboardingAuraDrift 6.2s ease-in-out infinite',
-          animationDelay: '1.1s',
-        }}
-      />
-      <div
-        className="bg-accent-cabbage-default/40 absolute left-[22%] top-[38%] h-[35%] w-[48%] rounded-full blur-2xl"
-        style={{
-          animation: 'onboardingAuraDrift 4.8s ease-in-out infinite',
-          animationDelay: '0.6s',
-        }}
-      />
-      {ONBOARDING_MAGIC_SPARK_SPECS.map((spark) => (
-        <span
-          key={`spark-${spark.left}-${spark.top}-${spark.delay}`}
-          className={classNames('absolute rounded-full', spark.className)}
-          style={
-            {
-              left: spark.left,
-              top: spark.top,
-              width: spark.size,
-              height: spark.size,
-              '--oms-x1': spark.x1,
-              '--oms-y1': spark.y1,
-              '--oms-x2': spark.x2,
-              '--oms-y2': spark.y2,
-              '--oms-x3': spark.x3,
-              '--oms-y3': spark.y3,
-              animation: `onboardingMagicSpark ${spark.duration}s ease-in-out infinite`,
-              animationDelay: `${spark.delay}s`,
-            } as React.CSSProperties
-          }
-        />
-      ))}
-      {ONBOARDING_BEHIND_PARTICLE_SPECS.map((particle) => (
-        <span
-          key={`${particle.left}-${particle.top}-${particle.delay}-${particle.duration}`}
-          className={classNames(
-            'absolute rounded-full blur-[0.0625rem]',
-            particle.className,
+const OnboardingBehindParticlesKeyframes = React.memo(
+  function OnboardingBehindParticlesKeyframes(): ReactElement {
+    return (
+      // eslint-disable-next-line react/no-unknown-property -- style tag for scoped keyframes
+      <style>{ONBOARDING_BEHIND_PARTICLES_CSS}</style>
+    );
+  },
+);
+
+const OnboardingScreenTransitionKeyframes = React.memo(
+  function OnboardingScreenTransitionKeyframes(): ReactElement {
+    return (
+      // eslint-disable-next-line react/no-unknown-property -- style tag for scoped onboarding transition
+      <style>{ONBOARDING_SCREEN_TRANSITION_KEYFRAMES}</style>
+    );
+  },
+);
+
+const OnboardingCardBehindParticles = React.memo(
+  function OnboardingCardBehindParticles({
+    lightweight,
+    reducedMotion,
+  }: {
+    lightweight: boolean;
+    reducedMotion: boolean;
+  }): ReactElement | null {
+    if (reducedMotion) {
+      return null;
+    }
+
+    const sparks = lightweight
+      ? ONBOARDING_MAGIC_SPARK_SPECS.slice(0, 3)
+      : ONBOARDING_MAGIC_SPARK_SPECS;
+    const particles = lightweight
+      ? ONBOARDING_BEHIND_PARTICLE_SPECS.slice(0, 3)
+      : ONBOARDING_BEHIND_PARTICLE_SPECS;
+
+    return (
+      <>
+        <div
+          aria-hidden
+          className="opacity-70 pointer-events-none absolute inset-0 z-[21] overflow-hidden rounded-16"
+        >
+          <div
+            className={classNames(
+              'bg-accent-avocado-default/50 absolute left-[5%] top-[8%] h-[42%] w-[55%] rounded-full',
+              lightweight ? 'blur-lg' : 'blur-2xl',
+            )}
+            style={{
+              animation: lightweight
+                ? undefined
+                : 'onboardingAuraDrift 5.5s ease-in-out infinite',
+            }}
+          />
+          {!lightweight && (
+            <>
+              <div
+                className="bg-accent-bacon-default/45 absolute bottom-[6%] right-[4%] h-[38%] w-[52%] rounded-full blur-2xl"
+                style={{
+                  animation: 'onboardingAuraDrift 6.2s ease-in-out infinite',
+                  animationDelay: '1.1s',
+                }}
+              />
+              <div
+                className="bg-accent-cabbage-default/40 absolute left-[22%] top-[38%] h-[35%] w-[48%] rounded-full blur-2xl"
+                style={{
+                  animation: 'onboardingAuraDrift 4.8s ease-in-out infinite',
+                  animationDelay: '0.6s',
+                }}
+              />
+            </>
           )}
-          style={
-            {
-              left: particle.left,
-              top: particle.top,
-              width: particle.size,
-              height: particle.size,
-              '--obp-tx': particle.tx,
-              '--obp-ty': particle.ty,
-              '--obp-ex': particle.ex,
-              animation: `onboardingBehindParticle ${particle.duration}s ease-in-out infinite`,
-              animationDelay: `${particle.delay}s`,
-            } as React.CSSProperties
-          }
-        />
-      ))}
-    </div>
-  </>
+          {sparks.map((spark) => (
+            <span
+              key={`spark-${spark.left}-${spark.top}-${spark.delay}`}
+              className={classNames('absolute rounded-full', spark.className)}
+              style={
+                {
+                  left: spark.left,
+                  top: spark.top,
+                  width: spark.size,
+                  height: spark.size,
+                  '--oms-x1': spark.x1,
+                  '--oms-y1': spark.y1,
+                  '--oms-x2': spark.x2,
+                  '--oms-y2': spark.y2,
+                  '--oms-x3': spark.x3,
+                  '--oms-y3': spark.y3,
+                  animation: `onboardingMagicSpark ${spark.duration}s ease-in-out infinite`,
+                  animationDelay: `${spark.delay}s`,
+                } as React.CSSProperties
+              }
+            />
+          ))}
+          {particles.map((particle) => (
+            <span
+              key={`${particle.left}-${particle.top}-${particle.delay}-${particle.duration}`}
+              className={classNames(
+                'absolute rounded-full blur-[0.0625rem]',
+                particle.className,
+              )}
+              style={
+                {
+                  left: particle.left,
+                  top: particle.top,
+                  width: particle.size,
+                  height: particle.size,
+                  '--obp-tx': particle.tx,
+                  '--obp-ty': particle.ty,
+                  '--obp-ex': particle.ex,
+                  animation: `onboardingBehindParticle ${particle.duration}s ease-in-out infinite`,
+                  animationDelay: `${particle.delay}s`,
+                } as React.CSSProperties
+              }
+            />
+          ))}
+        </div>
+      </>
+    );
+  },
 );
 
 const OnboardingSwipeEdgeHalos = ({
   deltaX,
   isDragging,
+  useLiveIntensity,
 }: {
   deltaX: number;
   isDragging: boolean;
+  useLiveIntensity: boolean;
 }): ReactElement | null => {
   if (!isDragging) {
     return null;
   }
 
-  const intensity = Math.min(
-    Math.max(Math.abs(deltaX) / SWIPE_THRESHOLD, 0.18),
-    1,
-  );
-  const activeDirection = deltaX >= 0 ? 'right' : 'left';
+  const intensities = getOnboardingSwipeVisualIntensities(deltaX);
 
   const renderHalo = (direction: 'left' | 'right'): ReactElement => {
     const isRight = direction === 'right';
     const accentColor = isRight
       ? 'var(--theme-accent-avocado-default)'
       : 'var(--theme-accent-bacon-default)';
-    const strength =
-      direction === activeDirection ? intensity : intensity * 0.35;
+    let strength: number | string = intensities[direction];
+    if (useLiveIntensity) {
+      strength =
+        direction === 'right'
+          ? ONBOARDING_RIGHT_INTENSITY_VAR
+          : ONBOARDING_LEFT_INTENSITY_VAR;
+    }
+    const opacity =
+      typeof strength === 'number'
+        ? strength * 0.48
+        : `calc(${strength} * 0.48)`;
 
     return (
       <span
@@ -515,7 +730,7 @@ const OnboardingSwipeEdgeHalos = ({
         className="pointer-events-none absolute inset-y-6 z-[7] w-8 rounded-full blur-lg transition-opacity duration-150"
         style={{
           [direction]: 0,
-          opacity: strength * 0.48,
+          opacity,
           background: `linear-gradient(${
             isRight ? '270deg' : '90deg'
           }, color-mix(in srgb, ${accentColor} 72%, transparent) 0%, color-mix(in srgb, ${accentColor} 28%, transparent) 44%, transparent 100%)`,
@@ -622,7 +837,7 @@ const OnboardingSwipeHintIcons = ({
   );
 };
 
-const getElasticDelta = (delta: number): number => {
+export const getElasticDelta = (delta: number): number => {
   const absoluteDelta = Math.abs(delta);
   if (absoluteDelta <= SWIPE_THRESHOLD) {
     return delta;
@@ -633,6 +848,288 @@ const getElasticDelta = (delta: number): number => {
     Math.sign(delta) *
     (SWIPE_THRESHOLD + overshoot * SKIP_DRAG_ELASTICITY_FACTOR)
   );
+};
+
+const getFeedbackBorderColor = (
+  accentColor: string,
+  intensity: number,
+): string =>
+  `color-mix(in srgb, ${accentColor} ${Math.round(
+    intensity * 100,
+  )}%, var(--theme-border-subtlest-tertiary))`;
+
+const getFeedbackBoxShadow = ({
+  accentColor,
+  intensity,
+  isLightweight,
+  isSkip,
+}: {
+  accentColor: string;
+  intensity: number;
+  isLightweight: boolean;
+  isSkip: boolean;
+}): string | undefined => {
+  if (isLightweight) {
+    return undefined;
+  }
+
+  const primarySize = isSkip ? 22 : 24;
+  const primarySpread = 8;
+  const primaryAlpha = isSkip ? 60 : 65;
+  const secondarySize = isSkip ? 28 : 34;
+  const secondarySpread = isSkip ? 12 : 14;
+
+  return `0 0 ${6 + intensity * primarySize}px ${
+    2 + intensity * primarySpread
+  }px color-mix(in srgb, ${accentColor} ${Math.round(
+    intensity * primaryAlpha,
+  )}%, transparent), 0 0 ${10 + intensity * secondarySize}px ${
+    4 + intensity * secondarySpread
+  }px color-mix(in srgb, ${accentColor} ${Math.round(
+    intensity * 42,
+  )}%, transparent)`;
+};
+
+const getHotTakeFeedbackState = ({
+  swipeDelta,
+  skipEffectIntensity,
+  isLightweight,
+}: {
+  swipeDelta: number;
+  skipEffectIntensity: number;
+  isLightweight: boolean;
+}): {
+  swipeDirection: SwipeDirection | null;
+  effectIntensity: number;
+  hotEffectIntensity: number;
+  coldEffectIntensity: number;
+  skipEffectIntensity: number;
+  activeBorderColor?: string;
+  activeBoxShadow?: string;
+} => {
+  const swipeDirection = getSwipeDirectionFromDelta(swipeDelta);
+  const effectIntensity = getSwipeEffectIntensity(swipeDelta);
+  const hotEffectIntensity = swipeDirection === 'right' ? effectIntensity : 0;
+  const coldEffectIntensity = swipeDirection === 'left' ? effectIntensity : 0;
+  const isSkipVisualActive = skipEffectIntensity > 0.02;
+  const skipAccentColor = 'var(--theme-accent-blueCheese-default)';
+
+  if (swipeDirection) {
+    const accentColor =
+      swipeDirection === 'right'
+        ? 'var(--theme-accent-ketchup-default)'
+        : COLD_ACCENT_COLOR;
+
+    return {
+      swipeDirection,
+      effectIntensity,
+      hotEffectIntensity,
+      coldEffectIntensity,
+      skipEffectIntensity,
+      activeBorderColor: getFeedbackBorderColor(accentColor, effectIntensity),
+      activeBoxShadow: getFeedbackBoxShadow({
+        accentColor,
+        intensity: effectIntensity,
+        isLightweight,
+        isSkip: false,
+      }),
+    };
+  }
+
+  if (isSkipVisualActive) {
+    return {
+      swipeDirection,
+      effectIntensity,
+      hotEffectIntensity,
+      coldEffectIntensity,
+      skipEffectIntensity,
+      activeBorderColor: getFeedbackBorderColor(
+        skipAccentColor,
+        skipEffectIntensity,
+      ),
+      activeBoxShadow: getFeedbackBoxShadow({
+        accentColor: skipAccentColor,
+        intensity: skipEffectIntensity,
+        isLightweight,
+        isSkip: true,
+      }),
+    };
+  }
+
+  return {
+    swipeDirection,
+    effectIntensity,
+    hotEffectIntensity,
+    coldEffectIntensity,
+    skipEffectIntensity,
+  };
+};
+
+const applyHotTakeFeedbackStyles = ({
+  element,
+  swipeDelta,
+  skipDeltaY,
+  isLightweight,
+}: {
+  element: HTMLDivElement;
+  swipeDelta: number;
+  skipDeltaY: number;
+  isLightweight: boolean;
+}): void => {
+  const feedback = getHotTakeFeedbackState({
+    swipeDelta,
+    skipEffectIntensity:
+      skipDeltaY < 0 ? getSkipEffectIntensity(skipDeltaY) : 0,
+    isLightweight,
+  });
+
+  element.style.setProperty(
+    '--hot-take-hot-intensity',
+    formatIntensity(feedback.hotEffectIntensity),
+  );
+  element.style.setProperty(
+    '--hot-take-cold-intensity',
+    formatIntensity(feedback.coldEffectIntensity),
+  );
+  element.style.setProperty(
+    '--hot-take-skip-intensity',
+    formatIntensity(feedback.skipEffectIntensity),
+  );
+
+  if (feedback.activeBorderColor) {
+    element.style.setProperty('border-color', feedback.activeBorderColor);
+  } else {
+    element.style.removeProperty('border-color');
+  }
+
+  if (feedback.activeBoxShadow) {
+    element.style.setProperty('box-shadow', feedback.activeBoxShadow);
+  } else {
+    element.style.removeProperty('box-shadow');
+  }
+};
+
+const applyOnboardingFeedbackStyles = ({
+  element,
+  swipeAreaElement,
+  swipeDelta,
+}: {
+  element: HTMLDivElement;
+  swipeAreaElement: HTMLDivElement | null;
+  swipeDelta: number;
+}): void => {
+  const intensities = getOnboardingSwipeVisualIntensities(swipeDelta);
+  const swipeIntensity = getSwipeIntensity(swipeDelta);
+  const leftBadgeIntensity =
+    swipeDelta < -FEEDBACK_ACTIVATION_DELTA ? swipeIntensity : 0;
+  const rightBadgeIntensity =
+    swipeDelta > FEEDBACK_ACTIVATION_DELTA ? swipeIntensity : 0;
+  const targets = [element, swipeAreaElement].filter(
+    Boolean,
+  ) as HTMLDivElement[];
+
+  targets.forEach((target) => {
+    target.style.setProperty(
+      '--onboarding-swipe-left-intensity',
+      formatIntensity(intensities.left),
+    );
+    target.style.setProperty(
+      '--onboarding-swipe-right-intensity',
+      formatIntensity(intensities.right),
+    );
+    target.style.setProperty(
+      '--onboarding-swipe-left-badge-intensity',
+      formatIntensity(leftBadgeIntensity),
+    );
+    target.style.setProperty(
+      '--onboarding-swipe-right-badge-intensity',
+      formatIntensity(rightBadgeIntensity),
+    );
+  });
+};
+
+const clearHotTakeFeedbackStyles = (element: HTMLDivElement): void => {
+  element.style.setProperty('--hot-take-hot-intensity', '0');
+  element.style.setProperty('--hot-take-cold-intensity', '0');
+  element.style.setProperty('--hot-take-skip-intensity', '0');
+  element.style.removeProperty('border-color');
+  element.style.removeProperty('box-shadow');
+};
+
+const clearOnboardingFeedbackStyles = ({
+  element,
+  swipeAreaElement,
+}: {
+  element: HTMLDivElement;
+  swipeAreaElement: HTMLDivElement | null;
+}): void => {
+  const targets = [element, swipeAreaElement].filter(
+    Boolean,
+  ) as HTMLDivElement[];
+
+  targets.forEach((target) => {
+    target.style.setProperty('--onboarding-swipe-left-intensity', '0');
+    target.style.setProperty('--onboarding-swipe-right-intensity', '0');
+    target.style.setProperty('--onboarding-swipe-left-badge-intensity', '0');
+    target.style.setProperty('--onboarding-swipe-right-badge-intensity', '0');
+  });
+};
+
+const applyActiveSwipeFrame = ({
+  element,
+  swipeAreaElement,
+  swipeDelta,
+  skipDeltaY,
+  isHotTake,
+  isLightweight,
+}: {
+  element: HTMLDivElement;
+  swipeAreaElement: HTMLDivElement | null;
+  swipeDelta: number;
+  skipDeltaY: number;
+  isHotTake: boolean;
+  isLightweight: boolean;
+}): void => {
+  element.style.setProperty(
+    'transform',
+    `translateX(${swipeDelta}px) translateY(${skipDeltaY}px) rotate(${getSwipeRotation(
+      swipeDelta,
+    )}deg) scale(1)`,
+  );
+  element.style.setProperty('will-change', 'transform');
+
+  if (isHotTake) {
+    applyHotTakeFeedbackStyles({
+      element,
+      swipeDelta,
+      skipDeltaY,
+      isLightweight,
+    });
+    return;
+  }
+
+  applyOnboardingFeedbackStyles({
+    element,
+    swipeAreaElement,
+    swipeDelta,
+  });
+};
+
+const requestSwipeAnimationFrame = (callback: FrameRequestCallback): number => {
+  if (typeof window.requestAnimationFrame === 'function') {
+    return window.requestAnimationFrame(callback);
+  }
+
+  return window.setTimeout(() => callback(performance.now()), 16);
+};
+
+const cancelSwipeAnimationFrame = (frameId: number): void => {
+  if (typeof window.cancelAnimationFrame === 'function') {
+    window.cancelAnimationFrame(frameId);
+    return;
+  }
+
+  window.clearTimeout(frameId);
 };
 
 const EFFECT_KEYFRAMES = `
@@ -843,16 +1340,609 @@ const SLEEP_BUBBLES: ReadonlyArray<{
   { left: '88%', bottom: '8%', size: 8, delay: 0.45, duration: 2.5 },
 ];
 
-const HotTakeCard = ({
-  hotTake,
-  isTop,
-  offset,
-  swipeDelta,
-  skipDeltaY = 0,
-  isDismissAnimating,
-  isDragging,
-  dismissDurationMs,
+const LIGHTWEIGHT_FLAMES = FLAMES.filter((_, index) =>
+  [1, 4, 7, 9].includes(index),
+);
+const LIGHTWEIGHT_EMBERS = EMBERS.filter((_, index) =>
+  [0, 4, 8, 12].includes(index),
+);
+const LIGHTWEIGHT_ICICLES = ICICLES.filter((_, index) =>
+  [1, 4, 7, 10].includes(index),
+);
+const LIGHTWEIGHT_SNOWFLAKES = SNOWFLAKES.filter((_, index) =>
+  [1, 5, 8, 13].includes(index),
+);
+const LIGHTWEIGHT_SLEEP_ZS = SLEEP_ZS.filter((_, index) =>
+  [0, 2, 4].includes(index),
+);
+const LIGHTWEIGHT_SLEEP_BUBBLES = SLEEP_BUBBLES.filter((_, index) =>
+  [0, 3, 6].includes(index),
+);
+
+type FeedbackEffectLayerProps = {
+  active: boolean;
+  intensity: number;
+  lightweight: boolean;
+  reducedMotion: boolean;
+  useLiveIntensity: boolean;
+};
+
+const getEffectIntensityValue = (
+  fallbackIntensity: number,
+  liveIntensity: string,
+  useLiveIntensity: boolean,
+): CssIntensity => (useLiveIntensity ? liveIntensity : fallbackIntensity);
+
+const HotTakeEffectKeyframes = React.memo(
+  function HotTakeEffectKeyframes(): ReactElement {
+    return (
+      // eslint-disable-next-line react/no-unknown-property -- style tag for scoped keyframes
+      <style>{EFFECT_KEYFRAMES}</style>
+    );
+  },
+);
+
+const HotSwipeEffectLayer = React.memo(function HotSwipeEffectLayer({
+  active,
+  intensity: fallbackIntensity,
+  lightweight,
+  reducedMotion,
+  useLiveIntensity,
+}: FeedbackEffectLayerProps): ReactElement | null {
+  if (!active) {
+    return null;
+  }
+
+  const intensity = getEffectIntensityValue(
+    fallbackIntensity,
+    HOT_INTENSITY_VAR,
+    useLiveIntensity,
+  );
+  const flames = lightweight ? LIGHTWEIGHT_FLAMES : FLAMES;
+  const embers = lightweight ? LIGHTWEIGHT_EMBERS : EMBERS;
+  const showParticles = !reducedMotion;
+
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-0 overflow-hidden rounded-16"
+      style={{ opacity: intensity }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          borderRadius: 'inherit',
+          background: `linear-gradient(180deg, rgba(255,150,20,${cssAlpha(
+            intensity,
+            0.08,
+          )}) 0%, rgba(255,90,0,${cssAlpha(
+            intensity,
+            0.16,
+          )}) 42%, rgba(100,20,0,${cssAlpha(intensity, 0.24)}) 100%)`,
+          boxShadow: lightweight
+            ? undefined
+            : [
+                `inset 0 ${cssNegativePixelText(intensity, 55)} ${cssPixelText(
+                  intensity,
+                  44,
+                )} ${cssNegativePixelText(intensity, 16)} rgba(255,100,0,0.4)`,
+                `inset ${cssPixelText(intensity, 26)} 0 ${cssPixelText(
+                  intensity,
+                  28,
+                )} ${cssNegativePixelText(intensity, 14)} rgba(255,60,0,0.15)`,
+                `inset ${cssNegativePixelText(intensity, 26)} 0 ${cssPixelText(
+                  intensity,
+                  28,
+                )} ${cssNegativePixelText(intensity, 14)} rgba(255,60,0,0.15)`,
+              ].join(', '),
+          animation: reducedMotion
+            ? undefined
+            : `hotTakeHeatShimmer ${cssNumber(
+                intensity,
+                -0.4,
+                1,
+              )}s ease-in-out infinite`,
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          left: '-10%',
+          right: '-10%',
+          bottom: '-16%',
+          height: '44%',
+          borderRadius: '50%',
+          background: `radial-gradient(ellipse at 50% 100%, rgba(255,80,0,${cssAlpha(
+            intensity,
+            0.42,
+          )}) 0%, rgba(255,125,0,${cssAlpha(
+            intensity,
+            0.24,
+          )}) 40%, transparent 78%)`,
+          filter: lightweight
+            ? undefined
+            : `blur(${cssPixelText(intensity, 5, 5)})`,
+          animation: reducedMotion
+            ? undefined
+            : 'hotTakeHeatShimmer 1.1s ease-in-out infinite',
+        }}
+      />
+      {showParticles &&
+        flames.map((flame, i) => (
+          <div
+            key={flame.left}
+            data-hot-take-particle="flame"
+            style={{
+              position: 'absolute',
+              bottom: -2,
+              left: flame.left,
+              width: flame.size * 0.55,
+              height: cssPixels(intensity, flame.size),
+              background:
+                'radial-gradient(ellipse at 50% 88%, #fff29a 0%, #ffcf3d 20%, #ff8a00 45%, #ff3b00 66%, rgba(0,0,0,0) 84%)',
+              borderRadius: '50% 50% 20% 20%',
+              filter: lightweight
+                ? undefined
+                : `blur(${cssPixelText(
+                    intensity,
+                    1.8,
+                    1.4,
+                  )}) saturate(${cssNumber(intensity, 0.35, 1)})`,
+              animation: reducedMotion
+                ? undefined
+                : `hotTakeFlame ${
+                    0.3 + i * 0.06
+                  }s ease-in-out infinite alternate`,
+              animationDelay: `${flame.delay}s`,
+              transform: 'translateX(-50%)',
+              opacity: cssNumber(intensity, 0.55, 0.45),
+            }}
+          />
+        ))}
+      {showParticles &&
+        embers.map((ember) => (
+          <div
+            key={`${ember.left}-${ember.bottom}`}
+            data-hot-take-particle="ember"
+            style={{
+              position: 'absolute',
+              left: ember.left,
+              bottom: ember.bottom,
+              width: ember.size,
+              height: ember.size,
+              borderRadius: '50%',
+              background:
+                'radial-gradient(circle, #fff6ba 0%, #ffcb58 22%, #ff7a1a 54%, rgba(255,80,0,0.2) 80%, transparent 100%)',
+              boxShadow: lightweight
+                ? undefined
+                : `0 0 ${ember.size + 3}px rgba(255,120,0,${cssAlpha(
+                    intensity,
+                    0.55,
+                    0.35,
+                  )})`,
+              animation: reducedMotion
+                ? undefined
+                : `hotTakeEmber ${ember.duration}s ease-out infinite`,
+              animationDelay: `${ember.delay}s`,
+              opacity: cssNumber(intensity, 0.7, 0.3),
+            }}
+          />
+        ))}
+    </div>
+  );
+});
+
+const ColdSwipeEffectLayer = React.memo(function ColdSwipeEffectLayer({
+  active,
+  intensity: fallbackIntensity,
+  lightweight,
+  reducedMotion,
+  useLiveIntensity,
+}: FeedbackEffectLayerProps): ReactElement | null {
+  if (!active) {
+    return null;
+  }
+
+  const intensity = getEffectIntensityValue(
+    fallbackIntensity,
+    COLD_INTENSITY_VAR,
+    useLiveIntensity,
+  );
+  const icicles = lightweight ? LIGHTWEIGHT_ICICLES : ICICLES;
+  const snowflakes = lightweight ? LIGHTWEIGHT_SNOWFLAKES : SNOWFLAKES;
+  const showParticles = !reducedMotion;
+
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-0 overflow-hidden rounded-16"
+      style={{ opacity: intensity }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          borderRadius: 'inherit',
+          background: `linear-gradient(180deg, rgba(210,240,255,${cssAlpha(
+            intensity,
+            0.22,
+          )}) 0%, rgba(140,210,255,${cssAlpha(
+            intensity,
+            0.12,
+          )}) 42%, rgba(120,170,255,${cssAlpha(intensity, 0.1)}) 100%)`,
+          boxShadow: lightweight
+            ? undefined
+            : [
+                `inset 0 ${cssPixelText(intensity, 52)} ${cssPixelText(
+                  intensity,
+                  42,
+                )} ${cssNegativePixelText(
+                  intensity,
+                  15,
+                )} rgba(150,210,255,0.35)`,
+                `inset ${cssPixelText(intensity, 24)} 0 ${cssPixelText(
+                  intensity,
+                  26,
+                )} ${cssNegativePixelText(
+                  intensity,
+                  15,
+                )} rgba(130,200,255,0.12)`,
+                `inset ${cssNegativePixelText(intensity, 24)} 0 ${cssPixelText(
+                  intensity,
+                  26,
+                )} ${cssNegativePixelText(
+                  intensity,
+                  15,
+                )} rgba(130,200,255,0.12)`,
+              ].join(', '),
+          backdropFilter: lightweight
+            ? undefined
+            : `blur(${cssPixelText(intensity, 1.2)})`,
+          animation: reducedMotion
+            ? undefined
+            : `hotTakeFrostBreath ${cssNumber(
+                intensity,
+                -0.35,
+                1.2,
+              )}s ease-in-out infinite`,
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          top: 0,
+          height: cssPercent(intensity, 10, 18),
+          background: `linear-gradient(180deg, rgba(225,245,255,${cssAlpha(
+            intensity,
+            0.42,
+          )}) 0%, rgba(170,220,255,${cssAlpha(
+            intensity,
+            0.14,
+          )}) 75%, transparent 100%)`,
+          filter: lightweight
+            ? undefined
+            : `blur(${cssPixelText(intensity, 1.2, 1.5)})`,
+          animation: reducedMotion
+            ? undefined
+            : 'hotTakeFrostBreath 1.2s ease-in-out infinite',
+        }}
+      />
+      {showParticles &&
+        icicles.map((icicle, i) => (
+          <div
+            key={icicle.left}
+            data-hot-take-particle="icicle"
+            style={{
+              position: 'absolute',
+              top: -1,
+              left: icicle.left,
+              width: icicle.width,
+              height: cssPixels(intensity, icicle.height),
+              background:
+                'linear-gradient(180deg, rgba(220,240,255,0.95) 0%, rgba(140,210,255,0.85) 40%, rgba(100,180,255,0.5) 100%)',
+              clipPath: ICICLE_SHAPES[icicle.shape],
+              transform: `translateX(-50%) rotate(${icicle.rotate}deg)`,
+              transformOrigin: 'top center',
+              boxShadow: lightweight
+                ? undefined
+                : `0 2px ${cssPixelText(
+                    intensity,
+                    4,
+                    4,
+                  )} rgba(175,220,255,${cssAlpha(intensity, 0.4, 0.3)})`,
+              filter: lightweight
+                ? undefined
+                : `saturate(${cssNumber(intensity, 0.25, 1)})`,
+              animation: reducedMotion
+                ? undefined
+                : `hotTakeIcicleShimmer ${2 + i * 0.2}s ease-in-out infinite`,
+              animationDelay: `${icicle.delay}s`,
+            }}
+          />
+        ))}
+      {showParticles &&
+        snowflakes.map((flake) => (
+          <div
+            key={`${flake.left}-${flake.top}`}
+            data-hot-take-particle="snowflake"
+            style={{
+              position: 'absolute',
+              left: flake.left,
+              top: flake.top,
+              width: flake.size,
+              height: flake.size,
+              borderRadius: '50%',
+              background:
+                'radial-gradient(circle, white 0%, rgba(200,230,255,0.8) 60%, transparent 100%)',
+              boxShadow: lightweight
+                ? undefined
+                : `0 0 ${cssPixelText(
+                    intensity,
+                    2,
+                    flake.size,
+                  )} rgba(200,230,255,${cssAlpha(intensity, 0.5, 0.35)})`,
+              animation: reducedMotion
+                ? undefined
+                : `hotTakeSnowfall ${flake.duration}s ease-in-out infinite`,
+              animationDelay: `${flake.delay}s`,
+              opacity: cssNumber(intensity, 0.65, 0.35),
+            }}
+          />
+        ))}
+    </div>
+  );
+});
+
+const SkipSwipeEffectLayer = React.memo(function SkipSwipeEffectLayer({
+  active,
+  intensity: fallbackIntensity,
+  lightweight,
+  reducedMotion,
+  useLiveIntensity,
+}: FeedbackEffectLayerProps): ReactElement | null {
+  if (!active) {
+    return null;
+  }
+
+  const intensity = getEffectIntensityValue(
+    fallbackIntensity,
+    SKIP_INTENSITY_VAR,
+    useLiveIntensity,
+  );
+  const sleepZs = lightweight ? LIGHTWEIGHT_SLEEP_ZS : SLEEP_ZS;
+  const bubbles = lightweight ? LIGHTWEIGHT_SLEEP_BUBBLES : SLEEP_BUBBLES;
+  const showParticles = !reducedMotion;
+
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-0 overflow-hidden rounded-16"
+      style={{ opacity: intensity }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          borderRadius: 'inherit',
+          background: `linear-gradient(180deg, rgba(222,246,255,${cssAlpha(
+            intensity,
+            0.2,
+          )}) 0%, rgba(180,230,255,${cssAlpha(
+            intensity,
+            0.12,
+          )}) 46%, rgba(120,186,240,${cssAlpha(intensity, 0.16)}) 100%)`,
+          boxShadow: lightweight
+            ? undefined
+            : [
+                `inset 0 ${cssPixelText(intensity, 52)} ${cssPixelText(
+                  intensity,
+                  44,
+                )} ${cssNegativePixelText(
+                  intensity,
+                  15,
+                )} rgba(170,225,255,0.32)`,
+                `inset ${cssPixelText(intensity, 24)} 0 ${cssPixelText(
+                  intensity,
+                  24,
+                )} ${cssNegativePixelText(
+                  intensity,
+                  14,
+                )} rgba(140,210,255,0.18)`,
+                `inset ${cssNegativePixelText(intensity, 24)} 0 ${cssPixelText(
+                  intensity,
+                  24,
+                )} ${cssNegativePixelText(
+                  intensity,
+                  14,
+                )} rgba(140,210,255,0.18)`,
+              ].join(', '),
+          backdropFilter: lightweight
+            ? undefined
+            : `blur(${cssPixelText(intensity, 1.5, 0.4)})`,
+          animation: reducedMotion
+            ? undefined
+            : `hotTakeSleepBreath ${cssNumber(
+                intensity,
+                -0.4,
+                1.6,
+              )}s ease-in-out infinite`,
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          left: '-8%',
+          right: '-8%',
+          top: '-16%',
+          height: '42%',
+          borderRadius: '50%',
+          background: `radial-gradient(ellipse at 50% 0%, rgba(220,245,255,${cssAlpha(
+            intensity,
+            0.52,
+          )}) 0%, rgba(170,220,255,${cssAlpha(
+            intensity,
+            0.22,
+          )}) 42%, transparent 78%)`,
+          filter: lightweight
+            ? undefined
+            : `blur(${cssPixelText(intensity, 5, 4)})`,
+        }}
+      />
+      {showParticles &&
+        sleepZs.map((sleepZ) => (
+          <span
+            key={`${sleepZ.left}-${sleepZ.bottom}`}
+            data-hot-take-particle="sleep-z"
+            style={{
+              position: 'absolute',
+              left: sleepZ.left,
+              bottom: sleepZ.bottom,
+              fontSize: sleepZ.size,
+              fontWeight: 800,
+              lineHeight: 1,
+              color: `rgba(230,248,255,${cssAlpha(intensity, 0.75, 0.25)})`,
+              textShadow: lightweight
+                ? undefined
+                : `0 0 ${cssPixelText(
+                    intensity,
+                    10,
+                    4,
+                  )} rgba(150,220,255,${cssAlpha(intensity, 0.52, 0.18)})`,
+              transform: `translateX(-50%) rotate(${sleepZ.rotate}deg)`,
+              animation: reducedMotion
+                ? undefined
+                : `hotTakeSleepFloat ${sleepZ.duration}s ease-in infinite`,
+              animationDelay: `${sleepZ.delay}s`,
+              opacity: cssNumber(intensity, 0.76, 0.24),
+            }}
+          >
+            Z
+          </span>
+        ))}
+      {showParticles &&
+        bubbles.map((bubble) => (
+          <div
+            key={`${bubble.left}-${bubble.bottom}`}
+            data-hot-take-particle="sleep-bubble"
+            style={{
+              position: 'absolute',
+              left: bubble.left,
+              bottom: bubble.bottom,
+              width: bubble.size,
+              height: bubble.size,
+              borderRadius: '50%',
+              background:
+                'radial-gradient(circle at 28% 28%, rgba(255,255,255,0.95) 0%, rgba(225,245,255,0.55) 44%, rgba(170,220,255,0.2) 100%)',
+              border: `1px solid rgba(208,240,255,${cssAlpha(
+                intensity,
+                0.5,
+                0.18,
+              )})`,
+              boxShadow: lightweight
+                ? undefined
+                : `0 0 ${bubble.size + 4}px rgba(150,220,255,${cssAlpha(
+                    intensity,
+                    0.48,
+                    0.15,
+                  )})`,
+              animation: reducedMotion
+                ? undefined
+                : `hotTakeBubbleRise ${bubble.duration}s ease-out infinite`,
+              animationDelay: `${bubble.delay}s`,
+              opacity: cssNumber(intensity, 0.8, 0.2),
+            }}
+          />
+        ))}
+    </div>
+  );
+});
+
+const HotTakeFeedbackBadges = React.memo(function HotTakeFeedbackBadges({
+  active,
+  useLiveIntensity,
+  hotIntensity,
+  coldIntensity,
+  skipIntensity,
 }: {
+  active: boolean;
+  useLiveIntensity: boolean;
+  hotIntensity: number;
+  coldIntensity: number;
+  skipIntensity: number;
+}): ReactElement | null {
+  if (!active) {
+    return null;
+  }
+
+  const hotOpacity = getEffectIntensityValue(
+    hotIntensity,
+    HOT_INTENSITY_VAR,
+    useLiveIntensity,
+  );
+  const coldOpacity = getEffectIntensityValue(
+    coldIntensity,
+    COLD_INTENSITY_VAR,
+    useLiveIntensity,
+  );
+  const skipOpacity = getEffectIntensityValue(
+    skipIntensity,
+    SKIP_INTENSITY_VAR,
+    useLiveIntensity,
+  );
+
+  return (
+    <>
+      <div
+        className="z-20 absolute left-1/2 top-4 -translate-x-1/2 rounded-10 bg-accent-ketchup-default px-4 py-1 font-bold text-white typo-title3"
+        style={{
+          opacity: hotOpacity,
+          animation: 'hotTakeBadgePulse 0.18s ease-out',
+          boxShadow: `0 6px ${cssPixelText(
+            hotOpacity,
+            10,
+            12,
+          )} rgba(0,0,0,${cssAlpha(hotOpacity, 0.18, 0.1)})`,
+        }}
+      >
+        HOT 🔥
+      </div>
+      <div
+        className="z-20 absolute left-1/2 top-4 -translate-x-1/2 rounded-10 px-4 py-1 font-bold text-white typo-title3"
+        style={{
+          opacity: coldOpacity,
+          animation: 'hotTakeBadgePulse 0.18s ease-out',
+          backgroundColor: COLD_ACCENT_COLOR,
+          boxShadow: `0 6px ${cssPixelText(
+            coldOpacity,
+            10,
+            12,
+          )} rgba(0,0,0,${cssAlpha(coldOpacity, 0.18, 0.1)})`,
+        }}
+      >
+        COLD 🥶
+      </div>
+      <div
+        className="z-20 absolute left-1/2 top-4 -translate-x-1/2 rounded-10 bg-accent-blueCheese-default px-4 py-1 font-bold text-white typo-title3"
+        style={{
+          opacity: skipOpacity,
+          animation: 'hotTakeBadgePulse 0.18s ease-out',
+          boxShadow: `0 6px ${cssPixelText(
+            skipOpacity,
+            10,
+            12,
+          )} rgba(0,0,0,${cssAlpha(skipOpacity, 0.18, 0.1)})`,
+        }}
+      >
+        SKIP 😴
+      </div>
+    </>
+  );
+});
+
+type HotTakeCardProps = {
   hotTake: HotTake;
   isTop: boolean;
   offset: number;
@@ -861,536 +1951,224 @@ const HotTakeCard = ({
   isDismissAnimating: boolean;
   isDragging: boolean;
   dismissDurationMs: number;
-}): ReactElement => {
-  const isSkipAnimating = isTop && isDismissAnimating && skipDeltaY !== 0;
-  const isSkipDragging = isTop && !isDismissAnimating && skipDeltaY < 0;
-  const rotation = isTop ? Math.max(Math.min(swipeDelta * 0.08, 18), -18) : 0;
-  const translateX = isTop ? swipeDelta : 0;
-  const stackScale = isTop ? 1 : 1 - offset * 0.05;
-  const translateY = isTop ? 0 : offset * 8;
-  const getDismissProgress = (): number => {
-    if (!isTop || !isDismissAnimating) {
-      return 0;
-    }
-    if (isSkipAnimating) {
-      return Math.min(Math.abs(skipDeltaY) / SKIP_DISMISS_FLY_DISTANCE, 1);
-    }
-    return Math.min(Math.abs(swipeDelta) / DISMISS_FLY_DISTANCE, 1);
-  };
-  const dismissProgress = getDismissProgress();
-  const scale = isTop ? 1 - dismissProgress * 0.06 : stackScale;
-  const dismissLift = isTop ? dismissProgress * -22 : 0;
-  const translateYWithOutro =
-    translateY + dismissLift + (isTop ? skipDeltaY : 0);
-
-  const intensity = isTop
-    ? Math.min(Math.abs(swipeDelta) / SWIPE_THRESHOLD, 1)
-    : 0;
-  const effectIntensity = isTop ? intensity ** 0.78 : 0;
-  const skipDragIntensity = isTop
-    ? Math.min(Math.abs(skipDeltaY) / SWIPE_THRESHOLD, 1)
-    : 0;
-  let skipEffectIntensity = 0;
-  if (isTop) {
-    if (isSkipAnimating) {
-      skipEffectIntensity = dismissProgress;
-    } else if (isSkipDragging) {
-      skipEffectIntensity = skipDragIntensity ** 0.78;
-    }
-  }
-  const isSkipVisualActive = isTop && skipEffectIntensity > 0.02;
-  const getSwipeDirection = (): 'right' | 'left' | null => {
-    if (!isTop || Math.abs(swipeDelta) <= 20) {
-      return null;
-    }
-    return swipeDelta > 0 ? 'right' : 'left';
-  };
-  const swipeDirection = getSwipeDirection();
-
-  const accentColor =
-    swipeDirection === 'right'
-      ? 'var(--theme-accent-ketchup-default)'
-      : COLD_ACCENT_COLOR;
-  const skipAccentColor = 'var(--theme-accent-blueCheese-default)';
-  let activeBorderColor;
-  if (swipeDirection) {
-    activeBorderColor = `color-mix(in srgb, ${accentColor} ${Math.round(
-      effectIntensity * 100,
-    )}%, var(--theme-border-subtlest-tertiary))`;
-  } else if (isSkipVisualActive) {
-    activeBorderColor = `color-mix(in srgb, ${skipAccentColor} ${Math.round(
-      skipEffectIntensity * 100,
-    )}%, var(--theme-border-subtlest-tertiary))`;
-  }
-
-  let activeBoxShadow;
-  if (swipeDirection) {
-    activeBoxShadow = `0 0 ${6 + effectIntensity * 24}px ${
-      2 + effectIntensity * 8
-    }px color-mix(in srgb, ${accentColor} ${Math.round(
-      effectIntensity * 65,
-    )}%, transparent), 0 0 ${10 + effectIntensity * 34}px ${
-      4 + effectIntensity * 14
-    }px color-mix(in srgb, ${accentColor} ${Math.round(
-      effectIntensity * 42,
-    )}%, transparent)`;
-  } else if (isSkipVisualActive) {
-    activeBoxShadow = `0 0 ${6 + skipEffectIntensity * 22}px ${
-      2 + skipEffectIntensity * 8
-    }px color-mix(in srgb, ${skipAccentColor} ${Math.round(
-      skipEffectIntensity * 60,
-    )}%, transparent), 0 0 ${10 + skipEffectIntensity * 28}px ${
-      4 + skipEffectIntensity * 12
-    }px color-mix(in srgb, ${skipAccentColor} ${Math.round(
-      skipEffectIntensity * 42,
-    )}%, transparent)`;
-  }
-  let transition =
-    'transform 0.3s ease, border-color 0.2s ease, box-shadow 0.2s ease';
-  if (isTop) {
-    if (isDismissAnimating) {
-      transition = `transform ${dismissDurationMs}ms cubic-bezier(0.16, 0.86, 0.22, 1), opacity ${dismissDurationMs}ms ease-out, filter ${dismissDurationMs}ms ease-out, border-color 0.2s ease, box-shadow 0.2s ease`;
-    } else if (isDragging) {
-      transition = 'border-color 0.2s ease, box-shadow 0.2s ease';
-    } else {
-      transition =
-        'transform 0.28s cubic-bezier(0.22, 1, 0.36, 1), border-color 0.2s ease, box-shadow 0.2s ease';
-    }
-  }
-
-  return (
-    <div
-      className={classNames(
-        'absolute inset-0 flex select-none flex-col rounded-16 border border-border-subtlest-tertiary bg-background-subtle shadow-2',
-        !isTop && 'pointer-events-none',
-      )}
-      style={{
-        transform: `translateX(${translateX}px) translateY(${translateYWithOutro}px) rotate(${rotation}deg) scale(${scale})`,
-        zIndex: 10 - offset,
-        transition,
-        opacity: isTop ? 1 - dismissProgress * 0.75 : 1,
-        filter:
-          isTop && isDismissAnimating
-            ? `blur(${dismissProgress * 1.8}px)`
-            : undefined,
-        borderColor: activeBorderColor,
-        boxShadow: activeBoxShadow,
-      }}
-    >
-      {/* eslint-disable-next-line react/no-unknown-property */}
-      {isTop && <style>{EFFECT_KEYFRAMES}</style>}
-
-      {swipeDirection === 'right' && (
-        <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-16">
-          <div
-            style={{
-              position: 'absolute',
-              inset: 0,
-              borderRadius: 'inherit',
-              background: `linear-gradient(180deg, rgba(255,150,20,${
-                effectIntensity * 0.08
-              }) 0%, rgba(255,90,0,${
-                effectIntensity * 0.16
-              }) 42%, rgba(100,20,0,${effectIntensity * 0.24}) 100%)`,
-              boxShadow: [
-                `inset 0 ${-55 * effectIntensity}px ${44 * effectIntensity}px ${
-                  -16 * effectIntensity
-                }px rgba(255,100,0,0.4)`,
-                `inset ${26 * effectIntensity}px 0 ${28 * effectIntensity}px ${
-                  -14 * effectIntensity
-                }px rgba(255,60,0,0.15)`,
-                `inset ${-26 * effectIntensity}px 0 ${28 * effectIntensity}px ${
-                  -14 * effectIntensity
-                }px rgba(255,60,0,0.15)`,
-              ].join(', '),
-              animation: `hotTakeHeatShimmer ${
-                0.6 + (1 - effectIntensity) * 0.4
-              }s ease-in-out infinite`,
-            }}
-          />
-          <div
-            style={{
-              position: 'absolute',
-              left: '-10%',
-              right: '-10%',
-              bottom: '-16%',
-              height: '44%',
-              borderRadius: '50%',
-              background: `radial-gradient(ellipse at 50% 100%, rgba(255,80,0,${
-                effectIntensity * 0.42
-              }) 0%, rgba(255,125,0,${
-                effectIntensity * 0.24
-              }) 40%, transparent 78%)`,
-              filter: `blur(${5 + effectIntensity * 5}px)`,
-              animation: 'hotTakeHeatShimmer 1.1s ease-in-out infinite',
-            }}
-          />
-          {FLAMES.map((flame, i) => (
-            <div
-              key={flame.left}
-              style={{
-                position: 'absolute',
-                bottom: -2,
-                left: flame.left,
-                width: flame.size * 0.55,
-                height: flame.size * effectIntensity,
-                background:
-                  'radial-gradient(ellipse at 50% 88%, #fff29a 0%, #ffcf3d 20%, #ff8a00 45%, #ff3b00 66%, rgba(0,0,0,0) 84%)',
-                borderRadius: '50% 50% 20% 20%',
-                filter: `blur(${1.4 + effectIntensity * 1.8}px) saturate(${
-                  1 + effectIntensity * 0.35
-                })`,
-                animation: `hotTakeFlame ${
-                  0.3 + i * 0.06
-                }s ease-in-out infinite alternate`,
-                animationDelay: `${flame.delay}s`,
-                transform: 'translateX(-50%)',
-                opacity: 0.45 + effectIntensity * 0.55,
-                willChange: 'transform, opacity, filter',
-              }}
-            />
-          ))}
-          {EMBERS.map((ember) => (
-            <div
-              key={`${ember.left}-${ember.bottom}`}
-              style={{
-                position: 'absolute',
-                left: ember.left,
-                bottom: ember.bottom,
-                width: ember.size,
-                height: ember.size,
-                borderRadius: '50%',
-                background:
-                  'radial-gradient(circle, #fff6ba 0%, #ffcb58 22%, #ff7a1a 54%, rgba(255,80,0,0.2) 80%, transparent 100%)',
-                boxShadow: `0 0 ${ember.size + 3}px rgba(255,120,0,${
-                  0.35 + effectIntensity * 0.55
-                })`,
-                animation: `hotTakeEmber ${ember.duration}s ease-out infinite`,
-                animationDelay: `${ember.delay}s`,
-                opacity: 0.3 + effectIntensity * 0.7,
-              }}
-            />
-          ))}
-        </div>
-      )}
-
-      {swipeDirection === 'left' && (
-        <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-16">
-          <div
-            style={{
-              position: 'absolute',
-              inset: 0,
-              borderRadius: 'inherit',
-              background: `linear-gradient(180deg, rgba(210,240,255,${
-                effectIntensity * 0.22
-              }) 0%, rgba(140,210,255,${
-                effectIntensity * 0.12
-              }) 42%, rgba(120,170,255,${effectIntensity * 0.1}) 100%)`,
-              boxShadow: [
-                `inset 0 ${52 * effectIntensity}px ${42 * effectIntensity}px ${
-                  -15 * effectIntensity
-                }px rgba(150,210,255,0.35)`,
-                `inset ${24 * effectIntensity}px 0 ${26 * effectIntensity}px ${
-                  -15 * effectIntensity
-                }px rgba(130,200,255,0.12)`,
-                `inset ${-24 * effectIntensity}px 0 ${26 * effectIntensity}px ${
-                  -15 * effectIntensity
-                }px rgba(130,200,255,0.12)`,
-              ].join(', '),
-              backdropFilter: `blur(${effectIntensity * 1.2}px)`,
-              animation: `hotTakeFrostBreath ${
-                0.85 + (1 - effectIntensity) * 0.35
-              }s ease-in-out infinite`,
-            }}
-          />
-          <div
-            style={{
-              position: 'absolute',
-              left: 0,
-              right: 0,
-              top: 0,
-              height: `${18 + effectIntensity * 10}%`,
-              background: `linear-gradient(180deg, rgba(225,245,255,${
-                effectIntensity * 0.42
-              }) 0%, rgba(170,220,255,${
-                effectIntensity * 0.14
-              }) 75%, transparent 100%)`,
-              filter: `blur(${1.5 + effectIntensity * 1.2}px)`,
-              animation: 'hotTakeFrostBreath 1.2s ease-in-out infinite',
-            }}
-          />
-          {ICICLES.map((icicle, i) => (
-            <div
-              key={icicle.left}
-              style={{
-                position: 'absolute',
-                top: -1,
-                left: icicle.left,
-                width: icicle.width,
-                height: icicle.height * effectIntensity,
-                background:
-                  'linear-gradient(180deg, rgba(220,240,255,0.95) 0%, rgba(140,210,255,0.85) 40%, rgba(100,180,255,0.5) 100%)',
-                clipPath: ICICLE_SHAPES[icicle.shape],
-                transform: `translateX(-50%) rotate(${icicle.rotate}deg)`,
-                transformOrigin: 'top center',
-                boxShadow: `0 2px ${
-                  4 + effectIntensity * 4
-                }px rgba(175,220,255,${0.3 + effectIntensity * 0.4})`,
-                filter: `saturate(${1 + effectIntensity * 0.25})`,
-                animation: `hotTakeIcicleShimmer ${
-                  2 + i * 0.2
-                }s ease-in-out infinite`,
-                animationDelay: `${icicle.delay}s`,
-              }}
-            />
-          ))}
-          {SNOWFLAKES.map((flake) => (
-            <div
-              key={`${flake.left}-${flake.top}`}
-              style={{
-                position: 'absolute',
-                left: flake.left,
-                top: flake.top,
-                width: flake.size,
-                height: flake.size,
-                borderRadius: '50%',
-                background:
-                  'radial-gradient(circle, white 0%, rgba(200,230,255,0.8) 60%, transparent 100%)',
-                boxShadow: `0 0 ${
-                  flake.size + effectIntensity * 2
-                }px rgba(200,230,255,${0.35 + effectIntensity * 0.5})`,
-                animation: `hotTakeSnowfall ${flake.duration}s ease-in-out infinite`,
-                animationDelay: `${flake.delay}s`,
-                opacity: 0.35 + effectIntensity * 0.65,
-              }}
-            />
-          ))}
-        </div>
-      )}
-
-      {isSkipVisualActive && (
-        <div className="pointer-events-none absolute inset-0 overflow-hidden rounded-16">
-          <div
-            style={{
-              position: 'absolute',
-              inset: 0,
-              borderRadius: 'inherit',
-              background: `linear-gradient(180deg, rgba(222,246,255,${
-                skipEffectIntensity * 0.2
-              }) 0%, rgba(180,230,255,${
-                skipEffectIntensity * 0.12
-              }) 46%, rgba(120,186,240,${skipEffectIntensity * 0.16}) 100%)`,
-              boxShadow: [
-                `inset 0 ${52 * skipEffectIntensity}px ${
-                  44 * skipEffectIntensity
-                }px ${-15 * skipEffectIntensity}px rgba(170,225,255,0.32)`,
-                `inset ${24 * skipEffectIntensity}px 0 ${
-                  24 * skipEffectIntensity
-                }px ${-14 * skipEffectIntensity}px rgba(140,210,255,0.18)`,
-                `inset ${-24 * skipEffectIntensity}px 0 ${
-                  24 * skipEffectIntensity
-                }px ${-14 * skipEffectIntensity}px rgba(140,210,255,0.18)`,
-              ].join(', '),
-              backdropFilter: `blur(${0.4 + skipEffectIntensity * 1.5}px)`,
-              animation: `hotTakeSleepBreath ${
-                1.2 + (1 - skipEffectIntensity) * 0.4
-              }s ease-in-out infinite`,
-            }}
-          />
-          <div
-            style={{
-              position: 'absolute',
-              left: '-8%',
-              right: '-8%',
-              top: '-16%',
-              height: '42%',
-              borderRadius: '50%',
-              background: `radial-gradient(ellipse at 50% 0%, rgba(220,245,255,${
-                skipEffectIntensity * 0.52
-              }) 0%, rgba(170,220,255,${
-                skipEffectIntensity * 0.22
-              }) 42%, transparent 78%)`,
-              filter: `blur(${4 + skipEffectIntensity * 5}px)`,
-            }}
-          />
-          {SLEEP_ZS.map((sleepZ) => (
-            <span
-              key={`${sleepZ.left}-${sleepZ.bottom}`}
-              style={{
-                position: 'absolute',
-                left: sleepZ.left,
-                bottom: sleepZ.bottom,
-                fontSize: sleepZ.size,
-                fontWeight: 800,
-                lineHeight: 1,
-                color: `rgba(230,248,255,${0.25 + skipEffectIntensity * 0.75})`,
-                textShadow: `0 0 ${
-                  4 + skipEffectIntensity * 10
-                }px rgba(150,220,255,${0.18 + skipEffectIntensity * 0.52})`,
-                transform: `translateX(-50%) rotate(${sleepZ.rotate}deg)`,
-                animation: `hotTakeSleepFloat ${sleepZ.duration}s ease-in infinite`,
-                animationDelay: `${sleepZ.delay}s`,
-                opacity: 0.24 + skipEffectIntensity * 0.76,
-              }}
-            >
-              Z
-            </span>
-          ))}
-          {SLEEP_BUBBLES.map((bubble) => (
-            <div
-              key={`${bubble.left}-${bubble.bottom}`}
-              style={{
-                position: 'absolute',
-                left: bubble.left,
-                bottom: bubble.bottom,
-                width: bubble.size,
-                height: bubble.size,
-                borderRadius: '50%',
-                background:
-                  'radial-gradient(circle at 28% 28%, rgba(255,255,255,0.95) 0%, rgba(225,245,255,0.55) 44%, rgba(170,220,255,0.2) 100%)',
-                border: `1px solid rgba(208,240,255,${
-                  0.18 + skipEffectIntensity * 0.5
-                })`,
-                boxShadow: `0 0 ${bubble.size + 4}px rgba(150,220,255,${
-                  0.15 + skipEffectIntensity * 0.48
-                })`,
-                animation: `hotTakeBubbleRise ${bubble.duration}s ease-out infinite`,
-                animationDelay: `${bubble.delay}s`,
-                opacity: 0.2 + skipEffectIntensity * 0.8,
-              }}
-            />
-          ))}
-        </div>
-      )}
-
-      {isTop && swipeDirection && (
-        <div
-          className={classNames(
-            'z-20 absolute left-1/2 top-4 -translate-x-1/2 rounded-10 px-4 py-1 font-bold typo-title3',
-            swipeDirection === 'right'
-              ? 'bg-accent-ketchup-default text-white'
-              : 'text-white',
-          )}
-          style={{
-            opacity: effectIntensity,
-            animation: 'hotTakeBadgePulse 0.18s ease-out',
-            backgroundColor:
-              swipeDirection === 'right' ? undefined : COLD_ACCENT_COLOR,
-            boxShadow: `0 6px ${12 + effectIntensity * 10}px rgba(0,0,0,${
-              0.1 + effectIntensity * 0.18
-            })`,
-          }}
-        >
-          {swipeDirection === 'right' ? 'HOT 🔥' : 'COLD 🥶'}
-        </div>
-      )}
-
-      {isSkipVisualActive && (
-        <div
-          className="z-20 absolute left-1/2 top-4 -translate-x-1/2 rounded-10 bg-accent-blueCheese-default px-4 py-1 font-bold text-white typo-title3"
-          style={{
-            opacity: skipEffectIntensity,
-            animation: 'hotTakeBadgePulse 0.18s ease-out',
-            boxShadow: `0 6px ${12 + skipEffectIntensity * 10}px rgba(0,0,0,${
-              0.1 + skipEffectIntensity * 0.18
-            })`,
-          }}
-        >
-          SKIP 😴
-        </div>
-      )}
-
-      <div className="relative flex min-h-0 flex-1 flex-col items-center justify-center gap-3 overflow-y-auto break-words p-6">
-        <div className="flex size-16 items-center justify-center rounded-16 bg-overlay-quaternary-cabbage text-[2.5rem]">
-          {hotTake.emoji}
-        </div>
-
-        <Typography
-          type={TypographyType.Title3}
-          color={TypographyColor.Primary}
-          bold
-          className="w-full break-words text-center"
-        >
-          {hotTake.title}
-        </Typography>
-
-        {hotTake.subtitle && (
-          <Typography
-            type={TypographyType.Body}
-            color={TypographyColor.Tertiary}
-            className="w-full break-words text-center"
-          >
-            {hotTake.subtitle}
-          </Typography>
-        )}
-
-        {hotTake.upvotes > 0 && (
-          <div className="flex items-center gap-1 rounded-10 bg-surface-hover px-3 py-1">
-            <HotIcon className="text-accent-cabbage-default" />
-            <Typography
-              type={TypographyType.Footnote}
-              color={TypographyColor.Secondary}
-              bold
-            >
-              {hotTake.upvotes}
-            </Typography>
-          </div>
-        )}
-      </div>
-
-      {hotTake.user && (
-        <a
-          href={hotTake.user.permalink}
-          className="relative flex items-center gap-3 border-t border-border-subtlest-tertiary p-4 hover:bg-surface-hover"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <ProfilePicture
-            user={hotTake.user}
-            size={ProfileImageSize.Large}
-            nativeLazyLoading
-          />
-          <div className="flex min-w-0 flex-1 flex-col">
-            <div className="flex min-w-0 items-center gap-1">
-              <span className="min-w-0 truncate font-bold typo-callout">
-                {hotTake.user.name}
-              </span>
-              {hotTake.user.isPlus && (
-                <PlusUserBadge
-                  user={{ isPlus: hotTake.user.isPlus }}
-                  tooltip={false}
-                />
-              )}
-              <span className="min-w-0 truncate text-text-tertiary typo-footnote">
-                @{hotTake.user.username}
-              </span>
-            </div>
-            <div className="flex gap-2">
-              <ReputationUserBadge user={hotTake.user} disableTooltip />
-              {(hotTake.user.companies?.length ?? 0) > 0 && (
-                <VerifiedCompanyUserBadge
-                  user={{ companies: hotTake.user.companies }}
-                />
-              )}
-            </div>
-          </div>
-        </a>
-      )}
-    </div>
-  );
+  isLightweightEffects: boolean;
+  prefersReducedMotion: boolean;
 };
 
-const OnboardingPostCard = ({
-  card,
-  isTop,
-  offset,
-  swipeDelta,
-  skipDeltaY = 0,
-  isDismissAnimating,
-  isDragging,
-  dismissDurationMs,
-  useInstantSwipeTransform = false,
-}: {
+const HotTakeCard = React.memo(
+  React.forwardRef<HTMLDivElement, HotTakeCardProps>(function HotTakeCard(
+    {
+      hotTake,
+      isTop,
+      offset,
+      swipeDelta,
+      skipDeltaY = 0,
+      isDismissAnimating,
+      isDragging,
+      dismissDurationMs,
+      isLightweightEffects,
+      prefersReducedMotion,
+    },
+    ref,
+  ): ReactElement {
+    const isSkipAnimating = isTop && isDismissAnimating && skipDeltaY !== 0;
+    const isSkipDragging = isTop && !isDismissAnimating && skipDeltaY < 0;
+    const rotation = isTop ? getSwipeRotation(swipeDelta) : 0;
+    const translateX = isTop ? swipeDelta : 0;
+    const stackScale = isTop ? 1 : 1 - offset * 0.05;
+    const translateY = isTop ? 0 : offset * 8;
+    const getDismissProgress = (): number => {
+      if (!isTop || !isDismissAnimating) {
+        return 0;
+      }
+      if (isSkipAnimating) {
+        return Math.min(Math.abs(skipDeltaY) / SKIP_DISMISS_FLY_DISTANCE, 1);
+      }
+      return Math.min(Math.abs(swipeDelta) / DISMISS_FLY_DISTANCE, 1);
+    };
+    const dismissProgress = getDismissProgress();
+    const scale = isTop ? 1 - dismissProgress * 0.06 : stackScale;
+    const dismissLift = isTop ? dismissProgress * -22 : 0;
+    const translateYWithOutro =
+      translateY + dismissLift + (isTop ? skipDeltaY : 0);
+
+    let skipEffectIntensity = 0;
+    if (isTop) {
+      if (isSkipAnimating) {
+        skipEffectIntensity = dismissProgress;
+      } else if (isSkipDragging) {
+        skipEffectIntensity = getSkipEffectIntensity(skipDeltaY);
+      }
+    }
+    const feedback = getHotTakeFeedbackState({
+      swipeDelta: isTop ? swipeDelta : 0,
+      skipEffectIntensity: isTop ? skipEffectIntensity : 0,
+      isLightweight: isLightweightEffects,
+    });
+    const hotEffectIntensity = quantizeIntensity(feedback.hotEffectIntensity);
+    const coldEffectIntensity = quantizeIntensity(feedback.coldEffectIntensity);
+    const quantizedSkipEffectIntensity = quantizeIntensity(
+      feedback.skipEffectIntensity,
+    );
+    const useLiveIntensity = isTop && isDragging && !isDismissAnimating;
+    const feedbackActive =
+      isTop &&
+      (isDragging ||
+        isDismissAnimating ||
+        hotEffectIntensity > 0 ||
+        coldEffectIntensity > 0 ||
+        quantizedSkipEffectIntensity > 0);
+    let transition =
+      'transform 0.3s ease, border-color 0.2s ease, box-shadow 0.2s ease';
+    if (isTop) {
+      if (isDismissAnimating) {
+        transition = `transform ${dismissDurationMs}ms cubic-bezier(0.16, 0.86, 0.22, 1), opacity ${dismissDurationMs}ms ease-out, filter ${dismissDurationMs}ms ease-out, border-color 0.2s ease, box-shadow 0.2s ease`;
+      } else if (isDragging) {
+        transition = HOT_TAKE_DRAG_TRANSITION;
+      } else {
+        transition = HOT_TAKE_REST_TRANSITION;
+      }
+    }
+
+    return (
+      <div
+        ref={ref}
+        data-testid="hot-take-card"
+        data-active-card={isTop ? 'true' : 'false'}
+        className={classNames(
+          'absolute inset-0 flex select-none flex-col rounded-16 border border-border-subtlest-tertiary bg-background-subtle shadow-2',
+          !isTop && 'pointer-events-none',
+        )}
+        style={
+          {
+            '--hot-take-hot-intensity': hotEffectIntensity,
+            '--hot-take-cold-intensity': coldEffectIntensity,
+            '--hot-take-skip-intensity': quantizedSkipEffectIntensity,
+            transform: `translateX(${translateX}px) translateY(${translateYWithOutro}px) rotate(${rotation}deg) scale(${scale})`,
+            zIndex: 10 - offset,
+            transition,
+            opacity: isTop ? 1 - dismissProgress * 0.75 : 1,
+            filter:
+              isTop && isDismissAnimating
+                ? `blur(${dismissProgress * 1.8}px)`
+                : undefined,
+            borderColor: feedback.activeBorderColor,
+            boxShadow: feedback.activeBoxShadow,
+            willChange: useLiveIntensity ? 'transform' : undefined,
+          } as CSSPropertiesWithVars
+        }
+      >
+        <HotSwipeEffectLayer
+          active={feedbackActive}
+          intensity={hotEffectIntensity}
+          lightweight={isLightweightEffects}
+          reducedMotion={prefersReducedMotion}
+          useLiveIntensity={useLiveIntensity}
+        />
+        <ColdSwipeEffectLayer
+          active={feedbackActive}
+          intensity={coldEffectIntensity}
+          lightweight={isLightweightEffects}
+          reducedMotion={prefersReducedMotion}
+          useLiveIntensity={useLiveIntensity}
+        />
+        <SkipSwipeEffectLayer
+          active={feedbackActive}
+          intensity={quantizedSkipEffectIntensity}
+          lightweight={isLightweightEffects}
+          reducedMotion={prefersReducedMotion}
+          useLiveIntensity={useLiveIntensity}
+        />
+        <HotTakeFeedbackBadges
+          active={feedbackActive}
+          hotIntensity={hotEffectIntensity}
+          coldIntensity={coldEffectIntensity}
+          skipIntensity={quantizedSkipEffectIntensity}
+          useLiveIntensity={useLiveIntensity}
+        />
+
+        <div className="relative flex min-h-0 flex-1 flex-col items-center justify-center gap-3 overflow-y-auto break-words p-6">
+          <div className="flex size-16 items-center justify-center rounded-16 bg-overlay-quaternary-cabbage text-[2.5rem]">
+            {hotTake.emoji}
+          </div>
+
+          <Typography
+            type={TypographyType.Title3}
+            color={TypographyColor.Primary}
+            bold
+            className="w-full break-words text-center"
+          >
+            {hotTake.title}
+          </Typography>
+
+          {hotTake.subtitle && (
+            <Typography
+              type={TypographyType.Body}
+              color={TypographyColor.Tertiary}
+              className="w-full break-words text-center"
+            >
+              {hotTake.subtitle}
+            </Typography>
+          )}
+
+          {hotTake.upvotes > 0 && (
+            <div className="flex items-center gap-1 rounded-10 bg-surface-hover px-3 py-1">
+              <HotIcon className="text-accent-cabbage-default" />
+              <Typography
+                type={TypographyType.Footnote}
+                color={TypographyColor.Secondary}
+                bold
+              >
+                {hotTake.upvotes}
+              </Typography>
+            </div>
+          )}
+        </div>
+
+        {hotTake.user && (
+          <a
+            href={hotTake.user.permalink}
+            className="relative flex items-center gap-3 border-t border-border-subtlest-tertiary p-4 hover:bg-surface-hover"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <ProfilePicture
+              user={hotTake.user}
+              size={ProfileImageSize.Large}
+              nativeLazyLoading
+            />
+            <div className="flex min-w-0 flex-1 flex-col">
+              <div className="flex min-w-0 items-center gap-1">
+                <span className="min-w-0 truncate font-bold typo-callout">
+                  {hotTake.user.name}
+                </span>
+                {hotTake.user.isPlus && (
+                  <PlusUserBadge
+                    user={{ isPlus: hotTake.user.isPlus }}
+                    tooltip={false}
+                  />
+                )}
+                <span className="min-w-0 truncate text-text-tertiary typo-footnote">
+                  @{hotTake.user.username}
+                </span>
+              </div>
+              <div className="flex gap-2">
+                <ReputationUserBadge user={hotTake.user} disableTooltip />
+                {(hotTake.user.companies?.length ?? 0) > 0 && (
+                  <VerifiedCompanyUserBadge
+                    user={{ companies: hotTake.user.companies }}
+                  />
+                )}
+              </div>
+            </div>
+          </a>
+        )}
+      </div>
+    );
+  }),
+);
+
+type OnboardingPostCardProps = {
   card: OnboardingSwipeCard;
   isTop: boolean;
   offset: number;
@@ -1400,157 +2178,201 @@ const OnboardingPostCard = ({
   isDragging: boolean;
   dismissDurationMs: number;
   useInstantSwipeTransform?: boolean;
-}): ReactElement => {
-  const sourceName = card.source?.name || 'daily.dev';
-  const sourceImage = card.source?.image;
-  const isSkipAnimating = isTop && isDismissAnimating && skipDeltaY !== 0;
-  let swipeDirection: 'left' | 'right' | null = null;
-  if (isTop && Math.abs(swipeDelta) > 20) {
-    swipeDirection = swipeDelta > 0 ? 'right' : 'left';
-  }
-  const swipeIntensity = isTop
-    ? Math.min(Math.abs(swipeDelta) / SWIPE_THRESHOLD, 1)
-    : 0;
-  const rotation = isTop ? Math.max(Math.min(swipeDelta * 0.08, 18), -18) : 0;
-  const translateX = isTop ? swipeDelta : 0;
-  const stackScale = isTop ? 1 : 1 - offset * 0.05;
-  const translateY = isTop ? 0 : offset * 8;
-  const dismissDistance = isSkipAnimating
-    ? SKIP_DISMISS_FLY_DISTANCE
-    : DISMISS_FLY_DISTANCE;
-  const dismissProgress =
-    isTop && isDismissAnimating
-      ? Math.min(
-          Math.abs(isSkipAnimating ? skipDeltaY : swipeDelta) / dismissDistance,
-          1,
-        )
-      : 0;
-  const swipeFadeProgress =
-    isTop && (isDragging || isDismissAnimating)
-      ? Math.min(Math.abs(swipeDelta) / ONBOARDING_SWIPE_FADE_DISTANCE, 1)
-      : 0;
-  const scale = isTop ? 1 - dismissProgress * 0.06 : stackScale;
-  const dismissLift = isTop ? dismissProgress * -22 : 0;
-  const translateYWithOutro =
-    translateY + dismissLift + (isTop ? skipDeltaY : 0);
-
-  let transition =
-    'transform 0.3s ease, opacity 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease';
-  if (isTop) {
-    if (isDismissAnimating) {
-      transition = `transform ${dismissDurationMs}ms cubic-bezier(0.16, 0.86, 0.22, 1), opacity ${dismissDurationMs}ms ease-out, filter ${dismissDurationMs}ms ease-out`;
-    } else if (isDragging || useInstantSwipeTransform) {
-      transition = 'none';
-    } else {
-      transition = 'transform 0.28s cubic-bezier(0.22, 1, 0.36, 1)';
-    }
-  }
-
-  let sourceAvatar: ReactElement;
-  if (sourceImage) {
-    sourceAvatar = (
-      <img
-        alt={`${sourceName} source icon`}
-        className="size-6 rounded-full object-cover"
-        draggable={false}
-        src={sourceImage}
-      />
-    );
-  } else if (sourceName === 'daily.dev') {
-    sourceAvatar = (
-      <div
-        role="img"
-        aria-label="daily.dev source icon"
-        className="flex size-6 items-center justify-center rounded-full bg-surface-hover"
-      >
-        <LogoIcon className={{ container: 'h-2.5 w-auto' }} />
-      </div>
-    );
-  } else {
-    sourceAvatar = <div className="size-6 rounded-full bg-surface-hover" />;
-  }
-
-  return (
-    <div
-      className={classNames(
-        'flex min-h-0 w-full select-none flex-col overflow-hidden rounded-16',
-        isTop
-          ? 'relative border border-border-subtlest-tertiary bg-background-popover'
-          : 'pointer-events-none absolute left-0 right-0 top-0 bg-background-default',
-        isTop && 'cursor-grab active:cursor-grabbing',
-      )}
-      onDragStart={(event) => event.preventDefault()}
-      style={{
-        height: ONBOARDING_POST_CARD_HEIGHT,
-        transform: `translateX(${translateX}px) translateY(${translateYWithOutro}px) rotate(${rotation}deg) scale(${scale})`,
-        zIndex: 10 - offset,
-        transition,
-        opacity: isTop ? 1 - swipeFadeProgress : 1,
-        filter:
-          isTop && isDismissAnimating
-            ? `blur(${dismissProgress * 1.8}px)`
-            : undefined,
-        boxShadow: isTop
-          ? '0 1.25rem 2.75rem -0.75rem rgba(0, 0, 0, 0.45)'
-          : '0 0.75rem 1.75rem -0.75rem rgba(0, 0, 0, 0.32)',
-      }}
-    >
-      <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
-        <div className="flex shrink-0 items-center justify-between gap-3">
-          <div className="flex min-w-0 items-center gap-2">
-            {sourceAvatar}
-            <Typography
-              type={TypographyType.Footnote}
-              color={TypographyColor.Secondary}
-              className="min-w-0 truncate"
-              bold
-            >
-              {sourceName}
-            </Typography>
-          </div>
-          {swipeDirection ? (
-            <div
-              className={classNames(
-                'shrink-0 rounded-10 px-3 py-1 font-bold text-white typo-callout',
-                swipeDirection === 'right'
-                  ? 'bg-accent-avocado-default'
-                  : 'bg-accent-bacon-default',
-              )}
-              style={{ opacity: swipeIntensity }}
-            >
-              {swipeDirection === 'right' ? 'Good' : 'Meh'}
-            </div>
-          ) : null}
-        </div>
-        <div
-          className="shrink-0"
-          style={{ minHeight: ONBOARDING_CARD_TITLE_MIN_HEIGHT }}
-        >
-          <Typography
-            type={TypographyType.Title3}
-            color={TypographyColor.Primary}
-            className="line-clamp-3 text-balance"
-            bold
-          >
-            {card.title || 'Popular developer story'}
-          </Typography>
-        </div>
-        {card.tags && card.tags.length > 0 && (
-          <div className="flex shrink-0 flex-wrap gap-1.5">
-            {card.tags.slice(0, 5).map((tag) => (
-              <span
-                key={tag}
-                className="rounded-8 bg-surface-hover px-2 py-0.5 text-text-tertiary typo-footnote"
-              >
-                {tag}
-              </span>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  );
 };
+
+const OnboardingPostCard = React.memo(
+  React.forwardRef<HTMLDivElement, OnboardingPostCardProps>(
+    function OnboardingPostCard(
+      {
+        card,
+        isTop,
+        offset,
+        swipeDelta,
+        skipDeltaY = 0,
+        isDismissAnimating,
+        isDragging,
+        dismissDurationMs,
+        useInstantSwipeTransform = false,
+      },
+      ref,
+    ): ReactElement {
+      const sourceName = card.source?.name || 'daily.dev';
+      const sourceImage = card.source?.image;
+      const isSkipAnimating = isTop && isDismissAnimating && skipDeltaY !== 0;
+      const swipeDirection = isTop
+        ? getSwipeDirectionFromDelta(swipeDelta)
+        : null;
+      const swipeIntensity = isTop ? getSwipeIntensity(swipeDelta) : 0;
+      const rotation = isTop ? getSwipeRotation(swipeDelta) : 0;
+      const translateX = isTop ? swipeDelta : 0;
+      const stackScale = isTop ? 1 : 1 - offset * 0.05;
+      const translateY = isTop ? 0 : offset * 8;
+      const dismissDistance = isSkipAnimating
+        ? SKIP_DISMISS_FLY_DISTANCE
+        : DISMISS_FLY_DISTANCE;
+      const dismissProgress =
+        isTop && isDismissAnimating
+          ? Math.min(
+              Math.abs(isSkipAnimating ? skipDeltaY : swipeDelta) /
+                dismissDistance,
+              1,
+            )
+          : 0;
+      const swipeFadeProgress =
+        isTop && (isDragging || isDismissAnimating)
+          ? Math.min(Math.abs(swipeDelta) / ONBOARDING_SWIPE_FADE_DISTANCE, 1)
+          : 0;
+      const scale = isTop ? 1 - dismissProgress * 0.06 : stackScale;
+      const dismissLift = isTop ? dismissProgress * -22 : 0;
+      const translateYWithOutro =
+        translateY + dismissLift + (isTop ? skipDeltaY : 0);
+
+      let transition =
+        'transform 0.3s ease, opacity 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease';
+      if (isTop) {
+        if (isDismissAnimating) {
+          transition = `transform ${dismissDurationMs}ms cubic-bezier(0.16, 0.86, 0.22, 1), opacity ${dismissDurationMs}ms ease-out, filter ${dismissDurationMs}ms ease-out`;
+        } else if (isDragging || useInstantSwipeTransform) {
+          transition = ONBOARDING_DRAG_TRANSITION;
+        } else {
+          transition = ONBOARDING_REST_TRANSITION;
+        }
+      }
+      const useLiveSwipeIntensity = isTop && isDragging && !isDismissAnimating;
+      const leftBadgeIntensity = swipeDirection === 'left' ? swipeIntensity : 0;
+      const rightBadgeIntensity =
+        swipeDirection === 'right' ? swipeIntensity : 0;
+      const leftBadgeOpacity = useLiveSwipeIntensity
+        ? ONBOARDING_LEFT_BADGE_INTENSITY_VAR
+        : leftBadgeIntensity;
+      const rightBadgeOpacity = useLiveSwipeIntensity
+        ? ONBOARDING_RIGHT_BADGE_INTENSITY_VAR
+        : rightBadgeIntensity;
+      const showSwipeBadge =
+        isTop &&
+        (isDragging ||
+          leftBadgeIntensity > 0 ||
+          rightBadgeIntensity > 0 ||
+          isDismissAnimating);
+
+      let sourceAvatar: ReactElement;
+      if (sourceImage) {
+        sourceAvatar = (
+          <img
+            alt={`${sourceName} source icon`}
+            className="size-6 rounded-full object-cover"
+            draggable={false}
+            src={sourceImage}
+          />
+        );
+      } else if (sourceName === 'daily.dev') {
+        sourceAvatar = (
+          <div
+            role="img"
+            aria-label="daily.dev source icon"
+            className="flex size-6 items-center justify-center rounded-full bg-surface-hover"
+          >
+            <LogoIcon className={{ container: 'h-2.5 w-auto' }} />
+          </div>
+        );
+      } else {
+        sourceAvatar = <div className="size-6 rounded-full bg-surface-hover" />;
+      }
+
+      return (
+        <div
+          ref={ref}
+          data-testid="onboarding-post-card"
+          data-active-card={isTop ? 'true' : 'false'}
+          className={classNames(
+            'flex min-h-0 w-full select-none flex-col overflow-hidden rounded-16',
+            isTop
+              ? 'relative border border-border-subtlest-tertiary bg-background-popover'
+              : 'pointer-events-none absolute left-0 right-0 top-0 bg-background-default',
+            isTop && 'cursor-grab active:cursor-grabbing',
+          )}
+          onDragStart={(event) => event.preventDefault()}
+          style={
+            {
+              '--onboarding-swipe-left-badge-intensity': leftBadgeIntensity,
+              '--onboarding-swipe-right-badge-intensity': rightBadgeIntensity,
+              height: ONBOARDING_POST_CARD_HEIGHT,
+              transform: `translateX(${translateX}px) translateY(${translateYWithOutro}px) rotate(${rotation}deg) scale(${scale})`,
+              zIndex: 10 - offset,
+              transition,
+              opacity: isTop ? 1 - swipeFadeProgress : 1,
+              filter:
+                isTop && isDismissAnimating
+                  ? `blur(${dismissProgress * 1.8}px)`
+                  : undefined,
+              boxShadow: isTop
+                ? '0 1.25rem 2.75rem -0.75rem rgba(0, 0, 0, 0.45)'
+                : '0 0.75rem 1.75rem -0.75rem rgba(0, 0, 0, 0.32)',
+              willChange: useLiveSwipeIntensity ? 'transform' : undefined,
+            } as CSSPropertiesWithVars
+          }
+        >
+          <div className="flex min-h-0 flex-1 flex-col gap-4 p-4">
+            <div className="flex shrink-0 items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-2">
+                {sourceAvatar}
+                <Typography
+                  type={TypographyType.Footnote}
+                  color={TypographyColor.Secondary}
+                  className="min-w-0 truncate"
+                  bold
+                >
+                  {sourceName}
+                </Typography>
+              </div>
+              {showSwipeBadge ? (
+                <div className="relative h-7 w-16 shrink-0">
+                  <div
+                    className="absolute inset-0 rounded-10 bg-accent-avocado-default px-3 py-1 text-center font-bold text-white typo-callout"
+                    style={{ opacity: rightBadgeOpacity }}
+                  >
+                    Good
+                  </div>
+                  <div
+                    className="absolute inset-0 rounded-10 bg-accent-bacon-default px-3 py-1 text-center font-bold text-white typo-callout"
+                    style={{ opacity: leftBadgeOpacity }}
+                  >
+                    Meh
+                  </div>
+                </div>
+              ) : null}
+            </div>
+            <div
+              className="shrink-0"
+              style={{ minHeight: ONBOARDING_CARD_TITLE_MIN_HEIGHT }}
+            >
+              <Typography
+                type={TypographyType.Title3}
+                color={TypographyColor.Primary}
+                className="line-clamp-3 text-balance"
+                bold
+              >
+                {card.title || 'Popular developer story'}
+              </Typography>
+            </div>
+            {card.tags && card.tags.length > 0 && (
+              <div className="flex shrink-0 flex-wrap gap-1.5">
+                {card.tags.slice(0, 5).map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-8 bg-surface-hover px-2 py-0.5 text-text-tertiary typo-footnote"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    },
+  ),
+);
 
 const OnboardingFeedEmptyState = ({
   onRetry,
@@ -1704,10 +2526,18 @@ const HotAndColdModal = ({
   const { toggleUpvote, toggleDownvote, cancelHotTakeVote } = useVoteHotTake();
   const { logEvent } = useLogContext();
   const { user } = useAuthContext();
+  const isMobileViewport = useViewSize(ViewSize.MobileL);
+  const prefersReducedMotion = useMedia(
+    PREFERS_REDUCED_MOTION_QUERY,
+    MATCHED_MEDIA_VALUES,
+    false,
+  );
+  const isLightweightEffects = isMobileViewport || prefersReducedMotion;
   const [swipeDelta, setSwipeDelta] = useState(0);
   const swipeDeltaRef = useRef(0);
   const [isAnimating, setIsAnimating] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
+  const isDraggingRef = useRef(false);
   const [dismissDurationMs, setDismissDurationMs] =
     useState(DISMISS_ANIMATION_MS);
   const [animatingTakeId, setAnimatingTakeId] = useState<string | null>(null);
@@ -1716,6 +2546,15 @@ const HotAndColdModal = ({
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [skipDelta, setSkipDelta] = useState(0);
   const swipeDeltaYRef = useRef(0);
+  const activeCardRef = useRef<HTMLDivElement | null>(null);
+  const swipeAreaRef = useRef<HTMLDivElement | null>(null);
+  const swipeFrameRef = useRef<{
+    swipeDelta: number;
+    skipDeltaY: number;
+    isHotTake: boolean;
+    isLightweight: boolean;
+  } | null>(null);
+  const swipeFrameRafRef = useRef<number | null>(null);
   const [internalDismissedCardIds, setInternalDismissedCardIds] = useState<
     Set<string>
   >(() => new Set<string>());
@@ -1764,19 +2603,121 @@ const HotAndColdModal = ({
     ? ONBOARDING_SWIPE_AREA_HEIGHT
     : HOT_TAKE_CARD_HEIGHT;
 
+  const cancelQueuedSwipeFrame = useCallback(() => {
+    if (swipeFrameRafRef.current === null) {
+      return;
+    }
+
+    cancelSwipeAnimationFrame(swipeFrameRafRef.current);
+    swipeFrameRafRef.current = null;
+    swipeFrameRef.current = null;
+  }, []);
+
+  const clearActiveCardSwipeStyles = useCallback(
+    ({ snapToRest }: { snapToRest: boolean }) => {
+      const element = activeCardRef.current;
+      if (!element) {
+        return;
+      }
+
+      element.style.removeProperty('will-change');
+      if (snapToRest) {
+        element.style.setProperty(
+          'transition',
+          isOnboardingMode
+            ? ONBOARDING_REST_TRANSITION
+            : HOT_TAKE_REST_TRANSITION,
+        );
+        element.style.setProperty(
+          'transform',
+          'translateX(0px) translateY(0px) rotate(0deg) scale(1)',
+        );
+      }
+
+      if (isOnboardingMode) {
+        clearOnboardingFeedbackStyles({
+          element,
+          swipeAreaElement: swipeAreaRef.current,
+        });
+        return;
+      }
+
+      clearHotTakeFeedbackStyles(element);
+    },
+    [isOnboardingMode],
+  );
+
+  const queueActiveSwipeFrame = useCallback(
+    ({
+      nextSwipeDelta,
+      nextSkipDelta,
+    }: {
+      nextSwipeDelta: number;
+      nextSkipDelta: number;
+    }) => {
+      swipeFrameRef.current = {
+        swipeDelta: nextSwipeDelta,
+        skipDeltaY: nextSkipDelta,
+        isHotTake: !isOnboardingMode,
+        isLightweight: isLightweightEffects,
+      };
+
+      if (swipeFrameRafRef.current !== null) {
+        return;
+      }
+
+      swipeFrameRafRef.current = requestSwipeAnimationFrame(() => {
+        swipeFrameRafRef.current = null;
+        const frame = swipeFrameRef.current;
+        const element = activeCardRef.current;
+        if (!frame || !element || !isDraggingRef.current) {
+          return;
+        }
+
+        applyActiveSwipeFrame({
+          element,
+          swipeAreaElement: swipeAreaRef.current,
+          swipeDelta: frame.swipeDelta,
+          skipDeltaY: frame.skipDeltaY,
+          isHotTake: frame.isHotTake,
+          isLightweight: frame.isLightweight,
+        });
+      });
+    },
+    [isLightweightEffects, isOnboardingMode],
+  );
+
+  const finishDrag = useCallback(
+    ({ snapToRest }: { snapToRest: boolean }) => {
+      cancelQueuedSwipeFrame();
+      isDraggingRef.current = false;
+      setIsDragging(false);
+      clearActiveCardSwipeStyles({ snapToRest });
+    },
+    [cancelQueuedSwipeFrame, clearActiveCardSwipeStyles],
+  );
+
   useEffect(() => {
     animatingTakeIdRef.current = animatingTakeId;
   }, [animatingTakeId]);
 
   useEffect(() => {
     if (!isAnimating) {
+      cancelQueuedSwipeFrame();
       setSwipeDelta(0);
       swipeDeltaRef.current = 0;
       setSkipDelta(0);
       swipeDeltaYRef.current = 0;
+      isDraggingRef.current = false;
       setIsDragging(false);
+      clearActiveCardSwipeStyles({ snapToRest: true });
     }
-  }, [currentTake?.id, isAnimating]);
+  }, [
+    cancelQueuedSwipeFrame,
+    clearActiveCardSwipeStyles,
+    currentTake?.id,
+    isAnimating,
+  ]);
 
   useEffect(() => {
     return () => {
@@ -1786,8 +2727,9 @@ const HotAndColdModal = ({
       if (dismissTimerRef.current) {
         clearTimeout(dismissTimerRef.current);
       }
+      cancelQueuedSwipeFrame();
     };
-  }, []);
+  }, [cancelQueuedSwipeFrame]);
 
   useEffect(() => {
     if (
@@ -1873,6 +2815,8 @@ const HotAndColdModal = ({
     }
 
     abortOnboardingIntro();
+    cancelQueuedSwipeFrame();
+    clearActiveCardSwipeStyles({ snapToRest: false });
 
     if (flyTimerRef.current) {
       clearTimeout(flyTimerRef.current);
@@ -1887,12 +2831,18 @@ const HotAndColdModal = ({
     setAnimatingTakeId(null);
     setDismissDurationMs(DISMISS_ANIMATION_MS);
     setIsAnimating(false);
+    isDraggingRef.current = false;
     setIsDragging(false);
     setSwipeDelta(0);
     swipeDeltaRef.current = 0;
     setSkipDelta(0);
     swipeDeltaYRef.current = 0;
-  }, [hasOnboardingCards, abortOnboardingIntro]);
+  }, [
+    abortOnboardingIntro,
+    cancelQueuedSwipeFrame,
+    clearActiveCardSwipeStyles,
+    hasOnboardingCards,
+  ]);
 
   const startDismissAnimation = useCallback(
     ({
@@ -1912,6 +2862,10 @@ const HotAndColdModal = ({
       if (dismissTimerRef.current) {
         clearTimeout(dismissTimerRef.current);
       }
+
+      cancelQueuedSwipeFrame();
+      isDraggingRef.current = false;
+      clearActiveCardSwipeStyles({ snapToRest: false });
 
       animatingTakeIdRef.current = takeId;
       setAnimatingTakeId(takeId);
@@ -1958,6 +2912,8 @@ const HotAndColdModal = ({
     },
     [
       currentOnboardingCard,
+      cancelQueuedSwipeFrame,
+      clearActiveCardSwipeStyles,
       dismissCurrent,
       hasOnboardingCards,
       onboardingCards,
@@ -1978,6 +2934,7 @@ const HotAndColdModal = ({
       abortOnboardingIntro();
 
       const isButtonSource = source === 'button';
+      const currentSwipeDelta = swipeDeltaRef.current;
       const durationMs = isButtonSource
         ? BUTTON_DISMISS_ANIMATION_MS
         : DISMISS_ANIMATION_MS;
@@ -2021,8 +2978,8 @@ const HotAndColdModal = ({
       } else {
         initialPush =
           direction === 'right'
-            ? Math.max(swipeDelta, SWIPE_THRESHOLD * 1.25)
-            : Math.min(swipeDelta, -SWIPE_THRESHOLD * 1.25);
+            ? Math.max(currentSwipeDelta, SWIPE_THRESHOLD * 1.25)
+            : Math.min(currentSwipeDelta, -SWIPE_THRESHOLD * 1.25);
         flyDistance =
           direction === 'right' ? DISMISS_FLY_DISTANCE : -DISMISS_FLY_DISTANCE;
       }
@@ -2046,7 +3003,6 @@ const HotAndColdModal = ({
       toggleUpvote,
       logEvent,
       onSwipeAction,
-      swipeDelta,
       abortOnboardingIntro,
     ],
   );
@@ -2170,11 +3126,13 @@ const HotAndColdModal = ({
     onboardingIntroDelta !== 0;
 
   const handleSwiped = (direction: 'left' | 'right') => {
-    setIsDragging(false);
+    const currentSwipeDelta = swipeDeltaRef.current;
+    finishDrag({ snapToRest: false });
     setSkipDelta(0);
-    if (Math.abs(swipeDeltaRef.current) > SWIPE_THRESHOLD) {
+    if (Math.abs(currentSwipeDelta) > SWIPE_THRESHOLD) {
       handleDismiss(direction, 'swipe');
     } else {
+      clearActiveCardSwipeStyles({ snapToRest: true });
       setSwipeDelta(0);
       swipeDeltaRef.current = 0;
       swipeDeltaYRef.current = 0;
@@ -2183,31 +3141,39 @@ const HotAndColdModal = ({
 
   const handlers = useSwipeable({
     onSwiping: (e) => {
-      if (!isAnimating) {
-        if (isOnboardingMode && e.event.cancelable) {
-          e.event.preventDefault();
-        }
-        abortOnboardingIntro();
-        setIsDragging(true);
-        setSwipeDelta(e.deltaX);
-        if (
-          !isOnboardingMode &&
-          e.deltaY < 0 &&
-          Math.abs(e.deltaY) > Math.abs(e.deltaX)
-        ) {
-          setSkipDelta(getElasticDelta(e.deltaY));
-        } else {
-          setSkipDelta(0);
-        }
-        swipeDeltaRef.current = e.deltaX;
-        swipeDeltaYRef.current = e.deltaY;
+      if (isAnimating) {
+        return;
       }
+
+      if (isOnboardingMode && e.event.cancelable) {
+        e.event.preventDefault();
+      }
+
+      if (!isDraggingRef.current) {
+        abortOnboardingIntro();
+        isDraggingRef.current = true;
+        setIsDragging(true);
+      }
+
+      const nextSkipDelta =
+        !isOnboardingMode &&
+        e.deltaY < 0 &&
+        Math.abs(e.deltaY) > Math.abs(e.deltaX)
+          ? getElasticDelta(e.deltaY)
+          : 0;
+
+      swipeDeltaRef.current = e.deltaX;
+      swipeDeltaYRef.current = e.deltaY;
+      queueActiveSwipeFrame({
+        nextSwipeDelta: e.deltaX,
+        nextSkipDelta,
+      });
     },
     onSwipedLeft: () => handleSwiped('left'),
     onSwipedRight: () => handleSwiped('right'),
     onSwipedUp: () => {
-      setIsDragging(false);
       if (isOnboardingMode) {
+        finishDrag({ snapToRest: true });
         setSwipeDelta(0);
         swipeDeltaRef.current = 0;
         setSkipDelta(0);
@@ -2218,10 +3184,14 @@ const HotAndColdModal = ({
         swipeDeltaYRef.current < 0 &&
         Math.abs(swipeDeltaYRef.current) > SWIPE_THRESHOLD
       ) {
+        const currentSkipDelta = getElasticDelta(swipeDeltaYRef.current);
+        finishDrag({ snapToRest: false });
         setSwipeDelta(0);
         swipeDeltaRef.current = 0;
+        setSkipDelta(currentSkipDelta);
         handleSkip('swipe');
       } else {
+        finishDrag({ snapToRest: true });
         setSwipeDelta(0);
         swipeDeltaRef.current = 0;
         setSkipDelta(0);
@@ -2232,10 +3202,20 @@ const HotAndColdModal = ({
     preventScrollOnSwipe: true,
     touchEventOptions: { passive: false },
   });
+  const { ref: swipeableRef, ...swipeHandlers } = handlers;
+  const setSwipeAreaRef = useCallback(
+    (element: HTMLDivElement | null) => {
+      swipeAreaRef.current = element;
+      swipeableRef(element);
+    },
+    [swipeableRef],
+  );
 
   const cardSwipeArea = (
     <div
-      {...handlers}
+      {...swipeHandlers}
+      ref={setSwipeAreaRef}
+      data-testid="hot-takes-swipe-area"
       className={classNames(
         'relative touch-none select-none self-center',
         isOnboardingMode
@@ -2243,14 +3223,22 @@ const HotAndColdModal = ({
           : 'mt-4 w-[calc(100%-2rem)]',
       )}
       style={
-        swipeAreaHeight !== undefined ? { height: swipeAreaHeight } : undefined
+        {
+          '--onboarding-swipe-left-intensity': 0,
+          '--onboarding-swipe-right-intensity': 0,
+          '--onboarding-swipe-left-badge-intensity': 0,
+          '--onboarding-swipe-right-badge-intensity': 0,
+          height: swipeAreaHeight,
+        } as CSSPropertiesWithVars
       }
     >
       {isOnboardingMode ? (
         <>
+          <OnboardingBehindParticlesKeyframes />
           <OnboardingSwipeEdgeHalos
             deltaX={combinedOnboardingSwipeX}
             isDragging={isDragging}
+            useLiveIntensity={isDragging && !isCurrentTakeAnimating}
           />
           {nextOnboardingCard && (
             <OnboardingPostCard
@@ -2266,6 +3254,7 @@ const HotAndColdModal = ({
           )}
           {currentOnboardingCard && (
             <OnboardingPostCard
+              ref={activeCardRef}
               key={currentOnboardingCard.id}
               card={currentOnboardingCard}
               isTop
@@ -2278,10 +3267,14 @@ const HotAndColdModal = ({
               useInstantSwipeTransform={onboardingIntroPlaying}
             />
           )}
-          <OnboardingCardBehindParticles />
+          <OnboardingCardBehindParticles
+            lightweight={isLightweightEffects}
+            reducedMotion={prefersReducedMotion}
+          />
         </>
       ) : (
         <>
+          <HotTakeEffectKeyframes />
           {nextTake && (
             <HotTakeCard
               key={nextTake.id}
@@ -2292,10 +3285,13 @@ const HotAndColdModal = ({
               isDismissAnimating={false}
               isDragging={false}
               dismissDurationMs={DISMISS_ANIMATION_MS}
+              isLightweightEffects={isLightweightEffects}
+              prefersReducedMotion={prefersReducedMotion}
             />
           )}
           {currentTake && (
             <HotTakeCard
+              ref={activeCardRef}
               key={currentTake.id}
               hotTake={currentTake}
               isTop
@@ -2305,6 +3301,8 @@ const HotAndColdModal = ({
               isDismissAnimating={isCurrentTakeAnimating}
               isDragging={isDragging}
               dismissDurationMs={dismissDurationMs}
+              isLightweightEffects={isLightweightEffects}
+              prefersReducedMotion={prefersReducedMotion}
             />
           )}
         </>
@@ -2410,8 +3408,7 @@ const HotAndColdModal = ({
 
         {!isModalLoading && !isModalEmpty && isOnboardingMode && (
           <>
-            {/* eslint-disable-next-line react/no-unknown-property -- style tag for scoped onboarding transition */}
-            <style>{ONBOARDING_SCREEN_TRANSITION_KEYFRAMES}</style>
+            <OnboardingScreenTransitionKeyframes />
             <div className="mx-auto flex h-full min-h-0 w-full max-w-[46rem] flex-1 flex-col gap-6 px-4 pb-8 pt-4 tablet:min-h-0 tablet:justify-center tablet:gap-0 tablet:px-6 tablet:pb-8 tablet:pt-4">
               {headerSlot ? (
                 <div className="shrink-0 tablet:hidden">{headerSlot}</div>


### PR DESCRIPTION
## Summary
- Move live Hot Takes drag updates out of the React render loop and into a queued `requestAnimationFrame` DOM style update.
- Memoize and simplify the hot/cold/skip effect rendering while preserving vote, skip, onboarding, and dismiss behavior.
- Use lightweight mobile/reduced-motion effects and avoid expensive backdrop filters on that path.

## Verification
- `pnpm --filter @dailydotdev/shared exec jest src/components/modals/hotTakes/HotAndColdModal.spec.tsx --runInBand`
- `pnpm typecheck:strict:changed`
- `pnpm --filter @dailydotdev/shared exec eslint src/components/modals/hotTakes/HotAndColdModal.tsx src/components/modals/hotTakes/HotAndColdModal.spec.tsx --max-warnings 0`
- `pnpm --filter @dailydotdev/shared exec prettier --check src/components/modals/hotTakes/HotAndColdModal.tsx src/components/modals/hotTakes/HotAndColdModal.spec.tsx`
- `git diff --check`

Closes ENG-1686

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1686-feedback-performance-ho.preview.app.daily.dev