### PR TITLE
feat(tags): show tag titles in the tags directory page

### DIFF
--- a/packages/shared/src/components/tags/TagCategorySection.tsx
+++ b/packages/shared/src/components/tags/TagCategorySection.tsx
@@ -17,6 +17,7 @@ interface TagCategorySectionProps {
   category: TagCategory;
   followedTags: Set<string>;
   onToggleFollow: (tag: string) => void;
+  titleByValue?: Map<string, string>;
   className?: string;
 }
 
@@ -26,6 +27,7 @@ export function TagCategorySection({
   category,
   followedTags,
   onToggleFollow,
+  titleByValue,
   className,
 }: TagCategorySectionProps): ReactElement | null {
   const [expanded, setExpanded] = useState(false);
@@ -61,6 +63,7 @@ export function TagCategorySection({
           <TagDirectoryListItem
             key={tag}
             tag={tag}
+            title={titleByValue?.get(tag)}
             isFollowed={followedTags.has(tag)}
             onToggleFollow={onToggleFollow}
           />

--- a/packages/shared/src/components/tags/TagCategorySection.tsx
+++ b/packages/shared/src/components/tags/TagCategorySection.tsx
@@ -17,7 +17,6 @@ interface TagCategorySectionProps {
   category: TagCategory;
   followedTags: Set<string>;
   onToggleFollow: (tag: string) => void;
-  titleByValue?: Map<string, string>;
   className?: string;
 }
 
@@ -27,7 +26,6 @@ export function TagCategorySection({
   category,
   followedTags,
   onToggleFollow,
-  titleByValue,
   className,
 }: TagCategorySectionProps): ReactElement | null {
   const [expanded, setExpanded] = useState(false);
@@ -63,7 +61,6 @@ export function TagCategorySection({
           <TagDirectoryListItem
             key={tag}
             tag={tag}
-            title={titleByValue?.get(tag)}
             isFollowed={followedTags.has(tag)}
             onToggleFollow={onToggleFollow}
           />

--- a/packages/shared/src/components/tags/TagDirectoryListItem.tsx
+++ b/packages/shared/src/components/tags/TagDirectoryListItem.tsx
@@ -16,6 +16,7 @@ import {
 
 interface TagDirectoryListItemProps {
   tag: string;
+  title?: string;
   isFollowed: boolean;
   onToggleFollow: (tag: string) => void;
 }
@@ -25,6 +26,7 @@ interface TagDirectoryListItemProps {
 // unfollowed tags reveal a subtle "+" on hover/focus.
 export function TagDirectoryListItem({
   tag,
+  title,
   isFollowed,
   onToggleFollow,
 }: TagDirectoryListItemProps): ReactElement {
@@ -37,7 +39,7 @@ export function TagDirectoryListItem({
           color={TypographyColor.Secondary}
           className="block min-w-0 flex-1 cursor-pointer truncate px-2 py-1 no-underline transition-colors hover:text-text-primary"
         >
-          {formatKeyword(tag)}
+          {title || formatKeyword(tag)}
         </Typography>
       </Link>
       <Tooltip content={isFollowed ? `Following #${tag}` : `Follow #${tag}`}>

--- a/packages/shared/src/components/tags/TagsDirectoryPage.tsx
+++ b/packages/shared/src/components/tags/TagsDirectoryPage.tsx
@@ -110,18 +110,6 @@ export function TagsDirectoryPage({
     [tagsByLetter],
   );
 
-  // Maps a tag's normalized value to its human-readable title so every list in
-  // the directory can show the title version instead of the slug.
-  const titleByValue = useMemo(() => {
-    const map = new Map<string, string>();
-    tags?.forEach((tag) => {
-      if (tag.flags?.title) {
-        map.set(tag.value, tag.flags.title);
-      }
-    });
-    return map;
-  }, [tags]);
-
   const visibleLetters =
     activeLetter && tagsByLetter[activeLetter]?.length
       ? [activeLetter]
@@ -250,7 +238,7 @@ export function TagsDirectoryPage({
                   <TagDirectoryListItem
                     key={tag.value}
                     tag={tag.value}
-                    title={titleByValue.get(tag.value)}
+                    title={tag.flags?.title}
                     isFollowed={followedTags.has(tag.value)}
                     onToggleFollow={onToggleFollow}
                   />
@@ -312,7 +300,6 @@ export function TagsDirectoryPage({
                     category={list}
                     followedTags={followedTags}
                     onToggleFollow={onToggleFollow}
-                    titleByValue={titleByValue}
                   />
                 ))}
               </div>
@@ -353,7 +340,7 @@ export function TagsDirectoryPage({
                         <TagDirectoryListItem
                           key={tag.value}
                           tag={tag.value}
-                          title={titleByValue.get(tag.value)}
+                          title={tag.flags?.title}
                           isFollowed={followedTags.has(tag.value)}
                           onToggleFollow={onToggleFollow}
                         />

--- a/packages/shared/src/components/tags/TagsDirectoryPage.tsx
+++ b/packages/shared/src/components/tags/TagsDirectoryPage.tsx
@@ -110,6 +110,18 @@ export function TagsDirectoryPage({
     [tagsByLetter],
   );
 
+  // Maps a tag's normalized value to its human-readable title so every list in
+  // the directory can show the title version instead of the slug.
+  const titleByValue = useMemo(() => {
+    const map = new Map<string, string>();
+    tags?.forEach((tag) => {
+      if (tag.flags?.title) {
+        map.set(tag.value, tag.flags.title);
+      }
+    });
+    return map;
+  }, [tags]);
+
   const visibleLetters =
     activeLetter && tagsByLetter[activeLetter]?.length
       ? [activeLetter]
@@ -238,6 +250,7 @@ export function TagsDirectoryPage({
                   <TagDirectoryListItem
                     key={tag.value}
                     tag={tag.value}
+                    title={titleByValue.get(tag.value)}
                     isFollowed={followedTags.has(tag.value)}
                     onToggleFollow={onToggleFollow}
                   />
@@ -299,6 +312,7 @@ export function TagsDirectoryPage({
                     category={list}
                     followedTags={followedTags}
                     onToggleFollow={onToggleFollow}
+                    titleByValue={titleByValue}
                   />
                 ))}
               </div>
@@ -339,6 +353,7 @@ export function TagsDirectoryPage({
                         <TagDirectoryListItem
                           key={tag.value}
                           tag={tag.value}
+                          title={titleByValue.get(tag.value)}
                           isFollowed={followedTags.has(tag.value)}
                           onToggleFollow={onToggleFollow}
                         />


### PR DESCRIPTION
## Changes

The `/tags` directory page now displays each tag's human-readable title (`flags.title`) instead of the normalized slug, falling back to `formatKeyword(value)` when no title is set. This applies to the alphabetical directory, search results, and the featured lists (trending / popular / recently added).

## Key decisions

- Only the visible label changed — the normalized `value` is still used for links, follow keys, tooltips, and aria-labels.
- A single `value → title` map (`titleByValue`) built from the main `tags` array is the one source of truth for titles across all lists. The featured lists only carry tag `value` strings, so they resolve titles via this map; any miss falls back to `formatKeyword`.

Closes ENG-1790

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1790-use-tags-title-in-the-t.preview.app.daily.dev