### PR TITLE
feat: sync OneSignal web push subscriptions

### DIFF
--- a/packages/shared/src/contexts/PushNotificationContext.tsx
+++ b/packages/shared/src/contexts/PushNotificationContext.tsx
@@ -23,6 +23,8 @@ import { isTesting } from '../lib/constants';
 import { useLogContext } from './LogContext';
 import type { SubscriptionCallback } from '../components/notifications/utils';
 import { postWebKitMessage, WebKitMessageHandlers } from '../lib/ios';
+import { syncWebPushSubscription } from '../graphql/notifications';
+import { storageWrapper } from '../lib/storageWrapper';
 
 export interface PushNotificationsContextData {
   isPushSupported: boolean;
@@ -41,8 +43,8 @@ export const PushNotificationsContext =
     isSubscribed: false,
     isLoading: false,
     shouldOpenPopup: () => true,
-    subscribe: null,
-    unsubscribe: null,
+    subscribe: async () => false,
+    unsubscribe: async () => undefined,
   });
 
 interface PushNotificationContextProviderProps {
@@ -52,6 +54,17 @@ interface PushNotificationContextProviderProps {
 type ChangeEventHandler = Parameters<
   typeof OneSignal.Notifications.addEventListener<'permissionChange'>
 >[1];
+
+type PushSubscriptionChangeHandler = Parameters<
+  typeof OneSignal.User.PushSubscription.addEventListener
+>[1];
+
+type WebPushSubscriptionState = {
+  subscriptionId?: string | null;
+  optedIn?: boolean;
+};
+
+const webPushSyncStorageKey = 'web-push-subscription-synced';
 
 function OneSignalSubProvider({
   children,
@@ -75,6 +88,15 @@ function OneSignalSubProvider({
     queryKey: key,
 
     queryFn: async () => {
+      if (!user) {
+        throw new Error('Cannot initialize OneSignal push without user');
+      }
+
+      const appId = process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID;
+      if (!appId) {
+        throw new Error('NEXT_PUBLIC_ONESIGNAL_APP_ID is required');
+      }
+
       const osr = client.getQueryData<typeof OneSignal>(key);
 
       if (osr) {
@@ -84,14 +106,14 @@ function OneSignalSubProvider({
       const OneSignalImport = (await import('react-onesignal')).default;
 
       await OneSignalImport.init({
-        appId: process.env.NEXT_PUBLIC_ONESIGNAL_APP_ID,
+        appId,
         serviceWorkerParam: { scope: '/push/onesignal/' },
         serviceWorkerPath: '/push/onesignal/OneSignalSDKWorker.js',
       });
 
       await OneSignalImport.login(user.id);
 
-      setIsSubscribed(OneSignalImport.User.PushSubscription.optedIn);
+      setIsSubscribed(!!OneSignalImport.User.PushSubscription.optedIn);
 
       return OneSignalImport;
     },
@@ -101,6 +123,48 @@ function OneSignalSubProvider({
 
   const isPushSupported = OneSignalCache?.Notifications.isPushSupported();
 
+  const syncCurrentWebPushSubscription = useCallback(
+    async (state?: WebPushSubscriptionState) => {
+      if (!OneSignalCache || !user) {
+        return;
+      }
+
+      const subscriptionId =
+        state?.subscriptionId ??
+        OneSignalCache.User.PushSubscription.id ??
+        undefined;
+      const optedIn =
+        state?.optedIn ?? OneSignalCache.User.PushSubscription.optedIn ?? false;
+      const marker =
+        optedIn && subscriptionId ? `${user.id}:${subscriptionId}` : undefined;
+
+      if (marker && storageWrapper.getItem(webPushSyncStorageKey) === marker) {
+        return;
+      }
+
+      try {
+        await syncWebPushSubscription({
+          subscriptionId,
+          origin: globalThis.location?.origin,
+          optedIn,
+        });
+
+        if (marker) {
+          storageWrapper.setItem(webPushSyncStorageKey, marker);
+        }
+      } catch (err) {
+        logEvent({
+          event_name: LogEvent.GlobalError,
+          extra: JSON.stringify({
+            origin: 'web_push_subscription_sync',
+            error: err instanceof Error ? err.message : 'unknown',
+          }),
+        });
+      }
+    },
+    [OneSignalCache, logEvent, user],
+  );
+
   subscriptionCallbackRef.current = async (
     newPermission,
     source,
@@ -109,6 +173,7 @@ function OneSignalSubProvider({
     if (newPermission) {
       await OneSignalCache?.User.PushSubscription.optIn();
       setIsSubscribed(true);
+      await syncCurrentWebPushSubscription({ optedIn: true });
 
       logEvent({
         event_name: LogEvent.ClickEnableNotification,
@@ -147,8 +212,9 @@ function OneSignalSubProvider({
       return;
     }
     await OneSignalCache.User.PushSubscription.optOut();
+    await syncCurrentWebPushSubscription({ optedIn: false });
     setIsSubscribed(false);
-  }, [OneSignalCache]);
+  }, [OneSignalCache, syncCurrentWebPushSubscription]);
 
   useEffect(() => {
     if (!OneSignalCache) {
@@ -158,15 +224,40 @@ function OneSignalSubProvider({
     const onChange: ChangeEventHandler = (permission) => {
       subscriptionCallbackRef.current?.(permission);
     };
+    const onSubscriptionChange: PushSubscriptionChangeHandler = ({
+      current,
+    }) => {
+      setIsSubscribed(!!current.optedIn);
+      syncCurrentWebPushSubscription({
+        subscriptionId: current.id,
+        optedIn: current.optedIn,
+      });
+    };
 
     OneSignalCache.Notifications.addEventListener('permissionChange', onChange);
+    OneSignalCache.User.PushSubscription.addEventListener(
+      'change',
+      onSubscriptionChange,
+    );
     return () => {
       OneSignalCache.Notifications.removeEventListener(
         'permissionChange',
         onChange,
       );
+      OneSignalCache.User.PushSubscription.removeEventListener(
+        'change',
+        onSubscriptionChange,
+      );
     };
-  }, [OneSignalCache]);
+  }, [OneSignalCache, syncCurrentWebPushSubscription]);
+
+  useEffect(() => {
+    if (!OneSignalCache?.User.PushSubscription.optedIn) {
+      return;
+    }
+
+    syncCurrentWebPushSubscription();
+  }, [OneSignalCache, syncCurrentWebPushSubscription]);
 
   return (
     <PushNotificationsContext.Provider
@@ -201,6 +292,10 @@ function NativeAppleSubProvider({
     queryKey: key,
 
     queryFn: async () => {
+      if (!user) {
+        throw new Error('Cannot initialize native push without user');
+      }
+
       const promise = promisifyEventListener('push-state', (event) => {
         setIsSubscribed(!!event?.detail);
       });

--- a/packages/shared/src/graphql/notifications.spec.ts
+++ b/packages/shared/src/graphql/notifications.spec.ts
@@ -1,0 +1,44 @@
+import { gqlClient } from './common';
+import {
+  SYNC_WEB_PUSH_SUBSCRIPTION_MUTATION,
+  syncWebPushSubscription,
+} from './notifications';
+
+jest.mock('./common', () => ({
+  gqlClient: {
+    request: jest.fn(),
+  },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('should sync web push subscription', async () => {
+  jest.mocked(gqlClient.request).mockResolvedValue({
+    syncWebPushSubscription: {
+      cleanedUpSubscriptions: 2,
+    },
+  });
+
+  await expect(
+    syncWebPushSubscription({
+      subscriptionId: '11111111-1111-4111-8111-111111111111',
+      origin: 'https://daily.dev',
+      optedIn: true,
+    }),
+  ).resolves.toEqual({
+    cleanedUpSubscriptions: 2,
+  });
+
+  expect(gqlClient.request).toHaveBeenCalledWith(
+    SYNC_WEB_PUSH_SUBSCRIPTION_MUTATION,
+    {
+      input: {
+        subscriptionId: '11111111-1111-4111-8111-111111111111',
+        origin: 'https://daily.dev',
+        optedIn: true,
+      },
+    },
+  );
+});

--- a/packages/shared/src/graphql/notifications.ts
+++ b/packages/shared/src/graphql/notifications.ts
@@ -100,6 +100,34 @@ export const READ_NOTIFICATIONS_MUTATION = gql`
   }
 `;
 
+export const SYNC_WEB_PUSH_SUBSCRIPTION_MUTATION = gql`
+  mutation SyncWebPushSubscription($input: SyncWebPushSubscriptionInput) {
+    syncWebPushSubscription(input: $input) {
+      cleanedUpSubscriptions
+    }
+  }
+`;
+
+export type SyncWebPushSubscriptionInput = {
+  subscriptionId?: string;
+  origin?: string;
+  optedIn?: boolean;
+};
+
+export type SyncWebPushSubscriptionResult = {
+  cleanedUpSubscriptions: number;
+};
+
+export const syncWebPushSubscription = async (
+  input: SyncWebPushSubscriptionInput,
+): Promise<SyncWebPushSubscriptionResult> => {
+  const res = await gqlClient.request<{
+    syncWebPushSubscription: SyncWebPushSubscriptionResult;
+  }>(SYNC_WEB_PUSH_SUBSCRIPTION_MUTATION, { input });
+
+  return res.syncWebPushSubscription;
+};
+
 export type NewNotification = Pick<
   Notification,
   | 'createdAt'


### PR DESCRIPTION
## Summary
- add the `syncWebPushSubscription` GraphQL mutation helper
- sync OneSignal web push state after initial login, opt-in, opt-out, and SDK subscription changes
- cache successful syncs per user/subscription id to avoid calling cleanup on every page load

## Validation
- NODE_ENV=test pnpm --filter @dailydotdev/shared exec jest src/graphql/notifications.spec.ts --runInBand
- pnpm --filter @dailydotdev/shared exec eslint src/graphql/notifications.ts src/graphql/notifications.spec.ts src/contexts/PushNotificationContext.tsx --max-warnings 0
- node ./scripts/typecheck-strict-changed.js
- git diff --check

## Notes
- Production/staging still need `NEXT_PUBLIC_ONESIGNAL_APP_ID` updated to the new web OneSignal app id in Vercel.
- Full `pnpm --filter @dailydotdev/shared exec tsc -p tsconfig.json --noEmit` is currently blocked by unrelated existing SettingsContext/trusted-types/user-experience spec type errors.


### Preview domain
https://feat-sync-web-push-subscription.preview.app.daily.dev