### PR TITLE
feat(storybook): Open Graph share-preview review & recommendations

### DIFF
--- a/packages/storybook/.storybook/preview.tsx
+++ b/packages/storybook/.storybook/preview.tsx
@@ -18,6 +18,7 @@ const preview: Preview = {
           'Atoms',
           'Components',
           'Pages',
+          'Open Graph',
           'Experiments',
           'Extension',
         ],

--- a/packages/storybook/stories/open-graph/Benchmark.stories.tsx
+++ b/packages/storybook/stories/open-graph/Benchmark.stories.tsx
@@ -1,0 +1,526 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  Bullets,
+  Divider,
+  Heading,
+  Muted,
+  Page,
+  PageHeader,
+  SpecTable,
+} from './ogStoryLayout';
+
+const SANS =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+
+const CardLabel = ({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement => (
+  <div
+    style={{
+      fontFamily: SANS,
+      fontSize: 12,
+      fontWeight: 700,
+      textTransform: 'uppercase',
+      letterSpacing: 0.6,
+      color: 'var(--theme-text-tertiary)',
+      marginBottom: 10,
+    }}
+  >
+    {children}
+  </div>
+);
+
+/** How a YouTube link unfurls — the most-shared link type on the web. */
+const YouTubeCard = (): React.ReactElement => (
+  <div style={{ width: 360, maxWidth: '100%', fontFamily: SANS }}>
+    <div
+      style={{
+        position: 'relative',
+        aspectRatio: '16 / 9',
+        borderRadius: 12,
+        overflow: 'hidden',
+        background: 'linear-gradient(135deg, #3a1f2a, #14171c)',
+      }}
+    >
+      <span
+        style={{
+          position: 'absolute',
+          inset: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <span
+          style={{
+            width: 62,
+            height: 44,
+            borderRadius: 12,
+            background: '#FF0033',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#fff',
+            fontSize: 20,
+          }}
+        >
+          ▶
+        </span>
+      </span>
+      <span
+        style={{
+          position: 'absolute',
+          bottom: 8,
+          right: 8,
+          background: 'rgba(0,0,0,0.8)',
+          color: '#fff',
+          fontSize: 12,
+          padding: '1px 5px',
+          borderRadius: 4,
+        }}
+      >
+        12:04
+      </span>
+    </div>
+    <div style={{ display: 'flex', gap: 10, marginTop: 10 }}>
+      <span
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: '50%',
+          background: 'linear-gradient(135deg,#FF0033,#bb0026)',
+          flexShrink: 0,
+        }}
+      />
+      <div>
+        <div
+          style={{
+            color: 'var(--theme-text-primary)',
+            fontWeight: 700,
+            fontSize: 15,
+            lineHeight: 1.3,
+          }}
+        >
+          How we cut edge cold-starts by 90% with Rust and Wasm
+        </div>
+        <div
+          style={{
+            color: 'var(--theme-text-tertiary)',
+            fontSize: 13,
+            marginTop: 3,
+          }}
+        >
+          The Pragmatic Engineer · 1.2M views
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+/** How a Reddit link post unfurls — the model that sits between GitHub and X. */
+const RedditCard = (): React.ReactElement => (
+  <div
+    style={{
+      width: 440,
+      maxWidth: '100%',
+      border: '1px solid var(--theme-divider-secondary)',
+      borderRadius: 8,
+      background: 'var(--theme-surface-float)',
+      fontFamily: SANS,
+      display: 'flex',
+      overflow: 'hidden',
+    }}
+  >
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        padding: '10px 8px',
+        gap: 2,
+      }}
+    >
+      <span style={{ color: '#FF4500', fontSize: 15 }}>▲</span>
+      <span
+        style={{
+          fontWeight: 700,
+          fontSize: 13,
+          color: 'var(--theme-text-primary)',
+        }}
+      >
+        2.4k
+      </span>
+      <span style={{ color: 'var(--theme-text-tertiary)', fontSize: 15 }}>
+        ▼
+      </span>
+    </div>
+    <div style={{ flex: 1, padding: '8px 12px', minWidth: 0 }}>
+      <div style={{ color: 'var(--theme-text-tertiary)', fontSize: 12 }}>
+        r/programming · Posted by u/idoshamun · 5h
+      </div>
+      <div
+        style={{
+          color: 'var(--theme-text-primary)',
+          fontSize: 16,
+          fontWeight: 600,
+          margin: '4px 0',
+          lineHeight: 1.3,
+        }}
+      >
+        How we cut edge cold-starts by 90% with Rust and Wasm
+      </div>
+      <span
+        style={{
+          color: 'var(--theme-text-tertiary)',
+          fontSize: 12,
+          border: '1px solid var(--theme-divider-tertiary)',
+          borderRadius: 4,
+          padding: '2px 6px',
+        }}
+      >
+        app.daily.dev
+      </span>
+      <div
+        style={{
+          color: 'var(--theme-text-tertiary)',
+          fontSize: 12,
+          marginTop: 8,
+          display: 'flex',
+          gap: 16,
+        }}
+      >
+        <span>💬 340 comments</span>
+        <span>↗ Share</span>
+      </div>
+    </div>
+    <div
+      style={{
+        width: 86,
+        alignSelf: 'stretch',
+        background: 'linear-gradient(135deg,#CE3DF3,#9D70F8)',
+        flexShrink: 0,
+      }}
+    />
+  </div>
+);
+
+/** GitHub's auto-generated repo social card. */
+const GitHubRepoCard = (): React.ReactElement => (
+  <div
+    style={{
+      width: 440,
+      maxWidth: '100%',
+      aspectRatio: '2 / 1',
+      background: '#0d1117',
+      border: '1px solid #30363d',
+      borderRadius: 12,
+      padding: 24,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'space-between',
+      fontFamily: SANS,
+      color: '#e6edf3',
+    }}
+  >
+    <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+      <span
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: '50%',
+          background: '#6e7681',
+        }}
+      />
+      <span style={{ color: '#7d8590', fontSize: 18 }}>
+        vercel <span>/</span>{' '}
+        <span style={{ color: '#e6edf3', fontWeight: 700 }}>satori</span>
+      </span>
+    </div>
+    <div style={{ fontSize: 24, fontWeight: 700, lineHeight: 1.2 }}>
+      Enlightened library to convert HTML and CSS to SVG
+    </div>
+    <div
+      style={{
+        display: 'flex',
+        gap: 22,
+        color: '#7d8590',
+        fontSize: 16,
+        alignItems: 'center',
+      }}
+    >
+      <span style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+        <span
+          style={{
+            width: 11,
+            height: 11,
+            borderRadius: '50%',
+            background: '#f1e05a',
+          }}
+        />
+        TypeScript
+      </span>
+      <span>★ 11.8k</span>
+      <span>⑂ 312</span>
+    </div>
+  </div>
+);
+
+const Benchmark = (): React.ReactElement => (
+  <Page>
+    <PageHeader
+      eyebrow="Open Graph · Benchmark"
+      title="Which links travel — and what the winners do"
+    >
+      The question that matters isn’t how much traffic a platform sends us —
+      it’s <strong>whose links get shared everywhere else</strong>: pasted into
+      WhatsApp, posted on X, dropped in a Slack channel. So we looked at the
+      platforms whose links travel the most across the web and studied how they
+      unfurl. The pattern is stark: the most-shared platforms have{' '}
+      <strong>rich, open, contextual</strong> previews — and the ones that gate
+      their metadata get shared less because their links look broken.
+    </PageHeader>
+
+    <Heading>Whose links get shared the most</Heading>
+    <SpecTable
+      columns={['Platform', 'Why its links travel', 'How it unfurls', 'Grade']}
+      rows={[
+        [
+          'YouTube',
+          'Most-visited site on earth; a video fits any chat or feed',
+          'Rich card: big thumbnail + play shape + title + channel',
+          '★ best-in-class',
+        ],
+        [
+          'Reddit',
+          '2025’s biggest riser; threads get cited everywhere',
+          'Thumbnail + title + subreddit + upvotes/comments',
+          '★ excellent',
+        ],
+        [
+          'GitHub',
+          'Devs share repos/PRs/issues constantly',
+          'Generated card: owner + name + language + live stars/forks',
+          '★ excellent',
+        ],
+        [
+          'X / Twitter',
+          'High-velocity resharing; quote-tweets',
+          'Image-only large card (no body text) — image is everything',
+          '◑ good, image-dependent',
+        ],
+        [
+          'Wikipedia / news',
+          'Cited as sources across the web',
+          'Clean title + summary + lead image',
+          '◑ good',
+        ],
+        [
+          'Facebook',
+          'Largest social graph',
+          'Image + title + description bar',
+          '◑ good',
+        ],
+        [
+          'Instagram',
+          '2B users, hugely shared… as raw links',
+          'Gates OG behind a paid API → usually NO preview',
+          '✗ broken externally',
+        ],
+        [
+          'TikTok',
+          'Massive volume; links pasted everywhere',
+          'Restricted OG → text snippet, often no image',
+          '✗ broken externally',
+        ],
+        [
+          'WhatsApp / Slack / DMs',
+          'The pipes that carry everyone else’s links',
+          'Renders whatever OG the source provides',
+          'n/a — carrier',
+        ],
+      ]}
+    />
+    <Bullets
+      items={[
+        'YouTube is effectively the most-shared link type on the web — its preview is the benchmark for "a link people want to tap".',
+        'Messengers (WhatsApp/Slack/iMessage) are carriers, not sources — they just render the source’s OG. So our OG quality is what shows up in every DM.',
+        'The clearest signal: Instagram & TikTok deliberately gate their Open Graph, so their links unfurl as broken text — and that visibly dampens how shareable they feel. Openness is a feature.',
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>The three to model</Heading>
+    <Muted>
+      YouTube, Reddit and GitHub are where the most-shared, best-unfurling links
+      live. Here’s how each looks and exactly what we should take.
+    </Muted>
+
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 40,
+        alignItems: 'flex-start',
+        margin: '12px 0 8px',
+      }}
+    >
+      <div>
+        <CardLabel>YouTube — the thumbnail IS the product</CardLabel>
+        <YouTubeCard />
+        <div style={{ maxWidth: 360, marginTop: 12 }}>
+          <Bullets
+            tone="good"
+            items={[
+              'Self-explanatory image — you know what you’ll get before reading.',
+              'A recognizable shape (the red play button) = instant brand ID.',
+              'Creator identity (channel + avatar) builds trust.',
+            ]}
+          />
+        </div>
+      </div>
+      <div>
+        <CardLabel>GitHub — contextual + live stats</CardLabel>
+        <GitHubRepoCard />
+        <div style={{ maxWidth: 440, marginTop: 12 }}>
+          <Bullets
+            tone="good"
+            items={[
+              'A fresh card per object (repo/PR/issue) — never a generic logo.',
+              'Identity + live numbers (stars/forks) = instant credibility.',
+              'One recognizable system across every page type.',
+            ]}
+          />
+        </div>
+      </div>
+    </div>
+
+    <Divider />
+
+    <Heading badge="our north star">Reddit — between GitHub and X</Heading>
+    <Muted>
+      You called it: for developers Reddit sits right between GitHub’s
+      credibility and X’s reach. It’s a social network <em>and</em> a dev
+      watering hole, and its link cards are a masterclass in context — exactly
+      the balance daily.dev wants.
+    </Muted>
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 40,
+        alignItems: 'flex-start',
+        margin: '12px 0',
+      }}
+    >
+      <div>
+        <CardLabel>How a daily.dev link looks on Reddit</CardLabel>
+        <RedditCard />
+      </div>
+      <div style={{ maxWidth: 420 }}>
+        <Bullets
+          tone="good"
+          title="What to steal from Reddit"
+          items={[
+            'Community/topic context up front (r/programming) — we have Squads and tags; surface them.',
+            'Engagement is the hook: upvotes + comment count. Our Feed-card direction already shows this.',
+            'Literal, scannable titles win — no cleverness, no “| daily.dev” suffix.',
+            'The domain badge (app.daily.dev) is a trust signal — keep it clean and consistent.',
+            'Reddit fetches metadata via Embedly — so we must ship complete OG + oEmbed or the card degrades.',
+          ]}
+        />
+      </div>
+    </div>
+
+    <Divider />
+
+    <Heading>The anti-pattern: don’t be Instagram or TikTok</Heading>
+    <Bullets
+      tone="bad"
+      items={[
+        'Instagram gates Open Graph behind a paid API; most clients can’t unfurl it, so links show as plain text.',
+        'TikTok restricts its OG too — links usually render a bare text snippet with no image.',
+        'Result: despite huge volume, their individual links feel broken when shared — which suppresses re-sharing.',
+      ]}
+    />
+    <Muted>
+      The takeaway for us:{' '}
+      <strong>openness + complete, valid tags is itself a growth lever.</strong>{' '}
+      Every daily.dev link should unfurl richly for every scraper (Facebook, X,
+      Slack, Discord, and Reddit’s Embedly) — never gated, never half-formed.
+    </Muted>
+
+    <Divider />
+
+    <Heading>Enhanced principles (from the most-shared platforms)</Heading>
+    <SpecTable
+      columns={['Principle', 'Learned from', 'How we apply it']}
+      rows={[
+        [
+          'Open & complete metadata',
+          'Instagram/TikTok (anti)',
+          'Always emit full, valid OG + Twitter + oEmbed; never gate. Validate per scraper.',
+        ],
+        [
+          'The image is self-explanatory',
+          'YouTube',
+          'Headline + visual tell the whole story before any text is read.',
+        ],
+        [
+          'A recognizable shape',
+          'YouTube play button',
+          'Persistent daily.dev mark + cabbage→onion gradient so the card is ID’d as a shape.',
+        ],
+        [
+          'Context + engagement',
+          'Reddit',
+          'Show source/Squad/topic + reading time or upvotes/comments for social proof.',
+        ],
+        [
+          'Contextual per object',
+          'GitHub',
+          'A distinct card per share type (article/profile/squad/invite/comment).',
+        ],
+        [
+          'Literal, scannable titles',
+          'Reddit',
+          'Sentence-case, no suffix, ≤55–60 chars; say exactly what it is.',
+        ],
+        [
+          'Image carries everything',
+          'X',
+          'On the large card no text shows — bake the message into the image.',
+        ],
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>Sources</Heading>
+    <Bullets
+      items={[
+        'Most-visited websites / most-shared domains 2025 — proxidize.com/research/most-popular-websites & statvoo.com/blog/most-visited-websites-2025',
+        'Reddit as 2025’s biggest riser; Americans’ social use — pewresearch.org/internet/2025/11/20/americans-social-media-use-2025',
+        'How Reddit unfurls links via Embedly / Open Graph — opengraphplus.com/consumers/reddit & jameshfisher.com/2017/08/16/reddit-oembed-open-graph',
+        'GitHub’s framework for building Open Graph images — github.blog/open-source/git/framework-building-open-graph-images',
+        'Instagram/TikTok gate their Open Graph (broken previews) — share-preview.com/blog/instagram-link-preview & opengraph.io',
+        'YouTube rich link previews / Open Graph for video — blog.logrocket.com/open-graph-sharable-social-media-previews',
+      ]}
+    />
+  </Page>
+);
+
+const meta: Meta<typeof Benchmark> = {
+  title: 'Open Graph/6. How the Best Platforms Share',
+  component: Benchmark,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Benchmark>;
+
+export const Benchmarks: Story = { name: 'Platform benchmark' };

--- a/packages/storybook/stories/open-graph/CoverDna.stories.tsx
+++ b/packages/storybook/stories/open-graph/CoverDna.stories.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { COVER_DNA } from './coverDna';
+import { Cover } from './cover';
+import {
+  Bullets,
+  Divider,
+  Heading,
+  Muted,
+  Page,
+  PageHeader,
+} from './ogStoryLayout';
+
+const SANS =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+
+const label = (text: string): React.ReactElement => (
+  <div
+    style={{
+      fontFamily: SANS,
+      fontSize: 13,
+      fontWeight: 600,
+      color: 'var(--theme-text-tertiary)',
+      marginBottom: 10,
+    }}
+  >
+    {text}
+  </div>
+);
+
+const CoverDna = (): React.ReactElement => (
+  <Page>
+    <PageHeader
+      eyebrow="Open Graph · Recognizable as daily.dev"
+      title="20 ways to brand the cover — fresh start"
+    >
+      Clean slate. Base = the <strong>clean Layout A</strong> you liked (source
+      left, real logo right, cover art bottom-right, glass upvote + comment
+      bar). Each variation adds <strong>one</strong> recognizability device so
+      the cover instantly reads as daily.dev. Grouped into four{' '}
+      <strong>systems</strong> — tell me which system feels right, then we
+      refine.
+    </PageHeader>
+
+    <Heading>Baseline (no branding device)</Heading>
+    <Muted>The clean cover, unchanged — everything below builds on this.</Muted>
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(480px, 1fr))',
+        gap: 30,
+        marginTop: 16,
+      }}
+    >
+      <div>
+        {label('Layout A — clean')}
+        <Cover />
+      </div>
+    </div>
+
+    {COVER_DNA.map((cat, ci) => (
+      <section key={cat.category}>
+        <Divider />
+        <Heading badge={`${cat.items.length} variations`}>
+          {String.fromCharCode(65 + ci)}. {cat.category}
+        </Heading>
+        <Muted>{cat.blurb}</Muted>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fill, minmax(480px, 1fr))',
+            gap: 30,
+            marginTop: 16,
+          }}
+        >
+          {cat.items.map((it) => (
+            <div key={it.id}>
+              {label(`${it.id.toUpperCase()} · ${it.name}`)}
+              {it.Component()}
+            </div>
+          ))}
+        </div>
+      </section>
+    ))}
+
+    <Divider />
+    <Heading>Pick a direction</Heading>
+    <Bullets
+      items={[
+        'Which SYSTEM reads most “daily.dev” to you — A (frame), B (color), C (mark), or D (lockup)?',
+        'Then a code within it (e.g. A1, B3, D3) and any tweak — I’ll refine just that.',
+      ]}
+    />
+  </Page>
+);
+
+const meta: Meta<typeof CoverDna> = {
+  title: 'Open Graph/7 Recognizable Covers ★',
+  component: CoverDna,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CoverDna>;
+
+export const Recognizable: Story = { name: '20 branding devices' };

--- a/packages/storybook/stories/open-graph/CurrentOpenGraph.stories.tsx
+++ b/packages/storybook/stories/open-graph/CurrentOpenGraph.stories.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { MetaTagsTable, PlatformGrid } from './platformCards';
+import { USE_CASES } from './useCases';
+import {
+  Bullets,
+  Divider,
+  Heading,
+  Muted,
+  Page,
+  PageHeader,
+} from './ogStoryLayout';
+
+const CurrentPreviews = (): React.ReactElement => (
+  <Page>
+    <PageHeader eyebrow="Open Graph · Review" title="Current share previews">
+      Every place daily.dev content gets shared, rendered the way it actually
+      unfurls on X, LinkedIn, Facebook, Slack, Discord, WhatsApp and iMessage.
+      These are the <strong>real, live images daily.dev serves today</strong> —
+      pulled straight from the actual URLs (e.g.{' '}
+      <code>og.daily.dev/api/posts/&#123;id&#125;</code> for posts,{' '}
+      <code>daily.dev/og-image.png</code> for the homepage), not re-creations.
+      The tell is obvious: only posts get a real card — profile, source, tag,
+      squad, invite and Plus all fall back to the same generic image.
+    </PageHeader>
+
+    {USE_CASES.map((uc, i) => (
+      <section key={uc.id} id={uc.id} style={{ marginBottom: 8 }}>
+        <Heading badge={uc.source}>
+          {i + 1}. {uc.name}
+        </Heading>
+        <Muted>{uc.what}</Muted>
+
+        <div style={{ margin: '16px 0 24px' }}>
+          <MetaTagsTable data={uc.current} />
+        </div>
+
+        <Bullets title="Issues today" tone="bad" items={uc.issues} />
+
+        <div style={{ marginTop: 20 }}>
+          <PlatformGrid data={uc.current} />
+        </div>
+
+        {i < USE_CASES.length - 1 && <Divider />}
+      </section>
+    ))}
+  </Page>
+);
+
+const meta: Meta<typeof CurrentPreviews> = {
+  title: 'Open Graph/1. Current Share Previews',
+  component: CurrentPreviews,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CurrentPreviews>;
+
+export const AllUseCases: Story = { name: 'All use cases' };

--- a/packages/storybook/stories/open-graph/LinkCopyBehavior.stories.tsx
+++ b/packages/storybook/stories/open-graph/LinkCopyBehavior.stories.tsx
@@ -1,0 +1,314 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  Bullets,
+  CodeBlock,
+  Divider,
+  Heading,
+  Muted,
+  Page,
+  PageHeader,
+  SpecTable,
+  TwoCol,
+} from './ogStoryLayout';
+
+const SANS =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+
+/** Anatomy of a link preview, labeling the parts that are NOT the image. */
+const PreviewAnatomy = (): React.ReactElement => (
+  <div
+    style={{
+      width: 460,
+      maxWidth: '100%',
+      border: '1px solid #e0e0e0',
+      borderRadius: 8,
+      overflow: 'hidden',
+      fontFamily: SANS,
+      background: '#fff',
+    }}
+  >
+    <div
+      style={{
+        height: 110,
+        background: 'linear-gradient(135deg,#CE3DF3,#9D70F8)',
+      }}
+    />
+    <div style={{ padding: '10px 14px' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          marginBottom: 6,
+        }}
+      >
+        <span
+          style={{
+            width: 18,
+            height: 18,
+            borderRadius: 4,
+            background: '#0E1217',
+            color: '#fff',
+            fontSize: 11,
+            fontWeight: 800,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          d.
+        </span>
+        <span style={{ color: '#606770', fontSize: 12 }}>
+          app.daily.dev · favicon + domain
+        </span>
+      </div>
+      <div style={{ color: '#1d2129', fontSize: 16, fontWeight: 700 }}>
+        og:title — the headline
+      </div>
+      <div style={{ color: '#606770', fontSize: 13, marginTop: 2 }}>
+        og:description — the supporting line shown on FB, Slack, Discord,
+        WhatsApp.
+      </div>
+    </div>
+  </div>
+);
+
+const SHARE_TEXT_CODE = `// Today — shared/src/lib/share.ts
+getTwitterShareLink(link, text) // → "{text} via @dailydotdev"
+// "text" is usually just the post title, so a tweet reads:
+//   "How we cut edge cold-starts… via @dailydotdev  app.daily.dev/posts/…"
+
+// Recommended — context-aware, pre-filled share copy (still user-editable)
+share.article  = \`\${title}\\n\\nvia @dailydotdev\`;
+share.invite   = \`I use daily.dev to keep up with dev news — join me 👇\`;
+share.profile  = \`My developer profile on @dailydotdev 👇\`;
+share.squad    = \`We're sharing the best \${topic} content in this Squad 👇\`;
+// Keep "via @dailydotdev" for attribution; add 1 relevant emoji max; no hashtag spam.`;
+
+const LinkCopyBehavior = (): React.ReactElement => (
+  <Page>
+    <PageHeader
+      eyebrow="Open Graph · Beyond the image"
+      title="Link copy, metadata & sharing behavior"
+    >
+      The image gets the attention, but half of a great link preview is
+      everything around it: the title wording, the description, the little
+      favicon and brand avatar, the URL that shows, and the message we pre-fill
+      when someone taps “share”. This page covers all of it — current state vs.
+      what we should do — for the parts that live <em>outside</em> the Open
+      Graph image.
+    </PageHeader>
+
+    <Heading>Anatomy — the non-image parts</Heading>
+    <div
+      style={{
+        display: 'flex',
+        gap: 32,
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        margin: '8px 0 16px',
+      }}
+    >
+      <PreviewAnatomy />
+      <div style={{ maxWidth: 380 }}>
+        <Muted>
+          On messengers and Slack/Discord/Facebook the <strong>text</strong>{' '}
+          does most of the work — the image may be small or absent. The favicon
+          and domain are the trust signal. The pre-filled share message is what
+          actually frames the link for the recipient.
+        </Muted>
+      </div>
+    </div>
+
+    <Divider />
+
+    <Heading>Title & description copy</Heading>
+    <SpecTable
+      columns={['Field', 'Today', 'Recommended']}
+      rows={[
+        [
+          'og:title',
+          '“{title} | daily.dev” — suffix often pushes it past 60 chars and gets truncated',
+          'Drop the suffix on shareable content; sentence case; ≤ 55–60 chars',
+        ],
+        [
+          'og:description',
+          'Stripped article excerpt, or the generic site description as fallback',
+          'Value-framed, ≤ 110 chars, HTML stripped; generate a contextual line when empty',
+        ],
+        [
+          'Voice',
+          'Inconsistent across surfaces',
+          'Confident, concrete, developer-to-developer; no marketing fluff',
+        ],
+        [
+          'Emoji',
+          'None / inconsistent',
+          'At most one, only where it adds clarity (invites, milestones)',
+        ],
+        [
+          'Localization',
+          'og:locale set on posts',
+          'Keep locale; ensure copy + generated image text localize together',
+        ],
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>Favicon, site name & brand avatar</Heading>
+    <Muted>
+      Slack, Discord, iMessage and Reddit show a small favicon next to the
+      domain; X shows the <code>@dailydotdev</code> profile avatar. These are
+      tiny but they’re the brand’s handshake.
+    </Muted>
+    <SpecTable
+      columns={['Asset', 'Why it matters', 'Recommendation']}
+      rows={[
+        [
+          'favicon (16–48px)',
+          'Shown beside the domain on Slack/Discord/iMessage/Reddit',
+          'Crisp “d.” mark that reads at 16px; ship .ico + 32/48px PNG',
+        ],
+        [
+          'apple-touch-icon (180px)',
+          'iMessage / iOS rich links, home-screen',
+          'Provide 180×180 with safe padding',
+        ],
+        [
+          'og:site_name',
+          'Renders the brand without spending title chars',
+          'Always “daily.dev” (already set)',
+        ],
+        [
+          'X profile avatar',
+          'Shown on every tweet that links us',
+          'Keep @dailydotdev avatar high-contrast; it frames the card',
+        ],
+        [
+          'theme-color',
+          'Tints the bubble/chrome on some mobile clients',
+          'Set brand cabbage for a subtle on-brand tint',
+        ],
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>The pre-filled share message</Heading>
+    <Muted>
+      When a user shares from inside daily.dev, we pre-fill the text. Today it’s
+      basically the title plus “via @dailydotdev”. Tailoring it per context (and
+      keeping it editable) makes the share feel personal and lifts CTR.
+    </Muted>
+    <CodeBlock>{SHARE_TEXT_CODE}</CodeBlock>
+    <TwoCol
+      leftLabel="Today"
+      rightLabel="Recommended"
+      left={
+        <Bullets
+          tone="bad"
+          items={[
+            'One generic pattern: “{title} via @dailydotdev”.',
+            'No framing for invites/profiles/squads — the why is missing.',
+            'Same text regardless of platform norms.',
+          ]}
+        />
+      }
+      right={
+        <Bullets
+          tone="good"
+          items={[
+            'Context-aware copy per share type (article / invite / profile / squad / comment).',
+            'Keep “via @dailydotdev” for attribution; one relevant emoji max.',
+            'Always user-editable; we only pre-fill a strong default.',
+          ]}
+        />
+      }
+    />
+
+    <Divider />
+
+    <Heading>URLs & link behavior</Heading>
+    <SpecTable
+      columns={['Aspect', 'Today', 'Recommended']}
+      rows={[
+        [
+          'Displayed domain',
+          'app.daily.dev',
+          'Fine — keep consistent; ensure canonical matches',
+        ],
+        [
+          'Slug',
+          'Readable post slugs',
+          'Keep human-readable slugs; avoid IDs in the visible URL',
+        ],
+        [
+          'Tracking params',
+          'userid & cid appended to shared links (?userid=…&cid=share_post)',
+          'Keep for attribution, but exclude from og:url/canonical so previews dedupe to one',
+        ],
+        [
+          'Cache busting',
+          'No version param on the image',
+          'Append &v={contentHash} to the image URL so edits refresh FB/X/LinkedIn caches',
+        ],
+        [
+          'Canonical',
+          'Set on posts',
+          'Always canonical to the clean post URL; strip share/tracking params',
+        ],
+        [
+          'Link shortening',
+          'Full URL shared',
+          'Optional dub/short domain for messengers; ensure it preserves OG tags on unfurl',
+        ],
+      ]}
+    />
+    <Bullets
+      items={[
+        'Never put personal data in share URLs — userid/cid are campaign keys, which is fine; don’t add anything identifying.',
+        'Make sure the share route (/posts/[id]/share) and the canonical post URL resolve to the same unfurl so a link isn’t cached twice with different art.',
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>Priorities (beyond the image)</Heading>
+    <SpecTable
+      columns={['Priority', 'Change', 'Effort']}
+      rows={[
+        ['P0', 'Drop “| daily.dev” title suffix on shareable content', 'Low'],
+        [
+          'P0',
+          'Context-aware pre-filled share copy in the share sheet',
+          'Low/Med',
+        ],
+        [
+          'P1',
+          'Generated/contextual description fallbacks (no generic site copy)',
+          'Med',
+        ],
+        ['P1', 'Crisp favicon + apple-touch-icon + theme-color audit', 'Low'],
+        [
+          'P2',
+          'Content-hash (&v=) on image URLs; canonical strips tracking params',
+          'Low',
+        ],
+      ]}
+    />
+  </Page>
+);
+
+const meta: Meta<typeof LinkCopyBehavior> = {
+  title: 'Open Graph/8. Link Copy, Metadata & Behavior',
+  component: LinkCopyBehavior,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LinkCopyBehavior>;
+
+export const CopyAndBehavior: Story = { name: 'Copy, metadata & behavior' };

--- a/packages/storybook/stories/open-graph/OpenGraphComparison.stories.tsx
+++ b/packages/storybook/stories/open-graph/OpenGraphComparison.stories.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  LinkedInCard,
+  MetaTagsTable,
+  WhatsAppCard,
+  XCard,
+} from './platformCards';
+import type { OgData } from './platformCards';
+import { USE_CASES } from './useCases';
+import {
+  Bullets,
+  Divider,
+  Heading,
+  Muted,
+  Page,
+  PageHeader,
+  TwoCol,
+} from './ogStoryLayout';
+
+const Stack = ({ data }: { data: OgData }): React.ReactElement => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+    <XCard data={data} />
+    <LinkedInCard data={data} />
+    <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+      <WhatsAppCard data={data} />
+    </div>
+    <MetaTagsTable data={data} />
+  </div>
+);
+
+const Comparison = (): React.ReactElement => (
+  <Page>
+    <PageHeader eyebrow="Open Graph · Proposal" title="Current vs. recommended">
+      A side-by-side of what we ship today (the{' '}
+      <strong>real, live images</strong>, pulled from the actual URLs) against a
+      single, unified template system that adapts per share type. Each surface
+      keeps the same visual language so a daily.dev link is instantly
+      recognizable, while the headline, attribution and context change to fit
+      the object being shared. Red column = today; green column = proposed.
+    </PageHeader>
+
+    {USE_CASES.map((uc, i) => (
+      <section key={uc.id} id={uc.id}>
+        <Heading badge={uc.source}>
+          {i + 1}. {uc.name}
+        </Heading>
+        <Muted>{uc.what}</Muted>
+
+        <div style={{ margin: '20px 0 28px' }}>
+          <TwoCol
+            leftLabel="Current"
+            rightLabel="Recommended"
+            left={<Stack data={uc.current} />}
+            right={<Stack data={uc.recommended} />}
+          />
+        </div>
+
+        <TwoCol
+          leftLabel="Problems"
+          rightLabel="What to change"
+          left={<Bullets tone="bad" items={uc.issues} />}
+          right={<Bullets tone="good" items={uc.recommendations} />}
+        />
+
+        {i < USE_CASES.length - 1 && <Divider />}
+      </section>
+    ))}
+  </Page>
+);
+
+const meta: Meta<typeof Comparison> = {
+  title: 'Open Graph/2. Current vs Recommended',
+  component: Comparison,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Comparison>;
+
+export const SideBySide: Story = { name: 'Side by side' };

--- a/packages/storybook/stories/open-graph/OpenGraphGuidelines.stories.tsx
+++ b/packages/storybook/stories/open-graph/OpenGraphGuidelines.stories.tsx
@@ -1,0 +1,314 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  Bullets,
+  CodeBlock,
+  Divider,
+  Heading,
+  Muted,
+  Page,
+  PageHeader,
+  SpecTable,
+} from './ogStoryLayout';
+
+const Guidelines = (): React.ReactElement => (
+  <Page>
+    <PageHeader
+      eyebrow="Open Graph · Research"
+      title="Link preview guidelines & recommendations"
+    >
+      A condensed field guide to how link previews actually work across
+      platforms in 2026, the technical details that matter, and the concrete
+      changes we should make to daily.dev’s sharing. Pair this with the “Current
+      vs Recommended” page for the per-surface mock-ups.
+    </PageHeader>
+
+    <Heading>The one image spec that covers everything</Heading>
+    <Muted>
+      Ship a single <strong>1200 × 630 px (1.91:1)</strong> image. It satisfies
+      Facebook, LinkedIn, X large cards, Slack, Discord, WhatsApp and iMessage
+      without cropping the important bits. Keep the file under{' '}
+      <strong>~500 KB</strong> (hard ceiling ~1 MB or some crawlers skip it),
+      prefer PNG for text-heavy cards / JPEG for photographic ones, and keep all
+      critical content inside a centered <strong>~80% safe area</strong> since
+      some surfaces center-crop toward square.
+    </Muted>
+
+    <SpecTable
+      columns={[
+        'Platform',
+        'Card / behavior',
+        'Image',
+        'Title shown',
+        'Description shown',
+      ]}
+      rows={[
+        [
+          'X / Twitter',
+          'summary_large_image — big image, domain pill, no body text on card',
+          '1200×630 (≥1.91:1)',
+          '~70 chars (in composer)',
+          'Not shown on large card',
+        ],
+        [
+          'LinkedIn',
+          'Image on top, bold title, domain',
+          '1200×627',
+          '~60–100 chars',
+          'Rarely shown',
+        ],
+        [
+          'Facebook',
+          'Image, then domain / title / description bar',
+          '1200×630',
+          '~88–130 chars',
+          '~2 lines (~200)',
+        ],
+        [
+          'Slack',
+          'Color bar, site, title, full description, image',
+          '1200×630',
+          'Full (not cropped)',
+          'Full; supports label/data pairs',
+        ],
+        [
+          'Discord',
+          'Dark embed, site, link title, description, image',
+          '1200×630',
+          '~2 lines',
+          '~3 lines',
+        ],
+        [
+          'WhatsApp / Telegram',
+          'Compact bubble, thumbnail, title, host',
+          'Square-safe',
+          '~40–60 chars',
+          '~1–2 lines',
+        ],
+        [
+          'iMessage',
+          'Large image bubble + title/host footer',
+          '1200×630',
+          '~2 lines',
+          'Host only',
+        ],
+      ]}
+    />
+
+    <Muted>
+      Practical takeaway: <strong>write for the strictest platform.</strong>{' '}
+      Keep og:title ≤ ~60 chars and og:description ≤ ~110 chars so nothing
+      important is clipped on LinkedIn/X while still reading well on
+      Slack/Facebook where more is shown.
+    </Muted>
+
+    <Divider />
+
+    <Heading>Tags we should always emit</Heading>
+    <SpecTable
+      columns={['Tag', 'Why it matters', 'daily.dev status']}
+      rows={[
+        [
+          'og:title',
+          'Primary headline on every platform',
+          '⚠️ Has “| daily.dev” suffix that eats the headline',
+        ],
+        [
+          'og:description',
+          'Body copy on FB/Slack/Discord/WhatsApp',
+          '⚠️ Often a stripped excerpt or the generic site description',
+        ],
+        [
+          'og:image',
+          'The single biggest driver of click-through',
+          '✓ Set; ⚠️ generic fallback over-used',
+        ],
+        [
+          'og:image:width / :height',
+          'Lets crawlers render before fetching the image (no “first share looks broken”)',
+          '⚠️ Only set on the share route',
+        ],
+        [
+          'og:image:alt',
+          'Accessibility + a few crawlers',
+          '✗ Missing on most surfaces',
+        ],
+        [
+          'og:type',
+          'website vs article (article enables published_time, author, tags)',
+          '✓ article on posts',
+        ],
+        ['og:url', 'Canonical for the unfurl; dedupes shares', '✓ Set'],
+        [
+          'og:site_name',
+          'Renders the brand without spending title chars',
+          '✓ daily.dev',
+        ],
+        ['og:locale', 'Correct language hint per post', '✓ locale on posts'],
+        [
+          'twitter:card',
+          'summary_large_image for the big card',
+          '✓ Set globally',
+        ],
+        [
+          'twitter:site / :creator',
+          'Attributes the account / the author',
+          '⚠️ site only; no per-post creator',
+        ],
+        ['twitter:image:alt', 'Accessibility on X', '✗ Missing'],
+        [
+          'twitter:label1/data1 + label2/data2',
+          'Two extra fact rows on Slack (e.g. Author, Reading time)',
+          '✗ Unused — easy win for Slack-heavy dev audience',
+        ],
+        [
+          'oEmbed <link rel="alternate">',
+          'Lets Reddit (Embedly), Discord & others build richer cards',
+          '✗ Likely missing — add for the Reddit/dev audience',
+        ],
+      ]}
+    />
+
+    <CodeBlock>{`<!-- Recommended baseline for a shared post -->
+<meta property="og:title" content="How we cut edge cold-starts by 90% with Rust and Wasm" />
+<meta property="og:description" content="A deep dive into taking P99 cold start from 800ms to 80ms." />
+<meta property="og:image" content="https://og.daily.dev/api/posts/{id}?v={hash}" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:image:alt" content="How we cut edge cold-starts by 90% with Rust and Wasm" />
+<meta property="og:type" content="article" />
+<meta property="og:site_name" content="daily.dev" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="@dailydotdev" />
+<meta name="twitter:creator" content="@pragmaticeng" />
+<meta name="twitter:image:alt" content="How we cut edge cold-starts by 90% with Rust and Wasm" />
+<meta name="twitter:label1" content="Author" /><meta name="twitter:data1" content="The Pragmatic Engineer" />
+<meta name="twitter:label2" content="Reading time" /><meta name="twitter:data2" content="6 min" />`}</CodeBlock>
+
+    <Divider />
+
+    <Heading>Design principles for the generated image</Heading>
+    <Bullets
+      tone="good"
+      items={[
+        'One recognizable template family across every share type — a daily.dev link should be identifiable at a glance in a noisy feed.',
+        'The headline lives inside the image (large, ≤3 lines, high contrast) so X large cards — which show no body text — still communicate.',
+        'Always show identity: author/source for articles, the sharer for shares, the inviter for invites. Social proof is what earns the click.',
+        'A persistent but secondary daily.dev logo, top-right — present, never competing with the message.',
+        'The recognizable daily.dev engagement bar (avocado upvote + comment) as the ownable signal on article/discussion shares.',
+        'Generate text as real text (Satori/@vercel/og style), never bake copy into a static asset — it must stay legible at thumbnail size and localize.',
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>Lessons from the most-shared platforms</Heading>
+    <Muted>
+      We studied the platforms whose links travel the most across the web (see
+      the Benchmark page). The winners — YouTube, Reddit, GitHub — all share
+      rich, open, contextual cards; the gated ones (Instagram, TikTok) get
+      shared less because their links look broken. What that means for us:
+    </Muted>
+    <Bullets
+      tone="good"
+      items={[
+        'Openness is a growth lever: emit complete, valid OG + Twitter tags (and oEmbed) for every scraper — including Reddit’s Embedly. Never gate or half-form them, or the card degrades the way Instagram/TikTok links do.',
+        'Make the image self-explanatory (YouTube): the headline + visual should tell the whole story before any text renders.',
+        'Own a recognizable shape (YouTube’s play button): the persistent daily.dev mark + cabbage→onion gradient should ID the card even at a glance.',
+        'Lead with context + engagement (Reddit): source/Squad/topic + reading time or upvotes/comments — Reddit is our north star, sitting between GitHub’s credibility and X’s reach.',
+        'One contextual card per object (GitHub): article, profile, squad, invite and comment each get their own treatment, never a generic logo.',
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>Caching & invalidation</Heading>
+    <Muted>
+      Crawlers cache aggressively: Facebook and LinkedIn hold previews for{' '}
+      <strong>up to ~7 days</strong>, and they fetch your tags exactly once per
+      URL. Two consequences:
+    </Muted>
+    <Bullets
+      items={[
+        'Version the image URL with a content hash (…?v={hash}) so a redesign or edited title invalidates cleanly instead of serving stale art for a week.',
+        'Set a long, immutable Cache-Control on the generated image (e.g. s-maxage + immutable) keyed by that hash — generate once, serve from CDN after.',
+        'Keep og:url stable and canonical so the same post shared from different surfaces dedupes to one cached unfurl.',
+        'Document the debuggers for support: LinkedIn Post Inspector, Facebook Sharing Debugger, and X’s card validator force a re-scrape.',
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>Recommended rollout order</Heading>
+    <SpecTable
+      columns={['Priority', 'Change', 'Effort', 'Impact']}
+      rows={[
+        [
+          'P0',
+          'Stop appending “| daily.dev” to og:title on shareable content (posts, profiles, squads, sources)',
+          'Low',
+          'High',
+        ],
+        [
+          'P0',
+          'Replace generic-image fallbacks for invites, referrals, squads, sources, tags, Plus with generated contextual cards',
+          'Med',
+          'High',
+        ],
+        [
+          'P1',
+          'Unify all generated images into one template system (Layout A) — identity row + engagement bar',
+          'Med/High',
+          'High',
+        ],
+        [
+          'P1',
+          'Always emit og:image:width/height + og:image:alt + twitter:image:alt',
+          'Low',
+          'Med',
+        ],
+        [
+          'P2',
+          'Add twitter:label/data (Author, Reading time) for Slack',
+          'Low',
+          'Med',
+        ],
+        [
+          'P2',
+          'Add twitter:creator from the post author when known',
+          'Low',
+          'Low/Med',
+        ],
+        ['P2', 'Content-hash image URLs + immutable caching', 'Low', 'Med'],
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>Sources</Heading>
+    <Bullets
+      items={[
+        'Open Graph image sizes 2025 guide — krumzi.com/blog/open-graph-image-sizes-for-social-media-the-complete-2025-guide',
+        'OG image dimensions & size guide — myogimage.com/blog/og-image-size-meta-tags-complete-guide',
+        'Open Graph character limits per platform — lettercounter.org/blog/og-title-character-limit & ogtester.com',
+        'OG meta tags best practices checklist — ogfixer.com/blog/open-graph-meta-tags-best-practices',
+        'Clearing Facebook / X / LinkedIn caches — socialmediaexaminer.com & ogpreview.app/why-og-images-not-updating',
+        'Vercel OG / Satori dynamic image generation — vercel.com/blog/introducing-vercel-og-image-generation & vercel.com/docs/og-image-generation',
+        'twitter:label / twitter:data for Slack unfurls — dev.to/whitep4nth3r/level-up-your-link-previews-in-slack',
+        'og:image:alt / twitter:image:alt accessibility — stefanjudis.com & zhead.dev/meta/twitter-image-alt',
+      ]}
+    />
+  </Page>
+);
+
+const meta: Meta<typeof Guidelines> = {
+  title: 'Open Graph/3. Guidelines & Research',
+  component: Guidelines,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Guidelines>;
+
+export const Research: Story = { name: 'Guidelines & research' };

--- a/packages/storybook/stories/open-graph/Overview.stories.tsx
+++ b/packages/storybook/stories/open-graph/Overview.stories.tsx
@@ -1,0 +1,166 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { RecommendedOg } from './dailyOgImages';
+import {
+  Bullets,
+  Divider,
+  Heading,
+  Muted,
+  Page,
+  PageHeader,
+} from './ogStoryLayout';
+
+const SANS =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+
+const TOC: Array<{ n: string; name: string; what: string }> = [
+  {
+    n: '1',
+    name: 'Current Share Previews',
+    what: 'Every share type as it unfurls today on 7 platforms, with a meta-tag inspector.',
+  },
+  {
+    n: '2',
+    name: 'Current vs Recommended',
+    what: 'Side-by-side mock-ups and the fix for each surface.',
+  },
+  {
+    n: '3',
+    name: 'Guidelines & Research',
+    what: 'Platform spec cheat-sheet, tags to emit, caching, priorities.',
+  },
+  {
+    n: '4',
+    name: 'X (Twitter) Deep Dive',
+    what: 'How X actually renders links and how to win the surface where the image is everything.',
+  },
+  {
+    n: '5',
+    name: 'Recommended Template Spec',
+    what: 'The real @vercel/og template, tokens, text rules and rollout.',
+  },
+  {
+    n: '6',
+    name: 'How the Best Platforms Share',
+    what: 'What GitHub, X, Reddit & co. do — and which platforms drive the most shares.',
+  },
+  {
+    n: '7',
+    name: 'Design Directions',
+    what: 'Five creative directions for the image — pick one with me.',
+  },
+  {
+    n: '8',
+    name: 'Link Copy, Metadata & Behavior',
+    what: 'Everything outside the image: titles, descriptions, favicon, URLs, share text.',
+  },
+];
+
+const Overview = (): React.ReactElement => (
+  <Page>
+    <PageHeader
+      eyebrow="Open Graph · Initiative"
+      title="Make every shared daily.dev link impossible to ignore"
+    >
+      When a developer shares a daily.dev link — an article, their profile, a
+      squad, an invite — that preview is often the first time someone sees us.
+      It’s free, high-intent distribution, and right now we’re leaving most of
+      it on the table: titles get truncated by a “| daily.dev” suffix, several
+      share types fall back to one generic image, and nothing feels distinctly
+      ours. This initiative fixes the whole surface — the image, the copy, and
+      the link behavior — across every place we’re shared.
+    </PageHeader>
+
+    <div
+      style={{
+        borderRadius: 16,
+        overflow: 'hidden',
+        boxShadow: '0 10px 30px rgba(0,0,0,0.2)',
+        aspectRatio: '1200 / 630',
+        maxWidth: 760,
+        position: 'relative',
+        marginBottom: 32,
+      }}
+    >
+      <RecommendedOg
+        kind="article"
+        title="How we cut edge cold-starts by 90% with Rust and Wasm"
+        name="The Pragmatic Engineer"
+        meta="6 min read · 2.1k reads on daily.dev"
+        cover="https://media.daily.dev/image/upload/s--P4t4XyoV--/f_auto/v1722860399/public/Placeholder%2001"
+      />
+    </div>
+
+    <Heading>Why this matters now</Heading>
+    <Bullets
+      items={[
+        'Shared links are the cheapest growth channel we have — every share is a free impression in front of exactly the right audience.',
+        'Most real sharing happens in “dark social”: messengers (WhatsApp, Slack, Discord, iMessage) and communities (Reddit, Hacker News) — under-measured but huge. The preview has to look great there, not just on X.',
+        'For developers specifically, the preview competes in fast feeds against GitHub, Stripe and Linear — all of whom generate sharp, branded, contextual cards. We currently don’t.',
+        'A consistent, on-brand card makes a daily.dev link recognizable at a glance — which compounds every time someone shares.',
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>What’s in this section</Heading>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {TOC.map((t) => (
+        <div
+          key={t.n}
+          style={{
+            display: 'flex',
+            gap: 16,
+            alignItems: 'baseline',
+            padding: '12px 14px',
+            borderRadius: 10,
+            background: 'var(--theme-surface-float)',
+            marginBottom: 8,
+            fontFamily: SANS,
+          }}
+        >
+          <span
+            style={{
+              fontWeight: 800,
+              fontSize: 15,
+              color: '#CE3DF3',
+              minWidth: 18,
+            }}
+          >
+            {t.n}
+          </span>
+          <div>
+            <div
+              style={{
+                fontWeight: 700,
+                fontSize: 15,
+                color: 'var(--theme-text-primary)',
+              }}
+            >
+              {t.name}
+            </div>
+            <div style={{ fontSize: 14, color: 'var(--theme-text-secondary)' }}>
+              {t.what}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+    <Muted style={{ marginTop: 16 }}>
+      Open the numbered pages under “Open Graph” in the sidebar in order. Start
+      with the design directions (7) if you just want to react to visuals.
+    </Muted>
+  </Page>
+);
+
+const meta: Meta<typeof Overview> = {
+  title: 'Open Graph/0. Overview',
+  component: Overview,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Overview>;
+
+export const Start: Story = { name: 'Start here' };

--- a/packages/storybook/stories/open-graph/RecommendedSpec.stories.tsx
+++ b/packages/storybook/stories/open-graph/RecommendedSpec.stories.tsx
@@ -1,0 +1,470 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { RecommendedOg } from './dailyOgImages';
+import {
+  Bullets,
+  CodeBlock,
+  Divider,
+  Heading,
+  Muted,
+  Page,
+  PageHeader,
+  SpecTable,
+} from './ogStoryLayout';
+
+const SANS =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+
+const Callout = ({
+  n,
+  top,
+  left,
+}: {
+  n: number;
+  top: string;
+  left: string;
+}): React.ReactElement => (
+  <span
+    style={{
+      position: 'absolute',
+      top,
+      left,
+      zIndex: 20,
+      width: 28,
+      height: 28,
+      borderRadius: '50%',
+      background: '#CE3DF3',
+      color: '#fff',
+      fontSize: 15,
+      fontWeight: 800,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      boxShadow: '0 0 0 3px #fff, 0 2px 8px rgba(0,0,0,0.5)',
+      fontFamily: SANS,
+    }}
+  >
+    {n}
+  </span>
+);
+
+const Anatomy = (): React.ReactElement => (
+  <div style={{ position: 'relative', width: 600, maxWidth: '100%' }}>
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        aspectRatio: '1200 / 630',
+        borderRadius: 12,
+        overflow: 'hidden',
+      }}
+    >
+      <RecommendedOg
+        kind="article"
+        title="How we cut edge cold-starts by 90% with Rust and Wasm"
+        name="The Pragmatic Engineer"
+        meta="6 min read · 2.1k reads on daily.dev"
+        cover="https://media.daily.dev/image/upload/s--P4t4XyoV--/f_auto/v1722860399/public/Placeholder%2001"
+      />
+    </div>
+    <Callout n={1} top="9%" left="6%" />
+    <Callout n={2} top="9%" left="82%" />
+    <Callout n={3} top="33%" left="7%" />
+    <Callout n={4} top="80%" left="7%" />
+    <Callout n={5} top="55%" left="70%" />
+  </div>
+);
+
+const TEMPLATE_CODE = `// share-card.tsx — Satori (@vercel/og) template. Flexbox + inline styles only.
+// One component, driven by \`kind\`. No grid, no external CSS.
+
+type Kind =
+  | 'article' | 'shared' | 'profile' | 'squad'
+  | 'invite' | 'tag' | 'comment' | 'source' | 'generic';
+
+interface ShareCardProps {
+  kind: Kind;
+  title: string;          // already truncated to <= 3 lines server-side
+  subtitle?: string;      // 0–2 lines
+  identity?: { name: string; handle?: string; avatar?: string }; // top-left
+  upvotes?: string;       // article / shared / comment -> engagement bar
+  comments?: string;
+  meta?: string;          // other kinds -> glass meta pill ("4,210 members")
+  cover?: string;         // absolute https URL; drives backdrop + art thumbnail
+}
+
+export function ShareCard(p: ShareCardProps) {
+  const engage = ['article', 'shared', 'comment'].includes(p.kind);
+  return (
+    <div style={{ display: 'flex', position: 'relative', width: '100%', height: '100%', background: '#0B0E13' }}>
+      {/* Ambient backdrop — a pre-blurred cover (Satori can't blur at runtime),
+          else a brand-gradient glow. A dark gradient on top keeps text legible. */}
+      {p.cover
+        ? <img src={p.cover} style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', objectFit: 'cover' }} />
+        : <div style={{ position: 'absolute', inset: 0, background: 'radial-gradient(60% 90% at 100% 0, rgba(206,61,243,0.2), transparent)' }} />}
+      <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(180deg, rgba(7,9,13,0.5), rgba(7,9,13,0.78))' }} />
+
+      {/* Top bar: identity (left) + the real daily.dev logo (right) */}
+      <div style={{ position: 'absolute', top: 66, left: 66, right: 66, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Identity {...p.identity} kind={p.kind} />
+        <Logo />
+      </div>
+
+      {/* Left content: headline + subtitle on top, the glass bar pinned to the bottom */}
+      <div style={{ position: 'absolute', left: 66, top: 186, bottom: 66, right: p.cover ? '40%' : '12%',
+                    display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+          <div style={{ display: 'flex', color: '#fff', fontSize: 62, fontWeight: 800, lineHeight: 1.07, ...clamp(3) }}>{p.title}</div>
+          {p.subtitle && <div style={{ display: 'flex', color: '#A6AEBF', fontSize: 34, ...clamp(2) }}>{p.subtitle}</div>}
+        </div>
+        {/* Glass bar — pre-composited translucent fill (no runtime backdrop-blur in Satori) */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 40, padding: '24px 36px', borderRadius: 28,
+                      background: 'rgba(255,255,255,0.10)', border: '2px solid rgba(255,255,255,0.22)' }}>
+          {engage
+            ? <><Stat icon="upvote" color="#1DDC6F" value={p.upvotes ?? '0'} /><Stat icon="comment" color="#2CDCE6" value={p.comments ?? '0'} /></>
+            : <span style={{ display: 'flex', color: '#D7DCE6', fontSize: 30, fontWeight: 600 }}>{p.meta}</span>}
+        </div>
+      </div>
+
+      {/* Art bottom-right: cover thumbnail, avatar, or brand tile (radius 54) */}
+      <div style={{ position: 'absolute', right: 66, bottom: 66, width: 384, height: 384, display: 'flex' }}>
+        <Art {...p} />
+      </div>
+    </div>
+  );
+}
+
+// Satori clamps text with the webkit box trio:
+const clamp = (lines: number) =>
+  ({ display: '-webkit-box', WebkitBoxOrient: 'vertical', WebkitLineClamp: lines, overflow: 'hidden' });`;
+
+const ROUTE_CODE = `// /api/share route — edge runtime. Generates 1200×630 once, then CDN-cached.
+import { ImageResponse } from '@vercel/og'; // or 'next/og'
+
+export const runtime = 'edge';
+
+const FONT = (w: string) =>
+  fetch(\`https://og.daily.dev/fonts/Inter-\${w}.ttf\`).then((r) => r.arrayBuffer());
+
+export async function GET(req: Request) {
+  const u = new URL(req.url);
+  const kind = (u.searchParams.get('kind') ?? 'generic') as Kind;
+  const props = await resolveProps(kind, u.searchParams); // fetch post/squad/user, truncate title
+
+  const [regular, bold, extrabold] = await Promise.all([FONT('Regular'), FONT('Bold'), FONT('ExtraBold')]);
+
+  return new ImageResponse(<ShareCard {...props} kind={kind} />, {
+    width: 1200,
+    height: 630,
+    fonts: [
+      { name: 'Inter', data: regular,  weight: 400, style: 'normal' },
+      { name: 'Inter', data: bold,     weight: 700, style: 'normal' },
+      { name: 'Inter', data: extrabold, weight: 800, style: 'normal' },
+    ],
+    headers: {
+      // version the URL with ?v={contentHash}; then this immutable cache is safe.
+      'cache-control': 'public, immutable, no-transform, max-age=31536000',
+    },
+  });
+}`;
+
+const META_CODE = `// Webapp side — point og:image at the versioned generator and keep tags lean.
+const v = post.contentHash; // bust X/LinkedIn/FB caches on edit or redesign
+const img = \`https://og.daily.dev/api/share?kind=article&id=\${post.id}&v=\${v}\`;
+
+const seo: NextSeoProps = {
+  title: post.title,                                  // NO "| daily.dev" suffix
+  description: clamp(post.summary, 110),
+  openGraph: {
+    type: 'article',
+    title: post.title,
+    description: clamp(post.summary, 110),
+    siteName: 'daily.dev',
+    images: [{ url: img, width: 1200, height: 630, alt: post.title }],
+  },
+  twitter: { cardType: 'summary_large_image', site: '@dailydotdev' },
+  additionalMetaTags: [
+    { name: 'twitter:image:alt', content: post.title },
+    ...(post.author?.twitter ? [{ name: 'twitter:creator', content: post.author.twitter }] : []),
+    { name: 'twitter:label1', content: 'Author' }, { name: 'twitter:data1', content: post.source.name },
+    { name: 'twitter:label2', content: 'Reading time' }, { name: 'twitter:data2', content: \`\${post.readTime} min\` },
+  ],
+};`;
+
+const RecommendedSpec = (): React.ReactElement => (
+  <Page>
+    <PageHeader
+      eyebrow="Open Graph · Implementation spec"
+      title="The daily.dev share-card system"
+    >
+      A single, contextual template that renders every share type — driven by a{' '}
+      <code>kind</code> parameter — plus the text/naming rules and the actual{' '}
+      <code>@vercel/og</code> (Satori) implementation it should ship as on{' '}
+      <code>og.daily.dev</code>. The goal: a daily.dev link is recognizable at a
+      glance on any platform, and reads perfectly even on X where the image is
+      the entire message.
+    </PageHeader>
+
+    <Heading>Anatomy of the card</Heading>
+    <div
+      style={{
+        display: 'flex',
+        gap: 40,
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        marginBottom: 16,
+      }}
+    >
+      <Anatomy />
+      <ol
+        style={{
+          fontFamily: SANS,
+          fontSize: 15,
+          lineHeight: 1.6,
+          color: 'var(--theme-text-secondary)',
+          maxWidth: 380,
+          paddingLeft: 20,
+        }}
+      >
+        <li>
+          <strong>Identity</strong> — source / author / sharer top-left, where
+          the context lives (a small avatar + name).
+        </li>
+        <li>
+          <strong>daily.dev logo</strong> — top-right, the real wordmark;
+          present but secondary, never competes with the message.
+        </li>
+        <li>
+          <strong>Headline</strong> — the hero. ≤ 3 lines, the only thing X
+          shows; sits over an ambient backdrop derived from the cover.
+        </li>
+        <li>
+          <strong>Engagement bar</strong> — avocado upvote + comment in a
+          glass/blur pill; the ownable daily.dev signal.
+        </li>
+        <li>
+          <strong>Cover art</strong> — rounded thumbnail bottom-right (becomes
+          an avatar/tile for profiles, squads, tags…).
+        </li>
+      </ol>
+    </div>
+
+    <Divider />
+
+    <Heading>Design tokens</Heading>
+    <SpecTable
+      columns={['Token', 'Value', 'Use']}
+      rows={[
+        [
+          'Canvas',
+          '1200 × 630, #0E1217 (pepper)',
+          'Dark base; reads on light & dark feeds',
+        ],
+        [
+          'Brand gradient',
+          '#CE3DF3 → #9D70F8 (cabbage→onion)',
+          'Avatars, tiles (squad/tag/invite), accents',
+        ],
+        [
+          'Ambient backdrop',
+          'cover blurred ~13cqw + dark gradient',
+          'Color/vibe from the image; keeps text legible',
+        ],
+        [
+          'Headline',
+          'Inter ExtraBold 64px / 1.1, #FFFFFF',
+          'Down to 48px only if 3 lines overflow',
+        ],
+        ['Subtitle', 'Inter Regular 32px, #A8B3CF', '0–2 lines'],
+        [
+          'Identity',
+          'Inter Medium 28px #D7DCE6 + #A6AEBF',
+          'Source / author / sharer, top-left',
+        ],
+        [
+          'Engagement bar',
+          'Glass: white 10% + blur 8px; avocado #1DDC6F upvote',
+          'Upvote + comment; the recognizable signal',
+        ],
+        [
+          'Padding',
+          '66px (5.5cqw) content inset',
+          'Keeps all text in the ~80% safe area',
+        ],
+        [
+          'Cover art',
+          '384 × 384, radius 54',
+          'Rounded thumbnail, bottom-right',
+        ],
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>The text system — titles, descriptions, names</Heading>
+    <Muted>
+      The copy matters as much as the picture. Three global rules, then a
+      pattern per surface.
+    </Muted>
+    <Bullets
+      tone="good"
+      items={[
+        'Title: sentence case, NO "| daily.dev" suffix on shareable content (site_name carries the brand). Target ≤ 55 chars (doubles as twitter:title); hard-clamp the in-image headline to 3 lines, truncating at a word boundary with an ellipsis.',
+        'Description: ≤ 110 chars, value-framed, HTML stripped. When the source field is empty, generate a contextual one-liner instead of falling back to the generic site description.',
+        'Alt text: og:image:alt and twitter:image:alt always mirror the headline.',
+      ]}
+    />
+    <SpecTable
+      columns={[
+        'kind',
+        'Eyebrow (top-left)',
+        'og:title pattern',
+        'Bottom-left',
+        'Art (bottom-right)',
+      ]}
+      rows={[
+        [
+          'article',
+          '{source} · {readTime}',
+          '{post.title}',
+          'Upvote + comment bar',
+          'Cover thumbnail',
+        ],
+        [
+          'shared',
+          '{sharer} shared this',
+          '{post.title}',
+          'Upvote + comment bar',
+          'Cover thumbnail',
+        ],
+        [
+          'profile',
+          '@{handle}',
+          '{name} (@{handle})',
+          '{posts} read · {streak} streak',
+          'Avatar',
+        ],
+        [
+          'squad',
+          'Squad',
+          '{squad} — a Squad on daily.dev',
+          '{members} members · {newPosts} this week',
+          'Squad tile',
+        ],
+        [
+          'invite',
+          '{inviter} invited you',
+          '{inviter} invited you to {target}',
+          'Join {members} — it’s free',
+          'daily.dev tile',
+        ],
+        [
+          'source',
+          'daily.dev',
+          '{source} on daily.dev',
+          'Followed by {n} developers',
+          'Source tile',
+        ],
+        [
+          'tag',
+          'Topic',
+          '#{tag} on daily.dev',
+          '{n} developers follow this',
+          '# tile',
+        ],
+        [
+          'comment',
+          '{name} · commented',
+          '“{excerpt}” — {name} on daily.dev',
+          'Upvote + comment bar',
+          'Quote tile',
+        ],
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>1 · The Satori template</Heading>
+    <Muted>
+      One component, switched on <code>kind</code>. Satori supports flexbox,
+      inline styles, gradients, borders and the webkit line-clamp trio — no CSS
+      grid, no stylesheets. Fonts must be supplied explicitly (TTF/OTF/WOFF; not
+      WOFF2).
+    </Muted>
+    <CodeBlock>{TEMPLATE_CODE}</CodeBlock>
+
+    <Heading>2 · The edge route</Heading>
+    <Muted>
+      Generate once at the edge, then serve immutable from the CDN. The{' '}
+      <code>?v=</code> content hash is what lets us safely use a one-year
+      immutable cache while still busting stale previews on edit.
+    </Muted>
+    <CodeBlock>{ROUTE_CODE}</CodeBlock>
+
+    <Heading>3 · Meta tags on the webapp</Heading>
+    <Muted>
+      Point <code>og:image</code> at the versioned generator and keep the tags
+      lean. Note: no title suffix, explicit width/height, alt text, and the
+      Slack-only label/data pairs.
+    </Muted>
+    <CodeBlock>{META_CODE}</CodeBlock>
+
+    <Divider />
+
+    <Heading>Rollout against the existing code</Heading>
+    <SpecTable
+      columns={['Step', 'Where', 'Change']}
+      rows={[
+        [
+          '1',
+          'og.daily.dev service',
+          'Add /api/share?kind=… Satori route with the ShareCard template + Inter fonts',
+        ],
+        [
+          '2',
+          'webapp/components/layouts/utils.ts',
+          'Stop appending "| daily.dev" for shareable content (keep for nav pages)',
+        ],
+        [
+          '3',
+          'webapp/next-seo.ts + per-page SEO',
+          'Route every share surface to /api/share with its kind; emit width/height + alt',
+        ],
+        [
+          '4',
+          'shared/src/lib/share.ts',
+          'Append &v={contentHash} to shared links so caches refresh on edit',
+        ],
+        [
+          '5',
+          'webapp post/profile SEO',
+          'Add twitter:creator + twitter:label/data (Author, Reading time)',
+        ],
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>Sources</Heading>
+    <Bullets
+      items={[
+        'Satori README (supported CSS, fonts, clamping) — github.com/vercel/satori',
+        '@vercel/og reference & caching headers — vercel.com/docs/og-image-generation',
+        'Satori OG image guide — ogfixer.com/blog/satori-og-image-guide',
+        'OG image design for legible thumbnails — ghostlyinc.com/en-us/open-graph-images-complete-guide & screenshotengine.com/blog/open-graph-image-examples',
+      ]}
+    />
+  </Page>
+);
+
+const meta: Meta<typeof RecommendedSpec> = {
+  title: 'Open Graph/5. Recommended Template Spec',
+  component: RecommendedSpec,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RecommendedSpec>;
+
+export const Spec: Story = { name: 'Template spec & code' };

--- a/packages/storybook/stories/open-graph/XDeepDive.stories.tsx
+++ b/packages/storybook/stories/open-graph/XDeepDive.stories.tsx
@@ -1,0 +1,376 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactNode } from 'react';
+import { XCard } from './platformCards';
+import type { OgData } from './platformCards';
+import { RecommendedOg } from './dailyOgImages';
+import { USE_CASES } from './useCases';
+import {
+  Bullets,
+  Divider,
+  Heading,
+  Muted,
+  Page,
+  PageHeader,
+  SpecTable,
+  TwoCol,
+} from './ogStoryLayout';
+
+const SANS =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+
+const article = USE_CASES.find((u) => u.id === 'article');
+
+const labelStyle: React.CSSProperties = {
+  fontFamily: SANS,
+  fontSize: 12,
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: 0.6,
+  color: '#71717a',
+  marginBottom: 8,
+};
+
+/** Realistic X timeline chrome wrapped around a link card. */
+const Tweet = ({
+  data,
+  tweetText,
+}: {
+  data: OgData;
+  tweetText: string;
+}): React.ReactElement => (
+  <div
+    style={{
+      maxWidth: 560,
+      border: '1px solid #cfd9de',
+      borderRadius: 16,
+      padding: 16,
+      background: '#fff',
+      fontFamily: SANS,
+    }}
+  >
+    <div style={{ display: 'flex', gap: 12 }}>
+      <span
+        style={{
+          width: 44,
+          height: 44,
+          borderRadius: '50%',
+          background: 'linear-gradient(135deg, #CE3DF3, #9D70F8)',
+          flexShrink: 0,
+        }}
+      />
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <span style={{ color: '#0f1419', fontWeight: 700, fontSize: 15 }}>
+            Ido Shamun
+          </span>
+          <span style={{ color: '#536471', fontSize: 15 }}>
+            @idoshamun · 2h
+          </span>
+        </div>
+        <div
+          style={{
+            color: '#0f1419',
+            fontSize: 15,
+            lineHeight: 1.4,
+            margin: '2px 0 12px',
+          }}
+        >
+          {tweetText}
+        </div>
+        <XCard data={data} />
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            maxWidth: 360,
+            marginTop: 12,
+            color: '#536471',
+            fontSize: 13,
+          }}
+        >
+          <span>💬 24</span>
+          <span>🔁 108</span>
+          <span>♥ 642</span>
+          <span>📊 23K</span>
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+/** Overlay the 80% safe area + rounded-corner danger zones on an image. */
+const SafeAreaFrame = ({
+  children,
+}: {
+  children: ReactNode;
+}): React.ReactElement => (
+  <div
+    style={{
+      position: 'relative',
+      width: 480,
+      maxWidth: '100%',
+      aspectRatio: '1200 / 630',
+      borderRadius: 16,
+      overflow: 'hidden',
+      fontFamily: SANS,
+    }}
+  >
+    <div style={{ position: 'absolute', inset: 0 }}>{children}</div>
+    {/* 80% safe area */}
+    <div
+      style={{
+        position: 'absolute',
+        inset: '10%',
+        border: '2px dashed rgba(255,255,255,0.85)',
+        borderRadius: 8,
+        pointerEvents: 'none',
+      }}
+    />
+    <span
+      style={{
+        position: 'absolute',
+        top: '10%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        background: 'rgba(0,0,0,0.7)',
+        color: '#fff',
+        fontSize: 11,
+        padding: '2px 6px',
+        borderRadius: 4,
+      }}
+    >
+      80% safe area
+    </span>
+    {/* corner danger markers */}
+    {['0 0 auto auto', '0 auto auto 0', 'auto 0 0 auto', 'auto auto 0 0'].map(
+      (inset) => (
+        <span
+          key={inset}
+          style={{
+            position: 'absolute',
+            inset,
+            width: 26,
+            height: 26,
+            border: '2px solid #ffd23f',
+            borderRadius: '0 0 0 0',
+            opacity: 0.9,
+            pointerEvents: 'none',
+          }}
+        />
+      ),
+    )}
+  </div>
+);
+
+const XDeepDive = (): React.ReactElement => (
+  <Page>
+    <PageHeader
+      eyebrow="Open Graph · Platform deep dive"
+      title="Optimizing for X (Twitter)"
+    >
+      X is the highest-leverage surface for developer sharing — and the most
+      unforgiving. On a modern <code>summary_large_image</code> card, X shows{' '}
+      <strong>only the image and a small domain pill</strong>: no title, no
+      description, no body text outside the picture. Whatever you want a reader
+      to know has to live inside the 1200×630 frame. This page covers exactly
+      how X behaves and how our generated image should be built for it.
+    </PageHeader>
+
+    <Heading>Why X is where the image has to do all the work</Heading>
+    <Bullets
+      items={[
+        'On the large card, X renders the image edge-to-edge and drops og:title/og:description from the card entirely — the headline only survives if it is inside the image.',
+        'Cards with a large image get materially more engagement than text-only links (commonly cited as 2–5× more clicks/retweets), so the image quality is the click.',
+        'X rounds the card corners natively and overlays a domain pill bottom-left — anything in the corners gets clipped or covered.',
+        'X falls back to Open Graph when twitter:* tags are missing, so the only strictly required X tag is twitter:card — but twitter:creator and twitter:image:alt add real value.',
+        'X aggressively caches the first scrape; an edited title or redesigned image needs a versioned image URL to refresh.',
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>The same link, in an X timeline</Heading>
+    <Muted>
+      Today the card leads with the publisher’s cover and a small daily.dev mark
+      — the headline is barely legible and the brand is easy to miss. The
+      recommended card bakes the headline, author and brand into the image, so
+      it reads at a glance even at timeline scale.
+    </Muted>
+    {article && (
+      <div style={{ margin: '20px 0 28px' }}>
+        <TwoCol
+          leftLabel="Current on X"
+          rightLabel="Recommended on X"
+          left={
+            <Tweet
+              data={article.current}
+              tweetText="Great breakdown of edge cold-starts 👇"
+            />
+          }
+          right={
+            <Tweet
+              data={article.recommended}
+              tweetText="Great breakdown of edge cold-starts 👇"
+            />
+          }
+        />
+      </div>
+    )}
+
+    <Divider />
+
+    <Heading>Design for the X thumbnail, not the full-size image</Heading>
+    <Muted>
+      Keep everything that matters inside the centered{' '}
+      <strong>80% safe area</strong>, and out of the four corners (rounded +
+      domain pill). Headline ≥ 48px at 1200px width, bold, with a hard contrast
+      floor so it survives next to vibrant posts in the feed.
+    </Muted>
+    <div
+      style={{
+        display: 'flex',
+        gap: 40,
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        margin: '8px 0 16px',
+      }}
+    >
+      <SafeAreaFrame>
+        <RecommendedOg
+          kind="article"
+          title="How we cut edge cold-starts by 90% with Rust and Wasm"
+          name="The Pragmatic Engineer"
+          meta="6 min read · 2.1k reads on daily.dev"
+        />
+      </SafeAreaFrame>
+      <div style={{ maxWidth: 360 }}>
+        <Bullets
+          tone="good"
+          title="Thumbnail rules"
+          items={[
+            'Dashed box = keep all text/logos inside it.',
+            'Yellow corners = X clips/covers these — never put content there.',
+            'Headline up to 3 lines, ≥ 48px-equivalent, weight 700–800.',
+            'Domain pill sits bottom-left — leave that corner clear.',
+          ]}
+        />
+      </div>
+    </div>
+
+    <Divider />
+
+    <Heading>X-specific tag & image spec</Heading>
+    <SpecTable
+      columns={['Item', 'Spec', 'Notes']}
+      rows={[
+        [
+          'twitter:card',
+          'summary_large_image',
+          'Only strictly required X tag; everything else falls back to og:*',
+        ],
+        [
+          'Image size',
+          '1200×630 (1.91:1)',
+          'X also accepts 2:1; 1.91:1 is the safe cross-platform choice',
+        ],
+        [
+          'Image format / weight',
+          'PNG or WebP, < 5 MB',
+          'PNG for crisp text; absolute HTTPS URL required',
+        ],
+        [
+          'twitter:title',
+          '≤ 55 chars',
+          'Shown in composer/notifications, not on the large card — keep it tight',
+        ],
+        [
+          'twitter:description',
+          '≤ 125 chars',
+          'Not shown on large card; still set for fallbacks',
+        ],
+        [
+          'twitter:image:alt',
+          '≤ 420 chars',
+          'Accessibility; mirror the headline',
+        ],
+        ['twitter:site', '@dailydotdev', 'Attributes the brand account'],
+        [
+          'twitter:creator',
+          '@author (when known)',
+          'Attributes the post’s author — currently unused',
+        ],
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>Large vs summary card</Heading>
+    <Muted>
+      We should always request <code>summary_large_image</code>. The small{' '}
+      <code>summary</code> card (square thumbnail + text) is the weak fallback —
+      shown here only so the difference is obvious. With the small card the
+      image shrinks to a tile and the text X shows is our og:title/description,
+      so those still need to read well.
+    </Muted>
+    {article && (
+      <div
+        style={{
+          display: 'flex',
+          gap: 40,
+          flexWrap: 'wrap',
+          alignItems: 'flex-start',
+        }}
+      >
+        <div>
+          <div style={labelStyle}>summary_large_image (use this)</div>
+          <XCard data={article.recommended} />
+        </div>
+        <div>
+          <div style={labelStyle}>summary (avoid)</div>
+          <XCard data={{ ...article.recommended, cardType: 'summary' }} />
+        </div>
+      </div>
+    )}
+
+    <Divider />
+
+    <Heading>X recommendations</Heading>
+    <Bullets
+      tone="good"
+      items={[
+        'Treat the generated image as the entire message: headline + author/sharer + persistent daily.dev mark, all inside the safe area.',
+        'Keep og:title ≤ 55 chars (it doubles as twitter:title) and drop the "| daily.dev" suffix.',
+        'Emit twitter:creator from the post author’s X handle when we have it.',
+        'Add twitter:image:alt mirroring the headline on every card.',
+        'Version the image URL (…?v={hash}) so edits/redesigns bust X’s sticky cache.',
+        'Validate with an X card preview tool before high-visibility launches.',
+      ]}
+    />
+
+    <Divider />
+
+    <Heading>Sources</Heading>
+    <Bullets
+      items={[
+        'Twitter Card image guide & specs — ogmagic.dev/blog/twitter-card-image-guide',
+        'Twitter/X card OG specifications — og-image.org/docs/platforms/twitter',
+        'Twitter Card requirements & best practices — ogpreview.io/guide/twitter',
+        'X card markup & fallbacks — developer.x.com/en/docs/x-for-websites/cards/overview/markup',
+        'X (Twitter) image sizes 2025/26 — quirktools.com/blog/twitter-image-size & influencermarketinghub.com/twitter-image-size',
+      ]}
+    />
+  </Page>
+);
+
+const meta: Meta<typeof XDeepDive> = {
+  title: 'Open Graph/4. X (Twitter) Deep Dive',
+  component: XDeepDive,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof XDeepDive>;
+
+export const Optimizing: Story = { name: 'Optimizing for X' };

--- a/packages/storybook/stories/open-graph/cover.tsx
+++ b/packages/storybook/stories/open-graph/cover.tsx
@@ -1,0 +1,613 @@
+import React from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import LogoIcon from '@dailydotdev/shared/src/svg/LogoIcon';
+import LogoText from '@dailydotdev/shared/src/svg/LogoText';
+import { UpvoteIcon } from '@dailydotdev/shared/src/components/icons/Upvote';
+import { DiscussIcon } from '@dailydotdev/shared/src/components/icons/Discuss';
+
+/**
+ * The locked "Layout A — clean" baseline cover, self-contained.
+ * Source top-left, real daily.dev logo top-right, headline left, cover art
+ * bottom-right (bottom-aligned with the actions bar), and a glass/blur
+ * upvote + comment actions bar pinned bottom-left. This is the agreed base —
+ * recognizability explorations build on it via the slot props.
+ */
+
+export const SANS =
+  '-apple-system, "Helvetica Neue", Helvetica, Inter, Arial, "Segoe UI", system-ui, sans-serif';
+export const MONO =
+  '"SF Mono", "JetBrains Mono", "Fira Code", ui-monospace, Menlo, monospace';
+
+export const INK = '#0B0E13';
+export const CABBAGE = '#CE3DF3';
+export const ONION = '#8A63F4';
+export const AVOCADO = '#1DDC6F';
+export const CHEESE = '#FFE923';
+export const BLUECHEESE = '#2CDCE6';
+export const BACON = '#FF5C5C';
+export const TEXT = '#FFFFFF';
+export const TERTIARY = '#A6AEBF';
+export const SECONDARY = '#D7DCE6';
+export const GRAD = `linear-gradient(135deg, ${CABBAGE}, ${ONION})`;
+export const white = {
+  ['--theme-text-primary' as string]: '#FFFFFF',
+} as CSSProperties;
+
+const COVER =
+  'https://media.daily.dev/image/upload/s--P4t4XyoV--/f_auto/v1722860399/public/Placeholder%2001';
+
+export interface CoverData {
+  title: string;
+  source: string;
+  sourceColor: string;
+  readTime: string;
+  upvotes: string;
+  comments: string;
+  cover: string;
+}
+export const XD: CoverData = {
+  title: 'How we cut edge cold-starts by 90% with Rust and Wasm',
+  source: 'The Pragmatic Engineer',
+  sourceColor: '#FF8E3B',
+  readTime: '6m read',
+  upvotes: '312',
+  comments: '448',
+  cover: COVER,
+};
+
+export const clamp = (lines: number): CSSProperties => ({
+  display: '-webkit-box',
+  WebkitLineClamp: lines,
+  WebkitBoxOrient: 'vertical',
+  overflow: 'hidden',
+});
+
+export const Root = ({
+  children,
+}: {
+  children: ReactNode;
+}): React.ReactElement => (
+  <div
+    style={{
+      width: '100%',
+      aspectRatio: '1200 / 630',
+      containerType: 'inline-size',
+      position: 'relative',
+      overflow: 'hidden',
+      borderRadius: '2cqw',
+      background: INK,
+      fontFamily: SANS,
+    }}
+  >
+    {children}
+  </div>
+);
+
+export const Ambient = ({ src }: { src: string }): React.ReactElement => (
+  <>
+    <img
+      src={src}
+      alt=""
+      style={{
+        position: 'absolute',
+        inset: '-25%',
+        width: '150%',
+        height: '150%',
+        objectFit: 'cover',
+        filter: 'blur(13cqw) saturate(1.7) brightness(0.9)',
+        zIndex: 0,
+      }}
+    />
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 0,
+        background:
+          'linear-gradient(180deg, rgba(7,9,13,0.5), rgba(7,9,13,0.78))',
+      }}
+    />
+  </>
+);
+
+export const Logo = (): React.ReactElement => (
+  <span
+    style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '1.6cqw',
+      ...white,
+    }}
+  >
+    <span style={{ display: 'inline-flex', width: '5.25cqw', height: '3cqw' }}>
+      <LogoIcon className={{ container: 'h-full w-full' }} />
+    </span>
+    <span style={{ display: 'inline-flex', width: '11.5cqw', height: '3cqw' }}>
+      <LogoText className={{ container: 'h-full w-full' }} />
+    </span>
+  </span>
+);
+
+export const Source = ({ d }: { d: CoverData }): React.ReactElement => (
+  <div
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: '1.4cqw',
+      minWidth: 0,
+    }}
+  >
+    <span
+      style={{
+        width: '3.6cqw',
+        height: '3.6cqw',
+        borderRadius: '1cqw',
+        background: d.sourceColor,
+        flexShrink: 0,
+      }}
+    />
+    <span
+      style={{
+        color: SECONDARY,
+        fontSize: '2.3cqw',
+        fontWeight: 500,
+        ...clamp(1),
+      }}
+    >
+      {d.source}
+    </span>
+    <span style={{ color: TERTIARY, fontSize: '2.1cqw', flexShrink: 0 }}>
+      · {d.readTime}
+    </span>
+  </div>
+);
+
+const Stat = ({
+  Cmp,
+  count,
+}: {
+  Cmp: typeof UpvoteIcon;
+  count: string;
+}): React.ReactElement => (
+  <span style={{ display: 'inline-flex', alignItems: 'center', gap: '1.1cqw' }}>
+    <span
+      style={{
+        display: 'inline-flex',
+        width: '3.6cqw',
+        height: '3.6cqw',
+        color: TEXT,
+      }}
+    >
+      <Cmp style={{ width: '100%', height: '100%' }} />
+    </span>
+    <span
+      style={{
+        color: TEXT,
+        fontSize: '2.5cqw',
+        fontWeight: 600,
+        fontVariantNumeric: 'tabular-nums',
+      }}
+    >
+      {count}
+    </span>
+  </span>
+);
+
+// The glass/blur bar chrome — shared by the engagement bar and meta pills.
+export const GlassBar = ({
+  children,
+  style,
+}: {
+  children: ReactNode;
+  style?: CSSProperties;
+}): React.ReactElement => (
+  <div
+    style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      padding: '2cqw 3cqw',
+      borderRadius: '2.4cqw',
+      background: 'rgba(255,255,255,0.1)',
+      backdropFilter: 'blur(8px)',
+      WebkitBackdropFilter: 'blur(8px)',
+      border: '0.15cqw solid rgba(255,255,255,0.22)',
+      boxShadow: 'inset 0 0.15cqw 0 rgba(255,255,255,0.12)',
+      ...style,
+    }}
+  >
+    {children}
+  </div>
+);
+
+export const Actions = ({ d }: { d: CoverData }): React.ReactElement => (
+  <GlassBar>
+    <span style={{ display: 'flex', alignItems: 'center', gap: '3.4cqw' }}>
+      <Stat Cmp={UpvoteIcon} count={d.upvotes} />
+      <span
+        style={{
+          width: '0.15cqw',
+          height: '3.4cqw',
+          background: 'rgba(255,255,255,0.16)',
+        }}
+      />
+      <Stat Cmp={DiscussIcon} count={d.comments} />
+    </span>
+  </GlassBar>
+);
+
+export const MetaPill = ({ text }: { text: string }): React.ReactElement => (
+  <GlassBar>
+    <span style={{ color: SECONDARY, fontSize: '2.5cqw', fontWeight: 600 }}>
+      {text}
+    </span>
+  </GlassBar>
+);
+
+export interface StatItem {
+  label: string;
+  Cmp: typeof UpvoteIcon;
+  value: string;
+  color?: string;
+}
+
+// Glass bar with several icon+number stats (profile reputation/streak/posts,
+// squad members/posts/upvotes) — same chrome as the engagement bar.
+export const StatBar = ({
+  stats,
+}: {
+  stats: StatItem[];
+}): React.ReactElement => (
+  <GlassBar>
+    <span style={{ display: 'flex', alignItems: 'center', gap: '3cqw' }}>
+      {stats.map((s, i) => (
+        <React.Fragment key={s.label}>
+          {i > 0 && (
+            <span
+              style={{
+                width: '0.15cqw',
+                height: '3.4cqw',
+                background: 'rgba(255,255,255,0.16)',
+              }}
+            />
+          )}
+          <span
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '1.1cqw',
+            }}
+          >
+            <span
+              style={{
+                display: 'inline-flex',
+                width: '3.4cqw',
+                height: '3.4cqw',
+                color: s.color ?? TEXT,
+              }}
+            >
+              <s.Cmp secondary style={{ width: '100%', height: '100%' }} />
+            </span>
+            <span
+              style={{
+                color: TEXT,
+                fontSize: '2.5cqw',
+                fontWeight: 600,
+                fontVariantNumeric: 'tabular-nums',
+              }}
+            >
+              {s.value}
+            </span>
+          </span>
+        </React.Fragment>
+      ))}
+    </span>
+  </GlassBar>
+);
+
+// White primary button (daily.dev primary on a dark surface).
+export const PrimaryButton = ({
+  children,
+}: {
+  children: ReactNode;
+}): React.ReactElement => (
+  <span
+    style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '1.2cqw',
+      padding: '2.2cqw 4cqw',
+      borderRadius: '2.4cqw',
+      background: '#FFFFFF',
+      color: INK,
+      fontSize: '2.8cqw',
+      fontWeight: 800,
+      boxShadow: '0 1.5cqw 4cqw rgba(0,0,0,0.35)',
+    }}
+  >
+    {children}
+  </span>
+);
+
+export const Headline = ({ d }: { d: CoverData }): React.ReactElement => (
+  <span
+    style={{
+      color: TEXT,
+      fontSize: '5.2cqw',
+      fontWeight: 800,
+      lineHeight: 1.07,
+      letterSpacing: '-0.06cqw',
+      textWrap: 'balance',
+      ...clamp(3),
+    }}
+  >
+    {d.title}
+  </span>
+);
+
+// Headline/title for the generalized cover (any text, sized per use case).
+export const Title = ({
+  children,
+  size = 5.2,
+  lines = 3,
+}: {
+  children: ReactNode;
+  size?: number;
+  lines?: number;
+}): React.ReactElement => (
+  <span
+    style={{
+      color: TEXT,
+      fontSize: `${size}cqw`,
+      fontWeight: 800,
+      lineHeight: 1.07,
+      letterSpacing: '-0.06cqw',
+      textWrap: 'balance',
+      ...clamp(lines),
+    }}
+  >
+    {children}
+  </span>
+);
+
+export const Subtitle = ({
+  children,
+}: {
+  children: ReactNode;
+}): React.ReactElement => (
+  <span
+    style={{
+      color: TERTIARY,
+      fontSize: '2.8cqw',
+      lineHeight: 1.3,
+      textWrap: 'pretty',
+      ...clamp(2),
+    }}
+  >
+    {children}
+  </span>
+);
+
+export const ArtBox = ({
+  children,
+}: {
+  children?: ReactNode;
+}): React.ReactElement => (
+  <div
+    style={{
+      position: 'absolute',
+      right: '5.5cqw',
+      bottom: '5.5cqw',
+      width: '32%',
+      aspectRatio: '1',
+      zIndex: 2,
+    }}
+  >
+    <img
+      src={XD.cover}
+      alt=""
+      style={{
+        width: '100%',
+        height: '100%',
+        objectFit: 'cover',
+        borderRadius: '4.5cqw',
+        boxShadow: '0 4cqw 11cqw rgba(0,0,0,0.55)',
+      }}
+    />
+    {children}
+  </div>
+);
+
+export interface CoverProps {
+  d?: CoverData;
+  bg?: ReactNode;
+  overlay?: ReactNode;
+  logo?: ReactNode;
+  art?: ReactNode;
+  headlineNode?: ReactNode;
+}
+
+// The clean baseline cover. Pass slots to layer a recognizability signature
+// without touching the locked structure.
+export const Cover = ({
+  d = XD,
+  bg,
+  overlay,
+  logo,
+  art,
+  headlineNode,
+}: CoverProps): React.ReactElement => (
+  <Root>
+    <Ambient src={d.cover} />
+    {bg}
+    {art ?? <ArtBox />}
+    <div
+      style={{
+        position: 'absolute',
+        top: '5.5cqw',
+        left: '5.5cqw',
+        right: '5.5cqw',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: '3cqw',
+        zIndex: 2,
+      }}
+    >
+      <Source d={d} />
+      {logo ?? <Logo />}
+    </div>
+    <div
+      style={{
+        position: 'absolute',
+        left: '5.5cqw',
+        top: '15.5cqw',
+        bottom: '5.5cqw',
+        right: '40%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        zIndex: 2,
+      }}
+    >
+      <span style={{ flex: 1, minWidth: 0 }}>
+        {headlineNode ?? <Headline d={d} />}
+      </span>
+      <div style={{ display: 'flex' }}>
+        <Actions d={d} />
+      </div>
+    </div>
+    {overlay}
+  </Root>
+);
+
+// Brand backdrop for covers with no cover image (profile/squad/tag/etc.).
+const BrandBackdrop = (): React.ReactElement => (
+  <>
+    <div
+      style={{ position: 'absolute', inset: 0, zIndex: 0, background: INK }}
+    />
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 0,
+        background: `radial-gradient(55cqw 55cqw at 100% 0%, ${CABBAGE}30, transparent 62%), radial-gradient(55cqw 55cqw at 0% 100%, ${ONION}26, transparent 62%)`,
+      }}
+    />
+  </>
+);
+
+export interface OgCoverProps {
+  // When true, fills its positioned parent (e.g. a platform preview frame).
+  // Otherwise it is a self-sizing 1200×630 box.
+  fill?: boolean;
+  backdrop?: string;
+  eyebrow?: ReactNode;
+  title?: ReactNode;
+  subtitle?: ReactNode;
+  meta?: ReactNode;
+  art?: ReactNode;
+  logo?: ReactNode;
+  // Where the left content column starts (raise it for content-dense covers).
+  contentTop?: string;
+}
+
+/**
+ * The generalized Layout A — same clean structure for every share type:
+ * identity top-left, logo top-right, title + meta on the left, art bottom-right.
+ */
+export const OgCover = ({
+  fill = false,
+  backdrop,
+  eyebrow,
+  title,
+  subtitle,
+  meta,
+  art,
+  logo,
+  contentTop = '15.5cqw',
+}: OgCoverProps): React.ReactElement => {
+  const body = (
+    <>
+      {backdrop ? <Ambient src={backdrop} /> : <BrandBackdrop />}
+      {art && (
+        <div
+          style={{
+            position: 'absolute',
+            right: '5.5cqw',
+            bottom: '5.5cqw',
+            width: '32%',
+            aspectRatio: '1',
+            zIndex: 2,
+          }}
+        >
+          {art}
+        </div>
+      )}
+      <div
+        style={{
+          position: 'absolute',
+          top: '5.5cqw',
+          left: '5.5cqw',
+          right: '5.5cqw',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: '3cqw',
+          zIndex: 2,
+        }}
+      >
+        <span style={{ flex: 1, minWidth: 0 }}>{eyebrow}</span>
+        {logo ?? <Logo />}
+      </div>
+      <div
+        style={{
+          position: 'absolute',
+          left: '5.5cqw',
+          top: contentTop,
+          bottom: '5.5cqw',
+          right: art ? '43%' : '12%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          gap: '3cqw',
+          zIndex: 2,
+        }}
+      >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '2cqw' }}>
+          {title}
+          {subtitle}
+        </div>
+        {meta && <div style={{ display: 'flex' }}>{meta}</div>}
+      </div>
+    </>
+  );
+  if (fill) {
+    return (
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          overflow: 'hidden',
+          containerType: 'inline-size',
+          fontFamily: SANS,
+          background: INK,
+        }}
+      >
+        {body}
+      </div>
+    );
+  }
+  return <Root>{body}</Root>;
+};
+
+export interface CoverItem {
+  id: string;
+  name: string;
+  Component: () => React.ReactElement;
+}
+export interface CoverCategory {
+  category: string;
+  blurb: string;
+  items: CoverItem[];
+}

--- a/packages/storybook/stories/open-graph/coverDna.tsx
+++ b/packages/storybook/stories/open-graph/coverDna.tsx
@@ -1,0 +1,416 @@
+import React from 'react';
+import type { CSSProperties } from 'react';
+import LogoIcon from '@dailydotdev/shared/src/svg/LogoIcon';
+import LogoText from '@dailydotdev/shared/src/svg/LogoText';
+import { Cover, Logo, GRAD, CABBAGE, ONION, white } from './cover';
+import type { CoverCategory } from './cover';
+
+/**
+ * 20 fresh recognizability treatments on the locked clean baseline — four
+ * "systems" for making a cover instantly read as daily.dev:
+ *   A. Frame & edge   B. Brand color skin   C. Background brand mark
+ *   D. Brand lockup (the logo treatment top-right)
+ * Each changes exactly one thing; the rest of the clean cover is untouched.
+ */
+
+// ============================ A · FRAME & EDGE =============================
+const Keyline = (): React.ReactElement => (
+  <div
+    style={{
+      position: 'absolute',
+      inset: 0,
+      zIndex: 4,
+      borderRadius: '2cqw',
+      padding: '0.45cqw',
+      background: GRAD,
+      WebkitMask:
+        'linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
+      WebkitMaskComposite: 'xor',
+      maskComposite: 'exclude',
+      pointerEvents: 'none',
+    }}
+  />
+);
+const BottomBar = (): React.ReactElement => (
+  <div
+    style={{
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      bottom: 0,
+      height: '1.3cqw',
+      background: GRAD,
+      zIndex: 4,
+    }}
+  />
+);
+const LeftSpine = (): React.ReactElement => (
+  <div
+    style={{
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      bottom: 0,
+      width: '1.4cqw',
+      background: GRAD,
+      zIndex: 4,
+    }}
+  />
+);
+const bar = (s: CSSProperties): React.ReactElement => (
+  <span
+    style={{
+      position: 'absolute',
+      background: GRAD,
+      borderRadius: '1cqw',
+      ...s,
+    }}
+  />
+);
+const Brackets = (): React.ReactElement => (
+  <div
+    style={{ position: 'absolute', inset: 0, zIndex: 4, pointerEvents: 'none' }}
+  >
+    {bar({ top: '3cqw', left: '3cqw', width: '11cqw', height: '0.7cqw' })}
+    {bar({ top: '3cqw', left: '3cqw', width: '0.7cqw', height: '11cqw' })}
+    {bar({ bottom: '3cqw', right: '3cqw', width: '11cqw', height: '0.7cqw' })}
+    {bar({ bottom: '3cqw', right: '3cqw', width: '0.7cqw', height: '11cqw' })}
+  </div>
+);
+const InsetFrame = (): React.ReactElement => (
+  <div
+    style={{
+      position: 'absolute',
+      inset: '2.4cqw',
+      zIndex: 4,
+      borderRadius: '1.4cqw',
+      border: '0.18cqw solid rgba(255,255,255,0.45)',
+      pointerEvents: 'none',
+    }}
+  />
+);
+const A1 = (): React.ReactElement => <Cover overlay={<Keyline />} />;
+const A2 = (): React.ReactElement => <Cover overlay={<BottomBar />} />;
+const A3 = (): React.ReactElement => <Cover overlay={<LeftSpine />} />;
+const A4 = (): React.ReactElement => <Cover overlay={<Brackets />} />;
+const A5 = (): React.ReactElement => <Cover overlay={<InsetFrame />} />;
+
+// ============================ B · BRAND COLOR SKIN ========================
+const Duotone = (): React.ReactElement => (
+  <>
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 1,
+        background: GRAD,
+        mixBlendMode: 'color',
+        opacity: 0.72,
+      }}
+    />
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        zIndex: 1,
+        background:
+          'linear-gradient(180deg, rgba(8,11,16,0.2), rgba(8,11,16,0.55))',
+      }}
+    />
+  </>
+);
+const SoftWash = (): React.ReactElement => (
+  <div
+    style={{
+      position: 'absolute',
+      inset: 0,
+      zIndex: 1,
+      background: GRAD,
+      opacity: 0.16,
+    }}
+  />
+);
+const CornerGlow = (): React.ReactElement => (
+  <div
+    style={{
+      position: 'absolute',
+      inset: 0,
+      zIndex: 1,
+      background: `radial-gradient(40cqw 40cqw at 100% 0%, ${CABBAGE}55, transparent 60%), radial-gradient(40cqw 40cqw at 0% 100%, ${ONION}44, transparent 60%)`,
+    }}
+  />
+);
+const Vignette = (): React.ReactElement => (
+  <div
+    style={{
+      position: 'absolute',
+      inset: 0,
+      zIndex: 4,
+      boxShadow: `inset 0 0 16cqw 5cqw ${CABBAGE}22, inset 0 0 6cqw 2cqw ${ONION}22`,
+      borderRadius: '2cqw',
+      pointerEvents: 'none',
+    }}
+  />
+);
+const TopFlood = (): React.ReactElement => (
+  <div
+    style={{
+      position: 'absolute',
+      inset: 0,
+      zIndex: 1,
+      background: `linear-gradient(180deg, ${CABBAGE}3a, transparent 38%)`,
+    }}
+  />
+);
+const B1 = (): React.ReactElement => <Cover bg={<Duotone />} />;
+const B2 = (): React.ReactElement => <Cover bg={<SoftWash />} />;
+const B3 = (): React.ReactElement => <Cover bg={<CornerGlow />} />;
+const B4 = (): React.ReactElement => <Cover overlay={<Vignette />} />;
+const B5 = (): React.ReactElement => <Cover bg={<TopFlood />} />;
+
+// ============================ C · BACKGROUND BRAND MARK ===================
+const MonogramWatermark = (): React.ReactElement => (
+  <div
+    style={{
+      position: 'absolute',
+      left: '-5cqw',
+      bottom: '-8cqw',
+      width: '50cqw',
+      height: '29cqw',
+      opacity: 0.09,
+      zIndex: 1,
+      ...white,
+    }}
+  >
+    <LogoIcon className={{ container: 'h-full w-full' }} />
+  </div>
+);
+const CenterEmboss = (): React.ReactElement => (
+  <div
+    style={{
+      position: 'absolute',
+      left: '50%',
+      top: '50%',
+      transform: 'translate(-50%, -50%)',
+      width: '46cqw',
+      height: '27cqw',
+      opacity: 0.06,
+      zIndex: 1,
+      ...white,
+    }}
+  >
+    <LogoIcon className={{ container: 'h-full w-full' }} />
+  </div>
+);
+const Sheen = (): React.ReactElement => (
+  <div
+    style={{
+      position: 'absolute',
+      inset: 0,
+      zIndex: 1,
+      background: `linear-gradient(115deg, transparent 40%, ${CABBAGE}22 50%, transparent 60%)`,
+    }}
+  />
+);
+const DotGrid = (): React.ReactElement => (
+  <div
+    style={{
+      position: 'absolute',
+      inset: 0,
+      zIndex: 1,
+      backgroundImage:
+        'radial-gradient(rgba(255,255,255,0.06) 1px, transparent 1px)',
+      backgroundSize: '3.2cqw 3.2cqw',
+    }}
+  />
+);
+const GhostWordmark = (): React.ReactElement => (
+  <span
+    style={{
+      position: 'absolute',
+      left: '3cqw',
+      bottom: '-3.5cqw',
+      zIndex: 1,
+      fontSize: '17cqw',
+      fontWeight: 900,
+      letterSpacing: '-0.5cqw',
+      color: 'rgba(255,255,255,0.045)',
+      whiteSpace: 'nowrap',
+    }}
+  >
+    daily.dev
+  </span>
+);
+const C1 = (): React.ReactElement => <Cover bg={<MonogramWatermark />} />;
+const C2 = (): React.ReactElement => <Cover bg={<CenterEmboss />} />;
+const C3 = (): React.ReactElement => <Cover bg={<Sheen />} />;
+const C4 = (): React.ReactElement => <Cover bg={<DotGrid />} />;
+const C5 = (): React.ReactElement => <Cover bg={<GhostWordmark />} />;
+
+// ============================ D · BRAND LOCKUP (top-right) ================
+const Mark = ({
+  h = 3,
+  color = '#fff',
+}: {
+  h?: number;
+  color?: string;
+}): React.ReactElement => (
+  <span
+    style={{
+      display: 'inline-flex',
+      width: `${h * 1.75}cqw`,
+      height: `${h}cqw`,
+      ['--theme-text-primary' as string]: color,
+    }}
+  >
+    <LogoIcon className={{ container: 'h-full w-full' }} />
+  </span>
+);
+const Word = ({ h = 3 }: { h?: number }): React.ReactElement => (
+  <span
+    style={{
+      display: 'inline-flex',
+      width: `${h * 3.85}cqw`,
+      height: `${h}cqw`,
+      ...white,
+    }}
+  >
+    <LogoText className={{ container: 'h-full w-full' }} />
+  </span>
+);
+const LogoPill = (): React.ReactElement => (
+  <span
+    style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      padding: '1.4cqw 2.6cqw',
+      borderRadius: '99cqw',
+      background: 'rgba(255,255,255,0.1)',
+      border: '0.12cqw solid rgba(255,255,255,0.2)',
+      backdropFilter: 'blur(8px)',
+      WebkitBackdropFilter: 'blur(8px)',
+    }}
+  >
+    <Logo />
+  </span>
+);
+const LogoUnderline = (): React.ReactElement => (
+  <span
+    style={{
+      display: 'inline-flex',
+      flexDirection: 'column',
+      alignItems: 'flex-end',
+      gap: '1cqw',
+    }}
+  >
+    <Logo />
+    <span
+      style={{
+        width: '100%',
+        height: '0.8cqw',
+        borderRadius: '1cqw',
+        background: GRAD,
+      }}
+    />
+  </span>
+);
+const LogoTile = (): React.ReactElement => (
+  <span style={{ display: 'inline-flex', alignItems: 'center', gap: '1.6cqw' }}>
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        width: '6.4cqw',
+        height: '6.4cqw',
+        borderRadius: '1.8cqw',
+        background: GRAD,
+      }}
+    >
+      <Mark h={2.6} />
+    </span>
+    <Word h={3} />
+  </span>
+);
+const LogoDot = (): React.ReactElement => (
+  <span style={{ display: 'inline-flex', alignItems: 'center', gap: '1.6cqw' }}>
+    <span
+      style={{
+        width: '2cqw',
+        height: '2cqw',
+        borderRadius: '50%',
+        background: GRAD,
+        boxShadow: `0 0 1.8cqw ${CABBAGE}`,
+      }}
+    />
+    <Logo />
+  </span>
+);
+const LogoRail = (): React.ReactElement => (
+  <span style={{ display: 'inline-flex', alignItems: 'center', gap: '1.8cqw' }}>
+    <span
+      style={{
+        width: '0.7cqw',
+        height: '5.4cqw',
+        borderRadius: '1cqw',
+        background: GRAD,
+      }}
+    />
+    <Logo />
+  </span>
+);
+const D1 = (): React.ReactElement => <Cover logo={<LogoPill />} />;
+const D2 = (): React.ReactElement => <Cover logo={<LogoUnderline />} />;
+const D3 = (): React.ReactElement => <Cover logo={<LogoTile />} />;
+const D4 = (): React.ReactElement => <Cover logo={<LogoDot />} />;
+const D5 = (): React.ReactElement => <Cover logo={<LogoRail />} />;
+
+export const COVER_DNA: CoverCategory[] = [
+  {
+    category: 'Frame & edge',
+    blurb:
+      'A consistent border/edge brands every cover (the way a card chrome does). Cleanest, most system-like.',
+    items: [
+      { id: 'a1', name: 'Gradient keyline', Component: A1 },
+      { id: 'a2', name: 'Bottom brand bar', Component: A2 },
+      { id: 'a3', name: 'Left brand spine', Component: A3 },
+      { id: 'a4', name: 'Corner brackets', Component: A4 },
+      { id: 'a5', name: 'Inset frame', Component: A5 },
+    ],
+  },
+  {
+    category: 'Brand color skin',
+    blurb:
+      'A consistent color treatment of the imagery — ownable at thumbnail size.',
+    items: [
+      { id: 'b1', name: 'Brand duotone', Component: B1 },
+      { id: 'b2', name: 'Soft brand wash', Component: B2 },
+      { id: 'b3', name: 'Corner glow', Component: B3 },
+      { id: 'b4', name: 'Brand vignette', Component: B4 },
+      { id: 'b5', name: 'Top flood', Component: B5 },
+    ],
+  },
+  {
+    category: 'Background brand mark',
+    blurb: 'The mark/wordmark lives quietly behind the content as a watermark.',
+    items: [
+      { id: 'c1', name: 'Monogram watermark', Component: C1 },
+      { id: 'c2', name: 'Center emboss', Component: C2 },
+      { id: 'c3', name: 'Diagonal sheen', Component: C3 },
+      { id: 'c4', name: 'Dot grid', Component: C4 },
+      { id: 'c5', name: 'Ghost wordmark', Component: C5 },
+    ],
+  },
+  {
+    category: 'Brand lockup (the logo, top-right)',
+    blurb:
+      'A consistent treatment of the logo where it already sits — restrained.',
+    items: [
+      { id: 'd1', name: 'Logo pill', Component: D1 },
+      { id: 'd2', name: 'Logo underline', Component: D2 },
+      { id: 'd3', name: 'Logo tile', Component: D3 },
+      { id: 'd4', name: 'Brand dot', Component: D4 },
+      { id: 'd5', name: 'Brand rail', Component: D5 },
+    ],
+  },
+];

--- a/packages/storybook/stories/open-graph/dailyOgImages.tsx
+++ b/packages/storybook/stories/open-graph/dailyOgImages.tsx
@@ -1,0 +1,829 @@
+import React from 'react';
+import type { CSSProperties } from 'react';
+import LogoIcon from '@dailydotdev/shared/src/svg/LogoIcon';
+import { UpvoteIcon } from '@dailydotdev/shared/src/components/icons/Upvote';
+import { UserIcon } from '@dailydotdev/shared/src/components/icons/User';
+import { SquadIcon } from '@dailydotdev/shared/src/components/icons/Squad';
+import { DocsIcon } from '@dailydotdev/shared/src/components/icons/Docs';
+import { DevPlusIcon } from '@dailydotdev/shared/src/components/icons/DevPlus';
+import {
+  OgCover,
+  Ambient,
+  Logo,
+  Title,
+  Subtitle,
+  MetaPill,
+  Actions,
+  StatBar,
+  PrimaryButton,
+  GlassBar,
+  GRAD,
+  CABBAGE,
+  INK,
+  SANS,
+  TEXT,
+  SECONDARY,
+  TERTIARY,
+  clamp,
+  white,
+  XD,
+} from './cover';
+import type { StatItem } from './cover';
+
+// ===========================================================================
+// RECOMMENDED — one unified, contextual system
+// ===========================================================================
+
+export type RecommendedKind =
+  | 'article'
+  | 'shared'
+  | 'profile'
+  | 'squad'
+  | 'invite'
+  | 'tag'
+  | 'comment'
+  | 'plus'
+  | 'generic';
+
+interface RecommendedProps {
+  kind?: RecommendedKind;
+  title?: string;
+  subtitle?: string;
+  cover?: string;
+  name?: string;
+  handle?: string;
+  avatarSrc?: string;
+  meta?: string;
+  sharer?: string;
+  upvotes?: string;
+  comments?: string;
+  // profile stats
+  reputation?: string;
+  streak?: string;
+  posts?: string;
+  reads?: string;
+  tags?: string[];
+  sources?: string[]; // favorite source logo URLs ("reads the most")
+  // squad stats
+  members?: string;
+  // invite / referral / plus
+  cta?: string; // white primary button label
+  count?: string; // prominent count (number shows in cabbage)
+  countWord?: string; // e.g. "developers"
+  mascot?: string; // Charm illustration URL for the art slot
+  square?: boolean; // render the square (1:1) summary-card variant
+}
+
+// Square (1:1) variant — responsive fallback for summary cards. The headline
+// is dropped (unreadable at thumbnail size, and it's already in the link);
+// keep only what reads: the cover art, the daily.dev logo, and the source.
+const SquareCover = ({
+  cover,
+  source,
+}: {
+  cover?: string;
+  source?: string;
+}): React.ReactElement => (
+  <div
+    style={{
+      position: 'absolute',
+      inset: 0,
+      overflow: 'hidden',
+      containerType: 'inline-size',
+      fontFamily: SANS,
+      background: INK,
+    }}
+  >
+    {cover ? (
+      <Ambient src={cover} />
+    ) : (
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          background: `radial-gradient(60cqw 60cqw at 50% 0%, ${CABBAGE}33, transparent 60%)`,
+        }}
+      />
+    )}
+    {/* top bar: source (left) + logo (right) */}
+    <div
+      style={{
+        position: 'absolute',
+        top: '7cqw',
+        left: '7cqw',
+        right: '7cqw',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: '3cqw',
+        zIndex: 2,
+      }}
+    >
+      {source ? (
+        <span
+          style={{ display: 'inline-flex', alignItems: 'center', gap: '2cqw' }}
+        >
+          <span
+            style={{
+              width: '5cqw',
+              height: '5cqw',
+              borderRadius: '1.4cqw',
+              background: '#FF8E3B',
+              flexShrink: 0,
+            }}
+          />
+          <span
+            style={{ color: SECONDARY, fontSize: '3.6cqw', fontWeight: 500 }}
+          >
+            {source}
+          </span>
+        </span>
+      ) : (
+        <span />
+      )}
+      <Logo />
+    </div>
+    {/* centered cover art — the hero of the square */}
+    {cover && (
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 2,
+        }}
+      >
+        <img
+          src={cover}
+          alt=""
+          style={{
+            width: '60%',
+            aspectRatio: '1',
+            objectFit: 'cover',
+            borderRadius: '8cqw',
+            border: '1px solid rgba(255,255,255,0.2)',
+            boxSizing: 'border-box',
+            boxShadow: '0 4cqw 11cqw rgba(0,0,0,0.55)',
+          }}
+        />
+      </div>
+    )}
+  </div>
+);
+
+// ---- Layout A building blocks for the recommended template ----------------
+const RArt = ({
+  src,
+  circle = false,
+}: {
+  src: string;
+  circle?: boolean;
+}): React.ReactElement => (
+  <img
+    src={src}
+    alt=""
+    style={{
+      width: '100%',
+      height: '100%',
+      objectFit: 'cover',
+      borderRadius: circle ? '50%' : '4.5cqw',
+      border: '1px solid rgba(255,255,255,0.2)',
+      boxSizing: 'border-box',
+      boxShadow: '0 4cqw 11cqw rgba(0,0,0,0.55)',
+    }}
+  />
+);
+const RTile = ({
+  children,
+  circle = false,
+}: {
+  children: React.ReactNode;
+  circle?: boolean;
+}): React.ReactElement => (
+  <div
+    style={{
+      width: '100%',
+      height: '100%',
+      borderRadius: circle ? '50%' : '4.5cqw',
+      background: GRAD,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      overflow: 'hidden',
+      boxShadow: '0 4cqw 11cqw rgba(0,0,0,0.5)',
+    }}
+  >
+    {children}
+  </div>
+);
+const RMark = (): React.ReactElement => (
+  <span
+    style={{ display: 'inline-flex', width: '56%', height: '32%', ...white }}
+  >
+    <LogoIcon className={{ container: 'h-full w-full' }} />
+  </span>
+);
+const REyebrow = ({
+  text,
+  sub,
+  src,
+  dot = false,
+}: {
+  text: string;
+  sub?: string;
+  src?: string;
+  dot?: boolean;
+}): React.ReactElement => (
+  <div
+    style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: '1.4cqw',
+      minWidth: 0,
+    }}
+  >
+    {src && (
+      <img
+        src={src}
+        alt=""
+        style={{
+          width: '3.6cqw',
+          height: '3.6cqw',
+          borderRadius: '50%',
+          objectFit: 'cover',
+          flexShrink: 0,
+        }}
+      />
+    )}
+    {!src && dot && (
+      <span
+        style={{
+          width: '3.4cqw',
+          height: '3.4cqw',
+          borderRadius: '1cqw',
+          background: GRAD,
+          flexShrink: 0,
+        }}
+      />
+    )}
+    <span
+      style={{
+        color: SECONDARY,
+        fontSize: '2.3cqw',
+        fontWeight: 500,
+        ...clamp(1),
+      }}
+    >
+      {text}
+    </span>
+    {sub && (
+      <span style={{ color: TERTIARY, fontSize: '2.1cqw', flexShrink: 0 }}>
+        · {sub}
+      </span>
+    )}
+  </div>
+);
+
+// Charm mascot in the art slot.
+// Charm mascot — bigger, anchored bottom-right and dropped a bit lower so it
+// fills the corner instead of floating small. (The art slot is position:
+// absolute, so this positions against it.)
+const RMascot = ({ src }: { src: string }): React.ReactElement => (
+  <img
+    src={src}
+    alt=""
+    style={{
+      position: 'absolute',
+      right: '-2%',
+      bottom: '-10%',
+      width: '118%',
+      height: '118%',
+      maxWidth: 'none',
+      objectFit: 'contain',
+      // Anchor the dog to the bottom-right corner so it never reaches the
+      // top-right logo or runs into the headline on the left.
+      objectPosition: 'right bottom',
+      filter: 'drop-shadow(0 3cqw 7cqw rgba(0,0,0,0.45))',
+    }}
+  />
+);
+
+// Prominent count line — the number pops in cabbage, with a leading icon.
+const ProminentCount = ({
+  count,
+  word,
+}: {
+  count: string;
+  word?: string;
+}): React.ReactElement => (
+  <span
+    style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: '1.4cqw',
+      color: SECONDARY,
+      fontSize: '3.2cqw',
+      fontWeight: 600,
+    }}
+  >
+    <span
+      style={{
+        display: 'inline-flex',
+        width: '3.2cqw',
+        height: '3.2cqw',
+        color: CABBAGE,
+      }}
+    >
+      <UserIcon secondary style={{ width: '100%', height: '100%' }} />
+    </span>
+    <span>
+      <span style={{ color: CABBAGE, fontWeight: 800 }}>{count}</span>
+      {word ? ` ${word}` : ''}
+    </span>
+  </span>
+);
+
+// Community proof — a stack of real member avatars + the count, the way the
+// squad/source pages surface the community. Used for source + tag. Faces are
+// real daily.dev developer avatars.
+const COMMUNITY_FACES = [
+  'https://media.daily.dev/image/upload/s--FcI3RdS1--/f_auto/v1745335145/avatars/avatar_R9RafYjp15h3mJ9XdIkhy',
+  'https://media.daily.dev/image/upload/s--AVEMGQgE--/f_auto/v1744349812/avatars/avatar_RVvUzGofSIHGyTxdjqDN1',
+  'https://media.daily.dev/image/upload/s--CwdXky60--/f_auto/v1733031652/avatars/avatar_rmFJzNXUNPh163VaQkmF0',
+];
+const Community = ({ count }: { count: string }): React.ReactElement => (
+  <GlassBar>
+    <span
+      style={{ display: 'inline-flex', alignItems: 'center', gap: '1.8cqw' }}
+    >
+      <span style={{ display: 'flex' }}>
+        {COMMUNITY_FACES.map((src, i) => (
+          <img
+            key={src}
+            src={src}
+            alt=""
+            style={{
+              width: '3.8cqw',
+              height: '3.8cqw',
+              borderRadius: '50%',
+              objectFit: 'cover',
+              marginLeft: i === 0 ? 0 : '-1.2cqw',
+              boxShadow: '0 0 0 0.45cqw rgba(11,14,19,0.95)',
+            }}
+          />
+        ))}
+      </span>
+      <span style={{ color: SECONDARY, fontSize: '2.5cqw', fontWeight: 600 }}>
+        {count}
+      </span>
+    </span>
+  </GlassBar>
+);
+
+// ---- Developer profile — mirrors the real DevCard ------------------------
+// Rounded avatar with a clean 1px hairline border (subtle, low-opacity white —
+// a soft edge rather than a heavy band).
+const TiltAvatar = ({
+  label,
+  src,
+}: {
+  label?: string;
+  src?: string;
+}): React.ReactElement => {
+  const base: CSSProperties = {
+    width: '100%',
+    height: '100%',
+    borderRadius: '8cqw',
+    border: '1px solid rgba(255,255,255,0.2)',
+    boxSizing: 'border-box',
+    boxShadow: '0 4cqw 11cqw rgba(0,0,0,0.5)',
+  };
+  return src ? (
+    <img src={src} alt="" style={{ ...base, objectFit: 'cover' }} />
+  ) : (
+    <div
+      style={{
+        ...base,
+        background: GRAD,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <span style={{ color: '#fff', fontSize: '15cqw', fontWeight: 800 }}>
+        {label}
+      </span>
+    </div>
+  );
+};
+
+// The DevCard stats bar: 3 sections, each icon + number + label.
+const ProfileStatSection = ({
+  value,
+  label,
+}: {
+  value: string;
+  label: string;
+}): React.ReactElement => (
+  <span style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.05 }}>
+    <span
+      style={{
+        color: TEXT,
+        fontSize: '2.6cqw',
+        fontWeight: 800,
+        fontVariantNumeric: 'tabular-nums',
+      }}
+    >
+      {value}
+    </span>
+    <span style={{ color: TERTIARY, fontSize: '1.5cqw', fontWeight: 500 }}>
+      {label}
+    </span>
+  </span>
+);
+const ProfileStats = ({
+  reputation,
+  streak,
+  reads,
+}: {
+  reputation?: string;
+  streak?: string;
+  reads?: string;
+}): React.ReactElement => {
+  const divider = (
+    <span
+      style={{
+        width: '0.15cqw',
+        height: '4.2cqw',
+        background: 'rgba(255,255,255,0.16)',
+      }}
+    />
+  );
+  return (
+    <div
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '2cqw',
+        padding: '1.8cqw 2.6cqw',
+        borderRadius: '2.4cqw',
+        // Same glass background as the tag chips / engagement bar.
+        background: 'rgba(255,255,255,0.1)',
+        border: '0.12cqw solid rgba(255,255,255,0.2)',
+        backdropFilter: 'blur(8px)',
+        WebkitBackdropFilter: 'blur(8px)',
+        boxShadow: 'inset 0 0.15cqw 0 rgba(255,255,255,0.12)',
+      }}
+    >
+      {reputation && (
+        <ProfileStatSection value={reputation} label="Reputation" />
+      )}
+      {reputation && streak && divider}
+      {streak && <ProfileStatSection value={streak} label="Longest streak" />}
+      {streak && reads && divider}
+      {reads && <ProfileStatSection value={reads} label="Posts read" />}
+    </div>
+  );
+};
+
+const TagChips = ({ tags }: { tags: string[] }): React.ReactElement => (
+  <span style={{ display: 'inline-flex', gap: '1.4cqw', flexWrap: 'wrap' }}>
+    {tags.map((t) => (
+      <span
+        key={t}
+        style={{
+          padding: '0.5cqw 1.4cqw',
+          borderRadius: '99cqw',
+          background: 'rgba(255,255,255,0.1)',
+          border: '0.12cqw solid rgba(255,255,255,0.2)',
+          color: SECONDARY,
+          fontSize: '1.5cqw',
+          fontWeight: 600,
+        }}
+      >
+        #{t}
+      </span>
+    ))}
+  </span>
+);
+
+// Favorite sources the developer reads most — a "Reads" label + source logos
+// (rounded squares on white), like the DevCard footer.
+const SourceLogos = ({ logos }: { logos: string[] }): React.ReactElement => (
+  <span style={{ display: 'inline-flex', alignItems: 'center', gap: '1.4cqw' }}>
+    <span style={{ color: TERTIARY, fontSize: '1.9cqw', fontWeight: 600 }}>
+      Reads from
+    </span>
+    <span style={{ display: 'flex', gap: '0.9cqw' }}>
+      {logos.map((l) => (
+        <span
+          key={l}
+          style={{
+            width: '3.6cqw',
+            height: '3.6cqw',
+            borderRadius: '50%',
+            background: '#fff',
+            boxShadow: '0 0 0 0.3cqw rgba(11,14,19,0.85)',
+            overflow: 'hidden',
+            flexShrink: 0,
+          }}
+        >
+          <img
+            src={l}
+            alt=""
+            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+          />
+        </span>
+      ))}
+    </span>
+  </span>
+);
+
+/**
+ * The recommended template = the locked "Layout A — clean" cover, one system
+ * for every share type. Article/shared/comment keep the real engagement bar
+ * (avocado upvote + comment); other types show stats, a meta pill, or a CTA.
+ */
+export const RecommendedOg = ({
+  kind = 'article',
+  title = 'How to build a dynamic Open Graph image pipeline at the edge',
+  subtitle,
+  cover,
+  name,
+  handle,
+  avatarSrc,
+  meta,
+  sharer,
+  upvotes = '312',
+  comments = '448',
+  reputation,
+  streak,
+  posts,
+  reads,
+  tags,
+  sources,
+  members,
+  cta,
+  count,
+  countWord,
+  mascot,
+  square = false,
+}: RecommendedProps): React.ReactElement => {
+  if (square) {
+    return <SquareCover cover={cover} source={name} />;
+  }
+  const engagement = <Actions d={{ ...XD, upvotes, comments }} />;
+  const pill = meta ? <MetaPill text={meta} /> : undefined;
+  const sub = subtitle ? <Subtitle>{subtitle}</Subtitle> : undefined;
+  const ctaNode = cta ? <PrimaryButton>{cta}</PrimaryButton> : undefined;
+
+  const squadStats: StatItem[] = [];
+  if (members) {
+    squadStats.push({ label: 'members', Cmp: SquadIcon, value: members });
+  }
+  if (posts) {
+    squadStats.push({ label: 'posts', Cmp: DocsIcon, value: posts });
+  }
+  if (upvotes) {
+    squadStats.push({ label: 'upvotes', Cmp: UpvoteIcon, value: upvotes });
+  }
+
+  switch (kind) {
+    case 'shared':
+      return (
+        <OgCover
+          fill
+          backdrop={cover}
+          eyebrow={
+            <REyebrow text={`${sharer} shared this`} src={avatarSrc} dot />
+          }
+          title={<Title>{title}</Title>}
+          subtitle={name ? <Subtitle>{name}</Subtitle> : undefined}
+          meta={engagement}
+          art={cover ? <RArt src={cover} /> : undefined}
+        />
+      );
+    case 'comment':
+      // No art tile — the quote gets the full width.
+      return (
+        <OgCover
+          fill
+          eyebrow={
+            <REyebrow
+              text={name ?? 'Discussion'}
+              sub="commented"
+              src={avatarSrc}
+              dot
+            />
+          }
+          title={<Title size={5}>{title}</Title>}
+          subtitle={meta ? <Subtitle>{meta}</Subtitle> : undefined}
+          meta={engagement}
+        />
+      );
+    case 'profile':
+      // One ordered column with equal gaps: name/role → stats → tags → sources.
+      return (
+        <OgCover
+          fill
+          backdrop={cover}
+          contentTop="12cqw"
+          eyebrow={<REyebrow text={handle ? `@${handle}` : 'Developer'} />}
+          title={
+            <span
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '2.6cqw',
+              }}
+            >
+              <span
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '1cqw',
+                }}
+              >
+                <Title size={5.4} lines={1}>
+                  {title}
+                </Title>
+                {subtitle && <Subtitle>{subtitle}</Subtitle>}
+              </span>
+              {(reputation || streak || reads) && (
+                <span style={{ display: 'flex' }}>
+                  <ProfileStats
+                    reputation={reputation}
+                    streak={streak}
+                    reads={reads}
+                  />
+                </span>
+              )}
+              {sources?.length ? <SourceLogos logos={sources} /> : null}
+              {tags?.length ? <TagChips tags={tags} /> : null}
+            </span>
+          }
+          art={<TiltAvatar label={name?.[0]} src={avatarSrc} />}
+        />
+      );
+    case 'squad':
+      return (
+        <OgCover
+          fill
+          eyebrow={<REyebrow text="Squad" />}
+          title={<Title size={6}>{title}</Title>}
+          subtitle={sub}
+          meta={squadStats.length ? <StatBar stats={squadStats} /> : pill}
+          art={
+            cover ? (
+              <RArt src={cover} circle />
+            ) : (
+              <RTile>
+                <span
+                  style={{ color: '#fff', fontSize: '15cqw', fontWeight: 800 }}
+                >
+                  {(title ?? 'S')[0]}
+                </span>
+              </RTile>
+            )
+          }
+        />
+      );
+    case 'tag':
+      return (
+        <OgCover
+          fill
+          eyebrow={<REyebrow text="Topic" />}
+          title={<Title size={6.4}>{title}</Title>}
+          subtitle={sub}
+          meta={ctaNode ?? (meta ? <Community count={meta} /> : undefined)}
+          art={
+            mascot ? (
+              <RMascot src={mascot} />
+            ) : (
+              <RTile>
+                <span
+                  style={{ color: '#fff', fontSize: '18cqw', fontWeight: 800 }}
+                >
+                  #
+                </span>
+              </RTile>
+            )
+          }
+        />
+      );
+    case 'invite':
+      return (
+        <OgCover
+          fill
+          eyebrow={
+            <REyebrow text={`${sharer} invited you`} src={avatarSrc} dot />
+          }
+          title={<Title size={5.6}>{title}</Title>}
+          subtitle={
+            count ? <ProminentCount count={count} word={countWord} /> : sub
+          }
+          meta={ctaNode ?? pill}
+          art={
+            mascot ? (
+              <RMascot src={mascot} />
+            ) : cover ? (
+              <RArt src={cover} circle />
+            ) : (
+              <RTile>
+                <RMark />
+              </RTile>
+            )
+          }
+        />
+      );
+    case 'plus':
+      return (
+        <OgCover
+          fill
+          eyebrow={
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '1.4cqw',
+              }}
+            >
+              <span
+                style={{
+                  display: 'inline-flex',
+                  width: '4.2cqw',
+                  height: '4.2cqw',
+                  color: CABBAGE,
+                }}
+              >
+                <DevPlusIcon
+                  secondary
+                  style={{ width: '100%', height: '100%' }}
+                />
+              </span>
+              <span
+                style={{
+                  color: SECONDARY,
+                  fontSize: '2.3cqw',
+                  fontWeight: 600,
+                }}
+              >
+                daily.dev Plus
+              </span>
+            </span>
+          }
+          title={<Title size={5.6}>{title}</Title>}
+          subtitle={sub}
+          meta={ctaNode ?? (meta ? <Community count={meta} /> : undefined)}
+          art={
+            mascot ? (
+              <RMascot src={mascot} />
+            ) : (
+              <RTile>
+                <span style={{ display: 'inline-flex', width: '34%', ...white }}>
+                  <DevPlusIcon
+                    secondary
+                    style={{ width: '100%', height: '100%' }}
+                  />
+                </span>
+              </RTile>
+            )
+          }
+        />
+      );
+    case 'generic':
+      return (
+        <OgCover
+          fill
+          eyebrow={<REyebrow text="daily.dev" />}
+          title={<Title size={5.6}>{title}</Title>}
+          subtitle={sub}
+          meta={ctaNode ?? (meta ? <Community count={meta} /> : undefined)}
+          art={
+            mascot ? (
+              <RMascot src={mascot} />
+            ) : cover ? (
+              <RArt src={cover} circle />
+            ) : (
+              <RTile>
+                <RMark />
+              </RTile>
+            )
+          }
+        />
+      );
+    default:
+      return (
+        <OgCover
+          fill
+          backdrop={cover}
+          eyebrow={<REyebrow text={name ?? 'daily.dev'} src={avatarSrc} dot />}
+          title={<Title>{title}</Title>}
+          meta={engagement}
+          art={cover ? <RArt src={cover} /> : undefined}
+        />
+      );
+  }
+};

--- a/packages/storybook/stories/open-graph/ogStoryLayout.tsx
+++ b/packages/storybook/stories/open-graph/ogStoryLayout.tsx
@@ -1,0 +1,348 @@
+import React from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+
+/**
+ * Presentational scaffolding shared by the Open Graph review stories. Uses the
+ * daily.dev theme CSS variables so it follows Storybook's light/dark toggle,
+ * but keeps everything provider-free so the stories render standalone.
+ */
+
+const SANS =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+
+export const Page = ({
+  children,
+}: {
+  children: ReactNode;
+}): React.ReactElement => (
+  <div
+    style={{
+      fontFamily: SANS,
+      color: 'var(--theme-text-primary)',
+      background: 'var(--theme-background-default)',
+      padding: '32px 40px 80px',
+      maxWidth: 1400,
+      margin: '0 auto',
+    }}
+  >
+    {children}
+  </div>
+);
+
+export const PageHeader = ({
+  eyebrow,
+  title,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  children?: ReactNode;
+}): React.ReactElement => (
+  <header style={{ marginBottom: 40, maxWidth: 820 }}>
+    <div
+      style={{
+        fontSize: 13,
+        fontWeight: 700,
+        letterSpacing: 1,
+        textTransform: 'uppercase',
+        color: '#CE3DF3',
+        marginBottom: 8,
+      }}
+    >
+      {eyebrow}
+    </div>
+    <h1
+      style={{
+        fontSize: 34,
+        fontWeight: 800,
+        margin: 0,
+        lineHeight: 1.15,
+        textWrap: 'balance',
+      }}
+    >
+      {title}
+    </h1>
+    {children && (
+      <div
+        style={{
+          marginTop: 14,
+          fontSize: 16,
+          lineHeight: 1.55,
+          color: 'var(--theme-text-secondary)',
+          textWrap: 'pretty',
+        }}
+      >
+        {children}
+      </div>
+    )}
+  </header>
+);
+
+export const Heading = ({
+  children,
+  badge,
+}: {
+  children: ReactNode;
+  badge?: string;
+}): React.ReactElement => (
+  <div
+    style={{
+      display: 'flex',
+      alignItems: 'baseline',
+      gap: 12,
+      marginBottom: 6,
+    }}
+  >
+    <h2
+      style={{ fontSize: 22, fontWeight: 800, margin: 0, textWrap: 'balance' }}
+    >
+      {children}
+    </h2>
+    {badge && (
+      <code
+        style={{
+          fontSize: 12,
+          color: 'var(--theme-text-tertiary)',
+          background: 'var(--theme-surface-float)',
+          padding: '2px 8px',
+          borderRadius: 6,
+        }}
+      >
+        {badge}
+      </code>
+    )}
+  </div>
+);
+
+export const Muted = ({
+  children,
+  style,
+}: {
+  children: ReactNode;
+  style?: CSSProperties;
+}): React.ReactElement => (
+  <p
+    style={{
+      fontSize: 15,
+      lineHeight: 1.5,
+      color: 'var(--theme-text-secondary)',
+      margin: '0 0 12px',
+      textWrap: 'pretty',
+      ...style,
+    }}
+  >
+    {children}
+  </p>
+);
+
+export const Bullets = ({
+  items,
+  tone = 'neutral',
+  title,
+}: {
+  items: string[];
+  tone?: 'neutral' | 'bad' | 'good';
+  title?: string;
+}): React.ReactElement => {
+  const color = { bad: '#d4342c', good: '#1f9d55', neutral: 'inherit' }[tone];
+  const mark = { bad: '✗', good: '✓', neutral: '•' }[tone];
+  return (
+    <div style={{ marginBottom: 14 }}>
+      {title && (
+        <div
+          style={{
+            fontSize: 12,
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: 0.6,
+            color: 'var(--theme-text-tertiary)',
+            marginBottom: 6,
+          }}
+        >
+          {title}
+        </div>
+      )}
+      <ul style={{ margin: 0, padding: 0, listStyle: 'none' }}>
+        {items.map((item) => (
+          <li
+            key={item}
+            style={{
+              display: 'flex',
+              gap: 10,
+              fontSize: 14,
+              lineHeight: 1.5,
+              color: 'var(--theme-text-secondary)',
+              marginBottom: 6,
+            }}
+          >
+            <span style={{ color, fontWeight: 700, flexShrink: 0 }}>
+              {mark}
+            </span>
+            <span style={{ textWrap: 'pretty' }}>{item}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export const Divider = (): React.ReactElement => (
+  <hr
+    style={{
+      border: 0,
+      borderTop: '1px solid var(--theme-divider-tertiary)',
+      margin: '48px 0',
+    }}
+  />
+);
+
+export const TwoCol = ({
+  left,
+  right,
+  leftLabel,
+  rightLabel,
+}: {
+  left: ReactNode;
+  right: ReactNode;
+  leftLabel: string;
+  rightLabel: string;
+}): React.ReactElement => (
+  <div
+    style={{
+      display: 'grid',
+      gridTemplateColumns: '1fr 1fr',
+      gap: 28,
+      alignItems: 'start',
+    }}
+  >
+    {[
+      { label: leftLabel, node: left, tone: '#d4342c' },
+      { label: rightLabel, node: right, tone: '#1f9d55' },
+    ].map((col) => (
+      <div key={col.label}>
+        <div
+          style={{
+            fontSize: 12,
+            fontWeight: 800,
+            textTransform: 'uppercase',
+            letterSpacing: 0.8,
+            color: col.tone,
+            marginBottom: 12,
+            paddingBottom: 8,
+            borderBottom: `2px solid ${col.tone}`,
+          }}
+        >
+          {col.label}
+        </div>
+        {col.node}
+      </div>
+    ))}
+  </div>
+);
+
+const specCell: CSSProperties = {
+  padding: '8px 12px',
+  fontSize: 13,
+  textAlign: 'left',
+  borderBottom: '1px solid var(--theme-divider-tertiary)',
+  verticalAlign: 'top',
+};
+const specHead: CSSProperties = {
+  ...specCell,
+  fontWeight: 700,
+  color: 'var(--theme-text-primary)',
+  borderBottom: '2px solid var(--theme-divider-secondary)',
+};
+
+export const SpecTable = ({
+  columns,
+  rows,
+}: {
+  columns: string[];
+  rows: string[][];
+}): React.ReactElement => (
+  <div style={{ overflowX: 'auto', marginBottom: 24 }}>
+    <table
+      style={{
+        width: '100%',
+        borderCollapse: 'collapse',
+        background: 'var(--theme-surface-float)',
+        borderRadius: 8,
+        overflow: 'hidden',
+        minWidth: 720,
+      }}
+    >
+      <thead>
+        <tr>
+          {columns.map((c) => (
+            <th key={c} style={specHead}>
+              {c}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r) => (
+          <tr key={r.join('|')}>
+            {r.map((c, ci) => (
+              <td
+                key={columns[ci]}
+                style={{ ...specCell, color: 'var(--theme-text-secondary)' }}
+              >
+                {c}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+/** A 1200×630 (by default) frame for rendering share-image mock-ups. */
+export const OgFrame = ({
+  width,
+  ratio = '1200 / 630',
+  children,
+}: {
+  width: number | string;
+  ratio?: string;
+  children: ReactNode;
+}): React.ReactElement => (
+  <div
+    style={{
+      position: 'relative',
+      width,
+      maxWidth: '100%',
+      aspectRatio: ratio,
+      borderRadius: 14,
+      overflow: 'hidden',
+      boxShadow: '0 8px 28px rgba(0,0,0,0.18)',
+      flexShrink: 0,
+    }}
+  >
+    {children}
+  </div>
+);
+
+export const CodeBlock = ({
+  children,
+}: {
+  children: ReactNode;
+}): React.ReactElement => (
+  <pre
+    style={{
+      background: 'var(--theme-surface-float)',
+      border: '1px solid var(--theme-divider-tertiary)',
+      borderRadius: 8,
+      padding: '16px 18px',
+      fontSize: 12.5,
+      lineHeight: 1.55,
+      overflowX: 'auto',
+      color: 'var(--theme-text-primary)',
+      whiteSpace: 'pre',
+    }}
+  >
+    <code>{children}</code>
+  </pre>
+);

--- a/packages/storybook/stories/open-graph/platformCards.tsx
+++ b/packages/storybook/stories/open-graph/platformCards.tsx
@@ -1,0 +1,614 @@
+import React from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+
+/**
+ * Faithful mock-ups of how a shared link unfurls on each major platform.
+ * These intentionally use raw inline styles (not the daily.dev design tokens)
+ * because the goal is to reproduce the *third-party* chrome of X, LinkedIn,
+ * Facebook, Slack, Discord and the messengers as closely as possible so the
+ * team can review our Open Graph output in a realistic context.
+ */
+
+export type CardType = 'summary' | 'summary_large_image';
+
+export interface OgData {
+  /** Host shown in the preview, e.g. "app.daily.dev". */
+  domain: string;
+  /** og:url path, shown in the meta table only. */
+  path?: string;
+  /** og:title — the headline platforms display. */
+  title: string;
+  /** og:description. */
+  description: string;
+  /** og:image URL. Used when imageNode is not provided. */
+  image?: string;
+  /** Render a faithful mock of a dynamically generated image instead of <img>. */
+  imageNode?: ReactNode;
+  /** Square-ratio variant of the generated image, for summary cards. */
+  squareNode?: ReactNode;
+  /** twitter:card. */
+  cardType: CardType;
+  /** og:site_name. */
+  siteName?: string;
+  /** og:image:alt / twitter:image:alt. */
+  imageAlt?: string;
+  /** twitter:site handle, e.g. "@dailydotdev". */
+  twitterSite?: string;
+}
+
+const SANS =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+
+const clamp = (lines: number): CSSProperties => ({
+  display: '-webkit-box',
+  WebkitLineClamp: lines,
+  WebkitBoxOrient: 'vertical',
+  overflow: 'hidden',
+});
+
+const Favicon = ({ size = 16 }: { size?: number }): React.ReactElement => (
+  <span
+    style={{
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: size,
+      height: size,
+      borderRadius: 4,
+      background: '#0e1217',
+      color: '#fff',
+      fontSize: size * 0.6,
+      fontWeight: 700,
+      flexShrink: 0,
+      fontFamily: SANS,
+    }}
+  >
+    d.
+  </span>
+);
+
+const ImageFrame = ({
+  data,
+  radius = 0,
+  ratio = 1200 / 630,
+}: {
+  data: OgData;
+  radius?: number;
+  ratio?: number;
+}): React.ReactElement => (
+  <div
+    style={{
+      position: 'relative',
+      width: '100%',
+      aspectRatio: `${ratio}`,
+      overflow: 'hidden',
+      borderRadius: radius,
+      // Dark so a non-1.91:1 image letterboxes the way X/FB actually show it.
+      background: '#0e1217',
+      flexShrink: 0,
+    }}
+  >
+    {data.imageNode ? (
+      <div style={{ position: 'absolute', inset: 0 }}>{data.imageNode}</div>
+    ) : (
+      <img
+        src={data.image}
+        alt={data.imageAlt || ''}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          width: '100%',
+          height: '100%',
+          // contain → the WHOLE real image shows (the DevCard/squad banner are
+          // not 1.91:1, so cover would crop them into something broken-looking).
+          objectFit: 'contain',
+        }}
+      />
+    )}
+  </div>
+);
+
+const SquareThumb = ({
+  data,
+  size,
+}: {
+  data: OgData;
+  size: number;
+}): React.ReactElement => (
+  <div
+    style={{
+      position: 'relative',
+      width: size,
+      height: size,
+      flexShrink: 0,
+      overflow: 'hidden',
+      background: '#0e1217',
+      display: 'flex',
+      alignItems: 'center',
+    }}
+  >
+    {data.squareNode ? (
+      // A dedicated square-ratio design (logo + cover art + source, no title).
+      <div style={{ position: 'absolute', inset: 0 }}>{data.squareNode}</div>
+    ) : (
+      // Fallback: keep the 1.91:1 design intact and letterbox it into the
+      // square so the whole card still reads — rather than squishing it.
+      <div
+        style={{
+          position: 'relative',
+          width: '100%',
+          aspectRatio: '1200 / 630',
+        }}
+      >
+        {data.imageNode ? (
+          <div style={{ position: 'absolute', inset: 0 }}>{data.imageNode}</div>
+        ) : (
+          <img
+            src={data.image}
+            alt={data.imageAlt || ''}
+            style={{
+              position: 'absolute',
+              inset: 0,
+              width: '100%',
+              height: '100%',
+              objectFit: 'contain',
+            }}
+          />
+        )}
+      </div>
+    )}
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// X / Twitter
+// ---------------------------------------------------------------------------
+export const XCard = ({ data }: { data: OgData }): React.ReactElement => {
+  if (data.cardType === 'summary') {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          maxWidth: 438,
+          border: '1px solid #cfd9de',
+          borderRadius: 16,
+          overflow: 'hidden',
+          fontFamily: SANS,
+          background: '#fff',
+        }}
+      >
+        <SquareThumb data={data} size={128} />
+        <div style={{ padding: '8px 12px', minWidth: 0 }}>
+          <div style={{ color: '#536471', fontSize: 15 }}>{data.domain}</div>
+          <div style={{ color: '#0f1419', fontSize: 15, ...clamp(2) }}>
+            {data.title}
+          </div>
+          <div style={{ color: '#536471', fontSize: 15, ...clamp(2) }}>
+            {data.description}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        maxWidth: 504,
+        border: '1px solid #cfd9de',
+        borderRadius: 16,
+        overflow: 'hidden',
+        fontFamily: SANS,
+        background: '#fff',
+      }}
+    >
+      <ImageFrame data={data} />
+      <span
+        style={{
+          position: 'absolute',
+          bottom: 12,
+          left: 12,
+          background: 'rgba(0,0,0,0.77)',
+          color: '#fff',
+          fontSize: 13,
+          padding: '1px 6px',
+          borderRadius: 4,
+        }}
+      >
+        {data.domain}
+      </span>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// LinkedIn
+// ---------------------------------------------------------------------------
+export const LinkedInCard = ({
+  data,
+}: {
+  data: OgData;
+}): React.ReactElement => (
+  <div
+    style={{
+      maxWidth: 504,
+      border: '1px solid #e0e0e0',
+      borderRadius: 2,
+      overflow: 'hidden',
+      fontFamily: SANS,
+      background: '#fff',
+    }}
+  >
+    <ImageFrame data={data} />
+    <div style={{ padding: '8px 12px' }}>
+      <div
+        style={{
+          color: 'rgba(0,0,0,0.9)',
+          fontSize: 14,
+          fontWeight: 600,
+          lineHeight: 1.3,
+          ...clamp(2),
+        }}
+      >
+        {data.title}
+      </div>
+      <div style={{ color: 'rgba(0,0,0,0.6)', fontSize: 12, marginTop: 2 }}>
+        {data.domain}
+      </div>
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Facebook
+// ---------------------------------------------------------------------------
+export const FacebookCard = ({
+  data,
+}: {
+  data: OgData;
+}): React.ReactElement => (
+  <div
+    style={{
+      maxWidth: 504,
+      border: '1px solid #dddfe2',
+      borderRadius: 8,
+      overflow: 'hidden',
+      fontFamily: SANS,
+      background: '#fff',
+    }}
+  >
+    <ImageFrame data={data} />
+    <div style={{ background: '#f2f3f5', padding: '10px 12px' }}>
+      <div
+        style={{
+          color: '#606770',
+          fontSize: 12,
+          textTransform: 'uppercase',
+          letterSpacing: 0.2,
+        }}
+      >
+        {data.domain}
+      </div>
+      <div
+        style={{
+          color: '#1d2129',
+          fontSize: 16,
+          fontWeight: 600,
+          lineHeight: 1.25,
+          marginTop: 3,
+          ...clamp(2),
+        }}
+      >
+        {data.title}
+      </div>
+      <div
+        style={{ color: '#606770', fontSize: 14, marginTop: 3, ...clamp(1) }}
+      >
+        {data.description}
+      </div>
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Slack
+// ---------------------------------------------------------------------------
+export const SlackCard = ({ data }: { data: OgData }): React.ReactElement => (
+  <div
+    style={{
+      maxWidth: 460,
+      borderLeft: '4px solid #dddddd',
+      borderRadius: 4,
+      paddingLeft: 12,
+      fontFamily: `Lato, ${SANS}`,
+      background: '#fff',
+    }}
+  >
+    <div
+      style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}
+    >
+      <Favicon size={16} />
+      <span style={{ color: '#1d1c1d', fontSize: 13, fontWeight: 700 }}>
+        {data.siteName || 'daily.dev'}
+      </span>
+    </div>
+    <div
+      style={{
+        color: '#1264a3',
+        fontSize: 15,
+        fontWeight: 700,
+        lineHeight: 1.3,
+        ...clamp(2),
+      }}
+    >
+      {data.title}
+    </div>
+    <div
+      style={{
+        color: '#1d1c1d',
+        fontSize: 15,
+        lineHeight: 1.46,
+        margin: '2px 0 8px',
+        maxWidth: 380,
+        ...clamp(3),
+      }}
+    >
+      {data.description}
+    </div>
+    <div style={{ maxWidth: 360 }}>
+      <ImageFrame data={data} radius={8} />
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Discord
+// ---------------------------------------------------------------------------
+export const DiscordCard = ({ data }: { data: OgData }): React.ReactElement => (
+  <div
+    style={{
+      maxWidth: 432,
+      background: '#2b2d31',
+      borderRadius: 4,
+      borderLeft: '4px solid #1e1f22',
+      padding: '8px 16px 16px 12px',
+      fontFamily: SANS,
+    }}
+  >
+    <div style={{ color: '#dbdee1', fontSize: 12, margin: '8px 0 2px' }}>
+      {data.siteName || 'daily.dev'}
+    </div>
+    <div
+      style={{
+        color: '#00a8fc',
+        fontSize: 16,
+        fontWeight: 600,
+        lineHeight: 1.3,
+        ...clamp(2),
+      }}
+    >
+      {data.title}
+    </div>
+    <div
+      style={{
+        color: '#dbdee1',
+        fontSize: 14,
+        lineHeight: 1.3,
+        margin: '4px 0 8px',
+        ...clamp(3),
+      }}
+    >
+      {data.description}
+    </div>
+    <div style={{ maxWidth: 400 }}>
+      <ImageFrame data={data} radius={4} />
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// WhatsApp (received bubble)
+// ---------------------------------------------------------------------------
+export const WhatsAppCard = ({
+  data,
+}: {
+  data: OgData;
+}): React.ReactElement => (
+  <div
+    style={{
+      maxWidth: 330,
+      background: '#fff',
+      borderRadius: 8,
+      overflow: 'hidden',
+      boxShadow: '0 1px 1px rgba(0,0,0,0.13)',
+      fontFamily: SANS,
+    }}
+  >
+    <ImageFrame data={data} />
+    <div style={{ padding: '8px 10px' }}>
+      <div style={{ color: '#111b21', fontSize: 14, ...clamp(2) }}>
+        {data.title}
+      </div>
+      <div
+        style={{ color: '#667781', fontSize: 13, marginTop: 2, ...clamp(2) }}
+      >
+        {data.description}
+      </div>
+      <div style={{ color: '#667781', fontSize: 13, marginTop: 2 }}>
+        {data.domain}
+      </div>
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// iMessage (received bubble)
+// ---------------------------------------------------------------------------
+export const IMessageCard = ({
+  data,
+}: {
+  data: OgData;
+}): React.ReactElement => (
+  <div
+    style={{
+      maxWidth: 260,
+      background: '#e9e9eb',
+      borderRadius: 18,
+      overflow: 'hidden',
+      fontFamily: SANS,
+    }}
+  >
+    <ImageFrame data={data} />
+    <div style={{ padding: '8px 12px' }}>
+      <div
+        style={{
+          color: '#000',
+          fontSize: 13,
+          fontWeight: 600,
+          lineHeight: 1.3,
+          ...clamp(2),
+        }}
+      >
+        {data.title}
+      </div>
+      <div style={{ color: '#8e8e93', fontSize: 12, marginTop: 1 }}>
+        {data.domain}
+      </div>
+    </div>
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Platform grid — renders one preview per platform for a given OgData.
+// ---------------------------------------------------------------------------
+const PLATFORMS: Array<{ label: string; Card: typeof XCard }> = [
+  { label: 'X / Twitter', Card: XCard },
+  { label: 'LinkedIn', Card: LinkedInCard },
+  { label: 'Facebook', Card: FacebookCard },
+  { label: 'Slack', Card: SlackCard },
+  { label: 'Discord', Card: DiscordCard },
+  { label: 'WhatsApp', Card: WhatsAppCard },
+  { label: 'iMessage', Card: IMessageCard },
+];
+
+const platformLabelStyle: CSSProperties = {
+  fontFamily: SANS,
+  fontSize: 12,
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: 0.6,
+  color: '#71717a',
+  marginBottom: 8,
+};
+
+export const PlatformGrid = ({
+  data,
+}: {
+  data: OgData;
+}): React.ReactElement => (
+  <div
+    style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))',
+      gap: 28,
+      alignItems: 'start',
+    }}
+  >
+    {PLATFORMS.map(({ label, Card }) => (
+      <div key={label}>
+        <div style={platformLabelStyle}>{label}</div>
+        <Card data={data} />
+      </div>
+    ))}
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Meta-tag inspector table with per-platform length warnings.
+// ---------------------------------------------------------------------------
+const LIMITS = { title: 60, description: 110 };
+
+const Row = ({
+  tag,
+  value,
+  limit,
+}: {
+  tag: string;
+  value?: string;
+  limit?: number;
+}): React.ReactElement => {
+  const len = value?.length ?? 0;
+  const over = limit ? len > limit : false;
+  return (
+    <tr style={{ borderBottom: '1px solid var(--theme-divider-tertiary)' }}>
+      <td
+        style={{
+          padding: '6px 12px',
+          fontFamily: 'monospace',
+          fontSize: 12,
+          whiteSpace: 'nowrap',
+          verticalAlign: 'top',
+          color: 'var(--theme-text-tertiary)',
+        }}
+      >
+        {tag}
+      </td>
+      <td
+        style={{
+          padding: '6px 12px',
+          fontSize: 13,
+          color: 'var(--theme-text-primary)',
+        }}
+      >
+        {value || <em style={{ opacity: 0.5 }}>—</em>}
+      </td>
+      <td
+        style={{
+          padding: '6px 12px',
+          fontSize: 12,
+          whiteSpace: 'nowrap',
+          textAlign: 'right',
+          color: over ? '#d4342c' : 'var(--theme-text-tertiary)',
+          fontWeight: over ? 700 : 400,
+        }}
+      >
+        {limit ? `${len} / ${limit}` : len || ''}
+      </td>
+    </tr>
+  );
+};
+
+export const MetaTagsTable = ({
+  data,
+}: {
+  data: OgData;
+}): React.ReactElement => {
+  const url = `https://${data.domain}${data.path || ''}`;
+  return (
+    <table
+      style={{
+        width: '100%',
+        borderCollapse: 'collapse',
+        background: 'var(--theme-surface-float)',
+        borderRadius: 8,
+        overflow: 'hidden',
+      }}
+    >
+      <tbody>
+        <Row tag="og:title" value={data.title} limit={LIMITS.title} />
+        <Row
+          tag="og:description"
+          value={data.description}
+          limit={LIMITS.description}
+        />
+        <Row tag="og:image" value={data.image || '(generated)'} />
+        <Row tag="og:image:alt" value={data.imageAlt} />
+        <Row tag="og:url" value={url} />
+        <Row tag="og:site_name" value={data.siteName} />
+        <Row tag="twitter:card" value={data.cardType} />
+        <Row tag="twitter:site" value={data.twitterSite} />
+      </tbody>
+    </table>
+  );
+};

--- a/packages/storybook/stories/open-graph/useCases.tsx
+++ b/packages/storybook/stories/open-graph/useCases.tsx
@@ -1,0 +1,591 @@
+import React from 'react';
+import {
+  cloudinaryCharmEmptySquads,
+  cloudinaryCharmReadLater,
+  cloudinaryCharmNotEnoughTags,
+} from '@dailydotdev/shared/src/lib/image';
+import type { OgData } from './platformCards';
+import { RecommendedOg } from './dailyOgImages';
+
+export const DEFAULT_OG_IMAGE =
+  'https://media.daily.dev/image/upload/s--VAY5ToZt--/f_auto/v1724209435/public/daily.dev%20-%20open%20graph';
+
+// The CURRENT column uses the REAL images daily.dev serves today (raw, not
+// re-created). Reality check (verified live 2026-06-17): only POSTS get a
+// generated card; profile, source, tag, squad, invite, Plus and the app
+// default all fall back to the SAME generic image. The marketing homepage
+// serves its own og-image.png.
+const LANDING_OG = 'https://daily.dev/og-image.png';
+
+// A real, live daily.dev post (so the current post card is the genuine asset).
+const POST_OG = 'https://og.daily.dev/api/posts/qojM1enSN';
+// The shared variant adds the sharer (real endpoint, ?userid=).
+const SHARED_OG = `${POST_OG}?userid=u_123`;
+const POST_TITLE = 'How to use traces to avoid breaking changes';
+const POST_SOURCE = 'Community Picks';
+const POST_COVER =
+  'https://media.daily.dev/image/upload/f_auto,q_auto/v1/posts/2a3c2ca8481678b5c9178cd656700187';
+// The post's real source logo (Community Picks) and the real commenter avatar.
+const POST_SOURCE_LOGO =
+  'https://media.daily.dev/image/upload/t_logo,f_auto/v1655817725/logos/community';
+const COMMENT_AVATAR =
+  'https://media.daily.dev/image/upload/s--IbwvoTYq--/f_auto/v1772778404/avatars/avatar_giQfoBCN9hYxcvRVo3s95';
+
+// Profile share = the real DevCard "wide" image (ProfileLayout sets og:image to
+// /devcards/v2/{userId}.png?type=wide — a generated DevCard, NOT the generic).
+const PROFILE_OG =
+  'https://api.daily.dev/devcards/v2/28849d86070e4c099c877ab6837c61f0.png?type=wide';
+// Real assets for the recommended profile: the user's avatar, their rank-based
+// DevCard cover (the bg changes with reputation rank), and real source logos.
+const PROFILE_AVATAR =
+  'https://media.daily.dev/image/upload/s---xy_OAwk--/f_auto,q_auto/v1703781380/avatars/avatar_28849d86070e4c099c877ab6837c61f0';
+const PROFILE_RANK_COVER =
+  'https://media.daily.dev/image/upload/s--xDkKz00z--/f_auto/v1707920136/covers/cover_28849d86070e4c099c877ab6837c61f0';
+// The user's real "reads the most" sources, straight from their DevCard.
+const PROFILE_SOURCES = [
+  'https://media.daily.dev/image/upload/s--fk_6ycEi--/f_auto,q_auto/v1780996001/logos/collections',
+  'https://media.daily.dev/image/upload/s--stRJbTCn--/f_auto/v1752953684/squads/ad08ba59-6646-487f-a8bd-2147d9e572a6',
+  'https://media.daily.dev/image/upload/s--V91DY4ls--/f_auto,q_auto/v1772617267/logos/agents_digest',
+  'https://media.daily.dev/image/upload/t_logo,f_auto/v1/logos/hn',
+];
+// Real WebDev squad share image (its own image is what production serves).
+const WEBDEV_OG =
+  'https://media.daily.dev/image/upload/s--3B1fh4kU--/f_auto,q_auto/v1/squads/94fc7a56-e6d2-403f-acd6-b988b426574f';
+// Real freeCodeCamp source logo.
+const FREECODECAMP_LOGO =
+  'https://media.daily.dev/image/upload/t_logo,f_auto/v1628412854/logos/freecodecamp';
+
+export interface UseCase {
+  id: string;
+  /** Human label for the share type. */
+  name: string;
+  /** What object is being shared and from where. */
+  what: string;
+  /** ReferralCampaignKey / route that produces it. */
+  source: string;
+  /** Problems with the current treatment. */
+  issues: string[];
+  /** What we should change. */
+  recommendations: string[];
+  current: OgData;
+  recommended: OgData;
+}
+
+export const USE_CASES: UseCase[] = [
+  {
+    id: 'article',
+    name: 'Article / Post',
+    what: 'A developer shares an aggregated article from the feed or post page.',
+    source: '/posts/[slug] · ReferralCampaignKey.SharePost',
+    issues: [
+      'og:title always gets a " | daily.dev" suffix appended, eating ~12 chars of the headline and pushing it over the 60-char sweet spot.',
+      'og:description falls back to a truncated, often HTML-stripped excerpt with no consistent value framing.',
+      'The generated image leads with the publisher’s cover; daily.dev branding is small and easy to miss.',
+      'No og:image:alt / twitter:image:alt is set.',
+    ],
+    recommendations: [
+      'Drop the title suffix for shareable content — site_name already conveys the brand. Reserve the suffix for navigational pages.',
+      'Lead the image with the headline + author + reading time over a consistent branded frame; treat the cover as a supporting thumbnail.',
+      'Always emit og:image:alt mirroring the post title.',
+      'Add twitter:label/data (Author, Reading time) for richer Slack/X-adjacent unfurls.',
+    ],
+    current: {
+      domain: 'app.daily.dev',
+      path: '/posts/how-to-use-traces-to-avoid-breaking-changes',
+      title: 'How to use traces to avoid breaking changes | daily.dev',
+      description:
+        'How distributed traces help you catch breaking changes before they ship…',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      image: POST_OG,
+    },
+    recommended: {
+      domain: 'app.daily.dev',
+      path: '/posts/how-to-use-traces-to-avoid-breaking-changes',
+      title: 'How to use traces to avoid breaking changes',
+      description:
+        'How distributed traces help you catch breaking changes before they ship — a practical walkthrough.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      imageAlt: 'How to use traces to avoid breaking changes',
+      imageNode: (
+        <RecommendedOg
+          kind="article"
+          title={POST_TITLE}
+          name={POST_SOURCE}
+          avatarSrc={POST_SOURCE_LOGO}
+          meta="7 min read"
+          upvotes="21"
+          comments="2"
+          cover={POST_COVER}
+        />
+      ),
+      squareNode: (
+        <RecommendedOg
+          square
+          kind="article"
+          name={POST_SOURCE}
+          cover={POST_COVER}
+        />
+      ),
+    },
+  },
+  {
+    id: 'shared-post',
+    name: 'Shared post (with attribution)',
+    what: 'A user shares a post via their personal share link, attributing the share to them.',
+    source:
+      '/posts/[id]/share?userid=… · og.daily.dev/api/posts/{id}?userid={uid}',
+    issues: [
+      'Attribution ("X shared") is small and inconsistent vs. the standard post image.',
+      'Same title-suffix and description issues as a normal post.',
+      'The sharer’s avatar/identity is not reliably surfaced, weakening the social proof that drives the click.',
+    ],
+    recommendations: [
+      'Make the sharer a first-class element: avatar + "shared by {name}" pill at the top of the image.',
+      'Keep the rest of the article template identical so the share feels like a native daily.dev object.',
+    ],
+    current: {
+      domain: 'app.daily.dev',
+      path: '/posts/.../share?userid=u_123',
+      title: 'How to use traces to avoid breaking changes | daily.dev',
+      description:
+        'How distributed traces help you catch breaking changes before they ship…',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      image: SHARED_OG,
+    },
+    recommended: {
+      domain: 'app.daily.dev',
+      path: '/posts/.../share?userid=u_123',
+      title: 'How to use traces to avoid breaking changes',
+      description:
+        'Ido shared this on daily.dev — how traces catch breaking changes before they ship.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      imageAlt: 'Ido shared: How to use traces to avoid breaking changes',
+      imageNode: (
+        <RecommendedOg
+          kind="shared"
+          sharer="Ido Shamun"
+          avatarSrc={PROFILE_AVATAR}
+          title={POST_TITLE}
+          name={POST_SOURCE}
+          meta="7 min read"
+          upvotes="21"
+          comments="2"
+          cover={POST_COVER}
+        />
+      ),
+    },
+  },
+  {
+    id: 'profile',
+    name: 'Developer profile',
+    what: 'Sharing a user profile / DevCard.',
+    source:
+      '/[username] · DevCard v2 wide image · ReferralCampaignKey.ShareProfile',
+    issues: [
+      'The profile shares the DevCard image (/devcards/v2/{id}.png?type=wide) — a different visual language from post shares, and not 1.91:1, so it gets letterboxed/cropped in unfurls.',
+      'Bio (og:description) is often empty; falls back to the generic site description.',
+      'Title carries the " | daily.dev" suffix.',
+    ],
+    recommendations: [
+      'Use the same template family as posts, in "developer" mode: avatar, name, @handle, headline stat (streak, reputation).',
+      'Default description to a generated one-liner ("{name} reads about React, Rust & AI on daily.dev") when bio is empty.',
+    ],
+    current: {
+      domain: 'app.daily.dev',
+      path: '/idoshamun',
+      title: 'Ido Shamun (@idoshamun) | daily.dev',
+      description:
+        'daily.dev is the easiest way to stay updated on the latest programming news…',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      image: PROFILE_OG,
+    },
+    recommended: {
+      domain: 'app.daily.dev',
+      path: '/idoshamun',
+      title: 'Ido Shamun (@idoshamun)',
+      description:
+        'Ido reads about AI, LLMs & web dev on daily.dev — 20.5k posts read, 1,087-day longest streak.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      imageAlt: 'Ido Shamun on daily.dev',
+      imageNode: (
+        <RecommendedOg
+          kind="profile"
+          title="Ido Shamun"
+          subtitle="I’m to blame if something goes wrong here 🙈"
+          name="Ido Shamun"
+          handle="idoshamun"
+          avatarSrc={PROFILE_AVATAR}
+          cover={PROFILE_RANK_COVER}
+          reputation="168k"
+          streak="1,087"
+          reads="20.5k"
+          tags={['ai', 'llm', 'webdev']}
+          sources={PROFILE_SOURCES}
+        />
+      ),
+    },
+  },
+  {
+    id: 'squad',
+    name: 'Squad',
+    what: 'Sharing a Squad’s public page.',
+    source:
+      '/squads/[handle] · getSquadOpenGraph() · ReferralCampaignKey.ShareSource',
+    issues: [
+      'Uses the squad’s own uploaded banner, whose dimensions/quality vary wildly and may not be 1.91:1.',
+      'Falls back to the generic brand image when no banner is set — zero context.',
+      'No member count / activity signal in the preview to drive joins.',
+    ],
+    recommendations: [
+      'Render a generated, on-brand squad card: squad name + avatar + member count + "active today" signal, with the banner as a backdrop.',
+      'Never fall back to the bare generic image — always generate a contextual squad card.',
+    ],
+    current: {
+      domain: 'app.daily.dev',
+      path: '/squads/webdev',
+      title: 'WebDev | daily.dev',
+      description:
+        'The official daily.dev web development community. Led by thought leaders and webdev experts. Join the Squad!',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      image: WEBDEV_OG,
+    },
+    recommended: {
+      domain: 'app.daily.dev',
+      path: '/squads/webdev',
+      title: 'WebDev — a Squad on daily.dev',
+      description:
+        'The official daily.dev web development community, led by thought leaders and webdev experts.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      imageAlt: 'WebDev squad on daily.dev',
+      imageNode: (
+        <RecommendedOg
+          kind="squad"
+          title="WebDev"
+          subtitle="The official daily.dev web development community"
+          members="26,606"
+          posts="1,069"
+          upvotes="12.9k"
+          cover={WEBDEV_OG}
+        />
+      ),
+    },
+  },
+  {
+    id: 'squad-invite',
+    name: 'Squad invite link',
+    what: 'A member invites someone to a private/public Squad.',
+    source: '/squads/[handle]/[token]',
+    issues: [
+      'Title is good ("{inviter} invited you to {squad}") but the image is just the squad banner — the invite framing lives only in text the platform may truncate.',
+      'No inviter identity in the image; the personal, social hook is lost.',
+    ],
+    recommendations: [
+      'Bake the invite framing into the image: inviter avatar + "invited you to join {squad}" + member count + CTA chip.',
+      'Keep the strong title but ensure the image stands on its own when the title is clipped.',
+    ],
+    current: {
+      domain: 'app.daily.dev',
+      path: '/squads/webdev/abc123token',
+      title: 'Ido invited you to WebDev',
+      description:
+        'The official daily.dev web development community. Led by thought leaders and webdev experts. Join the Squad!',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      image: WEBDEV_OG,
+    },
+    recommended: {
+      domain: 'app.daily.dev',
+      path: '/squads/webdev/abc123token',
+      title: 'Ido invited you to join WebDev on daily.dev',
+      description:
+        'Join the official daily.dev web development community. It’s free.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      imageAlt: 'Ido invited you to join WebDev',
+      imageNode: (
+        <RecommendedOg
+          kind="invite"
+          sharer="Ido Shamun"
+          avatarSrc={PROFILE_AVATAR}
+          title="Join WebDev"
+          count="26,606"
+          countWord="developers"
+          cta="Tap to join"
+          cover={WEBDEV_OG}
+        />
+      ),
+    },
+  },
+  {
+    id: 'source',
+    name: 'Source / Publication',
+    what: 'Sharing a publication/source page.',
+    source: '/sources/[source]',
+    issues: [
+      'Uses the bare generic brand image (defaultOpenGraph) — no indication of which source it is.',
+      'Title + suffix only; description is the source description if present.',
+    ],
+    recommendations: [
+      'Generate a source card with the source logo, name and "Followed by N developers on daily.dev".',
+    ],
+    current: {
+      domain: 'app.daily.dev',
+      path: '/sources/freecodecamp',
+      title: 'freeCodeCamp | daily.dev',
+      description: 'The latest from freeCodeCamp on daily.dev.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      image: DEFAULT_OG_IMAGE,
+    },
+    recommended: {
+      domain: 'app.daily.dev',
+      path: '/sources/freecodecamp',
+      title: 'freeCodeCamp on daily.dev',
+      description:
+        'Followed by developers across daily.dev. Get every new post in your feed.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      imageAlt: 'freeCodeCamp on daily.dev',
+      imageNode: (
+        <RecommendedOg
+          kind="generic"
+          title="freeCodeCamp"
+          subtitle="Learn to code — for free."
+          meta="15k followers"
+          cover={FREECODECAMP_LOGO}
+        />
+      ),
+    },
+  },
+  {
+    id: 'tag',
+    name: 'Tag / Topic feed',
+    what: 'Sharing a tag feed (e.g. /tags/react).',
+    source: 'ReferralCampaignKey.ShareTag',
+    issues: ['Generic brand image; the topic name appears only in text.'],
+    recommendations: [
+      'Generate a topic card: "#react" + a one-line topic description + a few sample source logos.',
+    ],
+    current: {
+      domain: 'app.daily.dev',
+      path: '/tags/react',
+      title: 'react | daily.dev',
+      description:
+        'Explore the React JavaScript library for building user interfaces.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      image: DEFAULT_OG_IMAGE,
+    },
+    recommended: {
+      domain: 'app.daily.dev',
+      path: '/tags/react',
+      title: '#react on daily.dev',
+      description:
+        'Explore the React JavaScript library for building user interfaces.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      imageAlt: 'The #react topic on daily.dev',
+      imageNode: (
+        <RecommendedOg
+          kind="tag"
+          title="#react"
+          subtitle="Building user interfaces with the React library"
+          cta="Explore the feed"
+          mascot={cloudinaryCharmNotEnoughTags}
+        />
+      ),
+    },
+  },
+  {
+    id: 'comment',
+    name: 'Comment / Discussion',
+    what: 'Sharing a specific comment on a post.',
+    source: 'ReferralCampaignKey.ShareComment',
+    issues: [
+      'Reuses the post image; the comment that the user actually wanted to highlight is invisible in the preview.',
+    ],
+    recommendations: [
+      'Generate a discussion card: comment excerpt as the hero, commenter avatar/name, post title as context.',
+    ],
+    current: {
+      domain: 'app.daily.dev',
+      path: '/posts/qojM1enSN#c_456',
+      title: 'How to use traces to avoid breaking changes | daily.dev',
+      description:
+        'Reuses the post image — the highlighted comment is invisible in the preview.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      image: POST_OG,
+    },
+    recommended: {
+      domain: 'app.daily.dev',
+      path: '/posts/qojM1enSN#c_456',
+      title: '“Great article! Thanks for sharing 🙌” — sirajju on daily.dev',
+      description:
+        'sirajju commented on “How to use traces to avoid breaking changes”. Join the discussion.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      imageAlt: 'Comment by sirajju on a daily.dev discussion',
+      imageNode: (
+        <RecommendedOg
+          kind="comment"
+          title="“Great article! Thanks for sharing 🙌”"
+          name="sirajju"
+          handle="sirajju"
+          avatarSrc={COMMENT_AVATAR}
+          meta="on “How to use traces to avoid breaking changes”"
+          upvotes="21"
+          comments="2"
+        />
+      ),
+    },
+  },
+  {
+    id: 'invite',
+    name: 'Invite friends / Referral',
+    what: 'Personal referral link (the generic /?cid root link from Invite friends).',
+    source: '/?cid=… · ReferralCampaignKey.Generic',
+    issues: [
+      'The root referral link (app.daily.dev/?cid=…&userid=…) falls back to the generic brand image — no referrer, no incentive, no personalization.',
+      'Highest-intent growth surface, weakest preview. (A separate og.daily.dev/api/refs card exists for /join links, but it’s off the unified template and currently returns empty for many users.)',
+    ],
+    recommendations: [
+      'Generate a referral card with the referrer’s avatar + "{name} invited you to daily.dev" + a clear CTA, on the unified template.',
+    ],
+    current: {
+      domain: 'app.daily.dev',
+      path: '/?cid=generic&userid=u_123',
+      title: 'daily.dev | Where developers grow together',
+      description:
+        'daily.dev is the easiest way to stay updated on the latest programming news…',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      image: DEFAULT_OG_IMAGE,
+    },
+    recommended: {
+      domain: 'app.daily.dev',
+      path: '/?cid=generic&userid=u_123',
+      title: 'Ido invited you to daily.dev',
+      description:
+        'The professional network where developers grow together. Free forever.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      imageAlt: 'Ido invited you to daily.dev',
+      imageNode: (
+        <RecommendedOg
+          kind="invite"
+          sharer="Ido Shamun"
+          avatarSrc={PROFILE_AVATAR}
+          title="Join me on daily.dev"
+          subtitle="The one feed developers actually read"
+          cta="Tap to join"
+          mascot={cloudinaryCharmEmptySquads}
+        />
+      ),
+    },
+  },
+  {
+    id: 'plus',
+    name: 'Plus subscription',
+    what: 'Sharing / gifting daily.dev Plus.',
+    source: '/plus',
+    issues: [
+      'Generic brand image; nothing communicates the Plus value or the gift.',
+    ],
+    recommendations: [
+      'Generate a Plus card with the Plus mark, headline benefit and gift framing when applicable.',
+    ],
+    current: {
+      domain: 'app.daily.dev',
+      path: '/plus',
+      title: 'Unlock Premium Developer Features with Plus | daily.dev',
+      description:
+        'daily.dev is the easiest way to stay updated on the latest programming news…',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      image: DEFAULT_OG_IMAGE,
+    },
+    recommended: {
+      domain: 'app.daily.dev',
+      path: '/plus',
+      title: 'daily.dev Plus — your feed, supercharged',
+      description:
+        'AI summaries, advanced filters, and an ad-free feed. Try Plus free for 14 days.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      imageAlt: 'daily.dev Plus',
+      imageNode: (
+        <RecommendedOg
+          kind="plus"
+          title="daily.dev Plus"
+          subtitle="AI summaries, advanced filters, and an ad-free feed"
+          cta="Try Plus free"
+          mascot={cloudinaryCharmReadLater}
+        />
+      ),
+    },
+  },
+  {
+    id: 'home',
+    name: 'Homepage / default',
+    what: 'The root URL and any page without a specific override.',
+    source: 'next-seo.ts defaultOpenGraph',
+    issues: [
+      'Single static image; fine as a true fallback but currently does double duty for many specific share types it should not.',
+    ],
+    recommendations: [
+      'Keep as the genuine last-resort fallback only. Every specific surface above should override it.',
+    ],
+    current: {
+      domain: 'app.daily.dev',
+      path: '/',
+      title: 'daily.dev | Where developers grow together',
+      description:
+        'daily.dev is the easiest way to stay updated on the latest programming news. Get the best content from the top tech publications on any topic you want.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      image: DEFAULT_OG_IMAGE,
+    },
+    recommended: {
+      domain: 'app.daily.dev',
+      path: '/',
+      title: 'daily.dev | Where developers grow together',
+      description:
+        'The professional network for developers. One feed for the best engineering content, every day.',
+      cardType: 'summary_large_image',
+      siteName: 'daily.dev',
+      twitterSite: '@dailydotdev',
+      imageAlt: 'daily.dev — where developers grow together',
+      image: LANDING_OG,
+    },
+  },
+];


### PR DESCRIPTION
## Changes

Adds a new **Open Graph** Storybook section that audits daily.dev's outbound link previews across every share surface and proposes a unified, on-brand recommended template ("Layout A").

- **Current vs Recommended** for each share type — article, shared post, profile/DevCard, squad, squad invite, source, tag, comment, referral, Plus, homepage.
- The **Current** column renders the *real* images daily.dev serves today (raw, not re-created). The **Recommended** column renders the Layout A cover for the **same real entity** (real post engagement, real DevCard stats, WebDev squad, freeCodeCamp source, real commenter) so the before/after is apples-to-apples.
- Supporting pages: platform unfurl previews (X/LinkedIn/Slack/Discord/etc.) with per-platform meta-tag length warnings, guidelines & research, an X (Twitter) deep dive, a Satori template spec, a benchmark of how the best platforms share, and a link copy/metadata page.
- Single source of truth in `cover.tsx` (Layout A atoms + `OgCover`); `RecommendedOg` in `dailyOgImages.tsx` is the adapter every page consumes.

Docs/review only — no app/runtime code paths are touched (Storybook stories under `packages/storybook` plus one `preview.tsx` sidebar entry).

## Events

No new tracking events.

## Experiment

No new experiments.

## Manual Testing

Storybook-only change. Verified `pnpm --filter storybook build` succeeds and the strict typecheck guard passes for changed files. Covers render full-width across the section; all referenced real image assets resolve.

### Preview domain
https://claude-eager-leavitt-bfba54.preview.app.daily.dev