### PR TITLE
fix(giveback): mobile funnel overflow + hide create-post button

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackContributionSummary.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackContributionSummary.tsx
@@ -89,9 +89,13 @@ export const GivebackContributionSummary = (): ReactElement => {
               >
                 <InfoIcon size={IconSize.Size16} />
               </button>
+              {/* Center on the icon rather than left-anchor: left-0 + w-56 ran
+                  the (always-in-layout, opacity-0) tooltip past the right edge,
+                  widening the document and expanding the mobile layout viewport
+                  - which broke every fixed overlay (e.g. the funnel) on Android. */}
               <span
                 role="tooltip"
-                className="pointer-events-none absolute left-0 top-full z-3 mt-2 w-56 rounded-10 border border-border-subtlest-tertiary bg-background-default p-2.5 text-left opacity-0 shadow-2 transition-opacity duration-150 group-focus-within/info:opacity-100 group-hover/info:opacity-100"
+                className="pointer-events-none absolute left-1/2 top-full z-3 mt-2 w-56 -translate-x-1/2 rounded-10 border border-border-subtlest-tertiary bg-background-default p-2.5 text-left opacity-0 shadow-2 transition-opacity duration-150 group-focus-within/info:opacity-100 group-hover/info:opacity-100"
               >
                 <Typography
                   tag={TypographyTag.Span}

--- a/packages/shared/src/features/giveback/components/GivebackPage.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackPage.tsx
@@ -119,8 +119,13 @@ export const GivebackPage = (): ReactElement => {
 
   const activeLabel = givebackTabs.find((tab) => tab.id === activeTab)?.label;
 
+  // `overflow-x-clip` on the root guards against any descendant (decorative glow,
+  // popover, wide row) bleeding past the viewport: such bleed widens the document
+  // and makes Android expand the layout viewport, which then mis-sizes fixed
+  // overlays like the funnel (X/CTA pushed off-screen). `clip` (not `hidden`) adds
+  // no scroll container, so the sticky tab nav keeps working.
   return (
-    <div className="relative min-h-page w-full">
+    <div className="relative min-h-page w-full overflow-x-clip">
       <GivebackBackground />
 
       {/* Hold the body until we know whether to force the funnel. The funnel is a

--- a/packages/webapp/components/footer/FooterWrapper.tsx
+++ b/packages/webapp/components/footer/FooterWrapper.tsx
@@ -50,7 +50,8 @@ export default function FooterWrapper({
 
   const showPlusButton =
     !router?.pathname?.startsWith('/settings') &&
-    !router?.pathname?.startsWith('/posts/');
+    !router?.pathname?.startsWith('/posts/') &&
+    !router?.pathname?.startsWith('/giveback');
 
   return (
     <div


### PR DESCRIPTION
## What

Fixes the Giveback warm-up funnel being unusable on Android (horizontal + vertical scroll, X and CTA pushed off-screen), and hides the mobile create-post button on `/giveback`.

## Root cause

The info tooltip in `GivebackContributionSummary` was `absolute left-0 w-56`. Anchored near the right side of the row, its right edge ran ~40px past the viewport. Because it's `opacity-0` (still in layout), it **permanently** widened the document. On Android that expands the layout viewport, and `position: fixed; inset: 0` (the funnel) sizes to the layout viewport — so the funnel rendered wider/taller than the visible screen (X off the right, CTA off the bottom). iOS clamps fixed elements to the visual viewport, so it looked fine there.

Confirmed via on-device measurement: `innerWidth: 400` / `docScrollW: 400` vs `visualViewport.width: 360`.

## Changes

- **Tooltip**: center on its icon (`left-1/2 -translate-x-1/2`) instead of `left-0`, so it stays within the viewport.
- **Page root**: add `overflow-x-clip` as a guard so no descendant can widen the document and re-break fixed overlays. `clip` (not `hidden`) adds no scroll container, so the sticky tab nav keeps working. The funnel is portaled outside this root, so it just gets a correct 360px viewport to size against.
- **Footer**: hide the mobile create-post (`+`) button on `/giveback`.

## Testing

Verified on Android emulator: funnel X and CTA visible, no horizontal/vertical overflow; `innerWidth`/`docScrollW` back to `360`.

### Preview domain
https://fix-giveback-mobile-funnel-overf.preview.app.daily.dev