### PR TITLE
refactor: move Gift Plus to subscription page, restructure invite

### DIFF
--- a/packages/webapp/pages/settings/invite.tsx
+++ b/packages/webapp/pages/settings/invite.tsx
@@ -2,7 +2,6 @@ import type { ReactElement } from 'react';
 import React, { useMemo, useRef } from 'react';
 import {
   ReferralCampaignKey,
-  usePlusSubscription,
   useReferralCampaign,
 } from '@dailydotdev/shared/src/hooks';
 import { link } from '@dailydotdev/shared/src/lib/links';
@@ -24,7 +23,6 @@ import { SocialShareList } from '@dailydotdev/shared/src/components/widgets/Soci
 import { Separator } from '@dailydotdev/shared/src/components/cards/common/common';
 import type { UserShortProfile } from '@dailydotdev/shared/src/lib/user';
 import { format } from 'date-fns';
-import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import {
   LogEvent,
@@ -39,18 +37,10 @@ import type { NextSeoProps } from 'next-seo';
 import {
   Typography,
   TypographyColor,
+  TypographyTag,
   TypographyType,
 } from '@dailydotdev/shared/src/components/typography/Typography';
-import {
-  Button,
-  ButtonColor,
-  ButtonVariant,
-} from '@dailydotdev/shared/src/components/buttons/Button';
-import { useLazyModal } from '@dailydotdev/shared/src/hooks/useLazyModal';
-import { LazyModal } from '@dailydotdev/shared/src/components/modals/common/types';
 import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
-import { PlusUser } from '@dailydotdev/shared/src/components/PlusUser';
-import { GiftIcon } from '@dailydotdev/shared/src/components/icons';
 import AccountContentSection from '../../components/layouts/SettingsLayout/AccountContentSection';
 import { AccountPageContainer } from '../../components/layouts/SettingsLayout/AccountPageContainer';
 import { getSettingsLayout } from '../../components/layouts/SettingsLayout';
@@ -63,15 +53,12 @@ const seo: NextSeoProps = {
 };
 
 const AccountInvitePage = (): ReactElement => {
-  const { openModal } = useLazyModal();
   const { user } = useAuthContext();
   const container = useRef<HTMLDivElement>();
   const referredKey = generateQueryKey(RequestKey.ReferredUsers, user);
   const { url, referredUsersCount } = useReferralCampaign({
     campaignKey: ReferralCampaignKey.Generic,
   });
-  const { isValidRegion: isPlusAvailable } = useAuthContext();
-  const { logSubscriptionEvent } = usePlusSubscription();
   const { logEvent } = useLogContext();
   const inviteLink = url || link.referral.defaultUrl;
   const [, onShareOrCopyLink] = useShareOrCopyLink({
@@ -113,64 +100,42 @@ const AccountInvitePage = (): ReactElement => {
 
   return (
     <AccountPageContainer title="Invite friends">
-      {isPlusAvailable && (
-        <div className="mb-6 flex flex-col gap-4">
-          <div className="space-y-1">
-            <div className="flex gap-1">
-              <Typography type={TypographyType.Body} bold>
-                Gift daily.dev Plus
-              </Typography>
-              <PlusUser iconSize={IconSize.XSmall} withText={false} />
-            </div>
-            <Typography
-              className="border-plus"
-              color={TypographyColor.Tertiary}
-              type={TypographyType.Callout}
-            >
-              Gifting daily.dev Plus to a friend is the ultimate way to say,
-              &apos;I&apos;ve got your back.&apos; It unlocks an ad-free
-              experience, advanced content filtering and customizations, plus AI
-              superpowers to supercharge their daily.dev journey.
-            </Typography>
-          </div>
-          <Button
-            icon={<GiftIcon size={IconSize.Small} secondary />}
-            variant={ButtonVariant.Secondary}
-            color={ButtonColor.Bacon}
-            onClick={() => {
-              logSubscriptionEvent({
-                event_name: LogEvent.GiftSubscription,
-                target_id: TargetId.InviteFriendsPage,
-              });
-              openModal({
-                type: LazyModal.GiftPlus,
-              });
-            }}
-            className="max-w-fit border-action-plus-default text-action-plus-default"
-          >
-            Buy as gift
-          </Button>
-        </div>
-      )}
-      <InviteLinkInput
-        link={inviteLink}
-        logProps={{
-          event_name: LogEvent.CopyReferralLink,
-          target_id: TargetId.InviteFriendsPage,
-        }}
+      <AccountContentSection
+        className={{ heading: 'mt-0' }}
+        title="Grow the community"
+        description="Share daily.dev with developers you know. When they join through your link, they'll show up in your referrals list below."
       />
-      <span className="my-4 p-0.5 font-bold text-text-tertiary typo-callout">
-        or invite via
-      </span>
-      <div className="flex flex-row flex-wrap gap-2 gap-y-4">
-        <SocialShareList
+      <AccountContentSection
+        title="Share your invite link"
+        description="Copy your personal link or share it directly on social platforms."
+      >
+        <InviteLinkInput
+          className={{ container: 'mt-4' }}
           link={inviteLink}
-          description={labels.referral.generic.inviteText}
-          onNativeShare={onShareOrCopyLink}
-          onClickSocial={onLogShare}
-          shortenUrl={false}
+          logProps={{
+            event_name: LogEvent.CopyReferralLink,
+            target_id: TargetId.InviteFriendsPage,
+          }}
         />
-      </div>
+        <Typography
+          tag={TypographyTag.Span}
+          type={TypographyType.Callout}
+          color={TypographyColor.Tertiary}
+          bold
+          className="my-4 p-0.5"
+        >
+          or invite via
+        </Typography>
+        <div className="flex flex-row flex-wrap gap-2 gap-y-4">
+          <SocialShareList
+            link={inviteLink}
+            description={labels.referral.generic.inviteText}
+            onNativeShare={onShareOrCopyLink}
+            onClickSocial={onLogShare}
+            shortenUrl={false}
+          />
+        </div>
+      </AccountContentSection>
       <AccountContentSection
         title="Your referrals"
         description="Developers who joined through your invite link"

--- a/packages/webapp/pages/settings/subscription.tsx
+++ b/packages/webapp/pages/settings/subscription.tsx
@@ -8,6 +8,8 @@ import { SubscriptionProvider } from '@dailydotdev/shared/src/lib/plus';
 
 import { PlusUser } from '@dailydotdev/shared/src/components/PlusUser';
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
+import { GiftIcon } from '@dailydotdev/shared/src/components/icons';
+import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import {
   Typography,
   TypographyColor,
@@ -15,6 +17,7 @@ import {
 } from '@dailydotdev/shared/src/components/typography/Typography';
 import {
   Button,
+  ButtonColor,
   ButtonSize,
   ButtonVariant,
 } from '@dailydotdev/shared/src/components/buttons/Button';
@@ -30,6 +33,7 @@ import {
   defaultPlusInfoCopyControl,
   PlusType,
 } from '@dailydotdev/shared/src/components/plus/PlusInfo';
+import AccountContentSection from '../../components/layouts/SettingsLayout/AccountContentSection';
 import { AccountPageContainer } from '../../components/layouts/SettingsLayout/AccountPageContainer';
 import { getSettingsLayout } from '../../components/layouts/SettingsLayout';
 import { defaultSeo } from '../../next-seo';
@@ -53,7 +57,6 @@ const seo: NextSeoProps = {
 };
 
 const PlusInfo = (): ReactElement => {
-  const { openModal } = useLazyModal();
   const { isPlus, plusProvider, logSubscriptionEvent, plusHref } =
     usePlusSubscription();
 
@@ -69,8 +72,7 @@ const PlusInfo = (): ReactElement => {
         >
           {`Thank you for supporting daily.dev and unlocking the best experience
           we offer. Manage your subscription to update your plan, payment
-          details, or preferences anytime. Know a friend or colleague who might
-          love daily.dev? Gift them daily.dev Plus!`}
+          details, or preferences anytime.`}
         </Typography>
 
         {!isIOSNative() &&
@@ -120,23 +122,38 @@ const PlusInfo = (): ReactElement => {
         >
           Manage subscription
         </Button>
-        <Button
-          size={ButtonSize.Small}
-          variant={ButtonVariant.Secondary}
-          onClick={() => {
-            logSubscriptionEvent({
-              event_name: LogEvent.GiftSubscription,
-              target_id: TargetId.Account,
-            });
-            openModal({
-              type: LazyModal.GiftPlus,
-            });
-          }}
-        >
-          Gift Plus
-        </Button>
       </div>
     </>
+  );
+};
+
+const GiftPlusSection = (): ReactElement => {
+  const { openModal } = useLazyModal();
+  const { logSubscriptionEvent } = usePlusSubscription();
+
+  return (
+    <AccountContentSection
+      title="Gift daily.dev Plus"
+      description={defaultPlusInfoCopyControl[PlusType.Gift].description}
+    >
+      <Button
+        className="mt-4 max-w-fit border-action-plus-default text-action-plus-default"
+        icon={<GiftIcon size={IconSize.Small} secondary />}
+        variant={ButtonVariant.Secondary}
+        color={ButtonColor.Bacon}
+        onClick={() => {
+          logSubscriptionEvent({
+            event_name: LogEvent.GiftSubscription,
+            target_id: TargetId.Account,
+          });
+          openModal({
+            type: LazyModal.GiftPlus,
+          });
+        }}
+      >
+        Buy as gift
+      </Button>
+    </AccountContentSection>
   );
 };
 
@@ -168,6 +185,7 @@ const UpgradeToPlusInfo = (): ReactElement => {
 
 const AccountManageSubscriptionPage = (): ReactElement => {
   const { isPlus } = usePlusSubscription();
+  const { isValidRegion: isPlusAvailable } = useAuthContext();
 
   return (
     <AccountPageContainer title="Payment & Subscription">
@@ -179,6 +197,7 @@ const AccountManageSubscriptionPage = (): ReactElement => {
 
         {isPlus ? <PlusInfo /> : <UpgradeToPlusInfo />}
       </div>
+      {isPlusAvailable && <GiftPlusSection />}
     </AccountPageContainer>
   );
 };


### PR DESCRIPTION
## Summary
- Move the Gift daily.dev Plus block from `/settings/invite` to `/settings/subscription`, shown to all Plus-eligible users (`isValidRegion`) via a dedicated `AccountContentSection`.
- Reuse shared `defaultPlusInfoCopyControl[PlusType.Gift]` copy and remove the duplicate "Gift Plus" button + gift sentence from the Plus member view.
- Restructure `/settings/invite` into `AccountContentSection` blocks (intro, share link, referrals) so it matches other settings pages, and replace the raw "or invite via" `<span>` with `Typography`.

## Test plan
- [ ] `/settings/invite`: no Gift Plus block; three sections render; copy link + social share work; referrals list loads
- [ ] `/settings/subscription` (non-Plus, eligible region): upgrade content + Gift Plus section; "Buy as gift" opens GiftPlus modal
- [ ] `/settings/subscription` (Plus member): only "Manage subscription" in the action row; Gift Plus section still visible below
- [ ] `/settings/subscription` (non-eligible region): no Gift Plus section

Made with [Cursor](https://cursor.com)

### Preview domain
https://refactor-invite-subscription-gif.preview.app.daily.dev