### PR TITLE
fix(giveback): drop uppercase letterspaced eyebrow labels

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackActionCard.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCard.tsx
@@ -116,11 +116,7 @@ export const GivebackActionCard = ({
       return (
         <FlexRow className="shrink-0 items-center gap-1 text-text-quaternary">
           <statusMeta.Icon size={IconSize.XSmall} />
-          <Typography
-            tag={TypographyTag.Span}
-            type={TypographyType.Caption1}
-            className="uppercase tracking-wide"
-          >
+          <Typography tag={TypographyTag.Span} type={TypographyType.Caption1}>
             {statusMeta.label}
           </Typography>
         </FlexRow>
@@ -178,7 +174,7 @@ export const GivebackActionCard = ({
             type={TypographyType.Caption1}
             color={TypographyColor.Tertiary}
             bold
-            className="min-w-0 truncate uppercase tracking-wider"
+            className="min-w-0 truncate"
           >
             {platformName}
           </Typography>
@@ -214,7 +210,6 @@ export const GivebackActionCard = ({
                 tag={TypographyTag.Span}
                 type={TypographyType.Caption2}
                 bold
-                className="uppercase tracking-wide"
               >
                 {remaining} left
               </Typography>

--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
@@ -76,7 +76,7 @@ const ActionBrief = ({
             type={TypographyType.Caption1}
             color={TypographyColor.Tertiary}
             bold
-            className="min-w-0 truncate uppercase tracking-wider"
+            className="min-w-0 truncate"
           >
             {platformName}
           </Typography>
@@ -166,7 +166,6 @@ const InstructionsBlock = ({
         type={TypographyType.Caption1}
         color={TypographyColor.Tertiary}
         bold
-        className="uppercase tracking-wider"
       >
         How to complete it
       </Typography>

--- a/packages/shared/src/features/giveback/components/GivebackCausesPanel.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackCausesPanel.tsx
@@ -193,7 +193,6 @@ export const GivebackCausesPanel = ({
           type={TypographyType.Caption1}
           color={TypographyColor.Tertiary}
           bold
-          className="uppercase tracking-wider"
         >
           Your causes · {selectedCount}
         </Typography>
@@ -235,7 +234,6 @@ export const GivebackCausesPanel = ({
             type={TypographyType.Caption1}
             color={TypographyColor.Tertiary}
             bold
-            className="uppercase tracking-wider"
           >
             More causes to explore
           </Typography>

--- a/packages/shared/src/features/giveback/components/GivebackContributionSummary.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackContributionSummary.tsx
@@ -57,7 +57,7 @@ export const GivebackContributionSummary = (): ReactElement => {
             rounded={ProfileImageSize.XXLarge}
             className="ring-1 ring-border-subtlest-tertiary"
           />
-          <span className="absolute -bottom-2 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-6 border border-border-subtlest-tertiary bg-background-default px-2 py-0.5 font-bold uppercase tracking-wide text-accent-cabbage-default ring-2 ring-background-default typo-caption2">
+          <span className="absolute -bottom-2 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-6 border border-border-subtlest-tertiary bg-background-default px-2 py-0.5 font-bold text-accent-cabbage-default ring-2 ring-background-default typo-caption2">
             Lvl {currentLevel}
           </span>
         </div>

--- a/packages/shared/src/features/giveback/components/GivebackPersonalRoadmap.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackPersonalRoadmap.tsx
@@ -311,7 +311,6 @@ export const GivebackPersonalRoadmap = ({
             type={TypographyType.Caption1}
             color={TypographyColor.Tertiary}
             bold
-            className="uppercase tracking-wider"
           >
             Rewards you unlock along the way
           </Typography>

--- a/packages/shared/src/features/giveback/components/GivebackRoadmapNode.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackRoadmapNode.tsx
@@ -338,7 +338,6 @@ export const NodeRow = ({
                   type={TypographyType.Caption2}
                   color={TypographyColor.Tertiary}
                   bold
-                  className="uppercase tracking-wider"
                 >
                   Level {level.levelNumber} · {requirementLabel}
                 </Typography>

--- a/packages/shared/src/features/giveback/components/GivebackSponsorTiers.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSponsorTiers.tsx
@@ -164,7 +164,6 @@ export const GivebackSponsorTiers = (): ReactElement | null => {
           type={TypographyType.Caption1}
           color={TypographyColor.Tertiary}
           bold
-          className="uppercase tracking-wider"
         >
           Sponsored by
         </Typography>
@@ -189,7 +188,6 @@ export const GivebackSponsorTiers = (): ReactElement | null => {
                       tag={TypographyTag.Span}
                       type={TypographyType.Caption2}
                       bold
-                      className="uppercase tracking-wider"
                     >
                       {sponsorTierLabel[group.tier]}
                     </Typography>


### PR DESCRIPTION
## What

Removes the all-caps + wide letter-spacing (`uppercase tracking-wid*`) treatment from platform names and section/eyebrow labels across the contribution feature, replacing it with our regular typography (natural casing, normal spacing). Colors and weights are unchanged.

The uppercase + even per-character spacing read as a generic, AI-templated tell, especially on platform names (e.g. `GITHUB` → `GitHub`).

## Where

- `GivebackActionCard` — platform name, status pill, "X left"
- `GivebackActionSubmissionModal` — platform name, "How to complete it"
- `GivebackCausesPanel` — "Your causes", "More causes to explore"
- `GivebackContributionSummary` — "Lvl N" badge
- `GivebackPersonalRoadmap` — "Rewards you unlock along the way"
- `GivebackRoadmapNode` — "Level N · …"
- `GivebackSponsorTiers` — "Sponsored by", tier labels

### Preview domain
https://fix-giveback-label-typography.preview.app.daily.dev