### PR TITLE
feat(feed): content-visibility experiment for long feeds

### DIFF
--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { CSSProperties, ReactElement, ReactNode } from 'react';
 import React, {
   useRef,
   useEffect,
@@ -58,6 +58,7 @@ import { FeedCardContext } from '../features/posts/FeedCardContext';
 import {
   briefCardFeedFeature,
   featureFeedAdTemplate,
+  featureFeedContentVisibility,
 } from '../lib/featureManagement';
 import { useHasIntroQuests } from '../hooks/useHasIntroQuests';
 import type { AwardProps } from '../graphql/njord';
@@ -308,6 +309,27 @@ export default function Feed<T>({
   const { onMenuClick, postMenuIndex, postMenuLocation } = useFeedContextMenu();
   const useList = isListMode && numCards > 1;
   const virtualizedNumCards = useList ? 1 : numCards;
+
+  // Experiment: let the browser skip layout/paint for off-screen cards on long
+  // vertical feeds. Horizontal carousels are short and scroll on the other axis,
+  // so they get no benefit and are excluded from evaluation.
+  const { value: feedContentVisibility } = useConditionalFeature({
+    feature: featureFeedContentVisibility,
+    shouldEvaluate: !isHorizontal,
+  });
+  const useContentVisibility = feedContentVisibility && !isHorizontal;
+  // `contain-intrinsic-size: auto <estimate>` reserves height for skipped cards
+  // so the scrollbar stays stable; `auto` makes the browser remember each card's
+  // real size after its first paint, so the estimate only matters for cards not
+  // yet rendered. Grid cards use the `min-h-card` baseline; list cards are shorter.
+  const contentVisibilityStyle: CSSProperties | undefined = useContentVisibility
+    ? {
+        contentVisibility: 'auto',
+        containIntrinsicSize: shouldUseListFeedLayout
+          ? 'auto 12rem'
+          : 'auto 24rem',
+      }
+    : undefined;
   const {
     onOpenModal,
     onCloseModal,
@@ -675,7 +697,7 @@ export default function Feed<T>({
                 isWidened && (colSpan === 2 || colSpan === 3 || colSpan === 4)
                   ? (colSpan as FeaturedWideColSpan)
                   : undefined;
-              const itemNode = (
+              const itemNode: ReactElement = (
                 <FeedItemComponent
                   item={item}
                   index={index}
@@ -702,6 +724,37 @@ export default function Feed<T>({
                 />
               );
 
+              let renderedItem = itemNode;
+              if (isWidened) {
+                renderedItem = (
+                  <div
+                    className="flex h-full w-full [&>*]:h-full [&>*]:w-full"
+                    style={{
+                      gridColumn: `span ${colSpan}`,
+                      ...contentVisibilityStyle,
+                    }}
+                    data-testid="feedItemColSpanWrapper"
+                  >
+                    {itemNode}
+                  </div>
+                );
+              } else if (useContentVisibility) {
+                // List cards stack at natural height; grid cards must keep
+                // filling their equal-height row, so preserve the h-full pass-through.
+                renderedItem = (
+                  <div
+                    className={
+                      shouldUseListFeedLayout
+                        ? 'w-full'
+                        : 'flex h-full w-full [&>*]:h-full [&>*]:w-full'
+                    }
+                    style={contentVisibilityStyle}
+                  >
+                    {itemNode}
+                  </div>
+                );
+              }
+
               return (
                 <FeedCardContext.Provider
                   key={getFeedItemKey(item, index)}
@@ -720,17 +773,7 @@ export default function Feed<T>({
                       }}
                     />
                   )}
-                  {isWidened ? (
-                    <div
-                      className="flex h-full w-full [&>*]:h-full [&>*]:w-full"
-                      style={{ gridColumn: `span ${colSpan}` }}
-                      data-testid="feedItemColSpanWrapper"
-                    >
-                      {itemNode}
-                    </div>
-                  ) : (
-                    itemNode
-                  )}
+                  {renderedItem}
                 </FeedCardContext.Provider>
               );
             })}

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -251,6 +251,13 @@ export const featureOnboardingPermissionPrimer = new Feature(
 
 export const featureAuthGoogleOneTap = new Feature('auth_google_onetap', false);
 
+// Experiment: skip layout/paint for off-screen feed cards via CSS
+// `content-visibility: auto` to keep long feeds responsive.
+export const featureFeedContentVisibility = new Feature(
+  'feed_content_visibility',
+  false,
+);
+
 export const featurePublicSignupBanner = new Feature(
   'public_signup_banner',
   false,


### PR DESCRIPTION
## What
Experiment (`feed_content_visibility`, GrowthBook, default `false`) that adds `content-visibility: auto` + `contain-intrinsic-size` to feed cards so the browser skips layout/paint for off-screen cards on long vertical feeds.

## Why
Reports of long feeds becoming slow/unresponsive after scrolling through many posts (ENG-1676, ENG-1681). At ~1000 posts the entire flattened list is in the DOM with no virtualization, so every scroll frame pays layout+paint across all cards. This bounds the **render** cost at minimal risk without rewriting the col-span grid or scroll logic.

## Notes
- Control is unchanged: when the flag is off (or feed is horizontal), non-widened items render bare as today — the wrapper only appears in the variant.
- Grid cards keep the `h-full` equal-height-row pass-through; list cards stack at natural height.
- Bounds render cost, **not** memory — DOM nodes still accumulate. If iOS "refreshes to top" turns out to be OOM rather than CPU jank, escalate to row virtualization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://feat-content-visibility-feed.preview.app.daily.dev