### PR TITLE
chore: remove tag_source_social_proof feature flag, apply treatment

### DIFF
--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -222,7 +222,6 @@ const SourcePage = ({
   const { isV2 } = useLayoutVariant();
   const isV2Laptop = isV2;
   const { shouldShowAuthBanner } = useOnboardingActions();
-  const shouldShowTagSourceSocialProof = shouldShowAuthBanner && isLaptop;
   const { user } = useContext(AuthContext);
   const mostUpvotedQueryVariables = useMemo(
     () => ({
@@ -389,7 +388,7 @@ const SourcePage = ({
           variables={queryVariables}
           className={pageFeedClassName}
         />
-        {shouldShowTagSourceSocialProof && <AuthenticationBanner />}
+        {shouldShowAuthBanner && isLaptop && <AuthenticationBanner />}
       </FeedPageLayoutComponent>
     </>
   );


### PR DESCRIPTION
## Summary

Removes the `tag_source_social_proof` experiment and makes the treatment (signup banner on the sources page) the permanent default.

The experiment's feature flag, its `TagSourceSocialProof` enum, and the `TagSourceCustomAuthBannerExperiment` HOC had already been removed previously. The only remaining reference was the gating variable on the source page, which still carried the experiment name.

## Changes

- `packages/webapp/pages/sources/[source].tsx`: removed the `shouldShowTagSourceSocialProof` variable and inlined its now-permanent condition (`shouldShowAuthBanner && isLaptop`) at its single use site that renders `<AuthenticationBanner />`.

## Key decisions

- Inlined the single-use boolean rather than renaming it, per the repo guideline to keep single-use logic inline.
- No references to `tag_source_social_proof` remain anywhere in the codebase; treatment behavior is now the default with no flag gating.

Closes ENG-1794

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1794-remove-tag-source-socia.preview.app.daily.dev