### PR TITLE
feat: double freeform post content length to 20000

### DIFF
--- a/packages/shared/src/components/post/composer/TextForm.tsx
+++ b/packages/shared/src/components/post/composer/TextForm.tsx
@@ -45,7 +45,7 @@ export interface TextFormHandle {
   toggleMarkdownMode: () => void;
 }
 
-const BODY_MAX_LENGTH = 10_000;
+const BODY_MAX_LENGTH = 20_000;
 
 export const TextForm = forwardRef<TextFormHandle, TextFormProps>(
   function TextForm(


### PR DESCRIPTION
Doubles the freeform post composer body limit from 10,000 to 20,000 characters.

## Changes
- Bump `BODY_MAX_LENGTH` from `10_000` to `20_000` in `packages/shared/src/components/post/composer/TextForm.tsx`. This value is passed as `maxInputLength` to the rich text editor, so both the hard input cap and the "characters remaining" counter update automatically.

## Key decisions
- The client cap must stay numerically identical to the backend limit (`MAX_CONTENT_LENGTH` in daily-api, changed in a parallel PR) to preserve the client/server invariant — a client-only bump would let users write text the API rejects.
- Scope is the freeform post **body** only; post title and other limits are unchanged.
- No new test added on the apps side: `BODY_MAX_LENGTH` drives `maxInputLength` (and its counter) directly, and the shared testing philosophy keeps the correctness guarantee at the API boundary. Verified via strict typecheck, ESLint, and the existing `SmartComposerModal` spec that renders the composer.

Closes ENG-1823

---
Created by Huginn 🐦‍⬛


### Preview domain
https://eng-1823-double-the-post-content.preview.app.daily.dev