### PR TITLE
chore: simplify vote tooltip copy to Upvote / Downvote

### DIFF
--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -572,7 +572,7 @@ describe('Feed logged in', () => {
       },
       completeActionMock({ action: ActionType.VotePost }),
     ]);
-    const [el] = await screen.findAllByLabelText('More like this');
+    const [el] = await screen.findAllByLabelText('Upvote');
     el.click();
     await waitFor(() => expect(mutationCalled).toBeTruthy());
   });
@@ -687,7 +687,7 @@ describe('Feed logged in', () => {
       }),
     ]);
     await waitFor(async () => {
-      const [el] = await screen.findAllByLabelText('More like this');
+      const [el] = await screen.findAllByLabelText('Upvote');
       const parent = getRequiredValue(
         el.parentElement,
         'Expected upvote button parent element',
@@ -706,7 +706,7 @@ describe('Feed logged in', () => {
       },
     });
     await waitFor(async () => {
-      const [el] = await screen.findAllByLabelText('More like this');
+      const [el] = await screen.findAllByLabelText('Upvote');
       const parent = getRequiredValue(
         el.parentElement,
         'Expected upvote button parent element after subscription',
@@ -1688,7 +1688,7 @@ describe('Feed annonymous', () => {
       ],
       undefined,
     );
-    const [el] = await screen.findAllByLabelText('More like this');
+    const [el] = await screen.findAllByLabelText('Upvote');
     el.click();
     expect(showLogin).toBeCalledWith({ trigger: AuthTriggers.Upvote });
   });

--- a/packages/shared/src/components/cards/article/ArticleGrid.spec.tsx
+++ b/packages/shared/src/components/cards/article/ArticleGrid.spec.tsx
@@ -79,7 +79,7 @@ it('should call on watch video link click on component middle mouse up', async (
 
 it('should call on upvote click on upvote button click', async () => {
   renderComponent();
-  const el = await screen.findByLabelText('More like this');
+  const el = await screen.findByLabelText('Upvote');
   el.click();
   await waitFor(() => expect(defaultProps.onUpvoteClick).toBeCalledWith(post));
 });

--- a/packages/shared/src/components/cards/collection/CollectionGrid.spec.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionGrid.spec.tsx
@@ -66,7 +66,7 @@ it('should call on link click on component left click', async () => {
 
 it('should call on upvote click on upvote button click', async () => {
   renderComponent();
-  const el = await screen.findByLabelText('More like this');
+  const el = await screen.findByLabelText('Upvote');
   el.click();
   await waitFor(() => expect(defaultProps.onUpvoteClick).toBeCalledWith(post));
 });

--- a/packages/shared/src/components/cards/common/ActionButtons.tsx
+++ b/packages/shared/src/components/cards/common/ActionButtons.tsx
@@ -181,7 +181,7 @@ const ActionButtonsV1 = ({
     >
       <div className="flex flex-1 items-center justify-between">
         <Tooltip
-          content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
+          content={isUpvoteActive ? 'Remove upvote' : 'Upvote'}
           side={variant === 'grid' ? 'bottom' : undefined}
         >
           <QuaternaryButton
@@ -214,7 +214,7 @@ const ActionButtonsV1 = ({
         </Tooltip>
         {showDownvoteAction && (
           <Tooltip
-            content={isDownvoteActive ? 'Remove downvote' : 'Less like this'}
+            content={isDownvoteActive ? 'Remove downvote' : 'Downvote'}
             side={variant === 'grid' ? 'bottom' : undefined}
           >
             <QuaternaryButton

--- a/packages/shared/src/components/cards/common/ActionButtons.v2.tsx
+++ b/packages/shared/src/components/cards/common/ActionButtons.v2.tsx
@@ -157,7 +157,7 @@ const ActionButtons = ({
     >
       <CardActionBar layout="feedCard">
         <Tooltip
-          content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
+          content={isUpvoteActive ? 'Remove upvote' : 'Upvote'}
           side={variant === 'grid' ? 'bottom' : undefined}
         >
           <CardAction
@@ -170,14 +170,14 @@ const ActionButtons = ({
             iconPressed={
               <UpvoteButtonIcon secondary brandAnimation={brandAnimation} />
             }
-            label={isUpvoteActive ? 'Remove upvote' : 'More like this'}
+            label={isUpvoteActive ? 'Remove upvote' : 'Upvote'}
             count={upvoteCount}
             buttonClassName="pointer-events-auto"
           />
         </Tooltip>
         {showDownvoteAction && (
           <Tooltip
-            content={isDownvoteActive ? 'Remove downvote' : 'Less like this'}
+            content={isDownvoteActive ? 'Remove downvote' : 'Downvote'}
             side={variant === 'grid' ? 'bottom' : undefined}
           >
             <CardAction
@@ -186,7 +186,7 @@ const ActionButtons = ({
               color={ButtonColor.Ketchup}
               icon={<DownvoteIcon />}
               iconPressed={<DownvoteIcon secondary />}
-              label={isDownvoteActive ? 'Remove downvote' : 'Less like this'}
+              label={isDownvoteActive ? 'Remove downvote' : 'Downvote'}
               pressed={isDownvoteActive}
               onClick={onToggleDownvote}
               buttonClassName="pointer-events-auto"

--- a/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
+++ b/packages/shared/src/components/cards/common/FeedCardGlassActions.tsx
@@ -106,7 +106,7 @@ export function FeedCardGlassActions({
       <div className={outerClasses}>
         <div className={pillClasses} style={{ background: glassBackground }}>
           <Tooltip
-            content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
+            content={isUpvoteActive ? 'Remove upvote' : 'Upvote'}
             side="bottom"
           >
             <QuaternaryButton
@@ -158,7 +158,7 @@ export function FeedCardGlassActions({
           </Tooltip>
           {showDownvoteAction && (
             <Tooltip
-              content={isDownvoteActive ? 'Remove downvote' : 'Less like this'}
+              content={isDownvoteActive ? 'Remove downvote' : 'Downvote'}
               side="bottom"
             >
               <QuaternaryButton

--- a/packages/shared/src/components/cards/share/ShareGrid.spec.tsx
+++ b/packages/shared/src/components/cards/share/ShareGrid.spec.tsx
@@ -98,7 +98,7 @@ it('should call on link click on component left click', async () => {
 
 it('should call on upvote click on upvote button click', async () => {
   renderComponent();
-  const el = await screen.findByLabelText('More like this');
+  const el = await screen.findByLabelText('Upvote');
   el.click();
   await waitFor(() => expect(defaultProps.onUpvoteClick).toBeCalledWith(post));
 });

--- a/packages/shared/src/components/cards/socialTwitter/SocialTwitterGrid.spec.tsx
+++ b/packages/shared/src/components/cards/socialTwitter/SocialTwitterGrid.spec.tsx
@@ -126,7 +126,7 @@ it('should not render media for thread cards even when image exists', async () =
     },
   });
 
-  expect(await screen.findByLabelText('More like this')).toBeInTheDocument();
+  expect(await screen.findByLabelText('Upvote')).toBeInTheDocument();
   expect(screen.queryByAltText('Tweet media')).not.toBeInTheDocument();
 });
 
@@ -260,6 +260,6 @@ it('should keep actions visible when there is no media and no shared post detail
     },
   });
 
-  expect(await screen.findByLabelText('More like this')).toBeInTheDocument();
+  expect(await screen.findByLabelText('Upvote')).toBeInTheDocument();
   expect(screen.queryByAltText('Tweet media')).not.toBeInTheDocument();
 });

--- a/packages/shared/src/components/post/PostActions.tsx
+++ b/packages/shared/src/components/post/PostActions.tsx
@@ -219,9 +219,7 @@ function PostActionsV1({
           className="flex flex-1 items-center justify-between gap-x-1 overflow-hidden py-2 pl-4 pr-6"
           ref={actionsRef}
         >
-          <Tooltip
-            content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
-          >
+          <Tooltip content={isUpvoteActive ? 'Remove upvote' : 'Upvote'}>
             <QuaternaryButton
               id="upvote-post-btn"
               pressed={isUpvoteActive}
@@ -237,9 +235,7 @@ function PostActionsV1({
               color={ButtonColor.Avocado}
             />
           </Tooltip>
-          <Tooltip
-            content={isDownvoteActive ? 'Remove downvote' : 'Less like this'}
-          >
+          <Tooltip content={isDownvoteActive ? 'Remove downvote' : 'Downvote'}>
             <QuaternaryButton
               id="downvote-post-btn"
               pressed={isDownvoteActive}

--- a/packages/shared/src/components/post/PostActions.v2.tsx
+++ b/packages/shared/src/components/post/PostActions.v2.tsx
@@ -202,9 +202,7 @@ export function PostActions({
           layout="between"
           className="overflow-hidden p-2"
         >
-          <Tooltip
-            content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
-          >
+          <Tooltip content={isUpvoteActive ? 'Remove upvote' : 'Upvote'}>
             <CardAction
               id="upvote-post-btn"
               pressed={isUpvoteActive}
@@ -217,9 +215,7 @@ export function PostActions({
               color={ButtonColor.Avocado}
             />
           </Tooltip>
-          <Tooltip
-            content={isDownvoteActive ? 'Remove downvote' : 'Less like this'}
-          >
+          <Tooltip content={isDownvoteActive ? 'Remove downvote' : 'Downvote'}>
             <CardAction
               id="downvote-post-btn"
               pressed={isDownvoteActive}

--- a/packages/shared/src/components/post/focus/FocusCardActionBar.tsx
+++ b/packages/shared/src/components/post/focus/FocusCardActionBar.tsx
@@ -226,9 +226,7 @@ export const FocusCardActionBar = ({
         )}
       >
         <div className="flex items-center gap-1">
-          <Tooltip
-            content={isUpvoteActive ? 'Remove upvote' : 'More like this'}
-          >
+          <Tooltip content={isUpvoteActive ? 'Remove upvote' : 'Upvote'}>
             <CardAction
               id="upvote-post-btn"
               label="Upvote"
@@ -240,9 +238,7 @@ export const FocusCardActionBar = ({
               onClick={onToggleUpvote}
             />
           </Tooltip>
-          <Tooltip
-            content={isDownvoteActive ? 'Remove downvote' : 'Less like this'}
-          >
+          <Tooltip content={isDownvoteActive ? 'Remove downvote' : 'Downvote'}>
             <CardAction
               id="downvote-post-btn"
               label="Downvote"

--- a/packages/shared/src/components/post/reader/ReaderRailActionBar.tsx
+++ b/packages/shared/src/components/post/reader/ReaderRailActionBar.tsx
@@ -60,7 +60,7 @@ function ReaderRailActionBarV1({
       role="toolbar"
       aria-label="Post actions"
     >
-      <Tooltip content={isUpvoteActive ? 'Remove upvote' : 'More like this'}>
+      <Tooltip content={isUpvoteActive ? 'Remove upvote' : 'Upvote'}>
         <Button
           id="reader-upvote-btn"
           type="button"
@@ -76,9 +76,7 @@ function ReaderRailActionBarV1({
           color={ButtonColor.Avocado}
         />
       </Tooltip>
-      <Tooltip
-        content={isDownvoteActive ? 'Remove downvote' : 'Less like this'}
-      >
+      <Tooltip content={isDownvoteActive ? 'Remove downvote' : 'Downvote'}>
         <Button
           id="reader-downvote-btn"
           type="button"

--- a/packages/shared/src/components/post/reader/ReaderRailActionBar.v2.tsx
+++ b/packages/shared/src/components/post/reader/ReaderRailActionBar.v2.tsx
@@ -59,7 +59,7 @@ export function ReaderRailActionBar({
       role="toolbar"
       aria-label="Post actions"
     >
-      <Tooltip content={isUpvoteActive ? 'Remove upvote' : 'More like this'}>
+      <Tooltip content={isUpvoteActive ? 'Remove upvote' : 'Upvote'}>
         <CardAction
           id="reader-upvote-btn"
           pressed={isUpvoteActive}
@@ -74,9 +74,7 @@ export function ReaderRailActionBar({
           color={ButtonColor.Avocado}
         />
       </Tooltip>
-      <Tooltip
-        content={isDownvoteActive ? 'Remove downvote' : 'Less like this'}
-      >
+      <Tooltip content={isDownvoteActive ? 'Remove downvote' : 'Downvote'}>
         <CardAction
           id="reader-downvote-btn"
           pressed={isDownvoteActive}

--- a/packages/shared/src/hooks/post/usePostActions.spec.tsx
+++ b/packages/shared/src/hooks/post/usePostActions.spec.tsx
@@ -101,7 +101,7 @@ describe('usePostActions', () => {
   it('should show share overlay when post is upvoted', async () => {
     renderComponent();
 
-    const el = screen.getByLabelText('More like this');
+    const el = screen.getByLabelText('Upvote');
     el.click();
 
     expect(
@@ -123,7 +123,7 @@ describe('usePostActions', () => {
   it('should show bookmark overlay instead of share overlay when post is bookmarked after upvote click', async () => {
     renderComponent();
 
-    const upvoteBtn = screen.getByLabelText('More like this');
+    const upvoteBtn = screen.getByLabelText('Upvote');
     upvoteBtn.click();
 
     const bookmarkBtn = screen.getByLabelText('Bookmark');
@@ -140,7 +140,7 @@ describe('usePostActions', () => {
     const bookmarkBtn = screen.getByLabelText('Bookmark');
     bookmarkBtn.click();
 
-    const upvoteBtn = screen.getByLabelText('More like this');
+    const upvoteBtn = screen.getByLabelText('Upvote');
     upvoteBtn.click();
 
     expect(


### PR DESCRIPTION
## Summary
- Replace inactive upvote/downvote tooltip copy from "More like this" / "Less like this" to "Upvote" / "Downvote" across feed cards, post actions, focus card, and reader rail.
- Active-state copy ("Remove upvote" / "Remove downvote") is unchanged.
- Update affected specs that query vote buttons via `findByLabelText`.

## Test plan
- [x] `pnpm --filter shared` affected specs pass (ArticleGrid, CollectionGrid, ShareGrid, SocialTwitterGrid, usePostActions, Feed)
- [x] Strict typecheck on changed files passes
- [x] Prettier passes on changed source files

Made with [Cursor](https://cursor.com)

### Preview domain
https://chore-vote-tooltip-copy.preview.app.daily.dev