### PR TITLE
feat(giveback): assistType plumbing + display-only referral action

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackActionCard.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCard.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { GivebackActionCard } from './GivebackActionCard';
 import type { ContributionAction } from '../types';
-import { ContributionSubmissionStatus } from '../types';
+import { ContributionAssistType, ContributionSubmissionStatus } from '../types';
 
 const makeAction = (
   overrides: Partial<ContributionAction> = {},
@@ -18,6 +18,7 @@ const makeAction = (
     instructions: null,
     externalUrl: null,
     isLoveAction: false,
+    assistType: null,
   },
   cooldownSeconds: null,
   maxPerUser: null,
@@ -42,6 +43,25 @@ it('renders an actionable card with the payout and platform, and submits', () =>
     screen.getByRole('button', { name: 'Submit proof for Post about us on X' }),
   );
   expect(onSubmit).toHaveBeenCalledWith(makeAction());
+});
+
+it('labels a referral action as an invite rather than a proof submission', () => {
+  const action = makeAction({
+    title: 'Invite a friend',
+    metadata: {
+      platform: null,
+      instructions: null,
+      externalUrl: null,
+      isLoveAction: false,
+      assistType: ContributionAssistType.ReferralLink,
+    },
+  });
+  render(<GivebackActionCard action={action} onSubmit={onSubmit} />);
+
+  fireEvent.click(
+    screen.getByRole('button', { name: 'Invite friends: Invite a friend' }),
+  );
+  expect(onSubmit).toHaveBeenCalledWith(action);
 });
 
 it('locks an approved action into a non-interactive Done state', () => {
@@ -180,6 +200,7 @@ it('renders a love action with its appreciation tag instead of a payout', () => 
           instructions: null,
           externalUrl: null,
           isLoveAction: true,
+          assistType: null,
         },
       })}
       onSubmit={onSubmit}

--- a/packages/shared/src/features/giveback/components/GivebackActionCard.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCard.tsx
@@ -12,7 +12,7 @@ import { IconSize } from '../../../components/Icon';
 import type { IconProps } from '../../../components/Icon';
 import { RefreshIcon, TimerIcon, VIcon } from '../../../components/icons';
 import type { ContributionAction } from '../types';
-import { ContributionSubmissionStatus } from '../types';
+import { ContributionAssistType, ContributionSubmissionStatus } from '../types';
 import { formatDonationAmount } from '../utils';
 import { getActionPlatformVisual } from '../actionPlatform';
 import { GivebackPlatformLogo } from './GivebackPlatformLogo';
@@ -49,6 +49,8 @@ export const GivebackActionCard = ({
 }: GivebackActionCardProps): ReactElement => {
   const { metadata, latestUserSubmission } = action;
   const isLove = metadata.isLoveAction;
+  const isReferral =
+    metadata.assistType === ContributionAssistType.ReferralLink;
 
   const reachedMax =
     action.maxPerUser != null && action.userCompletions >= action.maxPerUser;
@@ -81,6 +83,17 @@ export const GivebackActionCard = ({
   // Any non-actionable state shares the same dimmed, non-interactive treatment.
   const isDimmed = isDone || isInReview || onCooldown;
   const isInteractive = !isDimmed && !!onSubmit;
+
+  const getInteractiveAriaLabel = (): string => {
+    if (isReferral) {
+      return `Invite friends: ${action.title}`;
+    }
+    if (isLove) {
+      return `Show some love: ${action.title}`;
+    }
+    return `Submit proof for ${action.title}`;
+  };
+  const interactiveAriaLabel = getInteractiveAriaLabel();
 
   const {
     Icon,
@@ -224,11 +237,7 @@ export const GivebackActionCard = ({
     return (
       <button
         type="button"
-        aria-label={
-          isLove
-            ? `Show some love: ${action.title}`
-            : `Submit proof for ${action.title}`
-        }
+        aria-label={interactiveAriaLabel}
         onClick={() => onSubmit?.(action)}
         className={classNames(
           'group relative flex h-full w-full flex-col gap-3 overflow-hidden rounded-16 p-4 text-left transition-all duration-200 hover:-translate-y-0.5 hover:shadow-2 active:translate-y-0 active:scale-[0.99] motion-reduce:transform-none',

--- a/packages/shared/src/features/giveback/components/GivebackActionCatalog.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCatalog.spec.tsx
@@ -31,6 +31,7 @@ const makeAction = (
     instructions: null,
     externalUrl: null,
     isLoveAction: false,
+    assistType: null,
   },
   cooldownSeconds: null,
   maxPerUser: null,
@@ -123,6 +124,7 @@ it('renders love actions in their own group', () => {
         instructions: null,
         externalUrl: null,
         isLoveAction: true,
+        assistType: null,
       },
     }),
   ]);

--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.spec.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { GivebackActionSubmissionModal } from './GivebackActionSubmissionModal';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import loggedUser from '../../../../__tests__/fixture/loggedUser';
+import type { ContributionAction } from '../types';
+import { ContributionAssistType } from '../types';
+
+jest.mock('../hooks/useSubmitContributionAction', () => ({
+  useSubmitContributionAction: () => ({ submit: jest.fn(), isPending: false }),
+}));
+
+jest.mock('../../../hooks/useToastNotification', () => ({
+  ...jest.requireActual('../../../hooks/useToastNotification'),
+  useToastNotification: () => ({ displayToast: jest.fn() }),
+}));
+
+jest.mock('../../../contexts/LogContext', () => ({
+  ...jest.requireActual('../../../contexts/LogContext'),
+  useLogContext: () => ({ logEvent: jest.fn() }),
+}));
+
+jest.mock('../../../hooks/referral/useReferralCampaign', () => ({
+  ...jest.requireActual('../../../hooks/referral/useReferralCampaign'),
+  useReferralCampaign: () => ({ url: 'https://dly.to/abc' }),
+}));
+
+const makeAction = (
+  overrides: Partial<ContributionAction> = {},
+): ContributionAction => ({
+  id: 'a1',
+  categoryId: 'cat1',
+  title: 'Invite a friend to daily.dev',
+  description: null,
+  points: 150,
+  evidence: {},
+  metadata: {
+    platform: null,
+    instructions: null,
+    externalUrl: null,
+    isLoveAction: false,
+    assistType: ContributionAssistType.ReferralLink,
+  },
+  cooldownSeconds: null,
+  maxPerUser: null,
+  userCooldownEndsAt: null,
+  userCompletions: 0,
+  latestUserSubmission: null,
+  ...overrides,
+});
+
+const renderModal = (action: ContributionAction): ReturnType<typeof render> => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <TestBootProvider client={client} auth={{ user: loggedUser }}>
+      <GivebackActionSubmissionModal action={action} onClose={jest.fn()} />
+    </TestBootProvider>,
+  );
+};
+
+it('shows the copyable invite link and no proof submission for a referral action', () => {
+  renderModal(makeAction());
+
+  expect(screen.getByDisplayValue('https://dly.to/abc')).toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: 'Submit for review' }),
+  ).not.toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
+});
+
+it('surfaces how many invited friends have counted so far', () => {
+  renderModal(makeAction({ userCompletions: 3 }));
+
+  expect(screen.getByText(/3 credited so far/)).toBeInTheDocument();
+});

--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.spec.tsx
@@ -4,6 +4,7 @@ import { QueryClient } from '@tanstack/react-query';
 import { GivebackActionSubmissionModal } from './GivebackActionSubmissionModal';
 import { TestBootProvider } from '../../../../__tests__/helpers/boot';
 import loggedUser from '../../../../__tests__/fixture/loggedUser';
+import { useReferralCampaign } from '../../../hooks/referral/useReferralCampaign';
 import type { ContributionAction } from '../types';
 import { ContributionAssistType } from '../types';
 
@@ -23,8 +24,17 @@ jest.mock('../../../contexts/LogContext', () => ({
 
 jest.mock('../../../hooks/referral/useReferralCampaign', () => ({
   ...jest.requireActual('../../../hooks/referral/useReferralCampaign'),
-  useReferralCampaign: () => ({ url: 'https://dly.to/abc' }),
+  useReferralCampaign: jest.fn(),
 }));
+
+const mockedUseReferralCampaign = useReferralCampaign as jest.Mock;
+
+beforeEach(() => {
+  mockedUseReferralCampaign.mockReturnValue({
+    url: 'https://dly.to/abc',
+    isReady: true,
+  });
+});
 
 const makeAction = (
   overrides: Partial<ContributionAction> = {},
@@ -76,4 +86,16 @@ it('surfaces how many invited friends have counted so far', () => {
   renderModal(makeAction({ userCompletions: 3 }));
 
   expect(screen.getByText(/3 credited so far/)).toBeInTheDocument();
+});
+
+it('shows a spinner instead of the fallback link while the invite link loads', () => {
+  mockedUseReferralCampaign.mockReturnValue({ url: undefined, isReady: false });
+  renderModal(makeAction());
+
+  expect(
+    screen.getByRole('status', { name: 'Loading your invite link' }),
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByDisplayValue('https://daily.dev'),
+  ).not.toBeInTheDocument();
 });

--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
@@ -26,6 +26,7 @@ import {
   ReferralCampaignKey,
 } from '../../../hooks/referral/useReferralCampaign';
 import { InviteLinkInput } from '../../../components/referral/InviteLinkInput';
+import { Loader } from '../../../components/Loader';
 import type { ContributionAction } from '../types';
 import { ContributionAssistType } from '../types';
 import { formatDonationAmount } from '../utils';
@@ -215,9 +216,13 @@ const ReferralPanel = ({
 }: {
   action: ContributionAction;
 }): ReactElement => {
-  const { url } = useReferralCampaign({
+  const { url, isReady } = useReferralCampaign({
     campaignKey: ReferralCampaignKey.Generic,
   });
+  // Wait for the personalized link rather than flashing the daily.dev fallback;
+  // once the query settles we show the real URL (or the fallback for the rare
+  // case it resolves empty).
+  const isLoading = !url && !isReady;
   const inviteLink = url || appLinks.referral.defaultUrl;
   const friendsCredited = action.userCompletions;
 
@@ -231,13 +236,20 @@ const ReferralPanel = ({
       >
         Your invite link
       </Typography>
-      <InviteLinkInput
-        link={inviteLink}
-        logProps={{
-          event_name: LogEvent.CopyGivebackReferralLink,
-          target_id: action.id,
-        }}
-      />
+      {isLoading ? (
+        // Match InviteLinkInput's h-12 so swapping in the field causes no shift.
+        <FlexRow className="h-12 items-center justify-center">
+          <Loader role="status" aria-label="Loading your invite link" />
+        </FlexRow>
+      ) : (
+        <InviteLinkInput
+          link={inviteLink}
+          logProps={{
+            event_name: LogEvent.CopyGivebackReferralLink,
+            target_id: action.id,
+          }}
+        />
+      )}
       <Typography
         type={TypographyType.Footnote}
         color={TypographyColor.Tertiary}

--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
@@ -20,7 +20,14 @@ import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
 import { labels } from '../../../lib/labels';
 import { anchorDefaultRel } from '../../../lib/strings';
+import { link as appLinks } from '../../../lib/links';
+import {
+  useReferralCampaign,
+  ReferralCampaignKey,
+} from '../../../hooks/referral/useReferralCampaign';
+import { InviteLinkInput } from '../../../components/referral/InviteLinkInput';
 import type { ContributionAction } from '../types';
+import { ContributionAssistType } from '../types';
 import { formatDonationAmount } from '../utils';
 import { getActionPlatformVisual } from '../actionPlatform';
 import { useSubmitContributionAction } from '../hooks/useSubmitContributionAction';
@@ -200,6 +207,50 @@ const InstructionsBlock = ({
   );
 };
 
+// Referral actions are credited automatically when an invited friend activates,
+// so there's no proof to submit. Instead we hand the user their own invite link
+// to copy and share, and show how many friends have counted so far.
+const ReferralPanel = ({
+  action,
+}: {
+  action: ContributionAction;
+}): ReactElement => {
+  const { url } = useReferralCampaign({
+    campaignKey: ReferralCampaignKey.Generic,
+  });
+  const inviteLink = url || appLinks.referral.defaultUrl;
+  const friendsCredited = action.userCompletions;
+
+  return (
+    <FlexCol className="gap-3 rounded-16 bg-surface-float p-4">
+      <Typography
+        tag={TypographyTag.Span}
+        type={TypographyType.Caption1}
+        color={TypographyColor.Tertiary}
+        bold
+      >
+        Your invite link
+      </Typography>
+      <InviteLinkInput
+        link={inviteLink}
+        logProps={{
+          event_name: LogEvent.CopyGivebackReferralLink,
+          target_id: action.id,
+        }}
+      />
+      <Typography
+        type={TypographyType.Footnote}
+        color={TypographyColor.Tertiary}
+        className="[text-wrap:pretty]"
+      >
+        {friendsCredited > 0
+          ? `Points land automatically when a friend joins and gets going — ${friendsCredited} credited so far.`
+          : 'Points land automatically when a friend joins and gets going.'}
+      </Typography>
+    </FlexCol>
+  );
+};
+
 export const GivebackActionSubmissionModal = ({
   action,
   onClose,
@@ -219,6 +270,8 @@ export const GivebackActionSubmissionModal = ({
 
   const { evidence, metadata } = action;
   const isLove = metadata.isLoveAction;
+  const isReferral =
+    metadata.assistType === ContributionAssistType.ReferralLink;
   const showUrl = !!evidence.url;
   const showScreenshot = !!evidence.screenshot;
   const showNote = !!evidence.note;
@@ -309,6 +362,61 @@ export const GivebackActionSubmissionModal = ({
     onClose();
   };
 
+  // Referral and love actions have nothing to submit — both close with a single
+  // acknowledge button. Only the proof flow shows the cancel/submit pair.
+  const renderFooterActions = (): ReactElement => {
+    if (isReferral) {
+      return (
+        <Button
+          type="button"
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Primary}
+          onClick={onClose}
+        >
+          Done
+        </Button>
+      );
+    }
+
+    if (isLove) {
+      return (
+        <Button
+          type="button"
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Primary}
+          onClick={onLoveAcknowledge}
+        >
+          Got it
+        </Button>
+      );
+    }
+
+    return (
+      <>
+        <Button
+          type="button"
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Tertiary}
+          onClick={onClose}
+        >
+          {isSubmitted ? 'Done' : 'Cancel'}
+        </Button>
+        {!isSubmitted && (
+          <Button
+            type="button"
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Primary}
+            disabled={!canSubmit}
+            loading={isPending}
+            onClick={onSubmit}
+          >
+            Submit for review
+          </Button>
+        )}
+      </>
+    );
+  };
+
   return (
     <RootPortal>
       <div className="fixed inset-0 z-modal flex items-center justify-center bg-overlay-primary-pepper px-4 backdrop-blur-sm">
@@ -347,6 +455,8 @@ export const GivebackActionSubmissionModal = ({
               <InstructionsBlock instructions={metadata.instructions} />
             )}
 
+            {isReferral && !isSubmitted && <ReferralPanel action={action} />}
+
             {isLove && !isSubmitted && (
               <Typography
                 type={TypographyType.Footnote}
@@ -378,7 +488,7 @@ export const GivebackActionSubmissionModal = ({
               </FlexCol>
             )}
 
-            {!isLove && !isSubmitted && (
+            {!isLove && !isReferral && !isSubmitted && (
               <FlexCol className="gap-4">
                 <Typography
                   type={TypographyType.Caption1}
@@ -441,39 +551,7 @@ export const GivebackActionSubmissionModal = ({
           {/* Pinned action bar: stays visible while the body above scrolls, so
               the submit control is always reachable on tall forms. */}
           <FlexRow className="relative shrink-0 justify-end gap-2 border-t border-border-subtlest-tertiary px-4 py-3 tablet:px-5">
-            {isLove ? (
-              <Button
-                type="button"
-                size={ButtonSize.Small}
-                variant={ButtonVariant.Primary}
-                onClick={onLoveAcknowledge}
-              >
-                Got it
-              </Button>
-            ) : (
-              <>
-                <Button
-                  type="button"
-                  size={ButtonSize.Small}
-                  variant={ButtonVariant.Tertiary}
-                  onClick={onClose}
-                >
-                  {isSubmitted ? 'Done' : 'Cancel'}
-                </Button>
-                {!isSubmitted && (
-                  <Button
-                    type="button"
-                    size={ButtonSize.Small}
-                    variant={ButtonVariant.Primary}
-                    disabled={!canSubmit}
-                    loading={isPending}
-                    onClick={onSubmit}
-                  >
-                    Submit for review
-                  </Button>
-                )}
-              </>
-            )}
+            {renderFooterActions()}
           </FlexRow>
         </section>
       </div>

--- a/packages/shared/src/features/giveback/graphql.ts
+++ b/packages/shared/src/features/giveback/graphql.ts
@@ -75,6 +75,7 @@ export const CONTRIBUTION_ACTIONS_QUERY = `
             instructions
             externalUrl
             isLoveAction
+            assistType
           }
           cooldownSeconds
           maxPerUser

--- a/packages/shared/src/features/giveback/types.ts
+++ b/packages/shared/src/features/giveback/types.ts
@@ -89,14 +89,25 @@ export interface ContributionSubmission {
   reviewedAt: string | null;
 }
 
+// How the card helps the user complete an action: open an outbound link, surface
+// their own invite link, or pick from a rotating pool of targets. Drives which
+// assist UI the submission modal renders.
+export enum ContributionAssistType {
+  ExternalLink = 'external_link',
+  ReferralLink = 'referral_link',
+  LinkPool = 'link_pool',
+}
+
 // What the action reads as on the catalog (which surface it lives on) plus the
 // optional how-to and outbound link. `isLoveAction` marks a voluntary
-// thank-you that carries no points and skips the proof flow.
+// thank-you that carries no points and skips the proof flow. `assistType` picks
+// the completion helper (see ContributionAssistType).
 export interface ContributionActionMetadata {
   platform: string | null;
   instructions: string | null;
   externalUrl: string | null;
   isLoveAction: boolean;
+  assistType: ContributionAssistType | null;
 }
 
 // Which kinds of proof an action asks for, and whether each is mandatory. Drives

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -505,6 +505,7 @@ export enum LogEvent {
   SubmitGivebackAction = 'submit giveback action',
   SubmitGivebackActionError = 'submit giveback action error',
   ClickGivebackLoveAction = 'click giveback love action',
+  CopyGivebackReferralLink = 'copy giveback referral link',
   ClaimGivebackReward = 'claim giveback reward',
   ClickGivebackCause = 'click giveback cause',
   ClickGivebackFaq = 'click giveback faq',


### PR DESCRIPTION
## What

Closes the frontend gap against the new contribution-action API. Depends on the merged daily-api PRs (`assistType` metadata + referral auto-award worker).

- **`assistType` plumbing** — adds `ContributionAssistType` (`external_link | referral_link | link_pool`), fetches `metadata.assistType` in `CONTRIBUTION_ACTIONS_QUERY`, and types it.
- **Referral actions are now display-only** — the submission modal branches on `referral_link` to show the user's copyable invite link (reusing `useReferralCampaign` + `InviteLinkInput`) and "friends credited so far", with a single **Done** button. No proof form, because the backend auto-awards referral points when an invited friend activates (avoids double-crediting).
- Cards label referral actions as "Invite friends: …" instead of "Submit proof for …".
- **external_link** is unchanged — the "Go to {platform}" button + instructions checklist already cover it.

## Scope

- `link_pool` intentionally left for a follow-up.

## Tests

- New modal spec: referral action shows the invite link, no submit button, and the friends-credited count.
- Card spec: referral aria-label.
- Existing catalog/card fixtures updated for the required `assistType` field.
- 53 giveback tests pass; strict-changed typecheck + eslint clean.

### Preview domain
https://feat-giveback-assist-referral.preview.app.daily.dev