### PR TITLE
feat(daily): always-expanded feed card glass actions

### DIFF
--- a/packages/shared/src/components/cards/Freeform/FreeformGrid.tsx
+++ b/packages/shared/src/components/cards/Freeform/FreeformGrid.tsx
@@ -128,6 +128,7 @@ export const FreeformGrid = forwardRef(function SharePostCard(
           image={image}
           contentHtml={post.contentHtml}
           post={post}
+          glassActions={useGlass}
           imageClassName={
             useGlass && image ? glassCoverImageClassName : undefined
           }

--- a/packages/shared/src/components/cards/ad/AdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/AdGrid.tsx
@@ -88,7 +88,11 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
           </div>
         </div>
       </CardTextContainer>
-      <AdImage className="mx-1 mb-0" ad={ad} ImageComponent={CardImage} />
+      <AdImage
+        className="!mx-0 !mb-0 !rounded-b-16 !rounded-t-none [&_img]:!rounded-none"
+        ad={ad}
+        ImageComponent={CardImage}
+      />
       <AdPixel pixel={ad.pixel} />
     </Card>
   );

--- a/packages/shared/src/components/cards/ad/AdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/AdGrid.tsx
@@ -56,7 +56,6 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
         ) : null}
         <AdAttribution className={{ main: 'font-normal' }} />
       </CardTextContainer>
-      <AdImage className="mx-1 mb-0" ad={ad} ImageComponent={CardImage} />
       <CardTextContainer className="!mx-1 my-1">
         <div className="flex items-center">
           {!!ad.callToAction && (
@@ -89,6 +88,7 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
           </div>
         </div>
       </CardTextContainer>
+      <AdImage className="mx-1 mb-0" ad={ad} ImageComponent={CardImage} />
       <AdPixel pixel={ad.pixel} />
     </Card>
   );

--- a/packages/shared/src/components/cards/ad/AdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/AdGrid.tsx
@@ -26,6 +26,7 @@ import { useFeature } from '../../GrowthBookProvider';
 import { adImprovementsV3Feature } from '../../../lib/featureManagement';
 import { TargetId } from '../../../lib/log';
 import { AdvertiseLink } from './common/AdvertiseLink';
+import { useFeedCardGlassActions } from '../../../hooks/useFeedCardGlassActions';
 
 export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
   { ad, onLinkClick, domProps, index, feedIndex },
@@ -33,6 +34,7 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
 ): ReactElement {
   const { isPlus } = usePlusSubscription();
   const adImprovementsV3 = useFeature(adImprovementsV3Feature);
+  const useGlass = useFeedCardGlassActions();
   const { ref } = useAutoRotatingAds(
     ad,
     index,
@@ -56,6 +58,9 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
         ) : null}
         <AdAttribution className={{ main: 'font-normal' }} />
       </CardTextContainer>
+      {!useGlass && (
+        <AdImage className="mx-1 mb-0" ad={ad} ImageComponent={CardImage} />
+      )}
       <CardTextContainer className="!mx-1 my-1">
         <div className="flex items-center">
           {!!ad.callToAction && (
@@ -88,11 +93,13 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
           </div>
         </div>
       </CardTextContainer>
-      <AdImage
-        className="!mx-0 !mb-0 !rounded-b-16 !rounded-t-none [&_img]:!rounded-none"
-        ad={ad}
-        ImageComponent={CardImage}
-      />
+      {useGlass && (
+        <AdImage
+          className="!mx-0 !mb-0 !rounded-b-16 !rounded-t-none [&_img]:!rounded-none"
+          ad={ad}
+          ImageComponent={CardImage}
+        />
+      )}
       <AdPixel pixel={ad.pixel} />
     </Card>
   );

--- a/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.tsx
@@ -291,7 +291,15 @@ export const ArticleFeaturedWideGridCard = forwardRef(
                     className="mt-1"
                   />
                   {description ? (
-                    <p className="mt-2 line-clamp-3 text-text-secondary typo-callout">
+                    <p
+                      className={classNames(
+                        'mt-2 text-text-secondary typo-callout',
+                        // The glass action bar floats over the column bottom.
+                        // Clamp one line tighter and reserve its height (pb-12)
+                        // so the summary never sits under it.
+                        useGlass ? 'line-clamp-2 pb-12' : 'line-clamp-3',
+                      )}
+                    >
                       {description}
                     </p>
                   ) : null}

--- a/packages/shared/src/components/cards/article/ArticleGrid.tsx
+++ b/packages/shared/src/components/cards/article/ArticleGrid.tsx
@@ -137,7 +137,11 @@ export const ArticleGrid = forwardRef(function ArticleGrid(
             onReadArticleClick={onReadArticleClick}
             showFeedback={showFeedback}
           />
-          <CardTitle lineClamp={showFeedback ? 'line-clamp-2' : undefined}>
+          <CardTitle
+            lineClamp={
+              showFeedback || glassActions ? 'line-clamp-2' : undefined
+            }
+          >
             {title}
           </CardTitle>
         </CardTextContainer>

--- a/packages/shared/src/components/cards/collection/CollectionGrid.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionGrid.tsx
@@ -118,6 +118,7 @@ export const CollectionGrid = forwardRef(function CollectionCard(
           contentHtml={post.contentHtml}
           post={post}
           onShare={onShare}
+          glassActions={useGlass}
           imageClassName={
             useGlass && image ? glassCoverImageClassName : undefined
           }

--- a/packages/shared/src/components/cards/common/CardCoverShare.tsx
+++ b/packages/shared/src/components/cards/common/CardCoverShare.tsx
@@ -12,12 +12,14 @@ interface CardCoverShareProps {
   onShare: () => void;
   onCopy: () => void;
   post: Post;
+  className?: string;
 }
 
 export function CardCoverShare({
   post,
   onCopy,
   onShare,
+  className,
 }: CardCoverShareProps): ReactElement {
   const { onCopyLink, isLoading } = useLoggedCopyPostLink(post);
   const onClick = () => {
@@ -28,7 +30,7 @@ export function CardCoverShare({
   return (
     <CardCoverContainer
       title="Should anyone else see this post?"
-      className="pb-12"
+      className={className}
     >
       <span className="mt-2 flex flex-row flex-wrap justify-center gap-3 p-2">
         <Button

--- a/packages/shared/src/components/cards/common/CardCoverShare.tsx
+++ b/packages/shared/src/components/cards/common/CardCoverShare.tsx
@@ -26,7 +26,10 @@ export function CardCoverShare({
   };
 
   return (
-    <CardCoverContainer title="Should anyone else see this post?">
+    <CardCoverContainer
+      title="Should anyone else see this post?"
+      className="pb-12"
+    >
       <span className="mt-2 flex flex-row flex-wrap justify-center gap-3 p-2">
         <Button
           variant={ButtonVariant.Secondary}

--- a/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
+++ b/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import type { ActionButtonsProps } from './ActionButtons';
@@ -23,52 +23,22 @@ import { useCardActions } from '../../../hooks/cards/useCardActions';
 export const glassCoverImageClassName =
   '!px-0 !mb-0 !rounded-t-none !rounded-b-16';
 
-const morphEase =
-  'duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none';
-
-// Positioning grid: track 1 holds the pill, track 2 is a spacer. Animating the
-// fr split expands the pill from content-hugging to full width on hover —
-// `fit-content → 100%` isn't animatable, but fr tracks are.
-const outerClasses = classNames(
-  'pointer-events-none absolute inset-x-2 bottom-2 z-1 grid',
-  `transition-[grid-template-columns] ${morphEase}`,
-  '[grid-template-columns:1fr_0fr]',
-  'laptop:mouse:[grid-template-columns:0fr_1fr]',
-  'laptop:mouse:group-hover:[grid-template-columns:1fr_0fr]',
-);
+const outerClasses = 'pointer-events-none absolute inset-x-2 bottom-2 z-1';
 
 // Only the rest color is pinned to text-primary for contrast on the glass;
 // hover/pressed colors are left to each `btn-tertiary-*` class so icons keep
 // their brand tint on hover, matching the standard ActionButtons.
 const pillClasses = classNames(
-  'pointer-events-auto flex h-10 min-w-fit items-center justify-between overflow-hidden px-1',
+  'pointer-events-auto flex h-10 w-full items-center overflow-hidden px-1',
   'rounded-12 border border-border-subtlest-tertiary',
   'bg-blur-bg text-text-primary backdrop-blur-xl backdrop-saturate-150',
   '[&_.btn-quaternary]:[--button-default-color:var(--theme-text-primary)]',
   '[&_.btn]:[--button-default-color:var(--theme-text-primary)]',
 );
 
-// One collapsible track per secondary action: width animates 0fr ↔ 1fr on hover
-// while the content fades in. `visibility` removes hidden buttons from focus order.
-const segmentClasses = classNames(
-  `grid transition-[grid-template-columns] ${morphEase}`,
-  '[grid-template-columns:1fr]',
-  'laptop:mouse:[grid-template-columns:0fr]',
-  'laptop:mouse:group-hover:[grid-template-columns:1fr]',
-);
-
-const segmentContentClasses = classNames(
-  'flex min-w-0 items-center justify-center overflow-hidden',
-  'transition-[opacity,visibility] duration-200 ease-out motion-reduce:transition-none',
-  'visible opacity-100',
-  'laptop:mouse:invisible laptop:mouse:opacity-0',
-  'laptop:mouse:group-hover:visible laptop:mouse:group-hover:opacity-100',
-);
-
-const segmentProps = {
-  wrapperClassName: segmentClasses,
-  contentClassName: segmentContentClasses,
-};
+// Every action gets an equal-width centered slot so the icons stay evenly spaced
+// across the pill regardless of upvote/comment counts widening a button.
+const slotClasses = 'flex min-w-0 flex-1 items-center justify-center';
 
 // Dark glow behind the pill so it stays readable over busy cover images. Fixed
 // pepper tint in both themes; inline gradient since it's a one-off scrim.
@@ -76,22 +46,6 @@ const scrimGradient =
   'radial-gradient(75% 90% at 0% 100%, rgba(14, 18, 23, 0.55) 0%, rgba(14, 18, 23, 0) 70%)';
 const scrimClasses =
   'pointer-events-none absolute bottom-0 left-0 z-0 h-24 w-3/5 rounded-bl-16';
-
-interface SegmentProps {
-  children: ReactNode;
-  wrapperClassName: string;
-  contentClassName: string;
-}
-
-const Segment = ({
-  children,
-  wrapperClassName,
-  contentClassName,
-}: SegmentProps): ReactElement => (
-  <div className={wrapperClassName}>
-    <div className={contentClassName}>{children}</div>
-  </div>
-);
 
 export function FeedCardGlassActions({
   post,
@@ -127,27 +81,6 @@ export function FeedCardGlassActions({
   const upvoteCount = post.numUpvotes ?? 0;
   const commentCount = post.numComments ?? 0;
 
-  const commentButton = (
-    <Tooltip content="Comments" side="bottom">
-      <QuaternaryButton
-        labelClassName="!pl-[1px] pr-1.5"
-        id={`post-${post.id}-comment-btn`}
-        icon={<CommentIcon secondary={post.commented} size={IconSize.XSmall} />}
-        pressed={post.commented}
-        onClick={() => onCommentClick?.(post)}
-        size={ButtonSize.Small}
-        className="btn-tertiary-blueCheese pointer-events-auto"
-      >
-        {commentCount > 0 && (
-          <InteractionCounter
-            className="tabular-nums !typo-footnote"
-            value={commentCount}
-          />
-        )}
-      </QuaternaryButton>
-    </Tooltip>
-  );
-
   return (
     <>
       {coverScrim && (
@@ -159,41 +92,63 @@ export function FeedCardGlassActions({
       )}
       <div className={outerClasses}>
         <div className={pillClasses}>
-          <Tooltip
-            content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
-            side="bottom"
-          >
-            <QuaternaryButton
-              labelClassName="!pl-[1px] pr-1.5"
-              className="btn-tertiary-avocado pointer-events-auto"
-              id={`post-${post.id}-upvote-btn`}
-              color={ButtonColor.Avocado}
-              pressed={isUpvoteActive}
-              onClick={onToggleUpvote}
-              variant={ButtonVariant.Tertiary}
-              size={ButtonSize.Small}
-              icon={
-                <UpvoteButtonIcon
-                  secondary={isUpvoteActive}
-                  size={IconSize.XSmall}
-                />
-              }
+          <div className={slotClasses}>
+            <Tooltip
+              content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
+              side="bottom"
             >
-              {upvoteCount > 0 && (
-                <InteractionCounter
-                  className="tabular-nums typo-footnote"
-                  value={upvoteCount}
-                />
-              )}
-            </QuaternaryButton>
-          </Tooltip>
-          {commentCount > 0 ? (
-            commentButton
-          ) : (
-            <Segment {...segmentProps}>{commentButton}</Segment>
-          )}
+              <QuaternaryButton
+                labelClassName="!pl-[1px] pr-1.5"
+                className="btn-tertiary-avocado pointer-events-auto"
+                id={`post-${post.id}-upvote-btn`}
+                color={ButtonColor.Avocado}
+                pressed={isUpvoteActive}
+                onClick={onToggleUpvote}
+                variant={ButtonVariant.Tertiary}
+                size={ButtonSize.Small}
+                icon={
+                  <UpvoteButtonIcon
+                    secondary={isUpvoteActive}
+                    size={IconSize.XSmall}
+                  />
+                }
+              >
+                {upvoteCount > 0 && (
+                  <InteractionCounter
+                    className="tabular-nums typo-footnote"
+                    value={upvoteCount}
+                  />
+                )}
+              </QuaternaryButton>
+            </Tooltip>
+          </div>
+          <div className={slotClasses}>
+            <Tooltip content="Comments" side="bottom">
+              <QuaternaryButton
+                labelClassName="!pl-[1px] pr-1.5"
+                id={`post-${post.id}-comment-btn`}
+                icon={
+                  <CommentIcon
+                    secondary={post.commented}
+                    size={IconSize.XSmall}
+                  />
+                }
+                pressed={post.commented}
+                onClick={() => onCommentClick?.(post)}
+                size={ButtonSize.Small}
+                className="btn-tertiary-blueCheese pointer-events-auto"
+              >
+                {commentCount > 0 && (
+                  <InteractionCounter
+                    className="tabular-nums !typo-footnote"
+                    value={commentCount}
+                  />
+                )}
+              </QuaternaryButton>
+            </Tooltip>
+          </div>
           {showDownvoteAction && (
-            <Segment {...segmentProps}>
+            <div className={slotClasses}>
               <Tooltip
                 content={
                   isDownvoteActive ? 'Remove downvote' : 'Less like this'
@@ -216,14 +171,14 @@ export function FeedCardGlassActions({
                   size={ButtonSize.Small}
                 />
               </Tooltip>
-            </Segment>
+            </div>
           )}
           {showAwardAction && (
-            <Segment {...segmentProps}>
+            <div className={slotClasses}>
               <PostAwardAction post={post} iconSize={IconSize.XSmall} />
-            </Segment>
+            </div>
           )}
-          <Segment {...segmentProps}>
+          <div className={slotClasses}>
             <BookmarkButton
               tooltipSide="bottom"
               post={post}
@@ -235,8 +190,8 @@ export function FeedCardGlassActions({
               }}
               iconSize={IconSize.XSmall}
             />
-          </Segment>
-          <Segment {...segmentProps}>
+          </div>
+          <div className={slotClasses}>
             <Tooltip content="Copy link" side="bottom">
               <QuaternaryButton
                 id="copy-post-btn"
@@ -248,9 +203,8 @@ export function FeedCardGlassActions({
                 className="pointer-events-auto"
               />
             </Tooltip>
-          </Segment>
+          </div>
         </div>
-        <div aria-hidden />
       </div>
     </>
   );

--- a/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
+++ b/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
@@ -140,7 +140,7 @@ export function FeedCardGlassActions({
               >
                 {commentCount > 0 && (
                   <InteractionCounter
-                    className="tabular-nums !typo-footnote"
+                    className="tabular-nums typo-footnote"
                     value={commentCount}
                   />
                 )}

--- a/packages/shared/src/components/cards/common/PostCardFooter.tsx
+++ b/packages/shared/src/components/cards/common/PostCardFooter.tsx
@@ -42,6 +42,9 @@ export const PostCardFooter = ({
         isVideoType={isVideoType}
         onShare={onShare}
         post={post}
+        // A glass cover (set via `className.cover`) has the action bar floating
+        // over its bottom; reserve its height so the share buttons clear it.
+        shareCoverClassName={className.cover ? 'pb-12' : undefined}
         imageProps={{
           alt: 'Post Cover image',
           className: classNames(

--- a/packages/shared/src/components/cards/common/SharedCardCover.tsx
+++ b/packages/shared/src/components/cards/common/SharedCardCover.tsx
@@ -25,6 +25,7 @@ export interface SharedCardCoverProps extends CommonCardCoverProps {
   isVideoType?: boolean;
   CardImageComponent: typeof CardImage;
   renderOverlay: (props: RenderProps) => ReactNode;
+  shareCoverClassName?: string;
 }
 
 export function SharedCardCover({
@@ -35,8 +36,13 @@ export function SharedCardCover({
   post,
   renderOverlay,
   CardImageComponent,
+  shareCoverClassName,
 }: SharedCardCoverProps): ReactElement {
-  const { overlay } = useCardCover({ post, onShare });
+  const { overlay } = useCardCover({
+    post,
+    onShare,
+    className: { share: { container: shareCoverClassName } },
+  });
   const imageClasses = classNames(
     imageProps?.className,
     !!overlay && 'opacity-16',

--- a/packages/shared/src/components/cards/common/WelcomePostCardFooter.tsx
+++ b/packages/shared/src/components/cards/common/WelcomePostCardFooter.tsx
@@ -13,6 +13,7 @@ interface WelcomePostCardFooterProps {
   contentHtml?: string;
   onShare?: (post: Post) => void;
   imageClassName?: string;
+  glassActions?: boolean;
 }
 
 export const WelcomePostCardFooter = ({
@@ -21,6 +22,7 @@ export const WelcomePostCardFooter = ({
   onShare,
   contentHtml,
   imageClassName,
+  glassActions = false,
 }: WelcomePostCardFooterProps): ReactElement | null => {
   const { overlay } = useCardCover({
     post,
@@ -67,7 +69,10 @@ export const WelcomePostCardFooter = ({
     return (
       <p
         className={classNames(
-          'mt-1 line-clamp-6 break-words px-4 typo-callout',
+          'mt-1 break-words px-4 typo-callout',
+          // The glass action bar floats over the card bottom. Clamp one line
+          // tighter and reserve its height (pb-12) so text never sits under it.
+          glassActions ? 'line-clamp-5 pb-12' : 'line-clamp-6',
         )}
       >
         {decodedText}

--- a/packages/shared/src/components/cards/common/WelcomePostCardFooter.tsx
+++ b/packages/shared/src/components/cards/common/WelcomePostCardFooter.tsx
@@ -51,6 +51,7 @@ export const WelcomePostCardFooter = ({
         <CardCover
           onShare={onShare}
           post={post}
+          shareCoverClassName={glassActions ? 'pb-12' : undefined}
           imageProps={{
             src: image,
             className: classNames('mb-1 mt-2 w-full px-1', imageClassName),

--- a/packages/shared/src/components/cards/placeholder/PlaceholderGrid.tsx
+++ b/packages/shared/src/components/cards/placeholder/PlaceholderGrid.tsx
@@ -5,6 +5,7 @@ import { CardSpace, CardTextContainer } from '../common/Card';
 import { ElementPlaceholder } from '../../ElementPlaceholder';
 import classed from '../../../lib/classed';
 import type { PlaceholderProps } from './common/common';
+import { useFeedCardGlassActions } from '../../../hooks/useFeedCardGlassActions';
 
 const Text = classed(ElementPlaceholder, 'h-3 rounded-12 my-2');
 
@@ -12,12 +13,15 @@ export const PlaceholderGrid = forwardRef(function PlaceholderCard(
   { className, ...props }: PlaceholderProps,
   ref: Ref<HTMLElement>,
 ): ReactElement {
+  const glassActions = useFeedCardGlassActions();
+
   return (
     <article
       aria-busy
       className={classNames(
         className,
-        'flex min-h-card flex-col rounded-16 bg-background-subtle p-2',
+        'flex flex-col rounded-16 bg-background-subtle p-2',
+        glassActions ? 'min-h-cardGlass' : 'min-h-card',
       )}
       {...props}
       ref={ref}
@@ -26,13 +30,21 @@ export const PlaceholderGrid = forwardRef(function PlaceholderCard(
         <ElementPlaceholder className="my-2 size-6 rounded-full" />
         <Text style={{ width: '100%' }} />
         <Text style={{ width: '100%' }} />
-        <Text style={{ width: '80%' }} />
+        {!glassActions && <Text style={{ width: '80%' }} />}
       </CardTextContainer>
       <CardSpace className="my-2" />
-      <ElementPlaceholder className="my-2 h-40 rounded-12" />
-      <CardTextContainer>
-        <Text style={{ width: '32%' }} />
-      </CardTextContainer>
+      {glassActions ? (
+        // Full-bleed cover matching the glass card: the action bar floats over
+        // the image, so there's no separate footer row beneath it.
+        <ElementPlaceholder className="-mx-2 -mb-2 mt-2 h-40 rounded-b-16" />
+      ) : (
+        <>
+          <ElementPlaceholder className="my-2 h-40 rounded-12" />
+          <CardTextContainer>
+            <Text style={{ width: '32%' }} />
+          </CardTextContainer>
+        </>
+      )}
     </article>
   );
 });

--- a/packages/shared/src/hooks/feed/useCardCover.tsx
+++ b/packages/shared/src/hooks/feed/useCardCover.tsx
@@ -21,6 +21,9 @@ interface UseCardCoverProps {
     bookmark?: {
       container?: string;
     };
+    share?: {
+      container?: string;
+    };
   };
 }
 
@@ -57,6 +60,7 @@ export const useCardCover = ({
       return (
         <CardCoverShare
           post={post}
+          className={className?.share?.container}
           onCopy={() => onInteract('none')}
           onShare={() => {
             onInteract('none');
@@ -87,6 +91,7 @@ export const useCardCover = ({
     return undefined;
   }, [
     className?.bookmark?.container,
+    className?.share?.container,
     interaction,
     onInteract,
     onShare,


### PR DESCRIPTION
## Changes

Productionizes the always-expanded variant of the floating glass action bar from mock-up #6222. The bar now renders fully expanded by default on every feed card that uses it, with no appearance animation, no hover-to-reveal behavior, and no header toggle.

- **`FeedCardGlassActions`** — removed the morph/fade transitions, the hover-collapse grid tracks, and the `Segment` wrapper. Every action now gets an equal-width centered slot (`flex-1`) so icons stay evenly spaced regardless of upvote/comment counts.
- **`ArticleGrid`** — clamp glass-card titles to 2 lines so long titles don't crowd the card.
- **`AdGrid`** — move the CTA / advertise / remove-ad row above the cover image to align the ad card with the new design.
- **`CardCoverShare`** — pad the "Should anyone else see this post?" downvote overlay (`pb-12`) so its buttons clear the bottom action bar.

Still gated behind the existing `featureFeedCardGlassActions` flag via `useFeedCardGlassActions`. Applies to all card types that render the bar (article, hero/wide, collection, freeform, poll, share).

### Dropped from the mock-up
The hover-reveal variation, the `ToggleGlassActionsExpanded` header button, and the `useGlassActionsExpanded` persistent-context hook were intentionally left out — the bar is always-expanded, so none of that wiring is needed.

## Events

No new tracking events.

## Experiment

No new experiments (uses the existing `featureFeedCardGlassActions` flag).

## Manual Testing

Affects the glass action bar on grid feed cards across webapp/extension/companion when the flag is on, plus the ad grid card layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-intelligent-elgamal-53432.preview.app.daily.dev