### PR TITLE
fix(daily): show feed card glass actions instantly

### DIFF
--- a/packages/shared/src/components/buttons/ToggleGlassActionsExpanded.tsx
+++ b/packages/shared/src/components/buttons/ToggleGlassActionsExpanded.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { ButtonProps } from './Button';
+import { Button, ButtonSize, ButtonVariant } from './Button';
+import { LayoutIcon } from '../icons';
+import type { IconSize } from '../Icon';
+import { Tooltip } from '../tooltip/Tooltip';
+import { useLayoutVariant } from '../../hooks/layout/useLayoutVariant';
+import { useFeedCardGlassActions } from '../../hooks/useFeedCardGlassActions';
+import { useGlassActionsExpanded } from '../../hooks/useGlassActionsExpanded';
+
+export const ToggleGlassActionsExpanded = ({
+  buttonProps = {},
+  iconSize,
+}: {
+  buttonProps?: ButtonProps<'button'>;
+  iconSize?: IconSize;
+}): ReactElement | null => {
+  const glassActions = useFeedCardGlassActions();
+  const [expanded, setExpanded] = useGlassActionsExpanded();
+  const { isV2 } = useLayoutVariant();
+
+  if (!glassActions) {
+    return null;
+  }
+
+  const icon = <LayoutIcon secondary={expanded} size={iconSize} />;
+
+  return (
+    <Tooltip
+      side="bottom"
+      content={`${expanded ? 'Hide' : 'Always show'} post actions`}
+    >
+      <Button
+        size={ButtonSize.Medium}
+        variant={isV2 ? ButtonVariant.Tertiary : ButtonVariant.Float}
+        {...buttonProps}
+        pressed={expanded}
+        icon={icon}
+        onClick={() => setExpanded(!expanded)}
+      />
+    </Tooltip>
+  );
+};

--- a/packages/shared/src/components/cards/ad/AdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/AdGrid.tsx
@@ -56,7 +56,6 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
         ) : null}
         <AdAttribution className={{ main: 'font-normal' }} />
       </CardTextContainer>
-      <AdImage className="mx-1 mb-0" ad={ad} ImageComponent={CardImage} />
       <CardTextContainer className="!mx-1 my-1">
         <div className="flex items-center">
           {!!ad.callToAction && (
@@ -89,6 +88,7 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
           </div>
         </div>
       </CardTextContainer>
+      <AdImage className="mx-1 mb-0" ad={ad} ImageComponent={CardImage} />
       <AdPixel pixel={ad.pixel} />
     </Card>
   );

--- a/packages/shared/src/components/cards/article/ArticleGrid.tsx
+++ b/packages/shared/src/components/cards/article/ArticleGrid.tsx
@@ -140,7 +140,9 @@ export const ArticleGrid = forwardRef(function ArticleGrid(
             showFeedback={showFeedback}
           />
           <CardTitle
-            lineClamp={showFeedback || glassActions ? 'line-clamp-2' : undefined}
+            lineClamp={
+              showFeedback || glassActions ? 'line-clamp-2' : undefined
+            }
           >
             {title}
           </CardTitle>

--- a/packages/shared/src/components/cards/article/ArticleGrid.tsx
+++ b/packages/shared/src/components/cards/article/ArticleGrid.tsx
@@ -31,7 +31,6 @@ import { FeedbackGrid } from './feedback/FeedbackGrid';
 import { ClickbaitShield } from '../common/ClickbaitShield';
 import { useSmartTitle } from '../../../hooks/post/useSmartTitle';
 import { useFeedCardGlassActions } from '../../../hooks/useFeedCardGlassActions';
-import { useGlassActionsExpanded } from '../../../hooks/useGlassActionsExpanded';
 
 export const ArticleGrid = forwardRef(function ArticleGrid(
   {
@@ -62,7 +61,6 @@ export const ArticleGrid = forwardRef(function ArticleGrid(
   const { title } = useSmartTitle(post);
   const isVideoType = isVideoPost(post);
   const glassActions = useFeedCardGlassActions();
-  const [glassActionsExpanded] = useGlassActionsExpanded();
 
   if (isHidden) {
     return (
@@ -187,7 +185,6 @@ export const ArticleGrid = forwardRef(function ArticleGrid(
                 onBookmarkClick={onBookmarkClick}
                 onDownvoteClick={onDownvoteClick}
                 coverScrim
-                expanded={glassActionsExpanded}
               />
             ) : (
               <ActionButtons

--- a/packages/shared/src/components/cards/article/ArticleGrid.tsx
+++ b/packages/shared/src/components/cards/article/ArticleGrid.tsx
@@ -31,6 +31,7 @@ import { FeedbackGrid } from './feedback/FeedbackGrid';
 import { ClickbaitShield } from '../common/ClickbaitShield';
 import { useSmartTitle } from '../../../hooks/post/useSmartTitle';
 import { useFeedCardGlassActions } from '../../../hooks/useFeedCardGlassActions';
+import { useGlassActionsExpanded } from '../../../hooks/useGlassActionsExpanded';
 
 export const ArticleGrid = forwardRef(function ArticleGrid(
   {
@@ -61,6 +62,7 @@ export const ArticleGrid = forwardRef(function ArticleGrid(
   const { title } = useSmartTitle(post);
   const isVideoType = isVideoPost(post);
   const glassActions = useFeedCardGlassActions();
+  const [glassActionsExpanded] = useGlassActionsExpanded();
 
   if (isHidden) {
     return (
@@ -137,7 +139,9 @@ export const ArticleGrid = forwardRef(function ArticleGrid(
             onReadArticleClick={onReadArticleClick}
             showFeedback={showFeedback}
           />
-          <CardTitle lineClamp={showFeedback ? 'line-clamp-2' : undefined}>
+          <CardTitle
+            lineClamp={showFeedback || glassActions ? 'line-clamp-2' : undefined}
+          >
             {title}
           </CardTitle>
         </CardTextContainer>
@@ -181,6 +185,7 @@ export const ArticleGrid = forwardRef(function ArticleGrid(
                 onBookmarkClick={onBookmarkClick}
                 onDownvoteClick={onDownvoteClick}
                 coverScrim
+                expanded={glassActionsExpanded}
               />
             ) : (
               <ActionButtons

--- a/packages/shared/src/components/cards/common/CardCoverShare.tsx
+++ b/packages/shared/src/components/cards/common/CardCoverShare.tsx
@@ -26,7 +26,10 @@ export function CardCoverShare({
   };
 
   return (
-    <CardCoverContainer title="Should anyone else see this post?">
+    <CardCoverContainer
+      title="Should anyone else see this post?"
+      className="pb-12"
+    >
       <span className="mt-2 flex flex-row flex-wrap justify-center gap-3 p-2">
         <Button
           variant={ButtonVariant.Secondary}

--- a/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
+++ b/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
@@ -23,12 +23,13 @@ import { useCardActions } from '../../../hooks/cards/useCardActions';
 export const glassCoverImageClassName =
   '!px-0 !mb-0 !rounded-t-none !rounded-b-16';
 
-// Positioning grid: track 1 holds the pill, track 2 is a spacer. The fr split
-// flips the pill between content-hugging and full width on hover — no transition
-// so it appears instantly.
-const outerClasses = classNames(
-  'pointer-events-none absolute inset-x-2 bottom-2 z-1 grid',
-  '[grid-template-columns:1fr_0fr]',
+// Positioning grid: track 1 holds the pill, track 2 is a spacer. Base keeps the
+// pill full width (the always-expanded variant); the collapse classes (compact
+// mode) shrink it to content width on desktop until the card is hovered. No
+// transition so it flips instantly.
+const outerBaseClasses =
+  'pointer-events-none absolute inset-x-2 bottom-2 z-1 grid [grid-template-columns:1fr_0fr]';
+const outerCollapseClasses = classNames(
   'laptop:mouse:[grid-template-columns:0fr_1fr]',
   'laptop:mouse:group-hover:[grid-template-columns:1fr_0fr]',
 );
@@ -49,27 +50,21 @@ const pillClasses = classNames(
 // upvote/comment counts make any single button.
 const slotClasses = 'flex min-w-0 flex-1 items-center justify-center';
 
-// Collapsible slot for secondary actions: equal-width by default (and on touch),
-// collapsed to zero width on desktop until the card is hovered. No transition so
-// it flips instantly. `visibility` removes hidden buttons from focus order.
-const segmentClasses = classNames(
-  slotClasses,
-  'overflow-hidden',
+// Secondary-action slot. Base (and the always-expanded variant) keeps it
+// equal-width and visible; the collapse classes shrink it to zero width on
+// desktop until hover. `visibility` removes hidden buttons from focus order.
+const segmentBaseClasses = classNames(slotClasses, 'overflow-hidden');
+const segmentCollapseClasses = classNames(
   'laptop:mouse:w-0 laptop:mouse:flex-none',
   'laptop:mouse:group-hover:w-auto laptop:mouse:group-hover:flex-1',
 );
 
-const segmentContentClasses = classNames(
-  'flex min-w-0 items-center justify-center overflow-hidden',
-  'visible opacity-100',
+const segmentContentBaseClasses =
+  'flex min-w-0 items-center justify-center overflow-hidden';
+const segmentContentCollapseClasses = classNames(
   'laptop:mouse:invisible',
   'laptop:mouse:group-hover:visible',
 );
-
-const segmentProps = {
-  wrapperClassName: segmentClasses,
-  contentClassName: segmentContentClasses,
-};
 
 // Dark glow behind the pill so it stays readable over busy cover images. Fixed
 // pepper tint in both themes; inline gradient since it's a one-off scrim.
@@ -104,7 +99,11 @@ export function FeedCardGlassActions({
   showDownvoteAction = true,
   showAwardAction = true,
   coverScrim = false,
-}: ActionButtonsProps & { coverScrim?: boolean }): ReactElement | null {
+  expanded = false,
+}: ActionButtonsProps & {
+  coverScrim?: boolean;
+  expanded?: boolean;
+}): ReactElement | null {
   const isFeedPreview = useFeedPreviewMode();
   const {
     isUpvoteActive,
@@ -124,6 +123,21 @@ export function FeedCardGlassActions({
   if (isFeedPreview) {
     return null;
   }
+
+  const outerClasses = classNames(
+    outerBaseClasses,
+    !expanded && outerCollapseClasses,
+  );
+  const segmentProps = {
+    wrapperClassName: classNames(
+      segmentBaseClasses,
+      !expanded && segmentCollapseClasses,
+    ),
+    contentClassName: classNames(
+      segmentContentBaseClasses,
+      !expanded && segmentContentCollapseClasses,
+    ),
+  };
 
   const upvoteCount = post.numUpvotes ?? 0;
   const commentCount = post.numComments ?? 0;

--- a/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
+++ b/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
@@ -37,26 +37,26 @@ const outerCollapseClasses = classNames(
 // Only the rest color is pinned to text-primary for contrast on the glass;
 // hover/pressed colors are left to each `btn-tertiary-*` class so icons keep
 // their brand tint on hover, matching the standard ActionButtons.
+// `justify-between` spreads the actions across the full-width pill and anchors
+// the ends, so the upvote stays put when the pill expands (no hover shift) —
+// matching the standard `CardActionBar` feedCard layout. `gap-1` keeps a minimum
+// spacing when the pill is content-width (compact, upvote only).
 const pillClasses = classNames(
-  'pointer-events-auto flex h-10 min-w-fit items-center overflow-hidden px-1',
+  'pointer-events-auto flex h-10 min-w-fit items-center justify-between gap-1 overflow-hidden px-1',
   'rounded-12 border border-border-subtlest-tertiary',
   'bg-blur-bg text-text-primary backdrop-blur-xl backdrop-saturate-150',
   '[&_.btn-quaternary]:[--button-default-color:var(--theme-text-primary)]',
   '[&_.btn]:[--button-default-color:var(--theme-text-primary)]',
 );
 
-// Every action sits in an equal-width slot with its content centered, so the
-// icons stay evenly spaced across the full-width pill no matter how wide the
-// upvote/comment counts make any single button.
-const slotClasses = 'flex min-w-0 flex-1 items-center justify-center';
-
-// Secondary-action slot. Base (and the always-expanded variant) keeps it
-// equal-width and visible; the collapse classes shrink it to zero width on
-// desktop until hover. `visibility` removes hidden buttons from focus order.
-const segmentBaseClasses = classNames(slotClasses, 'overflow-hidden');
+// One collapsible track per secondary action. Base (and the always-expanded
+// variant) keeps it content-width and visible; the collapse classes shrink the
+// track to zero width on desktop until the card is hovered. No transition so it
+// flips instantly. `visibility` removes hidden buttons from focus order.
+const segmentBaseClasses = 'grid [grid-template-columns:1fr]';
 const segmentCollapseClasses = classNames(
-  'laptop:mouse:w-0 laptop:mouse:flex-none',
-  'laptop:mouse:group-hover:w-auto laptop:mouse:group-hover:flex-1',
+  'laptop:mouse:[grid-template-columns:0fr]',
+  'laptop:mouse:group-hover:[grid-template-columns:1fr]',
 );
 
 const segmentContentBaseClasses =
@@ -174,38 +174,36 @@ export function FeedCardGlassActions({
       )}
       <div className={outerClasses}>
         <div className={pillClasses}>
-          <div className={slotClasses}>
-            <Tooltip
-              content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
-              side="bottom"
+          <Tooltip
+            content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
+            side="bottom"
+          >
+            <QuaternaryButton
+              labelClassName="!pl-[1px] pr-1.5"
+              className="btn-tertiary-avocado pointer-events-auto"
+              id={`post-${post.id}-upvote-btn`}
+              color={ButtonColor.Avocado}
+              pressed={isUpvoteActive}
+              onClick={onToggleUpvote}
+              variant={ButtonVariant.Tertiary}
+              size={ButtonSize.Small}
+              icon={
+                <UpvoteButtonIcon
+                  secondary={isUpvoteActive}
+                  size={IconSize.XSmall}
+                />
+              }
             >
-              <QuaternaryButton
-                labelClassName="!pl-[1px] pr-1.5"
-                className="btn-tertiary-avocado pointer-events-auto"
-                id={`post-${post.id}-upvote-btn`}
-                color={ButtonColor.Avocado}
-                pressed={isUpvoteActive}
-                onClick={onToggleUpvote}
-                variant={ButtonVariant.Tertiary}
-                size={ButtonSize.Small}
-                icon={
-                  <UpvoteButtonIcon
-                    secondary={isUpvoteActive}
-                    size={IconSize.XSmall}
-                  />
-                }
-              >
-                {upvoteCount > 0 && (
-                  <InteractionCounter
-                    className="tabular-nums typo-footnote"
-                    value={upvoteCount}
-                  />
-                )}
-              </QuaternaryButton>
-            </Tooltip>
-          </div>
+              {upvoteCount > 0 && (
+                <InteractionCounter
+                  className="tabular-nums typo-footnote"
+                  value={upvoteCount}
+                />
+              )}
+            </QuaternaryButton>
+          </Tooltip>
           {commentCount > 0 ? (
-            <div className={slotClasses}>{commentButton}</div>
+            commentButton
           ) : (
             <Segment {...segmentProps}>{commentButton}</Segment>
           )}

--- a/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
+++ b/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
@@ -23,15 +23,11 @@ import { useCardActions } from '../../../hooks/cards/useCardActions';
 export const glassCoverImageClassName =
   '!px-0 !mb-0 !rounded-t-none !rounded-b-16';
 
-const morphEase =
-  'duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none';
-
-// Positioning grid: track 1 holds the pill, track 2 is a spacer. Animating the
-// fr split expands the pill from content-hugging to full width on hover —
-// `fit-content → 100%` isn't animatable, but fr tracks are.
+// Positioning grid: track 1 holds the pill, track 2 is a spacer. The fr split
+// flips the pill between content-hugging and full width on hover — no transition
+// so it appears instantly.
 const outerClasses = classNames(
   'pointer-events-none absolute inset-x-2 bottom-2 z-1 grid',
-  `transition-[grid-template-columns] ${morphEase}`,
   '[grid-template-columns:1fr_0fr]',
   'laptop:mouse:[grid-template-columns:0fr_1fr]',
   'laptop:mouse:group-hover:[grid-template-columns:1fr_0fr]',
@@ -48,10 +44,11 @@ const pillClasses = classNames(
   '[&_.btn]:[--button-default-color:var(--theme-text-primary)]',
 );
 
-// One collapsible track per secondary action: width animates 0fr ↔ 1fr on hover
-// while the content fades in. `visibility` removes hidden buttons from focus order.
+// One collapsible track per secondary action: width flips 0fr ↔ 1fr on hover
+// while the content shows/hides. `visibility` removes hidden buttons from focus
+// order. No transition so secondary actions appear instantly.
 const segmentClasses = classNames(
-  `grid transition-[grid-template-columns] ${morphEase}`,
+  'grid',
   '[grid-template-columns:1fr]',
   'laptop:mouse:[grid-template-columns:0fr]',
   'laptop:mouse:group-hover:[grid-template-columns:1fr]',
@@ -59,7 +56,6 @@ const segmentClasses = classNames(
 
 const segmentContentClasses = classNames(
   'flex min-w-0 items-center justify-center overflow-hidden',
-  'transition-[opacity,visibility] duration-200 ease-out motion-reduce:transition-none',
   'visible opacity-100',
   'laptop:mouse:invisible laptop:mouse:opacity-0',
   'laptop:mouse:group-hover:visible laptop:mouse:group-hover:opacity-100',

--- a/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
+++ b/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
@@ -37,28 +37,33 @@ const outerClasses = classNames(
 // hover/pressed colors are left to each `btn-tertiary-*` class so icons keep
 // their brand tint on hover, matching the standard ActionButtons.
 const pillClasses = classNames(
-  'pointer-events-auto flex h-10 min-w-fit items-center justify-between overflow-hidden px-1',
+  'pointer-events-auto flex h-10 min-w-fit items-center overflow-hidden px-1',
   'rounded-12 border border-border-subtlest-tertiary',
   'bg-blur-bg text-text-primary backdrop-blur-xl backdrop-saturate-150',
   '[&_.btn-quaternary]:[--button-default-color:var(--theme-text-primary)]',
   '[&_.btn]:[--button-default-color:var(--theme-text-primary)]',
 );
 
-// One collapsible track per secondary action: width flips 0fr ↔ 1fr on hover
-// while the content shows/hides. `visibility` removes hidden buttons from focus
-// order. No transition so secondary actions appear instantly.
+// Every action sits in an equal-width slot with its content centered, so the
+// icons stay evenly spaced across the full-width pill no matter how wide the
+// upvote/comment counts make any single button.
+const slotClasses = 'flex min-w-0 flex-1 items-center justify-center';
+
+// Collapsible slot for secondary actions: equal-width by default (and on touch),
+// collapsed to zero width on desktop until the card is hovered. No transition so
+// it flips instantly. `visibility` removes hidden buttons from focus order.
 const segmentClasses = classNames(
-  'grid',
-  '[grid-template-columns:1fr]',
-  'laptop:mouse:[grid-template-columns:0fr]',
-  'laptop:mouse:group-hover:[grid-template-columns:1fr]',
+  slotClasses,
+  'overflow-hidden',
+  'laptop:mouse:w-0 laptop:mouse:flex-none',
+  'laptop:mouse:group-hover:w-auto laptop:mouse:group-hover:flex-1',
 );
 
 const segmentContentClasses = classNames(
   'flex min-w-0 items-center justify-center overflow-hidden',
   'visible opacity-100',
-  'laptop:mouse:invisible laptop:mouse:opacity-0',
-  'laptop:mouse:group-hover:visible laptop:mouse:group-hover:opacity-100',
+  'laptop:mouse:invisible',
+  'laptop:mouse:group-hover:visible',
 );
 
 const segmentProps = {
@@ -155,36 +160,38 @@ export function FeedCardGlassActions({
       )}
       <div className={outerClasses}>
         <div className={pillClasses}>
-          <Tooltip
-            content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
-            side="bottom"
-          >
-            <QuaternaryButton
-              labelClassName="!pl-[1px] pr-1.5"
-              className="btn-tertiary-avocado pointer-events-auto"
-              id={`post-${post.id}-upvote-btn`}
-              color={ButtonColor.Avocado}
-              pressed={isUpvoteActive}
-              onClick={onToggleUpvote}
-              variant={ButtonVariant.Tertiary}
-              size={ButtonSize.Small}
-              icon={
-                <UpvoteButtonIcon
-                  secondary={isUpvoteActive}
-                  size={IconSize.XSmall}
-                />
-              }
+          <div className={slotClasses}>
+            <Tooltip
+              content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
+              side="bottom"
             >
-              {upvoteCount > 0 && (
-                <InteractionCounter
-                  className="tabular-nums typo-footnote"
-                  value={upvoteCount}
-                />
-              )}
-            </QuaternaryButton>
-          </Tooltip>
+              <QuaternaryButton
+                labelClassName="!pl-[1px] pr-1.5"
+                className="btn-tertiary-avocado pointer-events-auto"
+                id={`post-${post.id}-upvote-btn`}
+                color={ButtonColor.Avocado}
+                pressed={isUpvoteActive}
+                onClick={onToggleUpvote}
+                variant={ButtonVariant.Tertiary}
+                size={ButtonSize.Small}
+                icon={
+                  <UpvoteButtonIcon
+                    secondary={isUpvoteActive}
+                    size={IconSize.XSmall}
+                  />
+                }
+              >
+                {upvoteCount > 0 && (
+                  <InteractionCounter
+                    className="tabular-nums typo-footnote"
+                    value={upvoteCount}
+                  />
+                )}
+              </QuaternaryButton>
+            </Tooltip>
+          </div>
           {commentCount > 0 ? (
-            commentButton
+            <div className={slotClasses}>{commentButton}</div>
           ) : (
             <Segment {...segmentProps}>{commentButton}</Segment>
           )}

--- a/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
+++ b/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
@@ -17,6 +17,7 @@ import { IconSize } from '../../Icon';
 import { Tooltip } from '../../tooltip/Tooltip';
 import { useFeedPreviewMode } from '../../../hooks/useFeedPreviewMode';
 import { useCardActions } from '../../../hooks/cards/useCardActions';
+import { useGlassActionsExpanded } from '../../../hooks/useGlassActionsExpanded';
 
 // Full-bleed cover: drop side padding/bottom margin and round only the bottom
 // corners so the image meets the card edges. Height/crop are untouched.
@@ -37,31 +38,40 @@ const outerCollapseClasses = classNames(
 // Only the rest color is pinned to text-primary for contrast on the glass;
 // hover/pressed colors are left to each `btn-tertiary-*` class so icons keep
 // their brand tint on hover, matching the standard ActionButtons.
-// `justify-between` spreads the actions across the full-width pill and anchors
-// the ends, so the upvote stays put when the pill expands (no hover shift) —
-// matching the standard `CardActionBar` feedCard layout. `gap-1` keeps a minimum
-// spacing when the pill is content-width (compact, upvote only).
-const pillClasses = classNames(
-  'pointer-events-auto flex h-10 min-w-fit items-center justify-between gap-1 overflow-hidden px-1',
+const pillBaseClasses = classNames(
+  'pointer-events-auto flex h-10 min-w-fit items-center overflow-hidden px-1',
   'rounded-12 border border-border-subtlest-tertiary',
   'bg-blur-bg text-text-primary backdrop-blur-xl backdrop-saturate-150',
   '[&_.btn-quaternary]:[--button-default-color:var(--theme-text-primary)]',
   '[&_.btn]:[--button-default-color:var(--theme-text-primary)]',
 );
 
-// One collapsible track per secondary action. Base (and the always-expanded
-// variant) keeps it content-width and visible; the collapse classes shrink the
-// track to zero width on desktop until the card is hovered. No transition so it
-// flips instantly. `visibility` removes hidden buttons from focus order.
-const segmentBaseClasses = 'grid [grid-template-columns:1fr]';
-const segmentCollapseClasses = classNames(
+// Compact (hover-to-reveal) mode: `justify-between` spreads the actions across
+// the pill and anchors the ends, so the upvote stays put when the pill expands
+// on hover (no layout shift). `gap-1` keeps a minimum spacing when the pill is
+// content-width (only the upvote showing).
+const pillCompactClasses = 'justify-between gap-1';
+
+// Always-expanded variant: every action gets an equal-width slot with its
+// content centered, so the icons are evenly spaced across the pill regardless of
+// upvote/comment counts. There's no hover here, so equal slots can't cause a
+// shift.
+const evenSlotClasses = 'flex min-w-0 flex-1 items-center justify-center';
+
+// Compact secondary action: one collapsible grid track that is content-width and
+// visible at rest, collapsed to zero width on desktop until the card is hovered.
+// No transition so it flips instantly. `visibility` drops hidden buttons from
+// the focus order.
+const segmentCompactClasses = classNames(
+  'grid [grid-template-columns:1fr]',
   'laptop:mouse:[grid-template-columns:0fr]',
   'laptop:mouse:group-hover:[grid-template-columns:1fr]',
 );
 
 const segmentContentBaseClasses =
   'flex min-w-0 items-center justify-center overflow-hidden';
-const segmentContentCollapseClasses = classNames(
+const segmentContentCompactClasses = classNames(
+  segmentContentBaseClasses,
   'laptop:mouse:invisible',
   'laptop:mouse:group-hover:visible',
 );
@@ -99,12 +109,14 @@ export function FeedCardGlassActions({
   showDownvoteAction = true,
   showAwardAction = true,
   coverScrim = false,
-  expanded = false,
 }: ActionButtonsProps & {
   coverScrim?: boolean;
-  expanded?: boolean;
 }): ReactElement | null {
   const isFeedPreview = useFeedPreviewMode();
+  // Read the per-device "always show actions" preference here so every card type
+  // that renders this bar respects the feed-header toggle without threading a
+  // prop through each card component.
+  const [expanded] = useGlassActionsExpanded();
   const {
     isUpvoteActive,
     isDownvoteActive,
@@ -124,20 +136,27 @@ export function FeedCardGlassActions({
     return null;
   }
 
+  const pillClasses = classNames(
+    pillBaseClasses,
+    !expanded && pillCompactClasses,
+  );
   const outerClasses = classNames(
     outerBaseClasses,
     !expanded && outerCollapseClasses,
   );
-  const segmentProps = {
-    wrapperClassName: classNames(
-      segmentBaseClasses,
-      !expanded && segmentCollapseClasses,
-    ),
-    contentClassName: classNames(
-      segmentContentBaseClasses,
-      !expanded && segmentContentCollapseClasses,
-    ),
-  };
+  // In the expanded variant every action is an equal-width slot; in compact mode
+  // the always-visible upvote/comment stay direct flex children (`contents`) so
+  // `justify-between` anchors them, and secondaries use the collapsible grid.
+  const alwaysWrapperClass = expanded ? evenSlotClasses : 'contents';
+  const segmentProps = expanded
+    ? {
+        wrapperClassName: classNames(evenSlotClasses, 'overflow-hidden'),
+        contentClassName: segmentContentBaseClasses,
+      }
+    : {
+        wrapperClassName: segmentCompactClasses,
+        contentClassName: segmentContentCompactClasses,
+      };
 
   const upvoteCount = post.numUpvotes ?? 0;
   const commentCount = post.numComments ?? 0;
@@ -174,36 +193,38 @@ export function FeedCardGlassActions({
       )}
       <div className={outerClasses}>
         <div className={pillClasses}>
-          <Tooltip
-            content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
-            side="bottom"
-          >
-            <QuaternaryButton
-              labelClassName="!pl-[1px] pr-1.5"
-              className="btn-tertiary-avocado pointer-events-auto"
-              id={`post-${post.id}-upvote-btn`}
-              color={ButtonColor.Avocado}
-              pressed={isUpvoteActive}
-              onClick={onToggleUpvote}
-              variant={ButtonVariant.Tertiary}
-              size={ButtonSize.Small}
-              icon={
-                <UpvoteButtonIcon
-                  secondary={isUpvoteActive}
-                  size={IconSize.XSmall}
-                />
-              }
+          <div className={alwaysWrapperClass}>
+            <Tooltip
+              content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
+              side="bottom"
             >
-              {upvoteCount > 0 && (
-                <InteractionCounter
-                  className="tabular-nums typo-footnote"
-                  value={upvoteCount}
-                />
-              )}
-            </QuaternaryButton>
-          </Tooltip>
+              <QuaternaryButton
+                labelClassName="!pl-[1px] pr-1.5"
+                className="btn-tertiary-avocado pointer-events-auto"
+                id={`post-${post.id}-upvote-btn`}
+                color={ButtonColor.Avocado}
+                pressed={isUpvoteActive}
+                onClick={onToggleUpvote}
+                variant={ButtonVariant.Tertiary}
+                size={ButtonSize.Small}
+                icon={
+                  <UpvoteButtonIcon
+                    secondary={isUpvoteActive}
+                    size={IconSize.XSmall}
+                  />
+                }
+              >
+                {upvoteCount > 0 && (
+                  <InteractionCounter
+                    className="tabular-nums typo-footnote"
+                    value={upvoteCount}
+                  />
+                )}
+              </QuaternaryButton>
+            </Tooltip>
+          </div>
           {commentCount > 0 ? (
-            commentButton
+            <div className={alwaysWrapperClass}>{commentButton}</div>
           ) : (
             <Segment {...segmentProps}>{commentButton}</Segment>
           )}

--- a/packages/shared/src/components/layout/common.spec.tsx
+++ b/packages/shared/src/components/layout/common.spec.tsx
@@ -75,6 +75,12 @@ jest.mock('../buttons/ToggleClickbaitShield', () => ({
   },
 }));
 
+jest.mock('../buttons/ToggleGlassActionsExpanded', () => ({
+  ToggleGlassActionsExpanded: function MockToggleGlassActionsExpanded() {
+    return null;
+  },
+}));
+
 jest.mock('../filters/AchievementTrackerButton', () => ({
   AchievementTrackerButton: function MockAchievementTrackerButton() {
     return null;

--- a/packages/shared/src/components/layout/common.tsx
+++ b/packages/shared/src/components/layout/common.tsx
@@ -34,6 +34,7 @@ import { QueryStateKeys, useQueryState } from '../../hooks/utils/useQueryState';
 import type { AllowedTags, TypographyProps } from '../typography/Typography';
 import { Typography } from '../typography/Typography';
 import { ToggleClickbaitShield } from '../buttons/ToggleClickbaitShield';
+import { ToggleGlassActionsExpanded } from '../buttons/ToggleGlassActionsExpanded';
 import { LogEvent, Origin } from '../../lib/log';
 import { AchievementTrackerButton } from '../filters/AchievementTrackerButton';
 import { IntroQuestButton } from '../filters/IntroQuestButton';
@@ -265,6 +266,21 @@ export const SearchControlHeader = ({
         }
         iconSize={isV2Strip ? IconSize.XSmall : undefined}
         key="toggle-clickbait-shield"
+      />
+    ),
+    hasFeedActions && (
+      <ToggleGlassActionsExpanded
+        key="toggle-glass-actions"
+        buttonProps={
+          isV2Strip
+            ? {
+                size: ButtonSize.Small,
+                variant: ButtonVariant.Tertiary,
+                className: compactIconButtonClassName,
+              }
+            : undefined
+        }
+        iconSize={isV2Strip ? IconSize.XSmall : undefined}
       />
     ),
     hasFeedActions && !isV2Strip && <IntroQuestButton key="intro-quests" />,

--- a/packages/shared/src/hooks/useGlassActionsExpanded.ts
+++ b/packages/shared/src/hooks/useGlassActionsExpanded.ts
@@ -2,7 +2,10 @@ import usePersistentContext from './usePersistentContext';
 
 const GLASS_ACTIONS_EXPANDED_KEY = 'glass_actions_expanded';
 
-export type UseGlassActionsExpanded = [boolean, (value: boolean) => Promise<void>];
+export type UseGlassActionsExpanded = [
+  boolean,
+  (value: boolean) => Promise<void>,
+];
 
 // Per-device preference (IndexedDB, not account-synced) that forces the feed
 // card glass action bar to render fully expanded instead of the hover-to-expand

--- a/packages/shared/src/hooks/useGlassActionsExpanded.ts
+++ b/packages/shared/src/hooks/useGlassActionsExpanded.ts
@@ -1,0 +1,20 @@
+import usePersistentContext from './usePersistentContext';
+
+const GLASS_ACTIONS_EXPANDED_KEY = 'glass_actions_expanded';
+
+export type UseGlassActionsExpanded = [boolean, (value: boolean) => Promise<void>];
+
+// Per-device preference (IndexedDB, not account-synced) that forces the feed
+// card glass action bar to render fully expanded instead of the hover-to-expand
+// compact mode. Backed by usePersistentContext so the feed-header toggle and
+// every card share the same React Query cache and stay in sync.
+export const useGlassActionsExpanded = (): UseGlassActionsExpanded => {
+  const [expanded, setExpanded] = usePersistentContext<boolean>(
+    GLASS_ACTIONS_EXPANDED_KEY,
+    false,
+    [true, false],
+    false,
+  );
+
+  return [expanded, setExpanded];
+};


### PR DESCRIPTION
## Changes

The floating glass action bar on feed cards (`FeedCardGlassActions`) morphed/faded into view on hover. This makes it appear **instantly** instead, matching the no-animation read post state.

- Removed the `morphEase` constant (`duration-300 ease-[cubic-bezier(...)]`) and all usages
- Removed `transition-[grid-template-columns]` on the outer positioning grid (pill expand)
- Removed `transition-[grid-template-columns]` on each secondary-action segment (per-button width morph)
- Removed `transition-[opacity,visibility] duration-200 ease-out` on segment content (fade-in)

The collapsed→expanded hover state changes and `visibility` focus-order handling are kept — only the transitions/effects are gone.

## Events

No new tracking events.

## Experiment

No new experiments.

## Manual Testing

Affects the glass action bar on grid feed cards across webapp/extension/companion. No behavioral change beyond removing the appearance animation.

### Preview domain
https://claude-relaxed-jemison-8de2c5.preview.app.daily.dev