### PR TITLE
chore(giveback): remove dead code found in review

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackFunnelSteps.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackFunnelSteps.tsx
@@ -151,12 +151,11 @@ export const GivebackFunnelStep = ({
   selection,
   videoSlotRef,
 }: GivebackFunnelStepProps): ReactElement => {
-  // The visitor's own picks, surfaced front-and-center on the finale so the
-  // moment celebrates exactly what they chose to fund.
-  const selectedCauses = selection.causes
-    .map((cause, index) => ({ cause, index }))
-    .filter(({ cause }) => selection.selectedIds.has(cause.id))
-    .slice(0, 3);
+  // Whether the visitor picked any causes, so the finale can celebrate their
+  // choice rather than fall back to the generic copy.
+  const hasSelectedCauses = selection.causes.some((cause) =>
+    selection.selectedIds.has(cause.id),
+  );
 
   switch (stepKey) {
     case 'how':
@@ -232,7 +231,7 @@ export const GivebackFunnelStep = ({
                 bold
                 className="[text-wrap:balance]"
               >
-                {selectedCauses.length > 0
+                {hasSelectedCauses
                   ? "You're in. Now every action funds them."
                   : 'Real causes. Real impact.'}
               </Typography>
@@ -242,7 +241,7 @@ export const GivebackFunnelStep = ({
                 color={TypographyColor.Secondary}
                 className="max-w-xl [text-wrap:pretty]"
               >
-                {selectedCauses.length > 0
+                {hasSelectedCauses
                   ? 'From here on, every action you take becomes real money for the causes you picked. We fund all of it. You never pay a thing.'
                   : "Your actions become real money for open-source maintainers, students, and devs who can't afford access. We fund all of it, no cost to you."}
               </Typography>
@@ -281,7 +280,7 @@ export const GivebackFunnelStep = ({
               ))}
             </div>
           </Reveal>
-          {selectedCauses.length > 0 && (
+          {hasSelectedCauses && (
             <Reveal delay={320}>
               <Typography
                 type={TypographyType.Callout}

--- a/packages/shared/src/features/giveback/components/GivebackLegalFooter.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackLegalFooter.tsx
@@ -8,6 +8,7 @@ import {
   TypographyType,
 } from '../../../components/typography/Typography';
 import { privacyPolicy, termsOfService } from '../../../lib/constants';
+import { anchorDefaultRel } from '../../../lib/strings';
 
 // Legal/footer home for the campaign. One quiet line: funding disclaimer on the
 // left, the terms/rules/privacy links on the right. Cookie policy is omitted on
@@ -35,7 +36,7 @@ export const GivebackLegalFooter = (): ReactElement => (
           key={link.label}
           href={link.href}
           target="_blank"
-          rel="noopener noreferrer"
+          rel={anchorDefaultRel}
           className="font-bold text-text-tertiary transition-colors typo-caption1 hover:text-text-primary"
         >
           {link.label}

--- a/packages/shared/src/features/giveback/components/GivebackMascot.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackMascot.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 
 // The daily.dev charm, themed as a "wish-granting genie" for Giveback: you make
 // a wish (pick a cause / take an action) and daily.dev grants it.
-export const GIVEBACK_CHARM_IMAGE = {
+const GIVEBACK_CHARM_IMAGE = {
   src: 'https://media.daily.dev/image/upload/s--d1dldAty--/f_auto,q_auto/v1780848838/public/daily.dev%20Charm%20-%20Giveback%20(1)',
   alt: 'daily.dev charm celebrating community impact for the Giveback campaign',
 };

--- a/packages/shared/src/features/giveback/components/GivebackSponsorTiers.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSponsorTiers.tsx
@@ -12,6 +12,7 @@ import { MedalBadgeIcon } from '../../../components/icons';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
 import { useContributionSponsors } from '../hooks/useContributionSponsors';
+import { anchorDefaultRel } from '../../../lib/strings';
 import { sponsorTierLabel } from '../utils';
 import type { ContributionSponsor } from '../types';
 import { ContributionSponsorTier } from '../types';
@@ -125,7 +126,7 @@ const SponsorLogo = ({
     <a
       href={sponsor.url}
       target="_blank"
-      rel="noopener noreferrer"
+      rel={anchorDefaultRel}
       aria-label={sponsor.name}
       className={tileClass}
       onClick={onClick}

--- a/packages/shared/src/features/giveback/utils.ts
+++ b/packages/shared/src/features/giveback/utils.ts
@@ -12,15 +12,6 @@ export const formatDonationAmount = (
     maximumFractionDigits: 0,
   }).format(amount);
 
-// Two-letter fallback for a sponsor with no logo (individuals, fresh sponsors).
-export const getSponsorInitials = (name: string): string =>
-  name
-    .split(' ')
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((word) => word[0]?.toUpperCase() ?? '')
-    .join('');
-
 export const getGoalProgressPercentage = (
   raised: number,
   goal: number,

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -495,7 +495,6 @@ export enum LogEvent {
   ExtensionPrimerCtaClick = 'click extension primer cta',
   ExtensionPrimerSkipped = 'skip extension primer',
   // Giveback
-  ClickJoinGiveback = 'click join giveback',
   ClickGivebackSponsor = 'click giveback sponsor',
   SaveGivebackCauses = 'save giveback causes',
   ClickGivebackTab = 'click giveback tab',


### PR DESCRIPTION
Dead-code/cleanup pass from a code review of the redesigned giveback feature (the rest of the feature came back clean: no leftover references to the 10 removed components, no real duplication, no correctness bugs).

- **`getSponsorInitials` (utils.ts)** — exported helper, **zero usages** anywhere in the repo. Deleted.
- **`LogEvent.ClickJoinGiveback`** — defined but **never fired**: the join CTA that fired it was removed with `GivebackStartPanel` in the funnel PR. Removed.
- **`GivebackFunnelStep`** — built a `selectedCauses` array (map/filter/slice) every render but only ever read `.length > 0`; the cause objects were never rendered and the comment described behavior that no longer exists. Replaced with a `hasSelectedCauses` boolean.
- **`GivebackLegalFooter` + `GivebackSponsorTiers`** — used a literal `rel="noopener noreferrer"` while sibling files use the shared `anchorDefaultRel`. Now consistent.
- **`GIVEBACK_CHARM_IMAGE`** — dropped an unnecessary `export` (used only as the internal default for the mascot `image` prop).

## Verification
- ✅ Strict typecheck + ESLint clean
- ✅ Shared + webapp `tsc`: no new errors
- ✅ Giveback tests: 10 suites / 50 pass

One non-blocking observation from the review (not fixed here): "Learn more" clicks log `ClickGivebackCause` in the causes-tab row path but not in the `GivebackCauseCard` path (funnel + "more causes" grid) — an analytics gap, not dead code. Happy to close it in a follow-up if wanted.

### Preview domain
https://chore-giveback-dead-code-cleanup.preview.app.daily.dev