### PR TITLE
feat(giveback): gift entry point with live activity + invite prompt

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="CommitMessageInspectionProfile">
-    <profile version="1.0">
-      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
-    </profile>
-  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
   </component>

--- a/packages/shared/src/components/layout/HeaderButtons.tsx
+++ b/packages/shared/src/components/layout/HeaderButtons.tsx
@@ -8,6 +8,7 @@ import classed from '../../lib/classed';
 import { useSettingsContext } from '../../contexts/SettingsContext';
 import { OpportunityEntryButton } from '../opportunity/OpportunityEntryButton';
 import { QuestHeaderButton } from '../header/QuestHeaderButton';
+import { GivebackGiftEntry } from '../../features/giveback/components/GivebackGiftEntry';
 
 interface HeaderButtonsProps {
   additionalButtons?: ReactNode;
@@ -42,6 +43,7 @@ export function HeaderButtons({
     <Container>
       <OpportunityEntryButton />
       <QuestHeaderButton />
+      <GivebackGiftEntry />
       {additionalButtons}
       <NotificationsBell />
       <ProfileButton className="hidden laptop:flex" />

--- a/packages/shared/src/components/sidebar/SidebarDesktopV2.tsx
+++ b/packages/shared/src/components/sidebar/SidebarDesktopV2.tsx
@@ -285,7 +285,7 @@ const SidebarInviteButton = (): ReactElement => {
 
   if (givebackEnabled) {
     return (
-      <GivebackGiftEntry variant="rail">
+      <GivebackGiftEntry variant="rail" isFeatureEnabled={givebackEnabled}>
         {railGiftLink('Giveback', `${webappUrl}giveback`)}
       </GivebackGiftEntry>
     );

--- a/packages/shared/src/components/sidebar/SidebarDesktopV2.tsx
+++ b/packages/shared/src/components/sidebar/SidebarDesktopV2.tsx
@@ -116,6 +116,9 @@ import { useCanPurchaseCores } from '../../hooks/useCoresFeature';
 import { useSquadNavigation } from '../../hooks';
 import { useAddBookmarkFolder } from '../../hooks/bookmark/useAddBookmarkFolder';
 import { useStreakRingState } from '../../hooks/streaks/useStreakRingState';
+import { useConditionalFeature } from '../../hooks/useConditionalFeature';
+import { featureGiveback } from '../../lib/featureManagement';
+import { GivebackGiftEntry } from '../../features/giveback/components/GivebackGiftEntry';
 import { FeedbackWidget } from '../feedback';
 import { HorizontalSeparator } from '../utilities';
 import { Typography, TypographyType } from '../typography/Typography';
@@ -258,17 +261,38 @@ const RailHoverCard = ({
   );
 };
 
-// Theme toggling now lives in the profile dropdown (ThemeSection, matching
-// production). The rail slot is reused for a quick "Invite friends" shortcut.
-const SidebarInviteButton = (): ReactElement => (
-  <Tooltip side="right" content="Invite friends">
-    <Link href={`${settingsUrl}/invite`} passHref>
-      <a aria-label="Invite friends" className={railButtonClass}>
+const railGiftLink = (label: string, href: string): ReactElement => (
+  <Tooltip side="right" content={label}>
+    <Link href={href} passHref>
+      <a aria-label={label} className={railButtonClass}>
         <GiftIcon size={IconSize.Small} aria-hidden />
       </a>
     </Link>
   </Tooltip>
 );
+
+// Theme toggling now lives in the profile dropdown (ThemeSection, matching
+// production). When the giveback experiment is on, the rail gift becomes the
+// giveback entry point — carrying the live money jumps + invite prompt via
+// GivebackGiftEntry — and otherwise falls back to the "Invite friends"
+// shortcut.
+const SidebarInviteButton = (): ReactElement => {
+  const { isAuthReady, isLoggedIn } = useAuthContext();
+  const { value: givebackEnabled } = useConditionalFeature({
+    feature: featureGiveback,
+    shouldEvaluate: isAuthReady && isLoggedIn,
+  });
+
+  if (givebackEnabled) {
+    return (
+      <GivebackGiftEntry variant="rail">
+        {railGiftLink('Giveback', `${webappUrl}giveback`)}
+      </GivebackGiftEntry>
+    );
+  }
+
+  return railGiftLink('Invite friends', `${settingsUrl}/invite`);
+};
 
 const supportItems: ProfileSectionItemProps[] = [
   {

--- a/packages/shared/src/features/giveback/components/GivebackConfettiBurst.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackConfettiBurst.tsx
@@ -20,7 +20,7 @@ interface ConfettiPiece {
   color: string;
 }
 
-// Fan the pieces mostly upward and outward, then let gravity pull them down —
+// Fan the pieces mostly upward and outward, then let gravity pull them down:
 // a quick celebratory pop rather than a full-screen confetti dump.
 const buildPieces = (count: number, spread: number): ConfettiPiece[] => {
   return Array.from({ length: count }, (_, index) => {

--- a/packages/shared/src/features/giveback/components/GivebackConfettiBurst.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackConfettiBurst.tsx
@@ -1,0 +1,116 @@
+import type { CSSProperties, ReactElement } from 'react';
+import React, { useEffect, useMemo } from 'react';
+
+// Money-forward palette: gold + green lead (cash/coins), brand accents fill in.
+const CONFETTI_COLORS = [
+  'var(--theme-accent-cheese-default)',
+  'var(--theme-accent-avocado-default)',
+  'var(--theme-accent-cabbage-default)',
+  'var(--theme-accent-bacon-default)',
+];
+
+interface ConfettiPiece {
+  id: string;
+  dx: number;
+  dy: number;
+  rotate: number;
+  delayMs: number;
+  durationMs: number;
+  color: string;
+}
+
+const prefersReducedMotion = (): boolean =>
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+// Fan the pieces mostly upward and outward, then let gravity pull them down —
+// a quick celebratory pop rather than a full-screen confetti dump.
+const buildPieces = (count: number, spread: number): ConfettiPiece[] => {
+  return Array.from({ length: count }, (_, index) => {
+    const angle = Math.PI + (Math.PI * (index + 0.5)) / count; // upper half
+    const distance = spread * (0.6 + Math.random() * 0.6);
+    const dx = Math.cos(angle) * distance;
+    const dy = Math.sin(angle) * distance + spread * (0.35 + Math.random());
+
+    return {
+      id: `giveback-confetti-${index.toString()}`,
+      dx,
+      dy,
+      rotate: (Math.random() - 0.5) * 540,
+      delayMs: Math.round(Math.random() * 90),
+      durationMs: 760 + Math.round(Math.random() * 320),
+      color: CONFETTI_COLORS[index % CONFETTI_COLORS.length],
+    };
+  });
+};
+
+export interface GivebackConfettiBurstProps {
+  // Bump to replay the burst (each new value spawns a fresh set of pieces).
+  trigger: number;
+  pieceCount?: number;
+  spread?: number;
+  onDone?: () => void;
+  className?: string;
+}
+
+export const GivebackConfettiBurst = ({
+  trigger,
+  pieceCount = 18,
+  spread = 88,
+  onDone,
+  className,
+}: GivebackConfettiBurstProps): ReactElement | null => {
+  const reduced = prefersReducedMotion();
+
+  const pieces = useMemo(
+    () => (reduced ? [] : buildPieces(pieceCount, spread)),
+    // trigger intentionally re-seeds the pieces on each replay.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [trigger, pieceCount, spread, reduced],
+  );
+
+  useEffect(() => {
+    if (!onDone) {
+      return undefined;
+    }
+    const longest = pieces.reduce(
+      (max, piece) => Math.max(max, piece.delayMs + piece.durationMs),
+      reduced ? 200 : 0,
+    );
+    const timer = window.setTimeout(onDone, longest + 80);
+    return () => window.clearTimeout(timer);
+  }, [pieces, onDone, reduced, trigger]);
+
+  if (!pieces.length) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-hidden
+      className={`pointer-events-none absolute inset-0 overflow-visible ${
+        className ?? ''
+      }`}
+    >
+      {pieces.map((piece) => (
+        <span
+          key={piece.id}
+          className="giveback-confetti-piece absolute left-1/2 top-1/2"
+          style={
+            {
+              color: piece.color,
+              animationDelay: `${piece.delayMs}ms`,
+              animationDuration: `${piece.durationMs}ms`,
+              '--giveback-confetti-x': `${piece.dx}px`,
+              '--giveback-confetti-y': `${piece.dy}px`,
+              '--giveback-confetti-r': `${piece.rotate}deg`,
+            } as CSSProperties
+          }
+        />
+      ))}
+    </div>
+  );
+};
+
+export default GivebackConfettiBurst;

--- a/packages/shared/src/features/giveback/components/GivebackConfettiBurst.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackConfettiBurst.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactElement } from 'react';
 import React, { useEffect, useMemo } from 'react';
+import { usePrefersReducedMotion } from '../useGivebackMotion';
 
 // Money-forward palette: gold + green lead (cash/coins), brand accents fill in.
 const CONFETTI_COLORS = [
@@ -18,11 +19,6 @@ interface ConfettiPiece {
   durationMs: number;
   color: string;
 }
-
-const prefersReducedMotion = (): boolean =>
-  typeof window !== 'undefined' &&
-  typeof window.matchMedia === 'function' &&
-  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 // Fan the pieces mostly upward and outward, then let gravity pull them down —
 // a quick celebratory pop rather than a full-screen confetti dump.
@@ -61,7 +57,7 @@ export const GivebackConfettiBurst = ({
   onDone,
   className,
 }: GivebackConfettiBurstProps): ReactElement | null => {
-  const reduced = prefersReducedMotion();
+  const reduced = usePrefersReducedMotion();
 
   const pieces = useMemo(
     () => (reduced ? [] : buildPieces(pieceCount, spread)),

--- a/packages/shared/src/features/giveback/components/GivebackGiftButton.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackGiftButton.tsx
@@ -23,7 +23,7 @@ export interface GivebackGiftButtonProps {
 
 const pressClass = 'transition-transform duration-150 ease-out active:scale-90';
 
-// The persistent giveback entry point. Calm at rest — a plain gift, no ambient
+// The persistent giveback entry point. Calm at rest: a plain gift, no ambient
 // progress meter and no notification badge. Ref-forwarding so the dock can
 // anchor money jumps and the milestone glow to the icon.
 export const GivebackGiftButton = forwardRef(function GivebackGiftButton(

--- a/packages/shared/src/features/giveback/components/GivebackGiftButton.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackGiftButton.tsx
@@ -1,0 +1,100 @@
+import type { ForwardedRef, ReactElement } from 'react';
+import React, { forwardRef } from 'react';
+import classNames from 'classnames';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../components/buttons/Button';
+import { GiftIcon } from '../../../components/icons';
+import { IconSize } from '../../../components/Icon';
+import { Tooltip } from '../../../components/tooltip/Tooltip';
+
+export type GivebackGiftButtonVariant = 'header' | 'rail';
+
+export interface GivebackGiftButtonProps {
+  variant?: GivebackGiftButtonVariant;
+  showLabel?: boolean;
+  label?: string;
+  tooltip?: string;
+  onClick?: () => void;
+  className?: string;
+}
+
+const pressClass = 'transition-transform duration-150 ease-out active:scale-90';
+
+// The persistent giveback entry point. Calm at rest — a plain gift, no ambient
+// progress meter and no notification badge. Ref-forwarding so the dock can
+// anchor money jumps and the milestone glow to the icon.
+export const GivebackGiftButton = forwardRef(function GivebackGiftButton(
+  {
+    variant = 'header',
+    showLabel = false,
+    label = 'Giveback',
+    tooltip = 'Giveback',
+    onClick,
+    className,
+  }: GivebackGiftButtonProps,
+  ref: ForwardedRef<HTMLButtonElement>,
+): ReactElement {
+  const isRail = variant === 'rail';
+
+  // Header: a square icon button that matches the notification bell exactly
+  // (Float, w-10, centered, no side padding) so it's not wider than its
+  // neighbours.
+  if (!isRail) {
+    return (
+      <Tooltip content={tooltip} side="bottom">
+        <Button
+          ref={ref}
+          type="button"
+          variant={ButtonVariant.Float}
+          aria-label={tooltip}
+          onClick={onClick}
+          icon={<GiftIcon />}
+          className={classNames(
+            'relative w-10 justify-center',
+            pressClass,
+            className,
+          )}
+        />
+      </Tooltip>
+    );
+  }
+
+  const railButton = (
+    <Button
+      ref={ref}
+      type="button"
+      variant={ButtonVariant.Tertiary}
+      size={ButtonSize.Small}
+      onClick={onClick}
+      aria-label={tooltip}
+      className={classNames(
+        'relative',
+        pressClass,
+        showLabel && '!justify-start gap-3',
+        className,
+      )}
+    >
+      <GiftIcon size={IconSize.Small} className="text-text-primary" />
+      {showLabel && (
+        <span className="font-bold text-text-primary typo-callout">
+          {label}
+        </span>
+      )}
+    </Button>
+  );
+
+  if (showLabel) {
+    return railButton;
+  }
+
+  return (
+    <Tooltip content={tooltip} side="right">
+      {railButton}
+    </Tooltip>
+  );
+});
+
+export default GivebackGiftButton;

--- a/packages/shared/src/features/giveback/components/GivebackGiftDock.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackGiftDock.tsx
@@ -144,9 +144,10 @@ export const GivebackGiftDock = forwardRef(function GivebackGiftDock(
         )}
         onMouseEnter={() => setGiftHovered(true)}
         onMouseLeave={() => setGiftHovered(false)}
-        // A custom anchor (rail link) navigates on its own; still dismiss the
-        // toast when it's clicked (capture phase — the link stays interactive).
-        onClickCapture={children ? () => setPrompt(null) : undefined}
+        // A custom anchor (rail link) navigates on its own via its href; on click
+        // (capture phase, so the link stays interactive) still run handleOpen to
+        // dismiss the toast and log the entry click, matching the header button.
+        onClickCapture={children ? handleOpen : undefined}
       >
         {/* Soft glow bloom on a celebratory community moment. */}
         {glowKey > 0 && (

--- a/packages/shared/src/features/giveback/components/GivebackGiftDock.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackGiftDock.tsx
@@ -1,0 +1,203 @@
+import type { ForwardedRef, ReactElement, ReactNode } from 'react';
+import React, {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+import classNames from 'classnames';
+import type { GivebackGiftButtonVariant } from './GivebackGiftButton';
+import { GivebackGiftButton } from './GivebackGiftButton';
+import { GivebackInvitePrompt } from './GivebackInvitePrompt';
+import type { GivebackInvitePromptData } from '../givebackInvitePrompts';
+
+// Imperative API the header/rail wiring drives. This surface is an acquisition
+// hook — everything here is generic + community-framed to pull people into
+// /giveback, never a personal reward notice.
+export interface GivebackGiftDockHandle {
+  // Ambient community money landing in the pot (social proof), e.g. "+$8".
+  // This bare dollar jump on the gift is the engagement/attention mechanism.
+  pulseActivity: (label: string) => void;
+  // The full invite bubble (rotating messages).
+  showPrompt: (prompt: GivebackInvitePromptData) => void;
+  reset: () => void;
+}
+
+interface ValuePop {
+  id: string;
+  label: string;
+  // Horizontal nudge (px) off the gift centre so it reads beside the icon and
+  // rapid pops don't stack exactly on top of each other.
+  dx: number;
+}
+
+interface GivebackGiftDockProps {
+  variant?: GivebackGiftButtonVariant;
+  showLabel?: boolean;
+  onOpenGiveback?: () => void;
+  // Override where the invite prompt opens (defaults follow the variant).
+  promptPlacement?: 'below' | 'above';
+  promptAlign?: 'start' | 'end';
+  // Custom anchor (e.g. the sidebar's own styled gift link). When provided it
+  // replaces the built-in gift button; the money/prompt overlays anchor to it.
+  children?: ReactNode;
+}
+
+const GIFT_POP_MS = 380;
+const VALUE_POP_LIFETIME_MS = 2000;
+const MILESTONE_TOAST_DELAY_MS = 180;
+
+let popCounter = 0;
+
+export const GivebackGiftDock = forwardRef(function GivebackGiftDock(
+  {
+    variant = 'header',
+    showLabel = false,
+    onOpenGiveback,
+    promptPlacement,
+    promptAlign,
+    children,
+  }: GivebackGiftDockProps,
+  ref: ForwardedRef<GivebackGiftDockHandle>,
+): ReactElement {
+  const isRail = variant === 'rail';
+  const [pops, setPops] = useState<ValuePop[]>([]);
+  const [popping, setPopping] = useState(false);
+  const [glowKey, setGlowKey] = useState(0);
+  const [giftHovered, setGiftHovered] = useState(false);
+  const [prompt, setPrompt] = useState<GivebackInvitePromptData | null>(null);
+  // Bumps per show so a replacing prompt remounts (fresh timer + confetti).
+  const [promptSeq, setPromptSeq] = useState(0);
+  const timers = useRef<number[]>([]);
+
+  const track = useCallback((id: number) => {
+    timers.current.push(id);
+  }, []);
+
+  const popGift = useCallback(() => {
+    setPopping(false);
+    window.requestAnimationFrame(() => setPopping(true));
+    track(window.setTimeout(() => setPopping(false), GIFT_POP_MS + 40));
+  }, [track]);
+
+  const pulseActivity = useCallback(
+    (label: string) => {
+      popCounter += 1;
+      const id = `giveback-pop-${popCounter.toString()}`;
+      // Bias to the right of the icon with a little spread.
+      const dx = Math.round(Math.random() * 18) + 6;
+      setPops((current) => [...current, { id, label, dx }]);
+      popGift();
+      track(
+        window.setTimeout(() => {
+          setPops((current) => current.filter((pop) => pop.id !== id));
+        }, VALUE_POP_LIFETIME_MS),
+      );
+    },
+    [popGift, track],
+  );
+
+  const showPrompt = useCallback(
+    (next: GivebackInvitePromptData) => {
+      if (next.celebrate) {
+        setGlowKey((current) => current + 1);
+      }
+      popGift();
+      track(
+        window.setTimeout(() => {
+          setPromptSeq((current) => current + 1);
+          setPrompt(next);
+        }, MILESTONE_TOAST_DELAY_MS),
+      );
+    },
+    [popGift, track],
+  );
+
+  const reset = useCallback(() => {
+    timers.current.forEach((id) => window.clearTimeout(id));
+    timers.current = [];
+    setPops([]);
+    setPopping(false);
+    setPrompt(null);
+  }, []);
+
+  useImperativeHandle(ref, () => ({ pulseActivity, showPrompt, reset }), [
+    pulseActivity,
+    showPrompt,
+    reset,
+  ]);
+
+  // Opening giveback (clicking the gift or the toast CTA) navigates to the page,
+  // so dismiss the prompt — the user is already there, no need to keep nagging.
+  const handleOpen = useCallback(() => {
+    setPrompt(null);
+    onOpenGiveback?.();
+  }, [onOpenGiveback]);
+
+  return (
+    <div className="relative inline-flex">
+      <span
+        className={classNames(
+          'relative inline-flex',
+          popping && 'giveback-gift-pop',
+        )}
+        onMouseEnter={() => setGiftHovered(true)}
+        onMouseLeave={() => setGiftHovered(false)}
+        // A custom anchor (rail link) navigates on its own; still dismiss the
+        // toast when it's clicked (capture phase — the link stays interactive).
+        onClickCapture={children ? () => setPrompt(null) : undefined}
+      >
+        {/* Soft glow bloom on a celebratory community moment. */}
+        {glowKey > 0 && (
+          <span
+            key={glowKey}
+            aria-hidden
+            className="giveback-glow-bloom bg-accent-cabbage-default/50 pointer-events-none absolute left-1/2 top-1/2 size-16 rounded-full blur-lg"
+          />
+        )}
+        {children ?? (
+          <GivebackGiftButton
+            variant={variant}
+            showLabel={showLabel}
+            onClick={handleOpen}
+          />
+        )}
+      </span>
+
+      {/* Community money landing in the pot — bare green numerals that pop in
+         beside the gift and drift up (Polymarket-style real-time jump). Offset
+         to the right of the icon per-pop so they stay legible, not on the
+         glyph. */}
+      <div className="pointer-events-none absolute inset-0">
+        {pops.map((pop) => (
+          <span
+            key={pop.id}
+            style={{ left: `calc(50% + ${pop.dx}px)` }}
+            className="giveback-value-rise absolute top-1 whitespace-nowrap font-bold tabular-nums text-status-success typo-callout [text-shadow:0_1px_3px_var(--theme-background-default)]"
+          >
+            {pop.label}
+          </span>
+        ))}
+      </div>
+
+      <GivebackInvitePrompt
+        key={promptSeq}
+        open={Boolean(prompt)}
+        eyebrow={prompt?.eyebrow}
+        headline={prompt?.headline}
+        body={prompt?.body}
+        ctaLabel={prompt?.ctaLabel}
+        celebrate={prompt?.celebrate}
+        dropdown={isRail}
+        paused={giftHovered}
+        placement={promptPlacement ?? (isRail ? 'above' : 'below')}
+        align={promptAlign ?? (isRail ? 'start' : 'end')}
+        onClick={handleOpen}
+        onClose={() => setPrompt(null)}
+      />
+    </div>
+  );
+});
+
+export default GivebackGiftDock;

--- a/packages/shared/src/features/giveback/components/GivebackGiftDock.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackGiftDock.tsx
@@ -2,6 +2,7 @@ import type { ForwardedRef, ReactElement, ReactNode } from 'react';
 import React, {
   forwardRef,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useRef,
   useState,
@@ -13,7 +14,7 @@ import { GivebackInvitePrompt } from './GivebackInvitePrompt';
 import type { GivebackInvitePromptData } from '../givebackInvitePrompts';
 
 // Imperative API the header/rail wiring drives. This surface is an acquisition
-// hook — everything here is generic + community-framed to pull people into
+// hook: everything here is generic + community-framed to pull people into
 // /giveback, never a personal reward notice.
 export interface GivebackGiftDockHandle {
   // Ambient community money landing in the pot (social proof), e.g. "+$8".
@@ -47,6 +48,9 @@ interface GivebackGiftDockProps {
 const GIFT_POP_MS = 380;
 const VALUE_POP_LIFETIME_MS = 2000;
 const MILESTONE_TOAST_DELAY_MS = 180;
+// Hard cap on concurrent money numerals so a burst of community events can never
+// stack dozens of overlapping labels beside the gift.
+const MAX_CONCURRENT_POPS = 4;
 
 let popCounter = 0;
 
@@ -71,15 +75,32 @@ export const GivebackGiftDock = forwardRef(function GivebackGiftDock(
   const [promptSeq, setPromptSeq] = useState(0);
   const timers = useRef<number[]>([]);
 
-  const track = useCallback((id: number) => {
-    timers.current.push(id);
+  const clearTimers = useCallback(() => {
+    timers.current.forEach((id) => window.clearTimeout(id));
+    timers.current = [];
   }, []);
+
+  // Track pending timeouts so they can be cleared on unmount, and self-prune
+  // each id once it fires so the list can't grow without bound over a long,
+  // event-heavy session.
+  const setTrackedTimeout = useCallback((callback: () => void, ms: number) => {
+    const id = window.setTimeout(() => {
+      timers.current = timers.current.filter((timerId) => timerId !== id);
+      callback();
+    }, ms);
+    timers.current.push(id);
+    return id;
+  }, []);
+
+  // Clear any pending timeouts when the dock unmounts so they never fire on an
+  // unmounted component (production never calls reset()).
+  useEffect(() => clearTimers, [clearTimers]);
 
   const popGift = useCallback(() => {
     setPopping(false);
     window.requestAnimationFrame(() => setPopping(true));
-    track(window.setTimeout(() => setPopping(false), GIFT_POP_MS + 40));
-  }, [track]);
+    setTrackedTimeout(() => setPopping(false), GIFT_POP_MS + 40);
+  }, [setTrackedTimeout]);
 
   const pulseActivity = useCallback(
     (label: string) => {
@@ -87,15 +108,15 @@ export const GivebackGiftDock = forwardRef(function GivebackGiftDock(
       const id = `giveback-pop-${popCounter.toString()}`;
       // Bias to the right of the icon with a little spread.
       const dx = Math.round(Math.random() * 18) + 6;
-      setPops((current) => [...current, { id, label, dx }]);
-      popGift();
-      track(
-        window.setTimeout(() => {
-          setPops((current) => current.filter((pop) => pop.id !== id));
-        }, VALUE_POP_LIFETIME_MS),
+      setPops((current) =>
+        [...current, { id, label, dx }].slice(-MAX_CONCURRENT_POPS),
       );
+      popGift();
+      setTrackedTimeout(() => {
+        setPops((current) => current.filter((pop) => pop.id !== id));
+      }, VALUE_POP_LIFETIME_MS);
     },
-    [popGift, track],
+    [popGift, setTrackedTimeout],
   );
 
   const showPrompt = useCallback(
@@ -104,23 +125,20 @@ export const GivebackGiftDock = forwardRef(function GivebackGiftDock(
         setGlowKey((current) => current + 1);
       }
       popGift();
-      track(
-        window.setTimeout(() => {
-          setPromptSeq((current) => current + 1);
-          setPrompt(next);
-        }, MILESTONE_TOAST_DELAY_MS),
-      );
+      setTrackedTimeout(() => {
+        setPromptSeq((current) => current + 1);
+        setPrompt(next);
+      }, MILESTONE_TOAST_DELAY_MS);
     },
-    [popGift, track],
+    [popGift, setTrackedTimeout],
   );
 
   const reset = useCallback(() => {
-    timers.current.forEach((id) => window.clearTimeout(id));
-    timers.current = [];
+    clearTimers();
     setPops([]);
     setPopping(false);
     setPrompt(null);
-  }, []);
+  }, [clearTimers]);
 
   useImperativeHandle(ref, () => ({ pulseActivity, showPrompt, reset }), [
     pulseActivity,
@@ -129,7 +147,7 @@ export const GivebackGiftDock = forwardRef(function GivebackGiftDock(
   ]);
 
   // Opening giveback (clicking the gift or the toast CTA) navigates to the page,
-  // so dismiss the prompt — the user is already there, no need to keep nagging.
+  // so dismiss the prompt since the user is already there, no need to keep nagging.
   const handleOpen = useCallback(() => {
     setPrompt(null);
     onOpenGiveback?.();
@@ -166,7 +184,7 @@ export const GivebackGiftDock = forwardRef(function GivebackGiftDock(
         )}
       </span>
 
-      {/* Community money landing in the pot — bare green numerals that pop in
+      {/* Community money landing in the pot: bare green numerals that pop in
          beside the gift and drift up (Polymarket-style real-time jump). Offset
          to the right of the icon per-pop so they stay legible, not on the
          glyph. */}

--- a/packages/shared/src/features/giveback/components/GivebackGiftEntry.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackGiftEntry.tsx
@@ -1,10 +1,10 @@
 import type { ReactElement, ReactNode } from 'react';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import type { GivebackGiftButtonVariant } from './GivebackGiftButton';
 import type { GivebackGiftDockHandle } from './GivebackGiftDock';
 import { GivebackGiftDock } from './GivebackGiftDock';
-import { givebackInvitePrompts } from '../givebackInvitePrompts';
+import { GivebackLiveActivityListener } from './GivebackLiveActivityListener';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { useLogContext } from '../../../contexts/LogContext';
 import { useViewSize, ViewSize } from '../../../hooks/useViewSize';
@@ -18,91 +18,80 @@ interface GivebackGiftEntryProps {
   showLabel?: boolean;
   promptPlacement?: 'below' | 'above';
   promptAlign?: 'start' | 'end';
+  // When the parent already evaluated `featureGiveback` (e.g. the rail, which
+  // branches on it), pass the value so we don't evaluate the flag a second time.
+  isFeatureEnabled?: boolean;
   // Custom anchor (e.g. the sidebar's own styled gift link).
   children?: ReactNode;
 }
 
-// Rotate a different opening message on each load.
-let promptCursor = 0;
-// Only one mounted entry runs the ambient cadence, so header + rail can't both
-// fire (whichever mounts first claims it).
-let cadenceClaimed = false;
+// The header and rail both mount an entry, but the live activity (money pops and
+// the milestone popover) should play on a single gift. We elect one owner across
+// all mounted entries and re-elect on mount/unmount, so ownership hands off
+// cleanly when the current owner disappears (a surviving sibling takes over).
+let liveOwners: string[] = [];
+const ownerListeners = new Set<() => void>();
+const notifyOwnerListeners = (): void => {
+  ownerListeners.forEach((listener) => listener());
+};
 
-// PLACEHOLDER CADENCE — the money pulses and the invite prompt are currently
-// driven on a local timer as a stand-in. Before this graduates past the
-// experiment, replace this timer with live backend community-activity signals
-// (real amounts landing in the pot) and drop the hardcoded figures in
-// `givebackInvitePrompts`. This whole surface is gated behind `featureGiveback`,
-// so it stays off in production until the experiment is turned on per cohort.
-const FIRST_PULSE_MS = 3500;
-const PULSE_INTERVAL_MS = 22000;
-const PROMPT_MS = 6000;
-const PULSE_AMOUNTS = [1, 2, 3, 5, 8];
-
-const randomPulse = (): string =>
-  `+$${PULSE_AMOUNTS[Math.floor(Math.random() * PULSE_AMOUNTS.length)]}`;
+// The live activity only plays for established accounts (older than a week).
+// Brand-new users get the calm gift without the attention-grabbing motion.
+const LIVE_ACTIVITY_MIN_ACCOUNT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 // The persistent giveback entry point. Gated on the same `featureGiveback` flag
-// as the page, so it shows wherever giveback is enabled. It drives its dock from
-// the ambient cadence, so the money jumps and invite prompts play on the real
-// gift (header or sidebar).
+// as the page, so it shows wherever giveback is enabled. The owning instance
+// drives its dock from remote community activity: real approved actions pop a
+// live "+$" jump and crossing a global milestone fires the celebratory popover.
 export function GivebackGiftEntry({
   variant = 'header',
   showLabel = false,
   promptPlacement,
   promptAlign,
+  isFeatureEnabled,
   children,
 }: GivebackGiftEntryProps): ReactElement | null {
   const router = useRouter();
-  const { isLoggedIn, isAuthReady } = useAuthContext();
+  const { user, isLoggedIn, isAuthReady } = useAuthContext();
   const { logEvent } = useLogContext();
   const dock = useRef<GivebackGiftDockHandle>(null);
 
-  // Desktop-only for now — the mobile placement is parked for a later PR, so
-  // the entry never shows on smaller viewports (header/rail are desktop anyway).
+  // Desktop-only for now. The mobile placement is parked for a later PR, so the
+  // entry never shows on smaller viewports (header/rail are desktop anyway).
   const isLaptop = useViewSize(ViewSize.Laptop);
-  const shouldEvaluate = isAuthReady && isLoggedIn && isLaptop;
-  const { value: isEnabled } = useConditionalFeature({
+  const baseGate = isAuthReady && isLoggedIn && isLaptop;
+  const hasExternalFlag = isFeatureEnabled !== undefined;
+  const { value: selfEnabled } = useConditionalFeature({
     feature: featureGiveback,
-    shouldEvaluate,
+    shouldEvaluate: baseGate && !hasExternalFlag,
   });
-  const show = shouldEvaluate && isEnabled;
+  const isEnabled = hasExternalFlag ? isFeatureEnabled : selfEnabled;
+  const show = baseGate && isEnabled;
 
-  // Ambient cadence (claimed by a single instance). See PLACEHOLDER note above.
+  const isEstablishedUser = user?.createdAt
+    ? Date.now() - new Date(user.createdAt).getTime() >
+      LIVE_ACTIVITY_MIN_ACCOUNT_AGE_MS
+    : false;
+  const canRunLiveActivity = show && isEstablishedUser;
+
+  // Elect a single owner for the live activity (see note above).
+  const instanceId = useId();
+  const [isLiveOwner, setIsLiveOwner] = useState(false);
   useEffect(() => {
-    if (!show || cadenceClaimed) {
+    if (!canRunLiveActivity) {
       return undefined;
     }
-    cadenceClaimed = true;
-
-    const timeouts: number[] = [];
-    timeouts.push(
-      window.setTimeout(() => {
-        dock.current?.pulseActivity(randomPulse());
-      }, FIRST_PULSE_MS),
-    );
-    timeouts.push(
-      window.setTimeout(() => {
-        const prompt =
-          givebackInvitePrompts[promptCursor % givebackInvitePrompts.length];
-        promptCursor += 1;
-        dock.current?.showPrompt(prompt);
-        logEvent({
-          event_name: LogEvent.ViewGivebackPrompt,
-          extra: JSON.stringify({ prompt: prompt.id }),
-        });
-      }, PROMPT_MS),
-    );
-    const pulse = window.setInterval(() => {
-      dock.current?.pulseActivity(randomPulse());
-    }, PULSE_INTERVAL_MS);
-
+    liveOwners.push(instanceId);
+    const sync = () => setIsLiveOwner(liveOwners[0] === instanceId);
+    ownerListeners.add(sync);
+    notifyOwnerListeners();
     return () => {
-      timeouts.forEach((id) => window.clearTimeout(id));
-      window.clearInterval(pulse);
-      cadenceClaimed = false;
+      ownerListeners.delete(sync);
+      liveOwners = liveOwners.filter((id) => id !== instanceId);
+      setIsLiveOwner(false);
+      notifyOwnerListeners();
     };
-  }, [show, logEvent]);
+  }, [canRunLiveActivity, instanceId]);
 
   if (!show) {
     return null;
@@ -111,23 +100,26 @@ export function GivebackGiftEntry({
   const openGiveback = () => {
     logEvent({ event_name: LogEvent.ClickGivebackGiftEntry });
     // The rail passes its own anchor (with an href) as children, so it navigates
-    // itself — only the built-in header button needs an explicit push here.
+    // itself. Only the built-in header button needs an explicit push here.
     if (!children) {
       router.push(`${webappUrl}giveback`);
     }
   };
 
   return (
-    <GivebackGiftDock
-      ref={dock}
-      variant={variant}
-      showLabel={showLabel}
-      onOpenGiveback={openGiveback}
-      promptPlacement={promptPlacement}
-      promptAlign={promptAlign}
-    >
-      {children}
-    </GivebackGiftDock>
+    <>
+      <GivebackGiftDock
+        ref={dock}
+        variant={variant}
+        showLabel={showLabel}
+        onOpenGiveback={openGiveback}
+        promptPlacement={promptPlacement}
+        promptAlign={promptAlign}
+      >
+        {children}
+      </GivebackGiftDock>
+      {isLiveOwner && <GivebackLiveActivityListener dock={dock} />}
+    </>
   );
 }
 

--- a/packages/shared/src/features/giveback/components/GivebackGiftEntry.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackGiftEntry.tsx
@@ -110,7 +110,11 @@ export function GivebackGiftEntry({
 
   const openGiveback = () => {
     logEvent({ event_name: LogEvent.ClickGivebackGiftEntry });
-    router.push(`${webappUrl}giveback`);
+    // The rail passes its own anchor (with an href) as children, so it navigates
+    // itself — only the built-in header button needs an explicit push here.
+    if (!children) {
+      router.push(`${webappUrl}giveback`);
+    }
   };
 
   return (

--- a/packages/shared/src/features/giveback/components/GivebackGiftEntry.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackGiftEntry.tsx
@@ -1,0 +1,130 @@
+import type { ReactElement, ReactNode } from 'react';
+import React, { useEffect, useRef } from 'react';
+import { useRouter } from 'next/router';
+import type { GivebackGiftButtonVariant } from './GivebackGiftButton';
+import type { GivebackGiftDockHandle } from './GivebackGiftDock';
+import { GivebackGiftDock } from './GivebackGiftDock';
+import { givebackInvitePrompts } from '../givebackInvitePrompts';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { useLogContext } from '../../../contexts/LogContext';
+import { useViewSize, ViewSize } from '../../../hooks/useViewSize';
+import { useConditionalFeature } from '../../../hooks/useConditionalFeature';
+import { featureGiveback } from '../../../lib/featureManagement';
+import { webappUrl } from '../../../lib/constants';
+import { LogEvent } from '../../../lib/log';
+
+interface GivebackGiftEntryProps {
+  variant?: GivebackGiftButtonVariant;
+  showLabel?: boolean;
+  promptPlacement?: 'below' | 'above';
+  promptAlign?: 'start' | 'end';
+  // Custom anchor (e.g. the sidebar's own styled gift link).
+  children?: ReactNode;
+}
+
+// Rotate a different opening message on each load.
+let promptCursor = 0;
+// Only one mounted entry runs the ambient cadence, so header + rail can't both
+// fire (whichever mounts first claims it).
+let cadenceClaimed = false;
+
+// PLACEHOLDER CADENCE — the money pulses and the invite prompt are currently
+// driven on a local timer as a stand-in. Before this graduates past the
+// experiment, replace this timer with live backend community-activity signals
+// (real amounts landing in the pot) and drop the hardcoded figures in
+// `givebackInvitePrompts`. This whole surface is gated behind `featureGiveback`,
+// so it stays off in production until the experiment is turned on per cohort.
+const FIRST_PULSE_MS = 3500;
+const PULSE_INTERVAL_MS = 22000;
+const PROMPT_MS = 6000;
+const PULSE_AMOUNTS = [1, 2, 3, 5, 8];
+
+const randomPulse = (): string =>
+  `+$${PULSE_AMOUNTS[Math.floor(Math.random() * PULSE_AMOUNTS.length)]}`;
+
+// The persistent giveback entry point. Gated on the same `featureGiveback` flag
+// as the page, so it shows wherever giveback is enabled. It drives its dock from
+// the ambient cadence, so the money jumps and invite prompts play on the real
+// gift (header or sidebar).
+export function GivebackGiftEntry({
+  variant = 'header',
+  showLabel = false,
+  promptPlacement,
+  promptAlign,
+  children,
+}: GivebackGiftEntryProps): ReactElement | null {
+  const router = useRouter();
+  const { isLoggedIn, isAuthReady } = useAuthContext();
+  const { logEvent } = useLogContext();
+  const dock = useRef<GivebackGiftDockHandle>(null);
+
+  // Desktop-only for now — the mobile placement is parked for a later PR, so
+  // the entry never shows on smaller viewports (header/rail are desktop anyway).
+  const isLaptop = useViewSize(ViewSize.Laptop);
+  const shouldEvaluate = isAuthReady && isLoggedIn && isLaptop;
+  const { value: isEnabled } = useConditionalFeature({
+    feature: featureGiveback,
+    shouldEvaluate,
+  });
+  const show = shouldEvaluate && isEnabled;
+
+  // Ambient cadence (claimed by a single instance). See PLACEHOLDER note above.
+  useEffect(() => {
+    if (!show || cadenceClaimed) {
+      return undefined;
+    }
+    cadenceClaimed = true;
+
+    const timeouts: number[] = [];
+    timeouts.push(
+      window.setTimeout(() => {
+        dock.current?.pulseActivity(randomPulse());
+      }, FIRST_PULSE_MS),
+    );
+    timeouts.push(
+      window.setTimeout(() => {
+        const prompt =
+          givebackInvitePrompts[promptCursor % givebackInvitePrompts.length];
+        promptCursor += 1;
+        dock.current?.showPrompt(prompt);
+        logEvent({
+          event_name: LogEvent.ViewGivebackPrompt,
+          extra: JSON.stringify({ prompt: prompt.id }),
+        });
+      }, PROMPT_MS),
+    );
+    const pulse = window.setInterval(() => {
+      dock.current?.pulseActivity(randomPulse());
+    }, PULSE_INTERVAL_MS);
+
+    return () => {
+      timeouts.forEach((id) => window.clearTimeout(id));
+      window.clearInterval(pulse);
+      cadenceClaimed = false;
+    };
+  }, [show, logEvent]);
+
+  if (!show) {
+    return null;
+  }
+
+  const openGiveback = () => {
+    logEvent({ event_name: LogEvent.ClickGivebackGiftEntry });
+    router.push(`${webappUrl}giveback`);
+  };
+
+  return (
+    <GivebackGiftDock
+      ref={dock}
+      variant={variant}
+      showLabel={showLabel}
+      onOpenGiveback={openGiveback}
+      promptPlacement={promptPlacement}
+      promptAlign={promptAlign}
+    >
+      {children}
+    </GivebackGiftDock>
+  );
+}
+
+export default GivebackGiftEntry;

--- a/packages/shared/src/features/giveback/components/GivebackGiftEntry.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackGiftEntry.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement, ReactNode } from 'react';
-import React, { useEffect, useId, useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import { useRouter } from 'next/router';
 import type { GivebackGiftButtonVariant } from './GivebackGiftButton';
 import type { GivebackGiftDockHandle } from './GivebackGiftDock';
@@ -25,24 +25,16 @@ interface GivebackGiftEntryProps {
   children?: ReactNode;
 }
 
-// The header and rail both mount an entry, but the live activity (money pops and
-// the milestone popover) should play on a single gift. We elect one owner across
-// all mounted entries and re-elect on mount/unmount, so ownership hands off
-// cleanly when the current owner disappears (a surviving sibling takes over).
-let liveOwners: string[] = [];
-const ownerListeners = new Set<() => void>();
-const notifyOwnerListeners = (): void => {
-  ownerListeners.forEach((listener) => listener());
-};
-
 // The live activity only plays for established accounts (older than a week).
 // Brand-new users get the calm gift without the attention-grabbing motion.
 const LIVE_ACTIVITY_MIN_ACCOUNT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 // The persistent giveback entry point. Gated on the same `featureGiveback` flag
-// as the page, so it shows wherever giveback is enabled. The owning instance
-// drives its dock from remote community activity: real approved actions pop a
-// live "+$" jump and crossing a global milestone fires the celebratory popover.
+// as the page, so it shows wherever giveback is enabled. It drives its dock from
+// remote community activity: real approved actions pop a live "+$" jump and
+// crossing a global milestone fires the celebratory popover. The header and the
+// sidebar-v2 rail are mutually exclusive layouts, so only one entry is ever
+// mounted and no cross-instance coordination is needed.
 export function GivebackGiftEntry({
   variant = 'header',
   showLabel = false,
@@ -74,25 +66,6 @@ export function GivebackGiftEntry({
     : false;
   const canRunLiveActivity = show && isEstablishedUser;
 
-  // Elect a single owner for the live activity (see note above).
-  const instanceId = useId();
-  const [isLiveOwner, setIsLiveOwner] = useState(false);
-  useEffect(() => {
-    if (!canRunLiveActivity) {
-      return undefined;
-    }
-    liveOwners.push(instanceId);
-    const sync = () => setIsLiveOwner(liveOwners[0] === instanceId);
-    ownerListeners.add(sync);
-    notifyOwnerListeners();
-    return () => {
-      ownerListeners.delete(sync);
-      liveOwners = liveOwners.filter((id) => id !== instanceId);
-      setIsLiveOwner(false);
-      notifyOwnerListeners();
-    };
-  }, [canRunLiveActivity, instanceId]);
-
   if (!show) {
     return null;
   }
@@ -118,7 +91,7 @@ export function GivebackGiftEntry({
       >
         {children}
       </GivebackGiftDock>
-      {isLiveOwner && <GivebackLiveActivityListener dock={dock} />}
+      {canRunLiveActivity && <GivebackLiveActivityListener dock={dock} />}
     </>
   );
 }

--- a/packages/shared/src/features/giveback/components/GivebackInvitePrompt.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackInvitePrompt.tsx
@@ -19,11 +19,11 @@ export interface GivebackInvitePromptProps {
   headline?: string;
   body?: string;
   ctaLabel?: string;
-  // Festive community moment — confetti bursts from the gift.
+  // Festive community moment. Confetti bursts from the gift.
   celebrate?: boolean;
   // Opens above the gift (rail, bottom-left) instead of below it (header).
   placement?: 'below' | 'above';
-  // Horizontal edge the tail points to — matches where the gift sits.
+  // Horizontal edge the tail points to, matching where the gift sits.
   align?: 'start' | 'end';
   // Open like a rail dropdown: portaled + fixed at the same left margin as the
   // support/settings/profile menus, instead of anchored to the gift with a tail.
@@ -37,7 +37,7 @@ export interface GivebackInvitePromptProps {
 }
 
 // A playful, community-framed invitation fronted by the daily.dev mascot. It's
-// an acquisition hook, not a personal reward notice — it leads with social
+// an acquisition hook, not a personal reward notice. It leads with social
 // proof + the honest trade and always ends in a clear way into /giveback. The
 // close button carries the auto-dismiss countdown ring (drains as it nears
 // exit), so there's no bulky progress bar.
@@ -74,7 +74,7 @@ export const GivebackInvitePrompt = ({
       onAnimationEnd: handleEnd,
     });
 
-  // Arm the countdown when the prompt opens (once — not on every render).
+  // Arm the countdown when the prompt opens (once, not on every render).
   useEffect(() => {
     if (!open) {
       return undefined;
@@ -219,7 +219,7 @@ export const GivebackInvitePrompt = ({
           <img
             src={cloudinaryCharmGiveback}
             alt="daily.dev Giveback charm"
-            className="mascot-bob relative h-full w-full object-contain mix-blend-screen"
+            className="relative h-full w-full animate-mascot-bob object-contain mix-blend-screen"
           />
         </div>
       </div>

--- a/packages/shared/src/features/giveback/components/GivebackInvitePrompt.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackInvitePrompt.tsx
@@ -1,0 +1,232 @@
+import type { ReactElement } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import classNames from 'classnames';
+import { useTimedAnimation } from '../../../hooks/useTimedAnimation';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../components/buttons/Button';
+import { MiniCloseIcon } from '../../../components/icons';
+import { IconSize } from '../../../components/Icon';
+import { RootPortal } from '../../../components/tooltips/Portal';
+import { cloudinaryCharmGiveback } from '../../../lib/image';
+import { GivebackConfettiBurst } from './GivebackConfettiBurst';
+
+export interface GivebackInvitePromptProps {
+  open: boolean;
+  eyebrow?: string;
+  headline?: string;
+  body?: string;
+  ctaLabel?: string;
+  // Festive community moment — confetti bursts from the gift.
+  celebrate?: boolean;
+  // Opens above the gift (rail, bottom-left) instead of below it (header).
+  placement?: 'below' | 'above';
+  // Horizontal edge the tail points to — matches where the gift sits.
+  align?: 'start' | 'end';
+  // Open like a rail dropdown: portaled + fixed at the same left margin as the
+  // support/settings/profile menus, instead of anchored to the gift with a tail.
+  dropdown?: boolean;
+  autoDismissMs?: number;
+  // Externally pause the auto-dismiss (e.g. while the cursor is over the gift).
+  paused?: boolean;
+  onClick?: () => void;
+  onClose?: () => void;
+  className?: string;
+}
+
+// A playful, community-framed invitation fronted by the daily.dev mascot. It's
+// an acquisition hook, not a personal reward notice — it leads with social
+// proof + the honest trade and always ends in a clear way into /giveback. The
+// close button carries the auto-dismiss countdown ring (drains as it nears
+// exit), so there's no bulky progress bar.
+export const GivebackInvitePrompt = ({
+  open,
+  eyebrow = 'Raised together',
+  headline = 'The community is funding real-world causes',
+  body = 'All from everyday daily.dev activity. Pick the causes you care about.',
+  ctaLabel = 'Join in',
+  celebrate = false,
+  placement = 'below',
+  align = 'end',
+  dropdown = false,
+  autoDismissMs = 5000,
+  paused = false,
+  onClick,
+  onClose,
+  className,
+}: GivebackInvitePromptProps): ReactElement | null => {
+  // Bumps every time the prompt opens, so the confetti restarts even when one
+  // prompt replaces another.
+  const [runId, setRunId] = useState(0);
+  const [hovered, setHovered] = useState(false);
+
+  // Keep onClose fresh without re-arming the timer every render.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const handleEnd = useCallback(() => onCloseRef.current?.(), []);
+
+  const { timer, startAnimation, pauseAnimation, resumeAnimation } =
+    useTimedAnimation({
+      autoEndAnimation: true,
+      outAnimationDuration: 150,
+      onAnimationEnd: handleEnd,
+    });
+
+  // Arm the countdown when the prompt opens (once — not on every render).
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+    setRunId((current) => current + 1);
+    startAnimation(autoDismissMs);
+    return () => pauseAnimation();
+  }, [open, autoDismissMs, startAnimation, pauseAnimation]);
+
+  // Pause the countdown while the pointer rests on the gift or the toast, and
+  // resume from where it left off (never restart) when it leaves.
+  const isPaused = paused || hovered;
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    if (isPaused) {
+      pauseAnimation();
+    } else {
+      resumeAnimation();
+    }
+  }, [isPaused, open, pauseAnimation, resumeAnimation]);
+
+  if (!open) {
+    return null;
+  }
+
+  const isAbove = placement === 'above';
+  // Countdown ring: drains 0 -> 100 as the remaining time elapses, and freezes
+  // while paused (the timer stops ticking).
+  const remaining = autoDismissMs > 0 ? (timer / autoDismissMs) * 100 : 0;
+  const dashoffset = Math.min(100, Math.max(0, 100 - remaining));
+  const giftSide = align === 'end' ? 'right-6' : 'left-6';
+
+  const content = (
+    <div
+      className={classNames(
+        'w-[25rem]',
+        dropdown
+          ? 'fixed bottom-3 left-20 z-popup ml-2 max-w-[calc(100vw-6rem)]'
+          : classNames(
+              'absolute z-3 max-w-[calc(100vw-2rem)]',
+              isAbove ? 'bottom-full mb-3' : 'top-full mt-3',
+              align === 'end' ? 'right-0' : 'left-0',
+            ),
+        className,
+      )}
+      role="status"
+    >
+      {celebrate && (
+        <div
+          className={classNames(
+            'pointer-events-none absolute',
+            dropdown
+              ? 'inset-x-0 top-0'
+              : [isAbove ? 'bottom-0' : 'top-0', giftSide],
+          )}
+        >
+          <GivebackConfettiBurst trigger={runId} />
+        </div>
+      )}
+
+      {/* Tail pointing to the gift (anchored mode only). */}
+      {!dropdown && (
+        <div
+          className={classNames(
+            'absolute size-3 rotate-45 border border-border-subtlest-tertiary bg-background-popover',
+            giftSide,
+            isAbove
+              ? 'bottom-[-6px] border-l-0 border-t-0'
+              : 'top-[-6px] border-b-0 border-r-0',
+          )}
+        />
+      )}
+
+      <div
+        className="giveback-toast-in relative flex items-center gap-3 rounded-16 border border-border-subtlest-tertiary bg-gradient-to-br from-accent-cabbage-flat to-background-popover p-3.5 antialiased shadow-3"
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+      >
+        {/* Close button (top-right corner) with the auto-dismiss countdown ring. */}
+        <button
+          type="button"
+          aria-label="Dismiss"
+          onClick={onClose}
+          className="absolute right-2.5 top-2.5 z-1 grid size-7 place-items-center rounded-full text-text-tertiary transition-colors hover:bg-surface-float hover:text-text-primary"
+        >
+          {autoDismissMs > 0 && (
+            <svg
+              viewBox="0 0 36 36"
+              className="pointer-events-none absolute inset-0 size-full -rotate-90 text-accent-cabbage-default"
+              aria-hidden
+            >
+              <circle
+                cx="18"
+                cy="18"
+                r="15"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                pathLength={100}
+                strokeDasharray="100"
+                strokeDashoffset={dashoffset}
+              />
+            </svg>
+          )}
+          <MiniCloseIcon size={IconSize.Small} />
+        </button>
+
+        {/* Left: full-width message + CTA. */}
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <div className="flex flex-col gap-1">
+            <span className="font-medium uppercase tracking-wide text-accent-cabbage-default typo-caption2">
+              {eyebrow}
+            </span>
+            <p className="font-semibold text-text-primary typo-callout [text-wrap:balance]">
+              {headline}
+            </p>
+            <p className="text-text-secondary typo-caption1 [text-wrap:pretty]">
+              {body}
+            </p>
+          </div>
+
+          <Button
+            type="button"
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Small}
+            onClick={onClick}
+            className="w-full"
+          >
+            {ctaLabel} →
+          </Button>
+        </div>
+
+        {/* The Giveback charm, bobbing on a soft glow. Its artwork sits on black,
+           so mix-blend-screen drops the black on the dark card. */}
+        <div className="relative flex h-36 w-32 shrink-0 items-center justify-center self-stretch">
+          <span
+            aria-hidden
+            className="bg-accent-cabbage-default/20 absolute left-1/2 top-1/2 size-28 -translate-x-1/2 -translate-y-1/2 rounded-full blur-2xl"
+          />
+          <img
+            src={cloudinaryCharmGiveback}
+            alt="daily.dev Giveback charm"
+            className="mascot-bob relative h-full w-full object-contain mix-blend-screen"
+          />
+        </div>
+      </div>
+    </div>
+  );
+
+  return dropdown ? <RootPortal>{content}</RootPortal> : content;
+};
+
+export default GivebackInvitePrompt;

--- a/packages/shared/src/features/giveback/components/GivebackLiveActivityListener.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackLiveActivityListener.tsx
@@ -25,7 +25,7 @@ const MILESTONE_POLL_MS = 60_000;
 // The community stream is global, so events can arrive in bursts. Pop at most
 // one money numeral per window and sum the amounts landing in between, so the
 // gift shows a single "+$<total>" jump instead of a flood of stacked labels.
-const POP_THROTTLE_MS = 1500;
+const POP_THROTTLE_MS = 500;
 // A crossed milestone only celebrates once per browser, so a reload never
 // re-pops one the visitor already saw.
 const LAST_MILESTONE_STORAGE_KEY = `${APP_KEY_PREFIX}:giveback:last-milestone`;

--- a/packages/shared/src/features/giveback/components/GivebackLiveActivityListener.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackLiveActivityListener.tsx
@@ -1,0 +1,158 @@
+import type { RefObject } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { GivebackGiftDockHandle } from './GivebackGiftDock';
+import { buildGivebackMilestonePrompt } from '../givebackInvitePrompts';
+import type {
+  ContributionActionCompleted,
+  ContributionMilestone,
+} from '../types';
+import {
+  CONTRIBUTION_ACTION_COMPLETED_SUBSCRIPTION,
+  CONTRIBUTION_LAST_MILESTONE_QUERY,
+} from '../graphql';
+import useSubscription from '../../../hooks/useSubscription';
+import { useLogContext } from '../../../contexts/LogContext';
+import { gqlClient } from '../../../graphql/common';
+import { disabledRefetch } from '../../../lib/func';
+import { generateQueryKey, RequestKey } from '../../../lib/query';
+import { LogEvent } from '../../../lib/log';
+import { APP_KEY_PREFIX } from '../../../lib/storage';
+
+// Poll the cached milestone endpoint on a relaxed cadence. Milestones are rare,
+// so we only need to catch a crossing within a minute or so.
+const MILESTONE_POLL_MS = 60_000;
+// The community stream is global, so events can arrive in bursts. Pop at most
+// one money numeral per window and sum the amounts landing in between, so the
+// gift shows a single "+$<total>" jump instead of a flood of stacked labels.
+const POP_THROTTLE_MS = 1500;
+// A crossed milestone only celebrates once per browser, so a reload never
+// re-pops one the visitor already saw.
+const LAST_MILESTONE_STORAGE_KEY = `${APP_KEY_PREFIX}:giveback:last-milestone`;
+
+const readLastCelebratedMilestone = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return window.localStorage.getItem(LAST_MILESTONE_STORAGE_KEY);
+};
+
+interface ContributionActionCompletedPayload {
+  contributionActionCompleted: ContributionActionCompleted | null;
+}
+
+interface ContributionLastMilestonePayload {
+  contributionLastReachedMilestone: ContributionMilestone | null;
+}
+
+interface GivebackLiveActivityListenerProps {
+  dock: RefObject<GivebackGiftDockHandle>;
+}
+
+// Drives the gift dock from remote events instead of a local timer:
+// - each approved action (real-time subscription) pops a live "+$" jump
+// - crossing a new global milestone (cached poll) fires the celebratory popover
+// Mounted once (only the owning gift entry renders it), so the two surfaces
+// never double-subscribe or double-pop.
+export function GivebackLiveActivityListener({
+  dock,
+}: GivebackLiveActivityListenerProps): null {
+  const { logEvent } = useLogContext();
+  const lastCelebratedRef = useRef<string | null>(
+    readLastCelebratedMilestone(),
+  );
+
+  // Throttle state for the money pops (see POP_THROTTLE_MS).
+  const pendingPointsRef = useRef(0);
+  const throttleTimerRef = useRef<number | null>(null);
+  const flushRef = useRef<() => void>();
+  flushRef.current = () => {
+    const total = pendingPointsRef.current;
+    pendingPointsRef.current = 0;
+    if (total <= 0) {
+      throttleTimerRef.current = null;
+      return;
+    }
+    dock.current?.pulseActivity(`+$${total.toString()}`);
+    throttleTimerRef.current = window.setTimeout(
+      () => flushRef.current?.(),
+      POP_THROTTLE_MS,
+    );
+  };
+
+  useEffect(() => {
+    return () => {
+      if (throttleTimerRef.current !== null) {
+        window.clearTimeout(throttleTimerRef.current);
+      }
+    };
+  }, []);
+
+  const onActionCompleted = useCallback(
+    ({ contributionActionCompleted }: ContributionActionCompletedPayload) => {
+      const awardedPoints = contributionActionCompleted?.awardedPoints ?? 0;
+      if (awardedPoints <= 0) {
+        return;
+      }
+      // Leading edge: pop the first event immediately, then coalesce the rest
+      // of the burst into the trailing flush.
+      if (throttleTimerRef.current === null) {
+        dock.current?.pulseActivity(`+$${awardedPoints.toString()}`);
+        throttleTimerRef.current = window.setTimeout(
+          () => flushRef.current?.(),
+          POP_THROTTLE_MS,
+        );
+      } else {
+        pendingPointsRef.current += awardedPoints;
+      }
+    },
+    [dock],
+  );
+
+  useSubscription<ContributionActionCompletedPayload>(
+    () => ({ query: CONTRIBUTION_ACTION_COMPLETED_SUBSCRIPTION }),
+    { next: onActionCompleted },
+  );
+
+  const { data } = useQuery({
+    queryKey: generateQueryKey(RequestKey.ContributionLastMilestone),
+    queryFn: () =>
+      gqlClient.request<ContributionLastMilestonePayload>(
+        CONTRIBUTION_LAST_MILESTONE_QUERY,
+      ),
+    refetchInterval: MILESTONE_POLL_MS,
+    ...disabledRefetch,
+  });
+
+  const milestone = data?.contributionLastReachedMilestone;
+
+  useEffect(() => {
+    if (!milestone) {
+      return;
+    }
+
+    // Seed on first sight without popping (the milestone may already be old);
+    // only a genuinely new crossing this session celebrates.
+    if (!lastCelebratedRef.current) {
+      lastCelebratedRef.current = milestone.id;
+      window.localStorage.setItem(LAST_MILESTONE_STORAGE_KEY, milestone.id);
+      return;
+    }
+
+    if (lastCelebratedRef.current === milestone.id) {
+      return;
+    }
+
+    lastCelebratedRef.current = milestone.id;
+    window.localStorage.setItem(LAST_MILESTONE_STORAGE_KEY, milestone.id);
+    dock.current?.showPrompt(buildGivebackMilestonePrompt(milestone));
+    logEvent({
+      event_name: LogEvent.ViewGivebackPrompt,
+      extra: JSON.stringify({ milestone: milestone.id }),
+    });
+  }, [milestone, dock, logEvent]);
+
+  return null;
+}
+
+export default GivebackLiveActivityListener;

--- a/packages/shared/src/features/giveback/components/GivebackMascot.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackMascot.tsx
@@ -1,11 +1,12 @@
 import type { ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
+import { cloudinaryCharmGiveback } from '../../../lib/image';
 
 // The daily.dev charm, themed as a "wish-granting genie" for Giveback: you make
 // a wish (pick a cause / take an action) and daily.dev grants it.
 const GIVEBACK_CHARM_IMAGE = {
-  src: 'https://media.daily.dev/image/upload/s--d1dldAty--/f_auto,q_auto/v1780848838/public/daily.dev%20Charm%20-%20Giveback%20(1)',
+  src: cloudinaryCharmGiveback,
   alt: 'daily.dev charm celebrating community impact for the Giveback campaign',
 };
 

--- a/packages/shared/src/features/giveback/givebackInvitePrompts.ts
+++ b/packages/shared/src/features/giveback/givebackInvitePrompts.ts
@@ -2,10 +2,17 @@
 // hook, not a personal tracker: most people never contribute, and we don't
 // track per-user interactions here. The popover celebrates one thing only:
 // a global campaign milestone being crossed, and exists to pull the user into
-// /giveback. Voice follows the giveback "honest trade" system: you help us
-// grow, we redirect the budget to causes you pick, you never pay. Org rules:
-// "daily.dev" lowercase; never state a user count (money-raised figures are
-// fine).
+// /giveback.
+//
+// The honest trade (keep the framing accurate): developers do small marketing
+// actions (share daily.dev, post, leave a review, cast a vote) that help more
+// devs discover us; in return we redirect our ad/growth budget into real
+// donations to causes the community picks. "Ad budgets buy clicks. Ours funds
+// real causes." The user never pays a cent. Do NOT imply the money comes from
+// everyday reading/usage.
+//
+// Org rules: "daily.dev" lowercase; never state a user count (money-raised
+// figures are fine).
 
 import { formatDonationAmount } from './utils';
 import type { ContributionMilestone } from './types';
@@ -21,21 +28,68 @@ export interface GivebackInvitePromptData {
   celebrate?: boolean;
 }
 
-// The single popover variation. Global milestones are the only thing the header
-// gift celebrates: a live community moment driven by a remote event, not a
-// rotating set of generic invites. Falls back to a raised-amount headline when
-// the milestone has no custom title. `value` maps 1:1 to currency.
+interface MilestonePromptVariation {
+  eyebrow: string;
+  // Built from the crossed amount (maps 1:1 to currency).
+  headline: (amount: string) => string;
+  body: string;
+  ctaLabel: string;
+}
+
+// A few takes on the same milestone moment, each hitting a different angle of
+// the honest trade (ad-budget redirect, the shared pot, community actions, the
+// causes). We pick one deterministically per milestone so a given threshold
+// always reads the same, but different milestones stay fresh.
+const MILESTONE_PROMPT_VARIATIONS: MilestonePromptVariation[] = [
+  {
+    eyebrow: 'Milestone reached',
+    headline: (amount) => `${amount} redirected from ads to real causes`,
+    body: 'Developers spread the word, we turn the growth budget into donations. You never pay a cent.',
+    ctaLabel: 'See how it works',
+  },
+  {
+    eyebrow: 'The pot just grew',
+    headline: (amount) => `${amount} in the giveback pot`,
+    body: 'Filled by developers sharing daily.dev, funded entirely by us. Pick where it goes.',
+    ctaLabel: 'Choose your causes',
+  },
+  {
+    eyebrow: 'Community milestone',
+    headline: (amount) => `${amount} raised, one action at a time`,
+    body: 'Every share, post, and review became a real donation. Never out of your pocket.',
+    ctaLabel: 'Take an action',
+  },
+  {
+    eyebrow: 'Funded together',
+    headline: (amount) => `${amount} for the causes you choose`,
+    body: "Our ad budget, redirected by developers spreading the word. You'll never pay a cent.",
+    ctaLabel: 'Back a cause',
+  },
+];
+
+// Deterministically pick a variation from the milestone's own threshold value,
+// so the same milestone always shows the same copy while different ones vary.
+const pickVariation = (milestone: ContributionMilestone) =>
+  MILESTONE_PROMPT_VARIATIONS[
+    Math.abs(Math.floor(milestone.value)) % MILESTONE_PROMPT_VARIATIONS.length
+  ];
+
+// The single popover type. Global milestones are the only thing the header gift
+// celebrates: a live community moment driven by a remote event, not a rotating
+// set of generic invites. A backend-authored `title` overrides the headline
+// when present.
 export const buildGivebackMilestonePrompt = (
   milestone: ContributionMilestone,
-): GivebackInvitePromptData => ({
-  id: `milestone-${milestone.id}`,
-  eyebrow: 'Milestone reached',
-  headline:
-    milestone.title ??
-    `The community just crossed ${formatDonationAmount(
-      milestone.value,
-    )} for good causes`,
-  body: 'All of it funded by everyday daily.dev activity, not out of anyone’s pocket.',
-  ctaLabel: 'Join in',
-  celebrate: true,
-});
+): GivebackInvitePromptData => {
+  const variation = pickVariation(milestone);
+  const amount = formatDonationAmount(milestone.value);
+
+  return {
+    id: `milestone-${milestone.id}`,
+    eyebrow: variation.eyebrow,
+    headline: milestone.title ?? variation.headline(amount),
+    body: variation.body,
+    ctaLabel: variation.ctaLabel,
+    celebrate: true,
+  };
+};

--- a/packages/shared/src/features/giveback/givebackInvitePrompts.ts
+++ b/packages/shared/src/features/giveback/givebackInvitePrompts.ts
@@ -1,10 +1,14 @@
 // Copy for the header/rail gift entry point. This surface is an ACQUISITION
 // hook, not a personal tracker: most people never contribute, and we don't
-// track per-user interactions here. Every prompt is generic + community-framed
-// and exists to pull the user into /giveback. Voice follows the giveback
-// "honest trade" system: you help us grow, we redirect the budget to causes you
-// pick, you never pay. Org rules: "daily.dev" lowercase; never state a user
-// count (money-raised figures are fine).
+// track per-user interactions here. The popover celebrates one thing only:
+// a global campaign milestone being crossed, and exists to pull the user into
+// /giveback. Voice follows the giveback "honest trade" system: you help us
+// grow, we redirect the budget to causes you pick, you never pay. Org rules:
+// "daily.dev" lowercase; never state a user count (money-raised figures are
+// fine).
+
+import { formatDonationAmount } from './utils';
+import type { ContributionMilestone } from './types';
 
 export interface GivebackInvitePromptData {
   id: string;
@@ -13,41 +17,25 @@ export interface GivebackInvitePromptData {
   headline: string;
   body: string;
   ctaLabel: string;
-  // Festive community moment — fires confetti + glow. Use sparingly.
+  // Festive community moment. Fires confetti + glow. Use sparingly.
   celebrate?: boolean;
 }
 
-// A rotating set so the header stays fresh and hits different motivations:
-// social proof, how-it-works/no-cost, cause spotlight, and a plain invite.
-export const givebackInvitePrompts: GivebackInvitePromptData[] = [
-  {
-    id: 'community-raised',
-    eyebrow: 'Raised together',
-    headline: 'The community just crossed $12,340 for good causes',
-    body: 'All of it funded by everyday daily.dev activity, not out of anyone’s pocket.',
-    ctaLabel: 'Join in',
-    celebrate: true,
-  },
-  {
-    id: 'how-it-works',
-    eyebrow: 'No cost to you',
-    headline: 'Turn your daily.dev activity into real donations',
-    body: 'You help us grow, we redirect the budget to causes you pick. You never pay a cent.',
-    ctaLabel: 'See how it works',
-  },
-  {
-    id: 'cause-funded',
-    eyebrow: 'Just funded',
-    headline: 'Dev scholarships just got a boost 🎓',
-    body: 'Choose which real-world causes your daily.dev activity backs.',
-    ctaLabel: 'Pick your causes',
-    celebrate: true,
-  },
-  {
-    id: 'invite',
-    eyebrow: 'Two clicks',
-    headline: 'Give back while you read',
-    body: 'Developers are turning their daily habit into donations right now. Add yours.',
-    ctaLabel: 'Start giving back',
-  },
-];
+// The single popover variation. Global milestones are the only thing the header
+// gift celebrates: a live community moment driven by a remote event, not a
+// rotating set of generic invites. Falls back to a raised-amount headline when
+// the milestone has no custom title. `value` maps 1:1 to currency.
+export const buildGivebackMilestonePrompt = (
+  milestone: ContributionMilestone,
+): GivebackInvitePromptData => ({
+  id: `milestone-${milestone.id}`,
+  eyebrow: 'Milestone reached',
+  headline:
+    milestone.title ??
+    `The community just crossed ${formatDonationAmount(
+      milestone.value,
+    )} for good causes`,
+  body: 'All of it funded by everyday daily.dev activity, not out of anyone’s pocket.',
+  ctaLabel: 'Join in',
+  celebrate: true,
+});

--- a/packages/shared/src/features/giveback/givebackInvitePrompts.ts
+++ b/packages/shared/src/features/giveback/givebackInvitePrompts.ts
@@ -1,0 +1,53 @@
+// Copy for the header/rail gift entry point. This surface is an ACQUISITION
+// hook, not a personal tracker: most people never contribute, and we don't
+// track per-user interactions here. Every prompt is generic + community-framed
+// and exists to pull the user into /giveback. Voice follows the giveback
+// "honest trade" system: you help us grow, we redirect the budget to causes you
+// pick, you never pay. Org rules: "daily.dev" lowercase; never state a user
+// count (money-raised figures are fine).
+
+export interface GivebackInvitePromptData {
+  id: string;
+  // Small kicker above the headline (e.g. a live/community tag).
+  eyebrow?: string;
+  headline: string;
+  body: string;
+  ctaLabel: string;
+  // Festive community moment — fires confetti + glow. Use sparingly.
+  celebrate?: boolean;
+}
+
+// A rotating set so the header stays fresh and hits different motivations:
+// social proof, how-it-works/no-cost, cause spotlight, and a plain invite.
+export const givebackInvitePrompts: GivebackInvitePromptData[] = [
+  {
+    id: 'community-raised',
+    eyebrow: 'Raised together',
+    headline: 'The community just crossed $12,340 for good causes',
+    body: 'All of it funded by everyday daily.dev activity, not out of anyone’s pocket.',
+    ctaLabel: 'Join in',
+    celebrate: true,
+  },
+  {
+    id: 'how-it-works',
+    eyebrow: 'No cost to you',
+    headline: 'Turn your daily.dev activity into real donations',
+    body: 'You help us grow, we redirect the budget to causes you pick. You never pay a cent.',
+    ctaLabel: 'See how it works',
+  },
+  {
+    id: 'cause-funded',
+    eyebrow: 'Just funded',
+    headline: 'Dev scholarships just got a boost 🎓',
+    body: 'Choose which real-world causes your daily.dev activity backs.',
+    ctaLabel: 'Pick your causes',
+    celebrate: true,
+  },
+  {
+    id: 'invite',
+    eyebrow: 'Two clicks',
+    headline: 'Give back while you read',
+    body: 'Developers are turning their daily habit into donations right now. Add yours.',
+    ctaLabel: 'Start giving back',
+  },
+];

--- a/packages/shared/src/features/giveback/graphql.ts
+++ b/packages/shared/src/features/giveback/graphql.ts
@@ -165,3 +165,31 @@ export const UPDATE_CONTRIBUTION_CAUSE_PREFERENCES_MUTATION = `
     }
   }
 `;
+
+// Real-time community activity: every approved action lands here so the gift
+// entry point can pop a live "+$" jump. `awardedPoints` maps 1:1 to USD, like
+// the campaign totals.
+export const CONTRIBUTION_ACTION_COMPLETED_SUBSCRIPTION = `
+  subscription ContributionActionCompleted {
+    contributionActionCompleted {
+      submissionId
+      userId
+      actionId
+      awardedPoints
+    }
+  }
+`;
+
+// The highest global milestone reached, served from cache for the gift-icon
+// poll. Null until the first milestone is crossed. Drives the celebratory
+// popover on the header/rail gift.
+export const CONTRIBUTION_LAST_MILESTONE_QUERY = `
+  query ContributionLastReachedMilestone {
+    contributionLastReachedMilestone {
+      id
+      value
+      title
+      reachedAt
+    }
+  }
+`;

--- a/packages/shared/src/features/giveback/types.ts
+++ b/packages/shared/src/features/giveback/types.ts
@@ -17,6 +17,25 @@ export interface ContributionStatus {
   userPoints: number | null;
 }
 
+// Real-time event fired when an approved action lands. Drives the live "+$"
+// pop on the gift entry point. `awardedPoints` maps 1:1 to currency.
+export interface ContributionActionCompleted {
+  submissionId: string;
+  userId: string;
+  actionId: string;
+  awardedPoints: number;
+}
+
+// A global campaign milestone (a lifetime approved-points threshold, which maps
+// 1:1 to currency). `contributionLastReachedMilestone` returns the highest one
+// crossed so far; crossing a new one pops the celebratory popover.
+export interface ContributionMilestone {
+  id: string;
+  value: number;
+  title: string | null;
+  reachedAt: string | null;
+}
+
 // Derived from the sponsored amount on the backend, so a pledge can never
 // disagree with its badge.
 export enum ContributionSponsorTier {

--- a/packages/shared/src/features/giveback/useGivebackMotion.ts
+++ b/packages/shared/src/features/giveback/useGivebackMotion.ts
@@ -1,7 +1,7 @@
 import type { RefObject } from 'react';
 import { useEffect, useRef, useState } from 'react';
 
-const usePrefersReducedMotion = (): boolean => {
+export const usePrefersReducedMotion = (): boolean => {
   const [reduced, setReduced] = useState(false);
 
   useEffect(() => {

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -474,3 +474,8 @@ export const cloudinaryCharmNoPosts =
 
 export const cloudinaryCharmNotEnoughTags =
   'https://media.daily.dev/image/upload/s--0PIPx07_--/f_auto,q_auto/v1781529338/public/daily.dev%20Charm%20-%20no%20enoght%20tags%20(1)';
+
+// The Giveback charm (genie-themed). Artwork sits on solid black — render with
+// `mix-blend-screen` on a dark surface so the black drops out.
+export const cloudinaryCharmGiveback =
+  'https://media.daily.dev/image/upload/s--d1dldAty--/f_auto,q_auto/v1780848838/public/daily.dev%20Charm%20-%20Giveback%20(1)';

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -516,6 +516,8 @@ export enum LogEvent {
   ViewGivebackFunnelStep = 'view giveback funnel step',
   CompleteGivebackFunnel = 'complete giveback funnel',
   ClickGivebackHowItWorks = 'click giveback how it works',
+  ClickGivebackGiftEntry = 'click giveback gift entry',
+  ViewGivebackPrompt = 'view giveback prompt',
   // Daily homepage
   DailyFeedback = 'daily feedback',
 }

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -279,6 +279,7 @@ export enum RequestKey {
   ContributionCausePicker = 'contribution_cause_picker',
   ContributionActions = 'contribution_actions',
   ContributionActionLinks = 'contribution_action_links',
+  ContributionLastMilestone = 'contribution_last_milestone',
   LeaderboardPosition = 'leaderboard_position',
 }
 

--- a/packages/shared/src/styles/base.css
+++ b/packages/shared/src/styles/base.css
@@ -1048,6 +1048,149 @@ meter::-webkit-meter-bar {
     will-change: transform, opacity;
   }
 
+  /* Giveback gift celebrations. Each confetti piece flies from the gift's
+     center to its own (x, y) offset while spinning and fading — offsets and
+     rotation are handed in per piece via CSS vars. */
+  @keyframes giveback-confetti-piece {
+    0% {
+      opacity: 0;
+      transform: translate(-50%, -50%) scale(0.2) rotate(0deg);
+    }
+
+    14% {
+      opacity: 1;
+      transform: translate(-50%, -50%) scale(1) rotate(30deg);
+    }
+
+    100% {
+      opacity: 0;
+      transform: translate(
+          calc(-50% + var(--giveback-confetti-x)),
+          calc(-50% + var(--giveback-confetti-y))
+        )
+        scale(0.85) rotate(var(--giveback-confetti-r));
+    }
+  }
+
+  .giveback-confetti-piece {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 1px;
+    background: currentColor;
+    animation: giveback-confetti-piece 0.9s cubic-bezier(0.12, 0.62, 0.28, 1)
+      forwards;
+    will-change: transform, opacity;
+  }
+
+  /* Real-time dollar jump beside the gift: a bare "+$" figure pops in, holds
+     legibly while drifting up a little, then fades. Slow enough to read; the
+     horizontal offset is set per-pop so it sits next to the icon, not on it. */
+  @keyframes giveback-value-rise {
+    0% {
+      opacity: 0;
+      transform: translateY(8px) scale(0.9);
+    }
+
+    16% {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+
+    70% {
+      opacity: 1;
+      transform: translateY(-14px) scale(1);
+    }
+
+    100% {
+      opacity: 0;
+      transform: translateY(-24px) scale(1);
+    }
+  }
+
+  .giveback-value-rise {
+    animation: giveback-value-rise 1.8s cubic-bezier(0.22, 0.61, 0.36, 1)
+      forwards;
+    will-change: transform, opacity;
+  }
+
+  /* Milestone toast: signature enter — rise + de-blur + fade, from the top
+     anchor (the gift), no overshoot. */
+  @keyframes giveback-toast-in {
+    0% {
+      opacity: 0;
+      transform: translateY(-8px);
+      filter: blur(8px);
+    }
+
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+      filter: blur(0);
+    }
+  }
+
+  .giveback-toast-in {
+    transform-origin: top center;
+    animation: giveback-toast-in 0.45s cubic-bezier(0.16, 1, 0.3, 1) both;
+    will-change: transform, opacity, filter;
+  }
+
+  /* Subtle "received" reaction on the gift when money lands — a settle up to
+     peak with no dip below rest (critically damped, no wobble). */
+  @keyframes giveback-gift-pop {
+    0% {
+      transform: scale(1);
+    }
+
+    35% {
+      transform: scale(1.12);
+    }
+
+    100% {
+      transform: scale(1);
+    }
+  }
+
+  .giveback-gift-pop {
+    animation: giveback-gift-pop 0.38s cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
+  /* Milestone: a soft radial glow blooms out from the gift and fades — a
+     warmer, classier beat than a hard expanding ring. */
+  @keyframes giveback-glow-bloom {
+    0% {
+      opacity: 0;
+      transform: translate(-50%, -50%) scale(0.5);
+    }
+
+    30% {
+      opacity: 0.9;
+    }
+
+    100% {
+      opacity: 0;
+      transform: translate(-50%, -50%) scale(1.9);
+    }
+  }
+
+  .giveback-glow-bloom {
+    animation: giveback-glow-bloom 0.9s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+    will-change: transform, opacity;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .giveback-confetti-piece,
+    .giveback-value-rise,
+    .giveback-glow-bloom {
+      animation-duration: 0.01ms;
+    }
+
+    .giveback-toast-in,
+    .giveback-gift-pop {
+      animation: none;
+    }
+  }
+
   @keyframes quest-claimed-stamp {
     0% {
       opacity: 0;

--- a/packages/storybook/stories/features/giveback/GivebackGiftButton.stories.tsx
+++ b/packages/storybook/stories/features/giveback/GivebackGiftButton.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { GivebackGiftButton } from '@dailydotdev/shared/src/features/giveback/components/GivebackGiftButton';
+import { withGiveback } from './giveback.mocks';
+
+// The persistent giveback entry point: a calm gift icon in the top header and,
+// on the new layout, at the bottom-left of the rail. No ambient progress meter —
+// the gift stays quiet at rest and only comes alive in the celebration moments.
+const meta: Meta<typeof GivebackGiftButton> = {
+  title: 'Features/Giveback/Entry points/Gift button',
+  component: GivebackGiftButton,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Resting states for the header/rail gift icon. Calm at rest — just the gift, no progress meter and no notification badge. Press feedback scales down.',
+      },
+    },
+  },
+  decorators: [withGiveback()],
+  argTypes: {
+    variant: { control: 'inline-radio', options: ['header', 'rail'] },
+    showLabel: { control: 'boolean' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GivebackGiftButton>;
+
+const HeaderFrame = ({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement => (
+  <div className="flex w-[560px] items-center gap-3 rounded-16 border border-border-subtlest-tertiary bg-background-default px-4 py-3">
+    <span className="font-bold text-text-primary typo-title3">daily.dev</span>
+    <div className="ml-auto flex items-center gap-3">
+      {children}
+      <span className="size-8 rounded-full bg-surface-float" />
+      <span className="size-8 rounded-full bg-surface-float" />
+    </div>
+  </div>
+);
+
+const RailFrame = ({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement => (
+  <div className="flex h-[420px] w-[240px] flex-col rounded-16 border border-border-subtlest-tertiary bg-background-default p-3">
+    <div className="flex flex-col gap-2">
+      {['Feed', 'Explore', 'Bookmarks'].map((item) => (
+        <div
+          key={item}
+          className="flex items-center gap-3 rounded-10 px-2 py-1.5 text-text-tertiary typo-callout"
+        >
+          <span className="size-5 rounded bg-surface-float" />
+          {item}
+        </div>
+      ))}
+    </div>
+    <div className="mt-auto border-t border-border-subtlest-tertiary pt-2">
+      {children}
+    </div>
+  </div>
+);
+
+export const Playground: Story = {
+  args: {
+    variant: 'header',
+  },
+};
+
+export const Placement: Story = {
+  parameters: { controls: { disable: true } },
+  render: () => (
+    <div className="flex flex-wrap items-start gap-8">
+      <div className="flex flex-col gap-2">
+        <span className="text-text-tertiary typo-caption1">Header</span>
+        <HeaderFrame>
+          <GivebackGiftButton />
+        </HeaderFrame>
+      </div>
+      <div className="flex flex-col gap-2">
+        <span className="text-text-tertiary typo-caption1">Rail, labelled</span>
+        <RailFrame>
+          <GivebackGiftButton variant="rail" showLabel />
+        </RailFrame>
+      </div>
+    </div>
+  ),
+};

--- a/packages/storybook/stories/features/giveback/GivebackGiftShowcase.stories.tsx
+++ b/packages/storybook/stories/features/giveback/GivebackGiftShowcase.stories.tsx
@@ -1,0 +1,181 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React, { useEffect, useRef, useState } from 'react';
+import type { GivebackGiftDockHandle } from '@dailydotdev/shared/src/features/giveback/components/GivebackGiftDock';
+import { GivebackGiftDock } from '@dailydotdev/shared/src/features/giveback/components/GivebackGiftDock';
+import { givebackInvitePrompts } from '@dailydotdev/shared/src/features/giveback/givebackInvitePrompts';
+import { useCountUp } from '@dailydotdev/shared/src/features/giveback/useGivebackMotion';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import { withGiveback } from './giveback.mocks';
+
+const ControlButton = ({
+  children,
+  onClick,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+}): React.ReactElement => (
+  <Button
+    variant={ButtonVariant.Secondary}
+    size={ButtonSize.Small}
+    onClick={onClick}
+  >
+    {children}
+  </Button>
+);
+
+// Mirrors the real old-layout header (MainLayoutHeader → HeaderButtons): full
+// width, bottom border, h-16, logo left, and the action cluster right in the
+// real order — opportunity, quests, [giveback gift], notifications, profile.
+// The neighbours are Float-button-sized placeholders; the gift is the real
+// component so it can be validated in its true header context.
+const HeaderBar = ({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement => (
+  <header className="flex h-16 w-full items-center gap-3 border-b border-border-subtlest-tertiary bg-background-default px-4">
+    <span className="font-bold text-text-primary typo-title3">daily.dev</span>
+    <div className="ml-auto flex items-center gap-3">
+      <span className="size-10 rounded-full bg-surface-float" />
+      <span className="size-10 rounded-full bg-surface-float" />
+      {children}
+      <span className="size-10 rounded-full bg-surface-float" />
+      <span className="size-10 rounded-full bg-surface-float" />
+    </div>
+  </header>
+);
+
+const LivePlayground = ({
+  variant,
+}: {
+  variant: 'header' | 'rail';
+}): React.ReactElement => {
+  const dock = useRef<GivebackGiftDockHandle>(null);
+  const promptIndex = useRef(0);
+  const [raisedToday, setRaisedToday] = useState(12340);
+  const [ambient, setAmbient] = useState(false);
+  const raised = useCountUp(raisedToday, true, 700);
+
+  const cyclePrompt = () => {
+    const next = givebackInvitePrompts[promptIndex.current];
+    promptIndex.current =
+      (promptIndex.current + 1) % givebackInvitePrompts.length;
+    dock.current?.showPrompt(next);
+  };
+
+  // Ambient community activity — money keeps landing on its own (social proof).
+  useEffect(() => {
+    if (!ambient) {
+      return undefined;
+    }
+    const tick = () => {
+      const amount = [1, 2, 3, 5, 8, 12][Math.floor(Math.random() * 6)];
+      setRaisedToday((current) => current + amount);
+      dock.current?.pulseActivity(`+$${amount}`);
+    };
+    const interval = window.setInterval(tick, 1600);
+    return () => window.clearInterval(interval);
+  }, [ambient]);
+
+  const dockNode = (
+    <GivebackGiftDock ref={dock} variant={variant} showLabel={variant === 'rail'} />
+  );
+
+  return (
+    <div className="flex w-[620px] max-w-full flex-col gap-6">
+      {variant === 'header' ? (
+        <HeaderBar>{dockNode}</HeaderBar>
+      ) : (
+        <div className="flex h-[380px] w-[240px] flex-col rounded-16 border border-border-subtlest-tertiary bg-background-default p-3">
+          <div className="flex flex-col gap-2">
+            {['Feed', 'Explore', 'Bookmarks'].map((item) => (
+              <div
+                key={item}
+                className="flex items-center gap-3 rounded-10 px-2 py-1.5 text-text-tertiary typo-callout"
+              >
+                <span className="size-5 rounded bg-surface-float" />
+                {item}
+              </div>
+            ))}
+          </div>
+          <div className="mt-auto border-t border-border-subtlest-tertiary pt-2">
+            {dockNode}
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-3 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-4 antialiased">
+        <span className="text-text-secondary typo-caption1 [text-wrap:pretty]">
+          This entry point is an acquisition hook — its job is to pull people
+          into the giveback page. Everything is generic + community-framed, not a
+          personal tracker.
+        </span>
+        <div className="flex items-center gap-2">
+          <span className="size-2 rounded-full bg-accent-avocado-default" />
+          <span className="text-text-secondary typo-caption1">
+            Community raised today:{' '}
+            <span className="font-bold tabular-nums text-status-success">
+              ${raised.toLocaleString('en-US')}
+            </span>
+          </span>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <ControlButton onClick={cyclePrompt}>
+            Show invite prompt →
+          </ControlButton>
+          <ControlButton onClick={() => setAmbient((v) => !v)}>
+            {ambient ? 'Stop' : 'Start'} community activity
+          </ControlButton>
+          <ControlButton
+            onClick={() => {
+              dock.current?.reset();
+              setRaisedToday(12340);
+              setAmbient(false);
+              promptIndex.current = 0;
+            }}
+          >
+            Reset
+          </ControlButton>
+        </div>
+
+        <span className="text-text-tertiary typo-caption2 [text-wrap:pretty]">
+          “Show invite prompt” cycles through the message variants (social proof,
+          how-it-works, cause spotlight, plain invite). Celebratory ones bloom +
+          confetti.
+        </span>
+      </div>
+    </div>
+  );
+};
+
+const meta: Meta = {
+  title: 'Features/Giveback/Entry points/Live playground',
+  decorators: [withGiveback()],
+  parameters: {
+    layout: 'centered',
+    controls: { disable: true },
+    docs: {
+      description: {
+        component:
+          'The gift entry point as an acquisition hook. Community money lands on the gift in real time — bare Polymarket-style dollar jumps (no chip) that flash on the button and leap up. A rotating generic invite prompt (with a visible auto-dismiss countdown) draws the eye into /giveback. No personal tracking. Motion is bounce:0 per the Jakub Krehel craft playbook.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const Header: Story = {
+  render: () => <LivePlayground variant="header" />,
+};
+
+export const Rail: Story = {
+  render: () => <LivePlayground variant="rail" />,
+};

--- a/packages/storybook/stories/features/giveback/GivebackGiftShowcase.stories.tsx
+++ b/packages/storybook/stories/features/giveback/GivebackGiftShowcase.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import React, { useEffect, useRef, useState } from 'react';
 import type { GivebackGiftDockHandle } from '@dailydotdev/shared/src/features/giveback/components/GivebackGiftDock';
 import { GivebackGiftDock } from '@dailydotdev/shared/src/features/giveback/components/GivebackGiftDock';
-import { givebackInvitePrompts } from '@dailydotdev/shared/src/features/giveback/givebackInvitePrompts';
+import { buildGivebackMilestonePrompt } from '@dailydotdev/shared/src/features/giveback/givebackInvitePrompts';
 import { useCountUp } from '@dailydotdev/shared/src/features/giveback/useGivebackMotion';
 import {
   Button,
@@ -55,16 +55,21 @@ const LivePlayground = ({
   variant: 'header' | 'rail';
 }): React.ReactElement => {
   const dock = useRef<GivebackGiftDockHandle>(null);
-  const promptIndex = useRef(0);
   const [raisedToday, setRaisedToday] = useState(12340);
   const [ambient, setAmbient] = useState(false);
   const raised = useCountUp(raisedToday, true, 700);
 
-  const cyclePrompt = () => {
-    const next = givebackInvitePrompts[promptIndex.current];
-    promptIndex.current =
-      (promptIndex.current + 1) % givebackInvitePrompts.length;
-    dock.current?.showPrompt(next);
+  // The real popover is driven by a remote global-milestone event; here we fake
+  // one crossing so the single milestone variation can be reviewed.
+  const showMilestone = () => {
+    dock.current?.showPrompt(
+      buildGivebackMilestonePrompt({
+        id: `milestone-${raisedToday.toString()}`,
+        value: raisedToday,
+        title: null,
+        reachedAt: null,
+      }),
+    );
   };
 
   // Ambient community activity — money keeps landing on its own (social proof).
@@ -125,8 +130,8 @@ const LivePlayground = ({
         </div>
 
         <div className="flex flex-wrap gap-2">
-          <ControlButton onClick={cyclePrompt}>
-            Show invite prompt →
+          <ControlButton onClick={showMilestone}>
+            Reach a milestone →
           </ControlButton>
           <ControlButton onClick={() => setAmbient((v) => !v)}>
             {ambient ? 'Stop' : 'Start'} community activity
@@ -136,7 +141,6 @@ const LivePlayground = ({
               dock.current?.reset();
               setRaisedToday(12340);
               setAmbient(false);
-              promptIndex.current = 0;
             }}
           >
             Reset
@@ -144,9 +148,9 @@ const LivePlayground = ({
         </div>
 
         <span className="text-text-tertiary typo-caption2 [text-wrap:pretty]">
-          “Show invite prompt” cycles through the message variants (social proof,
-          how-it-works, cause spotlight, plain invite). Celebratory ones bloom +
-          confetti.
+          In production the dollar jumps come from real approved actions and the
+          popover from a global milestone being crossed. “Reach a milestone”
+          fakes that one crossing — it blooms + confetti.
         </span>
       </div>
     </div>
@@ -162,7 +166,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'The gift entry point as an acquisition hook. Community money lands on the gift in real time — bare Polymarket-style dollar jumps (no chip) that flash on the button and leap up. A rotating generic invite prompt (with a visible auto-dismiss countdown) draws the eye into /giveback. No personal tracking. Motion is bounce:0 per the Jakub Krehel craft playbook.',
+          'The gift entry point as an acquisition hook. Community money lands on the gift in real time — bare Polymarket-style dollar jumps (no chip) that flash on the button and leap up, driven by real approved actions. Crossing a global milestone fires a single celebratory popover (with a visible auto-dismiss countdown) that draws the eye into /giveback. No personal tracking. Motion is bounce:0 per the Jakub Krehel craft playbook.',
       },
     },
   },

--- a/packages/storybook/stories/features/giveback/GivebackHeaderStates.stories.tsx
+++ b/packages/storybook/stories/features/giveback/GivebackHeaderStates.stories.tsx
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { GivebackGiftButton } from '@dailydotdev/shared/src/features/giveback/components/GivebackGiftButton';
+import { GivebackInvitePrompt } from '@dailydotdev/shared/src/features/giveback/components/GivebackInvitePrompt';
+import { givebackInvitePrompts } from '@dailydotdev/shared/src/features/giveback/givebackInvitePrompts';
+import { withGiveback } from './giveback.mocks';
+
+// A stand-in for the old-layout top header so the gift can be judged in its real
+// neighbourhood (logo left, action cluster right).
+const Header = ({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement => (
+  <div className="flex h-16 w-[680px] max-w-full items-center gap-3 rounded-16 border border-border-subtlest-tertiary bg-background-default px-4">
+    <span className="font-bold text-text-primary typo-title3">daily.dev</span>
+    <div className="ml-auto flex items-center gap-4">
+      <span className="size-8 rounded-full bg-surface-float" />
+      {children}
+      <span className="size-8 rounded-full bg-surface-float" />
+      <span className="size-8 rounded-full bg-surface-float" />
+    </div>
+  </div>
+);
+
+const Label = ({ text }: { text: string }): React.ReactElement => (
+  <span className="text-text-tertiary typo-caption1">{text}</span>
+);
+
+const meta: Meta = {
+  title: 'Features/Giveback/Entry points/Header states',
+  parameters: {
+    layout: 'fullscreen',
+    controls: { disable: true },
+    docs: {
+      description: {
+        component:
+          'Static poses of the header gift entry on the old layout, for review: resting icon, a community dollar jump, and the invite toast (celebration + plain).',
+      },
+    },
+  },
+  decorators: [withGiveback()],
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const AllStates: Story = {
+  render: () => (
+    <div className="flex flex-col gap-12 bg-background-default p-8">
+      <section data-testid="state-resting" className="flex flex-col gap-2">
+        <Label text="1 · Resting — the calm gift entry" />
+        <Header>
+          <GivebackGiftButton />
+        </Header>
+      </section>
+
+      <section data-testid="state-dollars" className="flex flex-col gap-2">
+        <Label text="2 · Community dollars jumping on the gift (real-time)" />
+        <Header>
+          <span className="relative inline-flex">
+            <GivebackGiftButton />
+            <span
+              className="pointer-events-none absolute -top-3 left-1/2 whitespace-nowrap font-bold tabular-nums text-status-success typo-callout [text-shadow:0_1px_3px_var(--theme-background-default)]"
+              style={{ transform: 'translate(6px, 0)' }}
+            >
+              +$8
+            </span>
+          </span>
+        </Header>
+      </section>
+
+      <section
+        data-testid="state-toast-celebrate"
+        className="flex flex-col gap-2 pb-52"
+      >
+        <Label text="3 · Invite toast — celebratory community moment" />
+        <Header>
+          <span className="relative inline-flex">
+            <GivebackGiftButton />
+            <GivebackInvitePrompt
+              open
+              autoDismissMs={600000}
+              celebrate
+              eyebrow={givebackInvitePrompts[0].eyebrow}
+              headline={givebackInvitePrompts[0].headline}
+              body={givebackInvitePrompts[0].body}
+              ctaLabel={givebackInvitePrompts[0].ctaLabel}
+              placement="below"
+              align="end"
+            />
+          </span>
+        </Header>
+      </section>
+
+      <section
+        data-testid="state-toast-plain"
+        className="flex flex-col gap-2 pb-52"
+      >
+        <Label text="4 · Invite toast — plain message variant" />
+        <Header>
+          <span className="relative inline-flex">
+            <GivebackGiftButton />
+            <GivebackInvitePrompt
+              open
+              autoDismissMs={600000}
+              eyebrow={givebackInvitePrompts[1].eyebrow}
+              headline={givebackInvitePrompts[1].headline}
+              body={givebackInvitePrompts[1].body}
+              ctaLabel={givebackInvitePrompts[1].ctaLabel}
+              placement="below"
+              align="end"
+            />
+          </span>
+        </Header>
+      </section>
+    </div>
+  ),
+};

--- a/packages/storybook/stories/features/giveback/GivebackHeaderStates.stories.tsx
+++ b/packages/storybook/stories/features/giveback/GivebackHeaderStates.stories.tsx
@@ -2,8 +2,16 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 import { GivebackGiftButton } from '@dailydotdev/shared/src/features/giveback/components/GivebackGiftButton';
 import { GivebackInvitePrompt } from '@dailydotdev/shared/src/features/giveback/components/GivebackInvitePrompt';
-import { givebackInvitePrompts } from '@dailydotdev/shared/src/features/giveback/givebackInvitePrompts';
+import { buildGivebackMilestonePrompt } from '@dailydotdev/shared/src/features/giveback/givebackInvitePrompts';
 import { withGiveback } from './giveback.mocks';
+
+// The popover celebrates one thing only: a global milestone being crossed.
+const milestonePrompt = buildGivebackMilestonePrompt({
+  id: 'milestone-12k',
+  value: 12340,
+  title: null,
+  reachedAt: null,
+});
 
 // A stand-in for the old-layout top header so the gift can be judged in its real
 // neighbourhood (logo left, action cluster right).
@@ -35,7 +43,7 @@ const meta: Meta = {
     docs: {
       description: {
         component:
-          'Static poses of the header gift entry on the old layout, for review: resting icon, a community dollar jump, and the invite toast (celebration + plain).',
+          'Static poses of the header gift entry on the old layout, for review: resting icon, a community dollar jump, and the global-milestone popover.',
       },
     },
   },
@@ -75,40 +83,18 @@ export const AllStates: Story = {
         data-testid="state-toast-celebrate"
         className="flex flex-col gap-2 pb-52"
       >
-        <Label text="3 · Invite toast — celebratory community moment" />
+        <Label text="3 · Milestone popover — global community moment" />
         <Header>
           <span className="relative inline-flex">
             <GivebackGiftButton />
             <GivebackInvitePrompt
               open
               autoDismissMs={600000}
-              celebrate
-              eyebrow={givebackInvitePrompts[0].eyebrow}
-              headline={givebackInvitePrompts[0].headline}
-              body={givebackInvitePrompts[0].body}
-              ctaLabel={givebackInvitePrompts[0].ctaLabel}
-              placement="below"
-              align="end"
-            />
-          </span>
-        </Header>
-      </section>
-
-      <section
-        data-testid="state-toast-plain"
-        className="flex flex-col gap-2 pb-52"
-      >
-        <Label text="4 · Invite toast — plain message variant" />
-        <Header>
-          <span className="relative inline-flex">
-            <GivebackGiftButton />
-            <GivebackInvitePrompt
-              open
-              autoDismissMs={600000}
-              eyebrow={givebackInvitePrompts[1].eyebrow}
-              headline={givebackInvitePrompts[1].headline}
-              body={givebackInvitePrompts[1].body}
-              ctaLabel={givebackInvitePrompts[1].ctaLabel}
+              celebrate={milestonePrompt.celebrate}
+              eyebrow={milestonePrompt.eyebrow}
+              headline={milestonePrompt.headline}
+              body={milestonePrompt.body}
+              ctaLabel={milestonePrompt.ctaLabel}
               placement="below"
               align="end"
             />


### PR DESCRIPTION
## Changes

Adds the **giveback header + new-layout rail gift entry point** — an acquisition hook whose job is to pull people into `/giveback`. Ported from design mock-up #6278 into a clean, review-ready state (QA/debug scaffolding dropped).

- **`GivebackGiftButton`** — a calm gift icon at rest (header + rail variants, press feedback). No progress meter, no notification badge. Header variant matches `NotificationsBell` (Float, `w-10`, centered).
- **`GivebackGiftDock`** — composition point with an imperative API (`pulseActivity`, `showPrompt`, `reset`) the entry drives; renders the `+$` dollar jumps and celebration glow.
- **Polymarket-style dollar jumps** — bare green `+$` figures pop beside the gift as community money lands (social proof), offset per-pop to stay legible.
- **`GivebackInvitePrompt`** — a wide, mascot-fronted invite card (daily.dev Giveback charm) with rotating community-framed messaging, confetti on celebratory moments, and an auto-dismiss **countdown ring** on the close button (driven by `useTimedAnimation`, pauses on hover).
- **`GivebackConfettiBurst`** + new motion classes in `base.css` — all `bounce:0` (no overshoot) and reduced-motion safe.
- **`GivebackGiftEntry`** — container gated on the existing `featureGiveback` flag + logged-in + desktop; wired into `HeaderButtons` (between quests and notifications) and the `SidebarDesktopV2` rail gift (which falls back to the *Invite friends* shortcut when the flag is off). Navigates to `/giveback`.
- **Storybook** — `Features/Giveback/Entry points/*`: resting gift-button states, header states, and an interactive live playground.

> [!NOTE]
> The money pulses and invite-prompt cadence are currently driven by a **local timer as a clearly-marked placeholder**. Before this graduates past the experiment, replace them with live backend community-activity signals and drop the hardcoded figures in `givebackInvitePrompts`.

## Experiment

No new flag — reuses the existing **`giveback`** feature flag that already gates the page. When off (production default), `HeaderButtons` is unchanged and the rail gift keeps its *Invite friends* behavior.

## Events

| Type | event_name | extra |
|------|-----------|-------|
| New | click giveback gift entry | — |
| New | view giveback prompt | `{ prompt }` |

## Notes for reviewers

Ported from mock-up #6278. Relative to that branch, the review-only QA scaffolding was intentionally **removed** for merge: the `GivebackDevPanel`, the `givebackQa` window event bus, the `?giveback_debug` force-show overrides, and the global `MainLayout` mount.

## Manual Testing

- [x] `node ./scripts/typecheck-strict-changed.js` passes
- [x] `HeaderButtons` / `MainLayoutHeader` specs pass (entry renders null when flag off — no regression)
- [x] Full giveback feature suite passes (63 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-goofy-ishizaka-979a95.preview.app.daily.dev