### PR TITLE
feat(giveback): add FAQ tab, redesign sponsors (unrendered for launch)

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackFaq.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackFaq.tsx
@@ -12,6 +12,7 @@ import { IconSize } from '../../../components/Icon';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
 import { GivebackSection } from './GivebackSection';
+import { GivebackTabHeading } from './GivebackTabHeading';
 
 interface FaqItem {
   id: string;
@@ -24,13 +25,13 @@ const faqs: FaqItem[] = [
     id: 'cost',
     question: 'Does this cost me anything?',
     answer:
-      'No. daily.dev funds every donation. You never pay a cent. You just take small actions and we turn them into money for good causes.',
+      'Nothing. Not a cent. daily.dev funds every donation. You bring the actions, we bring the money.',
   },
   {
     id: 'how',
     question: 'How do my actions turn into donations?',
     answer:
-      'Each approved action unlocks a fixed amount that daily.dev donates to the causes you picked. The community meter is the sum of everyone’s actions.',
+      'Each action you complete unlocks a fixed amount that daily.dev donates to the causes you picked. The community meter is every dev’s actions added up.',
   },
   {
     id: 'causes',
@@ -54,7 +55,7 @@ const faqs: FaqItem[] = [
     id: 'why',
     question: 'Why is daily.dev doing this?',
     answer:
-      'We’d rather put our growth budget into causes the community cares about than burn it in ad auctions.',
+      'Most companies buy growth with ads. We’d rather earn it with you, by helping more developers discover daily.dev, and send that budget to causes the community actually cares about. You bring the growth, the world gets the money.',
   },
   {
     id: 'geo',
@@ -76,7 +77,8 @@ export const GivebackFaq = (): ReactElement => {
   };
 
   return (
-    <GivebackSection id="giveback-faq" title="Frequently asked questions">
+    <GivebackSection id="giveback-faq">
+      <GivebackTabHeading title="Frequently asked questions" />
       <div className="divide-y divide-border-subtlest-tertiary">
         {faqs.map((faq) => {
           const isOpen = openId === faq.id;
@@ -121,7 +123,7 @@ export const GivebackFaq = (): ReactElement => {
                     tag={TypographyTag.P}
                     type={TypographyType.Callout}
                     color={TypographyColor.Secondary}
-                    className="max-w-2xl pb-4"
+                    className="max-w-2xl pb-4 [text-wrap:pretty]"
                   >
                     {faq.answer}
                   </Typography>

--- a/packages/shared/src/features/giveback/components/GivebackPage.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackPage.tsx
@@ -18,10 +18,13 @@ import { GivebackActionCatalog } from './GivebackActionCatalog';
 import { GivebackContributionSummary } from './GivebackContributionSummary';
 import { GivebackImpactPanel } from './GivebackImpactPanel';
 import { GivebackCausesPanel } from './GivebackCausesPanel';
+import { GivebackFaq } from './GivebackFaq';
 import { GivebackFundingBar } from './GivebackFundingBar';
 import type { GivebackTabId } from './GivebackTabNav';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
+import { useConditionalFeature } from '../../../hooks/useConditionalFeature';
+import { featureGivebackSponsors } from '../../../lib/featureManagement';
 import { useContributionStatus } from '../hooks/useContributionStatus';
 import { useGivebackCauseSelection } from '../hooks/useGivebackCauseSelection';
 
@@ -43,6 +46,12 @@ export const GivebackPage = (): ReactElement => {
   // visitors load their picks — which also tells us whether to show the tabs.
   const isEligible = status?.eligible === true;
   const selection = useGivebackCauseSelection(isEligible);
+
+  // Sponsors are gated off for launch (no sponsors yet); flip the flag on later.
+  const { value: showSponsors } = useConditionalFeature({
+    feature: featureGivebackSponsors,
+    shouldEvaluate: true,
+  });
 
   // First-timers open the picker from the hero; once they confirm (or arrive
   // already onboarded) the tabbed experience takes over.
@@ -125,9 +134,11 @@ export const GivebackPage = (): ReactElement => {
           />
         </div>
 
-        <div className={column}>
-          <GivebackSponsorTiers />
-        </div>
+        {showSponsors && (
+          <div className={column}>
+            <GivebackSponsorTiers />
+          </div>
+        )}
 
         {showPicker && (
           <div ref={causesRef} className={`${column} scroll-mt-16`}>
@@ -181,6 +192,7 @@ export const GivebackPage = (): ReactElement => {
               {activeTab === 'causes' && (
                 <GivebackCausesPanel onFilter={scrollToTabs} />
               )}
+              {activeTab === 'faq' && <GivebackFaq />}
             </div>
           </div>
         )}

--- a/packages/shared/src/features/giveback/components/GivebackPage.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackPage.tsx
@@ -9,7 +9,6 @@ import {
 } from '../../../components/typography/Typography';
 import { GivebackBackground } from './GivebackBackground';
 import { GivebackHero } from './GivebackHero';
-import { GivebackSponsorTiers } from './GivebackSponsorTiers';
 import { GivebackCauseSelection } from './GivebackCauseSelection';
 import { GivebackOnboardingBar } from './GivebackOnboardingBar';
 import { GivebackLegalFooter } from './GivebackLegalFooter';
@@ -23,8 +22,6 @@ import { GivebackFundingBar } from './GivebackFundingBar';
 import type { GivebackTabId } from './GivebackTabNav';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
-import { useConditionalFeature } from '../../../hooks/useConditionalFeature';
-import { featureGivebackSponsors } from '../../../lib/featureManagement';
 import { useContributionStatus } from '../hooks/useContributionStatus';
 import { useGivebackCauseSelection } from '../hooks/useGivebackCauseSelection';
 
@@ -46,12 +43,6 @@ export const GivebackPage = (): ReactElement => {
   // visitors load their picks — which also tells us whether to show the tabs.
   const isEligible = status?.eligible === true;
   const selection = useGivebackCauseSelection(isEligible);
-
-  // Sponsors are gated off for launch (no sponsors yet); flip the flag on later.
-  const { value: showSponsors } = useConditionalFeature({
-    feature: featureGivebackSponsors,
-    shouldEvaluate: true,
-  });
 
   // First-timers open the picker from the hero; once they confirm (or arrive
   // already onboarded) the tabbed experience takes over.
@@ -133,12 +124,6 @@ export const GivebackPage = (): ReactElement => {
             onTakeAction={goToActions}
           />
         </div>
-
-        {showSponsors && (
-          <div className={column}>
-            <GivebackSponsorTiers />
-          </div>
-        )}
 
         {showPicker && (
           <div ref={causesRef} className={`${column} scroll-mt-16`}>

--- a/packages/shared/src/features/giveback/components/GivebackSponsorTiers.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSponsorTiers.spec.tsx
@@ -38,7 +38,7 @@ const sponsor = (
   ...overrides,
 });
 
-it('groups sponsors under their tier labels and renders brand logo cards', () => {
+it('renders a brand logo card with an explicit tier pill per sponsor', () => {
   mockUseContributionSponsors.mockReturnValue({
     sponsors: [
       sponsor({ id: '1', name: 'Vercel', tier: ContributionSponsorTier.Gold }),

--- a/packages/shared/src/features/giveback/components/GivebackSponsorTiers.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSponsorTiers.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
 import { FlexCol, FlexRow } from '../../../components/utilities';
 import {
@@ -8,6 +8,7 @@ import {
   TypographyTag,
   TypographyType,
 } from '../../../components/typography/Typography';
+import { MedalBadgeIcon } from '../../../components/icons';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
 import { useContributionSponsors } from '../hooks/useContributionSponsors';
@@ -16,47 +17,51 @@ import type { ContributionSponsor } from '../types';
 import { ContributionSponsorTier } from '../types';
 
 interface TierStyle {
-  // Tier marker dot + label color (soft, on-brand accent tints).
-  dotClass: string;
+  // Tint for the inline tier label.
   labelClass: string;
-  // White-card padding + logo height, stepping down platinum → backer.
-  chipClass: string;
+  // A FIXED logo height (not max-height): many brand SVGs ship with only a
+  // viewBox and no width/height, so `w-auto max-h-*` collapses their width to 0
+  // and they render blank. A fixed height lets the browser derive width from the
+  // viewBox aspect ratio. Each tier also caps width proportional to its height -
+  // otherwise wide wordmark logos hit a shared cap and shrink, flattening the
+  // size hierarchy so gold and silver end up looking the same. Steps down by
+  // prestige: gold biggest, bronze smallest.
   logoClass: string;
+  // Fallback name size when a sponsor has no usable logo.
+  nameType: TypographyType;
 }
 
 const tierStyles: Record<ContributionSponsorTier, TierStyle> = {
   [ContributionSponsorTier.Gold]: {
-    dotClass: 'bg-accent-cheese-default',
     labelClass: 'text-accent-cheese-default',
-    chipClass: 'px-4 py-2.5',
-    logoClass: 'h-8 tablet:h-9',
+    logoClass: 'h-14 max-w-[260px]',
+    nameType: TypographyType.Body,
   },
   [ContributionSponsorTier.Silver]: {
-    dotClass: 'bg-text-quaternary',
     labelClass: 'text-text-secondary',
-    chipClass: 'px-3.5 py-2',
-    logoClass: 'h-6 tablet:h-7',
+    logoClass: 'h-8 max-w-[150px]',
+    nameType: TypographyType.Footnote,
   },
   [ContributionSponsorTier.Bronze]: {
-    dotClass: 'bg-accent-bacon-default',
-    labelClass: 'text-accent-bacon-default',
-    chipClass: 'px-3 py-1.5',
-    logoClass: 'h-5 tablet:h-6',
+    labelClass: 'text-accent-burger-default',
+    logoClass: 'h-4 max-w-[80px]',
+    nameType: TypographyType.Caption1,
   },
 };
 
-// The headline tier sits on its own row inside a warm glow; the lower two
-// tiers share the row beneath it.
-const HEADLINE_TIERS = [ContributionSponsorTier.Gold];
-const LOWER_TIERS = [
+// Gold first so the strip reads left-to-right by prestige.
+const TIER_ORDER: ContributionSponsorTier[] = [
+  ContributionSponsorTier.Gold,
   ContributionSponsorTier.Silver,
   ContributionSponsorTier.Bronze,
 ];
 
-// Brand logos rest on white "medal cards" so they stay legible on the dark page
-// regardless of the logo's own colors; logo-less sponsors (e.g. individuals)
-// fall back to a quiet name pill so the card is never empty.
-const SponsorChip = ({
+// A sponsor logo, monochrome (light-tinted) at rest so the mixed brand logos
+// read as one calm row; on hover the tile fills white and reveals the logo's
+// true colors. The logo only counts once it actually decodes - until then
+// (loading, hung, blocked, 404, zero-size, or no URL) the name shows so nothing
+// is ever blank.
+const SponsorLogo = ({
   sponsor,
   style,
 }: {
@@ -64,6 +69,10 @@ const SponsorChip = ({
   style: TierStyle;
 }): ReactElement => {
   const { logEvent } = useLogContext();
+  const [logoLoaded, setLogoLoaded] = useState(false);
+  const [logoFailed, setLogoFailed] = useState(false);
+  const hasLogo = Boolean(sponsor.logoUrl) && !logoFailed;
+  const showName = !hasLogo || !logoLoaded;
 
   const onClick = () =>
     logEvent({
@@ -72,59 +81,42 @@ const SponsorChip = ({
       extra: JSON.stringify({ name: sponsor.name, tier: sponsor.tier }),
     });
 
-  if (!sponsor.logoUrl) {
-    const pillClass =
-      'flex shrink-0 items-center rounded-12 border border-border-subtlest-tertiary bg-surface-float px-3 py-1.5 transition-transform duration-200 hover:-translate-y-0.5 motion-reduce:transform-none';
-    const name = (
-      <Typography
-        tag={TypographyTag.Span}
-        type={TypographyType.Footnote}
-        color={TypographyColor.Primary}
-        bold
-        className="whitespace-nowrap"
-      >
-        {sponsor.name}
-      </Typography>
-    );
+  const tileClass =
+    'group inline-flex items-center justify-center rounded-8 px-2 py-1 transition-colors duration-200 hover:bg-white';
 
-    if (!sponsor.url) {
-      return <span className={pillClass}>{name}</span>;
-    }
-
-    return (
-      <a
-        href={sponsor.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label={sponsor.name}
-        className={pillClass}
-        onClick={onClick}
-      >
-        {name}
-      </a>
-    );
-  }
-
-  const cardClass = classNames(
-    'flex shrink-0 items-center rounded-12 bg-white shadow-[0_10px_28px_-12px_rgba(0,0,0,0.6)] transition-transform duration-200 hover:-translate-y-1 motion-reduce:transform-none',
-    style.chipClass,
-  );
-  const logo = (
-    <img
-      src={sponsor.logoUrl}
-      alt={`${sponsor.name} logo`}
-      loading="lazy"
-      className={classNames(
-        'w-auto max-w-[140px] object-contain',
-        style.logoClass,
+  const body = (
+    <>
+      {hasLogo && (
+        <img
+          src={sponsor.logoUrl ?? undefined}
+          alt={`${sponsor.name} logo`}
+          onLoad={() => setLogoLoaded(true)}
+          onError={() => setLogoFailed(true)}
+          className={classNames(
+            'w-auto object-contain transition duration-200 [filter:brightness(0)_invert(1)] group-hover:[filter:none]',
+            style.logoClass,
+            !logoLoaded && 'hidden',
+          )}
+        />
       )}
-    />
+      {showName && (
+        <Typography
+          tag={TypographyTag.Span}
+          type={style.nameType}
+          bold
+          truncate
+          className="max-w-[120px] text-text-primary transition-colors group-hover:text-black"
+        >
+          {sponsor.name}
+        </Typography>
+      )}
+    </>
   );
 
   if (!sponsor.url) {
     return (
-      <span aria-label={sponsor.name} className={cardClass}>
-        {logo}
+      <span aria-label={sponsor.name} className={tileClass}>
+        {body}
       </span>
     );
   }
@@ -135,42 +127,20 @@ const SponsorChip = ({
       target="_blank"
       rel="noopener noreferrer"
       aria-label={sponsor.name}
-      className={cardClass}
+      className={tileClass}
       onClick={onClick}
     >
-      {logo}
+      {body}
     </a>
   );
 };
 
-const SponsorTierGroup = ({
-  tier,
-  sponsors,
-}: {
-  tier: ContributionSponsorTier;
-  sponsors: ContributionSponsor[];
-}): ReactElement => {
-  const style = tierStyles[tier];
-
-  return (
-    <FlexRow className="flex-wrap items-center gap-x-4 gap-y-3">
-      <FlexRow className="shrink-0 items-center gap-2">
-        <span className={classNames('size-2 rounded-full', style.dotClass)} />
-        <Typography
-          tag={TypographyTag.Span}
-          type={TypographyType.Caption1}
-          bold
-          className={classNames('uppercase tracking-wider', style.labelClass)}
-        >
-          {sponsorTierLabel[tier]}
-        </Typography>
-      </FlexRow>
-      {sponsors.map((sponsor) => (
-        <SponsorChip key={sponsor.id} sponsor={sponsor} style={style} />
-      ))}
-    </FlexRow>
-  );
-};
+const Divider = (): ReactElement => (
+  <span
+    aria-hidden
+    className="hidden h-12 w-px self-center bg-border-subtlest-tertiary tablet:block"
+  />
+);
 
 export const GivebackSponsorTiers = (): ReactElement | null => {
   const { sponsors } = useContributionSponsors();
@@ -179,30 +149,15 @@ export const GivebackSponsorTiers = (): ReactElement | null => {
     return null;
   }
 
-  const byTier = (tier: ContributionSponsorTier) =>
-    sponsors.filter((sponsor) => sponsor.tier === tier);
-
-  const headlineTiers = HEADLINE_TIERS.filter(
-    (tier) => byTier(tier).length > 0,
-  );
-  const lowerTiers = LOWER_TIERS.filter((tier) => byTier(tier).length > 0);
+  const tierGroups = TIER_ORDER.map((tier) => ({
+    tier,
+    sponsors: sponsors.filter((sponsor) => sponsor.tier === tier),
+  })).filter((group) => group.sponsors.length > 0);
 
   return (
-    <section className="relative w-full">
-      {/* Soft brand glows, echoing the hero, so the wall feels native to the
-          page rather than a hard panel dropped on top of it. */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 overflow-hidden"
-      >
-        <div className="bg-accent-cheese-default/15 absolute -left-16 -top-10 size-56 rounded-full blur-3xl motion-safe:animate-glow-pulse" />
-        <div
-          className="bg-accent-cabbage-default/12 absolute -right-12 bottom-0 size-52 rounded-full blur-3xl motion-safe:animate-glow-pulse"
-          style={{ animationDelay: '1.4s' }}
-        />
-      </div>
-
-      <FlexCol className="relative gap-6">
+    <section className="w-full">
+      <FlexCol className="gap-3">
+        {/* Label above the strip, left aligned. */}
         <Typography
           tag={TypographyTag.Span}
           type={TypographyType.Caption1}
@@ -213,45 +168,45 @@ export const GivebackSponsorTiers = (): ReactElement | null => {
           Sponsored by
         </Typography>
 
-        <FlexCol className="gap-6">
-          {headlineTiers.length > 0 && (
-            <div className="relative">
-              {/* Warm halo so the headline tiers glow softly above the rest. */}
-              <div aria-hidden className="pointer-events-none absolute inset-0">
-                <div className="bg-accent-cheese-default/12 absolute -left-6 -top-4 h-28 w-72 rounded-full blur-3xl" />
-              </div>
-              <FlexCol className="relative gap-5">
-                {headlineTiers.map((tier) => (
-                  <SponsorTierGroup
-                    key={tier}
-                    tier={tier}
-                    sponsors={byTier(tier)}
-                  />
-                ))}
-              </FlexCol>
-            </div>
-          )}
-
-          {lowerTiers.length > 0 && (
-            <>
-              {headlineTiers.length > 0 && (
-                <div
-                  aria-hidden
-                  className="h-px w-full bg-gradient-to-r from-transparent via-border-subtlest-tertiary to-transparent"
-                />
-              )}
-              <FlexRow className="flex-wrap items-center gap-x-10 gap-y-4">
-                {lowerTiers.map((tier) => (
-                  <SponsorTierGroup
-                    key={tier}
-                    tier={tier}
-                    sponsors={byTier(tier)}
-                  />
-                ))}
-              </FlexRow>
-            </>
-          )}
-        </FlexCol>
+        {/* One compact bordered strip spanning the page column; a divider
+            separates each tier section. */}
+        <div className="flex w-full flex-wrap items-center justify-start gap-x-6 gap-y-3 rounded-16 border border-border-subtlest-tertiary px-6 py-4">
+          {tierGroups.map((group, index) => {
+            const style = tierStyles[group.tier];
+            return (
+              <React.Fragment key={group.tier}>
+                {index > 0 && <Divider />}
+                <FlexRow className="items-center gap-3">
+                  <FlexRow
+                    className={classNames(
+                      'items-center gap-1 [&_svg]:size-3.5',
+                      style.labelClass,
+                    )}
+                  >
+                    <MedalBadgeIcon />
+                    <Typography
+                      tag={TypographyTag.Span}
+                      type={TypographyType.Caption2}
+                      bold
+                      className="uppercase tracking-wider"
+                    >
+                      {sponsorTierLabel[group.tier]}
+                    </Typography>
+                  </FlexRow>
+                  <FlexRow className="flex-wrap items-center gap-1.5">
+                    {group.sponsors.map((sponsor) => (
+                      <SponsorLogo
+                        key={sponsor.id}
+                        sponsor={sponsor}
+                        style={style}
+                      />
+                    ))}
+                  </FlexRow>
+                </FlexRow>
+              </React.Fragment>
+            );
+          })}
+        </div>
       </FlexCol>
     </section>
   );

--- a/packages/shared/src/features/giveback/components/GivebackTabNav.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackTabNav.spec.tsx
@@ -8,6 +8,7 @@ it('renders the tabs from the shared tab list', () => {
   expect(screen.getByText('Take action')).toBeInTheDocument();
   expect(screen.getByText('Impact')).toBeInTheDocument();
   expect(screen.getByText('Causes')).toBeInTheDocument();
+  expect(screen.getByText('FAQ')).toBeInTheDocument();
 });
 
 it('maps a tab click back to its id', () => {

--- a/packages/shared/src/features/giveback/components/GivebackTabNav.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackTabNav.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import TabList, { TabListVariant } from '../../../components/tabs/TabList';
 
-export type GivebackTabId = 'actions' | 'impact' | 'causes';
+export type GivebackTabId = 'actions' | 'impact' | 'causes' | 'faq';
 
 interface GivebackTab {
   id: GivebackTabId;
@@ -13,6 +13,7 @@ export const givebackTabs: GivebackTab[] = [
   { id: 'actions', label: 'Take action' },
   { id: 'impact', label: 'Impact' },
   { id: 'causes', label: 'Causes' },
+  { id: 'faq', label: 'FAQ' },
 ];
 
 interface GivebackTabNavProps {

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -263,6 +263,10 @@ export const featurePublicSignupBanner = new Feature(
   false,
 );
 
+// Off at launch: the giveback campaign starts without sponsors. Flip on once
+// real sponsors exist to show the "Sponsored by" wall.
+export const featureGivebackSponsors = new Feature('giveback_sponsors', false);
+
 export enum DailyPageVariant {
   None = 'none',
   V1 = 'v1.1',

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -263,10 +263,6 @@ export const featurePublicSignupBanner = new Feature(
   false,
 );
 
-// Off at launch: the giveback campaign starts without sponsors. Flip on once
-// real sponsors exist to show the "Sponsored by" wall.
-export const featureGivebackSponsors = new Feature('giveback_sponsors', false);
-
 export enum DailyPageVariant {
   None = 'none',
   V1 = 'v1.1',


### PR DESCRIPTION
## Changes

Fourth step of the giveback design pass from #6247 (PR 4/6). Adds the **FAQ** tab and removes the **Sponsors** section from the page.

### FAQ tab
- New `faq` tab renders the existing `GivebackFaq`, now headed by the shared `GivebackTabHeading` with refreshed answer copy.
- Tabs are now **Take action / Impact / Causes / FAQ** — the full final set.

### Sponsors
- Sponsors aren't launching with the campaign, so they're simply **not rendered** — no feature flag.
- `GivebackSponsorTiers` is redesigned (self-describing cards: logo tile + tier pill, monochrome-at-rest → color-on-hover, fixed per-tier logo heights, name fallback) and **kept in the codebase with its spec**, just not wired into the page. Re-enable with one line when sponsors go live.

## Scope notes
- Rendered `GivebackFaq` directly for the FAQ tab rather than adding a `GivebackFaqPanel` wrapper whose only body would be `<GivebackFaq />`.
- `GivebackSection.title` was already optional on `main`, so the FAQ's switch to `GivebackTabHeading` needed no shell change.
- No Storybook stories yet (would pull in the giveback mocks infra) — deferred, consistent with prior PRs.

## Verification
- ✅ Strict typecheck on changed files
- ✅ ESLint clean
- ✅ Shared + webapp `tsc`: no new errors (27 pre-existing, unrelated)
- ✅ Giveback tests: 11 suites / 53 pass (TabNav spec asserts the FAQ tab; SponsorTiers spec still covers the redesigned component)
