### PR TITLE
feat(giveback): action card + submission modal redesign

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackActionCard.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCard.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, ReactElement, ReactNode } from 'react';
-import React, { useState } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import {
   Typography,
@@ -15,6 +15,7 @@ import type { ContributionAction } from '../types';
 import { ContributionSubmissionStatus } from '../types';
 import { formatDonationAmount } from '../utils';
 import { getActionPlatformVisual } from '../actionPlatform';
+import { GivebackPlatformLogo } from './GivebackPlatformLogo';
 
 interface GivebackActionCardProps {
   action: ContributionAction;
@@ -39,48 +40,7 @@ const formatCooldownRemaining = (endsAt: string): string => {
   return `${Math.max(1, minutes)}m`;
 };
 
-interface PlatformLogoProps {
-  logoUrl?: string;
-  Icon: ComponentType<IconProps>;
-  forceDark?: boolean;
-  isDimmed: boolean;
-}
-
-// Prefers the real brand logo (an SVG from the logo CDN) and falls back to the
-// internal glyph if there is no logo for the surface or the remote one fails to
-// load — so a tile is never broken or blank. The parent tile already pins the
-// background and applies the dimmed/grayscale treatment.
-const PlatformLogo = ({
-  logoUrl,
-  Icon,
-  forceDark,
-  isDimmed,
-}: PlatformLogoProps): ReactElement => {
-  const [failed, setFailed] = useState(false);
-
-  if (logoUrl && !failed) {
-    return (
-      <img
-        src={logoUrl}
-        alt=""
-        aria-hidden
-        loading="lazy"
-        onError={() => setFailed(true)}
-        className="size-6 object-contain"
-      />
-    );
-  }
-
-  return (
-    <Icon
-      secondary
-      size={IconSize.Small}
-      className={classNames(!isDimmed && forceDark && 'brightness-0')}
-    />
-  );
-};
-
-// One sharp, explicit title carries the ask — no competing subtitle. The
+// One sharp, explicit title carries the ask - no competing subtitle. The
 // supporting details (payout, status, "just for love") sit in a calm top/bottom
 // frame around it so the card stays easy to scan at a glance.
 export const GivebackActionCard = ({
@@ -206,7 +166,7 @@ export const GivebackActionCard = ({
                 : 'shadow-1 bg-white text-black group-hover:scale-105',
             )}
           >
-            <PlatformLogo
+            <GivebackPlatformLogo
               logoUrl={logoUrl}
               Icon={Icon}
               forceDark={forceDark}
@@ -282,7 +242,7 @@ export const GivebackActionCard = ({
             : 'bg-surface-float hover:bg-surface-hover',
         )}
       >
-        {/* Glossy sheen that sweeps across on hover — a small reward flourish. */}
+        {/* Glossy sheen that sweeps across on hover - a small reward flourish. */}
         <span
           aria-hidden
           className="via-white/10 pointer-events-none absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent to-transparent transition-transform duration-700 ease-out group-hover:translate-x-full motion-reduce:hidden"
@@ -297,7 +257,7 @@ export const GivebackActionCard = ({
   // read as temporary rather than finished.
   return (
     <FlexCol
-      aria-label={`${action.title} — ${statusMeta?.label ?? ''}`}
+      aria-label={`${action.title}, ${statusMeta?.label ?? ''}`}
       className={classNames(
         'h-full w-full gap-3 rounded-16 p-4',
         isDone

--- a/packages/shared/src/features/giveback/components/GivebackActionCatalog.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCatalog.tsx
@@ -212,8 +212,8 @@ export const GivebackActionCatalog = ({
               type={TypographyType.Footnote}
               color={TypographyColor.Tertiary}
             >
-              We can&apos;t pay for these, but we&apos;d genuinely appreciate
-              them.
+              No donation rides on these. They just help us out. We&apos;d love
+              you for it.
             </Typography>
           </FlexCol>
           <ActionGrid actions={loveActions} onSubmit={setSubmissionAction} />

--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
@@ -7,34 +7,198 @@ import {
 } from '../../../components/buttons/Button';
 import {
   Typography,
+  TypographyColor,
   TypographyTag,
   TypographyType,
 } from '../../../components/typography/Typography';
 import { FlexCol, FlexRow } from '../../../components/utilities';
 import { RootPortal } from '../../../components/tooltips/Portal';
+import { OpenLinkIcon } from '../../../components/icons';
 import { uploadContentImage } from '../../../graphql/posts';
 import { useToastNotification } from '../../../hooks/useToastNotification';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
 import { labels } from '../../../lib/labels';
+import { anchorDefaultRel } from '../../../lib/strings';
 import type { ContributionAction } from '../types';
 import { formatDonationAmount } from '../utils';
+import { getActionPlatformVisual } from '../actionPlatform';
 import { useSubmitContributionAction } from '../hooks/useSubmitContributionAction';
 import { GivebackScreenshotField } from './GivebackScreenshotField';
+import { GivebackPlatformLogo } from './GivebackPlatformLogo';
 
 interface GivebackActionSubmissionModalProps {
   action: ContributionAction;
   onClose: () => void;
 }
 
-const getDialogTitle = (isLove: boolean, isSubmitted: boolean): string => {
-  if (isLove) {
-    return 'Show some love';
-  }
-  if (isSubmitted) {
-    return 'Proof submitted';
-  }
-  return 'Submit proof';
+// Instructions may arrive as one paragraph or as several lines (one step each).
+// Split on line breaks so multi-line how-tos render as a numbered checklist the
+// user can follow top to bottom.
+const toInstructionSteps = (instructions: string): string[] =>
+  instructions
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+// The explicit "what we're asking you to do" block at the top of every action.
+// Leads with the platform identity and the reward, states the ask in a big
+// title, and hands the user a one-tap way to go start it on the real surface.
+const ActionBrief = ({
+  action,
+  titleId,
+}: {
+  action: ContributionAction;
+  titleId: string;
+}): ReactElement => {
+  const { metadata } = action;
+  const isLove = metadata.isLoveAction;
+  const {
+    Icon,
+    name: platformName,
+    forceDark,
+    logoUrl,
+  } = getActionPlatformVisual(metadata.platform);
+
+  return (
+    <FlexCol className="gap-4">
+      <FlexRow className="items-center justify-between gap-3">
+        <FlexRow className="min-w-0 items-center gap-2.5">
+          <span className="shadow-1 flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-12 bg-white text-black">
+            <GivebackPlatformLogo
+              logoUrl={logoUrl}
+              Icon={Icon}
+              forceDark={forceDark}
+            />
+          </span>
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+            bold
+            className="min-w-0 truncate uppercase tracking-wider"
+          >
+            {platformName}
+          </Typography>
+        </FlexRow>
+        {isLove ? (
+          <span className="shrink-0 rounded-10 bg-accent-cabbage-flat px-3 py-1.5">
+            <Typography
+              bold
+              type={TypographyType.Caption1}
+              className="text-accent-cabbage-default"
+            >
+              Just for love
+            </Typography>
+          </span>
+        ) : (
+          <FlexCol className="shrink-0 items-end rounded-10 bg-surface-float px-3 py-1">
+            <Typography
+              bold
+              type={TypographyType.Title4}
+              className="tabular-nums text-status-success"
+            >
+              +{formatDonationAmount(action.points)}
+            </Typography>
+            <Typography
+              tag={TypographyTag.Span}
+              type={TypographyType.Caption2}
+              color={TypographyColor.Tertiary}
+            >
+              to your causes
+            </Typography>
+          </FlexCol>
+        )}
+      </FlexRow>
+
+      <FlexCol className="gap-1.5">
+        <Typography
+          bold
+          id={titleId}
+          tag={TypographyTag.H2}
+          type={TypographyType.Title2}
+          className="[text-wrap:balance]"
+        >
+          {action.title}
+        </Typography>
+        {action.description && (
+          <Typography
+            type={TypographyType.Callout}
+            color={TypographyColor.Secondary}
+            className="[text-wrap:pretty]"
+          >
+            {action.description}
+          </Typography>
+        )}
+      </FlexCol>
+
+      {metadata.externalUrl && (
+        <Button
+          tag="a"
+          href={metadata.externalUrl}
+          target="_blank"
+          rel={anchorDefaultRel}
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Primary}
+          icon={<OpenLinkIcon />}
+          className="w-fit"
+        >
+          {isLove ? `Open ${platformName}` : `Go to ${platformName}`}
+        </Button>
+      )}
+    </FlexCol>
+  );
+};
+
+// The full how-to, surfaced prominently (not as fine print) so the requirement
+// is impossible to miss. Multi-line instructions become a numbered checklist.
+const InstructionsBlock = ({
+  instructions,
+}: {
+  instructions: string;
+}): ReactElement => {
+  const steps = toInstructionSteps(instructions);
+
+  return (
+    <FlexCol className="gap-3 rounded-16 bg-surface-float p-4">
+      <Typography
+        tag={TypographyTag.Span}
+        type={TypographyType.Caption1}
+        color={TypographyColor.Tertiary}
+        bold
+        className="uppercase tracking-wider"
+      >
+        How to complete it
+      </Typography>
+      {steps.length > 1 ? (
+        <ol className="flex flex-col gap-2.5">
+          {steps.map((step, index) => (
+            <li key={step} className="flex items-start gap-3">
+              <span className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-accent-cabbage-default font-bold tabular-nums text-white typo-caption2">
+                {index + 1}
+              </span>
+              <Typography
+                tag={TypographyTag.Span}
+                type={TypographyType.Callout}
+                color={TypographyColor.Secondary}
+                className="[text-wrap:pretty]"
+              >
+                {step}
+              </Typography>
+            </li>
+          ))}
+        </ol>
+      ) : (
+        <Typography
+          type={TypographyType.Callout}
+          color={TypographyColor.Secondary}
+          className="[text-wrap:pretty]"
+        >
+          {instructions}
+        </Typography>
+      )}
+    </FlexCol>
+  );
 };
 
 export const GivebackActionSubmissionModal = ({
@@ -172,63 +336,42 @@ export const GivebackActionSubmissionModal = ({
             aria-hidden
             className="bg-accent-onion-default/20 pointer-events-none absolute -bottom-24 -left-16 size-56 rounded-full blur-3xl"
           />
-          <FlexCol className="relative gap-5 overflow-y-auto p-5 tablet:p-6">
-            <FlexCol className="gap-2">
-              <Typography
-                bold
-                id="giveback-submission-title"
-                tag={TypographyTag.H2}
-                type={TypographyType.Title3}
-              >
-                {getDialogTitle(isLove, isSubmitted)}
-              </Typography>
-              <Typography
-                type={TypographyType.Callout}
-                className="text-text-tertiary"
-              >
-                {!isLove && isSubmitted
-                  ? "Added to your contribution. We'll only subtract it if validation fails."
-                  : action.title}
-              </Typography>
-            </FlexCol>
+          <FlexCol className="relative min-h-0 flex-1 gap-4 overflow-y-auto p-4 tablet:p-5">
+            {!isSubmitted && (
+              <ActionBrief
+                action={action}
+                titleId="giveback-submission-title"
+              />
+            )}
 
-            {isLove && (
-              <FlexCol className="gap-4">
-                <FlexCol className="gap-3 rounded-18 border border-accent-cabbage-default bg-accent-cabbage-flat p-5">
-                  <Typography
-                    bold
-                    type={TypographyType.Title4}
-                    className="text-accent-cabbage-default"
-                  >
-                    Just for love
-                  </Typography>
-                  <Typography
-                    type={TypographyType.Callout}
-                    className="text-text-tertiary"
-                  >
-                    This one&apos;s a voluntary thank-you — no reward or
-                    donation is attached. We just genuinely appreciate it.
-                  </Typography>
-                </FlexCol>
-                {metadata.instructions && (
-                  <Typography
-                    type={TypographyType.Footnote}
-                    className="text-text-tertiary"
-                  >
-                    {metadata.instructions}
-                  </Typography>
-                )}
-              </FlexCol>
+            {!isSubmitted && metadata.instructions && (
+              <InstructionsBlock instructions={metadata.instructions} />
+            )}
+
+            {isLove && !isSubmitted && (
+              <Typography
+                type={TypographyType.Footnote}
+                color={TypographyColor.Tertiary}
+                className="[text-wrap:pretty]"
+              >
+                This one&apos;s a voluntary thank-you. No reward or donation is
+                attached, we just genuinely appreciate it.
+              </Typography>
             )}
 
             {!isLove && isSubmitted && (
               <FlexCol className="relative gap-4 overflow-hidden rounded-18 border border-accent-cabbage-default bg-accent-cabbage-flat p-5 shadow-2-cabbage">
-                <Typography bold type={TypographyType.Title4}>
+                <Typography
+                  bold
+                  id="giveback-submission-title"
+                  tag={TypographyTag.H2}
+                  type={TypographyType.Title3}
+                >
                   You helped unlock {formatDonationAmount(action.points)}
                 </Typography>
                 <Typography
                   type={TypographyType.Callout}
-                  className="text-text-tertiary"
+                  className="text-text-tertiary [text-wrap:pretty]"
                 >
                   It already counts toward your contribution. If it&apos;s
                   rejected, we&apos;ll subtract it.
@@ -238,31 +381,14 @@ export const GivebackActionSubmissionModal = ({
 
             {!isLove && !isSubmitted && (
               <FlexCol className="gap-4">
-                <FlexCol className="gap-3 border-b border-border-subtlest-tertiary pb-4">
-                  <FlexRow className="items-center justify-between gap-3">
-                    <Typography
-                      type={TypographyType.Caption1}
-                      className="text-text-tertiary"
-                    >
-                      Counts toward your contribution the moment you submit.
-                    </Typography>
-                    <Typography
-                      bold
-                      type={TypographyType.Callout}
-                      className="shrink-0 tabular-nums text-status-success"
-                    >
-                      +{formatDonationAmount(action.points)}
-                    </Typography>
-                  </FlexRow>
-                  {metadata.instructions && (
-                    <Typography
-                      type={TypographyType.Footnote}
-                      className="text-text-tertiary"
-                    >
-                      {metadata.instructions}
-                    </Typography>
-                  )}
-                </FlexCol>
+                <Typography
+                  type={TypographyType.Caption1}
+                  color={TypographyColor.Tertiary}
+                  className="[text-wrap:pretty]"
+                >
+                  Done it? Add your proof below. It counts toward your
+                  contribution the moment you submit.
+                </Typography>
 
                 {showUrl && (
                   <label htmlFor={linkInputId} className="flex flex-col gap-2">
@@ -311,43 +437,45 @@ export const GivebackActionSubmissionModal = ({
                 )}
               </FlexCol>
             )}
+          </FlexCol>
 
-            <FlexRow className="justify-end gap-2">
-              {isLove ? (
+          {/* Pinned action bar: stays visible while the body above scrolls, so
+              the submit control is always reachable on tall forms. */}
+          <FlexRow className="relative shrink-0 justify-end gap-2 border-t border-border-subtlest-tertiary px-4 py-3 tablet:px-5">
+            {isLove ? (
+              <Button
+                type="button"
+                size={ButtonSize.Small}
+                variant={ButtonVariant.Primary}
+                onClick={onLoveAcknowledge}
+              >
+                Got it
+              </Button>
+            ) : (
+              <>
                 <Button
                   type="button"
                   size={ButtonSize.Small}
-                  variant={ButtonVariant.Primary}
-                  onClick={onLoveAcknowledge}
+                  variant={ButtonVariant.Tertiary}
+                  onClick={onClose}
                 >
-                  Got it
+                  {isSubmitted ? 'Done' : 'Cancel'}
                 </Button>
-              ) : (
-                <>
+                {!isSubmitted && (
                   <Button
                     type="button"
                     size={ButtonSize.Small}
-                    variant={ButtonVariant.Tertiary}
-                    onClick={onClose}
+                    variant={ButtonVariant.Primary}
+                    disabled={!canSubmit}
+                    loading={isPending}
+                    onClick={onSubmit}
                   >
-                    {isSubmitted ? 'Done' : 'Cancel'}
+                    Submit for review
                   </Button>
-                  {!isSubmitted && (
-                    <Button
-                      type="button"
-                      size={ButtonSize.Small}
-                      variant={ButtonVariant.Primary}
-                      disabled={!canSubmit}
-                      loading={isPending}
-                      onClick={onSubmit}
-                    >
-                      Submit for review
-                    </Button>
-                  )}
-                </>
-              )}
-            </FlexRow>
-          </FlexCol>
+                )}
+              </>
+            )}
+          </FlexRow>
         </section>
       </div>
     </RootPortal>

--- a/packages/shared/src/features/giveback/components/GivebackPlatformLogo.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackPlatformLogo.tsx
@@ -1,0 +1,52 @@
+import type { ComponentType, ReactElement } from 'react';
+import React, { useState } from 'react';
+import classNames from 'classnames';
+import { IconSize } from '../../../components/Icon';
+import type { IconProps } from '../../../components/Icon';
+
+interface GivebackPlatformLogoProps {
+  logoUrl?: string;
+  Icon: ComponentType<IconProps>;
+  forceDark?: boolean;
+  // Non-actionable tiles (done/in-review/cooldown) already grayscale the parent,
+  // so the glyph shouldn't be force-darkened on top of that.
+  isDimmed?: boolean;
+  iconSize?: IconSize;
+  className?: string;
+}
+
+// Prefers the real brand logo (an SVG from the logo CDN) and falls back to the
+// internal glyph if there is no logo for the surface or the remote one fails to
+// load - so a tile is never broken or blank. The parent tile pins the
+// background and applies any dimmed/grayscale treatment.
+export const GivebackPlatformLogo = ({
+  logoUrl,
+  Icon,
+  forceDark,
+  isDimmed,
+  iconSize = IconSize.Small,
+  className,
+}: GivebackPlatformLogoProps): ReactElement => {
+  const [failed, setFailed] = useState(false);
+
+  if (logoUrl && !failed) {
+    return (
+      <img
+        src={logoUrl}
+        alt=""
+        aria-hidden
+        loading="lazy"
+        onError={() => setFailed(true)}
+        className={classNames('object-contain', className ?? 'size-6')}
+      />
+    );
+  }
+
+  return (
+    <Icon
+      secondary
+      size={iconSize}
+      className={classNames(!isDimmed && forceDark && 'brightness-0')}
+    />
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackSection.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSection.tsx
@@ -39,6 +39,7 @@ export const GivebackSection = ({
               tag={TypographyTag.H3}
               type={TypographyType.Title3}
               bold
+              className="[text-wrap:balance]"
             >
               {title}
             </Typography>
@@ -48,6 +49,7 @@ export const GivebackSection = ({
               tag={TypographyTag.P}
               type={TypographyType.Callout}
               color={TypographyColor.Secondary}
+              className="[text-wrap:pretty]"
             >
               {description}
             </Typography>


### PR DESCRIPTION
The action surfaces were the remaining un-imported piece of the #6247 design pass (not covered by PRs 1-5).

- **`GivebackPlatformLogo` (new)** — extracts the inline `PlatformLogo` from the action card into a shared component, now used by **both** the action card and the submission modal (was duplicated in the design source).
- **`GivebackActionSubmissionModal`** — redesigned: an action brief, parsed instruction steps, and the platform logo.
- **`GivebackActionCard`** — uses the shared logo; minor aria-label fix.
- **`GivebackActionCatalog`** — refreshed love-actions copy.
- **`GivebackSection`** — `text-wrap` balance/pretty on headers.

## Verification
- ✅ Strict typecheck + ESLint clean
- ✅ Shared + webapp `tsc`: no new errors
- ✅ Giveback tests: 10 suites / 50 pass

### Preview domain
https://feat-giveback-action-surfaces.preview.app.daily.dev