### PR TITLE
feat: link post analytics header to the daily.dev post

### DIFF
--- a/packages/shared/src/components/post/analytics/PostShortInfo.tsx
+++ b/packages/shared/src/components/post/analytics/PostShortInfo.tsx
@@ -1,9 +1,8 @@
 import type { ReactElement } from 'react';
-import React, { useMemo } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import { BoostingLabel } from './BoostingLabel';
 import type { Post } from '../../../graphql/posts';
-import { PostType } from '../../../graphql/posts';
 import { ProfileImageLink } from '../../profile/ProfileImageLink';
 import { ProfileImageSize } from '../../ProfilePicture';
 import { DateFormat } from '../../utilities';
@@ -29,38 +28,12 @@ export function PostShortInfo({
   showImage = true,
   showLinkIcon = true,
 }: PostShortInfoProps): ReactElement | null {
-  const postLink = useMemo(() => {
-    if (!post) {
-      return undefined;
-    }
-
-    const postObject = post.sharedPost || post;
-
-    if (
-      [
-        PostType.Collection,
-        PostType.Brief,
-        PostType.Freeform,
-        PostType.Welcome,
-        PostType.Poll,
-        PostType.SocialTwitter,
-      ].includes(post.type)
-    ) {
-      return `${webappUrl}posts/${post.slug || post.id}`;
-    }
-
-    if (post.sharedPost?.type === PostType.Share) {
-      return `${webappUrl}posts/${post.sharedPost.id}`;
-    }
-
-    return postObject.permalink;
-  }, [post]);
-
   if (!post) {
     return null;
   }
 
   const { author, createdAt, title, image, sharedPost } = post;
+  const postLink = `${webappUrl}posts/${post.slug || post.id}`;
 
   const postTitle = title || sharedPost?.title;
   const postImage = sharedPost?.image || image;


### PR DESCRIPTION
## What

On `/posts/{id}/analytics`, the link in the post header pointed to the external article URL. It now points to the post page on daily.dev (`/posts/{slug|id}`) so authors can quickly jump to the discussion for that post.

## Key decisions

- Changed the link target in `PostShortInfo` rather than adding a new prop. The component is only used by the analytics page, so the change is fully scoped to the requested surface.
- Simplified `postLink` to always resolve to the daily.dev post URL, removing the per-post-type branching (and the now-unused `PostType` import and `useMemo`).
- Kept `target="_blank"` so the analytics page stays open when navigating to the post.

Closes ENG-1798

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1798-feedback-feature-reques.preview.app.daily.dev