### PR TITLE
feat(post): article view improvements (lightbox, action bar, modal shell)

### DIFF
--- a/packages/shared/src/components/Markdown.tsx
+++ b/packages/shared/src/components/Markdown.tsx
@@ -14,15 +14,15 @@ import useDebounceFn from '../hooks/useDebounceFn';
 import { useDomPurify } from '../hooks/useDomPurify';
 import { getUserShortInfo } from '../graphql/users';
 import { generateQueryKey, RequestKey } from '../lib/query';
+import { useLazyModal } from '../hooks/useLazyModal';
+import { LazyModal } from './modals/common/types';
+import type { ImageOriginRect } from './modals/ImageModal';
+import { useRequestProtocol } from '../hooks/useRequestProtocol';
 
 function isImageElement(
   element: Element | EventTarget,
 ): element is HTMLImageElement {
   return element instanceof HTMLImageElement;
-}
-
-function openImageInNewTab(src: string): void {
-  window.open(src, '_blank', 'noopener,noreferrer');
 }
 
 const UserEntityCard = dynamic(() => import('./cards/entity/UserEntityCard'), {
@@ -65,6 +65,8 @@ export default function Markdown({
   openLinksInNewTab = false,
 }: MarkdownProps): ReactElement {
   const purify = useDomPurify();
+  const { openModal } = useLazyModal();
+  const { isCompanion } = useRequestProtocol();
   const containerRef = useRef<HTMLDivElement>(null);
   const [userId, setUserId] = useState('');
   const [offset, setOffset] = useState<CaretOffset>([0, 0]);
@@ -91,7 +93,7 @@ export default function Markdown({
     images.forEach((img) => {
       img.setAttribute('tabindex', '0');
       img.setAttribute('role', 'button');
-      img.setAttribute('aria-label', 'Open image in new tab');
+      img.setAttribute('aria-label', 'Open image');
     });
   });
 
@@ -136,28 +138,52 @@ export default function Markdown({
     [cancelUserClearing, userId, clearUser],
   );
 
-  const onImageClick = useCallback((e: MouseEvent<HTMLDivElement>) => {
-    const element = e.target;
+  const openImage = useCallback(
+    (element: HTMLImageElement) => {
+      // The lazy-modal renderer isn't mounted in the extension companion, so
+      // fall back to opening the image in a new tab there.
+      if (isCompanion) {
+        window.open(element.src, '_blank', 'noopener,noreferrer');
+        return;
+      }
+      const { top, left, width, height } = element.getBoundingClientRect();
+      const originRect: ImageOriginRect = { top, left, width, height };
+      openModal({
+        type: LazyModal.ImageView,
+        props: { src: element.src, alt: element.alt || undefined, originRect },
+      });
+    },
+    [isCompanion, openModal],
+  );
 
-    if (isImageElement(element) && element.src) {
-      e.stopPropagation();
-      openImageInNewTab(element.src);
-    }
-  }, []);
+  const onImageClick = useCallback(
+    (e: MouseEvent<HTMLDivElement>) => {
+      const element = e.target;
 
-  const onImageKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
-    const element = e.target;
+      if (isImageElement(element) && element.src) {
+        e.stopPropagation();
+        openImage(element);
+      }
+    },
+    [openImage],
+  );
 
-    if (
-      isImageElement(element) &&
-      element.src &&
-      (e.key === 'Enter' || e.key === ' ')
-    ) {
-      e.preventDefault();
-      e.stopPropagation();
-      openImageInNewTab(element.src);
-    }
-  }, []);
+  const onImageKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      const element = e.target;
+
+      if (
+        isImageElement(element) &&
+        element.src &&
+        (e.key === 'Enter' || e.key === ' ')
+      ) {
+        e.preventDefault();
+        e.stopPropagation();
+        openImage(element);
+      }
+    },
+    [openImage],
+  );
 
   return (
     <HoverCard

--- a/packages/shared/src/components/Markdown.tsx
+++ b/packages/shared/src/components/Markdown.tsx
@@ -16,7 +16,7 @@ import { getUserShortInfo } from '../graphql/users';
 import { generateQueryKey, RequestKey } from '../lib/query';
 import { useLazyModal } from '../hooks/useLazyModal';
 import { LazyModal } from './modals/common/types';
-import type { ImageOriginRect } from './modals/ImageModal';
+import { getImageOriginRect } from './modals/ImageModal';
 import { useRequestProtocol } from '../hooks/useRequestProtocol';
 
 function isImageElement(
@@ -146,11 +146,13 @@ export default function Markdown({
         window.open(element.src, '_blank', 'noopener,noreferrer');
         return;
       }
-      const { top, left, width, height } = element.getBoundingClientRect();
-      const originRect: ImageOriginRect = { top, left, width, height };
       openModal({
         type: LazyModal.ImageView,
-        props: { src: element.src, alt: element.alt || undefined, originRect },
+        props: {
+          src: element.src,
+          alt: element.alt || undefined,
+          originRect: getImageOriginRect(element),
+        },
       });
     },
     [isCompanion, openModal],

--- a/packages/shared/src/components/markdown.module.css
+++ b/packages/shared/src/components/markdown.module.css
@@ -84,7 +84,7 @@
     @apply border-border-subtlest-secondary my-10;
   }
   & :where(img) {
-    @apply rounded-16 max-h-img-mobile tablet:max-h-img-desktop cursor-pointer;
+    @apply rounded-16 max-h-img-mobile tablet:max-h-img-desktop cursor-zoom-in;
 
     &:focus-visible {
       @apply outline-none ring-2 ring-accent-cabbage-default ring-offset-2 ring-offset-background-default;

--- a/packages/shared/src/components/modals/ArticlePostModal.tsx
+++ b/packages/shared/src/components/modals/ArticlePostModal.tsx
@@ -40,6 +40,7 @@ export default function ArticlePostModal({
       onAfterOpen={onLoad}
       size={showRedesign ? Modal.Size.Large : Modal.Size.XLarge}
       className={showRedesign ? 'laptop:!overflow-clip' : undefined}
+      navigationRedesign={showRedesign}
       onRequestClose={onRequestClose}
       postType={PostType.Article}
       source={post.source}

--- a/packages/shared/src/components/modals/BasePostModal.module.css
+++ b/packages/shared/src/components/modals/BasePostModal.module.css
@@ -5,9 +5,28 @@
     left: 0;
     right: 0;
     bottom: 0;
-    min-height: 100vh;
     padding: 0;
     overflow-y: auto;
+    /* Keep the scroll inside the overlay so overscroll doesn't chain to the
+       page behind. */
+    overscroll-behavior: contain;
     z-index: 100;
+    /* Backdrop tint lives on the fixed pseudo-element below, not on this
+       scroll container — painting it here made it scroll away with the
+       content and expose the feed. */
+    background-color: transparent;
+  }
+
+  /* Fixed backdrop pinned to the viewport: stays put while only the modal
+     content scrolls. z-index:-1 keeps it behind the modal content but, since
+     the overlay establishes a z-index:100 stacking context, still above the
+     feed. */
+  & :global(.post-modal-overlay)::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background-color: theme('colors.overlay.quaternary.onion');
   }
 }

--- a/packages/shared/src/components/modals/BasePostModal.tsx
+++ b/packages/shared/src/components/modals/BasePostModal.tsx
@@ -30,6 +30,12 @@ interface BasePostModalProps extends ModalProps {
   navigationCustomActions?: ReactNode;
   navigationContainerClassName?: string;
   navigationHideSubscribeAction?: boolean;
+  /**
+   * Redesign top-bar behavior: hide the top strip's "…" menu (it lives in the
+   * focus-card header) and, once scrolled, float a fixed bar with the post
+   * stats + "…" menu + close.
+   */
+  navigationRedesign?: boolean;
   loadingChildren?: ReactNode;
   post?: Post;
 }
@@ -48,6 +54,7 @@ function BasePostModal({
   navigationCustomActions,
   navigationContainerClassName,
   navigationHideSubscribeAction,
+  navigationRedesign,
   loadingChildren,
   post,
   onRequestClose,
@@ -131,6 +138,7 @@ function BasePostModal({
                 leadingContent={navigationLeadingContent}
                 customActions={navigationCustomActions}
                 hideSubscribeAction={navigationHideSubscribeAction}
+                hideOptions={navigationRedesign}
                 onClose={onRequestClose}
                 post={post}
               />

--- a/packages/shared/src/components/modals/CollectionPostModal.tsx
+++ b/packages/shared/src/components/modals/CollectionPostModal.tsx
@@ -42,6 +42,7 @@ export default function CollectionPostModal({
       onAfterOpen={onLoad}
       size={showRedesign ? Modal.Size.Large : Modal.Size.XLarge}
       className={showRedesign ? 'laptop:!overflow-clip' : undefined}
+      navigationRedesign={showRedesign}
       onRequestClose={onRequestClose}
       postType={PostType.Collection}
       source={post.source}

--- a/packages/shared/src/components/modals/ImageModal.spec.tsx
+++ b/packages/shared/src/components/modals/ImageModal.spec.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ImageModal from './ImageModal';
+
+const src = 'https://media.daily.dev/image.png';
+
+const setup = (onRequestClose = jest.fn()) => {
+  render(
+    <ImageModal
+      isOpen
+      src={src}
+      alt="Cover image"
+      onRequestClose={onRequestClose}
+    />,
+  );
+  return onRequestClose;
+};
+
+describe('ImageModal', () => {
+  it('renders the image full-screen with its alt and contained sizing', () => {
+    setup();
+    const img = screen.getByAltText('Cover image');
+    expect(img).toHaveAttribute('src', src);
+    expect(img).toHaveClass('object-contain', 'max-h-full', 'max-w-full');
+  });
+
+  it('closes when the backdrop is clicked', () => {
+    const onRequestClose = setup();
+    const [overlay] = screen.getAllByRole('button', { name: 'Close' });
+    fireEvent.click(overlay);
+    expect(onRequestClose).toHaveBeenCalled();
+  });
+
+  it('closes on Escape', () => {
+    const onRequestClose = setup();
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(onRequestClose).toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/components/modals/ImageModal.tsx
+++ b/packages/shared/src/components/modals/ImageModal.tsx
@@ -1,0 +1,164 @@
+import type { ReactElement } from 'react';
+import React, { useEffect, useLayoutEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import classNames from 'classnames';
+import type ReactModal from 'react-modal';
+import { ButtonSize, ButtonVariant } from '../buttons/Button';
+import CloseButton from '../CloseButton';
+import { useEventListener } from '../../hooks';
+
+export interface ImageOriginRect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+interface ImageModalProps extends ReactModal.Props {
+  src: string;
+  alt?: string;
+  /** Bounds of the thumbnail that was clicked, used to animate the image
+   * expanding from it into the full view (a FLIP transition). */
+  originRect?: ImageOriginRect;
+}
+
+/**
+ * Full-screen image lightbox. Unlike the standard Modal card (fixed width + top
+ * margins), this fills the viewport and centers the image on both axes, sizing
+ * it with `max-h-full max-w-full object-contain` inside a padded container — so
+ * the image is always fully visible and scales down with the screen while
+ * preserving its aspect ratio. Mirrors the workspace-photos lightbox.
+ *
+ * Portaled into `document.body` so it stacks above the post modal (which lives
+ * in its own body-level ReactModal portal); rendering inline would leave it
+ * trapped under that portal at the same z-index.
+ */
+export default function ImageModal({
+  onRequestClose,
+  src,
+  alt = 'Image',
+  originRect,
+}: ImageModalProps): ReactElement | null {
+  const close = () => onRequestClose?.(undefined as never);
+  const imgRef = useRef<HTMLImageElement>(null);
+  const hasPlayedRef = useRef(false);
+
+  // FLIP: render the image at its final centered size, but start it transformed
+  // to sit exactly over the clicked thumbnail, then animate the transform away
+  // so it visually grows/moves from the thumbnail into the full view.
+  const playFlip = () => {
+    const img = imgRef.current;
+    if (!originRect || !img || hasPlayedRef.current) {
+      return;
+    }
+    const final = img.getBoundingClientRect();
+    if (!final.width || !final.height) {
+      // Not laid out yet (image still loading) — onLoad will retry.
+      return;
+    }
+    hasPlayedRef.current = true;
+    const dx = originRect.left - final.left;
+    const dy = originRect.top - final.top;
+    const sx = originRect.width / final.width;
+    const sy = originRect.height / final.height;
+    img.style.transformOrigin = 'top left';
+    img.style.transition = 'none';
+    img.style.transform = `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`;
+    img.style.opacity = '1';
+    // Two frames: let the browser paint the start transform first, then
+    // transition to identity — doing both in one frame can coalesce and snap.
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        img.style.transition = 'transform 300ms cubic-bezier(0.16, 1, 0.3, 1)';
+        img.style.transform = 'none';
+      });
+    });
+  };
+
+  useLayoutEffect(() => {
+    playFlip();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Close on Escape, but only this lightbox: capture the event and stop it
+  // before it reaches the underlying post modal's react-modal Esc handler —
+  // otherwise Esc would close both at once.
+  useEventListener(
+    globalThis as unknown as Window,
+    'keydown',
+    (event) => {
+      if (event.key !== 'Escape') {
+        return;
+      }
+      event.stopImmediatePropagation();
+      event.preventDefault();
+      close();
+    },
+    true,
+  );
+
+  // Lock background scroll while open. Compensate for the removed scrollbar
+  // with matching padding so the page (and the FLIP's captured origin) doesn't
+  // shift sideways when the lightbox opens. Restores the previous values on
+  // close so a still-open underlying modal keeps its own (class-based) lock —
+  // where the scrollbar is already gone, so the width is 0 and we add nothing.
+  useEffect(() => {
+    const { style } = document.body;
+    const scrollbarWidth =
+      window.innerWidth - document.documentElement.clientWidth;
+    const previousOverflow = style.overflow;
+    const previousPaddingRight = style.paddingRight;
+    style.overflow = 'hidden';
+    if (scrollbarWidth > 0) {
+      style.paddingRight = `${scrollbarWidth}px`;
+    }
+    return () => {
+      style.overflow = previousOverflow;
+      style.paddingRight = previousPaddingRight;
+    };
+  }, []);
+
+  const body = globalThis?.document?.body;
+  if (!body) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-modal flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={alt}
+    >
+      <button
+        type="button"
+        aria-label="Close"
+        className="absolute inset-0 cursor-default bg-overlay-primary-pepper backdrop-blur-md"
+        onClick={close}
+      />
+      <img
+        ref={imgRef}
+        src={src}
+        alt={alt}
+        onLoad={playFlip}
+        className={classNames(
+          'relative max-h-full max-w-full rounded-16 object-contain',
+          // With an origin we drive the entrance via the FLIP transform (start
+          // hidden so a freshly-loaded image doesn't flash at full size first);
+          // otherwise fall back to a simple centered zoom-in.
+          originRect ? 'opacity-0' : 'animate-image-zoom-in',
+        )}
+      />
+      {/* Pinned to the screen corner (not the image) so a busy image can't
+          camouflage it. Primary (solid) variant stays visible over the dark
+          overlay. */}
+      <CloseButton
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Small}
+        className="absolute right-4 top-4 z-1"
+        onClick={close}
+      />
+    </div>,
+    body,
+  );
+}

--- a/packages/shared/src/components/modals/ImageModal.tsx
+++ b/packages/shared/src/components/modals/ImageModal.tsx
@@ -54,8 +54,8 @@ export default function ImageModal({
   const hasPlayedRef = useRef(false);
 
   // FLIP: render the image at its final centered size, but start it transformed
-  // to sit exactly over the clicked thumbnail, then animate the transform away
-  // so it visually grows/moves from the thumbnail into the full view.
+  // to sit over the clicked thumbnail, then animate the transform away so it
+  // visually grows from the thumbnail into the full view.
   const playFlip = () => {
     const img = imgRef.current;
     if (!originRect || !img || hasPlayedRef.current) {
@@ -67,20 +67,41 @@ export default function ImageModal({
       return;
     }
     hasPlayedRef.current = true;
-    const dx = originRect.left - final.left;
-    const dy = originRect.top - final.top;
-    const sx = originRect.width / final.width;
-    const sy = originRect.height / final.height;
-    img.style.transformOrigin = 'top left';
+
+    // A single uniform scale (not independent sx/sy) so the image keeps its
+    // aspect ratio and never warps mid-flight. `min` contains the start frame
+    // within the thumbnail's footprint, so it reads as lifting off from there.
+    const scale = Math.min(
+      originRect.width / final.width,
+      originRect.height / final.height,
+    );
+    // Translate centers together (transform-origin is the center too), so the
+    // image grows out of where the thumbnail sat rather than from a corner.
+    const dx =
+      originRect.left + originRect.width / 2 - (final.left + final.width / 2);
+    const dy =
+      originRect.top + originRect.height / 2 - (final.top + final.height / 2);
+    // Transform scales the corner radius along with everything else, so a fixed
+    // radius would render near-square at the small start scale and then "snap"
+    // round. Pre-divide by the scale so the rendered radius stays a constant
+    // ~16px (rounded-16) for the whole animation; read the resting value off the
+    // element so it tracks the class instead of a hardcoded number.
+    const restRadius =
+      parseFloat(getComputedStyle(img).borderTopLeftRadius) || 16;
+
+    img.style.transformOrigin = 'center center';
     img.style.transition = 'none';
-    img.style.transform = `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`;
+    img.style.transform = `translate(${dx}px, ${dy}px) scale(${scale})`;
+    img.style.borderRadius = `${restRadius / scale}px`;
     img.style.opacity = '1';
-    // Two frames: let the browser paint the start transform first, then
-    // transition to identity — doing both in one frame can coalesce and snap.
+    // Two frames: let the browser paint the start state first, then transition
+    // to identity — doing both in one frame can coalesce and snap.
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
-        img.style.transition = 'transform 300ms cubic-bezier(0.16, 1, 0.3, 1)';
+        img.style.transition =
+          'transform 300ms cubic-bezier(0.16, 1, 0.3, 1), border-radius 300ms cubic-bezier(0.16, 1, 0.3, 1)';
         img.style.transform = 'none';
+        img.style.borderRadius = `${restRadius}px`;
       });
     });
   };

--- a/packages/shared/src/components/modals/ImageModal.tsx
+++ b/packages/shared/src/components/modals/ImageModal.tsx
@@ -14,6 +14,16 @@ export interface ImageOriginRect {
   height: number;
 }
 
+/**
+ * Snapshot an element's viewport bounds for the lightbox FLIP entrance (see
+ * `ImageModal`). Shared by every surface that opens `LazyModal.ImageView` so
+ * the captured shape stays in one place.
+ */
+export const getImageOriginRect = (element: Element): ImageOriginRect => {
+  const { top, left, width, height } = element.getBoundingClientRect();
+  return { top, left, width, height };
+};
+
 interface ImageModalProps extends ReactModal.Props {
   src: string;
   alt?: string;
@@ -141,6 +151,14 @@ export default function ImageModal({
         src={src}
         alt={alt}
         onLoad={playFlip}
+        onError={() => {
+          // With an origin the image starts at opacity-0 and only the FLIP
+          // reveals it — which never runs if the image fails to load. Reveal it
+          // so the broken-image/alt state shows instead of an empty overlay.
+          if (imgRef.current) {
+            imgRef.current.style.opacity = '1';
+          }
+        }}
         className={classNames(
           'relative max-h-full max-w-full rounded-16 object-contain',
           // With an origin we drive the entrance via the FLIP transform (start

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -42,6 +42,7 @@ export default function PostModal({
       onAfterOpen={onLoad}
       size={showRedesign ? Modal.Size.Large : Modal.Size.XLarge}
       className={showRedesign ? 'laptop:!overflow-clip' : undefined}
+      navigationRedesign={showRedesign}
       onRequestClose={onRequestClose}
       postType={PostType.Share}
       source={post.source}

--- a/packages/shared/src/components/modals/common.tsx
+++ b/packages/shared/src/components/modals/common.tsx
@@ -91,6 +91,10 @@ const VideoModal = dynamic(
   () => import(/* webpackChunkName: "videoModal" */ './VideoModal'),
 );
 
+const ImageModal = dynamic(
+  () => import(/* webpackChunkName: "imageModal" */ './ImageModal'),
+);
+
 const GenericReferralModal = dynamic(
   () =>
     import(
@@ -524,6 +528,7 @@ export const modals = {
   [LazyModal.VerifySession]: VerifySession,
   [LazyModal.GenericReferral]: GenericReferralModal,
   [LazyModal.Video]: VideoModal,
+  [LazyModal.ImageView]: ImageModal,
   [LazyModal.NewStreak]: NewStreakModal,
   [LazyModal.ReputationPrivileges]: ReputationPrivilegesModal,
   [LazyModal.MarketingCta]: MarketingCtaModal,

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -41,6 +41,7 @@ export enum LazyModal {
   VerifySession = 'verifySession',
   GenericReferral = 'genericReferral',
   Video = 'video',
+  ImageView = 'imageView',
   NewStreak = 'newStreak',
   RecoverStreak = 'recoverStreak',
   ReputationPrivileges = 'reputationPrivileges',

--- a/packages/shared/src/components/post/PostHeaderActions.tsx
+++ b/packages/shared/src/components/post/PostHeaderActions.tsx
@@ -37,6 +37,7 @@ export function PostHeaderActions({
   isFixedNavigation,
   buttonSize,
   hideSubscribeAction,
+  hideOptions,
   ...props
 }: PostHeaderActionsProps): ReactElement {
   const { openNewTab } = useContext(SettingsContext);
@@ -126,11 +127,13 @@ export function PostHeaderActions({
       {isCollection && !hideSubscribeAction && (
         <CollectionSubscribeButton post={post} />
       )}
-      <PostMenuOptions
-        post={post}
-        origin={Origin.ArticleModal}
-        buttonSize={buttonSize}
-      />
+      {!hideOptions && (
+        <PostMenuOptions
+          post={post}
+          origin={Origin.ArticleModal}
+          buttonSize={buttonSize}
+        />
+      )}
     </Container>
   );
 }

--- a/packages/shared/src/components/post/common.tsx
+++ b/packages/shared/src/components/post/common.tsx
@@ -31,6 +31,7 @@ type PostActions = Pick<
   | 'inlineActions'
   | 'isFixedNavigation'
   | 'hideSubscribeAction'
+  | 'hideOptions'
 >;
 
 export interface PostNavigationClassName {
@@ -69,6 +70,8 @@ export interface PostHeaderActionsProps {
   isFixedNavigation?: boolean;
   buttonSize?: ButtonSize;
   hideSubscribeAction?: boolean;
+  /** Hide the "…" options menu (e.g. when it already lives elsewhere). */
+  hideOptions?: boolean;
 }
 
 export interface PostContentProps

--- a/packages/shared/src/components/post/focus/FocusCardActionBar.tsx
+++ b/packages/shared/src/components/post/focus/FocusCardActionBar.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import type { Post } from '../../../graphql/posts';
 import { UserVote } from '../../../graphql/posts';
-import { useVotePost } from '../../../hooks';
+import { useViewSize, useVotePost, ViewSize } from '../../../hooks';
 import { useBookmarkPost } from '../../../hooks/useBookmarkPost';
 import { useBlockPostPanel } from '../../../hooks/post/useBlockPostPanel';
 import { useCanAwardUser } from '../../../hooks/useCoresFeature';
@@ -22,7 +22,6 @@ import CloseButton from '../../CloseButton';
 import { UpvoteButtonIcon } from '../../cards/common/UpvoteButtonIcon';
 import { IconSize } from '../../Icon';
 import {
-  AnalyticsIcon,
   DiscussIcon as CommentIcon,
   DownvoteIcon,
   LinkIcon,
@@ -30,10 +29,8 @@ import {
 } from '../../icons';
 import { Tooltip } from '../../tooltip/Tooltip';
 import type { LoggedUser } from '../../../lib/user';
-import { canViewPostAnalytics } from '../../../lib/user';
-import { webappUrl } from '../../../lib/constants';
-import { PostMenuOptions } from '../PostMenuOptions';
 import { PostClickbaitShield } from '../common/PostClickbaitShield';
+import { PostMenuOptions } from '../PostMenuOptions';
 
 interface FocusCardActionBarProps {
   post: Post;
@@ -70,20 +67,28 @@ export const FocusCardActionBar = ({
     receivingUser: post.author as LoggedUser | undefined,
   });
 
-  // Detect when the sticky bar is pinned to the top so the X close button
-  // (modal only) appears just for the stuck state.
+  // Track whether the bar is pinned, and at which edge. The sentinel sits just
+  // above the bar: when it scrolls above the viewport top the bar is pinned at
+  // the TOP; when it's still below the viewport the bar is floating at the
+  // BOTTOM. The modal's X is only useful at the top (where the top nav strip
+  // has scrolled away) — at the bottom that strip is still on screen.
   const sentinelRef = useRef<HTMLDivElement>(null);
   const barRef = useRef<HTMLDivElement>(null);
   const copyLinkRef = useRef<HTMLDivElement>(null);
-  const analyticsRef = useRef<HTMLDivElement>(null);
   const [isStuck, setIsStuck] = useState(false);
+  const [isStuckTop, setIsStuckTop] = useState(false);
   useEffect(() => {
     const el = sentinelRef.current;
     if (!el || typeof IntersectionObserver === 'undefined') {
       return undefined;
     }
     const observer = new IntersectionObserver(
-      ([entry]) => setIsStuck(!entry.isIntersecting),
+      ([entry]) => {
+        const stuck = !entry.isIntersecting;
+        setIsStuck(stuck);
+        const rootTop = entry.rootBounds?.top ?? 0;
+        setIsStuckTop(stuck && entry.boundingClientRect.top < rootTop);
+      },
       { threshold: 0 },
     );
     observer.observe(el);
@@ -93,24 +98,41 @@ export const FocusCardActionBar = ({
   const isUpvoteActive = post?.userState?.vote === UserVote.Up;
   const isDownvoteActive = post?.userState?.vote === UserVote.Down;
   const isAwarded = !!post?.userState?.awarded;
+  // Counts are hidden in the resting bar (the stats row sitting right above it
+  // already shows them) and surface only once the bar is pinned and that row
+  // has scrolled away.
   const upvotes = post.numUpvotes || 0;
   const comments = post.numComments || 0;
   const awards = post.numAwards || 0;
-  const canSeeAnalytics = canViewPostAnalytics({ user, post });
-  // Sticky offset depends on the top chrome. The modal has no app header (pin
-  // to the very top). On the post page, the v2 rail layout hides the global
-  // header on laptop for logged-in users, so the bar sticks to the very top
-  // like the feed nav; the legacy/logged-out layout keeps a fixed 4rem header
-  // the bar must clear. `onClose` is only provided by the modal.
+  // The bar floats (sticky) from tablet up, so surface the metrics + menu
+  // whenever it's actually pinned there — including when a long post floats it
+  // at the bottom on load, where the stats row above has scrolled off. Below
+  // tablet the bar is plain in-flow, so keep it stable (no counts) — that's the
+  // width where toggling on scroll looked like flicker.
+  const barFloats = useViewSize(ViewSize.Tablet);
+  const isPinned = isStuck && barFloats;
+  // The X (modal close) only makes sense when pinned at the top; at the bottom
+  // the modal's top strip — and its own close — are still on screen.
+  const isPinnedTop = isStuckTop && barFloats;
+  // Sticky at BOTH edges (`top` + `bottom`), tablet and up only — on mobile the
+  // dedicated floating bottom bar already covers this, so the desktop treatment
+  // is excluded there. While its natural spot is still below the fold the bar
+  // pins near the bottom (always reachable), scrolls naturally through the
+  // viewport, then pins near the top once it scrolls above. `top-4`/`bottom-4`
+  // leave a gap from each edge so the pill reads as floating. The top offset
+  // also accounts for the top chrome — the modal has no app header; on the post
+  // page the v2 rail hides the global header on laptop for logged-in users, so
+  // the bar floats near the top, while the legacy/logged-out layout must clear
+  // a fixed 4rem header (4rem + 1rem gap = top-20). `onClose` is modal-only.
   const railOwnsHeader = isV2 && !!user;
-  const stickyTopClassName =
-    onClose || railOwnsHeader ? 'top-0' : 'top-0 laptop:top-16';
+  const stickyOffsetClassName =
+    onClose || railOwnsHeader
+      ? 'tablet:top-4 tablet:bottom-4'
+      : 'tablet:top-4 tablet:bottom-4 laptop:top-20';
 
-  // Dynamically fold the lowest-priority utilities into the "…" menu (which
-  // already lists Share and Post analytics) whenever the bar would overflow,
-  // and bring them back inline when there is room again. Measured against the
-  // real available width — not breakpoints — so it reacts to page/modal
-  // resizing. Priority (first to fold): analytics, then copy/share.
+  // Fold copy link out of the row when the bar would overflow, and bring it
+  // back inline when there is room again. Measured against the real available
+  // width — not breakpoints — so it reacts to page/modal resizing.
   useEffect(() => {
     const bar = barRef.current;
     if (!bar) {
@@ -118,19 +140,12 @@ export const FocusCardActionBar = ({
     }
     const fit = () => {
       const copyLink = copyLinkRef.current;
-      const analytics = analyticsRef.current;
-      // Show both first (inline display overrides the SSR fallback classes),
-      // then hide in priority order until the row stops overflowing.
+      // Show first (inline display overrides the SSR fallback classes), then
+      // hide it if the row still overflows.
       if (copyLink) {
         copyLink.style.display = 'flex';
       }
-      if (analytics) {
-        analytics.style.display = 'flex';
-      }
       const overflows = () => bar.scrollWidth > bar.clientWidth;
-      if (analytics && overflows()) {
-        analytics.style.display = 'none';
-      }
       if (copyLink && overflows()) {
         copyLink.style.display = 'none';
       }
@@ -142,14 +157,15 @@ export const FocusCardActionBar = ({
     const observer = new ResizeObserver(fit);
     observer.observe(bar);
     return () => observer.disconnect();
+    // isPinned/counts change the row width (counts + "…" menu appear when pinned).
   }, [
-    canSeeAnalytics,
-    upvotes,
-    comments,
-    awards,
     canAward,
     post.clickbaitTitleDetected,
     post.bookmarked,
+    isPinned,
+    upvotes,
+    comments,
+    awards,
   ]);
 
   const onToggleUpvote = async () => {
@@ -200,13 +216,12 @@ export const FocusCardActionBar = ({
       <div
         ref={barRef}
         className={classNames(
-          // Static on mobile (no sticky), sticky from tablet up so the bar
-          // never overlaps the small-screen reading flow.
-          'relative z-3 flex items-center justify-between gap-2 border-b border-border-subtlest-tertiary bg-background-default px-1 py-2 tablet:sticky',
-          // Drop the top border once pinned so it doesn't double up with the
-          // header border above it.
-          !isStuck && 'border-t',
-          stickyTopClassName,
+          // Same floating-pill design on every resolution (incl. the
+          // translucent surface): rounded, blur, soft shadow, full border.
+          // Sticky from tablet up only — on mobile it stays in-flow, since the
+          // dedicated footer floating bar handles the pinned behavior there.
+          'relative z-3 flex items-center justify-between gap-2 rounded-16 border border-border-subtlest-tertiary bg-surface-float px-2 py-1 shadow-[0_0.25rem_1.5rem_0_var(--theme-shadow-shadow1)] backdrop-blur-[2.5rem] tablet:sticky',
+          stickyOffsetClassName,
           className,
         )}
       >
@@ -220,7 +235,7 @@ export const FocusCardActionBar = ({
               color={ButtonColor.Avocado}
               icon={<UpvoteButtonIcon />}
               iconPressed={<UpvoteButtonIcon secondary />}
-              count={upvotes}
+              count={isPinned ? upvotes : undefined}
               pressed={isUpvoteActive}
               onClick={onToggleUpvote}
             />
@@ -245,7 +260,7 @@ export const FocusCardActionBar = ({
               color={ButtonColor.BlueCheese}
               icon={<CommentIcon />}
               iconPressed={<CommentIcon secondary />}
-              count={comments}
+              count={isPinned ? comments : undefined}
               pressed={post.commented}
               onClick={onComment}
             />
@@ -260,7 +275,7 @@ export const FocusCardActionBar = ({
                 color={ButtonColor.Cabbage}
                 icon={<MedalBadgeIcon secondary />}
                 iconPressed={<MedalBadgeIcon />}
-                count={awards}
+                count={isPinned ? awards : undefined}
                 pressed={isAwarded}
                 onClick={onGiveAward}
               />
@@ -279,11 +294,11 @@ export const FocusCardActionBar = ({
               size: ButtonSize.Medium,
             }}
           />
-          {/* Bookmark stays — it is the primary save action and is not in the
-              menu. Copy/share and analytics fold into the "…" menu when space
-              is tight (see the overflow effect); the `hidden tablet:flex` /
-              `hidden laptop:flex` classes are only the pre-measurement (SSR)
-              fallback — the effect overrides display once it measures. */}
+          {/* Bookmark stays — it is the primary save action. Copy link folds
+              out when space is tight (see the overflow effect); the
+              `hidden tablet:flex` classes are only the pre-measurement (SSR)
+              fallback — the effect overrides display once it measures. The "…"
+              menu and analytics now live in the card header / stats row. */}
           <div ref={copyLinkRef} className="hidden tablet:flex">
             <Tooltip content="Copy link">
               <CardAction
@@ -297,23 +312,16 @@ export const FocusCardActionBar = ({
           {post.clickbaitTitleDetected && (
             <PostClickbaitShield post={post} iconOnly />
           )}
-          {canSeeAnalytics && (
-            <div ref={analyticsRef} className="hidden laptop:flex">
-              <Tooltip content="Analytics">
-                <CardAction
-                  label="Analytics"
-                  icon={<AnalyticsIcon />}
-                  href={`${webappUrl}posts/${post.id}/analytics`}
-                />
-              </Tooltip>
-            </div>
+          {/* While pinned, the article header (which owns the "…" menu) has
+              scrolled away, so surface the menu here — to the left of the X. */}
+          {isPinned && (
+            <PostMenuOptions
+              post={post}
+              origin={origin}
+              buttonSize={ButtonSize.Medium}
+            />
           )}
-          <PostMenuOptions
-            post={post}
-            origin={Origin.ArticleModal}
-            buttonSize={ButtonSize.Medium}
-          />
-          {isStuck && onClose && (
+          {isPinnedTop && onClose && (
             <CloseButton size={ButtonSize.Medium} onClick={() => onClose()} />
           )}
         </div>

--- a/packages/shared/src/components/post/focus/PostDiscussionPanel.tsx
+++ b/packages/shared/src/components/post/focus/PostDiscussionPanel.tsx
@@ -20,19 +20,10 @@ import {
 } from '../../ProfilePicture';
 import { Image } from '../../image/Image';
 import { fallbackImages } from '../../../lib/config';
-import {
-  Button,
-  ButtonIconPosition,
-  ButtonSize,
-  ButtonVariant,
-} from '../../buttons/Button';
+import { ClickableText } from '../../buttons/ClickableText';
+import { IconSize } from '../../Icon';
 import { TimeSortIcon } from '../../icons/Sort/Time';
 import { SortCommentsBy } from '../../../graphql/comments';
-import {
-  Typography,
-  TypographyColor,
-  TypographyType,
-} from '../../typography/Typography';
 import { DiscussionMetaBar } from './DiscussionMetaBar';
 import { DiscussionShareRow } from './DiscussionShareRow';
 
@@ -89,7 +80,6 @@ export const PostDiscussionPanel = ({
     useSettingsContext();
   const isNewestFirst = sortBy === SortCommentsBy.NewestFirst;
   const commentRef = useRef<NewCommentRef | null>(null);
-  const rootRef = useRef<HTMLElement | null>(null);
   const [isComposerOpen, setIsComposerOpen] = useState(false);
   const { onShowUpvoted } = useUpvoteQuery();
   const { openShareComment } = useShareComment(origin);
@@ -114,7 +104,9 @@ export const PostDiscussionPanel = ({
       return modalParentSelector();
     }
 
-    return rootRef.current ?? document.body;
+    // Append to the document body, not the panel root: the redesign modal card
+    // clips overflow, which would cut off profile hover cards near its edges.
+    return document.body;
   };
 
   const renderComposerTrigger = ({
@@ -125,7 +117,7 @@ export const PostDiscussionPanel = ({
       type="button"
       aria-label="Add a comment"
       onClick={() => onCommentClick(Origin.StartDiscussion)}
-      className="group flex w-full items-center gap-3 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-3 text-left transition-colors hover:border-border-subtlest-primary hover:bg-surface-hover"
+      className="group flex w-full items-center gap-3 rounded-16 border border-border-subtlest-tertiary p-3 text-left transition-colors hover:border-border-subtlest-primary"
     >
       {triggerUser ? (
         <ProfilePicture
@@ -161,7 +153,6 @@ export const PostDiscussionPanel = ({
 
   return (
     <section
-      ref={rootRef}
       aria-label="Discussion"
       className={classNames('flex min-h-0 min-w-0 flex-col gap-2', className)}
     >
@@ -178,36 +169,27 @@ export const PostDiscussionPanel = ({
       </div>
       <DiscussionShareRow post={post} withSquads />
       {showSortHeader && (
-        <span className="flex shrink-0 flex-row items-center">
-          <Typography
-            color={TypographyColor.Tertiary}
-            type={TypographyType.Footnote}
-          >
-            Sort:
-          </Typography>
-          <Button
-            className="ml-1 !px-1 !text-text-tertiary"
-            icon={
-              <TimeSortIcon
-                secondary
-                className={isNewestFirst ? undefined : 'rotate-180'}
-              />
-            }
-            iconPosition={ButtonIconPosition.Right}
-            onClick={() =>
-              setSortBy(
-                isNewestFirst
-                  ? SortCommentsBy.OldestFirst
-                  : SortCommentsBy.NewestFirst,
-              )
-            }
-            size={ButtonSize.XSmall}
-            type="button"
-            variant={ButtonVariant.Tertiary}
-          >
-            {isNewestFirst ? 'Newest first' : 'Oldest first'}
-          </Button>
-        </span>
+        // A text link (not a button) so it aligns flush-left with the comments
+        // below it; `mb-2` adds breathing room before the first comment.
+        <ClickableText
+          type="button"
+          defaultTypo={false}
+          className="mb-2 w-fit gap-1 typo-footnote"
+          onClick={() =>
+            setSortBy(
+              isNewestFirst
+                ? SortCommentsBy.OldestFirst
+                : SortCommentsBy.NewestFirst,
+            )
+          }
+        >
+          {isNewestFirst ? 'Newest first' : 'Oldest first'}
+          <TimeSortIcon
+            secondary
+            size={IconSize.XSmall}
+            className={isNewestFirst ? undefined : 'rotate-180'}
+          />
+        </ClickableText>
       )}
       <div className="min-w-0">
         <PostComments

--- a/packages/shared/src/components/post/focus/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.tsx
@@ -19,6 +19,8 @@ import { useUpvoteQuery } from '../../../hooks/useUpvoteQuery';
 import { useReaderInstallPromptGate } from '../../../hooks/useReaderInstallPromptGate';
 import { useReaderModalEligibility } from '../reader/hooks/useReaderModalEligibility';
 import { EarthIcon } from '../../icons';
+import { useLazyModal } from '../../../hooks/useLazyModal';
+import { LazyModal } from '../../modals/common/types';
 import PostMetadata from '../../cards/common/PostMetadata';
 import YoutubeVideo from '../../video/YoutubeVideo';
 import Markdown from '../../Markdown';
@@ -43,6 +45,7 @@ import type { UserShortProfile } from '../../../lib/user';
 import { FollowButton } from '../../contentPreference/FollowButton';
 import { ContentPreferenceType } from '../../../graphql/contentPreference';
 import { PostSidebarAdWidget } from '../PostSidebarAdWidget';
+import { PostMenuOptions } from '../PostMenuOptions';
 import { FocusCardActionBar } from './FocusCardActionBar';
 import { PostDiscussionPanel } from './PostDiscussionPanel';
 import { CollectionSources } from './CollectionSources';
@@ -231,6 +234,7 @@ export const PostFocusCard = ({
   const isVideoType = isVideoPost(article);
   const { title } = useSmartTitle(article);
   const { onCopyPostLink, onReadArticle } = usePostContent({ origin, post });
+  const { openModal } = useLazyModal();
   const { onShowUpvoted } = useUpvoteQuery();
   const { onReadClick: onReaderInstallGateClick } =
     useReaderInstallPromptGate(post);
@@ -268,9 +272,8 @@ export const PostFocusCard = ({
     return () => window.removeEventListener('blur', onWindowBlur);
   }, [isVideoType, isVideoExpanded]);
 
-  // Shared by the cover image and the Read button so both honor the reader
-  // gate (open the reader inside daily.dev / install nudge) before falling back
-  // to opening the external article.
+  // Honors the reader gate (open the reader inside daily.dev / install nudge)
+  // before falling back to opening the external article.
   const handleReadClick = (event: React.MouseEvent) => {
     if (onReaderInstallGateClick(event)) {
       return;
@@ -287,8 +290,9 @@ export const PostFocusCard = ({
     focusCommentRef.current();
   };
 
-  // Rendered in the header on tablet+ (next to Follow) but moved below the
-  // title on mobile, where the header row is too tight to hold both.
+  // Rendered in the title column, directly under the title, so it stays close
+  // to the title regardless of the cover image height. The engagement bar lives
+  // further down by the comment composer where the reader's cursor rests.
   const renderReadButton = (className: string): ReactElement | null =>
     readHref && !isInternalReadType(post) ? (
       <Button
@@ -347,7 +351,13 @@ export const PostFocusCard = ({
                 />
               )
             )}
-            {renderReadButton('ml-auto hidden shrink-0 tablet:flex')}
+            <div className="ml-auto shrink-0">
+              <PostMenuOptions
+                post={post}
+                origin={origin}
+                buttonSize={ButtonSize.Medium}
+              />
+            </div>
           </div>
 
           <div className="flex min-w-0 flex-col gap-3">
@@ -392,10 +402,11 @@ export const PostFocusCard = ({
             {!isShared && isCollection && (
               <p className="text-text-tertiary typo-footnote">Collection</p>
             )}
-            {/* Title and image are top-aligned columns. The below-title read
-                button lives in the SAME column as the title (tight gap) so it
-                sits right under it regardless of the image height; from tablet
-                (656px) up the button moves to the top row and this one hides. */}
+            {/* Title and image are top-aligned columns. The cover image opens a
+                lightbox rather than navigating away. The read button lives in
+                the title column (right under the title) so it hugs the title
+                regardless of the image height — a short title next to a tall
+                image keeps the button close instead of dragging it down. */}
             <div className="flex min-w-0 flex-row items-start gap-4">
               <div className="flex min-w-0 flex-1 flex-col gap-4">
                 <h1
@@ -410,16 +421,25 @@ export const PostFocusCard = ({
                 >
                   {title}
                 </h1>
-                {renderReadButton('w-fit tablet:hidden')}
+                {renderReadButton('w-fit')}
               </div>
               {!isVideoType && article.image && (
-                <a
-                  className="block h-fit w-24 shrink-0 overflow-hidden rounded-16 bg-background-subtle tablet:w-40"
-                  href={readHref}
-                  onClick={handleReadClick}
-                  rel="noopener"
-                  target="_blank"
-                  title="Go to post"
+                <button
+                  type="button"
+                  aria-label="View cover image"
+                  className="block h-fit w-24 shrink-0 cursor-zoom-in overflow-hidden rounded-16 bg-background-subtle tablet:w-40"
+                  onClick={(event) => {
+                    const { top, left, width, height } =
+                      event.currentTarget.getBoundingClientRect();
+                    openModal({
+                      type: LazyModal.ImageView,
+                      props: {
+                        src: article.image as string,
+                        alt: 'Post cover image',
+                        originRect: { top, left, width, height },
+                      },
+                    });
+                  }}
                 >
                   <LazyImage
                     eager
@@ -431,18 +451,10 @@ export const PostFocusCard = ({
                     imgAlt="Post cover image"
                     imgSrc={article.image}
                   />
-                </a>
+                </button>
               )}
             </div>
           </div>
-
-          <FocusCardActionBar
-            post={post}
-            origin={origin}
-            onComment={scrollToComment}
-            onCopyLinkClick={onCopyPostLink}
-            onClose={onClose}
-          />
 
           <PostMetadata
             className="!typo-callout"
@@ -519,6 +531,10 @@ export const PostFocusCard = ({
             post={post}
             onUpvotesClick={(upvotes) => onShowUpvoted(post.id, upvotes)}
             onCommentsClick={scrollToComment}
+            // Spacing in this column is governed by its `gap-4`; drop the stats
+            // row's own bottom margin so the gap above the action bar matches
+            // the gap below it.
+            className="!mb-0"
           />
 
           {isCollection && <CollectionSources post={article} />}
@@ -530,6 +546,17 @@ export const PostFocusCard = ({
           )}
 
           <PostSidebarAdWidget postId={post.id} variant="inline" />
+
+          <FocusCardActionBar
+            post={post}
+            origin={origin}
+            onComment={scrollToComment}
+            onCopyLinkClick={onCopyPostLink}
+            onClose={onClose}
+            // Tighten the gap to the stats row above (the column's gap-4 alone
+            // read as too large here).
+            className="-mt-2"
+          />
 
           <div ref={discussionRef} className="scroll-mt-16">
             <PostDiscussionPanel

--- a/packages/shared/src/components/post/focus/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.tsx
@@ -21,6 +21,7 @@ import { useReaderModalEligibility } from '../reader/hooks/useReaderModalEligibi
 import { EarthIcon } from '../../icons';
 import { useLazyModal } from '../../../hooks/useLazyModal';
 import { LazyModal } from '../../modals/common/types';
+import { getImageOriginRect } from '../../modals/ImageModal';
 import PostMetadata from '../../cards/common/PostMetadata';
 import YoutubeVideo from '../../video/YoutubeVideo';
 import Markdown from '../../Markdown';
@@ -429,14 +430,12 @@ export const PostFocusCard = ({
                   aria-label="View cover image"
                   className="block h-fit w-24 shrink-0 cursor-zoom-in overflow-hidden rounded-16 bg-background-subtle tablet:w-40"
                   onClick={(event) => {
-                    const { top, left, width, height } =
-                      event.currentTarget.getBoundingClientRect();
                     openModal({
                       type: LazyModal.ImageView,
                       props: {
                         src: article.image as string,
                         alt: 'Post cover image',
-                        originRect: { top, left, width, height },
+                        originRect: getImageOriginRect(event.currentTarget),
                       },
                     });
                   }}

--- a/packages/shared/src/components/profile/ProfileTooltip.tsx
+++ b/packages/shared/src/components/profile/ProfileTooltip.tsx
@@ -156,6 +156,23 @@ export function ProfileTooltip({
     interactive: true,
     onHide,
     appendTo: tooltip?.appendTo || globalThis?.document?.body,
+    // Render the card with a fixed strategy so it escapes any
+    // `overflow: clip/hidden` ancestor (e.g. the post modal card, which would
+    // otherwise cut it off), and keep it inside the viewport on every screen
+    // size — shifting/flipping rather than spilling past an edge.
+    popperOptions: {
+      strategy: 'fixed',
+      modifiers: [
+        {
+          name: 'preventOverflow',
+          options: { padding: 8, altAxis: true, rootBoundary: 'viewport' },
+        },
+        {
+          name: 'flip',
+          options: { padding: 8, fallbackPlacements: ['bottom', 'top'] },
+        },
+      ],
+    },
     container: { bgClassName: '' },
     content:
       !isLoading && tooltipUser ? (

--- a/packages/shared/src/components/tooltips/BaseTooltip.tsx
+++ b/packages/shared/src/components/tooltips/BaseTooltip.tsx
@@ -39,6 +39,7 @@ export interface TooltipProps
     | 'plugins'
     | 'zIndex'
     | 'onClickOutside'
+    | 'popperOptions'
   > {
   container?: Omit<
     BaseTooltipContainerProps,

--- a/packages/shared/src/features/profile/components/workspacePhotos/ProfileUserWorkspacePhotos.spec.tsx
+++ b/packages/shared/src/features/profile/components/workspacePhotos/ProfileUserWorkspacePhotos.spec.tsx
@@ -4,6 +4,7 @@ import type { PublicProfile } from '../../../../lib/user';
 import { ProfileUserWorkspacePhotos } from './ProfileUserWorkspacePhotos';
 import { useUserWorkspacePhotos } from '../../hooks/useUserWorkspacePhotos';
 import { useGear } from '../../hooks/useGear';
+import { LazyModal } from '../../../../components/modals/common/types';
 
 jest.mock('../../hooks/useUserWorkspacePhotos', () => ({
   ...jest.requireActual('../../hooks/useUserWorkspacePhotos'),
@@ -22,6 +23,11 @@ jest.mock('../../../../hooks/usePrompt', () => ({
   usePrompt: () => ({ showPrompt: jest.fn() }),
 }));
 
+const mockOpenModal = jest.fn();
+jest.mock('../../../../hooks/useLazyModal', () => ({
+  useLazyModal: () => ({ openModal: mockOpenModal }),
+}));
+
 const mockUseUserWorkspacePhotos =
   useUserWorkspacePhotos as jest.MockedFunction<typeof useUserWorkspacePhotos>;
 const mockUseGear = useGear as jest.MockedFunction<typeof useGear>;
@@ -38,11 +44,6 @@ const baseUser: PublicProfile = {
 };
 
 const photo = { id: 'p1', image: 'https://daily.dev/desk.png', position: 0 };
-
-const renderAndOpenLightbox = () => {
-  render(<ProfileUserWorkspacePhotos user={baseUser} />);
-  fireEvent.click(screen.getByRole('button', { name: 'View workspace photo' }));
-};
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -63,27 +64,28 @@ beforeEach(() => {
 });
 
 describe('ProfileUserWorkspacePhotos lightbox', () => {
-  it('opens a dialog with a blurred backdrop when a photo is clicked', () => {
-    renderAndOpenLightbox();
+  it('opens the shared image lightbox with the photo when clicked', () => {
+    render(<ProfileUserWorkspacePhotos user={baseUser} />);
 
-    expect(
-      screen.getByRole('dialog', { name: 'Workspace photo lightbox' }),
-    ).toBeInTheDocument();
-    const backdrop = screen.getByRole('button', { name: 'Close lightbox' });
-    expect(backdrop.className).toMatch(/backdrop-blur/);
-  });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'View workspace photo' }),
+    );
 
-  it('closes the lightbox when the backdrop is clicked', () => {
-    renderAndOpenLightbox();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Close lightbox' }));
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-  });
-
-  it('closes the lightbox when the close button is clicked', () => {
-    renderAndOpenLightbox();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(mockOpenModal).toHaveBeenCalledTimes(1);
+    expect(mockOpenModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: LazyModal.ImageView,
+        props: expect.objectContaining({
+          src: photo.image,
+          alt: 'Workspace',
+          originRect: expect.objectContaining({
+            top: expect.any(Number),
+            left: expect.any(Number),
+            width: expect.any(Number),
+            height: expect.any(Number),
+          }),
+        }),
+      }),
+    );
   });
 });

--- a/packages/shared/src/features/profile/components/workspacePhotos/ProfileUserWorkspacePhotos.tsx
+++ b/packages/shared/src/features/profile/components/workspacePhotos/ProfileUserWorkspacePhotos.tsx
@@ -15,7 +15,6 @@ import {
   sortableKeyboardCoordinates,
   rectSortingStrategy,
 } from '@dnd-kit/sortable';
-import { useEventListener } from '../../../../hooks/useEventListener';
 import type { PublicProfile } from '../../../../lib/user';
 import {
   useUserWorkspacePhotos,
@@ -33,7 +32,9 @@ import {
   ButtonVariant,
 } from '../../../../components/buttons/Button';
 import { CameraIcon, SettingsIcon } from '../../../../components/icons';
-import CloseButton from '../../../../components/CloseButton';
+import { useLazyModal } from '../../../../hooks/useLazyModal';
+import { LazyModal } from '../../../../components/modals/common/types';
+import { getImageOriginRect } from '../../../../components/modals/ImageModal';
 import { SortableWorkspacePhotoItem } from './WorkspacePhotoItem';
 import { WorkspacePhotoUploadModal } from './WorkspacePhotoUploadModal';
 import { GearModal } from '../gear/GearModal';
@@ -63,10 +64,10 @@ export function ProfileUserWorkspacePhotos({
   const { displayToast } = useToastNotification();
   const { showPrompt } = usePrompt();
   const { logEvent } = useLogContext();
+  const { openModal } = useLazyModal();
 
   const [isPhotoModalOpen, setIsPhotoModalOpen] = useState(false);
   const [isGearModalOpen, setIsGearModalOpen] = useState(false);
-  const [selectedPhoto, setSelectedPhoto] = useState<string | null>(null);
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -197,20 +198,19 @@ export function ProfileUserWorkspacePhotos({
     setIsGearModalOpen(false);
   }, []);
 
-  const handlePhotoClick = useCallback((photo: { image: string }) => {
-    setSelectedPhoto(photo.image);
-  }, []);
-
-  const handleCloseLightbox = useCallback(() => {
-    setSelectedPhoto(null);
-  }, []);
-
-  // Close lightbox on ESC key
-  useEventListener(globalThis as unknown as Window, 'keydown', (event) => {
-    if (event.key === 'Escape' && selectedPhoto) {
-      handleCloseLightbox();
-    }
-  });
+  const handlePhotoClick = useCallback(
+    (photo: { image: string }, event: React.MouseEvent<HTMLButtonElement>) => {
+      openModal({
+        type: LazyModal.ImageView,
+        props: {
+          src: photo.image,
+          alt: 'Workspace',
+          originRect: getImageOriginRect(event.currentTarget),
+        },
+      });
+    },
+    [openModal],
+  );
 
   const hasPhotos = photos.length > 0;
   const hasGear = gearItems.length > 0;
@@ -354,33 +354,6 @@ export function ProfileUserWorkspacePhotos({
           onRequestClose={handleCloseGearModal}
           onSubmit={handleAddGear}
         />
-      )}
-
-      {selectedPhoto && (
-        <div
-          className="fixed inset-0 z-modal flex items-center justify-center p-4"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Workspace photo lightbox"
-        >
-          <button
-            type="button"
-            className="absolute inset-0 bg-overlay-primary-pepper backdrop-blur-md"
-            onClick={handleCloseLightbox}
-            aria-label="Close lightbox"
-          />
-          <img
-            src={selectedPhoto}
-            alt="Workspace"
-            className="relative max-h-full max-w-full rounded-16 object-contain"
-          />
-          <CloseButton
-            size={ButtonSize.Small}
-            variant={ButtonVariant.Primary}
-            className="absolute right-4 top-4 z-1"
-            onClick={handleCloseLightbox}
-          />
-        </div>
       )}
     </div>
   );

--- a/packages/shared/src/features/profile/components/workspacePhotos/WorkspacePhotoItem.tsx
+++ b/packages/shared/src/features/profile/components/workspacePhotos/WorkspacePhotoItem.tsx
@@ -15,7 +15,10 @@ interface WorkspacePhotoItemProps {
   photo: UserWorkspacePhoto;
   isOwner: boolean;
   onDelete?: (photo: UserWorkspacePhoto) => void;
-  onClick?: (photo: UserWorkspacePhoto) => void;
+  onClick?: (
+    photo: UserWorkspacePhoto,
+    event: React.MouseEvent<HTMLButtonElement>,
+  ) => void;
 }
 
 export function WorkspacePhotoItem({
@@ -35,7 +38,7 @@ export function WorkspacePhotoItem({
       <button
         type="button"
         className="size-full"
-        onClick={onClick ? () => onClick(photo) : undefined}
+        onClick={onClick ? (event) => onClick(photo, event) : undefined}
         aria-label="View workspace photo"
       >
         <img

--- a/packages/shared/tailwind.config.ts
+++ b/packages/shared/tailwind.config.ts
@@ -240,6 +240,10 @@ export default {
         20: '1.25rem',
       },
       keyframes: {
+        'image-zoom-in': {
+          from: { opacity: '0', transform: 'scale(0.85)' },
+          to: { opacity: '1', transform: 'scale(1)' },
+        },
         'scale-down-pulse': {
           '0%, 100%': { transform: 'scale(1)', opacity: '1' },
           '50%': { transform: 'scale(0.7)', opacity: '0.5' },
@@ -367,6 +371,7 @@ export default {
         },
       },
       animation: {
+        'image-zoom-in': 'image-zoom-in 0.2s cubic-bezier(0.16, 1, 0.3, 1)',
         'scale-down-pulse':
           'scale-down-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
         'fade-slide-up': 'fade-slide-up 0.5s ease-out 1s both',


### PR DESCRIPTION
## What

Reading-focused improvements to `PostFocusCard` and the post-modal shell, across **all** redesign post types (article, video, share/freeform/welcome, collection) on **both** the modal and the page — plus reuse of the new shared image lightbox in the profile workspace-photos grid.

### Image lightbox
- Cover image and in-article (markdown) images open a full-screen, viewport-centered viewer (`max-h/max-w` `object-contain`, dark blurred backdrop, X pinned to the screen corner) instead of navigating away. New `ImageModal` registered as `LazyModal.ImageView`; the extension companion falls back to a new tab.
- Expands from the clicked thumbnail with a smooth, uniform-scale FLIP (the corner radius stays a constant ~16px throughout — no distortion or radius snap), and a zoom-in cursor on clickable images. Closes on backdrop / X / Esc (Esc scoped so it doesn't also close the post modal) and locks background scroll while open (with scrollbar compensation so the page doesn't shift).

### Focus card
- **Engagement bar** moved above the "Share your thoughts" composer; restyled as a floating pill (translucent `surface-float`, blur, soft shadow) and sticky at both edges, tablet and up. Surfaces upvote/comment/award counts + the "…" menu when pinned; analytics icon dropped (redundant with the stats-row link).
- **Read post** button moved under the title; **three-dots menu** moved to the card header.
- **Comment sort** is now a flush-left text link (no "Sort:" label).

### Modal shell
- Hide the duplicate top-strip "…" menu in the redesign via a new `hideOptions` prop wired through `navigationRedesign` on the Article/Collection/Share modals.
- Backdrop pinned to a fixed `::before` layer so it no longer scrolls away; `overscroll-behavior: contain` stops scroll chaining to the feed.

### Tooltips
- Profile hover cards use a fixed Popper strategy + viewport `preventOverflow`/`flip` so they're no longer clipped by the modal's `overflow: clip`.

### Profile workspace photos
- The bespoke inline lightbox in `ProfileUserWorkspacePhotos` is replaced by the shared `LazyModal.ImageView`, so both surfaces share one implementation (FLIP entrance, Esc handling, scroll-lock, onError fallback) and can't drift.

## Notes
- Rebased cleanly onto current `main`, preserving the newer reader-variant logic (`useReaderModalEligibility` / reader install gate) on the Read button while applying the cover-image → lightbox change.
- Replaces the mock-up PR #6211 (and folds in #6227).

## Verification
- `node ./scripts/typecheck-strict-changed.js` ✅ · `eslint` on changed files ✅ · `ImageModal` + workspace-photos jest specs ✅ · full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-elegant-sammet-973b0a.preview.app.daily.dev