### PR TITLE
fix: use absolute post canonical urls

### DIFF
--- a/packages/webapp/lib/seo.ts
+++ b/packages/webapp/lib/seo.ts
@@ -25,3 +25,6 @@ export const getSiteOrigin = (): string =>
   normalizeOrigin(process.env.NEXT_PUBLIC_SITE_ORIGIN) || DEFAULT_SITE_ORIGIN;
 
 export const getLlmsTxtUrl = (): string => `${getAppOrigin()}/llms.txt`;
+
+export const getPostCanonicalUrl = (slug: string): string =>
+  `${getAppOrigin()}/posts/${slug}`;

--- a/packages/webapp/pages/posts/[id]/analytics/index.tsx
+++ b/packages/webapp/pages/posts/[id]/analytics/index.tsx
@@ -97,6 +97,7 @@ import type { Props } from '../index';
 import { seoTitle } from '../index';
 import { getPageSeoTitles } from '../../../../components/layouts/utils';
 import { getLayout } from '../../../../components/layouts/MainLayout';
+import { getPostCanonicalUrl } from '../../../../lib/seo';
 import type { SharePostPageProps } from '../share';
 import type { AnalyticsNumberList } from '../../../../../shared/src/components/analytics/common';
 
@@ -131,7 +132,7 @@ export const getServerSideProps: GetServerSideProps<
       [seoTitle(post), 'Analytics'].filter(Boolean).join(' | '),
     );
     const seo: NextSeoProps = {
-      canonical: post?.slug ? `${webappUrl}posts/${post.slug}` : undefined,
+      canonical: post?.slug ? getPostCanonicalUrl(post.slug) : undefined,
       title: pageSeoTitles.title,
       description: getSeoDescription(post),
       openGraph: {

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -37,7 +37,6 @@ import { ApiError, gqlClient } from '@dailydotdev/shared/src/graphql/common';
 import PostLoadingSkeleton from '@dailydotdev/shared/src/components/post/PostLoadingSkeleton';
 import classNames from 'classnames';
 import { useOnboardingActions } from '@dailydotdev/shared/src/hooks/auth/useOnboardingActions';
-import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import { useFeatureTheme } from '@dailydotdev/shared/src/hooks/utils/useFeatureTheme';
 import CustomAuthBanner from '@dailydotdev/shared/src/components/auth/CustomAuthBanner';
 import { isSourceUserSource } from '@dailydotdev/shared/src/graphql/sources';
@@ -61,6 +60,7 @@ import {
 } from '../../../components/PostSEOSchema';
 import type { DynamicSeoProps } from '../../../components/common';
 import useSharedByToast from '../../../hooks/useSharedByToast';
+import { getPostCanonicalUrl } from '../../../lib/seo';
 
 const Unauthorized = dynamic(
   () =>
@@ -354,7 +354,7 @@ export async function getStaticProps({
     const topComments = commentsData.topComments || [];
     const pageSeoTitles = getPageSeoTitles(seoTitle(post) ?? '');
     const seo: NextSeoProps = {
-      canonical: post?.slug ? `${webappUrl}posts/${post.slug}` : undefined,
+      canonical: post?.slug ? getPostCanonicalUrl(post.slug) : undefined,
       title: pageSeoTitles.title,
       description: getSeoDescription(post),
       noindex: shouldNoindexPost(post),

--- a/packages/webapp/pages/posts/[id]/share/index.tsx
+++ b/packages/webapp/pages/posts/[id]/share/index.tsx
@@ -8,7 +8,6 @@ import type { TopCommentsData } from '@dailydotdev/shared/src/graphql/comments';
 import { TOP_COMMENTS_QUERY } from '@dailydotdev/shared/src/graphql/comments';
 import type { ClientError } from 'graphql-request';
 import type { NextSeoProps } from 'next-seo';
-import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import CustomAuthBanner from '@dailydotdev/shared/src/components/auth/CustomAuthBanner';
 import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
 import { useUserShortByIdQuery } from '@dailydotdev/shared/src/hooks/user/useUserShortByIdQuery';
@@ -20,6 +19,7 @@ import { getSeoDescription } from '../../../../components/PostSEOSchema';
 import type { Props } from '../index';
 import { PostPage, seoTitle } from '../index';
 import { getLayout } from '../../../../components/layouts/MainLayout';
+import { getPostCanonicalUrl } from '../../../../lib/seo';
 
 export type SharePostPageProps = Props & {
   shareUserId?: string;
@@ -80,7 +80,7 @@ export const getServerSideProps: GetServerSideProps<
     const post = initialData.post as Post;
     const pageSeoTitles = getPageSeoTitles(seoTitle(post));
     const seo: NextSeoProps = {
-      canonical: post?.slug ? `${webappUrl}posts/${post.slug}` : undefined,
+      canonical: post?.slug ? getPostCanonicalUrl(post.slug) : undefined,
       title: pageSeoTitles.title,
       description: getSeoDescription(post),
       openGraph: {


### PR DESCRIPTION
## What changed
- Added a normalized post canonical URL helper that falls back to `https://daily.dev` when `NEXT_PUBLIC_WEBAPP_URL` is relative.
- Updated post, post share, and post analytics SEO overrides to emit absolute canonicals for post slugs.

## Why
Post detail surfaces were overriding the app-wide absolute canonical with `webappUrl`, which can resolve to `/`, causing `<link rel="canonical">` and fallback `og:url` to render as relative paths.

## Validation
- `pnpm --filter webapp exec eslint lib/seo.ts 'pages/posts/[id]/index.tsx' 'pages/posts/[id]/share/index.tsx' 'pages/posts/[id]/analytics/index.tsx' --ext .ts,.tsx --max-warnings 0`
- `git diff --check`

## Known CI
- `typecheck_strict_changed` fails on existing strict-null issues in the touched post share/analytics files. Those fixes were intentionally removed to keep this PR limited to canonical URL behavior.


### Preview domain
https://codex-fix-post-canonical-urls.preview.app.daily.dev