### PR TITLE
feat(giveback): surface link_pool suggested threads in submission modal

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.spec.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
 import { GivebackActionSubmissionModal } from './GivebackActionSubmissionModal';
 import { TestBootProvider } from '../../../../__tests__/helpers/boot';
 import loggedUser from '../../../../__tests__/fixture/loggedUser';
 import { useReferralCampaign } from '../../../hooks/referral/useReferralCampaign';
+import { useContributionActionLinks } from '../hooks/useContributionActionLinks';
 import type { ContributionAction } from '../types';
 import { ContributionAssistType } from '../types';
 
@@ -27,12 +28,24 @@ jest.mock('../../../hooks/referral/useReferralCampaign', () => ({
   useReferralCampaign: jest.fn(),
 }));
 
+jest.mock('../hooks/useContributionActionLinks', () => ({
+  useContributionActionLinks: jest.fn(),
+}));
+
 const mockedUseReferralCampaign = useReferralCampaign as jest.Mock;
+const mockedUseContributionActionLinks =
+  useContributionActionLinks as jest.Mock;
 
 beforeEach(() => {
   mockedUseReferralCampaign.mockReturnValue({
     url: 'https://dly.to/abc',
     isReady: true,
+  });
+  mockedUseContributionActionLinks.mockReturnValue({
+    links: [],
+    isPending: false,
+    isFetching: false,
+    shuffle: jest.fn(),
   });
 });
 
@@ -98,4 +111,67 @@ it('shows a spinner instead of the fallback link while the invite link loads', (
   expect(
     screen.queryByDisplayValue('https://daily.dev'),
   ).not.toBeInTheDocument();
+});
+
+const makeLinkPoolAction = (): ContributionAction =>
+  makeAction({
+    title: 'Mention daily.dev in a relevant Reddit discussion',
+    evidence: { url: { required: true } },
+    metadata: {
+      platform: 'reddit',
+      instructions: null,
+      externalUrl: null,
+      isLoveAction: false,
+      assistType: ContributionAssistType.LinkPool,
+    },
+  });
+
+it('surfaces suggested pool threads and still asks for proof for a link_pool action', () => {
+  mockedUseContributionActionLinks.mockReturnValue({
+    links: [
+      {
+        id: 'l1',
+        url: 'https://reddit.com/r/webdev/comments/1',
+        label: 'r/webdev: keep up with dev news',
+      },
+      { id: 'l2', url: 'https://reddit.com/r/x/comments/2', label: null },
+    ],
+    isPending: false,
+    isFetching: false,
+    shuffle: jest.fn(),
+  });
+
+  renderModal(makeLinkPoolAction());
+
+  expect(screen.getByText('Suggested threads')).toBeInTheDocument();
+  const firstThread = screen.getByText('r/webdev: keep up with dev news');
+  expect(firstThread.closest('a')).toHaveAttribute(
+    'href',
+    'https://reddit.com/r/webdev/comments/1',
+  );
+  // A label-less link falls back to its URL.
+  expect(
+    screen.getByText('https://reddit.com/r/x/comments/2'),
+  ).toBeInTheDocument();
+  // link_pool keeps the proof flow (unlike referral).
+  expect(
+    screen.getByRole('button', { name: 'Submit for review' }),
+  ).toBeInTheDocument();
+});
+
+it('shuffles the pool on request', () => {
+  const shuffle = jest.fn();
+  mockedUseContributionActionLinks.mockReturnValue({
+    links: [
+      { id: 'l1', url: 'https://reddit.com/r/webdev/comments/1', label: 'One' },
+    ],
+    isPending: false,
+    isFetching: false,
+    shuffle,
+  });
+
+  renderModal(makeLinkPoolAction());
+
+  fireEvent.click(screen.getByRole('button', { name: /shuffle/i }));
+  expect(shuffle).toHaveBeenCalled();
 });

--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.spec.tsx
@@ -176,6 +176,21 @@ it('shuffles the pool on request', () => {
   expect(shuffle).toHaveBeenCalled();
 });
 
+it('reserves space with placeholder rows while the pool loads', () => {
+  mockedUseContributionActionLinks.mockReturnValue({
+    links: [],
+    isPending: true,
+    isFetching: false,
+    shuffle: jest.fn(),
+  });
+
+  renderModal(makeLinkPoolAction());
+
+  expect(
+    screen.getByRole('status', { name: 'Loading suggested threads' }),
+  ).toBeInTheDocument();
+});
+
 it('disables shuffle while a fresh set is loading', () => {
   mockedUseContributionActionLinks.mockReturnValue({
     links: [

--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.spec.tsx
@@ -175,3 +175,18 @@ it('shuffles the pool on request', () => {
   fireEvent.click(screen.getByRole('button', { name: /shuffle/i }));
   expect(shuffle).toHaveBeenCalled();
 });
+
+it('disables shuffle while a fresh set is loading', () => {
+  mockedUseContributionActionLinks.mockReturnValue({
+    links: [
+      { id: 'l1', url: 'https://reddit.com/r/webdev/comments/1', label: 'One' },
+    ],
+    isPending: false,
+    isFetching: true,
+    shuffle: jest.fn(),
+  });
+
+  renderModal(makeLinkPoolAction());
+
+  expect(screen.getByRole('button', { name: /shuffle/i })).toBeDisabled();
+});

--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
@@ -358,7 +358,7 @@ const LinkPoolPanel = ({
             disabled={isFetching}
             className="hover:opacity-80 disabled:opacity-60 flex items-center gap-1 uppercase tracking-wide text-text-tertiary transition-opacity typo-caption2 [&_svg]:size-3.5"
           >
-            <RefreshIcon />
+            <RefreshIcon className={isFetching ? 'animate-spin' : undefined} />
             Shuffle
           </button>
         )}

--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../../hooks/referral/useReferralCampaign';
 import { InviteLinkInput } from '../../../components/referral/InviteLinkInput';
 import { Loader } from '../../../components/Loader';
+import { ElementPlaceholder } from '../../../components/ElementPlaceholder';
 import type { ContributionAction } from '../types';
 import { ContributionAssistType } from '../types';
 import { formatDonationAmount } from '../utils';
@@ -264,6 +265,14 @@ const ReferralPanel = ({
   );
 };
 
+// Shared box for both real and skeleton pool rows. The fixed min height keeps
+// the two identical so swapping the skeleton for real links causes no shift.
+const POOL_ROW_CLASS =
+  'flex min-h-10 items-center gap-2 rounded-12 border border-border-subtlest-tertiary bg-background-default px-3 py-2';
+// Mirrors the backend's default handful size, so the skeleton reserves the exact
+// height the loaded list will occupy.
+const POOL_PLACEHOLDER_KEYS = ['s0', 's1', 's2', 's3', 's4'];
+
 // link_pool actions carry a curated pool of targets (e.g. Reddit threads). We
 // surface a randomized handful the user can open, with a shuffle for a fresh set,
 // then they submit their own comment link as proof below.
@@ -289,9 +298,18 @@ const LinkPoolPanel = ({
   const renderBody = (): ReactElement => {
     if (isPending) {
       return (
-        <FlexRow className="h-10 items-center justify-center">
-          <Loader role="status" aria-label="Loading suggested threads" />
-        </FlexRow>
+        <FlexCol
+          className="gap-2"
+          role="status"
+          aria-label="Loading suggested threads"
+        >
+          {POOL_PLACEHOLDER_KEYS.map((key) => (
+            <div key={key} aria-hidden className={POOL_ROW_CLASS}>
+              <ElementPlaceholder className="h-3.5 flex-1 animate-pulse rounded-8" />
+              <ElementPlaceholder className="size-4 shrink-0 animate-pulse rounded-full" />
+            </div>
+          ))}
+        </FlexCol>
       );
     }
 
@@ -323,7 +341,7 @@ const LinkPoolPanel = ({
                 extra: JSON.stringify({ url: poolLink.url }),
               })
             }
-            className="flex items-center gap-2 rounded-12 border border-border-subtlest-tertiary bg-background-default px-3 py-2 transition-colors hover:bg-surface-hover"
+            className={`${POOL_ROW_CLASS} transition-colors hover:bg-surface-hover`}
           >
             <Typography
               type={TypographyType.Footnote}

--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../../components/typography/Typography';
 import { FlexCol, FlexRow } from '../../../components/utilities';
 import { RootPortal } from '../../../components/tooltips/Portal';
-import { OpenLinkIcon } from '../../../components/icons';
+import { OpenLinkIcon, RefreshIcon } from '../../../components/icons';
 import { uploadContentImage } from '../../../graphql/posts';
 import { useToastNotification } from '../../../hooks/useToastNotification';
 import { useLogContext } from '../../../contexts/LogContext';
@@ -32,6 +32,7 @@ import { ContributionAssistType } from '../types';
 import { formatDonationAmount } from '../utils';
 import { getActionPlatformVisual } from '../actionPlatform';
 import { useSubmitContributionAction } from '../hooks/useSubmitContributionAction';
+import { useContributionActionLinks } from '../hooks/useContributionActionLinks';
 import { GivebackScreenshotField } from './GivebackScreenshotField';
 import { GivebackPlatformLogo } from './GivebackPlatformLogo';
 
@@ -263,6 +264,110 @@ const ReferralPanel = ({
   );
 };
 
+// link_pool actions carry a curated pool of targets (e.g. Reddit threads). We
+// surface a randomized handful the user can open, with a shuffle for a fresh set,
+// then they submit their own comment link as proof below.
+const LinkPoolPanel = ({
+  action,
+}: {
+  action: ContributionAction;
+}): ReactElement => {
+  const { logEvent } = useLogContext();
+  const { links, isPending, isFetching, shuffle } = useContributionActionLinks({
+    actionId: action.id,
+    enabled: true,
+  });
+
+  const onShuffle = () => {
+    logEvent({
+      event_name: LogEvent.ShuffleGivebackPoolLinks,
+      target_id: action.id,
+    });
+    shuffle();
+  };
+
+  const renderBody = (): ReactElement => {
+    if (isPending) {
+      return (
+        <FlexRow className="h-10 items-center justify-center">
+          <Loader role="status" aria-label="Loading suggested threads" />
+        </FlexRow>
+      );
+    }
+
+    if (links.length === 0) {
+      return (
+        <Typography
+          type={TypographyType.Footnote}
+          color={TypographyColor.Tertiary}
+          className="[text-wrap:pretty]"
+        >
+          No suggestions right now. Pick any relevant thread and share your
+          comment below.
+        </Typography>
+      );
+    }
+
+    return (
+      <FlexCol className="gap-2">
+        {links.map((poolLink) => (
+          <a
+            key={poolLink.id}
+            href={poolLink.url}
+            target="_blank"
+            rel={anchorDefaultRel}
+            onClick={() =>
+              logEvent({
+                event_name: LogEvent.ClickGivebackPoolLink,
+                target_id: action.id,
+                extra: JSON.stringify({ url: poolLink.url }),
+              })
+            }
+            className="flex items-center gap-2 rounded-12 border border-border-subtlest-tertiary bg-background-default px-3 py-2 transition-colors hover:bg-surface-hover"
+          >
+            <Typography
+              type={TypographyType.Footnote}
+              className="min-w-0 flex-1 truncate"
+            >
+              {poolLink.label || poolLink.url}
+            </Typography>
+            <span className="shrink-0 text-text-tertiary [&_svg]:size-4">
+              <OpenLinkIcon />
+            </span>
+          </a>
+        ))}
+      </FlexCol>
+    );
+  };
+
+  return (
+    <FlexCol className="gap-3 rounded-16 bg-surface-float p-4">
+      <FlexRow className="items-center justify-between gap-3">
+        <Typography
+          tag={TypographyTag.Span}
+          type={TypographyType.Caption1}
+          color={TypographyColor.Tertiary}
+          bold
+        >
+          Suggested threads
+        </Typography>
+        {links.length > 0 && (
+          <button
+            type="button"
+            onClick={onShuffle}
+            disabled={isFetching}
+            className="hover:opacity-80 disabled:opacity-60 flex items-center gap-1 uppercase tracking-wide text-text-tertiary transition-opacity typo-caption2 [&_svg]:size-3.5"
+          >
+            <RefreshIcon />
+            Shuffle
+          </button>
+        )}
+      </FlexRow>
+      {renderBody()}
+    </FlexCol>
+  );
+};
+
 export const GivebackActionSubmissionModal = ({
   action,
   onClose,
@@ -284,6 +389,7 @@ export const GivebackActionSubmissionModal = ({
   const isLove = metadata.isLoveAction;
   const isReferral =
     metadata.assistType === ContributionAssistType.ReferralLink;
+  const isLinkPool = metadata.assistType === ContributionAssistType.LinkPool;
   const showUrl = !!evidence.url;
   const showScreenshot = !!evidence.screenshot;
   const showNote = !!evidence.note;
@@ -466,6 +572,8 @@ export const GivebackActionSubmissionModal = ({
             {!isSubmitted && metadata.instructions && (
               <InstructionsBlock instructions={metadata.instructions} />
             )}
+
+            {isLinkPool && !isSubmitted && <LinkPoolPanel action={action} />}
 
             {isReferral && !isSubmitted && <ReferralPanel action={action} />}
 

--- a/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionSubmissionModal.tsx
@@ -189,7 +189,7 @@ const InstructionsBlock = ({
                 tag={TypographyTag.Span}
                 type={TypographyType.Callout}
                 color={TypographyColor.Secondary}
-                className="[text-wrap:pretty]"
+                className="min-w-0 flex-1 [text-wrap:pretty]"
               >
                 {step}
               </Typography>

--- a/packages/shared/src/features/giveback/graphql.ts
+++ b/packages/shared/src/features/giveback/graphql.ts
@@ -123,6 +123,18 @@ export const CONTRIBUTION_ACTIONS_QUERY = `
   }
 `;
 
+// A randomized handful of targets for a link_pool action. Re-fetched to shuffle,
+// so the user always has fresh threads to pick from.
+export const CONTRIBUTION_ACTION_LINKS_QUERY = `
+  query ContributionActionLinks($actionId: ID!, $limit: Int) {
+    contributionActionLinks(actionId: $actionId, limit: $limit) {
+      id
+      url
+      label
+    }
+  }
+`;
+
 export const CLAIM_CONTRIBUTION_REWARD_MUTATION = `
   mutation ClaimContributionReward($tierId: ID!) {
     claimContributionReward(tierId: $tierId) {

--- a/packages/shared/src/features/giveback/hooks/useContributionActionLinks.ts
+++ b/packages/shared/src/features/giveback/hooks/useContributionActionLinks.ts
@@ -1,0 +1,52 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { gqlClient } from '../../../graphql/common';
+import { disabledRefetch } from '../../../lib/func';
+import { generateQueryKey, RequestKey } from '../../../lib/query';
+import { CONTRIBUTION_ACTION_LINKS_QUERY } from '../graphql';
+import type { ContributionActionLink } from '../types';
+
+interface UseContributionActionLinksProps {
+  actionId: string;
+  enabled: boolean;
+}
+
+interface UseContributionActionLinks {
+  links: ContributionActionLink[];
+  isPending: boolean;
+  isFetching: boolean;
+  shuffle: () => void;
+}
+
+// A link_pool action's suggested targets. The backend returns a random handful,
+// so refetching (`shuffle`) swaps in a fresh set. staleTime 0 keeps each refetch
+// live rather than served from cache.
+export const useContributionActionLinks = ({
+  actionId,
+  enabled,
+}: UseContributionActionLinksProps): UseContributionActionLinks => {
+  const { user } = useAuthContext();
+
+  const { data, isPending, isFetching, refetch } = useQuery({
+    queryKey: generateQueryKey(RequestKey.ContributionActionLinks, user, {
+      actionId,
+    }),
+    queryFn: async () => {
+      const res = await gqlClient.request<{
+        contributionActionLinks: ContributionActionLink[];
+      }>(CONTRIBUTION_ACTION_LINKS_QUERY, { actionId });
+
+      return res.contributionActionLinks;
+    },
+    enabled,
+    staleTime: 0,
+    ...disabledRefetch,
+  });
+
+  return {
+    links: data ?? [],
+    isPending: enabled && isPending,
+    isFetching,
+    shuffle: () => refetch(),
+  };
+};

--- a/packages/shared/src/features/giveback/types.ts
+++ b/packages/shared/src/features/giveback/types.ts
@@ -110,6 +110,14 @@ export interface ContributionActionMetadata {
   assistType: ContributionAssistType | null;
 }
 
+// A single target from a link_pool action's pool (e.g. a Reddit thread to
+// comment on). The catalog surfaces a randomized handful at a time.
+export interface ContributionActionLink {
+  id: string;
+  url: string;
+  label: string | null;
+}
+
 // Which kinds of proof an action asks for, and whether each is mandatory. Drives
 // the submission form: a field is only rendered when its key is present.
 export interface ContributionActionEvidence {

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -507,6 +507,8 @@ export enum LogEvent {
   SubmitGivebackActionError = 'submit giveback action error',
   ClickGivebackLoveAction = 'click giveback love action',
   CopyGivebackReferralLink = 'copy giveback referral link',
+  ClickGivebackPoolLink = 'click giveback pool link',
+  ShuffleGivebackPoolLinks = 'shuffle giveback pool links',
   ClaimGivebackReward = 'claim giveback reward',
   ClickGivebackCause = 'click giveback cause',
   ClickGivebackFaq = 'click giveback faq',

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -278,6 +278,7 @@ export enum RequestKey {
   ContributionOverview = 'contribution_overview',
   ContributionCausePicker = 'contribution_cause_picker',
   ContributionActions = 'contribution_actions',
+  ContributionActionLinks = 'contribution_action_links',
   LeaderboardPosition = 'leaderboard_position',
 }
 


### PR DESCRIPTION
## What

Builds the `link_pool` assist UI (the last of the three assist types). Powers the new "Mention daily.dev in a relevant Reddit discussion" action, whose pool of 1186 Reddit threads is already loaded in prod.

- New `useContributionActionLinks(actionId)` hook fetching the backend's randomized handful (`contributionActionLinks` query), with `shuffle` (refetch) for a fresh set.
- `LinkPoolPanel` in the submission modal: for `link_pool` actions it shows "Suggested threads" — each opens in a new tab — plus a Shuffle control. The proof form stays below (user submits their own comment link), unlike referral which replaces it.
- Loading spinner and an empty-state fallback; per-link and shuffle analytics.

## Tests

- Modal spec: suggested threads render + open, label-less link falls back to URL, proof flow still present, shuffle triggers refetch.
- 56 giveback tests pass; lint + strict-changed typecheck clean; full webapp tsc shows only pre-existing errors (none in touched files).

## Notes

- This completes all three assist types (external_link, referral_link, link_pool). Depends on merged #3951 (API) and #6269 (assistType plumbing).

### Preview domain
https://feat-giveback-link-pool.preview.app.daily.dev